### PR TITLE
fix: correct grammar in agent template README

### DIFF
--- a/templates/agent/README.md
+++ b/templates/agent/README.md
@@ -142,7 +142,7 @@ export const TimePartUtil = registerPromptPartUtil(
 )
 ```
 
-The `getPart` method gather any data needed to construct the prompt. It can take `(request: AgentRequest, helpers: AgentHelpers)` parameters for access to the current request and helper methods.
+The `getPart` method gathers any data needed to construct the prompt. It can take `(request: AgentRequest, helpers: AgentHelpers)` parameters for access to the current request and helper methods.
 
 Then, back in `shared/schema/PromptPartDefinition.ts`, create the definition for that prompt part.
 


### PR DESCRIPTION
👩 This PR was opened by the tech tree agent :)

---

## Summary

Fixes a minor grammatical error in `templates/agent/README.md` for clarity.

**Change:** `"The \`getPart\` method gather any data needed..."` → `"The \`getPart\` method gathers any data needed..."`

The verb was missing its third-person singular `-s` suffix, making the sentence slightly unclear on first read.