### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -229,7 +229,9 @@ A new `Cmd+Shift+V` / `Ctrl+Shift+V` shortcut pastes clipboard content as plain 
 
 Note: `Cmd+Shift+V` previously toggled paste-at-cursor positioning. Since the "Paste at cursor" preference now covers that use case, this shortcut has been repurposed for plain text paste. Users who relied on `Cmd+Shift+V` for paste-at-cursor should use the preference toggle instead.
 
-### 💥 Canvas overlay system ([overlay utils](/sdk-features/overlay-utils))
+### 💥 Canvas overlay system ([#8633](https://github.com/tldraw/tldraw/pull/8633))
+
+See the [overlay utils documentation](/sdk-features/overlay-utils) for the full API.
 
 Canvas overlay UI — the selection foreground, brush rectangles, snap indicators, shape indicators, shape handles, scribbles, arrow hints, and collaborator presence visuals — is now rendered via a new `OverlayUtil` system instead of React components. Overlays draw directly to a `<canvas>` element using the Canvas 2D API, with optional hit-test geometry for pointer interactions.
 
@@ -378,6 +380,8 @@ This is enabled by default through a new `rightClickPanning` option on `TldrawOp
 - Add Canva to `DEFAULT_EMBED_DEFINITIONS` as a supported embed type. ([#8459](https://github.com/tldraw/tldraw/pull/8459))
 - Add `PeopleMenu`, `PeopleMenuItem`, `PeopleMenuFacePile`, and `UserPresenceEditor` to the overridable `TldrawUiComponents`. ([#8346](https://github.com/tldraw/tldraw/pull/8346)) (contributed by [@kaneel](https://github.com/kaneel))
 - Add `defaultHandleExternalFileReplaceContent` to public exports. ([#8579](https://github.com/tldraw/tldraw/pull/8579)) (contributed by [@angrycaptain19](https://github.com/angrycaptain19))
+- Add `editor.collaborators` (`CollaboratorsManager`) owning the collaborator visibility clock and presence queries. Add `CollaboratorShapeIndicatorOverlayUtil` for remote-collaborator selection indicators (split out of `ShapeIndicatorOverlayUtil`) and `strokeShapeIndicators` helper. `Editor.setCursor` now skips redundant writes when the requested cursor type and rotation match the current cursor. ([#8648](https://github.com/tldraw/tldraw/pull/8648))
+- Add support for holding the accel key (Cmd on macOS, Ctrl elsewhere) while drawing or highlighting to temporarily erase. Releasing accel returns to the originating tool. ([#8651](https://github.com/tldraw/tldraw/pull/8651))
 - 💥 Remove `Brush`, `CollaboratorBrush`, `CollaboratorCursor`, `CollaboratorHint`, `CollaboratorScribble`, `CollaboratorShapeIndicator`, `Cursor`, `Handle`, `Handles`, `Overlays`, `Scribble`, `SelectionForeground`, `ShapeIndicator`, `ShapeIndicatorErrorFallback`, `ShapeIndicators`, `SnapIndicator`, and `ZoomBrush` from `TLEditorComponents`. Remove their default implementations and prop types. These are now rendered via the `OverlayUtil` system.
 - 💥 Remove `TldrawArrowHints`, `TldrawCropHandles`, `TldrawCropHandlesProps`, `TldrawHandles`, `TldrawOverlays`, `TldrawScribble`, `TldrawSelectionForeground`, and `TldrawShapeIndicators` from `tldraw`.
 - 💥 Change shape indicators from SVG to canvas paths: `ShapeUtil.getIndicatorPath()` is now abstract, `ShapeUtil.indicator()` is deprecated and no longer rendered, and `ShapeUtil.useLegacyIndicator()` has been removed.
@@ -385,11 +389,14 @@ This is enabled by default through a new `rightClickPanning` option on `TldrawOp
 - 💥 Add `snap`, `selectionStroke`, `selectionFill`, `brushFill`, `brushStroke`, `selectedContrast`, and `laser` to the required `TLThemeDefaultColors` / `TLThemeUiColorKeys` UI color keys.
 - Add `OverlayUtil` base class, `OverlayManager`, `TLOverlay`, `TLOverlayEntry`, `TLOverlayUtilConstructor`, and `TLAnyOverlayUtilConstructor` to `@tldraw/editor`. Add `overlayUtils` prop to `<Tldraw>` and `<TldrawEditor>`. Add `Editor.overlays` (`OverlayManager`) with `getOverlayUtil()`, `getOverlayUtilsInZOrder()`, `getActiveOverlayEntries()`, `getCurrentOverlays()`, `getOverlayGeometry()`, `getOverlayAtPoint()`, `getHoveredOverlayId()`, `getHoveredOverlay()`, and `setHoveredOverlay()`.
 - Add `ShapeIndicatorOverlayUtil`, `BrushOverlayUtil`, `ZoomBrushOverlayUtil`, `ScribbleOverlayUtil`, `CollaboratorBrushOverlayUtil`, `CollaboratorCursorOverlayUtil`, `CollaboratorScribbleOverlayUtil`, `CollaboratorHintOverlayUtil`, `ShapeHandleOverlayUtil`, `SelectionForegroundOverlayUtil`, `SnapIndicatorOverlayUtil`, `ArrowHintOverlayUtil`, `ArrowBindingHintOverlayUtil`, their overlay types, and `defaultOverlayUtils` to `tldraw`.
-- Add `Vec.IsFinite()` static method for checking whether a vector has finite coordinates. ([#8176](https://github.com/tldraw/tldraw/pull/8176))
+- Add `getOverlayDisplayValues()` and `OverlayOptionsWithDisplayValues` in `@tldraw/editor`, plus `BrushOverlayUtilDisplayValues` and `BrushOverlayUtilOptions` in `tldraw`, for theme-aware display value customization on overlays. `BrushOverlayUtil.options` now uses display value callbacks instead of a direct `lineWidth`. ([#8721](https://github.com/tldraw/tldraw/pull/8721))
 
 ## Improvements
 
 - Optimize geometry hot paths for hit testing: reduce allocations and function call overhead in `Vec`, `Edge2d`, `Circle2d`, `Arc2d`, `Polyline2d`, and intersection routines. Circle hit testing is up to 19x faster, polyline nearest-point is 6.8x faster. ([#8210](https://github.com/tldraw/tldraw/pull/8210))
+- Reduce canvas state rerenders for smoother interactions. ([#8647](https://github.com/tldraw/tldraw/pull/8647))
+- Reduce per-frame canvas render work for the overlay system. ([#8644](https://github.com/tldraw/tldraw/pull/8644))
+- Skip the per-shape CSS transform update when dynamic size mode is not active, saving work during pan and zoom. ([#8570](https://github.com/tldraw/tldraw/pull/8570))
 - Exports now automatically trim to visual content bounds, capturing overflow like thick strokes and arrowheads without extra whitespace. ([#8202](https://github.com/tldraw/tldraw/pull/8202))
 - Improve resize performance for multiple geo shapes with text labels by batching DOM measurements into a single pass per frame. ([#7949](https://github.com/tldraw/tldraw/pull/7949))
 - Allow Cmd+click / Ctrl+click on style panel items to apply style changes only to selected shapes without updating defaults for future shapes. ([#8452](https://github.com/tldraw/tldraw/pull/8452))
@@ -418,7 +425,6 @@ This is enabled by default through a new `rightClickPanning` option on `TldrawOp
 - Fix crash from duplicate fractional index keys in `kickoutOccludedShapes` during multiplayer sync. ([#8448](https://github.com/tldraw/tldraw/pull/8448))
 - Fix spiky artifacts on draw-style geometric shapes by using a circular random offset distribution instead of a square one. ([#8466](https://github.com/tldraw/tldraw/pull/8466))
 - Fix opacity slider drag not working on Safari due to `stopPropagation` blocking pointer events. ([#8519](https://github.com/tldraw/tldraw/pull/8519))
-- Fix crash when isolating curved arrows whose geometry became degenerate (e.g., during shape deletion). ([#8176](https://github.com/tldraw/tldraw/pull/8176))
 - Fix `Cmd+Shift+V` doing nothing when the clipboard contains an image; the shortcut now falls back to the regular paste flow when there is no plain-text payload. ([#8490](https://github.com/tldraw/tldraw/pull/8490))
 - Fix a memory leak where `Editor` instances were retained after unmount via the `window.__tldraw__hardReset` global. ([#8476](https://github.com/tldraw/tldraw/pull/8476))
 - Fix crash in browsers without `OffscreenCanvas` support (e.g. older Safari) when interacting with image shapes. ([#8582](https://github.com/tldraw/tldraw/pull/8582))
@@ -433,3 +439,13 @@ This is enabled by default through a new `rightClickPanning` option on `TldrawOp
 - Fix style keyboard shortcuts not setting `isChangingStyle`, so consecutive style changes weren't grouped correctly. ([#8599](https://github.com/tldraw/tldraw/pull/8599)) (contributed by [@danieljamesross](https://github.com/danieljamesross))
 - Fix note author attribution overflowing the sticky note width in SVG and PNG exports. ([#8664](https://github.com/tldraw/tldraw/pull/8664))
 - Fix keyboard shortcuts not matching on alternative Latin keyboard layouts (Dvorak, Colemak, AZERTY) by replacing the `hotkeys-js` library with a small layout-aware native event matcher. ([#8669](https://github.com/tldraw/tldraw/pull/8669))
+- Fix cursor not resetting when entering editing mode. ([#8685](https://github.com/tldraw/tldraw/pull/8685))
+- Fix comma-key pointer release using incorrect coordinates when the editor's `screenBounds` has a non-zero offset. ([#8704](https://github.com/tldraw/tldraw/pull/8704))
+- Fix box-shadow on note shapes not rendering correctly in dark mode. ([#8698](https://github.com/tldraw/tldraw/pull/8698))
+- Fix collaborator cursor head and tail rendering as a single fill, so each can be themed independently. ([#8710](https://github.com/tldraw/tldraw/pull/8710))
+- Fix style panel colors not following the active theme. ([#8696](https://github.com/tldraw/tldraw/pull/8696))
+- Fix minimap drag continuing after a right-click or pointer cancel. ([#8700](https://github.com/tldraw/tldraw/pull/8700))
+- Fix crash from `navigator.connection` being null in `resolveAssetUrl` on browsers without the Network Information API. ([#8662](https://github.com/tldraw/tldraw/pull/8662))
+- Fix module-level state leaks that retained editor data after unmount. ([#8604](https://github.com/tldraw/tldraw/pull/8604))
+- Fix shape indicators using `Path2D.roundRect`, which is unsupported on older browsers. ([#8642](https://github.com/tldraw/tldraw/pull/8642))
+- Fix the arrow binding hint's dashed stub overlapping the precision cross marker, dash spacing on arc-shaped stubs, and unreadable dashes at low zoom. ([#8716](https://github.com/tldraw/tldraw/pull/8716))


### PR DESCRIPTION
In order to keep the next release notes in sync with main, this run added entries for two PRs that have landed since the last update: a brush overlay display value refactor with new public types (#8721) and a fix for the arrow binding hint dashed stub (#8716). No stale entries needed pruning. Source: main.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +19 / -3   |