### PR TITLE
fix(editor): restore pre-pinch selection on touch devices

### DIFF
--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -179,6 +179,70 @@ test.describe('camera', () => {
 		expect(await page.evaluate(() => editor.getZoomLevel())).toBe(8)
 	})
 
+	test('two-finger pinch does not change the selection', async ({ page, isMobile }) => {
+		test.skip(!isMobile)
+
+		client = await page.context().newCDPSession(page)
+
+		// Finger 1 lands here; finger 2 above it. Both are kept inside the mobile
+		// viewport so the gesture registers.
+		const f1 = { x: 196, y: 470, id: 0 }
+		const f2 = { x: 196, y: 300, id: 1 }
+
+		// Shape "a" (selected, off to the side) plus shape "b" placed directly under
+		// finger 1, so the first finger's pointer_down selects it.
+		await page.evaluate((f) => {
+			const p = editor.screenToPage({ x: f.x, y: f.y })
+			editor.createShapes([
+				{
+					id: 'shape:e2eA',
+					type: 'geo',
+					x: -1000,
+					y: -1000,
+					props: { w: 100, h: 100, fill: 'solid' },
+				},
+				{
+					id: 'shape:e2eB',
+					type: 'geo',
+					x: p.x - 60,
+					y: p.y - 60,
+					props: { w: 120, h: 120, fill: 'solid' },
+				},
+			] as any)
+			editor.setSelectedShapes(['shape:e2eA'] as any)
+		}, f1)
+
+		expect(await page.evaluate(() => editor.getSelectedShapeIds())).toEqual(['shape:e2eA'])
+
+		// Finger 1 down on shape b — through the real touch/pointer pipeline this
+		// changes the selection to b.
+		await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [f1] })
+		await sleep(30)
+		expect(await page.evaluate(() => editor.getSelectedShapeIds())).toEqual(['shape:e2eB'])
+
+		// Finger 2 joins, then both fingers move apart to pinch-zoom, then lift.
+		await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [f1, f2] })
+		await sleep(30)
+		const steps = 12
+		for (let i = 1; i <= steps; i++) {
+			await client.send('Input.dispatchTouchEvent', {
+				type: 'touchMove',
+				touchPoints: [
+					{ x: f1.x, y: f1.y + i * 8, id: 0 }, // finger 1 moves down
+					{ x: f2.x, y: f2.y - i * 8, id: 1 }, // finger 2 moves up
+				],
+			})
+			await sleep(10)
+		}
+		await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+		await sleep(100)
+
+		// The incidental selection of b is rolled back to the pre-gesture selection.
+		expect(await page.evaluate(() => editor.getSelectedShapeIds())).toEqual(['shape:e2eA'])
+		// ...and the pinch really did zoom (sanity check that a pinch happened).
+		expect(await page.evaluate(() => editor.getZoomLevel())).not.toBe(1)
+	})
+
 	test.fixme('minimap', async () => {
 		// todo
 	})

--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -223,6 +223,9 @@ test.describe('camera', () => {
 		// Finger 2 joins, then both fingers move apart to pinch-zoom, then lift.
 		await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [f1, f2] })
 		await sleep(30)
+		// The pinch has started, so the incidental selection is already rolled back —
+		// the original selection is shown during the gesture, not only after it ends.
+		expect(await page.evaluate(() => editor.getSelectedShapeIds())).toEqual(['shape:e2eA'])
 		const steps = 12
 		for (let i = 1; i <= steps; i++) {
 			await client.send('Input.dispatchTouchEvent', {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10768,6 +10768,16 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _selectedShapeIdsAtPointerDown: TLShapeId[] = []
 
+	/**
+	 * Whether `_selectedShapeIdsAtPointerDown` holds a pre-gesture selection
+	 * captured by a `pointer_down` (the touch path) that a following pinch
+	 * should restore. False when no pointer_down preceded the pinch (the
+	 * Safari trackpad path uses gesture events), in which case `pinch_start`
+	 * captures the live selection instead.
+	 * @internal
+	 */
+	private _didCaptureSelectionAtPointerDown = false
+
 	/** @internal */
 	private _longPressTimeout = -1 as any
 
@@ -10933,10 +10943,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 						if (inputs.getIsPinching()) return
 
 						if (!inputs.getIsEditing()) {
-							// Always capture the current selection when pinch starts.
-							// This ensures Safari (which uses gesture events instead of wheel)
-							// doesn't restore a stale selection from an earlier pointer_down.
-							this._selectedShapeIdsAtPointerDown = [...pageState.selectedShapeIds]
+							// If a pointer_down already captured the pre-gesture selection,
+							// keep it: on touch, the first finger's pointer_down can change
+							// the selection before the second finger starts the pinch, and we
+							// want to restore the selection from before that change. When no
+							// pointer_down preceded the pinch (Safari delivers trackpad pinches
+							// as gesture events), capture the live selection now.
+							if (!this._didCaptureSelectionAtPointerDown) {
+								this._selectedShapeIdsAtPointerDown = [...pageState.selectedShapeIds]
+							}
 
 							this._didPinch = true
 
@@ -10994,6 +11009,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						const { _selectedShapeIdsAtPointerDown: shapesToReselect } = this
 						this.setSelectedShapes(this._selectedShapeIdsAtPointerDown)
 						this._selectedShapeIdsAtPointerDown = []
+						this._didCaptureSelectionAtPointerDown = false
 
 						if (this._didPinch) {
 							this._didPinch = false
@@ -11122,8 +11138,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 							}, this.options.longPressDurationMs)
 						}
 
-						// Save the selected ids at pointer down
-						this._selectedShapeIdsAtPointerDown = this.getSelectedShapeIds()
+						// Save the selected ids at the start of an interaction so a pinch can
+						// restore the pre-gesture selection. Only capture on the first pointer:
+						// on touch, the second finger's pointer_down arrives after the first
+						// has already changed the selection, and we want the earlier snapshot.
+						// Cleared on pointer_up / pinch_end.
+						if (!this._didCaptureSelectionAtPointerDown) {
+							this._selectedShapeIdsAtPointerDown = this.getSelectedShapeIds()
+							this._didCaptureSelectionAtPointerDown = true
+						}
 
 						// Firefox bug fix...
 						// If it's a left-mouse-click, we store the pointer id for later user
@@ -11243,6 +11266,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						if (this.inputs.getIsRightPointing() && !this.inputs.getIsPanning()) {
 							this.inputs.setIsRightPointing(false)
 							this._selectedShapeIdsAtPointerDown = []
+							this._didCaptureSelectionAtPointerDown = false
 							break // fall through to state chart dispatch as right_click
 						}
 
@@ -11289,6 +11313,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 										this.slideCamera({ speed: slideSpeed, direction: slideDirection })
 									}
 									this._selectedShapeIdsAtPointerDown = []
+									this._didCaptureSelectionAtPointerDown = false
 									return this
 								}
 							}
@@ -11307,6 +11332,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// Clear the stashed selection so the next pinch captures fresh state.
 						// This fixes Safari pinch zoom restoring outdated selections.
 						this._selectedShapeIdsAtPointerDown = []
+						this._didCaptureSelectionAtPointerDown = false
 
 						break
 					}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10958,6 +10958,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 							inputs.setIsPinching(true)
 
 							this.interrupt()
+
+							// If the first finger changed the selection, roll it back now rather
+							// than waiting for the pinch to end, so the pre-gesture selection is
+							// what's shown during the pinch.
+							if (this._didCaptureSelectionAtPointerDown) {
+								this.setSelectedShapes(this._selectedShapeIdsAtPointerDown)
+							}
 						}
 
 						this.emit('event', info)

--- a/packages/tldraw/src/test/pinch-dom.test.tsx
+++ b/packages/tldraw/src/test/pinch-dom.test.tsx
@@ -1,0 +1,170 @@
+import { act } from '@testing-library/react'
+import { Box, Editor, createShapeId } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+// These tests drive the real DOM event handlers (useCanvasEvents for pointer
+// events, useGestureEvents for touch pinch) rather than dispatching synthetic
+// editor events, so they exercise the same path a touch device takes. jsdom is
+// missing a few browser APIs those handlers rely on, so we polyfill them here.
+
+if (typeof (globalThis as any).PointerEvent === 'undefined') {
+	// jsdom has no PointerEvent; the canvas handlers do `e instanceof PointerEvent`.
+	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
+		pointerId: number
+		pointerType: string
+		pressure: number
+		isPrimary: boolean
+		constructor(type: string, params: any = {}) {
+			super(type, params)
+			this.pointerId = params.pointerId ?? 0
+			this.pointerType = params.pointerType ?? ''
+			this.pressure = params.pressure ?? 0
+			this.isPrimary = params.isPrimary ?? false
+		}
+	}
+}
+if (!Element.prototype.setPointerCapture) {
+	Element.prototype.setPointerCapture = () => {}
+	Element.prototype.releasePointerCapture = () => {}
+	Element.prototype.hasPointerCapture = () => false
+}
+
+const ids = {
+	a: createShapeId('a'),
+	b: createShapeId('b'),
+	c: createShapeId('c'),
+}
+
+function pointerDownEvent(clientX: number, clientY: number, pointerId = 1) {
+	return new (globalThis as any).PointerEvent('pointerdown', {
+		bubbles: true,
+		cancelable: true,
+		clientX,
+		clientY,
+		button: 0,
+		pointerId,
+		pointerType: 'touch',
+		isPrimary: pointerId === 1,
+	})
+}
+
+function touchEvent(type: string, points: Array<{ clientX: number; clientY: number }>) {
+	const e = new Event(type, { bubbles: true, cancelable: true })
+	const touches = points.map((p, i) => ({ clientX: p.clientX, clientY: p.clientY, identifier: i }))
+	Object.defineProperties(e, {
+		touches: { value: touches },
+		targetTouches: { value: touches },
+		changedTouches: { value: touches },
+	})
+	return e
+}
+
+async function setupScene() {
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+	const canvas = document.querySelector('[data-testid="canvas"]') as HTMLElement
+	await act(async () => {
+		editor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+		editor.createShapes([
+			// centers: a (50,50), b (250,50), c (450,50)
+			{ id: ids.a, type: 'geo', x: 0, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+			{ id: ids.b, type: 'geo', x: 200, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+			{ id: ids.c, type: 'geo', x: 400, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+		])
+	})
+	return { editor, canvas }
+}
+
+// Two-finger pinch-zoom. The gesture handler defers pinch_end to a rAF, so we
+// wait for it to fire and then flush the editor's pending event queue.
+async function pinchZoom(editor: Editor, canvas: HTMLElement) {
+	await act(async () => {
+		canvas.dispatchEvent(
+			touchEvent('touchstart', [
+				{ clientX: 250, clientY: 50 },
+				{ clientX: 350, clientY: 50 },
+			])
+		)
+		editor.emit('tick', 16)
+	})
+	await act(async () => {
+		canvas.dispatchEvent(
+			touchEvent('touchmove', [
+				{ clientX: 220, clientY: 50 },
+				{ clientX: 380, clientY: 50 },
+			])
+		)
+		editor.emit('tick', 16)
+	})
+	await act(async () => {
+		canvas.dispatchEvent(touchEvent('touchend', []))
+	})
+	await act(async () => {
+		await new Promise((r) => setTimeout(r, 32)) // let the deferred rAF dispatch pinch_end
+		editor.emit('tick', 16) // flush pinch_end (immediate restore)
+		editor.emit('tick', 16) // run the deferred once('tick') re-restore
+	})
+}
+
+describe('pinch selection via real DOM events', () => {
+	it('rolls back an incidental first-finger selection on a touch pinch', async () => {
+		const { editor, canvas } = await setupScene()
+
+		await act(async () => {
+			editor.select(ids.a)
+		})
+
+		// First finger lands on shape b — through the real pointer handler this
+		// changes the selection before the pinch starts.
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(250, 50))
+			editor.emit('tick', 16)
+		})
+		expect(editor.getSelectedShapeIds()).toEqual([ids.b])
+
+		await pinchZoom(editor, canvas)
+
+		expect(editor.getZoomLevel()).toBeGreaterThan(1) // the pinch really zoomed
+		expect(editor.getSelectedShapeIds()).toEqual([ids.a]) // incidental change rolled back
+	})
+
+	it('restores correctly when a second pointer_down arrives before pinch_start', async () => {
+		// Models the touch ordering where both fingers' pointer_down events are
+		// processed before touchstart fires pinch_start. The pre-gesture selection
+		// must still win.
+		const { editor, canvas } = await setupScene()
+
+		await act(async () => {
+			editor.select(ids.a)
+		})
+
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(250, 50, 1)) // finger 1 on b
+			editor.emit('tick', 16)
+			canvas.dispatchEvent(pointerDownEvent(450, 50, 2)) // finger 2 on c
+			editor.emit('tick', 16)
+		})
+
+		await pinchZoom(editor, canvas)
+
+		expect(editor.getSelectedShapeIds()).toEqual([ids.a])
+	})
+
+	it('keeps the live selection for a pinch with no preceding pointer_down', async () => {
+		// Models the Safari-style path: a click changes the selection, then a pinch
+		// arrives with no fresh pointer_down. The clicked shape must stay selected.
+		const { editor, canvas } = await setupScene()
+
+		await act(async () => {
+			editor.select(ids.a, ids.b)
+			editor.setSelectedShapes([ids.c]) // "click" outcome, no live pointer_down
+		})
+
+		await pinchZoom(editor, canvas)
+
+		expect(editor.getSelectedShapeIds()).toEqual([ids.c])
+	})
+})

--- a/packages/tldraw/src/test/pinch.test.ts
+++ b/packages/tldraw/src/test/pinch.test.ts
@@ -51,6 +51,26 @@ describe('Pinch preserves the pre-gesture selection', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 	})
 
+	it('rolls the incidental selection back at pinch start, not only at the end (touch)', () => {
+		editor.select(ids.box1)
+
+		editor.pointerMove(250, 50)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+
+		// As soon as the pinch starts we know the first finger's selection was
+		// incidental, so it's rolled back immediately — not shown for the whole
+		// gesture and reverted only on pinch end.
+		editor.pinchStart(250, 50, editor.getZoomLevel(), 0, 0, 0)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		// ...and it stays rolled back through the rest of the gesture.
+		editor.pinchTo(250, 50, 2, 0, 0, 0)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pinchEnd(250, 50, 2, 0, 0, 0)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
 	it('restores an empty selection when nothing was selected before the pinch (touch)', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([])
 

--- a/packages/tldraw/src/test/pinch.test.ts
+++ b/packages/tldraw/src/test/pinch.test.ts
@@ -1,0 +1,119 @@
+import { createShapeId } from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+const ids = {
+	box1: createShapeId('box1'),
+	box2: createShapeId('box2'),
+	box3: createShapeId('box3'),
+}
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor.setScreenBounds({ w: 1000, h: 1000, x: 0, y: 0 })
+	editor.createShapes([
+		// box1 center (50, 50)
+		{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+		// box2 center (250, 50)
+		{ id: ids.box2, type: 'geo', x: 200, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+		// box3 center (450, 50)
+		{ id: ids.box3, type: 'geo', x: 400, y: 0, props: { fill: 'solid', w: 100, h: 100 } },
+	])
+})
+
+// Drive a zoom pinch around an origin without any preceding pointer_down.
+// This models the Safari trackpad path, where pinches arrive as gesture events.
+function pinchZoom(originX = 250, originY = 50, toZoom = 2) {
+	editor
+		.pinchStart(originX, originY, editor.getZoomLevel(), 0, 0, 0)
+		.pinchTo(originX, originY, toZoom, 0, 0, 0)
+		.pinchEnd(originX, originY, toZoom, 0, 0, 0)
+}
+
+describe('Pinch preserves the pre-gesture selection', () => {
+	it('rolls back an incidental selection change made by the first finger (touch)', () => {
+		editor.select(ids.box1)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		// First finger lands on box2 and changes the selection. We don't lift it —
+		// the second finger arrives and starts the pinch while box2 is selected.
+		editor.pointerMove(250, 50)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+
+		pinchZoom()
+
+		// The incidental selection of box2 is rolled back to the pre-gesture selection.
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		// ...and stays rolled back through the deferred re-restore on the next tick.
+		editor.forceTick()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('restores an empty selection when nothing was selected before the pinch (touch)', () => {
+		expect(editor.getSelectedShapeIds()).toEqual([])
+
+		// First finger selects box2, then the pinch begins.
+		editor.pointerMove(250, 50)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+
+		pinchZoom()
+
+		// Because the pre-gesture selection was empty, box2 is deselected again.
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+
+	it('restores correctly across two consecutive pinches (touch)', () => {
+		editor.select(ids.box1)
+
+		editor.pointerMove(250, 50)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+		pinchZoom()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+
+		// Reset the camera so screen coordinates map back to page coordinates.
+		editor.setCamera({ x: 0, y: 0, z: 1 }, { immediate: true }).forceTick()
+
+		// A second pinch must capture fresh state, not reuse the first pinch's snapshot.
+		editor.select(ids.box3)
+		editor.pointerMove(50, 50)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		pinchZoom(50, 50)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+	})
+
+	it('keeps the live selection for a pinch with no preceding pointer down (Safari trackpad)', () => {
+		// Regression guard for #6907: a click changes the selection, then a later
+		// pinch must keep that selection rather than reverting to an earlier one.
+		editor.select(ids.box1, ids.box2)
+
+		// A complete click on box3 (pointer down + up) selects box3.
+		editor.pointerMove(450, 50)
+		editor.pointerDown()
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+
+		// Safari delivers the pinch as gesture events — there is no pointer_down to
+		// stash a pre-gesture selection, so the live selection (box3) is preserved.
+		pinchZoom(450, 50)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+		editor.forceTick()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+	})
+
+	it('does not stash or restore selection for a pinch while editing a shape', () => {
+		editor.select(ids.box1)
+		editor.setEditingShape(ids.box1)
+		expect(editor.getEditingShapeId()).toBe(ids.box1)
+
+		pinchZoom()
+
+		// Editing pinches are a no-op for selection (guarded by isEditing).
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		expect(editor.getEditingShapeId()).toBe(ids.box1)
+	})
+})


### PR DESCRIPTION
In order to stop a two-finger pinch from leaving the selection changed on touch devices, this PR captures the pre-gesture selection on the first `pointer_down` and rolls back any incidental change when the pinch starts. Fixes #8397.

On touch, the first finger of a pinch fires a `pointer_down` that can change the selection (for example by landing on a different shape) before the second finger starts the gesture. The snapshot used to roll this back was taken at `pinch_start`, by which point the change had already happened, so the incidental selection persisted after the pinch. Now the snapshot is taken on the first `pointer_down` only, and `pinch_start` keeps that snapshot rather than overwriting it. When no `pointer_down` precedes the pinch — Safari delivers trackpad pinches as gesture events — `pinch_start` still captures the live selection, so the Safari fix from #6907 / #7777 is preserved.

The rollback happens at `pinch_start` (as soon as we know it's a pinch), not at `pinch_end`, so the pre-gesture selection is what's shown *during* the pinch rather than the wrong shape appearing selected for the whole gesture and snapping back on release.

The regression dates to #7777 (which made the `pinch_start` snapshot unconditional to fix a Safari case) and was surfaced by the gesture-handling rewrite in #8392. A deeper follow-up — unifying pinch detection and selection onto a single pointer event stream — is tracked separately.

### Change type

- [x] `bugfix`

### Test plan

Three layers of coverage, each of which fails on the pre-fix behavior and passes with the fix:

- `packages/tldraw/src/test/pinch.test.ts` — unit tests via `TestEditor`: rollback at pinch start (not just end), empty selection, consecutive pinches, the Safari/no-pointer-down path, and the editing guard.
- `packages/tldraw/src/test/pinch-dom.test.tsx` — integration tests that drive the real canvas handlers (`useCanvasEvents`, `useGestureEvents`) with native `pointerdown` and `touchstart`/`touchmove`/`touchend` events, including the case where the second finger's `pointer_down` is processed before `pinch_start`.
- `apps/examples/e2e/tests/test-camera.spec.ts` — a Mobile Chrome e2e that dispatches a real two-finger touch pinch via CDP `Input.dispatchTouchEvent`, asserting the selection is rolled back both during and after the pinch.

Manual check on a touch device: select a shape, start a two-finger pinch with the first finger landing on a different shape, zoom, lift both fingers — the originally selected shape stays selected throughout.

- [x] Unit tests
- [x] End to end tests

### Release notes

- Fix a two-finger pinch unintentionally changing the selection on touch devices.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +39 / -6   |
| Tests     | +376 / -0  |