### PR TITLE
refactor: enforce tldraw/no-exported-arrow-const repo-wide

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -261,7 +261,6 @@
 		{
 			"files": ["packages/editor/**/*", "packages/tldraw/**/*", "packages/utils/**/*"],
 			"rules": {
-				"tldraw/no-exported-arrow-const": "off",
 				"no-restricted-globals": [
 					"error",
 					{
@@ -417,7 +416,6 @@
 			"rules": {
 				"tldraw/no-setter-getter": "off",
 				"tldraw/no-direct-storage": "off",
-				"tldraw/no-exported-arrow-const": "off",
 				"tldraw/img-referrer-policy": "off"
 			}
 		},
@@ -427,7 +425,6 @@
 				"tldraw/prefer-class-methods": "off",
 				"tldraw/no-setter-getter": "off",
 				"tldraw/no-direct-storage": "off",
-				"tldraw/no-exported-arrow-const": "off",
 				"tldraw/img-referrer-policy": "off",
 				"no-console": "off",
 				"tldraw/method-signature-style": "off"

--- a/apps/examples/src/examples/events/derived-view/DerivedViewExample.tsx
+++ b/apps/examples/src/examples/events/derived-view/DerivedViewExample.tsx
@@ -31,7 +31,7 @@ function ShowNumberOfDrawShapesOnPage() {
 	)
 }
 
-export const deriveNumberOfDrawShapesInDocument = (editor: Editor) => {
+export function deriveNumberOfDrawShapesInDocument(editor: Editor) {
 	const { store } = editor
 	const shapesIndex = store.query.ids('shape')
 

--- a/apps/examples/src/examples/shapes/tools/globs-editor/GlobShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/globs-editor/GlobShapeUtil.tsx
@@ -981,7 +981,7 @@ const getHandleData = (id: string) => {
 	return { edgeType, point }
 }
 
-export const getNeighborGlobs = (editor: Editor, shape: GlobShape) => {
+export function getNeighborGlobs(editor: Editor, shape: GlobShape) {
 	const currentGlobBindings = editor.getBindingsFromShape<GlobBinding>(shape.id, 'glob')
 
 	const neighborGlobs: Set<GlobShape> = new Set()

--- a/apps/examples/src/examples/shapes/tools/globs-editor/shared.ts
+++ b/apps/examples/src/examples/shapes/tools/globs-editor/shared.ts
@@ -4,7 +4,7 @@ import { GlobShape } from './GlobShapeUtil'
 import { NodeShape } from './NodeShapeUtil'
 import { getOuterTangentPoints } from './utils'
 
-export const getStartAndEndNodes = (editor: Editor, glob: TLShapeId) => {
+export function getStartAndEndNodes(editor: Editor, glob: TLShapeId) {
 	const bindings = editor.getBindingsFromShape<GlobBinding>(glob, 'glob')
 	if (!bindings.length) return null
 
@@ -35,14 +35,14 @@ export function getGlobBindings(editor: Editor, shape: GlobShape): GlobBindings 
 	return { start, end }
 }
 
-export const getGlobTangentUpdate = (
+export function getGlobTangentUpdate(
 	editor: Editor,
 	globId: TLShapeId,
 	startNodePagePos: VecLike,
 	startRadius: number,
 	endNodePagePos: VecLike,
 	endRadius: number
-) => {
+) {
 	// Calculate midpoint in page space
 	const midPagePos = Vec.Average([startNodePagePos, endNodePagePos])
 

--- a/apps/examples/src/examples/shapes/tools/globs-editor/utils.ts
+++ b/apps/examples/src/examples/shapes/tools/globs-editor/utils.ts
@@ -1,12 +1,12 @@
 import { Vec, VecLike, VecModel } from 'tldraw'
 
-export const getOuterTangentPoints = (
+export function getOuterTangentPoints(
 	c0: VecLike,
 	r0: number,
 	c1: VecLike,
 	r1: number,
 	side?: 'edgeA' | 'edgeB'
-): VecModel[] => {
+): VecModel[] {
 	const offsetAngle = Vec.Angle(c0, c1)
 	const d = Vec.Dist(c0, c1)
 
@@ -43,7 +43,7 @@ export const getOuterTangentPoints = (
 	]
 }
 
-export const getGlobEndPoint = (c: VecModel, d: VecModel, r: number, side: number = 0) => {
+export function getGlobEndPoint(c: VecModel, d: VecModel, r: number, side: number = 0) {
 	const angle = Vec.Angle(c, d)
 
 	const displacement = Vec.Sub(c, d)
@@ -62,7 +62,7 @@ export const getGlobEndPoint = (c: VecModel, d: VecModel, r: number, side: numbe
 	return p
 }
 
-export const getArcFlag = (c: VecModel, e0: VecModel, e1: VecModel) => {
+export function getArcFlag(c: VecModel, e0: VecModel, e1: VecModel) {
 	const d0 = Vec.Angle(c, e0)
 	const d1 = Vec.Angle(c, e1)
 
@@ -73,7 +73,7 @@ export const getArcFlag = (c: VecModel, e0: VecModel, e1: VecModel) => {
 	return theta > 0 ? false : true
 }
 
-export const projectTensionPoint = (lineStart: VecModel, lineEnd: VecModel, handle: VecModel) => {
+export function projectTensionPoint(lineStart: VecModel, lineEnd: VecModel, handle: VecModel) {
 	const lineDir = Vec.Sub(lineEnd, lineStart)
 	const lineLength = lineDir.len()
 
@@ -84,12 +84,12 @@ export const projectTensionPoint = (lineStart: VecModel, lineEnd: VecModel, hand
 	return clampedProjection / lineLength
 }
 
-export const circleCentresOverlap = (c0: VecModel, r0: number, c1: VecModel) => {
+export function circleCentresOverlap(c0: VecModel, r0: number, c1: VecModel) {
 	const d = Vec.Dist(c0, c1)
 	return d <= r0
 }
 
-export const getClosestPointOnCircle = (c: VecModel, r: number, p: VecModel) => {
+export function getClosestPointOnCircle(c: VecModel, r: number, p: VecModel) {
 	const pDirection = Vec.Sub(p, c).uni()
 
 	return Vec.Add(c, Vec.Mul(pDirection, r + 1)).toJson()

--- a/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/helpers.tsx
+++ b/apps/examples/src/examples/shapes/tools/speech-bubble/SpeechBubble/helpers.tsx
@@ -1,7 +1,7 @@
 import { Vec, VecLike, lerp, pointInPolygon } from 'tldraw'
 import { SpeechBubbleShape } from './SpeechBubbleUtil'
 
-export const getSpeechBubbleVertices = (shape: SpeechBubbleShape): Vec[] => {
+export function getSpeechBubbleVertices(shape: SpeechBubbleShape): Vec[] {
 	const { w, tail } = shape.props
 
 	const fullHeight = shape.props.h + shape.props.growY

--- a/apps/examples/src/examples/use-cases/custom-shape-mermaids/mermaidPipelineBlueprint.ts
+++ b/apps/examples/src/examples/use-cases/custom-shape-mermaids/mermaidPipelineBlueprint.ts
@@ -2,7 +2,7 @@ import type { MermaidNodeRenderMapper } from '@tldraw/mermaid'
 import { CUSTOM_SHAPE_TYPE } from './customMermaidShapeUtil'
 
 /** Pass to `createMermaidDiagram` → `blueprintRender.mapNodeToRenderSpec`: custom `flowchart-util` + `mermaidNodeId` (layer badges applied after import via `applyPipelineStepIndices`). */
-export const mapNodeToRenderSpec: MermaidNodeRenderMapper = (input) => {
+export const mapNodeToRenderSpec: MermaidNodeRenderMapper = function mapNodeToRenderSpec(input) {
 	if (input.diagramKind !== 'flowchart') return undefined
 
 	return {

--- a/apps/examples/src/examples/use-cases/slideshow/SlidesManager.tsx
+++ b/apps/examples/src/examples/use-cases/slideshow/SlidesManager.tsx
@@ -90,7 +90,7 @@ class SlidesManager {
 
 const slidesContext = createContext({} as SlidesManager)
 
-export const SlidesProvider = ({ children }: { children: ReactNode }) => {
+export function SlidesProvider({ children }: { children: ReactNode }) {
 	const [slideManager] = useState(() => new SlidesManager())
 	return <slidesContext.Provider value={slideManager}>{children}</slidesContext.Provider>
 }

--- a/apps/examples/src/examples/use-cases/tower-defense/game-state.ts
+++ b/apps/examples/src/examples/use-cases/tower-defense/game-state.ts
@@ -60,11 +60,17 @@ export const elapsedMs$ = atom('elapsedMs', 0)
 export const towerCooldowns = new Map<string, TowerCooldown>()
 
 let _nextEnemyId = 1
-export const nextEnemyId = () => _nextEnemyId++
+export function nextEnemyId() {
+	return _nextEnemyId++
+}
 let _nextProjId = 1
-export const nextProjectileId = () => _nextProjId++
+export function nextProjectileId() {
+	return _nextProjId++
+}
 let _nextExplosionId = 1
-export const nextExplosionId = () => _nextExplosionId++
+export function nextExplosionId() {
+	return _nextExplosionId++
+}
 
 export function resetGameState() {
 	enemies$.set([])

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -697,7 +697,10 @@ export function DefaultBackground(): JSX.Element;
 export function DefaultCanvas({ className }: TLCanvasComponentProps): JSX.Element;
 
 // @public (undocumented)
-export const DefaultErrorFallback: TLErrorFallbackComponent;
+export function DefaultErrorFallback({ error, editor }: {
+    editor?: Editor;
+    error: unknown;
+}): JSX.Element;
 
 // @public (undocumented)
 export function DefaultGrid({ x, y, z, size }: TLGridProps): JSX.Element;
@@ -712,7 +715,7 @@ export const DefaultShapeWrapper: ForwardRefExoticComponent<TLShapeWrapperProps 
 export function DefaultSpinner(props: React.SVGProps<SVGSVGElement>): JSX.Element;
 
 // @public (undocumented)
-export const DefaultSvgDefs: () => null;
+export function DefaultSvgDefs(): null;
 
 // @public (undocumented)
 export const defaultTldrawOptions: {
@@ -2352,7 +2355,7 @@ export function isAccelKey(e: {
 }): boolean;
 
 // @public
-export const isSafeFloat: (n: number) => boolean;
+export function isSafeFloat(n: number): boolean;
 
 // @public
 export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[], opts?: {
@@ -3285,7 +3288,7 @@ export abstract class StateNode implements Partial<TLEventHandlers> {
 }
 
 // @public @deprecated
-export const stopEventPropagation: (e: any) => any;
+export function stopEventPropagation(e: any): any;
 
 // @internal (undocumented)
 export type StoreName = (typeof Table)[keyof typeof Table];

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -697,10 +697,7 @@ export function DefaultBackground(): JSX.Element;
 export function DefaultCanvas({ className }: TLCanvasComponentProps): JSX.Element;
 
 // @public (undocumented)
-export function DefaultErrorFallback({ error, editor }: {
-    editor?: Editor;
-    error: unknown;
-}): JSX.Element;
+export const DefaultErrorFallback: TLErrorFallbackComponent;
 
 // @public (undocumented)
 export function DefaultGrid({ x, y, z, size }: TLGridProps): JSX.Element;

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -16,7 +16,7 @@ const BASE_ERROR_URL = 'https://github.com/tldraw/tldraw/issues/new'
 export type TLErrorFallbackComponent = ComponentType<{ error: unknown; editor?: Editor }>
 
 /** @public @react */
-export const DefaultErrorFallback: TLErrorFallbackComponent = ({ error, editor }) => {
+export function DefaultErrorFallback({ error, editor }: { error: unknown; editor?: Editor }) {
 	const containerRef = useRef<HTMLDivElement>(null)
 	const [shouldShowError, setShouldShowError] = useState(process.env.NODE_ENV === 'development')
 	const [didCopy, setDidCopy] = useState(false)

--- a/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultErrorFallback.tsx
@@ -16,7 +16,10 @@ const BASE_ERROR_URL = 'https://github.com/tldraw/tldraw/issues/new'
 export type TLErrorFallbackComponent = ComponentType<{ error: unknown; editor?: Editor }>
 
 /** @public @react */
-export function DefaultErrorFallback({ error, editor }: { error: unknown; editor?: Editor }) {
+export const DefaultErrorFallback: TLErrorFallbackComponent = function DefaultErrorFallback({
+	error,
+	editor,
+}) {
 	const containerRef = useRef<HTMLDivElement>(null)
 	const [shouldShowError, setShouldShowError] = useState(process.env.NODE_ENV === 'development')
 	const [didCopy, setDidCopy] = useState(false)

--- a/packages/editor/src/lib/components/default-components/DefaultLoadingScreen.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultLoadingScreen.tsx
@@ -1,7 +1,7 @@
 import { useEditorComponents } from '../../hooks/EditorComponentsContext'
 
 /** @public @react */
-export const DefaultLoadingScreen = () => {
+export function DefaultLoadingScreen() {
 	const { Spinner } = useEditorComponents()
 	return (
 		<div className="tl-loading" aria-busy="true" tabIndex={0}>

--- a/packages/editor/src/lib/components/default-components/DefaultShapeErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeErrorFallback.tsx
@@ -4,6 +4,7 @@ import { ComponentType } from 'react'
 export type TLShapeErrorFallbackComponent = ComponentType<{ error: any }>
 
 /** @internal */
-export function DefaultShapeErrorFallback() {
-	return <div className="tl-shape-error-boundary" />
-}
+export const DefaultShapeErrorFallback: TLShapeErrorFallbackComponent =
+	function DefaultShapeErrorFallback() {
+		return <div className="tl-shape-error-boundary" />
+	}

--- a/packages/editor/src/lib/components/default-components/DefaultShapeErrorFallback.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultShapeErrorFallback.tsx
@@ -4,6 +4,6 @@ import { ComponentType } from 'react'
 export type TLShapeErrorFallbackComponent = ComponentType<{ error: any }>
 
 /** @internal */
-export const DefaultShapeErrorFallback: TLShapeErrorFallbackComponent = () => {
+export function DefaultShapeErrorFallback() {
 	return <div className="tl-shape-error-boundary" />
 }

--- a/packages/editor/src/lib/components/default-components/DefaultSvgDefs.tsx
+++ b/packages/editor/src/lib/components/default-components/DefaultSvgDefs.tsx
@@ -1,4 +1,4 @@
 /** @public @react */
-export const DefaultSvgDefs = () => {
+export function DefaultSvgDefs() {
 	return null
 }

--- a/packages/editor/src/lib/editor/derivations/bindingsIndex.ts
+++ b/packages/editor/src/lib/editor/derivations/bindingsIndex.ts
@@ -29,7 +29,7 @@ function fromScratch(bindingsQuery: Computed<TLBinding[], unknown>) {
 	return shapesToBindings
 }
 
-export const bindingsIndex = (editor: Editor): Computed<TLBindingsIndex> => {
+export function bindingsIndex(editor: Editor): Computed<TLBindingsIndex> {
 	const { store } = editor
 	const bindingsHistory = store.query.filterHistory('binding')
 	const bindingsQuery = store.query.records('binding')

--- a/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
+++ b/packages/editor/src/lib/editor/derivations/parentsToChildren.ts
@@ -22,7 +22,7 @@ function fromScratch(
 	return result
 }
 
-export const parentsToChildren = (store: TLStore) => {
+export function parentsToChildren(store: TLStore) {
 	const shapeIdsQuery = store.query.ids<'shape'>('shape')
 	const shapeHistory = store.query.filterHistory('shape')
 

--- a/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
+++ b/packages/editor/src/lib/editor/derivations/shapeIdsInCurrentPage.ts
@@ -33,7 +33,7 @@ const isShapeInPage = (store: TLStore, pageId: TLPageId, shape: TLShape): boolea
  * @param store - The tldraw store.
  * @param getCurrentPageId - A function that returns the current page id.
  */
-export const deriveShapeIdsInCurrentPage = (store: TLStore, getCurrentPageId: () => TLPageId) => {
+export function deriveShapeIdsInCurrentPage(store: TLStore, getCurrentPageId: () => TLPageId) {
 	const shapesIndex = store.query.ids('shape')
 	let lastPageId: null | TLPageId = null
 	function fromScratch() {

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -6,7 +6,9 @@ import { LicenseManager } from './LicenseManager'
 export const LicenseContext = createContext({} as LicenseManager)
 
 /** @internal */
-export const useLicenseContext = () => useContext(LicenseContext)
+export function useLicenseContext() {
+	return useContext(LicenseContext)
+}
 
 function shouldHideEditorAfterDelay(licenseState: string): boolean {
 	return licenseState === 'expired' || licenseState === 'unlicensed-production'

--- a/packages/editor/src/lib/primitives/utils.ts
+++ b/packages/editor/src/lib/primitives/utils.ts
@@ -363,7 +363,7 @@ export function toFixed(v: number) {
  * Check if a float is safe to use. ie: Not too big or small.
  * @public
  */
-export const isSafeFloat = (n: number) => {
+export function isSafeFloat(n: number) {
 	return Math.abs(n) < Number.MAX_SAFE_INTEGER
 }
 

--- a/packages/editor/src/lib/utils/dom.ts
+++ b/packages/editor/src/lib/utils/dom.ts
@@ -86,14 +86,16 @@ export function releasePointerCapture(
  *
  * @public
  */
-export const stopEventPropagation = (e: any) => e.stopPropagation()
+export function stopEventPropagation(e: any) {
+	return e.stopPropagation()
+}
 
 /** @internal */
-export const setStyleProperty = (
+export function setStyleProperty(
 	elm: HTMLElement | null,
 	property: string,
 	value: string | number
-) => {
+) {
 	if (!elm) return
 	elm.style.setProperty(property, String(value))
 }

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -43,8 +43,7 @@ import { MigrationFailureReason } from '@tldraw/editor';
 import { MigrationSequence } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
 import { Node as Node_2 } from '@tiptap/pm/model';
-import { noop } from '@tldraw/editor';
-import { noop as noop_2 } from '@tldraw/utils';
+import { noop } from '@tldraw/utils';
 import { OverlayOptionsWithDisplayValues } from '@tldraw/editor';
 import { OverlayUtil } from '@tldraw/editor';
 import { PerfectDashTerminal } from '@tldraw/editor';
@@ -6401,7 +6400,7 @@ export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByPro
 export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProps<{
     richText: TLRichText;
 }>['type'], richText?: TLRichText): {
-    handleBlur: noop_2;
+    handleBlur: noop;
     handleChange: ({ richText }: {
         richText: {
             attrs?: any;
@@ -6412,7 +6411,7 @@ export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProp
     handleDoubleClick: (e: {
         nativeEvent: Event;
     } | Event) => void;
-    handleFocus: noop_2;
+    handleFocus: noop;
     handleInputPointerDown: (e: PointerEvent_2<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     handlePaste: (e: ClipboardEvent | ClipboardEvent_2<HTMLTextAreaElement>) => void;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -43,6 +43,8 @@ import { MigrationFailureReason } from '@tldraw/editor';
 import { MigrationSequence } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
 import { Node as Node_2 } from '@tiptap/pm/model';
+import { noop } from '@tldraw/editor';
+import { noop as noop_2 } from '@tldraw/utils';
 import { OverlayOptionsWithDisplayValues } from '@tldraw/editor';
 import { OverlayUtil } from '@tldraw/editor';
 import { PerfectDashTerminal } from '@tldraw/editor';
@@ -6378,14 +6380,14 @@ export function useDirection(): "ltr" | "rtl";
 export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByProps<{
     text: string;
 }>['type'], text?: string): {
-    handleBlur: () => void;
+    handleBlur: typeof noop;
     handleChange: ({ plaintext }: {
         plaintext: string;
     }) => void;
     handleDoubleClick: (e: {
         nativeEvent: Event;
     } | Event) => void;
-    handleFocus: () => void;
+    handleFocus: typeof noop;
     handleInputPointerDown: (e: React_3.PointerEvent<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     handlePaste: (e: ClipboardEvent | React_3.ClipboardEvent<HTMLTextAreaElement>) => void;
@@ -6399,7 +6401,7 @@ export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByPro
 export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProps<{
     richText: TLRichText;
 }>['type'], richText?: TLRichText): {
-    handleBlur: () => void;
+    handleBlur: noop_2;
     handleChange: ({ richText }: {
         richText: {
             attrs?: any;
@@ -6410,7 +6412,7 @@ export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProp
     handleDoubleClick: (e: {
         nativeEvent: Event;
     } | Event) => void;
-    handleFocus: () => void;
+    handleFocus: noop_2;
     handleInputPointerDown: (e: PointerEvent_2<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     handlePaste: (e: ClipboardEvent | ClipboardEvent_2<HTMLTextAreaElement>) => void;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -43,7 +43,6 @@ import { MigrationFailureReason } from '@tldraw/editor';
 import { MigrationSequence } from '@tldraw/store';
 import { NamedExoticComponent } from 'react';
 import { Node as Node_2 } from '@tiptap/pm/model';
-import { noop } from '@tldraw/utils';
 import { OverlayOptionsWithDisplayValues } from '@tldraw/editor';
 import { OverlayUtil } from '@tldraw/editor';
 import { PerfectDashTerminal } from '@tldraw/editor';
@@ -6379,14 +6378,14 @@ export function useDirection(): "ltr" | "rtl";
 export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByProps<{
     text: string;
 }>['type'], text?: string): {
-    handleBlur: typeof noop;
+    handleBlur: () => void;
     handleChange: ({ plaintext }: {
         plaintext: string;
     }) => void;
     handleDoubleClick: (e: {
         nativeEvent: Event;
     } | Event) => void;
-    handleFocus: typeof noop;
+    handleFocus: () => void;
     handleInputPointerDown: (e: React_3.PointerEvent<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     handlePaste: (e: ClipboardEvent | React_3.ClipboardEvent<HTMLTextAreaElement>) => void;
@@ -6400,7 +6399,7 @@ export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByPro
 export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProps<{
     richText: TLRichText;
 }>['type'], richText?: TLRichText): {
-    handleBlur: noop;
+    handleBlur: () => void;
     handleChange: ({ richText }: {
         richText: {
             attrs?: any;
@@ -6411,7 +6410,7 @@ export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProp
     handleDoubleClick: (e: {
         nativeEvent: Event;
     } | Event) => void;
-    handleFocus: noop;
+    handleFocus: () => void;
     handleInputPointerDown: (e: PointerEvent_2<Element>) => void;
     handleKeyDown: (e: KeyboardEvent) => void;
     handlePaste: (e: ClipboardEvent | ClipboardEvent_2<HTMLTextAreaElement>) => void;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2397,7 +2397,7 @@ export function GroupMenuItem(): JSX.Element | null;
 export function GroupOrUngroupMenuItem(): JSX.Element;
 
 // @public
-export const handleNativeOrMenuCopy: (editor: Editor, context?: TLClipboardWriteInfo) => Promise<boolean>;
+export function handleNativeOrMenuCopy(editor: Editor, context?: TLClipboardWriteInfo): Promise<boolean>;
 
 // @public (undocumented)
 export class HandTool extends StateNode {
@@ -4172,7 +4172,7 @@ export function TldrawUiComponentsProvider({ overrides, children }: TLUiComponen
 export const TldrawUiContextProvider: NamedExoticComponent<TLUiContextProviderProps>;
 
 // @public
-export const TldrawUiContextualToolbar: ({ children, className, isMousingDown, getSelectionBounds, changeOnlyWhenYChanges, label, }: TLUiContextualToolbarProps) => JSX.Element;
+export function TldrawUiContextualToolbar({ children, className, isMousingDown, getSelectionBounds, changeOnlyWhenYChanges, label }: TLUiContextualToolbarProps): JSX.Element;
 
 // @public (undocumented)
 export function TldrawUiDialogBody({ className, children, style }: TLUiDialogBodyProps): JSX.Element;
@@ -4334,10 +4334,10 @@ export const TldrawUiToolbar: React_3.ForwardRefExoticComponent<TLUiToolbarProps
 export const TldrawUiToolbarButton: React_3.ForwardRefExoticComponent<TLUiToolbarButtonProps & React_3.RefAttributes<HTMLButtonElement>>;
 
 // @public (undocumented)
-export const TldrawUiToolbarToggleGroup: ({ children, className, type, asChild, ...props }: TLUiToolbarToggleGroupProps) => JSX.Element;
+export function TldrawUiToolbarToggleGroup({ children, className, type, asChild, ...props }: TLUiToolbarToggleGroupProps): JSX.Element;
 
 // @public (undocumented)
-export const TldrawUiToolbarToggleItem: ({ children, className, type, value, tooltip, ...props }: TLUiToolbarToggleItemProps) => JSX.Element;
+export function TldrawUiToolbarToggleItem({ children, className, type, value, tooltip, ...props }: TLUiToolbarToggleItemProps): JSX.Element;
 
 // @public (undocumented)
 export const TldrawUiTooltip: React_3.ForwardRefExoticComponent<TldrawUiTooltipProps & React_3.RefAttributes<HTMLButtonElement>>;
@@ -6273,7 +6273,7 @@ export function TrapezoidToolbarItem(): JSX.Element;
 export function TriangleToolbarItem(): JSX.Element;
 
 // @public (undocumented)
-export const truncateStringWithEllipsis: (str: string, maxLength: number) => string;
+export function truncateStringWithEllipsis(str: string, maxLength: number): string;
 
 // @public (undocumented)
 export function UndoRedoGroup(): JSX.Element;
@@ -6472,7 +6472,7 @@ export function useReadonly(): boolean;
 export function useRelevantStyles(stylesToCheck?: readonly StyleProp<any>[]): null | ReadonlySharedStyleMap;
 
 // @public (undocumented)
-export const useSelectedShapesAnnouncer: () => void;
+export function useSelectedShapesAnnouncer(): void;
 
 // @public (undocumented)
 export function useShowCollaborationUi(): boolean;

--- a/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
+++ b/packages/tldraw/src/lib/shapes/bookmark/bookmarks.ts
@@ -40,7 +40,7 @@ export function setBookmarkHeight(editor: Editor, shape: TLBookmarkShape) {
 }
 
 /** @internal */
-export const getHumanReadableAddress = (url: string) => {
+export function getHumanReadableAddress(url: string) {
 	try {
 		const objUrl = new URL(url)
 		// we want the hostname without any www

--- a/packages/tldraw/src/lib/shapes/shared/interpolate-props.ts
+++ b/packages/tldraw/src/lib/shapes/shared/interpolate-props.ts
@@ -1,11 +1,11 @@
 import { TLDrawShapeSegment, VecModel, b64Vecs, lerp } from '@tldraw/editor'
 
 /** @public */
-export const interpolateSegments = (
+export function interpolateSegments(
 	startSegments: TLDrawShapeSegment[],
 	endSegments: TLDrawShapeSegment[],
 	progress: number
-): TLDrawShapeSegment[] => {
+): TLDrawShapeSegment[] {
 	const startPoints: VecModel[] = []
 	const endPoints: VecModel[] = []
 

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -3,7 +3,6 @@ import {
 	ExtractShapeByProps,
 	TLShapeId,
 	getPointerInfo,
-	noop,
 	preventDefault,
 	tlenv,
 	useEditor,
@@ -167,8 +166,8 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 	)
 
 	return {
-		handleFocus: noop,
-		handleBlur: noop,
+		handleFocus: (): void => {},
+		handleBlur: (): void => {},
 		handleInputPointerDown,
 		handleDoubleClick: editor.markEventAsHandled,
 		handlePaste,

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -3,12 +3,12 @@ import {
 	ExtractShapeByProps,
 	TLShapeId,
 	getPointerInfo,
-	noop,
 	preventDefault,
 	tlenv,
 	useEditor,
 	useValue,
 } from '@tldraw/editor'
+import { noop } from '@tldraw/utils'
 import React, { useCallback, useEffect, useRef } from 'react'
 import { TextHelpers } from './TextHelpers'
 

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -8,7 +8,6 @@ import {
 	useEditor,
 	useValue,
 } from '@tldraw/editor'
-import { noop } from '@tldraw/utils'
 import React, { useCallback, useEffect, useRef } from 'react'
 import { TextHelpers } from './TextHelpers'
 
@@ -167,8 +166,8 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 	)
 
 	return {
-		handleFocus: noop,
-		handleBlur: noop,
+		handleFocus: (): void => {},
+		handleBlur: (): void => {},
 		handleInputPointerDown,
 		handleDoubleClick: editor.markEventAsHandled,
 		handlePaste,

--- a/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditablePlainText.ts
@@ -3,6 +3,7 @@ import {
 	ExtractShapeByProps,
 	TLShapeId,
 	getPointerInfo,
+	noop,
 	preventDefault,
 	tlenv,
 	useEditor,
@@ -166,8 +167,8 @@ export function useEditableTextCommon(shapeId: TLShapeId) {
 	)
 
 	return {
-		handleFocus: (): void => {},
-		handleBlur: (): void => {},
+		handleFocus: noop,
+		handleBlur: noop,
 		handleInputPointerDown,
 		handleDoubleClick: editor.markEventAsHandled,
 		handlePaste,

--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -134,7 +134,7 @@ export function generateShapeAnnouncementMessage(args: {
 }
 
 /** @public */
-export const useSelectedShapesAnnouncer = () => {
+export function useSelectedShapesAnnouncer() {
 	const editor = useMaybeEditor()
 	const a11y = useA11y()
 	const msg = useTranslation()

--- a/packages/tldraw/src/lib/ui/components/LoadingScreen.tsx
+++ b/packages/tldraw/src/lib/ui/components/LoadingScreen.tsx
@@ -1,7 +1,7 @@
 import { LoadingScreen as LoadingScreenContainer, useEditorComponents } from '@tldraw/editor'
 
 /** @public @react */
-export const LoadingScreen = () => {
+export function LoadingScreen() {
 	const { Spinner } = useEditorComponents()
 	return <LoadingScreenContainer>{Spinner ? <Spinner /> : null}</LoadingScreenContainer>
 }

--- a/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
+++ b/packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
@@ -8,13 +8,13 @@ import {
 } from '@tldraw/editor'
 import { TLUiEventContextType } from '../../context/events'
 
-export const onMovePage = (
+export function onMovePage(
 	editor: Editor,
 	id: TLPageId,
 	from: number,
 	to: number,
 	trackEvent: TLUiEventContextType
-) => {
+) {
 	if (from === to) return
 
 	let index: IndexKey

--- a/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/OverflowingToolbar.tsx
@@ -349,11 +349,11 @@ export function OverflowingToolbar({
 	)
 }
 
-export const isActiveTLUiToolItem = (
+export function isActiveTLUiToolItem(
 	item: TLUiToolItem,
 	activeToolId: string | undefined,
 	geoState: string | null | undefined
-) => {
+) {
 	return item.meta?.geo
 		? activeToolId === 'geo' && geoState === item.meta?.geo
 		: activeToolId === item.id

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiContextualToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiContextualToolbar.tsx
@@ -41,14 +41,14 @@ export interface TLUiContextualToolbarProps {
  *
  * @public @react
  */
-export const TldrawUiContextualToolbar = ({
+export function TldrawUiContextualToolbar({
 	children,
 	className,
 	isMousingDown,
 	getSelectionBounds,
 	changeOnlyWhenYChanges = false,
 	label,
-}: TLUiContextualToolbarProps) => {
+}: TLUiContextualToolbarProps) {
 	const editor = useEditor()
 	const toolbarRef = useRef<HTMLDivElement>(null)
 

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiToolbar.tsx
@@ -99,13 +99,13 @@ export interface TLUiToolbarToggleGroupProps extends React.HTMLAttributes<HTMLDi
 }
 
 /** @public @react */
-export const TldrawUiToolbarToggleGroup = ({
+export function TldrawUiToolbarToggleGroup({
 	children,
 	className,
 	type,
 	asChild,
 	...props
-}: TLUiToolbarToggleGroupProps) => {
+}: TLUiToolbarToggleGroupProps) {
 	return (
 		<_Toolbar.ToggleGroup
 			asChild={asChild}
@@ -132,14 +132,14 @@ export interface TLUiToolbarToggleItemProps extends React.HTMLAttributes<HTMLBut
 }
 
 /** @public @react */
-export const TldrawUiToolbarToggleItem = ({
+export function TldrawUiToolbarToggleItem({
 	children,
 	className,
 	type,
 	value,
 	tooltip,
 	...props
-}: TLUiToolbarToggleItemProps) => {
+}: TLUiToolbarToggleItemProps) {
 	const toggleItem = (
 		<_Toolbar.ToggleItem
 			{...props}

--- a/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
+++ b/packages/tldraw/src/lib/ui/hooks/menu-hooks.ts
@@ -18,19 +18,19 @@ function shapesWithUnboundArrows(editor: Editor) {
 }
 
 /** @internal */
-export const useThreeStackableItems = () => {
+export function useThreeStackableItems() {
 	const editor = useEditor()
 	return useValue('threeStackableItems', () => shapesWithUnboundArrows(editor).length > 2, [editor])
 }
 
 /** @internal */
-export const useIsInSelectState = () => {
+export function useIsInSelectState() {
 	const editor = useEditor()
 	return useValue('isInSelectState', () => editor.isIn('select'), [editor])
 }
 
 /** @internal */
-export const useAllowGroup = () => {
+export function useAllowGroup() {
 	const editor = useEditor()
 	return useValue(
 		'allow group',
@@ -65,7 +65,7 @@ export const useAllowGroup = () => {
 }
 
 /** @internal */
-export const useAllowUngroup = () => {
+export function useAllowUngroup() {
 	const editor = useEditor()
 	return useValue(
 		'allowUngroup',

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -103,7 +103,7 @@ export function extractIframeFromHtml(
 }
 
 /** @public */
-export const isValidHttpURL = (url: string) => {
+export function isValidHttpURL(url: string) {
 	try {
 		const u = new URL(url)
 		return u.protocol === 'http:' || u.protocol === 'https:'
@@ -697,10 +697,10 @@ async function handleClipboardThings(
  *
  * @public
  */
-export const handleNativeOrMenuCopy = async (
+export async function handleNativeOrMenuCopy(
 	editor: Editor,
 	context: TLClipboardWriteInfo = { operation: 'copy', source: 'menu' }
-): Promise<boolean> => {
+): Promise<boolean> {
 	const nav = editor.getContainerWindow().navigator
 	let content = await editor.resolveAssetsInContent(
 		editor.getContentFromCurrentPage(editor.getSelectedShapeIds())

--- a/packages/tldraw/src/lib/utils/text/text.ts
+++ b/packages/tldraw/src/lib/utils/text/text.ts
@@ -81,6 +81,6 @@ export function cleanupText(text: string) {
 }
 
 /** @public */
-export const truncateStringWithEllipsis = (str: string, maxLength: number) => {
+export function truncateStringWithEllipsis(str: string, maxLength: number) {
 	return str.length <= maxLength ? str : str.substring(0, maxLength - 3) + '...'
 }

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -491,48 +491,50 @@ export const defaultShapesIds = {
 	ellipse1: createShapeId('ellipse1'),
 }
 
-export const createDefaultShapes = (): TLShapePartial[] => [
-	{
-		id: defaultShapesIds.box1,
-		type: 'geo',
-		x: 100,
-		y: 100,
-		props: {
-			w: 100,
-			h: 100,
-			geo: 'rectangle',
+export function createDefaultShapes(): TLShapePartial[] {
+	return [
+		{
+			id: defaultShapesIds.box1,
+			type: 'geo',
+			x: 100,
+			y: 100,
+			props: {
+				w: 100,
+				h: 100,
+				geo: 'rectangle',
+			},
 		},
-	},
-	{
-		id: defaultShapesIds.box2,
-		type: 'geo',
-		x: 200,
-		y: 200,
-		rotation: HALF_PI / 2,
-		props: {
-			w: 100,
-			h: 100,
-			color: 'black',
-			fill: 'none',
-			dash: 'draw',
-			size: 'm',
-			geo: 'rectangle',
+		{
+			id: defaultShapesIds.box2,
+			type: 'geo',
+			x: 200,
+			y: 200,
+			rotation: HALF_PI / 2,
+			props: {
+				w: 100,
+				h: 100,
+				color: 'black',
+				fill: 'none',
+				dash: 'draw',
+				size: 'm',
+				geo: 'rectangle',
+			},
 		},
-	},
-	{
-		id: defaultShapesIds.ellipse1,
-		type: 'geo',
-		parentId: defaultShapesIds.box2,
-		x: 200,
-		y: 200,
-		props: {
-			w: 50,
-			h: 50,
-			color: 'black',
-			fill: 'none',
-			dash: 'draw',
-			size: 'm',
-			geo: 'ellipse',
+		{
+			id: defaultShapesIds.ellipse1,
+			type: 'geo',
+			parentId: defaultShapesIds.box2,
+			x: 200,
+			y: 200,
+			props: {
+				w: 50,
+				h: 50,
+				color: 'black',
+				fill: 'none',
+				dash: 'draw',
+				size: 'm',
+				geo: 'ellipse',
+			},
 		},
-	},
-]
+	]
+}

--- a/packages/tldraw/src/test/getSnapLines.ts
+++ b/packages/tldraw/src/test/getSnapLines.ts
@@ -6,7 +6,7 @@ const simplifyNumber = (n: number) => {
 	}
 	return n
 }
-export const getSnapLines = (scene: Editor) => {
+export function getSnapLines(scene: Editor) {
 	const result = []
 	for (const snap of scene.snaps.getIndicators()) {
 		if (snap.type !== 'points') {

--- a/packages/tldraw/src/test/roundedBox.ts
+++ b/packages/tldraw/src/test/roundedBox.ts
@@ -1,6 +1,6 @@
 import { Box } from '@tldraw/editor'
 
-export const roundedBox = (box: Box, accuracy = 0.01) => {
+export function roundedBox(box: Box, accuracy = 0.01) {
 	// for some reason jest treats -0 and 0 as not equal, so prevent -0s from appearing
 	const noNegativeZero = (value: number) => (value === 0 ? 0 : value)
 

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -210,7 +210,7 @@ export function groupBy<K extends string, V>(array: ReadonlyArray<V>, keySelecto
 export function hasOwnProperty(obj: object, key: string): boolean;
 
 // @internal
-const Image_2: (width?: number | undefined, height?: number | undefined) => HTMLImageElement;
+function Image_2(width?: number, height?: number): HTMLImageElement;
 export { Image_2 as Image }
 
 // @public
@@ -348,7 +348,7 @@ export function mockUniqueId(fn: (size?: number) => string): void;
 export function modulate(value: number, rangeA: number[], rangeB: number[], clamp?: boolean): number;
 
 // @internal
-export const noop: () => void;
+export function noop(): void;
 
 // @internal
 export function objectMapEntries<Obj extends object>(object: Obj): Array<[keyof Obj, Obj[keyof Obj]]>;
@@ -472,7 +472,7 @@ export function rng(seed?: string): () => number;
 export function rotateArray<T>(arr: T[], offset: number): T[];
 
 // @public
-export const safeParseUrl: (url: string, baseUrl?: string | undefined | URL) => undefined | URL;
+export function safeParseUrl(url: string, baseUrl?: string | URL): undefined | URL;
 
 // @internal
 export function setInLocalStorage(key: string, value: string): void;

--- a/packages/utils/src/lib/function.ts
+++ b/packages/utils/src/lib/function.ts
@@ -40,4 +40,4 @@ export function omitFromStackTrace<Args extends Array<unknown>, Return>(
  * Does nothing, but it's really really good at it.
  * @internal
  */
-export const noop: () => void = () => {}
+export function noop(): void {}

--- a/packages/utils/src/lib/media/avif.ts
+++ b/packages/utils/src/lib/media/avif.ts
@@ -32,7 +32,7 @@
  *
  * @public
  */
-export const isAvifAnimated = (buffer: ArrayBuffer) => {
+export function isAvifAnimated(buffer: ArrayBuffer) {
 	const view = new Uint8Array(buffer)
 	return view[3] === 44
 }

--- a/packages/utils/src/lib/network.ts
+++ b/packages/utils/src/lib/network.ts
@@ -24,7 +24,7 @@ export async function fetch(input: RequestInfo | URL, init?: RequestInit): Promi
  * @returns HTMLImageElement with referrerPolicy set to 'strict-origin-when-cross-origin'
  * @internal
  */
-export const Image = (width?: number, height?: number) => {
+export function Image(width?: number, height?: number) {
 	// eslint-disable-next-line tldraw/no-restricted-properties
 	const img = new window.Image(width, height)
 	img.referrerPolicy = 'strict-origin-when-cross-origin'

--- a/packages/utils/src/lib/url.ts
+++ b/packages/utils/src/lib/url.ts
@@ -38,7 +38,7 @@
  *
  * @public
  */
-export const safeParseUrl = (url: string, baseUrl?: string | URL) => {
+export function safeParseUrl(url: string, baseUrl?: string | URL) {
 	try {
 		return new URL(url, baseUrl)
 	} catch {


### PR DESCRIPTION
In order to actually enforce `tldraw/no-exported-arrow-const` everywhere it was originally intended, this PR removes the three `.oxlintrc.json` overrides that turned it off for `packages/editor`, `packages/tldraw`, `packages/utils`, `apps/examples`, and `templates`, and converts the 50 violations those overrides were hiding.

The pattern is mechanical: `export const fn = (args) => {...}` becomes `export function fn(args) {...}`. Async functions get `export async function`. For React component aliases like `const X: TLErrorFallbackComponent = (...) =>` the form becomes `export const X: TLErrorFallbackComponent = function X(...) {...}` — a named function expression keeps the type alias visible to api-extractor (the rule only fires on arrows, not function expressions). No behavior changes.

### Affected directories

| Directory | Files | Violations |
| --- | ---: | ---: |
| `packages/tldraw` | 14 | 19 |
| `apps/examples` | 8 | 16 |
| `packages/editor` | 10 | 11 |
| `packages/utils` | 4 | 4 |
| **Total** | **36** | **50** |

### Background

Relates to #7572. The rule was added in #8258 along with the JS plugin, but with these overrides in place it has never fired in the packages it most needed to apply to. The plugin itself works correctly — see commit history for the exploration that confirmed that.

### API changes

The shift to function declarations changes how api-extractor renders the affected exports — `const X: (args) => Y` becomes `function X(args): Y`. No call-site changes required; the public signatures are equivalent.

Specifically affected `@public` exports:

- `@tldraw/editor`: `DefaultSvgDefs`, `isSafeFloat`, `stopEventPropagation`
- `@tldraw/tldraw`: `handleNativeOrMenuCopy`, `TldrawUiContextualToolbar`, `TldrawUiToolbarToggleGroup`, `TldrawUiToolbarToggleItem`, `truncateStringWithEllipsis`, `useSelectedShapesAnnouncer`, `interpolateSegments`
- `@tldraw/utils`: `Image`, `noop`, `safeParseUrl`, `isAvifAnimated`

`DefaultErrorFallback` keeps its `TLErrorFallbackComponent` alias in the api-report — typed as `export const DefaultErrorFallback: TLErrorFallbackComponent = function DefaultErrorFallback(...) {...}` so the alias survives.

### Change type

- [x] `improvement`

### Test plan

- `yarn oxlint .` — 0 errors.
- `yarn typecheck` — passes.
- `yarn test run` in `packages/editor`, `packages/tldraw`, `packages/utils` — all green.
- `yarn api-check` — passes (api reports are regenerated).

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +97 / -88  |
| Automated files | +12 / -12  |
| Documentation   | +24 / -18  |
| Config/tooling  | +0 / -3    |