### PR TITLE
fix(editor): coordinate touch pinch and selection through an explicit gesture state

### DIFF
--- a/apps/examples/e2e/tests/test-camera.spec.ts
+++ b/apps/examples/e2e/tests/test-camera.spec.ts
@@ -243,6 +243,57 @@ test.describe('camera', () => {
 		expect(await page.evaluate(() => editor.getZoomLevel())).not.toBe(1)
 	})
 
+	test('a second finger does not select the shape it lands on', async ({ page, isMobile }) => {
+		test.skip(!isMobile)
+
+		client = await page.context().newCDPSession(page)
+
+		// Finger 1 lands low in the viewport, finger 2 above it — both kept inside
+		// the mobile viewport so the gesture registers.
+		const f1 = { x: 196, y: 470, id: 0 }
+		const f2 = { x: 196, y: 250, id: 1 }
+
+		// A shape under each finger, nothing selected to start.
+		await page.evaluate(
+			(fingers) => {
+				const pb = editor.screenToPage({ x: fingers.f1.x, y: fingers.f1.y })
+				const pc = editor.screenToPage({ x: fingers.f2.x, y: fingers.f2.y })
+				editor.createShapes([
+					{
+						id: 'shape:e2eB',
+						type: 'geo',
+						x: pb.x - 60,
+						y: pb.y - 60,
+						props: { w: 120, h: 120, fill: 'solid' },
+					},
+					{
+						id: 'shape:e2eC',
+						type: 'geo',
+						x: pc.x - 60,
+						y: pc.y - 60,
+						props: { w: 120, h: 120, fill: 'solid' },
+					},
+				] as any)
+				editor.selectNone()
+			},
+			{ f1, f2 }
+		)
+
+		// Finger 1 down on shape b selects it.
+		await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [f1] })
+		await sleep(30)
+		expect(await page.evaluate(() => editor.getSelectedShapeIds())).toEqual(['shape:e2eB'])
+
+		// Finger 2 lands on shape c. Because two touch pointers are now down, the
+		// multi-touch gate must stop the second finger from selecting c.
+		await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [f1, f2] })
+		await sleep(30)
+		expect(await page.evaluate(() => editor.getSelectedShapeIds())).toEqual(['shape:e2eB'])
+
+		await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+		await sleep(50)
+	})
+
 	test.fixme('minimap', async () => {
 		// todo
 	})

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -951,6 +951,7 @@ export class Editor extends EventEmitter<TLEventMap> {
                 currentPagePoint: VecModel;
                 currentScreenPoint: VecModel;
                 gesturePhase: TLGesturePhase;
+                interaction: TLInteractionState;
                 isDragging: boolean;
                 isEditing: boolean;
                 isPanning: boolean;
@@ -2194,6 +2195,8 @@ export class InputsManager {
     // @deprecated (undocumented)
     get altKey(): boolean;
     set altKey(altKey: boolean);
+    // @internal
+    beginPointing(): void;
     readonly buttons: AtomSet<number>;
     // @deprecated (undocumented)
     get ctrlKey(): boolean;
@@ -2204,12 +2207,15 @@ export class InputsManager {
     get currentScreenPoint(): Vec;
     // @internal
     endGesture(): void;
+    // @internal
+    endInteraction(): void;
     getAccelKey(): boolean;
     getAltKey(): boolean;
     getCtrlKey(): boolean;
     getCurrentPagePoint(): Vec;
     getCurrentScreenPoint(): Vec;
     getGesturePhase(): TLGesturePhase;
+    getInteraction(): TLInteractionState;
     getIsDragging(): boolean;
     getIsEditing(): boolean;
     getIsPanning(): boolean;
@@ -2265,6 +2271,8 @@ export class InputsManager {
     setAltKey(altKey: boolean): void;
     // @internal (undocumented)
     setCtrlKey(ctrlKey: boolean): void;
+    // @internal
+    setDragging(dragging: boolean): void;
     // (undocumented)
     setIsDragging(isDragging: boolean): void;
     // (undocumented)
@@ -2298,6 +2306,7 @@ export class InputsManager {
         currentPagePoint: VecModel;
         currentScreenPoint: VecModel;
         gesturePhase: TLGesturePhase;
+        interaction: TLInteractionState;
         isDragging: boolean;
         isEditing: boolean;
         isPanning: boolean;
@@ -4291,6 +4300,14 @@ export interface TLInteractionStartPerfEvent {
     path: string;
     timestamp: number;
 }
+
+// @public
+export type TLInteractionState = {
+    dragging: boolean;
+    name: 'pointing';
+} | {
+    name: 'idle';
+};
 
 // @public (undocumented)
 export type TLInterruptEvent = (info: TLInterruptEventInfo) => void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2281,18 +2281,10 @@ export class InputsManager {
     setIsDragging(isDragging: boolean): void;
     // (undocumented)
     setIsEditing(isEditing: boolean): void;
-    // @internal (undocumented)
-    setIsPanning(isPanning: boolean): void;
     // (undocumented)
     setIsPen(isPen: boolean): void;
     // @internal (undocumented)
     setIsPinching(isPinching: boolean): void;
-    // @internal (undocumented)
-    setIsPointing(isPointing: boolean): void;
-    // @internal (undocumented)
-    setIsRightPointing(isRightPointing: boolean): void;
-    // @internal (undocumented)
-    setIsSpacebarPanning(isSpacebarPanning: boolean): void;
     // @internal (undocumented)
     setMetaKey(metaKey: boolean): void;
     // @internal

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -909,6 +909,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     }): boolean;
     cancel(): this;
     cancelDoubleClick(): void;
+    // @internal
+    cancelPointer(pointerId: number): this;
     canCreateShape(shape: OptionalKeys<TLShapePartial<TLShape>, 'id'> | TLShape['id']): boolean;
     canCreateShapes(shapes: (OptionalKeys<TLShapePartial<TLShape>, 'id'> | TLShape['id'])[]): boolean;
     canCropShape<T extends TLShape | TLShapeId>(shape: null | T): shape is T;
@@ -1972,6 +1974,7 @@ export function getPointerInfo(editor: Editor, e: PointerEvent | React_3.Pointer
         z: number;
     };
     pointerId: number;
+    pointerType: string;
     shiftKey: boolean;
 };
 
@@ -4486,6 +4489,7 @@ export type TLPointerEvent = (info: TLPointerEventInfo) => void;
 
 // @public (undocumented)
 export type TLPointerEventInfo = TLBaseEventInfo & {
+    pointerType?: string;
     button: number;
     isPen: boolean;
     name: TLPointerEventName;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2196,6 +2196,8 @@ export class InputsManager {
     get altKey(): boolean;
     set altKey(altKey: boolean);
     // @internal
+    beginPanning(via: 'middle' | 'right' | 'spacebar'): void;
+    // @internal
     beginPointing(): void;
     readonly buttons: AtomSet<number>;
     // @deprecated (undocumented)
@@ -2209,6 +2211,8 @@ export class InputsManager {
     endGesture(): void;
     // @internal
     endInteraction(): void;
+    // @internal
+    endPanning(): void;
     getAccelKey(): boolean;
     getAltKey(): boolean;
     getCtrlKey(): boolean;
@@ -2292,7 +2296,11 @@ export class InputsManager {
     // @internal (undocumented)
     setMetaKey(metaKey: boolean): void;
     // @internal
+    setPanningPointerDown(pointerDown: boolean): void;
+    // @internal
     setPointerVelocity(pointerVelocity: Vec): void;
+    // @internal
+    setRightUndecided(rightUndecided: boolean): void;
     // @internal (undocumented)
     setShiftKey(shiftKey: boolean): void;
     // @deprecated (undocumented)
@@ -4305,8 +4313,13 @@ export interface TLInteractionStartPerfEvent {
 export type TLInteractionState = {
     dragging: boolean;
     name: 'pointing';
+    rightUndecided: boolean;
 } | {
     name: 'idle';
+} | {
+    name: 'panning';
+    pointerDown: boolean;
+    via: 'middle' | 'right' | 'spacebar';
 };
 
 // @public (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -950,6 +950,7 @@ export class Editor extends EventEmitter<TLEventMap> {
                 ctrlKey: boolean;
                 currentPagePoint: VecModel;
                 currentScreenPoint: VecModel;
+                gesturePhase: TLGesturePhase;
                 isDragging: boolean;
                 isEditing: boolean;
                 isPanning: boolean;
@@ -2188,6 +2189,8 @@ export class InputsManager {
     constructor(editor: Editor);
     // @deprecated (undocumented)
     get accelKey(): boolean;
+    // @internal
+    addTouchPointer(pointerId: number): boolean;
     // @deprecated (undocumented)
     get altKey(): boolean;
     set altKey(altKey: boolean);
@@ -2199,11 +2202,14 @@ export class InputsManager {
     get currentPagePoint(): Vec;
     // @deprecated (undocumented)
     get currentScreenPoint(): Vec;
+    // @internal
+    endGesture(): void;
     getAccelKey(): boolean;
     getAltKey(): boolean;
     getCtrlKey(): boolean;
     getCurrentPagePoint(): Vec;
     getCurrentScreenPoint(): Vec;
+    getGesturePhase(): TLGesturePhase;
     getIsDragging(): boolean;
     getIsEditing(): boolean;
     getIsPanning(): boolean;
@@ -2253,6 +2259,8 @@ export class InputsManager {
     get previousPagePoint(): Vec;
     // @deprecated (undocumented)
     get previousScreenPoint(): Vec;
+    // @internal
+    removeTouchPointer(pointerId: number): void;
     // @internal (undocumented)
     setAltKey(altKey: boolean): void;
     // @internal (undocumented)
@@ -2289,6 +2297,7 @@ export class InputsManager {
         ctrlKey: boolean;
         currentPagePoint: VecModel;
         currentScreenPoint: VecModel;
+        gesturePhase: TLGesturePhase;
         isDragging: boolean;
         isEditing: boolean;
         isPanning: boolean;
@@ -4190,6 +4199,9 @@ export interface TLFramePerfEvent {
 export interface TLGeometryOpts {
     context?: string;
 }
+
+// @public
+export type TLGesturePhase = 'idle' | 'multi-touch' | 'pinching';
 
 // @public
 export interface TLGetShapeAtPointOptions {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -106,7 +106,10 @@ export { ClickManager, type TLClickState } from './lib/editor/managers/ClickMana
 export { EdgeScrollManager } from './lib/editor/managers/EdgeScrollManager/EdgeScrollManager'
 export { FontManager } from './lib/editor/managers/FontManager/FontManager'
 export { HistoryManager } from './lib/editor/managers/HistoryManager/HistoryManager'
-export { InputsManager } from './lib/editor/managers/InputsManager/InputsManager'
+export {
+	InputsManager,
+	type TLGesturePhase,
+} from './lib/editor/managers/InputsManager/InputsManager'
 export {
 	ScribbleManager,
 	type ScribbleItem,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -109,6 +109,7 @@ export { HistoryManager } from './lib/editor/managers/HistoryManager/HistoryMana
 export {
 	InputsManager,
 	type TLGesturePhase,
+	type TLInteractionState,
 } from './lib/editor/managers/InputsManager/InputsManager'
 export {
 	ScribbleManager,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10278,6 +10278,40 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
+	 * Tear down a pointer interaction that the browser cancelled (a `pointercancel`
+	 * event — e.g. the browser took over the gesture or a palm was rejected). Unlike
+	 * a `pointer_up`, this must not commit a click: it drops the pointer from the
+	 * multi-touch tracking, resets the pointing state, and interrupts the active
+	 * tool. Without it a cancelled pointer leaves `isPointing` / `capturedPointerId`
+	 * stuck on, since no `pointer_up` ever arrives.
+	 *
+	 * @param pointerId - The id of the cancelled pointer.
+	 * @internal
+	 */
+	cancelPointer(pointerId: number): this {
+		this._activeTouchPointers.delete(pointerId)
+		this._wasMultiTouch = this._activeTouchPointers.size >= 2
+
+		// If a pinch owns the gesture, just keep the touch count accurate; the pinch
+		// ends through its own pinch_end.
+		if (this.inputs.getIsPinching()) return this
+
+		clearTimeout(this._longPressTimeout)
+		if (this.capturedPointerId === pointerId) this.capturedPointerId = null
+
+		if (this.inputs.getIsPointing()) {
+			this.inputs.setIsPointing(false)
+			this.inputs.setIsDragging(false)
+			this._selectedShapeIdsAtPointerDown = []
+			this._didCaptureSelectionAtPointerDown = false
+			// Abort the active tool interaction without firing a click.
+			this.interrupt()
+		}
+
+		return this
+	}
+
+	/**
 	 * Dispatch a pointer move event in the current position of the pointer. This is useful when
 	 * external circumstances have changed (e.g. the camera moved or a shape was moved) and you want
 	 * the current interaction to respond to that change.
@@ -10784,6 +10818,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	capturedPointerId: number | null = null
 
+	/**
+	 * The ids of the touch pointers currently down on the canvas. Tracked on the
+	 * pointer stream (the same stream as selection) so that the moment a second
+	 * finger lands we can deterministically treat the interaction as a multi-touch
+	 * gesture — independent of when the touch-stream `pinch_start` arrives. This is
+	 * what closes the cross-stream ordering race behind #8397.
+	 * @internal
+	 */
+	private _activeTouchPointers = new Set<number>()
+
+	/**
+	 * Whether the editor is currently in a multi-touch gesture, i.e. two or more
+	 * touch pointers are down. While this is true, pointer events are not routed to
+	 * the active tool (the fingers belong to a pinch/pan, not a selection).
+	 * @internal
+	 */
+	private _wasMultiTouch = false
+
 	/** @internal */
 	private readonly performanceTracker: PerformanceTracker
 
@@ -11011,6 +11063,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 						this._selectedShapeIdsAtPointerDown = []
 						this._didCaptureSelectionAtPointerDown = false
 
+						// The gesture is over: clear the multi-touch lifecycle state. The
+						// fingers' pointer_ups were ignored while pinching, so reset the
+						// pointing state here too rather than leaving it stuck on.
+						this._activeTouchPointers.clear()
+						this._wasMultiTouch = false
+						inputs.setIsPointing(false)
+						inputs.setIsDragging(false)
+
 						if (this._didPinch) {
 							this._didPinch = false
 							if (shapesToReselect.length > 0) {
@@ -11110,8 +11170,33 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'pointer': {
+				// Track touch pointers on the pointer stream — the same stream as
+				// selection — so the second finger of a pinch is recognised the moment it
+				// lands, rather than whenever the touch-stream pinch_start happens to
+				// arrive. This is what makes the multi-touch decision deterministic and
+				// closes the cross-stream ordering race behind #8397.
+				if (info.pointerType === 'touch') {
+					if (info.name === 'pointer_down') this._activeTouchPointers.add(info.pointerId)
+					else if (info.name === 'pointer_up') this._activeTouchPointers.delete(info.pointerId)
+				}
+
 				// Ignore pointer events while we're pinching
 				if (inputs.getIsPinching()) return
+
+				// While two or more touch pointers are down, the fingers belong to a
+				// pinch/pan rather than a selection, so don't route their pointer events to
+				// the active tool. The first time we cross into multi-touch, interrupt
+				// whatever interaction the first finger started so it doesn't linger behind
+				// the gesture.
+				if (this._activeTouchPointers.size >= 2) {
+					if (!this._wasMultiTouch) {
+						this._wasMultiTouch = true
+						clearTimeout(this._longPressTimeout)
+						this.interrupt()
+					}
+					return
+				}
+				this._wasMultiTouch = false
 
 				this.inputs.updateFromEvent(info)
 				const { isPen } = info

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10299,8 +10299,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (this.capturedPointerId === pointerId) this.capturedPointerId = null
 
 		if (this.inputs.getIsPointing()) {
-			this.inputs.setIsPointing(false)
-			this.inputs.setIsDragging(false)
+			this.inputs.endInteraction()
 			this._selectedShapeIdsAtPointerDown = []
 			this._didCaptureSelectionAtPointerDown = false
 			// Abort the active tool interaction without firing a click.
@@ -10911,11 +10910,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 		if (info.type === 'misc') {
 			// stop panning if the interaction is cancelled or completed
 			if (info.name === 'cancel' || info.name === 'complete') {
-				this.inputs.setIsDragging(false)
+				this.inputs.setDragging(false)
 
 				if (this.inputs.getIsPanning()) {
-					this.inputs.setIsPanning(false)
-					this.inputs.setIsSpacebarPanning(false)
+					this.inputs.endPanning()
 					this.setCursor({ type: this._prevCursor, rotation: 0 })
 				}
 			}
@@ -10958,7 +10956,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		}
 
 		if (!inputs.getIsPointing()) {
-			inputs.setIsDragging(false)
+			inputs.setDragging(false)
 		}
 
 		const instanceState = this.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
@@ -11046,10 +11044,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						// The gesture is over: return the gesture state machine to idle. The
 						// fingers' pointer_ups were ignored while pinching, so reset the
-						// pointing state here too rather than leaving it stuck on.
+						// pointer interaction here too rather than leaving it stuck on.
 						inputs.endGesture()
-						inputs.setIsPointing(false)
-						inputs.setIsDragging(false)
+						inputs.endInteraction()
 
 						if (this._didPinch) {
 							this._didPinch = false
@@ -11215,9 +11212,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 						// Add the button from the buttons set
 						inputs.buttons.add(info.button)
 
-						// Start pointing and stop dragging
-						inputs.setIsPointing(true)
-						inputs.setIsDragging(false)
+						// Start a pointer interaction
+						inputs.beginPointing()
 
 						// If pen mode is off but we're not already in pen mode, turn that on
 						if (!isPenMode && isPen) this.updateInstanceState({ isPenMode: true })
@@ -11232,10 +11228,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 							if (!this.inputs.getIsPanning()) {
 								this._prevCursor = this.getInstanceState().cursor.type
 							}
-							this.inputs.setIsPanning(true)
+							this.inputs.beginPanning('middle')
 							clearTimeout(this._longPressTimeout)
 						} else if (info.button === RIGHT_MOUSE_BUTTON && this.options.rightClickPanning) {
-							this.inputs.setIsRightPointing(true)
+							this.inputs.setRightUndecided(true)
 							clearTimeout(this._longPressTimeout)
 							return this
 						}
@@ -11265,7 +11261,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							) {
 								// Passed the drag threshold—transition to panning
 								this._prevCursor = this.getInstanceState().cursor.type
-								this.inputs.setIsPanning(true)
+								this.inputs.beginPanning('right')
 								this.setCursor({ type: 'grabbing', rotation: 0 })
 								this.stopCameraAnimation()
 								// Apply the initial delta from the pointer down origin
@@ -11303,34 +11299,37 @@ export class Editor extends EventEmitter<TLEventMap> {
 									cz
 						) {
 							// Start dragging
-							inputs.setIsDragging(true)
+							inputs.setDragging(true)
 							clearTimeout(this._longPressTimeout)
 						}
 						break
 					}
 					case 'pointer_up': {
-						// Stop dragging / pointing
-						inputs.setIsDragging(false)
-						inputs.setIsPointing(false)
+						// A pointer button lifted. Capture the interaction before tearing it down so
+						// the right-click and panning decisions below see the pre-up state.
+						const interaction = inputs.getInteraction()
+						const wasRightUndecided = interaction.name === 'pointing' && interaction.rightUndecided
+						const wasPanning = interaction.name === 'panning'
+
 						clearTimeout(this._longPressTimeout)
 						// Remove the button from the buttons set
 						inputs.buttons.delete(info.button)
 
 						// If we're in pen mode and we're not using a pen, stop here
-						if (instanceState.isPenMode && !isPen) return
+						if (instanceState.isPenMode && !isPen) {
+							inputs.endInteraction()
+							return
+						}
 
-						// Right-click pointing ended without dragging—this is a static
-						// right-click, so let it through to the state chart as right_click.
-						// Check isPanning first: if we transitioned to panning, isRightPointing
-						// is still true but we want the panning cleanup path instead.
-						if (this.inputs.getIsRightPointing() && !this.inputs.getIsPanning()) {
-							this.inputs.setIsRightPointing(false)
+						// Right-click pointing ended without dragging—this is a static right-click,
+						// so let it through to the state chart as right_click. (If it became a pan,
+						// take the panning cleanup path below instead.)
+						if (wasRightUndecided && !wasPanning) {
+							inputs.endInteraction()
 							this._selectedShapeIdsAtPointerDown = []
 							this._didCaptureSelectionAtPointerDown = false
 							break // fall through to state chart dispatch as right_click
 						}
-
-						this.inputs.setIsRightPointing(false)
 
 						// Firefox bug fix...
 						// If it's the same pointer that we stored earlier...
@@ -11340,11 +11339,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 							info.button = 0
 						}
 
-						if (inputs.getIsPanning()) {
-							if (!inputs.keys.has('Space')) {
-								inputs.setIsPanning(false)
-								inputs.setIsSpacebarPanning(false)
-							}
+						if (wasPanning) {
+							// The pointer accompanying the pan lifted. Keep panning only while the
+							// spacebar still holds it; otherwise end the pan.
+							inputs.setPanningPointerDown(false)
+							const keepPanning = inputs.keys.has('Space')
+							if (!keepPanning) inputs.endPanning()
+
 							const slideDirection = this.inputs.getPointerVelocity()
 							const slideSpeed = Math.min(2, slideDirection.len())
 
@@ -11354,19 +11355,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 									break
 								}
 								case MIDDLE_MOUSE_BUTTON: {
-									if (this.inputs.keys.has('Space')) {
-										this.setCursor({ type: 'grab', rotation: 0 })
-									} else {
-										this.setCursor({ type: this._prevCursor, rotation: 0 })
-									}
+									this.setCursor({ type: keepPanning ? 'grab' : this._prevCursor, rotation: 0 })
 									break
 								}
 								case RIGHT_MOUSE_BUTTON: {
-									if (this.inputs.keys.has('Space')) {
-										this.setCursor({ type: 'grab', rotation: 0 })
-									} else {
-										this.setCursor({ type: this._prevCursor, rotation: 0 })
-									}
+									this.setCursor({ type: keepPanning ? 'grab' : this._prevCursor, rotation: 0 })
 									// Don't pass right-click panning events to the state chart
 									// as it causes unintended shape selection on release
 									if (slideSpeed > 0) {
@@ -11382,6 +11375,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 								this.slideCamera({ speed: slideSpeed, direction: slideDirection })
 							}
 						} else {
+							inputs.endInteraction()
 							if (info.button === STYLUS_ERASER_BUTTON) {
 								// If we were erasing with a stylus button, restore the tool we were using before we started erasing
 								this.complete()
@@ -11418,8 +11412,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 									this._prevCursor = instanceState.cursor.type
 								}
 
-								this.inputs.setIsPanning(true)
-								this.inputs.setIsSpacebarPanning(true)
+								this.inputs.beginPanning('spacebar')
 								clearTimeout(this._longPressTimeout)
 								this.setCursor({
 									type: this.inputs.getIsPointing() ? 'grabbing' : 'grab',
@@ -11469,8 +11462,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 									// If we're still middle dragging, continue panning
 								} else {
 									// otherwise, stop panning
-									this.inputs.setIsPanning(false)
-									this.inputs.setIsSpacebarPanning(false)
+									this.inputs.endPanning()
 									this.setCursor({ type: this._prevCursor, rotation: 0 })
 								}
 							}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10289,8 +10289,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @internal
 	 */
 	cancelPointer(pointerId: number): this {
-		this._activeTouchPointers.delete(pointerId)
-		this._wasMultiTouch = this._activeTouchPointers.size >= 2
+		this.inputs.removeTouchPointer(pointerId)
 
 		// If a pinch owns the gesture, just keep the touch count accurate; the pinch
 		// ends through its own pinch_end.
@@ -10818,24 +10817,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	capturedPointerId: number | null = null
 
-	/**
-	 * The ids of the touch pointers currently down on the canvas. Tracked on the
-	 * pointer stream (the same stream as selection) so that the moment a second
-	 * finger lands we can deterministically treat the interaction as a multi-touch
-	 * gesture — independent of when the touch-stream `pinch_start` arrives. This is
-	 * what closes the cross-stream ordering race behind #8397.
-	 * @internal
-	 */
-	private _activeTouchPointers = new Set<number>()
-
-	/**
-	 * Whether the editor is currently in a multi-touch gesture, i.e. two or more
-	 * touch pointers are down. While this is true, pointer events are not routed to
-	 * the active tool (the fingers belong to a pinch/pan, not a selection).
-	 * @internal
-	 */
-	private _wasMultiTouch = false
-
 	/** @internal */
 	private readonly performanceTracker: PerformanceTracker
 
@@ -11063,11 +11044,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 						this._selectedShapeIdsAtPointerDown = []
 						this._didCaptureSelectionAtPointerDown = false
 
-						// The gesture is over: clear the multi-touch lifecycle state. The
+						// The gesture is over: return the gesture state machine to idle. The
 						// fingers' pointer_ups were ignored while pinching, so reset the
 						// pointing state here too rather than leaving it stuck on.
-						this._activeTouchPointers.clear()
-						this._wasMultiTouch = false
+						inputs.endGesture()
 						inputs.setIsPointing(false)
 						inputs.setIsDragging(false)
 
@@ -11170,33 +11150,28 @@ export class Editor extends EventEmitter<TLEventMap> {
 				break
 			}
 			case 'pointer': {
-				// Track touch pointers on the pointer stream — the same stream as
-				// selection — so the second finger of a pinch is recognised the moment it
-				// lands, rather than whenever the touch-stream pinch_start happens to
+				// Feed the gesture state machine from the pointer stream — the same stream
+				// as selection — so the second finger of a pinch is recognised the moment
+				// it lands, rather than whenever the touch-stream pinch_start happens to
 				// arrive. This is what makes the multi-touch decision deterministic and
 				// closes the cross-stream ordering race behind #8397.
 				if (info.pointerType === 'touch') {
-					if (info.name === 'pointer_down') this._activeTouchPointers.add(info.pointerId)
-					else if (info.name === 'pointer_up') this._activeTouchPointers.delete(info.pointerId)
-				}
-
-				// Ignore pointer events while we're pinching
-				if (inputs.getIsPinching()) return
-
-				// While two or more touch pointers are down, the fingers belong to a
-				// pinch/pan rather than a selection, so don't route their pointer events to
-				// the active tool. The first time we cross into multi-touch, interrupt
-				// whatever interaction the first finger started so it doesn't linger behind
-				// the gesture.
-				if (this._activeTouchPointers.size >= 2) {
-					if (!this._wasMultiTouch) {
-						this._wasMultiTouch = true
-						clearTimeout(this._longPressTimeout)
-						this.interrupt()
+					if (info.name === 'pointer_down') {
+						if (inputs.addTouchPointer(info.pointerId)) {
+							// A second finger just landed: interrupt whatever interaction the
+							// first finger started so it doesn't linger behind the gesture.
+							clearTimeout(this._longPressTimeout)
+							this.interrupt()
+						}
+					} else if (info.name === 'pointer_up') {
+						inputs.removeTouchPointer(info.pointerId)
 					}
-					return
 				}
-				this._wasMultiTouch = false
+
+				// While a multi-touch gesture is active (a pinch, or two-plus fingers down
+				// before the pinch starts) the fingers belong to that gesture rather than a
+				// selection, so don't route their pointer events to the active tool.
+				if (inputs.getGesturePhase() !== 'idle') return
 
 				this.inputs.updateFromEvent(info)
 				const { isPen } = info

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -18,17 +18,26 @@ const POINTER_VELOCITY_REFERENCE_SMOOTHING = 0.5
 export type TLGesturePhase = 'idle' | 'multi-touch' | 'pinching'
 
 /**
- * The current pointer interaction, modelled as one explicit state instead of the
- * `isPointing` / `isDragging` flags (and, once the pan dimension is folded in,
- * the panning flags too). The boolean getters are derived from it.
+ * The current pointer / pan interaction, modelled as one explicit state instead
+ * of the overlapping `isPointing` / `isDragging` / `isRightPointing` /
+ * `isPanning` / `isSpacebarPanning` flags. The boolean getters are derived from
+ * it.
  *
  * - `'idle'` — no pointer interaction.
  * - `'pointing'` — a pointer button is down; `dragging` once it passes the drag
- *   threshold.
+ *   threshold, `rightUndecided` while a right button is down and hasn't yet been
+ *   classified as a right-click or the start of a right-drag pan.
+ * - `'panning'` — the camera is being panned (`via` spacebar, the middle mouse
+ *   button, or a right-drag); `pointerDown` tracks whether a pointer button is
+ *   also held, which is what keeps `isPointing` true during a middle/right-drag
+ *   pan.
  *
  * @public
  */
-export type TLInteractionState = { name: 'idle' } | { name: 'pointing'; dragging: boolean }
+export type TLInteractionState =
+	| { name: 'idle' }
+	| { name: 'pointing'; dragging: boolean; rightUndecided: boolean }
+	| { name: 'panning'; via: 'spacebar' | 'middle' | 'right'; pointerDown: boolean }
 
 /** @public */
 export class InputsManager {
@@ -314,11 +323,18 @@ export class InputsManager {
 	}
 
 	/**
-	 * Begin a pointer interaction (a pointer button went down).
+	 * Begin a pointer interaction (a pointer button went down). If a pan is already
+	 * in progress (e.g. spacebar panning), this just records that a pointer is now
+	 * down rather than discarding the pan.
 	 * @internal
 	 */
 	beginPointing(): void {
-		this._interaction.set({ name: 'pointing', dragging: false })
+		const interaction = this._interaction.get()
+		if (interaction.name === 'panning') {
+			if (!interaction.pointerDown) this._interaction.set({ ...interaction, pointerDown: true })
+		} else {
+			this._interaction.set({ name: 'pointing', dragging: false, rightUndecided: false })
+		}
 	}
 
 	/**
@@ -328,11 +344,60 @@ export class InputsManager {
 	 */
 	setDragging(dragging: boolean): void {
 		const interaction = this._interaction.get()
-		if (interaction.name === 'pointing') {
-			if (interaction.dragging !== dragging) {
-				this._interaction.set({ name: 'pointing', dragging })
-			}
+		if (interaction.name === 'pointing' && interaction.dragging !== dragging) {
+			this._interaction.set({ ...interaction, dragging })
 		}
+	}
+
+	/**
+	 * Mark the current pointing interaction as a right button awaiting
+	 * classification (right-click vs. the start of a right-drag pan).
+	 * @internal
+	 */
+	setRightUndecided(rightUndecided: boolean): void {
+		const interaction = this._interaction.get()
+		if (interaction.name === 'pointing' && interaction.rightUndecided !== rightUndecided) {
+			this._interaction.set({ ...interaction, rightUndecided })
+		}
+	}
+
+	/**
+	 * Begin panning the camera. Preserves whether a pointer button is also held, so
+	 * a middle/right-drag pan keeps `isPointing` true.
+	 * @internal
+	 */
+	beginPanning(via: 'spacebar' | 'middle' | 'right'): void {
+		const interaction = this._interaction.get()
+		const pointerDown =
+			interaction.name === 'pointing' || (interaction.name === 'panning' && interaction.pointerDown)
+		this._interaction.set({ name: 'panning', via, pointerDown })
+	}
+
+	/**
+	 * Record whether a pointer button is held during a pan (e.g. cleared when the
+	 * pointer lifts but a spacebar pan continues).
+	 * @internal
+	 */
+	setPanningPointerDown(pointerDown: boolean): void {
+		const interaction = this._interaction.get()
+		if (interaction.name === 'panning' && interaction.pointerDown !== pointerDown) {
+			this._interaction.set({ ...interaction, pointerDown })
+		}
+	}
+
+	/**
+	 * Stop panning. Returns to `pointing` if a pointer is still down, otherwise to
+	 * `idle`.
+	 * @internal
+	 */
+	endPanning(): void {
+		const interaction = this._interaction.get()
+		if (interaction.name !== 'panning') return
+		this._interaction.set(
+			interaction.pointerDown
+				? { name: 'pointing', dragging: false, rightUndecided: false }
+				: { name: 'idle' }
+		)
 	}
 
 	/**
@@ -344,10 +409,14 @@ export class InputsManager {
 	}
 
 	/**
-	 * Whether a pointer button is down.
+	 * Whether a pointer button is down. True during a middle/right-drag pan (a
+	 * pointer is held), false during a spacebar pan with no pointer down.
 	 */
 	getIsPointing() {
-		return this._interaction.get().name === 'pointing'
+		const interaction = this._interaction.get()
+		return (
+			interaction.name === 'pointing' || (interaction.name === 'panning' && interaction.pointerDown)
+		)
 	}
 	/**
 	 * @deprecated Use `getIsPointing()` instead.
@@ -365,8 +434,13 @@ export class InputsManager {
 	 * @internal
 	 */
 	setIsPointing(isPointing: boolean) {
-		if (isPointing) this.beginPointing()
-		else this.endInteraction()
+		if (isPointing) {
+			this.beginPointing()
+		} else if (this._interaction.get().name === 'panning') {
+			this.setPanningPointerDown(false)
+		} else {
+			this.endInteraction()
+		}
 	}
 
 	/**
@@ -395,16 +469,17 @@ export class InputsManager {
 		this.setDragging(isDragging)
 	}
 
-	private _isRightPointing = atom<boolean>('isRightPointing', false)
 	/**
-	 * Whether the user is right-click pointing (before drag threshold).
+	 * Whether the user is right-click pointing (a right button is down and hasn't
+	 * yet been classified as a right-click or the start of a right-drag pan).
 	 */
 	getIsRightPointing() {
-		return this._isRightPointing.get()
+		const interaction = this._interaction.get()
+		return interaction.name === 'pointing' && interaction.rightUndecided
 	}
 	/** @internal */
 	setIsRightPointing(isRightPointing: boolean) {
-		this._isRightPointing.set(isRightPointing)
+		this.setRightUndecided(isRightPointing)
 	}
 
 	/**
@@ -530,12 +605,11 @@ export class InputsManager {
 		this._isEditing.set(isEditing)
 	}
 
-	private _isPanning = atom<boolean>('isPanning', false)
 	/**
-	 * Whether the user is panning.
+	 * Whether the user is panning the camera.
 	 */
 	getIsPanning() {
-		return this._isPanning.get()
+		return this._interaction.get().name === 'panning'
 	}
 	/**
 	 * @deprecated Use `getIsPanning()` instead.
@@ -553,15 +627,16 @@ export class InputsManager {
 	 * @internal
 	 */
 	setIsPanning(isPanning: boolean) {
-		this._isPanning.set(isPanning)
+		if (isPanning) this.beginPanning(this.keys.has('Space') ? 'spacebar' : 'middle')
+		else this.endPanning()
 	}
 
-	private _isSpacebarPanning = atom<boolean>('isSpacebarPanning', false)
 	/**
-	 * Whether the user is spacebar panning.
+	 * Whether the user is panning with the spacebar held.
 	 */
 	getIsSpacebarPanning() {
-		return this._isSpacebarPanning.get()
+		const interaction = this._interaction.get()
+		return interaction.name === 'panning' && interaction.via === 'spacebar'
 	}
 	/**
 	 * @deprecated Use `getIsSpacebarPanning()` instead.
@@ -579,7 +654,17 @@ export class InputsManager {
 	 * @internal
 	 */
 	setIsSpacebarPanning(isSpacebarPanning: boolean) {
-		this._isSpacebarPanning.set(isSpacebarPanning)
+		const interaction = this._interaction.get()
+		if (isSpacebarPanning) {
+			if (interaction.name === 'panning') {
+				if (interaction.via !== 'spacebar')
+					this._interaction.set({ ...interaction, via: 'spacebar' })
+			} else {
+				this.beginPanning('spacebar')
+			}
+		} else if (interaction.name === 'panning' && interaction.via === 'spacebar') {
+			this.endPanning()
+		}
 	}
 
 	@computed private _getHasCollaborators() {
@@ -713,8 +798,8 @@ export class InputsManager {
 			gesturePhase: this._gesturePhase.get(),
 			interaction: this._interaction.get(),
 			isEditing: this._isEditing.get(),
-			isPanning: this._isPanning.get(),
-			isSpacebarPanning: this._isSpacebarPanning.get(),
+			isPanning: this.getIsPanning(),
+			isSpacebarPanning: this.getIsSpacebarPanning(),
 			keys: Array.from(this.keys.keys()),
 			buttons: Array.from(this.buttons.keys()),
 		}

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -427,13 +427,6 @@ export class InputsManager {
 	}
 	// eslint-disable-next-line tldraw/no-setter-getter
 	set isPointing(isPointing: boolean) {
-		this.setIsPointing(isPointing)
-	}
-	/**
-	 * @param isPointing - Whether the user is pointing.
-	 * @internal
-	 */
-	setIsPointing(isPointing: boolean) {
 		if (isPointing) {
 			this.beginPointing()
 		} else if (this._interaction.get().name === 'panning') {
@@ -476,10 +469,6 @@ export class InputsManager {
 	getIsRightPointing() {
 		const interaction = this._interaction.get()
 		return interaction.name === 'pointing' && interaction.rightUndecided
-	}
-	/** @internal */
-	setIsRightPointing(isRightPointing: boolean) {
-		this.setRightUndecided(isRightPointing)
 	}
 
 	/**
@@ -620,13 +609,6 @@ export class InputsManager {
 	}
 	// eslint-disable-next-line tldraw/no-setter-getter
 	set isPanning(isPanning: boolean) {
-		this.setIsPanning(isPanning)
-	}
-	/**
-	 * @param isPanning - Whether the user is panning.
-	 * @internal
-	 */
-	setIsPanning(isPanning: boolean) {
 		if (isPanning) this.beginPanning(this.keys.has('Space') ? 'spacebar' : 'middle')
 		else this.endPanning()
 	}
@@ -647,13 +629,6 @@ export class InputsManager {
 	}
 	// eslint-disable-next-line tldraw/no-setter-getter
 	set isSpacebarPanning(isSpacebarPanning: boolean) {
-		this.setIsSpacebarPanning(isSpacebarPanning)
-	}
-	/**
-	 * @param isSpacebarPanning - Whether the user is spacebar panning.
-	 * @internal
-	 */
-	setIsSpacebarPanning(isSpacebarPanning: boolean) {
 		const interaction = this._interaction.get()
 		if (isSpacebarPanning) {
 			if (interaction.name === 'panning') {

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -17,6 +17,19 @@ const POINTER_VELOCITY_REFERENCE_SMOOTHING = 0.5
  */
 export type TLGesturePhase = 'idle' | 'multi-touch' | 'pinching'
 
+/**
+ * The current pointer interaction, modelled as one explicit state instead of the
+ * `isPointing` / `isDragging` flags (and, once the pan dimension is folded in,
+ * the panning flags too). The boolean getters are derived from it.
+ *
+ * - `'idle'` — no pointer interaction.
+ * - `'pointing'` — a pointer button is down; `dragging` once it passes the drag
+ *   threshold.
+ *
+ * @public
+ */
+export type TLInteractionState = { name: 'idle' } | { name: 'pointing'; dragging: boolean }
+
 /** @public */
 export class InputsManager {
 	constructor(private readonly editor: Editor) {}
@@ -290,37 +303,51 @@ export class InputsManager {
 		return this.getAccelKey()
 	}
 
-	private _isDragging = atom<boolean>('isDragging', false)
+	private _interaction = atom<TLInteractionState>('interaction', { name: 'idle' })
+
 	/**
-	 * Whether the user is dragging.
+	 * The current pointer interaction state. `isPointing` / `isDragging` are
+	 * derived from it.
 	 */
-	getIsDragging() {
-		return this._isDragging.get()
-	}
-	/**
-	 * Soon to be deprecated, use `getIsDragging()` instead.
-	 */
-	// eslint-disable-next-line tldraw/no-setter-getter
-	get isDragging() {
-		return this.getIsDragging()
-	}
-	// eslint-disable-next-line tldraw/no-setter-getter
-	set isDragging(isDragging: boolean) {
-		this.setIsDragging(isDragging)
-	}
-	/**
-	 * @param isDragging - Whether the user is dragging.
-	 */
-	setIsDragging(isDragging: boolean) {
-		this._isDragging.set(isDragging)
+	getInteraction(): TLInteractionState {
+		return this._interaction.get()
 	}
 
-	private _isPointing = atom<boolean>('isPointing', false)
 	/**
-	 * Whether the user is pointing.
+	 * Begin a pointer interaction (a pointer button went down).
+	 * @internal
+	 */
+	beginPointing(): void {
+		this._interaction.set({ name: 'pointing', dragging: false })
+	}
+
+	/**
+	 * Set whether the current pointing interaction has passed the drag threshold.
+	 * No-op when not pointing — there is no dragging without pointing.
+	 * @internal
+	 */
+	setDragging(dragging: boolean): void {
+		const interaction = this._interaction.get()
+		if (interaction.name === 'pointing') {
+			if (interaction.dragging !== dragging) {
+				this._interaction.set({ name: 'pointing', dragging })
+			}
+		}
+	}
+
+	/**
+	 * End the pointer interaction (pointer up / cancel / pinch), returning to idle.
+	 * @internal
+	 */
+	endInteraction(): void {
+		this._interaction.set({ name: 'idle' })
+	}
+
+	/**
+	 * Whether a pointer button is down.
 	 */
 	getIsPointing() {
-		return this._isPointing.get()
+		return this._interaction.get().name === 'pointing'
 	}
 	/**
 	 * @deprecated Use `getIsPointing()` instead.
@@ -338,7 +365,34 @@ export class InputsManager {
 	 * @internal
 	 */
 	setIsPointing(isPointing: boolean) {
-		this._isPointing.set(isPointing)
+		if (isPointing) this.beginPointing()
+		else this.endInteraction()
+	}
+
+	/**
+	 * Whether the user is dragging (a pointer is down and has passed the drag
+	 * threshold).
+	 */
+	getIsDragging() {
+		const interaction = this._interaction.get()
+		return interaction.name === 'pointing' && interaction.dragging
+	}
+	/**
+	 * Soon to be deprecated, use `getIsDragging()` instead.
+	 */
+	// eslint-disable-next-line tldraw/no-setter-getter
+	get isDragging() {
+		return this.getIsDragging()
+	}
+	// eslint-disable-next-line tldraw/no-setter-getter
+	set isDragging(isDragging: boolean) {
+		this.setIsDragging(isDragging)
+	}
+	/**
+	 * @param isDragging - Whether the user is dragging.
+	 */
+	setIsDragging(isDragging: boolean) {
+		this.setDragging(isDragging)
 	}
 
 	private _isRightPointing = atom<boolean>('isRightPointing', false)
@@ -653,10 +707,11 @@ export class InputsManager {
 			ctrlKey: this._ctrlKey.get(),
 			altKey: this._altKey.get(),
 			isPen: this._isPen.get(),
-			isDragging: this._isDragging.get(),
-			isPointing: this._isPointing.get(),
+			isDragging: this.getIsDragging(),
+			isPointing: this.getIsPointing(),
 			isPinching: this.getIsPinching(),
 			gesturePhase: this._gesturePhase.get(),
+			interaction: this._interaction.get(),
 			isEditing: this._isEditing.get(),
 			isPanning: this._isPanning.get(),
 			isSpacebarPanning: this._isSpacebarPanning.get(),

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -10,6 +10,13 @@ import { TLPinchEventInfo, TLPointerEventInfo, TLWheelEventInfo } from '../../ty
 const POINTER_VELOCITY_REFERENCE_INTERVAL_MS = 16
 const POINTER_VELOCITY_REFERENCE_SMOOTHING = 0.5
 
+/**
+ * The phase of the multi-touch / pinch gesture lifecycle tracked by
+ * {@link InputsManager.getGesturePhase}.
+ * @public
+ */
+export type TLGesturePhase = 'idle' | 'multi-touch' | 'pinching'
+
 /** @public */
 export class InputsManager {
 	constructor(private readonly editor: Editor) {}
@@ -346,12 +353,78 @@ export class InputsManager {
 		this._isRightPointing.set(isRightPointing)
 	}
 
-	private _isPinching = atom<boolean>('isPinching', false)
+	/**
+	 * The current multi-touch / pinch gesture lifecycle. Both input streams feed
+	 * this one state machine: the pointer stream tracks how many touch pointers are
+	 * down (so a second finger is recognised the moment it lands, deterministically,
+	 * rather than whenever the touch-stream `pinch_start` arrives), and the
+	 * touch/gesture stream confirms the pinch.
+	 *
+	 * - `'idle'` — no multi-touch gesture is active.
+	 * - `'multi-touch'` — two or more touch pointers are down, but a pinch hasn't
+	 *   started yet.
+	 * - `'pinching'` — a pinch is in progress.
+	 *
+	 * `getIsPinching()` is derived from this. The pointer dispatch ignores pointer
+	 * events whenever this is not `'idle'`, so the fingers of a gesture never reach
+	 * the active tool.
+	 * @internal
+	 */
+	private _gesturePhase = atom<TLGesturePhase>('gesturePhase', 'idle')
+
+	/** The ids of the touch pointers currently down. @internal */
+	private _touchPointerIds = new Set<number>()
+
+	/**
+	 * The current multi-touch / pinch gesture phase.
+	 */
+	getGesturePhase(): TLGesturePhase {
+		return this._gesturePhase.get()
+	}
+
+	/**
+	 * Record a touch pointer going down. Returns `true` if this is the pointer that
+	 * starts a multi-touch gesture (the transition into `'multi-touch'`), so the
+	 * caller can interrupt the first finger's interaction once.
+	 * @internal
+	 */
+	addTouchPointer(pointerId: number): boolean {
+		this._touchPointerIds.add(pointerId)
+		if (this._touchPointerIds.size >= 2 && this._gesturePhase.get() === 'idle') {
+			this._gesturePhase.set('multi-touch')
+			return true
+		}
+		return false
+	}
+
+	/**
+	 * Record a touch pointer going up or being cancelled. Drops back out of the
+	 * `'multi-touch'` phase once fewer than two fingers remain; a `'pinching'` phase
+	 * is left to end through `pinch_end` / {@link InputsManager.endGesture}.
+	 * @internal
+	 */
+	removeTouchPointer(pointerId: number): void {
+		this._touchPointerIds.delete(pointerId)
+		if (this._touchPointerIds.size < 2 && this._gesturePhase.get() === 'multi-touch') {
+			this._gesturePhase.set('idle')
+		}
+	}
+
+	/**
+	 * End the current gesture: clear the tracked touch pointers and return to the
+	 * `'idle'` phase. Called on `pinch_end`.
+	 * @internal
+	 */
+	endGesture(): void {
+		this._touchPointerIds.clear()
+		this._gesturePhase.set('idle')
+	}
+
 	/**
 	 * Whether the user is pinching.
 	 */
 	getIsPinching() {
-		return this._isPinching.get()
+		return this._gesturePhase.get() === 'pinching'
 	}
 	/**
 	 * @deprecated Use `getIsPinching()` instead.
@@ -369,7 +442,13 @@ export class InputsManager {
 	 * @internal
 	 */
 	setIsPinching(isPinching: boolean) {
-		this._isPinching.set(isPinching)
+		if (isPinching) {
+			this._gesturePhase.set('pinching')
+		} else if (this._gesturePhase.get() === 'pinching') {
+			// The pinch ended: fall back to multi-touch if fingers are still down,
+			// otherwise to idle.
+			this._gesturePhase.set(this._touchPointerIds.size >= 2 ? 'multi-touch' : 'idle')
+		}
 	}
 
 	private _isEditing = atom<boolean>('isEditing', false)
@@ -503,7 +582,7 @@ export class InputsManager {
 	updateFromEvent(info: TLPointerEventInfo | TLPinchEventInfo | TLWheelEventInfo): void {
 		const currentScreenPoint = this._currentScreenPoint.__unsafe__getWithoutCapture()
 		const currentPagePoint = this._currentPagePoint.__unsafe__getWithoutCapture()
-		const isPinching = this._isPinching.__unsafe__getWithoutCapture()
+		const isPinching = this._gesturePhase.__unsafe__getWithoutCapture() === 'pinching'
 		const { screenBounds } = this.editor.store.unsafeGetWithoutCapture(TLINSTANCE_ID)!
 		const { x: cx, y: cy, z: cz } = unsafe__withoutCapture(() => this.editor.getCamera())
 
@@ -576,7 +655,8 @@ export class InputsManager {
 			isPen: this._isPen.get(),
 			isDragging: this._isDragging.get(),
 			isPointing: this._isPointing.get(),
-			isPinching: this._isPinching.get(),
+			isPinching: this.getIsPinching(),
+			gesturePhase: this._gesturePhase.get(),
 			isEditing: this._isEditing.get(),
 			isPanning: this._isPanning.get(),
 			isSpacebarPanning: this._isSpacebarPanning.get(),

--- a/packages/editor/src/lib/editor/types/event-types.ts
+++ b/packages/editor/src/lib/editor/types/event-types.ts
@@ -63,6 +63,12 @@ export type TLPointerEventInfo = TLBaseEventInfo & {
 	pointerId: number
 	button: number
 	isPen: boolean
+	/**
+	 * The kind of device that produced the pointer event, mirroring the DOM
+	 * `PointerEvent.pointerType` (e.g. `'mouse'`, `'pen'`, `'touch'`). Optional
+	 * because synthetic events don't always set it.
+	 */
+	pointerType?: string
 } & TLPointerEventTarget
 
 /** @public */

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -78,6 +78,17 @@ export function useCanvasEvents() {
 				}
 			}
 
+			function onPointerCancel(e: React.PointerEvent) {
+				if (editor.wasEventAlreadyHandled(e)) return
+				editor.markEventAsHandled(e)
+				releasePointerCapture(e.currentTarget, e)
+				// The browser cancelled this pointer (e.g. it took over the gesture, or
+				// a palm was rejected). There will be no pointer_up, so tear the pointer
+				// interaction down here instead of leaving isPointing / capturedPointerId
+				// stuck on.
+				editor.cancelPointer(e.pointerId)
+			}
+
 			function onPointerEnter(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
 				if (editor.getInstanceState().isPenMode && e.pointerType !== 'pen') return
@@ -187,6 +198,7 @@ export function useCanvasEvents() {
 			return {
 				onPointerDown,
 				onPointerUp,
+				onPointerCancel,
 				onPointerEnter,
 				onPointerLeave,
 				onDragOver,

--- a/packages/editor/src/lib/utils/getPointerInfo.ts
+++ b/packages/editor/src/lib/utils/getPointerInfo.ts
@@ -20,5 +20,6 @@ export function getPointerInfo(editor: Editor, e: React.PointerEvent | PointerEv
 		pointerId: e.pointerId,
 		button: e.button,
 		isPen: e.pointerType === 'pen',
+		pointerType: e.pointerType,
 	}
 }

--- a/packages/tldraw/src/test/interactionState.test.ts
+++ b/packages/tldraw/src/test/interactionState.test.ts
@@ -1,0 +1,139 @@
+import { TestEditor } from './TestEditor'
+
+// The five interaction booleans (isPointing / isDragging / isRightPointing /
+// isPanning / isSpacebarPanning) are derived from a single `interaction` state.
+// These tests lock in that derivation — in particular the overlapping cases
+// where more than one boolean is true at once (a pointer is down *and* the
+// camera is panning), which the explicit state models directly.
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+function flags() {
+	const i = editor.inputs
+	return {
+		pointing: i.getIsPointing(),
+		dragging: i.getIsDragging(),
+		rightPointing: i.getIsRightPointing(),
+		panning: i.getIsPanning(),
+		spacebarPanning: i.getIsSpacebarPanning(),
+	}
+}
+
+describe('interaction state', () => {
+	it('starts idle', () => {
+		expect(editor.inputs.getInteraction()).toEqual({ name: 'idle' })
+		expect(flags()).toEqual({
+			pointing: false,
+			dragging: false,
+			rightPointing: false,
+			panning: false,
+			spacebarPanning: false,
+		})
+	})
+
+	it('left-button down then drag: pointing → dragging', () => {
+		editor.pointerDown(100, 100)
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'pointing',
+			dragging: false,
+			rightUndecided: false,
+		})
+		expect(flags()).toMatchObject({ pointing: true, dragging: false, panning: false })
+
+		editor.pointerMove(200, 200)
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'pointing',
+			dragging: true,
+			rightUndecided: false,
+		})
+		expect(flags()).toMatchObject({ pointing: true, dragging: true })
+
+		editor.pointerUp(200, 200)
+		expect(editor.inputs.getInteraction()).toEqual({ name: 'idle' })
+	})
+
+	it('middle-button pan: isPointing and isPanning are both true', () => {
+		editor.pointerDown(100, 100, { button: 1 })
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'panning',
+			via: 'middle',
+			pointerDown: true,
+		})
+		// The overlap the explicit state makes honest: a pointer is down *and* the
+		// camera is panning.
+		expect(flags()).toEqual({
+			pointing: true,
+			dragging: false,
+			rightPointing: false,
+			panning: true,
+			spacebarPanning: false,
+		})
+
+		editor.pointerUp(100, 100, { button: 1 })
+		expect(editor.inputs.getInteraction()).toEqual({ name: 'idle' })
+	})
+
+	it('right-button down is right-pointing, then promotes to panning on drag', () => {
+		editor.pointerDown(100, 100, { button: 2 })
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'pointing',
+			dragging: false,
+			rightUndecided: true,
+		})
+		expect(flags()).toMatchObject({ pointing: true, rightPointing: true, panning: false })
+
+		editor.pointerMove(200, 200)
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'panning',
+			via: 'right',
+			pointerDown: true,
+		})
+		// Once it becomes a pan it is no longer "right pointing".
+		expect(flags()).toMatchObject({ pointing: true, rightPointing: false, panning: true })
+
+		editor.pointerUp(200, 200, { button: 2 })
+		expect(editor.inputs.getInteraction()).toEqual({ name: 'idle' })
+	})
+
+	it('spacebar pan with no pointer down: panning but not pointing', () => {
+		editor.keyDown(' ')
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'panning',
+			via: 'spacebar',
+			pointerDown: false,
+		})
+		expect(flags()).toEqual({
+			pointing: false,
+			dragging: false,
+			rightPointing: false,
+			panning: true,
+			spacebarPanning: true,
+		})
+
+		editor.keyUp(' ')
+		expect(editor.inputs.getInteraction()).toEqual({ name: 'idle' })
+	})
+
+	it('spacebar pan with a pointer also down: pointing and spacebar-panning', () => {
+		editor.keyDown(' ')
+		editor.pointerDown(100, 100)
+		expect(editor.inputs.getInteraction()).toEqual({
+			name: 'panning',
+			via: 'spacebar',
+			pointerDown: true,
+		})
+		expect(flags()).toMatchObject({ pointing: true, panning: true, spacebarPanning: true })
+
+		// Lifting the pointer while the spacebar is still held keeps the pan going.
+		editor.pointerUp(100, 100)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+
+		editor.keyUp(' ')
+		expect(editor.inputs.getInteraction()).toEqual({ name: 'idle' })
+	})
+})

--- a/packages/tldraw/src/test/pinch-dom.test.tsx
+++ b/packages/tldraw/src/test/pinch-dom.test.tsx
@@ -225,6 +225,46 @@ describe('pinch selection via real DOM events', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.c])
 	})
 
+	it('moves through the gesture phases: idle → multi-touch → pinching → idle', async () => {
+		const { editor, canvas } = await setupScene()
+		expect(editor.inputs.getGesturePhase()).toBe('idle')
+
+		// One finger down is not yet a multi-touch gesture.
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(250, 50, 1))
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getGesturePhase()).toBe('idle')
+
+		// A second finger down enters the multi-touch phase.
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(350, 50, 2))
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getGesturePhase()).toBe('multi-touch')
+
+		// The touch stream confirms the pinch.
+		await act(async () => {
+			canvas.dispatchEvent(
+				touchEvent('touchstart', [
+					{ clientX: 250, clientY: 50 },
+					{ clientX: 350, clientY: 50 },
+				])
+			)
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getGesturePhase()).toBe('pinching')
+
+		// Lifting the fingers ends the gesture and returns to idle.
+		await act(async () => {
+			canvas.dispatchEvent(touchEvent('touchend', []))
+			await new Promise((r) => setTimeout(r, 32))
+			editor.emit('tick', 16)
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getGesturePhase()).toBe('idle')
+	})
+
 	it('keeps the live selection for a pinch with no preceding pointer_down', async () => {
 		// Models the Safari-style path: a click changes the selection, then a pinch
 		// arrives with no fresh pointer_down. The clicked shape must stay selected.

--- a/packages/tldraw/src/test/pinch-dom.test.tsx
+++ b/packages/tldraw/src/test/pinch-dom.test.tsx
@@ -49,6 +49,19 @@ function pointerDownEvent(clientX: number, clientY: number, pointerId = 1) {
 	})
 }
 
+function pointerCancelEvent(clientX: number, clientY: number, pointerId = 1) {
+	return new (globalThis as any).PointerEvent('pointercancel', {
+		bubbles: true,
+		cancelable: true,
+		clientX,
+		clientY,
+		button: 0,
+		pointerId,
+		pointerType: 'touch',
+		isPrimary: pointerId === 1,
+	})
+}
+
 function touchEvent(type: string, points: Array<{ clientX: number; clientY: number }>) {
 	const e = new Event(type, { bubbles: true, cancelable: true })
 	const touches = points.map((p, i) => ({ clientX: p.clientX, clientY: p.clientY, identifier: i }))
@@ -151,6 +164,65 @@ describe('pinch selection via real DOM events', () => {
 		await pinchZoom(editor, canvas)
 
 		expect(editor.getSelectedShapeIds()).toEqual([ids.a])
+	})
+
+	it('does not let a second finger change the selection (multi-touch gate)', async () => {
+		const { editor, canvas } = await setupScene()
+
+		await act(async () => {
+			editor.select(ids.a)
+		})
+
+		// First finger lands on b and selects it through the real pointer handler.
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(250, 50, 1))
+			editor.emit('tick', 16)
+		})
+		expect(editor.getSelectedShapeIds()).toEqual([ids.b])
+
+		// Second finger lands on c. Two touch pointers are now down, so this is a
+		// multi-touch gesture: the second finger must not change the selection
+		// (without the gate it would select c before pinch_start arrives).
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(450, 50, 2))
+			editor.emit('tick', 16)
+		})
+		expect(editor.getSelectedShapeIds()).toEqual([ids.b])
+
+		// The pinch still rolls the selection back to what it was before the gesture.
+		await pinchZoom(editor, canvas)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.a])
+	})
+
+	it('recovers from a cancelled pointer without leaving pointing state stuck', async () => {
+		const { editor, canvas } = await setupScene()
+
+		await act(async () => {
+			editor.select(ids.a)
+		})
+
+		// A finger lands on b and starts a pointing interaction.
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(250, 50, 1))
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getIsPointing()).toBe(true)
+		expect(editor.getSelectedShapeIds()).toEqual([ids.b])
+
+		// The browser cancels the pointer (e.g. palm rejection). No pointer_up will
+		// arrive, so the pointing state must be torn down here.
+		await act(async () => {
+			canvas.dispatchEvent(pointerCancelEvent(250, 50, 1))
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getIsPointing()).toBe(false)
+
+		// A later pointer interaction still works normally.
+		await act(async () => {
+			canvas.dispatchEvent(pointerDownEvent(450, 50, 3))
+			editor.emit('tick', 16)
+		})
+		expect(editor.getSelectedShapeIds()).toEqual([ids.c])
 	})
 
 	it('keeps the live selection for a pinch with no preceding pointer_down', async () => {


### PR DESCRIPTION
This builds on #9006 (which restores the pre-gesture selection after a pinch). In order to stop the _second_ finger of a two-finger pinch from changing the selection, this PR makes the pointer stream — the same stream selection runs on — the single authority for the multi-touch gesture lifecycle, so that decision no longer races the touch-stream `pinch_start`. Together with #9006 this closes #8397.

### Background

Touch pinch is detected on the **touch** event stream (`useGestureEvents`), while selection runs on the **pointer** event stream (`useCanvasEvents`). The two streams describe the same fingers with no guaranteed ordering, so whether the second finger's `pointer_down` is processed before or after `pinch_start` is browser-dependent — the root cause behind #8397. #9006 rolls back the _first_ finger's incidental selection change (intrinsic: a pinch isn't detectable until the second finger lands). This PR additionally makes the _second_ finger deterministic, and does so without moving pinch geometry off the touch stream, so the sub-pixel pinch accuracy from #8392 is preserved.

### What changed

- The editor tracks touch pointers on the pointer stream. The moment a second touch pointer lands, the interaction is treated as a multi-touch gesture and its pointer events are no longer routed to the active tool, so the second finger can't change the selection. This is deterministic because it rides the same `pointerdown` the selection handler sees — it doesn't depend on when `pinch_start` arrives.
- Added a `pointercancel` handler. The browser can cancel a pointer (gesture takeover, palm rejection) with no following `pointer_up`, which previously left `isPointing` / `capturedPointerId` stuck on. `Editor.cancelPointer()` tears the interaction down and interrupts the active tool without committing a click.
- The multi-touch / pinch lifecycle is now one explicit state on `InputsManager` (`idle → multi-touch → pinching → idle`). Both streams feed it — the pointer stream counts fingers, the touch/gesture stream confirms the pinch — and `getIsPinching()` is derived from it. The pointer dispatch gate collapses to a single `getGesturePhase() !== 'idle'` check.
- **Input-flag consolidation (two commits).** The overlapping `isPointing` / `isDragging` / `isRightPointing` / `isPanning` / `isSpacebarPanning` booleans are replaced by a single explicit `interaction` state — `idle | pointing { dragging, rightUndecided } | panning { via, pointerDown }`. All five boolean getters are now _derived_ from it (so impossible combinations like dragging-without-pointing are unrepresentable), and the Editor dispatch drives it through named transitions (`beginPointing` / `setDragging` / `beginPanning` / `endPanning` / …) instead of toggling independent flags. The real overlaps are modelled honestly: a middle/right-drag pan is `panning { pointerDown: true }`, which is why `isPointing` and `isPanning` are both true then; a pan sustained by spacebar + middle still ends only when the sustaining input releases.

### Commits

1. `fix(editor)`: gate selection during multi-touch + `pointercancel` recovery
2. `refactor(editor)`: pinch gesture lifecycle as an explicit state
3. `test(examples)`: e2e for the multi-touch selection gate
4. `refactor(editor)`: model pointer interaction as one explicit state (pointing/dragging)
5. `refactor(editor)`: fold pan + right-pointing into the interaction state
6. `test(tldraw)`: cover the interaction state truth table
7. `refactor(editor)`: drop the redundant internal input setters

Commits 4–7 are the input-flag consolidation and are cleanly separable from the #8397 fix (1–3) if we'd rather land them apart.

### Deliberately out of scope

- Pinch geometry stays on the touch stream, preserving the drift fix from #8392. Moving it to the pointer stream would re-introduce ~0.5px pan drift; the gesture state here doesn't preclude that as a future change.
- `isEditing` and `isPen` are left as independent flags — they are orthogonal modes (you can be editing or using a pen while pointing/panning), not part of the pointer/pan interaction state, so folding them in would be wrong rather than just risky.

### Concepts

| Term | Type | Meaning |
| --- | --- | --- |
| `TLGesturePhase` | `'idle' \| 'multi-touch' \| 'pinching'` | The multi-touch / pinch gesture lifecycle phase |
| `TLInteractionState` | `idle \| pointing \| panning` (discriminated union) | The pointer / pan interaction; the `isPointing` / `isDragging` / `isRightPointing` / `isPanning` / `isSpacebarPanning` getters are derived from it |
| `InputsManager.getGesturePhase()` | method | Read the current gesture phase (`getIsPinching()` is derived from it) |
| `InputsManager.getInteraction()` | method | Read the current pointer / pan interaction state |

### API changes

- Added `TLGesturePhase`, `TLInteractionState`, `InputsManager.getGesturePhase()`, and `InputsManager.getInteraction()`.
- The `isPointing` / `isDragging` / `isRightPointing` / `isPanning` / `isSpacebarPanning` getters and setters are unchanged in signature; they now derive from / map onto `getInteraction()`.
- Added `pointerType` to `TLPointerEventInfo` and to `getPointerInfo()`'s return value.
- Added `Editor.cancelPointer()` (internal).

### Change type

- [x] `bugfix`

### Test plan

1. On a touch device, select shape A, then begin a two-finger pinch with the first finger landing on shape B: B should not stay selected, the second finger must never select whatever it lands on, and after the pinch ends shape A is selected again.
2. Two-finger pan and pinch-to-zoom behave as before.
3. Desktop Safari trackpad pinch and wheel zoom/pan are unchanged.

- [x] Unit tests
- [x] End to end tests

Unit and jsdom-integration tests (driving the real `useCanvasEvents` / `useGestureEvents` hooks) cover the gate, the `pointercancel` recovery, and the gesture phases; the e2e (Mobile Chrome, CDP `Input.dispatchTouchEvent`) covers real multi-touch. True iOS Safari behaviour — native `pointercancel` on multitouch and the native touch-vs-pointer event ordering — can't be reproduced in jsdom or Chromium emulation and should be confirmed with on-device QA.

### Release notes

- Fix touch pinch so the second finger of a two-finger gesture can no longer change the selection, and recover cleanly when the browser cancels a pointer mid-interaction.

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +372 / -102 |
| Tests           | +302 / -0   |
| Automated files | +46 / -8    |
