### PR TITLE
feat(dotcom): add dismissible tldraw.dev link for signed-out users

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
@@ -1,23 +1,41 @@
 .anonDotDevLink {
 	position: absolute;
-	bottom: max(var(--tl-space-2), env(safe-area-inset-bottom));
+	bottom: max(var(--tl-space-4), env(safe-area-inset-bottom));
 	right: max(var(--tl-space-2), env(safe-area-inset-right));
 	z-index: calc(var(--tl-layer-watermark) + 1);
-	display: flex;
-	align-items: center;
-	height: 32px;
+	height: 36px;
 	padding: 2px;
-	gap: 2px;
+}
+
+.anonDotDevLink > div {
 	font-size: 12px;
 	color: var(--tl-color-text);
-	background-color: var(--tl-color-background);
-	border: 1px solid var(--tl-color-low-border);
-	border-radius: 5px;
-	box-sizing: content-box;
 	pointer-events: all;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	width: 100%;
+	height: 100%;
+	background-color: var(--tl-color-background);
+	border: 1px solid var(--tl-color-text-1);
+	border-radius: 2px;
+}
+
+.anonDotDevLink::after {
+	content: '';
+	position: absolute;
+	top: 4px;
+	left: -4px;
+	right: 4px;
+	bottom: -4px;
+	border-radius: 2px;
+	border: 1px dashed var(--tl-color-text-1);
+	z-index: -1;
+	pointer-events: none;
 }
 
 .anonDotDevLink a {
+	position: relative;
 	display: flex;
 	align-items: center;
 	gap: 4px;
@@ -26,17 +44,24 @@
 	color: inherit;
 	text-decoration: none;
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .anonDotDevLink a div {
+	position: relative;
 	flex-shrink: 0;
 	transform: rotate(180deg);
+	transition: transform 3s ease-in-out 0s;
 }
 
 .anonDotDevDismissButton {
+	position: relative;
 	height: 28px;
 	width: 28px;
+	min-width: 0;
 	color: var(--tl-color-text-3);
+	transition: opacity 0.2s ease-in-out;
 }
 
 .anonDotDevDismissButton div {
@@ -44,8 +69,23 @@
 	height: 12px;
 }
 
-/* Hide on small viewports to match the watermark's mobile breakpoint */
-@media (max-width: 700px) {
+@media (hover: hover) {
+	.anonDotDevLink:hover a div {
+		transform: translate(80px, 0px) rotate(180deg);
+		transition: transform 6s ease-in-out 1s;
+	}
+
+	.anonDotDevLink:has(a:hover) .anonDotDevDismissButton {
+		opacity: 0;
+	}
+
+	.anonDotDevLink:has(a:hover)::after {
+		background-color: var(--tl-color-hover);
+	}
+}
+
+/* Hide on small viewports to match the navigation panel breakpoint */
+@media (max-width: 580px) {
 	.anonDotDevLink {
 		display: none;
 	}
@@ -60,4 +100,14 @@
 :global(.tl-container[dir='rtl']) .anonDotDevLink {
 	right: auto;
 	left: max(var(--tl-space-2), env(safe-area-inset-left));
+}
+
+:global(.tl-container[dir='rtl']) .anonDotDevLink::after {
+	left: 4px;
+	right: -4px;
+}
+
+/* Hide the watermark when this button is visible (they share the same corner) */
+:global(.tl-container):has(.anonDotDevLink) :global(.tl-watermark_SEE-LICENSE) {
+	display: none;
 }

--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
@@ -1,0 +1,63 @@
+.anonDotDevLink {
+	position: absolute;
+	bottom: max(var(--tl-space-2), env(safe-area-inset-bottom));
+	right: max(var(--tl-space-2), env(safe-area-inset-right));
+	z-index: calc(var(--tl-layer-watermark) + 1);
+	display: flex;
+	align-items: center;
+	height: 32px;
+	padding: 2px;
+	gap: 2px;
+	font-size: 12px;
+	color: var(--tl-color-text);
+	background-color: var(--tl-color-background);
+	border: 1px solid var(--tl-color-low-border);
+	border-radius: 5px;
+	box-sizing: content-box;
+	pointer-events: all;
+}
+
+.anonDotDevLink a {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	height: 100%;
+	padding: 0 8px;
+	color: inherit;
+	text-decoration: none;
+	white-space: nowrap;
+}
+
+.anonDotDevLink a div {
+	flex-shrink: 0;
+	transform: rotate(180deg);
+}
+
+.anonDotDevDismissButton {
+	height: 28px;
+	width: 28px;
+	color: var(--tl-color-text-3);
+}
+
+.anonDotDevDismissButton div {
+	width: 12px;
+	height: 12px;
+}
+
+/* Hide on small viewports to match the watermark's mobile breakpoint */
+@media (max-width: 700px) {
+	.anonDotDevLink {
+		display: none;
+	}
+}
+
+/* Match the watermark's debug-mode offset so we don't overlap the debug panel */
+.anonDotDevLink[data-debug='true'] {
+	bottom: max(46px, env(safe-area-inset-bottom));
+}
+
+/* RTL: mirror to bottom-left like the watermark */
+:global(.tl-container[dir='rtl']) .anonDotDevLink {
+	right: auto;
+	left: max(var(--tl-space-2), env(safe-area-inset-left));
+}

--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.tsx
@@ -1,0 +1,49 @@
+import { useAuth } from '@clerk/clerk-react'
+import { TldrawUiButton, TldrawUiIcon, useEditor, useLocalStorageState, useValue } from 'tldraw'
+import { trackEvent } from '../../../utils/analytics'
+import { defineMessages, F, useMsg } from '../../utils/i18n'
+import { ExternalLink } from '../ExternalLink/ExternalLink'
+import styles from './TlaAnonDotDevLink.module.css'
+
+const messages = defineMessages({
+	dismiss: { defaultMessage: 'Dismiss' },
+})
+
+const STORAGE_KEY = 'tldraw-dotcom:anon-dotdev-link:dismissed'
+
+export function TlaAnonDotDevLink() {
+	const { isSignedIn, isLoaded } = useAuth()
+	const [isDismissed, setIsDismissed] = useLocalStorageState(STORAGE_KEY, false)
+	const dismissLbl = useMsg(messages.dismiss)
+	const editor = useEditor()
+	const isDebugMode = useValue('debug mode', () => editor.getInstanceState().isDebugMode, [editor])
+
+	if (!isLoaded || isSignedIn !== false) return null
+	if (isDismissed) return null
+
+	return (
+		<div className={styles.anonDotDevLink} data-debug={isDebugMode}>
+			<ExternalLink
+				to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=anon-overlay-link"
+				data-testid="tla-anon-dotdev-link"
+				eventName="anon-dotdev-link-clicked"
+			>
+				<F defaultMessage="Build with the tldraw SDK" />
+				<TldrawUiIcon icon="arrow-left" label="Build with the tldraw SDK" small />
+			</ExternalLink>
+			<TldrawUiButton
+				type="icon"
+				title={dismissLbl}
+				aria-label={dismissLbl}
+				data-testid="tla-anon-dotdev-dismiss-button"
+				className={styles.anonDotDevDismissButton}
+				onClick={() => {
+					trackEvent('anon-dotdev-link-dismissed')
+					setIsDismissed(true)
+				}}
+			>
+				<TldrawUiIcon icon="cross-2" label={dismissLbl} small />
+			</TldrawUiButton>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.tsx
@@ -1,5 +1,13 @@
 import { useAuth } from '@clerk/clerk-react'
-import { TldrawUiButton, TldrawUiIcon, useEditor, useLocalStorageState, useValue } from 'tldraw'
+import {
+	PORTRAIT_BREAKPOINT,
+	TldrawUiButton,
+	TldrawUiIcon,
+	useBreakpoint,
+	useEditor,
+	useLocalStorageState,
+	useValue,
+} from 'tldraw'
 import { trackEvent } from '../../../utils/analytics'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
 import { ExternalLink } from '../ExternalLink/ExternalLink'
@@ -17,33 +25,37 @@ export function TlaAnonDotDevLink() {
 	const dismissLbl = useMsg(messages.dismiss)
 	const editor = useEditor()
 	const isDebugMode = useValue('debug mode', () => editor.getInstanceState().isDebugMode, [editor])
+	const breakpoint = useBreakpoint()
 
 	if (!isLoaded || isSignedIn !== false) return null
 	if (isDismissed) return null
+	if (breakpoint < PORTRAIT_BREAKPOINT.MOBILE) return null
 
 	return (
 		<div className={styles.anonDotDevLink} data-debug={isDebugMode}>
-			<ExternalLink
-				to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=anon-overlay-link"
-				data-testid="tla-anon-dotdev-link"
-				eventName="anon-dotdev-link-clicked"
-			>
-				<F defaultMessage="Build with the tldraw SDK" />
-				<TldrawUiIcon icon="arrow-left" label="Build with the tldraw SDK" small />
-			</ExternalLink>
-			<TldrawUiButton
-				type="icon"
-				title={dismissLbl}
-				aria-label={dismissLbl}
-				data-testid="tla-anon-dotdev-dismiss-button"
-				className={styles.anonDotDevDismissButton}
-				onClick={() => {
-					trackEvent('anon-dotdev-link-dismissed')
-					setIsDismissed(true)
-				}}
-			>
-				<TldrawUiIcon icon="cross-2" label={dismissLbl} small />
-			</TldrawUiButton>
+			<div>
+				<ExternalLink
+					to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=anon-overlay-link"
+					data-testid="tla-anon-dotdev-link"
+					eventName="anon-dotdev-link-clicked"
+				>
+					<F defaultMessage="Build with the tldraw SDK" />
+					<TldrawUiIcon icon="arrow-left" label="Build with the tldraw SDK" small />
+				</ExternalLink>
+				<TldrawUiButton
+					type="icon"
+					title={dismissLbl}
+					aria-label={dismissLbl}
+					data-testid="tla-anon-dotdev-dismiss-button"
+					className={styles.anonDotDevDismissButton}
+					onClick={() => {
+						trackEvent('anon-dotdev-link-dismissed')
+						setIsDismissed(true)
+					}}
+				>
+					<TldrawUiIcon icon="cross-2" label={dismissLbl} small />
+				</TldrawUiButton>
+			</div>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -43,6 +43,7 @@ import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
+import { TlaAnonDotDevLink } from '../TlaAnonDotDevLink/TlaAnonDotDevLink'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
 import { TlaEditorSharePanel } from './editor-components/TlaEditorSharePanel'
@@ -301,6 +302,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				{app && <SneakyTldrawFileDropHandler />}
 				<SneakyLargeFileHander />
 				<SneakyDebugModeToast />
+				<TlaAnonDotDevLink />
 			</Tldraw>
 		</TlaEditorWrapper>
 	)

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -4,6 +4,7 @@ import { assert, getFromSessionStorage, omit, react } from 'tldraw'
 import { LocalEditor } from '../../components/LocalEditor'
 import { routes } from '../../routeDefs'
 import { globalEditor } from '../../utils/globalEditor'
+import { TlaAnonDotDevLink } from '../components/TlaAnonDotDevLink/TlaAnonDotDevLink'
 import { SneakyDarkModeSync } from '../components/TlaEditor/sneaky/SneakyDarkModeSync'
 import { SneakyDebugModeToast } from '../components/TlaEditor/sneaky/SneakyDebugModeToast'
 import { components } from '../components/TlaEditor/TlaEditor'
@@ -130,6 +131,7 @@ function LocalTldraw() {
 			>
 				<SneakyDarkModeSync />
 				<SneakyDebugModeToast />
+				<TlaAnonDotDevLink />
 			</LocalEditor>
 		</TlaAnonLayout>
 	)


### PR DESCRIPTION
In order to promote the tldraw SDK to logged-out visitors of tldraw.com, this PR adds a dismissible "Build with the tldraw SDK" overlay link in the bottom-right of the editor — the same area used by the watermark. The overlay sits above the watermark layer (`z-index: calc(var(--tl-layer-watermark) + 1)`) so the watermark is not modified or hidden, and reappears underneath if the overlay is dismissed. Closes #8699.

Behavior:

- Renders only when Clerk's `useAuth().isSignedIn === false`, so signed-in users (and the still-loading state) never see it.
- Dismissal is persisted in `localStorage` under `tldraw-dotcom:anon-dotdev-link:dismissed`, so it stays dismissed across reloads.
- Hidden under 700px to match the watermark's mobile breakpoint.
- Tracks the watermark's `data-debug` offset and RTL direction so it stays aligned in those modes.

The component is rendered inside `<Tldraw>` in the local editor and the multiplayer file editor, so it shows on both the signed-out local editor and the signed-out file viewer.

### Change type

- [x] `feature`

### Test plan

1. Sign out and visit `localhost:3000` — overlay appears bottom-right.
2. Click the link — opens `tldraw.dev` in a new tab with the `anon-overlay-link` UTM campaign.
3. Click the dismiss (X) button — overlay disappears.
4. Reload — overlay stays dismissed.
5. `localStorage.removeItem('tldraw-dotcom:anon-dotdev-link:dismissed')` and reload — overlay reappears.
6. Sign in — overlay no longer renders.
7. Visit a shared file URL while signed out — overlay renders there too.
8. Resize below ~700px — overlay hides on mobile.
9. Toggle dark mode — colors track the tldraw theme tokens.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add a dismissible link to tldraw.dev in the bottom-right of the editor for signed-out visitors on tldraw.com.