### PR TITLE
chore(dotcom): remove stale next tsconfig plugin

### DIFF
--- a/apps/dotcom/client/tsconfig.json
+++ b/apps/dotcom/client/tsconfig.json
@@ -15,7 +15,6 @@
 		"jsxImportSource": "react",
 		"incremental": true,
 		"downlevelIteration": true,
-		"plugins": [{ "name": "next" }],
 		"experimentalDecorators": true,
 		"types": ["vitest/globals"]
 	},


### PR DESCRIPTION
In order to clear a tsserver warning in `apps/dotcom/client`, this PR removes the `"plugins": [{ "name": "next" }]` entry from its `tsconfig.json`. The dotcom client app builds with Vite (see `vite.config.ts` and the `dev`/`build` scripts in `package.json`) and has no `next` dependency, so the plugin reference is dead config.

### Change type

- [x] `other`

### Test plan

1. Open `apps/dotcom/client` in an editor with tsserver running and confirm the "next" plugin warning is gone.
2. Run `yarn typecheck` from the repo root and confirm it still passes.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +0 / -1    |