### PR TITLE
fix(tldraw): correct comma key pointer_up coordinates when screenBounds has non-zero offset

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -118,11 +118,12 @@ export function useKeyboardShortcuts() {
 
 				editor.inputs.keys.delete('Comma')
 
-				const { x, y, z } = editor.inputs.getCurrentScreenPoint()
+				const { x, y, z } = editor.inputs.getCurrentPagePoint()
+				const screenPoint = editor.pageToScreen({ x, y })
 				const info: TLPointerEventInfo = {
 					type: 'pointer',
 					name: 'pointer_up',
-					point: { x, y, z },
+					point: { x: screenPoint.x, y: screenPoint.y, z },
 					shiftKey: e.shiftKey,
 					altKey: e.altKey,
 					ctrlKey: e.metaKey || e.ctrlKey,

--- a/packages/tldraw/src/test/commaKeyClick.test.ts
+++ b/packages/tldraw/src/test/commaKeyClick.test.ts
@@ -1,0 +1,94 @@
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+/**
+ * Dispatches the pointer events that the comma key handler sends to the editor.
+ * The `useFixed` flag controls whether the pointer_up uses the fixed approach
+ * (pageToScreen, which produces absolute screen coords) or the old buggy approach
+ * (getCurrentScreenPoint, which is already canvas-relative and causes a double
+ * subtraction of screenBounds in updateFromEvent).
+ */
+function simulateCommaKeyClick(useFixed: boolean) {
+	const sharedProps = {
+		type: 'pointer' as const,
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		pointerId: 0,
+		button: 0,
+		isPen: false,
+		target: 'canvas' as const,
+	}
+
+	// pointer_down: both old and new code use pageToScreen (correct absolute coords)
+	const { x: pdx, y: pdy, z: pdz } = editor.inputs.getCurrentPagePoint()
+	const screenPointDown = editor.pageToScreen({ x: pdx, y: pdy })
+	editor.dispatch({
+		...sharedProps,
+		name: 'pointer_down',
+		point: { x: screenPointDown.x, y: screenPointDown.y, z: pdz },
+	})
+
+	if (useFixed) {
+		// Fixed pointer_up: also use pageToScreen (absolute coords)
+		const { x: pux, y: puy, z: puz } = editor.inputs.getCurrentPagePoint()
+		const screenPointUp = editor.pageToScreen({ x: pux, y: puy })
+		editor.dispatch({
+			...sharedProps,
+			name: 'pointer_up',
+			point: { x: screenPointUp.x, y: screenPointUp.y, z: puz },
+		})
+	} else {
+		// Buggy pointer_up: use getCurrentScreenPoint (canvas-relative — causes double subtraction)
+		const { x, y, z } = editor.inputs.getCurrentScreenPoint()
+		editor.dispatch({ ...sharedProps, name: 'pointer_up', point: { x, y, z } })
+	}
+}
+
+describe('comma key click - screenBounds offset', () => {
+	it('page point is unchanged after a click when screenBounds has no offset', () => {
+		// Default screenBounds has x=0, so both old and new code agree
+		editor.pointerMove(200, 200)
+		const before = { ...editor.inputs.getCurrentPagePoint() }
+
+		simulateCommaKeyClick(true)
+
+		const after = editor.inputs.getCurrentPagePoint()
+		expect(after.x).toBeCloseTo(before.x)
+		expect(after.y).toBeCloseTo(before.y)
+	})
+
+	it('page point is unchanged after a click when screenBounds has a non-zero x offset (fixed)', () => {
+		// Simulate a host that offsets the canvas by 300px (e.g. a wide sidebar)
+		editor.setScreenBounds({ x: 300, y: 0, w: 800, h: 600 })
+		editor.pointerMove(500, 200) // absolute screen x=500, canvas-relative x=200
+		const before = { ...editor.inputs.getCurrentPagePoint() }
+
+		simulateCommaKeyClick(true)
+
+		const after = editor.inputs.getCurrentPagePoint()
+		expect(after.x).toBeCloseTo(before.x)
+		expect(after.y).toBeCloseTo(before.y)
+	})
+
+	it('page point is wrong after a click when screenBounds has a non-zero x offset (regression — old buggy approach)', () => {
+		const screenBoundsX = 300
+		editor.setScreenBounds({ x: screenBoundsX, y: 0, w: 800, h: 600 })
+		editor.pointerMove(500, 200)
+		const before = { ...editor.inputs.getCurrentPagePoint() }
+
+		simulateCommaKeyClick(false) // old buggy approach
+
+		// The bug causes pointer_up to land screenBoundsX / camera.z to the left
+		const after = editor.inputs.getCurrentPagePoint()
+		const cameraZ = editor.getCamera().z
+		expect(after.x).toBeCloseTo(before.x - screenBoundsX / cameraZ)
+	})
+})


### PR DESCRIPTION
In order to fix a mis-positioned click when using the comma key on hosts with a canvas offset
(e.g. tldraw.com with the sidebar open), this PR corrects the `pointer_up` event dispatched by the
comma-key click handler.                                                                         
    
The `pointer_up` handler in `useKeyboardShortcuts` was passing `getCurrentScreenPoint()` as the   
event point. That value is canvas-relative (screenBounds already subtracted), but                 
`InputsManager.updateFromEvent` always subtracts `screenBounds` again — a double subtraction that
shifts the registered click position left by `screenBounds.x` (the sidebar width on tldraw.com).  
This also caused the distance between `pointer_down` and `pointer_up` to exceed the drag        
threshold, so comma-key clicks could register as drags instead.                         

The fix mirrors the existing `pointer_down` handler: convert `currentPagePoint` to absolute screen
coordinates via `editor.pageToScreen` before dispatching `pointer_up`.                           
                                                                         
Closes #8684                                                                                      

### Change type

- [x] `bugfix`

### Test plan   

1. Open tldraw.com with the sidebar open (or any host with a non-zero `screenBounds` offset).
2. Hover the cursor over a shape.                                                                 
3. Press and release comma. Confirm the click lands at the cursor position.

- [x] Unit tests                                                                                  

### Release notes                                                                                 

- Fix comma key click registering at the wrong position when the canvas has a
screen offset (e.g. with the tldraw.com sidebar open).