### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -5,10 +5,10 @@ author: tldraw
 date: 05/06/2026
 order: 0
 status: published
-last_version: v5.0.1
+last_version: v5.0.2
 ---
 
-This release redesigns the page menu around inline interaction, adds a `selectLockedShapes` option for inspecting locked shapes, and fixes a misleading "expired" banner for perpetual licenses, along with other UI and licensing bug fixes.
+This release redesigns the page menu around inline interaction, adds a keyboard shortcut to copy styles from a hovered shape, and adds a `selectLockedShapes` option for inspecting locked shapes, along with new public translation APIs and various rendering and UI bug fixes.
 
 ## What's new
 
@@ -19,10 +19,22 @@ The page menu no longer has an explicit edit mode. Reorder pages by dragging a r
 ## API changes
 
 - Add a `selectLockedShapes` option to `TldrawOptions`. When enabled, locked shapes can be selected by left click or by brush/scribble selection while remaining protected from edits, moves, and deletes. ([#8860](https://github.com/tldraw/tldraw/pull/8860))
+- Export `TldrawUiTranslationProvider`, `AssetUrlsProvider`, and `useAssetUrls` as public API so components like `TldrawSelectionForeground` can be rendered without the full `TldrawUiContextProvider`. ([#8909](https://github.com/tldraw/tldraw/pull/8909))
+- Add `FontManager.dispose()`, `OverlayManager.dispose()`, and `OverlayUtil.dispose()` for cleaning up manager state across editor lifecycles. ([#8896](https://github.com/tldraw/tldraw/pull/8896))
+
+## Improvements
+
+- Add a `q` shortcut that copies the styles of the hovered shape and applies them to the next shape you create. ([#8917](https://github.com/tldraw/tldraw/pull/8917)) (contributed by [@kaneel](https://github.com/kaneel))
+- Improve performance on busy canvases — `getRenderingShapes()` now skips its sort step when only shape props, not the set of shape ids, have changed. ([#8784](https://github.com/tldraw/tldraw/pull/8784))
 
 ## Bug fixes
 
 - Fix a misleading "license expired" console warning for perpetual licenses on covered versions. ([#8791](https://github.com/tldraw/tldraw/pull/8791))
 - Fix inconsistent tooltip behavior on the video toolbar by using `TldrawUiToolbarButton` for the replace and download buttons. ([#8794](https://github.com/tldraw/tldraw/pull/8794))
 - Fix the missing open-state hint on the page menu and zoom menu triggers when rendered outside the main toolbar. ([#8813](https://github.com/tldraw/tldraw/pull/8813))
-- Mark the tldraw UI layer with `role="document"` so toolbars, menus, and dialogs stay reachable to mobile screen readers like VoiceOver and TalkBack, which do not announce the outer canvas `role="application"`. ([#8849](https://github.com/tldraw/tldraw/issues/8849))
+- Mark the tldraw UI layer with `role="document"` so toolbars, menus, and dialogs stay reachable to mobile screen readers like VoiceOver and TalkBack, which do not announce the outer canvas `role="application"`. ([#8901](https://github.com/tldraw/tldraw/pull/8901))
+- Fix selection edge resize handles overlapping corner handles, which made corners hard to grab on small shapes. ([#8926](https://github.com/tldraw/tldraw/pull/8926))
+- Fix a bug where deleting a shape inside a group could move the group to a different z-index. ([#8925](https://github.com/tldraw/tldraw/pull/8925)) (contributed by [@kaneel](https://github.com/kaneel))
+- Avoid console errors from calling `preventDefault` on non-cancelable events. ([#8910](https://github.com/tldraw/tldraw/pull/8910))
+- Only log the missing-translation warning once per session instead of once per `useTranslation` consumer. ([#8909](https://github.com/tldraw/tldraw/pull/8909))
+- Catch `image.decode()` rejections from the icon preload effect so they no longer surface as uncaught promise errors in the console. ([#8824](https://github.com/tldraw/tldraw/pull/8824))

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -479,10 +479,15 @@ export const ASPECT_RATIO_TO_VALUE: Record<ASPECT_RATIO_OPTION, number>;
 export function AssetToolbarItem(): JSX.Element;
 
 // @public
-export function AssetUrlsProvider({ assetUrls, children }: {
+export function AssetUrlsProvider({ assetUrls, children }: AssetUrlsProviderProps): JSX.Element;
+
+// @public (undocumented)
+export interface AssetUrlsProviderProps {
+    // (undocumented)
     assetUrls: TLUiAssetUrls;
+    // (undocumented)
     children: React.ReactNode;
-}): JSX.Element;
+}
 
 // @public (undocumented)
 export interface BasePathBuilderOpts {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -721,7 +721,11 @@ export {
 	type TLUiActionItem,
 	type TLUiActionsContextType,
 } from './lib/ui/context/actions'
-export { AssetUrlsProvider, useAssetUrls } from './lib/ui/context/asset-urls'
+export {
+	AssetUrlsProvider,
+	useAssetUrls,
+	type AssetUrlsProviderProps,
+} from './lib/ui/context/asset-urls'
 export {
 	BreakPointProvider,
 	useBreakpoint,

--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -7,19 +7,19 @@ type UiAssetUrlsContextType = TLUiAssetUrls | null
 
 const AssetUrlsContext = createContext<UiAssetUrlsContextType>(null)
 
+/** @public */
+export interface AssetUrlsProviderProps {
+	assetUrls: TLUiAssetUrls
+	children: React.ReactNode
+}
+
 /**
  * Provides asset URLs (icons, fonts, translations, embed icons) to the editor's UI.
  * Required when using `TldrawUiTranslationProvider` without `TldrawUiContextProvider`.
  *
  * @public @react
  */
-export function AssetUrlsProvider({
-	assetUrls,
-	children,
-}: {
-	assetUrls: TLUiAssetUrls
-	children: React.ReactNode
-}) {
+export function AssetUrlsProvider({ assetUrls, children }: AssetUrlsProviderProps) {
 	useEffect(() => {
 		for (const src of Object.values(assetUrls.icons)) {
 			if (!src) continue


### PR DESCRIPTION
This PR does two things on the same branch: it refreshes the next-release notes, and it fixes a public API shape that was breaking the docs build.

**Release notes.** In order to keep the next release notes current with `main`, this updates `apps/docs/content/releases/next.mdx` with PRs that have landed since the v5.0.2 patch release. Source is `main` (development weeks), so these entries are preliminary and some may be pruned when the production branch is cut. It bumps `last_version` from v5.0.1 to v5.0.2 (no archive needed — v5.0.0 is already archived and v5.0.2 is a patch). New entries added:

- **API changes**: public `TldrawUiTranslationProvider`, `AssetUrlsProvider`, and `useAssetUrls` (#8909); `dispose()` methods for the font and overlay managers (#8896).
- **Improvements** (new section): the `q` copy-styles shortcut (#8917, community), and a `getRenderingShapes()` sort-caching perf win (#8784).
- **Bug fixes**: selection edge/corner handle hit areas (#8926), group z-index after deletion (#8925, community), `preventDefault` on non-cancelable events (#8910), the deduped missing-translation warning (#8909), and `image.decode()` rejection handling (#8824).

Same-cycle page-menu polish (#8927, #8924) and infra/chore/dotcom/docs PRs were skipped. The role=document entry now links to PR #8901 instead of issue #8849. No stale entries needed pruning.

**Build fix.** `AssetUrlsProvider` (made public in the already-merged #8909) declared its props as an inline object type, which the api docs build rejects for public React components ("Expected props parameter to be a simple reference. Rewrite this to use a `AssetUrlsProviderProps` interface."). This extracts the inline type into an exported `AssetUrlsProviderProps` interface and regenerates the API report. The same error currently affects `main`, so this also unblocks the docs deploy there.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### API changes

- Added `AssetUrlsProviderProps` as a public interface for `AssetUrlsProvider`'s props (no behavioral change).

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +12 / -8   |
| Automated files | +7 / -2    |
| Documentation   | +15 / -3   |
