### PR TITLE
perf(tldraw): lazy-load video shape elements

### DIFF
--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -24,6 +24,14 @@ import { HyperlinkButton } from '../shared/HyperlinkButton'
 import { useImageOrVideoAsset } from '../shared/useImageOrVideoAsset'
 import { usePrefersReducedMotion } from '../shared/usePrefersReducedMotion'
 
+// HTML now supports `loading="lazy"` on <video> and <audio> (Chrome 148+). React's
+// types haven't caught up yet, so we extend MediaHTMLAttributes here.
+declare module 'react' {
+	interface MediaHTMLAttributes<T> {
+		loading?: 'eager' | 'lazy'
+	}
+}
+
 const videoSvgExportCache = new WeakCache<TLAsset, Promise<string | null>>()
 
 /** @public */
@@ -213,6 +221,7 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 									autoPlay={shape.props.autoplay && !prefersReducedMotion}
 									muted
 									loop
+									loading="lazy"
 									disableRemotePlayback
 									disablePictureInPicture
 									controls={isEditing && showControls}


### PR DESCRIPTION
In order to reduce unnecessary network usage when a tldraw canvas contains many videos — especially when the canvas itself is embedded below the page fold — this PR adds `loading="lazy"` to the `<video>` element rendered by `VideoShapeUtil`. Browsers that support it (Chrome 148+ at time of writing, per [the Chrome 148 release notes](https://developer.chrome.com/blog/new-in-chrome-148)) will defer the underlying network request until the video is near the browser viewport. Browsers that don't support the attribute silently ignore it.

The attribute complements the editor's existing shape culling: culling hides shapes outside the camera viewport (`display: none`), but `loading="lazy"` additionally handles shapes that are inside the camera viewport but still outside the browser viewport. The two reinforce each other.

React's `@types/react` v19 doesn't include `loading` on `MediaHTMLAttributes` yet (only on `img` and `iframe`), so a tiny `declare module 'react'` augmentation is added alongside the usage.

### Module augmentation

```ts
declare module 'react' {
	interface MediaHTMLAttributes<T> {
		loading?: 'eager' | 'lazy'
	}
}
```

### Change type

- [x] `improvement`

### Test plan

1. In a Chromium 148+ browser, open a tldraw canvas containing video shapes positioned outside the browser viewport (e.g. below the page fold via an embedding `<iframe>` or wrapper) and confirm those videos don't fetch their source until they're scrolled into view.
2. Confirm existing behaviour is unchanged: muted-autoplay videos still autoplay once they're in view; editing/playing controls still appear on click.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Defer video shape loading until videos are near the browser viewport, in browsers that support `loading="lazy"` on `<video>`.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -0    |