### PR TITLE
fix(toolbar): scope OverflowingToolbar MutationObserver to relevant attributes

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -237,11 +237,18 @@ export function OverflowingToolbar({
 		if (!mainToolsRef.current) return
 
 		const mutationObserver = new MutationObserver(onDomUpdate)
+		// Watch for structure changes plus only the attributes onDomUpdate actually reads.
+		// `aria-pressed` flips when the active tool/geo variant changes — important for cases where
+		// only individual ToolbarItem children re-render and OverflowingToolbar itself does not (see
+		// #8689). `data-value` identifies the tool slot. We deliberately exclude all other
+		// attributes (notably `data-state`, `aria-describedby`, `aria-expanded` from tooltip /
+		// popover wrappers, and our own `data-toolbar-visible` writes) to avoid hover- and
+		// self-triggered recomputes that caused ResizeObserver loop warnings (see #8528).
 		mutationObserver.observe(mainToolsRef.current, {
 			childList: true,
 			subtree: true,
 			attributes: true,
-			characterData: true,
+			attributeFilter: ['aria-pressed', 'data-value'],
 		})
 
 		const sizingParent = findParentWithClassName(mainToolsRef.current, sizingParentClassName)


### PR DESCRIPTION
In order to fix the `ResizeObserver loop completed with undelivered notifications` warnings reported in #8528 without re-introducing the toolbar geo-icon regression in #8689, this PR replaces the broad `attributes: true` / `characterData: true` options on the `OverflowingToolbar` `MutationObserver` with `attributeFilter: ['aria-pressed', 'data-value']` — the only attributes `onDomUpdate` actually reads.

Closes #8528 

Background:

- #8574 fixed #8528 by dropping `attributes` and `characterData` entirely. That broke #8689 because tool selection inside individual `ToolbarItem` children no longer notified the parent toolbar (only the affected children re-render, not `OverflowingToolbar` itself, so its `useLayoutEffect` doesn't fire).
- #8690 reverted #8574, restoring #8689 but reopening #8528.
- This PR replaces both with a targeted filter, so attribute observation still happens but only for the attributes that actually matter.

Why the loop happened in the first place:

1. **Hover-driven attribute churn**: tooltip/popover wrappers flip `data-state`, `aria-describedby`, `aria-expanded` on toolbar descendants on hover/focus. With unfiltered observation, every flip re-ran `onDomUpdate`.
2. **Self-write feedback**: `onDomUpdate` writes `data-toolbar-visible` on items. Unfiltered observation re-fired the observer on those writes, creating a read→write→read cycle that the browser's ResizeObserver guards against.

Why the geo-variant regression happened:

- Pressing `R` then `O` only re-renders the rectangle and oval `ToolbarItem` children whose `useIsToolSelected` value changed — not `OverflowingToolbar` itself. Without attribute observation, the toolbar's `lastActiveOverflowItem` stayed pinned to the previous variant and the wrong icon kept showing in the visible slot.

How `attributeFilter: ['aria-pressed', 'data-value']` resolves both:

| Trigger | Attribute changed | In filter? | Observer fires? |
| --- | --- | --- | --- |
| Hover button | `data-state`, `aria-describedby` | no | no |
| Open popover | `aria-expanded`, `data-state` | no | no |
| Our own visibility write | `data-toolbar-visible` | no | no |
| Active tool changes (incl. R then O) | `aria-pressed` | yes | yes |
| Tool slot identity changes | `data-value` | yes | yes |
| Add / remove a toolbar item | (childList) | yes | yes |
| Window / container resize | (ResizeObserver) | n/a | yes |

Both feedback paths into the loop are closed (hover-driven mutations and self-writes are excluded), and the legitimate recompute path needed by #8689 is preserved (`aria-pressed` flips still fire the observer).

`characterData` is dropped: toolbar buttons are icon-only, and any genuine text-driven layout change (i18n locale switch) re-renders the parent and runs the unconditional `useLayoutEffect` already.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app or tldraw.com with the browser console open.
2. Move the pointer rapidly across the bottom toolbar buttons. Verify no `ResizeObserver loop completed with undelivered notifications` warnings appear.
3. Press `R` to select the rectangle tool, then `O` to select the oval tool. Verify the toolbar slot swaps to the ellipse icon with the selected indicator on it.
4. Resize the window so toolbar items overflow into the popover, then back. Verify items move in and out of the overflow correctly.
5. Open the overflow popover, click a tool. Verify it gets pinned into the visible toolbar slot.

### Release notes

- Fix intermittent `ResizeObserver loop` browser warnings when hovering over toolbar buttons, while preserving correct icon swapping when switching directly between geo variants.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -1    |

Made with [Cursor](https://cursor.com)