### PR TITLE
fix(repo): make issue form templates appear in new issue chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,9 +1,5 @@
 name: Bug report
 description: File a bug report
-type: Bug
-title: ''
-labels: []
-assignees: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/example_request.yml
+++ b/.github/ISSUE_TEMPLATE/example_request.yml
@@ -1,9 +1,5 @@
 name: Example request
 description: Submit a request for an example
-type: Example
-title: ''
-labels: []
-assignees: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,9 +1,5 @@
 name: Feature request
 description: Suggest a new feature or improvement
-type: Feature
-title: ''
-labels: []
-assignees: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,9 +1,5 @@
 name: Task
 description: Create a task
-type: Task
-title: ''
-labels: []
-assignees: []
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
## Summary

The four YAML issue forms in `.github/ISSUE_TEMPLATE/` are currently hidden from GitHub's **New issue** chooser because they fail GitHub's form validation. Contributors only see the blank-issue option and the contact links from `config.yml`.

Each template has two invalid keys:

- `type: <Bug|Feature|Example|Task>` — `type` is only a permitted top-level key when the org has Issue Types configured. `tldraw` does not use them, so GitHub treats this as an unexpected top-level key. ([docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#input-is-not-a-permitted-key))
- `title: ''` — empty strings are explicitly disallowed for `title`. ([docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/common-validation-errors-when-creating-issue-forms#key-must-be-a-string))

This PR removes the invalid `type` and empty `title` / `labels` / `assignees` keys from `bug_report.yml`, `example_request.yml`, `feature_request.yml`, and `task.yml`. All `body:` content (fields, ids, labels, required flags) is unchanged.

Net change: 16 deletions across 4 files, 0 additions.

Closes #8869

### Change type

- [x] `other`

## Test plan

- [ ] After merge, visit https://github.com/tldraw/tldraw/issues/new/choose and confirm Bug report, Example request, Feature request, and Task all appear
- [ ] Open each template file on GitHub and confirm no "Critical" validation banner
- [ ] Submit a test bug report end-to-end to confirm the body fields still render correctly