### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -5,5 +5,23 @@ author: tldraw
 date: 05/06/2026
 order: 0
 status: published
-last_version: v5.0.0
+last_version: v5.0.1
 ---
+
+This release redesigns the page menu around inline interaction, adds a `selectLockedShapes` option for inspecting locked shapes, and fixes a misleading "expired" banner for perpetual licenses, along with other UI and licensing bug fixes.
+
+## What's new
+
+### Page menu redesign ([#8836](https://github.com/tldraw/tldraw/pull/8836))
+
+The page menu no longer has an explicit edit mode. Reorder pages by dragging a row directly, rename inline by double-clicking the label or pressing Enter, and drag the new resize handle at the bottom of the popover to adjust the list height — the height is persisted across sessions and a double-click on the handle resets it to the default. The current page is now indicated by a subtle background pill, the row submenu trigger reveals on hover, and the "Create new page" button is pinned to the footer of the popover.
+
+## API changes
+
+- Add a `selectLockedShapes` option to `TldrawOptions`. When enabled, locked shapes can be selected by left click or by brush/scribble selection while remaining protected from edits, moves, and deletes. ([#8860](https://github.com/tldraw/tldraw/pull/8860))
+
+## Bug fixes
+
+- Fix a misleading "license expired" console warning for perpetual licenses on covered versions. ([#8791](https://github.com/tldraw/tldraw/pull/8791))
+- Fix inconsistent tooltip behavior on the video toolbar by using `TldrawUiToolbarButton` for the replace and download buttons. ([#8794](https://github.com/tldraw/tldraw/pull/8794))
+- Fix the missing open-state hint on the page menu and zoom menu triggers when rendered outside the main toolbar. ([#8813](https://github.com/tldraw/tldraw/pull/8813))


### PR DESCRIPTION
In order to keep the next release notes current with `main`, this PR updates `apps/docs/content/releases/next.mdx` with PRs that have landed since v5.0.1. It bumps `last_version` from v5.0.0 to v5.0.1 (no archive needed — v5.0.0 is already archived and v5.0.1 is a patch) and adds new entries for the page menu redesign, the `selectLockedShapes` option, the perpetual-license expired warning fix, the video toolbar tooltip fix, and the page/zoom menu open-state hint fix. These are preliminary — source is `main`, so some entries may be pruned later if they don't make it onto production.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +19 / -1   |