### PR TITLE
fix(tldraw):  fix reparenting in groups after a deletion

### DIFF
--- a/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
+++ b/packages/editor/src/lib/editor/shapes/group/GroupShapeUtil.tsx
@@ -133,7 +133,7 @@ export class GroupShapeUtil extends ShapeUtil<TLGroupShape> {
 			if (this.editor.getCurrentPageState().focusedGroupId === group.id) {
 				this.editor.popFocusedGroupId()
 			}
-			this.editor.reparentShapes(children, group.parentId)
+			this.editor.reparentShapes(children, group.parentId, group.index)
 			this.editor.deleteShapes([group.id])
 			return
 		}

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -1157,6 +1157,22 @@ describe("when a group's children are deleted", () => {
 		expect(editor.getShape(groupCId)).toBeUndefined()
 		expect(editor.getShape(groupAId)).not.toBeUndefined()
 	})
+
+	it('preserves the collapsed group z-index when reparenting the last child', () => {
+		// Page contains: groupC (lower) then boxX (on top). Deleting boxA collapses
+		// groupA inside groupC, so boxB should take groupA's z-index in groupC and
+		// stay below groupB instead of jumping to the top of groupC's children.
+		editor.createShapes([box(ids.boxX, 80, 0)])
+
+		const pageId = editor.getCurrentPageId()
+		expect(editor.getSortedChildIdsForParent(pageId)).toEqual([groupCId, ids.boxX])
+		expect(editor.getSortedChildIdsForParent(groupCId)).toEqual([groupAId, groupBId])
+
+		editor.deleteShapes([ids.boxA])
+
+		expect(editor.getShape(groupAId)).toBeUndefined()
+		expect(editor.getSortedChildIdsForParent(groupCId)).toEqual([ids.boxB, groupBId])
+	})
 })
 
 describe('creating new shapes', () => {


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8857

Deleting a shape in a group made the reparenting to repop the group at a different z-index, this should not happen and the group should keep the same index it previously owned

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Described in https://github.com/tldraw/tldraw/issues/8857

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue with deleting shapes in a group that caused a reparenting of the group at a different z-index