### PR TITLE
fix(ci): tolerate Supabase CLI branch-provisioning output in deploy preview

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -100,15 +100,20 @@ jobs:
           # Write to a temp file to avoid secrets leaking into CI step output.
           BRANCH_JSON=$(mktemp)
           for i in $(seq 1 24); do
+            # While the branch is still provisioning, `branches get` may exit
+            # non-zero and/or write a non-JSON line to stdout (the newer CLI
+            # renders an error there). Tolerate both: `|| true` keeps `set -e`
+            # from aborting on a non-zero get, and the guarded jq below treats
+            # any non-JSON / missing field as "not ready yet" so the loop retries.
             supabase branches get "$BRANCH_NAME" \
               --project-ref "$PROJECT_REF" \
-              -o json > "$BRANCH_JSON" 2>/dev/null
-            POSTGRES_URL_TRANSACTION=$(jq -r '.POSTGRES_URL // empty' "$BRANCH_JSON")
+              -o json > "$BRANCH_JSON" 2>/dev/null || true
+            POSTGRES_URL_TRANSACTION=$(jq -r '.POSTGRES_URL // empty' "$BRANCH_JSON" 2>/dev/null || true)
             if [ -n "$POSTGRES_URL_TRANSACTION" ]; then break; fi
             echo "Waiting for branch to be ready ($i/24)..."
             sleep 5
           done
-          POSTGRES_URL_NON_POOLING=$(jq -r '.POSTGRES_URL_NON_POOLING' "$BRANCH_JSON")
+          POSTGRES_URL_NON_POOLING=$(jq -r '.POSTGRES_URL_NON_POOLING // empty' "$BRANCH_JSON" 2>/dev/null || true)
           rm "$BRANCH_JSON"
 
           if [ -z "$POSTGRES_URL_TRANSACTION" ]; then

--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -109,7 +109,10 @@ jobs:
               --project-ref "$PROJECT_REF" \
               -o json > "$BRANCH_JSON" 2>/dev/null || true
             POSTGRES_URL_TRANSACTION=$(jq -r '.POSTGRES_URL // empty' "$BRANCH_JSON" 2>/dev/null || true)
-            if [ -n "$POSTGRES_URL_TRANSACTION" ]; then break; fi
+            if [ -n "$POSTGRES_URL_TRANSACTION" ]; then
+              echo "Branch $BRANCH_NAME is ready."
+              break
+            fi
             echo "Waiting for branch to be ready ($i/24)..."
             sleep 5
           done


### PR DESCRIPTION
In order to stop the "Deploy .com to preview" workflow from failing on the "Create Supabase preview branch" step, this PR makes the branch-provisioning wait loop tolerant of the Supabase CLI's output while a branch is still being created.

The Supabase CLI [v2.102.0](https://github.com/supabase/cli/releases/tag/v2.102.0) [ported the `branches` commands from Go to native TypeScript](https://github.com/supabase/cli/pull/5374). Because our workflow installs the CLI with `version: latest`, CI picked this up automatically. The rewrite changed what `supabase branches get -o json` writes to **stdout** while a branch is still provisioning: the old (Go) CLI wrote empty stdout there, but the new (TS) CLI renders a non-JSON error/status line. The workflow piped that straight into an unguarded `jq`, which exited with code 5 on the parse error, and since the step runs under `set -e` the whole step aborted on the first loop iteration — before the retry loop could wait for the branch to become ready.

This was a CLI behavior change, not a regression in our code: the script had been unchanged since the [Supabase preview-DB migration](https://github.com/tldraw/tldraw/pull/8066), and the same workflow passed on older CLI versions.

The fix adds `2>/dev/null || true` to `supabase branches get` and to both `jq` calls so that, while the branch is provisioning, non-JSON / non-zero output is treated as "not ready yet" and the loop keeps retrying as it was always meant to. Once the branch is ready the CLI returns valid JSON, `jq` extracts `POSTGRES_URL`, and the loop breaks normally. Field names (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`) are unchanged in the new CLI, so no other adjustments are needed, and the CLI stays on `latest`.

### Change type

- [x] `other` (CI)

### Test plan

1. Open a PR that triggers the "Deploy .com to preview" workflow with a brand-new preview branch (one that has to provision from scratch).
2. Confirm the "Create Supabase preview branch" step logs "Waiting for branch to be ready (i/24)..." while provisioning and then succeeds, instead of failing with `jq: parse error` / exit code 5.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +8 / -3    |
