### PR TITLE
fix(toolbar): update geo icon when switching between geo variants

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+	GeoShapeGeoStyle,
 	activeElementShouldCaptureKeys,
 	assert,
 	modulate,
@@ -7,6 +8,7 @@ import {
 	useEditor,
 	useEvent,
 	useUniqueSafeId,
+	useValue,
 } from '@tldraw/editor'
 import classNames from 'classnames'
 import { createContext, useEffect, useLayoutEffect, useRef, useState } from 'react'
@@ -75,6 +77,18 @@ export function OverflowingToolbar({
 	const [overflowTools, setOverflowTools] = useState<HTMLDivElement | null>(null)
 	const [lastActiveOverflowItem, setLastActiveOverflowItem] = useState<string | null>(null)
 	const [shouldShowOverflow, setShouldShowOverflow] = useState(false)
+
+	// Subscribe to tool and geo style changes so this component re-renders (and the
+	// unconditional useLayoutEffect fires onDomUpdate) when switching between geo
+	// variants directly, e.g. rectangle → ellipse.
+	useValue(
+		'current tool and geo style',
+		() => {
+			const toolId = editor.getCurrentToolId()
+			return toolId === 'geo' ? editor.getSharedStyles().getAsKnownValue(GeoShapeGeoStyle) : toolId
+		},
+		[editor]
+	)
 
 	const onDomUpdate = useEvent(() => {
 		if (!mainToolsRef.current) return


### PR DESCRIPTION
Closes #8689

In order to fix the toolbar geo icon not updating when switching directly between geo variants (e.g. pressing `R` then `O`), this PR subscribes `OverflowingToolbar` to the current tool ID and geo style via `useValue`. When either value changes, the component re-renders, the existing unconditional `useLayoutEffect` fires `onDomUpdate`, and `lastActiveOverflowItem` gets recalculated to promote the correct geo variant.

Previously, switching between geo variants only re-rendered the individual `ToolbarItem` children (whose `useIsToolSelected` hook toggled `aria-pressed`), but `OverflowingToolbar` itself did not re-render. After #8574 removed `attributes` from the `MutationObserver`, there was no remaining mechanism to trigger `onDomUpdate` for attribute-only changes. This fix uses reactive state as the source of truth rather than DOM attribute observation, avoiding the ResizeObserver loop that #8574 was solving.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app at localhost:5420
2. Press `R` to select the rectangle tool — the toolbar shows a rectangle icon with the blue selected indicator
3. Press `O` to select the oval tool
4. Verify the toolbar slot swaps to show the ellipse icon with the blue selected indicator
5. Try other direct geo→geo switches (e.g. `R` → `O` → `R`, triangle via overflow → rectangle via `R`)
6. Hover over toolbar items and verify no ResizeObserver loop warnings appear in the console

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix toolbar geo icon not updating when switching directly between geo variants via keyboard shortcuts.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +14 / -0   |