### PR TITLE
fix(github): remove invalid title field from issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: File a bug report
 type: Bug
-title: ''
 labels: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/example_request.yml
+++ b/.github/ISSUE_TEMPLATE/example_request.yml
@@ -1,7 +1,5 @@
 name: Example request
 description: Submit a request for an example
-type: Example
-title: ''
 labels: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: Suggest a new feature or improvement
 type: Feature
-title: ''
 labels: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,7 +1,6 @@
 name: Task
 description: Create a task
 type: Task
-title: ''
 labels: []
 assignees: []
 body:


### PR DESCRIPTION
## Summary

Fixes #8869. YAML issue form templates fail GitHub validation because of `title: ''` — empty strings are not allowed for the `title` key per [GitHub's docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms). When validation fails, templates are hidden from the new issue chooser.

- Removed `title: ''` from all four templates.
- Removed `type: Example` from `example_request.yml` — Bug, Feature, and Task are configured org issue types, but Example is not.
- Kept `type: Bug|Feature|Task` in the other three templates (these are valid; recent issues like #8898, #8894, #8889 carry these types).

### Change type

- [x] `bugfix`

## Test plan

- [ ] All four templates appear in the new issue chooser on GitHub
- [ ] No validation banner shown when viewing template files on GitHub
- [ ] Submit a test bug report successfully and confirm Bug type is applied