### PR TITLE
chore: remove unused type exports

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -79,11 +79,11 @@ import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
 import { updateLocalSessionState } from '../utils/local-session-state'
 import { Zero as ZeroPolyfill } from './zero-polyfill'
 
-export interface DragGroupOperation {
+interface DragGroupOperation {
 	reorder?: DragReorderOperation
 }
 
-export type DragState =
+type DragState =
 	| null
 	| {
 			type: 'file'

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarInlineInput.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarInlineInput.tsx
@@ -5,7 +5,7 @@ import { useHasFlag } from '../../../hooks/useHasFlag'
 import { pinIcon } from './pinIcon'
 import styles from '../sidebar.module.css'
 
-export interface TlaSidebarInlineInputProps {
+interface TlaSidebarInlineInputProps {
 	defaultValue?: string
 	placeholder?: string
 	onComplete(value: string): void

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -194,7 +194,7 @@ export function TlaMenuSelect<T extends string>({
 
 /* --------------------- Switch --------------------- */
 
-export interface TlaMenuSwitchProps extends Omit<HTMLAttributes<HTMLInputElement>, 'onChange'> {
+interface TlaMenuSwitchProps extends Omit<HTMLAttributes<HTMLInputElement>, 'onChange'> {
 	id: string
 	checked: boolean
 	onChange?(checked: boolean): void

--- a/apps/dotcom/client/src/tla/hooks/useDragTracking.ts
+++ b/apps/dotcom/client/src/tla/hooks/useDragTracking.ts
@@ -6,12 +6,6 @@ import { Vec } from 'tldraw'
 import { TldrawApp } from '../app/TldrawApp'
 import { useApp } from './useAppState'
 
-export interface DropTarget {
-	id: string
-	element: HTMLElement
-	rect: DOMRect
-}
-
 function detectDragOperations(
 	elements: DragElements,
 	mousePosition: { x: number; y: number },

--- a/apps/dotcom/client/src/tla/hooks/useUser.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useUser.tsx
@@ -4,7 +4,7 @@ import { ReactNode, createContext, useContext, useMemo } from 'react'
 import { DefaultSpinner, LoadingScreen, assert, useShallowObjectIdentity } from 'tldraw'
 import { useMaybeApp } from './useAppState'
 
-export interface TldrawUser {
+interface TldrawUser {
 	id: string
 	clerkUser: UserResource
 	isTldraw: boolean

--- a/apps/dotcom/client/src/tla/themes/ui-themes.ts
+++ b/apps/dotcom/client/src/tla/themes/ui-themes.ts
@@ -11,7 +11,7 @@ export interface UIThemeVariant {
 	tla: Record<string, string>
 }
 
-export interface UITheme {
+interface UITheme {
 	id: string
 	name: string
 	lightBackground: string

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -41,7 +41,7 @@ export function useAnalyticsConsentValue(): boolean | null {
 	])
 }
 
-export type AnalyticsOptions =
+type AnalyticsOptions =
 	| {
 			optedIn: true
 			user:

--- a/apps/examples/src/misc/end-to-end.tsx
+++ b/apps/examples/src/misc/end-to-end.tsx
@@ -30,7 +30,7 @@ declare module 'tldraw' {
 	}
 }
 
-export type HtmlCssShape = TLShape<typeof HTML_TYPE>
+type HtmlCssShape = TLShape<typeof HTML_TYPE>
 class HtmlCssShapeUtil extends BaseBoxShapeUtil<HtmlCssShape> {
 	static override type = HTML_TYPE
 

--- a/apps/mcp-app/src/shared/generated-data.ts
+++ b/apps/mcp-app/src/shared/generated-data.ts
@@ -1,4 +1,4 @@
-export type ArgKind =
+type ArgKind =
 	| 'id'
 	| 'id-or-shape'
 	| 'ids-or-shapes'
@@ -18,7 +18,7 @@ export type RetKind =
 	| 'ids'
 	| 'id-set'
 
-export interface MethodSpec {
+interface MethodSpec {
 	args: ArgKind[]
 	ret: RetKind
 }

--- a/apps/mcp-app/src/widget/exec-helpers.ts
+++ b/apps/mcp-app/src/widget/exec-helpers.ts
@@ -144,7 +144,7 @@ export function createExecHelpers(editor: Editor) {
 	return helpers
 }
 
-export type ExecHelpers = ReturnType<typeof createExecHelpers>
+type ExecHelpers = ReturnType<typeof createExecHelpers>
 
 const EXEC_TIMEOUT_MS = 10_000
 

--- a/apps/mcp-app/src/widget/focused/format.ts
+++ b/apps/mcp-app/src/widget/focused/format.ts
@@ -22,7 +22,7 @@ export const FOCUSED_COLORS = [
 	'white',
 ] as const
 
-export type FocusedColor = (typeof FOCUSED_COLORS)[number]
+type FocusedColor = (typeof FOCUSED_COLORS)[number]
 
 export function asColor(color: string): FocusedColor {
 	if (FOCUSED_COLORS.includes(color as FocusedColor)) {
@@ -38,7 +38,7 @@ export function asColor(color: string): FocusedColor {
 
 // ---- Fill ----
 
-export type FocusedFill = 'none' | 'tint' | 'background' | 'solid' | 'pattern'
+type FocusedFill = 'none' | 'tint' | 'background' | 'solid' | 'pattern'
 
 const FOCUSED_TO_SHAPE_FILLS: Record<FocusedFill, TLDefaultFillStyle> = {
 	none: 'none',

--- a/apps/mcp-app/src/widget/persistence.ts
+++ b/apps/mcp-app/src/widget/persistence.ts
@@ -177,7 +177,7 @@ function toAssetRecords(value: unknown): TLAsset[] {
 	return value.filter((a): a is TLAsset => isPlainObject(a) && typeof a.id === 'string')
 }
 
-export interface CheckpointResult {
+interface CheckpointResult {
 	checkpointId: string
 	sessionId: string | null
 	shapes: TLShape[]

--- a/internal/health-worker/src/updown_types.ts
+++ b/internal/health-worker/src/updown_types.ts
@@ -1,6 +1,6 @@
 // docs: https://updown.io/api#webhooks
 
-export interface BaseCheck {
+interface BaseCheck {
 	token: string
 	url: string
 	alias: null
@@ -23,41 +23,41 @@ export interface BaseCheck {
 	http_body: string
 }
 
-export interface FailingCheck extends BaseCheck {
+interface FailingCheck extends BaseCheck {
 	down: true
 	down_since: string
 	up_since: null
 	error: string
 }
 
-export interface SucceedingCheck extends BaseCheck {
+interface SucceedingCheck extends BaseCheck {
 	down: true
 	down_since: null
 	up_since: string
 	error: null
 }
 
-export interface BaseDowntime {
+interface BaseDowntime {
 	id: string
 	error: string
 	started_at: string
 	partial: unknown
 }
 
-export interface OngoingDowntime extends BaseDowntime {
+interface OngoingDowntime extends BaseDowntime {
 	ended_at: null
 	duration: null
 }
 
-export interface FinishedDowntime extends BaseDowntime {
+interface FinishedDowntime extends BaseDowntime {
 	ended_at: string
 	// seconds
 	duration: number
 }
 
-export type CustomHeaders = Record<string, string>
+type CustomHeaders = Record<string, string>
 
-export interface SslCert {
+interface SslCert {
 	subject: string
 	issuer: string
 	from: string
@@ -65,7 +65,7 @@ export interface SslCert {
 	algorithm: string
 }
 
-export interface EventDown {
+interface EventDown {
 	event: 'check.down'
 	time: string
 	description: string
@@ -73,7 +73,7 @@ export interface EventDown {
 	downtime: OngoingDowntime
 }
 
-export interface EventStillDown {
+interface EventStillDown {
 	event: 'check.still_down'
 	time: string
 	description: string
@@ -81,7 +81,7 @@ export interface EventStillDown {
 	downtime: OngoingDowntime
 }
 
-export interface EventUp {
+interface EventUp {
 	event: 'check.up'
 	time: string
 	description: string
@@ -89,7 +89,7 @@ export interface EventUp {
 	downtime: FinishedDowntime
 }
 
-export interface EventSslInvalid {
+interface EventSslInvalid {
 	event: 'check.ssl_invalid'
 	time: string
 	description: string
@@ -100,7 +100,7 @@ export interface EventSslInvalid {
 	}
 }
 
-export interface EventSslValid {
+interface EventSslValid {
 	event: 'check.ssl_valid'
 	time: string
 	description: string
@@ -110,7 +110,7 @@ export interface EventSslValid {
 	}
 }
 
-export interface EventSslExpiration {
+interface EventSslExpiration {
 	event: 'check.ssl_expiration'
 	time: string
 	description: string
@@ -121,7 +121,7 @@ export interface EventSslExpiration {
 	}
 }
 
-export interface EventSslRenewed {
+interface EventSslRenewed {
 	event: 'check.ssl_renewed'
 	time: string
 	description: string
@@ -132,7 +132,7 @@ export interface EventSslRenewed {
 	}
 }
 
-export interface EventPerformanceDrop {
+interface EventPerformanceDrop {
 	event: 'check.performance_drop'
 	time: string
 	description: string


### PR DESCRIPTION
In order to reduce dead exported surface area, this PR removes unused type exports from app, MCP, examples, and health worker code. Types that are still used locally remain in place without being exported, and one unused drag tracking type is removed entirely.

### Change type

- [x] `other`

### Test plan

- `yarn lint-current`
- `yarn typecheck`

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +1 / -1    |
| Apps          | +29 / -35  |