### PR TITLE
chore: bump @rocicorp/zero to 1.4.0

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@clerk/clerk-react": "^5.53.3",
 		"@clerk/elements": "^0.23.74",
-		"@rocicorp/zero": "1.3.0-canary.3",
+		"@rocicorp/zero": "1.4.0",
 		"@sentry/integrations": "^7.120.3",
 		"@sentry/react": "^7.120.3",
 		"@tldraw/assets": "workspace:*",

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@clerk/backend": "^1.23.7",
 		"@pierre/storage": "^1.1.0",
-		"@rocicorp/zero": "1.3.0-canary.3",
+		"@rocicorp/zero": "1.4.0",
 		"@supabase/auth-helpers-remix": "^0.2.6",
 		"@supabase/supabase-js": "^2.48.1",
 		"@tldraw/dotcom-shared": "workspace:*",

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -26,7 +26,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "1.3.0-canary.3",
+		"@rocicorp/zero": "1.4.0",
 		"kysely": "^0.28.12",
 		"pg": "^8.13.1"
 	},

--- a/packages/dotcom-shared/package.json
+++ b/packages/dotcom-shared/package.json
@@ -9,7 +9,7 @@
 	"files": [],
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "1.3.0-canary.3",
+		"@rocicorp/zero": "1.4.0",
 		"@tldraw/state": "workspace:*",
 		"@tldraw/store": "workspace:*",
 		"@tldraw/tlschema": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9004,9 +9004,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocicorp/zero@npm:1.3.0-canary.3":
-  version: 1.3.0-canary.3
-  resolution: "@rocicorp/zero@npm:1.3.0-canary.3"
+"@rocicorp/zero@npm:1.4.0":
+  version: 1.4.0
+  resolution: "@rocicorp/zero@npm:1.4.0"
   dependencies:
     "@badrap/valita": "npm:0.3.11"
     "@databases/escape-identifier": "npm:^1.0.3"
@@ -9060,10 +9060,13 @@ __metadata:
   peerDependencies:
     "@op-engineering/op-sqlite": ">=15"
     expo-sqlite: ">=15"
+    kysely: ^0.28.16
   peerDependenciesMeta:
     "@op-engineering/op-sqlite":
       optional: true
     expo-sqlite:
+      optional: true
+    kysely:
       optional: true
   bin:
     analyze-query: out/zero/src/analyze-query.js
@@ -9074,7 +9077,7 @@ __metadata:
     zero-cache-dev: out/zero/src/zero-cache-dev.js
     zero-deploy-permissions: out/zero/src/deploy-permissions.js
     zero-out: out/zero/src/zero-out.js
-  checksum: 10/c1e9ff270bd74d8a4505ccc40abdb5eb08b85abbb84d81b9479e4519d2b0035cb1e40a3c0eceb01ab81dbd4255435c43b479c97744c7e72e98e0657616d629b6
+  checksum: 10/a5c7135df3954bb0d1a7b9b8049fff71e88aa74e5ed1371056c1405fbf6c40acc9d2c46aa49a9954c9a6fa7c6b150a518d1d194c5092fa69e25aeb6c62e24f61
   languageName: node
   linkType: hard
 
@@ -11446,7 +11449,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/dotcom-shared@workspace:packages/dotcom-shared"
   dependencies:
-    "@rocicorp/zero": "npm:1.3.0-canary.3"
+    "@rocicorp/zero": "npm:1.4.0"
     "@tldraw/state": "workspace:*"
     "@tldraw/store": "workspace:*"
     "@tldraw/tlschema": "workspace:*"
@@ -11470,7 +11473,7 @@ __metadata:
     "@clerk/backend": "npm:^1.23.7"
     "@cloudflare/workers-types": "npm:^4.20260302.0"
     "@pierre/storage": "npm:^1.1.0"
-    "@rocicorp/zero": "npm:1.3.0-canary.3"
+    "@rocicorp/zero": "npm:1.4.0"
     "@supabase/auth-helpers-remix": "npm:^0.2.6"
     "@supabase/supabase-js": "npm:^2.48.1"
     "@tldraw/dotcom-shared": "workspace:*"
@@ -11915,7 +11918,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/zero-cache@workspace:apps/dotcom/zero-cache"
   dependencies:
-    "@rocicorp/zero": "npm:1.3.0-canary.3"
+    "@rocicorp/zero": "npm:1.4.0"
     concurrently: "npm:^9.1.2"
     dotenv: "npm:^16.4.7"
     esbuild: "npm:^0.28.0"
@@ -17434,7 +17437,7 @@ __metadata:
     "@formatjs/cli": "npm:^6.5.1"
     "@formatjs/unplugin": "npm:^1.1.0"
     "@playwright/test": "npm:^1.58.2"
-    "@rocicorp/zero": "npm:1.3.0-canary.3"
+    "@rocicorp/zero": "npm:1.4.0"
     "@sentry/cli": "npm:^2.41.1"
     "@sentry/integrations": "npm:^7.120.3"
     "@sentry/react": "npm:^7.120.3"
@@ -21900,9 +21903,9 @@ __metadata:
   linkType: hard
 
 "kysely@npm:^0.28.12":
-  version: 0.28.15
-  resolution: "kysely@npm:0.28.15"
-  checksum: 10/03d464d963ad46e4446004ca85df471871f66bb9be3072ae10efaf0faca8e9513639db09108a12ea012b5c2820a831b97122a03895223324362619e8a0f2ead0
+  version: 0.28.16
+  resolution: "kysely@npm:0.28.16"
+  checksum: 10/d0dffee9158a62103f61559588fffd7b34e01a1adf4f054599c3be50c10c6357cda09de456a931fd7eba6502cbb8804710805bbd56e6d94b19633e043cde3e31
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Bumps `@rocicorp/zero` from `1.3.0-canary.3` to `1.4.0` across `dotcom-shared`, `client`, `sync-worker`, and `zero-cache`. No code changes — version bump and lockfile only.

`@rocicorp/zero` 1.4.0 introduces a peer dep on `kysely ^0.28.16`. We currently pin `kysely ^0.28.12`, which raises a yarn `YN0060` peer warning. The bump is intentionally deferred to a follow-up PR that also evaluates Zero's new `zeroKysely` server adapter for replacing the hand-rolled `executeServerQuery` AST→SQL compiler in `TLUserDurableObject`.

### Change type

- [x] `other`

### Test plan

1. CI build/typecheck passes against Zero 1.4.0.
2. Boot dotcom locally, sign in, create/rename/delete files — verify Zero client mutators and sync-worker server mutators round-trip.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +18 / -15  |