### PR TITLE
chore(ci): notify Discord on important workflow failures

### DIFF
--- a/.github/actions/discord-fail-notify/action.yml
+++ b/.github/actions/discord-fail-notify/action.yml
@@ -17,7 +17,11 @@ runs:
         REF: ${{ github.ref_name }}
         RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       run: |
+        if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+          echo "::warning::DISCORD_WEBHOOK_URL is empty; skipping Discord notification."
+          exit 0
+        fi
         payload=$(jq -nc \
           --arg content "<@&1414904550917144586> ❌ **${WORKFLOW}** failed on \`${REF}\`: <${RUN_URL}>" \
           '{content: $content}')
-        curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"
+        curl -fsS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/actions/discord-fail-notify/action.yml
+++ b/.github/actions/discord-fail-notify/action.yml
@@ -1,0 +1,23 @@
+name: Discord fail notify
+description: Post a failure message to the Discord deploy/health channel.
+
+inputs:
+  webhook-url:
+    description: Discord webhook URL
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Notify Discord
+      shell: bash
+      env:
+        DISCORD_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        WORKFLOW: ${{ github.workflow }}
+        REF: ${{ github.ref_name }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        payload=$(jq -nc \
+          --arg content "<@&1414904550917144586> ❌ **${WORKFLOW}** failed on \`${REF}\`: <${RUN_URL}>" \
+          '{content: $content}')
+        curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -55,3 +55,9 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/deploy-mcp-app.yml
+++ b/.github/workflows/deploy-mcp-app.yml
@@ -45,3 +45,9 @@ jobs:
           VITE_TLDRAW_LICENSE_KEY: ${{ secrets.MCP_APP_TLDRAW_LICENSE_KEY }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/prune-preview-deploys.yml
+++ b/.github/workflows/prune-preview-deploys.yml
@@ -54,3 +54,9 @@ jobs:
           ZERO_R2_BUCKET_NAME: ${{ secrets.ZERO_R2_BUCKET_NAME }}
           ZERO_R2_ACCESS_KEY_ID: ${{ secrets.ZERO_R2_ACCESS_KEY_ID }}
           ZERO_R2_SECRET_ACCESS_KEY: ${{ secrets.ZERO_R2_SECRET_ACCESS_KEY }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/publish-branch.yml
+++ b/.github/workflows/publish-branch.yml
@@ -52,3 +52,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           body: |
             Published version ${{ steps.extract_version.outputs.version }} to npm.
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -54,3 +54,9 @@ jobs:
             -H "Authorization: Bearer ${{ steps.generate_token.outputs.token }}" \
             https://api.github.com/repos/tldraw/tldraw-desktop/dispatches \
             -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.publish.outputs.VERSION }}","tag":"next"}}'
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/publish-editor-extensions.yml
+++ b/.github/workflows/publish-editor-extensions.yml
@@ -53,3 +53,9 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
           TLDRAW_ENV: ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -47,6 +47,12 @@ jobs:
           TLDRAW_BEMO_URL: https://demo.tldraw.xyz
           TLDRAW_VERSION_STRING: ${{ inputs.version }}
 
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+
   publish_templates:
     name: Publishes code templates to separate repositories
     uses: tldraw/tldraw/.github/workflows/publish-templates.yml@main

--- a/.github/workflows/publish-manual.yml
+++ b/.github/workflows/publish-manual.yml
@@ -60,4 +60,5 @@ jobs:
     secrets:
       HUPPY_PRIVATE_KEY: ${{ secrets.HUPPY_PRIVATE_KEY }}
       HUPPY_APP_ID: ${{ vars.HUPPY_APP_ID }}
+      DISCORD_DEPLOY_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
     needs: deploy

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -83,6 +83,12 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_ACCESS_KEY_SECRET }}
           TLDRAW_BEMO_URL: https://demo.tldraw.xyz
 
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+
   publish_templates:
     name: Publishes code templates to separate repositories
     uses: tldraw/tldraw/.github/workflows/publish-templates.yml@main

--- a/.github/workflows/publish-new.yml
+++ b/.github/workflows/publish-new.yml
@@ -95,4 +95,5 @@ jobs:
     secrets:
       HUPPY_PRIVATE_KEY: ${{ secrets.HUPPY_PRIVATE_KEY }}
       HUPPY_APP_ID: ${{ vars.HUPPY_APP_ID }}
+      DISCORD_DEPLOY_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
     needs: [deploy]

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -61,6 +61,12 @@ jobs:
           R2_ACCESS_KEY_SECRET: ${{ secrets.R2_ACCESS_KEY_SECRET }}
           TLDRAW_BEMO_URL: https://demo.tldraw.xyz
 
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+
   publish_templates:
     name: Publishes code templates to separate repositories
     uses: tldraw/tldraw/.github/workflows/publish-templates.yml@main

--- a/.github/workflows/publish-patch.yml
+++ b/.github/workflows/publish-patch.yml
@@ -74,4 +74,5 @@ jobs:
     secrets:
       HUPPY_PRIVATE_KEY: ${{ secrets.HUPPY_PRIVATE_KEY }}
       HUPPY_APP_ID: ${{ vars.HUPPY_APP_ID }}
+      DISCORD_DEPLOY_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
     needs: deploy

--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -8,6 +8,8 @@ on:
         required: true
       HUPPY_APP_ID:
         required: true
+      DISCORD_DEPLOY_WEBHOOK_URL:
+        required: false
 
 env:
   CI: 1
@@ -61,3 +63,9 @@ jobs:
             yarn tsx ./internal/scripts/export-template.ts $template
             echo "::endgroup::"
           done
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -50,3 +50,9 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
           TLDRAW_ENV: production
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/trigger-production-build.yml
+++ b/.github/workflows/trigger-production-build.yml
@@ -113,3 +113,9 @@ jobs:
           git push origin production
           # reset hotfixes to the latest production
           git push origin production:hotfixes --force
+
+      - name: Notify Discord on failure
+        if: failure()
+        uses: ./.github/actions/discord-fail-notify
+        with:
+          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}

--- a/.github/workflows/trigger-production-build.yml
+++ b/.github/workflows/trigger-production-build.yml
@@ -113,9 +113,3 @@ jobs:
           git push origin production
           # reset hotfixes to the latest production
           git push origin production:hotfixes --force
-
-      - name: Notify Discord on failure
-        if: failure()
-        uses: ./.github/actions/discord-fail-notify
-        with:
-          webhook-url: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}


### PR DESCRIPTION
In order to catch silent failures in important pipelines (publishing SDK packages, publishing VS Code extensions, deploying the MCP app, daily preview cleanup), this PR adds a Discord notification step to each so failures show up in the same channel where dotcom deploy failures are already posted.

A new composite action at `.github/actions/discord-fail-notify` posts a brief message — `@Engineering ❌ <workflow> failed on <ref>: <run-url>` — to `DISCORD_DEPLOY_WEBHOOK_URL` when a job fails. It guards against an empty webhook (logs a warning and skips, so forks and misconfigured envs don't run misleading curl commands) and uses `curl -f` so a bad webhook surfaces as a failed step rather than a silent 4xx.

Workflows now wired up:

- `bump-versions`, `publish-canary`, `publish-patch`, `publish-new`, `publish-manual`, `publish-branch` — `npm deploy` env
- `publish-editor-extensions`, `publish-vscode-extension` — `vsce publish` env (still needs `DISCORD_DEPLOY_WEBHOOK_URL` added to that env in repo settings)
- `deploy-mcp-app` — `deploy-production` env
- `prune-preview-deploys` — `deploy-staging` env

`trigger-production-build` and `publish-templates` have no `environment:` block, so they can't resolve the env-scoped secret; left as-is for now.

The role mention `<@&1414904550917144586>` is the same `@Engineering` role already used by `Discord.AT_TEAM_MENTION` in `deploy-dotcom`, `deploy-bemo`, and `deploy-analytics`.

### Change type

- [x] `other`

### Test plan

Can't trigger a real workflow failure without merging. Verified by:

1. Walking through historical failure `publish-canary` run 25431962448 (S3 `AccessDenied` during `uploadStaticAssets`) — with the new step in place, the `if: failure()` step would have fired after the failing publish step.
2. Confirmed `jq` is preinstalled on the runner class (already used in `deploy-dotcom.yml`).
3. Confirmed the role mention matches the `@Engineering` role used by existing dotcom failure pings.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Config/tooling  | +87 / -0   |