### PR TITLE
refactor(editor): move ShapeIndicatorOverlayUtil to the tldraw package

### DIFF
--- a/apps/examples/src/examples/ui/indicators-logic/IndicatorsLogicExample.tsx
+++ b/apps/examples/src/examples/ui/indicators-logic/IndicatorsLogicExample.tsx
@@ -1,4 +1,10 @@
-import { ShapeIndicatorOverlayUtil, TLShapeIndicatorOverlay, Tldraw } from 'tldraw'
+import {
+	createShapeId,
+	ShapeIndicatorOverlayUtil,
+	TLShapeIndicatorOverlay,
+	Tldraw,
+	toRichText,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 
 // There's a guide at the bottom of this file!
@@ -28,12 +34,17 @@ export default function IndicatorsLogicExample() {
 				overlayUtils={overlayUtils}
 				onMount={(editor) => {
 					if (editor.getCurrentPageShapeIds().size === 0) {
+						const bottomLeftA = createShapeId()
+						const bottomLeftB = createShapeId()
 						editor.createShapes([
 							{ type: 'geo', x: 100, y: 100 },
-							{ type: 'geo', x: 500, y: 150 },
-							{ type: 'geo', x: 100, y: 500 },
-							{ type: 'geo', x: 500, y: 500 },
+							{ type: 'geo', x: 500, y: 150, props: { geo: 'ellipse' } },
+							{ id: bottomLeftA, type: 'geo', x: 100, y: 500 },
+							{ id: bottomLeftB, type: 'geo', x: 250, y: 400 },
+							{ type: 'text', x: 500, y: 500, props: { richText: toRichText('Hello, world!') } },
 						])
+						editor.groupShapes([bottomLeftA, bottomLeftB])
+						editor.setSelectedShapes([])
 					}
 				}}
 			/>

--- a/apps/examples/src/examples/ui/indicators-logic/README.md
+++ b/apps/examples/src/examples/ui/indicators-logic/README.md
@@ -15,8 +15,10 @@ keywords:
   ]
 ---
 
-Change when indicators are shown and how they appear.
+Change when shape indicators are shown and how they appear.
 
 ---
 
-This example shows how you can change when indicators are shown and how they appear.
+This example shows how you can change when shape indicators are shown and how they appear.
+
+Shape indicators are the lines that are drawn around the border of a shape when hovering over it. This examples makes them appear all of the time.

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2973,24 +2973,6 @@ export function setRuntimeOverrides(input: Partial<typeof runtime>): void;
 // @public (undocumented)
 export function setUserPreferences(user: TLUserPreferences): void;
 
-// @public
-export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverlay> {
-    // (undocumented)
-    getOverlays(): TLShapeIndicatorOverlay[];
-    // (undocumented)
-    isActive(): boolean;
-    // (undocumented)
-    options: {
-        hintedLineWidth: number;
-        lineWidth: number;
-        zIndex: number;
-    };
-    // (undocumented)
-    render(ctx: CanvasRenderingContext2D, overlays: TLShapeIndicatorOverlay[]): void;
-    // (undocumented)
-    static type: string;
-}
-
 // @public (undocumented)
 export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     constructor(editor: Editor);
@@ -4628,15 +4610,6 @@ export interface TLSessionStateSnapshot {
 export type TLShapeErrorFallbackComponent = ComponentType<{
     error: any;
 }>;
-
-// @public (undocumented)
-export interface TLShapeIndicatorOverlay extends TLOverlay {
-    // (undocumented)
-    props: {
-        hintingShapeIds: TLShapeId[];
-        idsToDisplay: TLShapeId[];
-    };
-}
 
 // @public
 export interface TLShapeOperationPerfEvent {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -185,11 +185,7 @@ export {
 	type TLOverlay,
 	type TLOverlayUtilConstructor,
 } from './lib/editor/overlays/OverlayUtil'
-export {
-	ShapeIndicatorOverlayUtil,
-	strokeShapeIndicators,
-	type TLShapeIndicatorOverlay,
-} from './lib/editor/overlays/ShapeIndicatorOverlayUtil'
+export { strokeShapeIndicators } from './lib/editor/overlays/strokeShapeIndicators'
 export {
 	getPerfectDashProps,
 	type PerfectDashTerminal,

--- a/packages/editor/src/lib/editor/overlays/strokeShapeIndicators.ts
+++ b/packages/editor/src/lib/editor/overlays/strokeShapeIndicators.ts
@@ -1,0 +1,86 @@
+import { createComputedCache } from '@tldraw/store'
+import { TLShape, TLShapeId } from '@tldraw/tlschema'
+import type { Editor } from '../Editor'
+
+const indicatorPathCache = createComputedCache(
+	'shapeIndicatorPath',
+	(editor: Editor, shape: TLShape) => {
+		const util = editor.getShapeUtil(shape)
+		return util.getIndicatorPath(shape)
+	},
+	{
+		areRecordsEqual(a, b) {
+			return a.props === b.props
+		},
+	}
+)
+
+/**
+ * Combine every batchable shape indicator into a single page-space `Path2D` and
+ * emit one stroke call. Shapes whose indicator needs an evenodd clip (e.g.
+ * arrows with labels or complex arrowheads) can't be batched — they still
+ * stroke individually inside a save/restore with `ctx.clip` applied.
+ *
+ * Shared by any overlay util that paints shape indicators (e.g. collaborator
+ * selections).
+ *
+ * @public
+ */
+export function strokeShapeIndicators(
+	editor: Editor,
+	ctx: CanvasRenderingContext2D,
+	shapeIds: TLShapeId[]
+): void {
+	if (shapeIds.length === 0) return
+
+	const batched = new Path2D()
+
+	for (const shapeId of shapeIds) {
+		const shape = editor.getShape(shapeId)
+		if (!shape || shape.isLocked) continue
+
+		const pageTransform = editor.getShapePageTransform(shape)
+		if (!pageTransform) continue
+
+		const indicatorPath = indicatorPathCache.get(editor, shape.id)
+		if (!indicatorPath) continue
+
+		if (indicatorPath instanceof Path2D) {
+			batched.addPath(indicatorPath, pageTransform)
+			continue
+		}
+
+		const { path, clipPath, additionalPaths } = indicatorPath
+
+		if (!clipPath) {
+			batched.addPath(path, pageTransform)
+			if (additionalPaths) {
+				for (const p of additionalPaths) batched.addPath(p, pageTransform)
+			}
+			continue
+		}
+
+		// Clipped case: fall back to an individual stroke. Rare (arrows with
+		// labels / complex arrowheads), so the extra save/restore/stroke
+		// pair per such shape isn't worth batching away.
+		ctx.save()
+		ctx.transform(
+			pageTransform.a,
+			pageTransform.b,
+			pageTransform.c,
+			pageTransform.d,
+			pageTransform.e,
+			pageTransform.f
+		)
+		ctx.save()
+		ctx.clip(clipPath, 'evenodd')
+		ctx.stroke(path)
+		ctx.restore()
+		if (additionalPaths) {
+			for (const p of additionalPaths) ctx.stroke(p)
+		}
+		ctx.restore()
+	}
+
+	ctx.stroke(batched)
+}

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -64,7 +64,6 @@ import { Result } from '@tldraw/editor';
 import { RichTextFontVisitorState } from '@tldraw/editor';
 import { RotateCorner } from '@tldraw/editor';
 import { SerializedSchema } from '@tldraw/editor';
-import { ShapeIndicatorOverlayUtil } from '@tldraw/editor';
 import { ShapeUtil } from '@tldraw/editor';
 import { ShapeWithCrop } from '@tldraw/editor';
 import { SharedStyle } from '@tldraw/editor';
@@ -1373,7 +1372,7 @@ export function DefaultMinimap(): JSX.Element;
 export const DefaultNavigationPanel: NamedExoticComponent<object>;
 
 // @public (undocumented)
-export const defaultOverlayUtils: readonly [typeof CollaboratorShapeIndicatorOverlayUtil, typeof ShapeIndicatorOverlayUtil, typeof SelectionForegroundOverlayUtil, typeof ShapeHandleOverlayUtil, typeof BrushOverlayUtil, typeof ZoomBrushOverlayUtil, typeof SnapIndicatorOverlayUtil, typeof ScribbleOverlayUtil, typeof CollaboratorBrushOverlayUtil, typeof CollaboratorScribbleOverlayUtil, typeof CollaboratorHintOverlayUtil, typeof ArrowHintOverlayUtil, typeof ArrowBindingHintOverlayUtil, typeof CollaboratorCursorOverlayUtil];
+export const defaultOverlayUtils: readonly [typeof ArrowBindingHintOverlayUtil, typeof ArrowHintOverlayUtil, typeof BrushOverlayUtil, typeof CollaboratorBrushOverlayUtil, typeof CollaboratorCursorOverlayUtil, typeof CollaboratorHintOverlayUtil, typeof CollaboratorScribbleOverlayUtil, typeof CollaboratorShapeIndicatorOverlayUtil, typeof ScribbleOverlayUtil, typeof SelectionForegroundOverlayUtil, typeof ShapeHandleOverlayUtil, typeof ShapeIndicatorOverlayUtil, typeof SnapIndicatorOverlayUtil, typeof ZoomBrushOverlayUtil];
 
 // @public (undocumented)
 export const DefaultPageMenu: NamedExoticComponent<object>;
@@ -3454,6 +3453,24 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
     static type: string;
 }
 
+// @public
+export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverlay> {
+    // (undocumented)
+    getOverlays(): TLShapeIndicatorOverlay[];
+    // (undocumented)
+    isActive(): boolean;
+    // (undocumented)
+    options: {
+        hintedLineWidth: number;
+        lineWidth: number;
+        zIndex: number;
+    };
+    // (undocumented)
+    render(ctx: CanvasRenderingContext2D, overlays: TLShapeIndicatorOverlay[]): void;
+    // (undocumented)
+    static type: string;
+}
+
 // @public (undocumented)
 export interface ShapeOptionsWithDisplayValues<Shape extends TLShape, DisplayValues extends object> {
     // (undocumented)
@@ -4460,6 +4477,15 @@ export interface TLShapeHandleOverlay extends TLOverlay {
     props: {
         handle: TLHandle;
         shapeId: TLShapeId;
+    };
+}
+
+// @public (undocumented)
+export interface TLShapeIndicatorOverlay extends TLOverlay {
+    // (undocumented)
+    props: {
+        hintingShapeIds: TLShapeId_2[];
+        idsToDisplay: TLShapeId_2[];
     };
 }
 

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -97,6 +97,10 @@ export {
 	type TLShapeHandleOverlay,
 } from './lib/overlays/ShapeHandleOverlayUtil'
 export {
+	ShapeIndicatorOverlayUtil,
+	type TLShapeIndicatorOverlay,
+} from './lib/overlays/ShapeIndicatorOverlayUtil'
+export {
 	SelectionForegroundOverlayUtil,
 	type TLSelectionForegroundOverlay,
 } from './lib/overlays/SelectionForegroundOverlayUtil'

--- a/packages/tldraw/src/lib/defaultOverlayUtils.ts
+++ b/packages/tldraw/src/lib/defaultOverlayUtils.ts
@@ -1,4 +1,3 @@
-import { ShapeIndicatorOverlayUtil } from '@tldraw/editor'
 import { ArrowBindingHintOverlayUtil } from './overlays/ArrowBindingHintOverlayUtil'
 import { ArrowHintOverlayUtil } from './overlays/ArrowHintOverlayUtil'
 import { BrushOverlayUtil } from './overlays/BrushOverlayUtil'
@@ -10,23 +9,24 @@ import { CollaboratorShapeIndicatorOverlayUtil } from './overlays/CollaboratorSh
 import { ScribbleOverlayUtil } from './overlays/ScribbleOverlayUtil'
 import { SelectionForegroundOverlayUtil } from './overlays/SelectionForegroundOverlayUtil'
 import { ShapeHandleOverlayUtil } from './overlays/ShapeHandleOverlayUtil'
+import { ShapeIndicatorOverlayUtil } from './overlays/ShapeIndicatorOverlayUtil'
 import { SnapIndicatorOverlayUtil } from './overlays/SnapIndicatorOverlayUtil'
 import { ZoomBrushOverlayUtil } from './overlays/ZoomBrushOverlayUtil'
 
 /** @public */
 export const defaultOverlayUtils = [
+	ArrowBindingHintOverlayUtil,
+	ArrowHintOverlayUtil,
+	BrushOverlayUtil,
+	CollaboratorBrushOverlayUtil,
+	CollaboratorCursorOverlayUtil,
+	CollaboratorHintOverlayUtil,
+	CollaboratorScribbleOverlayUtil,
 	CollaboratorShapeIndicatorOverlayUtil,
-	ShapeIndicatorOverlayUtil,
+	ScribbleOverlayUtil,
 	SelectionForegroundOverlayUtil,
 	ShapeHandleOverlayUtil,
-	BrushOverlayUtil,
-	ZoomBrushOverlayUtil,
+	ShapeIndicatorOverlayUtil,
 	SnapIndicatorOverlayUtil,
-	ScribbleOverlayUtil,
-	CollaboratorBrushOverlayUtil,
-	CollaboratorScribbleOverlayUtil,
-	CollaboratorHintOverlayUtil,
-	ArrowHintOverlayUtil,
-	ArrowBindingHintOverlayUtil,
-	CollaboratorCursorOverlayUtil,
+	ZoomBrushOverlayUtil,
 ] as const

--- a/packages/tldraw/src/lib/overlays/ShapeIndicatorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ShapeIndicatorOverlayUtil.ts
@@ -1,14 +1,6 @@
+import { OverlayUtil, strokeShapeIndicators, TLOverlay } from '@tldraw/editor'
 import { computed } from '@tldraw/state'
-import { createComputedCache } from '@tldraw/store'
-import { TLShape, TLShapeId } from '@tldraw/tlschema'
-import type { Editor } from '../Editor'
-import { OverlayUtil, TLOverlay } from './OverlayUtil'
-
-interface RelevantInstanceFlags {
-	isChangingStyle: boolean
-	isHoveringCanvas: boolean | null
-	isCoarsePointer: boolean
-}
+import { TLShapeId } from '@tldraw/tlschema'
 
 /** @public */
 export interface TLShapeIndicatorOverlay extends TLOverlay {
@@ -18,87 +10,10 @@ export interface TLShapeIndicatorOverlay extends TLOverlay {
 	}
 }
 
-const indicatorPathCache = createComputedCache(
-	'shapeIndicatorPath',
-	(editor: Editor, shape: TLShape) => {
-		const util = editor.getShapeUtil(shape)
-		return util.getIndicatorPath(shape)
-	},
-	{
-		areRecordsEqual(a, b) {
-			return a.props === b.props
-		},
-	}
-)
-
-/**
- * Combine every batchable shape indicator into a single page-space `Path2D` and
- * emit one stroke call. Shapes whose indicator needs an evenodd clip (e.g.
- * arrows with labels or complex arrowheads) can't be batched — they still
- * stroke individually inside a save/restore with `ctx.clip` applied.
- *
- * Shared by {@link ShapeIndicatorOverlayUtil} and any overlay util that paints
- * shape indicators (e.g. collaborator selections).
- *
- * @public
- */
-export function strokeShapeIndicators(
-	editor: Editor,
-	ctx: CanvasRenderingContext2D,
-	shapeIds: TLShapeId[]
-): void {
-	if (shapeIds.length === 0) return
-
-	const batched = new Path2D()
-
-	for (const shapeId of shapeIds) {
-		const shape = editor.getShape(shapeId)
-		if (!shape || shape.isLocked) continue
-
-		const pageTransform = editor.getShapePageTransform(shape)
-		if (!pageTransform) continue
-
-		const indicatorPath = indicatorPathCache.get(editor, shape.id)
-		if (!indicatorPath) continue
-
-		if (indicatorPath instanceof Path2D) {
-			batched.addPath(indicatorPath, pageTransform)
-			continue
-		}
-
-		const { path, clipPath, additionalPaths } = indicatorPath
-
-		if (!clipPath) {
-			batched.addPath(path, pageTransform)
-			if (additionalPaths) {
-				for (const p of additionalPaths) batched.addPath(p, pageTransform)
-			}
-			continue
-		}
-
-		// Clipped case: fall back to an individual stroke. Rare (arrows with
-		// labels / complex arrowheads), so the extra save/restore/stroke
-		// pair per such shape isn't worth batching away.
-		ctx.save()
-		ctx.transform(
-			pageTransform.a,
-			pageTransform.b,
-			pageTransform.c,
-			pageTransform.d,
-			pageTransform.e,
-			pageTransform.f
-		)
-		ctx.save()
-		ctx.clip(clipPath, 'evenodd')
-		ctx.stroke(path)
-		ctx.restore()
-		if (additionalPaths) {
-			for (const p of additionalPaths) ctx.stroke(p)
-		}
-		ctx.restore()
-	}
-
-	ctx.stroke(batched)
+interface RelevantInstanceFlags {
+	isChangingStyle: boolean
+	isHoveringCanvas: boolean | null
+	isCoarsePointer: boolean
 }
 
 /**


### PR DESCRIPTION
👩: this also has the nice effect of removing a hardcoded reference to the select tool from `editor` and moving it up into `tldraw`

---

In order to keep `@tldraw/editor` free of concrete default overlay utils, this PR moves `ShapeIndicatorOverlayUtil` (and its `TLShapeIndicatorOverlay` type) out of the editor package and into `tldraw`, where every other built-in overlay util already lives (`BrushOverlayUtil`, `ScribbleOverlayUtil`, `ShapeHandleOverlayUtil`, and the rest). `ShapeIndicatorOverlayUtil` was the lone concrete overlay util still defined in the editor package; after this change `defaultOverlayUtils` is assembled entirely from tldraw-local utils, and the editor package keeps only the abstractions: the `OverlayUtil` base class and the `strokeShapeIndicators` helper.

The `strokeShapeIndicators` helper stays in `@tldraw/editor` — it depends only on `ShapeUtil.getIndicatorPath` and is shared by other indicator overlays (e.g. `CollaboratorShapeIndicatorOverlayUtil`). It's been extracted into its own `strokeShapeIndicators.ts` module so the moved class can import it from the editor.

For consumers importing from `'tldraw'`, nothing changes — `ShapeIndicatorOverlayUtil` and `TLShapeIndicatorOverlay` are still exported from there. Only code importing those two symbols directly from `'@tldraw/editor'` needs to update its import path.

The `defaultOverlayUtils` array is also reordered alphabetically. This is cosmetic: registration order only breaks ties between utils with equal `zIndex`, and every overlay util has a distinct `zIndex`, so paint and hit-test order are unchanged.

This PR also tidies the `indicators-logic` example: the four geo shapes are given a clearer layout (an ellipse and a text shape are added), the two bottom-left shapes are grouped on mount to show indicators on a group, and the README explains what shape indicators are.

### Change type

- [x] `api`

### Test plan

1. Open the `indicators-logic` example; confirm indicators are drawn around every shape, including the grouped pair in the bottom left and the group itself.
2. In any default tldraw editor, confirm selection and hover indicators still render and hit-test correctly (selection, brushing, handles).
3. Confirm `import { ShapeIndicatorOverlayUtil, TLShapeIndicatorOverlay } from 'tldraw'` resolves.

- [x] Unit tests

### Release notes

- Move `ShapeIndicatorOverlayUtil` and `TLShapeIndicatorOverlay` from `@tldraw/editor` to `tldraw`. They remain exported from `tldraw`; update any direct `@tldraw/editor` imports of these two symbols.

### API changes

`@tldraw/editor`:

- Breaking! Removed `ShapeIndicatorOverlayUtil` (moved to `tldraw`).
- Breaking! Removed `TLShapeIndicatorOverlay` (moved to `tldraw`).
- `strokeShapeIndicators` is unchanged and still exported (now from its own module).

`tldraw`:

- Added `ShapeIndicatorOverlayUtil` (moved from `@tldraw/editor`).
- Added `TLShapeIndicatorOverlay` (moved from `@tldraw/editor`).
- `defaultOverlayUtils` now references the tldraw-local `ShapeIndicatorOverlayUtil`; its entries are reordered alphabetically (behavior-preserving, since all z-indices are distinct).

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +108 / -107 |
| Automated files | +28 / -29  |
| Documentation   | +19 / -6   |
