### PR TITLE
feat(tldraw): double-click arrowhead buttons to toggle them on or off

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDoubleDropdownPicker.tsx
@@ -66,6 +66,8 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 	const msg = useTranslation()
 	const [isOpenA, setIsOpenA] = React.useState(false)
 	const [isOpenB, setIsOpenB] = React.useState(false)
+	const lastValueARef = React.useRef<T | null>(null)
+	const lastValueBRef = React.useRef<T | null>(null)
 
 	const iconA = React.useMemo(
 		() =>
@@ -84,6 +86,31 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 
 	const idA = `style panel ${uiTypeA} A`
 	const idB = `style panel ${uiTypeB} B`
+
+	const handleToggle = (
+		style: StyleProp<T>,
+		value: SharedStyle<T>,
+		items: StyleValuesForUi<T>,
+		lastValueRef: React.RefObject<T | null>,
+		id: string,
+		setIsOpen: (open: boolean) => void
+	) => {
+		if (value?.type !== 'shared') return
+		const current = value.value
+		let next: T | undefined
+		if (current === ('none' as T)) {
+			next =
+				lastValueRef.current ??
+				(items.find((i) => i.value !== ('none' as T))?.value as T | undefined)
+		} else {
+			lastValueRef.current = current
+			next = 'none' as T
+		}
+		if (next === undefined) return
+		onValueChange(style, next)
+		tlmenus.deleteOpenMenu(id, editor.contextId)
+		setIsOpen(false)
+	}
 	return (
 		<>
 			<TldrawUiPopover id={idA} open={isOpenA} onOpenChange={setIsOpenA}>
@@ -97,6 +124,9 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 							(valueA === null || valueA.type === 'mixed'
 								? msg('style-panel.mixed')
 								: msg(`${uiTypeA}-style.${valueA.value}` as TLUiTranslationKey))
+						}
+						onDoubleClick={() =>
+							handleToggle(styleA, valueA, itemsA, lastValueARef, idA, setIsOpenA)
 						}
 					>
 						<TldrawUiButtonIcon icon={iconA} small invertIcon />
@@ -137,6 +167,9 @@ function StylePanelDoubleDropdownPickerInlineInner<T extends string>(
 							(valueB === null || valueB.type === 'mixed'
 								? msg('style-panel.mixed')
 								: msg(`${uiTypeB}-style.${valueB.value}` as TLUiTranslationKey))
+						}
+						onDoubleClick={() =>
+							handleToggle(styleB, valueB, itemsB, lastValueBRef, idB, setIsOpenB)
 						}
 					>
 						<TldrawUiButtonIcon icon={iconB} small />

--- a/packages/tldraw/src/test/ui/StylePanel.test.tsx
+++ b/packages/tldraw/src/test/ui/StylePanel.test.tsx
@@ -1,5 +1,11 @@
-import { act, screen, waitFor } from '@testing-library/react'
-import { DefaultColorStyle, Editor } from '@tldraw/editor'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import {
+	ArrowShapeArrowheadEndStyle,
+	ArrowShapeArrowheadStartStyle,
+	createShapeId,
+	DefaultColorStyle,
+	Editor,
+} from '@tldraw/editor'
 import { Tldraw } from '../../lib/Tldraw'
 import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
 
@@ -41,6 +47,95 @@ describe('StylePanel', () => {
 
 		await waitFor(() => {
 			expect(getBlackColorSwatch().style.color).toBe('rgb(29, 29, 29)')
+		})
+	})
+
+	describe('arrowhead double-click toggle', () => {
+		async function setupArrow() {
+			const id = createShapeId()
+			act(() => {
+				editor.createShape({
+					id,
+					type: 'arrow',
+					props: {
+						start: { x: 0, y: 0 },
+						end: { x: 100, y: 100 },
+						arrowheadStart: 'none',
+						arrowheadEnd: 'arrow',
+					},
+				})
+				editor.setSelectedShapes([id])
+			})
+			await screen.findByTestId('style.arrowheadStart')
+			await screen.findByTestId('style.arrowheadEnd')
+			return id
+		}
+
+		function getArrowheads(id: ReturnType<typeof createShapeId>) {
+			const shape = editor.getShape(id) as any
+			return {
+				start: shape.props.arrowheadStart as string,
+				end: shape.props.arrowheadEnd as string,
+			}
+		}
+
+		it('toggles arrowhead end to none on double-click', async () => {
+			const id = await setupArrow()
+			expect(getArrowheads(id).end).toBe('arrow')
+
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadEnd'))
+
+			expect(getArrowheads(id).end).toBe('none')
+		})
+
+		it('restores the previous arrowhead end value on a second double-click', async () => {
+			const id = await setupArrow()
+			act(() => {
+				editor.updateShape({ id, type: 'arrow', props: { arrowheadEnd: 'triangle' } })
+			})
+			expect(getArrowheads(id).end).toBe('triangle')
+
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadEnd'))
+			expect(getArrowheads(id).end).toBe('none')
+
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadEnd'))
+			expect(getArrowheads(id).end).toBe('triangle')
+		})
+
+		it('restores arrowhead end to a default when no previous value is remembered', async () => {
+			const id = await setupArrow()
+			act(() => {
+				editor.updateShape({ id, type: 'arrow', props: { arrowheadEnd: 'none' } })
+			})
+			expect(getArrowheads(id).end).toBe('none')
+
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadEnd'))
+
+			expect(getArrowheads(id).end).toBe('arrow')
+		})
+
+		it('toggles arrowhead start independently of arrowhead end', async () => {
+			const id = await setupArrow()
+			act(() => {
+				editor.updateShape({ id, type: 'arrow', props: { arrowheadStart: 'triangle' } })
+			})
+			expect(getArrowheads(id)).toEqual({ start: 'triangle', end: 'arrow' })
+
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadStart'))
+
+			expect(getArrowheads(id)).toEqual({ start: 'none', end: 'arrow' })
+		})
+
+		it('uses the editor style props after toggling', async () => {
+			const id = await setupArrow()
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadEnd'))
+			expect(editor.getStyleForNextShape(ArrowShapeArrowheadEndStyle)).toBe('none')
+
+			fireEvent.doubleClick(screen.getByTestId('style.arrowheadStart'))
+			expect(editor.getStyleForNextShape(ArrowShapeArrowheadStartStyle)).toBe('arrow')
+
+			// Reads the shape state too
+			expect(getArrowheads(id)).toEqual({ start: 'arrow', end: 'none' })
 		})
 	})
 })


### PR DESCRIPTION
In order to make iterating on arrow styles faster, this PR adds a double-click toggle to the start and end arrowhead buttons in the style panel. Double-clicking sets the arrowhead to `none` and stashes the previous value; double-clicking again restores the stashed value (or the first non-`none` item in the picker — `arrow` — if nothing has been stashed yet).

Closes #8815.

### Change type

- [x] `feature`

### Test plan

1. Open the examples app and draw an arrow.
2. With the arrow selected, double-click the end arrowhead button in the style panel — the arrowhead should disappear.
3. Double-click it again — the previous arrowhead style should return.
4. Pick a different arrowhead from the dropdown, double-click to toggle off, then double-click to toggle back on — the most recently picked style should return.
5. Repeat with the start arrowhead button; confirm start and end toggle independently.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Double-clicking the arrowhead start/end buttons in the style panel now toggles the arrowhead on or off, remembering the previous value when toggling back on.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +33 / -0   |
| Tests     | +97 / -2   |