### PR TITLE
feat(examples): progressive disclosure frame example

### DIFF
--- a/apps/examples/src/examples/shapes/tools/progressive-frame/ProgressiveFrameExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/progressive-frame/ProgressiveFrameExample.tsx
@@ -1,0 +1,427 @@
+import { useEffect } from 'react'
+import {
+	createShapeId,
+	Editor,
+	isShapeId,
+	TLArrowShapeProps,
+	TLComponents,
+	TLGeoShapeProps,
+	TLShapeId,
+	Tldraw,
+	toRichText,
+	useEditor,
+	useValue,
+	VecLike,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import {
+	exitFocusFrame,
+	focusedFrame$,
+	IProgressiveFrameShape,
+	PROGRESSIVE_FRAME_TYPE,
+	ProgressiveFrameShapeUtil,
+} from './ProgressiveFrameShapeUtil'
+
+// There's a guide at the bottom of this file!
+
+// [1]
+const shapeUtils = [ProgressiveFrameShapeUtil]
+
+// [2]
+// Listens for the Escape key while a frame is focused and exits focus mode.
+// Returns null — no visible UI. Escape is the only way out now.
+function EscapeToExit() {
+	const editor = useEditor()
+	const focused = useValue('focused progressive frame', () => focusedFrame$.get(), [])
+
+	useEffect(() => {
+		if (!focused) return
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') {
+				e.preventDefault()
+				e.stopPropagation()
+				exitFocusFrame(editor)
+			}
+		}
+		document.addEventListener('keydown', handler, true)
+		return () => document.removeEventListener('keydown', handler, true)
+	}, [editor, focused])
+
+	return null
+}
+
+const components: TLComponents = {
+	InFrontOfTheCanvas: EscapeToExit,
+}
+
+const tldrawOptions = { createTextOnCanvasDoubleClick: false }
+
+// Top-level layout: one connected architecture diagram. Each rectangle is a
+// progressive frame; arrows between them are top-level shapes that show how the
+// parts of the system relate. Double-click a frame to zoom in and see the
+// sub-diagram for that part.
+const FRAME_W = 560
+const FRAME_H = 320
+
+interface FrameSpec {
+	id: string
+	title: string
+	x: number
+	y: number
+	fill(editor: Editor, parentId: TLShapeId, w: number, h: number): void
+}
+
+const FRAMES: FrameSpec[] = [
+	{ id: 'user', title: 'User', x: 0, y: 480, fill: fillUserFrame },
+	{ id: 'react', title: 'React app', x: 760, y: 480, fill: fillReactFrame },
+	{ id: 'router', title: 'Router', x: 1520, y: 0, fill: fillRouterFrame },
+	{ id: 'store', title: 'State store', x: 1520, y: 960, fill: fillStoreFrame },
+	{ id: 'ui', title: 'UI components', x: 2280, y: 480, fill: fillUiFrame },
+]
+
+// Top-level edges: source frame id → target frame id.
+const FRAME_EDGES: Array<[string, string]> = [
+	['user', 'react'],
+	['react', 'router'],
+	['react', 'store'],
+	['router', 'ui'],
+	['store', 'ui'],
+]
+
+export default function ProgressiveFrameExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={shapeUtils}
+				components={components}
+				options={tldrawOptions}
+				// [3]
+				getShapeVisibility={(shape, editor) => {
+					if (!shape.parentId || !isShapeId(shape.parentId)) return 'inherit'
+					const parent = editor.getShape(shape.parentId)
+					if (!parent || parent.type !== PROGRESSIVE_FRAME_TYPE) return 'inherit'
+					return focusedFrame$.get()?.id === parent.id ? 'inherit' : 'hidden'
+				}}
+				// [4]
+				onMount={(editor) => {
+					const idByKey = new Map<string, TLShapeId>()
+
+					// Create the progressive frames at the top level.
+					for (const spec of FRAMES) {
+						const id = createShapeId(spec.id)
+						idByKey.set(spec.id, id)
+						editor.createShape<IProgressiveFrameShape>({
+							id,
+							type: PROGRESSIVE_FRAME_TYPE,
+							x: spec.x,
+							y: spec.y,
+							props: { w: FRAME_W, h: FRAME_H, title: spec.title },
+						})
+						spec.fill(editor, id, FRAME_W, FRAME_H)
+					}
+
+					// Connect frames with top-level arrows so the canvas reads as one
+					// connected architecture diagram.
+					for (const [fromKey, toKey] of FRAME_EDGES) {
+						const from = FRAMES.find((s) => s.id === fromKey)!
+						const to = FRAMES.find((s) => s.id === toKey)!
+						const fromCenter = { x: from.x + FRAME_W / 2, y: from.y + FRAME_H / 2 }
+						const toCenter = { x: to.x + FRAME_W / 2, y: to.y + FRAME_H / 2 }
+						const { start, end } = edgePoints(from, to, fromCenter, toCenter)
+						createArrow(editor, undefined, start, end, { size: 'l' })
+					}
+
+					editor.zoomToFit({ animation: { duration: 0 } })
+				}}
+			/>
+		</div>
+	)
+}
+
+// Pick start/end points on the source and target frame boundaries that face
+// each other, so arrows look like they connect the rectangles.
+function edgePoints(from: FrameSpec, to: FrameSpec, fromC: VecLike, toC: VecLike) {
+	const dx = toC.x - fromC.x
+	const dy = toC.y - fromC.y
+	const horizontal = Math.abs(dx) >= Math.abs(dy)
+	if (horizontal) {
+		return {
+			start: { x: dx > 0 ? from.x + FRAME_W : from.x, y: fromC.y },
+			end: { x: dx > 0 ? to.x : to.x + FRAME_W, y: toC.y },
+		}
+	}
+	return {
+		start: { x: fromC.x, y: dy > 0 ? from.y + FRAME_H : from.y },
+		end: { x: toC.x, y: dy > 0 ? to.y : to.y + FRAME_H },
+	}
+}
+
+// --- Diagram helpers ---
+
+const NODE_W = 130
+const NODE_H = 60
+
+function nodeEdge(
+	x: number,
+	y: number,
+	side: 'top' | 'right' | 'bottom' | 'left'
+): { x: number; y: number } {
+	switch (side) {
+		case 'top':
+			return { x: x + NODE_W / 2, y }
+		case 'right':
+			return { x: x + NODE_W, y: y + NODE_H / 2 }
+		case 'bottom':
+			return { x: x + NODE_W / 2, y: y + NODE_H }
+		case 'left':
+			return { x, y: y + NODE_H / 2 }
+	}
+}
+
+function createNode(
+	editor: Editor,
+	parentId: TLShapeId,
+	x: number,
+	y: number,
+	label: string,
+	color: TLGeoShapeProps['color'] = 'blue'
+) {
+	editor.createShape({
+		type: 'geo',
+		parentId,
+		x,
+		y,
+		props: {
+			geo: 'rectangle',
+			w: NODE_W,
+			h: NODE_H,
+			color,
+			fill: 'semi',
+			labelColor: 'black',
+			size: 's',
+			richText: toRichText(label),
+		} satisfies Partial<TLGeoShapeProps>,
+	})
+}
+
+function createArrow(
+	editor: Editor,
+	parentId: TLShapeId | undefined,
+	start: VecLike,
+	end: VecLike,
+	opts: { text?: string; size?: TLArrowShapeProps['size'] } = {}
+) {
+	editor.createShape({
+		type: 'arrow',
+		parentId,
+		x: 0,
+		y: 0,
+		props: {
+			start: { x: start.x, y: start.y },
+			end: { x: end.x, y: end.y },
+			color: 'grey',
+			size: opts.size ?? 's',
+			bend: 0,
+			...(opts.text ? { richText: toRichText(opts.text) } : null),
+		} satisfies Partial<TLArrowShapeProps>,
+	})
+}
+
+// --- Sub-diagrams (one per frame) ---
+
+function fillUserFrame(editor: Editor, parentId: TLShapeId, _w: number, _h: number) {
+	const browser = { x: 60, y: 50 }
+	const mobile = { x: 60, y: 210 }
+	const events = { x: 370, y: 50 }
+	const network = { x: 370, y: 210 }
+
+	createNode(editor, parentId, browser.x, browser.y, 'Browser', 'blue')
+	createNode(editor, parentId, mobile.x, mobile.y, 'Mobile device', 'blue')
+	createNode(editor, parentId, events.x, events.y, 'Input events', 'orange')
+	createNode(editor, parentId, network.x, network.y, 'Network', 'green')
+
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(browser.x, browser.y, 'right'),
+		nodeEdge(events.x, events.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(mobile.x, mobile.y, 'right'),
+		nodeEdge(events.x, events.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(events.x, events.y, 'bottom'),
+		nodeEdge(network.x, network.y, 'top')
+	)
+}
+
+function fillReactFrame(editor: Editor, parentId: TLShapeId, _w: number, _h: number) {
+	const tree = { x: 60, y: 50 }
+	const hooks = { x: 60, y: 210 }
+	const effects = { x: 370, y: 50 }
+	const refs = { x: 370, y: 210 }
+	const dom = { x: 215, y: 130 }
+
+	createNode(editor, parentId, tree.x, tree.y, 'Component tree', 'blue')
+	createNode(editor, parentId, hooks.x, hooks.y, 'Hooks', 'violet')
+	createNode(editor, parentId, effects.x, effects.y, 'Effects', 'orange')
+	createNode(editor, parentId, refs.x, refs.y, 'Refs', 'green')
+	createNode(editor, parentId, dom.x, dom.y, 'Virtual DOM', 'red')
+
+	createArrow(editor, parentId, nodeEdge(tree.x, tree.y, 'right'), nodeEdge(dom.x, dom.y, 'left'))
+	createArrow(editor, parentId, nodeEdge(hooks.x, hooks.y, 'right'), nodeEdge(dom.x, dom.y, 'left'))
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(dom.x, dom.y, 'right'),
+		nodeEdge(effects.x, effects.y, 'left')
+	)
+	createArrow(editor, parentId, nodeEdge(dom.x, dom.y, 'right'), nodeEdge(refs.x, refs.y, 'left'))
+}
+
+function fillRouterFrame(editor: Editor, parentId: TLShapeId, _w: number, _h: number) {
+	const url = { x: 60, y: 130 }
+	const matcher = { x: 215, y: 50 }
+	const guards = { x: 215, y: 210 }
+	const loader = { x: 370, y: 130 }
+
+	createNode(editor, parentId, url.x, url.y, 'URL', 'grey')
+	createNode(editor, parentId, matcher.x, matcher.y, 'Route matcher', 'violet')
+	createNode(editor, parentId, guards.x, guards.y, 'Guards', 'red')
+	createNode(editor, parentId, loader.x, loader.y, 'Data loader', 'green')
+
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(url.x, url.y, 'right'),
+		nodeEdge(matcher.x, matcher.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(url.x, url.y, 'right'),
+		nodeEdge(guards.x, guards.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(matcher.x, matcher.y, 'right'),
+		nodeEdge(loader.x, loader.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(guards.x, guards.y, 'right'),
+		nodeEdge(loader.x, loader.y, 'left')
+	)
+}
+
+function fillStoreFrame(editor: Editor, parentId: TLShapeId, _w: number, _h: number) {
+	const action = { x: 60, y: 130 }
+	const reducer = { x: 215, y: 130 }
+	const state = { x: 370, y: 50 }
+	const selector = { x: 370, y: 210 }
+
+	createNode(editor, parentId, action.x, action.y, 'Action', 'orange')
+	createNode(editor, parentId, reducer.x, reducer.y, 'Reducer', 'violet')
+	createNode(editor, parentId, state.x, state.y, 'State tree', 'blue')
+	createNode(editor, parentId, selector.x, selector.y, 'Selectors', 'green')
+
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(action.x, action.y, 'right'),
+		nodeEdge(reducer.x, reducer.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(reducer.x, reducer.y, 'right'),
+		nodeEdge(state.x, state.y, 'left')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(state.x, state.y, 'bottom'),
+		nodeEdge(selector.x, selector.y, 'top')
+	)
+}
+
+function fillUiFrame(editor: Editor, parentId: TLShapeId, _w: number, _h: number) {
+	const layout = { x: 60, y: 50 }
+	const button = { x: 60, y: 210 }
+	const input = { x: 370, y: 50 }
+	const modal = { x: 370, y: 210 }
+	const tokens = { x: 215, y: 130 }
+
+	createNode(editor, parentId, layout.x, layout.y, 'Layout', 'blue')
+	createNode(editor, parentId, button.x, button.y, 'Button', 'green')
+	createNode(editor, parentId, input.x, input.y, 'Input', 'orange')
+	createNode(editor, parentId, modal.x, modal.y, 'Modal', 'red')
+	createNode(editor, parentId, tokens.x, tokens.y, 'Design tokens', 'violet')
+
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(tokens.x, tokens.y, 'top'),
+		nodeEdge(layout.x, layout.y, 'bottom')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(tokens.x, tokens.y, 'top'),
+		nodeEdge(input.x, input.y, 'bottom')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(tokens.x, tokens.y, 'bottom'),
+		nodeEdge(button.x, button.y, 'top')
+	)
+	createArrow(
+		editor,
+		parentId,
+		nodeEdge(tokens.x, tokens.y, 'bottom'),
+		nodeEdge(modal.x, modal.y, 'top')
+	)
+}
+
+/*
+Introduction:
+
+This example shows a custom container shape — a "progressive disclosure frame" — used to build
+a zoomable architecture diagram. The canvas shows one connected diagram: User → React app →
+Router / State store → UI components. Each rectangle is a progressive frame; double-click one
+to zoom in and reveal the sub-diagram for that part of the system. Press "Back to overview" or
+Escape to step out and see the whole diagram again.
+
+[1]
+We register a single custom shape: the progressive frame. See ProgressiveFrameShapeUtil for the
+implementation. It extends BaseFrameLikeShapeUtil so it can hold child shapes and clip them to
+its bounds. It blocks nesting and uses double-click to "zoom in, lock the camera, and reveal
+contents". While focused the frame is hollow for hit-testing so clicks fall through to its
+children; while collapsed it's solid so the double-click registers.
+
+[2]
+The ExitFrameButton renders whenever a frame is focused (tracked via the focusedFrame$ signal
+in ProgressiveFrameShapeUtil, which also stores the camera position from before the
+double-click). Clicking it — or pressing Escape — unlocks the camera, clears the focus, and
+restores the saved camera. We also disable createTextOnCanvasDoubleClick on the editor so
+double-clicking the frame body doesn't try to create a text shape.
+
+[3]
+getShapeVisibility hides every shape whose parent is a progressive frame that isn't currently
+focused. Because the callback reads from focusedFrame$ — itself an atom — the visibility cache
+re-evaluates whenever the focus changes, so children appear and disappear automatically.
+
+[4]
+On mount we lay out five progressive frames at the canvas level in the same shape as a typical
+frontend architecture (User, React app, Router, State store, UI components), connected by
+plain arrows. Inside each frame we draw a small sub-diagram with its own internal components
+and arrows. So you can take in the whole system at a glance, then drill into any piece.
+*/

--- a/apps/examples/src/examples/shapes/tools/progressive-frame/ProgressiveFrameShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/progressive-frame/ProgressiveFrameShapeUtil.tsx
@@ -1,0 +1,288 @@
+import { useEffect } from 'react'
+import {
+	atom,
+	BaseFrameLikeShapeUtil,
+	Editor,
+	Geometry2d,
+	Group2d,
+	HTMLContainer,
+	RecordProps,
+	Rectangle2d,
+	SVGContainer,
+	T,
+	TLBaseShape,
+	TLShape,
+	TLShapeId,
+	useEditor,
+	useUniqueSafeId,
+	useValue,
+} from 'tldraw'
+
+export const PROGRESSIVE_FRAME_TYPE = 'progressive-frame'
+
+// Module-level signal tracking which progressive frame is currently "focused"
+// (zoomed-in with the camera locked), plus the camera position to restore when
+// the user exits focus. Null when no frame is focused.
+export const focusedFrame$ = atom<{
+	id: TLShapeId
+	camera: { x: number; y: number; z: number }
+} | null>('focused progressive frame', null)
+
+export type IProgressiveFrameShape = TLBaseShape<
+	typeof PROGRESSIVE_FRAME_TYPE,
+	{
+		w: number
+		h: number
+		title: string
+	}
+>
+
+declare module 'tldraw' {
+	interface TLGlobalShapePropsMap {
+		[PROGRESSIVE_FRAME_TYPE]: IProgressiveFrameShape['props']
+	}
+}
+
+const progressiveFrameProps: RecordProps<IProgressiveFrameShape> = {
+	w: T.number,
+	h: T.number,
+	title: T.string,
+}
+
+// Zooms in to a frame, locks the camera, and stores the prior camera so we
+// can restore it on exit. Shared between the shape util's onDoubleClick and the
+// title input's onDoubleClick (so double-clicking the title text also zooms,
+// rather than just selecting the word).
+export function zoomToFocusFrame(editor: Editor, shape: IProgressiveFrameShape) {
+	const bounds = editor.getShapePageBounds(shape)
+	if (!bounds) return
+	const prev = editor.getCamera()
+	// The expanded title sits above the frame's top edge (top: -32, ~20px tall),
+	// so extend the zoom bounds upward to keep it inside the viewport.
+	const TITLE_HEADROOM = 40
+	editor.zoomToBounds(
+		{ x: bounds.x, y: bounds.y - TITLE_HEADROOM, w: bounds.w, h: bounds.h + TITLE_HEADROOM },
+		{
+			inset: 50,
+			animation: { duration: 192 },
+		}
+	)
+	editor.setCameraOptions({ isLocked: true })
+	editor.selectNone()
+	editor.updateInstanceState({ isFocusMode: true })
+	focusedFrame$.set({
+		id: shape.id,
+		camera: { x: prev.x, y: prev.y, z: prev.z },
+	})
+}
+
+// Inverse of zoomToFocusFrame: unlocks the camera, clears focus, and restores
+// the saved viewport so the user lands back exactly where they were on the
+// overview.
+export function exitFocusFrame(editor: Editor) {
+	const focused = focusedFrame$.get()
+	if (!focused) return
+	editor.setCameraOptions({ isLocked: false })
+	editor.updateInstanceState({ isFocusMode: false })
+	focusedFrame$.set(null)
+	editor.setCamera(focused.camera, { animation: { duration: 192 } })
+}
+
+export class ProgressiveFrameShapeUtil extends BaseFrameLikeShapeUtil<IProgressiveFrameShape> {
+	static override type = PROGRESSIVE_FRAME_TYPE
+	static override props = progressiveFrameProps
+
+	override getDefaultProps(): IProgressiveFrameShape['props'] {
+		return {
+			w: 720,
+			h: 380,
+			title: 'Untitled topic',
+		}
+	}
+
+	override canResize() {
+		return true
+	}
+
+	// Suppress the selection rectangle / resize handles so the brief selection
+	// that fires before our onDoubleClick (zoom-in) isn't visible. Functionally
+	// the frame may still be selected for a moment, but visually nothing happens.
+	override hideSelectionBoundsBg() {
+		return true
+	}
+	override hideSelectionBoundsFg() {
+		return true
+	}
+	override hideResizeHandles() {
+		return true
+	}
+	override hideRotateHandle() {
+		return true
+	}
+
+	override canReceiveNewChildrenOfType(shape: IProgressiveFrameShape, type: TLShape['type']) {
+		if (type === PROGRESSIVE_FRAME_TYPE) return false
+		return !shape.isLocked
+	}
+
+	// While focused (expanded), keep the default frame-like behavior so the body
+	// is hollow for hit-testing and clicks pass through to children. While
+	// collapsed, return false so the body is solid and interior clicks reach
+	// onDoubleClick (which zooms in and focuses the frame).
+	override isFrameLike(shape: IProgressiveFrameShape) {
+		return focusedFrame$.get()?.id === shape.id
+	}
+
+	// Wrapped in a Group2d because the editor's hit-test code has a frame-like
+	// branch that expects geometry.children to be iterable for shapes that opt
+	// in to special label handling.
+	override getGeometry(shape: IProgressiveFrameShape): Geometry2d {
+		return new Group2d({
+			children: [
+				new Rectangle2d({
+					width: shape.props.w,
+					height: shape.props.h,
+					isFilled: true,
+				}),
+			],
+		})
+	}
+
+	override onDoubleClick(shape: IProgressiveFrameShape) {
+		zoomToFocusFrame(this.editor, shape)
+	}
+
+	override getIndicatorPath(shape: IProgressiveFrameShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+
+	override component(shape: IProgressiveFrameShape) {
+		return <ProgressiveFrameComponent shape={shape} />
+	}
+}
+
+function ProgressiveFrameComponent({ shape }: { shape: IProgressiveFrameShape }) {
+	const editor = useEditor()
+	const focusedId = useValue('focused progressive frame id', () => focusedFrame$.get()?.id, [])
+	const isCollapsed = focusedId !== shape.id
+
+	// Show a pointer cursor while hovering a collapsed frame to signal that it's
+	// clickable / drillable. When focused the frame is hollow for hit-testing, so
+	// hover never targets us anyway.
+	const isHovered = useValue(
+		'progressive frame hover',
+		() => editor.getHoveredShapeId() === shape.id,
+		[editor, shape.id]
+	)
+	useEffect(() => {
+		if (!isHovered || !isCollapsed) return
+		editor.setCursor({ type: 'pointer', rotation: 0 })
+		return () => {
+			editor.setCursor({ type: 'default', rotation: 0 })
+		}
+	}, [editor, isHovered, isCollapsed])
+
+	const updateProp = (patch: Partial<IProgressiveFrameShape['props']>) => {
+		editor.updateShape<IProgressiveFrameShape>({
+			id: shape.id,
+			type: PROGRESSIVE_FRAME_TYPE,
+			props: patch,
+		})
+	}
+
+	const shadowId = useUniqueSafeId('progressive-frame-shadow')
+	return (
+		<>
+			<SVGContainer>
+				<defs>
+					<filter id={shadowId} x="-10%" y="-10%" width="120%" height="130%">
+						<feDropShadow dx="0" dy="6" stdDeviation="8" floodColor="#000" floodOpacity="0.12" />
+					</filter>
+				</defs>
+				<rect
+					width={shape.props.w}
+					height={shape.props.h}
+					rx={12}
+					ry={12}
+					fill="var(--tl-color-panel)"
+					stroke="var(--tl-color-divider)"
+					strokeWidth={1}
+					filter={`url(#${shadowId})`}
+				/>
+			</SVGContainer>
+			<HTMLContainer
+				style={{
+					width: shape.props.w,
+					height: shape.props.h,
+				}}
+			>
+				<FrameTitle shape={shape} isCollapsed={isCollapsed} onChange={updateProp} />
+			</HTMLContainer>
+		</>
+	)
+}
+
+// Single animated title element. The same input slides + scales between the
+// centered "collapsed" position (big, vertically centered inside the frame) and
+// the "expanded" position (small, sitting just above the frame's top edge).
+// Using pixel values for `top` in both states lets CSS transition smoothly.
+function FrameTitle({
+	shape,
+	isCollapsed,
+	onChange,
+}: {
+	shape: IProgressiveFrameShape
+	isCollapsed: boolean
+	onChange(patch: Partial<IProgressiveFrameShape['props']>): void
+}) {
+	const editor = useEditor()
+	const COLLAPSED_INPUT_HEIGHT = 72
+	const EXPANDED_TOP = -32
+
+	return (
+		<input
+			type="text"
+			value={shape.props.title}
+			onChange={(e) => onChange({ title: e.currentTarget.value })}
+			onMouseDown={(e) => {
+				// Native double-click word-selection happens on the SECOND mousedown,
+				// not on the dblclick event — preventing it there is too late. Block
+				// it here when this is the second (or later) click of a sequence.
+				if (e.detail >= 2) e.preventDefault()
+				e.stopPropagation()
+			}}
+			onPointerDown={(e) => e.stopPropagation()}
+			onPointerUp={(e) => e.stopPropagation()}
+			onDoubleClick={(e) => {
+				e.preventDefault()
+				e.stopPropagation()
+				// Belt-and-braces: clear any selection that slipped through and
+				// blur the input so it doesn't capture caret state.
+				window.getSelection()?.removeAllRanges()
+				e.currentTarget.blur()
+				if (isCollapsed) zoomToFocusFrame(editor, shape)
+			}}
+			placeholder="Title"
+			style={{
+				position: 'absolute',
+				left: 0,
+				width: '100%',
+				top: isCollapsed ? (shape.props.h - COLLAPSED_INPUT_HEIGHT) / 2 : EXPANDED_TOP,
+				fontSize: isCollapsed ? 56 : 18,
+				fontWeight: 700,
+				textAlign: 'center',
+				color: 'var(--tl-color-text)',
+				background: 'transparent',
+				border: 'none',
+				outline: 'none',
+				padding: 0,
+				margin: 0,
+				pointerEvents: 'all',
+				fontFamily: 'var(--tl-font-sans, system-ui, sans-serif)',
+				transition: 'top 220ms ease, font-size 220ms ease',
+			}}
+		/>
+	)
+}

--- a/apps/examples/src/examples/shapes/tools/progressive-frame/README.md
+++ b/apps/examples/src/examples/shapes/tools/progressive-frame/README.md
@@ -1,0 +1,21 @@
+---
+title: Progressive disclosure frame
+component: ./ProgressiveFrameExample.tsx
+priority: 5
+keywords: [progressive, disclosure, level of detail, lod, zoom, frame, container, custom shape]
+---
+
+A custom container shape that shows only a short description when zoomed out, and reveals its contents when you double-click to zoom in.
+
+---
+
+The progressive disclosure frame is a custom shape that lets you explore a canvas at different levels of detail. When the frame is small on screen it shows a title and a one-line description. Double-click the frame and the camera zooms in to fit it — once the frame is large enough on screen, its contents become visible. Zoom out again and the contents are hidden, returning the frame to its summary state.
+
+This example demonstrates a few tldraw building blocks working together:
+
+- A custom shape that extends `BaseFrameLikeShapeUtil`, so it can hold and clip child shapes like a regular frame.
+- A double-click handler that calls `editor.zoomToBounds` to animate the camera to fit the shape.
+- The `getShapeVisibility` editor option, which reactively hides child shapes while their parent frame is below a screen-size threshold.
+- Inline text inputs for the title and description, with pointer events stopped so editing them doesn't fight the canvas.
+
+The frame blocks nesting to keep the model simple — you can drag any other shape into a progressive frame, but not another progressive frame.


### PR DESCRIPTION
Part of our internal hackathon.

https://github.com/user-attachments/assets/a25b6abb-a80c-40e4-8752-04e8ef3abeb7


In order to demonstrate level-of-detail patterns on a tldraw canvas, this PR adds a new example that defines a custom frame shape with progressive disclosure: when the frame is small on screen it shows just a title and a one-line description; double-clicking zooms in to fit the frame, and once it's large enough its child shapes become visible. Zooming out collapses it back to the summary view.

The example demonstrates a few tldraw building blocks working together:

- A custom shape extending `BaseFrameLikeShapeUtil` so it can hold and clip child shapes like a regular frame.
- A double-click handler that calls `editor.zoomToBounds` to animate the camera to fit the shape.
- The `getShapeVisibility` editor option, which reactively hides child shapes while their parent frame is below a screen-size threshold.
- Inline text inputs for the title and description, with pointer events stopped so editing them doesn't fight the canvas.

The frame blocks nesting to keep the model simple — you can drag any other shape into a progressive frame, but not another progressive frame.

### Change type

- [x] `other` (example only)

### Test plan

1. Run \`yarn dev\` and open the "Progressive disclosure frame" example.
2. Verify the canvas shows a top-level system diagram of frames with arrows between them.
3. Double-click any frame and confirm the camera zooms to fit it and the child shapes become visible.
4. Zoom out (or press escape) and confirm the contents hide again and the title/description return.
5. Edit a frame's title/description inline — confirm editing doesn't fight the canvas and double-click word-selection is suppressed.
6. Try dragging a regular shape into a frame (allowed) and another progressive frame into one (blocked).

### Release notes

- Added a new "Progressive disclosure frame" example showing how to build a level-of-detail container shape.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Documentation   | +736 / -0  |