### PR TITLE
example: tower defense game showcasing OverlayUtil

### DIFF
--- a/apps/examples/src/examples/use-cases/tower-defense/README.md
+++ b/apps/examples/src/examples/use-cases/tower-defense/README.md
@@ -1,0 +1,16 @@
+---
+title: Tower defense
+component: ./TowerDefenseExample.tsx
+priority: 5
+keywords: [overlay, overlayutil, canvas, animation, game, hit testing, raf, tick]
+---
+
+A tiny tower defense game built on the OverlayUtil system.
+
+---
+
+Draw triangle, rectangle, or ellipse geo shapes onto the canvas to place towers — each geo type maps to a different tower with its own range, fire rate, damage, and projectile. Enemies follow a fixed path; click an enemy to deal damage manually.
+
+The game's path, enemies, projectiles, and tower range indicator all render through `OverlayUtil` subclasses. The game state lives in `@tldraw/state` atoms read inside `getOverlays()`, so when the game loop ticks the atoms, every overlay redraws reactively. Hit-testing for clicks on enemies uses `getGeometry()` and the built-in `editor.overlays.getOverlayAtPoint` path; `getCursor()` swaps to a crosshair on hover and `onPointerDown()` applies damage.
+
+The game loop is driven by the editor's `tick` event, which fires once per frame with the elapsed delta in milliseconds. Towers are real geo shapes that the side-effects layer locks on creation so they can't be moved during play.

--- a/apps/examples/src/examples/use-cases/tower-defense/TowerDefenseExample.tsx
+++ b/apps/examples/src/examples/use-cases/tower-defense/TowerDefenseExample.tsx
@@ -1,0 +1,291 @@
+import { useCallback, useEffect } from 'react'
+import {
+	Box,
+	Editor,
+	TLAnyOverlayUtilConstructor,
+	TLUiComponents,
+	Tldraw,
+	defaultOverlayUtils,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { resetSpawnTimer, runGameTick } from './game-loop'
+import {
+	enemies$,
+	gameOver$,
+	gold$,
+	lives$,
+	placingTower$,
+	projectiles$,
+	resetGameState,
+	score$,
+} from './game-state'
+import { EnemyOverlayUtil } from './overlays/EnemyOverlayUtil'
+import { ExplosionOverlayUtil } from './overlays/ExplosionOverlayUtil'
+import { PathOverlayUtil } from './overlays/PathOverlayUtil'
+import { PlacementPreviewOverlayUtil } from './overlays/PlacementPreviewOverlayUtil'
+import { ProjectileOverlayUtil } from './overlays/ProjectileOverlayUtil'
+import { TowerRangeOverlayUtil } from './overlays/TowerRangeOverlayUtil'
+import { UpgradeButtonOverlayUtil } from './overlays/UpgradeButtonOverlayUtil'
+import { TOWER_GEOS, TOWER_STATS_BY_GEO, TowerGeo } from './tower-config'
+import './tower-defense.css'
+
+const overlayUtils: TLAnyOverlayUtilConstructor[] = [
+	...defaultOverlayUtils,
+	PathOverlayUtil,
+	TowerRangeOverlayUtil,
+	PlacementPreviewOverlayUtil,
+	EnemyOverlayUtil,
+	ProjectileOverlayUtil,
+	ExplosionOverlayUtil,
+	UpgradeButtonOverlayUtil,
+]
+
+function pickTower(geo: TowerGeo) {
+	const cost = TOWER_STATS_BY_GEO[geo].cost
+	// Refuse to arm a tower the player can't afford so the preview / placement
+	// flow only kicks in when a click would actually result in a tower.
+	if (gold$.get() < cost) return
+	placingTower$.set(geo)
+}
+
+function pickSelect(editor: Editor) {
+	placingTower$.set(null)
+	editor.setCurrentTool('select')
+}
+
+function restartGame(editor: Editor) {
+	resetGameState()
+	resetSpawnTimer()
+	placingTower$.set(null)
+	// Just nuke everything on the page — towers are the only thing the user
+	// can produce here, and starting fresh shouldn't leave any stragglers.
+	const allShapeIds = editor.getCurrentPageShapes().map((s) => s.id)
+	if (allShapeIds.length === 0) return
+	editor.run(() => editor.deleteShapes(allShapeIds), { ignoreShapeLock: true })
+}
+
+function GameRunner() {
+	const editor = useEditor()
+
+	useEffect(() => {
+		const onTick = (elapsedMs: number) => {
+			// Clamp on tab-resume; tldraw emits a single big elapsed when the tab
+			// has been idle, which would otherwise teleport enemies.
+			const dt = Math.min(60, elapsedMs)
+			runGameTick(editor, dt)
+		}
+		editor.on('tick', onTick)
+
+		// Keyboard: 1/2/3 arm a tower, Esc selects, Space restarts.
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.metaKey || e.ctrlKey || e.altKey) return
+			const target = e.target as HTMLElement | null
+			if (target?.matches('input, textarea, [contenteditable="true"]')) return
+			if (e.key === '1') pickTower('triangle')
+			else if (e.key === '2') pickTower('rectangle')
+			else if (e.key === '3') pickTower('ellipse')
+			else if (e.key === 'Escape') pickSelect(editor)
+			else if (e.key === ' ') {
+				e.preventDefault()
+				restartGame(editor)
+			}
+		}
+		window.addEventListener('keydown', onKeyDown)
+
+		return () => {
+			editor.off('tick', onTick)
+			window.removeEventListener('keydown', onKeyDown)
+			placingTower$.set(null)
+		}
+	}, [editor])
+
+	return null
+}
+
+function GameToolbar() {
+	const editor = useEditor()
+	const placingGeo = useValue('placingGeo', () => placingTower$.get(), [])
+	const gold = useValue('gold', () => gold$.get(), [])
+
+	const onPickSelect = useCallback(() => pickSelect(editor), [editor])
+
+	return (
+		<div className="td-toolbar">
+			<button
+				className={'td-toolbar__btn' + (placingGeo === null ? ' is-active' : '')}
+				onClick={onPickSelect}
+				title="Select (Esc)"
+			>
+				<SelectGlyph />
+				<span className="td-toolbar__label">Select</span>
+				<span className="td-toolbar__cost">
+					<kbd>esc</kbd>
+				</span>
+			</button>
+			{TOWER_GEOS.map((geo, i) => {
+				const stats = TOWER_STATS_BY_GEO[geo]
+				const isActive = placingGeo === geo
+				const canAfford = gold >= stats.cost
+				const cls =
+					'td-toolbar__btn' + (isActive ? ' is-active' : '') + (canAfford ? '' : ' is-disabled')
+				return (
+					<button
+						key={geo}
+						className={cls}
+						onClick={() => canAfford && pickTower(geo)}
+						disabled={!canAfford}
+						title={`${stats.label} (${geo}) — ${stats.cost} gold — press ${i + 1}`}
+					>
+						<TowerGlyph geo={geo} />
+						<span className="td-toolbar__label">{stats.label}</span>
+						<span className="td-toolbar__cost">
+							{stats.cost}g · <kbd>{i + 1}</kbd>
+						</span>
+					</button>
+				)
+			})}
+		</div>
+	)
+}
+
+function SelectGlyph() {
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20" aria-hidden>
+			<path
+				d="M4 3 L4 15 L7.5 12 L9.7 17 L11.5 16.2 L9.3 11.2 L14 11 Z"
+				fill="currentColor"
+				stroke="currentColor"
+				strokeWidth="1"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	)
+}
+
+function TowerGlyph({ geo }: { geo: TowerGeo }) {
+	const stroke = 'currentColor'
+	if (geo === 'triangle') {
+		return (
+			<svg width="20" height="20" viewBox="0 0 20 20" aria-hidden>
+				<polygon points="10,2 18,18 2,18" fill="none" stroke={stroke} strokeWidth="2" />
+			</svg>
+		)
+	}
+	if (geo === 'rectangle') {
+		return (
+			<svg width="20" height="20" viewBox="0 0 20 20" aria-hidden>
+				<rect x="2" y="4" width="16" height="12" fill="none" stroke={stroke} strokeWidth="2" />
+			</svg>
+		)
+	}
+	return (
+		<svg width="20" height="20" viewBox="0 0 20 20" aria-hidden>
+			<ellipse cx="10" cy="10" rx="8" ry="6" fill="none" stroke={stroke} strokeWidth="2" />
+		</svg>
+	)
+}
+
+function HUD() {
+	const editor = useEditor()
+	const score = useValue('score', () => score$.get(), [])
+	const gold = useValue('gold', () => gold$.get(), [])
+	const lives = useValue('lives', () => lives$.get(), [])
+	const enemyCount = useValue('enemies', () => enemies$.get().length, [])
+	const projectileCount = useValue('projectiles', () => projectiles$.get().length, [])
+	const gameOver = useValue('gameOver', () => gameOver$.get(), [])
+
+	const onRestart = useCallback(() => restartGame(editor), [editor])
+
+	return (
+		<div className="td-hud">
+			<div className="td-hud__row">
+				<span>
+					Gold <strong>{gold}</strong>
+				</span>
+				<span>
+					Score <strong>{score}</strong>
+				</span>
+				<span>
+					Lives <strong>{lives}</strong>
+				</span>
+				<span>
+					Enemies <strong>{enemyCount}</strong>
+				</span>
+				<span>
+					Shots <strong>{projectileCount}</strong>
+				</span>
+				<button className="td-hud__btn" onClick={onRestart}>
+					Restart
+				</button>
+			</div>
+			<div className="td-hud__hint">
+				Pick a tower from the toolbar (or press <kbd>1</kbd>/<kbd>2</kbd>/<kbd>3</kbd>), then click
+				the canvas to place it. Each tower costs gold; kill enemies to earn more. Magic blasts deal
+				area damage. Click an enemy to chip damage for free. Press <kbd>space</kbd> to restart.
+			</div>
+			{gameOver && <div className="td-hud__gameover">Game over — press Restart</div>}
+		</div>
+	)
+}
+
+const components: Required<TLUiComponents> = {
+	TopPanel: HUD,
+	Toolbar: GameToolbar,
+	ContextMenu: null,
+	ActionsMenu: null,
+	HelpMenu: null,
+	ZoomMenu: null,
+	MainMenu: null,
+	Minimap: null,
+	StylePanel: null,
+	PageMenu: null,
+	NavigationPanel: null,
+	KeyboardShortcutsDialog: null,
+	QuickActions: null,
+	HelperButtons: null,
+	DebugPanel: null,
+	DebugMenu: null,
+	SharePanel: null,
+	MenuPanel: null,
+	CursorChatBubble: null,
+	RichTextToolbar: null,
+	ImageToolbar: null,
+	VideoToolbar: null,
+	Dialogs: null,
+	Toasts: null,
+	A11y: null,
+	FollowingIndicator: null,
+	PeopleMenu: null,
+	PeopleMenuAvatar: null,
+	PeopleMenuItem: null,
+	PeopleMenuFacePile: null,
+	UserPresenceEditor: null,
+}
+
+function onEditorMount(editor: Editor) {
+	resetGameState()
+	resetSpawnTimer()
+	editor.zoomToBounds(new Box(-300, 0, 1700, 700), { immediate: true })
+}
+
+// Disable the built-in double-click-to-create-text behavior — there's no text
+// shape in this example and a stray double-click while clearing enemies would
+// otherwise drop a text shape on the canvas.
+const tldrawOptions = { createTextOnCanvasDoubleClick: false }
+
+export default function TowerDefenseExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				overlayUtils={overlayUtils}
+				components={components}
+				options={tldrawOptions}
+				onMount={onEditorMount}
+			>
+				<GameRunner />
+			</Tldraw>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/enemy-config.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/enemy-config.ts
@@ -1,0 +1,59 @@
+// Enemy archetypes. Each carries its own multipliers and visual identity so
+// later waves can mix tougher/faster targets and the overlay layer has more
+// to render than uniform circles.
+
+export type EnemyType = 'grunt' | 'runner' | 'brute'
+
+export interface EnemyConfig {
+	label: string
+	hpMultiplier: number
+	speedMultiplier: number
+	radius: number
+	bountyMultiplier: number
+	bodyColor: string
+	ringColor: string
+}
+
+export const ENEMY_CONFIG: Record<EnemyType, EnemyConfig> = {
+	grunt: {
+		label: 'Grunt',
+		hpMultiplier: 1,
+		speedMultiplier: 1,
+		radius: 18,
+		bountyMultiplier: 1,
+		bodyColor: '#c84',
+		ringColor: '#000',
+	},
+	runner: {
+		label: 'Runner',
+		hpMultiplier: 0.55,
+		speedMultiplier: 1.9,
+		radius: 13,
+		bountyMultiplier: 1.4,
+		bodyColor: '#3aa',
+		ringColor: '#055',
+	},
+	brute: {
+		label: 'Brute',
+		hpMultiplier: 3.2,
+		speedMultiplier: 0.62,
+		radius: 26,
+		bountyMultiplier: 2.6,
+		bodyColor: '#735',
+		ringColor: '#220',
+	},
+}
+
+// Weighted spawn picker: the longer the game runs, the more often runners and
+// brutes appear. Returns an enemy type.
+export function pickEnemyType(elapsedMs: number): EnemyType {
+	const t = Math.min(1, elapsedMs / 60_000)
+	const wGrunt = Math.max(0.2, 1 - t)
+	const wRunner = 0.3 + 0.4 * t
+	const wBrute = 0.05 + 0.5 * t
+	const total = wGrunt + wRunner + wBrute
+	const r = Math.random() * total
+	if (r < wGrunt) return 'grunt'
+	if (r < wGrunt + wRunner) return 'runner'
+	return 'brute'
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/game-loop.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/game-loop.ts
@@ -1,0 +1,278 @@
+import { Editor, TLGeoShape } from 'tldraw'
+import { ENEMY_CONFIG, pickEnemyType } from './enemy-config'
+import {
+	Enemy,
+	Explosion,
+	Projectile,
+	elapsedMs$,
+	enemies$,
+	explosions$,
+	gainBounty,
+	gameOver$,
+	lives$,
+	nextEnemyId,
+	nextExplosionId,
+	nextProjectileId,
+	projectiles$,
+	towerCooldowns,
+} from './game-state'
+import { PATH_LENGTH, getPositionAtDistance } from './path'
+import { playFireSound } from './sounds'
+import { getScaledStats, getTowerLevel, getTowerStats } from './tower-config'
+
+const SPAWN_BASE_INTERVAL_MS = 1400
+const SPAWN_RAMP_RATE = 0.00004 // shaves spawn interval over time
+const SPAWN_INTERVAL_FLOOR_MS = 350
+const ENEMY_BASE_HP = 50
+const ENEMY_HP_RAMP = 0.025 // per second of game time
+const ENEMY_BASE_SPEED = 65 // page units / sec
+const ENEMY_BASE_BOUNTY = 5
+const PROJECTILE_MAX_AGE_MS = 4000
+const MAGIC_AOE_RADIUS = 60
+// Magic projectiles slow enemies they hit for this long, scaling speed by
+// MAGIC_SLOW_FACTOR until the timer expires.
+const MAGIC_SLOW_DURATION_MS = 1500
+const MAGIC_SLOW_FACTOR = 0.4
+
+let lastSpawnAt = 0
+
+export function resetSpawnTimer() {
+	lastSpawnAt = 0
+}
+
+export function runGameTick(editor: Editor, dtMs: number) {
+	if (gameOver$.get()) return
+	const now = elapsedMs$.get() + dtMs
+	elapsedMs$.set(now)
+	const dt = dtMs / 1000
+
+	maybeSpawn(now)
+	moveEnemies(dt, now)
+	fireTowers(editor, now)
+	moveProjectiles(dt, dtMs)
+	resolveHits()
+	tickExplosions(dtMs)
+	checkGameOver()
+}
+
+const EXPLOSION_DURATION_MS = 320
+
+function spawnExplosion(x: number, y: number, radius: number) {
+	const exp: Explosion = {
+		id: nextExplosionId(),
+		x,
+		y,
+		radius,
+		ageMs: 0,
+		maxAgeMs: EXPLOSION_DURATION_MS,
+	}
+	explosions$.update((list) => [...list, exp])
+}
+
+function tickExplosions(dtMs: number) {
+	const list = explosions$.get()
+	if (list.length === 0) return
+	const next: Explosion[] = []
+	for (const e of list) {
+		const ageMs = e.ageMs + dtMs
+		if (ageMs >= e.maxAgeMs) continue
+		next.push({ ...e, ageMs })
+	}
+	explosions$.set(next)
+}
+
+function maybeSpawn(now: number) {
+	const interval = Math.max(
+		SPAWN_INTERVAL_FLOOR_MS,
+		SPAWN_BASE_INTERVAL_MS - now * SPAWN_RAMP_RATE * SPAWN_BASE_INTERVAL_MS
+	)
+	if (now - lastSpawnAt < interval) return
+	lastSpawnAt = now
+	const type = pickEnemyType(now)
+	const cfg = ENEMY_CONFIG[type]
+	const hpScale = 1 + (now / 1000) * ENEMY_HP_RAMP
+	const maxHp = Math.round(ENEMY_BASE_HP * hpScale * cfg.hpMultiplier)
+	const bounty = Math.round((ENEMY_BASE_BOUNTY + maxHp / 10) * cfg.bountyMultiplier)
+	const enemy: Enemy = {
+		id: nextEnemyId(),
+		type,
+		distance: 0,
+		hp: maxHp,
+		maxHp,
+		speed: (ENEMY_BASE_SPEED + Math.random() * 25) * cfg.speedMultiplier,
+		radius: cfg.radius,
+		bounty,
+		slowedUntilMs: 0,
+	}
+	enemies$.update((list) => [...list, enemy])
+}
+
+function moveEnemies(dt: number, now: number) {
+	const enemies = enemies$.get()
+	if (enemies.length === 0) return
+	const next: Enemy[] = []
+	let leaks = 0
+	for (const e of enemies) {
+		const isSlowed = e.slowedUntilMs > now
+		const speed = isSlowed ? e.speed * MAGIC_SLOW_FACTOR : e.speed
+		const distance = e.distance + speed * dt
+		if (distance >= PATH_LENGTH) {
+			leaks++
+			continue
+		}
+		next.push({ ...e, distance })
+	}
+	if (leaks > 0) lives$.update((l) => Math.max(0, l - leaks))
+	enemies$.set(next)
+}
+
+function fireTowers(editor: Editor, now: number) {
+	const enemies = enemies$.get()
+	if (enemies.length === 0) return
+	const shapes = editor.getCurrentPageShapes()
+	for (const shape of shapes) {
+		if (shape.type !== 'geo') continue
+		const baseStats = getTowerStats((shape as TLGeoShape).props.geo)
+		if (!baseStats) continue
+		const stats = getScaledStats(baseStats, getTowerLevel(shape))
+		const cooldown = towerCooldowns.get(shape.id)
+		if (cooldown && now - cooldown.lastFiredAt < stats.fireRateMs) continue
+		const bounds = editor.getShapePageBounds(shape.id)
+		if (!bounds) continue
+		const cx = bounds.center.x
+		const cy = bounds.center.y
+		// Pick the enemy closest to the end of the path within range.
+		let target: Enemy | null = null
+		let targetPos = { x: 0, y: 0 }
+		let bestProgress = -1
+		for (const enemy of enemies) {
+			const pos = getPositionAtDistance(enemy.distance)
+			const dx = pos.x - cx
+			const dy = pos.y - cy
+			if (dx * dx + dy * dy > stats.range * stats.range) continue
+			if (enemy.distance > bestProgress) {
+				bestProgress = enemy.distance
+				target = enemy
+				targetPos = pos
+			}
+		}
+		if (!target) continue
+		const dx = targetPos.x - cx
+		const dy = targetPos.y - cy
+		const dist = Math.hypot(dx, dy) || 1
+		const projectile: Projectile = {
+			id: nextProjectileId(),
+			x: cx,
+			y: cy,
+			vx: (dx / dist) * stats.projectileSpeed,
+			vy: (dy / dist) * stats.projectileSpeed,
+			damage: stats.damage,
+			kind: stats.projectileKind,
+			targetEnemyId: target.id,
+			ageMs: 0,
+		}
+		projectiles$.update((list) => [...list, projectile])
+		towerCooldowns.set(shape.id, { lastFiredAt: now })
+		playFireSound(stats.projectileKind)
+	}
+}
+
+function moveProjectiles(dt: number, dtMs: number) {
+	const list = projectiles$.get()
+	if (list.length === 0) return
+	const next: Projectile[] = []
+	for (const p of list) {
+		const ageMs = p.ageMs + dtMs
+		if (ageMs > PROJECTILE_MAX_AGE_MS) continue
+		next.push({ ...p, x: p.x + p.vx * dt, y: p.y + p.vy * dt, ageMs })
+	}
+	projectiles$.set(next)
+}
+
+function resolveHits() {
+	const projectiles = projectiles$.get()
+	if (projectiles.length === 0) return
+	const enemies = enemies$.get()
+	if (enemies.length === 0) {
+		// Projectiles whose targets vanished can keep flying until expiry.
+		return
+	}
+	const now = elapsedMs$.get()
+	const enemyById = new Map<number, Enemy>()
+	for (const e of enemies) enemyById.set(e.id, e)
+
+	const survivingProjectiles: Projectile[] = []
+	const damageByEnemyId = new Map<number, number>()
+	const slowedEnemyIds = new Set<number>()
+	for (const p of projectiles) {
+		// Use current position of the original target if still alive; otherwise
+		// look for any nearby enemy to make impacts feel responsive.
+		const target = enemyById.get(p.targetEnemyId)
+		let hit: Enemy | null = null
+		if (target) {
+			const pos = getPositionAtDistance(target.distance)
+			if (Math.hypot(p.x - pos.x, p.y - pos.y) <= target.radius) hit = target
+		}
+		if (!hit) {
+			for (const e of enemies) {
+				const pos = getPositionAtDistance(e.distance)
+				if (Math.hypot(p.x - pos.x, p.y - pos.y) <= e.radius) {
+					hit = e
+					break
+				}
+			}
+		}
+		if (hit) {
+			if (p.kind === 'orb') {
+				// Magic projectiles explode on impact: damage and slow every
+				// enemy in the AOE, plus a transient ring overlay.
+				spawnExplosion(p.x, p.y, MAGIC_AOE_RADIUS)
+				for (const e of enemies) {
+					const pos = getPositionAtDistance(e.distance)
+					if (Math.hypot(p.x - pos.x, p.y - pos.y) <= MAGIC_AOE_RADIUS + e.radius) {
+						damageByEnemyId.set(e.id, (damageByEnemyId.get(e.id) ?? 0) + p.damage)
+						slowedEnemyIds.add(e.id)
+					}
+				}
+			} else {
+				damageByEnemyId.set(hit.id, (damageByEnemyId.get(hit.id) ?? 0) + p.damage)
+			}
+		} else {
+			survivingProjectiles.push(p)
+		}
+	}
+	if (survivingProjectiles.length !== projectiles.length) {
+		projectiles$.set(survivingProjectiles)
+	}
+	if (damageByEnemyId.size === 0 && slowedEnemyIds.size === 0) return
+
+	let bountyGained = 0
+	const slowExpiry = now + MAGIC_SLOW_DURATION_MS
+	const nextEnemies: Enemy[] = []
+	for (const e of enemies) {
+		const dmg = damageByEnemyId.get(e.id) ?? 0
+		const slowed = slowedEnemyIds.has(e.id)
+		if (dmg === 0 && !slowed) {
+			nextEnemies.push(e)
+			continue
+		}
+		const hp = e.hp - dmg
+		if (hp <= 0) {
+			bountyGained += e.bounty
+			continue
+		}
+		nextEnemies.push({
+			...e,
+			hp,
+			// Slows refresh — multiple magic hits keep the effect alive rather
+			// than stacking duration.
+			slowedUntilMs: slowed ? Math.max(e.slowedUntilMs, slowExpiry) : e.slowedUntilMs,
+		})
+	}
+	enemies$.set(nextEnemies)
+	if (bountyGained > 0) gainBounty(bountyGained)
+}
+
+function checkGameOver() {
+	if (lives$.get() <= 0) gameOver$.set(true)
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/game-state.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/game-state.ts
@@ -1,0 +1,107 @@
+import { atom } from 'tldraw'
+import { EnemyType } from './enemy-config'
+import { ProjectileKind, TowerGeo } from './tower-config'
+
+export interface Enemy {
+	id: number
+	type: EnemyType
+	distance: number
+	hp: number
+	maxHp: number
+	speed: number
+	radius: number
+	bounty: number
+	// Absolute elapsedMs at which any active slow ends. 0 = not slowed.
+	slowedUntilMs: number
+}
+
+export interface Projectile {
+	id: number
+	x: number
+	y: number
+	vx: number
+	vy: number
+	damage: number
+	kind: ProjectileKind
+	targetEnemyId: number
+	ageMs: number
+}
+
+export interface TowerCooldown {
+	lastFiredAt: number
+}
+
+export interface Explosion {
+	id: number
+	x: number
+	y: number
+	radius: number
+	ageMs: number
+	maxAgeMs: number
+}
+
+export const STARTING_GOLD = 100
+export const STARTING_LIVES = 20
+
+export const enemies$ = atom<Enemy[]>('enemies', [])
+export const projectiles$ = atom<Projectile[]>('projectiles', [])
+export const explosions$ = atom<Explosion[]>('explosions', [])
+// Currently armed tower placement; non-null while the player has a tower
+// "in hand" from the toolbar / keyboard.
+export const placingTower$ = atom<TowerGeo | null>('placingTower', null)
+export const score$ = atom('score', 0)
+export const gold$ = atom('gold', STARTING_GOLD)
+export const lives$ = atom('lives', STARTING_LIVES)
+export const gameOver$ = atom('gameOver', false)
+export const elapsedMs$ = atom('elapsedMs', 0)
+
+// Tower cooldowns are keyed by shape id. Not an atom — only the game loop reads
+// and writes them, and they don't need to drive overlay reactivity.
+export const towerCooldowns = new Map<string, TowerCooldown>()
+
+let _nextEnemyId = 1
+export const nextEnemyId = () => _nextEnemyId++
+let _nextProjId = 1
+export const nextProjectileId = () => _nextProjId++
+let _nextExplosionId = 1
+export const nextExplosionId = () => _nextExplosionId++
+
+export function resetGameState() {
+	enemies$.set([])
+	projectiles$.set([])
+	explosions$.set([])
+	score$.set(0)
+	gold$.set(STARTING_GOLD)
+	lives$.set(STARTING_LIVES)
+	gameOver$.set(false)
+	elapsedMs$.set(0)
+	towerCooldowns.clear()
+	_nextEnemyId = 1
+	_nextProjId = 1
+	_nextExplosionId = 1
+}
+
+export function gainBounty(amount: number) {
+	score$.update((s) => s + amount)
+	gold$.update((g) => g + amount)
+}
+
+export function applyDamage(enemyId: number, amount: number) {
+	const enemies = enemies$.get()
+	const next: Enemy[] = []
+	let killed: Enemy | null = null
+	for (const e of enemies) {
+		if (e.id !== enemyId) {
+			next.push(e)
+			continue
+		}
+		const hp = e.hp - amount
+		if (hp <= 0) {
+			killed = e
+		} else {
+			next.push({ ...e, hp })
+		}
+	}
+	if (killed) gainBounty(killed.bounty)
+	enemies$.set(next)
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/EnemyOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/EnemyOverlayUtil.ts
@@ -1,0 +1,143 @@
+import { Circle2d, Geometry2d, OverlayUtil, TLCursorType, TLOverlay } from 'tldraw'
+import { ENEMY_CONFIG, EnemyType } from '../enemy-config'
+import { applyDamage, elapsedMs$, enemies$ } from '../game-state'
+import { getPositionAtDistance } from '../path'
+
+interface TLEnemyOverlay extends TLOverlay {
+	props: {
+		enemyId: number
+		type: EnemyType
+		x: number
+		y: number
+		hp: number
+		maxHp: number
+		radius: number
+		slowed: boolean
+	}
+}
+
+const CLICK_DAMAGE = 5
+
+export class EnemyOverlayUtil extends OverlayUtil<TLEnemyOverlay> {
+	static override type = 'td-enemy'
+	override options = { zIndex: 200 }
+
+	override isActive(): boolean {
+		return enemies$.get().length > 0
+	}
+
+	override getOverlays(): TLEnemyOverlay[] {
+		const now = elapsedMs$.get()
+		return enemies$.get().map((e) => {
+			const pos = getPositionAtDistance(e.distance)
+			return {
+				id: `td-enemy:${e.id}`,
+				type: 'td-enemy',
+				props: {
+					enemyId: e.id,
+					type: e.type,
+					x: pos.x,
+					y: pos.y,
+					hp: e.hp,
+					maxHp: e.maxHp,
+					radius: e.radius,
+					slowed: e.slowedUntilMs > now,
+				},
+			}
+		})
+	}
+
+	override getGeometry(overlay: TLEnemyOverlay): Geometry2d {
+		const { x, y, radius } = overlay.props
+		// Circle2d's x/y is the bounding-box top-left, so center = (x+radius, y+radius).
+		return new Circle2d({ x: x - radius, y: y - radius, radius, isFilled: true })
+	}
+
+	override getCursor(): TLCursorType {
+		return 'cross'
+	}
+
+	override onPointerDown(overlay: TLEnemyOverlay): boolean {
+		applyDamage(overlay.props.enemyId, CLICK_DAMAGE)
+		// Returning truthy keeps the editor from starting a brush/select drag on
+		// what is effectively a game click.
+		return true
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLEnemyOverlay[]): void {
+		const zoom = this.editor.getZoomLevel()
+		const isDark = this.editor.getColorMode() === 'dark'
+		const hoveredId = this.editor.overlays.getHoveredOverlayId()
+		for (const overlay of overlays) {
+			const { x, y, hp, maxHp, radius, type, slowed } = overlay.props
+			const cfg = ENEMY_CONFIG[type]
+			const t = Math.max(0, Math.min(1, hp / maxHp))
+
+			ctx.save()
+			ctx.beginPath()
+			ctx.arc(x, y, radius, 0, Math.PI * 2)
+			ctx.fillStyle = cfg.bodyColor
+			ctx.fill()
+			ctx.lineWidth = 2 / zoom
+			ctx.strokeStyle = cfg.ringColor
+			ctx.stroke()
+			// Inner ring shrinks/dims with HP so wounded enemies read at a glance.
+			ctx.beginPath()
+			ctx.arc(x, y, radius * 0.55, 0, Math.PI * 2)
+			ctx.fillStyle = `rgba(0, 0, 0, ${0.15 + 0.45 * (1 - t)})`
+			ctx.fill()
+
+			// Frosty halo when slowed by Magic.
+			if (slowed) {
+				ctx.beginPath()
+				ctx.arc(x, y, radius + 4 / zoom, 0, Math.PI * 2)
+				ctx.fillStyle = 'rgba(140, 200, 255, 0.35)'
+				ctx.fill()
+				ctx.lineWidth = 1.5 / zoom
+				ctx.strokeStyle = 'rgba(180, 220, 255, 0.9)'
+				ctx.setLineDash([4 / zoom, 3 / zoom])
+				ctx.stroke()
+				ctx.setLineDash([])
+			}
+
+			// HP bar above the enemy.
+			const barW = radius * 2
+			const barH = 5 / zoom
+			const barX = x - radius
+			const barY = y - radius - barH - 4 / zoom
+			ctx.fillStyle = isDark ? 'rgba(60,60,80,0.85)' : 'rgba(220,220,230,0.9)'
+			ctx.fillRect(barX, barY, barW, barH)
+			ctx.fillStyle = '#3bce5a'
+			ctx.fillRect(barX, barY, barW * t, barH)
+			ctx.lineWidth = 1 / zoom
+			ctx.strokeStyle = isDark ? '#000' : '#444'
+			ctx.strokeRect(barX, barY, barW, barH)
+
+			// HP readout above the bar when this enemy is hovered.
+			if (overlay.id === hoveredId) {
+				const text = `${cfg.label} · ${Math.max(0, Math.ceil(hp))} / ${maxHp}`
+				const fontPx = 12 / zoom
+				ctx.font = `600 ${fontPx}px sans-serif`
+				ctx.textAlign = 'center'
+				ctx.textBaseline = 'bottom'
+				const textY = barY - 4 / zoom
+				const metrics = ctx.measureText(text)
+				const padX = 6 / zoom
+				const padY = 3 / zoom
+				const boxW = metrics.width + padX * 2
+				const boxH = fontPx + padY * 2
+				const boxX = x - boxW / 2
+				const boxY = textY - boxH + padY
+				ctx.fillStyle = isDark ? 'rgba(20,20,28,0.92)' : 'rgba(255,255,255,0.95)'
+				ctx.fillRect(boxX, boxY, boxW, boxH)
+				ctx.lineWidth = 1 / zoom
+				ctx.strokeStyle = isDark ? '#fff' : '#000'
+				ctx.strokeRect(boxX, boxY, boxW, boxH)
+				ctx.fillStyle = isDark ? '#fff' : '#000'
+				ctx.fillText(text, x, textY)
+			}
+
+			ctx.restore()
+		}
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/ExplosionOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/ExplosionOverlayUtil.ts
@@ -1,0 +1,62 @@
+import { OverlayUtil, TLOverlay } from 'tldraw'
+import { explosions$ } from '../game-state'
+
+interface TLExplosionOverlay extends TLOverlay {
+	props: {
+		x: number
+		y: number
+		radius: number
+		t: number // 0 = just spawned, 1 = about to expire
+	}
+}
+
+export class ExplosionOverlayUtil extends OverlayUtil<TLExplosionOverlay> {
+	static override type = 'td-explosion'
+	override options = { zIndex: 230 }
+
+	override isActive(): boolean {
+		return explosions$.get().length > 0
+	}
+
+	override getOverlays(): TLExplosionOverlay[] {
+		return explosions$.get().map((e) => ({
+			id: `td-explosion:${e.id}`,
+			type: 'td-explosion',
+			props: {
+				x: e.x,
+				y: e.y,
+				radius: e.radius,
+				t: Math.min(1, e.ageMs / e.maxAgeMs),
+			},
+		}))
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLExplosionOverlay[]): void {
+		const zoom = this.editor.getZoomLevel()
+		ctx.save()
+		for (const overlay of overlays) {
+			const { x, y, radius, t } = overlay.props
+			// Expanding ring + fading filled core.
+			const ringR = radius * (0.4 + 0.6 * t)
+			const alpha = 1 - t
+
+			ctx.globalAlpha = alpha * 0.45
+			const grd = ctx.createRadialGradient(x, y, 1, x, y, radius)
+			grd.addColorStop(0, 'rgba(180, 220, 255, 1)')
+			grd.addColorStop(0.6, 'rgba(120, 160, 240, 0.5)')
+			grd.addColorStop(1, 'rgba(80, 120, 220, 0)')
+			ctx.fillStyle = grd
+			ctx.beginPath()
+			ctx.arc(x, y, radius, 0, Math.PI * 2)
+			ctx.fill()
+
+			ctx.globalAlpha = alpha
+			ctx.lineWidth = 3 / zoom
+			ctx.strokeStyle = 'rgba(180, 220, 255, 1)'
+			ctx.beginPath()
+			ctx.arc(x, y, ringR, 0, Math.PI * 2)
+			ctx.stroke()
+		}
+		ctx.restore()
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/PathOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/PathOverlayUtil.ts
@@ -1,0 +1,47 @@
+import { OverlayUtil, TLOverlay } from 'tldraw'
+import { PATH } from '../path'
+
+interface TLPathOverlay extends TLOverlay {
+	props: Record<string, never>
+}
+
+export class PathOverlayUtil extends OverlayUtil<TLPathOverlay> {
+	static override type = 'td-path'
+	override options = { zIndex: 50 }
+
+	override isActive(): boolean {
+		return true
+	}
+
+	override getOverlays(): TLPathOverlay[] {
+		return [{ id: 'td-path:main', type: 'td-path', props: {} }]
+	}
+
+	override render(ctx: CanvasRenderingContext2D): void {
+		const zoom = this.editor.getZoomLevel()
+		const isDark = this.editor.getColorMode() === 'dark'
+
+		ctx.save()
+		ctx.lineCap = 'round'
+		ctx.lineJoin = 'round'
+
+		// Wide soft track
+		ctx.lineWidth = 38
+		ctx.strokeStyle = isDark ? 'rgba(80, 80, 110, 0.45)' : 'rgba(160, 170, 200, 0.45)'
+		ctx.beginPath()
+		ctx.moveTo(PATH[0].x, PATH[0].y)
+		for (let i = 1; i < PATH.length; i++) ctx.lineTo(PATH[i].x, PATH[i].y)
+		ctx.stroke()
+
+		// Center dashed line
+		ctx.lineWidth = 2 / zoom
+		ctx.setLineDash([10 / zoom, 10 / zoom])
+		ctx.strokeStyle = isDark ? 'rgba(220, 220, 240, 0.7)' : 'rgba(60, 60, 80, 0.7)'
+		ctx.beginPath()
+		ctx.moveTo(PATH[0].x, PATH[0].y)
+		for (let i = 1; i < PATH.length; i++) ctx.lineTo(PATH[i].x, PATH[i].y)
+		ctx.stroke()
+
+		ctx.restore()
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/PlacementPreviewOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/PlacementPreviewOverlayUtil.ts
@@ -1,0 +1,116 @@
+import { Circle2d, Geometry2d, OverlayUtil, TLCursorType, TLOverlay, createShapeId } from 'tldraw'
+import { gold$, placingTower$ } from '../game-state'
+import { TOWER_PLACEMENT_SIZE, TOWER_STATS_BY_GEO, TowerGeo, getTowerStats } from '../tower-config'
+
+interface TLPlacementPreviewOverlay extends TLOverlay {
+	props: {
+		geo: TowerGeo
+		x: number
+		y: number
+		range: number
+	}
+}
+
+export class PlacementPreviewOverlayUtil extends OverlayUtil<TLPlacementPreviewOverlay> {
+	static override type = 'td-placement-preview'
+	override options = { zIndex: 150 }
+
+	override isActive(): boolean {
+		const placing = placingTower$.get()
+		if (!placing) return false
+		const stats = TOWER_STATS_BY_GEO[placing]
+		return gold$.get() >= stats.cost
+	}
+
+	override getOverlays(): TLPlacementPreviewOverlay[] {
+		const geo = placingTower$.get()
+		if (!geo) return []
+		const stats = getTowerStats(geo)
+		if (!stats) return []
+		const { x, y } = this.editor.inputs.getCurrentPagePoint()
+		return [
+			{
+				id: 'td-placement-preview:main',
+				type: 'td-placement-preview',
+				props: { geo, x, y, range: stats.range },
+			},
+		]
+	}
+
+	// The preview tracks the cursor, so a click at the cursor always lands inside
+	// this circle — that's how we route placement through the overlay system
+	// instead of bolting on a capture-phase canvas listener.
+	override getGeometry(overlay: TLPlacementPreviewOverlay): Geometry2d {
+		const { x, y } = overlay.props
+		const r = TOWER_PLACEMENT_SIZE / 2
+		return new Circle2d({ x: x - r, y: y - r, radius: r, isFilled: true })
+	}
+
+	override getCursor(): TLCursorType {
+		return 'cross'
+	}
+
+	override onPointerDown(overlay: TLPlacementPreviewOverlay): boolean {
+		const { geo, x, y } = overlay.props
+		const stats = TOWER_STATS_BY_GEO[geo]
+		if (gold$.get() < stats.cost) return true
+		this.editor.createShape({
+			id: createShapeId(),
+			type: 'geo',
+			x: x - TOWER_PLACEMENT_SIZE / 2,
+			y: y - TOWER_PLACEMENT_SIZE / 2,
+			isLocked: true,
+			props: { geo, w: TOWER_PLACEMENT_SIZE, h: TOWER_PLACEMENT_SIZE },
+		})
+		gold$.update((g) => g - stats.cost)
+		placingTower$.set(null)
+		return true
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLPlacementPreviewOverlay[]): void {
+		const overlay = overlays[0]
+		if (!overlay) return
+		const { geo, x, y, range } = overlay.props
+		const zoom = this.editor.getZoomLevel()
+		const colors = this.editor.getCurrentTheme().colors[this.editor.getColorMode()]
+
+		ctx.save()
+
+		// Range ring + soft fill.
+		ctx.lineWidth = 2 / zoom
+		ctx.setLineDash([8 / zoom, 6 / zoom])
+		ctx.strokeStyle = colors.selectionStroke
+		ctx.fillStyle = colors.selectionFill
+		ctx.globalAlpha = 0.35
+		ctx.beginPath()
+		ctx.arc(x, y, range, 0, Math.PI * 2)
+		ctx.fill()
+		ctx.globalAlpha = 1
+		ctx.stroke()
+		ctx.setLineDash([])
+
+		// Ghost shape silhouette at the would-be placement.
+		const half = TOWER_PLACEMENT_SIZE / 2
+		ctx.globalAlpha = 0.55
+		ctx.lineWidth = 2 / zoom
+		ctx.strokeStyle = colors.selectionStroke
+		ctx.fillStyle = colors.selectionFill
+
+		ctx.beginPath()
+		if (geo === 'rectangle') {
+			ctx.rect(x - half, y - half, TOWER_PLACEMENT_SIZE, TOWER_PLACEMENT_SIZE)
+		} else if (geo === 'ellipse') {
+			ctx.ellipse(x, y, half, half, 0, 0, Math.PI * 2)
+		} else {
+			// Triangle — match how the geo shape renders: top-center, bottom-left, bottom-right.
+			ctx.moveTo(x, y - half)
+			ctx.lineTo(x + half, y + half)
+			ctx.lineTo(x - half, y + half)
+			ctx.closePath()
+		}
+		ctx.fill()
+		ctx.stroke()
+
+		ctx.restore()
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/ProjectileOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/ProjectileOverlayUtil.ts
@@ -1,0 +1,82 @@
+import { OverlayUtil, TLOverlay } from 'tldraw'
+import { projectiles$ } from '../game-state'
+import { ProjectileKind } from '../tower-config'
+
+interface TLProjectileOverlay extends TLOverlay {
+	props: {
+		x: number
+		y: number
+		angle: number
+		kind: ProjectileKind
+	}
+}
+
+export class ProjectileOverlayUtil extends OverlayUtil<TLProjectileOverlay> {
+	static override type = 'td-projectile'
+	override options = { zIndex: 250 }
+
+	override isActive(): boolean {
+		return projectiles$.get().length > 0
+	}
+
+	override getOverlays(): TLProjectileOverlay[] {
+		return projectiles$.get().map((p) => ({
+			id: `td-projectile:${p.id}`,
+			type: 'td-projectile',
+			props: {
+				x: p.x,
+				y: p.y,
+				angle: Math.atan2(p.vy, p.vx),
+				kind: p.kind,
+			},
+		}))
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLProjectileOverlay[]): void {
+		const zoom = this.editor.getZoomLevel()
+		const isDark = this.editor.getColorMode() === 'dark'
+		for (const overlay of overlays) {
+			const { x, y, angle, kind } = overlay.props
+			ctx.save()
+			ctx.translate(x, y)
+			ctx.rotate(angle)
+			switch (kind) {
+				case 'arrow':
+					ctx.lineWidth = 2 / zoom
+					ctx.strokeStyle = isDark ? '#ddd' : '#222'
+					ctx.beginPath()
+					ctx.moveTo(-10, 0)
+					ctx.lineTo(8, 0)
+					ctx.stroke()
+					ctx.beginPath()
+					ctx.moveTo(8, 0)
+					ctx.lineTo(2, -3)
+					ctx.lineTo(2, 3)
+					ctx.closePath()
+					ctx.fillStyle = isDark ? '#ddd' : '#222'
+					ctx.fill()
+					break
+				case 'rock':
+					ctx.beginPath()
+					ctx.arc(0, 0, 6, 0, Math.PI * 2)
+					ctx.fillStyle = '#806040'
+					ctx.fill()
+					ctx.lineWidth = 1.5 / zoom
+					ctx.strokeStyle = '#3a2a1a'
+					ctx.stroke()
+					break
+				case 'orb': {
+					const grd = ctx.createRadialGradient(0, 0, 1, 0, 0, 8)
+					grd.addColorStop(0, 'rgba(180, 220, 255, 1)')
+					grd.addColorStop(1, 'rgba(80, 120, 220, 0.1)')
+					ctx.fillStyle = grd
+					ctx.beginPath()
+					ctx.arc(0, 0, 8, 0, Math.PI * 2)
+					ctx.fill()
+					break
+				}
+			}
+			ctx.restore()
+		}
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/TowerRangeOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/TowerRangeOverlayUtil.ts
@@ -1,0 +1,79 @@
+import { computed, OverlayUtil, TLGeoShape, TLOverlay } from 'tldraw'
+import { getScaledStats, getTowerLevel, getTowerStats } from '../tower-config'
+
+interface TLTowerRangeOverlay extends TLOverlay {
+	props: {
+		shapeId: string
+		cx: number
+		cy: number
+		range: number
+	}
+}
+
+export class TowerRangeOverlayUtil extends OverlayUtil<TLTowerRangeOverlay> {
+	static override type = 'td-tower-range'
+	override options = { zIndex: 100 }
+
+	// We deliberately don't rely on `editor.getHoveredShape()` here: default geo
+	// shapes have `fill: 'none'`, which makes their interiors transparent to
+	// hover hit-testing. Walking tower bounds directly means hovering anywhere
+	// inside a tower's bounding box highlights its range, regardless of fill.
+	// Memoised via computed so isActive() + getOverlays() share one walk per tick.
+	private _hoveredTowers = computed('td-tower-range:hovered', (): TLTowerRangeOverlay[] => {
+		const point = this.editor.inputs.getCurrentPagePoint()
+		const result: TLTowerRangeOverlay[] = []
+		for (const shape of this.editor.getCurrentPageShapes()) {
+			if (shape.type !== 'geo') continue
+			const baseStats = getTowerStats((shape as TLGeoShape).props.geo)
+			if (!baseStats) continue
+			const stats = getScaledStats(baseStats, getTowerLevel(shape))
+			const bounds = this.editor.getShapePageBounds(shape.id)
+			if (!bounds) continue
+			// Always preview the range while a tower is being placed (unlocked);
+			// once placed (locked), only show on hover. Filtering on isLocked
+			// avoids flicker as the in-progress shape's bounds chase the pointer.
+			const isPlacing = !shape.isLocked
+			if (!isPlacing && !bounds.containsPoint(point)) continue
+			result.push({
+				id: `td-tower-range:${shape.id}`,
+				type: 'td-tower-range',
+				props: {
+					shapeId: shape.id,
+					cx: bounds.center.x,
+					cy: bounds.center.y,
+					range: stats.range,
+				},
+			})
+		}
+		return result
+	})
+
+	override isActive(): boolean {
+		return this._hoveredTowers.get().length > 0
+	}
+
+	override getOverlays(): TLTowerRangeOverlay[] {
+		return this._hoveredTowers.get()
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLTowerRangeOverlay[]): void {
+		const zoom = this.editor.getZoomLevel()
+		const colors = this.editor.getCurrentTheme().colors[this.editor.getColorMode()]
+
+		ctx.save()
+		ctx.lineWidth = 2 / zoom
+		ctx.setLineDash([8 / zoom, 6 / zoom])
+		ctx.strokeStyle = colors.selectionStroke
+		ctx.fillStyle = colors.selectionFill
+		for (const overlay of overlays) {
+			const { cx, cy, range } = overlay.props
+			ctx.globalAlpha = 0.4
+			ctx.beginPath()
+			ctx.arc(cx, cy, range, 0, Math.PI * 2)
+			ctx.fill()
+			ctx.globalAlpha = 1
+			ctx.stroke()
+		}
+		ctx.restore()
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/overlays/UpgradeButtonOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/overlays/UpgradeButtonOverlayUtil.ts
@@ -1,0 +1,192 @@
+import {
+	Box,
+	Circle2d,
+	Geometry2d,
+	OverlayUtil,
+	TLCursorType,
+	TLGeoShape,
+	TLOverlay,
+	TLShapeId,
+	computed,
+} from 'tldraw'
+import { gold$ } from '../game-state'
+import { playUpgradeSound } from '../sounds'
+import {
+	MAX_TOWER_LEVEL,
+	getTowerLevel,
+	getTowerStats,
+	getUpgradeCost,
+	levelColor,
+} from '../tower-config'
+
+interface TLUpgradeBtnOverlay extends TLOverlay {
+	props: {
+		shapeId: TLShapeId
+		x: number
+		y: number
+		radius: number
+		level: number
+		upgradeCost: number
+		canAfford: boolean
+	}
+}
+
+const BTN_RADIUS = 14
+
+interface UpgradeCandidate {
+	shapeId: TLShapeId
+	cx: number
+	cy: number
+	bounds: Box
+	level: number
+	upgradeCost: number
+}
+
+export class UpgradeButtonOverlayUtil extends OverlayUtil<TLUpgradeBtnOverlay> {
+	static override type = 'td-upgrade-btn'
+	override options = { zIndex: 260 }
+
+	// Walk the page shapes once per shape/bounds change. Filtering by pointer
+	// happens in getOverlays(), so a mousemove storm only re-runs the cheap
+	// pointer filter — not the full shape scan and bounds resolution.
+	private _candidates = computed('td-upgrade-btn:candidates', (): UpgradeCandidate[] => {
+		const result: UpgradeCandidate[] = []
+		for (const shape of this.editor.getCurrentPageShapes()) {
+			if (shape.type !== 'geo' || !shape.isLocked) continue
+			const stats = getTowerStats((shape as TLGeoShape).props.geo)
+			if (!stats) continue
+			const level = getTowerLevel(shape)
+			if (level >= MAX_TOWER_LEVEL) continue
+			const bounds = this.editor.getShapePageBounds(shape.id)
+			if (!bounds) continue
+			result.push({
+				shapeId: shape.id,
+				cx: bounds.center.x,
+				cy: bounds.center.y,
+				bounds,
+				level,
+				upgradeCost: getUpgradeCost(stats.cost, level),
+			})
+		}
+		return result
+	})
+
+	override isActive(): boolean {
+		return this._candidates.get().length > 0
+	}
+
+	override getOverlays(): TLUpgradeBtnOverlay[] {
+		const candidates = this._candidates.get()
+		if (candidates.length === 0) return []
+		const gold = gold$.get()
+		const point = this.editor.inputs.getCurrentPagePoint()
+		const result: TLUpgradeBtnOverlay[] = []
+		for (const c of candidates) {
+			// Show only while the pointer is over the tower or the button itself —
+			// the button stays accessible after the cursor moves up onto it.
+			const overShape = c.bounds.containsPoint(point)
+			const dx = point.x - c.cx
+			const dy = point.y - c.cy
+			const overButton = dx * dx + dy * dy <= BTN_RADIUS * BTN_RADIUS
+			if (!overShape && !overButton) continue
+			result.push({
+				id: `td-upgrade-btn:${c.shapeId}`,
+				type: 'td-upgrade-btn',
+				props: {
+					shapeId: c.shapeId,
+					x: c.cx,
+					y: c.cy,
+					radius: BTN_RADIUS,
+					level: c.level,
+					upgradeCost: c.upgradeCost,
+					canAfford: gold >= c.upgradeCost,
+				},
+			})
+		}
+		return result
+	}
+
+	override getGeometry(overlay: TLUpgradeBtnOverlay): Geometry2d {
+		const { x, y, radius } = overlay.props
+		return new Circle2d({ x: x - radius, y: y - radius, radius, isFilled: true })
+	}
+
+	override getCursor(): TLCursorType {
+		return 'pointer'
+	}
+
+	override onPointerDown(overlay: TLUpgradeBtnOverlay): boolean {
+		const { shapeId, upgradeCost, level, canAfford } = overlay.props
+		if (!canAfford) return true
+		const shape = this.editor.getShape(shapeId)
+		if (!shape) return true
+		const nextLevel = level + 1
+		gold$.update((g) => g - upgradeCost)
+		// updateShape silently skips locked shapes unless run with ignoreShapeLock;
+		// without this the meta + props don't persist on placed (locked) towers.
+		this.editor.run(
+			() => {
+				this.editor.updateShape({
+					id: shapeId,
+					type: 'geo',
+					meta: { ...shape.meta, towerLevel: nextLevel },
+					props: { fill: 'solid', color: levelColor(nextLevel) },
+				})
+			},
+			{ ignoreShapeLock: true }
+		)
+		playUpgradeSound()
+		return true
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLUpgradeBtnOverlay[]): void {
+		const zoom = this.editor.getZoomLevel()
+		const isDark = this.editor.getColorMode() === 'dark'
+		for (const overlay of overlays) {
+			const { x, y, radius, level, upgradeCost, canAfford } = overlay.props
+			ctx.save()
+			ctx.beginPath()
+			ctx.arc(x, y, radius, 0, Math.PI * 2)
+			ctx.fillStyle = canAfford ? '#3aa56a' : isDark ? '#444' : '#aaa'
+			ctx.fill()
+			ctx.lineWidth = 2 / zoom
+			ctx.strokeStyle = isDark ? '#000' : '#222'
+			ctx.stroke()
+
+			// Plus sign.
+			ctx.lineWidth = 3 / zoom
+			ctx.lineCap = 'round'
+			ctx.strokeStyle = '#fff'
+			const arm = radius * 0.5
+			ctx.beginPath()
+			ctx.moveTo(x - arm, y)
+			ctx.lineTo(x + arm, y)
+			ctx.moveTo(x, y - arm)
+			ctx.lineTo(x, y + arm)
+			ctx.stroke()
+
+			// Cost + level chip below the button.
+			const fontPx = 11 / zoom
+			ctx.font = `600 ${fontPx}px sans-serif`
+			ctx.textAlign = 'center'
+			ctx.textBaseline = 'top'
+			const text = `L${level}→${level + 1} · ${upgradeCost}g`
+			const metrics = ctx.measureText(text)
+			const padX = 5 / zoom
+			const padY = 2 / zoom
+			const boxW = metrics.width + padX * 2
+			const boxH = fontPx + padY * 2
+			const boxX = x - boxW / 2
+			const boxY = y + radius + 3 / zoom
+			ctx.fillStyle = isDark ? 'rgba(20,20,28,0.92)' : 'rgba(255,255,255,0.95)'
+			ctx.fillRect(boxX, boxY, boxW, boxH)
+			ctx.lineWidth = 1 / zoom
+			ctx.strokeStyle = isDark ? '#fff' : '#000'
+			ctx.strokeRect(boxX, boxY, boxW, boxH)
+			ctx.fillStyle = canAfford ? (isDark ? '#fff' : '#000') : isDark ? '#888' : '#888'
+			ctx.fillText(text, x, boxY + padY)
+
+			ctx.restore()
+		}
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/path.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/path.ts
@@ -1,0 +1,63 @@
+// Hardcoded enemy path. Page-space waypoints; enemies move along it from start
+// to end. Kept simple so the OverlayUtil mechanics, not the routing, are the
+// point of the example.
+
+export interface Waypoint {
+	x: number
+	y: number
+}
+
+export const PATH: Waypoint[] = [
+	{ x: -200, y: 200 },
+	{ x: 200, y: 200 },
+	{ x: 200, y: 500 },
+	{ x: 600, y: 500 },
+	{ x: 600, y: 100 },
+	{ x: 1000, y: 100 },
+	{ x: 1000, y: 600 },
+	{ x: 1400, y: 600 },
+]
+
+const SEGMENT_LENGTHS: number[] = []
+let TOTAL_LENGTH = 0
+for (let i = 1; i < PATH.length; i++) {
+	const dx = PATH[i].x - PATH[i - 1].x
+	const dy = PATH[i].y - PATH[i - 1].y
+	const len = Math.hypot(dx, dy)
+	SEGMENT_LENGTHS.push(len)
+	TOTAL_LENGTH += len
+}
+
+export const PATH_LENGTH = TOTAL_LENGTH
+
+export interface PointOnPath {
+	x: number
+	y: number
+	angle: number
+}
+
+export function getPositionAtDistance(distance: number): PointOnPath {
+	if (distance <= 0) {
+		const a = PATH[0]
+		const b = PATH[1]
+		return { x: a.x, y: a.y, angle: Math.atan2(b.y - a.y, b.x - a.x) }
+	}
+	let remaining = distance
+	for (let i = 0; i < SEGMENT_LENGTHS.length; i++) {
+		const segLen = SEGMENT_LENGTHS[i]
+		if (remaining <= segLen) {
+			const a = PATH[i]
+			const b = PATH[i + 1]
+			const t = remaining / segLen
+			return {
+				x: a.x + (b.x - a.x) * t,
+				y: a.y + (b.y - a.y) * t,
+				angle: Math.atan2(b.y - a.y, b.x - a.x),
+			}
+		}
+		remaining -= segLen
+	}
+	const last = PATH[PATH.length - 1]
+	const prev = PATH[PATH.length - 2]
+	return { x: last.x, y: last.y, angle: Math.atan2(last.y - prev.y, last.x - prev.x) }
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/sounds.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/sounds.ts
@@ -1,0 +1,92 @@
+import { ProjectileKind } from './tower-config'
+
+// We synthesize fire sounds with Web Audio API rather than loading assets so
+// the example stays self-contained. The AudioContext is created lazily on the
+// first call to side-step browser autoplay restrictions — by then the user has
+// already clicked something to place a tower.
+
+let ctx: AudioContext | null = null
+let lastPlayedAt = 0
+const MIN_INTERVAL_MS = 25 // hard cap to stop a wall of overlapping shots
+
+function getCtx(): AudioContext | null {
+	if (ctx) return ctx
+	try {
+		const Ctor =
+			window.AudioContext ??
+			(window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+		if (!Ctor) return null
+		ctx = new Ctor()
+		return ctx
+	} catch {
+		return null
+	}
+}
+
+interface ToneSpec {
+	type: OscillatorType
+	startFreq: number
+	endFreq: number
+	durationMs: number
+	gain: number
+}
+
+const TONES: Record<ProjectileKind, ToneSpec> = {
+	arrow: { type: 'sawtooth', startFreq: 760, endFreq: 480, durationMs: 90, gain: 0.07 },
+	rock: { type: 'square', startFreq: 160, endFreq: 70, durationMs: 180, gain: 0.1 },
+	orb: { type: 'sine', startFreq: 880, endFreq: 320, durationMs: 220, gain: 0.09 },
+}
+
+export function playUpgradeSound() {
+	const c = getCtx()
+	if (!c) return
+	if (c.state === 'suspended') c.resume().catch(() => {})
+
+	// Two quick ascending sine notes — a small "level up" chime.
+	const t0 = c.currentTime
+	const notes = [
+		{ freq: 660, start: 0, durMs: 120 },
+		{ freq: 990, start: 90, durMs: 180 },
+	]
+	for (const n of notes) {
+		const osc = c.createOscillator()
+		osc.type = 'sine'
+		const gain = c.createGain()
+		const startAt = t0 + n.start / 1000
+		const stopAt = startAt + n.durMs / 1000
+		osc.frequency.setValueAtTime(n.freq, startAt)
+		gain.gain.setValueAtTime(0.001, startAt)
+		gain.gain.exponentialRampToValueAtTime(0.12, startAt + 0.01)
+		gain.gain.exponentialRampToValueAtTime(0.0001, stopAt)
+		osc.connect(gain).connect(c.destination)
+		osc.start(startAt)
+		osc.stop(stopAt + 0.02)
+	}
+}
+
+export function playFireSound(kind: ProjectileKind) {
+	const c = getCtx()
+	if (!c) return
+	if (c.state === 'suspended') c.resume().catch(() => {})
+
+	const now = performance.now()
+	if (now - lastPlayedAt < MIN_INTERVAL_MS) return
+	lastPlayedAt = now
+
+	const spec = TONES[kind]
+	const t0 = c.currentTime
+	const t1 = t0 + spec.durationMs / 1000
+
+	const osc = c.createOscillator()
+	osc.type = spec.type
+	osc.frequency.setValueAtTime(spec.startFreq, t0)
+	osc.frequency.exponentialRampToValueAtTime(Math.max(20, spec.endFreq), t1)
+
+	const gain = c.createGain()
+	gain.gain.setValueAtTime(spec.gain, t0)
+	gain.gain.exponentialRampToValueAtTime(0.0001, t1)
+
+	osc.connect(gain).connect(c.destination)
+	osc.start(t0)
+	osc.stop(t1 + 0.02)
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/tower-config.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/tower-config.ts
@@ -1,0 +1,92 @@
+// Maps geo shape variants to tower stats. Only these three geo types act as
+// towers; other geo shapes the user draws are ignored by the game loop so the
+// editor stays usable.
+
+import { TLShape } from 'tldraw'
+
+export type ProjectileKind = 'arrow' | 'rock' | 'orb'
+
+export const MAX_TOWER_LEVEL = 4
+
+export type TowerGeo = 'triangle' | 'rectangle' | 'ellipse'
+export const TOWER_GEOS: TowerGeo[] = ['triangle', 'rectangle', 'ellipse']
+export const TOWER_PLACEMENT_SIZE = 60
+
+export interface TowerStats {
+	label: string
+	range: number
+	fireRateMs: number
+	damage: number
+	projectileSpeed: number
+	projectileKind: ProjectileKind
+	cost: number
+}
+
+// Cost is roughly proportional to overall strength (range × damage / fireRate).
+// Starting gold (see game-state) is calibrated to afford one Archer immediately
+// and earn the others through kills.
+export const TOWER_STATS_BY_GEO: Record<string, TowerStats> = {
+	triangle: {
+		label: 'Archer',
+		range: 220,
+		fireRateMs: 350,
+		damage: 8,
+		projectileSpeed: 700,
+		projectileKind: 'arrow',
+		cost: 50,
+	},
+	rectangle: {
+		label: 'Cannon',
+		range: 160,
+		fireRateMs: 1100,
+		damage: 30,
+		projectileSpeed: 380,
+		projectileKind: 'rock',
+		cost: 120,
+	},
+	ellipse: {
+		label: 'Magic',
+		range: 190,
+		fireRateMs: 600,
+		damage: 14,
+		projectileSpeed: 520,
+		projectileKind: 'orb',
+		cost: 80,
+	},
+}
+
+export function getTowerStats(geo: string | undefined): TowerStats | null {
+	if (!geo) return null
+	return TOWER_STATS_BY_GEO[geo] ?? null
+}
+
+export function getTowerLevel(shape: TLShape): number {
+	const lvl = shape.meta?.towerLevel
+	return typeof lvl === 'number' && lvl >= 1 ? Math.min(MAX_TOWER_LEVEL, lvl) : 1
+}
+
+// Each upgrade adds 60% of base cost per level: L1→2 = 60%, L2→3 = 120%, L3→4 = 180%.
+export function getUpgradeCost(baseCost: number, currentLevel: number): number {
+	if (currentLevel >= MAX_TOWER_LEVEL) return 0
+	return Math.ceil(baseCost * 0.6 * currentLevel)
+}
+
+// Visual cue for tower level — also makes the level readable at a glance.
+export function levelColor(level: number): 'blue' | 'violet' | 'red' | 'orange' {
+	if (level >= 4) return 'red'
+	if (level === 3) return 'violet'
+	if (level === 2) return 'blue'
+	return 'orange'
+}
+
+// Damage and range grow with level; fire rate shortens. Level 1 returns base.
+export function getScaledStats(stats: TowerStats, level: number): TowerStats {
+	const k = Math.max(0, level - 1)
+	if (k === 0) return stats
+	return {
+		...stats,
+		damage: Math.round(stats.damage * Math.pow(1.4, k)),
+		range: Math.round(stats.range * Math.pow(1.06, k)),
+		fireRateMs: Math.round(stats.fireRateMs * Math.pow(0.9, k)),
+	}
+}

--- a/apps/examples/src/examples/use-cases/tower-defense/tower-defense.css
+++ b/apps/examples/src/examples/use-cases/tower-defense/tower-defense.css
@@ -1,0 +1,131 @@
+.td-hud {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+	padding: 8px 12px;
+	background: var(--color-panel);
+	border-radius: 8px;
+	box-shadow: var(--shadow-2);
+	font-size: 12px;
+	color: var(--color-text);
+	max-width: 720px;
+	pointer-events: auto;
+}
+
+.td-hud__row {
+	display: flex;
+	gap: 16px;
+	align-items: center;
+	flex-wrap: wrap;
+}
+
+.td-hud__row strong {
+	font-variant-numeric: tabular-nums;
+	font-weight: 600;
+}
+
+.td-hud__btn {
+	margin-left: auto;
+	padding: 4px 10px;
+	border: 1px solid var(--color-divider);
+	border-radius: 6px;
+	background: var(--color-low);
+	color: var(--color-text);
+	cursor: pointer;
+	font: inherit;
+}
+
+.td-hud__btn:hover {
+	background: var(--color-hint);
+}
+
+.td-hud__hint {
+	color: var(--color-text-1);
+	font-size: 11px;
+	opacity: 0.85;
+}
+
+.td-hud__hint code,
+.td-hud__hint kbd {
+	display: inline-block;
+	padding: 0 4px;
+	border-radius: 3px;
+	background: var(--color-low);
+	font: inherit;
+	font-size: 10px;
+}
+
+.td-hud__gameover {
+	color: #d33;
+	font-weight: 600;
+}
+
+.td-toolbar {
+	display: flex;
+	gap: 6px;
+	padding: 6px;
+	background: var(--color-panel);
+	border-radius: 10px;
+	box-shadow: var(--shadow-2);
+	pointer-events: auto;
+}
+
+.td-toolbar__btn {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 2px;
+	min-width: 56px;
+	padding: 6px 8px;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--color-text);
+	cursor: pointer;
+	font-size: 11px;
+	font: inherit;
+}
+
+.td-toolbar__btn:hover {
+	background: var(--color-hint);
+}
+
+.td-toolbar__btn.is-active {
+	border-color: var(--color-selected);
+	background: var(--color-selected-contrast);
+	color: var(--color-selected);
+}
+
+.td-toolbar__btn.is-disabled,
+.td-toolbar__btn:disabled {
+	opacity: 0.4;
+	cursor: not-allowed;
+}
+
+.td-toolbar__btn.is-disabled:hover,
+.td-toolbar__btn:disabled:hover {
+	background: transparent;
+}
+
+.td-toolbar__label {
+	font-size: 10px;
+	letter-spacing: 0.02em;
+}
+
+.td-toolbar__cost {
+	font-size: 10px;
+	color: var(--color-text-1);
+	font-variant-numeric: tabular-nums;
+}
+
+.td-toolbar__cost kbd {
+	display: inline-block;
+	padding: 0 4px;
+	min-width: 14px;
+	text-align: center;
+	border: 1px solid var(--color-divider);
+	border-radius: 3px;
+	background: var(--color-low);
+	font: inherit;
+	font-size: 9px;
+}


### PR DESCRIPTION
In order to exercise the new `OverlayUtil` system end-to-end under animation load, this PR adds a tower-defense mini-game example that uses overlays for everything except the towers themselves. Towers are real geo shapes; the path, enemies, projectiles, range indicators, placement preview, hit explosions, and per-tower upgrade button are all `OverlayUtil` subclasses. Builds on #8633.

The example covers most of the OverlayUtil surface: `isActive` reactivity, `getOverlays` driven by `@tldraw/state` atoms ticked from `editor.on('tick')`, `getGeometry` / `getOverlayAtPoint` hit testing, `getCursor` swaps, `onPointerDown` for placement and upgrades, custom zIndex layering, and shape↔overlay reactivity (towers as locked geo shapes feed projectile spawns and upgrade levels via `shape.meta`).

### How to play

- Pick a tower from the toolbar (or press `1` / `2` / `3`), then click the canvas to place it.
  - Triangle = Archer (50g, fast, low damage)
  - Rectangle = Cannon (120g, slow, high damage)
  - Ellipse = Magic (80g, medium, AOE)
- Hover a placed tower to see its range; click the `+` in its center to upgrade (cost scales 60% per level, max 4 levels). Upgrades change the shape's `fill` / `color` so the level is readable at a glance.
- Click an enemy to chip-damage it for free. Enemies that reach the end cost a life.
- `Esc` cancels placement, `Space` restarts.

### Overlays added by the example

| Util | zIndex | Role |
| --- | --- | --- |
| `PathOverlayUtil` | 50 | Decorative enemy path |
| `TowerRangeOverlayUtil` | 100 | Hover-driven range ring on placed towers |
| `PlacementPreviewOverlayUtil` | 150 | Ghost shape + range circle at the cursor while a tower is armed; click-to-place via `onPointerDown` |
| `EnemyOverlayUtil` | 200 | Animated enemies with HP bar; hit-test + click-to-damage |
| `ExplosionOverlayUtil` | 230 | Fading ring on Magic AOE impact |
| `ProjectileOverlayUtil` | 250 | Arrows / rocks / orbs in flight |
| `UpgradeButtonOverlayUtil` | 260 | Per-tower upgrade `+` button; click via `onPointerDown` |

### Notes for reviewers

- Placement clicks and upgrade clicks route through `OverlayUtil.onPointerDown` — no DOM intercept. Locked-shape clicks correctly fall through to overlays because `select.idle.onPointerDown` checks `getOverlayAtPoint` before the locked-shape skip.
- Upgrade and restart paths wrap `editor.updateShape` / `editor.deleteShapes` in `editor.run(..., { ignoreShapeLock: true })` because the runtime silently skips locked shapes otherwise.
- Per-tick shape walks (`UpgradeButtonOverlayUtil._candidates`, `TowerRangeOverlayUtil._hoveredTowers`) are memoised with `computed()` so a mousemove storm only re-runs the cheap pointer filter, not the bounds resolution pass.
- Sounds are synthesized with the Web Audio API (no asset loading) — fire tones per projectile kind and a small upgrade chime.

### Change type

- [x] `feature`

### Test plan

1. `yarn dev` and open `localhost:5420/use-cases/tower-defense`.
2. Place each tower type via the toolbar buttons and via `1` / `2` / `3` shortcuts.
3. Confirm the placement preview shows ghost shape + range while a tower is armed and disappears when you can't afford it.
4. Hover a placed tower → range ring; click the central `+` → tower's color/fill changes per level and the chime plays.
5. Magic projectile impact → fading explosion ring + AOE damage to nearby enemies.
6. Click an enemy → chip damage; hover an enemy → HP readout above its HP bar.
7. Let enemies through → lives drop, game-over state appears, restart via button or `Space` clears all shapes and resets gold/lives/score/wave timer.
8. Toggle dark/light mode → overlay strokes and fills update.

- [x] Unit tests
- [x] End to end tests

### Release notes

- Add a tower-defense example under `examples/use-cases/tower-defense` showcasing the new `OverlayUtil` system.
