### PR TITLE
fix(editor): transform locked shapes along with their group

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8099,14 +8099,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const id = typeof shape === 'string' ? shape : shape.id
 		if (this.getIsReadonly()) return this
 
-		// A locked shape that lives inside an unlocked ancestor (e.g. a locked child of a group)
-		// should still resize when that ancestor is resized — the resize is a downstream effect of
-		// an ancestor transform, not a direct edit of the locked shape. Re-run with shape-lock
-		// checks disabled so the update isn't dropped by updateShapes. A locked shape with no
-		// unlocked ancestor (e.g. a top-level locked shape) stays blocked.
+		// A shape that is locked down — either itself or via a locked ancestor — but still lives
+		// inside an unlocked ancestor (e.g. a locked child of a group, or any descendant of a locked
+		// subgroup nested in an unlocked group) should still resize when that outer ancestor is
+		// resized. The resize is a downstream effect of transforming the unlocked ancestor, not a
+		// direct edit. Re-run with shape-lock checks disabled so the update isn't dropped by
+		// updateShapes. A shape whose lock has no unlocked ancestor (e.g. a top-level locked shape,
+		// or any descendant of a top-level locked group) stays blocked.
 		if (!this._shouldIgnoreShapeLock) {
 			const target = this.getShape(id)
-			if (target?.isLocked && this.hasUnlockedAncestor(target)) {
+			if (target && this.isShapeOrAncestorLocked(target) && this.hasUnlockedAncestor(target)) {
 				this.run(() => this.resizeShape(shape, scale, opts), { ignoreShapeLock: true })
 				return this
 			}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5677,12 +5677,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @internal
 	 */
 	private hasUnlockedAncestor(shape?: TLShape | TLShapeId): boolean {
-		let parent = this.getShapeParent(shape)
-		while (parent) {
-			if (!parent.isLocked) return true
-			parent = this.getShapeParent(parent)
-		}
-		return false
+		// Unlike isShapeOrAncestorLocked, this starts from the parent so it only considers
+		// ancestors, not the shape itself.
+		const parent = this.getShapeParent(shape)
+		if (parent === undefined) return false
+		if (!parent.isLocked) return true
+		return this.hasUnlockedAncestor(parent)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5668,6 +5668,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
+	 * Check whether any of a shape's ancestors are unlocked. A locked shape with an unlocked
+	 * ancestor (e.g. a locked child of a group) can still be transformed as a downstream effect
+	 * of transforming that ancestor.
+	 *
+	 * @param shape - The shape (or shape id) to check.
+	 *
+	 * @internal
+	 */
+	private hasUnlockedAncestor(shape?: TLShape | TLShapeId): boolean {
+		let parent = this.getShapeParent(shape)
+		while (parent) {
+			if (!parent.isLocked) return true
+			parent = this.getShapeParent(parent)
+		}
+		return false
+	}
+
+	/**
 	 * Get shapes that are outside of the viewport.
 	 *
 	 * @public
@@ -8080,6 +8098,19 @@ export class Editor extends EventEmitter<TLEventMap> {
 	resizeShape(shape: TLShapeId | TLShape, scale: VecLike, opts: TLResizeShapeOptions = {}): this {
 		const id = typeof shape === 'string' ? shape : shape.id
 		if (this.getIsReadonly()) return this
+
+		// A locked shape that lives inside an unlocked ancestor (e.g. a locked child of a group)
+		// should still resize when that ancestor is resized — the resize is a downstream effect of
+		// an ancestor transform, not a direct edit of the locked shape. Re-run with shape-lock
+		// checks disabled so the update isn't dropped by updateShapes. A locked shape with no
+		// unlocked ancestor (e.g. a top-level locked shape) stays blocked.
+		if (!this._shouldIgnoreShapeLock) {
+			const target = this.getShape(id)
+			if (target?.isLocked && this.hasUnlockedAncestor(target)) {
+				this.run(() => this.resizeShape(shape, scale, opts), { ignoreShapeLock: true })
+				return this
+			}
+		}
 
 		if (!Number.isFinite(scale.x)) scale = new Vec(1, scale.y)
 		if (!Number.isFinite(scale.y)) scale = new Vec(scale.x, 1)

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -2141,6 +2141,48 @@ describe('Grouping / ungrouping locked shapes', () => {
 		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
 	})
 
+	it('resizes children of a locked subgroup when the outer group is resized', () => {
+		// group1 (unlocked)
+		//   boxA (unlocked)
+		//   group2 (locked)
+		//     boxB (unlocked)
+		//     boxC (locked)
+		const group1 = createShapeId('group1')
+		const group2 = createShapeId('group2')
+
+		const resizeAndReadBounds = (lockSubgroup: boolean) => {
+			editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+			editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0), box(ids.boxC, 40, 0)])
+			editor.groupShapes([ids.boxB, ids.boxC], { groupId: group2 })
+			editor.groupShapes([ids.boxA, group2], { groupId: group1 })
+			if (lockSubgroup) {
+				// Lock the leaf before the subgroup: once the subgroup is locked, writes to its
+				// children (including locking them) are blocked.
+				editor.updateShape({ id: ids.boxC, type: 'geo', isLocked: true })
+				editor.updateShape({ id: group2, type: 'group', isLocked: true })
+			}
+			editor.select(group1).resizeSelection({ scaleX: 2, scaleY: 2 }, 'top_left')
+			return {
+				a: editor.getShapePageBounds(ids.boxA)!.clone(),
+				b: editor.getShapePageBounds(ids.boxB)!.clone(),
+				c: editor.getShapePageBounds(ids.boxC)!.clone(),
+			}
+		}
+
+		// Locking the subgroup and one leaf must not change the resize result for any shape:
+		// the unlocked boxB and locked boxC both transform with the outer group.
+		const control = resizeAndReadBounds(false)
+		const locked = resizeAndReadBounds(true)
+
+		expect(locked.a).toCloselyMatchObject(control.a)
+		expect(locked.b).toCloselyMatchObject(control.b)
+		expect(locked.c).toCloselyMatchObject(control.c)
+
+		// Locks are preserved
+		expect(editor.getShape(group2)!.isLocked).toBe(true)
+		expect(editor.getShape(ids.boxC)!.isLocked).toBe(true)
+	})
+
 	it('still blocks resizing a locked shape that has no unlocked ancestor', () => {
 		editor.createShapes([box(ids.boxA, 0, 0)])
 		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -2048,4 +2048,118 @@ describe('Grouping / ungrouping locked shapes', () => {
 		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
 		expect(editor.getShape(ids.boxB)!.isLocked).toBe(false)
 	})
+
+	it('moves locked children along with their group when dragged', () => {
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB], { groupId: ids.groupA })
+		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+
+		// Drag the (unlocked) group by 100, 50
+		const group = editor.getShape(ids.groupA)!
+		editor.select(ids.groupA)
+		editor.pointerDown(5, 5, { target: 'shape', shape: group })
+		editor.pointerMove(105, 55)
+		editor.pointerUp()
+
+		// The locked child moves with the group
+		expect(editor.getShapePageBounds(ids.boxA)!).toCloselyMatchObject({
+			x: 100,
+			y: 50,
+			w: 10,
+			h: 10,
+		})
+		expect(editor.getShapePageBounds(ids.boxB)!).toCloselyMatchObject({
+			x: 120,
+			y: 50,
+			w: 10,
+			h: 10,
+		})
+		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
+	})
+
+	it('rotates locked children along with their group', () => {
+		// Control: capture where an unlocked child ends up after rotating its group
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB], { groupId: ids.groupA })
+		editor.rotateShapesBy([ids.groupA], Math.PI / 2)
+		const unlockedBounds = editor.getShapePageBounds(ids.boxA)!.clone()
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+
+		// With the child locked, it rotates with the group identically
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB], { groupId: ids.groupA })
+		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+		editor.rotateShapesBy([ids.groupA], Math.PI / 2)
+
+		expect(editor.getShapePageBounds(ids.boxA)!).toCloselyMatchObject(unlockedBounds)
+		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
+	})
+
+	it('resizes locked children along with their group', () => {
+		// 0   10  20  30
+		// ┌───┐   ┌───┐
+		// │ A │   │ B │
+		// └───┘   └───┘
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB], { groupId: ids.groupA })
+
+		// Lock boxA
+		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+
+		// Resize the group from its top-left, scaling everything 2x about the bottom-right corner
+		editor.select(ids.groupA).resizeSelection({ scaleX: 2, scaleY: 2 }, 'top_left')
+
+		// The locked child transforms with the group rather than being left behind
+		expect(editor.getShapePageBounds(ids.boxA)!).toCloselyMatchObject({
+			x: -30,
+			y: -10,
+			w: 20,
+			h: 20,
+		})
+		expect(editor.getShapePageBounds(ids.boxB)!).toCloselyMatchObject({
+			x: 10,
+			y: -10,
+			w: 20,
+			h: 20,
+		})
+
+		// The locked child stays locked
+		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
+	})
+
+	it('flips locked children along with their group', () => {
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB], { groupId: ids.groupA })
+
+		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+
+		// Flipping the group horizontally swaps the children's positions about the group center
+		editor.select(ids.groupA).flipShapes([ids.groupA], 'horizontal')
+
+		expect(editor.getShapePageBounds(ids.boxA)!).toCloselyMatchObject({ x: 20, y: 0, w: 10, h: 10 })
+		expect(editor.getShapePageBounds(ids.boxB)!).toCloselyMatchObject({ x: 0, y: 0, w: 10, h: 10 })
+		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
+	})
+
+	it('still blocks resizing a locked shape that has no unlocked ancestor', () => {
+		editor.createShapes([box(ids.boxA, 0, 0)])
+		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+
+		// Resizing a top-level locked shape directly is a no-op
+		editor.resizeShape(ids.boxA, { x: 2, y: 2 })
+
+		expect(editor.getShapePageBounds(ids.boxA)!).toCloselyMatchObject({ x: 0, y: 0, w: 10, h: 10 })
+	})
+
+	it('still blocks direct edits to a locked child of a group', () => {
+		editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0)])
+		editor.groupShapes([ids.boxA, ids.boxB], { groupId: ids.groupA })
+		editor.updateShape({ id: ids.boxA, type: 'geo', isLocked: true })
+
+		// A direct update to the locked child is still dropped, even though it has an unlocked
+		// ancestor. Only ancestor-driven transforms flow through.
+		editor.updateShape({ id: ids.boxA, type: 'geo', x: 999, props: { w: 999 } })
+
+		expect(editor.getShapePageBounds(ids.boxA)!).toCloselyMatchObject({ x: 0, y: 0, w: 10, h: 10 })
+	})
 })

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -2141,46 +2141,84 @@ describe('Grouping / ungrouping locked shapes', () => {
 		expect(editor.getShape(ids.boxA)!.isLocked).toBe(true)
 	})
 
-	it('resizes children of a locked subgroup when the outer group is resized', () => {
-		// group1 (unlocked)
-		//   boxA (unlocked)
-		//   group2 (locked)
-		//     boxB (unlocked)
-		//     boxC (locked)
+	it('transforms every descendant regardless of which are locked', () => {
+		// The heuristic: a transform on an (unlocked) group supersedes locking for anything inside
+		// it. Locking any subset of descendants must not change how the group transforms.
+		//
+		// group1 (the transform origin, never locked)
+		//   boxA
+		//   group2
+		//     boxB
+		//     boxC
 		const group1 = createShapeId('group1')
 		const group2 = createShapeId('group2')
+		const allIds: TLShapeId[] = [ids.boxA, ids.boxB, ids.boxC, group2, group1]
 
-		const resizeAndReadBounds = (lockSubgroup: boolean) => {
+		// Shapes whose locked state we vary (never group1 — it's the thing being transformed).
+		const lockable: TLShapeId[] = [ids.boxA, ids.boxB, ids.boxC, group2]
+		// Lock leaves before their containing group; once a group is locked, writes to its
+		// children (including locking them) are dropped.
+		const lockOrder: { id: TLShapeId; type: 'geo' | 'group' }[] = [
+			{ id: ids.boxC, type: 'geo' },
+			{ id: ids.boxB, type: 'geo' },
+			{ id: ids.boxA, type: 'geo' },
+			{ id: group2, type: 'group' },
+		]
+
+		const build = () => {
 			editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
-			editor.createShapes([box(ids.boxA, 0, 0), box(ids.boxB, 20, 0), box(ids.boxC, 40, 0)])
+			editor.createShapes([
+				box(ids.boxA, 0, 0, 10, 10),
+				box(ids.boxB, 20, 0, 10, 10),
+				box(ids.boxC, 40, 0, 20, 30),
+			])
 			editor.groupShapes([ids.boxB, ids.boxC], { groupId: group2 })
 			editor.groupShapes([ids.boxA, group2], { groupId: group1 })
-			if (lockSubgroup) {
-				// Lock the leaf before the subgroup: once the subgroup is locked, writes to its
-				// children (including locking them) are blocked.
-				editor.updateShape({ id: ids.boxC, type: 'geo', isLocked: true })
-				editor.updateShape({ id: group2, type: 'group', isLocked: true })
-			}
-			editor.select(group1).resizeSelection({ scaleX: 2, scaleY: 2 }, 'top_left')
-			return {
-				a: editor.getShapePageBounds(ids.boxA)!.clone(),
-				b: editor.getShapePageBounds(ids.boxB)!.clone(),
-				c: editor.getShapePageBounds(ids.boxC)!.clone(),
-			}
 		}
 
-		// Locking the subgroup and one leaf must not change the resize result for any shape:
-		// the unlocked boxB and locked boxC both transform with the outer group.
-		const control = resizeAndReadBounds(false)
-		const locked = resizeAndReadBounds(true)
+		const transforms: { name: string; apply(): void }[] = [
+			{
+				name: 'resize from top-left',
+				apply: () => editor.select(group1).resizeSelection({ scaleX: 2, scaleY: 2 }, 'top_left'),
+			},
+			{
+				name: 'resize from right edge',
+				apply: () => editor.select(group1).resizeSelection({ scaleX: 0.5 }, 'right'),
+			},
+			{ name: 'flip horizontal', apply: () => editor.flipShapes([group1], 'horizontal') },
+			{ name: 'flip vertical', apply: () => editor.flipShapes([group1], 'vertical') },
+			{ name: 'rotate', apply: () => editor.rotateShapesBy([group1], Math.PI / 5) },
+			{ name: 'nudge', apply: () => editor.nudgeShapes([group1], { x: 13, y: -7 }) },
+		]
 
-		expect(locked.a).toCloselyMatchObject(control.a)
-		expect(locked.b).toCloselyMatchObject(control.b)
-		expect(locked.c).toCloselyMatchObject(control.c)
+		for (const transform of transforms) {
+			// Control: perform the transform with nothing locked.
+			build()
+			transform.apply()
+			const control = new Map(allIds.map((id) => [id, editor.getShapePageBounds(id)!.clone()]))
 
-		// Locks are preserved
-		expect(editor.getShape(group2)!.isLocked).toBe(true)
-		expect(editor.getShape(ids.boxC)!.isLocked).toBe(true)
+			// Every non-empty subset of lockable shapes must produce identical geometry.
+			for (let mask = 1; mask < 1 << lockable.length; mask++) {
+				const lockedSet = new Set(lockable.filter((_, i) => mask & (1 << i)))
+
+				build()
+				for (const { id, type } of lockOrder) {
+					if (lockedSet.has(id)) editor.updateShape({ id, type, isLocked: true })
+				}
+				transform.apply()
+
+				const label = `${transform.name}, locked={${[...lockedSet].join(',')}}`
+				for (const id of allIds) {
+					expect(editor.getShapePageBounds(id), `${label}, shape=${id}`).toCloselyMatchObject(
+						control.get(id)!
+					)
+				}
+				// Locks are preserved through the transform.
+				for (const id of lockedSet) {
+					expect(editor.getShape(id)!.isLocked, `${label}, shape=${id} stays locked`).toBe(true)
+				}
+			}
+		}
 	})
 
 	it('still blocks resizing a locked shape that has no unlocked ancestor', () => {


### PR DESCRIPTION
In order to keep a locked shape positioned correctly inside its group, this PR lets a group transform move its locked children. Closes #8858.

Previously, a locked shape inside an unlocked group was left behind when the group was resized or flipped: the locked child kept its original size and position while its siblings transformed, breaking the group's layout. The cause was `Editor.updateShapes()` dropping every write to a locked shape — including the per-child geometry writes that `resizeShape` makes when a group is resized or flipped. It couldn't tell a direct edit of the locked shape apart from a downstream effect of transforming an unlocked ancestor.

The guiding rule here is that a transform on an unlocked group supersedes locking for anything within it. `resizeShape` now allows updating a shape that is locked down — either itself, or via a locked ancestor — as long as it still has an unlocked ancestor, treating the change as part of that ancestor's transform rather than a direct edit. This covers nesting: an unlocked group containing a locked subgroup resizes every descendant (the locked subgroup, its locked leaves, and its unlocked leaves) together. Moving and rotating a group already worked, because those only rewrite the group's own transform and children inherit it; resize and flip are the only operations that write each child individually, and both route through `resizeShape`. The net result is that all group transforms — move, rotate, resize, and flip — keep locked descendants in place relative to the group. Direct edits to a locked shape, resizing a top-level locked shape, and descendants of a top-level locked group all stay blocked.

### Change type

- [x] `bugfix`

### Test plan

1. Draw two shapes, select both, and group them (cmd/ctrl+G).
2. Drill into the group and lock one of the children (shift+L).
3. Select the group and resize it from a corner handle — the locked child scales with the group instead of being left behind.
4. Flip the group horizontally or vertically — the locked child flips into place with its siblings.
5. Drag and rotate the group — the locked child continues to follow (these already worked; covered here as regression tests).
6. Nest a locked subgroup (containing both locked and unlocked shapes) inside another group, then resize the outer group — every descendant transforms together.
7. Confirm the locked child still can't be selected, dragged, or edited directly, and that a top-level locked shape still can't be resized.

- [x] Unit tests

The unit tests include a combinatorial check: for a nested group structure, every non-empty subset of locked descendants is transformed (resize from two handles, flip horizontal/vertical, rotate, nudge) and asserted to produce geometry identical to the all-unlocked control, with locks preserved. This encodes the "group transform supersedes locking within" rule directly.

### Release notes

- Fix locked shapes being left behind when their parent group is transformed. Group transforms (move, rotate, resize, flip) now keep locked descendants in place relative to the group, including unlocked shapes nested inside a locked subgroup, while direct edits to locked shapes remain blocked.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +33 / -0   |
| Tests     | +194 / -0  |
