### PR TITLE
fix(tldraw): cancel pending shape creation on touch long press

### DIFF
--- a/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
+++ b/packages/editor/src/lib/editor/tools/BaseBoxShapeTool/children/Pointing.ts
@@ -77,6 +77,10 @@ export class Pointing extends StateNode {
 		this.cancel()
 	}
 
+	override onLongPress() {
+		if (this.editor.getInstanceState().isCoarsePointer) this.cancel()
+	}
+
 	complete() {
 		const originPagePoint = this.editor.inputs.getOriginPagePoint()
 

--- a/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/toolStates/Pointing.tsx
@@ -81,6 +81,10 @@ export class Pointing extends StateNode {
 		this.cancel()
 	}
 
+	override onLongPress() {
+		if (this.editor.getInstanceState().isCoarsePointer) this.cancel()
+	}
+
 	cancel() {
 		if (this.shape) {
 			// the arrow might not have been created yet!

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -756,6 +756,14 @@ export class Drawing extends StateNode {
 		this.cancel()
 	}
 
+	override onLongPress() {
+		if (!this.editor.getInstanceState().isCoarsePointer) return
+		if (this.markId) {
+			this.editor.bailToMark(this.markId)
+		}
+		this.cancel()
+	}
+
 	complete() {
 		const { initialShape } = this
 		if (!initialShape) return

--- a/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/geo/toolStates/Pointing.ts
@@ -72,6 +72,10 @@ export class Pointing extends StateNode {
 		this.cancel()
 	}
 
+	override onLongPress() {
+		if (this.editor.getInstanceState().isCoarsePointer) this.cancel()
+	}
+
 	private complete() {
 		const originPagePoint = this.editor.inputs.getOriginPagePoint()
 

--- a/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/line/toolStates/Pointing.ts
@@ -150,6 +150,10 @@ export class Pointing extends StateNode {
 		this.editor.snaps.clearIndicators()
 	}
 
+	override onLongPress() {
+		if (this.editor.getInstanceState().isCoarsePointer) this.cancel()
+	}
+
 	complete() {
 		this.parent.transition('idle', { shapeId: this.shape.id })
 		this.editor.snaps.clearIndicators()

--- a/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/note/toolStates/Pointing.ts
@@ -83,6 +83,10 @@ export class Pointing extends StateNode {
 		this.cancel()
 	}
 
+	override onLongPress() {
+		if (this.editor.getInstanceState().isCoarsePointer) this.cancel()
+	}
+
 	override onComplete() {
 		this.complete()
 	}

--- a/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
+++ b/packages/tldraw/src/lib/shapes/text/toolStates/Pointing.ts
@@ -107,6 +107,10 @@ export class Pointing extends StateNode {
 		this.cancel()
 	}
 
+	override onLongPress() {
+		if (this.editor.getInstanceState().isCoarsePointer) this.cancel()
+	}
+
 	private complete() {
 		this.editor.markHistoryStoppingPoint('creating text shape')
 		const id = createShapeId()

--- a/packages/tldraw/src/test/long-press-create.test.ts
+++ b/packages/tldraw/src/test/long-press-create.test.ts
@@ -1,0 +1,72 @@
+import { vi } from 'vitest'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+afterEach(() => {
+	editor?.dispose()
+})
+
+vi.useFakeTimers()
+
+// On a touch device a long press fires the browser `contextmenu` event. Each
+// shape-creation tool should respond to the long press by canceling any pending
+// creation and returning to idle, so the context menu opens with no stray shape
+// left behind. The guard is `isCoarsePointer`, so fine-pointer (desktop)
+// behavior must be preserved. See #8277.
+const CREATION_TOOLS = [
+	{ tool: 'geo', pointingState: 'geo.pointing' },
+	{ tool: 'note', pointingState: 'note.pointing' },
+	{ tool: 'text', pointingState: 'text.pointing' },
+	{ tool: 'line', pointingState: 'line.pointing' },
+	{ tool: 'arrow', pointingState: 'arrow.pointing' },
+	{ tool: 'draw', pointingState: 'draw.drawing' },
+	{ tool: 'frame', pointingState: 'frame.pointing' },
+] as const
+
+describe('long press on shape-creation tools', () => {
+	describe('with a coarse pointer', () => {
+		beforeEach(() => {
+			editor.updateInstanceState({ isCoarsePointer: true })
+		})
+
+		it.each(CREATION_TOOLS)(
+			'$tool cancels creation and returns to idle, leaving no shape behind',
+			({ tool }) => {
+				editor.setCurrentTool(tool)
+				editor.pointerDown(100, 100)
+				vi.advanceTimersByTime(editor.options.longPressDurationMs)
+
+				editor.expectToBeIn(`${tool}.idle`)
+				expect(editor.getCurrentPageShapes()).toHaveLength(0)
+
+				// releasing the long press must not create a shape either
+				editor.pointerUp(100, 100)
+				expect(editor.getCurrentPageShapes()).toHaveLength(0)
+			}
+		)
+	})
+
+	describe('with a fine pointer', () => {
+		beforeEach(() => {
+			editor.updateInstanceState({ isCoarsePointer: false })
+		})
+
+		it.each(CREATION_TOOLS)(
+			'$tool ignores the long press and stays in $pointingState',
+			({ tool, pointingState }) => {
+				editor.setCurrentTool(tool)
+				editor.pointerDown(100, 100)
+				editor.expectToBeIn(pointingState)
+
+				vi.advanceTimersByTime(editor.options.longPressDurationMs)
+
+				// desktop behavior is preserved: the tool is still mid-creation
+				editor.expectToBeIn(pointingState)
+			}
+		)
+	})
+})


### PR DESCRIPTION
In order to fix [#8277](https://github.com/tldraw/tldraw/issues/8277), this PR makes every shape-creation tool handle `onLongPress` in coarse pointer mode by canceling any pending creation and returning to idle. The browser-fired `contextmenu` then opens the context menu cleanly with no stray shape left behind, matching the behavior the Select tool already had.

Before this change, long-pressing the canvas on a touch device with a shape-creation tool active produced a mess: the geo and text tools created a default-sized shape on the eventual `pointerUp` (which fires when the long-press releases), while the note and line tools created a shape immediately in `onEnter` and left it behind once the menu opened. Other tools (draw, arrow, frame) simply ignored long-press entirely.

The cancel is gated on `editor.getInstanceState().isCoarsePointer` so desktop behavior is preserved. The "pause before drag to create an arrow with a precise start point" gesture, which relies on the 500ms long-press timer firing during a fine-pointer hold, still works on mouse devices.

Closes #8277

### Change type

- [x] `bugfix`

### Test plan

1. Open the app on a touch device, or enable touch + coarse pointer emulation in Chrome DevTools (⌘⇧M, pick a touch device).
2. For each tool (Rectangle, Ellipse, other geo variants, Note, Line, Arrow, Text, Frame, Draw): long-press the canvas without moving.
3. Confirm: the context menu opens and **no shape is left on the canvas**.
4. Turn touch emulation off. Press R for the Rectangle tool and click-drag — a shape should still be created normally.
5. Press the Arrow tool, mouse-down on a shape, pause for over 500ms, then drag — the arrow should still create with a precise start point (existing fine-pointer behavior).

This behavior is also covered by `packages/tldraw/src/test/long-press-create.test.ts`, which drives a long press through each tool in both coarse- and fine-pointer modes and asserts the coarse case returns to idle with no shape left behind while the fine case stays mid-creation.

- [x] Unit tests

### Release notes

- Fix touch long-press on shape-creation tools so the context menu opens without leaving a stray shape behind.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +32 / -0   |
