### PR TITLE
fix(tldraw): indent list on Tab in note shape instead of creating new note

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -671,6 +671,18 @@ function useNoteKeydownHandler(id: TLShapeId) {
 
 			const isTab = e.key === 'Tab'
 			const isCmdEnter = (e.metaKey || e.ctrlKey) && e.key === 'Enter'
+
+			if (isTab) {
+				// When editing a bullet or ordered list inside the note, Tab should
+				// indent the list item (the default rich text behavior) rather than
+				// create a new adjacent note. The rich text editor's own keymap
+				// handles the indentation, so we just bail out here.
+				const textEditor = editor.getRichTextEditor()
+				if (textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList')) {
+					return
+				}
+			}
+
 			if (isTab || isCmdEnter) {
 				e.preventDefault()
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -37,6 +37,7 @@ import { startEditingShapeWithRichText } from '../../tools/SelectTool/selectHelp
 import { TldrawUiTooltip } from '../../ui/components/primitives/TldrawUiTooltip'
 import { TranslationsContext } from '../../ui/hooks/useTranslation/useTranslation'
 import {
+	isEditingRichTextList,
 	isEmptyRichText,
 	renderHtmlFromRichTextForMeasurement,
 	renderPlaintextFromRichText,
@@ -672,13 +673,10 @@ function useNoteKeydownHandler(id: TLShapeId) {
 			const isTab = e.key === 'Tab'
 			const isCmdEnter = (e.metaKey || e.ctrlKey) && e.key === 'Enter'
 
-			if (isTab) {
+			if (isTab && isEditingRichTextList(editor)) {
 				// In a list, let the rich text editor indent the item instead of
 				// creating a new note.
-				const textEditor = editor.getRichTextEditor()
-				if (textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList')) {
-					return
-				}
+				return
 			}
 
 			if (isTab || isCmdEnter) {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -675,7 +675,9 @@ function useNoteKeydownHandler(id: TLShapeId) {
 
 			if (isTab && isEditingRichTextList(editor)) {
 				// In a list, let the rich text editor indent the item instead of
-				// creating a new note.
+				// creating a new note. Prevent default so Tab doesn't move focus out
+				// of the editor when the item can't be indented (e.g. the first item).
+				e.preventDefault()
 				return
 			}
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -673,10 +673,8 @@ function useNoteKeydownHandler(id: TLShapeId) {
 			const isCmdEnter = (e.metaKey || e.ctrlKey) && e.key === 'Enter'
 
 			if (isTab) {
-				// When editing a bullet or ordered list inside the note, Tab should
-				// indent the list item (the default rich text behavior) rather than
-				// create a new adjacent note. The rich text editor's own keymap
-				// handles the indentation, so we just bail out here.
+				// In a list, let the rich text editor indent the item instead of
+				// creating a new note.
 				const textEditor = editor.getRichTextEditor()
 				if (textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList')) {
 					return

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -16,6 +16,7 @@ import {
 	useUniqueSafeId,
 } from '@tldraw/editor'
 import React, { useLayoutEffect, useRef } from 'react'
+import { isEditingRichTextList } from '../../utils/text/richText'
 
 /** @public */
 export interface TextAreaProps {
@@ -264,8 +265,7 @@ function handleTab(editor: Editor, view: EditorView, event: KeyboardEvent) {
 	// Don't exit the editor.
 	event.preventDefault()
 
-	const textEditor = editor.getRichTextEditor()
-	if (textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList')) return
+	if (isEditingRichTextList(editor)) return
 
 	const { state, dispatch } = view
 	const { $from, $to } = state.selection

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -114,6 +114,15 @@ export function isEmptyRichText(richText: TLRichText) {
 }
 
 /**
+ * Whether the editor's active rich text selection is inside a bullet or ordered list.
+ * @internal
+ */
+export function isEditingRichTextList(editor: Editor) {
+	const textEditor = editor.getRichTextEditor()
+	return !!(textEditor?.isActive('bulletList') || textEditor?.isActive('orderedList'))
+}
+
+/**
  * Renders plaintext from a rich text string.
  * @param editor - The editor instance.
  * @param richText - The rich text content.


### PR DESCRIPTION
In order to make list editing in note shapes behave like text and geo shape labels, this PR stops `Tab` from creating a new adjacent note when the caret is inside a bullet or ordered list. Closes #8713.

Previously the note's keydown handler always created a new note on `Tab`, while the rich text editor's own keymap *also* indented the list item on the original note. This produced two bugs: an unwanted new note was created and focused, and the original note's list item was silently indented. Now, when a bullet or ordered list is active, the handler bails out early and lets the rich text editor indent the list item.

### Change type

- [x] `bugfix`

### Test plan

1. Create a note shape and start editing it.
2. Open the rich text toolbar and turn on a bullet list (or ordered list).
3. Type some text, press `Enter` to start a second item, then press `Tab`.
4. Confirm the second item is indented under the first and no new note is created.
5. With no list active, confirm `Tab` still creates an adjacent note as before.

### Release notes

- Fixed a bug where pressing `Tab` while editing a list inside a note shape created a new note instead of indenting the list item.
