### PR TITLE
fix(tldraw): style panel dropdown sizing and offset

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3646,6 +3646,7 @@ export interface StylePanelDropdownPickerProps<T extends string> {
     label?: Exclude<string, TLUiTranslationKey> | TLUiTranslationKey;
     // (undocumented)
     onValueChange?(style: StyleProp<T>, value: T): void;
+    sideOffset?: number;
     // (undocumented)
     style: StyleProp<T>;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1137,6 +1137,12 @@ tldraw? probably.
 	border-bottom: 1px solid var(--tl-color-divider);
 }
 
+.tlui-toolbar-toggle-group-item,
+.tlui-style-panel__dropdown-picker > .tlui-button__icon {
+	width: 40px;
+	padding: 0;
+}
+
 .tlui-style-panel__dropdown-picker:only-child {
 	flex: 1;
 }

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -172,6 +172,7 @@ export function StylePanelFillPicker() {
 					style={DefaultFillStyle}
 					items={STYLES.fillExtra}
 					value={fill}
+					sideOffset={116}
 				/>
 			</TldrawUiToolbar>
 		</>
@@ -316,6 +317,7 @@ export function StylePanelLabelAlignPicker() {
 						style={DefaultVerticalAlignStyle}
 						items={STYLES.verticalAlign}
 						value={verticalLabelAlign}
+						sideOffset={116}
 					/>
 				)}
 			</TldrawUiToolbar>

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -28,6 +28,8 @@ export interface StylePanelDropdownPickerProps<T extends string> {
 	onValueChange?(style: StyleProp<T>, value: T): void
 	/** Override the test ID prefix. Defaults to uiType. */
 	testIdType?: string
+	/** Distance to push the popover left of the trigger so it lands flush with the style panel. */
+	sideOffset?: number
 }
 
 function StylePanelDropdownPickerInner<T extends string>(props: StylePanelDropdownPickerProps<T>) {
@@ -57,6 +59,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 		value,
 		onValueChange = ctx.onValueChange,
 		testIdType = uiType,
+		sideOffset = 0,
 	} = props
 	const msg = useTranslation()
 	const editor = useEditor()
@@ -95,7 +98,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 					<TldrawUiButtonIcon icon={icon as TLUiIconType} />
 				</TldrawUiToolbarButton>
 			</TldrawUiPopoverTrigger>
-			<TldrawUiPopoverContent side="left" align="center" sideOffset={0}>
+			<TldrawUiPopoverContent side="left" align="center" sideOffset={sideOffset}>
 				<TldrawUiToolbar orientation={items.length > 4 ? 'grid' : 'horizontal'} label={labelStr}>
 					<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
 						{items.map((item) => {

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -95,7 +95,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 					<TldrawUiButtonIcon icon={icon as TLUiIconType} />
 				</TldrawUiToolbarButton>
 			</TldrawUiPopoverTrigger>
-			<TldrawUiPopoverContent side="left" align="center">
+			<TldrawUiPopoverContent side="left" align="center" sideOffset={0}>
 				<TldrawUiToolbar orientation={items.length > 4 ? 'grid' : 'horizontal'} label={labelStr}>
 					<TldrawUiMenuContextProvider type="icons" sourceId="style-panel">
 						{items.map((item) => {


### PR DESCRIPTION
In order to keep the style panel dropdown triggers visually aligned with adjacent toolbar buttons and have their popovers open consistently against the panel, this PR fixes the icon button sizing for dropdown triggers, removes the default side offset for standalone dropdowns, and pushes the inline `fill-extra` and `vertical-align` popovers out to the left edge of the panel — matching how arrowhead and other standalone dropdown popovers already behave.

- Sets a consistent 40px width and zero padding for toolbar toggle group items and style panel dropdown picker icons.
- Passes `sideOffset={0}` to standalone dropdown popovers (geo, arrow kind, spline) so they open flush against the trigger.
- Adds an optional `sideOffset` prop to `StylePanelDropdownPicker` and uses it to push the inline `fill-extra` and `vertical-align` popovers to the left of the style panel.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app and select a shape that surfaces style panel dropdowns (e.g. an arrow to see arrowhead pickers, or a geo shape to see dash/fill/size pickers).
2. Verify the dropdown trigger buttons match the size of adjacent toolbar toggle buttons.
3. Open each style-panel dropdown (geo, arrow kind, spline, arrowheads, fill-extra, vertical-align) and verify the popover opens to the left of the style panel rather than over the panel itself.

- [ ] Unit tests
- [ ] End to end tests

### API changes

- Added optional `sideOffset` prop to `StylePanelDropdownPickerProps` for tuning popover position when the trigger isn't at the panel's left edge.

### Release notes

- Fix sizing and offset for style panel dropdown buttons so fill pattern and vertical alignment popovers open left of the style panel.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +13 / -2   |
| Automated files | +1 / -0    |