### PR TITLE
fix(ci): check out Discord notify action when a step fails before checkout

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -55,6 +55,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
+      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      - name: Check out Discord notify action
+        if: failure()
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/discord-fail-notify
+
       - name: Notify Discord on failure
         if: failure()
         uses: ./.github/actions/discord-fail-notify

--- a/.github/workflows/publish-editor-extensions.yml
+++ b/.github/workflows/publish-editor-extensions.yml
@@ -54,6 +54,13 @@ jobs:
           TLDRAW_ENV: ${{ (github.ref == 'refs/heads/production' && 'production') || (github.ref == 'refs/heads/main' && 'staging') }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
+      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      - name: Check out Discord notify action
+        if: failure()
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/discord-fail-notify
+
       - name: Notify Discord on failure
         if: failure()
         uses: ./.github/actions/discord-fail-notify

--- a/.github/workflows/publish-vscode-extension.yml
+++ b/.github/workflows/publish-vscode-extension.yml
@@ -51,6 +51,13 @@ jobs:
           TLDRAW_ENV: production
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
+      # Earlier steps run before checkout, so re-fetch the local action on failure.
+      - name: Check out Discord notify action
+        if: failure()
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/discord-fail-notify
+
       - name: Notify Discord on failure
         if: failure()
         uses: ./.github/actions/discord-fail-notify

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,9 +245,7 @@ jobs:
             https://api.github.com/repos/tldraw/tldraw-desktop/dispatches \
             -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","tag":"next"}}'
 
-      # "Determine publish mode" runs before "Check out code", so a failure there
-      # leaves the repo un-checked-out and the local notify action unavailable.
-      # Sparsely check it out on failure so the notification always runs.
+      # Earlier steps run before checkout, so re-fetch the local action on failure.
       - name: Check out Discord notify action
         if: failure()
         uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,6 +245,15 @@ jobs:
             https://api.github.com/repos/tldraw/tldraw-desktop/dispatches \
             -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","tag":"next"}}'
 
+      # "Determine publish mode" runs before "Check out code", so a failure there
+      # leaves the repo un-checked-out and the local notify action unavailable.
+      # Sparsely check it out on failure so the notification always runs.
+      - name: Check out Discord notify action
+        if: failure()
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/actions/discord-fail-notify
+
       - name: Notify Discord on failure
         if: failure()
         uses: ./.github/actions/discord-fail-notify


### PR DESCRIPTION
In order to make our failure alerts reliable, this PR ensures the Discord notify step can always find its local action. The notify step uses a local action (`./.github/actions/discord-fail-notify`), but several publish workflows run steps before `Check out code` (e.g. `Determine publish mode`, `Generate GH token`). When one of those fails, checkout is skipped, so the local action can't be found and the failure notification itself fails — as seen in [this run](https://github.com/tldraw/tldraw/actions/runs/26878352925/job/79271600922):

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.github/actions/discord-fail-notify'.
Did you forget to run actions/checkout before running your local action?
```

The fix adds a `failure()`-gated sparse checkout of just the action immediately before each notify step, so the action is always present regardless of where the failure occurred. It's a no-op on success.

A scan of all workflows found four with this pattern (a `failure()` local-action notify after a step that runs before checkout): `publish.yml`, `bump-versions.yml`, `publish-editor-extensions.yml`, `publish-vscode-extension.yml`. Other workflows using the action run checkout as their first step, so they're unaffected.

### Change type

- [x] `other`

### Test plan

- Cannot be meaningfully tested without deliberately failing a publish workflow; verified by inspecting step ordering across all workflows.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +28 / -0   |
