### PR TITLE
fix(notes): render box-shadow in dark mode

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -335,9 +335,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const nw = dv.noteWidth * scale
 		const nh = getNoteHeight(shape, dv.noteHeight)
 
-		// Shadows are hidden when zoomed out far enough or in dark mode
-		let hideShadows = useEfficientZoomThreshold(0.25 / scale)
-		if (colorMode === 'dark') hideShadows = true
+		// Shadows are hidden when zoomed out far enough; the cheap borderBottom takes over.
+		const hideShadows = useEfficientZoomThreshold(0.25 / scale)
 
 		const isSelected = shape.id === this.editor.getOnlySelectedShapeId()
 


### PR DESCRIPTION
In order to fix the bug where notes display a solid line at the bottom edge in non-default dark mode themes (Ocean, Sunset, and any developer-registered theme via #8410), this PR removes the `if (colorMode === 'dark') hideShadows = true` shortcut in `NoteShapeUtil.tsx`. With the shortcut gone, dark-mode notes render the existing 3-layer box-shadow at normal zoom — the same path light mode already uses. On the default-dark canvas the hardcoded `rgba(15, 23, 31, ...)` shadow is essentially invisible, so default-dark looks unchanged; on lighter dark-theme backgrounds the shadow becomes visible and reads correctly, with no more solid line.

Closes #8688.

### Why this is safe perf-wise

The dark-mode shortcut was a "free" perf bonus (skip an invisible shadow), not load-bearing. The actual perf optimization is `useEfficientZoomThreshold(0.25 / scale)`, which is mode-agnostic and still active. After this change:

- Light mode, normal zoom: 3-layer box-shadow per note (unchanged).
- Light mode, low zoom: borderBottom (perf path, unchanged).
- Dark mode, normal zoom: 3-layer box-shadow per note — now matches light mode. (Was: borderBottom.)
- Dark mode, low zoom: borderBottom (perf path, unchanged).

Dark-mode at normal zoom now hits the same compositor path as light-mode at normal zoom, with the same shadow string. If light mode perf is acceptable, dark mode will be too — they're equalized, not regressed.

### Change type

- [x] `bugfix`

### Test plan

1. Open the multiple-themes example (`apps/examples/src/examples/ui/multiple-themes/`), switch to dark mode, switch through Default / Ocean / Sunset, drop a note in each.
2. Confirm no conspicuous solid line under notes on Ocean / Sunset and unchanged appearance on default-dark.
3. Verify low-zoom borderBottom still kicks in on dark mode (zoom out past the threshold).

- [x] Unit tests

### Release notes

- Fix note shapes rendering a solid line at the bottom edge in non-default dark mode themes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -3    |