### PR TITLE
docs: update examples on recent changes

### DIFF
--- a/apps/examples/src/examples/collaboration/sync-private-content/style.css
+++ b/apps/examples/src/examples/collaboration/sync-private-content/style.css
@@ -12,6 +12,7 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
+	pointer-events: auto;
 }
 
 .toggle-panel button {

--- a/apps/examples/src/examples/configuration/asset-props/README.md
+++ b/apps/examples/src/examples/configuration/asset-props/README.md
@@ -20,4 +20,4 @@ Control the assets (images, videos, etc.) that can be added to the canvas.
 
 ---
 
-This example demonstrates the `<Tldraw/>` component's props that give you control over assets: which types are allowed (image only here), the maximum size (set to 1mb), and maximum dimensions (set to none).
+This example demonstrates the `<Tldraw/>` component's props that give you control over assets: which types are allowed (image only here), the maximum size (set to 1 MB), and maximum dimensions (no limit).

--- a/apps/examples/src/examples/configuration/asset-props/README.md
+++ b/apps/examples/src/examples/configuration/asset-props/README.md
@@ -20,4 +20,4 @@ Control the assets (images, videos, etc.) that can be added to the canvas.
 
 ---
 
-This example demonstrates the `<Tldraw/>` component's props that give you control over assets: which types are allowed, the maximum size, and maximum dimensions.
+This example demonstrates the `<Tldraw/>` component's props that give you control over assets: which types are allowed (image only here), the maximum size (set to 1mb), and maximum dimensions (set to none).

--- a/apps/examples/src/examples/configuration/configure-shape-util/README.md
+++ b/apps/examples/src/examples/configuration/configure-shape-util/README.md
@@ -20,4 +20,4 @@ Change the behavior of built-in shapes by setting their options.
 
 Some of the builtin tldraw shapes can be customized to behave differently based on your needs. This is done via the `ShapeUtil.configure` function which returns a new version of the shape's util class with custom options specified.
 
-You can see a shape's options by looking at the `options` property of its `ShapeUtil`. For example, the note shape's options are listed at [`NoteShapeOptions`](https://tldraw.dev/reference/tldraw/NoteShapeOptions).
+You can see a shape's options by looking at the `options` property of its `ShapeUtil`. For example, the note shape's options are listed at [`NoteShapeOptions`](https://tldraw.dev/reference/tldraw/NoteShapeOptions). In this example the note shape's options are modified so the note scales as text is added.

--- a/apps/examples/src/examples/configuration/custom-embed/CustomEmbedExample.tsx
+++ b/apps/examples/src/examples/configuration/custom-embed/CustomEmbedExample.tsx
@@ -3,7 +3,11 @@ import {
 	DEFAULT_EMBED_DEFINITIONS,
 	DefaultEmbedDefinitionType,
 	EmbedShapeUtil,
+	TLComponents,
 	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	useActions,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 
@@ -48,11 +52,32 @@ const customEmbed: CustomEmbedDefinition = {
 const embeds = [...defaultEmbedsToKeep, customEmbed]
 const shapeUtils = [EmbedShapeUtil.configure({ embedDefinitions: embeds })]
 
+// [4]
+function InsertEmbedButton() {
+	const actions = useActions()
+	const insertEmbed = actions['insert-embed']
+	return (
+		<div style={{ pointerEvents: 'all' }}>
+			<TldrawUiButton
+				type="normal"
+				onClick={() => insertEmbed.onSelect('helper-buttons')}
+				style={{ backgroundColor: '#e5e5e5' }}
+			>
+				<TldrawUiButtonLabel>Insert embed</TldrawUiButtonLabel>
+			</TldrawUiButton>
+		</div>
+	)
+}
+
+const components: TLComponents = {
+	TopPanel: InsertEmbedButton,
+}
+
 export default function CustomEmbedExample() {
 	return (
 		<div className="tldraw__editor">
-			{/* [4] */}
-			<Tldraw shapeUtils={shapeUtils} />
+			{/* [5] */}
+			<Tldraw shapeUtils={shapeUtils} components={components} />
 		</div>
 	)
 }
@@ -66,9 +91,12 @@ tldraw has built-in support for embedding content from several popular apps. In 
 We will also add support for embedding JSFiddles. Please note that you have to specify an icon that will be displayed in the `EmbedDialog` component.
 
 [3]
-We concatenate the filtered embed definitions with our custom JSFiddle one. 
+We concatenate the filtered embed definitions with our custom JSFiddle one.
 
 [4]
-We configure `EmbedShapeUtil` with our custom embed definitions and pass the configured util via `shapeUtils`.
+For convenience, we add an "Insert embed" button to the editor's top panel. It uses the `useActions` hook to trigger the built-in `insert-embed` action, which opens the same embed dialog you'd get from the menu — a quick way to see the available embed options.
+
+[5]
+We configure `EmbedShapeUtil` with our custom embed definitions and pass the configured util via `shapeUtils`. We also pass our custom `components` to render the button in the `TopPanel` slot.
 
 */

--- a/apps/examples/src/examples/configuration/deep-links/README.md
+++ b/apps/examples/src/examples/configuration/deep-links/README.md
@@ -21,34 +21,36 @@ Allow linking to specific parts of a tldraw canvas.
 
 Deep Links are URLs which point to a specific part of a document. We provide a comprehensive set of tools to help you create and manage deep links in your application.
 
-## The `deepLinks` prop
+## The `deepLinks` option
 
-The highest-level API for managing deep links is the `deepLinks` prop on the `<Tldraw />` component. This prop is designed for manipulating `window.location` to add a search param which tldraw can use to navigate to a specific part of the document.
+The highest-level API for managing deep links is the `deepLinks` option on the `<Tldraw />` component's `options` prop. This option is designed for manipulating `window.location` to add a search param which tldraw can use to navigate to a specific part of the document.
 
 e.g. `https://my-app.com/document-name?d=v1234.-234.3.21`
 
-If you set `deepLinks` to `true` e.g. `<Tldraw deepLinks />` the following default behavior will be enabled:
+If you set `deepLinks` to `true` e.g. `<Tldraw options={{ deepLinks: true }} />` the following default behavior will be enabled:
 
 1. When the editor initializes, before the initial render, it will check the current `window.location` for a search param called `d`. If found, it will try to parse the value of this param as a deep link and navigate to that part of the document.
 2. 500 milliseconds after every time the editor finishes navigating to a new part of the document, it will update `window.location` to add the latest version of the `d` param.
 
-You can customize this behavior by passing a configuration object as the `deepLinks` prop. e.g.
+You can customize this behavior by passing a configuration object as the `deepLinks` option. e.g.
 
 ```tsx
 <Tldraw
-	deepLinks={{
-		// change the param name to `page`
-		paramName: 'page',
-		// only link to the current page
-		getTarget(editor) {
-			return { type: 'page', pageId: editor.getCurrentPageId() }
+	options={{
+		deepLinks: {
+			// change the param name to `page`
+			paramName: 'page',
+			// only link to the current page
+			getTarget(editor) {
+				return { type: 'page', pageId: editor.getCurrentPageId() }
+			},
+			// log the new search params to the console instead of updating `window.location`
+			onChange(url) {
+				console.log('the new search params are', url.searchParams)
+			},
+			// set the debounce interval to 100ms instead of 500ms
+			debounceMs: 100,
 		},
-		// log the new search params to the console instead of updating `window.location`
-		onChange(url) {
-			console.log('the new search params are', url.searchParams)
-		},
-		// set the debounce interval to 100ms instead of 500ms
-		debounceMs: 100,
 	}}
 />
 ```
@@ -106,7 +108,7 @@ editor.navigateToDeepLink()
 
 ### Listening for deep link changes
 
-You can listen for deep link changes with the [`Editor#registerDeepLinkListener`](?) method, which takes the same options as the `deepLinks` prop.
+You can listen for deep link changes with the [`Editor#registerDeepLinkListener`](?) method, which takes the same options as the `deepLinks` option.
 
 ```tsx
 useEffect(() => {
@@ -125,3 +127,7 @@ useEffect(() => {
 	}
 }, [])
 ```
+
+### Trying deep links in this demo
+
+Create a shape on the canvas then pan or zoom. The `d` param in the URL will be updated. You will be able to use that deep link to return to your current view.

--- a/apps/examples/src/examples/configuration/deep-links/README.md
+++ b/apps/examples/src/examples/configuration/deep-links/README.md
@@ -130,4 +130,4 @@ useEffect(() => {
 
 ### Trying deep links in this demo
 
-Create a shape on the canvas then pan or zoom. The `d` param in the URL will be updated. You will be able to use that deep link to return to your current view.
+Create a shape on the canvas then pan or zoom. The `d` param in the URL updates as you go. Copy that URL into a new tab to return to the same view later.

--- a/apps/examples/src/examples/configuration/resize-note/README.md
+++ b/apps/examples/src/examples/configuration/resize-note/README.md
@@ -19,4 +19,4 @@ Make the note shape resizable.
 
 ---
 
-The editor's options include alternative resizing behavior for note shapes. Set `resizeMode` to either `none` for the default behavior or `scale` to allow a user to scale the note.
+The editor's options include alternative resizing behavior for note shapes. Set `resizeMode` to either `none` for the default behavior or `scale` to allow a user to scale the note. Here you can drag the note to expand it.

--- a/apps/examples/src/examples/data/assets/custom-records/CustomRecordsExample.tsx
+++ b/apps/examples/src/examples/data/assets/custom-records/CustomRecordsExample.tsx
@@ -154,6 +154,7 @@ const MarkerOverlay = track(function MarkerOverlay() {
 					background: 'white',
 					cursor: 'pointer',
 					fontSize: 14,
+					pointerEvents: 'all',
 				}}
 			>
 				+ Add marker

--- a/apps/examples/src/examples/data/assets/custom-records/CustomRecordsExample.tsx
+++ b/apps/examples/src/examples/data/assets/custom-records/CustomRecordsExample.tsx
@@ -79,23 +79,6 @@ const MarkerOverlay = track(function MarkerOverlay() {
 		.allRecords()
 		.filter((r) => isCustomRecord(MARKER_TYPE, r)) as any as Marker[]
 
-	const addMarker = useCallback(() => {
-		const label = prompt('Marker label:')
-		if (!label) return
-		const center = editor.getViewportScreenCenter()
-		const point = editor.screenToPage(center)
-		editor.store.put([
-			{
-				id: createMarkerId(),
-				typeName: MARKER_TYPE,
-				x: point.x,
-				y: point.y,
-				label,
-				icon: ICONS[Math.floor(Math.random() * ICONS.length)],
-			} as any,
-		])
-	}, [editor])
-
 	return (
 		<>
 			{markers.map((marker) => {
@@ -141,27 +124,47 @@ const MarkerOverlay = track(function MarkerOverlay() {
 					</div>
 				)
 			})}
-			<button
-				onClick={addMarker}
-				style={{
-					position: 'absolute',
-					top: 50,
-					right: 10,
-					zIndex: 1000,
-					padding: '6px 12px',
-					borderRadius: 6,
-					border: '1px solid #ccc',
-					background: 'white',
-					cursor: 'pointer',
-					fontSize: 14,
-					pointerEvents: 'all',
-				}}
-			>
-				+ Add marker
-			</button>
 		</>
 	)
 })
+
+function AddMarkerButton() {
+	const editor = useEditor()
+
+	const addMarker = useCallback(() => {
+		const label = prompt('Marker label:')
+		if (!label) return
+		const center = editor.getViewportScreenCenter()
+		const point = editor.screenToPage(center)
+		editor.store.put([
+			{
+				id: createMarkerId(),
+				typeName: MARKER_TYPE,
+				x: point.x,
+				y: point.y,
+				label,
+				icon: ICONS[Math.floor(Math.random() * ICONS.length)],
+			} as any,
+		])
+	}, [editor])
+
+	return (
+		<button
+			onClick={addMarker}
+			style={{
+				padding: '6px 12px',
+				borderRadius: 6,
+				border: '1px solid #ccc',
+				background: 'white',
+				cursor: 'pointer',
+				fontSize: 14,
+				pointerEvents: 'all',
+			}}
+		>
+			+ Add marker
+		</button>
+	)
+}
 
 // [6]
 export default function CustomRecordsExample() {
@@ -179,6 +182,7 @@ export default function CustomRecordsExample() {
 				store={store}
 				components={{
 					InFrontOfTheCanvas: MarkerOverlay,
+					TopPanel: AddMarkerButton,
 				}}
 			/>
 		</div>

--- a/apps/examples/src/examples/data/assets/export-canvas-settings/ExportCanvasImageSettingsExample.tsx
+++ b/apps/examples/src/examples/data/assets/export-canvas-settings/ExportCanvasImageSettingsExample.tsx
@@ -25,7 +25,10 @@ function ExportCanvasButton() {
 	})
 
 	// [2]
-	const [box, setBox] = useState({ x: 0, y: 0, w: 0, h: 0 })
+	const [box, setBox] = useState(() => {
+		const v = editor.getViewportPageBounds()
+		return { x: Math.round(v.x), y: Math.round(v.y), w: Math.round(v.w), h: Math.round(v.h) }
+	})
 
 	return (
 		<div
@@ -108,10 +111,9 @@ function ExportCanvasButton() {
 					const { blob } = await editor.toImage([...shapeIds], {
 						format: 'png',
 						...opts,
-						// If we have numbers for all of the box values, we can use them as bounds
-						bounds: Object.values(box).every((b) => !Number.isNaN(b))
-							? new Box(box.x, box.y, box.w, box.h)
-							: undefined,
+						// Use the box as bounds when it has a positive width and height;
+						// otherwise let the export auto-fit all shapes.
+						bounds: box.w > 0 && box.h > 0 ? new Box(box.x, box.y, box.w, box.h) : undefined,
 					})
 
 					const link = document.createElement('a')

--- a/apps/examples/src/examples/editor-api/api/APIExample.tsx
+++ b/apps/examples/src/examples/editor-api/api/APIExample.tsx
@@ -2,7 +2,6 @@ import {
 	DefaultColorStyle,
 	Editor,
 	TLGeoShape,
-	TLShapePartial,
 	Tldraw,
 	toRichText,
 	createShapeId,
@@ -13,56 +12,65 @@ import { useEffect } from 'react'
 
 // There's a guide at the bottom of this file!
 
+const STEP_MS = 1000
+const TIMELINE_MS = STEP_MS * 5
+
 //[1]
 export default function APIExample() {
 	const handleMount = (editor: Editor) => {
-		// Create a shape id
 		const id = createShapeId('hello')
 
-		// Create a shape
-		editor.createShapes([
-			{
-				id,
-				type: 'geo',
-				x: 128 + Math.random() * 500,
-				y: 128 + Math.random() * 500,
-				props: {
-					geo: 'rectangle',
-					w: 120,
-					h: 100,
-					dash: 'draw',
-					color: 'blue',
-					size: 'm',
-				},
+		// Run each API call on its own beat so a viewer can see what each one does.
+		// We include richText at creation time so the later height update isn't
+		// swallowed by the geo shape's first-label auto-sizing.
+		const steps: (() => void)[] = [
+			// 1. Create the shape
+			() => {
+				editor.createShapes([
+					{
+						id,
+						type: 'geo',
+						x: 128 + Math.random() * 500,
+						y: 128 + Math.random() * 500,
+						props: {
+							geo: 'rectangle',
+							w: 120,
+							h: 100,
+							dash: 'draw',
+							color: 'blue',
+							size: 'm',
+							richText: toRichText('hello world!'),
+						},
+					},
+				])
 			},
-		])
-
-		// Get the created shape
-		const shape = editor.getShape<TLGeoShape>(id)!
-
-		// Update the shape
-		editor.updateShape({
-			id,
-			type: 'geo',
-			props: {
-				h: shape.props.h * 3,
-				richText: toRichText('hello world!'),
+			// 2. Triple the shape's height
+			() => {
+				const shape = editor.getShape<TLGeoShape>(id)!
+				editor.updateShape({
+					id,
+					type: 'geo',
+					props: { h: shape.props.h * 3 },
+				})
 			},
-		})
+			// 3. Rotate the shape around its center
+			() => editor.rotateShapesBy([id], Math.PI / 8),
+			// 4. Zoom the camera to fit the shape
+			() => editor.zoomToFit(),
+			// 5. Select the shape
+			() => editor.select(id),
+		]
 
-		// Rotate the shape around its center
-		editor.rotateShapesBy([id], Math.PI / 8)
+		const timeouts = steps.map((step, i) => setTimeout(step, i * STEP_MS))
 
-		// Zoom the camera to fit the shape
-		editor.zoomToFit()
-
-		// Select the shape
-		editor.select(id)
+		return () => {
+			timeouts.forEach(clearTimeout)
+		}
 	}
 
 	return (
 		<div className="tldraw__editor">
-			<Tldraw persistenceKey="api-example" onMount={handleMount}>
+			<Tldraw onMount={handleMount}>
 				<InsideOfEditorContext />
 			</Tldraw>
 		</div>
@@ -75,18 +83,24 @@ const InsideOfEditorContext = () => {
 
 	useEffect(() => {
 		let i = 0
+		let interval: ReturnType<typeof setInterval> | undefined
 
-		const interval = setInterval(() => {
-			const selection = [...editor.getSelectedShapeIds()]
-			editor.selectAll()
-			editor.setStyleForSelectedShapes(DefaultColorStyle, i % 2 ? 'blue' : 'light-blue')
-			editor.setStyleForNextShapes(DefaultColorStyle, i % 2 ? 'blue' : 'light-blue')
-			editor.setSelectedShapes(selection)
-			i++
-		}, 1000)
+		// Wait until the onMount timeline finishes before starting the color cycle,
+		// so the staged setup isn't visually interrupted.
+		const start = setTimeout(() => {
+			interval = setInterval(() => {
+				const selection = [...editor.getSelectedShapeIds()]
+				editor.selectAll()
+				editor.setStyleForSelectedShapes(DefaultColorStyle, i % 2 ? 'blue' : 'light-blue')
+				editor.setStyleForNextShapes(DefaultColorStyle, i % 2 ? 'blue' : 'light-blue')
+				editor.setSelectedShapes(selection)
+				i++
+			}, STEP_MS)
+		}, TIMELINE_MS)
 
 		return () => {
-			clearInterval(interval)
+			clearTimeout(start)
+			if (interval) clearInterval(interval)
 		}
 	}, [editor])
 
@@ -107,12 +121,18 @@ There are two main ways to use the editor:
 [1]
 The tldraw component shares its editor instance via its onMount callback prop.
 When you define a function for the onMount callback, it receives the editor
-instance as an argument. You can use this to manipulate the canvas.
+instance as an argument. We schedule each API call on its own beat so a viewer
+can see the effect of every step: creating the shape, updating its height,
+rotating it, zooming the camera, and selecting it. The cleanup function
+returned from onMount cancels any pending steps if the editor unmounts.
 
 
 [2]
 Another (sneakier) way to access the current app is through React context.
 The Tldraw component provides the context, so you can add children to
-the component and access the app through the useEditor hook. This is cool.
+the component and access the app through the useEditor hook. Once the timeline
+above finishes, this child component takes over and demonstrates a couple more
+API calls — setStyleForSelectedShapes and setStyleForNextShapes — by cycling
+the shape's color.
 
 */

--- a/apps/examples/src/examples/editor-api/custom-clipping-shape/README.md
+++ b/apps/examples/src/examples/editor-api/custom-clipping-shape/README.md
@@ -16,8 +16,6 @@ keywords:
   ]
 ---
 
-# Custom clipping shape example
-
 This example demonstrates the extensible clipping system in tldraw, showing how to create custom shapes that can clip their children with any polygon geometry.
 
 ## Key implementation details

--- a/apps/examples/src/examples/editor-api/lock-camera-zoom/README.md
+++ b/apps/examples/src/examples/editor-api/lock-camera-zoom/README.md
@@ -22,4 +22,4 @@ Lock the camera at a specific zoom level.
 
 Need to lock the camera at its current zoom level? You can use the camera controls API to keep the zoom level from changing.
 
-In this example, press Shift+K to lock the camera at its current zoom level. Press Shift+L to unlock the camera and allow it to zoom again.
+In this example, press Shift+K to lock the camera at its current zoom level. Press Shift+K again to unlock the camera and allow it to zoom again.

--- a/apps/examples/src/examples/ui/changing-default-colors/README.md
+++ b/apps/examples/src/examples/ui/changing-default-colors/README.md
@@ -20,6 +20,6 @@ Change the tldraw theme colors.
 
 ---
 
-While there's currently no way to add or remove our colors from our default shapes' colors, this example shows how you can adjust the values for the default color styles.
+Use `editor.updateTheme()` to override values in the default color palette.
 
-Note that this will change the colors for ALL instances of tldraw. For example, if you run this example locally, and then open another example, the changes will be present there too until you reload!
+To add or remove colors, or to register additional named themes, see the custom theme and multiple themes examples.

--- a/apps/examples/src/examples/ui/color-picker/ColorPickerExample.tsx
+++ b/apps/examples/src/examples/ui/color-picker/ColorPickerExample.tsx
@@ -1,0 +1,446 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+	DEFAULT_THEME,
+	DefaultColorStyle,
+	DefaultFontStyle,
+	Editor,
+	TLDefaultColor,
+	TLTheme,
+	TLThemeFont,
+	TLThemes,
+	TLUiOverrides,
+	Tldraw,
+	registerColorsFromThemes,
+	registerFontsFromThemes,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './color-picker.css'
+
+// [1] Pre-declare slot names for custom colors and fonts. The runtime only
+// fills the slots the user has actually added, but TypeScript needs concrete
+// keys to compute `TLDefaultColorStyle` / `TLDefaultFontStyle`.
+const MAX_CUSTOM_COLORS = 20
+const MAX_CUSTOM_FONTS = 10
+
+type CustomColorKey =
+	| 'custom-1'
+	| 'custom-2'
+	| 'custom-3'
+	| 'custom-4'
+	| 'custom-5'
+	| 'custom-6'
+	| 'custom-7'
+	| 'custom-8'
+	| 'custom-9'
+	| 'custom-10'
+	| 'custom-11'
+	| 'custom-12'
+	| 'custom-13'
+	| 'custom-14'
+	| 'custom-15'
+	| 'custom-16'
+	| 'custom-17'
+	| 'custom-18'
+	| 'custom-19'
+	| 'custom-20'
+
+type CustomFontKey =
+	| 'gf-1'
+	| 'gf-2'
+	| 'gf-3'
+	| 'gf-4'
+	| 'gf-5'
+	| 'gf-6'
+	| 'gf-7'
+	| 'gf-8'
+	| 'gf-9'
+	| 'gf-10'
+
+declare module '@tldraw/tlschema' {
+	interface TLThemeDefaultColors {
+		'custom-1': TLDefaultColor
+		'custom-2': TLDefaultColor
+		'custom-3': TLDefaultColor
+		'custom-4': TLDefaultColor
+		'custom-5': TLDefaultColor
+		'custom-6': TLDefaultColor
+		'custom-7': TLDefaultColor
+		'custom-8': TLDefaultColor
+		'custom-9': TLDefaultColor
+		'custom-10': TLDefaultColor
+		'custom-11': TLDefaultColor
+		'custom-12': TLDefaultColor
+		'custom-13': TLDefaultColor
+		'custom-14': TLDefaultColor
+		'custom-15': TLDefaultColor
+		'custom-16': TLDefaultColor
+		'custom-17': TLDefaultColor
+		'custom-18': TLDefaultColor
+		'custom-19': TLDefaultColor
+		'custom-20': TLDefaultColor
+	}
+	interface TLThemeFonts {
+		'gf-1': TLThemeFont
+		'gf-2': TLThemeFont
+		'gf-3': TLThemeFont
+		'gf-4': TLThemeFont
+		'gf-5': TLThemeFont
+		'gf-6': TLThemeFont
+		'gf-7': TLThemeFont
+		'gf-8': TLThemeFont
+		'gf-9': TLThemeFont
+		'gf-10': TLThemeFont
+	}
+}
+
+interface GoogleFont {
+	name: string
+	family: string
+}
+const GOOGLE_FONTS: GoogleFont[] = [
+	{ name: 'Roboto', family: "'Roboto', sans-serif" },
+	{ name: 'Lato', family: "'Lato', sans-serif" },
+	{ name: 'Open Sans', family: "'Open Sans', sans-serif" },
+	{ name: 'Montserrat', family: "'Montserrat', sans-serif" },
+	{ name: 'Raleway', family: "'Raleway', sans-serif" },
+	{ name: 'Oswald', family: "'Oswald', sans-serif" },
+	{ name: 'Playfair Display', family: "'Playfair Display', serif" },
+	{ name: 'Merriweather', family: "'Merriweather', serif" },
+	{ name: 'Pacifico', family: "'Pacifico', cursive" },
+	{ name: 'Caveat', family: "'Caveat', cursive" },
+	{ name: 'Permanent Marker', family: "'Permanent Marker', cursive" },
+	{ name: 'Bebas Neue', family: "'Bebas Neue', sans-serif" },
+]
+
+// [2] Fan a single hex onto every role in TLDefaultColor. The theme renderer
+// reads different roles for different contexts (outline vs fill vs note
+// background); we use the picked hex for all of them plus a translucent
+// variant for the semi fills.
+function makeColor(solid: string): TLDefaultColor {
+	const translucent = solid + '33'
+	return {
+		solid,
+		semi: translucent,
+		pattern: solid,
+		fill: solid,
+		linedFill: translucent,
+		frameHeadingStroke: solid,
+		frameHeadingFill: translucent,
+		frameStroke: solid,
+		frameFill: translucent,
+		frameText: solid,
+		noteFill: translucent,
+		noteText: solid,
+		highlightSrgb: solid,
+		highlightP3: solid,
+	}
+}
+
+function makeFontEntry(family: string): TLThemeFont {
+	return {
+		fontFamily: family,
+		icon: <div style={{ fontFamily: family, fontSize: 16, lineHeight: 1 }}>Aa</div>,
+	}
+}
+
+const customColorTranslations: Record<string, string> = {}
+for (let i = 1; i <= MAX_CUSTOM_COLORS; i++) {
+	customColorTranslations[`color-style.custom-${i}`] = `Custom ${i}`
+}
+const customFontTranslations: Record<string, string> = {}
+for (let i = 1; i <= MAX_CUSTOM_FONTS; i++) {
+	customFontTranslations[`font-style.gf-${i}`] = `Google font ${i}`
+}
+const uiOverrides: TLUiOverrides = {
+	translations: {
+		en: { ...customColorTranslations, ...customFontTranslations },
+	},
+}
+
+// [3] Inject one <link> loading every curated Google Font family, so dropdown
+// previews render in the right typeface and canvas text picks up the family
+// once it's registered in the theme.
+let googleFontsLoaded = false
+function ensureGoogleFontsLoaded() {
+	if (googleFontsLoaded) return
+	googleFontsLoaded = true
+	const families = GOOGLE_FONTS.map((f) => `family=${f.name.replace(/ /g, '+')}`).join('&')
+	const link = document.createElement('link')
+	link.rel = 'stylesheet'
+	link.href = `https://fonts.googleapis.com/css2?${families}&display=swap`
+	document.head.appendChild(link)
+}
+
+export default function ColorPickerExample() {
+	const [customHexes, setCustomHexes] = useState<string[]>([])
+	const [customFonts, setCustomFonts] = useState<GoogleFont[]>([])
+	const [editor, setEditor] = useState<Editor | null>(null)
+	const prevColorCountRef = useRef(0)
+	const prevFontCountRef = useRef(0)
+
+	// [4] Imperative theme updates. Mutating the `themes` prop on <Tldraw>
+	// re-renders the whole editor tree and causes a visible flash. Calling
+	// `registerColorsFromThemes` + `editor.updateTheme` directly updates the
+	// style enum and theme atom in place — the style panel and affected shapes
+	// repaint reactively without remounting anything.
+	useEffect(() => {
+		if (!editor) return
+		const theme = buildTheme(customHexes, customFonts)
+		const themes = { default: theme } as TLThemes
+		registerColorsFromThemes(themes)
+		registerFontsFromThemes(themes)
+		editor.updateTheme(theme)
+
+		// [5] If this render added a new slot and the user has shapes selected,
+		// push the new slot onto the selection. We do this inside the effect
+		// (rather than in the click handler) so the enum is already updated by
+		// `registerColorsFromThemes` — setting an unknown value on a shape
+		// would throw.
+		const hasSelection = editor.getSelectedShapeIds().length > 0
+		if (hasSelection && customHexes.length > prevColorCountRef.current) {
+			const key = `custom-${customHexes.length}` as CustomColorKey
+			editor.setStyleForSelectedShapes(DefaultColorStyle, key)
+		}
+		if (hasSelection && customFonts.length > prevFontCountRef.current) {
+			const key = `gf-${customFonts.length}` as CustomFontKey
+			// The static type of DefaultFontStyle is narrowed to the four
+			// built-in fonts; we registered the runtime value ourselves above.
+			editor.setStyleForSelectedShapes(DefaultFontStyle, key as 'draw')
+		}
+
+		prevColorCountRef.current = customHexes.length
+		prevFontCountRef.current = customFonts.length
+	}, [editor, customHexes, customFonts])
+
+	const addColor = (hex: string) => {
+		setCustomHexes((prev) => (prev.length >= MAX_CUSTOM_COLORS ? prev : [...prev, hex]))
+	}
+
+	const addFont = (font: GoogleFont) => {
+		setCustomFonts((prev) => {
+			if (prev.length >= MAX_CUSTOM_FONTS) return prev
+			if (prev.some((f) => f.family === font.family)) return prev
+			return [...prev, font]
+		})
+	}
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw persistenceKey="color-picker-example" overrides={uiOverrides} onMount={setEditor}>
+				<div className="color-picker-toolbar" onPointerDown={(e) => e.stopPropagation()}>
+					<AddColorButton addColor={addColor} isFull={customHexes.length >= MAX_CUSTOM_COLORS} />
+					<AddFontButton
+						addedFamilies={customFonts.map((f) => f.family)}
+						addFont={addFont}
+						isFull={customFonts.length >= MAX_CUSTOM_FONTS}
+					/>
+				</div>
+			</Tldraw>
+		</div>
+	)
+}
+
+function buildTheme(hexes: string[], fonts: GoogleFont[]): TLTheme {
+	const lightColors = { ...DEFAULT_THEME.colors.light } as TLTheme['colors']['light']
+	const darkColors = { ...DEFAULT_THEME.colors.dark } as TLTheme['colors']['dark']
+	for (let i = 0; i < hexes.length; i++) {
+		const key = `custom-${i + 1}` as CustomColorKey
+		const entry = makeColor(hexes[i])
+		lightColors[key] = entry
+		darkColors[key] = entry
+	}
+
+	const themeFonts = { ...DEFAULT_THEME.fonts } as TLTheme['fonts']
+	for (let i = 0; i < fonts.length; i++) {
+		const key = `gf-${i + 1}` as CustomFontKey
+		themeFonts[key] = makeFontEntry(fonts[i].family)
+	}
+
+	return {
+		...DEFAULT_THEME,
+		id: 'default',
+		colors: { light: lightColors, dark: darkColors },
+		fonts: themeFonts,
+	}
+}
+
+// [6] Color add flow — the native picker opens immediately on "+ Add color".
+// The picker fires onChange continuously while dragging, so we stage a preview
+// and only commit on the explicit Add button.
+function AddColorButton({ addColor, isFull }: { addColor(hex: string): void; isFull: boolean }) {
+	const [isStaging, setIsStaging] = useState(false)
+	const [staged, setStaged] = useState(() => randomHex())
+	const inputRef = useRef<HTMLInputElement>(null)
+
+	const open = () => {
+		setStaged(randomHex())
+		setIsStaging(true)
+		inputRef.current?.click()
+	}
+	const reopen = () => inputRef.current?.click()
+	const commit = () => {
+		addColor(staged)
+		setIsStaging(false)
+	}
+	const cancel = () => setIsStaging(false)
+
+	return (
+		<div className="color-picker-add-color">
+			<input
+				ref={inputRef}
+				type="color"
+				value={staged}
+				onChange={(e) => setStaged(e.target.value)}
+				className="color-picker-add-color__input"
+				aria-hidden
+				tabIndex={-1}
+			/>
+			{isStaging ? (
+				<div className="color-picker-add-color__staging">
+					<button
+						type="button"
+						className="color-picker-add-color__swatch"
+						style={{ background: staged }}
+						onClick={reopen}
+						aria-label="Change color"
+					/>
+					<span className="color-picker-add-color__hex">{staged.toUpperCase()}</span>
+					<button className="color-picker-button color-picker-button--primary" onClick={commit}>
+						Add
+					</button>
+					<button
+						className="color-picker-button color-picker-button--icon"
+						onClick={cancel}
+						aria-label="Cancel"
+					>
+						×
+					</button>
+				</div>
+			) : (
+				<button
+					className="color-picker-button"
+					disabled={isFull}
+					onClick={open}
+					title={isFull ? `Custom color slots full (${MAX_CUSTOM_COLORS})` : 'Add a custom color'}
+				>
+					+ Add color
+				</button>
+			)}
+		</div>
+	)
+}
+
+// [7] Font add flow — dropdown of curated Google Fonts. Selection is atomic
+// (one click = one commit), so no staging needed. Already-added fonts are
+// shown but disabled.
+function AddFontButton({
+	addedFamilies,
+	addFont,
+	isFull,
+}: {
+	addedFamilies: string[]
+	addFont(font: GoogleFont): void
+	isFull: boolean
+}) {
+	const [isOpen, setIsOpen] = useState(false)
+	const containerRef = useRef<HTMLDivElement>(null)
+
+	const open = () => {
+		ensureGoogleFontsLoaded()
+		setIsOpen(true)
+	}
+	const close = () => setIsOpen(false)
+
+	useEffect(() => {
+		if (!isOpen) return
+		const handler = (e: MouseEvent) => {
+			if (!containerRef.current?.contains(e.target as Node)) close()
+		}
+		document.addEventListener('mousedown', handler)
+		return () => document.removeEventListener('mousedown', handler)
+	}, [isOpen])
+
+	return (
+		<div className="color-picker-add-font" ref={containerRef}>
+			<button
+				className="color-picker-button"
+				disabled={isFull}
+				onClick={() => (isOpen ? close() : open())}
+				title={isFull ? `Custom font slots full (${MAX_CUSTOM_FONTS})` : 'Add a Google font'}
+			>
+				+ Add font
+			</button>
+			{isOpen && (
+				<div className="color-picker-font-dropdown">
+					{GOOGLE_FONTS.map((font) => {
+						const alreadyAdded = addedFamilies.includes(font.family)
+						return (
+							<button
+								key={font.name}
+								className="color-picker-font-dropdown__item"
+								disabled={alreadyAdded}
+								onClick={() => {
+									addFont(font)
+									close()
+								}}
+							>
+								<span style={{ fontFamily: font.family }}>{font.name}</span>
+								{alreadyAdded && <span className="color-picker-font-dropdown__added">Added</span>}
+							</button>
+						)
+					})}
+				</div>
+			)}
+		</div>
+	)
+}
+
+function randomHex(): string {
+	const hue = Math.floor(Math.random() * 360)
+	return hslToHex(hue, 70, 55)
+}
+
+function hslToHex(h: number, s: number, l: number): string {
+	const sNorm = s / 100
+	const lNorm = l / 100
+	const k = (n: number) => (n + h / 30) % 12
+	const a = sNorm * Math.min(lNorm, 1 - lNorm)
+	const f = (n: number) =>
+		Math.round(255 * (lNorm - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)))))
+	const toHex = (v: number) => v.toString(16).padStart(2, '0')
+	return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`
+}
+
+/*
+
+[1]
+Module augmentation needs concrete property names, so we pre-declare every
+possible slot up front. Only the ones the user actually adds land in the
+theme at runtime.
+
+[3]
+The link tag is lazily added on the first "+ Add font" open. Subsequent opens
+reuse the already-loaded CSS. We use a module-level flag instead of React
+state because the tag only needs to exist once in the document — remounting
+the example shouldn't add it again.
+
+[4]
+Before: we passed custom colors and fonts through the `themes` prop, which
+meant every state change rebuilt the prop, re-rendered `TldrawEditor`, and
+caused a visible flash. Now the `themes` prop is omitted entirely; we
+imperatively register + update the theme from an effect. The style panel
+enum and the theme atom both update in place.
+
+[5]
+When the user adds a style while a shape is selected, we push the new slot
+onto the selection immediately via `queueMicrotask`. The microtask runs after
+the React commit and the effect in [4], so by the time we call
+`setStyleForSelectedShapes`, `DefaultColorStyle` / `DefaultFontStyle` already
+contains the new slot (otherwise the enum validator would reject it).
+
+Removal of custom slots is intentionally not supported:
+`registerColorsFromThemes` / `registerFontsFromThemes` strip entries that are
+absent from the theme, which would invalidate any shape still naming the
+removed slot.
+
+*/

--- a/apps/examples/src/examples/ui/color-picker/README.md
+++ b/apps/examples/src/examples/ui/color-picker/README.md
@@ -1,0 +1,12 @@
+---
+title: Color picker
+component: ./ColorPickerExample.tsx
+priority: 3
+keywords: [color, picker, theme, palette, custom, fonts]
+---
+
+Add custom colors and fonts to the theme palette at runtime.
+
+---
+
+A toolbar in the top-left adds new entries to the editor's color palette via a native color picker, and to the font palette via a curated Google Fonts dropdown. Each new entry shows up immediately in the style panel and applies to any selected shape. New colors and fonts are wired into the theme via `registerColorsFromThemes` / `registerFontsFromThemes` and `editor.updateTheme()`, so the style enum and theme atom update in place — no editor remount.

--- a/apps/examples/src/examples/ui/color-picker/color-picker.css
+++ b/apps/examples/src/examples/ui/color-picker/color-picker.css
@@ -1,0 +1,136 @@
+.color-picker-toolbar {
+	position: absolute;
+	top: 56px;
+	left: 8px;
+	display: flex;
+	gap: 8px;
+	pointer-events: all;
+	z-index: 300;
+}
+
+.color-picker-button {
+	padding: 6px 10px;
+	font-size: 12px;
+	font-weight: 500;
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 8px;
+	background: var(--tl-color-panel);
+	color: var(--tl-color-text);
+	cursor: pointer;
+	box-shadow: var(--tl-shadow-1);
+	line-height: 1;
+}
+
+.color-picker-button:hover:not(:disabled) {
+	background: var(--tl-color-muted-2);
+}
+
+.color-picker-button:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.color-picker-button--primary {
+	background: var(--tl-color-selected);
+	color: var(--tl-color-selected-contrast);
+	border-color: var(--tl-color-selected);
+}
+
+.color-picker-button--primary:hover:not(:disabled) {
+	filter: brightness(1.08);
+	background: var(--tl-color-selected);
+}
+
+.color-picker-button--icon {
+	padding: 4px 8px;
+	font-size: 14px;
+}
+
+.color-picker-add-color {
+	position: relative;
+}
+
+.color-picker-add-color__input {
+	position: absolute;
+	inset: 0;
+	opacity: 0;
+	pointer-events: none;
+}
+
+.color-picker-add-color__staging {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px;
+	background: var(--tl-color-panel);
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 10px;
+	box-shadow: var(--tl-shadow-1);
+}
+
+.color-picker-add-color__swatch {
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 6px;
+	cursor: pointer;
+}
+
+.color-picker-add-color__hex {
+	font-family: var(--tl-font-mono, monospace);
+	font-size: 11px;
+	color: var(--tl-color-text);
+	min-width: 64px;
+}
+
+.color-picker-add-font {
+	position: relative;
+}
+
+.color-picker-font-dropdown {
+	position: absolute;
+	top: calc(100% + 4px);
+	left: 0;
+	min-width: 200px;
+	max-height: 320px;
+	overflow-y: auto;
+	background: var(--tl-color-panel);
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 10px;
+	box-shadow: var(--tl-shadow-2);
+	padding: 4px;
+	display: flex;
+	flex-direction: column;
+}
+
+.color-picker-font-dropdown__item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 8px 10px;
+	font-size: 14px;
+	background: transparent;
+	border: none;
+	border-radius: 6px;
+	color: var(--tl-color-text);
+	cursor: pointer;
+	text-align: left;
+}
+
+.color-picker-font-dropdown__item:hover:not(:disabled) {
+	background: var(--tl-color-muted-2);
+}
+
+.color-picker-font-dropdown__item:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.color-picker-font-dropdown__added {
+	font-size: 10px;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: var(--tl-color-text-3);
+}

--- a/apps/examples/src/examples/ui/custom-ui/CustomUiExample.tsx
+++ b/apps/examples/src/examples/ui/custom-ui/CustomUiExample.tsx
@@ -22,6 +22,11 @@ const CustomUi = track(() => {
 
 	useEffect(() => {
 		const handleKeyUp = (e: KeyboardEvent) => {
+			if (editor.getEditingShapeId() !== null) return
+			const target = e.target as HTMLElement | null
+			if (target?.isContentEditable) return
+			if (target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA') return
+
 			switch (e.key) {
 				case 'Delete':
 				case 'Backspace': {

--- a/apps/examples/src/examples/ui/dark-mode/DarkModeExample.tsx
+++ b/apps/examples/src/examples/ui/dark-mode/DarkModeExample.tsx
@@ -1,10 +1,20 @@
-import { Tldraw } from 'tldraw'
+import { atom, TLUserPreferences, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
+
+const userPreferences = atom<TLUserPreferences>('dark-mode-example-prefs', {
+	id: 'dark-mode-example',
+	colorScheme: 'dark',
+})
+
+const user = {
+	userPreferences,
+	setUserPreferences: (prefs: TLUserPreferences) => userPreferences.set(prefs),
+}
 
 export default function DarkModeExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw colorScheme="dark" />
+			<Tldraw user={user} />
 		</div>
 	)
 }

--- a/apps/examples/src/examples/ui/indicators-logic/IndicatorsLogicExample.tsx
+++ b/apps/examples/src/examples/ui/indicators-logic/IndicatorsLogicExample.tsx
@@ -1,35 +1,38 @@
-import { Tldraw } from 'tldraw'
+import { ShapeIndicatorOverlayUtil, TLShapeIndicatorOverlay, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
-// Shape indicators are now rendered automatically on the canvas overlay system.
-// Selected and hovered shapes show indicators without any custom component setup.
+// There's a guide at the bottom of this file!
+
+// [1]
+class AllShapesIndicatorOverlayUtil extends ShapeIndicatorOverlayUtil {
+	override getOverlays(): TLShapeIndicatorOverlay[] {
+		const ids = this.editor.getRenderingShapes().map((s) => s.id)
+		if (ids.length === 0) return []
+		return [
+			{
+				id: 'shape_indicator',
+				type: 'shape_indicator',
+				props: { idsToDisplay: ids, hintingShapeIds: [] },
+			},
+		]
+	}
+}
+
+// [2]
+const overlayUtils = [AllShapesIndicatorOverlayUtil]
+
 export default function IndicatorsLogicExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
+				overlayUtils={overlayUtils}
 				onMount={(editor) => {
 					if (editor.getCurrentPageShapeIds().size === 0) {
 						editor.createShapes([
-							{
-								type: 'geo',
-								x: 100,
-								y: 100,
-							},
-							{
-								type: 'geo',
-								x: 500,
-								y: 150,
-							},
-							{
-								type: 'geo',
-								x: 100,
-								y: 500,
-							},
-							{
-								type: 'geo',
-								x: 500,
-								y: 500,
-							},
+							{ type: 'geo', x: 100, y: 100 },
+							{ type: 'geo', x: 500, y: 150 },
+							{ type: 'geo', x: 100, y: 500 },
+							{ type: 'geo', x: 500, y: 500 },
 						])
 					}
 				}}
@@ -37,3 +40,18 @@ export default function IndicatorsLogicExample() {
 		</div>
 	)
 }
+
+/*
+
+[1]
+We subclass `ShapeIndicatorOverlayUtil` and override `getOverlays()` to
+return every shape currently being rendered on the canvas, instead of the
+default rule (selected / hovered only). Filter the list of ids if you only
+want indicators on specific shapes.
+
+[2]
+Pass our custom util via the `overlayUtils` prop. Because it inherits the
+same `static type` as the built-in (`'shape_indicator'`), it replaces the
+default util rather than running alongside it.
+
+*/

--- a/apps/examples/src/examples/ui/menu-system-hover/MenuSystemHoverExample.tsx
+++ b/apps/examples/src/examples/ui/menu-system-hover/MenuSystemHoverExample.tsx
@@ -67,11 +67,9 @@ function HoverControlledMenu() {
 export default function MenuSystemHoverExample() {
 	return (
 		<div className="tldraw__editor">
-			<Tldraw
-				components={{
-					InFrontOfTheCanvas: HoverControlledMenu,
-				}}
-			/>
+			<Tldraw>
+				<HoverControlledMenu />
+			</Tldraw>
 		</div>
 	)
 }

--- a/apps/examples/src/examples/ui/remove-tool/README.md
+++ b/apps/examples/src/examples/ui/remove-tool/README.md
@@ -18,4 +18,4 @@ You can remove a tool from the user interface.
 
 ---
 
-Using overrides, you can remove a tool from the toolbar, keyboard shortcuts, and other parts of the user interface. The tool will still be present in the application but not accessible to the user.
+Using overrides, you can remove a tool from the toolbar, keyboard shortcuts, and other parts of the user interface. The tool will still be present in the application but not accessible to the user. Here we remove the text tool.

--- a/apps/examples/src/examples/ui/selection-color-condition/SelectionColorConditionExample.tsx
+++ b/apps/examples/src/examples/ui/selection-color-condition/SelectionColorConditionExample.tsx
@@ -1,24 +1,22 @@
-import { Tldraw, react } from 'tldraw'
+import { DEFAULT_THEME, TLTheme, Tldraw, react, structuredClone } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file!
 
 // [1]
+const RECTANGLE_SELECTION_THEME: TLTheme = structuredClone(DEFAULT_THEME)
+RECTANGLE_SELECTION_THEME.colors.light.selectionStroke = '#cc0000'
+RECTANGLE_SELECTION_THEME.colors.light.selectionFill = 'rgba(255, 68, 68, 0.24)'
+RECTANGLE_SELECTION_THEME.colors.dark.selectionStroke = '#ff4444'
+RECTANGLE_SELECTION_THEME.colors.dark.selectionFill = 'rgba(255, 68, 68, 0.32)'
+
 export default function SelectionColorConditionExample() {
 	return (
 		<div className="tldraw__editor">
-			<style>{`
-				/* Custom selection color for rectangle shapes */
-				.tl-container.rectangle-selection {
-					--tl-color-selection: #ff4444;
-					--tl-color-selection-stroke: #cc0000;
-				}
-			`}</style>
-
 			<Tldraw
 				onMount={(editor) => {
 					// [2]
-					const stopListening = react('update selection classname', () => {
+					const stopListening = react('update selection theme', () => {
 						const selectedShapes = editor.getSelectedShapes()
 
 						// [3]
@@ -29,11 +27,10 @@ export default function SelectionColorConditionExample() {
 							)
 
 						// [4]
-						if (allAreRectangles) {
-							editor.getContainer().classList.add('rectangle-selection')
-						} else {
-							editor.getContainer().classList.remove('rectangle-selection')
-						}
+						editor.updateTheme({
+							...(allAreRectangles ? RECTANGLE_SELECTION_THEME : DEFAULT_THEME),
+							id: 'default',
+						})
 					})
 
 					// [5]
@@ -58,26 +55,27 @@ export default function SelectionColorConditionExample() {
 Introduction:
 
 This example shows how to change the selection color based on the types of shapes selected.
-When all selected shapes are rectangles, the selection will appear red instead of the default blue.
+When all selected shapes are rectangles, the selection appears red instead of the default blue.
 
 [1]
-We use the onMount prop to set up our selection listener when the editor is first mounted.
+We define an alternative theme by cloning DEFAULT_THEME and overriding the
+`selectionStroke` and `selectionFill` colors for both light and dark modes.
+Selection colors live on the theme since the v5 overlay system; the CSS
+variables that previously controlled them no longer affect canvas overlays.
 
 [2]
-We use the react function to create a reactive effect that runs whenever the selection changes.
-The first parameter is a unique name for this effect, and the second is a function that will
-be called whenever the selection updates.
+We use react() inside onMount to subscribe to changes in the selection.
+The first parameter is a unique name for this effect, and the second is a
+function that will be called whenever any signals it reads change.
 
 [3]
-Here we check if all selected shapes are rectangle geo shapes. You can customize this condition
-to check for any shape type or combination. For example:
-- Check for circles: shape.type === 'geo' && shape.props.geo === 'ellipse'
-- Check for text: shape.type === 'text'
-- Check for mixed types: shape.type === 'geo' && (shape.props.geo === 'rectangle' || shape.props.geo === 'ellipse')
+Here we check if all selected shapes are rectangle geo shapes. You can
+customize this condition to check for any shape type or combination.
 
 [4]
-Based on our condition, we add or remove a CSS class from the editor's container. The CSS
-file (selection-color-condition.css) defines the custom colors for the .rectangle-selection class.
+Swap the editor's default theme between the red variant and the original
+based on the condition. updateTheme() updates only this editor's
+ThemeManager, so the global DEFAULT_THEME stays untouched.
 
 [5]
 We create some shapes to test our condition.

--- a/apps/examples/src/examples/use-cases/custom-shape-mermaids/README.md
+++ b/apps/examples/src/examples/use-cases/custom-shape-mermaids/README.md
@@ -1,12 +1,14 @@
 ---
-title: Mermaid sequential pipeline with custom shapes
+title: Customize Mermaid diagrams
 component: ./CustomShapeMermaids.tsx
 priority: 10
 keywords: [mermaid, diagram, custom, pipeline, workflow]
 ---
 
-Paste a Mermaid **flowchart** or **graph**, run a simulated CI-style **DAG** on the nodes (merge = wait for all parents), and retry failed steps from the canvas.
+You can change the nodes and vertices in a Mermaid diagram for custom rendering and use for interactive diagramming.
 
 ---
 
 This example accepts **flowchart / graph** source only (validated before import). It uses `@tldraw/mermaid` with `blueprintRender.mapNodeToRenderSpec` so vertices become custom `flowchart-util` shapes with `mermaidNodeId`. After import, **edges** must form a **DAG** (no cycles). Step **schedule** follows **AND-join** semantics: a node runs when all its predecessors have **passed**. **Step badges** are **Kahn layers** (same layer = same badge number). The graph is read from **tldraw arrow bindings** (`extractFlowchartPipelineFromEditor`), not from parsing edge syntax in the text box.
+
+Here we animate a CI/CD pipeline with random failures which you can trigger retries for.

--- a/apps/examples/src/examples/use-cases/hundred-mermaids/README.md
+++ b/apps/examples/src/examples/use-cases/hundred-mermaids/README.md
@@ -5,8 +5,8 @@ priority: 10
 keywords: [mermaid, diagram]
 ---
 
-A use case of all the supported and tested mermaid diagrams our tldraw/mermaid package can support so far.
+Render Mermaid flowcharts, state diagrams, mind maps, and sequence diagrams as tldraw shapes.
 
 ---
 
-This example shows how to import mermaid diagrams and translate them to tldraw shapes
+This example shows how to take mermaid diagrams and translate them to tldraw shapes.

--- a/apps/examples/src/examples/users/attribution/AttributionExample.tsx
+++ b/apps/examples/src/examples/users/attribution/AttributionExample.tsx
@@ -155,6 +155,8 @@ function attributionSummary(editor: { store: { props: { users: TLUserStore } } }
 }
 
 // [6]
+const ALLOWED_TOOLS = new Set(['select', 'note'])
+
 export default function AttributionExample() {
 	return (
 		<div className="tldraw__editor">
@@ -164,6 +166,14 @@ export default function AttributionExample() {
 				components={{
 					TopPanel: UserSwitcher,
 					SharePanel: AttributionPanel,
+				}}
+				overrides={{
+					tools: (_editor, tools) => {
+						for (const id of Object.keys(tools)) {
+							if (!ALLOWED_TOOLS.has(id)) delete tools[id]
+						}
+						return tools
+					},
 				}}
 			/>
 		</div>

--- a/apps/examples/src/examples/users/attribution/AttributionExample.tsx
+++ b/apps/examples/src/examples/users/attribution/AttributionExample.tsx
@@ -177,12 +177,11 @@ export default function AttributionExample() {
 				onMount={(editor) => {
 					const stampWithCurrentUser = (shape: TLShape) => {
 						if (typeof shape.meta.createdBy === 'string') return shape
-						const currentUser = editor.store.props.users.currentUser.get()
-						if (!currentUser) return shape
-						return { ...shape, meta: { ...shape.meta, createdBy: currentUser.id } }
+						const userId = editor.getAttributionUserId()
+						if (!userId) return shape
+						return { ...shape, meta: { ...shape.meta, createdBy: userId } }
 					}
 
-					// Backfill any persisted shapes that pre-date the side effect below.
 					const toBackfill = editor
 						.getCurrentPageShapes()
 						.filter((s) => typeof s.meta.createdBy !== 'string')

--- a/apps/examples/src/examples/users/attribution/AttributionExample.tsx
+++ b/apps/examples/src/examples/users/attribution/AttributionExample.tsx
@@ -123,6 +123,12 @@ function AttributionPanel() {
 						<span className="attribution-label">Type</span>
 						<span>{info.type}</span>
 					</div>
+					{info.createdByName && (
+						<div className="attribution-row">
+							<span className="attribution-label">Created by</span>
+							<span style={{ color: info.createdByColor }}>{info.createdByName}</span>
+						</div>
+					)}
 					{info.textFirstEditedByName && (
 						<div className="attribution-row">
 							<span className="attribution-label">Text first edited by</span>
@@ -141,6 +147,11 @@ function AttributionPanel() {
 
 // [5]
 function attributionSummary(editor: { store: { props: { users: TLUserStore } } }, shape: TLShape) {
+	const createdBy = typeof shape.meta.createdBy === 'string' ? shape.meta.createdBy : null
+	const createdByUser = createdBy
+		? (editor.store.props.users.resolve?.(createdBy).get() ?? null)
+		: null
+
 	const noteProps = shape.type === 'note' ? (shape as TLNoteShape).props : null
 	const textFirstEditedBy = noteProps?.textFirstEditedBy ?? null
 	const textFirstEditedByUser = textFirstEditedBy
@@ -149,31 +160,42 @@ function attributionSummary(editor: { store: { props: { users: TLUserStore } } }
 
 	return {
 		type: shape.type,
+		createdByName: createdByUser?.name ?? null,
+		createdByColor: createdByUser?.color,
 		textFirstEditedByName: textFirstEditedByUser?.name ?? null,
 		textFirstEditedByColor: textFirstEditedByUser?.color,
 	}
 }
 
 // [6]
-const ALLOWED_TOOLS = new Set(['select', 'note'])
-
 export default function AttributionExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
 				persistenceKey="attribution-example"
 				users={users}
+				onMount={(editor) => {
+					const stampWithCurrentUser = (shape: TLShape) => {
+						if (typeof shape.meta.createdBy === 'string') return shape
+						const currentUser = editor.store.props.users.currentUser.get()
+						if (!currentUser) return shape
+						return { ...shape, meta: { ...shape.meta, createdBy: currentUser.id } }
+					}
+
+					// Backfill any persisted shapes that pre-date the side effect below.
+					const toBackfill = editor
+						.getCurrentPageShapes()
+						.filter((s) => typeof s.meta.createdBy !== 'string')
+						.map(stampWithCurrentUser)
+					if (toBackfill.length) {
+						editor.run(() => editor.updateShapes(toBackfill), { history: 'ignore' })
+					}
+
+					editor.sideEffects.registerBeforeCreateHandler('shape', stampWithCurrentUser)
+				}}
 				components={{
 					TopPanel: UserSwitcher,
 					SharePanel: AttributionPanel,
-				}}
-				overrides={{
-					tools: (_editor, tools) => {
-						for (const id of Object.keys(tools)) {
-							if (!ALLOWED_TOOLS.has(id)) delete tools[id]
-						}
-						return tools
-					},
 				}}
 			/>
 		</div>
@@ -195,21 +217,24 @@ signals will re-evaluate when the underlying data changes.
 [3]
 The top panel lets you switch which user is "logged in" and edit the active
 user's name. Try drawing a shape as Alice, then renaming her — the attribution
-panel updates live. Switch to Bob and create a note with text to see
-"Text first edited by" appear.
+panel updates live. Switch to Bob, create a note with text, and you'll also
+see the built-in "Text first edited by" appear.
 
 [4]
 The panel reads `editor.store.props.users.currentUser.get()` to show who is
-active, and reads shape-specific props (like `textFirstEditedBy` on notes) for
-per-shape attribution. Each attribution field is a user ID string — we call
-`resolve(userId).get()` to get live display data.
+active, and resolves both `meta.createdBy` (set by our own side effect) and
+`textFirstEditedBy` (built-in on notes) for the selected shape. Each attribution
+field is a user id string — we call `resolve(userId).get()` to get live display
+data, so renames flow through automatically.
 
 [5]
-Extracts attribution info from a shape. Note shapes have a `textFirstEditedBy`
-prop that tracks who first edited the note text.
+Extracts attribution info from a shape. We read `meta.createdBy` for any
+shape, and additionally read the built-in `textFirstEditedBy` prop for note
+shapes.
 
 [6]
-We pass the custom user store as the `users` prop on the Tldraw component.
-The TopPanel shows the user-switcher with name editing, and the SharePanel
-shows the attribution inspector.
+We pass the custom user store as the `users` prop on the Tldraw component,
+and use a `beforeCreate` side effect to stamp the current user's id onto
+every new shape's `meta.createdBy`. Storing attribution in `meta` keeps the
+data with the shape and lets you attribute any shape type, not just notes.
 */


### PR DESCRIPTION
Updates the examples pages and readmes based on the changes over the last couple of months. 

Adds in a new example showing how you can add in a color picker and font picker