### PR TITLE
fix(docs): canonical URLs for SEO — metadata, sitemap, and footer lin…

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -209,7 +209,14 @@ const nextConfig = {
 	},
 	async rewrites() {
 		return {
-			beforeFiles: [],
+			// Canonical top-level URLs (/quick-start, …) are not in the content DB; articles
+			// live under /getting-started/*. Redirects send /getting-started/:id → /:id;
+			// these rewrites serve the article without a second hop (avoids /quick-start 404).
+			beforeFiles: [
+				{ source: '/quick-start', destination: '/getting-started/quick-start' },
+				{ source: '/installation', destination: '/getting-started/installation' },
+				{ source: '/releases', destination: '/getting-started/releases' },
+			],
 		}
 	},
 }

--- a/apps/docs/utils/sitemap-canonical-paths.test.ts
+++ b/apps/docs/utils/sitemap-canonical-paths.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { canonicalDocsPageUrl, canonicalizeDocsSitemapPath } from './sitemap-canonical-paths'
+
+describe('canonicalizeDocsSitemapPath', () => {
+	it('maps duplicate-content alias paths to canonical URLs', () => {
+		expect(canonicalizeDocsSitemapPath('/getting-started/quick-start')).toBe('/quick-start')
+		expect(canonicalizeDocsSitemapPath('/getting-started/installation')).toBe('/installation')
+		expect(canonicalizeDocsSitemapPath('/releases-versioning')).toBe('/releases')
+	})
+
+	it('leaves canonical paths unchanged', () => {
+		expect(canonicalizeDocsSitemapPath('/quick-start')).toBe('/quick-start')
+		expect(canonicalizeDocsSitemapPath('/releases')).toBe('/releases')
+	})
+})
+
+describe('canonicalDocsPageUrl', () => {
+	it('emits production-absolute canonical for alias and canonical paths', () => {
+		expect(canonicalDocsPageUrl('/getting-started/quick-start')).toBe(
+			'https://tldraw.dev/quick-start'
+		)
+		expect(canonicalDocsPageUrl('/quick-start')).toBe('https://tldraw.dev/quick-start')
+	})
+})

--- a/apps/docs/utils/sitemap-canonical-paths.ts
+++ b/apps/docs/utils/sitemap-canonical-paths.ts
@@ -1,0 +1,36 @@
+/** Public marketing apex — canonical `<link>` and sitemap `<loc>` URLs. */
+export const PRODUCTION_SITE_ORIGIN = 'https://tldraw.dev'
+
+/**
+ * Paths that 301 or rewrite to a canonical URL. Sitemap and `<link rel="canonical">`
+ * must use the canonical path so alias URLs do not dilute link equity.
+ */
+const DOCS_SITEMAP_PATH_ALIASES: Record<string, string> = {
+	'/getting-started/quick-start': '/quick-start',
+	'/getting-started/installation': '/installation',
+	'/getting-started/releases': '/releases',
+	'/releases-versioning': '/releases',
+	'/examples': '/examples/basic',
+	'/starter-kits': '/starter-kits/overview',
+}
+
+function normalizePathname(path: string): string {
+	const trimmed = path.trim()
+	if (!trimmed || trimmed === '/') return '/'
+	const withLeading = trimmed.startsWith('/') ? trimmed : `/${trimmed}`
+	return withLeading.replace(/\/+$/, '') || '/'
+}
+
+export function canonicalizeDocsSitemapPath(path: string): string {
+	const normalized = normalizePathname(path)
+	return DOCS_SITEMAP_PATH_ALIASES[normalized] ?? normalized
+}
+
+export function canonicalizeDocsSitemapPaths(paths: string[]): string[] {
+	return Array.from(new Set(paths.map(canonicalizeDocsSitemapPath))).sort()
+}
+
+/** Absolute canonical URL for a docs article path (alias or canonical). */
+export function canonicalDocsPageUrl(pathname: string): string {
+	return `${PRODUCTION_SITE_ORIGIN}${canonicalizeDocsSitemapPath(pathname)}`
+}


### PR DESCRIPTION
Cherry picking changes from https://github.com/tldraw/tldraw/pull/8952 + https://github.com/tldraw/tldraw/pull/8959 in order to trigger a deploy of the docs with the changes