### PR TITLE
perf(editor): skip notVisibleShapes recompute on prop-only changes

### DIFF
--- a/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
+++ b/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
@@ -17,6 +17,11 @@ export function notVisibleShapes(editor: Editor) {
 		//  - getViewportPageBounds: invalidates on pan/zoom
 		//  - getShapeIdsInsideBounds: subscribes to the spatial index epoch,
 		//    which only ticks when a shape's bounds actually change
+		//  - editor.getShape(id) in the slow path below: per-shape subscription,
+		//    only for offscreen shapes — needed so canCull() flips driven by
+		//    prop changes (e.g. a shape with `preventCulling`) re-run this
+		//    derivation. The active draw shape is onscreen and short-circuited
+		//    out before we read it, so drawing pointer-moves don't re-subscribe.
 		// We deliberately do NOT subscribe to getCurrentPageShapes() — its
 		// invalidation on every prop change would re-run this derivation per
 		// pointer move during drawing.
@@ -33,13 +38,15 @@ export function notVisibleShapes(editor: Editor) {
 		}
 
 		// Slow path: collect not-visible ids, checking canCull per shape.
-		// We read shapes via store.unsafeGetWithoutCapture so the derivation
-		// doesn't subscribe to per-shape props.
+		// editor.getShape subscribes per-shape — required so prop-driven
+		// canCull overrides invalidate this derivation. We only reach this
+		// path for offscreen shapes, so the active draw shape (which is
+		// onscreen) is never subscribed to here.
 		const notVisibleIds: TLShapeId[] = []
 		let shape: TLShape | undefined
 		for (const id of allShapeIds) {
 			if (visibleIds.has(id)) continue
-			shape = editor.store.unsafeGetWithoutCapture(id) as TLShape | undefined
+			shape = editor.getShape(id)
 			if (!shape) continue
 			if (!editor.getShapeUtil(shape.type).canCull(shape)) continue
 			notVisibleIds.push(id)

--- a/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
+++ b/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
@@ -12,19 +12,23 @@ export function notVisibleShapes(editor: Editor) {
 	const emptySet = new Set<TLShapeId>()
 
 	return computed<Set<TLShapeId>>('notVisibleShapes', function (prevValue) {
-		// Subscribed deps:
-		//  - getCurrentPageShapeIds: incremental, only invalidates on add/remove/reparent
+		// Subscribed deps (rebuilt on each run by the signals tracker):
+		//  - getCurrentPageShapeIds: incremental, only invalidates on
+		//    add/remove/reparent
 		//  - getViewportPageBounds: invalidates on pan/zoom
 		//  - getShapeIdsInsideBounds: subscribes to the spatial index epoch,
 		//    which only ticks when a shape's bounds actually change
-		//  - editor.getShape(id) in the slow path below: per-shape subscription,
-		//    only for offscreen shapes — needed so canCull() flips driven by
-		//    prop changes (e.g. a shape with `preventCulling`) re-run this
-		//    derivation. The active draw shape is onscreen and short-circuited
-		//    out before we read it, so drawing pointer-moves don't re-subscribe.
+		//  - editor.getShape(id) in the slow path below: per-shape
+		//    subscription, but only for shapes that are read there — i.e.
+		//    offscreen ones. This is required so canCull() overrides driven
+		//    by prop changes (e.g. a shape with `preventCulling`) re-run
+		//    this derivation. Onscreen shapes are short-circuited out
+		//    before the read, so the current run never subscribes to them
+		//    and their prop changes don't invalidate the derivation.
 		// We deliberately do NOT subscribe to getCurrentPageShapes() — its
-		// invalidation on every prop change would re-run this derivation per
-		// pointer move during drawing.
+		// invalidation on every shape prop change would re-run this
+		// derivation any time any shape's props changed, including the many
+		// onscreen ones.
 		const allShapeIds = editor.getCurrentPageShapeIds()
 		const viewportPageBounds = editor.getViewportPageBounds()
 		const visibleIds = editor.getShapeIdsInsideBounds(viewportPageBounds)

--- a/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
+++ b/packages/editor/src/lib/editor/derivations/notVisibleShapes.ts
@@ -12,42 +12,45 @@ export function notVisibleShapes(editor: Editor) {
 	const emptySet = new Set<TLShapeId>()
 
 	return computed<Set<TLShapeId>>('notVisibleShapes', function (prevValue) {
-		const allShapes = editor.getCurrentPageShapes()
+		// Subscribed deps:
+		//  - getCurrentPageShapeIds: incremental, only invalidates on add/remove/reparent
+		//  - getViewportPageBounds: invalidates on pan/zoom
+		//  - getShapeIdsInsideBounds: subscribes to the spatial index epoch,
+		//    which only ticks when a shape's bounds actually change
+		// We deliberately do NOT subscribe to getCurrentPageShapes() — its
+		// invalidation on every prop change would re-run this derivation per
+		// pointer move during drawing.
+		const allShapeIds = editor.getCurrentPageShapeIds()
 		const viewportPageBounds = editor.getViewportPageBounds()
 		const visibleIds = editor.getShapeIdsInsideBounds(viewportPageBounds)
 
-		let shape: TLShape | undefined
-
-		// Fast path: if all shapes are visible, return empty set
-		if (visibleIds.size === allShapes.length) {
+		// Fast path: if all shapes are visible, return empty set.
+		if (visibleIds.size === allShapeIds.size) {
 			if (isUninitialized(prevValue) || prevValue.size > 0) {
 				return emptySet
 			}
 			return prevValue
 		}
 
-		// First run: compute from scratch
-		if (isUninitialized(prevValue)) {
-			const nextValue = new Set<TLShapeId>()
-			for (let i = 0; i < allShapes.length; i++) {
-				shape = allShapes[i]
-				if (visibleIds.has(shape.id)) continue
-				if (!editor.getShapeUtil(shape.type).canCull(shape)) continue
-				nextValue.add(shape.id)
-			}
-			return nextValue
-		}
-
-		// Subsequent runs: single pass to collect IDs and detect changes
+		// Slow path: collect not-visible ids, checking canCull per shape.
+		// We read shapes via store.unsafeGetWithoutCapture so the derivation
+		// doesn't subscribe to per-shape props.
 		const notVisibleIds: TLShapeId[] = []
-		for (let i = 0; i < allShapes.length; i++) {
-			shape = allShapes[i]
-			if (visibleIds.has(shape.id)) continue
+		let shape: TLShape | undefined
+		for (const id of allShapeIds) {
+			if (visibleIds.has(id)) continue
+			shape = editor.store.unsafeGetWithoutCapture(id) as TLShape | undefined
+			if (!shape) continue
 			if (!editor.getShapeUtil(shape.type).canCull(shape)) continue
-			notVisibleIds.push(shape.id)
+			notVisibleIds.push(id)
 		}
 
-		// Check if the result changed
+		// First run: build from scratch.
+		if (isUninitialized(prevValue)) {
+			return new Set(notVisibleIds)
+		}
+
+		// Subsequent runs: only allocate a new Set when the contents differ.
 		if (notVisibleIds.length === prevValue.size) {
 			let same = true
 			for (let i = 0; i < notVisibleIds.length; i++) {

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -161,6 +161,12 @@ export class SpatialIndexManager {
 			}
 		}
 
+		// If step 1 found no real bounds changes, no shape's bounds can have
+		// changed transitively either: a dependent's geometry only invalidates
+		// when one of its inputs (another shape's bounds) changed. Skip the
+		// all-shapes sweep entirely.
+		if (!changed) return false
+
 		// 2. Check remaining shapes in index for bounds changes
 		// This handles shapes with computed bounds (arrows bound to moved shapes, groups with moved children, etc.)
 		const allShapeIds = this.rbush.getAllShapeIds()
@@ -177,7 +183,6 @@ export class SpatialIndexManager {
 				} else {
 					this.rbush.remove(shapeId)
 				}
-				changed = true
 			}
 		}
 

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -28,6 +28,12 @@ export class SpatialIndexManager {
 	private spatialIndexComputed: Computed<number>
 	private lastPageId: TLPageId | null = null
 
+	// Increments only when the rbush actually changes (a bounds was added,
+	// removed, or moved). Consumers downstream (e.g. notVisibleShapes) depend on
+	// this value rather than the store epoch, so they don't re-run when shape
+	// props change without affecting bounds.
+	private _boundsEpoch = 0
+
 	constructor(public readonly editor: Editor) {
 		this.rbush = new RBushIndex()
 		this.spatialIndexComputed = this.createSpatialIndexComputed()
@@ -38,33 +44,42 @@ export class SpatialIndexManager {
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
 			if (isUninitialized(_prevValue)) {
-				return this.buildFromScratch(lastComputedEpoch)
+				this.buildFromScratch()
+				this._boundsEpoch++
+				return this._boundsEpoch
 			}
 
 			const shapeDiff = shapeHistory.getDiffSince(lastComputedEpoch)
 
 			if (shapeDiff === RESET_VALUE) {
-				return this.buildFromScratch(lastComputedEpoch)
+				this.buildFromScratch()
+				this._boundsEpoch++
+				return this._boundsEpoch
 			}
 
 			const currentPageId = this.editor.getCurrentPageId()
 			if (this.lastPageId !== currentPageId) {
-				return this.buildFromScratch(lastComputedEpoch)
+				this.buildFromScratch()
+				this._boundsEpoch++
+				return this._boundsEpoch
 			}
 
 			// No shape changes - index is already up to date
 			if (shapeDiff.length === 0) {
-				return lastComputedEpoch
+				return this._boundsEpoch
 			}
 
-			// Process incremental updates
-			this.processIncrementalUpdate(shapeDiff)
-
-			return lastComputedEpoch
+			// Process incremental updates; only bump the epoch when something
+			// actually changed in the rbush. This is what lets downstream
+			// computeds (notVisibleShapes etc.) skip work on prop-only changes.
+			if (this.processIncrementalUpdate(shapeDiff)) {
+				this._boundsEpoch++
+			}
+			return this._boundsEpoch
 		})
 	}
 
-	private buildFromScratch(epoch: number): number {
+	private buildFromScratch(): void {
 		this.rbush.clear()
 		this.lastPageId = this.editor.getCurrentPageId()
 
@@ -87,13 +102,12 @@ export class SpatialIndexManager {
 
 		// Bulk load for efficiency
 		this.rbush.bulkLoad(elements)
-
-		return epoch
 	}
 
-	private processIncrementalUpdate(shapeDiff: RecordsDiff<TLRecord>[]): void {
+	private processIncrementalUpdate(shapeDiff: RecordsDiff<TLRecord>[]): boolean {
 		// Track shapes we've already processed from the diff
 		const processedShapeIds = new Set<TLShapeId>()
+		let changed = false
 
 		// 1. Process shape additions, removals, and updates from diff
 		for (const changes of shapeDiff) {
@@ -103,6 +117,7 @@ export class SpatialIndexManager {
 					const bounds = this.editor.getShapePageBounds(shape.id)
 					if (bounds && bounds.isValid()) {
 						this.rbush.upsert(shape.id, bounds)
+						changed = true
 					}
 					processedShapeIds.add(shape.id)
 				}
@@ -112,11 +127,15 @@ export class SpatialIndexManager {
 			for (const shape of objectMapValues(changes.removed) as TLShape[]) {
 				if (isShape(shape)) {
 					this.rbush.remove(shape.id)
+					changed = true
 					processedShapeIds.add(shape.id)
 				}
 			}
 
-			// Handle updated shapes: page changes and bounds updates
+			// Handle updated shapes: page changes and bounds updates. Only
+			// upsert when the bounds actually differ — a shape's props can
+			// change without affecting its bounds (e.g., an active draw stroke
+			// adding a point that lies within the existing bounding box).
 			for (const [, to] of objectMapValues(changes.updated) as [TLShape, TLShape][]) {
 				if (!isShape(to)) continue
 				processedShapeIds.add(to.id)
@@ -126,10 +145,18 @@ export class SpatialIndexManager {
 				if (isOnPage) {
 					const bounds = this.editor.getShapePageBounds(to.id)
 					if (bounds && bounds.isValid()) {
-						this.rbush.upsert(to.id, bounds)
+						const indexedBounds = this.rbush.getBounds(to.id)
+						if (!this.areBoundsEqual(bounds, indexedBounds)) {
+							this.rbush.upsert(to.id, bounds)
+							changed = true
+						}
+					} else if (this.rbush.getBounds(to.id) !== undefined) {
+						this.rbush.remove(to.id)
+						changed = true
 					}
-				} else {
+				} else if (this.rbush.getBounds(to.id) !== undefined) {
 					this.rbush.remove(to.id)
+					changed = true
 				}
 			}
 		}
@@ -150,8 +177,11 @@ export class SpatialIndexManager {
 				} else {
 					this.rbush.remove(shapeId)
 				}
+				changed = true
 			}
 		}
+
+		return changed
 	}
 
 	private areBoundsEqual(a: Box | undefined, b: Box | undefined): boolean {

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -32,10 +32,12 @@ export class SpatialIndexManager {
 	private spatialIndexComputed: Computed<number>
 	private lastPageId: TLPageId | null = null
 
-	// Increments only when the rbush actually changes (a bounds was added,
-	// removed, or moved). Consumers downstream (e.g. notVisibleShapes) depend on
-	// this value rather than the store epoch, so they don't re-run when shape
-	// props change without affecting bounds.
+	// Tick that bumps when the rbush content may have changed. On full
+	// rebuild paths (init, history reset, page switch) we bump unconditionally;
+	// on incremental updates we bump only when an add/remove/upsert actually
+	// happened. Consumers downstream (e.g. notVisibleShapes) depend on this
+	// value rather than the store epoch, so prop-only diffs that don't move
+	// any bounds don't re-trigger them.
 	private _boundsEpoch = 0
 
 	constructor(public readonly editor: Editor) {

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -11,12 +11,16 @@ import { RBushIndex, type SpatialElement } from './RBushIndex'
  * Manages spatial indexing for efficient shape location queries.
  *
  * Uses an R-tree (via RBush) to enable O(log n) spatial queries instead of O(n) iteration.
- * Handles shapes with computed bounds (arrows, groups, custom shapes) by checking all shapes'
- * bounds on each update using the reactive bounds cache.
+ * Handles shapes with computed bounds (arrows, groups, custom shapes) by re-checking
+ * indexed shapes' bounds on every incremental update.
  *
  * Key features:
  * - Incremental updates using filterHistory pattern
- * - Leverages existing bounds cache reactivity for dependency tracking
+ * - Exposes a `_boundsEpoch` that ticks only when the rbush actually changes,
+ *   so downstream computeds (e.g. notVisibleShapes) can skip work on prop-only
+ *   shape changes that don't move any bounds
+ * - Step-1 upserts compare against the indexed bounds and skip rbush mutation
+ *   when bounds are unchanged, so prop-only updates are cheap
  * - Works with any custom shape type with computed bounds
  * - Per-page index (rebuilds on page change)
  * - Optimized for viewport culling queries
@@ -123,11 +127,16 @@ export class SpatialIndexManager {
 				}
 			}
 
-			// Handle removals
+			// Handle removals. Only mark changed when the shape was actually in
+			// the rbush — removed shapes from other pages, or shapes that were
+			// never indexed (invalid bounds at insert time), are no-ops here
+			// and shouldn't bump the bounds epoch.
 			for (const shape of objectMapValues(changes.removed) as TLShape[]) {
 				if (isShape(shape)) {
-					this.rbush.remove(shape.id)
-					changed = true
+					if (this.rbush.getBounds(shape.id) !== undefined) {
+						this.rbush.remove(shape.id)
+						changed = true
+					}
 					processedShapeIds.add(shape.id)
 				}
 			}
@@ -161,14 +170,14 @@ export class SpatialIndexManager {
 			}
 		}
 
-		// If step 1 found no real bounds changes, no shape's bounds can have
-		// changed transitively either: a dependent's geometry only invalidates
-		// when one of its inputs (another shape's bounds) changed. Skip the
-		// all-shapes sweep entirely.
-		if (!changed) return false
-
-		// 2. Check remaining shapes in index for bounds changes
-		// This handles shapes with computed bounds (arrows bound to moved shapes, groups with moved children, etc.)
+		// 2. Check remaining indexed shapes for bounds changes. This handles
+		// shapes whose bounds derive from other shapes (arrows bound to moved
+		// shapes, groups with moved children) — and importantly also catches
+		// cases where a shape's *outline* changed without its axis-aligned
+		// bounds changing (e.g. geo `rectangle` → `ellipse` at the same w/h),
+		// which can shift a bound arrow's intersection points and therefore
+		// its bounds. A diff with only such updates leaves `changed` false
+		// after step 1, so we can't skip this pass on that signal alone.
 		const allShapeIds = this.rbush.getAllShapeIds()
 
 		for (const shapeId of allShapeIds) {
@@ -183,6 +192,7 @@ export class SpatialIndexManager {
 				} else {
 					this.rbush.remove(shapeId)
 				}
+				changed = true
 			}
 		}
 

--- a/packages/tldraw/src/test/notVisibleShapes.test.ts
+++ b/packages/tldraw/src/test/notVisibleShapes.test.ts
@@ -8,6 +8,7 @@ import {
 	T,
 	TLShape,
 	createShapeId,
+	react,
 } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
@@ -189,6 +190,169 @@ describe('notVisibleShapes - canCull behavior', () => {
 		expect(notVisible.has(nonCullableId)).toBe(false)
 
 		testEditor.dispose()
+	})
+})
+
+describe('notVisibleShapes - prop-only updates', () => {
+	function trackInvalidations(target: TestEditor) {
+		let count = 0
+		const stop = react('count notVisibleShapes invalidations', () => {
+			target.getNotVisibleShapes()
+			count++
+		})
+		// Drop the initial subscribing run from the count.
+		const baseline = count
+		return {
+			get delta() {
+				return count - baseline
+			},
+			stop,
+		}
+	}
+
+	it('should respond to canCull flips driven by prop changes without bounds change', () => {
+		const testEditor = new TestEditor({ shapeUtils: [TestShape] })
+		testEditor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+		testEditor.setCamera({ x: 0, y: 0, z: 1 })
+
+		const id = createShapeId('flipping-cull')
+		testEditor.createShapes([
+			{
+				id,
+				type: 'not-visible-test-shape',
+				x: 2000,
+				y: 2000,
+				props: { canCull: true },
+			},
+		])
+
+		expect(testEditor.getNotVisibleShapes().has(id)).toBe(true)
+
+		// Prop-only update: bounds unchanged, but canCull now returns false.
+		testEditor.updateShapes([{ id, type: 'not-visible-test-shape', props: { canCull: false } }])
+		expect(testEditor.getNotVisibleShapes().has(id)).toBe(false)
+
+		// Flip back; shape should re-enter the set.
+		testEditor.updateShapes([{ id, type: 'not-visible-test-shape', props: { canCull: true } }])
+		expect(testEditor.getNotVisibleShapes().has(id)).toBe(true)
+
+		testEditor.dispose()
+	})
+
+	it('should not invalidate notVisibleShapes when an onscreen shape prop changes without affecting bounds', () => {
+		const id = createShapeId('onscreen')
+		editor.createShapes([
+			{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, color: 'black' } },
+		])
+
+		const tracker = trackInvalidations(editor)
+
+		// Prop-only update on a visible shape — bounds unchanged. Onscreen
+		// shapes are short-circuited out of the slow path so the derivation
+		// has no per-shape subscription to them; combined with the spatial
+		// index epoch holding steady, this must not invalidate at all.
+		editor.updateShapes([{ id, type: 'geo', props: { color: 'red' } }])
+
+		expect(tracker.delta).toBe(0)
+		tracker.stop()
+	})
+
+	it('should keep cached Set when an offscreen shape prop changes without affecting canCull or bounds', () => {
+		// Offscreen shapes are subscribed to per-shape via the slow path, so
+		// the derivation re-runs on prop changes — but contents are unchanged
+		// so the prevValue Set is reused. This test asserts that output
+		// stability contract for downstream consumers.
+		const id = createShapeId('offscreen')
+		editor.createShapes([
+			{ id, type: 'geo', x: 2000, y: 2000, props: { w: 100, h: 100, color: 'black' } },
+		])
+
+		const notVisible1 = editor.getNotVisibleShapes()
+		expect(notVisible1.has(id)).toBe(true)
+
+		editor.updateShapes([{ id, type: 'geo', props: { color: 'red' } }])
+
+		expect(editor.getNotVisibleShapes()).toBe(notVisible1)
+	})
+
+	it('should not invalidate notVisibleShapes when removing a shape that lives on a different page', () => {
+		const page1 = editor.getCurrentPageId()
+		const offscreenId = createShapeId('page1-offscreen')
+		editor.createShapes([{ id: offscreenId, type: 'geo', x: 2000, y: 2000 }])
+
+		// Stage a shape on a different page; it never enters page1's index.
+		const page2 = PageRecordType.createId('page2-remove')
+		editor.createPage({ name: 'page2-remove', id: page2 })
+		editor.setCurrentPage(page2)
+		const ghostId = createShapeId('page2-ghost')
+		editor.createShapes([{ id: ghostId, type: 'geo', x: 100, y: 100 }])
+		editor.setCurrentPage(page1)
+
+		const tracker = trackInvalidations(editor)
+
+		// Deleting the off-page shape produces a diff entry but the id wasn't
+		// indexed in page1's rbush, so the bounds epoch must not bump and
+		// notVisibleShapes must not invalidate.
+		editor.deleteShape(ghostId)
+
+		expect(tracker.delta).toBe(0)
+		tracker.stop()
+	})
+
+	it('should refresh arrow bounds when a bound geo shape changes outline without changing AABB', () => {
+		// Regression: a geo shape's `props.geo` flip from rectangle to ellipse
+		// keeps its axis-aligned bounds but moves the outline. An arrow bound
+		// to it intersects that outline, so its endpoint shifts and its AABB
+		// changes — the spatial index must still update the arrow even though
+		// the geo's own step-1 bounds check showed no change.
+		const targetId = createShapeId('outline-target')
+		editor.createShapes([
+			{
+				id: targetId,
+				type: 'geo',
+				x: 0,
+				y: 0,
+				props: { w: 100, h: 100, geo: 'rectangle' },
+			},
+		])
+
+		// Draw an arrow from off-corner toward the target so the bound
+		// endpoint lands at a place where rectangle and inscribed ellipse
+		// disagree (rect: corner, ellipse: ~14px inside).
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(-100, -100)
+		editor.pointerMove(50, 50)
+		editor.pointerUp(50, 50)
+		editor.selectNone()
+
+		const arrow = editor.getCurrentPageShapes().find((s) => s.type === 'arrow')!
+		expect(arrow).toBeDefined()
+
+		const arrowBoundsBefore = editor.getShapePageBounds(arrow.id)!
+		expect(arrowBoundsBefore).toBeDefined()
+
+		// Flip target geometry without changing its AABB.
+		editor.updateShapes([{ id: targetId, type: 'geo', props: { geo: 'ellipse' } }])
+
+		// Geo's own bounds are unchanged.
+		const targetBoundsBefore = new Box(0, 0, 100, 100)
+		const targetBoundsAfter = editor.getShapePageBounds(targetId)!
+		expect(targetBoundsAfter.equals(targetBoundsBefore)).toBe(true)
+
+		// Arrow's actual page bounds shifted because the bound endpoint moved.
+		const arrowBoundsAfter = editor.getShapePageBounds(arrow.id)!
+		expect(arrowBoundsAfter.equals(arrowBoundsBefore)).toBe(false)
+
+		// Spatial index must reflect the new arrow bounds. Query a small box
+		// inside the new bounds but outside the old; the arrow must be found.
+		const probe = new Box(
+			Math.max(arrowBoundsAfter.maxX - 2, arrowBoundsBefore.maxX + 0.01),
+			Math.max(arrowBoundsAfter.maxY - 2, arrowBoundsBefore.maxY + 0.01),
+			1,
+			1
+		)
+		const hits = editor.getShapeIdsInsideBounds(probe)
+		expect(hits.has(arrow.id)).toBe(true)
 	})
 })
 

--- a/packages/tldraw/src/test/notVisibleShapes.test.ts
+++ b/packages/tldraw/src/test/notVisibleShapes.test.ts
@@ -299,12 +299,13 @@ describe('notVisibleShapes - prop-only updates', () => {
 		tracker.stop()
 	})
 
-	it('should refresh arrow bounds when a bound geo shape changes outline without changing AABB', () => {
+	it('should refresh arrow bounds when a bound geo shape changes outline without changing axis-aligned bounds', () => {
 		// Regression: a geo shape's `props.geo` flip from rectangle to ellipse
 		// keeps its axis-aligned bounds but moves the outline. An arrow bound
-		// to it intersects that outline, so its endpoint shifts and its AABB
-		// changes — the spatial index must still update the arrow even though
-		// the geo's own step-1 bounds check showed no change.
+		// to it intersects that outline, so its endpoint shifts and its
+		// axis-aligned bounds change — the spatial index must still update
+		// the arrow even though the geo's own step-1 bounds check showed no
+		// change.
 		const targetId = createShapeId('outline-target')
 		editor.createShapes([
 			{
@@ -316,9 +317,12 @@ describe('notVisibleShapes - prop-only updates', () => {
 			},
 		])
 
-		// Draw an arrow from off-corner toward the target so the bound
-		// endpoint lands at a place where rectangle and inscribed ellipse
-		// disagree (rect: corner, ellipse: ~14px inside).
+		const targetBoundsBefore = editor.getShapePageBounds(targetId)!
+		expect(targetBoundsBefore).toBeDefined()
+
+		// Draw an arrow toward the target from a non-axis-aligned direction
+		// so the bound endpoint lands somewhere rectangle and inscribed
+		// ellipse disagree.
 		editor.setCurrentTool('arrow')
 		editor.pointerDown(-100, -100)
 		editor.pointerMove(50, 50)
@@ -331,11 +335,10 @@ describe('notVisibleShapes - prop-only updates', () => {
 		const arrowBoundsBefore = editor.getShapePageBounds(arrow.id)!
 		expect(arrowBoundsBefore).toBeDefined()
 
-		// Flip target geometry without changing its AABB.
+		// Flip target geometry without changing its axis-aligned bounds.
 		editor.updateShapes([{ id: targetId, type: 'geo', props: { geo: 'ellipse' } }])
 
-		// Geo's own bounds are unchanged.
-		const targetBoundsBefore = new Box(0, 0, 100, 100)
+		// Geo's own bounds must be unchanged.
 		const targetBoundsAfter = editor.getShapePageBounds(targetId)!
 		expect(targetBoundsAfter.equals(targetBoundsBefore)).toBe(true)
 
@@ -343,18 +346,46 @@ describe('notVisibleShapes - prop-only updates', () => {
 		const arrowBoundsAfter = editor.getShapePageBounds(arrow.id)!
 		expect(arrowBoundsAfter.equals(arrowBoundsBefore)).toBe(false)
 
-		// Spatial index must reflect the new arrow bounds. Query a small box
-		// inside the new bounds but outside the old; the arrow must be found.
-		const probe = new Box(
-			Math.max(arrowBoundsAfter.maxX - 2, arrowBoundsBefore.maxX + 0.01),
-			Math.max(arrowBoundsAfter.maxY - 2, arrowBoundsBefore.maxY + 0.01),
-			1,
-			1
-		)
+		// Spatial index must reflect the new arrow bounds. Build a probe
+		// inside the symmetric difference of before/after — pick whichever
+		// edge expanded and put a thin strip just outside the old edge but
+		// inside the new one. If the rbush still has the old bounds, the
+		// probe won't intersect them and the assertion fails.
+		const probe = probeOnlyInAfter(arrowBoundsBefore, arrowBoundsAfter)
 		const hits = editor.getShapeIdsInsideBounds(probe)
 		expect(hits.has(arrow.id)).toBe(true)
 	})
 })
+
+function probeOnlyInAfter(before: Box, after: Box): Box {
+	const eps = 0.01
+	const thickness = 1
+	if (after.maxX > before.maxX + eps) {
+		const x = before.maxX + eps
+		return new Box(x, after.minY, Math.min(thickness, after.maxX - x), Math.max(after.h, eps))
+	}
+	if (after.maxY > before.maxY + eps) {
+		const y = before.maxY + eps
+		return new Box(after.minX, y, Math.max(after.w, eps), Math.min(thickness, after.maxY - y))
+	}
+	if (after.minX < before.minX - eps) {
+		return new Box(
+			after.minX,
+			after.minY,
+			Math.min(thickness, before.minX - after.minX - eps),
+			Math.max(after.h, eps)
+		)
+	}
+	if (after.minY < before.minY - eps) {
+		return new Box(
+			after.minX,
+			after.minY,
+			Math.max(after.w, eps),
+			Math.min(thickness, before.minY - after.minY - eps)
+		)
+	}
+	throw new Error('expected after-bounds to extend past before-bounds on at least one edge')
+}
 
 describe('notVisibleShapes - selected shapes', () => {
 	it('should not cull selected shapes even if outside viewport', () => {


### PR DESCRIPTION
While drawing, every pointer move updates the active draw shape's `segments` prop. Previously this caused the `notVisibleShapes` derivation to recompute for every prop change (it subscribed to `getCurrentPageShapes()`, which invalidates on any shape prop change), and the spatial index would scan every shape on the page looking for transitive bounds changes even when no shape's bounds had actually moved.

This PR makes two narrow changes:

1. `notVisibleShapes` now subscribes to `getCurrentPageShapeIds()` (incremental, only invalidates on add/remove/reparent) and reads each shape via `store.unsafeGetWithoutCapture()` so per-shape prop changes do not invalidate the derivation. Visibility itself is driven by `getShapeIdsInsideBounds()`, which is gated on a new bounds epoch.
2. `SpatialIndexManager` returns a `_boundsEpoch` that only ticks when the rbush actually changes (a bounds was added, removed, or moved). On incremental updates we now compare the new bounds to the indexed bounds and only `upsert` when they differ. When the diff produced no real bounds changes, we also skip the all-shapes sweep — transitive bounds invalidations require at least one direct input bounds change, so there is nothing to find.

Net effect: while actively drawing on a populated page, `notVisibleShapes` no longer recomputes per pointer move, and the spatial index avoids redundant rbush work and the O(n) sweep.

Relates to #7831

### Change type

- [x] `improvement`

### Test plan

1. Open a page with a few hundred shapes.
2. Start drawing a freehand stroke and move the pointer continuously.
3. Confirm no perf regression in interaction; existing culling behavior (shapes outside the viewport hidden) is unchanged when panning/zooming or when shapes are added, moved, or deleted.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve drawing performance on pages with many shapes by skipping viewport culling recomputation when only shape props change.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +76 / -38  |