### PR TITLE
[HOTFIX] chore(dotcom): scale Zero view-syncer to 5 machines

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -304,7 +304,7 @@ const zeroVmSizes = {
 		rm: { cpus: 2, memory: '4gb', cpuKind: 'performance' },
 		vs: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
 		volumeSize: '8gb',
-		vsMinMachines: 4,
+		vsMinMachines: 5,
 		killTimeout: '5m',
 	},
 	preview: { single: { cpus: 2, memory: '2gb' } },


### PR DESCRIPTION
Cherry-pick of #8666 onto `hotfixes` for immediate dotcom deployment.

**Original PR:** #8666

In order to add headroom for Zero view-syncer at peak, this bumps `vsMinMachines` for production from 4 to 5. The hot machine has been running ~75% CPU at peak with `advancement-timeout` pipeline resets starting to appear.

### Change type

- [x] `other`

### Test plan

- [ ] After merge + deploy, confirm 5 machines running in fra (`fly status -a production-zero-vs`)