### PR TITLE
fix(dotcom): unify sidebar group hover color with file/user rows

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -863,6 +863,14 @@
 	visibility: visible;
 }
 
+.sidebarGroupItem:has(.sidebarGroupItemHeader:hover)::after {
+	background-color: var(--tla-color-hover-1);
+}
+
+.sidebarGroupItem[data-menu-open='true']::after {
+	background-color: var(--tla-color-hover-2);
+}
+
 .sidebarGroupItem[data-is-dragging='true'] {
 	opacity: 0.5;
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -354,6 +354,8 @@
 	gap: 0px;
 	text-align: left;
 	cursor: pointer;
+	/* Match .sidebarFileListItem so the hover overlay composites identically. */
+	opacity: 0.999;
 }
 
 .sidebarUserSettingsTrigger:focus-visible {
@@ -811,6 +813,8 @@
 	margin-bottom: 0px;
 	transition: margin-bottom 0.15s cubic-bezier(0.4, 0, 0.2, 1);
 	--tla-sidebar-group-item-padding-left: 8px;
+	/* Match .sidebarFileListItem so the hover overlay composites identically. */
+	opacity: 0.999;
 }
 .sidebarGroupItem .sidebarFileListItemContent {
 	padding-left: var(--tla-sidebar-group-item-padding-left);


### PR DESCRIPTION
In order to fix inconsistent sidebar hover colors on tldraw.com, this PR changes the hover background for sidebar group headers (e.g. "Today", "Yesterday", named groups) to use the same `--tla-color-hover-1` variable that file rows and the user settings row already use. Closes #8811.

Previously the group header `::after` shared a single rule with the drop-zone/menu-open/dragging visuals and painted `--tla-color-drop-zone` for all of them. In dark mode `--tla-color-drop-zone` is a dark overlay while `--tla-color-hover-1` is a white overlay, so hovering a group header darkened the row instead of lightening it — the opposite of every other hover state. In light mode the colors were close but still inconsistent (2.5% vs 3% dark overlay).

The fix splits the rule:

- Hover → `--tla-color-hover-1` (matches `.hoverable`)
- Menu open → `--tla-color-hover-2` (matches `.hoverable`'s open/active state)
- Empty first group hint and dragging → unchanged, still `--tla-color-drop-zone`

A second, smaller fix: `.sidebarFileListItem` has `opacity: 0.999` (a Chrome drag-image hack from #6974) which puts file rows into a separate compositing layer. That made the *composited* hover color render ~2/256 units darker on file rows than on group items and the user settings row, even though all three referenced the same CSS variable. To keep all three rows compositing the same way, the same `opacity: 0.999` is applied to `.sidebarGroupItem` and `.sidebarUserSettingsTrigger`.

### Change type

- [x] `bugfix`

### Test plan

1. Open a tldraw.com workspace with files grouped under date headings.
2. In **dark mode**, hover a group header — the row should lighten, matching the hover for file rows and the user settings row at the bottom of the sidebar.
3. In **light mode**, hover the same three items — all should share the same hover tint.
4. Sample the hover color across all three rows with a color picker — they should match.
5. Right-click a group header (or open its kebab menu) — the open-menu background should match the open-menu background on file rows.
6. Drag a file between groups — the drop-zone highlight on the target group should be unchanged, and the file drag image should still render with a transparent background.
7. Confirm the empty-first-group hint state (when the first date group has no files) still uses the drop-zone tint.
8. Confirm the `.dropping::after` blue drop-target border is unchanged.

### Release notes

- Fix inconsistent hover background color for sidebar group items on tldraw.com, especially in dark mode where the group hover was nearly invisible.