### PR TITLE
fix(tldraw): keep dragged shape selected when pasting mid-interaction

### DIFF
--- a/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ArrowBindingHintOverlayUtil.ts
@@ -10,6 +10,8 @@ import {
 import { TLArrowInfo } from '../shapes/arrow/arrow-types'
 import { getArrowInfo } from '../shapes/arrow/getArrowInfo'
 import { getArrowBindings } from '../shapes/arrow/shared'
+import { DraggingHandle } from '../tools/SelectTool/childStates/DraggingHandle'
+import { PointingHandle } from '../tools/SelectTool/childStates/PointingHandle'
 
 /** @public */
 export interface TLArrowBindingHintOverlay extends TLOverlay {
@@ -41,10 +43,6 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 	override isActive(): boolean {
 		const editor = this.editor
 		if (editor.getIsReadonly()) return false
-		const id = editor.getOnlySelectedShapeId()
-		if (!id) return false
-		const shape = editor.getShape(id)
-		if (!shape || shape.type !== 'arrow') return false
 		if (
 			!editor.isInAny(
 				'select.idle',
@@ -56,12 +54,16 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 		) {
 			return false
 		}
+		const id = this.getActiveArrowId()
+		if (!id) return false
+		const shape = editor.getShape(id)
+		if (!shape || shape.type !== 'arrow') return false
 		const bindings = getArrowBindings(editor, shape as TLArrowShape)
 		return Boolean(bindings.start || bindings.end)
 	}
 
 	override getOverlays(): TLArrowBindingHintOverlay[] {
-		const id = this.editor.getOnlySelectedShapeId()
+		const id = this.getActiveArrowId()
 		if (!id) return []
 		return [
 			{
@@ -70,6 +72,26 @@ export class ArrowBindingHintOverlayUtil extends OverlayUtil<TLArrowBindingHintO
 				props: { arrowId: id },
 			},
 		]
+	}
+
+	/**
+	 * Resolve the arrow this hint applies to. While pointing or dragging an
+	 * arrow's handle, the selection can be stolen mid-interaction (e.g. pasting
+	 * a shape, which selects the pasted shape), so we read the arrow from the
+	 * interaction state rather than the current selection. Otherwise we fall
+	 * back to the only selected shape.
+	 */
+	private getActiveArrowId(): TLShapeId | null {
+		const editor = this.editor
+		if (editor.isIn('select.dragging_handle')) {
+			const node: DraggingHandle = editor.getStateDescendant('select.dragging_handle')!
+			if (node.info.shape.type === 'arrow') return node.info.shape.id
+		}
+		if (editor.isIn('select.pointing_handle')) {
+			const node: PointingHandle = editor.getStateDescendant('select.pointing_handle')!
+			if (node.info.shape.type === 'arrow') return node.info.shape.id
+		}
+		return editor.getOnlySelectedShapeId()
 	}
 
 	override render(ctx: CanvasRenderingContext2D, overlays: TLArrowBindingHintOverlay[]): void {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/DraggingHandle.tsx
@@ -247,6 +247,12 @@ export class DraggingHandle extends StateNode {
 			}
 		}
 
+		// Reselect the shape whose handle we were dragging, in case the selection
+		// changed mid-drag (e.g. pasting while dragging creates and selects a new shape).
+		if (this.editor.getShape(this.shapeId)) {
+			this.editor.select(this.shapeId)
+		}
+
 		this.parent.transition('idle')
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -173,6 +173,10 @@ export class Resizing extends StateNode {
 			}
 		}
 
+		// Reselect the shapes we were resizing, in case the selection changed mid-resize
+		// (e.g. pasting while resizing creates and selects a new shape).
+		this.editor.setSelectedShapes(this.snapshot.selectedShapeIds)
+
 		this.parent.transition('idle')
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -211,6 +211,9 @@ export class Translating extends StateNode {
 		if (this.isCreating) {
 			this.onCreate?.(this.editor.getOnlySelectedShape())
 		} else {
+			// Reselect the shapes we were moving, in case the selection changed mid-drag
+			// (e.g. pasting while translating creates and selects a new shape).
+			this.editor.setSelectedShapes(this.snapshot.movingShapes.map((s) => s.id))
 			this.parent.transition('idle')
 		}
 	}

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -336,6 +336,72 @@ describe('Pasting during an interaction', () => {
 		editor.expectToBeIn('select.idle')
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 	})
+
+	it('keeps the arrow binding hint visible while dragging a handle after a shape paste steals selection', () => {
+		// Regression for #8305: the dashed binding hint is gated on the
+		// interacted arrow, not the current selection, so pasting a shape
+		// mid-drag (which selects the pasted shape) must not hide it.
+		const overlayEditor = new TestEditor({ overlayUtils: defaultOverlayUtils })
+		const arrowId = createShapeId('hintArrow')
+		const targetId = createShapeId('hintTarget')
+		const clipboardId = createShapeId('hintClipboard')
+		overlayEditor.createShapes([
+			{ id: targetId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } },
+			{ id: clipboardId, type: 'geo', x: 400, y: 400, props: { w: 50, h: 50 } },
+			{
+				id: arrowId,
+				type: 'arrow',
+				x: 150,
+				y: 150,
+				props: { start: { x: 0, y: 0 }, end: { x: 120, y: 0 } },
+			},
+		])
+		// Bind the arrow's start to the target so a binding survives an end-handle drag.
+		overlayEditor.createBindings([
+			{
+				fromId: arrowId,
+				toId: targetId,
+				type: 'arrow',
+				props: {
+					terminal: 'start',
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					isExact: false,
+					isPrecise: false,
+				},
+			},
+		])
+
+		// Put a shape on the clipboard
+		overlayEditor.select(clipboardId)
+		overlayEditor.copy()
+
+		const hasBindingHint = () =>
+			overlayEditor.overlays.getCurrentOverlays().some((o) => o.type === 'arrow_binding_hint')
+
+		const arrow = overlayEditor.getShape(arrowId)!
+		const endHandle = overlayEditor.getShapeHandles(arrow)!.find((h) => h.id === 'end')!
+
+		overlayEditor.select(arrowId)
+		overlayEditor.pointerDown(arrow.x + endHandle.x, arrow.y + endHandle.y, {
+			target: 'handle',
+			shape: arrow,
+			handle: endHandle,
+		})
+		overlayEditor.pointerMove(arrow.x + endHandle.x + 20, arrow.y + endHandle.y)
+		overlayEditor.expectToBeIn('select.dragging_handle')
+		expect(hasBindingHint()).toBe(true)
+
+		// Pasting mid-drag steals the selection
+		const countBefore = overlayEditor.getCurrentPageShapes().length
+		overlayEditor.paste()
+		expect(overlayEditor.getCurrentPageShapes().length).toBeGreaterThan(countBefore)
+		expect(overlayEditor.getOnlySelectedShape()?.id).not.toBe(arrowId)
+
+		// The hint should still be visible while we keep dragging
+		expect(hasBindingHint()).toBe(true)
+
+		overlayEditor.pointerUp()
+	})
 })
 
 describe('PointingLabel', () => {

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -261,6 +261,83 @@ describe('DraggingHandle', () => {
 	})
 })
 
+describe('Pasting during an interaction', () => {
+	// Regression test for #8305: pasting mid-interaction creates and selects a new
+	// shape, but the shape being dragged/resized should be reselected when the
+	// interaction completes.
+
+	it('reselects the arrow whose handle is being dragged', () => {
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 100,
+				y: 100,
+				props: { start: { x: 0, y: 0 }, end: { x: 100, y: 100 } },
+			},
+		])
+
+		// Put something on the clipboard
+		editor.select(ids.box1)
+		editor.copy()
+
+		const arrow = editor.getShape(ids.arrow1)!
+		const endHandle = editor.getShapeHandles(arrow)!.find((h) => h.id === 'end')!
+
+		editor.select(ids.arrow1)
+		editor.pointerDown(200, 200, { target: 'handle', shape: arrow, handle: endHandle })
+		editor.pointerMove(260, 260)
+		editor.expectToBeIn('select.dragging_handle')
+
+		// Pasting mid-drag steals the selection
+		const countBefore = editor.getCurrentPageShapes().length
+		editor.paste()
+		expect(editor.getCurrentPageShapes().length).toBeGreaterThan(countBefore)
+		expect(editor.getOnlySelectedShape()?.id).not.toBe(ids.arrow1)
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.arrow1])
+	})
+
+	it('reselects the shape being translated', () => {
+		editor.select(ids.box1)
+		editor.copy()
+
+		const box1 = editor.getShape(ids.box1)!
+		editor.pointerDown(150, 150, { target: 'shape', shape: box1 })
+		editor.pointerMove(250, 250)
+		editor.expectToBeIn('select.translating')
+
+		const countBefore = editor.getCurrentPageShapes().length
+		editor.paste()
+		expect(editor.getCurrentPageShapes().length).toBeGreaterThan(countBefore)
+		expect(editor.getOnlySelectedShape()?.id).not.toBe(ids.box1)
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('reselects the shape being resized', () => {
+		editor.select(ids.box1)
+		editor.copy()
+
+		editor.pointerDown(200, 200, { target: 'selection', handle: 'bottom_right' })
+		editor.pointerMove(250, 250)
+		editor.expectToBeIn('select.resizing')
+
+		const countBefore = editor.getCurrentPageShapes().length
+		editor.paste()
+		expect(editor.getCurrentPageShapes().length).toBeGreaterThan(countBefore)
+		expect(editor.getOnlySelectedShape()?.id).not.toBe(ids.box1)
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+})
+
 describe('PointingLabel', () => {
 	it('Enters from pointing_arrow_label and exits to idle', () => {
 		editor.createShapes([


### PR DESCRIPTION
In order to fix #8305, this PR makes two related changes so that pasting (Cmd+V / Ctrl+V) while dragging an arrow terminal, resizing, or translating a shape no longer disrupts the interaction. Paste itself is intentionally left to go through (it's only suppressed while editing text), per the discussion on the issue.

**1. Keep the dragged shape selected.** Pasting mid-interaction creates and selects the pasted shape. Previously that selection persisted, so when the interaction ended the pasted shape stayed selected instead of the shape the user was actually dragging/resizing. The fix lives in the `SelectTool` state machine rather than the clipboard handler: `DraggingHandle`, `Resizing`, and `Translating` now restore the selection to the interacted shape(s) in their `complete()` handlers, just before transitioning back to idle. `setSelectedShapes` short-circuits when the selection already matches, so this is a no-op in the normal case and only takes effect when something (like a paste) changed the selection mid-interaction.

**2. Keep the arrow binding hint visible while dragging.** The dashed binding hint (`ArrowBindingHintOverlayUtil`) was gated on the only-selected shape being the arrow, so when a paste stole the arrow's selection mid-drag the hint disappeared until the drag ended. It now resolves the hinted arrow from the handle-drag/point interaction state (`select.dragging_handle` / `select.pointing_handle`) and only falls back to the current selection otherwise, so the hint stays visible throughout the drag.

### Change type

- [x] `bugfix`

### Test plan

1. Create a geo shape and an arrow on a tldraw canvas, and copy any shape to the clipboard.
2. Press and hold on the arrow's end handle and drag it toward the geo shape — the dashed binding hint appears.
3. While the pointer is still down, press Cmd+V. The binding hint stays visible (it no longer disappears until the drag ends).
4. Release the pointer — the arrow (not the pasted shape) is selected.
5. Repeat with a shape resize and a shape translate — in both cases the shape you were manipulating stays selected after pasting mid-drag.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix paste while dragging an arrow handle, resizing, or moving a shape stealing the selection from the shape being manipulated, and the arrow binding hint disappearing mid-drag after a paste.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +40 / -5   |
| Tests     | +143 / -0  |