### PR TITLE
fix(docs): fix missing images in bento

### DIFF
--- a/apps/docs/components/content/bento.tsx
+++ b/apps/docs/components/content/bento.tsx
@@ -1,3 +1,4 @@
+import { assetUrl } from '@/utils/asset-url'
 import { cn } from '@/utils/cn'
 
 // Content definitions
@@ -185,7 +186,11 @@ export function StarterKitBento({
 					href={href}
 					className="block relative mb-2 overflow-hidden rounded-lg border border-zinc-200 bg-zinc-50"
 				>
-					<img src={img.src} alt={img.alt || type} className="!my-0 h-auto w-full object-cover" />
+					<img
+						src={assetUrl(img.src)}
+						alt={img.alt || type}
+						className="!my-0 h-auto w-full object-cover"
+					/>
 				</a>
 			)}
 


### PR DESCRIPTION
Fixed problem with direct images mentioned in components that are not wrapped with the assetUrl

@max-drake props for finding this one, should have thought about the issue much faster and identified it.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`