### PR TITLE
fix(docs): fixed the quick-start and some more redirections

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -209,7 +209,14 @@ const nextConfig = {
 	},
 	async rewrites() {
 		return {
-			beforeFiles: [],
+			// Canonical top-level URLs (/quick-start, …) are not in the content DB; articles
+			// live under /getting-started/*. Redirects send /getting-started/:id → /:id;
+			// these rewrites serve the article without a second hop (avoids /quick-start 404).
+			beforeFiles: [
+				{ source: '/quick-start', destination: '/getting-started/quick-start' },
+				{ source: '/installation', destination: '/getting-started/installation' },
+				{ source: '/releases', destination: '/getting-started/releases' },
+			],
 		}
 	},
 }


### PR DESCRIPTION
Seems I went a bit too quickly with the previous work on docs and canonical urls and actually removed the thing that makes the quick-start page actually work

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`