### PR TITLE
fix(dotcom): recover Zero view-syncer when fly_machine_id pins removed machines

### DIFF
--- a/apps/dotcom/zero-cache/nginx.conf.template
+++ b/apps/dotcom/zero-cache/nginx.conf.template
@@ -24,9 +24,24 @@ http {
                 set $check_replay "${check_replay}_replayed";
             }
 
-            # Case: cookie exists, differs, NOT a replay → tell Fly to route to correct machine
+            # Fly already fell back from a dead/unreachable preferred instance — do not
+            # fly-replay again to the cookie ID (would loop). Fall through and refresh cookie.
+            set $prefer_instance_unavailable "";
+            if ($http_fly_preferred_instance_unavailable != "") {
+                set $prefer_instance_unavailable "1";
+            }
+
+            # Case: cookie exists, differs, NOT a replay → ask Fly to prefer the cookie machine
+            # (prefer_instance avoids strict replay to a destroyed machine; see Fly fly-replay docs)
+            set $issue_fly_replay "0";
             if ($check_replay = "has_cookie_different") {
-                add_header fly-replay "instance=$cookie_fly_machine_id" always;
+                set $issue_fly_replay "1";
+            }
+            if ($prefer_instance_unavailable = "1") {
+                set $issue_fly_replay "0";
+            }
+            if ($issue_fly_replay = "1") {
+                add_header fly-replay "prefer_instance=$cookie_fly_machine_id" always;
                 return 307;
             }
 

--- a/apps/dotcom/zero-cache/nginx.conf.template
+++ b/apps/dotcom/zero-cache/nginx.conf.template
@@ -6,12 +6,37 @@ http {
     server {
         listen 4848;
 
-        # Machine ID from environment (substituted at container start via envsubst)
+        # envsubst from start.sh replaces FLY_MACHINE_ID only
         set $machine_id "${FLY_MACHINE_ID}";
 
         location / {
-            # Build state for routing decision
-            # Check if cookie exists and differs from this machine
+            # Sticky routing for multi-machine Zero view-syncer. Clients store fly_machine_id (which
+            # Fly machine they last used). Same idea as Fly replay_cache in flyio-view-syncer. Goal:
+            # keep a session on one box for warm Zero state (see zero.rocicorp.dev self-host sticky sessions).
+            #
+            # $machine_id = this container (FLY_MACHINE_ID). The cookie may name another machine.
+            # Only the proxy_pass branch below sets Set-Cookie; a 307 fly-replay response does not, so
+            # fixing a bad cookie always ends with a successful proxy response.
+            #
+            # Paths (nginx picks the first that applies):
+            #
+            # A — No cookie, or cookie already matches $machine_id: do not fly-replay. Proxy to Zero on
+            #     :4849 and set fly_machine_id to this machine (first visit, refresh, or already correct).
+            #
+            # B — Cookie names a different machine, first hop (no Fly-Replay-Src), Fly did not already
+            #     signal Fly-Preferred-Instance-Unavailable: return 307 + fly-replay prefer_instance=<cookie>.
+            #     Fly’s edge tries to route the request to that machine if it exists and can take load.
+            #     If that machine is gone, busy (hard_limit), etc., Fly may deliver the request here instead
+            #     and set Fly-Preferred-Instance-Unavailable (see Fly fly-replay docs).
+            #
+            # C — Cookie names a different machine but Fly-Replay-Src is present: Fly already replayed
+            #     once (e.g. previous hop asked for the cookie machine and it was unreachable). Do not
+            #     return another 307—proxy here and rewrite the cookie to $machine_id.
+            #
+            # D — Cookie names a different machine and Fly-Preferred-Instance-Unavailable is present:
+            #     Fly already decided prefer_instance could not be satisfied for that ID. Do not return
+            #     another 307 (would loop). Proxy here and rewrite the cookie. Header is forgeable in
+            #     theory; low impact (stickiness only); typical browsers hit Fly first.
             set $check_replay "";
             if ($cookie_fly_machine_id != "") {
                 set $check_replay "has_cookie";
@@ -19,20 +44,15 @@ http {
             if ($cookie_fly_machine_id != $machine_id) {
                 set $check_replay "${check_replay}_different";
             }
-            # Check if this is a replayed request (Fly adds this header on replay)
             if ($http_fly_replay_src != "") {
                 set $check_replay "${check_replay}_replayed";
             }
 
-            # Fly already fell back from a dead/unreachable preferred instance — do not
-            # fly-replay again to the cookie ID (would loop). Fall through and refresh cookie.
             set $prefer_instance_unavailable "";
             if ($http_fly_preferred_instance_unavailable != "") {
                 set $prefer_instance_unavailable "1";
             }
 
-            # Case: cookie exists, differs, NOT a replay → ask Fly to prefer the cookie machine
-            # (prefer_instance avoids strict replay to a destroyed machine; see Fly fly-replay docs)
             set $issue_fly_replay "0";
             if ($check_replay = "has_cookie_different") {
                 set $issue_fly_replay "1";
@@ -45,11 +65,7 @@ http {
                 return 307;
             }
 
-            # Case: cookie exists, differs, IS a replay → target machine is dead
-            # Fall through to proxy normally and set new cookie (handled below)
-            # This covers "has_cookie_different_replayed"
-
-            # Proxy to Zero on internal port
+            # Zero (upstream); sticky cookie refreshed below
             proxy_pass http://127.0.0.1:4849;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -59,16 +75,15 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
 
-            # Increase buffer sizes for large headers from zero-cache
+            # zero-cache can send large headers
             proxy_buffer_size 64k;
             proxy_buffers 8 64k;
 
-            # WebSocket timeout - keep alive for long-running connections
+            # Long-lived sync / WebSocket upstream
             proxy_read_timeout 86400;
             proxy_send_timeout 86400;
 
-            # Always set cookie to current machine (refreshes existing or establishes new)
-            # SameSite=None required for cross-site requests (client on tldraw.com, zero on fly.dev)
+            # Pin this machine; SameSite=None for cross-origin (e.g. tldraw.com → fly.dev)
             add_header Set-Cookie "fly_machine_id=$machine_id; Path=/; Max-Age=3600; SameSite=None; Secure" always;
         }
     }


### PR DESCRIPTION
In order to stop dotcom clients from looping on `WebSocket connection closed abruptly` when `fly_machine_id` still references a destroyed Fly machine, this PR updates the view-syncer front nginx to use `fly-replay: prefer_instance=…` instead of strict `instance=…`, clears the replay path when Fly sets `Fly-Preferred-Instance-Unavailable`, and documents the routing branches. `Set-Cookie` only runs on the proxy path, so recovery requires reaching that path after a failed sticky target.

### Change type

- [x] `bugfix`

### Test plan

1. On staging view-syncer, connect from dotcom with Zero enabled; note `fly_machine_id` for the fly.dev host.
2. Destroy the machine ID in the cookie (or point the cookie at a fake id), trigger reconnect; confirm WebSocket connects and the cookie updates to a live machine id without waiting for `Max-Age`.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix dotcom Zero reconnecting after a view-syncer machine is removed while the browser still holds an old `fly_machine_id` cookie.

### Code changes

| Area | Net change |
|------|------------|
| `apps/dotcom/zero-cache/nginx.conf.template` | +45 / −15 |

Made with [Cursor](https://cursor.com)