### PR TITLE
fix(ui): use TldrawUiToolbarButton for all video toolbar buttons

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultVideoToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultVideoToolbarContent.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react'
 import { useActions } from '../../context/actions'
 import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
-import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
 import { TldrawUiToolbarButton } from '../primitives/TldrawUiToolbar'
 
@@ -45,23 +44,23 @@ export const DefaultVideoToolbarContent = track(function DefaultVideoToolbarCont
 	return (
 		<>
 			{!isReadonly && (
-				<TldrawUiButton
+				<TldrawUiToolbarButton
 					type="icon"
 					title={msg('tool.replace-media')}
 					onClick={handleVideoReplace}
 					data-testid="tool.video-replace"
 				>
 					<TldrawUiButtonIcon small icon="tool-media" />
-				</TldrawUiButton>
+				</TldrawUiToolbarButton>
 			)}
-			<TldrawUiButton
+			<TldrawUiToolbarButton
 				type="icon"
 				title={msg('action.download-original')}
 				onClick={handleVideoDownload}
 				data-testid="tool.video-download"
 			>
 				<TldrawUiButtonIcon small icon="download" />
-			</TldrawUiButton>
+			</TldrawUiToolbarButton>
 			{(altText || !isReadonly) && (
 				<TldrawUiToolbarButton
 					type="icon"


### PR DESCRIPTION
In order to make tooltip behavior consistent across the video toolbar, this PR switches the replace and download buttons in `DefaultVideoToolbarContent` from `TldrawUiButton` to `TldrawUiToolbarButton`. The alt-text button already used `TldrawUiToolbarButton`, so the buttons now match each other and the image toolbar.

`TldrawUiToolbarButton` wraps the button in a `TldrawUiTooltip`, while `TldrawUiButton` falls back to the native `title` attribute. Mixing the two in the same toolbar produced inconsistent hover tooltips, as shown in the issue.

### Before


https://github.com/user-attachments/assets/55cb00ea-a801-4fe3-bd44-3d871477dea0

### After

https://github.com/user-attachments/assets/6d98885c-eefe-4eb1-a010-456a56d27d88


Closes #8787

### Change type

- [x] `bugfix`

### Test plan

1. Run \`yarn dev\` and open the examples app.
2. Drop a video onto the canvas and select it.
3. Hover each button on the video toolbar (replace, download, alt text).
4. Confirm all three show the same styled tooltip with the same delay.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix inconsistent tooltip behavior on the video toolbar buttons.