### PR TITLE
test(dotcom): fix flaky e2e sign-out

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -24,7 +24,7 @@ export class Sidebar {
 		this.helpMenu = this.page.getByTestId('tla-sidebar-help-menu-trigger')
 		this.themeButton = this.page.getByTestId('dialog-sub.help menu color-scheme-button')
 		this.darkModeButton = this.page.getByText('Dark')
-		this.signOutButton = this.page.getByText('Sign out')
+		this.signOutButton = this.page.getByTestId('dialog.sign-out')
 	}
 
 	async isVisible() {
@@ -62,6 +62,8 @@ export class Sidebar {
 	async openUserSettingsMenu() {
 		await this.userSettingsMenu.hover()
 		await this.userSettingsMenu.click()
+		// Wait for the dropdown content to mount before child-item clicks race the open animation.
+		await expect(this.page.getByRole('menu')).toBeVisible()
 	}
 
 	@step


### PR DESCRIPTION
In order to stop the dotcom `not-logged-in.spec.ts › can sign out` e2e test from intermittently failing, this PR de-flakes the sidebar sign-out fixture.

The fixture located the button with a loose `getByText('Sign out')` and clicked it without waiting for the Radix user-settings dropdown to finish opening. Playwright could therefore click mid-animation ("element is not stable") or match a node that re-portals and detaches ("element is detached from the DOM").

The fix targets the stable testid the menu item already renders (`dialog.sign-out`, from the `TldrawUiMenuItem` `${sourceId}.${id}` convention) and waits for the dropdown menu content to become visible in `openUserSettingsMenu()` before any child-item click, so child clicks no longer race the open animation. The change is confined to the e2e fixture; no project-wide `reducedMotion` override is used, so `cookie-consent.spec.ts` (which relies on animations running) is unaffected.

### Change type

- [x] `other`

### Test plan

1. From `apps/dotcom/client`, run the sign-out test repeatedly to confirm the flake is gone:
   `yarn e2e --grep "can sign out" --repeat-each=5`
2. Or from the repo root: `yarn e2e-dotcom`.

- [x] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +3 / -1    |