### PR TITLE
fix(ci): stop e2e workflows triggering on docs-only changes

### DIFF
--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -21,22 +21,33 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.fork == false }}
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      relevant: ${{ steps.includes.outputs.match == 'true' && steps.nondocs.outputs.match == 'true' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Check for relevant changes
+      - name: Check for changes to relevant paths
         uses: dorny/paths-filter@v3
-        id: filter
+        id: includes
         with:
           filters: |
-            relevant:
+            match:
               - 'packages/**'
               - 'apps/dotcom/**'
               - '.github/workflows/playwright-dotcom.yml'
               - '.github/actions/**'
               - 'yarn.lock'
+
+      - name: Check for any non-doc changes
+        uses: dorny/paths-filter@v3
+        id: nondocs
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            match:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
 
   build:
     name: 'End to end tests (dotcom)'

--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -37,8 +37,6 @@ jobs:
               - '.github/workflows/playwright-dotcom.yml'
               - '.github/actions/**'
               - 'yarn.lock'
-              - '!**/*.md'
-              - '!**/*.mdx'
 
   build:
     name: 'End to end tests (dotcom)'

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -35,8 +35,6 @@ jobs:
               - '.github/workflows/playwright-examples.yml'
               - '.github/actions/**'
               - 'yarn.lock'
-              - '!**/*.md'
-              - '!**/*.mdx'
 
   build:
     name: 'End to end tests (examples)'

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -19,22 +19,33 @@ jobs:
     name: 'Check for relevant changes'
     runs-on: ubuntu-latest
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      relevant: ${{ steps.includes.outputs.match == 'true' && steps.nondocs.outputs.match == 'true' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Check for relevant changes
+      - name: Check for changes to relevant paths
         uses: dorny/paths-filter@v3
-        id: filter
+        id: includes
         with:
           filters: |
-            relevant:
+            match:
               - 'packages/**'
               - 'apps/examples/**'
               - '.github/workflows/playwright-examples.yml'
               - '.github/actions/**'
               - 'yarn.lock'
+
+      - name: Check for any non-doc changes
+        uses: dorny/paths-filter@v3
+        id: nondocs
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            match:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
 
   build:
     name: 'End to end tests (examples)'

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -19,22 +19,33 @@ jobs:
     name: 'Check for relevant changes'
     runs-on: ubuntu-latest
     outputs:
-      relevant: ${{ steps.filter.outputs.relevant }}
+      relevant: ${{ steps.includes.outputs.match == 'true' && steps.nondocs.outputs.match == 'true' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v6
 
-      - name: Check for relevant changes
+      - name: Check for changes to relevant paths
         uses: dorny/paths-filter@v3
-        id: filter
+        id: includes
         with:
           filters: |
-            relevant:
+            match:
               - 'packages/**'
               - 'apps/examples/**'
               - '.github/workflows/playwright-perf.yml'
               - '.github/actions/**'
               - 'yarn.lock'
+
+      - name: Check for any non-doc changes
+        uses: dorny/paths-filter@v3
+        id: nondocs
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            match:
+              - '**'
+              - '!**/*.md'
+              - '!**/*.mdx'
 
   build:
     name: 'End to end tests (perf)'

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -35,8 +35,6 @@ jobs:
               - '.github/workflows/playwright-perf.yml'
               - '.github/actions/**'
               - 'yarn.lock'
-              - '!**/*.md'
-              - '!**/*.mdx'
 
   build:
     name: 'End to end tests (perf)'


### PR DESCRIPTION
In order to stop the dotcom, examples, and perf e2e workflows from running on PRs that don't touch their dependencies (for example, docs-only PRs or markdown-only changes inside `packages/`), this PR splits each workflow's relevance check into two `dorny/paths-filter` steps and ANDs the results in the job's `outputs:` expression.

Closes #8878

### Why the previous filter misbehaved

`dorny/paths-filter@v3` defaults to `predicate-quantifier: some`, so the filter returns `true` if **any** listed pattern matches. Under that quantifier, a negation like `!**/*.md` matches every file that isn't a `.md` — including `.mdx` files. A docs-only change to `apps/docs/content/releases/next.mdx` therefore matched `!**/*.md` and tripped the filter, even though no positive include matched it.

### Why one filter isn't enough

`dorny/paths-filter` only supports `predicate-quantifier: some | every` (it's a per-step option, not per-filter). Under `every`, every listed pattern must match for a file to count, which doesn't combine with multiple positive includes like `packages/**` **or** `apps/dotcom/**` — no single file is in both. So we use two steps and combine.

### How the new check works

Per workflow:

- `includes` (default `some`): true if any changed file is in a relevant path (`packages/**`, `apps/dotcom/**` or `apps/examples/**`, the workflow file itself, `.github/actions/**`, `yarn.lock`).
- `nondocs` (`predicate-quantifier: 'every'` with `['**', '!**/*.md', '!**/*.mdx']`): a file is included only if it matches `**` and is not `.md` and not `.mdx`, so the filter is true iff at least one non-markdown file changed.

`relevant = includes && nondocs`, evaluated in the job's `outputs:` expression. Behavior:

| PR contents | `includes` | `nondocs` | `relevant` |
| --- | --- | --- | --- |
| `apps/docs/content/foo.mdx` only | false | false | **false** (skip) |
| `packages/foo/README.md` only | true | false | **false** (skip) |
| `packages/foo/src/index.ts` only | true | true | **true** (run) |
| `packages/foo/src/index.ts` + `apps/docs/foo.mdx` | true | true | **true** (run, code change wins) |

### Change type

- [x] `other`

### Test plan

1. Open a PR that only changes `apps/docs/content/releases/next.mdx`. Confirm each of `End to end tests (dotcom)`, `End to end tests (examples)`, and `End to end tests (perf)` reports both filter steps and resolves `relevant = false`, and the matching `build` job is skipped.
2. Open a PR that only changes a `packages/**/README.md`. Confirm the same three workflows skip the `build` job (`includes = true`, `nondocs = false`).
3. Open a PR that changes a relevant code file (e.g. anything under `packages/<x>/src/`, `apps/dotcom/`, `apps/examples/`, the workflow file, `.github/actions/`, or `yarn.lock`). Confirm the corresponding e2e workflow still runs.
4. Open a PR that mixes a code change with a docs/markdown change. Confirm the workflow still runs (the code change satisfies `nondocs`).

### Release notes

- Internal CI fix; no user-facing changes.