### PR TITLE
fix(examples): drive selection color via theme in selection-color-condition

### DIFF
--- a/apps/examples/src/examples/ui/selection-color-condition/SelectionColorConditionExample.tsx
+++ b/apps/examples/src/examples/ui/selection-color-condition/SelectionColorConditionExample.tsx
@@ -1,42 +1,45 @@
-import { Tldraw, react } from 'tldraw'
+import { DEFAULT_THEME, TLTheme, TLThemeId, Tldraw, react, structuredClone } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file!
 
+const RECTANGLE_SELECTION_THEME_ID = 'rectangle-selection' as TLThemeId
+
 // [1]
+const RECTANGLE_SELECTION_THEME: TLTheme = structuredClone(DEFAULT_THEME)
+RECTANGLE_SELECTION_THEME.id = RECTANGLE_SELECTION_THEME_ID
+RECTANGLE_SELECTION_THEME.colors.light.selectionStroke = '#cc0000'
+RECTANGLE_SELECTION_THEME.colors.light.selectionFill = 'rgba(255, 68, 68, 0.24)'
+RECTANGLE_SELECTION_THEME.colors.dark.selectionStroke = '#ff4444'
+RECTANGLE_SELECTION_THEME.colors.dark.selectionFill = 'rgba(255, 68, 68, 0.24)'
+
+const themes = {
+	[RECTANGLE_SELECTION_THEME_ID]: RECTANGLE_SELECTION_THEME,
+}
+
 export default function SelectionColorConditionExample() {
 	return (
 		<div className="tldraw__editor">
-			<style>{`
-				/* Custom selection color for rectangle shapes */
-				.tl-container.rectangle-selection {
-					--tl-color-selection: #ff4444;
-					--tl-color-selection-stroke: #cc0000;
-				}
-			`}</style>
-
 			<Tldraw
+				// [2]
+				themes={themes}
 				onMount={(editor) => {
-					// [2]
-					const stopListening = react('update selection classname', () => {
+					// [3]
+					const stopListening = react('update selection theme', () => {
 						const selectedShapes = editor.getSelectedShapes()
 
-						// [3]
+						// [4]
 						const allAreRectangles =
 							selectedShapes.length > 0 &&
 							selectedShapes.every(
 								(shape) => editor.isShapeOfType(shape, 'geo') && shape.props.geo === 'rectangle'
 							)
 
-						// [4]
-						if (allAreRectangles) {
-							editor.getContainer().classList.add('rectangle-selection')
-						} else {
-							editor.getContainer().classList.remove('rectangle-selection')
-						}
+						// [5]
+						editor.setCurrentTheme(allAreRectangles ? RECTANGLE_SELECTION_THEME_ID : 'default')
 					})
 
-					// [5]
+					// [6]
 					editor
 						.createShapes([
 							{ type: 'geo', x: 0, y: 0 },
@@ -60,26 +63,32 @@ Introduction:
 This example shows how to change the selection color based on the types of shapes selected.
 When all selected shapes are rectangles, the selection will appear red instead of the default blue.
 
+Selection colors are painted to the canvas overlay from the editor's theme, so we swap the
+active theme rather than overriding CSS variables.
+
 [1]
-We use the onMount prop to set up our selection listener when the editor is first mounted.
+Clone `DEFAULT_THEME` and override `selectionStroke` and `selectionFill` for both the light
+and dark palettes. These are the keys the canvas overlay reads when drawing the selection.
 
 [2]
-We use the react function to create a reactive effect that runs whenever the selection changes.
-The first parameter is a unique name for this effect, and the second is a function that will
-be called whenever the selection updates.
+Pass our custom theme to `<Tldraw>` via the `themes` prop so it's registered at mount time.
+The `default` theme is always available, so we only need to register additional themes here.
 
 [3]
+We use the `react` function to create a reactive effect that runs whenever the selection changes.
+
+[4]
 Here we check if all selected shapes are rectangle geo shapes. You can customize this condition
 to check for any shape type or combination. For example:
 - Check for circles: shape.type === 'geo' && shape.props.geo === 'ellipse'
 - Check for text: shape.type === 'text'
 - Check for mixed types: shape.type === 'geo' && (shape.props.geo === 'rectangle' || shape.props.geo === 'ellipse')
 
-[4]
-Based on our condition, we add or remove a CSS class from the editor's container. The CSS
-file (selection-color-condition.css) defines the custom colors for the .rectangle-selection class.
-
 [5]
+Switch to the custom theme when the condition holds, and back to the default theme otherwise.
+The current theme is reactive, so the canvas re-paints with the new colors immediately.
+
+[6]
 We create some shapes to test our condition.
 
 */


### PR DESCRIPTION
## Summary

After #8633 introduced the OverlayUtil system, selection colors are painted to a canvas overlay from the editor's theme (`editor.getCurrentTheme().colors[mode].selectionStroke` / `.selectionFill`) rather than read from CSS variables. The `selection-color-condition` example was toggling a CSS class to swap `--tl-color-selection` / `--tl-color-selection-stroke` on `.tl-container`, which no longer affects the selection outline.

Switch the example to register a custom theme that overrides `selectionStroke` and `selectionFill`, and reactively call `editor.setCurrentTheme()` when the rectangle-only condition holds.

Closes #8711.

### Change type

- [x] `bugfix`

## Test plan

- [ ] Run `yarn dev`, open the `selection-color-condition` example.
- [ ] Confirm both seeded rectangles are selected on mount and the selection outline is red.
- [ ] Click the ellipse — selection outline returns to default blue.
- [ ] Reselect both rectangles — outline turns red again.
- [ ] Toggle dark mode — selection outline still recolors based on the same condition.

### Release notes

- Fix `selection-color-condition` example to drive selection color through the editor theme rather than CSS variables, which no longer affect canvas-rendered selection.