### PR TITLE
fix(scripts): make Discord webhook errors non-fatal in deploy

### DIFF
--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -67,12 +67,17 @@ export class Discord {
 				body: JSON.stringify(body),
 			})
 			if (!response.ok) {
-				console.warn(`Discord webhook request failed: ${response.status} ${response.statusText}`)
+				console.warn(
+					`Discord webhook request failed: ${method} -> ${response.status} ${response.statusText}`
+				)
 				return null
 			}
 			return response.json()
 		} catch (err) {
-			console.warn(`Discord webhook request failed:`, err)
+			const errString = err instanceof Error ? (err.stack ?? err.message) : String(err)
+			console.warn(
+				`Discord webhook request failed: ${method}\n${sanitizeVariables(errString, this.secretValues)}`
+			)
 			return null
 		}
 	}

--- a/internal/scripts/lib/discord.ts
+++ b/internal/scripts/lib/discord.ts
@@ -60,15 +60,21 @@ export class Discord {
 	private secretValues?: string[]
 
 	private async send(method: string, url: string, body: unknown): Promise<any> {
-		const response = await fetch(`${this.webhookUrl}${url}`, {
-			method,
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(body),
-		})
-		if (!response.ok) {
-			throw new Error(`Discord webhook request failed: ${response.status} ${response.statusText}`)
+		try {
+			const response = await fetch(`${this.webhookUrl}${url}`, {
+				method,
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(body),
+			})
+			if (!response.ok) {
+				console.warn(`Discord webhook request failed: ${response.status} ${response.statusText}`)
+				return null
+			}
+			return response.json()
+		} catch (err) {
+			console.warn(`Discord webhook request failed:`, err)
+			return null
 		}
-		return response.json()
 	}
 
 	async message(content: string, { always = false }: { always?: boolean } = {}) {
@@ -87,6 +93,7 @@ export class Discord {
 
 		return {
 			edit: async (newContent: string) => {
+				if (!message?.id) return
 				const prefixedNewContent = this.messagePrefix
 					? `${this.messagePrefix} ${newContent}`
 					: newContent


### PR DESCRIPTION
In order to stop transient Discord/Cloudflare webhook errors from aborting the dotcom deploy mid-flight, this PR makes `Discord.send` non-fatal: it now logs a warning and returns `null` on any non-OK response or network error instead of throwing. Closes #8625.

A recent prod deploy hit `Discord webhook request failed: 520 <none>` from the success-edit (`message.edit('… ✅')`) at the end of the `deploy cloudflare workers` step — all 5 CF workers had already deployed, but the throw skipped the Vercel deploy step. The same pattern previously surfaced as a 429 from rate limiting (#8625). Discord notifications are observability for humans; deploy progress should not depend on them.

### Changes

`internal/scripts/lib/discord.ts`:

- Wrap `fetch` in try/catch; on non-OK response or network error, `console.warn` and return `null` instead of throwing.
- Guard `edit()` to no-op when the initial POST returned `null` (no message id to PATCH).

### Change type

- [x] `bugfix`

### Test plan

1. Next production dotcom deploy completes end-to-end even if Discord returns a transient 5xx or 429.
2. Deploy progress messages still appear in Discord under normal conditions.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +15 / -8   |
