### PR TITLE
fix(docs): include component code in Copy markdown output

### DIFF
--- a/apps/docs/scripts/lib/connect.ts
+++ b/apps/docs/scripts/lib/connect.ts
@@ -74,6 +74,7 @@ export async function connect(opts: { reset?: boolean; mode: 'readonly' | 'readw
 			date TEXT,
 			sourceUrl TEXT,
 			componentCode TEXT,
+			componentCodeFilename TEXT,
 			componentCodeFiles TEXT,
 			keywords TEXT,
 			apiTags TEXT,

--- a/apps/docs/utils/addContent.ts
+++ b/apps/docs/utils/addContent.ts
@@ -41,6 +41,7 @@ export async function addContentToDb(
       date,
       sourceUrl,
 			componentCode,
+			componentCodeFilename,
 			componentCodeFiles,
       keywords,
 	  apiTags,
@@ -48,7 +49,7 @@ export async function addContentToDb(
 			path,
 			embed,
 			githubLink
-    ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ) VALUES ( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 	)
 
 	for (let i = 0; i < content.sections.length; i++) {
@@ -112,6 +113,7 @@ export async function addContentToDb(
 				article.date,
 				article.sourceUrl,
 				article.componentCode,
+				article.componentCodeFilename,
 				article.componentCodeFiles,
 				article.keywords.join(', '),
 				article.apiTags,


### PR DESCRIPTION
Closes #8823

The Copy markdown button on docs example pages (e.g. https://tldraw.dev/examples/z-order) was leaving out the main component file. You'd get the description prose plus any additional code files (like `z-order.css`), but the actual `App.tsx` / `ZOrderExample.tsx` was missing.

### Change type

- [x] `other`

### Root cause

`buildFullMarkdown` in `apps/docs/components/docs/docs-header.tsx` gates the main component on both fields:

```ts
if (article.componentCode && article.componentCodeFilename) {
    codeFiles.push({ name: article.componentCodeFilename, content: article.componentCode })
}
```

The article type has `componentCodeFilename`, and `generateSection.ts` populates it when reading the example folder, but the SQLite articles table is missing that column and the INSERT in `addContent.ts` never passes it. So at read time it was always `undefined`, the guard failed, and the main file was silently dropped — only the additional code files survived.

### Fix

- Add `componentCodeFilename TEXT` to the `articles` schema in `apps/docs/scripts/lib/connect.ts`.
- Include `componentCodeFilename` in the INSERT column list and bind `article.componentCodeFilename` in `apps/docs/utils/addContent.ts`.

### Test plan

- [ ] `yarn refresh-content` (or rebuild the docs DB) so the new column is created and populated.
- [ ] `yarn dev-docs`, open http://localhost:3000/examples/z-order, click "Copy markdown", and confirm the clipboard now contains a fenced `tsx` block with `// ZOrderExample.tsx` and the component source, in addition to the prose and `z-order.css` block.
- [ ] Repeat on another example with extra files (e.g. anything in `editor-api/`) to confirm both the main file and additional files appear.