### PR TITLE
fix(shapes): ignore colliding customGeoTypes keys in configure()

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
@@ -1,4 +1,12 @@
-import { Group2d, IndexKey, TLGeoShape, TLShapeId, createShapeId, toRichText } from '@tldraw/editor'
+import {
+	GeoShapeGeoStyle,
+	Group2d,
+	IndexKey,
+	TLGeoShape,
+	TLShapeId,
+	createShapeId,
+	toRichText,
+} from '@tldraw/editor'
 import { vi } from 'vitest'
 import { TestEditor } from '../../../test/TestEditor'
 import { PathBuilder } from '../shared/PathBuilder'
@@ -175,6 +183,18 @@ describe('Resizing geo shapes with labels', () => {
 })
 
 describe('GeoShapeUtil.configure with customGeoTypes', () => {
+	// Snapshot the built-in geo values so we can clean up any custom keys added
+	// during these tests. `GeoShapeUtil.configure({ customGeoTypes })` mutates
+	// `GeoShapeGeoStyle.values` globally via `addValues`, so without cleanup the
+	// state would leak between tests in this describe block.
+	const builtinGeoValues = [...GeoShapeGeoStyle.values]
+	afterEach(() => {
+		const toRemove = GeoShapeGeoStyle.values.filter((v) => !builtinGeoValues.includes(v))
+		if (toRemove.length > 0) {
+			GeoShapeGeoStyle.removeValues(...toRemove)
+		}
+	})
+
 	const validDef = {
 		getPath: (w: number, h: number) =>
 			new PathBuilder()
@@ -216,6 +236,19 @@ describe('GeoShapeUtil.configure with customGeoTypes', () => {
 				'my-shape': validDef,
 			})
 			expect(warn).toHaveBeenCalledWith(expect.stringMatching(/customGeoTypes key "rectangle"/))
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	test('reusing the same custom key across configure() calls still keeps the entry', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		try {
+			expect(getConfiguredOptions({ 'my-shape': validDef })).toEqual({ 'my-shape': validDef })
+			// A second configure() call with the same key should not treat it as a
+			// collision with built-ins, so the entry is preserved.
+			expect(getConfiguredOptions({ 'my-shape': validDef })).toEqual({ 'my-shape': validDef })
+			expect(warn).not.toHaveBeenCalled()
 		} finally {
 			warn.mockRestore()
 		}

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
@@ -1,5 +1,8 @@
 import { Group2d, IndexKey, TLGeoShape, TLShapeId, createShapeId, toRichText } from '@tldraw/editor'
+import { vi } from 'vitest'
 import { TestEditor } from '../../../test/TestEditor'
+import { PathBuilder } from '../shared/PathBuilder'
+import { GeoShapeUtil } from './GeoShapeUtil'
 
 let editor: TestEditor
 let ids: Record<string, TLShapeId>
@@ -168,5 +171,53 @@ describe('Resizing geo shapes with labels', () => {
 		const geo = getGeo()
 		expect(geo.props.w).toBeLessThan(50)
 		expect(geo.props.h).toBeLessThan(50)
+	})
+})
+
+describe('GeoShapeUtil.configure with customGeoTypes', () => {
+	const validDef = {
+		getPath: (w: number, h: number) =>
+			new PathBuilder()
+				.moveTo(0, 0, { geometry: { isFilled: true } })
+				.lineTo(w, 0)
+				.lineTo(w, h)
+				.lineTo(0, h)
+				.close(),
+		snapType: 'polygon' as const,
+		icon: 'geo-rectangle',
+		defaultSize: { w: 999, h: 999 },
+	}
+
+	function getConfiguredOptions(customGeoTypes: Record<string, typeof validDef>) {
+		const Configured = GeoShapeUtil.configure({ customGeoTypes })
+		const localEditor = new TestEditor({ shapeUtils: [Configured] })
+		try {
+			const util = localEditor.getShapeUtil('geo') as GeoShapeUtil
+			return util.options.customGeoTypes
+		} finally {
+			localEditor.dispose()
+		}
+	}
+
+	test('keeps non-colliding entries in options.customGeoTypes', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		try {
+			expect(getConfiguredOptions({ 'my-shape': validDef })).toEqual({ 'my-shape': validDef })
+			expect(warn).not.toHaveBeenCalled()
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	test('strips colliding keys from options so runtime lookups do not see them', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		try {
+			expect(getConfiguredOptions({ rectangle: validDef, 'my-shape': validDef })).toEqual({
+				'my-shape': validDef,
+			})
+			expect(warn).toHaveBeenCalledWith(expect.stringMatching(/customGeoTypes key "rectangle"/))
+		} finally {
+			warn.mockRestore()
+		}
 	})
 })

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -149,8 +149,8 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 		const opts = options as Partial<GeoShapeOptions>
 		if (opts.customGeoTypes) {
 			const existingValues = new Set<string>(GeoShapeGeoStyle.values)
-			const newValues: string[] = []
-			for (const key of Object.keys(opts.customGeoTypes)) {
+			const validEntries: Array<[string, GeoTypeDefinition]> = []
+			for (const [key, def] of Object.entries(opts.customGeoTypes)) {
 				if (existingValues.has(key)) {
 					if (process.env.NODE_ENV !== 'production') {
 						console.warn(
@@ -159,11 +159,17 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 					}
 					continue
 				}
-				newValues.push(key)
+				validEntries.push([key, def])
 			}
-			if (newValues.length > 0) {
-				GeoShapeGeoStyle.addValues(...(newValues as Parameters<typeof GeoShapeGeoStyle.addValues>))
+			if (validEntries.length > 0) {
+				GeoShapeGeoStyle.addValues(
+					...(validEntries.map(([k]) => k) as Parameters<typeof GeoShapeGeoStyle.addValues>)
+				)
 			}
+			// Strip colliding entries from the options so runtime lookups (tool
+			// defaultSize, style panel icons, double-click handlers) don't see them.
+			const filtered = { ...opts, customGeoTypes: Object.fromEntries(validEntries) }
+			return super.configure(filtered as unknown as typeof options) as T
 		}
 		return super.configure(options) as T
 	}

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.tsx
@@ -85,6 +85,13 @@ const GEO_SHAPE_VERTICAL_ALIGNS = Object.freeze({
 
 const GEO_SHAPE_EMPTY_LABEL_SIZE = Object.freeze({ w: 0, h: 0 })
 
+// Snapshot the built-in geo types at module init so that collision detection
+// in `configure()` only fires against the built-ins, not against keys added
+// by previous `configure()` calls. This lets repeat `configure()` calls reuse
+// the same custom key (e.g. when wrapping/extending the util) without having
+// the entry stripped from `options.customGeoTypes`.
+const BUILTIN_GEO_TYPES: ReadonlySet<string> = new Set(GeoShapeGeoStyle.values)
+
 /** @public */
 export interface GeoShapeUtilDisplayValues {
 	strokeColor: string
@@ -148,10 +155,9 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
 	): T {
 		const opts = options as Partial<GeoShapeOptions>
 		if (opts.customGeoTypes) {
-			const existingValues = new Set<string>(GeoShapeGeoStyle.values)
 			const validEntries: Array<[string, GeoTypeDefinition]> = []
 			for (const [key, def] of Object.entries(opts.customGeoTypes)) {
-				if (existingValues.has(key)) {
+				if (BUILTIN_GEO_TYPES.has(key)) {
 					if (process.env.NODE_ENV !== 'production') {
 						console.warn(
 							`[GeoShapeUtil.configure] customGeoTypes key "${key}" collides with a built-in geo type and will be ignored. Please use a unique name.`


### PR DESCRIPTION
In order to make `GeoShapeUtil.configure()` actually ignore colliding `customGeoTypes` keys, this PR strips the colliding entries out of the options before delegating to `super.configure()`. Follow-up to review feedback on #8705.

Previously, the dev-mode warning said the colliding key would be ignored, but only the schema registration was skipped. The colliding entry still landed in `this.options.customGeoTypes` and was consulted at runtime in three places that silently changed built-in behavior:

- `toolStates/Pointing.ts` — used the user's `defaultSize` for built-in geos when drag-creating with no drag.
- `DefaultStylePanelContent.tsx` — filtered the built-in style panel item out (`STYLES.geo.filter((item) => !customGeoTypes?.[item.value])`) and replaced its icon.
- `GeoShapeUtil.onDoubleClick` — ran the user's handler on the built-in geo.

Now the warning matches reality: colliding entries are dropped from the options object that's stored on the util.

### Change type

- [x] `bugfix`

### Test plan

1. Run the new tests in `GeoShapeUtil.test.tsx` (`describe('GeoShapeUtil.configure with customGeoTypes')`).

- [x] Unit tests

### Release notes

- Fix `GeoShapeUtil.configure()` so colliding `customGeoTypes` keys are actually ignored, instead of leaking through to the tool's default size, the style panel, and the double-click handler.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -5   |
| Tests     | +51 / -0   |


Made with [Cursor](https://cursor.com)