### PR TITLE
fix(tldraw): reset cursor when entering editing mode

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/EditingShape.ts
@@ -44,6 +44,7 @@ export class EditingShape extends StateNode {
 			this.parent.setCurrentToolIdMask('text')
 		}
 
+		this.editor.setCursor({ type: 'default', rotation: 0 })
 		updateHoveredShapeId(this.editor)
 		this.editor.select(editingShape)
 	}

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -443,6 +443,24 @@ describe('When double clicking the selection edge', () => {
 
 		expect(editor.getEditingShapeId()).toBe(id)
 	})
+
+	it('Resets the cursor to default when entering editing mode from a resize handle', () => {
+		const id = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([{ id, type: 'geo' }])
+			.select(id)
+
+		editor.setCursor({ type: 'ew-resize', rotation: 0 })
+		expect(editor.getInstanceState().cursor.type).toBe('ew-resize')
+
+		editor.doubleClick(100, 100, { target: 'selection', handle: 'left' })
+
+		expect(editor.getEditingShapeId()).toBe(id)
+		expect(editor.getInstanceState().cursor.type).toBe('default')
+	})
 })
 
 describe('When editing shapes', () => {


### PR DESCRIPTION
In order to stop the resize cursor from persisting when a user double-clicks a resize handle to enter text editing mode, this PR resets the cursor to `default` in `EditingShape.onEnter`.

Closes #8679

### Background

After #8633 (canvas OverlayUtil system), the resize-handle cursor is set imperatively in `updateHoveredOverlayId` while a handle overlay is hovered. The cursor is only reset when the pointer leaves an overlay during `Idle.onPointerMove`. Double-clicking a resize handle transitions the select tool from `idle` to `editing_shape`, so `Idle.onPointerMove` stops running and the resize cursor is never cleared.

### Fix

`EditingShape.onEnter` now resets the cursor to `default`. Edit mode has a single, deterministic correct cursor regardless of what set the cursor previously, so resetting unconditionally on entry is the safest place. This composes with whatever set the cursor previously and is robust to other future overlays or states that may leave a sticky cursor.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open the examples app at `localhost:5420`.
2. Draw a rectangle.
3. Hover the right edge resize handle — cursor becomes `ew-resize`.
4. Double-click the handle — text editing mode begins, and the cursor should now reset to default instead of staying as `ew-resize`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix the resize cursor persisting when double-clicking a resize handle to edit a shape's text.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -0    |
| Tests     | +18 / -0   |