### PR TITLE
fix(ci): make supabase preview branch wait loop tolerate set -e

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -101,17 +101,19 @@ jobs:
           BRANCH_JSON=$(mktemp)
           for i in $(seq 1 24); do
             # While the branch is still provisioning, `branches get` exits
-            # non-zero. Tolerate that here so the loop keeps retrying instead of
-            # tripping `set -e` on the first attempt.
-            supabase branches get "$BRANCH_NAME" \
+            # non-zero and/or writes non-JSON. Only parse its output when it
+            # succeeds, and keep `jq` failures from tripping `set -e`, so the
+            # loop keeps retrying instead of aborting the step.
+            if supabase branches get "$BRANCH_NAME" \
               --project-ref "$PROJECT_REF" \
-              -o json > "$BRANCH_JSON" 2>/dev/null || true
-            POSTGRES_URL_TRANSACTION=$(jq -r '.POSTGRES_URL // empty' "$BRANCH_JSON")
-            if [ -n "$POSTGRES_URL_TRANSACTION" ]; then break; fi
+              -o json > "$BRANCH_JSON" 2>/dev/null; then
+              POSTGRES_URL_TRANSACTION=$(jq -r '.POSTGRES_URL // empty' "$BRANCH_JSON" 2>/dev/null || true)
+              if [ -n "$POSTGRES_URL_TRANSACTION" ]; then break; fi
+            fi
             echo "Waiting for branch to be ready ($i/24)..."
             sleep 5
           done
-          POSTGRES_URL_NON_POOLING=$(jq -r '.POSTGRES_URL_NON_POOLING' "$BRANCH_JSON")
+          POSTGRES_URL_NON_POOLING=$(jq -r '.POSTGRES_URL_NON_POOLING // empty' "$BRANCH_JSON" 2>/dev/null || true)
           rm "$BRANCH_JSON"
 
           if [ -z "$POSTGRES_URL_TRANSACTION" ]; then

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -100,9 +100,12 @@ jobs:
           # Write to a temp file to avoid secrets leaking into CI step output.
           BRANCH_JSON=$(mktemp)
           for i in $(seq 1 24); do
+            # While the branch is still provisioning, `branches get` exits
+            # non-zero. Tolerate that here so the loop keeps retrying instead of
+            # tripping `set -e` on the first attempt.
             supabase branches get "$BRANCH_NAME" \
               --project-ref "$PROJECT_REF" \
-              -o json > "$BRANCH_JSON" 2>/dev/null
+              -o json > "$BRANCH_JSON" 2>/dev/null || true
             POSTGRES_URL_TRANSACTION=$(jq -r '.POSTGRES_URL // empty' "$BRANCH_JSON")
             if [ -n "$POSTGRES_URL_TRANSACTION" ]; then break; fi
             echo "Waiting for branch to be ready ($i/24)..."


### PR DESCRIPTION
In order to stop dotcom preview deploys from failing on PRs that provision a fresh Supabase preview branch, this PR makes the "Create Supabase preview branch" wait loop fully tolerant of a still-provisioning branch.

GitHub Actions runs the step's shell with `set -e` (`bash --noprofile --norc -e -o pipefail`). Right after `supabase branches create`, the branch is still provisioning, which broke the wait loop in two ways:

1. `supabase branches get` exits non-zero while the branch is provisioning, so under `set -e` the step aborted on the first poll — the "Waiting for branch to be ready" message never printed (observed on #8960, run 26629746345).
2. With the `get` call tolerated, it can still write non-JSON to the temp file while provisioning, so `jq` parse-errored (exit 5) and `set -e` aborted the step again (observed on #8961, run for `pr-8961`: `jq: parse error: Invalid numeric literal at line 1, column 2`).

The loop now only parses output when `get` succeeds (`if supabase branches get ...; then`), and `jq` calls swallow failures (`2>/dev/null || true`) so a transient non-zero exit or parse error just means "not ready yet, keep polling" rather than killing the step. The temp file still holds connection strings out of the step log, and the post-loop "branch not ready" / "missing POSTGRES_URL_NON_POOLING" error checks are unchanged. The existence check at the top of the step is already inside an `if`, so it was never affected by `set -e`.

### Change type

- [x] `other`

### Test plan

1. Open a PR that provisions a brand new Supabase preview branch (or apply the `reset-preview-db` label to force recreation).
2. Confirm the "Create Supabase preview branch" step prints "Waiting for branch to be ready (n/24)..." and proceeds once the branch is ready, instead of aborting on the first poll or on a `jq` parse error.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +10 / -5   |