### PR TITLE
fix(release): compare against latest published version in patch-release diff check

### DIFF
--- a/internal/scripts/lib/didAnyPackageChange.ts
+++ b/internal/scripts/lib/didAnyPackageChange.ts
@@ -5,6 +5,7 @@ import kleur from 'kleur'
 import * as tar from 'tar'
 import tmp from 'tmp'
 import { exec } from './exec'
+import { nicelog } from './nicelog'
 import { PackageDetails, getAllPackageDetails } from './publishing'
 
 async function getPackageFirstDiff(
@@ -25,6 +26,9 @@ async function getPackageFirstDiff(
 			// commit landed but before npm publish completed. In either case
 			// treat it as an added package so the release proceeds instead of
 			// failing the entire workflow.
+			nicelog(
+				`No published tarball for ${pkg.name}@${publishedVersion} (${url}); treating as added.`
+			)
 			return { type: 'added', packageName: pkg.name, filePath: pkg.name }
 		}
 		if (res.status >= 400) {

--- a/internal/scripts/lib/didAnyPackageChange.ts
+++ b/internal/scripts/lib/didAnyPackageChange.ts
@@ -7,18 +7,28 @@ import tmp from 'tmp'
 import { exec } from './exec'
 import { PackageDetails, getAllPackageDetails } from './publishing'
 
-async function getPackageFirstDiff(pkg: PackageDetails): Promise<Diff | null> {
+async function getPackageFirstDiff(
+	pkg: PackageDetails,
+	publishedVersion: string
+): Promise<Diff | null> {
 	assert(process.env.TLDRAW_BEMO_URL, 'TLDRAW_BEMO_URL env var must be set')
 	const dir = tmp.dirSync({ unsafeCleanup: true })
 	const dirPath = dir.name
 	try {
-		const version = pkg.version
-
 		const unscopedName = pkg.name.replace('@tldraw/', '')
-		const url = `https://registry.npmjs.org/${pkg.name}/-/${unscopedName}-${version}.tgz`
+		const url = `https://registry.npmjs.org/${pkg.name}/-/${unscopedName}-${publishedVersion}.tgz`
 		const res = await fetch(url)
+		if (res.status === 404) {
+			// The package is not published at this version. This happens when a
+			// new package was added to the monorepo since the last release, or
+			// when a previous publish was interrupted after the version-bump
+			// commit landed but before npm publish completed. In either case
+			// treat it as an added package so the release proceeds instead of
+			// failing the entire workflow.
+			return { type: 'added', packageName: pkg.name, filePath: pkg.name }
+		}
 		if (res.status >= 400) {
-			throw new Error(`Package not found at url ${url}: ${res.status}`)
+			throw new Error(`Failed to fetch ${url}: ${res.status}`)
 		}
 		const publishedTarballPath = `${dirPath}/published-package.tgz`
 		writeFileSync(publishedTarballPath, Buffer.from(await res.arrayBuffer()))
@@ -126,10 +136,21 @@ export function formatDiff(diff: Diff) {
 	return message
 }
 
-export async function getAnyPackageDiff(): Promise<Diff | null> {
+/**
+ * Compare each local package against the published tarball at
+ * `publishedVersion` on npm and return the first detected difference, or null
+ * if every package is identical to its published counterpart.
+ *
+ * Callers should pass the latest version that's actually published on npm
+ * (e.g. from `npm show <pkg> version`) rather than the version in the local
+ * `package.json`. The local version can drift ahead of npm if a previous
+ * publish was interrupted after the version-bump commit was pushed; using the
+ * known-published version keeps the diff check robust to that state.
+ */
+export async function getAnyPackageDiff(publishedVersion: string): Promise<Diff | null> {
 	const details = await getAllPackageDetails()
 	for (const pkg of Object.values(details)) {
-		const diff = await getPackageFirstDiff(pkg)
+		const diff = await getPackageFirstDiff(pkg, publishedVersion)
 		if (diff) {
 			return diff
 		}

--- a/internal/scripts/publish-patch.ts
+++ b/internal/scripts/publish-patch.ts
@@ -52,7 +52,7 @@ async function main() {
 
 	// Skip releasing a new version if the package contents are identical.
 	// This may happen when cherry-picking docs-only changes.
-	if (!(await getAnyPackageDiff())) {
+	if (!(await getAnyPackageDiff(latestVersionInBranch.format()))) {
 		nicelog('No packages have changed, skipping release')
 		return
 	}

--- a/internal/scripts/trigger-sdk-hotfix.ts
+++ b/internal/scripts/trigger-sdk-hotfix.ts
@@ -98,7 +98,7 @@ async function main() {
 			await exec('yarn', ['install'])
 			await exec('yarn', ['refresh-assets', '--force'])
 
-			const diff = await getAnyPackageDiff()
+			const diff = await getAnyPackageDiff(version.format())
 			if (diff) {
 				let message = kleur.red().bold(`・ERROR・`)
 				message += `\nCannot cherry-pick docs changes from PR '${kleur.cyan().bold(pr.title)}' https://github.com/tldraw/tldraw/pulls/${pr}`


### PR DESCRIPTION
In order to stop a half-finished previous patch release from permanently wedging a release branch's CI, this PR fixes `getAnyPackageDiff` so it compares each local package against the version that's actually published on npm rather than against `pkg.version` from the local `package.json`.

The patch-release workflow on `v4.0.x` and `v4.5.x` is currently broken in exactly this way (e.g. [run 25551498755](https://github.com/tldraw/tldraw/actions/runs/25551498755/job/75000238224) and [run 25551566270](https://github.com/tldraw/tldraw/actions/runs/25551566270/job/75000520586), both dying with `Package not found at url https://registry.npmjs.org/@tldraw/assets/-/assets-X.Y.Z.tgz: 404`). In both branches a previous run pushed the `v.X.Y.Z [skip ci]` version-bump commit but never finished `npm publish`, so the local `package.json`s are ahead of npm. The diff check then asks npm for the local-but-unpublished version, gets a 404, and crashes — and every subsequent push to that branch hits the same wall.

The fix has three parts:

- `getAnyPackageDiff(publishedVersion)` now takes a required version string and forwards it to `getPackageFirstDiff`, which uses it to build the npm tarball URL instead of `pkg.version`.
- A 404 from npm is no longer fatal — it's interpreted as "this package isn't published at this version yet" and returned as an `added` diff. This also handles the brand-new-monorepo-package case the previous code couldn't.
- Both callers (`publish-patch.ts`, `trigger-sdk-hotfix.ts`) pass in the latest npm version they already look up themselves (`latestVersionInBranch.format()` and `version.format()` respectively).

This unblocks the diff check in the broken-branch case. (Recovering the actual `v4.0.x` / `v4.5.x` releases will still need a one-off cleanup of the orphaned `[skip ci]` bump commits/tags — that's a separate follow-up.)

### Change type

- [x] `bugfix`

### Test plan

1. Verify the next patch-release workflow run on `v4.0.x` / `v4.5.x` gets past the diff check (it'll fetch `@tldraw/assets@4.0.3` / `@tldraw/assets@4.5.10` instead of the missing `4.0.4` / `4.5.11`).
2. Confirm normal (non-broken) release branches still publish unchanged — the comparison version is the same as `pkg.version` in steady state, so behaviour is identical.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Config/tooling  | +30 / -9   |


Made with [Cursor](https://cursor.com)