### PR TITLE
fix(dotcom): lower Zero kill_timeout to Fly's 5m API cap

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -289,8 +289,9 @@ const zeroQueryUrl = `${env.MULTIPLAYER_SERVER.replace(/^ws/, 'http')}/app/zero/
 // Production uses performance (dedicated) CPUs for both RM and VS; staging uses shared.
 // killTimeout: window between SIGTERM and SIGKILL on stop. Lets VS drain client
 // WebSockets and RM flush litestream / release /data handles before being killed.
-// Fly caps it at 5m on shared CPU and 24h on dedicated; production uses 10m to
-// match Rocicorp's CZ default, staging is pinned to the 5m shared-CPU ceiling.
+// Fly's API caps it at 5m regardless of CPU kind (the 24h dedicated-CPU figure
+// from their blog is not actually accepted by the Machines API today — deploys
+// fail with "invalid stop_config.timeout, cannot exceed 5 minutes").
 const zeroVmSizes = {
 	staging: {
 		rm: { cpus: 1, memory: '2gb', cpuKind: 'shared' },
@@ -304,7 +305,7 @@ const zeroVmSizes = {
 		vs: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
 		volumeSize: '8gb',
 		vsMinMachines: 4,
-		killTimeout: '10m',
+		killTimeout: '5m',
 	},
 	preview: { single: { cpus: 2, memory: '2gb' } },
 } as const


### PR DESCRIPTION
In order to unblock production deploys, this PR lowers the Zero RM/VS `kill_timeout` from `10m` back to `5m`. Fly's Machines API rejects anything over 5 minutes regardless of CPU kind:

```
Error: failed to update machine ...: invalid stop_config.timeout, cannot exceed 5 minutes
```

This contradicts Fly's [graceful VM exits guide](https://fly.io/blog/graceful-vm-exits-some-dials/), which suggests up to 24h on dedicated CPU. The 5m cap from the API is the authoritative limit today. Drain budget is now half what Rocicorp's CZ uses, but it's the ceiling Fly will accept.

Follow-up to #8627.

### Change type

- [x] `bugfix`

### Test plan

1. Merge to `production` → `deploy-dotcom.yml` should complete the VS/RM rolling update without the `invalid stop_config.timeout` error.
2. Verify generated `flyio-view-syncer.toml` and `flyio-replication-manager.toml` contain `kill_timeout = "5m"` at top level.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +4 / -3    |