### PR TITLE
fix(editor): warn when duplicate bindings are created

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -6656,6 +6656,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	createBindings<B extends TLBinding = TLBinding>(partials: TLBindingCreate<B>[]) {
 		const bindings: TLBinding[] = []
+		const seenInBatch = new Set<string>()
 		for (const partial of partials) {
 			const fromShape = this.getShape(partial.fromId)
 			const toShape = this.getShape(partial.toId)
@@ -6672,6 +6673,25 @@ export class Editor extends EventEmitter<TLEventMap> {
 					...partial.props,
 				},
 			}) as TLBinding
+
+			if (process.env.NODE_ENV !== 'production') {
+				const dedupeKey = `${binding.fromId}|${binding.toId}|${binding.type}`
+				if (seenInBatch.has(dedupeKey)) {
+					console.warn(
+						`Duplicate ${binding.type} binding from ${binding.fromId} to ${binding.toId} created in the same createBindings call. Duplicate bindings can cause unexpected behavior.`
+					)
+				} else {
+					const existing = this.getBindingsFromShape(binding.fromId, binding.type).find(
+						(b) => b.toId === binding.toId && b.id !== binding.id
+					)
+					if (existing) {
+						console.warn(
+							`Duplicate ${binding.type} binding from ${binding.fromId} to ${binding.toId} (a binding with these endpoints already exists: ${existing.id}). Duplicate bindings can cause unexpected behavior.`
+						)
+					}
+				}
+				seenInBatch.add(dedupeKey)
+			}
 
 			bindings.push(binding)
 		}


### PR DESCRIPTION
In order to help SDK users diagnose duplicate-binding issues, this PR adds a development-only `console.warn` in `Editor.createBindings()` when a new binding shares `(fromId, toId, type)` with an existing binding (or with another partial in the same call). Closes #8324.

Duplicate bindings were silently tolerated up to v4.3 but now cause subtle issues — most visibly broken arrow rendering, because lookups like `arrowBindingsCache` use `.find()` and silently pick the first match per terminal. Without feedback, this is hard to track down.

The warning fires only when `process.env.NODE_ENV !== 'production'`, so it's stripped from production bundles. It's purely diagnostic — duplicate bindings are still created, never auto-deleted or prevented. Replacing an existing binding by id (same id) is not flagged.

### Change type

- [x] `improvement`

### Test plan

1. Create two shapes.
2. Call `editor.createBindings([{ fromId, toId, type: 'arrow', ... }, { fromId, toId, type: 'arrow', ... }])` with identical endpoints — confirm a console warning fires for the in-batch duplicate.
3. Call `editor.createBindings()` again with the same endpoints — confirm a console warning fires for the existing-store duplicate.
4. Build a production bundle and confirm the warning is stripped.

### Release notes

- Warn in development when `editor.createBindings()` creates a binding with the same `(fromId, toId, type)` as an existing binding.