### PR TITLE
fix(tldraw): export TldrawUiTranslationProvider and dedupe missing-translation warning

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -478,7 +478,7 @@ export const ASPECT_RATIO_TO_VALUE: Record<ASPECT_RATIO_OPTION, number>;
 // @public (undocumented)
 export function AssetToolbarItem(): JSX.Element;
 
-// @internal (undocumented)
+// @public
 export function AssetUrlsProvider({ assetUrls, children }: {
     assetUrls: TLUiAssetUrls;
     children: React.ReactNode;
@@ -4364,7 +4364,7 @@ export interface TldrawUiTooltipProviderProps {
     children: React_3.ReactNode;
 }
 
-// @internal
+// @public
 export function TldrawUiTranslationProvider({ overrides, locale, children }: TLUiTranslationProviderProps): JSX.Element;
 
 // @public (undocumented)
@@ -6309,7 +6309,7 @@ export function useA11y(): TLUiA11yContextType;
 // @public (undocumented)
 export function useActions(): TLUiActionsContextType;
 
-// @internal (undocumented)
+// @public (undocumented)
 export function useAssetUrls(): TLUiAssetUrls;
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -7,7 +7,12 @@ type UiAssetUrlsContextType = TLUiAssetUrls | null
 
 const AssetUrlsContext = createContext<UiAssetUrlsContextType>(null)
 
-/** @internal */
+/**
+ * Provides asset URLs (icons, fonts, translations, embed icons) to the editor's UI.
+ * Required when using `TldrawUiTranslationProvider` without `TldrawUiContextProvider`.
+ *
+ * @public @react
+ */
 export function AssetUrlsProvider({
 	assetUrls,
 	children,
@@ -37,7 +42,7 @@ export function AssetUrlsProvider({
 	return <AssetUrlsContext.Provider value={assetUrls}>{children}</AssetUrlsContext.Provider>
 }
 
-/** @internal */
+/** @public */
 export function useAssetUrls() {
 	const assetUrls = useContext(AssetUrlsContext)
 	if (!assetUrls) {

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -36,9 +36,11 @@ export function useCurrentTranslation() {
 }
 
 /**
- * Provides a translation context to the editor.
+ * Provides a translation context to the editor. Wrap this around components that use
+ * `useTranslation` (such as `TldrawSelectionForeground`) when you don't want to use the
+ * full `TldrawUiContextProvider`. Must be rendered inside an `AssetUrlsProvider`.
  *
- * @internal
+ * @public @react
  */
 export function TldrawUiTranslationProvider({
 	overrides,
@@ -97,6 +99,8 @@ export function TldrawUiTranslationProvider({
 	)
 }
 
+let hasWarnedAboutMissingTranslations = false
+
 /**
  * Returns a function to translate a translation key into a string based on the current translation.
  *
@@ -114,8 +118,11 @@ export function useTranslation() {
 	const messages = translation?.messages ?? DEFAULT_TRANSLATION
 
 	React.useEffect(() => {
-		if (!translation?.messages) {
-			console.warn('No translation messages found, falling back to default translation.')
+		if (!translation?.messages && !hasWarnedAboutMissingTranslations) {
+			hasWarnedAboutMissingTranslations = true
+			console.warn(
+				'No translation messages found, falling back to default translation. Wrap your app in <TldrawUiContextProvider> or <TldrawUiTranslationProvider> to provide translations.'
+			)
 		}
 	}, [translation?.messages])
 

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -1,3 +1,4 @@
+import { warnOnce } from '@tldraw/editor'
 import * as React from 'react'
 import { useAssetUrls } from '../../context/asset-urls'
 import { DEFAULT_TRANSLATION } from './defaultTranslation'
@@ -99,8 +100,6 @@ export function TldrawUiTranslationProvider({
 	)
 }
 
-let hasWarnedAboutMissingTranslations = false
-
 /**
  * Returns a function to translate a translation key into a string based on the current translation.
  *
@@ -118,10 +117,9 @@ export function useTranslation() {
 	const messages = translation?.messages ?? DEFAULT_TRANSLATION
 
 	React.useEffect(() => {
-		if (!translation?.messages && !hasWarnedAboutMissingTranslations) {
-			hasWarnedAboutMissingTranslations = true
-			console.warn(
-				'No translation messages found, falling back to default translation. Wrap your app in <TldrawUiContextProvider> or <TldrawUiTranslationProvider> to provide translations.'
+		if (!translation?.messages) {
+			warnOnce(
+				'No translation messages found, falling back to default translation. Wrap your app in <TldrawUiContextProvider>, or in both <AssetUrlsProvider> and <TldrawUiTranslationProvider>, to provide translations.'
 			)
 		}
 	}, [translation?.messages])


### PR DESCRIPTION
In order to let consumers render components like `TldrawSelectionForeground` without pulling in the full `TldrawUiContextProvider` (and its icon preloading), this PR promotes `TldrawUiTranslationProvider`, `AssetUrlsProvider`, and `useAssetUrls` from `@internal` to `@public`. It also deduplicates the "No translation messages found" warning so it only logs once per session instead of once per component that calls `useTranslation`, and rewords the message to point developers at `TldrawUiTranslationProvider` as an alternative.

Closes #6236

Consumers can now do:

```tsx
<AssetUrlsProvider assetUrls={...}>
  <TldrawUiTranslationProvider locale="en">
    <TldrawSelectionForeground ... />
  </TldrawUiTranslationProvider>
</AssetUrlsProvider>
```

### Change type

- [x] `bugfix`

### Test plan

1. Render a component that uses `useTranslation` (e.g. `TldrawSelectionForeground`) outside of `TldrawUiContextProvider`.
2. Confirm the "No translation messages found" warning prints **once**, not once per consumer.
3. Wrap the same component in `<AssetUrlsProvider><TldrawUiTranslationProvider locale="en">` and confirm the warning is silenced and translations resolve.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Export `TldrawUiTranslationProvider`, `AssetUrlsProvider`, and `useAssetUrls` as public API so `TldrawSelectionForeground` and similar components can be used without `TldrawUiContextProvider`.
- Only log the missing-translation warning once per session instead of once per `useTranslation` consumer.

### API changes

- Changed `TldrawUiTranslationProvider` from `@internal` to `@public @react`.
- Changed `AssetUrlsProvider` from `@internal` to `@public @react`.
- Changed `useAssetUrls` from `@internal` to `@public`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +18 / -6   |
| Automated files | +3 / -3    |