### PR TITLE
fix(dotcom): navigate away from file when leaving its group

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
@@ -104,8 +104,13 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 
 	const handleLeaveGroup = async () => {
 		try {
+			const isCurrentlyOnAFileInThisGroup =
+				currentFileId && app.getFile(currentFileId)?.owningGroupId === groupId
 			await app.z.mutate.leaveGroup({ groupId }).client
 			onClose()
+			if (isCurrentlyOnAFileInThisGroup) {
+				navigate('/')
+			}
 		} catch (error) {
 			console.error('Error leaving group:', error)
 		}


### PR DESCRIPTION
In order to avoid leaving the user stuck on a file they no longer have access to, this PR makes `handleLeaveGroup` mirror `handleDeleteGroup` in `GroupSettingsDialog`: if the user is viewing a file owned by the group they just left, navigate them to `/`. Previously the sidebar updated but the file stayed open until the next server-side access check failed with `FORBIDDEN`.

Closes #8340

### Change type

- [x] `bugfix`

### Test plan

1. Be a member of a group that owns files.
2. Open a file belonging to that group.
3. Open group settings and leave the group.
4. You should be redirected away from the file instead of remaining on it.

### Release notes

- Fix: redirect away from a group file when leaving the group.