### PR TITLE
docs(dotcom): warn against exposing Zero replication-manager publicly

### DIFF
--- a/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
+++ b/apps/dotcom/zero-cache/flyio-replication-manager.template.toml
@@ -5,6 +5,10 @@ kill_timeout = "__KILL_TIMEOUT"
 [build]
 image = "registry.hub.docker.com/rocicorp/zero:__ZERO_VERSION"
 
+# Do not add [http_service] or [[services]] to this app. The replication-manager
+# serves Zero's unauthenticated change-streamer protocol on port 4849 and must
+# only be reachable over Fly's private network from view-syncers.
+
 [checks]
   [checks.keepalive]
   type = "http"


### PR DESCRIPTION
Adds a comment to the replication-manager Fly template warning future editors not to add `[http_service]` or `[[services]]` blocks. The replication-manager runs Zero's unauthenticated change-streamer protocol on port 4849 and must only be reachable over Fly's private network from view-syncers. Mirrors the warning Rocicorp added to their own Fly.io deployment docs.

Follow-up to #8672 / #8673 (which removed the existing `[http_service]` block that had been publicly exposing the change-streamer).

### Change type

- [x] `other`

### Test plan

- No code change; comment only.