### PR TITLE
example: digital tape drawing

### DIFF
--- a/apps/examples/src/examples/use-cases/digital-tape/DigitalTapeExample.tsx
+++ b/apps/examples/src/examples/use-cases/digital-tape/DigitalTapeExample.tsx
@@ -1,0 +1,166 @@
+import { useEffect } from 'react'
+import {
+	TLAnyOverlayUtilConstructor,
+	TLDrawShape,
+	Tldraw,
+	VecModel,
+	b64Vecs,
+	createShapeId,
+	defaultOverlayUtils,
+	useEditor,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { anchor$, tapeStroke$ } from './tape-state'
+import { TapeOverlayUtil } from './TapeOverlayUtil'
+import './digital-tape.css'
+
+// There's a guide at the bottom of this file!
+
+// [1]
+const ANCHOR_FOLLOW_RATE = 0.01
+const MIN_RECORD_DISTANCE = 2
+
+// [2]
+const overlayUtils: TLAnyOverlayUtilConstructor[] = [...defaultOverlayUtils, TapeOverlayUtil]
+
+function isEditableTarget(target: EventTarget | null) {
+	if (!(target instanceof HTMLElement)) return false
+	const tag = target.tagName
+	return tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable
+}
+
+// [3]
+function TapeController() {
+	const editor = useEditor()
+
+	useEffect(() => {
+		function onTick() {
+			const leader = editor.inputs.getCurrentPagePoint()
+			const current = anchor$.get()
+
+			// First tick: snap the anchor to the leader.
+			if (!current) {
+				anchor$.set({ x: leader.x, y: leader.y })
+				return
+			}
+
+			const next = {
+				x: current.x + (leader.x - current.x) * ANCHOR_FOLLOW_RATE,
+				y: current.y + (leader.y - current.y) * ANCHOR_FOLLOW_RATE,
+			}
+			anchor$.set(next)
+
+			// While the user is pulling tape, append the anchor's path to the
+			// in-progress stroke.
+			const stroke = tapeStroke$.get()
+			if (!stroke) return
+			const last = stroke.points[stroke.points.length - 1]
+			const rx = next.x - stroke.origin.x
+			const ry = next.y - stroke.origin.y
+			const dx = rx - last.x
+			const dy = ry - last.y
+			if (dx * dx + dy * dy > MIN_RECORD_DISTANCE * MIN_RECORD_DISTANCE) {
+				tapeStroke$.set({
+					origin: stroke.origin,
+					points: [...stroke.points, { x: rx, y: ry, z: 0.5 }],
+				})
+			}
+		}
+
+		editor.on('tick', onTick)
+		return () => {
+			editor.off('tick', onTick)
+		}
+	}, [editor])
+
+	useEffect(() => {
+		function onKeyDown(e: KeyboardEvent) {
+			if (e.code !== 'Space' || e.repeat) return
+			if (isEditableTarget(e.target)) return
+			if (editor.getEditingShapeId()) return
+			e.preventDefault()
+			if (tapeStroke$.get()) return
+
+			const anchor = anchor$.get() ?? { x: 0, y: 0 }
+			tapeStroke$.set({
+				origin: { x: anchor.x, y: anchor.y },
+				points: [{ x: 0, y: 0, z: 0.5 }],
+			})
+		}
+
+		function onKeyUp(e: KeyboardEvent) {
+			if (e.code !== 'Space') return
+			const stroke = tapeStroke$.get()
+			if (!stroke) return
+			tapeStroke$.set(null)
+
+			if (stroke.points.length < 2) return
+			const points: VecModel[] = stroke.points
+			editor.createShape<TLDrawShape>({
+				id: createShapeId(),
+				type: 'draw',
+				x: stroke.origin.x,
+				y: stroke.origin.y,
+				props: {
+					segments: [{ type: 'free', path: b64Vecs.encodePoints(points) }],
+				},
+			})
+		}
+
+		window.addEventListener('keydown', onKeyDown)
+		window.addEventListener('keyup', onKeyUp)
+		return () => {
+			window.removeEventListener('keydown', onKeyDown)
+			window.removeEventListener('keyup', onKeyUp)
+		}
+	}, [editor])
+
+	return <div className="tape-hint">Hold space to lay down tape</div>
+}
+
+// [4]
+export default function DigitalTapeExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="digital-tape-example"
+				options={{ spacebarPanning: false }}
+				overlayUtils={overlayUtils}
+			>
+				<TapeController />
+			</Tldraw>
+		</div>
+	)
+}
+
+/*
+This example recreates the "digital tape drawing" technique. There are two
+indicators on the canvas: a leader that tracks the cursor and an anchor that
+trails behind it. While you hold space, the anchor's path is recorded and
+rendered as a live preview. Releasing space commits the traced path as a draw
+shape, the same way a length of physical tape can be guided into a curve by
+pulling its loose end.
+
+[1]
+ANCHOR_FOLLOW_RATE controls how slowly the anchor catches up to the leader on
+each tick (0..1) — smaller numbers give a longer, smoother trail.
+MIN_RECORD_DISTANCE keeps the recorded path from being spammed with
+near-duplicate points.
+
+[2]
+The indicators, the connector line, and the live tape preview are all painted
+by a single `OverlayUtil` registered alongside the default overlays. Overlays
+draw into a shared canvas 2D context (already transformed to page space), so
+they redraw automatically whenever the atoms they read from change.
+
+[3]
+The controller component is a pure side-effect manager. On every tick it
+lerps the anchor toward the cursor and appends to the in-progress stroke.
+Spacebar starts and ends a stroke; on release we encode the recorded points
+into a draw shape positioned at the stroke origin.
+
+[4]
+We disable spacebarPanning so that holding space draws tape rather than
+panning the camera, and register `TapeOverlayUtil` after the defaults so it
+paints on top of selection handles and brush.
+*/

--- a/apps/examples/src/examples/use-cases/digital-tape/README.md
+++ b/apps/examples/src/examples/use-cases/digital-tape/README.md
@@ -1,0 +1,18 @@
+---
+title: Digital tape drawing
+component: ./DigitalTapeExample.tsx
+category: use-cases
+priority: 6
+keywords: [tape, drawing, smoothing, lazy, lag, indicator, overlay, animation, spacebar]
+---
+
+Two indicators trace smooth curves the way physical tape would.
+
+---
+
+A leader indicator follows your cursor. A second anchor indicator stays put
+until you hold space, at which point it is pulled toward the leader along a
+smooth, eased path. The trail it leaves behind is committed as a draw shape
+when you release. This is a take on the digital tape drawing technique used
+to ink curves with intentional, controlled strokes instead of free hand
+wobble.

--- a/apps/examples/src/examples/use-cases/digital-tape/TapeOverlayUtil.ts
+++ b/apps/examples/src/examples/use-cases/digital-tape/TapeOverlayUtil.ts
@@ -1,0 +1,104 @@
+import { OverlayUtil, TLOverlay, VecModel } from 'tldraw'
+import { TapePoint, anchor$, tapeStroke$ } from './tape-state'
+
+interface TLTapeOverlay extends TLOverlay {
+	props: {
+		leader: TapePoint
+		anchor: TapePoint
+		stroke: { origin: TapePoint; points: VecModel[] } | null
+	}
+}
+
+export class TapeOverlayUtil extends OverlayUtil<TLTapeOverlay> {
+	static override type = 'digital-tape'
+	override options = { zIndex: 400 }
+
+	override isActive(): boolean {
+		// Wait until the controller has seeded an anchor on first tick.
+		return anchor$.get() !== null
+	}
+
+	override getOverlays(): TLTapeOverlay[] {
+		const leader = this.editor.inputs.getCurrentPagePoint()
+		const anchor = anchor$.get()
+		if (!anchor) return []
+		return [
+			{
+				id: 'digital-tape:main',
+				type: 'digital-tape',
+				props: {
+					leader: { x: leader.x, y: leader.y },
+					anchor,
+					stroke: tapeStroke$.get(),
+				},
+			},
+		]
+	}
+
+	override render(ctx: CanvasRenderingContext2D, overlays: TLTapeOverlay[]): void {
+		const overlay = overlays[0]
+		if (!overlay) return
+		const { leader, anchor, stroke } = overlay.props
+		const zoom = this.editor.getZoomLevel()
+		const px = 1 / zoom
+		const colorMode = this.editor.getColorMode()
+		const isDark = colorMode === 'dark'
+		const fg = isDark ? '#fff' : '#111'
+		const muted = isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.25)'
+		const accent = this.editor.getCurrentTheme().colors[colorMode].selectionStroke
+
+		// Live tape preview while the user is pulling tape.
+		if (stroke && stroke.points.length > 1) {
+			ctx.save()
+			ctx.strokeStyle = fg
+			ctx.lineWidth = 3 * px
+			ctx.lineCap = 'round'
+			ctx.lineJoin = 'round'
+			ctx.beginPath()
+			for (let i = 0; i < stroke.points.length; i++) {
+				const p = stroke.points[i]
+				const x = stroke.origin.x + p.x
+				const y = stroke.origin.y + p.y
+				if (i === 0) ctx.moveTo(x, y)
+				else ctx.lineTo(x, y)
+			}
+			ctx.stroke()
+			ctx.restore()
+		}
+
+		// Connector between the two indicators.
+		ctx.save()
+		ctx.beginPath()
+		ctx.moveTo(anchor.x, anchor.y)
+		ctx.lineTo(leader.x, leader.y)
+		if (stroke) {
+			ctx.strokeStyle = accent
+			ctx.lineWidth = 2 * px
+		} else {
+			ctx.strokeStyle = muted
+			ctx.lineWidth = 1 * px
+			ctx.setLineDash([4 * px, 4 * px])
+		}
+		ctx.stroke()
+		ctx.restore()
+
+		// Anchor (trailing) indicator.
+		ctx.save()
+		ctx.beginPath()
+		ctx.arc(anchor.x, anchor.y, 6 * px, 0, Math.PI * 2)
+		ctx.fillStyle = stroke ? accent : fg
+		ctx.fill()
+		ctx.restore()
+
+		// Leader (cursor) indicator.
+		ctx.save()
+		ctx.beginPath()
+		ctx.arc(leader.x, leader.y, 7 * px, 0, Math.PI * 2)
+		ctx.fillStyle = isDark ? '#111' : '#fff'
+		ctx.fill()
+		ctx.lineWidth = 2 * px
+		ctx.strokeStyle = fg
+		ctx.stroke()
+		ctx.restore()
+	}
+}

--- a/apps/examples/src/examples/use-cases/digital-tape/digital-tape.css
+++ b/apps/examples/src/examples/use-cases/digital-tape/digital-tape.css
@@ -1,0 +1,15 @@
+.tape-hint {
+	position: absolute;
+	bottom: 12px;
+	left: 50%;
+	transform: translateX(-50%);
+	padding: 6px 12px;
+	border-radius: 6px;
+	background-color: rgba(0, 0, 0, 0.6);
+	color: #fff;
+	font-family: sans-serif;
+	font-size: 12px;
+	letter-spacing: 0.02em;
+	pointer-events: none;
+	z-index: 300;
+}

--- a/apps/examples/src/examples/use-cases/digital-tape/tape-state.ts
+++ b/apps/examples/src/examples/use-cases/digital-tape/tape-state.ts
@@ -1,0 +1,19 @@
+import { VecModel, atom } from 'tldraw'
+
+export interface TapePoint {
+	x: number
+	y: number
+}
+
+export interface TapeStroke {
+	origin: TapePoint
+	points: VecModel[]
+}
+
+// Trailing indicator position, in page coordinates. Lerped toward the leader
+// each tick by the controller component.
+export const anchor$ = atom<TapePoint | null>('tape.anchor', null)
+
+// While the user holds space we record the anchor's path here, relative to the
+// stroke origin. Setting this back to null on key-up clears the live preview.
+export const tapeStroke$ = atom<TapeStroke | null>('tape.stroke', null)


### PR DESCRIPTION
In order to demonstrate the new `OverlayUtil` system on a recognizable interaction, this PR adds a `digital-tape` use-case example that recreates the [digital tape drawing](https://www.youtube.com/watch?v=LvyzwN36PSw) technique. A leader indicator follows the cursor; a second anchor indicator trails behind it. While the user holds space, the anchor's path is recorded and rendered as a live preview, and on release that path is committed as a `draw` shape — the digital analogue of pulling tape into a smooth curve.

The whole on-canvas piece (two indicators, the connector line, and the live tape preview) is painted by a single `TapeOverlayUtil`. A small `TapeController` component owns the per-tick lerp, the spacebar handlers, and the shape commit; it writes into two atoms (`anchor$`, `tapeStroke$`) that the overlay reads in `getOverlays()`.

### New examples

- `use-cases/digital-tape` — two cursor indicators, lazy-mouse-style smoothing on a held key, commits the trace as a draw shape.

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev` and open `/digital-tape`.
2. Move the mouse — the trailing anchor should lag visibly behind the cursor.
3. Hold space while moving — the connector line should highlight, and a black stroke should appear under the anchor as it traces.
4. Release space — the live preview should clear and a draw shape should remain.
5. Pan and zoom — indicators stay attached to the cursor and tape, and stroke widths stay visually constant.
6. Toggle dark mode — colors should adapt.

### Release notes

- Add a digital tape drawing example under `use-cases/digital-tape`.