### PR TITLE
chore(dotcom): scale Zero view-syncer to 7 machines

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -304,7 +304,7 @@ const zeroVmSizes = {
 		rm: { cpus: 2, memory: '4gb', cpuKind: 'performance' },
 		vs: { cpus: 4, memory: '8gb', cpuKind: 'performance' },
 		volumeSize: '8gb',
-		vsMinMachines: 5,
+		vsMinMachines: 7,
 		killTimeout: '5m',
 	},
 	preview: { single: { cpus: 2, memory: '2gb' } },


### PR DESCRIPTION
Bumps production Zero view-syncer count from 5 to 7 machines.

Production VS machines are at 4-CPU saturation as we approach peak traffic. Symptoms: pipeline-resets jumped from 0 to ~0.033/s starting ~12:45 UTC, CPU climbing 50% → 65%+, slow SQLite queries (100-450 ms) on the small `_zero.changeLog2` table — slowness is contention-driven, not table size (only 16,646 rows). Memory is fine (~2 GB used of 8 GB).

Routing is sticky-by-cookie (`fly_machine_id`), so adding machines spreads independent client groups across more capacity. Follows #8666 which went 4 → 5.

### Change type

- [x] `other`

### Test plan

- After merge: `flyctl status -a production-zero-vs` shows 7 started machines.
- Confirm load avg drops back below 4.0 per machine and pipeline-resets metric returns toward 0.

### Release notes

- Internal: scale Zero view-syncer to 7 machines.