### PR TITLE
fix(release): skip past orphaned version bumps in patch-release flow

### DIFF
--- a/internal/scripts/publish-patch.ts
+++ b/internal/scripts/publish-patch.ts
@@ -1,5 +1,6 @@
-import { appendFileSync } from 'node:fs'
+import { appendFileSync, readFileSync } from 'node:fs'
 import { Octokit } from '@octokit/rest'
+import { parse } from 'semver'
 import { extractChangelog } from './extract-draft-changelog'
 import { getAnyPackageDiff } from './lib/didAnyPackageChange'
 import { exec } from './lib/exec'
@@ -66,7 +67,32 @@ async function main() {
 	// would return the new version and leave prevTag === tag, producing an empty changelog.
 	const prevTag = `v${latestVersionInBranch.format()}`
 
-	const nextVersion = latestVersionInBranch.inc('patch').format()
+	// Determine the version to bump from. Normally this is the latest version
+	// published on npm for this branch. But if a previous patch release was
+	// interrupted after the "v X.Y.Z [skip ci]" version-bump commit was pushed
+	// but before npm publish completed, the local package.json files (and the
+	// matching git tag) will be ahead of npm. In that case we bump from the
+	// local version so we sidestep the orphaned version+tag entirely instead
+	// of trying to re-create them - both `git commit` (no staged changes) and
+	// `git push --follow-tags` (tag already exists at a different commit on
+	// origin) would otherwise fail and permanently wedge the branch.
+	const localTldrawVersion = parse(
+		JSON.parse(readFileSync('packages/tldraw/package.json', 'utf8')).version
+	)
+	const baseVersion =
+		localTldrawVersion && localTldrawVersion.compare(latestVersionInBranch) > 0
+			? localTldrawVersion
+			: latestVersionInBranch
+	if (baseVersion !== latestVersionInBranch) {
+		nicelog(
+			`Local package version ${baseVersion.format()} is ahead of latest npm version ` +
+				`${latestVersionInBranch.format()}; bumping from local to skip past orphaned version.`
+		)
+	}
+
+	// .inc() mutates baseVersion; reparse so callers downstream of us see the
+	// original instance unchanged.
+	const nextVersion = parse(baseVersion.format())!.inc('patch').format()
 	nicelog('Releasing version', nextVersion)
 
 	await setAllVersions(nextVersion, { stageChanges: true })

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -6,7 +6,7 @@ import { importPublicKey, str2ab } from '../utils/licensing'
 const GRACE_PERIOD_DAYS = 30
 
 export const FLAGS = {
-	// -- MUTUALLY EXCLUSIVE FLAGS --
+	// -- MUTUALLY EXCLUSIVE FLAGS
 	// Annual means the license expires after a time period, usually 1 year.
 	ANNUAL_LICENSE: 1,
 	// Perpetual means the license never expires up to the max supported version.


### PR DESCRIPTION
In order to recover from a previously-interrupted patch release that wedges a release branch's CI, this PR makes the patch-release script bump from `max(latestPublishedVersion, localTldrawVersion)` instead of always from the latest version on npm. Follow-up to #8800.

[The `v4.0.x` patch-release run on the test commit](https://github.com/tldraw/tldraw/actions/runs/25747452078/job/75614452558) got past the diff-check fix from #8800 but then died at:

```
→ No staged files found.
cmd: 'git commit -m v4.0.4 [skip ci]'
```

That branch is in this state:

- npm `tldraw` latest = `4.0.3`
- Local `package.json`s already say `4.0.4` (from the orphaned `2293cc1a v4.0.4 [skip ci]` commit on `v4.0.x`)
- Tag `v4.0.4` already exists on origin pointing at that orphaned commit

So when the script tried to bump npm's `4.0.3` → `4.0.4` and call `setAllVersions("4.0.4")`, every package.json was already at `4.0.4`, nothing was staged, and `git commit` exited 1. Even with that fixed, the next step (`git push --follow-tags`) would have failed because `v4.0.4` already exists on origin at a different commit.

### Fix

Compute the bump base as the higher of (latest npm version, local `tldraw` version):

- **Happy path** (local equals npm): identical to today - bump from npm's latest, behaviour unchanged.
- **Broken-state path** (local ahead of npm): bump from the local version, which leapfrogs past the orphaned version+tag entirely. For `v4.0.x` that means publishing `4.0.5` instead of trying to re-create `4.0.4`. Both `git commit` (real changes from `4.0.4` -> `4.0.5`) and `git push --follow-tags` (fresh tag) work normally.

Logs a notice when the leapfrog path is taken, so it's obvious in CI output what's happening.

The `prevTag` used for changelog generation still points at the actual latest npm version (e.g. `v4.0.3`), so the GitHub release notes still cover all commits since the real previous release.

### Change type

- [x] `bugfix`

### Test plan

1. Push to `v4.0.x` again - the workflow should publish `4.0.5` successfully (4.0.4 stays orphaned on the abandoned commit, which is fine).
2. Confirm normal release branches (`v4.5.x`, etc.) bump as before. In the steady state where local equals npm, `baseVersion === latestVersionInBranch` and `nextVersion` is still `latest + 1 patch`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Config/tooling  | +28 / -2   |


Made with [Cursor](https://cursor.com)