### PR TITLE
fix(dotcom): always deploy Zero for dotcom previews

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -55,14 +55,8 @@ jobs:
             echo "DEPLOY_ZERO=flyio-multinode" >> $GITHUB_ENV
           elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             echo "DEPLOY_ZERO=flyio-multinode" >> $GITHUB_ENV
-          elif echo "${{ toJSON(github.event.pull_request.labels.*.name) }}" | grep -q "preview-flyio-zero-deploy-please"; then
-            echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
-          elif git fetch origin "${GITHUB_BASE_REF}" && git diff --name-only origin/"${GITHUB_BASE_REF}"...HEAD | grep -q '^apps/dotcom/'; then
-            # gh pr edit ${{ github.event.pull_request.number }} --add-label "preview-flyio-zero-deploy-please"
-            # echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
-            echo "DEPLOY_ZERO=false" >> $GITHUB_ENV
           else
-            echo "DEPLOY_ZERO=false" >> $GITHUB_ENV
+            echo "DEPLOY_ZERO=flyio" >> $GITHUB_ENV
           fi
 
       - name: Install Supabase CLI

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -458,13 +458,8 @@ async function main() {
 
 function getZeroUrl() {
 	switch (env.TLDRAW_ENV) {
-		case 'preview': {
-			if (deployZero === 'flyio') {
-				return `https://${flyioAppName}.fly.dev/`
-			} else {
-				return 'https://zero-backend-not-deployed.tldraw.com'
-			}
-		}
+		case 'preview':
+			return `https://${flyioAppName}.fly.dev/`
 		case 'staging':
 			if (deployZero === 'flyio-multinode') {
 				return `https://${flyioAppName}.fly.dev/`


### PR DESCRIPTION
Closes #8965

## What

Dotcom previews now always deploy a single-node Zero backend, so the `@tldraw.com` "proper Zero" opt-in is valid on every preview.

Previously a plain `dotcom-preview-please` deploy set `DEPLOY_ZERO=false` unless the `preview-flyio-zero-deploy-please` label was present, but the client still opted any `@tldraw.com` user into proper Zero — pointing staff at the placeholder backend `zero-backend-not-deployed.tldraw.com`, which doesn't exist for the preview.

This takes option 2 from the issue (deploy Zero for previews) rather than gating the opt-in client-side.

## Changes

- **`.github/workflows/deploy-dotcom.yml`** — "Determine zero deploy target": any PR preview now sets `DEPLOY_ZERO=flyio` (single-node). Removed the `preview-flyio-zero-deploy-please` label check, the commented-out auto-label block, and the diff-based `apps/dotcom/` fallback that resolved to `false`. `production`/`main` stay on `flyio-multinode`.
- **`internal/scripts/deploy-dotcom.ts`** — `getZeroUrl()` preview case now always returns the deployed fly URL; removed the dead `zero-backend-not-deployed` preview branch.

## Pruning / cleanup

No prune changes needed: each preview creates `pr-<n>-zero-cache`, which already matches `prune-preview-deploys.ts`'s `ZERO_CACHE_APP_REGEX` and is destroyed daily once the PR has been closed for >2 days.

## Follow-ups

- Delete the now-unused `preview-flyio-zero-deploy-please` GitHub label (not referenced anywhere in code).
- Every dotcom preview now provisions a fly `zero-cache` app + runs Zero migrations against its Supabase branch DB — small added per-preview cost/latency.

## Test plan

1. Open a PR and apply `dotcom-preview-please`.
2. Sign into the preview with a `@tldraw.com` account.
3. Confirm the console logs `[Zero] Using proper Zero (@tldraw.com email)` against the preview's `pr-<n>-zero-cache.fly.dev` backend and that Zero-backed features work.
