### PR TITLE
docs(releases): add migration guides for breaking changes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -122,7 +122,25 @@ The following slots have been removed from `TLEditorComponents`. Subclass the ma
 
 The corresponding `Default*` exports and `LiveCollaborators` have also been removed.
 
-Customizing shape indicators — `ShapeIndicator`, `ShapeIndicators`, and `ShapeIndicatorErrorFallback` are gone. Indicators now render through each shape util's `getIndicatorPath()`. Override it to change how a shape's indicator is drawn.
+**`ShapeUtil.indicator()` → `ShapeUtil.getIndicatorPath()`.** The shape util method that draws a shape's selection indicator no longer returns JSX. It now returns a `Path2D` (or a `TLIndicatorPath`) and is composited onto the canvas overlay layer. Every custom `ShapeUtil` that overrides `indicator` needs to migrate:
+
+```tsx
+// Before
+override indicator(shape: MyShape) {
+	return <rect width={shape.props.w} height={shape.props.h} />
+}
+
+// After
+override getIndicatorPath(shape: MyShape): Path2D {
+	const path = new Path2D()
+	path.rect(0, 0, shape.props.w, shape.props.h)
+	return path
+}
+```
+
+For shapes whose indicator should match the shape's geometry, return `path` built from the same primitives. For placeholder shapes (e.g. an `ErrorShape`), return an empty `new Path2D()` and declare the return type explicitly so TypeScript doesn't infer `never`.
+
+The React component slots `ShapeIndicator`, `ShapeIndicators`, and `ShapeIndicatorErrorFallback` are also removed from `TLEditorComponents` — there is no replacement React slot, since indicators now render through `getIndicatorPath()`.
 
 Overlays cannot render React; they draw into a 2D canvas context. For React-based overlays, render an HTML layer above the canvas via a regular `TLEditorComponents` slot like `InFrontOfTheCanvas`.
 
@@ -131,6 +149,57 @@ Overlay colors come from `TLTheme`, not CSS variables. Read them inside `render(
 These CSS variables have been removed: `--tl-color-snap`, `--tl-color-brush-fill`, `--tl-color-brush-stroke`, `--tl-color-laser`, `--tl-layer-overlays-custom`.
 
 Overriding them (or the removed selectors `.tl-brush`, `.tl-scribble`, `.tl-snap-indicator`, `.tl-handle*`, `.tl-selection__fg__outline`, `.tl-corner-handle`, `.tl-text-handle`, `.tl-corner-crop-handle`, `.tl-mobile-rotate__*`) no longer has any effect. Port these to `TLTheme` entries or to the overlay util's `render()`.
+
+</details>
+
+### 💥 Tldraw component options
+
+Several `<Tldraw>` props that previously lived at the top level have been consolidated under the `options` prop, and a few extension points moved off the component entirely.
+
+<details>
+<summary>Migration guide</summary>
+
+**`cameraOptions`, `textOptions`, and `deepLinks` props moved into `options`:**
+
+```tsx
+// Before
+<Tldraw cameraOptions={camOpts} textOptions={txtOpts} deepLinks />
+
+// After
+<Tldraw options={{ camera: camOpts, text: txtOpts, deepLinks: true }} />
+```
+
+**`embeds` prop removed; configure embed definitions on `EmbedShapeUtil`:**
+
+```tsx
+// Before
+<Tldraw embeds={[...DEFAULT_EMBED_DEFINITIONS, customEmbed]} />
+
+// After
+import { EmbedShapeUtil } from 'tldraw'
+const ConfiguredEmbedShapeUtil = EmbedShapeUtil.configure({
+	embedDefinitions: [...DEFAULT_EMBED_DEFINITIONS, customEmbed],
+})
+<Tldraw shapeUtils={[ConfiguredEmbedShapeUtil]} />
+```
+
+This silently compiles in some setups (the prop is unknown but JSX won't always reject it), so this is the kind of change that the typecheck won't always catch — search the source for `embeds=` and migrate any matches.
+
+**`setDefaultEditorAssetUrls()` and `setDefaultUiAssetUrls()` are no longer part of the public API.** They still exist at runtime for now, but they're marked `@internal` and should not be relied on. Pass `assetUrls` to each `<Tldraw>` instead:
+
+```tsx
+// Before
+import { setDefaultEditorAssetUrls, setDefaultUiAssetUrls } from 'tldraw'
+setDefaultEditorAssetUrls(assetUrls)
+setDefaultUiAssetUrls(assetUrls)
+
+<Tldraw />
+
+// After
+<Tldraw assetUrls={assetUrls} />
+```
+
+Do not reach for module augmentation to re-expose the old globals — find each `<Tldraw>` mount point and pass `assetUrls` directly.
 
 </details>
 
@@ -282,6 +351,33 @@ const schema = createTLSchema({
 
 Note shapes now track and display a "first edited by" attribution label in the bottom-right corner, showing who first added text to the note.
 
+<details>
+<summary>Migration guide</summary>
+
+**`useTldrawUser` has been removed.** Previously it bundled user *preferences* (color, color scheme) and user *identity* (id, name) into a single object. These are now separate concerns:
+
+- **Preferences** (color, color scheme, snap mode, etc.) are managed via `TLUserPreferences`. Set them with the editor's user-preferences API directly.
+- **Identity** for attribution comes from a `TLUserStore` provider passed to the new `users` prop on `<Tldraw>`.
+
+```tsx
+// Before
+const user = useTldrawUser({ userPreferences, setUserPreferences })
+<Tldraw user={user} />
+
+// After
+<Tldraw
+	users={{
+		getCurrentUser: () => currentUserSignal,
+		resolve: (userId) => resolvedUserSignal(userId),
+	}}
+	colorScheme={userPreferences.colorScheme}
+/>
+```
+
+If you only need preferences (no custom identity), pass `colorScheme` directly and seed preferences imperatively after mount; if you only need identity, pass `users`. Most apps want both.
+
+</details>
+
 ### @tldraw/driver ([#7952](https://github.com/tldraw/tldraw/pull/7952))
 
 A new `@tldraw/driver` package provides an imperative API for driving the tldraw editor programmatically. `Driver` wraps an `Editor` instance and exposes event dispatch, selection transforms, clipboard operations, and shape queries with fluent chaining.
@@ -387,6 +483,14 @@ New APIs include `handleSocketResume()` for restoring sessions from snapshots, `
 - 💥 Change `notifyIfFileNotAllowed` signature from `(file, options)` to `(editor, file, options)`. ([#8031](https://github.com/tldraw/tldraw/pull/8031))
 - 💥 Change `getAssetInfo` signature from `(file, options, assetId?)` to `(editor, file, assetId?)` and return `TLAsset | null` instead of throwing. ([#8031](https://github.com/tldraw/tldraw/pull/8031))
 - 💥 Move the `Cmd+Shift+C` / `Ctrl+Shift+C` shortcut from "Copy as SVG" to "Copy as PNG". ([#8532](https://github.com/tldraw/tldraw/pull/8532))
+- 💥 Replace `ShapeUtil.indicator()` (returned JSX) with `ShapeUtil.getIndicatorPath()` (returns `Path2D | TLIndicatorPath | undefined`). Indicators now render to the canvas overlay layer instead of as React elements. ([#8469](https://github.com/tldraw/tldraw/pull/8469))
+- 💥 Move `cameraOptions`, `textOptions`, and `deepLinks` from top-level `<Tldraw>` props into the `options` prop (e.g. `options={{ camera, text, deepLinks }}`).
+- 💥 Remove the `embeds` prop from `<Tldraw>`. Configure embed definitions via `EmbedShapeUtil.configure({ embedDefinitions })` and pass the configured util through `shapeUtils`.
+- 💥 Demote `setDefaultEditorAssetUrls()` and `setDefaultUiAssetUrls()` to `@internal`. Pass `assetUrls` to each `<Tldraw>` instead.
+- 💥 Remove `useTldrawUser`. Use the new `users` prop (`TLUserStore`) for identity and `TLUserPreferences` for preferences.
+- 💥 Replace `TLDrawShapeSegment.points` with the helper `getPointsFromDrawSegment(segment, scaleX, scaleY)` so segment points respect the shape's current scale.
+- 💥 Change `BindingUtil` hook params: `fromShapeType`/`toShapeType` are removed in favor of full `fromShape`/`toShape` records (read `fromShape.type` / `toShape.type` directly).
+- 💥 Add `'middle-legacy'` (and other legacy values) to the `align` union resolved by `PlainTextLabel`/`RichTextLabel`. If your code maps `align` into `PlainTextLabel.textAlign`, narrow legacy values to one of `'start' | 'center' | 'end'` before passing them through.
 - Add `TLTheme`, `TLThemeId`, `TLThemes`, `TLThemeDefaultColors`, `TLThemeColors`, `TLRemovedDefaultThemeColors`, `ThemeManager`, `getDisplayValues()`, `getColorValue()`, and `DEFAULT_THEME` for the new theme system. ([#8410](https://github.com/tldraw/tldraw/pull/8410))
 - Add `themes` and `initialTheme` props to `<Tldraw>` and `<TldrawEditor>`. ([#8410](https://github.com/tldraw/tldraw/pull/8410))
 - Add `getCurrentTheme()`, `setCurrentTheme()`, `getThemes()`, `getTheme()`, `updateTheme()`, `updateThemes()`, and `getColorMode()` to the editor. ([#8410](https://github.com/tldraw/tldraw/pull/8410))

--- a/apps/docs/content/releases/v4.2.0.mdx
+++ b/apps/docs/content/releases/v4.2.0.mdx
@@ -19,9 +19,42 @@ This month's release includes many bug fixes and small API additions, along with
 
 ## What's new
 
-### TipTap v3 ([#5717](https://github.com/tldraw/tldraw/pull/5717))
+### 💥 TipTap v3 ([#5717](https://github.com/tldraw/tldraw/pull/5717))
 
 We've upgraded TipTap from v2 to v3. If you've done any customization to our standard TipTap kit, please refer to TipTap's guide [How to upgrade Tiptap v2 to v3](https://tiptap.dev/docs/guides/upgrade-tiptap-v2) for breaking changes you might experience.
+
+<details>
+<summary>Migration guide</summary>
+
+Starting in v4.2, tldraw bundles TipTap v3 as a transitive dependency. If your project pins `@tiptap/*` v2 packages directly, upgrade them to v3 *before* trying to fix any code-level errors — leaving v2 in place produces a dual install that surfaces as confusing type errors.
+
+**Dual-install symptom.** Deeply-nested errors like *"Property 'getCharacterCount' is missing in type 'Editor' but required in type 'Editor'"*, with the two `Editor` types resolving to different paths (one under `node_modules/@tiptap/core`, the other under `node_modules/@tldraw/editor/node_modules/@tiptap/core`), are not API changes — they are the v2/v3 dual install. The `Editor` classes are structurally similar but nominally different. Finishing the v3 upgrade collapses the duplicate and these errors disappear without code changes.
+
+**Code-level changes that affect tldraw users:**
+
+- **Default → named exports.** Several extensions changed from default to named exports:
+
+  ```ts
+  // Before
+  import StarterKit from '@tiptap/starter-kit'
+
+  // After
+  import { StarterKit } from '@tiptap/starter-kit'
+  ```
+
+- **`TextStyle` → `TextStyleKit`, and `FontFamily` moved.** The `FontFamily` extension is no longer in `@tiptap/extension-font-family`; it's part of `TextStyleKit` in `@tiptap/extension-text-style`. The `setFontFamily` and `setFontSize` chain commands only exist on `TextStyleKit`, not on bare `TextStyle`.
+
+- **Transaction handler types.** Inline parameter type annotations on TipTap event handlers no longer work. Import the proper event-map type:
+
+  ```ts
+  import { EditorEvents } from '@tiptap/core'
+  // ...
+  onTransaction: (props: EditorEvents['transaction']) => { /* ... */ }
+  ```
+
+- **Custom chained commands** still register via `declare module '@tiptap/core'` augmentation in v3 — the augmentation target is the same.
+
+</details>
 
 ## API changes
 

--- a/apps/docs/content/releases/v4.3.0.mdx
+++ b/apps/docs/content/releases/v4.3.0.mdx
@@ -13,7 +13,7 @@ This release introduces several significant changes: a new pattern for defining 
 
 ---
 
-### New pattern for defining custom shape/binding types (breaking change) ([#7091](https://github.com/tldraw/tldraw/pull/7091))
+### 💥 New pattern for defining custom shape/binding types ([#7091](https://github.com/tldraw/tldraw/pull/7091))
 
 We've improved the developer experience of working with custom shape and binding types. There's now less boilerplate and fewer gotchas when using tldraw APIs in a type-safe manner.
 
@@ -61,7 +61,50 @@ editor.createShape({ type: 'my-shape', props: { w: 100, h: 100, text: 'Hello' } 
 editor.createShape({ type: 'my-shape', props: { w: 100, h: 100, text: 123 } })
 ```
 
-The same pattern applies to custom bindings. See the [Custom Shapes Guide](https://tldraw.dev/docs/shapes#custom-shapes) and the [Pin Bindings example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/pin-bindings) for details.
+The same pattern applies to custom bindings — augment `TLGlobalBindingPropsMap` and use `TLBinding<'binding-name'>`:
+
+```ts
+declare module 'tldraw' {
+	export interface TLGlobalBindingPropsMap {
+		'my-binding': { offset: number }
+	}
+}
+
+type MyBinding = TLBinding`<'my-binding'>`
+```
+
+See the [Custom Shapes Guide](https://tldraw.dev/docs/shapes#custom-shapes) and the [Pin Bindings example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/pin-bindings) for details.
+
+**After registering, remove the `TLBaseShape` import** — it's no longer used and will trip lint rules that flag unused imports.
+
+**Shape type names are global.** `TLGlobalShapePropsMap` is a single shared registry, so two custom shapes that previously used the same type name in different files now collide. Pick a unique name for each, and remember the rename ripples beyond the type alias:
+
+- `static override type = '...'` on the `ShapeUtil` subclass
+- Every `editor.createShape({ type: '...' })` and `editor.updateShape({ type: '...' })` call site
+- The `TLGlobalShapePropsMap` entry itself
+- Any persisted snapshot or migration JSON that references the old name
+
+**Use `as const` on the static `type` field.** TypeScript may widen `static override type = 'my-shape'` to `string`, which fails the new constraint. Add `as const` to keep it a string literal:
+
+```ts
+class MyShapeUtil extends ShapeUtil`<MyShape>` {
+	static override type = 'my-shape' as const
+	// ...
+}
+```
+
+The same fix applies to `BaseBoxShapeTool` (and other tool) subclasses, which expose `static override shapeType = '...'`. If you see TS2416 on a tool's `shapeType`, add `as const` there too. The two fields are easy to confuse — check both.
+
+**Heterogeneous `createShapes`/`updateShapes` arrays may need a cast.** Because `TLShape` is now a discriminated union over the global props map, a mapped array of mixed shape types no longer narrows automatically. For homogeneous arrays where every item shares one shape type, `as const` on the `type` field in the mapped object literal is enough. For genuinely heterogeneous arrays, go straight to `as TLShapePartial[]` (or `as TLCreateShapePartial[]` for `createShapes`):
+
+```ts
+// Heterogeneous update — the union doesn't narrow
+editor.updateShapes(
+	shapes.map((s) => ({ id: s.id, type: s.type, x: s.x + 10 })) as TLShapePartial[]
+)
+```
+
+Don't reach for `satisfies TLShapePartial` here — `TLShapePartial` is distributive over the `TLShape` union, so `satisfies` enforces a literal-per-variant constraint that mapped-over heterogeneous shapes can't meet. The cast is the right tool for this specific shape of code.
 
 </details>
 

--- a/skills/tldraw-migrate/SKILL.md
+++ b/skills/tldraw-migrate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tldraw-migrate
 description: Migrate a project to a newer version of the tldraw SDK. Use when upgrading tldraw packages, fixing TypeScript errors after a tldraw upgrade, or when the user mentions tldraw migration.
-argument-hint: '[previous-version]'
+argument-hint: '[from-version] [target]'
 disable-model-invocation: true
 user-invocable: true
 ---
@@ -10,16 +10,33 @@ user-invocable: true
 
 You are helping migrate a project to a newer version of the tldraw SDK. Follow this process carefully.
 
-Previous version (auto-detected from git history; pass an explicit version as `/tldraw-migrate <version>` to override): !`node ${CLAUDE_SKILL_DIR}/detect-versions.mjs $ARGUMENTS`
+Throughout this skill, `${SKILL_DIR}` refers to this skill's own directory (where `SKILL.md`, the helper `.mjs` scripts, and the cached `references/` folder live). The auto-fetch blocks below resolve it from the `SKILL_DIR` env var if set, otherwise probe the common skill locations (`.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `skills/`). When you run shell commands later in the workflow that reference `${SKILL_DIR}`, substitute the same absolute path.
+
+**Arguments**: `/tldraw-migrate [from-version] [target]`. Both optional. `from-version` defaults to the previous tldraw version detected from git history. `target` defaults to `latest` (the latest stable release on npm); pass a dist-tag (`canary`, `next`, `beta`) or a pre-release semver (e.g. `4.6.0-canary.abc123`) to migrate to a pre-release.
+
+Resolved migration: !`SKILL_DIR="${SKILL_DIR:-$(for d in .claude/skills/tldraw-migrate .agents/skills/tldraw-migrate .cursor/skills/tldraw-migrate skills/tldraw-migrate; do [ -d "$d" ] && printf %s "$d" && break; done)}" && FROM=$(node "$SKILL_DIR/detect-versions.mjs" $ARGUMENTS) && TARGET=$(node "$SKILL_DIR/detect-target.mjs" $ARGUMENTS) && echo "from $FROM → target $TARGET"`
 
 ## Resources (auto-fetched on invocation)
 
-!`mkdir -p ${CLAUDE_SKILL_DIR}/references && CHANGELOG=${CLAUDE_SKILL_DIR}/references/tldraw-releases.txt && PREV=$(node ${CLAUDE_SKILL_DIR}/detect-versions.mjs $ARGUMENTS) && curl --fail -sS https://tldraw.dev/llms-releases.txt | node ${CLAUDE_SKILL_DIR}/filter-changelog.mjs "$PREV" > "$CHANGELOG" && echo "Saved changelog (from $PREV) to $CHANGELOG ($(wc -l < "$CHANGELOG") lines)"`
+!`SKILL_DIR="${SKILL_DIR:-$(for d in .claude/skills/tldraw-migrate .agents/skills/tldraw-migrate .cursor/skills/tldraw-migrate skills/tldraw-migrate; do [ -d "$d" ] && printf %s "$d" && break; done)}" && mkdir -p "$SKILL_DIR/references" && CHANGELOG="$SKILL_DIR/references/tldraw-releases.txt" && PREV=$(node "$SKILL_DIR/detect-versions.mjs" $ARGUMENTS) && [ -n "$PREV" ] && curl --fail -sS https://tldraw.dev/llms-releases.txt | node "$SKILL_DIR/filter-changelog.mjs" "$PREV" > "$CHANGELOG" && echo "Saved changelog (from $PREV) to $CHANGELOG ($(wc -l < "$CHANGELOG") lines)"`
 
-!`DOCS=${CLAUDE_SKILL_DIR}/references/tldraw-full-docs.txt && if [ -s "$DOCS" ]; then echo "Using cached full docs at $DOCS ($(wc -l < "$DOCS") lines) — delete the file to refresh"; else curl --fail -sS https://tldraw.dev/llms-full.txt -o "$DOCS" && echo "Saved full docs to $DOCS ($(wc -l < "$DOCS") lines)"; fi`
+!`SKILL_DIR="${SKILL_DIR:-$(for d in .claude/skills/tldraw-migrate .agents/skills/tldraw-migrate .cursor/skills/tldraw-migrate skills/tldraw-migrate; do [ -d "$d" ] && printf %s "$d" && break; done)}" && DOCS="$SKILL_DIR/references/tldraw-full-docs.txt" && if [ -s "$DOCS" ]; then echo "Using cached full docs at $DOCS ($(wc -l < "$DOCS") lines) — delete the file to refresh"; else curl --fail -sS https://tldraw.dev/llms-full.txt -o "$DOCS" && echo "Saved full docs to $DOCS ($(wc -l < "$DOCS") lines)"; fi`
 
-- **[Filtered changelog](references/tldraw-releases.txt)** — release notes for versions between the previous version and now. Read this first to understand what changed.
+!`SKILL_DIR="${SKILL_DIR:-$(for d in .claude/skills/tldraw-migrate .agents/skills/tldraw-migrate .cursor/skills/tldraw-migrate skills/tldraw-migrate; do [ -d "$d" ] && printf %s "$d" && break; done)}" && mkdir -p "$SKILL_DIR/references" && TARGET=$(node "$SKILL_DIR/detect-target.mjs" $ARGUMENTS) && case "$TARGET" in canary|next|beta|alpha|rc|*-canary*|*-next*|*-beta*|*-alpha*|*-rc*) NEXT="$SKILL_DIR/references/tldraw-next.mdx" && curl --fail -sS https://raw.githubusercontent.com/tldraw/tldraw/main/apps/docs/content/releases/next.mdx -o "$NEXT" && echo "Pre-release target ($TARGET) — saved next-release notes to $NEXT ($(wc -l < "$NEXT") lines)" ;; *) echo "Stable target ($TARGET) — skipping next-release notes" ;; esac`
+
+- **[Filtered changelog](references/tldraw-releases.txt)** — release notes for stable versions between the previous version and now. Each breaking change (marked `💥`) carries a `<details><summary>Migration guide</summary>` block with a before/after recipe. **These migration blocks are the primary source for version-specific fixes** — this skill intentionally does not duplicate them. When you hit a TS error, grep for the relevant API name in this file and read its migration block.
 - **[Full docs](references/tldraw-full-docs.txt)** — complete tldraw SDK docs (~1.5MB). Do NOT read this upfront. Use Grep or Read with line ranges to search for specific topics as needed (e.g., custom shapes, TLTextOptions).
+- **[Next-release notes](references/tldraw-next.mdx)** — *only present when the target is a pre-release.* The in-progress release notes (raw MDX from `main`) for the upcoming version. Same `<details><summary>Migration guide</summary>` structure. The stable changelog won't cover canary/next deltas; this file is where you'll find them.
+
+**Searching for migration recipes:**
+
+```sh
+# List every breaking change with a migration block
+grep -nE '💥|<summary>Migration guide' ${SKILL_DIR}/references/tldraw-next.mdx
+
+# Find the migration recipe for a specific symbol
+grep -n -B2 -A20 'getIndicatorPath\|TLUserStore\|EmbedShapeUtil' ${SKILL_DIR}/references/tldraw-next.mdx
+```
 
 ## Step 1: Understand the environment
 
@@ -27,87 +44,100 @@ Before making any changes, scan the project to understand what you're working wi
 
 - **Package manager**: Check for lock files (`yarn.lock`, `pnpm-lock.yaml`, `bun.lockb`, `package-lock.json`). Use the corresponding tool throughout.
 - **tldraw packages**: `grep -E "tldraw|@tldraw" package.json` — which packages are installed, and at what versions? Note: not every project uses all tldraw packages.
-- **Import style**: `grep -r "from '@tldraw/" src/ --include="*.ts" --include="*.tsx" -l | head -5` — does the project import from `'tldraw'`, `'@tldraw/editor'`, or both? This affects module augmentation targets.
-- **TypeScript**: Check `package.json` for a `typecheck` or `tsc` script. Also check the TypeScript version — is it a direct dependency or does the project rely on a global install?
+- **Source directory**: figure out where the project's TypeScript sources live (commonly `src/`, `app/`, or `lib/`; Next.js App Router projects don't have `src/`). Use this directory for every grep below — don't assume `src/`.
+- **Import style**: `grep -r "from '@tldraw" <source-dir> --include="*.ts" --include="*.tsx" -l | head -5` — does the project import from `'tldraw'`, `'@tldraw/editor'`, or both? This affects module augmentation targets.
+- **TypeScript**: Check `package.json` for a `typecheck` or `tsc` script. If neither exists, fall back to `npx tsc --noEmit` (TypeScript is usually a devDependency). Also check the TypeScript version.
 - **Build tool**: Check `package.json` scripts for the build command (vite, next, webpack, esbuild, etc.)
 - **Linter**: Check for eslint/biome config files (`.eslintrc*`, `eslint.config.*`, `biome.json`). A linter may help catch deprecations later.
 - **Monorepo**: Is `package.json` at the working directory root, or is this a nested package? Check for workspaces config.
 
 ## Step 2: Upgrade packages
 
-Using the detected package manager, upgrade all tldraw packages that are already in the project's dependencies to the latest version. Don't add new packages the project doesn't already use.
+Using the detected package manager, upgrade all tldraw packages that are already in the project's dependencies to the resolved target (printed in the "Resolved migration" line above). Don't add new packages the project doesn't already use.
+
+- For a stable target (`latest` or a stable semver): install at that tag/version, e.g. `yarn add tldraw@latest` or `npm install tldraw@4.5.10`.
+- For a pre-release target (`canary`, `next`, `beta`, or a pre-release semver): install at that tag/version, e.g. `yarn add tldraw@canary`. If multiple `@tldraw/*` packages are listed, pin them all to the same target to avoid version skew.
 
 ## Step 3: Identify all TypeScript errors
 
 Run the project's typecheck command (from Step 1) and categorize the errors:
 
-1. **Count errors by TS code** (e.g., TS2344, TS2786) to understand the distribution
-2. **List unique files with errors** to understand the scope
-3. **Identify error patterns** — common categories in tldraw upgrades:
-   - React types mismatch (TS2786 "cannot be used as JSX component") — usually means `@types/react` version doesn't match what tldraw bundles. To find the bundled version: with npm or yarn classic, check `node_modules/@tldraw/editor/node_modules/@types/react/package.json`; with pnpm or yarn berry, run the package manager's "why" command (e.g. `pnpm why @types/react`, `yarn why @types/react`) to see the resolved range.
-   - Custom shape type registration (TS2344 "does not satisfy constraint TLShape/TLBaseBoxShape") — tldraw v4.3+ requires module augmentation of `TLGlobalShapePropsMap`
-   - Custom binding type registration — same pattern with `TLGlobalBindingPropsMap`
-   - `BaseBoxShapeTool.shapeType` type mismatch (TS2416) — needs `as const`
-   - API renames/removals (TS2305, TS2724) — check changelog for specific migrations
-   - `createShapes`/`updateShapes` type widening (TS2345) — mapped arrays need `TLShapePartial` or `TLCreateShapePartial` casts
+1. **Count errors by TS code** (e.g., TS2344, TS2786) to understand the distribution.
+2. **List unique files with errors** to understand the scope.
+3. **Identify error patterns.** The categories below are version-agnostic — they describe the *shape* of common errors. The *specific* fix for each rename, removal, or signature change lives in the release-notes migration blocks (see "Searching for migration recipes" above), not in this skill.
+
+   - **TS2786** "cannot be used as JSX component" / "bigint not assignable to ReactNode": React types skew. `@types/react` (and usually `@types/react-dom`) don't match the version tldraw bundles. To find the bundled version: with npm or yarn classic, check `node_modules/@tldraw/editor/node_modules/@types/react/package.json`; with pnpm or yarn berry, run the package manager's "why" command (e.g. `pnpm why @types/react`).
+   - **TS2344** "does not satisfy constraint TLShape/TLBaseBoxShape" / **TS2416** `shapeType` mismatch: custom shape or binding type isn't registered for the new global props maps. Fix pattern in 4b.
+   - **TS2305** / **TS2724** "has no exported member" / "is not exported": API removed or renamed. Find the replacement in the matching `Migration guide` block in `tldraw-releases.txt` / `tldraw-next.mdx`.
+   - **TS2339** "property does not exist": API renamed or method signature changed. Same lookup.
+   - **TS2515** "non-abstract class does not implement inherited abstract member": a base class gained a required method. The error names the method — search the migration blocks for that method name. (Note: if your implementation only throws, TypeScript may infer `never`; add an explicit return type to satisfy the base class signature.)
+   - **TS2345** on `createShapes`/`updateShapes`: heterogeneous mapped arrays need `as TLShapePartial[]` / `as TLCreateShapePartial[]` casts. See 4e.
+   - **TS2345** with two structurally-similar `Editor` classes resolving to different paths under `node_modules/@tiptap/core` and `node_modules/@tldraw/editor/node_modules/@tiptap/core`: TipTap v2/v3 dual install. See 4d.
 
 ## Step 4: Fix errors in order of impact
 
-Fix in this order (each fix eliminates many downstream errors):
+Fix in this order (each fix eliminates many downstream errors). After each sub-step, re-run the project's typecheck and confirm that the error codes targeted by *that* sub-step are resolved (or at least decreasing). Ignore unrelated error codes — they belong to later sub-steps. This catches regressions early without blocking on errors you haven't gotten to yet.
 
 ### 4a. Fix React types
 
-If you see TS2786 "bigint not assignable to ReactNode" errors, upgrade `@types/react` and `@types/react-dom` to match tldraw's bundled version.
+If you see TS2786 "bigint not assignable to ReactNode" errors, upgrade `@types/react` AND `@types/react-dom` together to match tldraw's bundled version. Bumping only `@types/react` will leave a transitive dependency on the old `@types/react-dom` and the same errors will reappear from a different path (e.g. inside `TldrawUiToolbarButton`).
+
+**Verify**: re-run typecheck — TS2786 errors should be gone.
 
 ### 4b. Register custom shapes and bindings
 
-For every `TLBaseShape<'name', Props>` in the codebase, add module augmentation. Use the import style detected in Step 1 as the module target:
+If you see TS2344 ("does not satisfy constraint `TLShape`/`TLBaseBoxShape`") or TS2416 (`shapeType` mismatch) errors, the project is using the pre-v4.3 `TLBaseShape<'name', Props>` pattern and needs to migrate to `TLGlobalShapePropsMap` module augmentation.
 
-```ts
-declare module 'tldraw' {
-	interface TLGlobalShapePropsMap {
-		'shape-name': {
-			/* props */
-		}
-	}
-}
-type MyShape = TLShape<'shape-name'>
+The full recipe — module augmentation for shapes and bindings, the rename ripple when shape names collide, `as const` on `static override type` / `static override shapeType`, and the heterogeneous `createShapes`/`updateShapes` cast guidance — lives in the v4.3 release notes migration block. Find it with:
+
+```sh
+grep -n -B2 -A80 'TLGlobalShapePropsMap' ${SKILL_DIR}/references/tldraw-releases.txt
 ```
 
-Same pattern for bindings with `TLGlobalBindingPropsMap` and `TLBinding<'name'>`.
+Apply that recipe across the project. Use the import style detected in Step 1 as the module-augmentation target (`declare module 'tldraw'` vs. `declare module '@tldraw/editor'`).
 
-**IMPORTANT**: If multiple files use the same shape type name with different props, rename them to be unique — they all share the global type registry.
+**Verify**: re-run typecheck — TS2344 and TS2416 errors should be gone.
 
-Add `as const` to all `static override shapeType = '...'` properties.
+### 4c. Fix API renames, removals, and abstract-method additions
 
-### 4c. Fix API renames and removals
+This is where the version-specific work happens, and it's driven entirely by the release-notes migration blocks. The skill does *not* enumerate which APIs changed — that's the changelog's job, and it would go stale on every release.
 
-Cross-reference each TS2305/TS2724/TS2339 error with the changelog. Common patterns:
+For each TS2305 / TS2724 / TS2339 / TS2515 error:
 
-- Removed exports: find replacement by grepping the tldraw type definitions
-- Renamed properties: check changelog for the new name
-- Changed method signatures: check the current type definitions
+1. Pull the symbol name out of the error.
+2. Grep the migration blocks for it: `grep -n -B2 -A20 'SymbolName' ${SKILL_DIR}/references/tldraw-releases.txt ${SKILL_DIR}/references/tldraw-next.mdx`.
+3. Apply the recipe shown in the matching `Migration guide` block. Migration blocks contain before/after code snippets; copy the structure.
 
-To find tldraw type definitions, check which paths exist — the location varies by version:
+If the symbol isn't in any migration block:
 
-- `node_modules/tldraw/dist-cjs/index.d.ts`
-- `node_modules/tldraw/dist/index.d.ts`
-- `node_modules/@tldraw/editor/dist-cjs/index.d.ts`
-- `node_modules/@tldraw/tlschema/dist-cjs/index.d.ts`
+- **Demoted to `@internal`** (still exported at runtime, but missing from `.d.ts`): check whether a `<details><summary>Migration guide</summary>` mentions it as part of a larger API. The right fix is almost always to switch to the public replacement, *not* to use module augmentation to re-expose the symbol. If you reach for `declare module 'tldraw' { export function X(): ... }`, stop — find the public replacement instead.
+- **Truly unmentioned**: check the type defs in `node_modules/tldraw/dist-cjs/index.d.ts`, `node_modules/@tldraw/editor/dist-cjs/index.d.ts`, or `node_modules/@tldraw/tlschema/dist-cjs/index.d.ts` (the layout varies by version and package manager). If the symbol is genuinely gone with no listed replacement, treat the gap as a documentation bug worth flagging in your final report.
+
+For TS2515 (newly-required abstract method): if your implementation only throws, declare the return type explicitly so TypeScript doesn't infer `never` and the abstract-mismatch error doesn't linger.
+
+**Verify**: re-run typecheck — count TS2305, TS2724, TS2339, and TS2515 errors before and after. Each fix should knock out one error. If counts haven't dropped, you missed a migration block — re-grep before continuing.
 
 ### 4d. Fix TipTap imports if needed
 
-If the project uses TipTap (`@tiptap/*` in dependencies or imports), the tldraw upgrade may require upgrading TipTap as well. Starting with tldraw v4.2, tldraw bundles TipTap v3 as a transitive dependency. If the project pins TipTap v2 packages directly, this will cause version conflicts and broken imports. **Upgrade the project's direct `@tiptap/*` dependencies to v3** to match what tldraw expects — leaving them on v2 will not work.
+**Skip this entire sub-step if the project has no `@tiptap/*` dependencies or imports.** Confirm with `grep -E '@tiptap/' package.json` and a recursive grep for `from '@tiptap` in the source directory. If both come back empty, jump to 4e.
 
-After upgrading, fix any breaking TipTap v2 → v3 changes:
+If the project uses TipTap, your migration may need to cross the v2 → v3 cutover (introduced in tldraw v4.2). The full v2 → v3 recipe — dual-install diagnostic, default-to-named export changes, `TextStyle`/`TextStyleKit`/`FontFamily` reorganization, transaction-handler types — lives in the v4.2 release notes migration block. Find it with:
 
-- **Default → named exports**: If a default import fails, switch to a named import: `import StarterKit from '@tiptap/starter-kit'` → `import { StarterKit } from '@tiptap/starter-kit'`
-- **Renames**: If a named import fails, check the package's actual exports: `grep 'export' node_modules/@tiptap/<package>/dist/index.js | head` — some extensions were renamed in TipTap v3 (e.g., `TextStyle` → `TextStyleKit`).
-- **Transaction handler types**: If TipTap event handler types break, import the proper types: `import { EditorEvents } from '@tiptap/core'` and type handlers as `(props: EditorEvents['transaction']) => void` rather than inline type annotations.
+```sh
+grep -n -B2 -A60 'TipTap v3' ${SKILL_DIR}/references/tldraw-releases.txt
+```
+
+Apply that recipe. The tldraw skill only adds two version-agnostic notes on top:
+
+> **Install ordering trap (any TipTap upgrade).** Running `npm install @tiptap/core@3 @tiptap/starter-kit@3 ...` against a project that already has v2 in `node_modules` will fail with `ERESOLVE`, because the v2 `starter-kit` declares `peer @tiptap/core@^2.7`. Either uninstall the v2 packages first (`npm uninstall @tiptap/core @tiptap/starter-kit ...`) or pass `--legacy-peer-deps`.
+
+> **Custom chained commands.** Whatever TipTap version, custom chain commands register via `declare module '@tiptap/core'` augmentation. This is a TipTap idiom, not a tldraw one — see TipTap's docs.
+
+**Verify**: re-run typecheck — TipTap import and type errors should be gone.
 
 ### 4e. Fix remaining type errors
 
-- `createShapes`/`updateShapes` with `.map()`: The proper fix is to add `as const` to the `type` field in the mapped object literal so TypeScript narrows it to the string literal type. If that's not sufficient, use a `satisfies` annotation on the return value. Only as a last resort, cast the result to `TLCreateShapePartial` or `TLShapePartial`.
+- `createShapes`/`updateShapes` with `.map()`: see the v4.3 migration block for the full recipe (`as const` on the `type` field for homogeneous arrays; `as TLShapePartial[]` / `as TLCreateShapePartial[]` for heterogeneous ones; *not* `satisfies TLShapePartial`).
 - TipTap extension commands not on `ChainedCommands`: use `declare module '@tiptap/core'` augmentation to register custom commands.
 - **General rule**: every `as` cast you add is tech debt. Before adding one, exhaust these alternatives in order:
   1. `as const` on object literals to narrow string literal types
@@ -116,15 +146,37 @@ After upgrading, fix any breaking TipTap v2 → v3 changes:
   4. Module augmentation to teach TypeScript about your types
   5. Only then, a targeted `as` cast with a comment explaining why it's needed
 
+**Verify**: re-run typecheck — remaining errors should all be resolved. If any remain, re-categorize and route them back to 4a–4d as appropriate.
+
 ## Step 5: Fix deprecations
 
-After all type errors are resolved, find and fix deprecated API usage. These still compile but should be migrated.
+After all type errors are resolved, find and fix `@deprecated` API usage. These still compile but should be migrated.
 
-1. **Find deprecated symbols** — grep the tldraw type definitions for `@deprecated` annotations. Also search the changelog for "deprecated" in `${CLAUDE_SKILL_DIR}/references/tldraw-releases.txt`.
+1. **Find deprecated symbols.** The changelog is the most reliable starting point — tldraw's `.d.ts` files use multi-line JSDoc, so grepping the type defs is fragile (the declaration line is typically 2–5 lines after the `@deprecated` tag, not adjacent to it).
 
-2. **Check if a linter is configured** — look for eslint, biome, or other linting config in the project. If available, run the linter — it may flag deprecated usage automatically (e.g., eslint's `deprecation/deprecation` rule). If no linter is configured, skip to step 3.
+   Start here:
 
-3. **Search the project source** for each deprecated symbol found in step 1. Replace with the recommended alternative from the `@deprecated` JSDoc comment or changelog.
+   ```sh
+   grep -i 'deprecated' ${SKILL_DIR}/references/tldraw-releases.txt
+   ```
+
+   When the target is a pre-release, also: `grep -i 'deprecated' ${SKILL_DIR}/references/tldraw-next.mdx`.
+
+   To cross-check against the type defs (one package at a time — repeat for each `@tldraw/*` package the project imports from, and `tldraw` itself), use `-A` not `-B`:
+
+   ```sh
+   grep -A5 '@deprecated' node_modules/@tldraw/editor/dist-cjs/index.d.ts \
+     | grep -oE '\b(class|function|interface|const|type|let|var)\s+\w+' \
+     | awk '{print $NF}' | sort -u
+   ```
+
+   This catches multi-line JSDoc but produces some false positives — treat the output as a candidate list, not an authoritative one. The changelog grep is what you should drive from.
+
+2. **Run the linter if configured** — eslint's `deprecation/deprecation` rule will flag deprecated imports automatically. If no linter is configured, skip this step.
+
+3. **Search the project source** for each deprecated symbol. Replace with the recommended alternative from the `@deprecated` JSDoc comment, the changelog entry, or the docs.
+
+4. **Sanity-check renames the typecheck didn't catch.** If the changelog or `tldraw-next.mdx` describes a rename and the project still imports the old name, TypeScript may resolve it through a wildcard re-export and miss it. Skim the changelog/next.mdx for "renamed" / "moved to" entries and grep the source for any old names you find.
 
 ## Step 6: Verify
 
@@ -136,9 +188,18 @@ If errors remain, repeat the categorize-and-fix cycle.
 
 After all errors are resolved, do a quick audit:
 
-1. **Count `as` casts before vs after**: Run `grep -rn ' as ' --include='*.ts' --include='*.tsx' src/` and compare against the same grep on the pre-migration code (use `git stash` or `git show HEAD:path`). **The migration should add no more than a small handful of new casts** (ideally zero). If you added more than ~5 new `as` casts across the entire migration, go back and fix them — you are almost certainly using the new API incorrectly.
-2. **Review every cast you added**: For each new `as` cast, verify it's truly necessary by checking whether `as const`, `satisfies`, generic type parameters, or module augmentation could replace it. Remove or replace any that have a cleaner alternative.
-3. **Verify no stubs or dead code**: If you stubbed out removed APIs (e.g., replaced a removed function with a no-op), make sure the calling code doesn't depend on the return value. If it does, find the proper replacement in the changelog or docs.
+1. **Count typed `as` casts added by this migration.** A naive `grep ' as '` overcounts because it includes `as const` (the recommended narrowing pattern) and `as` in import paths. Drive off the diff and filter:
+
+   ```sh
+   git diff -- '<source-dir>/**/*.ts' '<source-dir>/**/*.tsx' \
+     | grep -E '^\+' | grep -v '^+++' \
+     | grep -E '\bas\s+[A-Z]' | grep -v 'as const'
+   ```
+
+   **The migration should add no more than a small handful of new typed casts** (ideally zero, with `as TLShapePartial[]` / `as TLCreateShapePartial[]` for heterogeneous `createShapes`/`updateShapes` arrays as the main legitimate exception). If you added more than ~5 across the whole migration, go back and fix them — you are almost certainly using the new API incorrectly.
+2. **Review every typed cast you added**: For each, verify it's truly necessary by checking whether `as const`, `satisfies`, generic type parameters, or module augmentation could replace it. Remove or replace any that have a cleaner alternative.
+3. **Audit module augmentations.** Module augmentation is correct for `TLGlobalShapePropsMap` / `TLGlobalBindingPropsMap` registration and for adding genuinely-missing public types. It is **not** correct for re-exposing symbols that the SDK demoted to `@internal` — that's a workaround, not a fix. Find the public replacement instead (the migration block usually names it).
+4. **Verify no stubs or dead code**: If you stubbed out removed APIs (e.g., replaced a removed function with a no-op), make sure the calling code doesn't depend on the return value. If it does, find the proper replacement in the migration blocks or docs.
 
 ## Quality checks
 
@@ -146,10 +207,10 @@ After all errors are resolved, do a quick audit:
 - **Prefer TypeScript's narrowing features over casts.** Use `as const` for literal types, `satisfies` for type-checking without widening, generic parameters for call sites, and module augmentation for extending interfaces. These are the right tools for a migration — `as` casts are not.
 - Use parallel agents for fixing large batches of files with the same pattern.
 - **Don't just make errors go away — understand the new API.** When a method signature changes (e.g., new parameters added, property renamed to a richer type), read the changelog AND the current type definitions to understand _why_ it changed. A fix that compiles but passes hardcoded/dummy values where the new API expects real data is worse than a type error — it silently degrades behavior. For example, if a function gains new required parameters, check what shape props or editor state should feed those parameters rather than passing `0` or `1`.
-- **When unsure about an API pattern**, grep the full docs (`${CLAUDE_SKILL_DIR}/references/tldraw-full-docs.txt`) for usage examples of that specific API. The docs contain code samples that show the canonical way to use each API.
+- **When unsure about an API pattern**, grep the full docs (`${SKILL_DIR}/references/tldraw-full-docs.txt`) for usage examples of that specific API. The docs contain code samples that show the canonical way to use each API.
 
 ## Tips
 
-- Read `${CLAUDE_SKILL_DIR}/references/tldraw-releases.txt` for the filtered changelog — this is the primary source for what changed
-- Grep `${CLAUDE_SKILL_DIR}/references/tldraw-full-docs.txt` when you need docs on a specific API
+- Read `${SKILL_DIR}/references/tldraw-releases.txt` for the filtered changelog — this is the primary source for what changed
+- Grep `${SKILL_DIR}/references/tldraw-full-docs.txt` when you need docs on a specific API
 - When searching tldraw types, try multiple paths — the dist directory structure varies by version and package manager

--- a/skills/tldraw-migrate/detect-target.mjs
+++ b/skills/tldraw-migrate/detect-target.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Resolves the migration *target* (what version/tag to upgrade TO) from
+ * the skill's $ARGUMENTS, and writes it to stdout.
+ *
+ * Argument forms supported:
+ *   /tldraw-migrate                       → "latest"
+ *   /tldraw-migrate 4.4.0                 → "latest" (single semver = from-version)
+ *   /tldraw-migrate canary                → "canary" (single tag/pre-release = target)
+ *   /tldraw-migrate 4.4.0 canary          → "canary" (two args: <from> <target>)
+ *   /tldraw-migrate 4.4.0 4.6.0-canary.x  → "4.6.0-canary.x"
+ *
+ * Outputs just the resolved target with no trailing newline so it can be
+ * interpolated directly in shell.
+ */
+
+const args = process.argv
+	.slice(2)
+	.map((a) => a.trim())
+	.filter(Boolean)
+
+const STABLE_SEMVER = /^v?\d+\.\d+\.\d+$/
+
+function emit(target) {
+	process.stdout.write(target)
+	process.exit(0)
+}
+
+if (args.length === 0) emit('latest')
+if (args.length >= 2) emit(args[args.length - 1])
+
+// Single arg: stable semver = from-version (target defaults), anything else = target.
+const only = args[0]
+emit(STABLE_SEMVER.test(only) ? 'latest' : only)

--- a/skills/write-release-notes/SKILL.md
+++ b/skills/write-release-notes/SKILL.md
@@ -82,7 +82,46 @@ Create `apps/docs/content/releases/vX.Y.0.mdx` following the style guide.
 5. Add patch release sections if applicable
 6. Add GitHub release links
 
-### 6. Verify
+### 6. Write a migration guide for every breaking change
+
+Every `💥` in the article needs a migration recipe. The `tldraw-migrate` skill drives off these recipes — it intentionally does not duplicate them in its own SKILL.md, because version-specific knowledge belongs next to the breaking change that introduced it. If the recipe is missing, agents and contributors performing the upgrade have to reverse-engineer it from type defs.
+
+There are two acceptable forms:
+
+**For breaking changes with their own featured section** (renames, replaced APIs, new patterns), add a `<details><summary>Migration guide</summary>` block under the section. Include before/after code and call out any silent-compile traps (props the typecheck won't reject, signatures with optional new parameters, etc.):
+
+````mdx
+### 💥 Custom themes with display values
+
+[Description of what changed and why]
+
+<details>
+<summary>Migration guide</summary>
+
+`getDefaultColorTheme()` and `DefaultColorThemePalette` have been removed. Use `editor.getCurrentTheme().colors[colorMode]` instead:
+
+```tsx
+// Before
+const theme = getDefaultColorTheme({ isDarkMode })
+
+// After
+const theme = editor.getCurrentTheme()
+const colors = theme.colors[editor.getColorMode()]
+```
+
+</details>
+````
+
+**For one-line `💥` entries in the API changes list**, the bullet itself must contain the recipe — name the replacement and any caveats inline:
+
+- ✅ `💥 Replace TLDrawShapeSegment.points with the helper getPointsFromDrawSegment(segment, scaleX, scaleY) so segment points respect the shape's current scale.`
+- ❌ `💥 Remove TLDrawShapeSegment.points.` (no replacement → reader has to guess)
+
+A symbol that is removed without a replacement is a documentation bug — find the public alternative or, if there genuinely isn't one, say so explicitly so readers know to drop the call site rather than searching for a rename.
+
+**Special case — `@public` → `@internal` demotions:** these compile but disappear from public types. They are still breaking changes for consumers who imported the symbol. Treat them like a removal: mark with `💥`, name the public replacement, and explicitly tell readers *not* to reach for module augmentation to re-expose the demoted symbol.
+
+### 7. Verify
 
 Check that:
 
@@ -90,6 +129,7 @@ Check that:
 - PR links are correct and formatted properly
 - Community contributors are credited
 - Breaking changes are marked with 💥
+- **Every `💥` has either a migration guide block or an inline replacement** (run `grep -nE '💥' apps/docs/content/releases/<file>.mdx` and verify each bullet/section)
 - Sections are in the correct order
 
 ## References


### PR DESCRIPTION
In order to make the `tldraw-migrate` skill version-agnostic and stop duplicating migration recipes between the skill and the release notes, this PR adds explicit migration guide blocks for every breaking change in the v4.2, v4.3, and `next.mdx` release notes — and refactors the skill to drive off those blocks instead of carrying its own copies.

Version-specific knowledge belongs next to the breaking change that introduced it. The skill stays small and stable; the release notes own the recipes.

### Release notes content

- `apps/docs/content/releases/v4.2.0.mdx` — TipTap v3 section gets a migration block covering the dual-install diagnostic, default→named export changes, `TextStyleKit`/`FontFamily` reorganization, and transaction handler types.
- `apps/docs/content/releases/v4.3.0.mdx` — Custom shape/binding pattern section gets a migration block covering `TLGlobalShapePropsMap`/`TLGlobalBindingPropsMap` augmentation, the rename ripple when shape names collide, `as const` on `static override type` / `static override shapeType`, and the heterogeneous `createShapes`/`updateShapes` cast.
- `apps/docs/content/releases/next.mdx` — adds migration blocks for `ShapeUtil.indicator()` → `getIndicatorPath()`, `<Tldraw>` options consolidation (`cameraOptions`/`textOptions`/`deepLinks` → `options` prop, `embeds` → `EmbedShapeUtil.configure`, `setDefaultEditorAssetUrls`/`setDefaultUiAssetUrls` demoted to `@internal`), and `useTldrawUser` removal. Several previously-unmarked breaking changes in the API list are now marked with `💥` and given inline replacement guidance.

### Skill changes

- `skills/write-release-notes/SKILL.md` — new step requiring a migration recipe for every `💥` (block for featured sections; inline replacement for one-line API entries). Verify step now grep-checks that every `💥` has a recipe.
- `skills/tldraw-migrate/SKILL.md` — major refactor:
  - Renames `${CLAUDE_SKILL_DIR}` → `${SKILL_DIR}` and probes common skill locations so the skill works under non-Claude agent setups.
  - Adds support for migrating to a target version other than `latest`. Pass a dist-tag (`canary`, `next`, `beta`) or a pre-release semver as the second argument.
  - When the target is a pre-release, auto-fetches `apps/docs/content/releases/next.mdx` from `main` so canary/next deltas are searchable alongside the stable changelog.
  - Step 4 fix patterns are now version-agnostic — they categorize errors by TS code and route to the correct migration block in the changelog. Each sub-step ends with a verify step that re-runs typecheck.
  - Quality audit now distinguishes typed `as` casts from `as const` and import-path `as`, and adds a module-augmentation audit (catches the anti-pattern of re-exposing `@internal` symbols).
- `skills/tldraw-migrate/detect-target.mjs` (new) — resolves the migration target from the skill arguments. `latest` by default; supports dist-tags and pre-release semvers.

### Change type

- [x] `other` (skill + docs)

### Test plan

1. Skim each `<details><summary>Migration guide</summary>` block in `next.mdx`, `v4.2.0.mdx`, and `v4.3.0.mdx` for accuracy.
2. Verify every `💥` has a recipe: `grep -nE '💥' apps/docs/content/releases/{next,v4.2.0,v4.3.0}.mdx` and confirm each line has either a nearby migration block or an inline replacement.
3. Run the migrate skill on a v4.1 → 4.6.0-canary project: confirm the auto-fetch blocks resolve `${SKILL_DIR}` and that `references/tldraw-next.mdx` is pulled when the target is a pre-release.
4. Run with no second argument and confirm the target resolves to `latest` and `tldraw-next.mdx` is skipped.

### Release notes

- Add migration guides for every breaking change in the v4.2 and v4.3 release notes.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Documentation   | +184 / -4  |
| Config/tooling  | +195 / -60 |