### PR TITLE
chore: remove context7 integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,9 +34,7 @@
 			"Bash(yarn test:*)",
 			"Bash(yarn lint:*)",
 			"Bash(yarn typecheck)",
-			"Bash(git add:*)",
-			"mcp__Context7__resolve-library-id",
-			"mcp__Context7__get-library-docs"
+			"Bash(git add:*)"
 		]
 	},
 	"hooks": {

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,0 @@
-{
-	"url": "https://context7.com/tldraw/tldraw",
-	"public_key": "pk_pMHtZZcPXLY8ti5lsBvjP"
-}


### PR DESCRIPTION
In order to drop the Context7 docs integration from the repo, this PR removes the `context7.json` registration file (which pointed the repo at context7.com with a public key) and deletes the two `mcp__Context7__*` permission entries from `.claude/settings.json`. These were the only references to Context7 in the repository.

### Change type

- [x] `other`

### Test plan

- No user-facing behavior; nothing to test manually.

### Release notes

- Omit — internal tooling change with no user-facing impact.