### PR TITLE
feat(utils): add { signal } option to debounce

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10642,7 +10642,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 				window.history.replaceState({}, this.getContainerDocument().title, url.toString())
 			})
 
-		const scheduleEffect = debounce((execute: () => void) => execute(), opts?.debounceMs ?? 500)
+		const controller = new AbortController()
+		const scheduleEffect = debounce((execute: () => void) => execute(), opts?.debounceMs ?? 500, {
+			signal: controller.signal,
+		})
 
 		const unlisten = react(
 			'update url on state change',
@@ -10652,7 +10655,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		return () => {
 			unlisten()
-			scheduleEffect.cancel()
+			controller.abort()
 		}
 	}
 

--- a/packages/editor/src/lib/hooks/useZoomCss.ts
+++ b/packages/editor/src/lib/hooks/useZoomCss.ts
@@ -1,5 +1,4 @@
 import { EffectScheduler } from '@tldraw/state'
-import { debounce } from '@tldraw/utils'
 import * as React from 'react'
 import { useContainer } from './useContainer'
 import { useEditor } from './useEditor'
@@ -10,7 +9,6 @@ export function useZoomCss() {
 
 	React.useEffect(() => {
 		const setScale = (s: number) => container.style.setProperty('--tl-zoom', s.toString())
-		const setScaleDebounced = debounce(setScale, 100)
 
 		const scheduler = new EffectScheduler('useZoomCss', () =>
 			setScale(editor.getEfficientZoomLevel())
@@ -21,7 +19,6 @@ export function useZoomCss() {
 
 		return () => {
 			scheduler.detach()
-			setScaleDebounced.cancel()
 		}
 	}, [editor, container])
 }

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -44,9 +44,11 @@ export function clearSessionStorage(): void;
 export function compact<T>(arr: T[]): NonNullable<T>[];
 
 // @public
-export function debounce<T extends unknown[], U>(callback: (...args: T) => Awaitable<U>, wait: number): {
+export function debounce<T extends unknown[], U>(callback: (...args: T) => Awaitable<U>, wait: number, opts?: {
+    signal?: AbortSignal;
+}): {
     (...args: T): Promise<U>;
-    cancel: () => void;
+    cancel(): void;
 };
 
 // @public

--- a/packages/utils/src/lib/debounce.test.ts
+++ b/packages/utils/src/lib/debounce.test.ts
@@ -109,6 +109,77 @@ describe(debounce, () => {
 		expect(() => debounced.cancel()).not.toThrow()
 	})
 
+	it('rejects the pending promise when the signal aborts', async () => {
+		const controller = new AbortController()
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100, { signal: controller.signal })
+		const promiseA = debounced()
+		const promiseB = debounced()
+
+		controller.abort()
+		vi.advanceTimersByTime(200)
+
+		expect(fn).not.toHaveBeenCalled()
+		await expect(promiseA).rejects.toMatchObject({ name: 'AbortError' })
+		await expect(promiseB).rejects.toMatchObject({ name: 'AbortError' })
+	})
+
+	it('rejects with a custom abort reason', async () => {
+		const controller = new AbortController()
+		const reason = new Error('navigated away')
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100, { signal: controller.signal })
+		const promise = debounced()
+
+		controller.abort(reason)
+
+		await expect(promise).rejects.toBe(reason)
+	})
+
+	it('rejects immediately and never schedules when the signal is already aborted', async () => {
+		const controller = new AbortController()
+		controller.abort()
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100, { signal: controller.signal })
+
+		const promise = debounced()
+		vi.advanceTimersByTime(200)
+
+		expect(fn).not.toHaveBeenCalled()
+		await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+	})
+
+	it('does not fire the callback for a scheduled call after the signal aborts', async () => {
+		const controller = new AbortController()
+		const fn = vi.fn()
+		const debounced = debounce(fn, 100, { signal: controller.signal })
+		const promise = debounced()
+
+		controller.abort()
+		await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+
+		vi.advanceTimersByTime(200)
+		expect(fn).not.toHaveBeenCalled()
+	})
+
+	it('does not emit an unhandledrejection when a discarded promise is aborted', async () => {
+		const handler = vi.fn()
+		process.on('unhandledRejection', handler)
+		try {
+			const controller = new AbortController()
+			const fn = vi.fn()
+			const debounced = debounce(fn, 100, { signal: controller.signal })
+			debounced()
+			controller.abort()
+
+			await new Promise(process.nextTick)
+
+			expect(handler).not.toHaveBeenCalled()
+		} finally {
+			process.off('unhandledRejection', handler)
+		}
+	})
+
 	it('does not emit an unhandledrejection when the promise is discarded on cancel', async () => {
 		const handler = vi.fn()
 		process.on('unhandledRejection', handler)

--- a/packages/utils/src/lib/debounce.ts
+++ b/packages/utils/src/lib/debounce.ts
@@ -1,5 +1,16 @@
+import { promiseWithResolve } from './control'
 import { noop } from './function'
 import type { Awaitable } from './types'
+
+interface DebounceState<T extends unknown[], U> {
+	// eslint-disable-next-line no-restricted-globals
+	timeout?: ReturnType<typeof setTimeout>
+	deferred: Promise<U> & {
+		resolve(value: Awaitable<U>): void
+		reject(reason?: any): void
+	}
+	latestArgs: T
+}
 
 /**
  * Create a debounced version of a function that delays execution until after a specified wait time.
@@ -9,14 +20,16 @@ import type { Awaitable } from './types'
  * function returns a Promise that resolves with the result of the original function. Includes a
  * cancel method to prevent execution if needed.
  *
- * Calling `cancel()` while a call is pending rejects the returned promise with an `Error`
- * whose message is `'Debounced function was cancelled'`. Callers that discard the promise
- * are not affected — internal handling suppresses the unhandled-rejection warning — but
- * any code that `await`s or chains `.then()` on the promise must be prepared to handle the
- * rejection.
+ * Cancel a pending call with the `cancel()` method, or by passing an `AbortSignal` via the
+ * `signal` option and aborting it. Both reject any pending promise with the cancellation reason
+ * (an `AbortError` by default for an aborted signal). Callers that discard the promise are not
+ * affected — internal handling suppresses the unhandled-rejection warning — but any code that
+ * `await`s or chains `.then()` on the promise must be prepared to handle the rejection.
  *
  * @param callback - The function to debounce (can be sync or async)
  * @param wait - The delay in milliseconds before executing the function
+ * @param opts - Optional options. Pass `signal` to cancel the debounced function when the
+ *   `AbortSignal` aborts.
  * @returns A debounced function that returns a Promise and includes a cancel method
  *
  * @example
@@ -30,7 +43,7 @@ import type { Awaitable } from './types'
  * debouncedSearch('react hooks') // This cancels the previous call
  * debouncedSearch('react typescript') // Only this will execute
  *
- * // Cancel pending execution — any in-flight promise rejects
+ * // Cancel pending execution
  * debouncedSearch.cancel()
  *
  * // With async/await — wrap in try/catch if you might cancel
@@ -43,6 +56,12 @@ import type { Awaitable } from './types'
  * } catch (err) {
  *   // handle cancellation or callback error
  * }
+ *
+ * // Tie the debounced function to an AbortSignal — aborting cancels it
+ * const controller = new AbortController()
+ * const debouncedSave = debounce(saveDraft, 500, { signal: controller.signal })
+ * debouncedSave(draft)
+ * controller.abort() // rejects the pending promise and stops the scheduled call
  * ```
  *
  * @public
@@ -50,54 +69,66 @@ import type { Awaitable } from './types'
  */
 export function debounce<T extends unknown[], U>(
 	callback: (...args: T) => Awaitable<U>,
-	wait: number
-) {
-	let state:
-		| undefined
-		| {
-				// eslint-disable-next-line no-restricted-globals
-				timeout: ReturnType<typeof setTimeout>
-				promise: Promise<U>
-				resolve(value: U | PromiseLike<U>): void
-				reject(value: any): void
-				latestArgs: T
-		  } = undefined
+	wait: number,
+	opts?: { signal?: AbortSignal }
+): {
+	(...args: T): Promise<U>
+	/**
+	 * Cancel the pending debounced call, rejecting its promise. Alternatively, pass an
+	 * `AbortSignal` via the `signal` option and abort it.
+	 */
+	cancel(): void
+} {
+	const externalSignal = opts?.signal
+	let state: DebounceState<T, U> | undefined
+
+	// Both cancellation paths — the deprecated `.cancel()` and an aborted external `signal` — run
+	// through here: clear the pending timer and reject the in-flight promise with `reason`. A call
+	// afterwards starts a fresh window.
+	function cancel(reason: unknown) {
+		if (!state) return
+		const { timeout, deferred } = state
+		state = undefined
+		clearTimeout(timeout)
+		// Attach a no-op handler so callers that discarded the promise don't trigger an
+		// unhandled-rejection warning. Consumers that did `.then`, `.catch`, or `await` on the
+		// returned promise still observe the rejection through their own chain.
+		deferred.catch(noop)
+		deferred.reject(reason)
+	}
 
 	const fn = (...args: T): Promise<U> => {
-		if (!state) {
-			state = {} as any
-			state!.promise = new Promise((resolve, reject) => {
-				state!.resolve = resolve
-				state!.reject = reject
-			})
+		if (externalSignal?.aborted) {
+			// The signal already aborted, so never schedule. Attach a no-op handler so callers that
+			// discard the promise don't trigger an unhandled-rejection warning.
+			const rejected = Promise.reject(externalSignal.reason)
+			rejected.catch(noop)
+			return rejected
 		}
-		clearTimeout(state!.timeout)
-		state!.latestArgs = args
-		// It's up to the consumer of debounce to call `cancel`
+		if (!state) {
+			state = { deferred: promiseWithResolve<U>(), latestArgs: args }
+		}
+		clearTimeout(state.timeout)
+		state.latestArgs = args
 		// eslint-disable-next-line no-restricted-globals
-		state!.timeout = setTimeout(() => {
+		state.timeout = setTimeout(() => {
 			const s = state!
 			state = undefined
 			try {
-				s.resolve(callback(...s.latestArgs))
+				s.deferred.resolve(callback(...s.latestArgs))
 			} catch (e) {
-				s.reject(e)
+				s.deferred.reject(e)
 			}
 		}, wait)
 
-		return state!.promise
+		return state.deferred
 	}
-	fn.cancel = () => {
-		if (!state) return
-		clearTimeout(state.timeout)
-		const s = state
-		state = undefined
-		// Attach a no-op handler so callers that discard the promise don't
-		// trigger an unhandled-rejection warning. Consumers that did `.then`,
-		// `.catch`, or `await` on the returned promise still observe the
-		// rejection through their own chain.
-		s.promise.catch(noop)
-		s.reject(new Error('Debounced function was cancelled'))
-	}
+
+	fn.cancel = () => cancel(new Error('Debounced function was cancelled'))
+
+	// An external signal cancels the in-flight call. `{ once: true }` is enough cleanup — an
+	// AbortSignal only ever fires `abort` once.
+	externalSignal?.addEventListener('abort', () => cancel(externalSignal.reason), { once: true })
+
 	return fn
 }


### PR DESCRIPTION
In order to let callers cancel a debounced call with a standard web primitive, this PR adds an `AbortSignal`-based `{ signal }` option to the `debounce` util: `debounce(fn, wait, { signal })`. Aborting the signal rejects the pending promise with the signal's `reason` (an `AbortError` by default), matching how modern libraries (TanStack, es-toolkit) thread cancellation. The existing `.cancel()` method is kept as-is. Relates to #8683.

Along the way it refactors `debounce`'s internals to a single `cancel(reason)` closure and `promiseWithResolve` (dropping a hand-rolled deferred), migrates `Editor.scheduleEffect` to the new option, and removes a dead debounce call in `useZoomCss`.

### Change type

- [x] `api`

### Test plan

- [x] Unit tests

### API changes

- Added optional `opts?: { signal?: AbortSignal }` parameter to `debounce()`. Aborting the signal rejects the pending promise with `signal.reason`.
- `debounce(...).cancel()` is unchanged. The api-report now renders it as `cancel(): void` instead of `cancel: () => void` because the function gained an explicit return type — no behavioral change.

### Release notes

- Add an `AbortSignal` `{ signal }` option to the `debounce` utility for canceling a pending call.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +78 / -47  |
| Tests           | +71 / -0   |
| Automated files | +4 / -2    |