### PR TITLE
dev: add editor to window object when the debug menu is opened

### DIFF
--- a/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/DebugMenu/DefaultDebugMenu.tsx
@@ -1,4 +1,5 @@
-import { ReactNode } from 'react'
+import { useEditor } from '@tldraw/editor'
+import { ReactNode, useEffect } from 'react'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 import { TldrawUiMenuContextProvider } from '../primitives/menus/TldrawUiMenuContext'
@@ -16,7 +17,21 @@ export interface TLUiDebugMenuProps {
 
 /** @public @react */
 export function DefaultDebugMenu({ children }: TLUiDebugMenuProps) {
+	const editor = useEditor()
 	const content = children ?? <DefaultDebugMenuContent />
+
+	// While the debug menu is mounted, expose the editor on `window.editor` for
+	// console-driven debugging. We remove it on unmount so the editor isn't
+	// retained when debug mode is turned off.
+	useEffect(() => {
+		const win = window as any
+		win.editor = editor
+		return () => {
+			if (win.editor === editor) {
+				delete win.editor
+			}
+		}
+	}, [editor])
 
 	return (
 		<TldrawUiDropdownMenuRoot id="debug">


### PR DESCRIPTION
i keep reaching for editor but it's never there when i need it

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`
