### PR TITLE
docs: add /discord redirect to Discord invite

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -186,6 +186,11 @@ const nextConfig = {
 				destination: '/starter-kits/overview',
 				permanent: true,
 			},
+			{
+				source: '/discord',
+				destination: 'https://discord.com/invite/s4FXZ6fppJ',
+				permanent: false,
+			},
 		]
 	},
 	async rewrites() {


### PR DESCRIPTION
In order to give the docs site a stable, shareable shortlink to our Discord community, this PR adds a `/discord` redirect on tldraw.dev that points to the current Discord invite URL.

The redirect is marked non-permanent so we can swap the invite URL later without browsers caching a 308.

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev-docs`.
2. Visit `http://localhost:3001/discord` and confirm it redirects to `https://discord.com/invite/s4FXZ6fppJ`.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Documentation  | +5 / -0    |