### PR TITLE
docs(releases): update release notes

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -8,7 +8,7 @@ status: published
 last_version: v5.0.2
 ---
 
-This release redesigns the page menu around inline interaction, adds a keyboard shortcut to copy styles from a hovered shape, and adds a `selectLockedShapes` option for inspecting locked shapes, along with new public translation APIs and various rendering and UI bug fixes.
+This release redesigns the page menu around inline interaction, adds a keyboard shortcut to copy styles from a hovered shape, and adds a `selectLockedShapes` option for inspecting locked shapes, along with new public translation APIs, canvas performance improvements, and various rendering and UI bug fixes.
 
 ## What's new
 
@@ -26,6 +26,7 @@ The page menu no longer has an explicit edit mode. Reorder pages by dragging a r
 
 - Add a `q` shortcut that copies the styles of the hovered shape and applies them to the next shape you create. ([#8917](https://github.com/tldraw/tldraw/pull/8917)) (contributed by [@kaneel](https://github.com/kaneel))
 - Improve performance on busy canvases — `getRenderingShapes()` now skips its sort step when only shape props, not the set of shape ids, have changed. ([#8784](https://github.com/tldraw/tldraw/pull/8784))
+- Improve drawing performance on pages with many shapes by skipping spatial index and culling recomputation when only shape props change. ([#8799](https://github.com/tldraw/tldraw/pull/8799), [#8804](https://github.com/tldraw/tldraw/pull/8804))
 
 ## Bug fixes
 


### PR DESCRIPTION
In order to keep the next release notes aligned with what will ship in v5.1.0, this updates `apps/docs/content/releases/next.mdx` from the `production` branch (freeze week). All 14 existing entries are present on production, so no stale entries needed pruning and no archival was required (`last_version` stays at v5.0.2).

Two new editor performance entries were added to the Improvements section — skipping spatial index updates on prop-only shape diffs (#8799) and tiering `notVisibleShapes` per-shape subscriptions (#8804). These are complementary changes that improve drawing performance on pages with many shapes, so they're grouped into a single entry. The intro paragraph now mentions canvas performance improvements.

Other production PRs since the last update were skipped per the style guide: same-cycle page-menu polish (#8927, #8924, which fix the in-release page-menu redesign), internal refactors and manager hardening (#8833, #8895), examples-only additions (#8914, #8916, #8837), and the usual infra/chore/dotcom/docs/CI changes.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +2 / -1    |
