### PR TITLE
fix(tldraw): fix the shortcut associated to hoovering style

### DIFF
--- a/apps/examples/e2e/tests/test-kbds.spec.ts
+++ b/apps/examples/e2e/tests/test-kbds.spec.ts
@@ -202,6 +202,14 @@ test.describe('Keyboard Shortcuts', () => {
 			data: { source: 'kbd' },
 		})
 	})
+
+	test('Copy hovered styles', async () => {
+		await page.keyboard.press('Shift+q')
+		expect(await page.evaluate(() => __tldraw_ui_event)).toMatchObject({
+			name: 'copy-hovered-styles',
+			data: { source: 'kbd' },
+		})
+	})
 })
 
 test.describe('Actions on shapes', () => {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4952,6 +4952,8 @@ export interface TLUiEventMap {
         format: 'json' | 'png' | 'svg';
     };
     // (undocumented)
+    'copy-hovered-styles': null;
+    // (undocumented)
     'copy-link': null;
     // (undocumented)
     'create-new-project': null;

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1852,7 +1852,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			{
 				id: 'copy-hovered-styles',
 				label: 'action.copy-hovered-styles',
-				kbd: 'q',
+				kbd: 'shift+q',
 				async onSelect() {
 					const hovered = editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
 						hitInside: true,
@@ -1866,16 +1866,26 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 					if (!hovered || !isIdle) return
 
-					for (const style of editor.styleProps[hovered.type].keys()) {
-						const value = editor.getShapeStyleIfExists(hovered, style)
-						if (value === undefined || style === GeoShapeGeoStyle) continue
-
-						if (editor.isIn('select')) {
-							editor.setStyleForSelectedShapes(style, value)
-						} else {
-							editor.setStyleForNextShapes(style, value)
-						}
+					// Only applying styles to selected shapes modifies the document, so only that
+					// case needs a history stopping point. Setting styles for the next shape is
+					// instance state and shouldn't be undoable.
+					const isInSelect = editor.isIn('select')
+					if (isInSelect && editor.getSelectedShapeIds().length > 0) {
+						editor.markHistoryStoppingPoint('copy-hovered-styles')
 					}
+
+					editor.run(() => {
+						for (const style of editor.styleProps[hovered.type].keys()) {
+							const value = editor.getShapeStyleIfExists(hovered, style)
+							if (value === undefined || style === GeoShapeGeoStyle) continue
+
+							if (isInSelect) {
+								editor.setStyleForSelectedShapes(style, value)
+							} else {
+								editor.setStyleForNextShapes(style, value)
+							}
+						}
+					})
 				},
 			},
 		]

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1853,7 +1853,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 				id: 'copy-hovered-styles',
 				label: 'action.copy-hovered-styles',
 				kbd: 'shift+q',
-				async onSelect() {
+				async onSelect(source) {
 					const hovered = editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), {
 						hitInside: true,
 						renderingOnly: true,
@@ -1886,6 +1886,8 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 							}
 						}
 					})
+
+					trackEvent('copy-hovered-styles', { source })
 				},
 			},
 		]

--- a/packages/tldraw/src/lib/ui/context/events.tsx
+++ b/packages/tldraw/src/lib/ui/context/events.tsx
@@ -145,6 +145,7 @@ export interface TLUiEventMap {
 			| 'bulletList'
 	}
 	edit: null
+	'copy-hovered-styles': null
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -195,7 +195,10 @@ export function areShortcutsDisabled(editor: Editor) {
 // non-Latin layouts (Cyrillic, Greek, etc.) and macOS Option-letter dead-key combinations,
 // where `event.key` is a non-ASCII glyph.
 
-interface ParsedKbd {
+/**
+ * @internal
+ */
+export interface ParsedKbd {
 	key: string
 	shift: boolean
 	alt: boolean
@@ -319,33 +322,16 @@ const PHYSICAL_KEY_MAP: Record<string, string> = {
 	Backquote: '`',
 }
 
-function parseKbd(kbd: string): ParsedKbd[] {
+/**
+ * @internal
+ */
+export function parseKbd(kbd: string): ParsedKbd[] {
 	const out: ParsedKbd[] = []
 	for (const shortcut of getKeys(kbd)) {
 		const parsed = parseShortcut(shortcut)
 		if (parsed) out.push(parsed)
 	}
 	return out
-}
-
-function serializeParsedKbd(parsed: ParsedKbd): string {
-	const modifiers: string[] = []
-	if (parsed.meta) modifiers.push('meta')
-	if (parsed.ctrl) modifiers.push('ctrl')
-	if (parsed.alt) modifiers.push('alt')
-	if (parsed.shift) modifiers.push('shift')
-	return [...modifiers, parsed.key].join('+')
-}
-
-/**
- * Normalize a raw `kbd` string (the format used by actions and tools) into the list of canonical
- * key combos it binds to. Two registrations that produce overlapping combos will both fire on the
- * same keydown, so this is used to detect colliding shortcuts.
- *
- * @internal
- */
-export function getKbdKeyCombos(kbd: string): string[] {
-	return parseKbd(getHotkeysStringFromKbd(kbd)).map(serializeParsedKbd)
 }
 
 function parseShortcut(shortcut: string): ParsedKbd | null {
@@ -431,11 +417,16 @@ function shouldSkipEvent(e: KeyboardEvent): boolean {
 	return false
 }
 
-// The "raw" kbd here will look something like "a" or a combination of keys "del,backspace".
-// We need to first split them up by comma, then parse each key to ensure backwards compatibility
-// with the old kbd format. We used to have symbols to denote cmd/alt/shift,
-// using ! for shift, $ for cmd, and ? for alt.
-function getHotkeysStringFromKbd(kbd: string) {
+/**
+ * The "raw" kbd here will look something like "a" or a combination of keys
+ * "del,backspace". We need to first split them up by comma, then parse each
+ * key to ensure backwards compatibility with the old kbd format. We used to
+ * have symbols to denote cmd/alt/shift, using ! for shift, $ for cmd, and ?
+ * for alt.
+ *
+ * @internal
+ */
+export function getHotkeysStringFromKbd(kbd: string) {
 	return getKeys(kbd)
 		.map((kbd) => {
 			let str = ''

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -328,6 +328,26 @@ function parseKbd(kbd: string): ParsedKbd[] {
 	return out
 }
 
+function serializeParsedKbd(parsed: ParsedKbd): string {
+	const modifiers: string[] = []
+	if (parsed.meta) modifiers.push('meta')
+	if (parsed.ctrl) modifiers.push('ctrl')
+	if (parsed.alt) modifiers.push('alt')
+	if (parsed.shift) modifiers.push('shift')
+	return [...modifiers, parsed.key].join('+')
+}
+
+/**
+ * Normalize a raw `kbd` string (the format used by actions and tools) into the list of canonical
+ * key combos it binds to. Two registrations that produce overlapping combos will both fire on the
+ * same keydown, so this is used to detect colliding shortcuts.
+ *
+ * @internal
+ */
+export function getKbdKeyCombos(kbd: string): string[] {
+	return parseKbd(getHotkeysStringFromKbd(kbd)).map(serializeParsedKbd)
+}
+
 function parseShortcut(shortcut: string): ParsedKbd | null {
 	const parts = shortcut.split('+')
 	const result: ParsedKbd = {

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from 'react'
+import { Tldraw } from '../../lib/Tldraw'
+import { useActions } from '../../lib/ui/context/actions'
+import { getKbdKeyCombos } from '../../lib/ui/hooks/useKeyboardShortcuts'
+import { useTools } from '../../lib/ui/hooks/useTools'
+import { renderTldrawComponent } from '../testutils/renderTldrawComponent'
+
+// These kbds are intentionally not registered in the shortcut registry, they're handled by
+// useNativeClipboardEvents / the upload asset action instead. See SKIP_KBDS in useKeyboardShortcuts.
+const SKIP_KBDS = ['copy', 'cut', 'paste', 'asset']
+
+interface ShortcutEntry {
+	id: string
+	kbd: string
+}
+
+function ShortcutCapturer({ onCapture }: { onCapture(entries: ShortcutEntry[]): void }) {
+	const actions = useActions()
+	const tools = useTools()
+
+	useEffect(() => {
+		const entries: ShortcutEntry[] = []
+		for (const action of Object.values(actions)) {
+			if (!action.kbd || SKIP_KBDS.includes(action.id)) continue
+			entries.push({ id: `action.${action.id}`, kbd: action.kbd })
+		}
+		for (const tool of Object.values(tools)) {
+			if (!tool.kbd || SKIP_KBDS.includes(tool.id)) continue
+			entries.push({ id: `tool.${tool.id}`, kbd: tool.kbd })
+		}
+		onCapture(entries)
+	}, [actions, tools, onCapture])
+
+	return null
+}
+
+async function getDefaultShortcutEntries() {
+	let captured: ShortcutEntry[] = []
+	await renderTldrawComponent(
+		<Tldraw>
+			<ShortcutCapturer onCapture={(entries) => (captured = entries)} />
+		</Tldraw>,
+		{ waitForPatterns: false }
+	)
+	return captured
+}
+
+describe('default keyboard shortcuts', () => {
+	it('does not bind the same key combo to more than one action or tool', async () => {
+		const entries = await getDefaultShortcutEntries()
+
+		// Sanity check: we actually captured the default actions/tools.
+		expect(entries.length).toBeGreaterThan(0)
+
+		const comboToIds = new Map<string, string[]>()
+		for (const entry of entries) {
+			for (const combo of getKbdKeyCombos(entry.kbd)) {
+				const ids = comboToIds.get(combo) ?? []
+				ids.push(entry.id)
+				comboToIds.set(combo, ids)
+			}
+		}
+
+		const collisions = [...comboToIds.entries()]
+			.filter(([, ids]) => ids.length > 1)
+			.map(([combo, ids]) => `${combo} -> ${ids.join(', ')}`)
+
+		expect(collisions).toEqual([])
+	})
+})

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -1,7 +1,11 @@
 import { useEffect } from 'react'
 import { Tldraw } from '../../lib/Tldraw'
 import { useActions } from '../../lib/ui/context/actions'
-import { getKbdKeyCombos } from '../../lib/ui/hooks/useKeyboardShortcuts'
+import {
+	getHotkeysStringFromKbd,
+	ParsedKbd,
+	parseKbd,
+} from '../../lib/ui/hooks/useKeyboardShortcuts'
 import { useTools } from '../../lib/ui/hooks/useTools'
 import { renderTldrawComponent } from '../testutils/renderTldrawComponent'
 
@@ -12,6 +16,19 @@ const SKIP_KBDS = ['copy', 'cut', 'paste', 'asset']
 interface ShortcutEntry {
 	id: string
 	kbd: string
+}
+
+function serializeParsedKbd(parsed: ParsedKbd): string {
+	const modifiers: string[] = []
+	if (parsed.meta) modifiers.push('meta')
+	if (parsed.ctrl) modifiers.push('ctrl')
+	if (parsed.alt) modifiers.push('alt')
+	if (parsed.shift) modifiers.push('shift')
+	return [...modifiers, parsed.key].join('+')
+}
+
+export function getKbdKeyCombos(kbd: string): string[] {
+	return parseKbd(getHotkeysStringFromKbd(kbd)).map(serializeParsedKbd)
 }
 
 function ShortcutCapturer({ onCapture }: { onCapture(entries: ShortcutEntry[]): void }) {


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8962 

Following the release of the "hoovering style" feature ( https://github.com/tldraw/tldraw/pull/8917 ), it's been found `q` has been used twice for shortcuts.

I'm moving the shortcut to Q (shift+q) for hoovering styles (we can discuss this) 

+ adding a test that make sure we're not reusing the same shortcuts 
+ adding a missing record of the action, right now undoing goes two steps before because we're missing this.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape.
2. Create an other shape with different styles
3. Select one of the shape
4. hover the other and press shift+q
5. the selected shape hoovered the style of the hovered shape (bit complicated to read this one)
6. press ctrl+z to under 
7. the shape should go back to the previous styles

- [ ] Unit tests
- [ ] End to end tests

### API changes

- Added an ui event for `copy-hovered-styles`

### Release notes

-Fixed a keyboard shortcut conflict where q both toggled tool lock and copied hovered styles; copy hovered styles is now shift+q.
- Added a step record of the copy style features when the editor is not in select mode