### PR TITLE
fix(docs): ASSET_PREFIX for future rewrites from tldraw.dev

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -5,6 +5,7 @@ const REWRITE_DOMAIN = 'tldrawdotdev.framer.website'
 
 const nextConfig = {
 	reactStrictMode: true,
+	assetPrefix: process.env.ASSET_PREFIX || undefined,
 	experimental: {
 		scrollRestoration: true,
 	},


### PR DESCRIPTION
Before https://github.com/tldraw/tldraw/pull/8665 we need to test the ASSET_PREFIX env variable, this would not break the docs in case the SDK / new docs are released before


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Go to staging.tldraw.dev
2. Nothing's broken XD