### PR TITLE
fix(utils): reject pending promise on debounce.cancel()

### DIFF
--- a/packages/utils/src/lib/debounce.test.ts
+++ b/packages/utils/src/lib/debounce.test.ts
@@ -118,9 +118,7 @@ describe(debounce, () => {
 			debounced()
 			debounced.cancel()
 
-			vi.useRealTimers()
-			await new Promise((resolve) => setTimeout(resolve, 0))
-			vi.useFakeTimers()
+			await new Promise(process.nextTick)
 
 			expect(handler).not.toHaveBeenCalled()
 		} finally {

--- a/packages/utils/src/lib/debounce.test.ts
+++ b/packages/utils/src/lib/debounce.test.ts
@@ -65,4 +65,66 @@ describe(debounce, () => {
 		expect(fn).toHaveBeenCalledTimes(2)
 		expect(await Promise.all([promiseC, promiseD])).toEqual(['gh', 'gh'])
 	})
+
+	it('rejects the pending promise when cancelled', async () => {
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100)
+		const promiseA = debounced()
+		const promiseB = debounced()
+
+		debounced.cancel()
+		vi.advanceTimersByTime(200)
+
+		expect(fn).not.toHaveBeenCalled()
+		await expect(promiseA).rejects.toThrow('Debounced function was cancelled')
+		await expect(promiseB).rejects.toThrow('Debounced function was cancelled')
+	})
+
+	it('starts a fresh promise after cancel', async () => {
+		const fn = vi.fn((a, b) => a + b)
+		const debounced = debounce(fn, 100)
+		const cancelledPromise = debounced('a', 'b')
+
+		debounced.cancel()
+		await expect(cancelledPromise).rejects.toThrow('Debounced function was cancelled')
+
+		const freshPromise = debounced('c', 'd')
+		expect(freshPromise).not.toBe(cancelledPromise)
+
+		vi.advanceTimersByTime(200)
+		expect(fn).toHaveBeenCalledTimes(1)
+		expect(fn).toHaveBeenCalledWith('c', 'd')
+		expect(await freshPromise).toBe('cd')
+	})
+
+	it('cancel is a no-op when no call is pending', async () => {
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100)
+		expect(() => debounced.cancel()).not.toThrow()
+
+		const promise = debounced()
+		debounced.cancel()
+		await expect(promise).rejects.toThrow('Debounced function was cancelled')
+
+		expect(() => debounced.cancel()).not.toThrow()
+	})
+
+	it('does not emit an unhandledrejection when the promise is discarded on cancel', async () => {
+		const handler = vi.fn()
+		process.on('unhandledRejection', handler)
+		try {
+			const fn = vi.fn()
+			const debounced = debounce(fn, 100)
+			debounced()
+			debounced.cancel()
+
+			vi.useRealTimers()
+			await new Promise((resolve) => setTimeout(resolve, 0))
+			vi.useFakeTimers()
+
+			expect(handler).not.toHaveBeenCalled()
+		} finally {
+			process.off('unhandledRejection', handler)
+		}
+	})
 })

--- a/packages/utils/src/lib/debounce.ts
+++ b/packages/utils/src/lib/debounce.ts
@@ -1,3 +1,4 @@
+import { noop } from './function'
 import type { Awaitable } from './types'
 
 /**
@@ -7,6 +8,12 @@ import type { Awaitable } from './types'
  * even if called multiple times in rapid succession. Each new call resets the timer. The debounced
  * function returns a Promise that resolves with the result of the original function. Includes a
  * cancel method to prevent execution if needed.
+ *
+ * Calling `cancel()` while a call is pending rejects the returned promise with an `Error`
+ * whose message is `'Debounced function was cancelled'`. Callers that discard the promise
+ * are not affected — internal handling suppresses the unhandled-rejection warning — but
+ * any code that `await`s or chains `.then()` on the promise must be prepared to handle the
+ * rejection.
  *
  * @param callback - The function to debounce (can be sync or async)
  * @param wait - The delay in milliseconds before executing the function
@@ -23,15 +30,19 @@ import type { Awaitable } from './types'
  * debouncedSearch('react hooks') // This cancels the previous call
  * debouncedSearch('react typescript') // Only this will execute
  *
- * // Cancel pending execution
+ * // Cancel pending execution — any in-flight promise rejects
  * debouncedSearch.cancel()
  *
- * // With async/await
+ * // With async/await — wrap in try/catch if you might cancel
  * const saveData = debounce(async (data: any) => {
  *   return await api.save(data)
  * }, 1000)
  *
- * const result = await saveData({name: 'John'})
+ * try {
+ *   const result = await saveData({name: 'John'})
+ * } catch (err) {
+ *   // handle cancellation or callback error
+ * }
  * ```
  *
  * @public
@@ -79,7 +90,14 @@ export function debounce<T extends unknown[], U>(
 	fn.cancel = () => {
 		if (!state) return
 		clearTimeout(state.timeout)
+		const s = state
 		state = undefined
+		// Attach a no-op handler so callers that discard the promise don't
+		// trigger an unhandled-rejection warning. Consumers that did `.then`,
+		// `.catch`, or `await` on the returned promise still observe the
+		// rejection through their own chain.
+		s.promise.catch(noop)
+		s.reject(new Error('Debounced function was cancelled'))
 	}
 	return fn
 }


### PR DESCRIPTION
In order to stop callers from hanging forever when a debounced function is cancelled mid-flight, this PR makes `debounce(...).cancel()` reject the pending promise with `Error('Debounced function was cancelled')`. Follow-up to a review note on #8604, where `cancel()` was updated to release captured arguments but the pending promise was still left unsettled.

Previously, `cancel()` cleared the pending timeout but never resolved or rejected the in-flight promise — so any code that did `await debouncedFn(...)` and then called `.cancel()` (or had it called externally, e.g. via a hook cleanup) would hang forever. To avoid breaking the common fire-and-forget pattern (`useZoomCss`, `Editor.deepLink`, search debouncers, bookmark debouncer, VS Code change responder, etc.), an internal no-op `.catch` is attached so callers that discard the promise don't trigger unhandled-rejection warnings. Consumers that `await` or chain `.then` / `.catch` on the returned promise still observe the rejection through their own chain.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

New tests cover:

- `cancel()` rejects all pending callers from the same debounce window with the expected error.
- A fresh call after `cancel()` gets a brand-new promise (and verifies state is reset cleanly).
- `cancel()` is a no-op when nothing is pending; double-cancel is safe.
- No `unhandledRejection` event fires when callers discard the promise and call `cancel()` (verifies the fire-and-forget pattern is unaffected).

### Release notes

- Fixed `debounce(...).cancel()` leaving any in-flight promise unsettled. Calling `cancel()` while a debounced call is pending now rejects the returned promise with `Error('Debounced function was cancelled')`. Code that `await`s a debounced call across a cancel should wrap it in `try/catch`.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +21 / -3   |
| Tests     | +62 / -0   |

Made with [Cursor](https://cursor.com)