### PR TITLE
fix(tldraw): pattern fill exports broken in dark mode

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -8,6 +8,7 @@ import {
 	last,
 	suffixSafeId,
 	tlenv,
+	useColorMode,
 	useEditor,
 	useSharedSafeId,
 	useUniqueSafeId,
@@ -31,7 +32,7 @@ function HashPatternForExport() {
 	const getHashPatternZoomName = useGetHashPatternZoomName()
 	const maskId = useUniqueSafeId()
 	const editor = useEditor()
-	const colorMode = editor.getColorMode()
+	const colorMode = useColorMode()
 	const colors = editor.getCurrentTheme().colors[colorMode]
 	const t = 8 / 12
 	return (

--- a/packages/tldraw/src/test/commands/getSvgString.test.ts
+++ b/packages/tldraw/src/test/commands/getSvgString.test.ts
@@ -106,6 +106,25 @@ it('Accepts a scale option', async () => {
 	expect(svg2.width).toBe(1128)
 })
 
+it.each([
+	{ darkMode: false, label: 'light mode' },
+	{ darkMode: true, label: 'dark mode' },
+])('emits matching pattern id and reference in $label export', async ({ darkMode }) => {
+	const result = parseSvg(await editor.getSvgString([ids.boxC], { darkMode }))
+
+	const patternIds = Array.from(result.querySelectorAll('pattern')).map((p) => p.id)
+	expect(patternIds.length).toBeGreaterThan(0)
+
+	const fillUrlIds = Array.from(result.querySelectorAll('path'))
+		.map((p) => p.getAttribute('fill')?.match(/^url\(#(.+)\)$/)?.[1])
+		.filter((id): id is string => Boolean(id))
+	expect(fillUrlIds.length).toBeGreaterThan(0)
+
+	for (const id of fillUrlIds) {
+		expect(patternIds).toContain(id)
+	}
+})
+
 it('Accepts a background option', async () => {
 	const svg1 = parseSvg(
 		await editor.getSvgString(editor.getSelectedShapeIds(), { background: true })


### PR DESCRIPTION
In order to make pattern fills export correctly under `darkMode: true`, this PR fixes `HashPatternForExport` to read the color mode from the SVG export context instead of the editor. Before this fix, when the editor's color mode differed from the requested export color mode (e.g. light editor + `darkMode: true`), the `<pattern>` was emitted with the editor's color-mode id while the shape's `fill="url(#...)"` referenced the export's color-mode id, leaving the pattern broken.

Resolves #8854.

### Why the ids drifted

SVG export wraps the rendered shape tree in `SvgExportContextProvider` (see `getSvgJsx.tsx`). That context carries the export's effective `colorMode`, derived from `opts.darkMode ?? editor.getColorMode()`. The `useColorMode()` hook is wired to honor this:

```ts
export function useColorMode(): 'light' | 'dark' {
  const editor = useEditor()
  const exportContext = useSvgExportContext()
  return useValue(
    'colorMode',
    () => {
      if (exportContext) return exportContext.colorMode
      return editor.getColorMode()
    },
    [exportContext, editor]
  )
}
```

So inside an export render, `useColorMode()` returns the *export's* mode, while `editor.getColorMode()` keeps returning the editor's own mode. `PatternFill` already used `useColorMode()` to build the `fill="url(#...)"` reference, but `HashPatternForExport` was reading `editor.getColorMode()` directly to emit the `<pattern>` def, which is how the two sides could disagree.

The bug only surfaces in production-style setups because in local dev the editor often happens to match the requested mode (e.g. dev environment in dark mode); in headless/CLI exports the editor is left in light mode while `darkMode: true` is passed.

### Change type

- [x] `bugfix`

### Test plan

1. Create a geo shape with `fill: 'pattern'`.
2. Call `editor.toImage([id], { format: 'svg', darkMode: true })` from a light-mode editor.
3. The exported SVG should render the hash pattern (not a missing fill).

- [x] Unit tests

### Release notes

- Fix pattern fill exports broken in dark mode when the editor was in light mode (and vice versa).