### PR TITLE
test(sync-worker): make TLDrawDurableObject extend DurableObject

### DIFF
--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -22,7 +22,7 @@ import {
 	isAllowedOrigin,
 	notFound,
 } from '@tldraw/worker-shared'
-import { WorkerEntrypoint } from 'cloudflare:workers'
+import { DurableObject, WorkerEntrypoint } from 'cloudflare:workers'
 import { IRequest, cors, json } from 'itty-router'
 import { adminRoutes } from './adminRoutes'
 import { POSTHOG_URL } from './config'
@@ -54,7 +54,7 @@ export { TLLoggerDurableObject } from './TLLoggerDurableObject'
 export { TLPostgresReplicator } from './TLPostgresReplicator'
 export { TLStatsDurableObject } from './TLStatsDurableObject'
 export { TLUserDurableObject } from './TLUserDurableObject'
-export class TLDrawDurableObject {}
+export class TLDrawDurableObject extends DurableObject {}
 
 const { preflight, corsify } = cors({
 	origin: isAllowedOrigin,


### PR DESCRIPTION
In order to unblock dotcom preview deploys hitting Cloudflare error code 10074 (`Cannot apply delete-class migration to class 'TLDrawDurableObject' which was not exported in the previous version of the script`), this PR turns the `TLDrawDurableObject` no-op stub into a real Durable Object class so the v10 `deleted_classes` migration can apply cleanly on fresh preview workers.

The previous stub (`export class TLDrawDurableObject {}`) doesn't extend `DurableObject` and isn't recognized by Cloudflare's class extractor, so v1's `new_classes` registration never matches and v10's `deleted_classes` rejects on PR previews. Every other DO in this worker (`TLFileDurableObject`, `TLLoggerDurableObject`, `TLPostgresReplicator`, `TLStatsDurableObject`, `TLUserDurableObject`) already extends `DurableObject`.

This is a test PR — gating it on `dotcom-preview-please` to verify the preview deploy goes green before considering rolling forward. If preview still fails with 10074, fall back to dropping the v10 migration entirely (see `origin/fix/dotcom-remove-v10-delete-class-migration`).

### Change type

- [x] `other`

### Test plan

1. Confirm Deploy .com workflow runs against this branch.
2. Verify `wrangler deploy --env preview` completes past the migration step without 10074.

### Release notes

- Internal: unblock dotcom preview deploys after v10 delete-class migration.