### PR TITLE
refactor(shapes): rename customGeoStyles option back to customGeoTypes

### DIFF
--- a/apps/examples/src/examples/shapes/tools/custom-geo-types/CustomGeoTypesExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/custom-geo-types/CustomGeoTypesExample.tsx
@@ -14,7 +14,7 @@ import 'tldraw/tldraw.css'
 
 // [1]
 const CustomGeoShapeUtil = GeoShapeUtil.configure({
-	customGeoStyles: {
+	customGeoTypes: {
 		'rounded-rect': {
 			getPath(w, h, shape) {
 				// `isFilled` is used by the path builder to determine whether the
@@ -158,8 +158,8 @@ export default function CustomGeoTypesExample() {
 
 /*
 [1]
-Use GeoShapeUtil.configure() with a customGeoStyles map. Each entry
-defines a new geo style with:
+Use GeoShapeUtil.configure() with a customGeoTypes map. Each entry
+defines a new geo type with:
 - getPath: returns a PathBuilder describing the shape outline
 - snapType: 'polygon' (snap to vertices + center) or 'blobby' (center only)
 - icon: icon name for the style panel picker
@@ -167,25 +167,25 @@ defines a new geo style with:
 
 [2]
 Pass the configured shape util in an array. It replaces the default
-GeoShapeUtil but keeps all built-in geo styles alongside your custom ones.
+GeoShapeUtil but keeps all built-in geo types alongside your custom ones.
 
 [3]
-Provide custom icon SVGs for your geo styles via assetUrls. The icon key
-must be 'geo-' followed by the geo style name (e.g., 'geo-rounded-rect').
+Provide custom icon SVGs for your geo types via assetUrls. The icon key
+must be 'geo-' followed by the geo type name (e.g., 'geo-rounded-rect').
 
 [4]
 Provide translations for the tool labels so that the tooltips in the
 toolbar show the right name. The translation keys are 'tool.' followed
-by the geo style name (e.g., 'tool.rounded-rect').
+by the geo type name (e.g., 'tool.rounded-rect').
 
 [5]
 Override the Toolbar component to add ToolbarItems for your custom geo
-styles. The tool ID matches the key in your customGeoStyles map. Custom
-geo styles are automatically registered as tools, so you just need to
+types. The tool ID matches the key in your customGeoTypes map. Custom
+geo types are automatically registered as tools, so you just need to
 reference them by name.
 
 [6]
-Custom geo styles appear in the geo style panel picker. They support all
+Custom geo types appear in the geo style panel picker. They support all
 standard geo features: labels, fill/dash/color styles, resizing, SVG
 export, and snap points.
 */

--- a/apps/examples/src/examples/shapes/tools/custom-geo-types/README.md
+++ b/apps/examples/src/examples/shapes/tools/custom-geo-types/README.md
@@ -10,4 +10,4 @@ Add custom geo types that plug into the existing geo shape system.
 
 ---
 
-Use `GeoShapeUtil.configure()` with a `customGeoStyles` map to register new geometric shape types. Each custom style provides its own path geometry, snap behavior, default size, and style panel icon, while inheriting all standard geo shape features like labels, resizing, fill styles, and SVG export.
+Use `GeoShapeUtil.configure()` with a `customGeoTypes` map to register new geometric shape types. Each custom type provides its own path geometry, snap behavior, default size, and style panel icon, while inheriting all standard geo shape features like labels, resizing, fill styles, and SVG export.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1934,7 +1934,7 @@ export function FrameToolbarItem(): JSX.Element;
 
 // @public (undocumented)
 export interface GeoShapeOptions extends ShapeOptionsWithDisplayValues<TLGeoShape, GeoShapeUtilDisplayValues> {
-    customGeoStyles?: Record<string, GeoTypeDefinition>;
+    customGeoTypes?: Record<string, GeoTypeDefinition>;
     // (undocumented)
     showTextOutline: boolean;
 }

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeBody.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeBody.tsx
@@ -10,7 +10,7 @@ export function GeoShapeBody({
 	strokeWidth: unscaledStrokeWidth,
 	fillColor,
 	patternFillFallbackColor,
-	customGeoStyles,
+	customGeoTypes,
 }: {
 	shape: TLGeoShape
 	shouldScale: boolean
@@ -19,13 +19,13 @@ export function GeoShapeBody({
 	strokeWidth: number
 	fillColor: string
 	patternFillFallbackColor: string
-	customGeoStyles?: Record<string, GeoTypeDefinition>
+	customGeoTypes?: Record<string, GeoTypeDefinition>
 }) {
 	const scaleToUse = shouldScale ? shape.props.scale : 1
 	const strokeWidth = unscaledStrokeWidth * scaleToUse
 	const { dash, fill } = shape.props
 
-	const path = getGeoShapePath(shape, unscaledStrokeWidth, customGeoStyles)
+	const path = getGeoShapePath(shape, unscaledStrokeWidth, customGeoTypes)
 	const fillPath =
 		dash === 'draw' && !forceSolid
 			? path.toDrawD({ strokeWidth, randomSeed: shape.id, passes: 1, offset: 0, onlyFilled: true })

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -115,15 +115,15 @@ export interface GeoShapeOptions extends ShapeOptionsWithDisplayValues<
 > {
 	showTextOutline: boolean
 	/**
-	 * A map of custom geo style definitions. Each key becomes a new value for
+	 * A map of custom geo type definitions. Each key becomes a new value for
 	 * {@link @tldraw/editor#GeoShapeGeoStyle} that can be used in the style panel
-	 * and on shapes. Custom styles inherit all standard geo shape behavior
+	 * and on shapes. Custom geo types inherit all standard geo shape behavior
 	 * (labels, resizing, styling, etc.).
 	 *
 	 * @example
 	 * ```ts
 	 * const MyGeoShapeUtil = GeoShapeUtil.configure({
-	 *   customGeoStyles: {
+	 *   customGeoTypes: {
 	 *     'my-shape': {
 	 *       getPath: (w, h) => new PathBuilder().moveTo(0, 0).lineTo(w, 0).lineTo(w, h).lineTo(0, h).close(),
 	 *       snapType: 'polygon',
@@ -133,7 +133,7 @@ export interface GeoShapeOptions extends ShapeOptionsWithDisplayValues<
 	 * })
 	 * ```
 	 */
-	customGeoStyles?: Record<string, GeoTypeDefinition>
+	customGeoTypes?: Record<string, GeoTypeDefinition>
 }
 
 /** @public */
@@ -147,14 +147,14 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		options: T extends new (...args: any[]) => { options: infer Options } ? Partial<Options> : never
 	): T {
 		const opts = options as Partial<GeoShapeOptions>
-		if (opts.customGeoStyles) {
+		if (opts.customGeoTypes) {
 			const existingValues = new Set<string>(GeoShapeGeoStyle.values)
 			const newValues: string[] = []
-			for (const key of Object.keys(opts.customGeoStyles)) {
+			for (const key of Object.keys(opts.customGeoTypes)) {
 				if (existingValues.has(key)) {
 					if (process.env.NODE_ENV !== 'production') {
 						console.warn(
-							`[GeoShapeUtil.configure] customGeoStyles key "${key}" collides with a built-in geo style and will be ignored. Please use a unique name.`
+							`[GeoShapeUtil.configure] customGeoTypes key "${key}" collides with a built-in geo type and will be ignored. Please use a unique name.`
 						)
 					}
 					continue
@@ -238,7 +238,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const { props } = shape
 		const { scale } = props
 		const dv = getDisplayValues(this, shape)
-		const path = getGeoShapePath(shape, dv.strokeWidth, this.options.customGeoStyles)
+		const path = getGeoShapePath(shape, dv.strokeWidth, this.options.customGeoTypes)
 		const pathGeometry = path.toGeometry()
 
 		const scaledW = Math.max(1, props.w)
@@ -340,7 +340,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 				// blobby shapes only have a snap point in their center
 				return { outline: outline, points: [geometry.bounds.center] }
 			default: {
-				const customType = getCustomGeoType(shape.props.geo, this.options.customGeoStyles)
+				const customType = getCustomGeoType(shape.props.geo, this.options.customGeoTypes)
 				if (customType) {
 					if (customType.snapType === 'blobby') {
 						return { outline: outline, points: [geometry.bounds.center] }
@@ -398,7 +398,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 						strokeWidth={dv.strokeWidth}
 						fillColor={dv.fillColor}
 						patternFillFallbackColor={dv.patternFillFallbackColor}
-						customGeoStyles={this.options.customGeoStyles}
+						customGeoTypes={this.options.customGeoTypes}
 					/>
 				</SVGContainer>
 				{showHtmlContainer && (
@@ -447,7 +447,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const { dash, scale } = shape.props
 		const dv = getDisplayValues(this, shape)
 
-		const path = getGeoShapePath(shape, dv.strokeWidth, this.options.customGeoStyles)
+		const path = getGeoShapePath(shape, dv.strokeWidth, this.options.customGeoTypes)
 
 		return path.toPath2D({
 			style: dash === 'draw' ? 'draw' : 'solid',
@@ -504,7 +504,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 					strokeWidth={dv.strokeWidth}
 					fillColor={dv.fillColor}
 					patternFillFallbackColor={dv.patternFillFallbackColor}
-					customGeoStyles={this.options.customGeoStyles}
+					customGeoTypes={this.options.customGeoTypes}
 				/>
 				{textEl}
 			</>
@@ -726,7 +726,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 			}
 		}
 
-		const customType = getCustomGeoType(shape.props.geo, this.options.customGeoStyles)
+		const customType = getCustomGeoType(shape.props.geo, this.options.customGeoTypes)
 		if (customType?.onDoubleClick) {
 			const result = customType.onDoubleClick(shape)
 			if (result) {

--- a/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
+++ b/packages/tldraw/src/lib/shapes/geo/getGeoShapePath.ts
@@ -48,26 +48,26 @@ export interface GeoTypeDefinition {
 /** @internal */
 export function getCustomGeoType(
 	name: string,
-	customGeoStyles?: Record<string, GeoTypeDefinition>
+	customGeoTypes?: Record<string, GeoTypeDefinition>
 ): GeoTypeDefinition | undefined {
-	return customGeoStyles?.[name]
+	return customGeoTypes?.[name]
 }
 
 const pathCache = new WeakCache<TLGeoShape, PathBuilder>()
 export function getGeoShapePath(
 	shape: TLGeoShape,
 	strokeWidth: number,
-	customGeoStyles?: Record<string, GeoTypeDefinition>
+	customGeoTypes?: Record<string, GeoTypeDefinition>
 ) {
 	// Cache is keyed on shape only. For x-box, strokeWidth affects the diagonal
 	// inset, but theme changes are rare enough that stale cache entries are acceptable.
-	return pathCache.get(shape, (s) => _getGeoPath(s, strokeWidth, customGeoStyles))
+	return pathCache.get(shape, (s) => _getGeoPath(s, strokeWidth, customGeoTypes))
 }
 
 function _getGeoPath(
 	shape: TLGeoShape,
 	strokeWidth: number,
-	customGeoStyles?: Record<string, GeoTypeDefinition>
+	customGeoTypes?: Record<string, GeoTypeDefinition>
 ) {
 	const w = Math.max(1, shape.props.w)
 	const h = Math.max(1, shape.props.h + shape.props.growY)
@@ -234,7 +234,7 @@ function _getGeoPath(
 		case 'cloud':
 			return getCloudPath(w, h, shape.id, shape.props.size, shape.props.scale, isFilled)
 		default: {
-			const customType = getCustomGeoType(shape.props.geo, customGeoStyles)
+			const customType = getCustomGeoType(shape.props.geo, customGeoTypes)
 			if (customType) {
 				return customType.getPath(w, h, shape, sw)
 			}

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -83,7 +83,7 @@ export class Pointing extends StateNode {
 		const geo = this.editor.getStyleForNextShape(GeoShapeGeoStyle)
 		const geoShapeUtil = this.editor.getShapeUtil('geo') as GeoShapeUtil
 
-		const customType = geoShapeUtil.options.customGeoStyles?.[geo]
+		const customType = geoShapeUtil.options.customGeoTypes?.[geo]
 		const size =
 			geo === 'star'
 				? { w: 200, h: 190 }

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -322,13 +322,13 @@ export function StylePanelGeoShapePicker() {
 	const geo = styles.get(GeoShapeGeoStyle)
 	if (geo === undefined) return null
 
-	const customGeoStyles = (editor.getShapeUtil('geo') as GeoShapeUtil).options.customGeoStyles
-	const customItems = customGeoStyles
-		? Object.entries(customGeoStyles).map(([value, def]) => ({ value, icon: def.icon }))
+	const customGeoTypes = (editor.getShapeUtil('geo') as GeoShapeUtil).options.customGeoTypes
+	const customItems = customGeoTypes
+		? Object.entries(customGeoTypes).map(([value, def]) => ({ value, icon: def.icon }))
 		: []
 	const items =
 		customItems.length > 0
-			? [...STYLES.geo.filter((item) => !customGeoStyles?.[item.value]), ...customItems]
+			? [...STYLES.geo.filter((item) => !customGeoTypes?.[item.value]), ...customItems]
 			: STYLES.geo
 
 	return (


### PR DESCRIPTION
In order to make the geo extensibility API self-consistent before its first release, this PR renames the `customGeoStyles` option on `GeoShapeUtil.configure()` back to `customGeoTypes`. Follow-up to #8543.

The original PR introduced `customGeoTypes`, then it was renamed to `customGeoStyles` during review feedback. The rename was applied to the option name, but several adjacent surfaces were missed:

- The exported `GeoTypeDefinition` interface (still uses "type")
- The internal `getCustomGeoType` helper and `customType` locals
- The `apps/examples/src/examples/shapes/tools/custom-geo-types/` example folder, README title, and `CustomGeoTypesExample` component
- The release notes in `apps/docs/content/releases/next.mdx`, which still document `customGeoTypes` (so the example as published would not actually compile)

Re-aligning everything on "types" is the smaller change and matches the conceptual model — `'rectangle' | 'ellipse' | 'rounded-rect'` are kinds of geo, not styles. The "style" naming would have collided with the existing `GeoShapeGeoStyle` `StyleProp` and the unrelated style panel terminology.

This API has not shipped yet (it lives in `next.mdx`), so no released consumers are affected.

### Change type

- [x] `api`

### Test plan

1. Open the `custom geo types` example.
2. Verify the rounded rectangle and cross shapes render, drag-create from the toolbar, and appear in the geo style panel picker.

- [x] Unit tests (existing geo + style tests still pass)

### API changes

- Renamed `GeoShapeOptions.customGeoStyles` to `GeoShapeOptions.customGeoTypes`. The option keys this map populates on `GeoShapeGeoStyle` are unaffected.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +27 / -27  |
| Automated files | +1 / -1    |
| Documentation   | +11 / -11  |


Made with [Cursor](https://cursor.com)