### PR TITLE
feat(dotcom): link signed-in logo to tldraw.dev and track logo clicks

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -44,6 +44,7 @@ import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-eve
 import { getIsCoarsePointer } from '../../utils/getIsCoarsePointer'
 import { defineMessages, useIntl, useMsg } from '../../utils/i18n'
 import { TlaSignInDialog } from '../dialogs/TlaSignInDialog'
+import { ExternalLink } from '../ExternalLink/ExternalLink'
 import {
 	CookieConsentMenuItem,
 	GiveUsFeedbackMenuItem,
@@ -106,15 +107,14 @@ export function TlaEditorTopLeftPanelAnonymous() {
 
 	return (
 		<>
-			<a
-				href="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=top-left-logo"
-				target="_blank"
-				rel="noopener noreferrer"
+			<ExternalLink
+				to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=top-left-logo"
+				eventName="top-left-logo-clicked"
 				aria-label="tldraw.dev"
 				className={styles.topLeftOfflineLogo}
 			>
 				<TlaLogo data-testid="tla-top-left-logo-icon" />
-			</a>
+			</ExternalLink>
 			{anonFileName && (
 				<>
 					<span

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
@@ -1,10 +1,17 @@
+import { ExternalLink } from '../../ExternalLink/ExternalLink'
 import { TlaLogo } from '../../TlaLogo/TlaLogo'
 import styles from '../sidebar.module.css'
 
 export function TlaSidebarWorkspaceLink() {
 	return (
-		<div className={styles.sidebarWorkspaceButton} data-testid="tla-sidebar-workspace-link">
+		<ExternalLink
+			to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=top-left-logo"
+			eventName="sidebar-logo-clicked"
+			aria-label="tldraw.dev"
+			className={styles.sidebarWorkspaceButton}
+			data-testid="tla-sidebar-workspace-link"
+		>
 			<TlaLogo data-testid="tla-sidebar-logo-icon" />
-		</div>
+		</ExternalLink>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -236,7 +236,7 @@
 	flex: 0 0 auto;
 }
 
-/* Workspace link (sort of) */
+/* Workspace link */
 
 .sidebarWorkspaceButton {
 	background: none;


### PR DESCRIPTION
In order to extend the tldraw.com → tldraw.dev logo link to signed-in users, this PR makes the sidebar workspace logo an external link to tldraw.dev, and routes both logo links through the shared `ExternalLink` wrapper so they emit click analytics consistently. It follows up #8938, which repointed the logo only on the anonymous editor panel (where the logo sits in the top-left).

**Signed-in logo (new link).** Signed-in users never see the anonymous panel's logo — for them the logo lives in the sidebar via `TlaSidebarWorkspaceLink`, which until now was a non-clickable `<div>`. It now renders `ExternalLink` to `https://tldraw.dev`, opening in a new tab with `target="_blank"`, `rel="noopener noreferrer"`, and an `aria-label` (the logo is image-only). It reuses the same `utm_campaign=top-left-logo` value as #8938 so both logos roll up together on tldraw.dev's side.

**Anonymous logo (tracking + consistency).** #8938 used a raw `<a>` for the anon top-left logo, which had no click tracking. It now uses `ExternalLink` too, so both surfaces emit PostHog events — `top-left-logo-clicked` (anon) and `sidebar-logo-clicked` (signed-in) — distinct names so the two can be segmented, while the shared UTM campaign still attributes them together. This also moves `target`/`rel` into the wrapper rather than hand-maintained attributes.

Relates to #8871. Follows up #8938.

### Change type

- [x] `improvement`

### Test plan

1. **Signed in** (`yarn dev-app`, then sign in): click the tldraw logo at the top of the left sidebar.
2. **Anonymous** (logged out, shared file, or published file): click the tldraw logo in the top-left of the editor.
3. In both cases confirm a new tab opens at `https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=top-left-logo`, and the original tab stays on tldraw.com.
4. Inspect each logo's `<a>` element: `target="_blank"`, `rel="noopener noreferrer"`, `aria-label="tldraw.dev"`.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Link the tldraw logo in the signed-in sidebar to tldraw.dev.

### Code changes

| Section | LOC change |
| --- | --- |
| Apps | +15 / -8 |
