### PR TITLE
revert(toolbar): restore MutationObserver attribute observation in OverflowingToolbar

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -240,6 +240,8 @@ export function OverflowingToolbar({
 		mutationObserver.observe(mainToolsRef.current, {
 			childList: true,
 			subtree: true,
+			attributes: true,
+			characterData: true,
 		})
 
 		const sizingParent = findParentWithClassName(mainToolsRef.current, sizingParentClassName)


### PR DESCRIPTION
In order to fix #8689, this PR reverts #8574, which removed the `attributes` and `characterData` options from the `MutationObserver` in `OverflowingToolbar`. With those options gone, switching directly between two geo variants (e.g. pressing `R` then `O`) only re-renders the affected `ToolbarItem` children, not `OverflowingToolbar` itself, so its `useLayoutEffect` does not fire and `lastActiveOverflowItem` stays pinned to the previous geo variant — leaving the wrong icon in the toolbar slot.

Restoring the attribute/character-data observation makes those tool-selection updates trigger an overflow recompute again, so the toolbar slot swaps correctly when the active geo variant changes.

This re-introduces the intermittent `ResizeObserver loop completed with undelivered notifications` warning from #8528. We'll revisit a better fix that doesn't drop attribute observation — likely driving the recompute from a reactive value at the parent level, or filtering mutations to only those that actually change the visible toolbar layout.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app or tldraw.com.
2. Press `R` to select the rectangle tool — the toolbar shows the rectangle icon, selected.
3. Press `O` to select the oval tool.
4. Verify the toolbar slot swaps to the ellipse icon, with the selected indicator still on it.
5. Verify toolbar overflow still works correctly when resizing the window.

### Release notes

- Fix toolbar geo icon not swapping when switching directly between geo variants (e.g. rectangle to ellipse).

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -0    |

Made with [Cursor](https://cursor.com)