### PR TITLE
feat(dotcom): track sign_up conversions in GA4

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/TlaLegalAcceptance.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaLegalAcceptance.tsx
@@ -2,6 +2,7 @@ import { useUser } from '@clerk/clerk-react'
 import classNames from 'classnames'
 import { useCallback, useRef, useState } from 'react'
 import { TldrawUiDialogBody, TldrawUiDialogHeader, TldrawUiDialogTitle } from 'tldraw'
+import { getSignUpTrackingInfo, trackEvent } from '../../../utils/analytics'
 import { useAnalyticsConsent } from '../../hooks/useAnalyticsConsent'
 import { F } from '../../utils/i18n'
 import { TlaMenuSwitch } from '../tla-menu/tla-menu'
@@ -28,9 +29,15 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 		try {
 			if (!user) return
 
+			const signUpTrackingInfo = analyticsOptIn === true ? getSignUpTrackingInfo(user) : null
+
 			// Persist analytics choice before redirecting
 			if (analyticsOptIn !== null) {
 				updateAnalyticsConsent(analyticsOptIn)
+			}
+
+			if (signUpTrackingInfo) {
+				trackEvent('sign_up', signUpTrackingInfo)
 			}
 
 			// Store acceptance in user metadata
@@ -38,6 +45,7 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 				unsafeMetadata: {
 					...user.unsafeMetadata,
 					legal_accepted_at: new Date().toISOString(),
+					...(signUpTrackingInfo ? { signupTracked: true } : {}),
 				},
 			} as any)
 			await user.reload()

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -1,7 +1,8 @@
+import { useUser } from '@clerk/clerk-react'
 import { FEATURE_FLAG_KEYS } from '@tldraw/dotcom-shared'
 import posthog, { PostHogConfig, Properties } from 'posthog-js'
 import 'posthog-js/dist/web-vitals'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import ReactGA from 'react-ga4'
 import { useLocation } from 'react-router-dom'
 import { atom, getFromLocalStorage, react, setInLocalStorage, useValue, warnOnce } from 'tldraw'
@@ -319,10 +320,51 @@ export function trackEvent(name: string, data?: { [key: string]: any }) {
 			})
 		}
 	}
+
+	// Track signups in GA4 for Google Ads conversion imports
+	if (name === 'sign_up') {
+		if (getGA4()) {
+			ReactGA.gtag('event', 'sign_up', {
+				method: data?.method ?? 'unknown',
+			})
+		}
+	}
 }
 
 export function useHandleUiEvents() {
 	return trackEvent
+}
+
+export function useTrackSignUp(analyticsEnabled: boolean) {
+	const { user, isSignedIn } = useUser()
+	const fired = useRef(false)
+
+	useEffect(() => {
+		if (!analyticsEnabled || !isSignedIn || !user || fired.current) return
+
+		const createdAt = new Date(user.createdAt ?? 0).getTime()
+		const ageMs = Date.now() - createdAt
+		if (!Number.isFinite(ageMs) || ageMs > 30_000) return
+		if (user.unsafeMetadata?.signupTracked) return
+
+		fired.current = true
+		const provider = user.externalAccounts?.[0]?.provider
+		const method = provider ? provider.replace(/^oauth_/, '') : 'email'
+
+		trackEvent('sign_up', { method })
+
+		void user
+			.update({
+				unsafeMetadata: {
+					...user.unsafeMetadata,
+					signupTracked: true,
+				},
+			} as any)
+			.then(() => user.reload())
+			.catch((error) => {
+				console.error('Failed to mark signup event as tracked:', error)
+			})
+	}, [analyticsEnabled, isSignedIn, user])
 }
 
 export function SignedOutAnalytics() {
@@ -374,10 +416,10 @@ export function SignedInAnalytics() {
 	const app = useApp()
 	const user = useValue('userData', () => app.getUser(), [app])
 	const storedConsent = useAnalyticsConsentValue()
+	const userConsent = user.allowAnalyticsCookie
+	const finalConsent = userConsent !== null ? userConsent : storedConsent === true
 
 	useEffect(() => {
-		const userConsent = user.allowAnalyticsCookie
-
 		// If user has no preference in database but has one in atom/localStorage, sync it
 		if (userConsent === null && storedConsent !== null) {
 			app.updateUser({ id: user.id, allowAnalyticsCookie: storedConsent })
@@ -389,12 +431,10 @@ export function SignedInAnalytics() {
 			setStoredAnalyticsConsent(userConsent)
 		}
 
-		// Use user's database preference if available, otherwise fall back to stored consent
-		const finalConsent = userConsent !== null ? userConsent : storedConsent === true
-
 		configureAnalytics(finalConsent, { id: user.id, name: user.name, email: user.email })
-	}, [user.allowAnalyticsCookie, user.email, user.id, user.name, app, storedConsent])
+	}, [userConsent, user.email, user.id, user.name, app, storedConsent, finalConsent])
 
+	useTrackSignUp(finalConsent)
 	useTrackPageViews()
 
 	return null

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -1,4 +1,5 @@
 import { useUser } from '@clerk/clerk-react'
+import type { UserResource } from '@clerk/types'
 import { FEATURE_FLAG_KEYS } from '@tldraw/dotcom-shared'
 import posthog, { PostHogConfig, Properties } from 'posthog-js'
 import 'posthog-js/dist/web-vitals'
@@ -7,6 +8,7 @@ import ReactGA from 'react-ga4'
 import { useLocation } from 'react-router-dom'
 import { atom, getFromLocalStorage, react, setInLocalStorage, useValue, warnOnce } from 'tldraw'
 import { useApp } from '../tla/hooks/useAppState'
+import { hasNotAcceptedLegal } from '../tla/utils/auth'
 import { getCurrentFlags, hasResolvedFlagsOnce } from '../tla/utils/FeatureFlagPoller'
 
 // Local storage key for cookie consent
@@ -71,6 +73,7 @@ const GA4_MEASUREMENT_ID: string | undefined = import.meta.env.VITE_GA4_MEASUREM
 const shouldUseGA4 = GA4_MEASUREMENT_ID !== undefined
 
 const PROPERTIES_TO_REDACT = ['url', 'href', 'pathname']
+const SIGNUP_TRACKING_WINDOW_MS = 30_000
 
 // Match property names against the defined list
 function filterProperties(value: { [key: string]: any }) {
@@ -323,16 +326,28 @@ export function trackEvent(name: string, data?: { [key: string]: any }) {
 
 	// Track signups in GA4 for Google Ads conversion imports
 	if (name === 'sign_up') {
-		if (getGA4()) {
-			ReactGA.gtag('event', 'sign_up', {
-				method: data?.method ?? 'unknown',
-			})
-		}
+		getGA4()?.event('sign_up', {
+			method: data?.method ?? 'unknown',
+		})
 	}
 }
 
 export function useHandleUiEvents() {
 	return trackEvent
+}
+
+export function getSignUpTrackingInfo(
+	user: Pick<UserResource, 'createdAt' | 'externalAccounts' | 'unsafeMetadata'>
+) {
+	const createdAt = new Date(user.createdAt ?? 0).getTime()
+	const ageMs = Date.now() - createdAt
+	if (!Number.isFinite(ageMs) || ageMs > SIGNUP_TRACKING_WINDOW_MS) return null
+	if (user.unsafeMetadata?.signupTracked) return null
+
+	const provider = user.externalAccounts?.[0]?.provider
+	return {
+		method: provider ? provider.replace(/^oauth_/, '') : 'email',
+	}
 }
 
 export function useTrackSignUp(analyticsEnabled: boolean) {
@@ -341,17 +356,14 @@ export function useTrackSignUp(analyticsEnabled: boolean) {
 
 	useEffect(() => {
 		if (!analyticsEnabled || !isSignedIn || !user || fired.current) return
+		if (hasNotAcceptedLegal(user)) return
 
-		const createdAt = new Date(user.createdAt ?? 0).getTime()
-		const ageMs = Date.now() - createdAt
-		if (!Number.isFinite(ageMs) || ageMs > 30_000) return
-		if (user.unsafeMetadata?.signupTracked) return
+		const signUpTrackingInfo = getSignUpTrackingInfo(user)
+		if (!signUpTrackingInfo) return
 
 		fired.current = true
-		const provider = user.externalAccounts?.[0]?.provider
-		const method = provider ? provider.replace(/^oauth_/, '') : 'email'
 
-		trackEvent('sign_up', { method })
+		trackEvent('sign_up', signUpTrackingInfo)
 
 		void user
 			.update({


### PR DESCRIPTION
In order to feed Google Ads conversion imports from client-side attribution, this PR tracks opted-in new account creation as a GA4 `sign_up` event from the signed-in analytics mount.

The event still goes through the shared `trackEvent` path so PostHog receives the same `method` property, while GA4 delivery remains behind the existing consent/configuration plumbing. The hook checks Clerk's signed-in user, limits tracking to users created in the last 30 seconds, normalizes Google OAuth provider names to `google`, and writes `unsafeMetadata.signupTracked` after firing so reloads and future sign-ins do not duplicate the conversion.

### Change type

- [x] `feature`

### Test plan

1. With analytics consent accepted, create a new account through the email magic-code flow and confirm GA4 DebugView shows `sign_up` with `method: "email"` and PostHog receives the same event.
2. With analytics consent accepted, create a new account through Google OAuth and confirm GA4 DebugView shows `sign_up` with `method: "google"` and PostHog receives the same event.
3. Sign out and back in to the same account, then reload within 30 seconds of signup, and confirm no duplicate `sign_up` event is sent because `unsafeMetadata.signupTracked` is present.
4. Decline analytics consent, create a new account, and confirm the network panel shows no GA4 `sign_up` request.

Automated checks run locally:

- [x] `yarn lint-current`
- [x] `yarn typecheck`
- [ ] Unit tests
- [ ] End to end tests

I also ran `yarn lint`; it currently fails before this diff is linted because `packages/namespaced-tldraw/tldraw.css` and `packages/tldraw/tldraw.css` have formatting issues on the current base branch.

### Release notes

- Add signup conversion tracking for tldraw.com analytics.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps | +47 / -7 |