### PR TITLE
fix(tldraw): block paste while pointer is down

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2397,7 +2397,7 @@ export function GroupMenuItem(): JSX.Element | null;
 export function GroupOrUngroupMenuItem(): JSX.Element;
 
 // @public
-export const handleNativeOrMenuCopy: (editor: Editor, context?: TLClipboardWriteInfo) => Promise<boolean>;
+export function handleNativeOrMenuCopy(editor: Editor, context?: TLClipboardWriteInfo): Promise<boolean>;
 
 // @public (undocumented)
 export class HandTool extends StateNode {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2397,7 +2397,7 @@ export function GroupMenuItem(): JSX.Element | null;
 export function GroupOrUngroupMenuItem(): JSX.Element;
 
 // @public
-export function handleNativeOrMenuCopy(editor: Editor, context?: TLClipboardWriteInfo): Promise<boolean>;
+export const handleNativeOrMenuCopy: (editor: Editor, context?: TLClipboardWriteInfo) => Promise<boolean>;
 
 // @public (undocumented)
 export class HandTool extends StateNode {

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -236,13 +236,16 @@ type ClipboardThing =
  * @param point - The point to paste at
  * @internal
  */
-const handlePasteFromEventClipboardData = async (
+export const handlePasteFromEventClipboardData = async (
 	editor: Editor,
 	clipboardData: DataTransfer,
 	point?: VecLike
 ) => {
-	// Do not paste while in any editing state
-	if (editor.getEditingShapeId() !== null) return
+	// Do not paste while in any editing state, or while the user is in the middle
+	// of a pointer interaction (e.g. dragging an arrow handle, resizing, or
+	// translating a shape) — paste would change selection and create shapes
+	// under the active drag.
+	if (editor.getEditingShapeId() !== null || editor.inputs.getIsPointing()) return
 
 	if (!clipboardData) {
 		throw Error('No clipboard data')
@@ -813,8 +816,10 @@ export function useMenuClipboardEvents() {
 			if (!editor) return
 			// If we're editing a shape, or we are focusing an editable input, then
 			// we would want the user's paste interaction to go to that element or
-			// input instead; e.g. when pasting text into a text shape's content
-			if (editor.getEditingShapeId() !== null) return
+			// input instead; e.g. when pasting text into a text shape's content.
+			// Also skip when the user is in the middle of a pointer interaction
+			// (dragging a handle, resizing, translating) — paste would interrupt it.
+			if (editor.getEditingShapeId() !== null || editor.inputs.getIsPointing()) return
 
 			const win = editor.getContainerWindow()
 			if (Array.isArray(data) && data[0] instanceof win.ClipboardItem) {
@@ -927,8 +932,16 @@ export function useNativeClipboardEvents() {
 
 			// If we're editing a shape, or we are focusing an editable input, then
 			// we would want the user's paste interaction to go to that element or
-			// input instead; e.g. when pasting text into a text shape's content
-			if (editor.getEditingShapeId() !== null || areShortcutsDisabled(editor)) return
+			// input instead; e.g. when pasting text into a text shape's content.
+			// Also skip when the user is in the middle of a pointer interaction
+			// (dragging a handle, resizing, translating) — paste would interrupt it.
+			if (
+				editor.getEditingShapeId() !== null ||
+				editor.inputs.getIsPointing() ||
+				areShortcutsDisabled(editor)
+			) {
+				return
+			}
 
 			// Cmd+Shift+V / Ctrl+Shift+V = paste as plain text (no formatting).
 			// If there's no plain text on the clipboard (e.g., a copied PNG), fall

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -236,11 +236,11 @@ type ClipboardThing =
  * @param point - The point to paste at
  * @internal
  */
-export async function handlePasteFromEventClipboardData(
+export const handlePasteFromEventClipboardData = async (
 	editor: Editor,
 	clipboardData: DataTransfer,
 	point?: VecLike
-) {
+) => {
 	// Do not paste while in any editing state, or while the user is in the middle
 	// of a pointer interaction (e.g. dragging an arrow handle, resizing, or
 	// translating a shape) — paste would change selection and create shapes
@@ -295,7 +295,7 @@ export async function handlePasteFromEventClipboardData(
  * @param point - The point to paste at
  * @internal
  */
-async function handlePasteFromClipboardApi({
+const handlePasteFromClipboardApi = async ({
 	editor,
 	clipboardItems,
 	point,
@@ -307,7 +307,7 @@ async function handlePasteFromClipboardApi({
 	point?: VecLike
 	fallbackFiles?: File[]
 	clipboardPasteSource: 'native-event' | 'clipboard-read'
-}) {
+}) => {
 	// We need to populate the array of clipboard things
 	// based on the ClipboardItems from the Clipboard API.
 	// This is done in a different way than when using
@@ -700,10 +700,10 @@ async function handleClipboardThings(
  *
  * @public
  */
-export async function handleNativeOrMenuCopy(
+export const handleNativeOrMenuCopy = async (
 	editor: Editor,
 	context: TLClipboardWriteInfo = { operation: 'copy', source: 'menu' }
-): Promise<boolean> {
+): Promise<boolean> => {
 	const nav = editor.getContainerWindow().navigator
 	let content = await editor.resolveAssetsInContent(
 		editor.getContentFromCurrentPage(editor.getSelectedShapeIds())

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -236,11 +236,11 @@ type ClipboardThing =
  * @param point - The point to paste at
  * @internal
  */
-export const handlePasteFromEventClipboardData = async (
+export async function handlePasteFromEventClipboardData(
 	editor: Editor,
 	clipboardData: DataTransfer,
 	point?: VecLike
-) => {
+) {
 	// Do not paste while in any editing state, or while the user is in the middle
 	// of a pointer interaction (e.g. dragging an arrow handle, resizing, or
 	// translating a shape) — paste would change selection and create shapes
@@ -295,7 +295,7 @@ export const handlePasteFromEventClipboardData = async (
  * @param point - The point to paste at
  * @internal
  */
-const handlePasteFromClipboardApi = async ({
+async function handlePasteFromClipboardApi({
 	editor,
 	clipboardItems,
 	point,
@@ -307,7 +307,7 @@ const handlePasteFromClipboardApi = async ({
 	point?: VecLike
 	fallbackFiles?: File[]
 	clipboardPasteSource: 'native-event' | 'clipboard-read'
-}) => {
+}) {
 	// We need to populate the array of clipboard things
 	// based on the ClipboardItems from the Clipboard API.
 	// This is done in a different way than when using
@@ -700,10 +700,10 @@ async function handleClipboardThings(
  *
  * @public
  */
-export const handleNativeOrMenuCopy = async (
+export async function handleNativeOrMenuCopy(
 	editor: Editor,
 	context: TLClipboardWriteInfo = { operation: 'copy', source: 'menu' }
-): Promise<boolean> => {
+): Promise<boolean> {
 	const nav = editor.getContainerWindow().navigator
 	let content = await editor.resolveAssetsInContent(
 		editor.getContentFromCurrentPage(editor.getSelectedShapeIds())

--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -715,7 +715,11 @@ describe('When pasting during a pointer interaction', () => {
 			],
 		} as unknown as DataTransfer
 		await handlePasteFromEventClipboardData(editor, clipboardData)
-		// Let any deferred microtasks settle.
+		// The paste flow returns its outer Promise before its inner work runs;
+		// drain a couple of microtask ticks so the spy can observe whether
+		// `markHistoryStoppingPoint('paste')` was reached. setTimeout(0) is
+		// avoided here because it interleaves with the paste flow's own
+		// timer-based work and can hang the test on the negative case.
 		await Promise.resolve()
 		await Promise.resolve()
 

--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -1,4 +1,6 @@
-import { TLFrameShape, TLGeoShape, approximately, createShapeId } from '@tldraw/editor'
+import { IndexKey, TLFrameShape, TLGeoShape, approximately, createShapeId } from '@tldraw/editor'
+import { vi } from 'vitest'
+import { handlePasteFromEventClipboardData } from '../lib/ui/hooks/useClipboardEvents'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -663,5 +665,63 @@ describe('When pasting into frames...', () => {
 		// The left and right shapes are far outside the frame → kicked out to page
 		expect(left.parentId).toBe(editor.getCurrentPageId())
 		expect(right.parentId).toBe(editor.getCurrentPageId())
+	})
+})
+
+describe('When pasting during a pointer interaction', () => {
+	// Regression test for https://github.com/tldraw/tldraw/issues/8305 — paste
+	// while dragging an arrow handle (or any other pointer-driven interaction)
+	// should be suppressed so it doesn't interrupt the active drag.
+	it('does not paste while dragging an arrow handle', async () => {
+		const arrowId = createShapeId('arrow1')
+		editor.createShapes([
+			{
+				id: arrowId,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: { start: { x: 0, y: 0 }, end: { x: 100, y: 0 } },
+			},
+		])
+
+		const arrow = editor.getShape(arrowId)!
+
+		editor.pointerDown(200, 100, {
+			target: 'handle',
+			shape: arrow,
+			handle: { id: 'end', type: 'vertex', index: 'a2' as IndexKey, x: 100, y: 0 },
+		})
+		editor.pointerMove(250, 100)
+		editor.expectToBeIn('select.dragging_handle')
+		expect(editor.inputs.getIsPointing()).toBe(true)
+
+		// The actual paste flow is async and not awaited at the call site, so
+		// shape creation isn't observable synchronously. Spy on
+		// markHistoryStoppingPoint('paste') — it is called the moment the paste
+		// flow commits to applying clipboard content — to detect whether the
+		// guard bailed.
+		const markSpy = vi.spyOn(editor, 'markHistoryStoppingPoint')
+
+		// jsdom does not provide DataTransfer; mock just enough for the paste
+		// flow to (otherwise) commit a text paste, so an unblocked paste would
+		// be visible via the spy.
+		const clipboardData = {
+			items: [
+				{
+					kind: 'string',
+					type: 'text/plain',
+					getAsString: (cb: (s: string) => void) => cb('hello world'),
+				},
+			],
+		} as unknown as DataTransfer
+		await handlePasteFromEventClipboardData(editor, clipboardData)
+		// Let any deferred microtasks settle.
+		await Promise.resolve()
+		await Promise.resolve()
+
+		editor.expectToBeIn('select.dragging_handle')
+		expect(markSpy).not.toHaveBeenCalledWith('paste')
+
+		markSpy.mockRestore()
 	})
 })


### PR DESCRIPTION
In order to fix #8305, this PR adds an `editor.inputs.getIsPointing()` guard to the three paste handlers in `useClipboardEvents.ts`. Without it, pressing Cmd+V while dragging an arrow handle (or resizing/translating a shape) would create new shapes underneath the active drag and steal selection from it, so the in-progress interaction ended in a broken state — the dotted arrow-binding indicator disappeared, and on pointer-up the newly pasted shape became the selection instead of the arrow completing its binding.

The clipboard handler already short-circuited when `editor.getEditingShapeId() !== null` (the text-editing case). The fix extends the same guard pattern to cover pointer-driven interactions, which use `editor.inputs.isPointing` rather than `editingShapeId`. The state machine itself was unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. Create a geo shape and an arrow on a tldraw canvas.
2. Press and hold on the arrow's end handle, drag it toward the geo shape so the dotted binding indicator appears.
3. While the pointer is still down, press Cmd+V (with anything on the clipboard).
4. Confirm the binding indicator stays, no new shape is pasted, and releasing the pointer completes the arrow binding.
5. Repeat with a shape resize and a shape translate — pasting mid-drag should be a no-op in both cases.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix paste interrupting an in-progress arrow handle drag, shape resize, or shape translate.

### API changes

- Promoted `handlePasteFromEventClipboardData` from an unexported helper to an `@internal` export (used by the new regression test). No public surface change — `api-report.api.md` is unaffected.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +20 / -7   |
| Tests     | +65 / -1   |