### PR TITLE
fix(editor): restore ctrl+click and Android long-press context menu

### DIFF
--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -169,14 +169,19 @@ export function useCanvasEvents() {
 				// menu opens on press.
 				if (!editor.options.rightClickPanning) return
 				// Synthetic events — our own dispatch from onPointerUp, or tests using
-				// fireEvent.contextMenu — pass through so Radix can open the menu. The real
-				// browser contextmenu is always suppressed: right-click behavior has
-				// already been decided by our pointer handling (either we dispatched a
-				// synthetic to open the menu at the release position, or we panned and
-				// don't want a menu at all).
-				if (e.nativeEvent.isTrusted) {
-					preventDefault(e)
-				}
+				// fireEvent.contextMenu — pass through so Radix can open the menu.
+				if (!e.nativeEvent.isTrusted) return
+				// Only suppress the native browser contextmenu when it follows a real
+				// right-click (button=2 with no ctrl modifier). For those, our pointer
+				// handling has already decided what to do (either we'll dispatch a
+				// synthetic contextmenu on pointerup to open the menu at the release
+				// position, or we panned and don't want a menu at all).
+				//
+				// Other contextmenu sources must reach Radix so the menu opens:
+				// - ctrl+click on macOS (button=0, or button=2 with ctrlKey=true)
+				// - long-press on touch devices (button=0, pointerType=touch)
+				if (e.button !== 2 || e.ctrlKey) return
+				preventDefault(e)
 			}
 
 			return {


### PR DESCRIPTION
In order to fix two regressions introduced by #8501 (right-click and drag to pan the camera), this PR makes the canvas's `onContextMenu` handler more selective. The new handler was unconditionally calling `preventDefault` on every trusted `contextmenu` event, and Radix's `composeEventHandlers` skips its own handler when `event.defaultPrevented` is true. That broke the two context menu sources where the SDK relies on the browser-native `contextmenu` rather than synthesising one itself:

- ctrl+click on macOS — the OS-translated `contextmenu` after a `pointerdown` with `button=0` (closes #8771)
- long-press on Android (and other touch devices) — the `contextmenu` Android Chrome dispatches after the OS long-press timeout (closes #8770)

Now we only suppress the native `contextmenu` when it follows a real right-click (`button === 2` with no ctrl modifier). That's the only case where our pointer handling has already decided what to do — either we'll dispatch a synthetic `contextmenu` from `onPointerUp` to open the menu at the release position, or we'll have panned and don't want a menu at all. Every other source (ctrl+click, two-finger trackpad tap on macOS reported as `button=2 + ctrlKey=true` by some Chromium builds, long-press on touch) flows through to Radix as before.

### Change type

- [x] `bugfix`

### Test plan

1. On macOS, hold ctrl and click the canvas — the context menu opens at the click position.
2. On Android (or any touch device), long-press the canvas — the context menu opens after the long-press.
3. Right-click on empty canvas — the context menu still opens at the release position (existing behaviour).
4. Right-click + drag — the camera still pans without opening a menu (existing behaviour).
5. Two-finger trackpad tap on macOS — the context menu still opens (existing behaviour).

- [x] Unit tests
- [x] End to end tests

### Release notes

- Fix the context menu not opening on ctrl+click on macOS and long-press on Android.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -8   |

Made with [Cursor](https://cursor.com)