### PR TITLE
fix(tldraw): catch image.decode() errors in asset urls provider

### DIFF
--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -1,4 +1,4 @@
-import { Image } from '@tldraw/editor'
+import { Image, noop } from '@tldraw/editor'
 import { createContext, useContext, useEffect } from 'react'
 import { TLUiAssetUrls } from '../assetUrls'
 
@@ -6,11 +6,6 @@ import { TLUiAssetUrls } from '../assetUrls'
 type UiAssetUrlsContextType = TLUiAssetUrls | null
 
 const AssetUrlsContext = createContext<UiAssetUrlsContextType>(null)
-
-function noop() {
-	// Swallow image.decode() rejections (e.g. EncodingError) from icon preload —
-	// preload is best-effort and any real load failure surfaces where the icon is used.
-}
 
 /** @internal */
 export function AssetUrlsProvider({

--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -7,6 +7,11 @@ type UiAssetUrlsContextType = TLUiAssetUrls | null
 
 const AssetUrlsContext = createContext<UiAssetUrlsContextType>(null)
 
+function noop() {
+	// Swallow image.decode() rejections (e.g. EncodingError) from icon preload —
+	// preload is best-effort and any real load failure surfaces where the icon is used.
+}
+
 /** @internal */
 export function AssetUrlsProvider({
 	assetUrls,
@@ -22,7 +27,7 @@ export function AssetUrlsProvider({
 			const image = Image()
 			image.crossOrigin = 'anonymous'
 			image.src = src
-			image.decode()
+			image.decode().catch(noop)
 		}
 		for (const src of Object.values(assetUrls.embedIcons)) {
 			if (!src) continue
@@ -30,7 +35,7 @@ export function AssetUrlsProvider({
 			const image = Image()
 			image.crossOrigin = 'anonymous'
 			image.src = src
-			image.decode()
+			image.decode().catch(noop)
 		}
 	}, [assetUrls])
 


### PR DESCRIPTION
In order to silence noisy unhandled promise warnings from the icon preload effect, this PR catches rejections from `image.decode()` in `AssetUrlsProvider`. The preload is best-effort — any real load failure will still surface where the icon is actually used.

`image.decode()` returns a promise that can reject (e.g. with `EncodingError` when the browser cannot decode the image, or `AbortError` when the source changes). Without a `.catch()` handler, these rejections become uncaught promise errors in the console.

### Change type

- [x] `bugfix`

### Test plan

1. Open the editor in a browser
2. Confirm no `Uncaught (in promise) EncodingError` warnings appear in the console from the asset URLs provider

### Release notes

- Silently catch `image.decode()` rejections from the icon preload effect.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -2    |
