### PR TITLE
fix(editor): guard navigator.connection null in resolveAssetUrl

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5168,7 +5168,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const zoomStepFunction = (zoom: number) => Math.pow(2, Math.ceil(Math.log2(zoom)))
 		const steppedScreenScale = zoomStepFunction(screenScale)
 		const networkEffectiveType: string | null =
-			'connection' in navigator ? (navigator as any).connection.effectiveType : null
+			'connection' in navigator ? ((navigator as any).connection?.effectiveType ?? null) : null
 
 		return await this.store.props.assets.resolve(asset, {
 			screenScale: screenScale || 1,


### PR DESCRIPTION
In order to stop a recurring Sentry `TypeError: Cannot read properties of null (reading 'effectiveType')` originating from `Editor.resolveAssetUrl`, this PR null-checks `navigator.connection` before reading `effectiveType`.

The previous code used `'connection' in navigator` as a feature guard, but that returns `true` when the property exists with a `null` value (some Firefox configurations, Brave with shields up, certain WebView contexts), so the subsequent `.effectiveType` access threw.

### Change type

- [x] `bugfix`

### Test plan

1. Hard to reproduce without a browser environment that defines `navigator.connection` as `null`. Verified via type and logic inspection; behavior unchanged when `navigator.connection` is a valid object.

### Release notes

- Fix a crash in asset URL resolution on browsers where `navigator.connection` is defined but null.