### PR TITLE
fix(dotcom): unblock preview deploys (DO migrations + vercel --yes)

### DIFF
--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -54,6 +54,10 @@ export { TLLoggerDurableObject } from './TLLoggerDurableObject'
 export { TLPostgresReplicator } from './TLPostgresReplicator'
 export { TLStatsDurableObject } from './TLStatsDurableObject'
 export { TLUserDurableObject } from './TLUserDurableObject'
+// no-op stub. wrangler.toml v1 created TLDrawDurableObject and v10 deletes it.
+// staging/prod still have it in their applied-migration history, so removing
+// this export breaks their deploys (see #8124). preview skips both v1 and v10,
+// so this export is just an unbound class on preview - harmless.
 export class TLDrawDurableObject {}
 
 const { preflight, corsify } = cors({

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -8,9 +8,11 @@ port = 8787
 ip = "0.0.0.0"
 
 # these migrations are append-only. you can't change them. if you do need to change something, do so
-# by creating new migrations
+# by creating new migrations.
+# IMPORTANT: when adding a new migration here, also add it to the [[env.preview.migrations]] block below
+# env-level migrations fully replace the top-level list, so preview won't inherit new entries.
 [[migrations]]
-tag = "v1" # Should be unique for each entry
+tag = "v1"                            # Should be unique for each entry
 new_classes = ["TLDrawDurableObject"]
 
 [[migrations]]
@@ -50,6 +52,42 @@ new_sqlite_classes = ["TLFileDurableObject"]
 tag = "v10"
 deleted_classes = ["TLDrawDurableObject"]
 
+# preview workers are fresh deploys, so CF rejects v10's delete-class for
+# TLDrawDurableObject (code 10074). skip v1 and v10 here; env-level migrations
+# fully replace the top-level list.
+[[env.preview.migrations]]
+tag = "v2"
+new_classes = ["TLProWorkspaceDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v3"
+deleted_classes = ["TLProWorkspaceDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v4"
+new_classes = ["TLAppDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v5"
+new_sqlite_classes = ["TLPostgresReplicator"]
+new_classes = ["TLUserDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v6"
+new_sqlite_classes = ["TLLoggerDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v7"
+new_sqlite_classes = ["TLStatsDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v8"
+deleted_classes = ["TLAppDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v9"
+new_sqlite_classes = ["TLFileDurableObject"]
+
 [[analytics_engine_datasets]]
 binding = "MEASURE"
 
@@ -69,7 +107,7 @@ MULTIPLAYER_SERVER = "http://localhost:3000"
 # staging is the same as a preview on main:
 [env.staging]
 name = "main-tldraw-multiplayer"
-workers_dev = true # todo: remove this once clients are updated
+workers_dev = true               # todo: remove this once clients are updated
 
 [env.staging.vars]
 HEALTH_CHECK_DB_SIZE_THRESHOLD_GB = "4"
@@ -79,7 +117,7 @@ HEALTH_CHECK_WAL_SIZE_THRESHOLD_MB = "1024"
 # production gets the proper name
 [env.production]
 name = "tldraw-multiplayer"
-workers_dev = true # todo: remove this once clients are updated
+workers_dev = true          # todo: remove this once clients are updated
 
 [env.production.vars]
 HEALTH_CHECK_DB_SIZE_THRESHOLD_GB = "10"

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -372,7 +372,9 @@ async function main() {
 		await withTiming('prebuild assets', () => exec('yarn', ['lazy', 'prebuild']))
 
 		// link to vercel and supabase projects:
-		await withTiming('vercel link', () => vercelCli('link', ['--project', env.VERCEL_PROJECT_ID]))
+		await withTiming('vercel link', () =>
+			vercelCli('link', ['--yes', '--project', env.VERCEL_PROJECT_ID])
+		)
 	})
 
 	// deploy pre-flight steps:
@@ -658,6 +660,11 @@ async function deployHealthWorker({ dryRun }: { dryRun: boolean }) {
 }
 
 type ExecOpts = NonNullable<Parameters<typeof exec>[2]>
+// `--yes` is per-subcommand in the vercel CLI, not a global flag. it is valid
+// for `link`, `deploy`, and `alias rm`; passing it to other subcommands like
+// `alias set` now hard-errors with "unknown or unexpected option: --yes" since
+// vercel removed permissive arg parsing. callers add `--yes` to `args` when
+// they want the non-interactive prompt skip.
 async function vercelCli(command: string, args: string[], opts?: ExecOpts) {
 	return exec(
 		'yarn',
@@ -670,7 +677,6 @@ async function vercelCli(command: string, args: string[], opts?: ExecOpts) {
 			env.VERCEL_TOKEN,
 			'--scope',
 			env.VERCEL_ORG_ID,
-			'--yes',
 			...args,
 		],
 		{
@@ -905,7 +911,7 @@ async function deploySpa(): Promise<{ deploymentUrl: string; inspectUrl: string 
 	// both 'staging' and 'production' are deployed to vercel as 'production' deploys
 	// in separate 'projects'
 	const prod = env.TLDRAW_ENV !== 'preview'
-	const out = await vercelCli('deploy', ['--prebuilt', ...(prod ? ['--prod'] : [])], {
+	const out = await vercelCli('deploy', ['--yes', '--prebuilt', ...(prod ? ['--prod'] : [])], {
 		pwd: dotcom,
 	})
 


### PR DESCRIPTION
This PR fixes two distinct breakages in dotcom preview deploys.

## 1. Sync worker durable-object migrations

In order to make preview builds of the sync worker succeed, this PR overrides the durable-object migration list at the `env.preview` level so preview workers skip the v10 `delete_classes` migration for `TLDrawDurableObject`.

Background:
- v1 created `TLDrawDurableObject`. v10 deletes it.
- Fresh preview workers (`pr-XXXX-tldraw-multiplayer`) have no prior script version, so Cloudflare rejects v10 with code 10074: `Cannot apply delete-class migration to class 'TLDrawDurableObject' which was not exported in the previous version of the script`.
- Staging and production already have v10 applied; they keep the top-level migration list unchanged.

#8638 attempted to drop v10 outright, which would have violated the append-only invariant (and would orphan the migration tag staging/prod already recorded). This PR instead adds an `[[env.preview.migrations]]` block: per Cloudflare's docs, env-level migrations fully replace the top-level list, so this is a preview-only override.

The preview block also skips v1, since the only point of creating `TLDrawDurableObject` was to delete it in v10. The leftover `export class TLDrawDurableObject {}` stub in `worker.ts` is an unbound class export with no migration record on preview, which CF treats as a no-op (verified by this PR's own preview deploy).

Relates to #8638 (closed).

## 2. Vercel CLI `--yes` flag

After fixing (1), the deploy job still failed at the `vercel alias set` step with `Error: unknown or unexpected option: --yes` ([failed run](https://github.com/tldraw/tldraw/actions/runs/25655757937/job/75303692969)).

Cause: `internal/scripts/deploy-dotcom.ts` had a `vercelCli` helper that unconditionally injected `--yes` into every subcommand. Per [Vercel's docs](https://vercel.com/docs/cli/alias), `--yes` is per-subcommand, not a global flag — valid for `vercel link`, `vercel deploy`, and `vercel alias rm`, but never for `vercel alias set` / `alias ls`. The injection was silently tolerated for a long time because the Vercel CLI parsed `alias` permissively; [vercel/vercel#14881](https://github.com/vercel/vercel/pull/14881) removed `permissive: true` from leaf commands so unknown flags now hard-error.

Fix: drop `--yes` from the generic helper and pass it explicitly only at the `link` and `deploy` call sites.

### Change type

- [x] `bugfix`

### Test plan

1. Confirm preview deploy of this PR succeeds end-to-end: sync worker uploads cleanly, and `vercel alias set` no longer rejects `--yes`.
2. Confirm staging/production deploys still apply v1-v10 from the top-level migration list and still skip prompts via the explicit `--yes` on `vercel link` and `vercel deploy`.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +50 / -4   |
| Config/tooling | +9 / -3    |
