### PR TITLE
perf(editor): skip rbush mutation on prop-only shape diffs

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3146,7 +3146,7 @@ export class SnapManager {
 // @internal
 export class SpatialIndexManager {
     constructor(editor: Editor);
-    // @public (undocumented)
+    // @public
     dispose(): void;
     // (undocumented)
     readonly editor: Editor;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3146,7 +3146,7 @@ export class SnapManager {
 // @internal
 export class SpatialIndexManager {
     constructor(editor: Editor);
-    // @public
+    // @public (undocumented)
     dispose(): void;
     // (undocumented)
     readonly editor: Editor;

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts
@@ -135,6 +135,27 @@ export class RBushIndex {
 	}
 
 	/**
+	 * Get the raw stored element for a shape, without allocating a Box.
+	 * Use when you only need to read the indexed bounds for comparison.
+	 *
+	 * @internal
+	 */
+	getElement(id: TLShapeId): SpatialElement | undefined {
+		return this.elementsInTree.get(id)
+	}
+
+	/**
+	 * Iterate the entries currently in the index.
+	 * Safe to call while mutating existing keys (upsert) or removing keys —
+	 * but do not insert new keys during iteration.
+	 *
+	 * @internal
+	 */
+	entries(): IterableIterator<[TLShapeId, SpatialElement]> {
+		return this.elementsInTree.entries()
+	}
+
+	/**
 	 * Dispose of the spatial index.
 	 * Clears all data structures to prevent memory leaks.
 	 */

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/RBushIndex.ts
@@ -113,28 +113,6 @@ export class RBushIndex {
 	}
 
 	/**
-	 * Get all shape IDs currently in the spatial index.
-	 */
-	getAllShapeIds(): TLShapeId[] {
-		return Array.from(this.elementsInTree.keys())
-	}
-
-	/**
-	 * Get the bounds currently stored in the spatial index for a shape.
-	 * Returns undefined if the shape is not in the index.
-	 */
-	getBounds(id: TLShapeId): Box | undefined {
-		const element = this.elementsInTree.get(id)
-		if (!element) return undefined
-		return new Box(
-			element.minX,
-			element.minY,
-			element.maxX - element.minX,
-			element.maxY - element.minY
-		)
-	}
-
-	/**
 	 * Get the raw stored element for a shape, without allocating a Box.
 	 * Use when you only need to read the indexed bounds for comparison.
 	 *
@@ -145,9 +123,9 @@ export class RBushIndex {
 	}
 
 	/**
-	 * Iterate the entries currently in the index.
-	 * Safe to call while mutating existing keys (upsert) or removing keys —
-	 * but do not insert new keys during iteration.
+	 * Iterate the entries currently in the index. Callers may upsert existing
+	 * keys or remove keys during iteration; current callers do not insert new
+	 * keys.
 	 *
 	 * @internal
 	 */

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -11,12 +11,16 @@ import { RBushIndex, type SpatialElement } from './RBushIndex'
  * Manages spatial indexing for efficient shape location queries.
  *
  * Uses an R-tree (via RBush) to enable O(log n) spatial queries instead of O(n) iteration.
- * Handles shapes with computed bounds (arrows, groups, custom shapes) by checking all shapes'
- * bounds on each update using the reactive bounds cache.
+ * Handles shapes with computed bounds (arrows, groups, custom shapes) by re-checking
+ * indexed shapes' bounds on every incremental update.
  *
  * Key features:
  * - Incremental updates using filterHistory pattern
- * - Leverages existing bounds cache reactivity for dependency tracking
+ * - Exposes a `_boundsEpoch` that ticks only when the rbush actually changes,
+ *   so downstream computeds (e.g. notVisibleShapes) can skip work on prop-only
+ *   shape changes that don't move any bounds
+ * - Step-1 upserts compare against the indexed bounds and skip rbush mutation
+ *   when bounds are unchanged, so prop-only updates are cheap
  * - Works with any custom shape type with computed bounds
  * - Per-page index (rebuilds on page change)
  * - Optimized for viewport culling queries
@@ -28,6 +32,14 @@ export class SpatialIndexManager {
 	private spatialIndexComputed: Computed<number>
 	private lastPageId: TLPageId | null = null
 
+	// Tick that bumps when the rbush content may have changed. On full
+	// rebuild paths (init, history reset, page switch) we bump unconditionally;
+	// on incremental updates we bump only when an add/remove/upsert actually
+	// happened. Consumers downstream (e.g. notVisibleShapes) depend on this
+	// value rather than the store epoch, so prop-only diffs that don't move
+	// any bounds don't re-trigger them.
+	private _boundsEpoch = 0
+
 	constructor(public readonly editor: Editor) {
 		this.rbush = new RBushIndex()
 		this.spatialIndexComputed = this.createSpatialIndexComputed()
@@ -38,33 +50,42 @@ export class SpatialIndexManager {
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
 			if (isUninitialized(_prevValue)) {
-				return this.buildFromScratch(lastComputedEpoch)
+				this.buildFromScratch()
+				this._boundsEpoch++
+				return this._boundsEpoch
 			}
 
 			const shapeDiff = shapeHistory.getDiffSince(lastComputedEpoch)
 
 			if (shapeDiff === RESET_VALUE) {
-				return this.buildFromScratch(lastComputedEpoch)
+				this.buildFromScratch()
+				this._boundsEpoch++
+				return this._boundsEpoch
 			}
 
 			const currentPageId = this.editor.getCurrentPageId()
 			if (this.lastPageId !== currentPageId) {
-				return this.buildFromScratch(lastComputedEpoch)
+				this.buildFromScratch()
+				this._boundsEpoch++
+				return this._boundsEpoch
 			}
 
 			// No shape changes - index is already up to date
 			if (shapeDiff.length === 0) {
-				return lastComputedEpoch
+				return this._boundsEpoch
 			}
 
-			// Process incremental updates
-			this.processIncrementalUpdate(shapeDiff)
-
-			return lastComputedEpoch
+			// Process incremental updates; only bump the epoch when something
+			// actually changed in the rbush. This is what lets downstream
+			// computeds (notVisibleShapes etc.) skip work on prop-only changes.
+			if (this.processIncrementalUpdate(shapeDiff)) {
+				this._boundsEpoch++
+			}
+			return this._boundsEpoch
 		})
 	}
 
-	private buildFromScratch(epoch: number): number {
+	private buildFromScratch(): void {
 		this.rbush.clear()
 		this.lastPageId = this.editor.getCurrentPageId()
 
@@ -87,13 +108,12 @@ export class SpatialIndexManager {
 
 		// Bulk load for efficiency
 		this.rbush.bulkLoad(elements)
-
-		return epoch
 	}
 
-	private processIncrementalUpdate(shapeDiff: RecordsDiff<TLRecord>[]): void {
+	private processIncrementalUpdate(shapeDiff: RecordsDiff<TLRecord>[]): boolean {
 		// Track shapes we've already processed from the diff
 		const processedShapeIds = new Set<TLShapeId>()
+		let changed = false
 
 		// 1. Process shape additions, removals, and updates from diff
 		for (const changes of shapeDiff) {
@@ -103,20 +123,30 @@ export class SpatialIndexManager {
 					const bounds = this.editor.getShapePageBounds(shape.id)
 					if (bounds && bounds.isValid()) {
 						this.rbush.upsert(shape.id, bounds)
+						changed = true
 					}
 					processedShapeIds.add(shape.id)
 				}
 			}
 
-			// Handle removals
+			// Handle removals. Only mark changed when the shape was actually in
+			// the rbush — removed shapes from other pages, or shapes that were
+			// never indexed (invalid bounds at insert time), are no-ops here
+			// and shouldn't bump the bounds epoch.
 			for (const shape of objectMapValues(changes.removed) as TLShape[]) {
 				if (isShape(shape)) {
-					this.rbush.remove(shape.id)
+					if (this.rbush.has(shape.id)) {
+						this.rbush.remove(shape.id)
+						changed = true
+					}
 					processedShapeIds.add(shape.id)
 				}
 			}
 
-			// Handle updated shapes: page changes and bounds updates
+			// Handle updated shapes: page changes and bounds updates. Only
+			// upsert when the bounds actually differ — a shape's props can
+			// change without affecting its bounds (e.g., an active draw stroke
+			// adding a point that lies within the existing bounding box).
 			for (const [, to] of objectMapValues(changes.updated) as [TLShape, TLShape][]) {
 				if (!isShape(to)) continue
 				processedShapeIds.add(to.id)
@@ -126,35 +156,53 @@ export class SpatialIndexManager {
 				if (isOnPage) {
 					const bounds = this.editor.getShapePageBounds(to.id)
 					if (bounds && bounds.isValid()) {
-						this.rbush.upsert(to.id, bounds)
+						const indexedElement = this.rbush.getElement(to.id)
+						if (!this.areBoundsEqualToElement(bounds, indexedElement)) {
+							this.rbush.upsert(to.id, bounds)
+							changed = true
+						}
+					} else if (this.rbush.has(to.id)) {
+						this.rbush.remove(to.id)
+						changed = true
 					}
-				} else {
+				} else if (this.rbush.has(to.id)) {
 					this.rbush.remove(to.id)
+					changed = true
 				}
 			}
 		}
 
-		// 2. Check remaining shapes in index for bounds changes
-		// This handles shapes with computed bounds (arrows bound to moved shapes, groups with moved children, etc.)
-		const allShapeIds = this.rbush.getAllShapeIds()
-
-		for (const shapeId of allShapeIds) {
+		// 2. Check remaining indexed shapes for bounds changes. This handles
+		// shapes whose bounds derive from other shapes (arrows bound to moved
+		// shapes, groups with moved children) — and importantly also catches
+		// cases where a shape's *outline* changed without its axis-aligned
+		// bounds changing (e.g. geo `rectangle` → `ellipse` at the same w/h),
+		// which can shift a bound arrow's intersection points and therefore
+		// its bounds. A diff with only such updates leaves `changed` false
+		// after step 1, so we can't skip this pass on that signal alone.
+		// Iterate the rbush's element map directly to avoid allocating a
+		// shape-id array per pointer move; mutation during iteration here is
+		// limited to upserts of existing keys and deletions, both safe per
+		// the JS Map iteration spec.
+		for (const [shapeId, indexedElement] of this.rbush.entries()) {
 			if (processedShapeIds.has(shapeId)) continue
 
 			const currentBounds = this.editor.getShapePageBounds(shapeId)
-			const indexedBounds = this.rbush.getBounds(shapeId)
 
-			if (!this.areBoundsEqual(currentBounds, indexedBounds)) {
+			if (!this.areBoundsEqualToElement(currentBounds, indexedElement)) {
 				if (currentBounds && currentBounds.isValid()) {
 					this.rbush.upsert(shapeId, currentBounds)
 				} else {
 					this.rbush.remove(shapeId)
 				}
+				changed = true
 			}
 		}
+
+		return changed
 	}
 
-	private areBoundsEqual(a: Box | undefined, b: Box | undefined): boolean {
+	private areBoundsEqualToElement(a: Box | undefined, b: SpatialElement | undefined): boolean {
 		if (!a && !b) return true
 		if (!a || !b) return false
 		return a.minX === b.minX && a.minY === b.minY && a.maxX === b.maxX && a.maxY === b.maxY

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -197,7 +197,11 @@ export class SpatialIndexManager {
 		return this.rbush.search(new Box(point.x - margin, point.y - margin, margin * 2, margin * 2))
 	}
 
-	/** @public */
+	/**
+	 * Dispose of the spatial index manager. Clears the R-tree.
+	 *
+	 * @public
+	 */
 	dispose(): void {
 		this.rbush.dispose()
 		this.lastPageId = null

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -10,23 +10,9 @@ import { RBushIndex, type SpatialElement } from './RBushIndex'
 /**
  * Manages spatial indexing for efficient shape location queries.
  *
- * Uses an R-tree (via RBush) to enable O(log n) spatial queries instead of O(n) iteration.
- * Handles shapes with computed bounds (arrows, groups, custom shapes) by re-checking
- * indexed shapes' bounds on every incremental update.
- *
- * Key features:
- * - Incremental updates using filterHistory pattern
- * - The `spatialIndexComputed` returns an internal bounds-epoch tick that only
- *   advances when the rbush actually changes, so downstream computeds (e.g.
- *   notVisibleShapes) can skip work on prop-only shape changes that don't move
- *   any bounds. The epoch itself is private; consumers subscribe via
- *   `getShapeIdsInsideBounds` / `getShapeIdsAtPoint`, which gate on the
- *   computed.
- * - Step-1 upserts compare against the indexed bounds and skip rbush mutation
- *   when bounds are unchanged, so prop-only updates are cheap
- * - Works with any custom shape type with computed bounds
- * - Per-page index (rebuilds on page change)
- * - Optimized for viewport culling queries
+ * Uses an R-tree (via RBush) for O(log n) spatial queries. Handles shapes with
+ * derived bounds (arrows, groups) by re-checking indexed bounds on every
+ * incremental update. Per-page; rebuilds on page change.
  *
  * @internal
  */
@@ -35,12 +21,9 @@ export class SpatialIndexManager {
 	private spatialIndexComputed: Computed<number>
 	private lastPageId: TLPageId | null = null
 
-	// Tick that bumps when the rbush content may have changed. On full
-	// rebuild paths (init, history reset, page switch) we bump unconditionally;
-	// on incremental updates we bump only when an add/remove/upsert actually
-	// happened. Consumers downstream (e.g. notVisibleShapes) depend on this
-	// value rather than the store epoch, so prop-only diffs that don't move
-	// any bounds don't re-trigger them.
+	// Bumps only when the rbush content may have changed. Consumers subscribe
+	// via the computed; a stable epoch lets prop-only diffs skip downstream
+	// invalidations.
 	private _boundsEpoch = 0
 
 	constructor(public readonly editor: Editor) {
@@ -73,14 +56,8 @@ export class SpatialIndexManager {
 				return this.rebuildAndBumpEpoch()
 			}
 
-			// No shape changes - index is already up to date
-			if (shapeDiff.length === 0) {
-				return this._boundsEpoch
-			}
+			if (shapeDiff.length === 0) return this._boundsEpoch
 
-			// Process incremental updates; only bump the epoch when something
-			// actually changed in the rbush. This is what lets downstream
-			// computeds (notVisibleShapes etc.) skip work on prop-only changes.
 			if (this.processIncrementalUpdate(shapeDiff)) {
 				this._boundsEpoch++
 			}
@@ -92,11 +69,8 @@ export class SpatialIndexManager {
 		this.rbush.clear()
 		this.lastPageId = this.editor.getCurrentPageId()
 
-		const shapes = this.editor.getCurrentPageShapes()
 		const elements: SpatialElement[] = []
-
-		// Collect all shape elements for bulk loading
-		for (const shape of shapes) {
+		for (const shape of this.editor.getCurrentPageShapes()) {
 			const bounds = this.editor.getShapePageBounds(shape.id)
 			if (bounds && bounds.isValid()) {
 				elements.push({
@@ -108,19 +82,18 @@ export class SpatialIndexManager {
 				})
 			}
 		}
-
-		// Bulk load for efficiency
 		this.rbush.bulkLoad(elements)
 	}
 
 	private processIncrementalUpdate(shapeDiff: RecordsDiff<TLRecord>[]): boolean {
-		// Track shapes we've already processed from the diff
 		const processedShapeIds = new Set<TLShapeId>()
 		let changed = false
 
-		// 1. Process shape additions, removals, and updates from diff
+		// Step 1: apply diff entries directly. `changed` flips only on real
+		// rbush mutations, so prop-only updates and no-op removes (e.g. shapes
+		// from other pages, or never-indexed shapes with invalid bounds) don't
+		// bump the epoch.
 		for (const changes of shapeDiff) {
-			// Handle additions (only for shapes on current page)
 			for (const shape of objectMapValues(changes.added) as TLShape[]) {
 				if (isShape(shape) && this.editor.getAncestorPageId(shape) === this.lastPageId) {
 					const bounds = this.editor.getShapePageBounds(shape.id)
@@ -132,10 +105,6 @@ export class SpatialIndexManager {
 				}
 			}
 
-			// Handle removals. Only mark changed when the shape was actually in
-			// the rbush — removed shapes from other pages, or shapes that were
-			// never indexed (invalid bounds at insert time), are no-ops here
-			// and shouldn't bump the bounds epoch.
 			for (const shape of objectMapValues(changes.removed) as TLShape[]) {
 				if (isShape(shape)) {
 					if (this.rbush.has(shape.id)) {
@@ -146,10 +115,6 @@ export class SpatialIndexManager {
 				}
 			}
 
-			// Handle updated shapes: page changes and bounds updates. Only
-			// upsert when the bounds actually differ — a shape's props can
-			// change without affecting its bounds (e.g., an active draw stroke
-			// adding a point that lies within the existing bounding box).
 			for (const [, to] of objectMapValues(changes.updated) as [TLShape, TLShape][]) {
 				if (!isShape(to)) continue
 				processedShapeIds.add(to.id)
@@ -175,31 +140,30 @@ export class SpatialIndexManager {
 			}
 		}
 
-		// 2. Check remaining indexed shapes for bounds changes. This handles
-		// shapes whose bounds derive from other shapes (arrows bound to moved
-		// shapes, groups with moved children) — and importantly also catches
-		// cases where a shape's *outline* changed without its axis-aligned
-		// bounds changing (e.g. geo `rectangle` → `ellipse` at the same w/h),
-		// which can shift a bound arrow's intersection points and therefore
-		// its bounds. A diff with only such updates leaves `changed` false
-		// after step 1, so we can't skip this pass on that signal alone.
-		// Iterate the rbush's element map directly to avoid allocating a
-		// shape-id array per pointer move; mutation during iteration here is
-		// limited to upserts of existing keys and deletions, both safe per
-		// the JS Map iteration spec.
+		// Step 2: must always run. Diff entries can dirty derived bounds —
+		// arrows bound to moved shapes, groups with moved children — without
+		// touching any record visited in step 1. Also catches outline-only
+		// changes (e.g. geo rectangle→ellipse at the same w/h) that shift a
+		// bound arrow's intersection points: step 1 sees the geo's
+		// axis-aligned bounds unchanged and skips, but the dependent arrow's
+		// bounds have moved.
+		//
+		// Iterating the rbush's element map directly avoids allocating a
+		// shape-id array per pointer move. Mutation here is limited to
+		// upserts of existing keys and deletions, both safe during Map
+		// iteration.
 		for (const [shapeId, indexedElement] of this.rbush.entries()) {
 			if (processedShapeIds.has(shapeId)) continue
 
 			const currentBounds = this.editor.getShapePageBounds(shapeId)
+			if (this.areBoundsEqualToElement(currentBounds, indexedElement)) continue
 
-			if (!this.areBoundsEqualToElement(currentBounds, indexedElement)) {
-				if (currentBounds && currentBounds.isValid()) {
-					this.rbush.upsert(shapeId, currentBounds)
-				} else {
-					this.rbush.remove(shapeId)
-				}
-				changed = true
+			if (currentBounds && currentBounds.isValid()) {
+				this.rbush.upsert(shapeId, currentBounds)
+			} else {
+				this.rbush.remove(shapeId)
 			}
+			changed = true
 		}
 
 		return changed
@@ -212,17 +176,8 @@ export class SpatialIndexManager {
 	}
 
 	/**
-	 * Get shape IDs within the given bounds.
-	 * Optimized for viewport culling queries.
-	 *
-	 * Note: Results are unordered. If you need z-order, combine with sorted shapes:
-	 * ```ts
-	 * const candidates = editor.spatialIndex.getShapeIdsInsideBounds(bounds)
-	 * const sorted = editor.getCurrentPageShapesSorted().filter(s => candidates.has(s.id))
-	 * ```
-	 *
-	 * @param bounds - The bounds to search within
-	 * @returns Unordered set of shape IDs within the bounds
+	 * Get shape IDs whose bounds intersect `bounds`. Results are unordered;
+	 * combine with `getCurrentPageShapesSorted()` for z-order.
 	 *
 	 * @public
 	 */
@@ -232,18 +187,8 @@ export class SpatialIndexManager {
 	}
 
 	/**
-	 * Get shape IDs at a point (with optional margin).
-	 * Creates a small bounding box around the point and searches the spatial index.
-	 *
-	 * Note: Results are unordered. If you need z-order, combine with sorted shapes:
-	 * ```ts
-	 * const candidates = editor.spatialIndex.getShapeIdsAtPoint(point, margin)
-	 * const sorted = editor.getCurrentPageShapesSorted().filter(s => candidates.has(s.id))
-	 * ```
-	 *
-	 * @param point - The point to search at
-	 * @param margin - The margin around the point to search (default: 0)
-	 * @returns Unordered set of shape IDs that could potentially contain the point
+	 * Get shape IDs whose bounds intersect a margin-expanded box around
+	 * `point`. Results are unordered.
 	 *
 	 * @public
 	 */
@@ -252,12 +197,7 @@ export class SpatialIndexManager {
 		return this.rbush.search(new Box(point.x - margin, point.y - margin, margin * 2, margin * 2))
 	}
 
-	/**
-	 * Dispose of the spatial index manager.
-	 * Clears the R-tree to prevent memory leaks.
-	 *
-	 * @public
-	 */
+	/** @public */
 	dispose(): void {
 		this.rbush.dispose()
 		this.lastPageId = null

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -134,7 +134,7 @@ export class SpatialIndexManager {
 					const bounds = this.editor.getShapePageBounds(to.id)
 					if (bounds && bounds.isValid()) {
 						const indexedElement = this.rbush.getElement(to.id)
-						if (!this.areBoundsEqualToElement(bounds, indexedElement)) {
+						if (!this.areBoundsEqualToSpatialElement(bounds, indexedElement)) {
 							this.rbush.upsert(to.id, bounds)
 							changed = true
 						}
@@ -165,7 +165,7 @@ export class SpatialIndexManager {
 			if (processedShapeIds.has(shapeId)) continue
 
 			const currentBounds = this.editor.getShapePageBounds(shapeId)
-			if (this.areBoundsEqualToElement(currentBounds, indexedElement)) continue
+			if (this.areBoundsEqualToSpatialElement(currentBounds, indexedElement)) continue
 
 			if (currentBounds && currentBounds.isValid()) {
 				this.rbush.upsert(shapeId, currentBounds)
@@ -178,7 +178,10 @@ export class SpatialIndexManager {
 		return changed
 	}
 
-	private areBoundsEqualToElement(a: Box | undefined, b: SpatialElement | undefined): boolean {
+	private areBoundsEqualToSpatialElement(
+		a: Box | undefined,
+		b: SpatialElement | undefined
+	): boolean {
 		if (!a && !b) return true
 		if (!a || !b) return false
 		return a.minX === b.minX && a.minY === b.minY && a.maxX === b.maxX && a.maxY === b.maxY

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -16,9 +16,12 @@ import { RBushIndex, type SpatialElement } from './RBushIndex'
  *
  * Key features:
  * - Incremental updates using filterHistory pattern
- * - Exposes a `_boundsEpoch` that ticks only when the rbush actually changes,
- *   so downstream computeds (e.g. notVisibleShapes) can skip work on prop-only
- *   shape changes that don't move any bounds
+ * - The `spatialIndexComputed` returns an internal bounds-epoch tick that only
+ *   advances when the rbush actually changes, so downstream computeds (e.g.
+ *   notVisibleShapes) can skip work on prop-only shape changes that don't move
+ *   any bounds. The epoch itself is private; consumers subscribe via
+ *   `getShapeIdsInsideBounds` / `getShapeIdsAtPoint`, which gate on the
+ *   computed.
  * - Step-1 upserts compare against the indexed bounds and skip rbush mutation
  *   when bounds are unchanged, so prop-only updates are cheap
  * - Works with any custom shape type with computed bounds
@@ -45,29 +48,29 @@ export class SpatialIndexManager {
 		this.spatialIndexComputed = this.createSpatialIndexComputed()
 	}
 
+	private rebuildAndBumpEpoch(): number {
+		this.buildFromScratch()
+		this._boundsEpoch++
+		return this._boundsEpoch
+	}
+
 	private createSpatialIndexComputed() {
 		const shapeHistory = this.editor.store.query.filterHistory('shape')
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
 			if (isUninitialized(_prevValue)) {
-				this.buildFromScratch()
-				this._boundsEpoch++
-				return this._boundsEpoch
+				return this.rebuildAndBumpEpoch()
 			}
 
 			const shapeDiff = shapeHistory.getDiffSince(lastComputedEpoch)
 
 			if (shapeDiff === RESET_VALUE) {
-				this.buildFromScratch()
-				this._boundsEpoch++
-				return this._boundsEpoch
+				return this.rebuildAndBumpEpoch()
 			}
 
 			const currentPageId = this.editor.getCurrentPageId()
 			if (this.lastPageId !== currentPageId) {
-				this.buildFromScratch()
-				this._boundsEpoch++
-				return this._boundsEpoch
+				return this.rebuildAndBumpEpoch()
 			}
 
 			// No shape changes - index is already up to date

--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -10,9 +10,16 @@ import { RBushIndex, type SpatialElement } from './RBushIndex'
 /**
  * Manages spatial indexing for efficient shape location queries.
  *
- * Uses an R-tree (via RBush) for O(log n) spatial queries. Handles shapes with
- * derived bounds (arrows, groups) by re-checking indexed bounds on every
- * incremental update. Per-page; rebuilds on page change.
+ * Uses an R-tree (via RBush) to enable O(log n) spatial queries instead of O(n) iteration.
+ * Handles shapes with computed bounds (arrows, groups, custom shapes) by checking all shapes'
+ * bounds on each update using the reactive bounds cache.
+ *
+ * Key features:
+ * - Incremental updates using filterHistory pattern
+ * - Leverages existing bounds cache reactivity for dependency tracking
+ * - Works with any custom shape type with computed bounds
+ * - Per-page index (rebuilds on page change)
+ * - Optimized for viewport culling queries
  *
  * @internal
  */
@@ -82,6 +89,8 @@ export class SpatialIndexManager {
 				})
 			}
 		}
+
+		// Bulk load for efficiency
 		this.rbush.bulkLoad(elements)
 	}
 
@@ -176,8 +185,17 @@ export class SpatialIndexManager {
 	}
 
 	/**
-	 * Get shape IDs whose bounds intersect `bounds`. Results are unordered;
-	 * combine with `getCurrentPageShapesSorted()` for z-order.
+	 * Get shape IDs within the given bounds.
+	 * Optimized for viewport culling queries.
+	 *
+	 * Note: Results are unordered. If you need z-order, combine with sorted shapes:
+	 * ```ts
+	 * const candidates = editor.spatialIndex.getShapeIdsInsideBounds(bounds)
+	 * const sorted = editor.getCurrentPageShapesSorted().filter(s => candidates.has(s.id))
+	 * ```
+	 *
+	 * @param bounds - The bounds to search within
+	 * @returns Unordered set of shape IDs within the bounds
 	 *
 	 * @public
 	 */
@@ -187,8 +205,18 @@ export class SpatialIndexManager {
 	}
 
 	/**
-	 * Get shape IDs whose bounds intersect a margin-expanded box around
-	 * `point`. Results are unordered.
+	 * Get shape IDs at a point (with optional margin).
+	 * Creates a small bounding box around the point and searches the spatial index.
+	 *
+	 * Note: Results are unordered. If you need z-order, combine with sorted shapes:
+	 * ```ts
+	 * const candidates = editor.spatialIndex.getShapeIdsAtPoint(point, margin)
+	 * const sorted = editor.getCurrentPageShapesSorted().filter(s => candidates.has(s.id))
+	 * ```
+	 *
+	 * @param point - The point to search at
+	 * @param margin - The margin around the point to search (default: 0)
+	 * @returns Unordered set of shape IDs that could potentially contain the point
 	 *
 	 * @public
 	 */
@@ -198,7 +226,8 @@ export class SpatialIndexManager {
 	}
 
 	/**
-	 * Dispose of the spatial index manager. Clears the R-tree.
+	 * Dispose of the spatial index manager.
+	 * Clears the R-tree to prevent memory leaks.
 	 *
 	 * @public
 	 */

--- a/packages/tldraw/src/test/spatialIndex.test.ts
+++ b/packages/tldraw/src/test/spatialIndex.test.ts
@@ -1,4 +1,4 @@
-import { Box, PageRecordType, createShapeId, react, type TLShapeId } from '@tldraw/editor'
+import { Box, PageRecordType, createShapeId, react } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -19,18 +19,14 @@ afterEach(() => {
 // from the count.
 function trackSpatialIndexInvalidations(target: TestEditor, bounds: Box) {
 	let count = 0
-	let lastIds: Set<TLShapeId> | undefined
 	const stop = react('count spatial index invalidations', () => {
-		lastIds = target.getShapeIdsInsideBounds(bounds)
+		target.getShapeIdsInsideBounds(bounds)
 		count++
 	})
 	const baseline = count
 	return {
 		get delta() {
 			return count - baseline
-		},
-		get ids() {
-			return lastIds!
 		},
 		stop,
 	}
@@ -85,22 +81,6 @@ describe('SpatialIndexManager - bounds epoch', () => {
 		editor.deleteShape(ghostId)
 
 		expect(tracker.delta).toBe(0)
-		tracker.stop()
-	})
-
-	it('does not tick when adding a shape with invalid bounds is cleaned up', () => {
-		// Adding a normal shape ticks the epoch; we use that as a control
-		// to make sure the tracker actually sees ticks when expected.
-		const id = createShapeId('control')
-		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
-
-		editor.createShapes([{ id, type: 'geo', x: 100, y: 100 }])
-		expect(tracker.delta).toBe(1)
-
-		// A redundant prop-only update must not bump again.
-		editor.updateShapes([{ id, type: 'geo', props: { color: 'blue' } }])
-		expect(tracker.delta).toBe(1)
-
 		tracker.stop()
 	})
 
@@ -181,7 +161,7 @@ describe('SpatialIndexManager - step-2 transitive bounds sweep', () => {
 		expect(hits.has(arrow.id)).toBe(true)
 	})
 
-	it('updates an indexed shape when its bounds become invalid (e.g. moved off-page)', () => {
+	it('removes an indexed shape from the source page when it is reparented to another page', () => {
 		const page1 = editor.getCurrentPageId()
 		const id = createShapeId('migrating')
 		editor.createShapes([{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
@@ -189,15 +169,15 @@ describe('SpatialIndexManager - step-2 transitive bounds sweep', () => {
 		// Confirm it's indexed on page1.
 		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(true)
 
-		// Reparent to a new page — on the original page index, the shape
-		// must be removed and the epoch must bump.
 		const page2 = PageRecordType.createId('page2-migrate')
 		editor.createPage({ name: 'page2-migrate', id: page2 })
 
 		editor.setCurrentPage(page1)
 		const tracker = trackSpatialIndexInvalidations(editor, new Box(0, 0, 1000, 1000))
 
-		editor.updateShapes([{ id, type: 'geo', x: 100, y: 100, parentId: page2 } as any])
+		// Reparent to page2 — on the original page index, the shape must
+		// be removed and the epoch must bump.
+		editor.reparentShapes([id], page2)
 
 		expect(tracker.delta).toBeGreaterThanOrEqual(1)
 		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(false)

--- a/packages/tldraw/src/test/spatialIndex.test.ts
+++ b/packages/tldraw/src/test/spatialIndex.test.ts
@@ -1,4 +1,5 @@
 import { Box, PageRecordType, createShapeId, react } from '@tldraw/editor'
+import { vi } from 'vitest'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -46,8 +47,8 @@ describe('SpatialIndexManager - bounds epoch', () => {
 	})
 
 	it('does not tick on a prop-only update with unchanged bounds', () => {
-		// Color change on a geo shape doesn't move bounds — step-1 must
-		// short-circuit the upsert and the epoch must stay still.
+		// Color change doesn't move bounds — step-1 must short-circuit
+		// the upsert and the epoch must stay still.
 		const id = createShapeId('prop-only')
 		editor.createShapes([
 			{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, color: 'black' } },
@@ -58,6 +59,54 @@ describe('SpatialIndexManager - bounds epoch', () => {
 		editor.updateShapes([{ id, type: 'geo', props: { color: 'red' } }])
 
 		expect(tracker.delta).toBe(0)
+		tracker.stop()
+	})
+
+	it('skips the rbush upsert call on a prop-only diff', () => {
+		// Direct check on the headline optimization: `RBushIndex.upsert`
+		// must not be called when only props change.
+		const id = createShapeId('upsert-spy')
+		editor.createShapes([{ id, type: 'geo', x: 100, y: 100 }])
+		// Initialize the computed before spying so buildFromScratch's
+		// bulkLoad runs outside the spy window.
+		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
+
+		const rbush = (editor as any)._spatialIndex.rbush
+		const spy = vi.spyOn(rbush, 'upsert')
+
+		editor.updateShapes([{ id, type: 'geo', props: { color: 'red' } }])
+		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
+		expect(spy).not.toHaveBeenCalled()
+
+		// Sanity: a real bounds change does call upsert.
+		editor.updateShapes([{ id, type: 'geo', x: 200, y: 200 }])
+		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
+		expect(spy).toHaveBeenCalled()
+
+		spy.mockRestore()
+	})
+
+	it('ticks exactly once when a multi-shape diff mixes prop-only and bounds changes', () => {
+		// Guards against a future "if (changed) return early after step 1"
+		// regression: with one mover and one prop-only shape in the same
+		// transaction, the epoch must bump exactly once.
+		const moverId = createShapeId('multi-mover')
+		const propOnlyId = createShapeId('multi-prop-only')
+		editor.createShapes([
+			{ id: moverId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+			{ id: propOnlyId, type: 'geo', x: 300, y: 300, props: { w: 100, h: 100, color: 'black' } },
+		])
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		editor.run(() => {
+			editor.updateShapes([
+				{ id: moverId, type: 'geo', x: 200, y: 200 },
+				{ id: propOnlyId, type: 'geo', props: { color: 'red' } },
+			])
+		})
+
+		expect(tracker.delta).toBe(1)
 		tracker.stop()
 	})
 
@@ -84,10 +133,9 @@ describe('SpatialIndexManager - bounds epoch', () => {
 		tracker.stop()
 	})
 
-	it('ticks on page switch (full rebuild)', () => {
+	it('ticks exactly once on page switch (full rebuild)', () => {
 		editor.createShapes([{ id: createShapeId('p1-shape'), type: 'geo', x: 100, y: 100 }])
-
-		// Establish a baseline read so the computed is initialized.
+		// Initialize the computed before tracking.
 		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
 
 		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
@@ -96,21 +144,17 @@ describe('SpatialIndexManager - bounds epoch', () => {
 		editor.createPage({ name: 'page2-switch', id: page2 })
 		editor.setCurrentPage(page2)
 
-		// Switching pages forces a full rebuild — the bounds epoch must bump.
-		expect(tracker.delta).toBeGreaterThanOrEqual(1)
+		expect(tracker.delta).toBe(1)
 		tracker.stop()
 	})
 })
 
 describe('SpatialIndexManager - step-2 transitive bounds sweep', () => {
 	it('refreshes arrow bounds when a bound geo shape changes outline without changing axis-aligned bounds', () => {
-		// Regression: a geo shape's `props.geo` flip from rectangle to
-		// ellipse keeps its axis-aligned bounds but moves the outline. An
-		// arrow bound to it intersects that outline, so its endpoint
-		// shifts and its axis-aligned bounds change. The spatial index
-		// must update the arrow even though the geo's own step-1 bounds
-		// check showed no change — the step-2 sweep is the only thing
-		// that catches this.
+		// Regression: rectangle→ellipse keeps axis-aligned bounds the
+		// same but moves the outline. The bound arrow's endpoint shifts,
+		// changing the arrow's bounds. Step 1 sees the geo unchanged;
+		// only step 2's sweep catches the dependent arrow.
 		const targetId = createShapeId('outline-target')
 		editor.createShapes([
 			{
@@ -151,35 +195,29 @@ describe('SpatialIndexManager - step-2 transitive bounds sweep', () => {
 		const arrowBoundsAfter = editor.getShapePageBounds(arrow.id)!
 		expect(arrowBoundsAfter.equals(arrowBoundsBefore)).toBe(false)
 
-		// Spatial index must reflect the new arrow bounds. Build a probe
-		// inside the symmetric difference of before/after — pick whichever
-		// edge expanded and put a thin strip just outside the old edge but
-		// inside the new one. If the rbush still has the old bounds, the
-		// probe won't intersect them and the assertion fails.
+		// Probe a region that's only inside the new bounds, not the old.
+		// If the rbush still has the old bounds, the probe misses.
 		const probe = probeOnlyInAfter(arrowBoundsBefore, arrowBoundsAfter)
 		const hits = editor.getShapeIdsInsideBounds(probe)
 		expect(hits.has(arrow.id)).toBe(true)
 	})
 
 	it('removes an indexed shape from the source page when it is reparented to another page', () => {
+		// Reparent-to-other-page hits step 1's "updated, not on page,
+		// `rbush.has(id)` true → remove" branch.
 		const page1 = editor.getCurrentPageId()
 		const id = createShapeId('migrating')
 		editor.createShapes([{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
-
-		// Confirm it's indexed on page1.
 		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(true)
 
 		const page2 = PageRecordType.createId('page2-migrate')
 		editor.createPage({ name: 'page2-migrate', id: page2 })
-
 		editor.setCurrentPage(page1)
-		const tracker = trackSpatialIndexInvalidations(editor, new Box(0, 0, 1000, 1000))
 
-		// Reparent to page2 — on the original page index, the shape must
-		// be removed and the epoch must bump.
+		const tracker = trackSpatialIndexInvalidations(editor, new Box(0, 0, 1000, 1000))
 		editor.reparentShapes([id], page2)
 
-		expect(tracker.delta).toBeGreaterThanOrEqual(1)
+		expect(tracker.delta).toBe(1)
 		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(false)
 		tracker.stop()
 	})

--- a/packages/tldraw/src/test/spatialIndex.test.ts
+++ b/packages/tldraw/src/test/spatialIndex.test.ts
@@ -1,0 +1,260 @@
+import { Box, PageRecordType, createShapeId, react, type TLShapeId } from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+	editor.setCamera({ x: 0, y: 0, z: 1 })
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+// Track how many times a `getShapeIdsInsideBounds` reactor re-runs. The
+// reactor's only dep is the spatial index epoch, so the delta is a direct
+// proxy for "did the rbush epoch tick?". Initial subscribing run is dropped
+// from the count.
+function trackSpatialIndexInvalidations(target: TestEditor, bounds: Box) {
+	let count = 0
+	let lastIds: Set<TLShapeId> | undefined
+	const stop = react('count spatial index invalidations', () => {
+		lastIds = target.getShapeIdsInsideBounds(bounds)
+		count++
+	})
+	const baseline = count
+	return {
+		get delta() {
+			return count - baseline
+		},
+		get ids() {
+			return lastIds!
+		},
+		stop,
+	}
+}
+
+describe('SpatialIndexManager - bounds epoch', () => {
+	it('ticks when a shape moves (real bounds change)', () => {
+		const id = createShapeId('mover')
+		editor.createShapes([{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		editor.updateShapes([{ id, type: 'geo', x: 200, y: 200 }])
+
+		expect(tracker.delta).toBe(1)
+		tracker.stop()
+	})
+
+	it('does not tick on a prop-only update with unchanged bounds', () => {
+		// Color change on a geo shape doesn't move bounds — step-1 must
+		// short-circuit the upsert and the epoch must stay still.
+		const id = createShapeId('prop-only')
+		editor.createShapes([
+			{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, color: 'black' } },
+		])
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		editor.updateShapes([{ id, type: 'geo', props: { color: 'red' } }])
+
+		expect(tracker.delta).toBe(0)
+		tracker.stop()
+	})
+
+	it('does not tick when removing a shape that lives on a different page', () => {
+		const page1 = editor.getCurrentPageId()
+		editor.createShapes([{ id: createShapeId('p1-anchor'), type: 'geo', x: 100, y: 100 }])
+
+		// Stage a shape on a different page so its lifecycle never touches
+		// page1's rbush.
+		const page2 = PageRecordType.createId('page2-remove-epoch')
+		editor.createPage({ name: 'page2-remove-epoch', id: page2 })
+		editor.setCurrentPage(page2)
+		const ghostId = createShapeId('p2-ghost')
+		editor.createShapes([{ id: ghostId, type: 'geo', x: 100, y: 100 }])
+		editor.setCurrentPage(page1)
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		// Removing a shape that was never indexed on the active page must
+		// not bump the bounds epoch.
+		editor.deleteShape(ghostId)
+
+		expect(tracker.delta).toBe(0)
+		tracker.stop()
+	})
+
+	it('does not tick when adding a shape with invalid bounds is cleaned up', () => {
+		// Adding a normal shape ticks the epoch; we use that as a control
+		// to make sure the tracker actually sees ticks when expected.
+		const id = createShapeId('control')
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		editor.createShapes([{ id, type: 'geo', x: 100, y: 100 }])
+		expect(tracker.delta).toBe(1)
+
+		// A redundant prop-only update must not bump again.
+		editor.updateShapes([{ id, type: 'geo', props: { color: 'blue' } }])
+		expect(tracker.delta).toBe(1)
+
+		tracker.stop()
+	})
+
+	it('ticks on page switch (full rebuild)', () => {
+		editor.createShapes([{ id: createShapeId('p1-shape'), type: 'geo', x: 100, y: 100 }])
+
+		// Establish a baseline read so the computed is initialized.
+		editor.getShapeIdsInsideBounds(editor.getViewportPageBounds())
+
+		const tracker = trackSpatialIndexInvalidations(editor, editor.getViewportPageBounds())
+
+		const page2 = PageRecordType.createId('page2-switch')
+		editor.createPage({ name: 'page2-switch', id: page2 })
+		editor.setCurrentPage(page2)
+
+		// Switching pages forces a full rebuild — the bounds epoch must bump.
+		expect(tracker.delta).toBeGreaterThanOrEqual(1)
+		tracker.stop()
+	})
+})
+
+describe('SpatialIndexManager - step-2 transitive bounds sweep', () => {
+	it('refreshes arrow bounds when a bound geo shape changes outline without changing axis-aligned bounds', () => {
+		// Regression: a geo shape's `props.geo` flip from rectangle to
+		// ellipse keeps its axis-aligned bounds but moves the outline. An
+		// arrow bound to it intersects that outline, so its endpoint
+		// shifts and its axis-aligned bounds change. The spatial index
+		// must update the arrow even though the geo's own step-1 bounds
+		// check showed no change — the step-2 sweep is the only thing
+		// that catches this.
+		const targetId = createShapeId('outline-target')
+		editor.createShapes([
+			{
+				id: targetId,
+				type: 'geo',
+				x: 0,
+				y: 0,
+				props: { w: 100, h: 100, geo: 'rectangle' },
+			},
+		])
+
+		const targetBoundsBefore = editor.getShapePageBounds(targetId)!
+		expect(targetBoundsBefore).toBeDefined()
+
+		// Draw an arrow from a non-axis-aligned direction so the bound
+		// endpoint lands somewhere rectangle and inscribed ellipse disagree.
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(-100, -100)
+		editor.pointerMove(50, 50)
+		editor.pointerUp(50, 50)
+		editor.selectNone()
+
+		const arrow = editor.getCurrentPageShapes().find((s) => s.type === 'arrow')!
+		expect(arrow).toBeDefined()
+
+		const arrowBoundsBefore = editor.getShapePageBounds(arrow.id)!
+		expect(arrowBoundsBefore).toBeDefined()
+
+		// Flip target geometry without changing its axis-aligned bounds.
+		editor.updateShapes([{ id: targetId, type: 'geo', props: { geo: 'ellipse' } }])
+
+		// Geo's own bounds must be unchanged.
+		const targetBoundsAfter = editor.getShapePageBounds(targetId)!
+		expect(targetBoundsAfter.equals(targetBoundsBefore)).toBe(true)
+
+		// Arrow's actual page bounds shifted because the bound endpoint
+		// moved.
+		const arrowBoundsAfter = editor.getShapePageBounds(arrow.id)!
+		expect(arrowBoundsAfter.equals(arrowBoundsBefore)).toBe(false)
+
+		// Spatial index must reflect the new arrow bounds. Build a probe
+		// inside the symmetric difference of before/after — pick whichever
+		// edge expanded and put a thin strip just outside the old edge but
+		// inside the new one. If the rbush still has the old bounds, the
+		// probe won't intersect them and the assertion fails.
+		const probe = probeOnlyInAfter(arrowBoundsBefore, arrowBoundsAfter)
+		const hits = editor.getShapeIdsInsideBounds(probe)
+		expect(hits.has(arrow.id)).toBe(true)
+	})
+
+	it('updates an indexed shape when its bounds become invalid (e.g. moved off-page)', () => {
+		const page1 = editor.getCurrentPageId()
+		const id = createShapeId('migrating')
+		editor.createShapes([{ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
+
+		// Confirm it's indexed on page1.
+		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(true)
+
+		// Reparent to a new page — on the original page index, the shape
+		// must be removed and the epoch must bump.
+		const page2 = PageRecordType.createId('page2-migrate')
+		editor.createPage({ name: 'page2-migrate', id: page2 })
+
+		editor.setCurrentPage(page1)
+		const tracker = trackSpatialIndexInvalidations(editor, new Box(0, 0, 1000, 1000))
+
+		editor.updateShapes([{ id, type: 'geo', x: 100, y: 100, parentId: page2 } as any])
+
+		expect(tracker.delta).toBeGreaterThanOrEqual(1)
+		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(false)
+		tracker.stop()
+	})
+})
+
+describe('SpatialIndexManager - basic queries', () => {
+	it('returns shapes inside the queried bounds', () => {
+		const insideId = createShapeId('inside')
+		const outsideId = createShapeId('outside')
+		editor.createShapes([
+			{ id: insideId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+			{ id: outsideId, type: 'geo', x: 5000, y: 5000, props: { w: 100, h: 100 } },
+		])
+
+		const hits = editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000))
+		expect(hits.has(insideId)).toBe(true)
+		expect(hits.has(outsideId)).toBe(false)
+	})
+
+	it('removes a shape from the index when it is deleted', () => {
+		const id = createShapeId('doomed')
+		editor.createShapes([{ id, type: 'geo', x: 100, y: 100 }])
+		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(true)
+
+		editor.deleteShape(id)
+		expect(editor.getShapeIdsInsideBounds(new Box(0, 0, 1000, 1000)).has(id)).toBe(false)
+	})
+})
+
+function probeOnlyInAfter(before: Box, after: Box): Box {
+	const eps = 0.01
+	const thickness = 1
+	if (after.maxX > before.maxX + eps) {
+		const x = before.maxX + eps
+		return new Box(x, after.minY, Math.min(thickness, after.maxX - x), Math.max(after.h, eps))
+	}
+	if (after.maxY > before.maxY + eps) {
+		const y = before.maxY + eps
+		return new Box(after.minX, y, Math.max(after.w, eps), Math.min(thickness, after.maxY - y))
+	}
+	if (after.minX < before.minX - eps) {
+		return new Box(
+			after.minX,
+			after.minY,
+			Math.min(thickness, before.minX - after.minX - eps),
+			Math.max(after.h, eps)
+		)
+	}
+	if (after.minY < before.minY - eps) {
+		return new Box(
+			after.minX,
+			after.minY,
+			Math.max(after.w, eps),
+			Math.min(thickness, before.minY - after.minY - eps)
+		)
+	}
+	throw new Error('expected after-bounds to extend past before-bounds on at least one edge')
+}


### PR DESCRIPTION
In order to avoid redundant work in the spatial index when shape props change without affecting bounds, this PR makes `SpatialIndexManager` skip rbush mutation on prop-only diffs and exposes a private `_boundsEpoch` that only ticks when the index actually changes.

While drawing on a populated page, every pointer move emits one updated shape (the active draw shape with new `segments`) through the store diff. Previously the index would unconditionally `upsert` the shape — an O(log N) tree rebalance — and bump its return value, invalidating downstream consumers like `getShapeIdsInsideBounds`. It also walked every indexed shape allocating a `Box` per shape during the transitive-bounds sweep.

Three changes:

1. `processIncrementalUpdate` compares incoming bounds to the indexed bounds and skips `upsert` when they're equal, removing the rebalance for prop-only updates.
2. The computed returns a private `_boundsEpoch` that only ticks when an add/remove/upsert actually happened, so consumers like `notVisibleShapes` no longer invalidate when nothing in the rbush moved. Bookkeeping is centralised in a small `rebuildAndBumpEpoch` helper.
3. The transitive-bounds sweep iterates the rbush's element map directly and compares against the raw `SpatialElement` instead of allocating a `Box` per shape and a fresh shape-id array. Existence checks use `RBushIndex.has(id)` instead of `getBounds(id) !== undefined`.

The transitive sweep itself still runs unconditionally — it has to, because some diffs (e.g. a geo's `rectangle`→`ellipse` flip at the same width/height) leave the source shape's axis-aligned bounds unchanged but shift a bound arrow's intersection points. There's a regression test covering exactly that case.

### Change type

- [x] \`improvement\`

### Test plan

1. Open a page with a few hundred shapes.
2. Start drawing a freehand stroke and move the pointer continuously.
3. Confirm no perf regression in interaction; existing culling behavior (shapes outside the viewport hidden) is unchanged when panning/zooming or when shapes are added, moved, or deleted.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Improve drawing performance on pages with many shapes by skipping spatial index updates when only shape props change.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +100 / -28 |
| Tests     | +240 / -0  |