### PR TITLE
feat(tldraw): shortcut for adding bound text under arrow terminal while dragging

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.test.ts
@@ -24,11 +24,18 @@ describe('dropBoundTextShapeAtArrowTerminal', () => {
 		editor.pointerMove(500, 500)
 		editor.expectToBeIn('select.dragging_handle')
 
-		const arrow = editor.getCurrentPageShapes().find((s) => s.type === 'arrow') as TLArrowShape
-		expect(arrow).toBeTruthy()
+		const arrowId = editor.getCurrentPageShapes().find((s) => s.type === 'arrow')!
+			.id as TLArrowShape['id']
+		editor.pointerMove(600, 400)
+
+		const arrow = editor.getShape<TLArrowShape>(arrowId)!
 		const terminalBeforeDrop = getArrowTerminalsInPageSpace(editor, arrow).end
 
 		editor.keyDown('t')
+		editor.expectToBeIn('select.dragging_handle')
+		expect(editor.getCurrentPageShapes().filter((s) => s.type === 'text')).toHaveLength(0)
+
+		editor.keyUp('t')
 
 		editor.expectToBeIn('select.editing_shape')
 

--- a/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.test.ts
@@ -1,0 +1,51 @@
+import { TLArrowShape, TLTextShape, Vec, createShapeId } from '@tldraw/editor'
+import { TestEditor } from '../../../test/TestEditor'
+import { getArrowBindings, getArrowTerminalsInPageSpace } from './shared'
+
+let editor: TestEditor
+
+const ids = {
+	box1: createShapeId('box1'),
+}
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor
+		.selectAll()
+		.deleteShapes(editor.getSelectedShapeIds())
+		.createShapes([{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
+})
+
+describe('dropBoundTextShapeAtArrowTerminal', () => {
+	it('drops a text shape from the text shortcut while dragging an arrow terminal', () => {
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(0, 0)
+		editor.inputs.setPointerVelocity(new Vec(1, 1))
+		editor.pointerMove(500, 500)
+		editor.expectToBeIn('select.dragging_handle')
+
+		const arrow = editor.getCurrentPageShapes().find((s) => s.type === 'arrow') as TLArrowShape
+		expect(arrow).toBeTruthy()
+		const terminalBeforeDrop = getArrowTerminalsInPageSpace(editor, arrow).end
+
+		editor.keyDown('t')
+
+		editor.expectToBeIn('select.editing_shape')
+
+		const text = editor.getCurrentPageShapes().find((s) => s.type === 'text') as TLTextShape
+		expect(text).toBeTruthy()
+		expect(text.props.autoSize).toBe(true)
+		expect(editor.getEditingShapeId()).toBe(text.id)
+		expect(editor.getShapePageBounds(text)!.center).toCloselyMatchObject(terminalBeforeDrop)
+
+		const bindings = getArrowBindings(editor, editor.getShape<TLArrowShape>(arrow.id)!)
+		expect(bindings.start).toBeUndefined()
+		expect(bindings.end).toMatchObject({
+			toId: text.id,
+			props: {
+				terminal: 'end',
+				normalizedAnchor: { x: 0.5, y: 0.5 },
+			},
+		})
+	})
+})

--- a/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.ts
@@ -1,0 +1,83 @@
+import { Editor, TLArrowShape, TLTextShape, createShapeId, toRichText } from '@tldraw/editor'
+import { startEditingShapeWithRichText } from '../../tools/SelectTool/selectHelpers'
+import { createOrUpdateArrowBinding, getArrowTerminalsInPageSpace } from './shared'
+
+/**
+ * Drop a new text shape at the dragged arrow terminal and bind the terminal of the
+ * in-flight arrow to its center. Ends the arrow drag and enters editing mode
+ * on the new text shape so the user can type immediately.
+ */
+export function dropBoundTextShapeAtArrowTerminal(
+	editor: Editor,
+	arrow: TLArrowShape,
+	terminal: 'start' | 'end'
+) {
+	const scale = editor.getResizeScaleFactor()
+	const center = getArrowTerminalsInPageSpace(editor, arrow)[terminal]
+	const id = createShapeId()
+
+	editor.run(() => {
+		editor.createShape<TLTextShape>({
+			id,
+			type: 'text',
+			x: center.x,
+			y: center.y,
+			props: {
+				richText: toRichText(''),
+				autoSize: true,
+				scale,
+			},
+		})
+
+		// Center the text on the arrow terminal; autoSize means we have to read the
+		// resulting bounds to compute the offset, matching the text tool's placement logic.
+		const shape = editor.getShape<TLTextShape>(id)
+		if (shape) {
+			const bounds = editor.getShapePageBounds(shape)
+			if (bounds) {
+				editor.updateShape({
+					id,
+					type: 'text',
+					x: shape.x - bounds.width / 2,
+					y: shape.y - bounds.height / 2,
+				})
+			}
+		}
+
+		createOrUpdateArrowBinding(editor, arrow.id, id, {
+			terminal,
+			normalizedAnchor: { x: 0.5, y: 0.5 },
+			isPrecise: true,
+			isExact: false,
+			snap: 'center',
+		})
+
+		const textAlign = getTextAlignFromArrowAngle(editor, arrow)
+		editor.updateShape({
+			id,
+			type: 'text',
+			props: { textAlign },
+		})
+	})
+
+	editor.complete()
+	editor.select(id)
+	startEditingShapeWithRichText(editor, id, { selectAll: true })
+}
+
+function getTextAlignFromArrowAngle(
+	editor: Editor,
+	arrow: TLArrowShape
+): TLTextShape['props']['textAlign'] {
+	const { start, end } = getArrowTerminalsInPageSpace(editor, arrow)
+
+	const angle = Math.atan2(end.y - start.y, end.x - start.x)
+
+	if (angle >= -Math.PI / 3 && angle <= Math.PI / 3) {
+		return 'start'
+	} else if (angle > (2 * Math.PI) / 3 || angle < (-2 * Math.PI) / 3) {
+		return 'end'
+	} else {
+		return 'middle'
+	}
+}

--- a/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/dropShapeOnArrowDrag.ts
@@ -1,11 +1,24 @@
-import { Editor, TLArrowShape, TLTextShape, createShapeId, toRichText } from '@tldraw/editor'
+import {
+	Editor,
+	TLArrowShape,
+	TLTextShape,
+	VecLike,
+	createShapeId,
+	toRichText,
+} from '@tldraw/editor'
 import { startEditingShapeWithRichText } from '../../tools/SelectTool/selectHelpers'
 import { createOrUpdateArrowBinding, getArrowTerminalsInPageSpace } from './shared'
 
 /**
- * Drop a new text shape at the dragged arrow terminal and bind the terminal of the
- * in-flight arrow to its center. Ends the arrow drag and enters editing mode
- * on the new text shape so the user can type immediately.
+ * Drop a new text shape at the dragged arrow terminal and bind that terminal of the
+ * in-flight arrow to the text's center. The text is centered on the terminal point and
+ * its alignment is chosen from the arrow's direction (see {@link getTextAlignFromVecAngle}).
+ * Ends the arrow drag and enters editing mode on the new text shape so the user can type
+ * immediately.
+ *
+ * @param editor - The editor instance.
+ * @param arrow - The arrow shape whose terminal is being dragged.
+ * @param terminal - Which arrow terminal (`start` or `end`) to drop the text at and bind to.
  */
 export function dropBoundTextShapeAtArrowTerminal(
 	editor: Editor,
@@ -13,15 +26,16 @@ export function dropBoundTextShapeAtArrowTerminal(
 	terminal: 'start' | 'end'
 ) {
 	const scale = editor.getResizeScaleFactor()
-	const center = getArrowTerminalsInPageSpace(editor, arrow)[terminal]
+	const terminals = getArrowTerminalsInPageSpace(editor, arrow)
+	const terminalPoint = terminals[terminal]
 	const id = createShapeId()
 
 	editor.run(() => {
 		editor.createShape<TLTextShape>({
 			id,
 			type: 'text',
-			x: center.x,
-			y: center.y,
+			x: terminalPoint.x,
+			y: terminalPoint.y,
 			props: {
 				richText: toRichText(''),
 				autoSize: true,
@@ -52,7 +66,7 @@ export function dropBoundTextShapeAtArrowTerminal(
 			snap: 'center',
 		})
 
-		const textAlign = getTextAlignFromArrowAngle(editor, arrow)
+		const textAlign = getTextAlignFromVecAngle(terminals)
 		editor.updateShape({
 			id,
 			type: 'text',
@@ -65,11 +79,20 @@ export function dropBoundTextShapeAtArrowTerminal(
 	startEditingShapeWithRichText(editor, id, { selectAll: true })
 }
 
-function getTextAlignFromArrowAngle(
-	editor: Editor,
-	arrow: TLArrowShape
-): TLTextShape['props']['textAlign'] {
-	const { start, end } = getArrowTerminalsInPageSpace(editor, arrow)
+/**
+ * Choose a text alignment for a label dropped on an arrow based on the arrow's direction,
+ * so the label reads naturally relative to the way the arrow points. Arrows pointing
+ * roughly rightward align to `start`, roughly leftward to `end`, and roughly vertical
+ * arrows are centered (`middle`).
+ *
+ * @param terminals - The arrow's `start` and `end` terminals in page space.
+ * @returns The text alignment to use for the dropped label.
+ */
+function getTextAlignFromVecAngle(terminals: {
+	start: VecLike
+	end: VecLike
+}): TLTextShape['props']['textAlign'] {
+	const { start, end } = terminals
 
 	const angle = Math.atan2(end.y - start.y, end.x - start.x)
 

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -70,30 +70,65 @@ export function getBoundShapeInfoForTerminal(
 	}
 }
 
+function getBoundShapeTerminalPoint(
+	editor: Editor,
+	binding: TLArrowBinding,
+	forceImprecise: boolean
+) {
+	const boundShape = editor.getShape(binding.toId)
+	if (!boundShape) return
+
+	const { point, size } = editor.getShapeGeometry(boundShape).bounds
+	// If the parent is the bound shape, then it's always treated as precise.
+	const shouldUsePreciseAnchor = binding.props.isPrecise || forceImprecise
+	const normalizedAnchor = shouldUsePreciseAnchor
+		? clampNormalizedAnchor(binding.props.normalizedAnchor)
+		: { x: 0.5, y: 0.5 }
+
+	return {
+		boundShape,
+		shapePoint: Vec.Add(point, Vec.MulV(normalizedAnchor, size)),
+	}
+}
+
+/** @internal */
+export function getArrowTerminalInPageSpace(
+	editor: Editor,
+	arrowPageTransform: Mat,
+	binding: TLArrowBinding,
+	forceImprecise: boolean
+) {
+	const terminal = getBoundShapeTerminalPoint(editor, binding, forceImprecise)
+
+	if (!terminal) {
+		// this can happen in multiplayer contexts where the shape is being deleted
+		return Mat.applyToPoint(arrowPageTransform, new Vec(0, 0))
+	} else {
+		// Find the actual local point of the normalized terminal on
+		// the bound shape and transform it to page space.
+		return Mat.applyToPoint(editor.getShapePageTransform(terminal.boundShape), terminal.shapePoint)
+	}
+}
+
 export function getArrowTerminalInArrowSpace(
 	editor: Editor,
 	arrowPageTransform: Mat,
 	binding: TLArrowBinding,
 	forceImprecise: boolean
 ) {
-	const boundShape = editor.getShape(binding.toId)
+	const terminal = getBoundShapeTerminalPoint(editor, binding, forceImprecise)
 
-	if (!boundShape) {
+	if (!terminal) {
 		// this can happen in multiplayer contexts where the shape is being deleted
 		return new Vec(0, 0)
 	} else {
 		// Find the actual local point of the normalized terminal on
 		// the bound shape and transform it to page space, then transform
 		// it to arrow space
-		const { point, size } = editor.getShapeGeometry(boundShape).bounds
-		// If the parent is the bound shape, then it's always treated as precise.
-		const shouldUsePreciseAnchor = binding.props.isPrecise || forceImprecise
-		const normalizedAnchor = shouldUsePreciseAnchor
-			? clampNormalizedAnchor(binding.props.normalizedAnchor)
-			: { x: 0.5, y: 0.5 }
-
-		const shapePoint = Vec.Add(point, Vec.MulV(normalizedAnchor, size))
-		const pagePoint = Mat.applyToPoint(editor.getShapePageTransform(boundShape)!, shapePoint)
+		const pagePoint = Mat.applyToPoint(
+			editor.getShapePageTransform(terminal.boundShape),
+			terminal.shapePoint
+		)
 		const arrowPoint = Mat.applyToPoint(Mat.Inverse(arrowPageTransform), pagePoint)
 		return arrowPoint
 	}
@@ -160,6 +195,39 @@ export function getArrowTerminalsInArrowSpace(
 					boundShapeRelationships === 'end-contains-start'
 			)
 		: Vec.From(shape.props.end)
+
+	return { start, end }
+}
+
+/** @internal */
+export function getArrowTerminalsInPageSpace(editor: Editor, shape: TLArrowShape) {
+	const bindings = getArrowBindings(editor, shape)
+	const arrowPageTransform = editor.getShapePageTransform(shape)!
+	const boundShapeRelationships = getBoundShapeRelationships(
+		editor,
+		bindings.start?.toId,
+		bindings.end?.toId
+	)
+
+	const start = bindings.start
+		? getArrowTerminalInPageSpace(
+				editor,
+				arrowPageTransform,
+				bindings.start,
+				boundShapeRelationships === 'double-bound' ||
+					boundShapeRelationships === 'start-contains-end'
+			)
+		: Mat.applyToPoint(arrowPageTransform, Vec.From(shape.props.start))
+
+	const end = bindings.end
+		? getArrowTerminalInPageSpace(
+				editor,
+				arrowPageTransform,
+				bindings.end,
+				boundShapeRelationships === 'double-bound' ||
+					boundShapeRelationships === 'end-contains-start'
+			)
+		: Mat.applyToPoint(arrowPageTransform, Vec.From(shape.props.end))
 
 	return { start, end }
 }

--- a/packages/tldraw/src/lib/shapes/arrow/shared.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/shared.ts
@@ -69,66 +69,30 @@ export function getBoundShapeInfoForTerminal(
 		geometry,
 	}
 }
-
-function getBoundShapeTerminalPoint(
-	editor: Editor,
-	binding: TLArrowBinding,
-	forceImprecise: boolean
-) {
-	const boundShape = editor.getShape(binding.toId)
-	if (!boundShape) return
-
-	const { point, size } = editor.getShapeGeometry(boundShape).bounds
-	// If the parent is the bound shape, then it's always treated as precise.
-	const shouldUsePreciseAnchor = binding.props.isPrecise || forceImprecise
-	const normalizedAnchor = shouldUsePreciseAnchor
-		? clampNormalizedAnchor(binding.props.normalizedAnchor)
-		: { x: 0.5, y: 0.5 }
-
-	return {
-		boundShape,
-		shapePoint: Vec.Add(point, Vec.MulV(normalizedAnchor, size)),
-	}
-}
-
-/** @internal */
-export function getArrowTerminalInPageSpace(
-	editor: Editor,
-	arrowPageTransform: Mat,
-	binding: TLArrowBinding,
-	forceImprecise: boolean
-) {
-	const terminal = getBoundShapeTerminalPoint(editor, binding, forceImprecise)
-
-	if (!terminal) {
-		// this can happen in multiplayer contexts where the shape is being deleted
-		return Mat.applyToPoint(arrowPageTransform, new Vec(0, 0))
-	} else {
-		// Find the actual local point of the normalized terminal on
-		// the bound shape and transform it to page space.
-		return Mat.applyToPoint(editor.getShapePageTransform(terminal.boundShape), terminal.shapePoint)
-	}
-}
-
 export function getArrowTerminalInArrowSpace(
 	editor: Editor,
 	arrowPageTransform: Mat,
 	binding: TLArrowBinding,
 	forceImprecise: boolean
 ) {
-	const terminal = getBoundShapeTerminalPoint(editor, binding, forceImprecise)
+	const boundShape = editor.getShape(binding.toId)
 
-	if (!terminal) {
+	if (!boundShape) {
 		// this can happen in multiplayer contexts where the shape is being deleted
 		return new Vec(0, 0)
 	} else {
 		// Find the actual local point of the normalized terminal on
 		// the bound shape and transform it to page space, then transform
 		// it to arrow space
-		const pagePoint = Mat.applyToPoint(
-			editor.getShapePageTransform(terminal.boundShape),
-			terminal.shapePoint
-		)
+		const { point, size } = editor.getShapeGeometry(boundShape).bounds
+		// If the parent is the bound shape, then it's always treated as precise.
+		const shouldUsePreciseAnchor = binding.props.isPrecise || forceImprecise
+		const normalizedAnchor = shouldUsePreciseAnchor
+			? clampNormalizedAnchor(binding.props.normalizedAnchor)
+			: { x: 0.5, y: 0.5 }
+
+		const shapePoint = Vec.Add(point, Vec.MulV(normalizedAnchor, size))
+		const pagePoint = Mat.applyToPoint(editor.getShapePageTransform(boundShape)!, shapePoint)
 		const arrowPoint = Mat.applyToPoint(Mat.Inverse(arrowPageTransform), pagePoint)
 		return arrowPoint
 	}
@@ -199,37 +163,25 @@ export function getArrowTerminalsInArrowSpace(
 	return { start, end }
 }
 
-/** @internal */
+/**
+ * Get both arrow terminals (`start` and `end`) as page-space points. Bound terminals are
+ * resolved against their target shapes; unbound terminals use the arrow's own start/end
+ * props transformed into page space.
+ *
+ * @param editor - The editor instance.
+ * @param shape - The arrow shape.
+ * @returns The `start` and `end` terminals as page-space points.
+ * @internal
+ */
 export function getArrowTerminalsInPageSpace(editor: Editor, shape: TLArrowShape) {
-	const bindings = getArrowBindings(editor, shape)
 	const arrowPageTransform = editor.getShapePageTransform(shape)!
-	const boundShapeRelationships = getBoundShapeRelationships(
-		editor,
-		bindings.start?.toId,
-		bindings.end?.toId
-	)
+	const bindings = getArrowBindings(editor, shape)
+	const { start, end } = getArrowTerminalsInArrowSpace(editor, shape, bindings)
 
-	const start = bindings.start
-		? getArrowTerminalInPageSpace(
-				editor,
-				arrowPageTransform,
-				bindings.start,
-				boundShapeRelationships === 'double-bound' ||
-					boundShapeRelationships === 'start-contains-end'
-			)
-		: Mat.applyToPoint(arrowPageTransform, Vec.From(shape.props.start))
-
-	const end = bindings.end
-		? getArrowTerminalInPageSpace(
-				editor,
-				arrowPageTransform,
-				bindings.end,
-				boundShapeRelationships === 'double-bound' ||
-					boundShapeRelationships === 'end-contains-start'
-			)
-		: Mat.applyToPoint(arrowPageTransform, Vec.From(shape.props.end))
-
-	return { start, end }
+	return {
+		start: Mat.applyToPoint(arrowPageTransform, start),
+		end: Mat.applyToPoint(arrowPageTransform, end),
+	}
 }
 
 /**

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -187,19 +187,22 @@ export class DraggingHandle extends StateNode {
 	}
 
 	override onKeyDown(info: TLKeyboardEventInfo) {
-		if (
-			info.key.toLowerCase() === 't' &&
-			this.editor.isShapeOfType(this.info.shape, 'arrow') &&
-			(this.info.handle.id === 'start' || this.info.handle.id === 'end')
-		) {
-			dropBoundTextShapeAtArrowTerminal(this.editor, this.info.shape, this.info.handle.id)
-			return
-		}
-
 		this.update()
 	}
 
-	override onKeyUp() {
+	override onKeyUp(info: TLKeyboardEventInfo) {
+		if (
+			info.key.toLowerCase() === 't' &&
+			this.editor.isShapeOfType(this.info.shape, 'arrow') &&
+			this.info.handle.id === 'end'
+		) {
+			const arrow = this.editor.getShape<TLArrowShape>(this.shapeId)
+			if (!arrow) return
+
+			dropBoundTextShapeAtArrowTerminal(this.editor, arrow, this.info.handle.id)
+			return
+		}
+
 		this.update()
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -190,6 +190,11 @@ export class DraggingHandle extends StateNode {
 		this.update()
 	}
 
+	/**
+	 * Pressing `T` while dragging an arrow's `end` terminal drops a bound text shape at that
+	 * terminal and starts editing it, instead of completing the drag. Any other key just
+	 * refreshes the drag.
+	 */
 	override onKeyUp(info: TLKeyboardEventInfo) {
 		if (
 			info.key.toLowerCase() === 't' &&

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -3,6 +3,7 @@ import {
 	StateNode,
 	TLArrowShape,
 	TLHandle,
+	TLKeyboardEventInfo,
 	TLLineShape,
 	TLPointerEventInfo,
 	TLShapeId,
@@ -16,6 +17,7 @@ import {
 } from '@tldraw/editor'
 import { ArrowShapeUtil } from '../../../shapes/arrow/ArrowShapeUtil'
 import { clearArrowTargetState } from '../../../shapes/arrow/arrowTargetState'
+import { dropBoundTextShapeAtArrowTerminal } from '../../../shapes/arrow/dropShapeOnArrowDrag'
 import { getArrowBindings } from '../../../shapes/arrow/shared'
 
 export type DraggingHandleInfo = TLPointerEventInfo & {
@@ -184,7 +186,16 @@ export class DraggingHandle extends StateNode {
 		this.update()
 	}
 
-	override onKeyDown() {
+	override onKeyDown(info: TLKeyboardEventInfo) {
+		if (
+			info.key.toLowerCase() === 't' &&
+			this.editor.isShapeOfType(this.info.shape, 'arrow') &&
+			(this.info.handle.id === 'start' || this.info.handle.id === 'end')
+		) {
+			dropBoundTextShapeAtArrowTerminal(this.editor, this.info.shape, this.info.handle.id)
+			return
+		}
+
 		this.update()
 	}
 

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -73,6 +73,8 @@ export function useKeyboardShortcuts() {
 
 			register(getHotkeysStringFromKbd(tool.kbd), (event) => {
 				if (areShortcutsDisabled(editor)) return
+				// only switch tools in idle states, active states handle keys themselves
+				if (!editor.getPath().endsWith('.idle')) return
 				preventDefault(event)
 				tool.onSelect('kbd')
 			})

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -75,6 +75,8 @@ export function useKeyboardShortcuts() {
 
 			hot(getHotkeysStringFromKbd(tool.kbd), (event) => {
 				if (areShortcutsDisabled(editor)) return
+				// only switch tools in idle states, active states handle keys themselves
+				if (!editor.getPath().endsWith('.idle')) return
 				preventDefault(event)
 				tool.onSelect('kbd')
 			})


### PR DESCRIPTION
👩 diagramming annoying sometimes because it requires too many clicks. my most recent take on making this easier is adding the ability to press t while dragging an arrow's end to spawn a bound text shape in editing mode at your pointer

💥 important note: in order to enable this, this PR includes a change to `useKeyboardShortcuts()` that blocks tool switching via keyboard shortcuts unless the user is in an idle state. I _didn't_ include the same logic to block actions in non idle states, because I can imagine there are certain actions that a user or sdk consumer might want to enable while in some non-idle state. 
doing this frees up the tool hotkeys while doing things like dragging, resizing, etc, which opens up some more design space for us to do things like this.

---

In order to label arrow endpoints while adjusting bindings, this PR lets you press **T** while dragging an arrow start or end handle: on key up, tldraw creates a text shape at that terminal, binds it there, and opens it for editing. Page-space terminal helpers in `shared.ts` support correct placement; global tool letter shortcuts are ignored unless the current tool path ends in `.idle`, so an active handle drag is not replaced by switching to the text tool.

### Change type

- [x] `feature`

### Test plan

1. Select an arrow, drag the start or end handle (bound or unbound).
2. Press **T** and release; a new text shape should appear at that terminal and enter edit mode without switching to the text tool first or inserting **t** into the new label.
3. Run `yarn test run src/lib/shapes/arrow/dropShapeOnArrowDrag.test.ts` in `packages/tldraw`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Add **T** while dragging an arrow terminal to create bound, editable text at that terminal.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +180 / -13 |
| Tests           | +58 / -0   |
| Automated files | +0 / -0    |
| Documentation   | +0 / -0    |
| Apps            | +0 / -0    |
| Templates       | +0 / -0    |
| Config/tooling  | +0 / -0    |

Made with [Cursor](https://cursor.com)