### PR TITLE
docs: clarify WebGLManager description in shader template README

### DIFF
--- a/templates/shader/README.md
+++ b/templates/shader/README.md
@@ -58,7 +58,7 @@ A bare-bones template for starting new shader projects. Renders a solid color th
 
 ### WebGLManager
 
-The `WebGLManager` class ([`src/WebGLManager.ts`](src/WebGLManager.ts)) provides the foundation for all shader examples. It handles:
+The `WebGLManager` class ([`src/WebGLManager.ts`](src/WebGLManager.ts)) provides the shared foundation that all shader examples build on. It handles:
 
 - WebGL2 context creation and lifecycle management
 - Automatic viewport synchronization with tldraw's canvas


### PR DESCRIPTION
👩 this PR was opened with the tech tree app

---

## What changed

In `templates/shader/README.md`, the opening sentence of the **WebGLManager** architecture section was slightly reworded for clarity:

**Before:**
> The `WebGLManager` class … provides the foundation for all shader examples. It handles:

**After:**
> The `WebGLManager` class … provides the shared foundation that all shader examples build on. It handles:

The new phrasing makes it clearer that the class is a *shared* base that examples actively *build on*, rather than just passively "providing a foundation".

## Why

Test task — improve one sentence in the shader template README to be slightly more clear.