### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -2,7 +2,7 @@
 title: Next release
 description: Changes coming in the next release
 author: tldraw
-date: 05/02/2026
+date: 05/04/2026
 order: 0
 status: published
 last_version: v4.5.11
@@ -476,3 +476,4 @@ New APIs include `handleSocketResume()` for restoring sessions from snapshots, `
 - Fix the minimap getting stuck in a dragging state when right-clicked or when the pointer is cancelled during a drag. ([#8700](https://github.com/tldraw/tldraw/pull/8700))
 - Fix the comma-key click shortcut landing at the wrong position on hosts with a non-zero canvas offset (e.g. tldraw.com with the sidebar open). ([#8704](https://github.com/tldraw/tldraw/pull/8704)) (contributed by [@danieljamesross](https://github.com/danieljamesross))
 - Fix toolbar group dividers referencing the wrong CSS variable, so dividers now render correctly. ([#8734](https://github.com/tldraw/tldraw/pull/8734))
+- Fix the iOS context menu closing immediately after a long-press release. ([#8741](https://github.com/tldraw/tldraw/pull/8741))

--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -2,10 +2,10 @@
 title: Next release
 description: Changes coming in the next release
 author: tldraw
-date: 05/01/2026
+date: 05/02/2026
 order: 0
 status: published
-last_version: v4.5.10
+last_version: v4.5.11
 ---
 
 This major release introduces a first-class theme system with display values, a new `OverlayUtil` system for canvas overlays, and extensibility APIs for custom record types, asset types, geo shapes, and frame-like shapes. Two new packages ship alongside it: `@tldraw/driver` for imperative editor control and `@tldraw/mermaid` for converting Mermaid diagrams into native shapes. It also adds a shape attribution system with the `TLUserStore` provider, clipboard and performance-measurement hooks, WebSocket hibernation in tlsync, RTL support, cross-window embedding, and various other improvements and bug fixes.
@@ -473,3 +473,6 @@ New APIs include `handleSocketResume()` for restoring sessions from snapshots, `
 - Fix note author attribution overflowing the sticky note width in SVG and PNG exports. ([#8664](https://github.com/tldraw/tldraw/pull/8664))
 - Fix keyboard shortcuts not matching on alternative Latin keyboard layouts (Dvorak, Colemak, AZERTY) by replacing the `hotkeys-js` library with a small layout-aware native event matcher. ([#8669](https://github.com/tldraw/tldraw/pull/8669))
 - Fix TypeScript signature mismatch on `ShapeUtil` base-class methods so overrides that need a `shape` parameter can declare it without errors. ([#8521](https://github.com/tldraw/tldraw/pull/8521))
+- Fix the minimap getting stuck in a dragging state when right-clicked or when the pointer is cancelled during a drag. ([#8700](https://github.com/tldraw/tldraw/pull/8700))
+- Fix the comma-key click shortcut landing at the wrong position on hosts with a non-zero canvas offset (e.g. tldraw.com with the sidebar open). ([#8704](https://github.com/tldraw/tldraw/pull/8704)) (contributed by [@danieljamesross](https://github.com/danieljamesross))
+- Fix toolbar group dividers referencing the wrong CSS variable, so dividers now render correctly. ([#8734](https://github.com/tldraw/tldraw/pull/8734))


### PR DESCRIPTION
In order to keep the in-progress release notes in sync with `main`, this updates `next.mdx` with three new bug-fix entries since the last sweep, advances `last_version` to `v4.5.11`, and refreshes the date. Source for the sweep was `main` (recent merges since #8669/#8675); same-cycle iteration on the new theme/overlay/customGeoTypes/MutationObserver work was excluded per the style guide.

Added entries:

- #8700 — minimap drag stuck on right-click / pointer cancel
- #8704 — comma-key click positioning when canvas has a non-zero offset (community contributor)
- #8734 — toolbar group dividers referencing the wrong CSS variable

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +5 / -2    |