### PR TITLE
fix(dotcom): wait for migrations before starting zero-cache in dev

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -11,7 +11,7 @@
 		"defaults"
 	],
 	"scripts": {
-		"dev": "./wait-for-postgres.sh && yarn run -T tsx scripts/dev-app.ts",
+		"dev": "../wait-for-migrations.sh && yarn run -T tsx scripts/dev-app.ts",
 		"build": "yarn run -T tsx scripts/build.ts",
 		"build-i18n": "yarn i18n:extract && yarn i18n:compile",
 		"start": "VITE_PREVIEW=1 yarn run -T tsx scripts/dev-app.ts",

--- a/apps/dotcom/client/wait-for-postgres.sh
+++ b/apps/dotcom/client/wait-for-postgres.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-until curl -s http://localhost:7654 | grep -q "ok"; do
-  echo "Waiting for Postgres to be ready..."
-  sleep 2
-done
-echo "Postgres is ready!"

--- a/apps/dotcom/wait-for-migrations.sh
+++ b/apps/dotcom/wait-for-migrations.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Block until `apps/dotcom/zero-cache`'s `migrate --signal-success` HTTP server
+# replies "ok" on localhost:7654, which means Postgres is up and all migrations
+# have been applied. Used by `apps/dotcom/client` and `apps/dotcom/zero-cache`
+# dev scripts to avoid racing against migration startup.
+
+until curl -s http://localhost:7654 | grep -q "ok"; do
+  echo "Waiting for migrations to finish..."
+  sleep 2
+done
+echo "Migrations are ready!"

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -14,7 +14,7 @@
 		"dev": "concurrently 'yarn docker-up' 'yarn migrate --signal-success' 'yarn bundle-schema:watch' 'yarn zero-server'",
 		"bundle-schema": "esbuild --bundle --platform=node --format=esm --outfile=./.schema.js ../../../packages/dotcom-shared/src/tlaSchema.ts",
 		"bundle-schema:watch": "esbuild --bundle --watch --platform=node --format=esm --outfile=./.schema.js ../../../packages/dotcom-shared/src/tlaSchema.ts",
-		"zero-server": "./wait-for-migrations.sh && nodemon --watch ./.schema.js --exec 'zero-cache-dev' --signal SIGINT",
+		"zero-server": "../wait-for-migrations.sh && nodemon --watch ./.schema.js --exec 'zero-cache-dev' --signal SIGINT",
 		"docker-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up",
 		"docker-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
 		"migrate": "yarn tsx ./migrate.ts",

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -14,7 +14,7 @@
 		"dev": "concurrently 'yarn docker-up' 'yarn migrate --signal-success' 'yarn bundle-schema:watch' 'yarn zero-server'",
 		"bundle-schema": "esbuild --bundle --platform=node --format=esm --outfile=./.schema.js ../../../packages/dotcom-shared/src/tlaSchema.ts",
 		"bundle-schema:watch": "esbuild --bundle --watch --platform=node --format=esm --outfile=./.schema.js ../../../packages/dotcom-shared/src/tlaSchema.ts",
-		"zero-server": "nodemon --watch ./.schema.js --exec 'zero-cache-dev' --signal SIGINT",
+		"zero-server": "./wait-for-migrations.sh && nodemon --watch ./.schema.js --exec 'zero-cache-dev' --signal SIGINT",
 		"docker-up": "docker compose --env-file .env -f ./docker/docker-compose.yml up",
 		"docker-down": "docker compose --env-file .env -f ./docker/docker-compose.yml down",
 		"migrate": "yarn tsx ./migrate.ts",

--- a/apps/dotcom/zero-cache/wait-for-migrations.sh
+++ b/apps/dotcom/zero-cache/wait-for-migrations.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+until curl -s http://localhost:7654 | grep -q "ok"; do
+  echo "Waiting for migrations to finish..."
+  sleep 2
+done
+echo "Migrations are ready!"

--- a/apps/dotcom/zero-cache/wait-for-migrations.sh
+++ b/apps/dotcom/zero-cache/wait-for-migrations.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-until curl -s http://localhost:7654 | grep -q "ok"; do
-  echo "Waiting for migrations to finish..."
-  sleep 2
-done
-echo "Migrations are ready!"


### PR DESCRIPTION
On a fresh `yarn dev` boot, `apps/dotcom/zero-cache` runs `docker-up`, `migrate --signal-success`, `bundle-schema:watch`, and `zero-server` concurrently. When Postgres comes up faster than migrations apply, `zero-server` connects before migration `016_zero_publication.sql` has created the `zero_data` publication and crashes with `Error: Unknown or invalid publications. Specified: [zero_data]. Found: []`. Nodemon then parks (`app crashed - waiting for file changes before starting...`) and zero-cache stays dead even after migrations finish, because nothing touches `.schema.js`.

This PR mirrors the existing `apps/dotcom/client/wait-for-postgres.sh` pattern: a new `apps/dotcom/zero-cache/wait-for-migrations.sh` polls the migrate process's HTTP signal on `localhost:7654` until it returns `ok`. The `zero-server` script now waits on it before launching nodemon, so initial sync only runs after migrations have been applied. Subsequent nodemon reloads (when `.schema.js` rebuilds) are effectively instant since the signal endpoint stays up for the lifetime of the dev session.

### Change type

- [x] `bugfix`

### Test plan

1. `cd apps/dotcom/zero-cache && yarn clean` (removes the docker volume).
2. `yarn dev` from the repo root.
3. `zero-cache` should print `Waiting for migrations to finish...` a couple of times, then `Migrations are ready!`, then boot cleanly with no `Unknown or invalid publications` error.
4. Edit `packages/dotcom-shared/src/tlaSchema.ts`; `bundle-schema:watch` rebuilds `.schema.js`, nodemon restarts `zero-cache-dev`, and the wait passes instantly.

### Release notes

- Internal dev tooling only; no user-facing change.

Made with [Cursor](https://cursor.com)