### PR TITLE
fix(arrows): offset binding hint stub to cross's corner distance

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -208,6 +208,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
     options: {
         crossSize: number;
         dashLengthRatio: number;
+        dashScaleZoomFloor: number;
         dotRadius: number;
         opacity: number;
         strokeWidth: number;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -207,8 +207,8 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
     // (undocumented)
     options: {
         crossSize: number;
+        dashedMinZoom: number;
         dashLengthRatio: number;
-        dashScaleZoomFloor: number;
         dotRadius: number;
         opacity: number;
         strokeWidth: number;

--- a/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
@@ -141,8 +141,10 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		const dist = Vec.Dist(handle, point)
 
 		// Stop the dashed stub at the marker's outer edge so it doesn't pass
-		// through the dot/cross.
-		const markerRadius = (isPrecise ? this.options.crossSize / 2 : this.options.dotRadius) / zoom
+		// through the dot/cross. The cross's corners (leg endpoints) sit at
+		// half the diagonal of its bounding square, not half its side.
+		const markerRadius =
+			(isPrecise ? (this.options.crossSize / 2) * Math.SQRT2 : this.options.dotRadius) / zoom
 
 		if (dist > markerRadius + 0.5) {
 			const visibleDist = dist - markerRadius

--- a/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
@@ -35,7 +35,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		dashLengthRatio: 2.5,
 		dotRadius: 4,
 		crossSize: 6,
-		dashScaleZoomFloor: 0.25,
+		dashedMinZoom: 0.25,
 	}
 
 	override isActive(): boolean {
@@ -92,11 +92,6 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		const zoom = editor.getZoomLevel()
 		const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
 		const strokeWidth = this.options.strokeWidth / zoom
-		// Below the floor zoom, freeze the dash sizing's world-space scale so
-		// the dashes shrink linearly with zoom on screen (e.g. half-size at
-		// half the floor zoom). Line width keeps its screen-constant behavior.
-		const dashStrokeWidth =
-			this.options.strokeWidth / Math.max(zoom, this.options.dashScaleZoomFloor)
 
 		ctx.save()
 		ctx.transform(
@@ -122,7 +117,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				'start',
 				bindings.start.props.isExact,
 				bindings.start.props.isPrecise,
-				dashStrokeWidth,
+				strokeWidth,
 				zoom
 			)
 		}
@@ -133,7 +128,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				'end',
 				bindings.end.props.isExact,
 				bindings.end.props.isPrecise,
-				dashStrokeWidth,
+				strokeWidth,
 				zoom
 			)
 		}
@@ -147,7 +142,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		side: 'start' | 'end',
 		isExact: boolean,
 		isPrecise: boolean,
-		dashStrokeWidth: number,
+		strokeWidth: number,
 		zoom: number
 	) {
 		const handle = info[side].handle
@@ -200,20 +195,20 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				ctx.lineTo(point.x, point.y)
 			}
 
-			const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
-				pathLength,
-				dashStrokeWidth,
-				{
+			// Below the dash threshold the dashes get too small to read, so
+			// fall back to a solid stub.
+			if (zoom >= this.options.dashedMinZoom) {
+				const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(pathLength, strokeWidth, {
 					style: 'dashed',
 					end: 'skip',
 					start: 'skip',
-				}
-			)
+				})
 
-			if (strokeDasharray !== 'none') {
-				const [dashLength, gapLength] = strokeDasharray.split(' ').map(Number)
-				ctx.setLineDash([dashLength, gapLength])
-				ctx.lineDashOffset = Number(strokeDashoffset)
+				if (strokeDasharray !== 'none') {
+					const [dashLength, gapLength] = strokeDasharray.split(' ').map(Number)
+					ctx.setLineDash([dashLength, gapLength])
+					ctx.lineDashOffset = Number(strokeDashoffset)
+				}
 			}
 
 			ctx.stroke()

--- a/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
@@ -35,7 +35,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		dashLengthRatio: 2.5,
 		dotRadius: 4,
 		crossSize: 6,
-		dashedMinZoom: 0.25,
+		dashedMinZoom: 0.2,
 	}
 
 	override isActive(): boolean {

--- a/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
@@ -1,4 +1,12 @@
-import { OverlayUtil, PI2, TLArrowShape, TLOverlay, TLShapeId, Vec } from '@tldraw/editor'
+import {
+	getPerfectDashProps,
+	OverlayUtil,
+	PI2,
+	TLArrowShape,
+	TLOverlay,
+	TLShapeId,
+	Vec,
+} from '@tldraw/editor'
 import { TLArrowInfo } from '../shapes/arrow/arrow-types'
 import { getArrowInfo } from '../shapes/arrow/getArrowInfo'
 import { getArrowBindings } from '../shapes/arrow/shared'
@@ -27,6 +35,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		dashLengthRatio: 2.5,
 		dotRadius: 4,
 		crossSize: 6,
+		dashScaleZoomFloor: 0.25,
 	}
 
 	override isActive(): boolean {
@@ -83,6 +92,11 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		const zoom = editor.getZoomLevel()
 		const colors = editor.getCurrentTheme().colors[editor.getColorMode()]
 		const strokeWidth = this.options.strokeWidth / zoom
+		// Below the floor zoom, freeze the dash sizing's world-space scale so
+		// the dashes shrink linearly with zoom on screen (e.g. half-size at
+		// half the floor zoom). Line width keeps its screen-constant behavior.
+		const dashStrokeWidth =
+			this.options.strokeWidth / Math.max(zoom, this.options.dashScaleZoomFloor)
 
 		ctx.save()
 		ctx.transform(
@@ -108,7 +122,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				'start',
 				bindings.start.props.isExact,
 				bindings.start.props.isPrecise,
-				strokeWidth,
+				dashStrokeWidth,
 				zoom
 			)
 		}
@@ -119,7 +133,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				'end',
 				bindings.end.props.isExact,
 				bindings.end.props.isPrecise,
-				strokeWidth,
+				dashStrokeWidth,
 				zoom
 			)
 		}
@@ -133,7 +147,7 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		side: 'start' | 'end',
 		isExact: boolean,
 		isPrecise: boolean,
-		strokeWidth: number,
+		dashStrokeWidth: number,
 		zoom: number
 	) {
 		const handle = info[side].handle
@@ -147,12 +161,10 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 			(isPrecise ? (this.options.crossSize / 2) * Math.SQRT2 : this.options.dotRadius) / zoom
 
 		if (dist > markerRadius + 0.5) {
-			const visibleDist = dist - markerRadius
-			const dashLength = Math.min(strokeWidth * this.options.dashLengthRatio, visibleDist / 2)
 			ctx.save()
-			ctx.setLineDash([dashLength, dashLength])
-			ctx.lineDashOffset = -dashLength / 2
 			ctx.beginPath()
+
+			let pathLength: number
 
 			if (info.type === 'arc') {
 				// Render along the body arc so the stub sits on the same circle as
@@ -163,12 +175,22 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				const anticlockwise = !sweepFlag
 				const sign = (sweepFlag ? 1 : -1) * (side === 'start' ? 1 : -1)
 				const trimmedHandleAngle = handleAngle + sign * (markerRadius / radius)
+
+				// Handle and point are close points on the same circle, so the
+				// stub follows the short arc between them. Use the shortest signed
+				// angular distance to get the arc length, then trim the marker.
+				let handleToPointSweep = pointAngle - handleAngle
+				if (handleToPointSweep > Math.PI) handleToPointSweep -= PI2
+				else if (handleToPointSweep < -Math.PI) handleToPointSweep += PI2
+				pathLength = Math.max(0, radius * Math.abs(handleToPointSweep) - markerRadius)
+
 				if (side === 'start') {
 					ctx.arc(center.x, center.y, radius, trimmedHandleAngle, pointAngle, anticlockwise)
 				} else {
 					ctx.arc(center.x, center.y, radius, pointAngle, trimmedHandleAngle, anticlockwise)
 				}
 			} else {
+				pathLength = dist - markerRadius
 				const t = markerRadius / dist
 				const trimmedHandle = {
 					x: handle.x + (point.x - handle.x) * t,
@@ -176,6 +198,22 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				}
 				ctx.moveTo(trimmedHandle.x, trimmedHandle.y)
 				ctx.lineTo(point.x, point.y)
+			}
+
+			const { strokeDasharray, strokeDashoffset } = getPerfectDashProps(
+				pathLength,
+				dashStrokeWidth,
+				{
+					style: 'dashed',
+					end: 'skip',
+					start: 'skip',
+				}
+			)
+
+			if (strokeDasharray !== 'none') {
+				const [dashLength, gapLength] = strokeDasharray.split(' ').map(Number)
+				ctx.setLineDash([dashLength, gapLength])
+				ctx.lineDashOffset = Number(strokeDashoffset)
 			}
 
 			ctx.stroke()


### PR DESCRIPTION
In order to make the arrow binding hint's dashed stub render cleanly across markers, zoom levels, and arc paths, this PR fixes the cross-marker offset, replaces the ad hoc dash math with `getPerfectDashProps`, computes the arc stub's length along the arc rather than as straight-line distance, and falls back to a solid stub below a minimum zoom.

The stub was offset from the handle by `crossSize / 2`, but the cross is drawn from `(-half, -half)` to `(half, half)`, so its leg endpoints sit at `(crossSize / 2) * sqrt(2)` from the handle. The stub ended inside the cross's footprint, which read as having no offset at all next to the dot case (where the offset matches the dot's full radius). The arc branch also used the chord distance to size dashes, which produced uneven dash lengths along curved stubs.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app and draw an arrow.
2. Bind one end of the arrow to a shape and drag the other end so that there is a visible gap between the bound point and the user's intended position.
3. Confirm the dashed stub stops short of the precision cross marker, with the same visual gap as the dot marker case.
4. Try the same on an arc-shaped arrow and confirm dashes are evenly spaced along the arc.
5. Zoom out below 20% and confirm the stub renders as a solid line instead of unreadable dashes.

### Release notes

- Fix the arrow binding hint's dashed stub overlapping the precision cross marker, dash spacing on arc-shaped stubs, and unreadable dashes at low zoom.

### API changes

- Added `dashedMinZoom` option to `ArrowBindingHintOverlayUtil` (default `0.2`); below this zoom the stub renders as a solid line.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +42 / -7   |
| Automated files | +1 / -0    |