### PR TITLE
fix(tldraw): VideoShapeUtil.configure({ autoplay: false }) disables autoplay everywhere

### DIFF
--- a/apps/docs/content/sdk-features/default-shapes.mdx
+++ b/apps/docs/content/sdk-features/default-shapes.mdx
@@ -314,20 +314,16 @@ Properties:
 
 Configuration options:
 
-| Option     | Type      | Default | Description                                     |
-| ---------- | --------- | ------- | ----------------------------------------------- |
-| `autoplay` | `boolean` | `true`  | Default autoplay behavior for new video shapes. |
+| Option     | Type      | Default | Description                                                                                                               |
+| ---------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `autoplay` | `boolean` | `true`  | Whether videos may autoplay. When `false`, new shapes default to `autoplay: false` and no video autoplays at render time. |
+
+To disable autoplay across the board — including for pasted or restored shapes — configure the `VideoShapeUtil`:
 
 ```tsx
 const ConfiguredVideoUtil = VideoShapeUtil.configure({
 	autoplay: false,
 })
-```
-
-To disable autoplay across the board — including for pasted or restored shapes — set the editor-level `allowVideoAutoplay` option to `false` instead:
-
-```tsx
-<Tldraw options={{ allowVideoAutoplay: false }} />
 ```
 
 ### Bookmark

--- a/apps/docs/content/sdk-features/options.mdx
+++ b/apps/docs/content/sdk-features/options.mdx
@@ -201,7 +201,6 @@ When `debouncedZoom` is enabled and the page has more shapes than `debouncedZoom
 | `laserDelayMs`                   | 1200      | Duration laser pointer remains visible         |
 | `laserFadeoutMs`                 | 500       | Duration for laser pointer fadeout animation   |
 | `quickZoomPreservesScreenBounds` | true      | Whether quick zoom brush keeps viewport scale  |
-| `allowVideoAutoplay`             | true      | Whether video shapes are allowed to autoplay   |
 | `branding`                       | undefined | App name for accessibility labels              |
 | `nonce`                          | undefined | CSP nonce for inline styles                    |
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -718,7 +718,6 @@ export const DefaultSvgDefs: () => null;
 export const defaultTldrawOptions: {
     readonly actionShortcutsLocation: "swap";
     readonly adjacentShapeMargin: 10;
-    readonly allowVideoAutoplay: true;
     readonly animationMediumMs: 320;
     readonly camera: TLCameraOptions;
     readonly cameraMovingTimeoutMs: 64;
@@ -3755,7 +3754,6 @@ export interface TldrawOptions {
     readonly actionShortcutsLocation: 'menu' | 'swap' | 'toolbar';
     // (undocumented)
     readonly adjacentShapeMargin: number;
-    readonly allowVideoAutoplay: boolean;
     // (undocumented)
     readonly animationMediumMs: number;
     readonly branding?: string;

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -210,17 +210,6 @@ export interface TldrawOptions {
 	 */
 	readonly quickZoomPreservesScreenBounds: boolean
 	/**
-	 * Whether video shapes are allowed to autoplay. When `true` (the default), each
-	 * video respects its own `shape.props.autoplay` value. When `false`, no video
-	 * autoplays regardless of its shape prop — useful for host apps that want to
-	 * disable autoplay across the board, including for pasted or restored shapes.
-	 *
-	 * This does not change the per-shape `autoplay` prop on new video shapes — that
-	 * default is controlled by `VideoShapeOptions.autoplay` on `VideoShapeUtil`. The
-	 * `prefers-reduced-motion` media query continues to suppress autoplay independently.
-	 */
-	readonly allowVideoAutoplay: boolean
-	/**
 	 * Called before content is written to the clipboard during a copy or cut operation.
 	 * Receives the serialized content (shapes, bindings, assets) and can filter or transform
 	 * it before it reaches the clipboard.
@@ -358,7 +347,6 @@ export const defaultTldrawOptions = {
 	text: {},
 	deepLinks: undefined,
 	quickZoomPreservesScreenBounds: true,
-	allowVideoAutoplay: true,
 	onBeforeCopyToClipboard: undefined,
 	onBeforePasteFromClipboard: undefined,
 	onClipboardPasteRaw: undefined,

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -36,7 +36,16 @@ export interface VideoShapeOptions extends ShapeOptionsWithDisplayValues<
 	VideoShapeUtilDisplayValues
 > {
 	/**
-	 * Should videos play automatically?
+	 * Whether videos may play automatically.
+	 *
+	 * - `true` (default): new video shapes are created with `props.autoplay: true`,
+	 *   and videos with `props.autoplay: true` autoplay at render time.
+	 * - `false`: new video shapes are created with `props.autoplay: false`, and
+	 *   no video autoplays regardless of its `props.autoplay` value — including
+	 *   pasted, restored, or programmatically created shapes.
+	 *
+	 * The `prefers-reduced-motion` media query continues to suppress autoplay
+	 * independently of this option.
 	 */
 	autoplay: boolean
 }
@@ -212,7 +221,7 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 									playsInline
 									autoPlay={
 										shape.props.autoplay &&
-										editor.options.allowVideoAutoplay &&
+										editor.getShapeUtil<VideoShapeUtil>(shape).options.autoplay &&
 										!prefersReducedMotion
 									}
 									muted


### PR DESCRIPTION
Follow-up to [#8943](https://github.com/tldraw/tldraw/pull/8943) in response to [Mime's review on #8915](https://github.com/tldraw/tldraw/issues/8915#issuecomment-4594216589).

Rather than add a top-level `TldrawOptions.allowVideoAutoplay` knob to control whether videos may autoplay, this PR moves the concern onto `VideoShapeUtil` where the rest of the video shape's configuration already lives. `VideoShapeOptions.autoplay` already existed as the per-shape default for new videos; this PR expands its semantics so that `false` also acts as a render-time ceiling — no video autoplays at all, including pasted, restored, or programmatically created shapes.

```tsx
const ConfiguredVideoUtil = VideoShapeUtil.configure({ autoplay: false })

<Tldraw shapeUtils={[ConfiguredVideoUtil]} />
```

### Behavior matrix

| `VideoShapeOptions.autoplay` | `shape.props.autoplay` | Result        |
| ---------------------------- | ---------------------- | ------------- |
| `true` (default)             | `true`                 | Autoplays     |
| `true` (default)             | `false`                | Does not play |
| `false`                      | `true`                 | Does not play |
| `false`                      | `false`                | Does not play |

The `prefers-reduced-motion` check at the render site continues to apply independently.

### Why this shape instead of an editor option

Per Mime's review: video-specific configuration belongs next to `VideoShapeUtil`, not in `TldrawOptions`. Top-level options should stay focused on cross-cutting editor concerns (animation timings, drag distances, clipboard hooks, etc.) — if every shape added its own knobs there, the interface would balloon. Keeping shape concerns on the shape util localizes the cost.

### Behavior change

This is technically a behavior change for anyone already calling `VideoShapeUtil.configure({ autoplay: false })`. Before this PR that only affected newly created shapes; after, it also suppresses autoplay on existing/pasted shapes. Framed as "the option now does what the docs suggested it did" rather than a breaking change — the documented intent of `.configure({ autoplay: false })` was always "disable autoplay," but it silently failed for pasted/restored shapes. Anyone reaching for this option almost certainly wanted both behaviors.

Closes [#8915](https://github.com/tldraw/tldraw/issues/8915) (reopened after #8943).

### Change type

- [x] `bugfix`

### Test plan

1. In an examples app, register a custom video util via `VideoShapeUtil.configure({ autoplay: false })` and pass it as `shapeUtils`.
2. Drop a video file onto the canvas — confirm it does not autoplay.
3. Click into the video to edit and press play — confirm the user can still play it manually.
4. Copy the video and paste it into a fresh tab using the same configured editor — confirm the pasted shape (which still has `props.autoplay: true`) does not autoplay.
5. With the default util (no `configure`), drop a video and confirm it still autoplays as before.

### Release notes

- `VideoShapeUtil.configure({ autoplay: false })` now disables autoplay across the board — including for pasted or restored shapes — in addition to setting the default for new video shapes.

### API changes

- `VideoShapeOptions.autoplay` semantics expanded: `false` now also acts as a render-time ceiling, not just a default for new shapes. No type signature changes.
- Reverts the `TldrawOptions.allowVideoAutoplay` field added in #8943.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +11 / -14  |
| Automated files | +0 / -2    |
| Documentation   | +5 / -10   |