### PR TITLE
chore(create-tldraw): track starter kit choice on teamldraw.com

### DIFF
--- a/packages/create-tldraw/src/main.ts
+++ b/packages/create-tldraw/src/main.ts
@@ -113,6 +113,17 @@ function trackStarterKitChoice(templateId: string, noTelemetry?: boolean) {
 	}).catch(() => {
 		// Silently ignore errors
 	})
+
+	// Fire and forget - don't block on this request
+	fetch('https://teamldraw.com/api/starter-kit-choice', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({ id: templateId }),
+	}).catch(() => {
+		// Silently ignore errors
+	})
 }
 
 async function namePicker(argOption?: string) {


### PR DESCRIPTION
In order to mirror `create-tldraw` starter kit telemetry to `teamldraw.com`, this PR adds a second fire-and-forget POST to `https://teamldraw.com/api/starter-kit-choice` inside `trackStarterKitChoice`. The new request runs alongside the existing `dashboard.tldraw.pro` call, respects the `--no-telemetry` flag, and fails silently.

### Change type

- [x] `other`

### Test plan

1. Run `yarn create tldraw` and pick a starter kit.
2. Confirm a POST is sent to `https://teamldraw.com/api/starter-kit-choice` with body `{ id: <templateId> }`.
3. Re-run with `--no-telemetry` and confirm no request is sent.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -0   |