### PR TITLE
chore: remove unnecessary useCallback in apps/docs and apps/dotcom/client

### DIFF
--- a/apps/docs/components/content/copy-button.tsx
+++ b/apps/docs/components/content/copy-button.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { RefObject, useCallback, useState } from 'react'
+import { RefObject, useState } from 'react'
 import { Button } from '../common/button'
 
 export function CopyButton({
@@ -11,7 +11,7 @@ export function CopyButton({
 	className?: string
 }) {
 	const [copied, setCopied] = useState<boolean>(false)
-	const handleClick = useCallback(() => {
+	const handleClick = () => {
 		const code: string = typeof copy === 'string' ? copy : (copy.current?.innerText ?? '')
 
 		navigator.clipboard.writeText(code)
@@ -25,7 +25,7 @@ export function CopyButton({
 
 		setCopied(true)
 		setTimeout(() => setCopied(false), 1500)
-	}, [copy])
+	}
 
 	return (
 		<Button

--- a/apps/docs/components/docs/copy-markdown-button.tsx
+++ b/apps/docs/components/docs/copy-markdown-button.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { Button } from '../common/button'
 
 export function CopyMarkdownButton({
@@ -12,7 +12,7 @@ export function CopyMarkdownButton({
 }) {
 	const [copied, setCopied] = useState(false)
 
-	const handleClick = useCallback(() => {
+	const handleClick = () => {
 		navigator.clipboard.writeText(markdown)
 
 		if (window.tlanalytics?.trackCopyCode) {
@@ -24,7 +24,7 @@ export function CopyMarkdownButton({
 
 		setCopied(true)
 		setTimeout(() => setCopied(false), 1500)
-	}, [markdown])
+	}
 
 	return (
 		<Button

--- a/apps/docs/components/docs/docs-feedback-widget.tsx
+++ b/apps/docs/components/docs/docs-feedback-widget.tsx
@@ -4,7 +4,7 @@ import { Field, Label, Textarea } from '@headlessui/react'
 import { ArrowLongRightIcon, CheckCircleIcon, HandThumbDownIcon } from '@heroicons/react/20/solid'
 import { HandThumbUpIcon } from '@heroicons/react/24/solid'
 import { usePathname } from 'next/navigation'
-import { FormEventHandler, useCallback, useState } from 'react'
+import { FormEventHandler, useState } from 'react'
 import { track } from '@/app/analytics'
 import { cn } from '@/utils/cn'
 import { useLocalStorageState } from '@/utils/storage'
@@ -42,7 +42,7 @@ export function DocsFeedbackWidget({ className }: { className?: string }) {
 		'idle' | 'thumbs-up' | 'thumbs-down' | 'loading' | 'success' | 'error'
 	>('idle')
 
-	const handleThumbsDown = useCallback(async () => {
+	const handleThumbsDown = async () => {
 		setState((s) => {
 			const next = s === 'thumbs-down' ? 'idle' : 'thumbs-down'
 			if (s === 'thumbs-down') {
@@ -50,9 +50,9 @@ export function DocsFeedbackWidget({ className }: { className?: string }) {
 			}
 			return next
 		})
-	}, [pathname, sessionId])
+	}
 
-	const handleThumbsUp = useCallback(() => {
+	const handleThumbsUp = () => {
 		setState((s) => {
 			const next = s === 'thumbs-up' ? 'idle' : 'thumbs-up'
 			if (s === 'thumbs-up') {
@@ -60,31 +60,28 @@ export function DocsFeedbackWidget({ className }: { className?: string }) {
 			}
 			return next
 		})
-	}, [pathname, sessionId])
+	}
 
-	const handleSubmit = useCallback<FormEventHandler<HTMLFormElement>>(
-		async (e) => {
-			e.preventDefault()
-			if (state === 'loading') return
-			if (!sessionId) return
+	const handleSubmit: FormEventHandler<HTMLFormElement> = async (e) => {
+		e.preventDefault()
+		if (state === 'loading') return
+		if (!sessionId) return
 
-			try {
-				const form = e.currentTarget
-				const formData = new FormData(form)
-				const feedback = formData.get('feedback') as string
+		try {
+			const form = e.currentTarget
+			const formData = new FormData(form)
+			const feedback = formData.get('feedback') as string
 
-				setState('loading')
-				await submitFeedback(sessionId, pathname, state === 'thumbs-up' ? 1 : -1, feedback)
-				setState('success')
-				setTimeout(() => {
-					setDidSubmit(true)
-				}, 3000)
-			} catch {
-				setState('error')
-			}
-		},
-		[state, sessionId, pathname, setDidSubmit]
-	)
+			setState('loading')
+			await submitFeedback(sessionId, pathname, state === 'thumbs-up' ? 1 : -1, feedback)
+			setState('success')
+			setTimeout(() => {
+				setDidSubmit(true)
+			}, 3000)
+		} catch {
+			setState('error')
+		}
+	}
 
 	// todo, improve this so that thumbs ups and thumbs downs are also captured
 	if (didSubmit && !(DEBUGGING && process.env.NODE_ENV === 'development')) return null

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaAnonCopyLinkTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaAnonCopyLinkTab.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react'
 import { useEditor } from 'tldraw'
 import { useEditorDeepLink } from '../../../hooks/useDeepLink'
 import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
@@ -26,11 +25,11 @@ function TlaAnonCopyLinkButton({ url }: { url: string }) {
 	const editor = useEditor()
 	const trackEvent = useTldrawAppUiEvents()
 
-	const handleCopyLinkClick = useCallback(() => {
+	const handleCopyLinkClick = () => {
 		copyTextToClipboard(editor.createDeepLink({ url }).toString())
 		// no toasts please
 		trackEvent('copy-share-link', { source: 'file-share-menu' })
-	}, [url, editor, trackEvent])
+	}
 
 	return (
 		<TlaShareMenuCopyButton onClick={handleCopyLinkClick}>

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaExportTab.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import { useCallback, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import {
 	Box,
 	Editor,
@@ -39,19 +39,16 @@ export function TlaExportTab() {
 
 	const preferences = useValue('preferences', () => getExportPreferences(app), [app])
 
-	const onChange = useCallback(
-		<T extends keyof TldrawAppSessionState['exportSettings']>(
-			key: T,
-			value: TldrawAppSessionState['exportSettings'][T]
-		) => {
-			if (app) {
-				app.updateUserExportPreferences({ [key]: value })
-			} else {
-				updateLocalSessionState((s) => ({ exportSettings: { ...s.exportSettings, [key]: value } }))
-			}
-		},
-		[app]
-	)
+	const onChange = <T extends keyof TldrawAppSessionState['exportSettings']>(
+		key: T,
+		value: TldrawAppSessionState['exportSettings'][T]
+	) => {
+		if (app) {
+			app.updateUserExportPreferences({ [key]: value })
+		} else {
+			updateLocalSessionState((s) => ({ exportSettings: { ...s.exportSettings, [key]: value } }))
+		}
+	}
 
 	const { exportPadding, exportBackground, exportTheme, exportFormat } = preferences
 
@@ -81,11 +78,11 @@ function ExportPaddingToggle({
 }) {
 	const trackEvent = useTldrawAppUiEvents()
 
-	const handleChange = useCallback(() => {
+	const handleChange = () => {
 		const padding = !value
 		onChange('exportPadding', padding)
 		trackEvent('toggle-export-padding', { padding, source: 'file-share-menu' })
-	}, [trackEvent, value, onChange])
+	}
 
 	return (
 		<TlaMenuControl>
@@ -109,11 +106,11 @@ function ExportBackgroundToggle({
 }) {
 	const trackEvent = useTldrawAppUiEvents()
 
-	const handleChange = useCallback(() => {
+	const handleChange = () => {
 		const background = !value
 		onChange('exportBackground', background)
 		trackEvent('toggle-export-background', { background, source: 'file-share-menu' })
-	}, [value, onChange, trackEvent])
+	}
 
 	return (
 		<TlaMenuControl>
@@ -137,13 +134,10 @@ function ExportFormatSelect({
 }) {
 	const trackEvent = useTldrawAppUiEvents()
 
-	const handleChange = useCallback(
-		(value: TldrawAppSessionState['exportSettings']['exportFormat']) => {
-			onChange('exportFormat', value)
-			trackEvent('set-export-format', { format: value, source: 'file-share-menu' })
-		},
-		[onChange, trackEvent]
-	)
+	const handleChange = (value: TldrawAppSessionState['exportSettings']['exportFormat']) => {
+		onChange('exportFormat', value)
+		trackEvent('set-export-format', { format: value, source: 'file-share-menu' })
+	}
 
 	return (
 		<TlaMenuControl>
@@ -179,13 +173,10 @@ function ExportThemeSelect({
 }) {
 	const label = useMsg(messages[value as 'auto' | 'light' | 'dark'])
 	const trackEvent = useTldrawAppUiEvents()
-	const handleChange = useCallback(
-		(value: TldrawAppSessionState['exportSettings']['exportTheme']) => {
-			onChange('exportTheme', value)
-			trackEvent('set-export-theme', { theme: value, source: 'file-share-menu' })
-		},
-		[onChange, trackEvent]
-	)
+	const handleChange = (value: TldrawAppSessionState['exportSettings']['exportTheme']) => {
+		onChange('exportTheme', value)
+		trackEvent('set-export-theme', { theme: value, source: 'file-share-menu' })
+	}
 
 	return (
 		<TlaMenuControl>
@@ -213,7 +204,7 @@ function ExportImageButton() {
 
 	const [exported, setExported] = useState(false)
 
-	const handleClick = useCallback(() => {
+	const handleClick = () => {
 		if (exported) return
 
 		const editor = getCurrentEditor()
@@ -253,7 +244,7 @@ function ExportImageButton() {
 		return () => {
 			setExported(false)
 		}
-	}, [exported, trackEvent, app])
+	}
 
 	return (
 		<>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarCreateFileButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react'
+import { useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { TldrawUiButton, tltime } from 'tldraw'
 import { routes } from '../../../../routeDefs'
@@ -19,7 +19,7 @@ export function TlaSidebarCreateFileButton() {
 
 	const rCanCreate = useRef(true)
 
-	const handleSidebarCreate = useCallback(async () => {
+	const handleSidebarCreate = async () => {
 		if (!rCanCreate.current) return
 		const res = await app.createFile()
 		if (res.ok) {
@@ -40,7 +40,7 @@ export function TlaSidebarCreateFileButton() {
 				toggleMobileSidebar(false)
 			}
 		}
-	}, [app, navigate, trackEvent])
+	}
 
 	return (
 		<TldrawUiButton

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -1,7 +1,7 @@
 import { TlaFile } from '@tldraw/dotcom-shared'
 import classNames from 'classnames'
 import { ContextMenu as _ContextMenu } from 'radix-ui'
-import { KeyboardEvent, MouseEvent, useCallback, useEffect, useRef } from 'react'
+import { KeyboardEvent, MouseEvent, useEffect, useRef } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import {
 	TldrawUiMenuContextProvider,
@@ -300,17 +300,14 @@ function GuestBadge({ file, href }: { file: TlaFile; href: string }) {
 	const testId = `guest-badge-${file.name}`
 	const navigate = useNavigate()
 
-	const handleToolTipClick = useCallback(
-		(e: MouseEvent) => {
-			e.preventDefault()
-			// the tool tip needs pointer events in order to accept the click...
-			// but that means it also blocks the link to the file. Here we bend
-			// the world to our will, ruling by desire: clicking the tooltip will
-			// navigate to the file
-			navigate(href)
-		},
-		[navigate, href]
-	)
+	const handleToolTipClick = (e: MouseEvent) => {
+		e.preventDefault()
+		// the tool tip needs pointer events in order to accept the click...
+		// but that means it also blocks the link to the file. Here we bend
+		// the world to our will, ruling by desire: clicking the tooltip will
+		// navigate to the file
+		navigate(href)
+	}
 
 	return (
 		<div className={styles.sidebarFileListItemGuestBadge} data-testid={testId}>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -1,5 +1,4 @@
 import { useAuth } from '@clerk/clerk-react'
-import { useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
 	TldrawUiButton,
@@ -32,7 +31,7 @@ export function TlaDeleteFileDialog({
 
 	const isOwner = useHasFileAdminRights(fileId)
 
-	const handleDelete = useCallback(async () => {
+	const handleDelete = async () => {
 		const token = await auth.getToken()
 		if (!token) throw new Error('No token')
 		trackEvent('delete-file', { source: 'file-menu' })
@@ -47,7 +46,7 @@ export function TlaDeleteFileDialog({
 			navigate(routes.tlaFile(recentFiles[0].fileId))
 		}
 		onClose()
-	}, [auth, app, fileId, groupId, onClose, navigate, trackEvent])
+	}
 
 	return (
 		<>


### PR DESCRIPTION
In order to remove bookkeeping that has no downstream consumer, this PR drops `useCallback` wrappers from event handlers in 8 components across `apps/docs` and `apps/dotcom/client`. In every case the consumer component is not wrapped in `React.memo`, the callback is not used as a dependency in any other hook, and there is no other reason for the cached reference to matter — so the `useCallback` was pure overhead.

Opening as a draft because I am unsure about whether there is something I cannot see!

### Motivation

While reviewing `apps/docs/components/content/copy-button.tsx`, the `useCallback` on `handleClick` looked unnecessary. The consumer (`Button` in `apps/docs/components/common/button.tsx`) is not wrapped in `React.memo`, the callback was never used as a hook dep, and `Button` itself creates a fresh inline arrow function each render and forwards _that_ to the real DOM `<button>` — so any reference stability from the parent's `useCallback` was discarded one component down. Investigating the same pattern across `apps/docs` and `apps/dotcom/client` surfaced 7 more files.

Related: https://react.dev/learn/you-might-not-need-an-effect

### What changed

Replaced `useCallback` wrappers with plain function declarations (and dropped the now-unused `useCallback` imports):

| File | useCallbacks removed |
| ---- | -------------------- |
| `apps/docs/components/content/copy-button.tsx` | 1 |
| `apps/docs/components/docs/copy-markdown-button.tsx` | 1 |
| `apps/docs/components/docs/docs-feedback-widget.tsx` | 3 |
| `apps/dotcom/client/.../TlaSidebarCreateFileButton.tsx` | 1 |
| `apps/dotcom/client/.../TlaFileShareMenu/Tabs/TlaAnonCopyLinkTab.tsx` | 1 |
| `apps/dotcom/client/.../TlaFileShareMenu/Tabs/TlaExportTab.tsx` | 6 |
| `apps/dotcom/client/.../dialogs/TlaDeleteFileDialog.tsx` | 1 |
| `apps/dotcom/client/.../TlaSidebar/components/TlaSidebarFileLink.tsx` | 1 |

**Skipped:** `apps/docs/components/search/FullPageSearch.tsx`. Its `handleKeyDown` is passed to a third-party Ariakit `Combobox`. I did not want to remove memoization without verifying Ariakit's internals.

### Reasoning

For each file I verified three things:

1. The consumer component is not wrapped in `React.memo`. Confirmed for `Button`, `TldrawUiButton` (`forwardRef` only, not `memo`), `TlaShareMenuCopyButton`, `TlaMenuSwitch`, `TlaMenuSelect`, and `TlaButton` (`forwardRef` only, not `memo`).
2. The callback is not referenced as a dependency in any other hook in the same file.
3. Every handler is a local `const` inside its component body — no cross-file consumption.

Without a memoized child or another hook depending on the function reference, `useCallback` adds bookkeeping cost (deps comparison, cached-function retention) without any downstream benefit. The deps arrays exist because `eslint-plugin-react-hooks/exhaustive-deps` requires them once `useCallback` is in use — not because the callback relies on stale-capture semantics. Every closure here reads values that should always be fresh, so removing `useCallback` is, if anything, slightly safer (no risk of a missing dep producing a stale closure later).

### Verification

- `yarn typecheck` from repo root: passes.
- `yarn lint-current` on changed files: 0 warnings, 0 errors.
- `yarn test run` in `apps/dotcom/client`: 133 tests pass.
- `yarn test run` in `apps/docs`: 10 tests pass.
- Manual smoke testing of affected UI surfaces: not done.

### Open questions for reviewers

1. Is there a team convention I'm missing where `useCallback` is preferred prophylactically (e.g. in case a child is later memoized)? If so, this PR contradicts that convention.
2. Are any of the affected dotcom components (`TlaButton`, `TldrawUiButton`, etc.) intended to be wrapped in `React.memo` in the future? If so, leaving the `useCallback`s in might be the right call.
3. Should `FullPageSearch.tsx` be cleaned up too? I left it because the consumer is third-party.
4. The cleanup is consistent with React's official guidance ("you don't need useCallback unless..."), but I want to confirm that matches this codebase's preference before extending the audit.

### Proposition

If the reasoning holds, I'd like to extend a similar audit/cleanup pass to other parts of the repo where the pattern recurs. I'd want sign-off on the philosophy first.

### Change type

- [x] `other`

### Test plan

1. In docs, navigate to a page with a code block, click the copy button — text should copy and the icon should briefly change to a checkmark.
2. In docs, on any docs page click the feedback widget thumbs up/down, then submit feedback in the textarea — the success state should appear.
3. In tldraw.com, sign in and click the sidebar "Create file" button — it should create a new file and open inline rename.
4. In tldraw.com, open the share menu on a file, switch to the Export tab, toggle padding/background, change theme/format, click "Export image" — should produce an image download.
5. In tldraw.com (signed out), open the share menu and click "Copy link" — clipboard should contain a deep link.
6. In tldraw.com, right-click a file in the sidebar and choose Delete — the confirm dialog should fire and the file should be deleted/forgotten.
7. In tldraw.com, hover the guest badge on a shared file in the sidebar — clicking the tooltip should navigate to the file.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Documentation   | +29 / -32  |
| Apps            | +41 / -55  |