### PR TITLE
fix(minimap): end drag on right-click and pointer cancel

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
@@ -74,6 +74,8 @@ export function DefaultMinimap() {
 	const onPointerDown = React.useCallback(
 		(e: React.PointerEvent<HTMLCanvasElement>) => {
 			if (!minimapRef.current) return
+			if (e.button !== 0) return
+
 			const elm = e.currentTarget
 			setPointerCapture(elm, e)
 			if (!editor.getCurrentPageShapeIds().size) return
@@ -123,6 +125,7 @@ export function DefaultMinimap() {
 				if (rActivePointerId.current !== null && elm.hasPointerCapture(rActivePointerId.current)) {
 					elm.releasePointerCapture(rActivePointerId.current)
 				}
+
 				rPointing.current = false
 				rActivePointerId.current = null
 				body.removeEventListener('pointerup', onPointerUp)

--- a/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
@@ -5,7 +5,6 @@ import {
 	getPointerInfo,
 	isAccelKey,
 	normalizeWheel,
-	releasePointerCapture,
 	setPointerCapture,
 	useContainer,
 	useColorMode,
@@ -24,6 +23,7 @@ export function DefaultMinimap() {
 
 	const rCanvas = React.useRef<HTMLCanvasElement>(null!)
 	const rPointing = React.useRef(false)
+	const rActivePointerId = React.useRef<number | null>(null)
 
 	const minimapRef = React.useRef<MinimapManager | undefined>(undefined)
 
@@ -79,6 +79,7 @@ export function DefaultMinimap() {
 			if (!editor.getCurrentPageShapeIds().size) return
 
 			rPointing.current = true
+			rActivePointerId.current = e.pointerId
 
 			minimapRef.current.isInViewport = false
 
@@ -118,16 +119,31 @@ export function DefaultMinimap() {
 				minimapRef.current.originPageCenter.setTo(_vpPageBounds.center)
 			}
 
-			const body = editor.getContainerDocument().body
-			function release(e: PointerEvent) {
-				if (elm) {
-					releasePointerCapture(elm, e)
+			function endDrag() {
+				if (rActivePointerId.current !== null && elm.hasPointerCapture(rActivePointerId.current)) {
+					elm.releasePointerCapture(rActivePointerId.current)
 				}
 				rPointing.current = false
-				body.removeEventListener('pointerup', release)
+				rActivePointerId.current = null
+				body.removeEventListener('pointerup', onPointerUp)
+				body.removeEventListener('pointercancel', onPointerCancel)
+				body.removeEventListener('contextmenu', onContextMenu, true)
 			}
 
-			body.addEventListener('pointerup', release)
+			function onPointerUp() {
+				endDrag()
+			}
+			function onPointerCancel() {
+				endDrag()
+			}
+			function onContextMenu() {
+				endDrag()
+			}
+
+			const body = editor.getContainerDocument().body
+			body.addEventListener('pointerup', onPointerUp)
+			body.addEventListener('pointercancel', onPointerCancel)
+			body.addEventListener('contextmenu', onContextMenu, true)
 		},
 		[editor]
 	)


### PR DESCRIPTION
In order to keep the minimap from getting stuck in a dragging state, this PR ends the active drag when a right-click (contextmenu), `pointerup`, or `pointercancel` happens during a minimap drag. Previously, right-clicking the minimap mid-drag did not dispatch a `pointerup`, so pointer capture was never released and `rPointing` stayed true — subsequent pointer moves continued to recenter the camera until the user clicked again.

The pointer being released is now tracked by id, so we release capture on the same pointer that started the drag instead of synthesising a release from the next event.

Closes #8693

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn dev` and open an example with content so the minimap is interactive.
2. Press and hold the left mouse button on the minimap to start dragging the viewport.
3. While still holding, right-click on the minimap and dismiss the context menu.
4. Move the mouse over the canvas — the camera should not continue to follow the pointer.
5. Repeat with a `pointercancel` (e.g. touch interruption) and confirm the drag ends.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix minimap getting stuck in a dragging state when right-clicked (or when the pointer is cancelled) during a drag.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +23 / -7   |