### PR TITLE
fix(docs): skip workerd postinstall self-check on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,17 @@
 		"our examples app depenends on pdf.js which pulls in canvas as an optional dependency.",
 		"it slows down installs quite a bit though, so we replace it with an empty package."
 	],
+	"// dependenciesMeta.workerd": [
+		"workerd's postinstall script runs the native binary to self-check it, which fails on",
+		"CI images without GLIBC 2.35+ (e.g. Vercel, which builds the docs site). Skipping the",
+		"build script doesn't affect wrangler at dev time — wrangler still invokes the platform",
+		"binary normally on developer machines."
+	],
+	"dependenciesMeta": {
+		"workerd": {
+			"built": false
+		}
+	},
 	"resolutions": {
 		"domino@^2.1.6": "patch:domino@npm%3A2.1.6#./.yarn/patches/domino-npm-2.1.6-b0dc3de857.patch",
 		"canvas": "npm:empty-npm-package@1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12045,6 +12045,9 @@ __metadata:
     vite-plugin-circular-dependency: "npm:^0.5.0"
     vitest: "npm:^3.2.4"
     vitest-canvas-mock: "npm:^1.1.3"
+  dependenciesMeta:
+    workerd:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
### Problem

Spotted on https://github.com/tldraw/tldraw/pull/8665 that I should have merged, we get errors when trying to build docs in preview 

### Root cause

- `#8256` bumped wrangler, which resolved `workerd` to `1.20260317.1`.
- `workerd` 2026 builds require **GLIBC 2.35+**.
- Vercel's build image is **Amazon Linux 2023 (GLIBC 2.34)** and AWS hasn't shipped a successor, so we can't bump it.
- `workerd`'s postinstall script self-checks the native binary by running it. On Vercel that exits non-zero and `yarn install` fails.

### Why nobody noticed for two months

- PR previews mostly skipped the docs build via `should-build-docs.sh`, which gates on `git diff HEAD^ HEAD ./apps/docs` (the tip-commit diff, not the full PR diff).
- `main` and production *always* build per the same script — so docs deploys to `tldraw.dev` have actually been failing for ~2 months. Vercel kept serving the last successful build, which is why the site looked fine while silently going stale.

### Fix

Add `dependenciesMeta.workerd.built: false` to the root `package.json` so Yarn skips workerd's postinstall self-check at install time. This is safe because:

- On Vercel, `workerd` is never invoked at runtime — only `next build` runs there.
- On developer machines, `wrangler dev` still spawns the platform `workerd` binary normally; this opt-out only disables the install-time self-check, not the binary itself.
- Cloudflare-hosted workers run on Cloudflare's own infrastructure, not our locally installed `workerd`.

One line in root `package.json` with a JSON comment in the same style as the existing `// resolutions.canvas` block.

### Change type

- [x] `bugfix`

### Test plan

1. Open a PR with a change to `apps/docs/` and confirm the Vercel docs preview install step gets past the workerd postinstall.
2. On merge, confirm the docs production deploy succeeds and `tldraw.dev` picks up the change.

### Release notes

- Internal only; no user-facing change.