### PR TITLE
explore: lightweight read-only editor for grid previews

### DIFF
--- a/apps/dotcom/client/src/routeDefs.ts
+++ b/apps/dotcom/client/src/routeDefs.ts
@@ -4,6 +4,8 @@ export const ROUTES = {
 	tlaOptIn: '/preview',
 
 	tlaRoot: `/`,
+	tlaGrid: `/grid`,
+	tlaGridOriginal: `/grid-original`,
 	tlaNew: `/new`,
 	tlaFile: `/f/:fileSlug`,
 	tlaFileHistory: `/f/:fileSlug/history`,

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -73,6 +73,9 @@ export const router = createRoutesFromElements(
 				/>
 				{/* File view */}
 				<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
+				{/* Grid views (read-only previews of user's files) */}
+				<Route path={ROUTES.tlaGrid} lazy={() => import('./tla/pages/grid')} />
+				<Route path={ROUTES.tlaGridOriginal} lazy={() => import('./tla/pages/grid-original')} />
 				<Route path={ROUTES.tlaFileHistory} lazy={() => import('./tla/pages/file-history')} />
 				<Route
 					path={ROUTES.tlaFileHistorySnapshot}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/BulkShapeCreator.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/BulkShapeCreator.tsx
@@ -1,0 +1,252 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { useState } from 'react'
+import { createShapeId, TLShapeId, TLShapePartial, toRichText, useEditor } from 'tldraw'
+
+const COLORS = ['black', 'blue', 'green', 'red', 'orange', 'violet', 'yellow'] as const
+const GEOS = ['rectangle', 'ellipse', 'diamond', 'hexagon', 'triangle'] as const
+const LABELS = [
+	'Idea',
+	'Plan',
+	'Goal',
+	'Task',
+	'Note',
+	'Step',
+	'First',
+	'Next',
+	'Then',
+	'Done',
+	'Input',
+	'Output',
+]
+const TEXT_LINES = [
+	'The quick brown fox',
+	'Jumps over the lazy dog',
+	'Hello, world!',
+	'tldraw rocks',
+	'A line of text',
+	'Another note here',
+]
+
+export function BulkShapeCreator() {
+	const editor = useEditor()
+	const [count, setCount] = useState(100)
+	const [isBusy, setIsBusy] = useState(false)
+
+	const handleClick = () => {
+		if (isBusy) return
+		setIsBusy(true)
+
+		const numArrows = Math.floor(count * 0.2)
+		const numText = Math.floor(count * 0.2)
+		const numGeos = Math.max(2, count - numArrows - numText)
+
+		const totalCells = numGeos + numText
+		const gridSize = Math.max(1, Math.ceil(Math.sqrt(totalCells)))
+		const spacing = 180
+		const pickIndex = (arr: readonly unknown[]) => Math.floor(Math.random() * arr.length)
+		const jitter = (range: number) => (Math.random() - 0.5) * range
+
+		const geoIds: TLShapeId[] = []
+		const shapes: TLShapePartial[] = []
+
+		// geos with text labels
+		for (let i = 0; i < numGeos; i++) {
+			const id = createShapeId()
+			geoIds.push(id)
+			const cell = i
+			const row = Math.floor(cell / gridSize)
+			const col = cell % gridSize
+			const w = 80 + Math.floor(Math.random() * 100)
+			const h = 60 + Math.floor(Math.random() * 80)
+			shapes.push({
+				id,
+				type: 'geo',
+				x: col * spacing + jitter(spacing * 0.4),
+				y: row * spacing + jitter(spacing * 0.4),
+				rotation: Math.random() < 0.2 ? (Math.random() - 0.5) * 0.6 : 0,
+				props: {
+					w,
+					h,
+					geo: GEOS[pickIndex(GEOS)],
+					color: COLORS[pickIndex(COLORS)],
+					fill: Math.random() < 0.7 ? 'semi' : 'solid',
+					richText: toRichText(LABELS[pickIndex(LABELS)]),
+				},
+			})
+		}
+
+		// standalone text shapes
+		for (let i = 0; i < numText; i++) {
+			const cell = numGeos + i
+			const row = Math.floor(cell / gridSize)
+			const col = cell % gridSize
+			shapes.push({
+				id: createShapeId(),
+				type: 'text',
+				x: col * spacing + jitter(spacing * 0.5),
+				y: row * spacing + jitter(spacing * 0.5),
+				rotation: Math.random() < 0.15 ? (Math.random() - 0.5) * 0.4 : 0,
+				props: {
+					color: COLORS[pickIndex(COLORS)],
+					richText: toRichText(TEXT_LINES[pickIndex(TEXT_LINES)]),
+				},
+			})
+		}
+
+		// arrows connecting random geo shape pairs
+		const arrowBindings: { arrowId: TLShapeId; from: TLShapeId; to: TLShapeId }[] = []
+		for (let i = 0; i < numArrows && geoIds.length >= 2; i++) {
+			const arrowId = createShapeId()
+			shapes.push({
+				id: arrowId,
+				type: 'arrow',
+				props: {
+					color: COLORS[pickIndex(COLORS)],
+					richText: toRichText(Math.random() < 0.3 ? LABELS[pickIndex(LABELS)] : ''),
+				},
+			})
+			const fromIdx = Math.floor(Math.random() * geoIds.length)
+			let toIdx = Math.floor(Math.random() * geoIds.length)
+			if (toIdx === fromIdx) toIdx = (toIdx + 1) % geoIds.length
+			arrowBindings.push({ arrowId, from: geoIds[fromIdx], to: geoIds[toIdx] })
+		}
+
+		editor.run(
+			() => {
+				editor.markHistoryStoppingPoint('bulk shapes')
+				editor.createShapes(shapes)
+				if (arrowBindings.length) {
+					editor.createBindings(
+						arrowBindings.flatMap(({ arrowId, from, to }) => [
+							{
+								fromId: arrowId,
+								toId: from,
+								type: 'arrow' as const,
+								props: {
+									terminal: 'start' as const,
+									normalizedAnchor: { x: 0.5, y: 0.5 },
+									isExact: false,
+									isPrecise: false,
+								},
+							},
+							{
+								fromId: arrowId,
+								toId: to,
+								type: 'arrow' as const,
+								props: {
+									terminal: 'end' as const,
+									normalizedAnchor: { x: 0.5, y: 0.5 },
+									isExact: false,
+									isPrecise: false,
+								},
+							},
+						])
+					)
+				}
+			},
+			{ history: 'record' }
+		)
+		setIsBusy(false)
+	}
+
+	const handleAddBoundsRect = () => {
+		const vp = editor.getViewportPageBounds()
+		const inset = 50
+		const previewViewport = {
+			x: Math.round(vp.x + inset),
+			y: Math.round(vp.y + inset),
+			w: Math.round(Math.max(1, vp.w - inset * 2)),
+			h: Math.round(Math.max(1, vp.h - inset * 2)),
+		}
+		const existing = editor
+			.getCurrentPageShapes()
+			.find((s) => (s.meta as Record<string, unknown>)?.isPreviewBoundsRect === true)
+		editor.run(
+			() => {
+				editor.markHistoryStoppingPoint('preview bounds rect')
+				if (existing) {
+					editor.updateShape({
+						id: existing.id,
+						type: 'geo' as const,
+						x: previewViewport.x,
+						y: previewViewport.y,
+						props: { w: previewViewport.w, h: previewViewport.h },
+					})
+				} else {
+					editor.createShape({
+						id: createShapeId(),
+						type: 'geo',
+						x: previewViewport.x,
+						y: previewViewport.y,
+						meta: { isPreviewBoundsRect: true },
+						props: {
+							w: previewViewport.w,
+							h: previewViewport.h,
+							geo: 'rectangle',
+							color: 'red',
+							fill: 'none',
+							dash: 'dashed',
+						},
+					})
+				}
+				const settings = editor.getDocumentSettings()
+				editor.updateDocumentSettings({
+					meta: { ...(settings.meta ?? {}), previewViewport },
+				})
+			},
+			{ history: 'record' }
+		)
+	}
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				top: 96,
+				left: 12,
+				display: 'flex',
+				gap: 8,
+				alignItems: 'center',
+				padding: '8px 12px',
+				background: 'var(--color-panel, white)',
+				color: 'var(--color-text, #000)',
+				border: '2px solid var(--color-selected, #1d8df1)',
+				borderRadius: 8,
+				boxShadow: '0 4px 16px rgba(0,0,0,0.12)',
+				fontSize: 12,
+				pointerEvents: 'all',
+				zIndex: 1000,
+			}}
+			onPointerDown={(e) => e.stopPropagation()}
+			onPointerUp={(e) => e.stopPropagation()}
+		>
+			<span style={{ fontWeight: 600 }}>Bulk:</span>
+			<input
+				type="number"
+				min={1}
+				max={50000}
+				value={count}
+				disabled={isBusy}
+				onChange={(e) => setCount(Math.max(1, Number(e.target.value) || 1))}
+				style={{ width: 80, padding: '4px 6px' }}
+			/>
+			<button
+				onClick={handleClick}
+				disabled={isBusy}
+				style={{
+					padding: '4px 10px',
+					cursor: isBusy ? 'wait' : 'pointer',
+				}}
+			>
+				{isBusy ? 'Adding…' : `Add ${count} shapes`}
+			</button>
+			<button
+				onClick={handleAddBoundsRect}
+				style={{ padding: '4px 10px', cursor: 'pointer' }}
+				title="Save the current viewport as the document's preview bounds and insert a rectangle marking it"
+			>
+				Add bounds rect
+			</button>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -44,6 +44,7 @@ import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracki
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
 import { TlaAnonDotDevLink } from '../TlaAnonDotDevLink/TlaAnonDotDevLink'
+import { BulkShapeCreator } from './BulkShapeCreator'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
 import { TlaEditorSharePanel } from './editor-components/TlaEditorSharePanel'
@@ -274,6 +275,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		return {
 			...components,
 			DebugMenu: () => <CustomDebugMenu />,
+			InFrontOfTheCanvas: BulkShapeCreator,
 		}
 	}, [])
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect } from 'react'
+import { NavLink } from 'react-router-dom'
 import { useTldrFileDrop } from '../../hooks/useTldrFileDrop'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import {
@@ -101,6 +102,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 				</div>
 				<div className={styles.sidebarContent}>
 					<div className={styles.sidebarContentInner}>
+						<TlaSidebarGridLinks />
 						{hasGroups ? <NewSidebarLayout /> : <LegacySidebarLayout />}
 					</div>
 				</div>
@@ -135,3 +137,18 @@ function NewSidebarLayout() {
 		</>
 	)
 }
+
+/* eslint-disable tldraw/jsx-no-literals */
+function TlaSidebarGridLinks() {
+	return (
+		<div className={styles.sidebarGridLinks}>
+			<NavLink to="/grid" className={styles.sidebarGridLink}>
+				Grid
+			</NavLink>
+			<NavLink to="/grid-original" className={styles.sidebarGridLink}>
+				Grid original
+			</NavLink>
+		</div>
+	)
+}
+/* eslint-enable tldraw/jsx-no-literals */

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -1056,3 +1056,29 @@
 [data-no-animation='true'] * {
 	animation-duration: 0s !important;
 }
+
+.sidebarGridLinks {
+	display: flex;
+	flex-direction: column;
+	margin-bottom: 8px;
+}
+
+.sidebarGridLink {
+	display: flex;
+	align-items: center;
+	height: 32px;
+	padding: 0 12px;
+	color: var(--tla-color-text-1);
+	font-size: 13px;
+	border-radius: 6px;
+	text-decoration: none;
+}
+
+.sidebarGridLink:hover {
+	background: var(--tla-color-hover);
+}
+
+.sidebarGridLink[aria-current='page'] {
+	background: var(--tla-color-active);
+	font-weight: 500;
+}

--- a/apps/dotcom/client/src/tla/pages/grid-focus-camera.ts
+++ b/apps/dotcom/client/src/tla/pages/grid-focus-camera.ts
@@ -1,0 +1,57 @@
+import { Editor } from 'tldraw'
+import { PREVIEW_BOUNDS } from './grid-preview-bounds'
+
+export interface PreviewViewport {
+	x: number
+	y: number
+	w: number
+	h: number
+}
+
+/**
+ * Read the per-document preview viewport from `TLDocument.meta.previewViewport`,
+ * if set. Falls back to the shared `PREVIEW_BOUNDS` default for documents that
+ * haven't had a preview viewport configured yet.
+ */
+export function readPreviewBounds(editor: Editor): PreviewViewport | null {
+	const meta = editor.getDocumentSettings().meta as Record<string, unknown> | undefined
+	const candidate = meta?.previewViewport
+	if (!candidate || typeof candidate !== 'object') return null
+	const { x, y, w, h } = candidate as Record<string, unknown>
+	if (
+		typeof x !== 'number' ||
+		typeof y !== 'number' ||
+		typeof w !== 'number' ||
+		typeof h !== 'number'
+	) {
+		return null
+	}
+	if (w <= 0 || h <= 0) return null
+	return { x, y, w, h }
+}
+
+/**
+ * Center the editor's camera on the document's preview bounds at 100% zoom.
+ *
+ * When the editor first mounts the tile's viewport screen bounds may not have
+ * been measured yet (grid layout still computing). We retry on the next
+ * animation frame and again after the `useScreenBounds` throttle window so the
+ * camera ends up positioned correctly regardless of when layout settles.
+ */
+export function focusOnPreviewBounds(editor: Editor): void {
+	const bounds = readPreviewBounds(editor) ?? PREVIEW_BOUNDS
+
+	const apply = (): boolean => {
+		if (editor.isDisposed) return true
+		const vp = editor.getViewportScreenBounds()
+		if (vp.w <= 0 || vp.h <= 0) return false
+		editor.zoomToBounds(bounds, { immediate: true, inset: 0, force: true })
+		return true
+	}
+
+	if (apply()) return
+	requestAnimationFrame(() => {
+		if (apply()) return
+		setTimeout(apply, 250)
+	})
+}

--- a/apps/dotcom/client/src/tla/pages/grid-original.tsx
+++ b/apps/dotcom/client/src/tla/pages/grid-original.tsx
@@ -1,0 +1,151 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useSync } from '@tldraw/sync'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { Tldraw, useEvent, useValue } from 'tldraw'
+import { routes } from '../../routeDefs'
+import { assetUrls } from '../../utils/assetUrls'
+import { MULTIPLAYER_SERVER } from '../../utils/config'
+import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
+import { useMaybeApp } from '../hooks/useAppState'
+import { useTldrawCurrentUser } from '../hooks/useUser'
+import { TlaSidebarLayout } from '../layouts/TlaSidebarLayout/TlaSidebarLayout'
+import { focusOnPreviewBounds } from './grid-focus-camera'
+
+export function Component() {
+	const app = useMaybeApp()
+	const files = useValue('my files', () => app?.getMyFiles() ?? [], [app])
+
+	if (!app) {
+		return (
+			<div style={{ padding: 20 }}>
+				<p>Sign in to view the grid.</p>
+			</div>
+		)
+	}
+
+	return (
+		<TlaSidebarLayout>
+			<div style={{ padding: '60px 20px 20px 60px', overflow: 'auto', height: '100%' }}>
+				<h1 style={{ marginBottom: 16 }}>Grid (original) — full editor per tile</h1>
+				<p style={{ marginBottom: 16, opacity: 0.7 }}>
+					{files.length} file{files.length === 1 ? '' : 's'}. Each tile mounts a regular Tldraw
+					component with its own sync connection.
+				</p>
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+						gap: 16,
+					}}
+				>
+					{files.map(({ fileId }) => (
+						<GridTileOriginal
+							key={fileId}
+							fileId={fileId}
+							name={app.getFileName(fileId) || fileId}
+						/>
+					))}
+				</div>
+			</div>
+		</TlaSidebarLayout>
+	)
+}
+
+function GridTileOriginal({ fileId, name }: { fileId: string; name: string }) {
+	const user = useTldrawCurrentUser()
+	const getUserToken = useEvent(async () => (await user?.getToken()) ?? 'not-logged-in')
+	const hasUser = !!user
+
+	const assets = useMemo(
+		() => multiplayerAssetStore({ getFileId: () => fileId, getToken: getUserToken }),
+		[fileId, getUserToken]
+	)
+
+	const t0Ref = useRef(performance.now())
+	const tSyncedRef = useRef<number | null>(null)
+	const store = useSync({
+		uri: useCallback(async () => {
+			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileId}`)
+			if (hasUser) {
+				url.searchParams.set('accessToken', await getUserToken())
+			}
+			return url.toString()
+		}, [fileId, hasUser, getUserToken]),
+		assets,
+	})
+
+	useEffect(() => {
+		if (store.status === 'synced-remote') {
+			if (tSyncedRef.current === null) {
+				tSyncedRef.current = performance.now()
+			}
+		}
+	}, [fileId, store.status])
+
+	return (
+		<Link
+			to={routes.tlaFile(fileId)}
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 6,
+				color: 'inherit',
+				textDecoration: 'none',
+				cursor: 'pointer',
+			}}
+		>
+			<div
+				style={{
+					fontSize: 13,
+					fontWeight: 500,
+					whiteSpace: 'nowrap',
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+				}}
+				title={name}
+			>
+				{name}
+			</div>
+			<div
+				style={{
+					aspectRatio: '4 / 3',
+					border: '1px solid var(--tla-color-border, #e0e0e0)',
+					borderRadius: 8,
+					overflow: 'hidden',
+					position: 'relative',
+					background: 'var(--color-low, #fafafa)',
+				}}
+			>
+				<div
+					style={{
+						position: 'absolute',
+						inset: 0,
+						pointerEvents: 'none',
+					}}
+				>
+					<Tldraw
+						store={store}
+						licenseKey={getLicenseKey()}
+						assetUrls={assetUrls}
+						hideUi
+						onMount={(editor) => {
+							focusOnPreviewBounds(editor)
+							const tMount = performance.now()
+							const t0 = t0Ref.current
+							const tSync = tSyncedRef.current ?? tMount
+							const shapes = editor.getCurrentPageShapeIds().size
+							const sync = Math.round(tSync - t0)
+							const render = Math.round(tMount - tSync)
+							const total = Math.round(tMount - t0)
+							console.warn(
+								`[grid-original:${fileId}] ${shapes} shapes — sync ${sync}ms + render ${render}ms = total ${total}ms`
+							)
+						}}
+					/>
+				</div>
+			</div>
+		</Link>
+	)
+}

--- a/apps/dotcom/client/src/tla/pages/grid-parse-worker.ts
+++ b/apps/dotcom/client/src/tla/pages/grid-parse-worker.ts
@@ -1,0 +1,18 @@
+/// <reference lib="webworker" />
+
+// JSON.parse off the main thread for snapshot fetches.
+// Messages: { id: number, text: string } → { id: number, ok: boolean, data?: unknown, error?: string }
+
+declare const self: DedicatedWorkerGlobalScope
+
+self.onmessage = (e: MessageEvent<{ id: number; text: string }>) => {
+	const { id, text } = e.data
+	try {
+		const data = JSON.parse(text)
+		self.postMessage({ id, ok: true, data })
+	} catch (err) {
+		self.postMessage({ id, ok: false, error: String(err) })
+	}
+}
+
+export {}

--- a/apps/dotcom/client/src/tla/pages/grid-parse.ts
+++ b/apps/dotcom/client/src/tla/pages/grid-parse.ts
@@ -1,0 +1,39 @@
+// Shared worker-based JSON parser. Single worker handles all `/grid` tile
+// parses, off the main thread, so concurrent fetches don't fight for the parse
+// step (which was the dominant per-tile cost after the bounds filter).
+
+let workerInstance: Worker | null = null
+let nextId = 0
+const pending = new Map<number, { resolve(value: unknown): void; reject(error: Error): void }>()
+
+function getWorker(): Worker {
+	if (workerInstance) return workerInstance
+	workerInstance = new Worker(new URL('./grid-parse-worker.ts', import.meta.url), {
+		type: 'module',
+	})
+	workerInstance.onmessage = (
+		e: MessageEvent<{ id: number; ok: boolean; data?: unknown; error?: string }>
+	) => {
+		const handler = pending.get(e.data.id)
+		if (!handler) return
+		pending.delete(e.data.id)
+		if (e.data.ok) handler.resolve(e.data.data)
+		else handler.reject(new Error(e.data.error ?? 'parse failed'))
+	}
+	workerInstance.onerror = (e) => {
+		// Fail every pending request if the worker itself errors.
+		for (const { reject } of pending.values()) {
+			reject(new Error(e.message))
+		}
+		pending.clear()
+	}
+	return workerInstance
+}
+
+export function parseJsonInWorker<T = unknown>(text: string): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const id = nextId++
+		pending.set(id, { resolve: resolve as (v: unknown) => void, reject })
+		getWorker().postMessage({ id, text })
+	})
+}

--- a/apps/dotcom/client/src/tla/pages/grid-preview-bounds.ts
+++ b/apps/dotcom/client/src/tla/pages/grid-preview-bounds.ts
@@ -1,0 +1,7 @@
+/**
+ * The page-space bounds the grid pages use as the preview viewport. Both
+ * `/grid` (filters shapes server-side to these bounds) and `/grid-original`
+ * (renders the full file, but focuses the camera on this region) must agree
+ * on this value so the rendered previews are comparable.
+ */
+export const PREVIEW_BOUNDS = { x: 0, y: 0, w: 500, h: 500 } as const

--- a/apps/dotcom/client/src/tla/pages/grid.tsx
+++ b/apps/dotcom/client/src/tla/pages/grid.tsx
@@ -1,0 +1,220 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+	fetch,
+	SerializedSchema,
+	TldrawPreview,
+	TLRecord,
+	TLStoreSnapshot,
+	useEvent,
+	useValue,
+} from 'tldraw'
+import { routes } from '../../routeDefs'
+import { assetUrls } from '../../utils/assetUrls'
+import { MULTIPLAYER_SERVER } from '../../utils/config'
+import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
+import { useMaybeApp } from '../hooks/useAppState'
+import { useTldrawCurrentUser } from '../hooks/useUser'
+import { TlaSidebarLayout } from '../layouts/TlaSidebarLayout/TlaSidebarLayout'
+import { focusOnPreviewBounds } from './grid-focus-camera'
+import { parseJsonInWorker } from './grid-parse'
+import { PREVIEW_BOUNDS } from './grid-preview-bounds'
+
+// Suppress the internal LoadingScreen that TldrawViewer renders while the editor
+// is initializing — tile keeps its blank background instead.
+const EMPTY_COMPONENTS = { LoadingScreen: () => null }
+
+export function Component() {
+	const app = useMaybeApp()
+	const files = useValue('my files', () => app?.getMyFiles() ?? [], [app])
+
+	if (!app) {
+		return (
+			<div style={{ padding: 20 }}>
+				<p>Sign in to view the grid.</p>
+			</div>
+		)
+	}
+
+	return (
+		<TlaSidebarLayout>
+			<div style={{ padding: '60px 20px 20px 60px', overflow: 'auto', height: '100%' }}>
+				<h1 style={{ marginBottom: 16 }}>Grid — read-only preview per tile</h1>
+				<p style={{ marginBottom: 16, opacity: 0.7 }}>
+					{files.length} file{files.length === 1 ? '' : 's'}. Each tile fetches a snapshot over HTTP
+					and renders with TldrawPreview (no event handlers, no UI, no sync).
+				</p>
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+						gap: 16,
+					}}
+				>
+					{files.map(({ fileId }) => (
+						<GridTile key={fileId} fileId={fileId} name={app.getFileName(fileId) || fileId} />
+					))}
+				</div>
+			</div>
+		</TlaSidebarLayout>
+	)
+}
+
+function GridTile({ fileId, name }: { fileId: string; name: string }) {
+	const user = useTldrawCurrentUser()
+	const getUserToken = useEvent(async () => (await user?.getToken()) ?? 'not-logged-in')
+
+	const containerRef = useRef<HTMLAnchorElement>(null)
+	const [isVisible, setIsVisible] = useState(false)
+
+	useEffect(() => {
+		if (isVisible || !containerRef.current) return
+		const observer = new IntersectionObserver(
+			(entries) => {
+				if (entries.some((e) => e.isIntersecting)) {
+					setIsVisible(true)
+					observer.disconnect()
+				}
+			},
+			{ rootMargin: '400px' }
+		)
+		observer.observe(containerRef.current)
+		return () => observer.disconnect()
+	}, [isVisible])
+
+	const [snapshot, setSnapshot] = useState<TLStoreSnapshot | null>(null)
+	const [error, setError] = useState<string | null>(null)
+	const timings = useRef<{
+		t0: number
+		tFetched: number
+		tParsed: number
+		tSet: number
+		recordCount: number
+	} | null>(null)
+
+	useEffect(() => {
+		if (!isVisible) return
+		let cancelled = false
+		const t0 = performance.now()
+		const b = PREVIEW_BOUNDS
+		const boundsKey = `${b.x},${b.y},${b.w},${b.h}`
+		;(async () => {
+			try {
+				const token = await getUserToken()
+				const headers: Record<string, string> = {}
+				if (token && token !== 'not-logged-in') {
+					headers['Authorization'] = `Bearer ${token}`
+				}
+				const httpBase = MULTIPLAYER_SERVER.replace(/^ws/, 'http')
+				const url = `${httpBase}/app/file/${fileId}/download?bounds=${boundsKey}`
+				const res = await fetch(url, { headers })
+				if (!res.ok) throw new Error(`HTTP ${res.status}`)
+				const text = await res.text()
+				const tFetched = performance.now()
+				const data = await parseJsonInWorker<{
+					tldrawFileFormatVersion: number
+					schema: SerializedSchema
+					records: TLRecord[]
+				}>(text)
+				const tParsed = performance.now()
+				if (cancelled) return
+				setSnapshot({
+					schema: data.schema,
+					store: Object.fromEntries(data.records.map((r) => [r.id, r])),
+				})
+				timings.current = {
+					t0,
+					tFetched,
+					tParsed,
+					tSet: performance.now(),
+					recordCount: data.records.length,
+				}
+			} catch (e) {
+				console.error(`[grid:${fileId}] fetch error`, e)
+				if (!cancelled) setError(String(e))
+			}
+		})()
+		return () => {
+			cancelled = true
+		}
+	}, [fileId, getUserToken, isVisible])
+
+	const assets = useMemo(
+		() => multiplayerAssetStore({ getFileId: () => fileId, getToken: getUserToken }),
+		[fileId, getUserToken]
+	)
+
+	return (
+		<Link
+			ref={containerRef}
+			to={routes.tlaFile(fileId)}
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 6,
+				color: 'inherit',
+				textDecoration: 'none',
+				cursor: 'pointer',
+			}}
+		>
+			<div
+				style={{
+					fontSize: 13,
+					fontWeight: 500,
+					whiteSpace: 'nowrap',
+					overflow: 'hidden',
+					textOverflow: 'ellipsis',
+				}}
+				title={name}
+			>
+				{name}
+			</div>
+			<div
+				style={{
+					aspectRatio: '4 / 3',
+					border: '1px solid var(--tla-color-border, #e0e0e0)',
+					borderRadius: 8,
+					overflow: 'hidden',
+					position: 'relative',
+					background: 'var(--color-low, #fafafa)',
+				}}
+			>
+				{error ? (
+					<div style={{ padding: 12, fontSize: 12, color: 'red' }}>{error}</div>
+				) : snapshot ? (
+					<div style={{ position: 'absolute', inset: 0 }}>
+						<TldrawPreview
+							snapshot={snapshot}
+							assets={assets}
+							licenseKey={getLicenseKey()}
+							assetUrls={assetUrls}
+							components={EMPTY_COMPONENTS}
+							onMount={(editor) => {
+								try {
+									focusOnPreviewBounds(editor)
+									const shapes = editor.getCurrentPageShapeIds().size
+									const tMount = performance.now()
+									const t = timings.current
+									if (t) {
+										const network = Math.round(t.tFetched - t.t0)
+										const parse = Math.round(t.tParsed - t.tFetched)
+										const load = Math.round(t.tSet - t.t0)
+										const render = Math.round(tMount - t.tSet)
+										const total = Math.round(tMount - t.t0)
+										console.warn(
+											`[grid:${fileId}] ${shapes} shapes (${t.recordCount} records) — load ${load}ms (network ${network} + parse ${parse}) + render ${render}ms = total ${total}ms`
+										)
+									}
+								} catch (e) {
+									console.error(`[grid:${fileId}] onMount error`, e)
+								}
+							}}
+						/>
+					</div>
+				) : null}
+			</div>
+		</Link>
+	)
+}

--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -6,6 +6,7 @@ export const cspDirectives: { [key: string]: string[] } = {
 		`wss:`,
 		'blob:',
 		'data:',
+		'http://localhost:8787',
 		'http://localhost:8788',
 		'http://localhost:8789',
 		`https://*.tldraw.xyz`,

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -18,6 +18,7 @@ import {
 	TlaFile,
 	type RoomOpenMode,
 } from '@tldraw/dotcom-shared'
+import { SerializedSchema } from '@tldraw/store'
 import {
 	DEFAULT_INITIAL_SNAPSHOT,
 	DurableObjectSqliteSyncWrapper,
@@ -62,6 +63,11 @@ import { EventData, writeDataPoint } from './utils/analytics'
 import { createPierreClient, isSlugInPierreRollout } from './utils/createPierreClient'
 import { createSupabaseClient } from './utils/createSupabaseClient'
 import { getRoomDurableObject } from './utils/durableObjects'
+import {
+	filterRecordsToBounds,
+	parsePreviewBounds,
+	readPreviewBoundsFromDocument,
+} from './utils/filterRecordsToBounds'
 import { reconstructSnapshotFromPierre } from './utils/pierreSnapshot'
 import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
@@ -300,6 +306,20 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	private readonly changeSource = 'TLFileDurableObject'
+
+	/**
+	 * In-memory cache of the post-prune, post-asset-inlined records for this
+	 * file's snapshot, used by `onDownloadTldr` so concurrent preview tile
+	 * requests don't each re-read SQLite storage and re-base64 every asset.
+	 *
+	 * Invalidated by short TTL (30s); ok if previews are mildly stale.
+	 */
+	private downloadRecordsCache: {
+		records: TLRecord[]
+		schema: SerializedSchema | undefined
+		documentName?: string
+		expiresAt: number
+	} | null = null
 
 	constructor(
 		private state: DurableObjectState,
@@ -725,6 +745,73 @@ export class TLFileDurableObject extends DurableObject {
 		}
 	}
 
+	/**
+	 * Returns the post-prune, post-asset-inlined records for this file. Cached in
+	 * DO instance memory for 30s; concurrent preview requests skip the SQLite
+	 * read and R2 asset-inline loop.
+	 */
+	private async getDownloadRecordsCached(): Promise<{
+		records: TLRecord[]
+		schema: SerializedSchema | undefined
+		documentName?: string
+	}> {
+		const existing = this.downloadRecordsCache
+		if (existing && existing.expiresAt > Date.now()) {
+			return existing
+		}
+
+		const storage = await this.getStorage()
+		assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
+		const snapshot = storage.getSnapshot()
+		const pruned = pruneUnusedAssetsForTldr(snapshot.documents.map((d) => d.state) as TLRecord[])
+
+		const assetRows = await this.db
+			.selectFrom('asset')
+			.where('fileId', '=', this.documentInfo.slug)
+			.select('objectName')
+			.execute()
+		const assetObjectNames = new Set(assetRows.map((r) => r.objectName))
+
+		const env = this.env
+		const inlined: TLRecord[] = await Promise.all(
+			pruned.map(async (record) => {
+				if (record.typeName !== 'asset') return record
+				const assetRecord = record as TLAsset
+				if (assetRecord.type === 'bookmark') return record
+				const assetSrc = assetRecord.props.src
+				if (!assetSrc || assetSrc.startsWith('data:')) return record
+				const objectName = new URL(assetSrc).pathname.split('/').pop()
+				if (!objectName || !assetObjectNames.has(objectName)) return record
+				const blob = await env.UPLOADS.get(objectName)
+				if (!blob) return record
+				const ab = await blob.arrayBuffer()
+				const base64 = arrayBufferToBase64(ab)
+				const mimeType =
+					'mimeType' in assetRecord.props && assetRecord.props.mimeType
+						? assetRecord.props.mimeType
+						: 'application/octet-stream'
+				return {
+					...record,
+					props: {
+						...assetRecord.props,
+						src: `data:${mimeType};base64,${base64}`,
+					},
+				} as TLRecord
+			})
+		)
+
+		const documentRecord = inlined.find((r) => r.typeName === 'document') as TLDocument | undefined
+
+		const entry = {
+			records: inlined,
+			schema: snapshot.schema,
+			documentName: documentRecord?.name,
+			expiresAt: Date.now() + 30_000,
+		}
+		this.downloadRecordsCache = entry
+		return entry
+	}
+
 	/** Stream .tldr download (schema + records, R2 assets inlined as base64). Same access as joining the file. */
 	async onDownloadTldr(req: IRequest): Promise<Response> {
 		const TLDRAW_FILE_MIMETYPE = 'application/vnd.tldraw+json'
@@ -770,69 +857,48 @@ export class TLFileDurableObject extends DurableObject {
 			return new Response('Forbidden', { status: 403 })
 		}
 
-		const storage = await this.getStorage()
-		assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
-		const snapshot = storage.getSnapshot()
-		const records = pruneUnusedAssetsForTldr(snapshot.documents.map((d) => d.state) as TLRecord[])
+		const cached = await this.getDownloadRecordsCached()
+		let records = cached.records
 
-		const assetRows = await this.db
-			.selectFrom('asset')
-			.where('fileId', '=', this.documentInfo.slug)
-			.select('objectName')
-			.execute()
-		const assetObjectNames = new Set(assetRows.map((r) => r.objectName))
+		// Prefer the document's own preview viewport (set via the editor UI) over
+		// any client-supplied default.
+		const docBounds = readPreviewBoundsFromDocument(records)
+		const queryBounds = parsePreviewBounds(url.searchParams.get('bounds'))
+		const previewBounds = docBounds ?? queryBounds
+		const boundsSource = docBounds ? 'doc' : queryBounds ? 'query' : 'none'
+		if (previewBounds) {
+			const before = records.length
+			const t0 = performance.now()
+			records = filterRecordsToBounds(records, previewBounds)
+			const elapsed = Math.round((performance.now() - t0) * 100) / 100
+			console.error(
+				`[download:${this.documentInfo.slug}] filter (${boundsSource}) bounds=${previewBounds.x},${previewBounds.y},${previewBounds.w}x${previewBounds.h} ${before}→${records.length} records in ${elapsed}ms`
+			)
+		} else {
+			console.error(
+				`[download:${this.documentInfo.slug}] no bounds filter, ${records.length} records`
+			)
+		}
 
-		const documentRecord = records.find((r) => r.typeName === 'document') as TLDocument | undefined
 		// Prefer the TlaFile.name (kept in sync by the app layer) over the TLDocument.name
 		// (which is only updated when the document is open in an editor).
-		const rawName = file.name?.trim() || documentRecord?.name?.trim()
+		const rawName = file.name?.trim() || cached.documentName?.trim()
 		const sanitized =
 			rawName?.replace(/[^ \w-]/g, '_').slice(0, 200) || `${this.documentInfo.slug}.tldr`
 		const filename = sanitized.endsWith('.tldr') ? sanitized : `${sanitized}.tldr`
 
-		const env = this.env
+		const schema = cached.schema
 		const stream = new ReadableStream({
 			async start(controller) {
 				try {
 					const encoder = new TextEncoder()
 					controller.enqueue(
 						encoder.encode(
-							`{"tldrawFileFormatVersion":${TLDRAW_FILE_FORMAT_VERSION},"schema":${JSON.stringify(snapshot.schema)},"records":[`
+							`{"tldrawFileFormatVersion":${TLDRAW_FILE_FORMAT_VERSION},"schema":${JSON.stringify(schema)},"records":[`
 						)
 					)
 					for (let i = 0; i < records.length; i++) {
-						let record = records[i] as TLRecord
-						const assetSrc = record.typeName === 'asset' ? (record as TLAsset).props.src : null
-						if (
-							record.typeName === 'asset' &&
-							(record as TLAsset).type !== 'bookmark' &&
-							assetSrc &&
-							!assetSrc.startsWith('data:')
-						) {
-							const objectName = new URL(assetSrc).pathname.split('/').pop()
-							if (objectName && assetObjectNames.has(objectName)) {
-								const blob = await env.UPLOADS.get(objectName)
-								if (blob) {
-									const ab = await blob.arrayBuffer()
-									const base64 = arrayBufferToBase64(ab)
-									const assetRecord = record as TLAsset
-									const mimeType =
-										assetRecord.type !== 'bookmark' &&
-										'mimeType' in assetRecord.props &&
-										assetRecord.props.mimeType
-											? assetRecord.props.mimeType
-											: 'application/octet-stream'
-									record = {
-										...record,
-										props: {
-											...(record as TLAsset).props,
-											src: `data:${mimeType};base64,${base64}`,
-										},
-									} as TLRecord
-								}
-							}
-						}
-						controller.enqueue(encoder.encode((i > 0 ? ',' : '') + JSON.stringify(record)))
+						controller.enqueue(encoder.encode((i > 0 ? ',' : '') + JSON.stringify(records[i])))
 					}
 					controller.enqueue(encoder.encode(']}'))
 					controller.close()
@@ -846,6 +912,13 @@ export class TLFileDurableObject extends DurableObject {
 			headers: {
 				'Content-Type': TLDRAW_FILE_MIMETYPE,
 				'Content-Disposition': `attachment; filename="${filename}"`,
+				// Short-lived cache so /grid preview tiles don't re-fetch the
+				// same snapshot repeatedly. Private because access is auth-gated;
+				// vary on Authorization so caches don't serve user A's response to
+				// user B. Vary on bounds query is implicit (different URL = different
+				// cache entry).
+				'Cache-Control': 'private, max-age=30',
+				Vary: 'Authorization',
 			},
 		})
 	}

--- a/apps/dotcom/sync-worker/src/utils/filterRecordsToBounds.ts
+++ b/apps/dotcom/sync-worker/src/utils/filterRecordsToBounds.ts
@@ -1,0 +1,253 @@
+import { TLBinding, TLDocument, TLRecord, TLShape } from '@tldraw/tlschema'
+
+export interface PreviewBounds {
+	x: number
+	y: number
+	w: number
+	h: number
+}
+
+/**
+ * Parse a `bounds=x,y,w,h` query value. Returns null if missing/invalid.
+ */
+export function parsePreviewBounds(raw: string | null): PreviewBounds | null {
+	if (!raw) return null
+	const parts = raw.split(',').map(Number)
+	if (parts.length !== 4) return null
+	const [x, y, w, h] = parts
+	if (![x, y, w, h].every(Number.isFinite)) return null
+	if (w <= 0 || h <= 0) return null
+	return { x, y, w, h }
+}
+
+/**
+ * Look at `TLDocument.meta.previewViewport` on the document record in `records`,
+ * if present and well-formed. Documents opt in to per-doc preview viewports by
+ * writing this field (e.g. via the `Set preview to viewport` UI).
+ */
+export function readPreviewBoundsFromDocument(records: TLRecord[]): PreviewBounds | null {
+	const doc = records.find((r) => r.typeName === 'document') as TLDocument | undefined
+	const candidate = (doc?.meta as Record<string, unknown> | undefined)?.previewViewport
+	if (!candidate || typeof candidate !== 'object') return null
+	const { x, y, w, h } = candidate as Record<string, unknown>
+	if (
+		typeof x !== 'number' ||
+		typeof y !== 'number' ||
+		typeof w !== 'number' ||
+		typeof h !== 'number'
+	) {
+		return null
+	}
+	if (w <= 0 || h <= 0) return null
+	return { x, y, w, h }
+}
+
+/**
+ * Conservative server-side filter: keep records likely to appear inside the given
+ * page-space bounds. Heuristic — covers shapes with explicit `w`/`h` or point lists;
+ * keeps arrows / groups / unknown shapes / non-shape records unconditionally.
+ *
+ * Bindings whose `fromId` or `toId` references a filtered-out shape are dropped, so
+ * the store loads cleanly without orphan binding references.
+ */
+export function filterRecordsToBounds(records: TLRecord[], bounds: PreviewBounds): TLRecord[] {
+	const shapesById = new Map<string, TLShape>()
+	for (const r of records) {
+		if (r.typeName === 'shape') shapesById.set(r.id, r as TLShape)
+	}
+
+	const bindingsByFromId = new Map<string, TLBinding[]>()
+	for (const r of records) {
+		if (r.typeName !== 'binding') continue
+		const b = r as TLBinding
+		const arr = bindingsByFromId.get(b.fromId)
+		if (arr) arr.push(b)
+		else bindingsByFromId.set(b.fromId, [b])
+	}
+
+	const keptShapeIds = new Set<string>()
+
+	// Pass 1: non-arrow shapes whose local aabb intersects bounds.
+	for (const record of records) {
+		if (record.typeName !== 'shape') continue
+		const shape = record as TLShape
+		if (shape.type === 'arrow') continue
+		if (shapeIntersectsBounds(shape, bounds)) {
+			keptShapeIds.add(record.id)
+		}
+	}
+
+	// Pass 2: arrows — compute rough page-space segment using binding targets
+	// (or stored local terminals when unbound). Drop arrows whose segment
+	// doesn't cross the bounds. Keep binding-target shapes for surviving arrows
+	// so they render at their true positions.
+	for (const record of records) {
+		if (record.typeName !== 'shape') continue
+		const shape = record as TLShape
+		if (shape.type !== 'arrow') continue
+		if (arrowIntersectsBounds(shape, bounds, shapesById, bindingsByFromId)) {
+			keptShapeIds.add(record.id)
+			for (const b of bindingsByFromId.get(record.id) ?? []) {
+				keptShapeIds.add(b.toId)
+			}
+		}
+	}
+
+	return records.filter((record) => {
+		if (record.typeName === 'shape') {
+			return keptShapeIds.has(record.id)
+		}
+		if (record.typeName === 'binding') {
+			const b = record as TLBinding
+			return keptShapeIds.has(b.fromId) && keptShapeIds.has(b.toId)
+		}
+		return true
+	})
+}
+
+function arrowIntersectsBounds(
+	arrow: TLShape,
+	bounds: PreviewBounds,
+	shapesById: Map<string, TLShape>,
+	bindingsByFromId: Map<string, TLBinding[]>
+): boolean {
+	const props = arrow.props as Record<string, any>
+	const start = {
+		x: arrow.x + (props.start?.x ?? 0),
+		y: arrow.y + (props.start?.y ?? 0),
+	}
+	const end = {
+		x: arrow.x + (props.end?.x ?? 0),
+		y: arrow.y + (props.end?.y ?? 0),
+	}
+
+	for (const b of bindingsByFromId.get(arrow.id) ?? []) {
+		const target = shapesById.get(b.toId)
+		if (!target) continue
+		const aabb = getLocalAabb(target)
+		const cx = target.x + (aabb ? aabb.x + aabb.w / 2 : 0)
+		const cy = target.y + (aabb ? aabb.y + aabb.h / 2 : 0)
+		const terminal = (b.props as Record<string, any> | undefined)?.terminal
+		if (terminal === 'start') {
+			start.x = cx
+			start.y = cy
+		} else if (terminal === 'end') {
+			end.x = cx
+			end.y = cy
+		}
+	}
+
+	// Elbow arrows route through right-angle corners that sit on the start/end
+	// AABB, so the chord AABB already covers their path. Arc arrows bulge
+	// perpendicular to the chord by `|bend|` — pad the AABB by that amount.
+	const bend = Math.abs(Number(props.bend) || 0)
+	const minX = Math.min(start.x, end.x) - bend
+	const maxX = Math.max(start.x, end.x) + bend
+	const minY = Math.min(start.y, end.y) - bend
+	const maxY = Math.max(start.y, end.y) + bend
+	return (
+		maxX > bounds.x && minX < bounds.x + bounds.w && maxY > bounds.y && minY < bounds.y + bounds.h
+	)
+}
+
+function shapeIntersectsBounds(shape: TLShape, bounds: PreviewBounds): boolean {
+	// Groups depend on children. Frames can be very large containers. Keep both.
+	if (shape.type === 'group' || shape.type === 'frame') {
+		return true
+	}
+
+	const sx = shape.x
+	const sy = shape.y
+	if (!Number.isFinite(sx) || !Number.isFinite(sy)) return true
+
+	const localAabb = getLocalAabb(shape)
+	if (!localAabb) return true
+
+	let minX = sx + localAabb.x
+	let minY = sy + localAabb.y
+	let w = localAabb.w
+	let h = localAabb.h
+
+	if (shape.rotation) {
+		// Conservative bounding circle around the local aabb, then re-aabb after rotation.
+		const cx = minX + w / 2
+		const cy = minY + h / 2
+		const r = Math.sqrt(w * w + h * h) / 2
+		minX = cx - r
+		minY = cy - r
+		w = 2 * r
+		h = 2 * r
+	}
+
+	const maxX = bounds.x + bounds.w
+	const maxY = bounds.y + bounds.h
+	return minX < maxX && minX + w > bounds.x && minY < maxY && minY + h > bounds.y
+}
+
+/**
+ * Local-space aabb of the shape — `x`/`y` relative to the shape's origin. Returns
+ * null if we can't compute it cheaply (caller should keep the shape).
+ */
+function getLocalAabb(shape: TLShape): { x: number; y: number; w: number; h: number } | null {
+	const props = shape.props as Record<string, any>
+
+	switch (shape.type) {
+		case 'geo':
+		case 'image':
+		case 'video':
+		case 'embed':
+		case 'bookmark': {
+			const w = props.w
+			const h = props.h
+			if (!Number.isFinite(w) || !Number.isFinite(h)) return null
+			return { x: 0, y: 0, w, h }
+		}
+		case 'note': {
+			// Default tldraw note is 200×200 with optional growY for autosized content.
+			const w = Number.isFinite(props.w) ? props.w : 200
+			const h =
+				(Number.isFinite(props.h) ? props.h : 200) +
+				(Number.isFinite(props.growY) ? props.growY : 0)
+			return { x: 0, y: 0, w, h }
+		}
+		case 'text': {
+			const w = Number.isFinite(props.w) ? props.w : 200
+			// Text height is computed from content; use w as a generous proxy.
+			return { x: 0, y: 0, w, h: w }
+		}
+		case 'draw':
+		case 'highlight': {
+			const segments = props.segments as
+				| Array<{ points: Array<{ x: number; y: number }> }>
+				| undefined
+			return aabbFromPoints(segments?.flatMap((s) => s.points ?? []))
+		}
+		case 'line': {
+			const points = props.points
+				? (Object.values(props.points) as Array<{ x: number; y: number }>)
+				: null
+			return aabbFromPoints(points)
+		}
+		default:
+			return null
+	}
+}
+
+function aabbFromPoints(
+	points: Array<{ x: number; y: number }> | null | undefined
+): { x: number; y: number; w: number; h: number } | null {
+	if (!points || points.length === 0) return null
+	let minX = Infinity
+	let minY = Infinity
+	let maxX = -Infinity
+	let maxY = -Infinity
+	for (const p of points) {
+		if (!Number.isFinite(p?.x) || !Number.isFinite(p?.y)) continue
+		if (p.x < minX) minX = p.x
+		if (p.y < minY) minY = p.y
+		if (p.x > maxX) maxX = p.x
+		if (p.y > maxY) maxY = p.y
+	}
+	if (!Number.isFinite(minX)) return null
+	return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -25,6 +25,7 @@ import { JsonObject } from '@tldraw/utils';
 import { JSX } from 'react/jsx-runtime';
 import { LegacyMigrations } from '@tldraw/store';
 import { MigrationSequence } from '@tldraw/store';
+import { NamedExoticComponent } from 'react';
 import { Node as Node_2 } from '@tiptap/pm/model';
 import { PerformanceTracker } from '@tldraw/utils';
 import * as React_2 from 'react';
@@ -3856,6 +3857,39 @@ export interface TldrawOptions {
     readonly zoomToFitPadding: number;
 }
 
+// @public
+export const TldrawViewer: NamedExoticComponent<TldrawViewerProps>;
+
+// @public (undocumented)
+export interface TldrawViewerProps {
+    // (undocumented)
+    assets?: TLAssetStore;
+    // (undocumented)
+    assetUrls?: {
+        fonts?: {
+            [key: string]: string | undefined;
+        };
+    };
+    // (undocumented)
+    assetUtils: readonly TLAnyAssetUtilConstructor[];
+    // (undocumented)
+    bindingUtils: readonly TLAnyBindingUtilConstructor[];
+    // (undocumented)
+    className?: string;
+    // (undocumented)
+    components?: TLEditorComponents;
+    // (undocumented)
+    licenseKey?: string;
+    // (undocumented)
+    onMount?: TLOnMountHandler;
+    // (undocumented)
+    options?: Partial<TldrawOptions>;
+    // (undocumented)
+    shapeUtils: readonly TLAnyShapeUtilConstructor[];
+    // (undocumented)
+    snapshot: TLStoreSnapshot;
+}
+
 // @public (undocumented)
 export interface TLDropShapesOverInfo {
     // (undocumented)
@@ -5412,6 +5446,9 @@ export class Vec {
 
 // @public (undocumented)
 export type VecLike = Vec | VecModel;
+
+// @public
+export function ViewerCanvas({ className }: TLCanvasComponentProps): JSX.Element;
 
 
 export * from "@tldraw/state";

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -18,6 +18,7 @@ export {
 	DefaultCanvas,
 	type TLCanvasComponentProps,
 } from './lib/components/default-components/DefaultCanvas'
+export { ViewerCanvas } from './lib/components/default-components/ViewerCanvas'
 export {
 	DefaultErrorFallback,
 	type TLErrorFallbackComponent,
@@ -436,6 +437,7 @@ export {
 	type TldrawEditorWithStoreProps,
 	type TLOnMountHandler,
 } from './lib/TldrawEditor'
+export { TldrawViewer, type TldrawViewerProps } from './lib/TldrawViewer'
 export { dataUrlToFile, getDefaultCdnBaseUrl } from './lib/utils/assets'
 export { clampToBrowserMaxCanvasSize, type CanvasMaxSize } from './lib/utils/browserCanvasMaxSize'
 export {

--- a/packages/editor/src/lib/TldrawViewer.tsx
+++ b/packages/editor/src/lib/TldrawViewer.tsx
@@ -1,0 +1,211 @@
+import { TLAssetStore, TLStoreSnapshot } from '@tldraw/tlschema'
+import { annotateError } from '@tldraw/utils'
+import classNames from 'classnames'
+import { memo, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import { version } from '../version'
+import { DefaultErrorFallback } from './components/default-components/DefaultErrorFallback'
+import { ViewerCanvas } from './components/default-components/ViewerCanvas'
+import { OptionalErrorBoundary } from './components/ErrorBoundary'
+import { createTLCurrentUser } from './config/createTLCurrentUser'
+import { createTLStore } from './config/createTLStore'
+import { TLAnyAssetUtilConstructor } from './config/defaultAssets'
+import { TLAnyBindingUtilConstructor } from './config/defaultBindings'
+import { TLAnyShapeUtilConstructor } from './config/defaultShapes'
+import { Editor } from './editor/Editor'
+import type { TLEditorComponents } from './hooks/EditorComponentsContext'
+import { ContainerProvider, useContainer } from './hooks/useContainer'
+import { EditorProvider } from './hooks/useEditor'
+import { EditorComponentsProvider, useEditorComponents } from './hooks/useEditorComponents'
+import { LicenseProvider } from './license/LicenseProvider'
+import { TldrawOptions } from './options'
+import { TL_CONTAINER_CLASS, TLOnMountHandler } from './TldrawEditor'
+
+const EMPTY_TOOLS_ARRAY = [] as const
+
+/** @public */
+export interface TldrawViewerProps {
+	snapshot: TLStoreSnapshot
+	shapeUtils: readonly TLAnyShapeUtilConstructor[]
+	bindingUtils: readonly TLAnyBindingUtilConstructor[]
+	assetUtils: readonly TLAnyAssetUtilConstructor[]
+	assets?: TLAssetStore
+	components?: TLEditorComponents
+	onMount?: TLOnMountHandler
+	className?: string
+	options?: Partial<TldrawOptions>
+	licenseKey?: string
+	assetUrls?: { fonts?: { [key: string]: string | undefined } }
+}
+
+/**
+ * A read-only renderer for a tldraw document. Standalone from {@link TldrawEditor} —
+ * no event handlers, no UI, no watermark, no tools, no live theme/camera sync, no
+ * focus management. Use it to render many document previews on a single page.
+ *
+ * @public @react
+ */
+export const TldrawViewer = memo(function TldrawViewer({
+	snapshot,
+	shapeUtils,
+	bindingUtils,
+	assetUtils,
+	assets,
+	components,
+	onMount,
+	className,
+	options,
+	licenseKey,
+	assetUrls,
+}: TldrawViewerProps) {
+	const [container, setContainer] = useState<HTMLElement | null>(null)
+
+	const ErrorFallback =
+		components?.ErrorFallback === undefined ? DefaultErrorFallback : components?.ErrorFallback
+
+	const componentsWithViewerCanvas = useMemo<TLEditorComponents>(
+		() => ({ Canvas: ViewerCanvas, ...components }),
+		[components]
+	)
+
+	return (
+		<div
+			ref={setContainer}
+			data-tldraw={version}
+			draggable={false}
+			className={classNames(`${TL_CONTAINER_CLASS} tl-theme__light`, className)}
+			tabIndex={-1}
+			role="application"
+			aria-label="tldraw preview"
+		>
+			<OptionalErrorBoundary
+				fallback={ErrorFallback}
+				onError={(error) => annotateError(error, { tags: { origin: 'react.tldraw-viewer' } })}
+			>
+				{container && (
+					<LicenseProvider licenseKey={licenseKey}>
+						<ContainerProvider container={container}>
+							<EditorComponentsProvider overrides={componentsWithViewerCanvas}>
+								<TldrawViewerInner
+									snapshot={snapshot}
+									shapeUtils={shapeUtils}
+									bindingUtils={bindingUtils}
+									assetUtils={assetUtils}
+									assets={assets}
+									options={options}
+									licenseKey={licenseKey}
+									onMount={onMount}
+									assetUrls={assetUrls}
+								/>
+							</EditorComponentsProvider>
+						</ContainerProvider>
+					</LicenseProvider>
+				)}
+			</OptionalErrorBoundary>
+		</div>
+	)
+})
+
+interface TldrawViewerInnerProps {
+	snapshot: TLStoreSnapshot
+	shapeUtils: readonly TLAnyShapeUtilConstructor[]
+	bindingUtils: readonly TLAnyBindingUtilConstructor[]
+	assetUtils: readonly TLAnyAssetUtilConstructor[]
+	assets?: TLAssetStore
+	options?: Partial<TldrawOptions>
+	licenseKey?: string
+	onMount?: TLOnMountHandler
+	assetUrls?: { fonts?: { [key: string]: string | undefined } }
+}
+
+function TldrawViewerInner({
+	snapshot,
+	shapeUtils,
+	bindingUtils,
+	assetUtils,
+	assets,
+	options,
+	licenseKey,
+	onMount,
+	assetUrls,
+}: TldrawViewerInnerProps) {
+	const container = useContainer()
+	const user = useMemo(() => createTLCurrentUser(), [])
+
+	const store = useMemo(
+		() => createTLStore({ shapeUtils, bindingUtils, assetUtils, snapshot, assets }),
+		[shapeUtils, bindingUtils, assetUtils, snapshot, assets]
+	)
+
+	const [editor, setEditor] = useState<Editor | null>(null)
+
+	useLayoutEffect(() => {
+		const newEditor = new Editor({
+			store,
+			shapeUtils,
+			bindingUtils,
+			assetUtils,
+			tools: EMPTY_TOOLS_ARRAY,
+			getContainer: () => container,
+			user,
+			autoFocus: false,
+			options,
+			licenseKey,
+			fontAssetUrls: assetUrls?.fonts,
+		})
+		newEditor.updateViewportScreenBounds(container)
+		setEditor(newEditor)
+		return () => {
+			newEditor.dispose()
+		}
+	}, [store, shapeUtils, bindingUtils, assetUtils, container, options, licenseKey, user, assetUrls])
+
+	useLayoutEffect(() => {
+		if (!editor) return
+		let teardown: (() => void | undefined) | undefined | void
+		editor.run(
+			() => {
+				const storeTeardown = editor.store.props.onMount(editor)
+				const userTeardown = onMount?.(editor)
+				teardown = () => {
+					storeTeardown?.()
+					userTeardown?.()
+				}
+				editor.emit('mount')
+			},
+			{ history: 'ignore' }
+		)
+		return () => {
+			teardown?.()
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [editor])
+
+	const [fontsLoaded, setFontsLoaded] = useState(false)
+	useEffect(() => {
+		setFontsLoaded(false)
+		if (!editor) return
+		if (editor.options.maxFontsToLoadBeforeRender === 0) {
+			setFontsLoaded(true)
+			return
+		}
+		let cancelled = false
+		editor.fonts
+			.loadRequiredFontsForCurrentPage(editor.options.maxFontsToLoadBeforeRender)
+			.finally(() => {
+				if (!cancelled) setFontsLoaded(true)
+			})
+		return () => {
+			cancelled = true
+		}
+	}, [editor])
+
+	const { Canvas } = useEditorComponents()
+
+	if (!editor || !fontsLoaded) return null
+
+	return (
+		<EditorProvider editor={editor}>
+			{Canvas ? <Canvas key={editor.contextId} /> : null}
+		</EditorProvider>
+	)
+}

--- a/packages/editor/src/lib/components/default-components/ViewerCanvas.tsx
+++ b/packages/editor/src/lib/components/default-components/ViewerCanvas.tsx
@@ -1,0 +1,128 @@
+import { useQuickReactor, useValue } from '@tldraw/state-react'
+import { modulate, objectMapValues } from '@tldraw/utils'
+import classNames from 'classnames'
+import { JSX, useRef } from 'react'
+import { tlenv } from '../../globals/environment'
+import { useEditorComponents } from '../../hooks/EditorComponentsContext'
+import { useContainer } from '../../hooks/useContainer'
+import { useEditor } from '../../hooks/useEditor'
+import { useScreenBounds } from '../../hooks/useScreenBounds'
+import { toDomPrecision } from '../../primitives/utils'
+import { setStyleProperty } from '../../utils/dom'
+import { Shape } from '../Shape'
+import { TLCanvasComponentProps } from './DefaultCanvas'
+
+/**
+ * Minimal canvas for read-only document previews. Renders only shapes inside the
+ * viewport, no event handlers, no overlays, no selection, no culling controller.
+ *
+ * @public @react
+ */
+export function ViewerCanvas({ className }: TLCanvasComponentProps) {
+	const editor = useEditor()
+	const { Background, SvgDefs } = useEditorComponents()
+
+	const rCanvas = useRef<HTMLDivElement>(null)
+	const rHtmlLayer = useRef<HTMLDivElement>(null)
+	const container = useContainer()
+
+	useScreenBounds(rCanvas)
+
+	const rMemoizedStuff = useRef({ lodDisableTextOutline: false, allowTextOutline: true })
+
+	useQuickReactor(
+		'position layers',
+		function positionLayersWhenCameraMoves() {
+			const { x, y, z } = editor.getCamera()
+
+			if (rMemoizedStuff.current.allowTextOutline && tlenv.isSafari) {
+				container.style.setProperty('--tl-text-outline', 'none')
+				rMemoizedStuff.current.allowTextOutline = false
+			}
+
+			if (
+				rMemoizedStuff.current.allowTextOutline &&
+				z < editor.options.textShadowLod !== rMemoizedStuff.current.lodDisableTextOutline
+			) {
+				const lodDisableTextOutline = z < editor.options.textShadowLod
+				container.style.setProperty(
+					'--tl-text-outline',
+					lodDisableTextOutline ? 'none' : `var(--tl-text-outline-reference)`
+				)
+				rMemoizedStuff.current.lodDisableTextOutline = lodDisableTextOutline
+			}
+
+			const offset =
+				z >= 1 ? modulate(z, [1, 8], [0.125, 0.5], true) : modulate(z, [0.1, 1], [-2, 0.125], true)
+
+			const transform = `scale(${toDomPrecision(z)}) translate(${toDomPrecision(
+				x + offset
+			)}px,${toDomPrecision(y + offset)}px)`
+
+			setStyleProperty(rHtmlLayer.current, 'transform', transform)
+		},
+		[editor, container]
+	)
+
+	const shapeSvgDefs = useValue(
+		'shapeSvgDefs',
+		() => {
+			const shapeSvgDefsByKey = new Map<string, JSX.Element>()
+			for (const util of objectMapValues(editor.shapeUtils)) {
+				if (!util) return
+				const defs = util.getCanvasSvgDefs()
+				for (const { key, component: Component } of defs) {
+					if (shapeSvgDefsByKey.has(key)) continue
+					shapeSvgDefsByKey.set(key, <Component key={key} />)
+				}
+			}
+			return [...shapeSvgDefsByKey.values()]
+		},
+		[editor]
+	)
+
+	return (
+		<div
+			ref={rCanvas}
+			draggable={false}
+			className={classNames('tl-canvas', 'tl-canvas__viewer', className)}
+			data-testid="canvas"
+		>
+			<svg className="tl-svg-context" aria-hidden="true">
+				<defs>
+					{shapeSvgDefs}
+					{SvgDefs && <SvgDefs />}
+				</defs>
+			</svg>
+			{Background && (
+				<div className="tl-background__wrapper">
+					<Background />
+				</div>
+			)}
+			<div ref={rHtmlLayer} className="tl-html-layer tl-shapes" draggable={false}>
+				<ShapesLayer />
+			</div>
+		</div>
+	)
+}
+
+function ShapesLayer() {
+	const editor = useEditor()
+	const visibleShapes = useValue(
+		'visible rendering shapes',
+		() => {
+			const all = editor.getRenderingShapes()
+			const culled = editor.getCulledShapes()
+			if (culled.size === 0) return all
+			return all.filter((s) => !culled.has(s.id))
+		},
+		[editor]
+	)
+	return (
+		<>
+			{visibleShapes.map((result) => (
+				<Shape key={result.id + '_shape'} {...result} />
+			))}
+		</>
+	)
+}

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -223,7 +223,7 @@ export function useCanvasEvents() {
 			// so it appears like the ink is working locally, when really it's just that `useCoalescedEvents`
 			// is disabled. The intent here is to have `useCoalescedEvents` disabled for iOS.
 			const events =
-				!tlenv.isIos && currentTool.useCoalescedEvents && e.getCoalescedEvents
+				!tlenv.isIos && currentTool?.useCoalescedEvents && e.getCoalescedEvents
 					? e.getCoalescedEvents()
 					: [e]
 

--- a/packages/editor/src/lib/hooks/useShapeCulling.tsx
+++ b/packages/editor/src/lib/hooks/useShapeCulling.tsx
@@ -86,15 +86,19 @@ export function ShapeCullingProvider({ children }: ShapeCullingProviderProps) {
 	return <ShapeCullingContext.Provider value={value}>{children}</ShapeCullingContext.Provider>
 }
 
+const NOOP_CULLING: ShapeCullingContextValue = {
+	register: () => {},
+	unregister: () => {},
+	updateCulling: () => {},
+}
+
 /**
- * Hook to access the shape culling context for container registration.
+ * Hook to access the shape culling context for container registration. Returns a
+ * no-op value when used outside a `ShapeCullingProvider` (e.g. inside the
+ * viewer, where culling is handled by filtering shapes at render time).
  *
  * @internal
  */
 export function useShapeCulling(): ShapeCullingContextValue {
-	const context = useContext(ShapeCullingContext)
-	if (!context) {
-		throw new Error('useShapeCulling must be used within ShapeCullingProvider')
-	}
-	return context
+	return useContext(ShapeCullingContext) ?? NOOP_CULLING
 }

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -74,6 +74,7 @@ import { StyleProp } from '@tldraw/editor';
 import { SvgExportContext } from '@tldraw/editor';
 import { SVGProps } from 'react';
 import { TiptapEditor } from '@tldraw/editor';
+import { TLAnyAssetUtilConstructor } from '@tldraw/editor';
 import { TLAnyBindingUtilConstructor } from '@tldraw/editor';
 import { TLAnyShapeUtilConstructor } from '@tldraw/editor';
 import { TLArrowBinding } from '@tldraw/editor';
@@ -101,6 +102,7 @@ import { TldrawOptions } from '@tldraw/editor';
 import { TLDrawShape } from '@tldraw/editor';
 import { TLDrawShapeProps } from '@tldraw/editor';
 import { TLDrawShapeSegment } from '@tldraw/editor';
+import { TldrawViewerProps } from '@tldraw/editor';
 import { TLEditorComponents } from '@tldraw/editor';
 import { TLEditorSnapshot } from '@tldraw/editor';
 import { TLEditStartInfo } from '@tldraw/editor';
@@ -4134,6 +4136,16 @@ export interface TldrawImageProps extends TLImageExportOptions {
     // @deprecated
     textOptions?: TLTextOptions;
 }
+
+// @public
+export function TldrawPreview({ shapeUtils, bindingUtils, assetUtils, onMount, assetUrls, options, ...rest }: TldrawPreviewProps): JSX.Element;
+
+// @public
+export type TldrawPreviewProps = Omit<TldrawViewerProps, 'assetUtils' | 'bindingUtils' | 'shapeUtils'> & {
+    assetUtils?: readonly TLAnyAssetUtilConstructor[];
+    bindingUtils?: readonly TLAnyBindingUtilConstructor[];
+    shapeUtils?: readonly TLAnyShapeUtilConstructor[];
+};
 
 // @public (undocumented)
 export type TldrawProps = TldrawBaseProps & TldrawEditorStoreProps;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -295,6 +295,7 @@ export {
 export { getColorStyleItems, getFontStyleItems, type StyleValuesForUi } from './lib/styles'
 export { Tldraw, type TLComponents, type TldrawBaseProps, type TldrawProps } from './lib/Tldraw'
 export { TldrawImage, type TldrawImageProps } from './lib/TldrawImage'
+export { TldrawPreview, type TldrawPreviewProps } from './lib/TldrawPreview'
 export { EraserTool } from './lib/tools/EraserTool/EraserTool'
 export { HandTool } from './lib/tools/HandTool/HandTool'
 export { LaserTool } from './lib/tools/LaserTool/LaserTool'

--- a/packages/tldraw/src/lib/TldrawPreview.tsx
+++ b/packages/tldraw/src/lib/TldrawPreview.tsx
@@ -1,0 +1,103 @@
+import {
+	mergeArraysAndReplaceDefaults,
+	TLAnyAssetUtilConstructor,
+	TLAnyBindingUtilConstructor,
+	TLAnyShapeUtilConstructor,
+	TLOnMountHandler,
+	TldrawViewer,
+	TldrawViewerProps,
+	useShallowArrayIdentity,
+} from '@tldraw/editor'
+import { useCallback, useMemo } from 'react'
+import { defaultAssetUtils } from './defaultAssetUtils'
+import { defaultBindingUtils } from './defaultBindingUtils'
+import { defaultShapeUtils } from './defaultShapeUtils'
+import { allDefaultFontFaces } from './shapes/shared/defaultFonts'
+import { useDefaultEditorAssetsWithOverrides } from './utils/static-assets/assetUrls'
+import { defaultAddFontsFromNode, tipTapDefaultExtensions } from './utils/text/richText'
+
+/**
+ * Props for the {@link TldrawPreview} component.
+ *
+ * @public
+ */
+export type TldrawPreviewProps = Omit<
+	TldrawViewerProps,
+	'shapeUtils' | 'bindingUtils' | 'assetUtils'
+> & {
+	shapeUtils?: readonly TLAnyShapeUtilConstructor[]
+	bindingUtils?: readonly TLAnyBindingUtilConstructor[]
+	assetUtils?: readonly TLAnyAssetUtilConstructor[]
+}
+
+/**
+ * A read-only preview renderer pre-configured with tldraw's default shape, binding,
+ * and asset utils. Use this to render a tldraw document as a static preview without
+ * mounting the full editor UI, tools, or event handlers.
+ *
+ * @public @react
+ */
+export function TldrawPreview({
+	shapeUtils = [],
+	bindingUtils = [],
+	assetUtils = [],
+	onMount,
+	assetUrls,
+	options,
+	...rest
+}: TldrawPreviewProps) {
+	const _shapeUtils = useShallowArrayIdentity(shapeUtils)
+	const shapeUtilsWithDefaults = useMemo(
+		() => mergeArraysAndReplaceDefaults('type', _shapeUtils, defaultShapeUtils),
+		[_shapeUtils]
+	)
+
+	const _bindingUtils = useShallowArrayIdentity(bindingUtils)
+	const bindingUtilsWithDefaults = useMemo(
+		() => mergeArraysAndReplaceDefaults('type', _bindingUtils, defaultBindingUtils),
+		[_bindingUtils]
+	)
+
+	const _assetUtils = useShallowArrayIdentity(assetUtils)
+	const assetUtilsWithDefaults = useMemo(
+		() => mergeArraysAndReplaceDefaults('type', _assetUtils, defaultAssetUtils),
+		[_assetUtils]
+	)
+
+	const assets = useDefaultEditorAssetsWithOverrides(assetUrls)
+
+	const optionsWithDefaults = useMemo(
+		() => ({
+			...options,
+			text: {
+				addFontsFromNode: defaultAddFontsFromNode,
+				...options?.text,
+				tipTapConfig: {
+					extensions: tipTapDefaultExtensions,
+					...options?.text?.tipTapConfig,
+				},
+			},
+		}),
+		[options]
+	)
+
+	const handleMount = useCallback<TLOnMountHandler>(
+		(editor) => {
+			editor.fonts.requestFonts(allDefaultFontFaces)
+			return onMount?.(editor)
+		},
+		[onMount]
+	)
+
+	return (
+		<TldrawViewer
+			{...rest}
+			shapeUtils={shapeUtilsWithDefaults}
+			bindingUtils={bindingUtilsWithDefaults}
+			assetUtils={assetUtilsWithDefaults}
+			assetUrls={assets}
+			options={optionsWithDefaults}
+			onMount={handleMount}
+		/>
+	)
+}


### PR DESCRIPTION
Exploration on a lightweight tldraw editor for rendering many read-only document previews on one page.

Adds a standalone `TldrawViewer` (no UI, tools, events, watermark, or theme/camera sync) and a `TldrawPreview` wrapper that pre-wires the default shape, binding, and asset utils. Backs a `/grid` page that fetches a snapshot per file and renders a tile, with a `/grid-original` baseline for comparison.

Also includes a server-side bounds filter on `/app/file/:slug/download?bounds=…` that drops shapes outside a per-document preview viewport (with arrow / binding-target handling for arc and elbow arrows), and a `BulkShapeCreator` button + per-doc `meta.previewViewport` for setting the bounds.

Drafted as exploration — not aimed at landing as-is.

Comparison of loading the readonly grid vs the original (full editor)

https://github.com/user-attachments/assets/86a0aa93-c4d1-483e-820e-333c6aab04b9

