### PR TITLE
chore: include user description verbatim in issue skill

### DIFF
--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -9,6 +9,14 @@ Create a GitHub issue on `tldraw/tldraw` from a user description, then research 
 
 Use `../write-issue/SKILL.md` as the standards reference for issue titles, bodies, types, labels, and triage conventions.
 
+At the top of the issue, include the user's original description verbatim. Annotate it with the human emoji, separated from your work by a horizontal rule. Example:
+
+```
+🧑: {user_description}
+
+---
+```
+
 ## Workflow
 
 1. Gather context:


### PR DESCRIPTION
In order to preserve the user's original intent when creating GitHub issues via the issue skill, this PR adds a convention to include the user's description verbatim at the top of the issue body, annotated with a human emoji and separated from researched content by a horizontal rule.

### Change type

- [x] `other`

### Test plan

- [ ] Run `/issue` with a description and verify the user's text appears verbatim at the top of the created issue

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +8 / -0    |