### PR TITLE
feat: hold accel to temporarily erase from draw / highlight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,10 +126,10 @@ opencode.json
 # PR walkthrough intermediate files
 .claude/worktrees
 .claude/settings.local.json
-.claude/skills/pr-walkthrough/tmp
-.claude/skills/pr-walkthrough/out
-.claude/skills/pr-walkthrough/video/node_modules
-.claude/skills/pr-walkthrough/video/dist
-.claude/skills/pr-walkthrough/video/public/audio-*
-.claude/skills/pr-walkthrough/video/public/manifest.json
+skills/pr-walkthrough/tmp
+skills/pr-walkthrough/out
+skills/pr-walkthrough/video/node_modules
+skills/pr-walkthrough/video/dist
+skills/pr-walkthrough/video/public/audio-*
+skills/pr-walkthrough/video/public/manifest.json
 todo.md

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1750,11 +1750,24 @@ export class EraserTool extends StateNode {
     // (undocumented)
     static id: string;
     // (undocumented)
+    info: {
+        onInteractionEnd?: string | undefined;
+    };
+    // (undocumented)
     static initial: string;
     // (undocumented)
     static isLockable: boolean;
+    maybeReturnToOriginatingTool(): void;
     // (undocumented)
-    onEnter(): void;
+    onEnter(info?: {
+        onInteractionEnd?: string;
+    }): void;
+    // (undocumented)
+    onExit(): void;
+    // (undocumented)
+    onKeyDown(info: TLKeyboardEventInfo): void;
+    // (undocumented)
+    onKeyUp(info: TLKeyboardEventInfo): void;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1757,6 +1757,7 @@ export class EraserTool extends StateNode {
     static initial: string;
     // (undocumented)
     static isLockable: boolean;
+    // @internal
     maybeReturnToOriginatingTool(): void;
     // (undocumented)
     onEnter(info?: {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1764,10 +1764,6 @@ export class EraserTool extends StateNode {
     }): void;
     // (undocumented)
     onExit(): void;
-    // (undocumented)
-    onKeyDown(info: TLKeyboardEventInfo): void;
-    // (undocumented)
-    onKeyUp(info: TLKeyboardEventInfo): void;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1757,7 +1757,7 @@ export class EraserTool extends StateNode {
     static initial: string;
     // (undocumented)
     static isLockable: boolean;
-    // @internal
+    // (undocumented)
     maybeReturnToOriginatingTool(): void;
     // (undocumented)
     onEnter(info?: {

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
@@ -1,4 +1,4 @@
-import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
+import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo } from '@tldraw/editor'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
@@ -9,6 +9,16 @@ export class Idle extends StateNode {
 
 	override onEnter() {
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onKeyDown(info: TLKeyboardEventInfo) {
+		// Hold accel (Cmd on macOS, Ctrl elsewhere) before starting a stroke to
+		// temporarily switch into the eraser tool. The originating tool stays
+		// visible in the toolbar via setCurrentToolIdMask. Releasing accel
+		// returns to this tool.
+		if (info.accelKey && (info.key === 'Meta' || info.key === 'Control')) {
+			this.editor.setCurrentTool('eraser', { onInteractionEnd: this.parent.id })
+		}
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
@@ -4,6 +4,13 @@ export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onPointerDown(info: TLPointerEventInfo) {
+		// Safety net: if accel is held when the pointer goes down (e.g. the
+		// keydown switch missed because the editor wasn't focused yet), switch
+		// to the eraser and forward the event so the click is treated as an erase.
+		if (info.accelKey) {
+			this.transitionToTransientErase(info)
+			return
+		}
 		this.parent.transition('drawing', info)
 	}
 
@@ -17,11 +24,20 @@ export class Idle extends StateNode {
 		// visible in the toolbar via setCurrentToolIdMask. Releasing accel
 		// returns to this tool.
 		if (info.accelKey && (info.key === 'Meta' || info.key === 'Control')) {
-			this.editor.setCurrentTool('eraser', { onInteractionEnd: this.parent.id })
+			this.transitionToTransientErase()
 		}
 	}
 
 	override onCancel() {
 		this.editor.setCurrentTool('select')
+	}
+
+	private transitionToTransientErase(forwardEvent?: TLPointerEventInfo) {
+		this.editor.setCurrentTool('eraser', { onInteractionEnd: this.parent.id })
+		// If we were triggered from a pointerDown, hand the event off to the
+		// eraser tool so its idle state can transition to pointing.
+		if (forwardEvent) {
+			this.editor.root.handleEvent(forwardEvent)
+		}
 	}
 }

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
@@ -5,9 +5,6 @@ export class Idle extends StateNode {
 
 	override onPointerDown(info: TLPointerEventInfo) {
 		if (info.accelKey && !info.shiftKey) {
-			// If the user is holding the accel key (but not shift, which is used for multi-point drawing),
-			// temporarily switch to pointing to erase shapes instead of drawing. Enter the eraser's pointing
-			// state with the current tool as the onInteractionEnd so we can return to it when accel is released.
 			this.editor.setCurrentTool('eraser.pointing', { ...info, onInteractionEnd: this.parent.id })
 			return
 		}

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Idle.ts
@@ -1,16 +1,17 @@
-import { StateNode, TLKeyboardEventInfo, TLPointerEventInfo } from '@tldraw/editor'
+import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onPointerDown(info: TLPointerEventInfo) {
-		// Safety net: if accel is held when the pointer goes down (e.g. the
-		// keydown switch missed because the editor wasn't focused yet), switch
-		// to the eraser and forward the event so the click is treated as an erase.
-		if (info.accelKey) {
-			this.transitionToTransientErase(info)
+		if (info.accelKey && !info.shiftKey) {
+			// If the user is holding the accel key (but not shift, which is used for multi-point drawing),
+			// temporarily switch to pointing to erase shapes instead of drawing. Enter the eraser's pointing
+			// state with the current tool as the onInteractionEnd so we can return to it when accel is released.
+			this.editor.setCurrentTool('eraser.pointing', { ...info, onInteractionEnd: this.parent.id })
 			return
 		}
+
 		this.parent.transition('drawing', info)
 	}
 
@@ -18,26 +19,7 @@ export class Idle extends StateNode {
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
 	}
 
-	override onKeyDown(info: TLKeyboardEventInfo) {
-		// Hold accel (Cmd on macOS, Ctrl elsewhere) before starting a stroke to
-		// temporarily switch into the eraser tool. The originating tool stays
-		// visible in the toolbar via setCurrentToolIdMask. Releasing accel
-		// returns to this tool.
-		if (info.accelKey && (info.key === 'Meta' || info.key === 'Control')) {
-			this.transitionToTransientErase()
-		}
-	}
-
 	override onCancel() {
 		this.editor.setCurrentTool('select')
-	}
-
-	private transitionToTransientErase(forwardEvent?: TLPointerEventInfo) {
-		this.editor.setCurrentTool('eraser', { onInteractionEnd: this.parent.id })
-		// If we were triggered from a pointerDown, hand the event off to the
-		// eraser tool so its idle state can transition to pointing.
-		if (forwardEvent) {
-			this.editor.root.handleEvent(forwardEvent)
-		}
 	}
 }

--- a/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
@@ -1,4 +1,4 @@
-import { isAccelKey, StateNode, TLKeyboardEventInfo, TLStateNodeConstructor } from '@tldraw/editor'
+import { StateNode, TLStateNodeConstructor } from '@tldraw/editor'
 import { Erasing } from './childStates/Erasing'
 import { Idle } from './childStates/Idle'
 import { Pointing } from './childStates/Pointing'
@@ -14,15 +14,9 @@ export class EraserTool extends StateNode {
 
 	info = {} as { onInteractionEnd?: string }
 
-	// Tracked from key events directly because inputs.getAccelKey() is debounced
-	// by ~150ms in Editor.dispatch and lags real-time release.
-	private _accelHeld = false
-
 	override onEnter(info: { onInteractionEnd?: string } = {}) {
 		this.info = info
-		this._accelHeld = false
 		if (info.onInteractionEnd) {
-			this._accelHeld = true
 			this.setCurrentToolIdMask(info.onInteractionEnd)
 		}
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
@@ -31,35 +25,16 @@ export class EraserTool extends StateNode {
 	override onExit() {
 		this.setCurrentToolIdMask(undefined)
 		this.info = {}
-		this._accelHeld = false
-	}
-
-	override onKeyDown(info: TLKeyboardEventInfo) {
-		if (!this.info.onInteractionEnd) return
-		if (info.key === 'Meta' || info.key === 'Control') {
-			this._accelHeld = true
-		}
-	}
-
-	override onKeyUp(info: TLKeyboardEventInfo) {
-		if (!this.info.onInteractionEnd) return
-		if (info.key !== 'Meta' && info.key !== 'Control') return
-		if (isAccelKey(info)) return
-		this._accelHeld = false
-		this.maybeReturnToOriginatingTool()
 	}
 
 	/**
-	 * If the eraser was entered transiently (via accel-hold from another tool)
-	 * and accel is no longer held, return to the originating tool. We only
-	 * return when no pointer interaction is in progress so an in-flight erase
-	 * isn't cancelled mid-drag.
+	 * Return to the originating tool. Called from the eraser's `Idle` child
+	 * state when accel is no longer held, so an in-flight pointer interaction
+	 * (Pointing / Erasing) is allowed to complete before we switch back.
 	 */
 	maybeReturnToOriginatingTool() {
 		const { onInteractionEnd } = this.info
 		if (!onInteractionEnd) return
-		if (this._accelHeld) return
-		if (this.getCurrent()?.id !== 'idle') return
 		this.editor.setCurrentTool(onInteractionEnd)
 	}
 }

--- a/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
@@ -27,12 +27,6 @@ export class EraserTool extends StateNode {
 		this.info = {}
 	}
 
-	/**
-	 * Return to the originating tool. Called from the eraser's `Idle` child
-	 * state when accel is no longer held, so an in-flight pointer interaction
-	 * (Pointing / Erasing) is allowed to complete before we switch back.
-	 * @internal
-	 */
 	maybeReturnToOriginatingTool() {
 		const { onInteractionEnd } = this.info
 		if (!onInteractionEnd) return

--- a/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
@@ -1,4 +1,4 @@
-import { StateNode, TLStateNodeConstructor } from '@tldraw/editor'
+import { isAccelKey, StateNode, TLKeyboardEventInfo, TLStateNodeConstructor } from '@tldraw/editor'
 import { Erasing } from './childStates/Erasing'
 import { Idle } from './childStates/Idle'
 import { Pointing } from './childStates/Pointing'
@@ -12,7 +12,54 @@ export class EraserTool extends StateNode {
 		return [Idle, Pointing, Erasing]
 	}
 
-	override onEnter() {
+	info = {} as { onInteractionEnd?: string }
+
+	// Tracked from key events directly because inputs.getAccelKey() is debounced
+	// by ~150ms in Editor.dispatch and lags real-time release.
+	private _accelHeld = false
+
+	override onEnter(info: { onInteractionEnd?: string } = {}) {
+		this.info = info
+		this._accelHeld = false
+		if (info.onInteractionEnd) {
+			this._accelHeld = true
+			this.setCurrentToolIdMask(info.onInteractionEnd)
+		}
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onExit() {
+		this.setCurrentToolIdMask(undefined)
+		this.info = {}
+		this._accelHeld = false
+	}
+
+	override onKeyDown(info: TLKeyboardEventInfo) {
+		if (!this.info.onInteractionEnd) return
+		if (info.key === 'Meta' || info.key === 'Control') {
+			this._accelHeld = true
+		}
+	}
+
+	override onKeyUp(info: TLKeyboardEventInfo) {
+		if (!this.info.onInteractionEnd) return
+		if (info.key !== 'Meta' && info.key !== 'Control') return
+		if (isAccelKey(info)) return
+		this._accelHeld = false
+		this.maybeReturnToOriginatingTool()
+	}
+
+	/**
+	 * If the eraser was entered transiently (via accel-hold from another tool)
+	 * and accel is no longer held, return to the originating tool. We only
+	 * return when no pointer interaction is in progress so an in-flight erase
+	 * isn't cancelled mid-drag.
+	 */
+	maybeReturnToOriginatingTool() {
+		const { onInteractionEnd } = this.info
+		if (!onInteractionEnd) return
+		if (this._accelHeld) return
+		if (this.getCurrent()?.id !== 'idle') return
+		this.editor.setCurrentTool(onInteractionEnd)
 	}
 }

--- a/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/EraserTool.ts
@@ -31,6 +31,7 @@ export class EraserTool extends StateNode {
 	 * Return to the originating tool. Called from the eraser's `Idle` child
 	 * state when accel is no longer held, so an in-flight pointer interaction
 	 * (Pointing / Erasing) is allowed to complete before we switch back.
+	 * @internal
 	 */
 	maybeReturnToOriginatingTool() {
 		const { onInteractionEnd } = this.info

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -1,11 +1,4 @@
-import {
-	Box,
-	StateNode,
-	TLPointerEventInfo,
-	TLShapeId,
-	isAccelKey,
-	pointInPolygon,
-} from '@tldraw/editor'
+import { Box, StateNode, TLPointerEventInfo, TLShapeId, pointInPolygon } from '@tldraw/editor'
 
 export class Erasing extends StateNode {
 	static override id = 'erasing'
@@ -16,15 +9,9 @@ export class Erasing extends StateNode {
 	private markId = ''
 	private excludedShapeIds = new Set<TLShapeId>()
 
-	_isHoldingAccelKey = false
-	_firstErasingShapeId: TLShapeId | null = null
 	_erasingShapeIds: TLShapeId[] = []
 
 	override onEnter(info: TLPointerEventInfo) {
-		this._isHoldingAccelKey = isAccelKey(this.editor.inputs)
-		this._firstErasingShapeId = this.editor.getErasingShapeIds()[0] // the first one should be the first one we hit... is it?
-		this._erasingShapeIds = this.editor.getErasingShapeIds()
-
 		this.markId = this.editor.markHistoryStoppingPoint('erase scribble begin')
 		this.info = info
 
@@ -46,6 +33,13 @@ export class Erasing extends StateNode {
 				})
 				.map((shape) => shape.id)
 		)
+
+		this._erasingShapeIds = this.editor
+			.getShapesAtPoint(originPagePoint)
+			.filter((s) => !this.excludedShapeIds.has(s.id))
+			.map((s) => s.id)
+
+		this.editor.setErasingShapes(this._erasingShapeIds)
 
 		const scribble = this.editor.scribbles.addScribble({
 			color: 'muted-1',
@@ -80,16 +74,6 @@ export class Erasing extends StateNode {
 
 	override onComplete() {
 		this.complete()
-	}
-
-	override onKeyUp() {
-		this._isHoldingAccelKey = isAccelKey(this.editor.inputs)
-		this.update()
-	}
-
-	override onKeyDown() {
-		this._isHoldingAccelKey = isAccelKey(this.editor.inputs)
-		this.update()
 	}
 
 	update() {
@@ -162,15 +146,6 @@ export class Erasing extends StateNode {
 			this._erasingShapeIds = [...erasing]
 		}
 
-		// If the user is holding the meta / ctrl key, we should only erase the first shape we hit
-		if (this._isHoldingAccelKey && this._firstErasingShapeId) {
-			const erasingShapeId = this._firstErasingShapeId
-			if (erasingShapeId && this.editor.getShape(erasingShapeId)) {
-				editor.setErasingShapes([erasingShapeId])
-			}
-			return
-		}
-
 		// Remove the hit shapes, except if they're in the list of excluded shapes
 		// (these excluded shapes will be any frames or groups the pointer was inside of
 		// when the user started erasing)
@@ -182,7 +157,6 @@ export class Erasing extends StateNode {
 		editor.deleteShapes(editor.getCurrentPageState().erasingShapeIds)
 		this.parent.transition('idle')
 		this._erasingShapeIds = []
-		this._firstErasingShapeId = null
 	}
 
 	cancel() {

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -34,12 +34,17 @@ export class Erasing extends StateNode {
 				.map((shape) => shape.id)
 		)
 
+		// Set the erasing shapes to be any shapes that are hit at the origin point, except for any excluded shapes
 		this._erasingShapeIds = this.editor
 			.getShapesAtPoint(originPagePoint)
 			.filter((s) => !this.excludedShapeIds.has(s.id))
 			.map((s) => s.id)
 
-		this.editor.setErasingShapes(this._erasingShapeIds)
+		// ...and union that with any shapes that are already being erased
+		this.editor.setErasingShapes([
+			...new Set(this.editor.getErasingShapeIds()),
+			...this._erasingShapeIds,
+		])
 
 		const scribble = this.editor.scribbles.addScribble({
 			color: 'muted-1',

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -34,16 +34,13 @@ export class Erasing extends StateNode {
 				.map((shape) => shape.id)
 		)
 
-		// Set the erasing shapes to be any shapes that are hit at the origin point, except for any excluded shapes
 		this._erasingShapeIds = this.editor
 			.getShapesAtPoint(originPagePoint)
 			.filter((s) => !this.excludedShapeIds.has(s.id))
 			.map((s) => s.id)
 
-		// ...and union that with any shapes that are already being erased
 		this.editor.setErasingShapes([
-			...new Set(this.editor.getErasingShapeIds()),
-			...this._erasingShapeIds,
+			...new Set([...this.editor.getErasingShapeIds(), ...this._erasingShapeIds]),
 		])
 
 		const scribble = this.editor.scribbles.addScribble({
@@ -69,8 +66,8 @@ export class Erasing extends StateNode {
 		this.update()
 	}
 
-	override onPointerUp() {
-		this.complete()
+	override onPointerUp(info: TLPointerEventInfo) {
+		this.complete(info)
 	}
 
 	override onCancel() {
@@ -157,10 +154,10 @@ export class Erasing extends StateNode {
 		this.editor.setErasingShapes(this._erasingShapeIds.filter((id) => !excludedShapeIds.has(id)))
 	}
 
-	complete() {
+	complete(info?: TLPointerEventInfo) {
 		const { editor } = this
 		editor.deleteShapes(editor.getCurrentPageState().erasingShapeIds)
-		this.parent.transition('idle')
+		this.parent.transition('idle', info)
 		this._erasingShapeIds = []
 	}
 

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Idle.ts
@@ -1,13 +1,21 @@
 import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
+import type { EraserTool } from '../EraserTool'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
+
+	override onEnter() {
+		// After a transient (accel-hold) erase finishes and we re-enter idle,
+		// return to the originating tool if accel has already been released.
+		;(this.parent as EraserTool).maybeReturnToOriginatingTool()
+	}
 
 	override onPointerDown(info: TLPointerEventInfo) {
 		this.parent.transition('pointing', info)
 	}
 
 	override onCancel() {
-		this.editor.setCurrentTool('select')
+		const onInteractionEnd = (this.parent as EraserTool).info.onInteractionEnd
+		this.editor.setCurrentTool(onInteractionEnd ?? 'select')
 	}
 }

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Idle.ts
@@ -4,8 +4,8 @@ import type { EraserTool } from '../EraserTool'
 export class Idle extends StateNode {
 	static override id = 'idle'
 
-	override onEnter() {
-		if (!this.editor.inputs.getAccelKey()) {
+	override onEnter(info?: TLPointerEventInfo) {
+		if (!(info?.accelKey ?? this.editor.inputs.getAccelKey())) {
 			;(this.parent as EraserTool).maybeReturnToOriginatingTool()
 		}
 	}

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Idle.ts
@@ -1,13 +1,19 @@
-import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
+import { isAccelKey, StateNode, TLPointerEventInfo, type TLKeyboardEventInfo } from '@tldraw/editor'
 import type { EraserTool } from '../EraserTool'
 
 export class Idle extends StateNode {
 	static override id = 'idle'
 
 	override onEnter() {
-		// After a transient (accel-hold) erase finishes and we re-enter idle,
-		// return to the originating tool if accel has already been released.
-		;(this.parent as EraserTool).maybeReturnToOriginatingTool()
+		if (!this.editor.inputs.getAccelKey()) {
+			;(this.parent as EraserTool).maybeReturnToOriginatingTool()
+		}
+	}
+
+	override onKeyUp(info: TLKeyboardEventInfo) {
+		if (!isAccelKey(info)) {
+			;(this.parent as EraserTool).maybeReturnToOriginatingTool()
+		}
 	}
 
 	override onPointerDown(info: TLPointerEventInfo) {

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -5,8 +5,8 @@ export class Pointing extends StateNode {
 
 	_isHoldingAccelKey = false
 
-	override onEnter() {
-		this._isHoldingAccelKey = isAccelKey(this.editor.inputs)
+	override onEnter(info: TLPointerEventInfo) {
+		this._isHoldingAccelKey = isAccelKey(info)
 
 		const zoomLevel = this.editor.getZoomLevel()
 		const currentPageShapesSorted = this.editor.getCurrentPageRenderingShapesSorted()
@@ -55,6 +55,8 @@ export class Pointing extends StateNode {
 	}
 
 	override onLongPress(info: TLPointerEventInfo) {
+		// don't transition to erasing if the user is holding the accel key, they want to keep pointing
+		if (info.accelKey) return
 		this.startErasing(info)
 	}
 
@@ -65,8 +67,6 @@ export class Pointing extends StateNode {
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {
-		if (this._isHoldingAccelKey) return
-
 		if (this.editor.inputs.getIsDragging()) {
 			this.startErasing(info)
 		}

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -1,13 +1,10 @@
-import { isAccelKey, StateNode, TLPointerEventInfo, TLShapeId } from '@tldraw/editor'
+import { StateNode, TLPointerEventInfo, TLShapeId } from '@tldraw/editor'
 
 export class Pointing extends StateNode {
 	static override id = 'pointing'
 
-	_isHoldingAccelKey = false
-
 	override onEnter(info: TLPointerEventInfo) {
-		this._isHoldingAccelKey = isAccelKey(info)
-
+		const onlyEraseTopShape = info.accelKey
 		const zoomLevel = this.editor.getZoomLevel()
 		const currentPageShapesSorted = this.editor.getCurrentPageRenderingShapesSorted()
 		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
@@ -36,26 +33,14 @@ export class Pointing extends StateNode {
 
 				erasing.add(hitShape.id)
 
-				// If the user is holding the meta / ctrl key, stop after the first shape
-				if (this._isHoldingAccelKey) {
-					break
-				}
+				if (onlyEraseTopShape) break
 			}
 		}
 
 		this.editor.setErasingShapes([...erasing])
 	}
 
-	override onKeyUp() {
-		this._isHoldingAccelKey = isAccelKey(this.editor.inputs)
-	}
-
-	override onKeyDown() {
-		this._isHoldingAccelKey = isAccelKey(this.editor.inputs)
-	}
-
 	override onLongPress(info: TLPointerEventInfo) {
-		// don't transition to erasing if the user is holding the accel key, they want to keep pointing
 		if (info.accelKey) return
 		this.startErasing(info)
 	}
@@ -72,8 +57,8 @@ export class Pointing extends StateNode {
 		}
 	}
 
-	override onPointerUp() {
-		this.complete()
+	override onPointerUp(info: TLPointerEventInfo) {
+		this.complete(info)
 	}
 
 	override onCancel() {
@@ -92,7 +77,7 @@ export class Pointing extends StateNode {
 		this.parent.transition('erasing', info)
 	}
 
-	complete() {
+	complete(info?: TLPointerEventInfo) {
 		const erasingShapeIds = this.editor.getErasingShapeIds()
 
 		if (erasingShapeIds.length) {
@@ -100,7 +85,7 @@ export class Pointing extends StateNode {
 			this.editor.deleteShapes(erasingShapeIds)
 		}
 
-		this.parent.transition('idle')
+		this.parent.transition('idle', info)
 	}
 
 	cancel() {

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -480,22 +480,19 @@ describe('When shift clicking', () => {
 })
 
 describe('When holding meta/ctrl key (accel key)', () => {
-	it('Only erases the first shape hit when clicking with accel key held', () => {
+	it('Only erases the top shape hit when clicking with accel key held', () => {
 		editor.setCurrentTool('eraser')
 		editor.expectToBeIn('eraser.idle')
 
 		const shapesBeforeCount = editor.getCurrentPageShapes().length
 
-		// Simulate holding meta key (accel key)
 		editor.keyDown('Meta')
 		editor.pointerDown(99, 99) // next to box1 AND in box2
 
-		// Should only erase the first shape hit (box2, since it's rendered on top)
 		expect(editor.getErasingShapeIds()).toEqual([ids.box2])
 
 		editor.pointerUp()
 
-		// Should only delete the first shape
 		expect(editor.getShape(ids.box1)).toBeDefined()
 		expect(editor.getShape(ids.box2)).toBeUndefined()
 
@@ -505,137 +502,55 @@ describe('When holding meta/ctrl key (accel key)', () => {
 		editor.keyUp('Meta')
 	})
 
-	it('Only erases the first shape hit when dragging with accel key held', () => {
+	it('Erases all hit shapes once an accel pointer becomes a drag', () => {
 		editor.setCurrentTool('eraser')
 		editor.expectToBeIn('eraser.idle')
 
-		const shapesBeforeCount = editor.getCurrentPageShapes().length
+		editor.keyDown('Meta')
+		editor.pointerDown(99, 99) // next to box1 AND in box2
 
-		// Start dragging without accel key to establish first erasing shape
-		editor.pointerDown(-100, -100) // outside of any shapes
-		editor.pointerMove(99, 99) // next to box1 AND in box2
+		expect(editor.getErasingShapeIds()).toEqual([ids.box2])
+
+		editor.pointerMove(350, 350) // in box3
+		editor.expectToBeIn('eraser.erasing')
+		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2, ids.box3]))
 
 		vi.advanceTimersByTime(16)
 		expect(editor.getInstanceState().scribbles.length).toBe(1)
-
-		// Should include all shapes hit initially
-		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2]))
-
-		// Now press accel key during erasing
-		editor.keyDown('Meta')
-
-		// The accel key should restrict to only the first shape hit
-		// Note: The implementation may not immediately restrict to first shape
-		// until the next update cycle, so we check that at least one shape is still being erased
-		expect(editor.getErasingShapeIds().length).toBeGreaterThan(0)
+		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2, ids.box3]))
 
 		editor.pointerUp()
 
-		// Should delete at least one shape
-		const shapesAfterCount = editor.getCurrentPageShapes().length
-		expect(shapesAfterCount).toBeLessThan(shapesBeforeCount)
+		expect(editor.getShape(ids.box1)).toBeUndefined()
+		expect(editor.getShape(ids.box2)).toBeUndefined()
+		expect(editor.getShape(ids.box3)).toBeUndefined()
 
 		editor.keyUp('Meta')
 	})
 
-	it('Returns to normal erasing behavior when accel key is released during erasing', () => {
+	it('Still erases normally when accel key is released during erasing', () => {
 		editor.setCurrentTool('eraser')
 		editor.expectToBeIn('eraser.idle')
 
-		const shapesBeforeCount = editor.getCurrentPageShapes().length
-
-		// Start dragging without accel key to establish first erasing shape
 		editor.pointerDown(-100, -100) // outside of any shapes
 		editor.pointerMove(99, 99) // next to box1 AND in box2
 
 		vi.advanceTimersByTime(16)
 		expect(editor.getInstanceState().scribbles.length).toBe(1)
 
-		// Should include all shapes hit initially
 		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2]))
 
-		// Press accel key to restrict to first shape
 		editor.keyDown('Meta')
-		// The accel key should affect the erasing behavior
-		expect(editor.getErasingShapeIds().length).toBeGreaterThan(0)
-
-		// Release the accel key
 		editor.keyUp('Meta')
-
-		// Should still include shapes hit
-		expect(editor.getErasingShapeIds().length).toBeGreaterThan(0)
-
-		editor.pointerUp()
-
-		// Should delete shapes
-		const shapesAfterCount = editor.getCurrentPageShapes().length
-		expect(shapesAfterCount).toBeLessThan(shapesBeforeCount)
-	})
-
-	it('Preserves only first erasing shape when accel key is pressed during erasing (only if there is a first erasing shape)', () => {
-		editor.setCurrentTool('eraser')
-		editor.expectToBeIn('eraser.idle')
-
-		const shapesBeforeCount = editor.getCurrentPageShapes().length
-
-		// Start erasing normally
-		editor.pointerDown(-100, -100) // outside of any shapes
-		editor.pointerMove(99, 99) // next to box1 AND in box2
-
-		vi.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
-
-		// Should include all shapes hit initially
-		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2]))
-
-		// Press accel key during erasing
-		editor.keyDown('Meta')
-
-		// The accel key should affect the erasing behavior
-		expect(editor.getErasingShapeIds().length).toBeGreaterThan(0)
-
-		editor.pointerUp()
-
-		// Should delete at least one shape
-		const shapesAfterCount = editor.getCurrentPageShapes().length
-		expect(shapesAfterCount).toBeLessThan(shapesBeforeCount)
-
-		editor.keyUp('Meta')
-	})
-
-	it('Maintains first shape erasing behavior when accel key is held throughout the erasing session (only if there is a first erasing shape)', () => {
-		editor.setCurrentTool('eraser')
-		editor.expectToBeIn('eraser.idle')
-
-		const shapesBeforeCount = editor.getCurrentPageShapes().length
-
-		// Start dragging without accel key to establish first erasing shape
-		editor.pointerDown(-100, -100) // outside of any shapes
-		editor.pointerMove(99, 99) // next to box1 AND in box2
-
-		vi.advanceTimersByTime(16)
-		expect(editor.getInstanceState().scribbles.length).toBe(1)
-
-		// Should include all shapes hit initially
-		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2]))
-
-		// Press accel key to restrict to first shape
-		editor.keyDown('Meta')
-		expect(editor.getErasingShapeIds().length).toBeGreaterThan(0)
-
-		// Move to hit more shapes
 		editor.pointerMove(350, 350) // in box3
 
-		// Should still include shapes being erased
-		expect(editor.getErasingShapeIds().length).toBeGreaterThan(0)
+		expect(new Set(editor.getErasingShapeIds())).toEqual(new Set([ids.box1, ids.box2, ids.box3]))
 
 		editor.pointerUp()
 
-		// Should delete at least one shape
-		const shapesAfterCount = editor.getCurrentPageShapes().length
-		expect(shapesAfterCount).toBeLessThan(shapesBeforeCount)
-
-		editor.keyUp('Meta')
+		expect(editor.getShape(ids.box1)).toBeUndefined()
+		expect(editor.getShape(ids.box2)).toBeUndefined()
+		expect(editor.getShape(ids.box3)).toBeUndefined()
 	})
 })
 
@@ -660,10 +575,9 @@ describe('Hold accel to temporarily erase from the draw / highlight tool', () =>
 				editor.setCurrentTool(tool)
 				editor.keyDown('Meta')
 
-				editor.pointerDown(99, 99) // hits box2
+				editor.pointerDown(99, 99) // next to box1 AND in box2
 
 				editor.expectToBeIn('eraser.pointing')
-				// The eraser is active but the toolbar still reports the originating tool.
 				expect(editor.getCurrentTool().id).toBe('eraser')
 				expect(editor.getCurrentToolId()).toBe(tool)
 				expect(editor.getErasingShapeIds()).toEqual([ids.box2])
@@ -678,8 +592,9 @@ describe('Hold accel to temporarily erase from the draw / highlight tool', () =>
 				editor.pointerUp()
 
 				expect(editor.getCurrentPageShapes().length).toBe(shapesBefore - 1)
+				expect(editor.getShape(ids.box1)).toBeDefined()
+				expect(editor.getShape(ids.box2)).toBeUndefined()
 
-				// Accel still held: stay in transient eraser.idle so the next click also erases.
 				editor.expectToBeIn('eraser.idle')
 				expect(editor.getCurrentTool().id).toBe('eraser')
 				expect(editor.getCurrentToolId()).toBe(tool)
@@ -698,27 +613,40 @@ describe('Hold accel to temporarily erase from the draw / highlight tool', () =>
 				expect(editor.getCurrentToolId()).toBe(tool)
 			})
 
+			it(`release event on transient click returns to ${tool}`, () => {
+				editor.setCurrentTool(tool)
+				editor.keyDown('Meta')
+
+				editor.pointerDown(99, 99)
+				editor.expectToBeIn('eraser.pointing')
+				expect(editor.inputs.getAccelKey()).toBe(true)
+
+				editor.pointerUp(99, 99, { accelKey: false, metaKey: false, ctrlKey: false })
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentToolId()).toBe(tool)
+			})
+
 			it(`releasing accel mid-erase does not yank back; pointer up returns to ${tool}`, () => {
 				editor.setCurrentTool(tool)
 				editor.keyDown('Meta')
 
 				editor.pointerDown(99, 99)
 				editor.expectToBeIn('eraser.pointing')
+				editor.pointerMove(350, 350)
+				editor.expectToBeIn('eraser.erasing')
+				expect(new Set(editor.getErasingShapeIds())).toEqual(
+					new Set([ids.box1, ids.box2, ids.box3])
+				)
 
-				// Simulate accel release mid-interaction. Set both metaKey and
-				// ctrlKey directly to bypass the editor's 150ms debounce on accel
-				// release — in real browsers each subsequent event carries the
-				// up-to-date modifier state, so this models reality even though
-				// `keyUp('Meta')` in tests defers the state update. (The driver
-				// treats Meta as also setting ctrlKey on key down, so both must be
-				// cleared for `inputs.getAccelKey()` to flip on non-Darwin envs.)
-				editor.inputs.setMetaKey(false)
-				editor.inputs.setCtrlKey(false)
 				expect(editor.getCurrentTool().id).toBe('eraser')
+				expect(editor.inputs.getAccelKey()).toBe(true)
 
-				editor.pointerUp()
+				editor.pointerUp(350, 350, { accelKey: false, metaKey: false, ctrlKey: false })
 				editor.expectToBeIn(`${tool}.idle`)
 				expect(editor.getCurrentToolId()).toBe(tool)
+				expect(editor.getShape(ids.box1)).toBeUndefined()
+				expect(editor.getShape(ids.box2)).toBeUndefined()
+				expect(editor.getShape(ids.box3)).toBeUndefined()
 			})
 
 			it(`accel pressed mid-stroke does not switch tools`, () => {

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -572,25 +572,6 @@ describe('When holding meta/ctrl key (accel key)', () => {
 		expect(shapesAfterCount).toBeLessThan(shapesBeforeCount)
 	})
 
-	it('Prevents pointer move from starting erasing when accel key is held in pointing state (only if there is a first erasing shape)', () => {
-		editor.setCurrentTool('eraser')
-		editor.expectToBeIn('eraser.idle')
-
-		// Start with accel key held and click on a shape
-		editor.keyDown('Meta')
-		editor.pointerDown(0, 0) // in box1
-		editor.expectToBeIn('eraser.pointing')
-
-		expect(editor.getErasingShapeIds()).toEqual([ids.box1])
-
-		// Try to move pointer - should not start erasing
-		editor.pointerMove(50, 50)
-		editor.expectToBeIn('eraser.pointing') // Should still be in pointing state
-
-		editor.pointerUp()
-		editor.keyUp('Meta')
-	})
-
 	it('Preserves only first erasing shape when accel key is pressed during erasing (only if there is a first erasing shape)', () => {
 		editor.setCurrentTool('eraser')
 		editor.expectToBeIn('eraser.idle')
@@ -661,56 +642,86 @@ describe('When holding meta/ctrl key (accel key)', () => {
 describe('Hold accel to temporarily erase from the draw / highlight tool', () => {
 	for (const tool of ['draw', 'highlight'] as const) {
 		describe(`from ${tool}`, () => {
-			it(`switches into eraser while keeping ${tool} masked when accel is pressed in idle`, () => {
+			it(`holding accel alone does not switch tools`, () => {
 				editor.setCurrentTool(tool)
 				editor.expectToBeIn(`${tool}.idle`)
-				expect(editor.getCurrentToolId()).toBe(tool)
 
 				editor.keyDown('Meta')
 
-				editor.expectToBeIn('eraser.idle')
-				// Eraser is the active tool but the toolbar still reports the originating tool.
-				expect(editor.getCurrentTool().id).toBe('eraser')
+				// No tool switch on key down — the switch only happens on pointer down.
+				editor.expectToBeIn(`${tool}.idle`)
 				expect(editor.getCurrentToolId()).toBe(tool)
 
 				editor.keyUp('Meta')
-
 				editor.expectToBeIn(`${tool}.idle`)
-				expect(editor.getCurrentToolId()).toBe(tool)
 			})
 
-			it(`returns to ${tool} after a transient erase completes`, () => {
+			it(`accel + click in idle goes straight into eraser.pointing with ${tool} masked`, () => {
 				editor.setCurrentTool(tool)
 				editor.keyDown('Meta')
-				editor.expectToBeIn('eraser.idle')
+
+				editor.pointerDown(99, 99) // hits box2
+
+				editor.expectToBeIn('eraser.pointing')
+				// The eraser is active but the toolbar still reports the originating tool.
+				expect(editor.getCurrentTool().id).toBe('eraser')
+				expect(editor.getCurrentToolId()).toBe(tool)
+				expect(editor.getErasingShapeIds()).toEqual([ids.box2])
+			})
+
+			it(`accel + click + release with accel held returns to eraser.idle, masked as ${tool}`, () => {
+				editor.setCurrentTool(tool)
+				editor.keyDown('Meta')
 
 				const shapesBefore = editor.getCurrentPageShapes().length
-				editor.pointerDown(99, 99) // hits box2
+				editor.pointerDown(99, 99)
 				editor.pointerUp()
 
 				expect(editor.getCurrentPageShapes().length).toBe(shapesBefore - 1)
 
-				editor.keyUp('Meta')
-				editor.expectToBeIn(`${tool}.idle`)
+				// Accel still held: stay in transient eraser.idle so the next click also erases.
+				editor.expectToBeIn('eraser.idle')
+				expect(editor.getCurrentTool().id).toBe('eraser')
 				expect(editor.getCurrentToolId()).toBe(tool)
 			})
 
-			it(`stays in eraser while pointer is down even if accel is released, then returns to ${tool}`, () => {
+			it(`releasing accel after a transient erase returns to ${tool}`, () => {
 				editor.setCurrentTool(tool)
 				editor.keyDown('Meta')
 
 				editor.pointerDown(99, 99)
-				// Mid-interaction; releasing accel must not yank the user back to ${tool}.
-				editor.keyUp('Meta')
-				expect(editor.getCurrentTool().id).toBe('eraser')
-
 				editor.pointerUp()
-				// Once the erase finishes and we re-enter eraser idle with accel released, return.
+				editor.expectToBeIn('eraser.idle')
+
+				editor.keyUp('Meta')
 				editor.expectToBeIn(`${tool}.idle`)
 				expect(editor.getCurrentToolId()).toBe(tool)
 			})
 
-			it(`does not switch tools when accel is pressed mid-stroke`, () => {
+			it(`releasing accel mid-erase does not yank back; pointer up returns to ${tool}`, () => {
+				editor.setCurrentTool(tool)
+				editor.keyDown('Meta')
+
+				editor.pointerDown(99, 99)
+				editor.expectToBeIn('eraser.pointing')
+
+				// Simulate accel release mid-interaction. Set both metaKey and
+				// ctrlKey directly to bypass the editor's 150ms debounce on accel
+				// release — in real browsers each subsequent event carries the
+				// up-to-date modifier state, so this models reality even though
+				// `keyUp('Meta')` in tests defers the state update. (The driver
+				// treats Meta as also setting ctrlKey on key down, so both must be
+				// cleared for `inputs.getAccelKey()` to flip on non-Darwin envs.)
+				editor.inputs.setMetaKey(false)
+				editor.inputs.setCtrlKey(false)
+				expect(editor.getCurrentTool().id).toBe('eraser')
+
+				editor.pointerUp()
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentToolId()).toBe(tool)
+			})
+
+			it(`accel pressed mid-stroke does not switch tools`, () => {
 				editor.setCurrentTool(tool)
 				editor.pointerDown(0, 0)
 				editor.expectToBeIn(`${tool}.drawing`)
@@ -722,39 +733,15 @@ describe('Hold accel to temporarily erase from the draw / highlight tool', () =>
 				editor.pointerUp()
 			})
 
-			it(`safety net: pointerDown with accel held in ${tool} idle erases instead of drawing`, () => {
+			it(`shift + accel + click does not switch (preserves shift+cmd straight-line snap)`, () => {
 				editor.setCurrentTool(tool)
-				editor.expectToBeIn(`${tool}.idle`)
+				editor.keyDown('Shift')
+				editor.keyDown('Meta')
 
-				const shapesBefore = editor.getCurrentPageShapes().length
+				editor.pointerDown(99, 99)
 
-				// Simulate the case where the keydown was missed (e.g. the editor
-				// wasn't focused yet) by dispatching a pointerDown with accel set
-				// without a prior keyDown('Meta').
-				editor.dispatch({
-					type: 'pointer',
-					name: 'pointer_down',
-					point: { x: 99, y: 99, z: 0 },
-					pointerId: 1,
-					button: 0,
-					isPen: false,
-					target: 'canvas',
-					shiftKey: false,
-					altKey: false,
-					ctrlKey: true,
-					metaKey: true,
-					accelKey: true,
-				})
-
-				// We should have switched to the eraser and started erasing the hit
-				// shape, not started drawing a new shape.
-				expect(editor.getCurrentTool().id).toBe('eraser')
-				expect(editor.getCurrentToolId()).toBe(tool)
-				expect(editor.getErasingShapeIds()).toEqual([ids.box2])
-
-				editor.pointerUp()
-
-				expect(editor.getCurrentPageShapes().length).toBe(shapesBefore - 1)
+				// Should be drawing (straight-line mode), not erasing.
+				editor.expectToBeIn(`${tool}.drawing`)
 			})
 		})
 	}
@@ -766,7 +753,7 @@ describe('Hold accel to temporarily erase from the draw / highlight tool', () =>
 		editor.keyDown('Meta')
 		editor.keyUp('Meta')
 
-		// Still eraser; no transient return.
+		// Still eraser; no transient return because there's no onInteractionEnd.
 		expect(editor.getCurrentToolId()).toBe('eraser')
 		expect(editor.getCurrentTool().id).toBe('eraser')
 	})

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -721,6 +721,41 @@ describe('Hold accel to temporarily erase from the draw / highlight tool', () =>
 				editor.keyUp('Meta')
 				editor.pointerUp()
 			})
+
+			it(`safety net: pointerDown with accel held in ${tool} idle erases instead of drawing`, () => {
+				editor.setCurrentTool(tool)
+				editor.expectToBeIn(`${tool}.idle`)
+
+				const shapesBefore = editor.getCurrentPageShapes().length
+
+				// Simulate the case where the keydown was missed (e.g. the editor
+				// wasn't focused yet) by dispatching a pointerDown with accel set
+				// without a prior keyDown('Meta').
+				editor.dispatch({
+					type: 'pointer',
+					name: 'pointer_down',
+					point: { x: 99, y: 99, z: 0 },
+					pointerId: 1,
+					button: 0,
+					isPen: false,
+					target: 'canvas',
+					shiftKey: false,
+					altKey: false,
+					ctrlKey: true,
+					metaKey: true,
+					accelKey: true,
+				})
+
+				// We should have switched to the eraser and started erasing the hit
+				// shape, not started drawing a new shape.
+				expect(editor.getCurrentTool().id).toBe('eraser')
+				expect(editor.getCurrentToolId()).toBe(tool)
+				expect(editor.getErasingShapeIds()).toEqual([ids.box2])
+
+				editor.pointerUp()
+
+				expect(editor.getCurrentPageShapes().length).toBe(shapesBefore - 1)
+			})
 		})
 	}
 

--- a/packages/tldraw/src/test/EraserTool.test.ts
+++ b/packages/tldraw/src/test/EraserTool.test.ts
@@ -657,3 +657,82 @@ describe('When holding meta/ctrl key (accel key)', () => {
 		editor.keyUp('Meta')
 	})
 })
+
+describe('Hold accel to temporarily erase from the draw / highlight tool', () => {
+	for (const tool of ['draw', 'highlight'] as const) {
+		describe(`from ${tool}`, () => {
+			it(`switches into eraser while keeping ${tool} masked when accel is pressed in idle`, () => {
+				editor.setCurrentTool(tool)
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentToolId()).toBe(tool)
+
+				editor.keyDown('Meta')
+
+				editor.expectToBeIn('eraser.idle')
+				// Eraser is the active tool but the toolbar still reports the originating tool.
+				expect(editor.getCurrentTool().id).toBe('eraser')
+				expect(editor.getCurrentToolId()).toBe(tool)
+
+				editor.keyUp('Meta')
+
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentToolId()).toBe(tool)
+			})
+
+			it(`returns to ${tool} after a transient erase completes`, () => {
+				editor.setCurrentTool(tool)
+				editor.keyDown('Meta')
+				editor.expectToBeIn('eraser.idle')
+
+				const shapesBefore = editor.getCurrentPageShapes().length
+				editor.pointerDown(99, 99) // hits box2
+				editor.pointerUp()
+
+				expect(editor.getCurrentPageShapes().length).toBe(shapesBefore - 1)
+
+				editor.keyUp('Meta')
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentToolId()).toBe(tool)
+			})
+
+			it(`stays in eraser while pointer is down even if accel is released, then returns to ${tool}`, () => {
+				editor.setCurrentTool(tool)
+				editor.keyDown('Meta')
+
+				editor.pointerDown(99, 99)
+				// Mid-interaction; releasing accel must not yank the user back to ${tool}.
+				editor.keyUp('Meta')
+				expect(editor.getCurrentTool().id).toBe('eraser')
+
+				editor.pointerUp()
+				// Once the erase finishes and we re-enter eraser idle with accel released, return.
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentToolId()).toBe(tool)
+			})
+
+			it(`does not switch tools when accel is pressed mid-stroke`, () => {
+				editor.setCurrentTool(tool)
+				editor.pointerDown(0, 0)
+				editor.expectToBeIn(`${tool}.drawing`)
+
+				editor.keyDown('Meta')
+				editor.expectToBeIn(`${tool}.drawing`)
+
+				editor.keyUp('Meta')
+				editor.pointerUp()
+			})
+		})
+	}
+
+	it('explicit eraser (not from accel) does not get masked or auto-return on key up', () => {
+		editor.setCurrentTool('eraser')
+		expect(editor.getCurrentToolId()).toBe('eraser')
+
+		editor.keyDown('Meta')
+		editor.keyUp('Meta')
+
+		// Still eraser; no transient return.
+		expect(editor.getCurrentToolId()).toBe('eraser')
+		expect(editor.getCurrentTool().id).toBe('eraser')
+	})
+})

--- a/packages/tldraw/src/test/drawing.test.ts
+++ b/packages/tldraw/src/test/drawing.test.ts
@@ -188,7 +188,16 @@ for (const toolType of ['draw', 'highlight'] as const) {
 			const x = magnitude * Math.cos(angle)
 			const y = magnitude * Math.sin(angle)
 
-			editor.setCurrentTool(toolType).keyDown('Meta').pointerDown(0, 0).pointerMove(x, y)
+			// Shift held during pointerDown enters straight-line (angle-snapping) mode.
+			// Cmd pressed after pointerDown disables the angle snap. We press cmd
+			// after pointerDown so the accel-to-erase shortcut (which fires from
+			// the tool's idle state) doesn't intercept it.
+			editor
+				.setCurrentTool(toolType)
+				.keyDown('Shift')
+				.pointerDown(0, 0)
+				.keyDown('Meta')
+				.pointerMove(x, y)
 
 			const shape = editor.getCurrentPageShapes()[0] as DrawableShape
 			const segment = shape.props.segments[0]

--- a/skills/pr-walkthrough/SKILL.md
+++ b/skills/pr-walkthrough/SKILL.md
@@ -42,6 +42,17 @@ git log main..HEAD --oneline
 git diff main..HEAD --stat
 ```
 
+**Skip generated files.** When reading the diff, ignore files that are auto-generated rather than hand-edited. These add noise without informing the walkthrough. Common examples in this repo:
+
+- `**/api-report.md`, `**/api-report.api.md` — generated API surface reports
+- `**/*.api.json`, `**/temp/*.api.json` — API extractor output
+- `apps/docs/content/reference/**` — generated reference docs
+- `yarn.lock`, `package-lock.json` — lockfiles
+- `**/CHANGELOG.md` — auto-generated changelogs
+- Any file the repo's tooling regenerates (snapshots, schema dumps, bundled assets)
+
+If unsure whether a file is generated, check for a header comment like "DO NOT EDIT" or check whether the repo has a generator command that produces it. Filter these out when picking which files to feature in `diff`/`code` slides.
+
 ### Step 2: Write the narration
 
 Write the narration as continuous text, broken into logical segments. Each segment is a beat of the walkthrough — a concept, a change, or a group of related changes. Save this as `tmp/pr-<number>/SCRIPT.md`.


### PR DESCRIPTION
In order to let users dip into the eraser without leaving the draw or highlight tool, this PR makes accel-click temporarily erase. While in draw / highlight idle, holding the accel key (Cmd on macOS, Ctrl elsewhere) and clicking goes straight into eraser pointing/dragging. The toolbar still shows the originating tool, and releasing accel returns to it.

Closes #8650.

## How it works

`Idle` (shared by draw and highlight) intercepts `onPointerDown` when accel is held (and shift isn't, since shift is multi-point drawing). It calls `setCurrentTool('eraser.pointing', { ...info, onInteractionEnd: this.parent.id })`, which:

- Enters the eraser tool, masking the toolbar as the originating tool via `setCurrentToolIdMask(onInteractionEnd)`.
- Skips eraser `idle` and goes directly into `pointing` with the original pointer event, so the click counts as the start of the erase interaction.

Returning to the originating tool is driven by the eraser's `idle` child state:

- `Idle.onEnter` returns to the originating tool if accel is no longer held (e.g. user pressed accel, clicked-and-dragged, released accel, then pointer-up brought us back to idle).
- `Idle.onKeyUp` returns immediately when accel is released while idle (the eraser just sits there with no in-flight interaction).

This lets in-flight interactions (`Pointing` → `Erasing`) finish naturally before we switch back, regardless of when the user releases accel.

## Why this approach

The earlier draft pre-switched into the eraser on `keydown` and tracked accel state on the eraser itself. That had two problems: there was no visual cue for the silent swap (both tools use the cross cursor), and accel state had to be hand-rolled because `editor.inputs.getAccelKey()` is debounced. Pointer-down-only is simpler and matches the user's mental model — the swap commits when they actually click.

This also removes the eraser's old "hold accel to erase only the first shape" mode. Accel inside the eraser now means "switch back to the originating tool," and the inner mode added confusion. Erasing now snapshots the shapes at the origin point and erases along the drag path.

## Behavior matrix

| Scenario | Result |
| -- | -- |
| Hold accel in draw idle, no click | Toolbar / cursor unchanged; release accel is a no-op |
| Hold accel + click | Erase as normal; toolbar still shows draw |
| Click + drag with accel held | Drag erases shapes along the path (single-shape mode is gone) |
| Release accel mid-drag | Continue erase; return to draw on pointer up |
| Press accel while drawing a stroke | Existing draw behavior preserved (no tool switch mid-stroke) |
| Eraser opened standalone (E key) | No mask, no transient mode |

### Change type

- [x] `feature`

### Test plan

1. In the draw tool, hold Cmd (or Ctrl) and click a shape — it erases. The toolbar still shows draw.
2. Hold Cmd, drag across multiple shapes — they all erase.
3. Hold Cmd, click-drag, release Cmd mid-drag — drag continues erasing; on pointer up, you're back in draw.
4. Press Cmd while mid-stroke — existing draw behavior (no tool switch) is preserved.
5. Repeat 1–4 with the highlight tool.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Hold accel (Cmd / Ctrl) in the draw or highlight tool to temporarily erase. Click or drag to erase, release accel to return to drawing.

### API changes

- Added public `EraserTool.info: { onInteractionEnd?: string }` field on `EraserTool`.
- Added `EraserTool.maybeReturnToOriginatingTool()`.
- Added `EraserTool.onExit()`.
- Changed `EraserTool.onEnter()` to accept an optional `{ onInteractionEnd?: string }` argument.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +64 / -41  |
| Tests           | +130 / -20 |
| Automated files | +10 / -1   |

