### PR TITLE
fix(editor): guard preventDefault against non-cancelable events

### DIFF
--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -35,6 +35,7 @@ export function loopToHtmlElement(elm: Element): HTMLElement {
  * @public
  */
 export function preventDefault(event: React.BaseSyntheticEvent | Event) {
+	if ('cancelable' in event && !event.cancelable) return
 	event.preventDefault()
 	if (debugFlags.logPreventDefaults.get()) {
 		console.warn('preventDefault called on event:', event)


### PR DESCRIPTION
In order to avoid intermittent `Unable to preventDefault inside passive event listener` console errors, this PR guards our `preventDefault` helper against non-cancelable events. Some events (notably touch events on passive listeners, and certain synthetic/scroll events) report `cancelable: false`; calling `preventDefault()` on them is a no-op that also logs an error in the browser.

The helper now early-returns when `'cancelable' in event && !event.cancelable`, matching the standard guard pattern.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app and interact with the canvas (touch/scroll/wheel events).
2. Confirm no `Unable to preventDefault inside passive event listener` errors appear in the console.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Avoid console errors from calling `preventDefault` on non-cancelable events.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -0    |