### PR TITLE
fix(tldraw): truncate note attribution name in SVG/PNG export

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -3,6 +3,7 @@ import {
 	Box,
 	DefaultFontFamilies,
 	EMPTY_ARRAY,
+	Editor,
 	Group2d,
 	IndexKey,
 	Rectangle2d,
@@ -459,10 +460,13 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		})
 
 		const { textFirstEditedBy } = shape.props
-		const attributionName =
+		const attributionFirstName =
 			textFirstEditedBy && !isEmptyRichText(shape.props.richText)
 				? this.editor.getAttributionDisplayName(textFirstEditedBy)?.split(' ')[0]
 				: null
+		const attributionName = attributionFirstName
+			? truncateAttributionForSvg(this.editor, attributionFirstName, dv.noteWidth)
+			: null
 
 		return (
 			<>
@@ -722,6 +726,27 @@ function useNoteKeydownHandler(id: TLShapeId) {
 
 function getNoteHeight(shape: TLNoteShape, noteHeight: number) {
 	return (noteHeight + shape.props.growY) * shape.props.scale
+}
+
+// Matches `.tl-note__attribution { max-width: 60% }` so SVG export truncates the same way.
+const ATTRIBUTION_MAX_WIDTH_RATIO = 0.6
+
+function truncateAttributionForSvg(editor: Editor, name: string, noteWidth: number) {
+	if (process.env.NODE_ENV === 'test') return name
+	const spans = editor.textMeasure.measureTextSpans(name, {
+		fontSize: 11,
+		fontFamily: DefaultFontFamilies['sans'],
+		textAlign: 'end',
+		width: Math.floor(noteWidth * ATTRIBUTION_MAX_WIDTH_RATIO),
+		height: 16,
+		padding: 0,
+		lineHeight: 1,
+		fontStyle: 'normal',
+		fontWeight: 'normal',
+		overflow: 'truncate-ellipsis',
+	})
+	if (spans.length === 0) return name
+	return spans.map((s) => s.text).join('')
 }
 
 function getNoteShadow(id: string, rotation: number, scale: number) {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -737,7 +737,7 @@ function truncateAttributionForSvg(editor: Editor, name: string, noteWidth: numb
 		fontSize: 11,
 		fontFamily: DefaultFontFamilies['sans'],
 		textAlign: 'end',
-		width: Math.floor(noteWidth * ATTRIBUTION_MAX_WIDTH_RATIO),
+		width: noteWidth * ATTRIBUTION_MAX_WIDTH_RATIO,
 		height: 16,
 		padding: 0,
 		lineHeight: 1,


### PR DESCRIPTION
The on-canvas sticky note truncates a long author name with CSS (`.tl-note__attribution { max-width: 60%; text-overflow: ellipsis }`), but the SVG export path rendered the raw first name with no width constraint, so copy/paste-as-PNG showed the full name overflowing the note.

Mirror the CSS rule in `NoteShapeUtil.toSvg` by measuring the name with `editor.textMeasure.measureTextSpans` using the same 60% width cap and `truncate-ellipsis` overflow, then rendering the truncated string in the SVG `<text>` element.

Closes #8613

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a sticky note while signed in as a user whose attributed display name is long enough that the on-canvas note already truncates it with an ellipsis.
2. Type some content so the attribution shows.
3. Select the note and copy/paste it as a PNG (or use export as PNG/SVG).
4. Confirm the attribution name in the exported image is truncated with an ellipsis the same way it appears on canvas, instead of overflowing.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where the attribution name on a sticky note was not truncated when copy/pasted or exported as PNG/SVG, so long names overflowed the note.