### PR TITLE
fix(tldraw): show context menu in non-select tools

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -1126,7 +1126,7 @@ export { DefaultContextMenu as ContextMenu }
 export { DefaultContextMenu }
 
 // @public (undocumented)
-export function DefaultContextMenuContent(): JSX.Element | null;
+export function DefaultContextMenuContent(): JSX.Element;
 
 // @public (undocumented)
 export function DefaultDebugMenu({ children }: TLUiDebugMenuProps): JSX.Element;

--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenuContent.tsx
@@ -17,16 +17,9 @@ export function DefaultContextMenuContent() {
 	const editor = useEditor()
 	const showCollaborationUi = useShowCollaborationUi()
 
-	const selectToolActive = useValue(
-		'isSelectToolActive',
-		() => editor.getCurrentToolId() === 'select',
-		[editor]
-	)
 	const isSinglePageMode = useValue('isSinglePageMode', () => editor.options.maxPages <= 1, [
 		editor,
 	])
-
-	if (!selectToolActive) return null
 
 	return (
 		<>

--- a/packages/tldraw/src/test/ui/ContextMenu.test.tsx
+++ b/packages/tldraw/src/test/ui/ContextMenu.test.tsx
@@ -23,6 +23,23 @@ it('opens on right-click', async () => {
 	expect(screen.queryByTestId('context-menu')).toBeNull()
 })
 
+it('opens on right-click when a non-select tool is active', async () => {
+	await renderTldrawComponent(
+		<Tldraw
+			onMount={(editor) => {
+				editor.createShape({ id: createShapeId(), type: 'geo' })
+				editor.setCurrentTool('draw')
+			}}
+		/>,
+		{ waitForPatterns: false }
+	)
+	const canvas = await screen.findByTestId('canvas')
+
+	fireEvent.contextMenu(canvas)
+	await screen.findByTestId('context-menu')
+	await screen.findByTestId('context-menu.select-all')
+})
+
 it('tunnels context menu', async () => {
 	const components: TLComponents = {
 		ContextMenu: (props) => {


### PR DESCRIPTION
In order to fix #8828, this PR removes the blanket `if (!selectToolActive) return null` guard at the top of `DefaultContextMenuContent`. Right-clicking the canvas while any non-select tool (draw, eraser, hand, etc.) was active opened an empty context menu. Each submenu inside the context menu already self-hides when not applicable — `EditMenuSubmenu`, `ArrangeMenuSubmenu`, and `ReorderMenuSubmenu` short-circuit when there is no selection; `ConversionsMenuGroup` short-circuits when there are no shapes on the page; `SelectAllMenuItem` disables itself when the page is empty. With the outer guard removed, the menu now renders in any tool and useful items like Select All, Paste, and the export/conversion actions are reachable without first switching to the select tool.

### Change type

- [x] `bugfix`

### Test plan

1. Run the examples app and switch to any non-select tool (draw, eraser, hand, etc.).
2. Right-click on the canvas.
3. The context menu should open with the items that apply to the current state (e.g. Select All, Paste, and any export/conversion actions for shapes on the page).
4. Add a shape, switch back to a non-select tool, right-click on the shape, and confirm the appropriate per-selection items also appear.

- [x] Unit tests

### Release notes

- Fixed the context menu being empty when right-clicking the canvas while any non-select tool was active.

### API changes

- `DefaultContextMenuContent` return type narrowed from `JSX.Element | null` to `JSX.Element` (it no longer returns `null`).

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +0 / -7    |
| Tests           | +17 / -0   |
| Automated files | +1 / -1    |