### PR TITLE
fix(dotcom): stop publicly exposing zero replication-manager

### DIFF
--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -5,18 +5,14 @@ kill_timeout = "__KILL_TIMEOUT"
 [build]
 image = "registry.hub.docker.com/rocicorp/zero:__ZERO_VERSION"
 
-[http_service]
-internal_port = 4849
-force_https = false
-auto_stop_machines = "off"
-min_machines_running = 1
-
-[[http_service.checks]]
-grace_period = "30s"
-interval = "5s"
-method = "GET"
-timeout = "5s"
-path = "/keepalive"
+[checks]
+  [checks.keepalive]
+  type = "http"
+  port = 4849
+  grace_period = "30s"
+  interval = "5s"
+  timeout = "5s"
+  path = "/keepalive"
 
 [[restart]]
 policy = "always"


### PR DESCRIPTION
The replication-manager's fly config used `[http_service]` on port 4849, which routes the entire port through Fly's public edge proxy. 

This PR removes `[http_service]` and replaces it with a top-level `[checks]` block that performs the same `/keepalive` HTTP probe for machine health. The replication-manager remains reachable to view-syncers over Fly's private `.internal` network, but is no longer published through the public edge.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy the replication-manager and confirm machines pass health checks.
2. Confirm view-syncers can still reach the change-streamer over the private network.
3. Confirm the public `<app>.fly.dev` hostname no longer routes to port 4849.

### Release notes

- Internal: stop publicly exposing the Zero replication-manager change-streamer port on Fly.