### PR TITLE
fix(text): expand text shape bounds to fit cursive and RTL glyph ink

### DIFF
--- a/apps/examples/e2e/tests/test-text-ink-bounds.spec.ts
+++ b/apps/examples/e2e/tests/test-text-ink-bounds.spec.ts
@@ -10,12 +10,17 @@ test.describe('text shape ink bounds', () => {
 	// Creates an autosized text shape, waits for its webfont to load — so the canvas ink
 	// measurement uses real glyph metrics and the geometry recomputes — then returns the
 	// advance-box width alongside the (possibly ink-padded) geometry bounds.
-	async function measure(page: Page, text: string, font: 'draw' | 'sans') {
+	async function measure(
+		page: Page,
+		text: string,
+		font: 'draw' | 'sans' | 'serif',
+		italic = false
+	) {
 		// Plain string (not a branded TLShapeId): the template-literal `shape:${string}` type
 		// trips TS2589 in page.evaluate's Serializable check on the argument.
 		const id = 'shape:textInkBounds'
 		return await page.evaluate(
-			async ({ id, text, font }) => {
+			async ({ id, text, font, italic }) => {
 				// Drop into `any` for the editor calls: fully typing a text-shape partial and
 				// reaching TextShapeUtil.getMinDimensions inside page.evaluate trips TS2589 (the
 				// shape-util union is too deep). The other e2e tests lean on `as any` similarly.
@@ -29,7 +34,14 @@ test.describe('text shape ink bounds', () => {
 					props: {
 						richText: {
 							type: 'doc',
-							content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+							content: [
+								{
+									type: 'paragraph',
+									content: [
+										{ type: 'text', text, marks: italic ? [{ type: 'italic' }] : undefined },
+									],
+								},
+							],
 						},
 						font,
 						size: 'xl',
@@ -50,15 +62,16 @@ test.describe('text shape ink bounds', () => {
 					geometryWidth: bounds.width as number,
 				}
 			},
-			{ id, text, font }
+			{ id, text, font, italic }
 		)
 	}
 
-	test('grows the box to enclose RTL ink that spills past the advance width', async ({ page }) => {
-		// Hebrew in the default (draw) font has cursive side bearings whose ink extends past
-		// the pen-advance box. The shape's geometry must expand to contain them so the text
-		// isn't drawn outside its own bounding box (#8803).
-		const { advanceWidth, geometryWidth } = await measure(page, 'שלום עולם', 'draw')
+	test('expands the box to enclose ink that spills past the advance width', async ({ page }) => {
+		// Italic glyphs slant past their pen-advance box. We use an italic mark on a built-in
+		// tldraw font (a real embedded face, so the metrics are stable across platforms —
+		// unlike fallback-rendered scripts) to exercise the same overflow path that fixes
+		// RTL/cursive clipping (#8803). The geometry must grow to contain the ink.
+		const { advanceWidth, geometryWidth } = await measure(page, 'Affjjy WV', 'serif', true)
 		expect(geometryWidth).toBeGreaterThan(advanceWidth)
 	})
 

--- a/apps/examples/e2e/tests/test-text-ink-bounds.spec.ts
+++ b/apps/examples/e2e/tests/test-text-ink-bounds.spec.ts
@@ -1,0 +1,72 @@
+import test, { expect, Page } from '@playwright/test'
+import { Editor } from 'tldraw'
+import { setup } from '../shared-e2e'
+
+declare const editor: Editor
+
+test.describe('text shape ink bounds', () => {
+	test.beforeEach(setup)
+
+	// Creates an autosized text shape, waits for its webfont to load — so the canvas ink
+	// measurement uses real glyph metrics and the geometry recomputes — then returns the
+	// advance-box width alongside the (possibly ink-padded) geometry bounds.
+	async function measure(page: Page, text: string, font: 'draw' | 'sans') {
+		// Plain string (not a branded TLShapeId): the template-literal `shape:${string}` type
+		// trips TS2589 in page.evaluate's Serializable check on the argument.
+		const id = 'shape:textInkBounds'
+		return await page.evaluate(
+			async ({ id, text, font }) => {
+				// Drop into `any` for the editor calls: fully typing a text-shape partial and
+				// reaching TextShapeUtil.getMinDimensions inside page.evaluate trips TS2589 (the
+				// shape-util union is too deep). The other e2e tests lean on `as any` similarly.
+				const ed = editor as any
+				ed.selectAll().deleteShapes(ed.getSelectedShapeIds())
+				ed.createShape({
+					id,
+					type: 'text',
+					x: 200,
+					y: 200,
+					props: {
+						richText: {
+							type: 'doc',
+							content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+						},
+						font,
+						size: 'xl',
+						autoSize: true,
+						color: 'black',
+					},
+				})
+
+				await ed.fonts.loadRequiredFontsForCurrentPage()
+				await ed.getContainerDocument().fonts.ready
+
+				const shape = ed.getShape(id)
+				const advanceWidth: number = ed.getShapeUtil(shape).getMinDimensions(shape).width
+				const bounds = ed.getShapeGeometry(shape).bounds
+				return {
+					advanceWidth,
+					geometryX: bounds.x as number,
+					geometryWidth: bounds.width as number,
+				}
+			},
+			{ id, text, font }
+		)
+	}
+
+	test('grows the box to enclose RTL ink that spills past the advance width', async ({ page }) => {
+		// Hebrew in the default (draw) font has cursive side bearings whose ink extends past
+		// the pen-advance box. The shape's geometry must expand to contain them so the text
+		// isn't drawn outside its own bounding box (#8803).
+		const { advanceWidth, geometryWidth } = await measure(page, 'שלום עולם', 'draw')
+		expect(geometryWidth).toBeGreaterThan(advanceWidth)
+	})
+
+	test('leaves the box unchanged for text that fits its advance width', async ({ page }) => {
+		// Latin text in the sans font sits entirely inside its advance box, so there should
+		// be no padding and no shift in the geometry origin.
+		const { advanceWidth, geometryX, geometryWidth } = await measure(page, 'Hello world', 'sans')
+		expect(geometryX).toBeCloseTo(0, 1)
+		expect(geometryWidth).toBeCloseTo(advanceWidth, 1)
+	})
+})

--- a/apps/examples/e2e/tests/test-text-ink-bounds.spec.ts
+++ b/apps/examples/e2e/tests/test-text-ink-bounds.spec.ts
@@ -69,4 +69,45 @@ test.describe('text shape ink bounds', () => {
 		expect(geometryX).toBeCloseTo(0, 1)
 		expect(geometryWidth).toBeCloseTo(advanceWidth, 1)
 	})
+
+	test('does not over-expand fixed-width text that soft-wraps', async ({ page }) => {
+		// A fixed-width shape wraps long text across several lines. Ink overflow can only be
+		// attributed for lines that fit the box, so wrapped lines are skipped — the geometry
+		// must stay at the fixed width rather than ballooning to the unwrapped advance.
+		const result = await page.evaluate(
+			async ({ id, text, width }) => {
+				const ed = editor as any
+				ed.selectAll().deleteShapes(ed.getSelectedShapeIds())
+				ed.createShape({
+					id,
+					type: 'text',
+					x: 100,
+					y: 100,
+					props: {
+						richText: {
+							type: 'doc',
+							content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+						},
+						font: 'sans',
+						size: 'm',
+						autoSize: false,
+						w: width,
+						color: 'black',
+					},
+				})
+				await ed.fonts.loadRequiredFontsForCurrentPage()
+				await ed.getContainerDocument().fonts.ready
+				const shape = ed.getShape(id)
+				const bounds = ed.getShapeGeometry(shape).bounds
+				return { geometryWidth: bounds.width as number }
+			},
+			{
+				id: 'shape:fixedWrap',
+				text: 'The quick brown fox jumps over the lazy dog and keeps on running',
+				width: 200,
+			}
+		)
+		// Stays at the fixed width (a few px of slack), never the full unwrapped advance.
+		expect(result.geometryWidth).toBeLessThan(210)
+	})
 })

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3353,8 +3353,11 @@ export class TextManager {
     measureHtml(html: string, opts: TLMeasureTextOpts): TLMeasuredTextSize;
     // (undocumented)
     measureHtmlBatch(requests: BatchMeasurementRequest[]): TLMeasuredTextSize[];
+    // @internal
+    measureHtmlInkOverflow(html: string, opts: TLMeasureTextOpts): TLTextInkOverflow;
     // (undocumented)
     measureText(textToMeasure: string, opts: TLMeasureTextOpts): TLMeasuredTextSize;
+    measureTextInkBounds(element: HTMLElement): BoxModel | null;
     measureTextSpans(textToMeasure: string, opts: TLMeasureTextSpanOpts): {
         box: BoxModel;
         text: string;
@@ -4811,6 +4814,18 @@ export interface TLTextExternalContentSource {
     subtype: 'html' | 'json' | 'text' | 'url';
     // (undocumented)
     type: 'text';
+}
+
+// @internal
+export interface TLTextInkOverflow {
+    // (undocumented)
+    bottom: number;
+    // (undocumented)
+    left: number;
+    // (undocumented)
+    right: number;
+    // (undocumented)
+    top: number;
 }
 
 // @public (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3354,7 +3354,10 @@ export class TextManager {
     // (undocumented)
     measureHtmlBatch(requests: BatchMeasurementRequest[]): TLMeasuredTextSize[];
     // @internal
-    measureHtmlInkOverflow(html: string, opts: TLMeasureTextOpts): TLTextInkOverflow;
+    measureHtmlBounds(html: string, opts: TLMeasureTextOpts): {
+        advance: TLMeasuredTextSize;
+        ink: BoxModel | null;
+    };
     // (undocumented)
     measureText(textToMeasure: string, opts: TLMeasureTextOpts): TLMeasuredTextSize;
     measureTextInkBounds(element: HTMLElement): BoxModel | null;
@@ -4814,18 +4817,6 @@ export interface TLTextExternalContentSource {
     subtype: 'html' | 'json' | 'text' | 'url';
     // (undocumented)
     type: 'text';
-}
-
-// @internal
-export interface TLTextInkOverflow {
-    // (undocumented)
-    bottom: number;
-    // (undocumented)
-    left: number;
-    // (undocumented)
-    right: number;
-    // (undocumented)
-    top: number;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -132,7 +132,6 @@ export {
 	type TLMeasuredTextSize,
 	type TLMeasureTextOpts,
 	type TLMeasureTextSpanOpts,
-	type TLTextInkOverflow,
 } from './lib/editor/managers/TextManager/TextManager'
 export { DEFAULT_THEME } from './lib/editor/managers/ThemeManager/defaultThemes'
 export { ThemeManager, resolveThemes } from './lib/editor/managers/ThemeManager/ThemeManager'

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -132,6 +132,7 @@ export {
 	type TLMeasuredTextSize,
 	type TLMeasureTextOpts,
 	type TLMeasureTextSpanOpts,
+	type TLTextInkOverflow,
 } from './lib/editor/managers/TextManager/TextManager'
 export { DEFAULT_THEME } from './lib/editor/managers/ThemeManager/defaultThemes'
 export { ThemeManager, resolveThemes } from './lib/editor/managers/ThemeManager/ThemeManager'

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -76,6 +76,20 @@ export interface TLMeasureTextSpanOpts {
 	measureScrollWidth?: boolean
 }
 
+/**
+ * The distance, in px, that rendered glyph ink extends past the layout (advance) box on
+ * each physical side — what cursive/RTL/italic side bearings and tall diacritics paint
+ * outside the box.
+ *
+ * @internal
+ */
+export interface TLTextInkOverflow {
+	left: number
+	right: number
+	top: number
+	bottom: number
+}
+
 const spaceCharacterRegex = /\s/
 
 const initialDefaultStyles = Object.freeze({
@@ -91,6 +105,7 @@ const initialDefaultStyles = Object.freeze({
 export class TextManager {
 	private elm: HTMLDivElement
 	private poolElms: PoolItem[] = []
+	private inkCtx: CanvasRenderingContext2D | null | undefined
 
 	constructor(public editor: Editor) {
 		this.elm = this.createMeasurementEl()
@@ -434,6 +449,122 @@ export class TextManager {
 			}
 
 			return spans
+		} finally {
+			restoreStyles()
+		}
+	}
+
+	private getInkContext(): CanvasRenderingContext2D | null {
+		if (this.inkCtx !== undefined) return this.inkCtx
+		const canvas = this.editor.getContainerDocument().createElement('canvas')
+		this.inkCtx = canvas.getContext('2d')
+		return this.inkCtx
+	}
+
+	/**
+	 * Measure the actual ink bounds of the text rendered inside an element, in element-local
+	 * coordinates (relative to the element's bounding rect). Unlike the layout box, this
+	 * includes glyph side bearings, italic slant, and tall diacritics that paint outside the
+	 * advance width.
+	 *
+	 * The element must already be laid out (attached, with client rects). Wrapping, bidi,
+	 * alignment, and per-run bold/italic are all read back from the browser's layout; only the
+	 * ink delta is measured with canvas. Returns null when there is no measurable text (or no
+	 * canvas available, e.g. in a headless environment).
+	 *
+	 * @public
+	 */
+	measureTextInkBounds(element: HTMLElement): BoxModel | null {
+		const ctx = this.getInkContext()
+		if (!ctx) return null
+
+		const doc = this.editor.getContainerDocument()
+		const view = doc.defaultView ?? window
+		const ref = element.getBoundingClientRect()
+		const range = doc.createRange()
+		const walker = doc.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+
+		let minX = Infinity
+		let minY = Infinity
+		let maxX = -Infinity
+		let maxY = -Infinity
+
+		for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+			const text = node.textContent
+			const parent = node.parentElement
+			if (!text || !text.trim() || !parent) continue
+
+			// Computed style is already resolved — CSS vars are expanded, and a bold/italic run
+			// reports its own weight/style because it lives in its own element.
+			const cs = view.getComputedStyle(parent)
+			ctx.font = `${cs.fontStyle} ${cs.fontWeight} ${cs.fontSize} ${cs.fontFamily}`
+
+			// Split the node's characters into per-line fragments using the browser's layout: a
+			// change in a character's `top` means the text wrapped to a new line.
+			const fragments: { text: string; left: number; top: number; height: number }[] = []
+			let idx = 0
+			for (const char of text) {
+				range.setStart(node, idx)
+				range.setEnd(node, idx + char.length)
+				idx += char.length
+				const rects = range.getClientRects()
+				const rect = rects[rects.length - 1]
+				if (!rect) continue
+				const last = fragments[fragments.length - 1]
+				if (!last || rect.top !== last.top) {
+					fragments.push({ text: char, left: rect.left, top: rect.top, height: rect.height })
+				} else {
+					last.text += char
+					if (rect.left < last.left) last.left = rect.left
+				}
+			}
+
+			for (const frag of fragments) {
+				const m = ctx.measureText(frag.text)
+				const fontAscent = m.fontBoundingBoxAscent || parseFloat(cs.fontSize) || 0
+				const fontDescent = m.fontBoundingBoxDescent || 0
+				// Anchor the pen at the fragment's physical left edge and place the baseline within
+				// the line box the way CSS line-height does (half-leading above the font ascent).
+				const penX = frag.left - ref.left
+				const baseline =
+					frag.top - ref.top + (frag.height - (fontAscent + fontDescent)) / 2 + fontAscent
+				const left = penX - (m.actualBoundingBoxLeft || 0)
+				const right = penX + (m.actualBoundingBoxRight || 0)
+				const top = baseline - (m.actualBoundingBoxAscent || 0)
+				const bottom = baseline + (m.actualBoundingBoxDescent || 0)
+				if (left < minX) minX = left
+				if (right > maxX) maxX = right
+				if (top < minY) minY = top
+				if (bottom > maxY) maxY = bottom
+			}
+		}
+
+		if (!Number.isFinite(minX)) return null
+		return { x: minX, y: minY, w: maxX - minX, h: maxY - minY }
+	}
+
+	/**
+	 * Render html into the measurement element and report how far the rendered ink spills past
+	 * the resulting layout (advance) box on each physical side, in px. A convenience over
+	 * {@link TextManager.measureTextInkBounds} for callers that already have html and measure
+	 * options (e.g. a text shape sizing its geometry).
+	 *
+	 * @internal
+	 */
+	measureHtmlInkOverflow(html: string, opts: TLMeasureTextOpts): TLTextInkOverflow {
+		const { elm } = this
+		const restoreStyles = this.setElementStyles(elm, this.getMeasureStyles(opts))
+		try {
+			elm.innerHTML = html
+			const rect = elm.getBoundingClientRect()
+			const ink = this.measureTextInkBounds(elm)
+			if (!ink) return { left: 0, right: 0, top: 0, bottom: 0 }
+			return {
+				left: Math.max(0, -ink.x),
+				top: Math.max(0, -ink.y),
+				right: Math.max(0, ink.x + ink.w - rect.width),
+				bottom: Math.max(0, ink.y + ink.h - rect.height),
+			}
 		} finally {
 			restoreStyles()
 		}

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -76,20 +76,6 @@ export interface TLMeasureTextSpanOpts {
 	measureScrollWidth?: boolean
 }
 
-/**
- * The distance, in px, that rendered glyph ink extends past the layout (advance) box on
- * each physical side — what cursive/RTL/italic side bearings and tall diacritics paint
- * outside the box.
- *
- * @internal
- */
-export interface TLTextInkOverflow {
-	left: number
-	right: number
-	top: number
-	bottom: number
-}
-
 const spaceCharacterRegex = /\s/
 
 const initialDefaultStyles = Object.freeze({
@@ -549,27 +535,27 @@ export class TextManager {
 	}
 
 	/**
-	 * Render html into the measurement element and report how far the rendered ink spills past
-	 * the resulting layout (advance) box on each physical side, in px. A convenience over
-	 * {@link TextManager.measureTextInkBounds} for callers that already have html and measure
-	 * options (e.g. a text shape sizing its geometry).
+	 * Render html into the measurement element once and return both its layout (advance) size
+	 * and the actual ink bounds (relative to the advance box's top-left). A single-pass
+	 * convenience over {@link TextManager.measureHtml} + {@link TextManager.measureTextInkBounds}
+	 * for callers that need both, e.g. a text shape sizing its geometry. `ink` is null when
+	 * there's no measurable text or no canvas (headless).
 	 *
 	 * @internal
 	 */
-	measureHtmlInkOverflow(html: string, opts: TLMeasureTextOpts): TLTextInkOverflow {
+	measureHtmlBounds(
+		html: string,
+		opts: TLMeasureTextOpts
+	): { advance: TLMeasuredTextSize; ink: BoxModel | null } {
 		const { elm } = this
 		const restoreStyles = this.setElementStyles(elm, this.getMeasureStyles(opts))
 		try {
 			elm.innerHTML = html
+			const scrollWidth = opts.measureScrollWidth ? elm.scrollWidth : 0
 			const rect = elm.getBoundingClientRect()
+			const advance = { x: 0, y: 0, w: rect.width, h: rect.height, scrollWidth }
 			const ink = this.measureTextInkBounds(elm)
-			if (!ink) return { left: 0, right: 0, top: 0, bottom: 0 }
-			return {
-				left: Math.max(0, -ink.x),
-				top: Math.max(0, -ink.y),
-				right: Math.max(0, ink.x + ink.w - rect.width),
-				bottom: Math.max(0, ink.y + ink.h - rect.height),
-			}
+			return { advance, ink }
 		} finally {
 			restoreStyles()
 		}

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -480,8 +480,13 @@ export class TextManager {
 
 		const doc = this.editor.getContainerDocument()
 		const view = doc.defaultView ?? window
-		const ref = element.getBoundingClientRect()
 		const range = doc.createRange()
+		// Some non-rendering environments (e.g. jsdom under test) provide a canvas context but
+		// don't lay text out, so ranges have no client rects. Without layout there are no ink
+		// bounds to measure.
+		if (typeof range.getClientRects !== 'function') return null
+
+		const ref = element.getBoundingClientRect()
 		const walker = doc.createTreeWalker(element, NodeFilter.SHOW_TEXT)
 
 		let minX = Infinity

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -6,8 +6,10 @@ import {
 	ShapeUtil,
 	SvgExportContext,
 	TLGeometryOpts,
+	TLMeasureTextOpts,
 	TLResizeInfo,
 	TLShapeId,
+	TLTextInkOverflow,
 	TLTextShape,
 	Vec,
 	createComputedCache,
@@ -42,19 +44,21 @@ const sizeCache = createComputedCache(
 	{ areRecordsEqual: (a, b) => a.props === b.props }
 )
 
-// How far the rendered ink extends beyond the advance-width box that `getTextSize`
-// measures, per physical side. Used by `getGeometry` to pad the shape's bounds so
-// cursive/RTL/italic glyphs (e.g. Arabic, see #8803) aren't drawn outside the box.
+const ZERO_INK_OVERFLOW: TLTextInkOverflow = { left: 0, right: 0, top: 0, bottom: 0 }
+
+// How far the rendered glyph ink extends past the advance-width box the browser lays out,
+// per physical side. Used by `getGeometry` to grow the shape's bounds so cursive/RTL/italic
+// glyphs and tall diacritics (e.g. Arabic, see #8803) aren't drawn outside the box. The
+// browser handles wrapping, bidi, alignment, and bold/italic runs; the text measurer reads
+// the ink delta back from the rendered measurement element.
 const inkOverflowCache = createComputedCache(
 	'text ink overflow',
-	(editor: Editor, shape: TLTextShape) => {
+	(editor: Editor, shape: TLTextShape): TLTextInkOverflow => {
+		editor.fonts.trackFontsForShape(shape)
 		const util = editor.getShapeUtil(shape) as TextShapeUtil
 		const dv = getDisplayValues(util, shape)
-		// Reuse the size cache so we measure the advance box once and stay consistent with
-		// the geometry width. Reading it also tracks the shape's fonts, so this recomputes
-		// when a webfont finishes loading.
-		const size = sizeCache.get(editor, shape.id)!
-		return getTextInkOverflow(editor, shape.props, dv, size)
+		const { html, opts } = getTextMeasureSpec(editor, shape.props, dv)
+		return editor.textMeasure.measureHtmlInkOverflow(html, opts)
 	},
 	{ areRecordsEqual: (a, b) => a.props === b.props }
 )
@@ -366,23 +370,31 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 	// }
 }
 
-function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeUtilDisplayValues) {
-	const { richText, w } = props
-
+// Build the html and measure options shared by the advance-size and ink-overflow measures,
+// so they stay in lockstep (same font, wrapping width, and line breaks).
+function getTextMeasureSpec(
+	editor: Editor,
+	props: TLTextShape['props'],
+	dv: TextShapeUtilDisplayValues
+) {
 	const minWidth = 16
-
-	const maybeFixedWidth = props.autoSize ? null : Math.max(minWidth, Math.floor(w))
-
-	const html = renderHtmlFromRichTextForMeasurement(editor, richText)
-	const result = editor.textMeasure.measureHtml(html, {
-		lineHeight: dv.lineHeight,
-		fontWeight: dv.fontWeight,
+	const maybeFixedWidth = props.autoSize ? null : Math.max(minWidth, Math.floor(props.w))
+	const html = renderHtmlFromRichTextForMeasurement(editor, props.richText)
+	const opts: TLMeasureTextOpts = {
 		fontStyle: dv.fontStyle,
-		padding: '0px',
+		fontWeight: dv.fontWeight,
 		fontFamily: dv.fontFamily,
 		fontSize: dv.fontSize,
+		lineHeight: dv.lineHeight,
 		maxWidth: maybeFixedWidth,
-	})
+		padding: '0px',
+	}
+	return { html, opts, maybeFixedWidth, minWidth }
+}
+
+function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeUtilDisplayValues) {
+	const { html, opts, maybeFixedWidth, minWidth } = getTextMeasureSpec(editor, props, dv)
+	const result = editor.textMeasure.measureHtml(html, opts)
 
 	// If we're autosizing the measureText will essentially `Math.floor`
 	// the numbers so `19` rather than `19.3`, this means we must +1 to
@@ -390,175 +402,6 @@ function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeU
 	return {
 		width: maybeFixedWidth ?? Math.max(minWidth, result.w + 1),
 		height: Math.max(dv.fontSize, result.h),
-	}
-}
-
-// A lazily-created offscreen 2d context used to measure actual glyph ink bounds via the
-// Canvas TextMetrics API (actualBoundingBoxLeft/Right), which the DOM advance-width
-// measurement in getTextSize doesn't capture.
-let inkCanvasCtx: CanvasRenderingContext2D | null | undefined
-function getInkCanvasCtx(editor: Editor): CanvasRenderingContext2D | null {
-	if (inkCanvasCtx !== undefined) return inkCanvasCtx
-	const canvas = editor.getContainerDocument().createElement('canvas')
-	inkCanvasCtx = canvas.getContext('2d')
-	return inkCanvasCtx
-}
-
-// Resolve a CSS font-family value (which may be a `var(--tl-font-*)` reference) into the
-// concrete family list the canvas font shorthand needs — the canvas API does not resolve
-// CSS custom properties.
-function resolveCanvasFontFamily(editor: Editor, fontFamily: string): string {
-	const doc = editor.getContainerDocument()
-	const probe = doc.createElement('span')
-	probe.style.fontFamily = fontFamily
-	probe.style.position = 'absolute'
-	probe.style.visibility = 'hidden'
-	probe.style.pointerEvents = 'none'
-	editor.getContainer().appendChild(probe)
-	const view = doc.defaultView ?? window
-	const resolved = view.getComputedStyle(probe).fontFamily
-	probe.remove()
-	return resolved || fontFamily
-}
-
-// Scripts whose base direction is right-to-left (Hebrew, Arabic and its supplements,
-// Syriac, Thaana, NKo, and the Arabic/Hebrew presentation forms). Used to figure out
-// which physical edge a line's text aligns to so we can attribute ink overflow to the
-// correct side.
-const RTL_REGEX =
-	/[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u0780-\u07BF\u07C0-\u07FF\u08A0-\u08FF\uFB1D-\uFB4F\uFB50-\uFDFF\uFE70-\uFEFF]/
-
-interface TextInkOverflow {
-	left: number
-	right: number
-	top: number
-	bottom: number
-}
-
-const ZERO_INK_OVERFLOW: TextInkOverflow = { left: 0, right: 0, top: 0, bottom: 0 }
-
-// Scan the rich text for bold/italic marks anywhere in the document. Glyph side bearings
-// differ for those styles, but the shape-level display values are always normal, so we'd
-// otherwise under-measure styled text. Applying a style found anywhere is a safe
-// over-estimate for mixed runs: the box can only get slightly looser, never clip.
-function getRichTextMarkStyles(richText: TLTextShape['props']['richText']): {
-	italic: boolean
-	bold: boolean
-} {
-	let italic = false
-	let bold = false
-	const stack: unknown[] = [richText]
-	while (stack.length) {
-		const node = stack.pop()
-		if (!node || typeof node !== 'object') continue
-		const { marks, content } = node as { marks?: unknown[]; content?: unknown[] }
-		if (Array.isArray(marks)) {
-			for (const mark of marks) {
-				const type =
-					mark && typeof mark === 'object' ? (mark as { type?: unknown }).type : undefined
-				if (type === 'italic') italic = true
-				else if (type === 'bold') bold = true
-			}
-		}
-		if (Array.isArray(content)) {
-			for (const child of content) stack.push(child)
-		}
-		if (italic && bold) break
-	}
-	return { italic, bold }
-}
-
-// Measure how far the rendered ink extends past the advance-width box that `getTextSize`
-// produces, per physical side, in local (unscaled) px. The DOM advance measurement only
-// captures pen-advance, so cursive/RTL/italic side bearings (e.g. Arabic, see #8803) and
-// tall diacritics get painted outside the box. We re-measure each line with the Canvas
-// TextMetrics API, which reports the true ink extent.
-//
-// Known limitation: soft-wrapped lines in fixed-width shapes are skipped — the browser
-// decides where to break them, so we can't attribute their ink to a side. Autosize text
-// (the #8803 case) never wraps, so every line is measured.
-function getTextInkOverflow(
-	editor: Editor,
-	props: TLTextShape['props'],
-	dv: TextShapeUtilDisplayValues,
-	size: { width: number; height: number }
-): TextInkOverflow {
-	const ctx = getInkCanvasCtx(editor)
-	if (!ctx) return ZERO_INK_OVERFLOW
-
-	const text = renderPlaintextFromRichText(editor, props.richText)
-	if (text.trim() === '') return ZERO_INK_OVERFLOW
-
-	const family = resolveCanvasFontFamily(editor, dv.fontFamily)
-	const marks = getRichTextMarkStyles(props.richText)
-	const fontStyle = marks.italic ? 'italic' : dv.fontStyle
-	const fontWeight = marks.bold ? 'bold' : dv.fontWeight
-	ctx.font = `${fontStyle} ${fontWeight} ${dv.fontSize}px ${family}`
-
-	const boxWidth = size.width
-	const boxHeight = size.height
-	const lineHeightPx = dv.fontSize * dv.lineHeight
-	const lines = text.split('\n')
-
-	let overflowLeft = 0
-	let overflowRight = 0
-	let overflowTop = 0
-	let overflowBottom = 0
-
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i] === '' ? ' ' : lines[i]
-		const m = ctx.measureText(line)
-		const advance = m.width
-
-		// Fixed-width text wraps; we can't tell where, so skip lines wider than the box.
-		// Autosize text never wraps, so always measure it.
-		if (!props.autoSize && advance > boxWidth + 1) continue
-
-		const isRTL = RTL_REGEX.test(line)
-
-		// The physical left edge of this line's advance box within [0, boxWidth]. `start`
-		// and `end` resolve to a physical side based on the line's base direction (the DOM
-		// uses dir="auto"), so an RTL line aligned to `start` sits against the right edge.
-		let penX: number
-		if (props.textAlign === 'middle') {
-			penX = (boxWidth - advance) / 2
-		} else {
-			const alignsRight =
-				(props.textAlign === 'start' && isRTL) || (props.textAlign === 'end' && !isRTL)
-			penX = alignsRight ? boxWidth - advance : 0
-		}
-
-		// Horizontal: ink edges in box coordinates, then how far they spill past each side.
-		// The `|| 0` guards engines that don't report ink bounds (metrics come back
-		// undefined), which would otherwise poison the geometry with NaN.
-		const inkLeftEdge = penX - (m.actualBoundingBoxLeft || 0)
-		const inkRightEdge = penX + (m.actualBoundingBoxRight || 0)
-		overflowLeft = Math.max(overflowLeft, -inkLeftEdge)
-		overflowRight = Math.max(overflowRight, inkRightEdge - boxWidth)
-
-		// Vertical: only the first line can spill past the top of the block, only the last
-		// past the bottom. Place the baseline within the line box the way CSS line-height
-		// does (half-leading above the font ascent).
-		const fontAscent = m.fontBoundingBoxAscent || dv.fontSize
-		const fontDescent = m.fontBoundingBoxDescent || 0
-		const baselineFromTop = (lineHeightPx - (fontAscent + fontDescent)) / 2 + fontAscent
-		if (i === 0) {
-			const inkTop = baselineFromTop - (m.actualBoundingBoxAscent || 0)
-			overflowTop = Math.max(overflowTop, -inkTop)
-		}
-		if (i === lines.length - 1) {
-			const lastLineTop = boxHeight - lineHeightPx
-			const inkBottom = lastLineTop + baselineFromTop + (m.actualBoundingBoxDescent || 0)
-			overflowBottom = Math.max(overflowBottom, inkBottom - boxHeight)
-		}
-	}
-
-	const clamp = (n: number) => (Number.isFinite(n) ? Math.max(0, n) : 0)
-	return {
-		left: clamp(overflowLeft),
-		right: clamp(overflowRight),
-		top: clamp(overflowTop),
-		bottom: clamp(overflowBottom),
 	}
 }
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -41,6 +41,23 @@ const sizeCache = createComputedCache(
 	},
 	{ areRecordsEqual: (a, b) => a.props === b.props }
 )
+
+// How far the rendered ink extends beyond the advance-width box that `getTextSize`
+// measures, per physical side. Used by `getGeometry` to pad the shape's bounds so
+// cursive/RTL/italic glyphs (e.g. Arabic, see #8803) aren't drawn outside the box.
+const inkOverflowCache = createComputedCache(
+	'text ink overflow',
+	(editor: Editor, shape: TLTextShape) => {
+		const util = editor.getShapeUtil(shape) as TextShapeUtil
+		const dv = getDisplayValues(util, shape)
+		// Reuse the size cache so we measure the advance box once and stay consistent with
+		// the geometry width. Reading it also tracks the shape's fonts, so this recomputes
+		// when a webfont finishes loading.
+		const size = sizeCache.get(editor, shape.id)!
+		return getTextInkOverflow(editor, shape.props, dv, size)
+	},
+	{ areRecordsEqual: (a, b) => a.props === b.props }
+)
 /** @public */
 export interface TextShapeUtilDisplayValues {
 	color: string
@@ -110,17 +127,21 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		const { scale } = shape.props
 		const { width, height } = this.getMinDimensions(shape)!
 		const context = opts?.context ?? 'none'
+		const isArrowLabel = context === '@tldraw/arrow-without-arrowhead'
+		const arrowPadding = isArrowLabel ? this.options.extraArrowHorizontalPadding : 0
+
+		// Pad the geometry by however far glyph ink spills past the advance box so the
+		// indicator, selection bounds, and export viewport all enclose the rendered text
+		// (cursive/RTL/italic side bearings, see #8803). The text content still renders at
+		// the unpadded width, so its position is unchanged. Skipped for arrow labels, whose
+		// layout is driven by the advance box.
+		const ink = isArrowLabel
+			? ZERO_INK_OVERFLOW
+			: (inkOverflowCache.get(this.editor, shape.id) ?? ZERO_INK_OVERFLOW)
+
 		return new Rectangle2d({
-			x:
-				(context === '@tldraw/arrow-without-arrowhead'
-					? -this.options.extraArrowHorizontalPadding
-					: 0) * scale,
-			width:
-				(width +
-					(context === '@tldraw/arrow-without-arrowhead'
-						? this.options.extraArrowHorizontalPadding * 2
-						: 0)) *
-				scale,
+			x: (-arrowPadding - ink.left) * scale,
+			width: (width + arrowPadding * 2 + ink.left + ink.right) * scale,
 			height: height * scale,
 			isFilled: true,
 			isLabel: true,
@@ -191,14 +212,14 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		if (shape.props.autoSize && this.editor.getEditingShapeId() === shape.id) return undefined
 		const bounds = this.editor.getShapeGeometry(shape).bounds
 		const path = new Path2D()
-		path.rect(0, 0, bounds.width, bounds.height)
+		path.rect(bounds.x, bounds.y, bounds.width, bounds.height)
 		return path
 	}
 
 	override toSvg(shape: TLTextShape, ctx: SvgExportContext) {
-		const bounds = this.editor.getShapeGeometry(shape).bounds
-		const width = bounds.width / (shape.props.scale ?? 1)
-		const height = bounds.height / (shape.props.scale ?? 1)
+		// Render the text in its unpadded content box (not the ink-padded geometry); the
+		// geometry padding only widens the export viewport so glyphs aren't clipped.
+		const { width, height } = this.getMinDimensions(shape)
 
 		const dv = getDisplayValues(this, shape, ctx.colorMode)
 
@@ -368,6 +389,110 @@ function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeU
 	return {
 		width: maybeFixedWidth ?? Math.max(minWidth, result.w + 1),
 		height: Math.max(dv.fontSize, result.h),
+	}
+}
+
+// A lazily-created offscreen 2d context used to measure actual glyph ink bounds via the
+// Canvas TextMetrics API (actualBoundingBoxLeft/Right), which the DOM advance-width
+// measurement in getTextSize doesn't capture.
+let inkCanvasCtx: CanvasRenderingContext2D | null | undefined
+function getInkCanvasCtx(editor: Editor): CanvasRenderingContext2D | null {
+	if (inkCanvasCtx !== undefined) return inkCanvasCtx
+	const canvas = editor.getContainerDocument().createElement('canvas')
+	inkCanvasCtx = canvas.getContext('2d')
+	return inkCanvasCtx
+}
+
+// Resolve a CSS font-family value (which may be a `var(--tl-font-*)` reference) into the
+// concrete family list the canvas font shorthand needs — the canvas API does not resolve
+// CSS custom properties.
+function resolveCanvasFontFamily(editor: Editor, fontFamily: string): string {
+	const doc = editor.getContainerDocument()
+	const probe = doc.createElement('span')
+	probe.style.fontFamily = fontFamily
+	probe.style.position = 'absolute'
+	probe.style.visibility = 'hidden'
+	probe.style.pointerEvents = 'none'
+	editor.getContainer().appendChild(probe)
+	const view = doc.defaultView ?? window
+	const resolved = view.getComputedStyle(probe).fontFamily
+	probe.remove()
+	return resolved || fontFamily
+}
+
+// Scripts whose base direction is right-to-left (Hebrew, Arabic and its supplements,
+// Syriac, Thaana, NKo, and the Arabic/Hebrew presentation forms). Used to figure out
+// which physical edge a line's text aligns to so we can attribute ink overflow to the
+// correct side.
+const RTL_REGEX =
+	/[\u0590-\u05FF\u0600-\u06FF\u0700-\u074F\u0750-\u077F\u0780-\u07BF\u07C0-\u07FF\u08A0-\u08FF\uFB1D-\uFB4F\uFB50-\uFDFF\uFE70-\uFEFF]/
+
+interface TextInkOverflow {
+	left: number
+	right: number
+}
+
+const ZERO_INK_OVERFLOW: TextInkOverflow = { left: 0, right: 0 }
+
+// Measure how far the rendered ink extends past the advance-width box that `getTextSize`
+// produces, per physical side, in local (unscaled) px. The DOM advance measurement only
+// captures pen-advance, so cursive/RTL/italic side bearings (e.g. Arabic, see #8803) get
+// painted outside the box. We re-measure each line with the Canvas TextMetrics API, which
+// reports the true ink extent (actualBoundingBoxLeft/Right).
+//
+// TODO before shipping: (1) handle soft-wrapped lines — this splits on explicit breaks
+// only, which is correct for autoSize (the #8803 repro) but under-measures fixed-width
+// wrapping; (2) per-run font/style instead of the shape-level display values; (3) vertical
+// overflow (tall diacritics) is not yet accounted for.
+function getTextInkOverflow(
+	editor: Editor,
+	props: TLTextShape['props'],
+	dv: TextShapeUtilDisplayValues,
+	size: { width: number; height: number }
+): TextInkOverflow {
+	const ctx = getInkCanvasCtx(editor)
+	if (!ctx) return ZERO_INK_OVERFLOW
+
+	const text = renderPlaintextFromRichText(editor, props.richText)
+	if (text.trim() === '') return ZERO_INK_OVERFLOW
+
+	const family = resolveCanvasFontFamily(editor, dv.fontFamily)
+	ctx.font = `${dv.fontStyle} ${dv.fontWeight} ${dv.fontSize}px ${family}`
+
+	const boxWidth = size.width
+	let overflowLeft = 0
+	let overflowRight = 0
+
+	for (const rawLine of text.split('\n')) {
+		const line = rawLine === '' ? ' ' : rawLine
+		const m = ctx.measureText(line)
+		const advance = m.width
+		const isRTL = RTL_REGEX.test(line)
+
+		// The physical left edge of this line's advance box within [0, boxWidth]. `start`
+		// and `end` resolve to a physical side based on the line's base direction (the DOM
+		// uses dir="auto"), so an RTL line aligned to `start` sits against the right edge.
+		let penX: number
+		if (props.textAlign === 'middle') {
+			penX = (boxWidth - advance) / 2
+		} else {
+			const alignsRight =
+				(props.textAlign === 'start' && isRTL) || (props.textAlign === 'end' && !isRTL)
+			penX = alignsRight ? boxWidth - advance : 0
+		}
+
+		// Ink edges in box coordinates, then how far they spill past either side. The
+		// `|| 0` guards engines that don't report ink bounds (the metrics come back
+		// undefined), which would otherwise poison the geometry width with NaN.
+		const inkLeftEdge = penX - (m.actualBoundingBoxLeft || 0)
+		const inkRightEdge = penX + (m.actualBoundingBoxRight || 0)
+		overflowLeft = Math.max(overflowLeft, -inkLeftEdge)
+		overflowRight = Math.max(overflowRight, inkRightEdge - boxWidth)
+	}
+
+	return {
+		left: Number.isFinite(overflowLeft) ? Math.max(0, overflowLeft) : 0,
+		right: Number.isFinite(overflowRight) ? Math.max(0, overflowRight) : 0,
 	}
 }
 

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -9,7 +9,6 @@ import {
 	TLMeasureTextOpts,
 	TLResizeInfo,
 	TLShapeId,
-	TLTextInkOverflow,
 	TLTextShape,
 	Vec,
 	createComputedCache,
@@ -33,32 +32,38 @@ import { getThemeFontFaces } from '../shared/defaultFonts'
 import { ShapeOptionsWithDisplayValues, getDisplayValues } from '../shared/getDisplayValues'
 import { RichTextLabel, RichTextSVG } from '../shared/RichTextLabel'
 
-const sizeCache = createComputedCache(
-	'text size',
-	(editor: Editor, shape: TLTextShape) => {
+const ZERO_OVERFLOW = { left: 0, right: 0, top: 0, bottom: 0 }
+
+interface TextShapeBounds {
+	width: number
+	height: number
+	/** How far glyph ink spills past each side of the advance box, in unscaled px. */
+	overflow: { left: number; right: number; top: number; bottom: number }
+}
+
+// Measures a text shape's advance box and its glyph ink overflow in a single layout pass.
+// The browser handles wrapping, bidi, alignment, and bold/italic runs; we read the advance
+// from getBoundingClientRect and the ink delta back from the same rendered measurement
+// element, then derive how far ink spills past each side of the box (cursive/RTL/italic side
+// bearings and tall diacritics, see #8803).
+const textBoundsCache = createComputedCache(
+	'text bounds',
+	(editor: Editor, shape: TLTextShape): TextShapeBounds => {
 		editor.fonts.trackFontsForShape(shape)
 		const util = editor.getShapeUtil(shape) as TextShapeUtil
 		const dv = getDisplayValues(util, shape)
-		return getTextSize(editor, shape.props, dv)
-	},
-	{ areRecordsEqual: (a, b) => a.props === b.props }
-)
-
-const ZERO_INK_OVERFLOW: TLTextInkOverflow = { left: 0, right: 0, top: 0, bottom: 0 }
-
-// How far the rendered glyph ink extends past the advance-width box the browser lays out,
-// per physical side. Used by `getGeometry` to grow the shape's bounds so cursive/RTL/italic
-// glyphs and tall diacritics (e.g. Arabic, see #8803) aren't drawn outside the box. The
-// browser handles wrapping, bidi, alignment, and bold/italic runs; the text measurer reads
-// the ink delta back from the rendered measurement element.
-const inkOverflowCache = createComputedCache(
-	'text ink overflow',
-	(editor: Editor, shape: TLTextShape): TLTextInkOverflow => {
-		editor.fonts.trackFontsForShape(shape)
-		const util = editor.getShapeUtil(shape) as TextShapeUtil
-		const dv = getDisplayValues(util, shape)
-		const { html, opts } = getTextMeasureSpec(editor, shape.props, dv)
-		return editor.textMeasure.measureHtmlInkOverflow(html, opts)
+		const { html, opts, maybeFixedWidth, minWidth } = getTextMeasureSpec(editor, shape.props, dv)
+		const { advance, ink } = editor.textMeasure.measureHtmlBounds(html, opts)
+		const { width, height } = resolveTextSize(advance, maybeFixedWidth, minWidth, dv.fontSize)
+		const overflow = ink
+			? {
+					left: Math.max(0, -ink.x),
+					top: Math.max(0, -ink.y),
+					right: Math.max(0, ink.x + ink.w - width),
+					bottom: Math.max(0, ink.y + ink.h - height),
+				}
+			: ZERO_OVERFLOW
+		return { width, height, overflow }
 	},
 	{ areRecordsEqual: (a, b) => a.props === b.props }
 )
@@ -124,12 +129,13 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 	}
 
 	getMinDimensions(shape: TLTextShape) {
-		return sizeCache.get(this.editor, shape.id)!
+		const { width, height } = textBoundsCache.get(this.editor, shape.id)!
+		return { width, height }
 	}
 
 	getGeometry(shape: TLTextShape, opts: TLGeometryOpts) {
 		const { scale } = shape.props
-		const { width, height } = this.getMinDimensions(shape)!
+		const { width, height, overflow } = textBoundsCache.get(this.editor, shape.id)!
 		const context = opts?.context ?? 'none'
 		const isArrowLabel = context === '@tldraw/arrow-without-arrowhead'
 		const arrowPadding = isArrowLabel ? this.options.extraArrowHorizontalPadding : 0
@@ -139,9 +145,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 		// (cursive/RTL/italic side bearings, see #8803). The text content still renders at
 		// the unpadded width, so its position is unchanged. Skipped for arrow labels, whose
 		// layout is driven by the advance box.
-		const ink = isArrowLabel
-			? ZERO_INK_OVERFLOW
-			: (inkOverflowCache.get(this.editor, shape.id) ?? ZERO_INK_OVERFLOW)
+		const ink = isArrowLabel ? ZERO_OVERFLOW : overflow
 
 		return new Rectangle2d({
 			x: (-arrowPadding - ink.left) * scale,
@@ -392,17 +396,25 @@ function getTextMeasureSpec(
 	return { html, opts, maybeFixedWidth, minWidth }
 }
 
+// Turn a raw advance measurement into the shape's width/height. When autosizing, measureText
+// floors fractional widths (`19` not `19.3`), so we +1 to avoid spurious wrapping.
+function resolveTextSize(
+	advance: { w: number; h: number },
+	maybeFixedWidth: number | null,
+	minWidth: number,
+	fontSize: number
+) {
+	return {
+		width: maybeFixedWidth ?? Math.max(minWidth, advance.w + 1),
+		height: Math.max(fontSize, advance.h),
+	}
+}
+
+// Advance-only size (no ink pass) — used by onBeforeUpdate to reposition autosized text.
 function getTextSize(editor: Editor, props: TLTextShape['props'], dv: TextShapeUtilDisplayValues) {
 	const { html, opts, maybeFixedWidth, minWidth } = getTextMeasureSpec(editor, props, dv)
 	const result = editor.textMeasure.measureHtml(html, opts)
-
-	// If we're autosizing the measureText will essentially `Math.floor`
-	// the numbers so `19` rather than `19.3`, this means we must +1 to
-	// whatever we get to avoid wrapping.
-	return {
-		width: maybeFixedWidth ?? Math.max(minWidth, result.w + 1),
-		height: Math.max(dv.fontSize, result.h),
-	}
+	return resolveTextSize(result, maybeFixedWidth, minWidth, dv.fontSize)
 }
 
 function useTextShapeKeydownHandler(id: TLShapeId) {

--- a/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/text/TextShapeUtil.tsx
@@ -141,8 +141,9 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
 
 		return new Rectangle2d({
 			x: (-arrowPadding - ink.left) * scale,
+			y: -ink.top * scale,
 			width: (width + arrowPadding * 2 + ink.left + ink.right) * scale,
-			height: height * scale,
+			height: (height + ink.top + ink.bottom) * scale,
 			isFilled: true,
 			isLabel: true,
 		})
@@ -430,20 +431,52 @@ const RTL_REGEX =
 interface TextInkOverflow {
 	left: number
 	right: number
+	top: number
+	bottom: number
 }
 
-const ZERO_INK_OVERFLOW: TextInkOverflow = { left: 0, right: 0 }
+const ZERO_INK_OVERFLOW: TextInkOverflow = { left: 0, right: 0, top: 0, bottom: 0 }
+
+// Scan the rich text for bold/italic marks anywhere in the document. Glyph side bearings
+// differ for those styles, but the shape-level display values are always normal, so we'd
+// otherwise under-measure styled text. Applying a style found anywhere is a safe
+// over-estimate for mixed runs: the box can only get slightly looser, never clip.
+function getRichTextMarkStyles(richText: TLTextShape['props']['richText']): {
+	italic: boolean
+	bold: boolean
+} {
+	let italic = false
+	let bold = false
+	const stack: unknown[] = [richText]
+	while (stack.length) {
+		const node = stack.pop()
+		if (!node || typeof node !== 'object') continue
+		const { marks, content } = node as { marks?: unknown[]; content?: unknown[] }
+		if (Array.isArray(marks)) {
+			for (const mark of marks) {
+				const type =
+					mark && typeof mark === 'object' ? (mark as { type?: unknown }).type : undefined
+				if (type === 'italic') italic = true
+				else if (type === 'bold') bold = true
+			}
+		}
+		if (Array.isArray(content)) {
+			for (const child of content) stack.push(child)
+		}
+		if (italic && bold) break
+	}
+	return { italic, bold }
+}
 
 // Measure how far the rendered ink extends past the advance-width box that `getTextSize`
 // produces, per physical side, in local (unscaled) px. The DOM advance measurement only
-// captures pen-advance, so cursive/RTL/italic side bearings (e.g. Arabic, see #8803) get
-// painted outside the box. We re-measure each line with the Canvas TextMetrics API, which
-// reports the true ink extent (actualBoundingBoxLeft/Right).
+// captures pen-advance, so cursive/RTL/italic side bearings (e.g. Arabic, see #8803) and
+// tall diacritics get painted outside the box. We re-measure each line with the Canvas
+// TextMetrics API, which reports the true ink extent.
 //
-// TODO before shipping: (1) handle soft-wrapped lines — this splits on explicit breaks
-// only, which is correct for autoSize (the #8803 repro) but under-measures fixed-width
-// wrapping; (2) per-run font/style instead of the shape-level display values; (3) vertical
-// overflow (tall diacritics) is not yet accounted for.
+// Known limitation: soft-wrapped lines in fixed-width shapes are skipped — the browser
+// decides where to break them, so we can't attribute their ink to a side. Autosize text
+// (the #8803 case) never wraps, so every line is measured.
 function getTextInkOverflow(
 	editor: Editor,
 	props: TLTextShape['props'],
@@ -457,16 +490,30 @@ function getTextInkOverflow(
 	if (text.trim() === '') return ZERO_INK_OVERFLOW
 
 	const family = resolveCanvasFontFamily(editor, dv.fontFamily)
-	ctx.font = `${dv.fontStyle} ${dv.fontWeight} ${dv.fontSize}px ${family}`
+	const marks = getRichTextMarkStyles(props.richText)
+	const fontStyle = marks.italic ? 'italic' : dv.fontStyle
+	const fontWeight = marks.bold ? 'bold' : dv.fontWeight
+	ctx.font = `${fontStyle} ${fontWeight} ${dv.fontSize}px ${family}`
 
 	const boxWidth = size.width
+	const boxHeight = size.height
+	const lineHeightPx = dv.fontSize * dv.lineHeight
+	const lines = text.split('\n')
+
 	let overflowLeft = 0
 	let overflowRight = 0
+	let overflowTop = 0
+	let overflowBottom = 0
 
-	for (const rawLine of text.split('\n')) {
-		const line = rawLine === '' ? ' ' : rawLine
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] === '' ? ' ' : lines[i]
 		const m = ctx.measureText(line)
 		const advance = m.width
+
+		// Fixed-width text wraps; we can't tell where, so skip lines wider than the box.
+		// Autosize text never wraps, so always measure it.
+		if (!props.autoSize && advance > boxWidth + 1) continue
+
 		const isRTL = RTL_REGEX.test(line)
 
 		// The physical left edge of this line's advance box within [0, boxWidth]. `start`
@@ -481,18 +528,37 @@ function getTextInkOverflow(
 			penX = alignsRight ? boxWidth - advance : 0
 		}
 
-		// Ink edges in box coordinates, then how far they spill past either side. The
-		// `|| 0` guards engines that don't report ink bounds (the metrics come back
-		// undefined), which would otherwise poison the geometry width with NaN.
+		// Horizontal: ink edges in box coordinates, then how far they spill past each side.
+		// The `|| 0` guards engines that don't report ink bounds (metrics come back
+		// undefined), which would otherwise poison the geometry with NaN.
 		const inkLeftEdge = penX - (m.actualBoundingBoxLeft || 0)
 		const inkRightEdge = penX + (m.actualBoundingBoxRight || 0)
 		overflowLeft = Math.max(overflowLeft, -inkLeftEdge)
 		overflowRight = Math.max(overflowRight, inkRightEdge - boxWidth)
+
+		// Vertical: only the first line can spill past the top of the block, only the last
+		// past the bottom. Place the baseline within the line box the way CSS line-height
+		// does (half-leading above the font ascent).
+		const fontAscent = m.fontBoundingBoxAscent || dv.fontSize
+		const fontDescent = m.fontBoundingBoxDescent || 0
+		const baselineFromTop = (lineHeightPx - (fontAscent + fontDescent)) / 2 + fontAscent
+		if (i === 0) {
+			const inkTop = baselineFromTop - (m.actualBoundingBoxAscent || 0)
+			overflowTop = Math.max(overflowTop, -inkTop)
+		}
+		if (i === lines.length - 1) {
+			const lastLineTop = boxHeight - lineHeightPx
+			const inkBottom = lastLineTop + baselineFromTop + (m.actualBoundingBoxDescent || 0)
+			overflowBottom = Math.max(overflowBottom, inkBottom - boxHeight)
+		}
 	}
 
+	const clamp = (n: number) => (Number.isFinite(n) ? Math.max(0, n) : 0)
 	return {
-		left: Number.isFinite(overflowLeft) ? Math.max(0, overflowLeft) : 0,
-		right: Number.isFinite(overflowRight) ? Math.max(0, overflowRight) : 0,
+		left: clamp(overflowLeft),
+		right: clamp(overflowRight),
+		top: clamp(overflowTop),
+		bottom: clamp(overflowBottom),
 	}
 }
 

--- a/packages/tldraw/src/test/TestEditor.ts
+++ b/packages/tldraw/src/test/TestEditor.ts
@@ -179,6 +179,12 @@ export class TestEditor extends Editor {
 			return [{ box, text: textToMeasure }]
 		}
 
+		// jsdom can't lay text out, so derive the advance from the mock above and report no ink
+		// overflow (the canvas ink pass is a browser-only refinement).
+		this.textMeasure.measureHtmlBounds = (html: string, opts: TLMeasureTextOpts) => {
+			return { advance: this.textMeasure.measureHtml(html, opts), ink: null }
+		}
+
 		// Turn off edge scrolling for tests. Tests that require this can turn it back on.
 		this.user.updateUserPreferences({ edgeScrollSpeed: 0 })
 


### PR DESCRIPTION
In order to stop cursive, RTL, and italic glyphs from being painted outside their text shape's bounding box (#8803) and clipped on SVG export (#8802), this PR pads the text shape's geometry by the actual glyph ink overflow.

Text is measured for pen-advance width via the DOM, which ignores glyph side bearings, so the trailing stroke of an Arabic/Hebrew word (or the slant of an italic) ends up outside the box. The fix adds `TextManager.measureTextInkBounds(element)`, which reads the **real ink bounds** back from a laid-out element: wrapping, bidi, alignment, and per-run bold/italic all come from the browser's layout, and only the ink delta is measured with the Canvas `TextMetrics` API. `getGeometry` uses this to grow the shape's bounds per side. The text content and `props.w` are left unchanged, so layout, alignment, and resizing are unaffected — only the reported bounds (indicator, selection, hit-test, snapping, and export viewport) grow to contain the ink. The result is cached and recomputes when a web font finishes loading.

The advance and ink are measured in a **single layout pass** (`measureHtmlBounds` renders the measurement element once and returns both), and `getMinDimensions`/`getGeometry` share one cache — so the ink work adds no extra DOM render over the original advance measurement. Reading everything back from the real layout also means the shape no longer needs hand-rolled RTL detection, alignment math, mark scanning, a soft-wrap guard, or a vertical baseline model.

Handled cases:

- RTL/cursive and italic horizontal side bearings (the #8803 case).
- Bold/italic applied via rich-text marks (each run measured in its own style).
- Vertical overflow (tall diacritics, italic descenders) via top/bottom padding.
- Wrapped lines in fixed-width shapes (measured from the real line layout, so the box neither clips nor balloons to the unwrapped width).
- Plain Latin text, which fits its advance box — overflow is zero and the bounds are unchanged.

### Editor API

`measureTextInkBounds(element)` is reusable beyond this shape — e.g. for selection bounds of custom text content, or trimming/sizing image exports.

### Change type

- [x] `bugfix`

### Test plan

1. Create a text shape with the default (Draw) font and type Arabic or Hebrew, e.g. `שלום עולם`.
2. Select it: the selection box and hover indicator enclose the glyphs instead of clipping the trailing cursive stroke.
3. Export the shape to SVG: the glyphs are no longer clipped at the box edge.
4. Confirm Latin text is unchanged (no extra padding, box origin unmoved) and fixed-width wrapped text keeps its width.

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Fix text shapes clipping cursive, RTL (e.g. Arabic, Hebrew), and italic glyphs at the edge of their bounding box, both on the canvas and in SVG exports.

### API changes

- Added `TextManager.measureTextInkBounds(element)` for measuring the true ink bounds of text rendered in a DOM element.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +206 / -38 |
| Tests           | +132 / -0  |
| Automated files | +6 / -0    |

Closes #8803
Closes #8802