### PR TITLE
fix(license): don't show expired warning for perpetual licenses on covered versions

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -606,6 +606,20 @@ describe('LicenseManager', () => {
 			expect(result.isPerpetualLicense).toBe(true)
 			expect(result.isPerpetualLicenseExpired).toBe(true)
 		})
+
+		it('Reports daysSinceExpiry as 0 for a perpetual license past its calendar expiry but still on a covered version', async () => {
+			// Calendar expiry was 10 days ago, but the installed version (publishDates.minor)
+			// was released before the expiry date, so the perpetual license still covers it.
+			const now = new Date()
+			const expiryDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 10)
+			const perpetualLicenseInfo = ['id', ['www.example.com'], FLAGS.PERPETUAL_LICENSE, expiryDate]
+			const licenseKey = await generateLicenseKey(JSON.stringify(perpetualLicenseInfo), keyPair)
+
+			const result = (await licenseManager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+			expect(result.isPerpetualLicense).toBe(true)
+			expect(result.isPerpetualLicenseExpired).toBe(false)
+			expect(result.daysSinceExpiry).toBe(0)
+		})
 	})
 })
 

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -274,9 +274,18 @@ export class LicenseManager {
 			const expiryDate = new Date(licenseInfo.expiryDate)
 			const isAnnualLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.ANNUAL_LICENSE)
 			const isPerpetualLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.PERPETUAL_LICENSE)
-
 			const isEvaluationLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.EVALUATION_LICENSE)
-			const daysSinceExpiry = this.getDaysSinceExpiry(expiryDate)
+
+			const isAnnualLicenseExpired = isAnnualLicense && this.isAnnualLicenseExpired(expiryDate)
+			const isPerpetualLicenseExpired =
+				isPerpetualLicense && this.isPerpetualLicenseExpired(expiryDate)
+
+			// For perpetual licenses, the calendar expiry date only gates access to future
+			// major/minor releases; it does not "expire" the license itself. While the user
+			// is still on a covered version we report `daysSinceExpiry` as 0 so consumers
+			// (and the grace-period warning) don't treat them as past expiry.
+			const daysSinceExpiry =
+				isPerpetualLicense && !isPerpetualLicenseExpired ? 0 : this.getDaysSinceExpiry(expiryDate)
 
 			const result: ValidLicenseKeyResult = {
 				license: licenseInfo,
@@ -285,9 +294,9 @@ export class LicenseManager {
 				isDomainValid: this.isDomainValid(licenseInfo),
 				expiryDate,
 				isAnnualLicense,
-				isAnnualLicenseExpired: isAnnualLicense && this.isAnnualLicenseExpired(expiryDate),
+				isAnnualLicenseExpired,
 				isPerpetualLicense,
-				isPerpetualLicenseExpired: isPerpetualLicense && this.isPerpetualLicenseExpired(expiryDate),
+				isPerpetualLicenseExpired,
 				isInternalLicense: this.isFlagEnabled(licenseInfo.flags, FLAGS.INTERNAL_LICENSE),
 				isNativeLicense: this.isNativeLicense(licenseInfo),
 				isLicensedWithWatermark: this.isFlagEnabled(licenseInfo.flags, FLAGS.WITH_WATERMARK),


### PR DESCRIPTION
For perpetual licenses, the calendar expiry date only gates access to future major and minor releases — it does not actually expire the license while the user is on a covered version. Previously, `daysSinceExpiry` was computed from the calendar expiry date for every license type, which caused the grace-period branch in `getLicenseState` to fire and log a misleading red console banner saying "Your tldraw license has expired" even though the editor was working exactly as licensed.

This PR makes `daysSinceExpiry` reflect the *functional* expiry semantics: for perpetual licenses, it stays at `0` while `isPerpetualLicenseExpired` is `false`. The "expired for more than 30 days" path still fires once a perpetual customer upgrades to a version released outside their license coverage.

| License type | Past calendar expiry, still covered | Past coverage / 30‑day grace |
| --- | --- | --- |
| Perpetual | `daysSinceExpiry = 0`, `'licensed'`, no console message (was: misleading "expired" banner) | unchanged: `'expired'` with the standard banner |
| Annual | unchanged: grace-period warning, `'licensed'` | unchanged: `'expired'` with the standard banner |
| Evaluation | unchanged | unchanged |

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

Added a unit test in `LicenseManager.test.ts` covering a perpetual license whose calendar expiry is in the past but whose installed version is still within coverage — `daysSinceExpiry` is now `0` and no grace-period message is logged.

### Release notes

- Perpetual licenses no longer show a misleading "license expired" console warning when the user is past their calendar expiry date but still on a version covered by the license.

Made with [Cursor](https://cursor.com)