### PR TITLE
feat(sync): keep full sync rate with multiple sessions in a room

### DIFF
--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -319,13 +319,17 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			getUserPresence,
 		})(store)
 
-		const otherUserPresences = store.query.ids('instance_presence', () => ({
-			userId: { neq: currentUser.get().id },
-		}))
+		// Every connected session — each tab, window, or device — pushes its
+		// presence on connect, so the store holds one instance_presence record per
+		// *other* session in the room, including the user's own other tabs. (The
+		// server never echoes a session its own record.) So an empty set means
+		// we're genuinely the only session and can throttle to solo; any other
+		// session — another user, or just another tab of our own — keeps us at the
+		// full sync rate so edits propagate without the solo-mode lag.
+		const otherSessions = store.query.ids('instance_presence')
 
 		const presenceMode = computed<TLPresenceMode>('presenceMode', () => {
-			if (otherUserPresences.get().size === 0) return 'solo'
-			return 'full'
+			return otherSessions.get().size === 0 ? 'solo' : 'full'
 		})
 
 		const client = new TLSyncClient<TLRecord, TLStore>({


### PR DESCRIPTION
Closes #8920.

In order to stop multi-tab editing from feeling sluggish, this PR keeps a room at the full network sync rate whenever it has more than one session. Today a tab drops into "solo" mode — which throttles network sync to 1fps — whenever there are no *other users* present. But each tab, window, or device the same user opens is its own session, so two tabs of your own were both treated as single-player and both throttled, leaving edits to propagate between your own tabs with up to ~1s of lag.

The fix is to count *all* other sessions in the room, not just other users'. Every session pushes its presence once on connect (ungated by presence mode), and the server never echoes a session its own record, so the store already holds one `instance_presence` record per other session — including your own other tabs and devices. An empty set means we're genuinely the only session and can throttle to solo; anything else (another user, or just another tab of our own) keeps us at full rate.

### Relationship to #8920 / #8949

This resolves #8920 by targeting the symptom users actually feel — multi-tab edit lag — rather than its original framing of sharing a single WebSocket to cut connection count. That heavier approach was explored in #8949 (a leader/presenter/follower layer, ~850 lines of new code) and closed in favor of this ~9-line change. Note this does **not** reduce the WebSocket count: each tab keeps its own socket, as today. If reducing connections per user becomes a priority later, #8949 remains the reference for that work.

Because detection is server-mediated (via `instance_presence`) rather than a `BroadcastChannel`, it also works across **separate devices**, not just tabs in the same browser.

### Trade-off worth knowing

With multiple of your own sessions in full mode, each pushes live presence. The editor renders one cursor per remote user (`CollaboratorsManager` dedupes by `userId`, newest activity wins), so collaborators see a single cursor that "teleports" to whichever of your windows you last touched — rather than two cursors. This is already today's behavior when you have multiple tabs open alongside other collaborators; this PR just extends full mode to the no-other-users case. Avoiding the teleport entirely is what the presenter role in #8949 buys.

One caveat: detection relies on presence being enabled (the default). A consumer that disables presence pushes no `instance_presence` record, so its multi-tab sessions would still throttle to solo.

### Per-session presence is preserved end-to-end

Worth flagging for future work: the collapse to one cursor per user happens *only* in the editor's view layer — not in the protocol or the store. The server assigns every session (each tab, window, or device) its own `presenceId` and broadcasts a distinct `instance_presence` record per session, and the client store keeps all of them (one per other session, including the user's own other tabs). It's `CollaboratorsManager.getCollaborators()` that groups those by `userId` and keeps only the most-recently-active record per user — which is why collaborators see one cursor rather than several.

So showing a cursor *per session* — multiple live cursors for one user, one per tab/device — is already supported by the backend and the store. It would only take a change to that editor-side derivation (keying by the presence record instead of by `userId`), with no protocol or server change. This PR doesn't do that, but it doesn't foreclose it either.

### Change type

- [x] `improvement`

### Test plan

1. Open a room in a single tab with no other users. Confirm it's in solo mode (network sync throttled).
2. Open the same room in a second tab as the same user. Confirm both tabs now sync at full rate — an edit in one appears in the other promptly, not ~1s later.
3. Open the same room on a second device as the same user. Confirm the same full-rate behavior (validates server-mediated, cross-device detection).
4. Close the second tab/device. Confirm the remaining lone session returns to solo throttling.
5. Confirm existing multi-user behavior is unchanged: with another user present, the room is at full rate.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Opening the same multiplayer room in multiple tabs, windows, or devices now keeps changes syncing at full speed between them, instead of throttling to once per second.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -5    |

Of the 9 added lines, 7 are an explanatory comment; the behavioral change is dropping the `userId` filter on the presence query and simplifying the `presenceMode` branch.
