### PR TITLE
feature(docs): process image url through an asset url helper

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -5,6 +5,7 @@ import localFont from 'next/font/local'
 import AutoRefresh from '@/components/common/autorefresh'
 import { Footer } from '@/components/navigation/footer'
 import { Header } from '@/components/navigation/header'
+import { assetUrl } from '@/utils/asset-url'
 import { cn } from '@/utils/cn'
 import Analytics from './analytics'
 import './github-dark.css'
@@ -37,13 +38,13 @@ export const metadata: Metadata = {
 		statusBarStyle: 'black',
 	},
 	icons: [
-		{ rel: 'shortcut icon', url: '/favicon.svg' },
-		{ rel: 'icon', url: '/favicon-32x32.svg', sizes: '32x32' },
-		{ rel: 'icon', url: '/favicon-16x16.svg', sizes: '16x16' },
-		{ rel: 'apple-touch-icon', url: '/apple-touch-icon.png' },
-		{ rel: 'apple-touch-icon', url: '/apple-touch-icon-152x152.svg', sizes: '152x152' },
-		{ rel: 'apple-touch-icon', url: '/apple-touch-icon-180x180.svg', sizes: '180x180' },
-		{ rel: 'apple-touch-icon', url: '/apple-touch-icon-167x167.svg', sizes: '167x167' },
+		{ rel: 'shortcut icon', url: assetUrl('/favicon.svg') },
+		{ rel: 'icon', url: assetUrl('/favicon-32x32.svg'), sizes: '32x32' },
+		{ rel: 'icon', url: assetUrl('/favicon-16x16.svg'), sizes: '16x16' },
+		{ rel: 'apple-touch-icon', url: assetUrl('/apple-touch-icon.png') },
+		{ rel: 'apple-touch-icon', url: assetUrl('/apple-touch-icon-152x152.svg'), sizes: '152x152' },
+		{ rel: 'apple-touch-icon', url: assetUrl('/apple-touch-icon-180x180.svg'), sizes: '180x180' },
+		{ rel: 'apple-touch-icon', url: assetUrl('/apple-touch-icon-167x167.svg'), sizes: '167x167' },
 	],
 }
 

--- a/apps/docs/components/content/image.tsx
+++ b/apps/docs/components/content/image.tsx
@@ -1,13 +1,16 @@
+import { assetUrl } from '@/utils/asset-url'
 import { TldrawLink } from '../common/tldraw-link'
 
 export function Image(props: any) {
+	const src = typeof props.src === 'string' ? assetUrl(props.src) : props.src
+	const href = props.href ?? src
 	return (
 		<span className="block">
 			<TldrawLink
-				href={props.href ?? props.src}
+				href={href}
 				className="block bg-zinc-100 dark:bg-zinc-800 py-1 sm:rounded-2xl -mx-5 sm:mx-0 sm:px-1"
 			>
-				<img alt={props.title} {...props} className="w-full sm:rounded-xl !my-0 shadow" />
+				<img alt={props.title} {...props} src={src} className="w-full sm:rounded-xl !my-0 shadow" />
 			</TldrawLink>
 			{props.caption && (
 				<span className="block text-xs text-zinc-500 mt-3 text-center text-balance">

--- a/apps/docs/utils/asset-url.test.ts
+++ b/apps/docs/utils/asset-url.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { assetUrl } from './asset-url'
+
+describe('assetUrl', () => {
+	it('returns the original path when ASSET_PREFIX is unset', () => {
+		const prev = process.env.ASSET_PREFIX
+		try {
+			delete process.env.ASSET_PREFIX
+			expect(assetUrl('/favicon.svg')).toBe('/favicon.svg')
+		} finally {
+			process.env.ASSET_PREFIX = prev
+		}
+	})
+
+	it('returns the original path when ASSET_PREFIX is empty/whitespace', () => {
+		const prev = process.env.ASSET_PREFIX
+		try {
+			process.env.ASSET_PREFIX = '   '
+			expect(assetUrl('/favicon.svg')).toBe('/favicon.svg')
+		} finally {
+			process.env.ASSET_PREFIX = prev
+		}
+	})
+
+	it('prefixes root-relative paths', () => {
+		const prev = process.env.ASSET_PREFIX
+		try {
+			process.env.ASSET_PREFIX = 'https://docs.example.com'
+			expect(assetUrl('/images/foo.png')).toBe('https://docs.example.com/images/foo.png')
+		} finally {
+			process.env.ASSET_PREFIX = prev
+		}
+	})
+
+	it('strips a trailing slash from the prefix', () => {
+		const prev = process.env.ASSET_PREFIX
+		try {
+			process.env.ASSET_PREFIX = 'https://docs.example.com/'
+			expect(assetUrl('/images/foo.png')).toBe('https://docs.example.com/images/foo.png')
+		} finally {
+			process.env.ASSET_PREFIX = prev
+		}
+	})
+
+	it('does not change non-root-relative paths', () => {
+		const prev = process.env.ASSET_PREFIX
+		try {
+			process.env.ASSET_PREFIX = 'https://docs.example.com'
+			expect(assetUrl('https://cdn.example.com/a.png')).toBe('https://cdn.example.com/a.png')
+			expect(assetUrl('relative.png')).toBe('relative.png')
+		} finally {
+			process.env.ASSET_PREFIX = prev
+		}
+	})
+})

--- a/apps/docs/utils/asset-url.ts
+++ b/apps/docs/utils/asset-url.ts
@@ -1,0 +1,6 @@
+export function assetUrl(path: string): string {
+	if (!path.startsWith('/')) return path
+	const prefix = process.env.ASSET_PREFIX?.trim()
+	if (!prefix) return path
+	return `${prefix.replace(/\/$/, '')}${path}`
+}


### PR DESCRIPTION
Following dotdev imminent release, we need to make sure all assets URLs in doc can be prefixed with the right url so we don't have issues when visitors are coming from dotdev urls

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [ ] visit staging docs
- [ ] images are working 
