### PR TITLE
feat(tldraw): export addRoundedRectPath utility

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -186,6 +186,9 @@ export interface ActionsProviderProps {
     overrides?(editor: Editor, actions: TLUiActionsContextType, helpers: TLUiOverrideHelpers): TLUiActionsContextType;
 }
 
+// @public
+export function addRoundedRectPath(path: Path2D, bounds: Box, radius: number, counterClockwise?: boolean): void;
+
 // @public (undocumented)
 export type AlertSeverity = 'error' | 'info' | 'success' | 'warning';
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -240,6 +240,7 @@ export {
 	type NoteShapeOptions,
 	type NoteShapeUtilDisplayValues,
 } from './lib/shapes/note/NoteShapeUtil'
+export { addRoundedRectPath } from './lib/shapes/shared/addRoundedRectPath'
 export {
 	ASPECT_RATIO_OPTIONS,
 	ASPECT_RATIO_TO_VALUE,

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -50,6 +50,7 @@ import {
 import React, { useMemo } from 'react'
 import { updateArrowTerminal } from '../../bindings/arrow/ArrowBindingUtil'
 import { isEmptyRichText, renderPlaintextFromRichText } from '../../utils/text/richText'
+import { addRoundedRectPath } from '../shared/addRoundedRectPath'
 import {
 	ARROW_LABEL_FONT_SIZES,
 	ARROW_LABEL_PADDING,
@@ -87,40 +88,6 @@ const ArrowHandles = {
 	End: 'end',
 } as const
 type ArrowHandles = (typeof ArrowHandles)[keyof typeof ArrowHandles]
-
-function addRoundedRectPath(path: Path2D, bounds: Box, radius: number, counterClockwise = false) {
-	const r = Math.max(0, Math.min(radius, bounds.w / 2, bounds.h / 2))
-
-	if (r === 0) {
-		path.rect(bounds.x, bounds.y, bounds.w, bounds.h)
-		return
-	}
-
-	if (counterClockwise) {
-		path.moveTo(bounds.x, bounds.y + r)
-		path.lineTo(bounds.x, bounds.maxY - r)
-		path.arcTo(bounds.x, bounds.maxY, bounds.x + r, bounds.maxY, r)
-		path.lineTo(bounds.maxX - r, bounds.maxY)
-		path.arcTo(bounds.maxX, bounds.maxY, bounds.maxX, bounds.maxY - r, r)
-		path.lineTo(bounds.maxX, bounds.y + r)
-		path.arcTo(bounds.maxX, bounds.y, bounds.maxX - r, bounds.y, r)
-		path.lineTo(bounds.x + r, bounds.y)
-		path.arcTo(bounds.x, bounds.y, bounds.x, bounds.y + r, r)
-		path.closePath()
-		return
-	}
-
-	path.moveTo(bounds.x + r, bounds.y)
-	path.lineTo(bounds.maxX - r, bounds.y)
-	path.arcTo(bounds.maxX, bounds.y, bounds.maxX, bounds.y + r, r)
-	path.lineTo(bounds.maxX, bounds.maxY - r)
-	path.arcTo(bounds.maxX, bounds.maxY, bounds.maxX - r, bounds.maxY, r)
-	path.lineTo(bounds.x + r, bounds.maxY)
-	path.arcTo(bounds.x, bounds.maxY, bounds.x, bounds.maxY - r, r)
-	path.lineTo(bounds.x, bounds.y + r)
-	path.arcTo(bounds.x, bounds.y, bounds.x + r, bounds.y, r)
-	path.closePath()
-}
 
 /** @public */
 export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {

--- a/packages/tldraw/src/lib/shapes/shared/addRoundedRectPath.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/addRoundedRectPath.tsx
@@ -1,0 +1,63 @@
+import { Box } from '@tldraw/editor'
+
+/**
+ * Append a rounded rectangle subpath to a `Path2D`, sized to the given bounds. The corner radius
+ * is clamped so it never exceeds half the bounds' width or height; passing `0` falls back to a
+ * plain `path.rect()`.
+ *
+ * Pass `counterClockwise: true` when the subpath is being added to a path that will be used as a
+ * clip or fill mask and you want this rectangle to punch a hole through an enclosing
+ * clockwise shape (using the non-zero fill rule).
+ *
+ * @example
+ * ```ts
+ * const path = new Path2D()
+ * addRoundedRectPath(path, bounds, 8)
+ * ctx.fill(path)
+ * ```
+ *
+ * @param path - The `Path2D` to append the subpath to.
+ * @param bounds - The rectangle's position and size.
+ * @param radius - The corner radius, in the same units as `bounds`.
+ * @param counterClockwise - Draw the path counter-clockwise instead of clockwise. Defaults to `false`.
+ *
+ * @public
+ */
+export function addRoundedRectPath(
+	path: Path2D,
+	bounds: Box,
+	radius: number,
+	counterClockwise = false
+) {
+	const r = Math.max(0, Math.min(radius, bounds.w / 2, bounds.h / 2))
+
+	if (r === 0) {
+		path.rect(bounds.x, bounds.y, bounds.w, bounds.h)
+		return
+	}
+
+	if (counterClockwise) {
+		path.moveTo(bounds.x, bounds.y + r)
+		path.lineTo(bounds.x, bounds.maxY - r)
+		path.arcTo(bounds.x, bounds.maxY, bounds.x + r, bounds.maxY, r)
+		path.lineTo(bounds.maxX - r, bounds.maxY)
+		path.arcTo(bounds.maxX, bounds.maxY, bounds.maxX, bounds.maxY - r, r)
+		path.lineTo(bounds.maxX, bounds.y + r)
+		path.arcTo(bounds.maxX, bounds.y, bounds.maxX - r, bounds.y, r)
+		path.lineTo(bounds.x + r, bounds.y)
+		path.arcTo(bounds.x, bounds.y, bounds.x, bounds.y + r, r)
+		path.closePath()
+		return
+	}
+
+	path.moveTo(bounds.x + r, bounds.y)
+	path.lineTo(bounds.maxX - r, bounds.y)
+	path.arcTo(bounds.maxX, bounds.y, bounds.maxX, bounds.y + r, r)
+	path.lineTo(bounds.maxX, bounds.maxY - r)
+	path.arcTo(bounds.maxX, bounds.maxY, bounds.maxX - r, bounds.maxY, r)
+	path.lineTo(bounds.x + r, bounds.maxY)
+	path.arcTo(bounds.x, bounds.maxY, bounds.x, bounds.maxY - r, r)
+	path.lineTo(bounds.x, bounds.y + r)
+	path.arcTo(bounds.x, bounds.y, bounds.x + r, bounds.y, r)
+	path.closePath()
+}


### PR DESCRIPTION
In order to let SDK consumers draw rounded rectangle subpaths into a `Path2D` without copy/pasting from `ArrowShapeUtil`, this PR moves the existing `addRoundedRectPath` helper out of `ArrowShapeUtil.tsx` into its own file under `packages/tldraw/src/lib/shapes/shared/`, re-exports it from the package, and adds typedoc.

Closes #8907.

### Change type

- [x] `api`

### Test plan

- Arrow labels still render with a rounded background and clip out the arrow body cleanly behind the label.

### Release notes

- Export `addRoundedRectPath`, a helper for appending a rounded-rectangle subpath to a `Path2D`.

### API changes

- Added `addRoundedRectPath(path, bounds, radius, counterClockwise?)` for drawing rounded rectangle subpaths into a `Path2D`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +65 / -34  |
| Automated files | +3 / -0    |