### PR TITLE
fix(tldraw):  fix dbl clicking over grouped shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
+++ b/packages/tldraw/src/lib/shapes/note/noteCloning.test.ts
@@ -335,6 +335,10 @@ it('Puts the new shape into a frame based on its center', () => {
 })
 
 function testNoteShapeFrameRotations(sourceRotation: number, rotation: number) {
+	// This helper runs several times per test; reset the click state so the
+	// next handle pointer-down starts a fresh click sequence instead of
+	// coalescing with the previous call into a double-click.
+	editor.cancelDoubleClick()
 	editor.createShape({ type: 'frame', x: 1220, y: 1000, rotation: rotation })
 	const frameA = editor.getLastCreatedShape()!
 	// top left won't be in the frame, but the center will (barely but yes)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -367,9 +367,9 @@ export class Idle extends StateNode {
 						// The shape is a child of a group that the user hasn't
 						// drilled into yet (it's outside the focused group and
 						// not an ancestor of it). The user's double-click is a
-						// drill action, not an edit action: select the right
-						// shape via `selectOnCanvasPointerUp` and stop.
-						selectOnCanvasPointerUp(this.editor, info)
+						// drill action, not an edit action: drill one level and
+						// stop.
+						this.drillIntoGroupOnDoubleClick(hitShape)
 						return
 					}
 
@@ -404,6 +404,10 @@ export class Idle extends StateNode {
 					this.editor.isShapeOfType(parent, 'group') &&
 					!this.isGroupInPreviousDrillContext(parent.id)
 				) {
+					// The shape is a child of a group the user hasn't drilled into
+					// yet. Treat the double-click as a drill action — drill one
+					// level — but don't start editing.
+					this.drillIntoGroupOnDoubleClick(onlySelectedShape)
 					break
 				}
 
@@ -480,6 +484,10 @@ export class Idle extends StateNode {
 					this.editor.isShapeOfType(parent, 'group') &&
 					!this.isGroupInPreviousDrillContext(parent.id)
 				) {
+					// The shape is a child of a group the user hasn't drilled into
+					// yet. Treat the double-click as a drill action — drill one
+					// level — but don't start editing.
+					this.drillIntoGroupOnDoubleClick(shape)
 					break
 				}
 
@@ -783,6 +791,64 @@ export class Idle extends StateNode {
 		// focused group, so a shape whose parent is `groupId` is at the
 		// user's effective level (e.g. siblings of the inner focused group).
 		return this.editor.hasAncestor(focusedGroup, groupId)
+	}
+
+	/**
+	 * Drill exactly one level into a group on double-click: select the shape
+	 * one level deeper than a single click would.
+	 *
+	 * A single click from a given focus selects that focus's child on the path
+	 * down to `hitShape`; a double-click should select one level deeper. We
+	 * compute both **structurally** from the focused group captured at the
+	 * start of the click sequence (`focusedGroupIdBeforePointerDown`) rather
+	 * than from the live focused group. The live focus is unreliable here: the
+	 * first click of the double-click has already drilled and moved the focused
+	 * group, so reading it now (or asking `getOutermostSelectableShape`, which
+	 * reads it internally) drills an inconsistent number of levels — e.g. a
+	 * shape nested two groups below the focused group would jump straight to the
+	 * leaf instead of stepping in one level.
+	 *
+	 * The focused group follows the selection automatically (see the
+	 * selection-change reactor in `Editor`), so we only need to select.
+	 */
+	private drillIntoGroupOnDoubleClick(hitShape: TLShape) {
+		const snapshotFocus = this.focusedGroupIdBeforePointerDown ?? this.editor.getCurrentPageId()
+
+		// The outermost *selectable group* ancestor of `hitShape` below the
+		// captured focus — i.e. what a single click selects. We count levels by
+		// group, not raw parent, so non-group parents (e.g. frames) don't act as
+		// a drill level.
+		let outermostGroup: TLShape | null = null
+		let node = this.editor.getShapeParent(hitShape)
+		while (node && node.id !== snapshotFocus) {
+			if (this.editor.isShapeOfType(node, 'group')) outermostGroup = node
+			node = this.editor.getShapeParent(node)
+		}
+		if (!outermostGroup) return
+
+		// One level deeper than the single-click selection: the child of that
+		// group on the path down to `hitShape` (which is `hitShape` itself when
+		// the group directly contains it, or the next nested group when it
+		// doesn't).
+		const target = this.getChildOnPathToShape(outermostGroup.id, hitShape) ?? hitShape
+
+		if (!this.editor.getSelectedShapeIds().includes(target.id)) {
+			this.editor.markHistoryStoppingPoint('drilling into group')
+			this.editor.select(target.id)
+		}
+	}
+
+	/**
+	 * Returns the ancestor-or-self of `shape` whose direct parent is
+	 * `ancestorId`, or `null` if `ancestorId` is not an ancestor of `shape`.
+	 */
+	private getChildOnPathToShape(ancestorId: TLShapeId | TLPageId, shape: TLShape): TLShape | null {
+		let node: TLShape | undefined = shape
+		while (node) {
+			if (node.parentId === ancestorId) return node
+			node = this.editor.getShapeParent(node)
+		}
+		return null
 	}
 
 	private startEditingShape(

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -310,7 +310,7 @@ export class Idle extends StateNode {
 
 				// todo
 				// double clicking on the middle of a hollow geo shape without a label, or
-				// over the label of a hollwo shape that has a label, should start editing
+				// over the label of a hollow shape that has a label, should start editing
 				// that shape's label. We can't support "double click anywhere inside"
 				// of the shape yet because that also creates text shapes, and can produce
 				// unexpected results when working "inside of" a hollow shape.
@@ -368,65 +368,75 @@ export class Idle extends StateNode {
 			case 'selection': {
 				const onlySelectedShape = this.editor.getOnlySelectedShape()
 
-				if (onlySelectedShape) {
-					const util = this.editor.getShapeUtil(onlySelectedShape)
-					const isEdge =
-						info.handle === 'right' ||
-						info.handle === 'left' ||
-						info.handle === 'top' ||
-						info.handle === 'bottom'
-					const isCorner =
-						info.handle === 'top_left' ||
-						info.handle === 'top_right' ||
-						info.handle === 'bottom_right' ||
-						info.handle === 'bottom_left'
+				if (!onlySelectedShape) {
+					break
+				}
 
-					if (this.editor.getIsReadonly()) {
-						// includes readonly check
-						if (
-							this.editor.canEditShape(onlySelectedShape, {
-								type: isCorner
-									? 'double-click-corner'
-									: isEdge
-										? 'double-click-edge'
-										: 'double-click',
-							})
-						) {
-							this.startEditingShape(onlySelectedShape, info, true /* select all */)
-						}
-						break
-					}
+				const parent = this.editor.getShapeParent(onlySelectedShape)
+				const isParentGroup = parent ? this.editor.isShapeOfType(parent, 'group') : false
 
-					// Test edges for an onDoubleClickEdge handler
-					if (isEdge) {
-						const change = util.onDoubleClickEdge?.(onlySelectedShape, info)
-						if (change) {
-							this.editor.markHistoryStoppingPoint('double click edge')
-							this.editor.updateShapes([change])
-							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
-							return
-						}
-					}
+				if (isParentGroup) {
+					this.editor.setSelectedShapes([onlySelectedShape])
+					break
+				}
 
-					if (isCorner) {
-						const change = util.onDoubleClickCorner?.(onlySelectedShape, info)
-						if (change) {
-							this.editor.markHistoryStoppingPoint('double click corner')
-							this.editor.updateShapes([change])
-							kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
-							return
-						}
-					}
+				const util = this.editor.getShapeUtil(onlySelectedShape)
+				const isEdge =
+					info.handle === 'right' ||
+					info.handle === 'left' ||
+					info.handle === 'top' ||
+					info.handle === 'bottom'
+				const isCorner =
+					info.handle === 'top_left' ||
+					info.handle === 'top_right' ||
+					info.handle === 'bottom_right' ||
+					info.handle === 'bottom_left'
 
-					// For corners OR edges but NOT rotation corners
-					if (this.editor.canCropShape(onlySelectedShape)) {
-						this.parent.transition('crop', info)
-						return
-					}
-
-					if (this.editor.canEditShape(onlySelectedShape)) {
+				if (this.editor.getIsReadonly()) {
+					// includes readonly check
+					if (
+						this.editor.canEditShape(onlySelectedShape, {
+							type: isCorner
+								? 'double-click-corner'
+								: isEdge
+									? 'double-click-edge'
+									: 'double-click',
+						})
+					) {
 						this.startEditingShape(onlySelectedShape, info, true /* select all */)
 					}
+					break
+				}
+
+				// Test edges for an onDoubleClickEdge handler
+				if (isEdge) {
+					const change = util.onDoubleClickEdge?.(onlySelectedShape, info)
+					if (change) {
+						this.editor.markHistoryStoppingPoint('double click edge')
+						this.editor.updateShapes([change])
+						kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
+						return
+					}
+				}
+
+				if (isCorner) {
+					const change = util.onDoubleClickCorner?.(onlySelectedShape, info)
+					if (change) {
+						this.editor.markHistoryStoppingPoint('double click corner')
+						this.editor.updateShapes([change])
+						kickoutOccludedShapes(this.editor, [onlySelectedShape.id])
+						return
+					}
+				}
+
+				// For corners OR edges but NOT rotation corners
+				if (this.editor.canCropShape(onlySelectedShape)) {
+					this.parent.transition('crop', info)
+					return
+				}
+
+				if (this.editor.canEditShape(onlySelectedShape)) {
+					this.startEditingShape(onlySelectedShape, info, true /* select all */)
 				}
 				break
 			}
@@ -436,6 +446,14 @@ export class Idle extends StateNode {
 
 				// Allow playing videos and embeds
 				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
+
+				const parent = this.editor.getShapeParent(shape)
+				const isParentGroup = parent ? this.editor.isShapeOfType(parent, 'group') : false
+
+				if (isParentGroup) {
+					this.editor.setSelectedShapes([shape])
+					break
+				}
 
 				if (util.onDoubleClick) {
 					// Call the shape's double click handler

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -1,11 +1,14 @@
 import {
+	ClickManager,
 	Editor,
 	StateNode,
 	TLAdjacentDirection,
 	TLClickEventInfo,
 	TLKeyboardEventInfo,
+	TLPageId,
 	TLPointerEventInfo,
 	TLShape,
+	TLShapeId,
 	Vec,
 	VecLike,
 	createShapeId,
@@ -41,6 +44,15 @@ export class Idle extends StateNode {
 
 	selectedShapesOnKeyDown: TLShape[] = []
 
+	// Snapshot of `getFocusedGroupId()` captured at the first pointer-down of
+	// the current potential multi-click sequence. Used by `onDoubleClick` to
+	// distinguish "user was already drilled into the group" from "user is
+	// drilling in right now". Without this snapshot the two cases look
+	// identical at `onDoubleClick` time, because the second click's
+	// `onPointerUp` drills in and sets the focused group before the synthetic
+	// `double_click` event fires.
+	private focusedGroupIdBeforePointerDown: TLShapeId | TLPageId | null = null
+
 	override onEnter() {
 		this.parent.setCurrentToolIdMask(undefined)
 		this.editor.setCursor({ type: 'default', rotation: 0 })
@@ -67,6 +79,21 @@ export class Idle extends StateNode {
 	}
 
 	override onPointerDown(info: TLPointerEventInfo) {
+		// Snapshot the focused group id at the *start* of a potential
+		// multi-click sequence so that `onDoubleClick` can later distinguish
+		// "user was already drilled into the group" from "user is drilling in
+		// right now". The drilling happens in `pointing_shape.onPointerUp`,
+		// after this point, and would otherwise make the two cases
+		// indistinguishable.
+		//
+		// `ClickManager.handlePointerEvent` has already advanced the click
+		// state for this pointer-down before we get here, so `pendingDouble`
+		// means this *is* the first click of a fresh sequence (idle ->
+		// pendingDouble). Subsequent clicks would be pendingTriple or later.
+		if (this.getClickManager().clickState === 'pendingDouble') {
+			this.focusedGroupIdBeforePointerDown = this.editor.getFocusedGroupId()
+		}
+
 		switch (info.target) {
 			case 'canvas': {
 				// Check overlays first — if we hit an overlay, re-dispatch as an overlay event
@@ -373,11 +400,16 @@ export class Idle extends StateNode {
 				}
 
 				const parent = this.editor.getShapeParent(onlySelectedShape)
-				const isParentGroup = parent ? this.editor.isShapeOfType(parent, 'group') : false
-
-				if (isParentGroup) {
-					this.editor.setSelectedShapes([onlySelectedShape])
-					break
+				if (parent && this.editor.isShapeOfType(parent, 'group')) {
+					// Only allow the double-click through when the user had
+					// already drilled into this group *before* the click that
+					// triggered this double-click. Otherwise the second click
+					// of a drilling sequence (which is what set this group as
+					// the focused group in the first place) would also enter
+					// editing — see the snapshot captured in `onPointerDown`.
+					if (parent.id !== this.focusedGroupIdBeforePointerDown) {
+						break
+					}
 				}
 
 				const util = this.editor.getShapeUtil(onlySelectedShape)
@@ -448,11 +480,16 @@ export class Idle extends StateNode {
 				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
 
 				const parent = this.editor.getShapeParent(shape)
-				const isParentGroup = parent ? this.editor.isShapeOfType(parent, 'group') : false
-
-				if (isParentGroup) {
-					this.editor.setSelectedShapes([shape])
-					break
+				if (parent && this.editor.isShapeOfType(parent, 'group')) {
+					// Only allow the double-click through when the user had
+					// already drilled into this group *before* the click that
+					// triggered this double-click. Otherwise the second click
+					// of a drilling sequence (which is what set this group as
+					// the focused group in the first place) would also enter
+					// editing — see the snapshot captured in `onPointerDown`.
+					if (parent.id !== this.focusedGroupIdBeforePointerDown) {
+						break
+					}
 				}
 
 				if (util.onDoubleClick) {
@@ -716,6 +753,14 @@ export class Idle extends StateNode {
 				break
 			}
 		}
+	}
+
+	private getClickManager(): ClickManager {
+		// `_clickManager` is a protected property of `Editor`. We need to read
+		// its click state to detect the start of a multi-click sequence; the
+		// `ClickManager` class itself is exported as public API. See the
+		// snapshot logic in `onPointerDown` / `onDoubleClick` for the why.
+		return (this.editor as unknown as { _clickManager: ClickManager })._clickManager
 	}
 
 	private startEditingShape(

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -368,9 +368,10 @@ export class Idle extends StateNode {
 						// drilled into yet (it's outside the focused group and
 						// not an ancestor of it). The user's double-click is a
 						// drill action, not an edit action: drill one level and
-						// stop.
-						this.drillIntoGroupOnDoubleClick(hitShape)
-						return
+						// stop. If there was nothing left to drill (already
+						// selected), fall through to the re-dispatch below so the
+						// shape can be edited.
+						if (this.drillIntoGroupOnDoubleClick(hitShape)) return
 					}
 
 					// Either there's no group parent, or the group parent is
@@ -406,9 +407,9 @@ export class Idle extends StateNode {
 				) {
 					// The shape is a child of a group the user hasn't drilled into
 					// yet. Treat the double-click as a drill action — drill one
-					// level — but don't start editing.
-					this.drillIntoGroupOnDoubleClick(onlySelectedShape)
-					break
+					// level — but don't start editing. If there was nothing left
+					// to drill (already selected), fall through to editing.
+					if (this.drillIntoGroupOnDoubleClick(onlySelectedShape)) break
 				}
 
 				const util = this.editor.getShapeUtil(onlySelectedShape)
@@ -486,9 +487,9 @@ export class Idle extends StateNode {
 				) {
 					// The shape is a child of a group the user hasn't drilled into
 					// yet. Treat the double-click as a drill action — drill one
-					// level — but don't start editing.
-					this.drillIntoGroupOnDoubleClick(shape)
-					break
+					// level — but don't start editing. If there was nothing left
+					// to drill (already selected), fall through to editing.
+					if (this.drillIntoGroupOnDoubleClick(shape)) break
 				}
 
 				if (util.onDoubleClick) {
@@ -811,8 +812,9 @@ export class Idle extends StateNode {
 	 * The focused group follows the selection automatically (see the
 	 * selection-change reactor in `Editor`), so we only need to select.
 	 */
-	private drillIntoGroupOnDoubleClick(hitShape: TLShape) {
-		const snapshotFocus = this.focusedGroupIdBeforePointerDown ?? this.editor.getCurrentPageId()
+	private drillIntoGroupOnDoubleClick(hitShape: TLShape): boolean {
+		const pageId = this.editor.getCurrentPageId()
+		const snapshotFocus = this.focusedGroupIdBeforePointerDown ?? pageId
 
 		// The outermost *selectable group* ancestor of `hitShape` below the
 		// captured focus — i.e. what a single click selects. We count levels by
@@ -824,7 +826,7 @@ export class Idle extends StateNode {
 			if (this.editor.isShapeOfType(node, 'group')) outermostGroup = node
 			node = this.editor.getShapeParent(node)
 		}
-		if (!outermostGroup) return
+		if (!outermostGroup) return true
 
 		// One level deeper than the single-click selection: the child of that
 		// group on the path down to `hitShape` (which is `hitShape` itself when
@@ -835,7 +837,27 @@ export class Idle extends StateNode {
 		if (!this.editor.getSelectedShapeIds().includes(target.id)) {
 			this.editor.markHistoryStoppingPoint('drilling into group')
 			this.editor.select(target.id)
+			return true
 		}
+
+		// The drill target is already selected — there's nothing left to drill
+		// at this step. If the double-click has reached the actual clicked shape
+		// *and* the gesture began already drilled into a group, treat it as an
+		// edit: fall through so the caller can start editing. This keeps a
+		// drill-through consistent across click cadences — at "fast"/"slow"
+		// speeds the final click reaches `PointingShape` and edits, but at
+		// "moderate" speeds the ClickManager re-parses it as a double-click,
+		// which would otherwise be swallowed here as a no-op.
+		//
+		// When the gesture began from outside every group (focus was the page),
+		// this is instead a first double-click into the group, which should only
+		// select the shape (see issue #8898), so we keep the no-op.
+		const startedDrilledIntoGroup = snapshotFocus !== pageId
+		if (target.id === hitShape.id && startedDrilledIntoGroup) {
+			return false
+		}
+
+		return true
 	}
 
 	/**

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -356,27 +356,26 @@ export class Idle extends StateNode {
 						// Probably select the shape
 						selectOnCanvasPointerUp(this.editor, info)
 						return
-					} else {
-						const parent = this.editor.getShape(hitShape.parentId)
-						if (parent && this.editor.isShapeOfType(parent, 'group')) {
-							// The shape is the direct child of a group. If the group is
-							// selected, then we can select the shape.
-							const focusedGroupId = this.editor.getFocusedGroupId()
-							if (focusedGroupId && parent.id === focusedGroupId) {
-								// If the group is the focus layer id, then we can double click into it as usual.
-								// So here's a noop, double click on the shape as normal below
-							} else {
-								// The shape is the child of some group other than our current
-								// focus layer (ie the canvas or some other group). We should probably select the group instead.
-								selectOnCanvasPointerUp(this.editor, info)
-								return
-							}
-						}
 					}
 
-					// double click on the shape. We'll start editing the
-					// shape if it's editable or else do a double click on
-					// the canvas.
+					const parent = this.editor.getShape(hitShape.parentId)
+					if (
+						parent &&
+						this.editor.isShapeOfType(parent, 'group') &&
+						!this.isGroupInPreviousDrillContext(parent.id)
+					) {
+						// The shape is a child of a group that the user hasn't
+						// drilled into yet (it's outside the focused group and
+						// not an ancestor of it). The user's double-click is a
+						// drill action, not an edit action: select the right
+						// shape via `selectOnCanvasPointerUp` and stop.
+						selectOnCanvasPointerUp(this.editor, info)
+						return
+					}
+
+					// Either there's no group parent, or the group parent is
+					// part of the user's drill context. Re-dispatch as 'shape'
+					// so the editing/cropping logic can run.
 					this.onDoubleClick({
 						...info,
 						shape: hitShape,
@@ -400,16 +399,12 @@ export class Idle extends StateNode {
 				}
 
 				const parent = this.editor.getShapeParent(onlySelectedShape)
-				if (parent && this.editor.isShapeOfType(parent, 'group')) {
-					// Only allow the double-click through when the user had
-					// already drilled into this group *before* the click that
-					// triggered this double-click. Otherwise the second click
-					// of a drilling sequence (which is what set this group as
-					// the focused group in the first place) would also enter
-					// editing — see the snapshot captured in `onPointerDown`.
-					if (parent.id !== this.focusedGroupIdBeforePointerDown) {
-						break
-					}
+				if (
+					parent &&
+					this.editor.isShapeOfType(parent, 'group') &&
+					!this.isGroupInPreviousDrillContext(parent.id)
+				) {
+					break
 				}
 
 				const util = this.editor.getShapeUtil(onlySelectedShape)
@@ -480,16 +475,12 @@ export class Idle extends StateNode {
 				if (shape.type !== 'video' && shape.type !== 'embed' && this.editor.getIsReadonly()) break
 
 				const parent = this.editor.getShapeParent(shape)
-				if (parent && this.editor.isShapeOfType(parent, 'group')) {
-					// Only allow the double-click through when the user had
-					// already drilled into this group *before* the click that
-					// triggered this double-click. Otherwise the second click
-					// of a drilling sequence (which is what set this group as
-					// the focused group in the first place) would also enter
-					// editing — see the snapshot captured in `onPointerDown`.
-					if (parent.id !== this.focusedGroupIdBeforePointerDown) {
-						break
-					}
+				if (
+					parent &&
+					this.editor.isShapeOfType(parent, 'group') &&
+					!this.isGroupInPreviousDrillContext(parent.id)
+				) {
+					break
 				}
 
 				if (util.onDoubleClick) {
@@ -761,6 +752,37 @@ export class Idle extends StateNode {
 		// `ClickManager` class itself is exported as public API. See the
 		// snapshot logic in `onPointerDown` / `onDoubleClick` for the why.
 		return (this.editor as unknown as { _clickManager: ClickManager })._clickManager
+	}
+
+	/**
+	 * Is `groupId` part of the user's drill context as of the start of this
+	 * click sequence? The drill context is the focused group plus all of
+	 * its group ancestors — every group the user has actually "entered". A
+	 * shape whose parent is in that set responds to a double-click like a
+	 * top-level shape (edit, crop, fire `onDoubleClick*`).
+	 *
+	 * Descendants of the focused group are *not* in the drill context: each
+	 * level of drilling is its own click action, so a double-click on a
+	 * deeper-nested shape drills one level rather than skipping straight to
+	 * editing. That matches how every other interaction in the select tool
+	 * treats drilling.
+	 *
+	 * We compare against `focusedGroupIdBeforePointerDown` rather than the
+	 * current `getFocusedGroupId()` because the focused group changes during
+	 * a drilling click sequence — see the snapshot in `onPointerDown`.
+	 */
+	private isGroupInPreviousDrillContext(groupId: TLShapeId): boolean {
+		const focusedGroupId = this.focusedGroupIdBeforePointerDown
+		if (focusedGroupId === null) return false
+		if (focusedGroupId === groupId) return true
+		// `getShape` returns `undefined` for a `TLPageId`, which means we're
+		// not drilled into any group and the drill context is empty.
+		const focusedGroup = this.editor.getShape(focusedGroupId as TLShapeId)
+		if (!focusedGroup) return false
+		// Sibling-at-current-level case: `groupId` is an ancestor of the
+		// focused group, so a shape whose parent is `groupId` is at the
+		// user's effective level (e.g. siblings of the inner focused group).
+		return this.editor.hasAncestor(focusedGroup, groupId)
 	}
 
 	private startEditingShape(

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -540,7 +540,7 @@ describe('When double clicking a shape', () => {
 			.expectToBeIn('select.editing_shape')
 	})
 
-	it('does not edit a shape whose parent is a group', () => {
+	it('does not edit a shape while double clicking into a group', () => {
 		const childAId = createShapeId()
 		const childBId = createShapeId()
 		editor
@@ -553,9 +553,16 @@ describe('When double clicking a shape', () => {
 			])
 			.groupShapes([childAId, childBId])
 
-		editor.doubleClick(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
+		const groupId = editor.getOnlySelectedShapeId()!
+		editor.selectNone()
+
+		editor
+			.click(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
+			.click(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
 
 		expect(editor.getEditingShapeId()).toBe(null)
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		expect(editor.getFocusedGroupId()).toBe(groupId)
 		editor.expectToBeIn('select.idle')
 	})
 })
@@ -672,7 +679,7 @@ describe('When double clicking the selection edge', () => {
 		expect(editor.getEditingShapeId()).toBe(id)
 	})
 
-	it('does not enter editing for a single-selected shape inside a group', () => {
+	it('selects a grouped shape without editing when double clicking its edge from outside the group', () => {
 		const childAId = createShapeId()
 		const childBId = createShapeId()
 		editor
@@ -684,14 +691,80 @@ describe('When double clicking the selection edge', () => {
 				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
 			])
 			.groupShapes([childAId, childBId])
-			.select(childAId)
 
-		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		const groupId = editor.getOnlySelectedShapeId()!
 
-		editor.doubleClick(150, 150, { target: 'selection', handle: 'left' })
+		editor.pointerMove(100, 150).click(100, 150).pointerMove(100, 150).click(100, 150)
 
 		expect(editor.getEditingShapeId()).toBe(null)
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		expect(editor.getFocusedGroupId()).toBe(groupId)
 		editor.expectToBeIn('select.idle')
+	})
+
+	it('enters editing when triple clicking a grouped shape edge', () => {
+		const childAId = createShapeId()
+		const childBId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([childAId, childBId])
+
+		const groupId = editor.getOnlySelectedShapeId()!
+		editor.selectNone()
+
+		editor
+			.pointerMove(100, 150)
+			.click(100, 150)
+			.pointerMove(100, 150)
+			.click(100, 150)
+			.pointerMove(100, 150)
+			.click(100, 150)
+
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		expect(editor.getFocusedGroupId()).toBe(groupId)
+		expect(editor.getEditingShapeId()).toBe(childAId)
+		editor.expectToBeIn('select.editing_shape')
+	})
+
+	it('enters editing when quadruple clicking a shape edge inside nested groups', () => {
+		const childAId = createShapeId()
+		const childBId = createShapeId()
+		const childCId = createShapeId()
+		const innerGroupId = createShapeId()
+		const outerGroupId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
+				{ id: childCId, type: 'geo', x: 500, y: 100, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([childAId, childBId], { groupId: innerGroupId })
+			.groupShapes([innerGroupId, childCId], { groupId: outerGroupId })
+			.selectNone()
+
+		editor
+			.pointerMove(100, 150)
+			.click(100, 150)
+			.pointerMove(100, 150)
+			.click(100, 150)
+			.pointerMove(100, 150)
+			.click(100, 150)
+			.pointerMove(100, 150)
+			.click(100, 150)
+
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
+		expect(editor.getEditingShapeId()).toBe(childAId)
+		editor.expectToBeIn('select.editing_shape')
 	})
 
 	it('enters editing for a selected shape inside the focused group when double clicking its edge', () => {
@@ -707,7 +780,7 @@ describe('When double clicking the selection edge', () => {
 			])
 			.groupShapes([childAId, childBId])
 
-		const groupId = editor.getLastCreatedShape()?.id
+		const groupId = editor.getOnlySelectedShapeId()!
 		expect(editor.isShapeOfType(editor.getShape(groupId)!, 'group')).toBe(true)
 
 		editor.click(100, 100) // select the group

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -556,9 +556,11 @@ describe('When double clicking a shape', () => {
 		const groupId = editor.getOnlySelectedShapeId()!
 		editor.selectNone()
 
-		editor
-			.click(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
-			.click(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
+		editor.click(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
+		// Each click is a separate user click that drills one level. Reset the
+		// click state between them so they aren't coalesced into a double-click.
+		editor.cancelDoubleClick()
+		editor.click(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
 
 		expect(editor.getEditingShapeId()).toBe(null)
 		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
@@ -722,10 +724,15 @@ describe('When double clicking the selection edge', () => {
 		editor.selectNone()
 
 		const childA = editor.getShape(childAId)!
-		editor
-			.click(150, 150, { target: 'shape', shape: childA })
-			.click(150, 150, { target: 'shape', shape: childA })
-			.click(150, 150, { target: 'shape', shape: childA })
+		// Each click is a separate user click. Reset the click state between
+		// them so they aren't coalesced into a single multi-click sequence:
+		// click 1 selects the group, click 2 drills to the child, click 3 lands
+		// on the now-selected child's label and starts editing.
+		editor.click(150, 150, { target: 'shape', shape: childA })
+		editor.cancelDoubleClick()
+		editor.click(150, 150, { target: 'shape', shape: childA })
+		editor.cancelDoubleClick()
+		editor.click(150, 150, { target: 'shape', shape: childA })
 
 		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
 		expect(editor.getFocusedGroupId()).toBe(groupId)
@@ -758,11 +765,17 @@ describe('When double clicking the selection edge', () => {
 			.selectNone()
 
 		const childA = editor.getShape(childAId)!
-		editor
-			.click(150, 150, { target: 'shape', shape: childA })
-			.click(150, 150, { target: 'shape', shape: childA })
-			.click(150, 150, { target: 'shape', shape: childA })
-			.click(150, 150, { target: 'shape', shape: childA })
+		// Each click is a separate user click that drills one level. Reset the
+		// click state between them so they aren't coalesced: click 1 selects the
+		// outer group, click 2 drills to the inner group, click 3 drills to
+		// childA, click 4 lands on childA's label and starts editing.
+		editor.click(150, 150, { target: 'shape', shape: childA })
+		editor.cancelDoubleClick()
+		editor.click(150, 150, { target: 'shape', shape: childA })
+		editor.cancelDoubleClick()
+		editor.click(150, 150, { target: 'shape', shape: childA })
+		editor.cancelDoubleClick()
+		editor.click(150, 150, { target: 'shape', shape: childA })
 
 		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
 		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
@@ -845,12 +858,13 @@ describe('When double clicking the selection edge', () => {
 
 		editor.cancelDoubleClick()
 
-		// Double-click childB. This should drill into innerGroup and select
-		// childB — and stop there. Editing must not start.
+		// Drill into innerGroup and select childB — and stop there. Editing
+		// must not start. The two clicks are separate user clicks, so reset the
+		// click state between them.
 		const childB = editor.getShape(childBId)!
-		editor
-			.click(85, 25, { target: 'shape', shape: childB })
-			.click(85, 25, { target: 'shape', shape: childB })
+		editor.click(85, 25, { target: 'shape', shape: childB })
+		editor.cancelDoubleClick()
+		editor.click(85, 25, { target: 'shape', shape: childB })
 
 		expect(editor.getOnlySelectedShapeId()).toBe(childBId)
 		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
@@ -885,26 +899,26 @@ describe('When double clicking the selection edge', () => {
 			.selectNone()
 
 		// Drill into the outer group by clicking the sibling shape twice:
-		// click 1 selects the outer group, click 2 drills and selects S.
+		// click 1 selects the outer group, click 2 drills and selects S. The
+		// clicks are separate user clicks, so reset the click state between them.
 		const sibling = editor.getShape(siblingId)!
-		editor
-			.click(225, 25, { target: 'shape', shape: sibling })
-			.click(225, 25, { target: 'shape', shape: sibling })
+		editor.click(225, 25, { target: 'shape', shape: sibling })
+		editor.cancelDoubleClick()
+		editor.click(225, 25, { target: 'shape', shape: sibling })
 		expect(editor.getOnlySelectedShapeId()).toBe(siblingId)
 		expect(editor.getFocusedGroupId()).toBe(outerGroupId)
 
 		editor.cancelDoubleClick()
 
-		// Double-click (2 quick clicks) on the grandchild. Click 1 selects
-		// the inner group (drilling from the outer group's level), click 2
-		// drills into the inner group and selects the grandchild. The
-		// synthetic double_click that fires must NOT enter editing — the
-		// inner group is deeper than the outer group the user has actually
-		// entered, so editing requires a further click.
+		// Two clicks on the grandchild. Click 1 selects the inner group
+		// (drilling from the outer group's level), click 2 drills into the inner
+		// group and selects the grandchild. Editing must NOT start — the inner
+		// group is deeper than the outer group the user has actually entered, so
+		// editing requires a further click.
 		const grandChild = editor.getShape(grandChildId)!
-		editor
-			.click(25, 25, { target: 'shape', shape: grandChild })
-			.click(25, 25, { target: 'shape', shape: grandChild })
+		editor.click(25, 25, { target: 'shape', shape: grandChild })
+		editor.cancelDoubleClick()
+		editor.click(25, 25, { target: 'shape', shape: grandChild })
 
 		expect(editor.getOnlySelectedShapeId()).toBe(grandChildId)
 		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
@@ -940,10 +954,13 @@ describe('When double clicking the selection edge', () => {
 		// inner, 3) drill to inner's child. After this the focused group is
 		// the inner group.
 		const innerChild = editor.getShape(innerChildId)!
-		editor
-			.click(25, 25, { target: 'shape', shape: innerChild })
-			.click(25, 25, { target: 'shape', shape: innerChild })
-			.click(25, 25, { target: 'shape', shape: innerChild })
+		// Separate user clicks, each drilling one level; reset the click state
+		// between them so they aren't coalesced into a double-click.
+		editor.click(25, 25, { target: 'shape', shape: innerChild })
+		editor.cancelDoubleClick()
+		editor.click(25, 25, { target: 'shape', shape: innerChild })
+		editor.cancelDoubleClick()
+		editor.click(25, 25, { target: 'shape', shape: innerChild })
 		expect(editor.getOnlySelectedShapeId()).toBe(innerChildId)
 		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
 

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -1010,6 +1010,128 @@ describe('When double clicking the selection edge', () => {
 		editor.expectToBeIn('select.editing_shape')
 	})
 
+	it('drills a fresh double-click into a group consistently across canvas and shape targets', () => {
+		// A rapid double-click on a filled shape inside an un-entered group
+		// should drill in — select the child and focus the group — without
+		// entering editing. This must hold whether the double-click event
+		// arrives with target 'canvas' (hollow shapes / margins) or 'shape'
+		// (filled shapes), so the two paths can't disagree.
+		const setup = () => {
+			const childAId = createShapeId()
+			const childBId = createShapeId()
+			editor
+				.selectAll()
+				.deleteShapes(editor.getSelectedShapeIds())
+				.selectNone()
+				.createShapes([
+					{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+					{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+				])
+				.groupShapes([childAId, childBId])
+			const groupId = editor.getOnlySelectedShapeId()!
+			editor.selectNone()
+			return { childAId, groupId }
+		}
+
+		const viaCanvas = setup()
+		editor.pointerMove(150, 150).doubleClick(150, 150)
+		expect(editor.getOnlySelectedShapeId()).toBe(viaCanvas.childAId)
+		expect(editor.getFocusedGroupId()).toBe(viaCanvas.groupId)
+		expect(editor.getEditingShapeId()).toBe(null)
+
+		const viaShape = setup()
+		editor
+			.pointerMove(150, 150)
+			.doubleClick(150, 150, { target: 'shape', shape: editor.getShape(viaShape.childAId)! })
+		expect(editor.getOnlySelectedShapeId()).toBe(viaShape.childAId)
+		expect(editor.getFocusedGroupId()).toBe(viaShape.groupId)
+		expect(editor.getEditingShapeId()).toBe(null)
+	})
+
+	it('drills a fresh double-click only one level into a group-inside-a-group', () => {
+		// page -> outerGroup -> { innerGroup -> { childA, childB }, sibling }
+		// A fresh double-click on childA should drill a single level: select the
+		// inner group (and focus the outer group), NOT jump straight to the leaf
+		// childA. This must hold for both canvas and shape targets.
+		const setup = () => {
+			const childAId = createShapeId()
+			const childBId = createShapeId()
+			const siblingId = createShapeId()
+			const innerGroupId = createShapeId()
+			const outerGroupId = createShapeId()
+			editor
+				.selectAll()
+				.deleteShapes(editor.getSelectedShapeIds())
+				.selectNone()
+				.createShapes([
+					{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+					{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+					{ id: siblingId, type: 'geo', x: 600, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+				])
+				.groupShapes([childAId, childBId], { groupId: innerGroupId })
+				.groupShapes([innerGroupId, siblingId], { groupId: outerGroupId })
+				.selectNone()
+			return { childAId, innerGroupId, outerGroupId }
+		}
+
+		const viaCanvas = setup()
+		editor.pointerMove(150, 150).doubleClick(150, 150)
+		expect(editor.getOnlySelectedShapeId()).toBe(viaCanvas.innerGroupId)
+		expect(editor.getFocusedGroupId()).toBe(viaCanvas.outerGroupId)
+		expect(editor.getEditingShapeId()).toBe(null)
+
+		const viaShape = setup()
+		editor
+			.pointerMove(150, 150)
+			.doubleClick(150, 150, { target: 'shape', shape: editor.getShape(viaShape.childAId)! })
+		expect(editor.getOnlySelectedShapeId()).toBe(viaShape.innerGroupId)
+		expect(editor.getFocusedGroupId()).toBe(viaShape.outerGroupId)
+		expect(editor.getEditingShapeId()).toBe(null)
+	})
+
+	it('drills only one level per double-click when already drilled into an outer group', () => {
+		// page -> G1 -> { G2 -> { G3 -> { leaf, leafB }, leafC }, sibling }
+		// The user has already drilled into G1 (G2 selected, G1 focused). A
+		// rapid double-click on `leaf` must drill exactly one more level —
+		// select G3 (and focus G2) — not jump straight to the leaf. This guards
+		// against reading the live focused group (which the first click already
+		// advanced) instead of the focus captured at the start of the sequence.
+		const leafId = createShapeId()
+		const leafBId = createShapeId()
+		const leafCId = createShapeId()
+		const siblingId = createShapeId()
+		const g3 = createShapeId()
+		const g2 = createShapeId()
+		const g1 = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: leafId, type: 'geo', x: 100, y: 100, props: { w: 80, h: 80, fill: 'solid' } },
+				{ id: leafBId, type: 'geo', x: 200, y: 100, props: { w: 80, h: 80, fill: 'solid' } },
+				{ id: leafCId, type: 'geo', x: 320, y: 100, props: { w: 80, h: 80, fill: 'solid' } },
+				{ id: siblingId, type: 'geo', x: 500, y: 100, props: { w: 80, h: 80, fill: 'solid' } },
+			])
+			.groupShapes([leafId, leafBId], { groupId: g3 })
+			.groupShapes([g3, leafCId], { groupId: g2 })
+			.groupShapes([g2, siblingId], { groupId: g1 })
+			.selectNone()
+
+		// Drill into G1: selecting G2 focuses G1 (its nearest group ancestor).
+		editor.select(g2)
+		expect(editor.getFocusedGroupId()).toBe(g1)
+		editor.cancelDoubleClick()
+
+		editor
+			.pointerMove(130, 130)
+			.doubleClick(130, 130, { target: 'shape', shape: editor.getShape(leafId)! })
+
+		expect(editor.getOnlySelectedShapeId()).toBe(g3)
+		expect(editor.getFocusedGroupId()).toBe(g2)
+		expect(editor.getEditingShapeId()).toBe(null)
+	})
+
 	it('Resets the cursor to default when entering editing mode from a resize handle', () => {
 		const id = createShapeId()
 		editor

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -702,7 +702,10 @@ describe('When double clicking the selection edge', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
-	it('enters editing when triple clicking a grouped shape edge', () => {
+	it('drills into a group and enters editing on the trailing third click (2 + 1)', () => {
+		// 3 rapid clicks decompose as "double_click (drill) + click (edit)":
+		// click 1 selects the group, click 2 drills to the child, click 3
+		// lands on the now-selected child's text label and starts editing.
 		const childAId = createShapeId()
 		const childBId = createShapeId()
 		editor
@@ -718,13 +721,11 @@ describe('When double clicking the selection edge', () => {
 		const groupId = editor.getOnlySelectedShapeId()!
 		editor.selectNone()
 
+		const childA = editor.getShape(childAId)!
 		editor
-			.pointerMove(100, 150)
-			.click(100, 150)
-			.pointerMove(100, 150)
-			.click(100, 150)
-			.pointerMove(100, 150)
-			.click(100, 150)
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
 
 		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
 		expect(editor.getFocusedGroupId()).toBe(groupId)
@@ -732,7 +733,12 @@ describe('When double clicking the selection edge', () => {
 		editor.expectToBeIn('select.editing_shape')
 	})
 
-	it('enters editing when quadruple clicking a shape edge inside nested groups', () => {
+	it('drills through nested groups and enters editing on the fourth click', () => {
+		// Each rapid click drills one level via PointingShape.onPointerUp:
+		// click 1 selects the outer group, click 2 drills to the inner group,
+		// click 3 drills to childA. Click 4 lands on the already-selected
+		// childA's text label and fires the PointingShape text-label-edit
+		// branch — drill, drill, drill, edit.
 		const childAId = createShapeId()
 		const childBId = createShapeId()
 		const childCId = createShapeId()
@@ -751,15 +757,12 @@ describe('When double clicking the selection edge', () => {
 			.groupShapes([innerGroupId, childCId], { groupId: outerGroupId })
 			.selectNone()
 
+		const childA = editor.getShape(childAId)!
 		editor
-			.pointerMove(100, 150)
-			.click(100, 150)
-			.pointerMove(100, 150)
-			.click(100, 150)
-			.pointerMove(100, 150)
-			.click(100, 150)
-			.pointerMove(100, 150)
-			.click(100, 150)
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
 
 		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
 		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
@@ -783,13 +786,55 @@ describe('When double clicking the selection edge', () => {
 		const groupId = editor.getOnlySelectedShapeId()!
 		expect(editor.isShapeOfType(editor.getShape(groupId)!, 'group')).toBe(true)
 
-		editor.click(100, 100) // select the group
-		editor.click(100, 100) // select the child A and focus the group
+		// Drill into the group: first click selects the group, second click
+		// focuses the group and selects child A.
+		const childA = editor.getShape(childAId)!
+		editor
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
 		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
 		expect(editor.getFocusedGroupId()).toBe(groupId)
 
-		// Double click on the right edge of the child A
+		// Simulate the user pausing between drilling and starting the
+		// double-click — the ClickManager (and our snapshot of the focused
+		// group) reset at that boundary in production.
+		editor.cancelDoubleClick()
+
+		// Double-click on the right edge of child A — must enter editing even
+		// though the parent is a group, because the group is the focused one.
 		editor.doubleClick(200, 150, { target: 'selection', handle: 'right' })
+
+		expect(editor.getEditingShapeId()).toBe(childAId)
+		editor.expectToBeIn('select.editing_shape')
+	})
+
+	it('enters editing for a shape inside the focused group when double clicking the shape', () => {
+		const childAId = createShapeId()
+		const childBId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([childAId, childBId])
+
+		const groupId = editor.getOnlySelectedShapeId()!
+
+		// Drill into the group, then (after the click sequence has settled)
+		// double-click the child directly.
+		const childA = editor.getShape(childAId)!
+		editor
+			.click(150, 150, { target: 'shape', shape: childA })
+			.click(150, 150, { target: 'shape', shape: childA })
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		expect(editor.getFocusedGroupId()).toBe(groupId)
+
+		editor.cancelDoubleClick()
+
+		editor.doubleClick(150, 150, { target: 'shape', shape: childA })
 
 		expect(editor.getEditingShapeId()).toBe(childAId)
 		editor.expectToBeIn('select.editing_shape')

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -1132,6 +1132,54 @@ describe('When double clicking the selection edge', () => {
 		expect(editor.getEditingShapeId()).toBe(null)
 	})
 
+	it('drills through nested groups and edits the leaf consistently at any click cadence', () => {
+		// Regression: at "fast" and "slow" cadences the final click of a
+		// drill-through reaches PointingShape and edits, but at "moderate"
+		// cadences (gaps between multiClickDurationMs and doubleClickDurationMs)
+		// the ClickManager re-parses the final click as a double-click, which
+		// used to be swallowed as a no-op drill. All cadences must end up
+		// editing the leaf.
+		// page -> outerGroup -> { innerGroup -> { childA, childB }, sibling }
+		const setup = () => {
+			const childAId = createShapeId()
+			const childBId = createShapeId()
+			const siblingId = createShapeId()
+			const innerGroupId = createShapeId()
+			const outerGroupId = createShapeId()
+			editor
+				.selectAll()
+				.deleteShapes(editor.getSelectedShapeIds())
+				.selectNone()
+				.createShapes([
+					{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+					{ id: childBId, type: 'geo', x: 220, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+					{ id: siblingId, type: 'geo', x: 500, y: 100, props: { w: 100, h: 100, fill: 'solid' } },
+				])
+				.groupShapes([childAId, childBId], { groupId: innerGroupId })
+				.groupShapes([innerGroupId, siblingId], { groupId: outerGroupId })
+				.selectNone()
+			return { childAId, innerGroupId }
+		}
+
+		for (const gap of [0, 250, 300, 500]) {
+			const { childAId, innerGroupId } = setup()
+			const shape = editor.getShape(childAId)!
+			for (let i = 0; i < 4; i++) {
+				editor.pointerDown(150, 150, { target: 'shape', shape })
+				editor.pointerUp(150, 150, { target: 'shape', shape })
+				if (i < 3) vi.advanceTimersByTime(gap)
+			}
+			expect({
+				gap,
+				selected: editor.getOnlySelectedShapeId(),
+				focused: editor.getFocusedGroupId(),
+				editing: editor.getEditingShapeId(),
+			}).toEqual({ gap, selected: childAId, focused: innerGroupId, editing: childAId })
+			// Reset click state between cadences.
+			editor.cancelDoubleClick()
+		}
+	})
+
 	it('Resets the cursor to default when entering editing mode from a resize handle', () => {
 		const id = createShapeId()
 		editor

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -694,6 +694,34 @@ describe('When double clicking the selection edge', () => {
 		editor.expectToBeIn('select.idle')
 	})
 
+	it('enters editing for a selected shape inside the focused group when double clicking its edge', () => {
+		const childAId = createShapeId()
+		const childBId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([childAId, childBId])
+
+		const groupId = editor.getLastCreatedShape()?.id
+		expect(editor.isShapeOfType(editor.getShape(groupId)!, 'group')).toBe(true)
+
+		editor.click(100, 100) // select the group
+		editor.click(100, 100) // select the child A and focus the group
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+		expect(editor.getFocusedGroupId()).toBe(groupId)
+
+		// Double click on the right edge of the child A
+		editor.doubleClick(200, 150, { target: 'selection', handle: 'right' })
+
+		expect(editor.getEditingShapeId()).toBe(childAId)
+		editor.expectToBeIn('select.editing_shape')
+	})
+
 	it('Resets the cursor to default when entering editing mode from a resize handle', () => {
 		const id = createShapeId()
 		editor

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -808,6 +808,159 @@ describe('When double clicking the selection edge', () => {
 		editor.expectToBeIn('select.editing_shape')
 	})
 
+	it('does not edit when double-clicking into a group from page level, even with a page-level sibling already selected', () => {
+		// page
+		// ├── innerGroup
+		// │   ├── child
+		// │   └── childB
+		// └── sibling
+		//
+		// The user is at page level. Selecting the page-level sibling does
+		// not focus any group, so focusedGroupId stays at pageId. A
+		// subsequent double-click on childB must drill into the group and
+		// select the child, never enter editing — the drill context is empty
+		// because no group has been entered yet.
+		const childId = createShapeId()
+		const childBId = createShapeId()
+		const siblingId = createShapeId()
+		const innerGroupId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childId, type: 'geo', x: 0, y: 0, props: { w: 50, h: 50 } },
+				{ id: childBId, type: 'geo', x: 60, y: 0, props: { w: 50, h: 50 } },
+				{ id: siblingId, type: 'geo', x: 200, y: 0, props: { w: 50, h: 50 } },
+			])
+			.groupShapes([childId, childBId], { groupId: innerGroupId })
+			.selectNone()
+
+		// Select the page-level sibling with a single click. This shouldn't
+		// focus any group.
+		const sibling = editor.getShape(siblingId)!
+		editor.click(225, 25, { target: 'shape', shape: sibling })
+		expect(editor.getOnlySelectedShapeId()).toBe(siblingId)
+		expect(editor.getFocusedGroupId()).toBe(editor.getCurrentPageId())
+
+		editor.cancelDoubleClick()
+
+		// Double-click childB. This should drill into innerGroup and select
+		// childB — and stop there. Editing must not start.
+		const childB = editor.getShape(childBId)!
+		editor
+			.click(85, 25, { target: 'shape', shape: childB })
+			.click(85, 25, { target: 'shape', shape: childB })
+
+		expect(editor.getOnlySelectedShapeId()).toBe(childBId)
+		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
+		expect(editor.getEditingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('drills one level on double-click of a deeper-nested shape without entering editing', () => {
+		// Outer group contains an inner group (with two children) and a
+		// sibling shape S. The user drills into the outer group by selecting
+		// S. They then double-click a grandchild (a child of the inner
+		// group, which is itself inside the outer group). The inner group is
+		// *deeper* than the user's current drill level, so the double-click
+		// drills one level (into the inner group, selecting the grandchild)
+		// and stops there — editing requires another click.
+		const grandChildId = createShapeId()
+		const grandChildBId = createShapeId()
+		const siblingId = createShapeId()
+		const innerGroupId = createShapeId()
+		const outerGroupId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: grandChildId, type: 'geo', x: 0, y: 0, props: { w: 50, h: 50 } },
+				{ id: grandChildBId, type: 'geo', x: 60, y: 0, props: { w: 50, h: 50 } },
+				{ id: siblingId, type: 'geo', x: 200, y: 0, props: { w: 50, h: 50 } },
+			])
+			.groupShapes([grandChildId, grandChildBId], { groupId: innerGroupId })
+			.groupShapes([innerGroupId, siblingId], { groupId: outerGroupId })
+			.selectNone()
+
+		// Drill into the outer group by clicking the sibling shape twice:
+		// click 1 selects the outer group, click 2 drills and selects S.
+		const sibling = editor.getShape(siblingId)!
+		editor
+			.click(225, 25, { target: 'shape', shape: sibling })
+			.click(225, 25, { target: 'shape', shape: sibling })
+		expect(editor.getOnlySelectedShapeId()).toBe(siblingId)
+		expect(editor.getFocusedGroupId()).toBe(outerGroupId)
+
+		editor.cancelDoubleClick()
+
+		// Double-click (2 quick clicks) on the grandchild. Click 1 selects
+		// the inner group (drilling from the outer group's level), click 2
+		// drills into the inner group and selects the grandchild. The
+		// synthetic double_click that fires must NOT enter editing — the
+		// inner group is deeper than the outer group the user has actually
+		// entered, so editing requires a further click.
+		const grandChild = editor.getShape(grandChildId)!
+		editor
+			.click(25, 25, { target: 'shape', shape: grandChild })
+			.click(25, 25, { target: 'shape', shape: grandChild })
+
+		expect(editor.getOnlySelectedShapeId()).toBe(grandChildId)
+		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
+		expect(editor.getEditingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('enters editing for a sibling shape inside an outer group when drilled into a nested group', () => {
+		// Outer group contains an inner group and a sibling shape S. The user
+		// drills into the inner group; S is still directly selectable because
+		// the outer group is on the drill stack. Double-clicking S should
+		// therefore enter editing, even though S's parent (the outer group) is
+		// not the currently focused group.
+		const innerChildId = createShapeId()
+		const innerChildBId = createShapeId()
+		const siblingId = createShapeId()
+		const innerGroupId = createShapeId()
+		const outerGroupId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: innerChildId, type: 'geo', x: 0, y: 0, props: { w: 50, h: 50 } },
+				{ id: innerChildBId, type: 'geo', x: 60, y: 0, props: { w: 50, h: 50 } },
+				{ id: siblingId, type: 'geo', x: 200, y: 0, props: { w: 50, h: 50 } },
+			])
+			.groupShapes([innerChildId, innerChildBId], { groupId: innerGroupId })
+			.groupShapes([innerGroupId, siblingId], { groupId: outerGroupId })
+			.selectNone()
+
+		// Drill all the way into the inner group: 1) select outer, 2) drill to
+		// inner, 3) drill to inner's child. After this the focused group is
+		// the inner group.
+		const innerChild = editor.getShape(innerChildId)!
+		editor
+			.click(25, 25, { target: 'shape', shape: innerChild })
+			.click(25, 25, { target: 'shape', shape: innerChild })
+			.click(25, 25, { target: 'shape', shape: innerChild })
+		expect(editor.getOnlySelectedShapeId()).toBe(innerChildId)
+		expect(editor.getFocusedGroupId()).toBe(innerGroupId)
+
+		// Reset the click manager state so the next double-click starts a
+		// fresh sequence.
+		editor.cancelDoubleClick()
+
+		// Double-click the sibling shape. Its parent is the outer group,
+		// which is an ancestor of the focused inner group, so editing must
+		// start.
+		const sibling = editor.getShape(siblingId)!
+		editor.doubleClick(225, 25, { target: 'shape', shape: sibling })
+
+		expect(editor.getEditingShapeId()).toBe(siblingId)
+		editor.expectToBeIn('select.editing_shape')
+	})
+
 	it('enters editing for a shape inside the focused group when double clicking the shape', () => {
 		const childAId = createShapeId()
 		const childBId = createShapeId()

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -539,6 +539,25 @@ describe('When double clicking a shape', () => {
 			.doubleClick(50, 50, { target: 'shape', shape: editor.getCurrentPageShapes()[0] })
 			.expectToBeIn('select.editing_shape')
 	})
+
+	it('does not edit a shape whose parent is a group', () => {
+		const childAId = createShapeId()
+		const childBId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([childAId, childBId])
+
+		editor.doubleClick(150, 150, { target: 'shape', shape: editor.getShape(childAId)! })
+
+		expect(editor.getEditingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
+	})
 })
 
 describe('When pressing enter on a selected shape', () => {
@@ -651,6 +670,28 @@ describe('When double clicking the selection edge', () => {
 		editor.doubleClick(100, 100, { target: 'selection', handle: 'left' })
 
 		expect(editor.getEditingShapeId()).toBe(id)
+	})
+
+	it('does not enter editing for a single-selected shape inside a group', () => {
+		const childAId = createShapeId()
+		const childBId = createShapeId()
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.selectNone()
+			.createShapes([
+				{ id: childAId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+				{ id: childBId, type: 'geo', x: 300, y: 100, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([childAId, childBId])
+			.select(childAId)
+
+		expect(editor.getOnlySelectedShapeId()).toBe(childAId)
+
+		editor.doubleClick(150, 150, { target: 'selection', handle: 'left' })
+
+		expect(editor.getEditingShapeId()).toBe(null)
+		editor.expectToBeIn('select.idle')
 	})
 
 	it('Resets the cursor to default when entering editing mode from a resize handle', () => {

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -216,21 +216,8 @@ export class TestEditor extends Editor {
 		return this
 	}
 
-	/**
-	 * If you need to trigger a double click, you can either mock the implementation of one of these
-	 * methods, or call mockRestore() to restore the actual implementation (e.g.
-	 * _transformPointerDownSpy.mockRestore())
-	 */
-	_transformPointerDownSpy = vi
-		.spyOn(this._clickManager, 'handlePointerEvent')
-		.mockImplementation((info) => {
-			return info
-		})
-	_transformPointerUpSpy = vi
-		.spyOn(this._clickManager, 'handlePointerEvent')
-		.mockImplementation((info) => {
-			return info
-		})
+	_transformPointerDownSpy = vi.spyOn(this._clickManager, 'handlePointerEvent')
+	_transformPointerUpSpy = vi.spyOn(this._clickManager, 'handlePointerEvent')
 
 	/* ---- Delegated to Driver ---- */
 

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -295,6 +295,12 @@ export class TestEditor extends Editor {
 	}
 	doubleClick(...args: Parameters<Driver['doubleClick']>) {
 		this.controller.doubleClick(...args)
+		// Tests run with fake timers, so the ClickManager's double-click timeout
+		// never fires on its own. A `doubleClick()` is a complete gesture, so
+		// reset the click state afterwards; otherwise a following pointer event
+		// is coalesced into this double-click sequence (e.g. a `pointerDown`
+		// right after `doubleClick()` would be treated as a triple click).
+		this.cancelDoubleClick()
 		return this
 	}
 	keyPress(...args: Parameters<Driver['keyPress']>) {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1520,6 +1520,10 @@ describe('Unparenting behavior', () => {
 		expect(editor.getOnlySelectedShape()?.id).toBe(triangle.id)
 		expect(editor.getShape(triangle.id)!.parentId).toBe(frame.id)
 
+		// Reset the click state so the drag below starts a fresh pointer
+		// sequence instead of coalescing with the select click into a
+		// double-click.
+		editor.cancelDoubleClick()
 		editor.pointerDown(50, 50)
 		editor.pointerMove(135, 135) // the bounds are still overlapping but the geometry is not
 

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -17,6 +17,7 @@ import {
 	sortByIndex,
 	toRichText,
 } from '@tldraw/editor'
+import { vi } from 'vitest'
 import { getArrowBindings } from '../lib/shapes/arrow/shared'
 import { TestEditor } from './TestEditor'
 
@@ -955,10 +956,14 @@ describe('the select tool', () => {
 		editor.pointerDown(0, 0, ids.boxA).pointerUp(0, 0)
 		expect(onlySelectedId()).toBe(groupCId)
 		expect(editor.getFocusedGroupId()).toBe(editor.getCurrentPageId())
+		vi.advanceTimersByTime(500)
+
 		editor.pointerDown(0, 0, ids.boxA)
 		editor.pointerUp(0, 0, ids.boxA)
 		expect(onlySelectedId()).toBe(groupAId)
 		expect(editor.getFocusedGroupId()).toBe(groupCId)
+		vi.advanceTimersByTime(500)
+
 		editor.pointerDown(0, 0, ids.boxA).pointerUp(0, 0, ids.boxA)
 		expect(onlySelectedId()).toBe(ids.boxA)
 		expect(editor.getFocusedGroupId()).toBe(groupAId)

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -17,7 +17,6 @@ import {
 	sortByIndex,
 	toRichText,
 } from '@tldraw/editor'
-import { vi } from 'vitest'
 import { getArrowBindings } from '../lib/shapes/arrow/shared'
 import { TestEditor } from './TestEditor'
 
@@ -956,13 +955,13 @@ describe('the select tool', () => {
 		editor.pointerDown(0, 0, ids.boxA).pointerUp(0, 0)
 		expect(onlySelectedId()).toBe(groupCId)
 		expect(editor.getFocusedGroupId()).toBe(editor.getCurrentPageId())
-		vi.advanceTimersByTime(500)
+		editor.cancelDoubleClick()
 
 		editor.pointerDown(0, 0, ids.boxA)
 		editor.pointerUp(0, 0, ids.boxA)
 		expect(onlySelectedId()).toBe(groupAId)
 		expect(editor.getFocusedGroupId()).toBe(groupCId)
-		vi.advanceTimersByTime(500)
+		editor.cancelDoubleClick()
 
 		editor.pointerDown(0, 0, ids.boxA).pointerUp(0, 0, ids.boxA)
 		expect(onlySelectedId()).toBe(ids.boxA)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1052,6 +1052,10 @@ describe('Selects inside of groups', () => {
 		editor.pointerDown()
 		editor.pointerUp()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
+		// The two manual click pairs are separate user clicks; reset the click
+		// state between them so the second pointer-down isn't coalesced into a
+		// double-click.
+		editor.cancelDoubleClick()
 		editor.pointerDown()
 		editor.expectToBeIn('select.pointing_shape')
 		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
@@ -1574,6 +1578,7 @@ describe('When double clicking an editable shape', () => {
 		editor.pointerMove(50, 50).click() // selects the child shape
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.getEditingShapeId()).toBe(null)
+		editor.cancelDoubleClick()
 		editor.pointerMove(50, 50).click() // edits the selected child shape
 		editor.cancelDoubleClick()
 

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1569,11 +1569,13 @@ describe('When double clicking an editable shape', () => {
 		editor.pointerMove(50, 50).click() // selects the group
 		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
 		expect(editor.getEditingShapeId()).toBe(null)
+		editor.cancelDoubleClick()
 
 		editor.pointerMove(50, 50).click() // selects the child shape
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.getEditingShapeId()).toBe(null)
 		editor.pointerMove(50, 50).click() // edits the selected child shape
+		editor.cancelDoubleClick()
 
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.getEditingShapeId()).toBe(ids.box1)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1569,10 +1569,12 @@ describe('When double clicking an editable shape', () => {
 		editor.pointerMove(50, 50).click() // selects the group
 		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
 		expect(editor.getEditingShapeId()).toBe(null)
+
 		editor.pointerMove(50, 50).click() // selects the child shape
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.getEditingShapeId()).toBe(null)
 		editor.pointerMove(50, 50).click() // edits the selected child shape
+
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		expect(editor.getEditingShapeId()).toBe(ids.box1)
 		editor.expectToBeIn('select.editing_shape')


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8898 

I had to fix it in case of a "shape" and a "selection" because for shapes with no background, the only way to select it is to hover the selection area (and doing that also ended up activating the "edit" mode)

https://github.com/user-attachments/assets/4aa867c2-9bfc-4d67-8a81-41821e494778

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape
2. Copy and paste this shape
3. Group the two shapes
4. try double clicking one of the shape 

The dbl clicked shape should _not_ enter its edit mode but be selected so it can be moved around in the group.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed double clicking on grouped shapes by making it select the shape instead of activating the shape's edit mode. 