### PR TITLE
chore(dotcom): bump zero to 1.5.0

### DIFF
--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -31,7 +31,7 @@
 	"dependencies": {
 		"@clerk/clerk-react": "^5.53.3",
 		"@clerk/elements": "^0.23.74",
-		"@rocicorp/zero": "1.4.0",
+		"@rocicorp/zero": "1.5.0",
 		"@sentry/integrations": "^7.120.3",
 		"@sentry/react": "^7.120.3",
 		"@tldraw/assets": "workspace:*",

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -24,7 +24,7 @@
 	"dependencies": {
 		"@clerk/backend": "^1.23.7",
 		"@pierre/storage": "^1.1.0",
-		"@rocicorp/zero": "1.4.0",
+		"@rocicorp/zero": "1.5.0",
 		"@supabase/auth-helpers-remix": "^0.2.6",
 		"@supabase/supabase-js": "^2.48.1",
 		"@tldraw/dotcom-shared": "workspace:*",

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -200,14 +200,15 @@ const router = createRouter<Environment>()
 		if (!auth) {
 			return Response.json({ error: 'Unauthorized' }, { status: 401 })
 		}
-		const result = await handleQueryRequest(
-			(name, args) => {
+		const result = await handleQueryRequest({
+			handler: (name, args) => {
 				const query = mustGetQuery(queries, name)
 				return query.fn({ args, ctx: { userId: auth.userId } })
 			},
 			schema,
-			req
-		)
+			request: req,
+			userID: auth.userId,
+		})
 		return json(result)
 	})
 	.all('*', notFound)

--- a/apps/dotcom/zero-cache/package.json
+++ b/apps/dotcom/zero-cache/package.json
@@ -26,7 +26,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "1.4.0",
+		"@rocicorp/zero": "1.5.0",
 		"kysely": "^0.28.12",
 		"pg": "^8.13.1"
 	},

--- a/packages/dotcom-shared/package.json
+++ b/packages/dotcom-shared/package.json
@@ -9,7 +9,7 @@
 	"files": [],
 	"type": "module",
 	"dependencies": {
-		"@rocicorp/zero": "1.4.0",
+		"@rocicorp/zero": "1.5.0",
 		"@tldraw/state": "workspace:*",
 		"@tldraw/store": "workspace:*",
 		"@tldraw/tlschema": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9346,9 +9346,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rocicorp/zero@npm:1.4.0":
-  version: 1.4.0
-  resolution: "@rocicorp/zero@npm:1.4.0"
+"@rocicorp/zero@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@rocicorp/zero@npm:1.5.0"
   dependencies:
     "@badrap/valita": "npm:0.3.11"
     "@databases/escape-identifier": "npm:^1.0.3"
@@ -9419,7 +9419,7 @@ __metadata:
     zero-cache-dev: out/zero/src/zero-cache-dev.js
     zero-deploy-permissions: out/zero/src/deploy-permissions.js
     zero-out: out/zero/src/zero-out.js
-  checksum: 10/a5c7135df3954bb0d1a7b9b8049fff71e88aa74e5ed1371056c1405fbf6c40acc9d2c46aa49a9954c9a6fa7c6b150a518d1d194c5092fa69e25aeb6c62e24f61
+  checksum: 10/dcf15f543e7ed38fc3970307ee3d770ee7c6f0cf6e141c7f7666a38981b95f9d80a95a6da84462aa631d0054fc88b2d90a4a98c98f1df8057000c57a9ea6e870
   languageName: node
   linkType: hard
 
@@ -11881,7 +11881,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/dotcom-shared@workspace:packages/dotcom-shared"
   dependencies:
-    "@rocicorp/zero": "npm:1.4.0"
+    "@rocicorp/zero": "npm:1.5.0"
     "@tldraw/state": "workspace:*"
     "@tldraw/store": "workspace:*"
     "@tldraw/tlschema": "workspace:*"
@@ -11905,7 +11905,7 @@ __metadata:
     "@clerk/backend": "npm:^1.23.7"
     "@cloudflare/workers-types": "npm:^4.20260302.0"
     "@pierre/storage": "npm:^1.1.0"
-    "@rocicorp/zero": "npm:1.4.0"
+    "@rocicorp/zero": "npm:1.5.0"
     "@supabase/auth-helpers-remix": "npm:^0.2.6"
     "@supabase/supabase-js": "npm:^2.48.1"
     "@tldraw/dotcom-shared": "workspace:*"
@@ -12350,7 +12350,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/zero-cache@workspace:apps/dotcom/zero-cache"
   dependencies:
-    "@rocicorp/zero": "npm:1.4.0"
+    "@rocicorp/zero": "npm:1.5.0"
     concurrently: "npm:^9.1.2"
     dotenv: "npm:^16.4.7"
     esbuild: "npm:^0.28.0"
@@ -18077,7 +18077,7 @@ __metadata:
     "@formatjs/cli": "npm:^6.5.1"
     "@formatjs/unplugin": "npm:^1.1.0"
     "@playwright/test": "npm:^1.58.2"
-    "@rocicorp/zero": "npm:1.4.0"
+    "@rocicorp/zero": "npm:1.5.0"
     "@sentry/cli": "npm:^2.41.1"
     "@sentry/integrations": "npm:^7.120.3"
     "@sentry/react": "npm:^7.120.3"


### PR DESCRIPTION
Bumps `@rocicorp/zero` from 1.4.0 to 1.5.0 across the dotcom packages.

### Change type

- [x] `other`

### Test plan

1. CI passes.
2. Verify zero-cache + sync-worker still come up locally.