### PR TITLE
fix(dotcom): tighten mermaid detection for common words

### DIFF
--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
@@ -1,7 +1,7 @@
 import { simpleMermaidStringTest, stripMarkdownMermaidFence } from './simpleMermaidStringTest'
 
 describe('simpleMermaidStringTest', () => {
-	describe('bare keywords', () => {
+	describe('diagram keywords with content', () => {
 		const keywords = [
 			['flowchart', 'flowchart TD\n  A --> B'],
 			['graph', 'graph LR\n  A --> B'],
@@ -18,19 +18,19 @@ describe('simpleMermaidStringTest', () => {
 			['sankey', 'sankey-beta'],
 			['xychart', 'xychart-beta'],
 			['block', 'block-beta'],
-			['quadrantChart', 'quadrantChart'],
+			['quadrantChart', 'quadrantChart\n  title Reach vs Engagement'],
 			['requirement', 'requirement test_req'],
 			['C4Context', 'C4Context\n  Person(user, "User")'],
-			['C4Container', 'C4Container'],
-			['C4Component', 'C4Component'],
-			['C4Dynamic', 'C4Dynamic'],
-			['C4Deployment', 'C4Deployment'],
+			['C4Container', 'C4Container\n  Container(web, "Web")'],
+			['C4Component', 'C4Component\n  Component(c, "Component")'],
+			['C4Dynamic', 'C4Dynamic\n  rel(a, b, "uses")'],
+			['C4Deployment', 'C4Deployment\n  Node(n, "Node")'],
 			['packet', 'packet-beta'],
-			['kanban', 'kanban'],
+			['kanban', 'kanban\n  todo[Todo]'],
 			['architecture', 'architecture-beta'],
 			['treemap', 'treemap-beta'],
 			['radar', 'radar-beta'],
-			['info', 'info'],
+			['info', 'info showInfo'],
 		] as const
 
 		for (const [keyword, input] of keywords) {
@@ -109,6 +109,13 @@ describe('simpleMermaidStringTest', () => {
 			].join('\n')
 			expect(simpleMermaidStringTest(text)).toBe(true)
 		})
+
+		it('detects a bare keyword inside an explicit mermaid fence', () => {
+			// Inside a ```mermaid fence the user has declared intent, so a bare
+			// keyword that would otherwise be rejected is still treated as mermaid.
+			expect(simpleMermaidStringTest('```mermaid\ntimeline\n```')).toBe(true)
+			expect(simpleMermaidStringTest('```mermaid\nkanban\n```')).toBe(true)
+		})
 	})
 
 	describe('negative cases', () => {
@@ -145,6 +152,45 @@ describe('simpleMermaidStringTest', () => {
 		it('rejects a fence label that is not lowercase mermaid', () => {
 			const text = '```MERMAID\npie\n  "A" : 1\n```'
 			expect(simpleMermaidStringTest(text)).toBe(false)
+		})
+
+		it('rejects a bare keyword that is also a common word', () => {
+			for (const word of [
+				'timeline',
+				'graph',
+				'pie',
+				'block',
+				'info',
+				'kanban',
+				'journey',
+				'requirement',
+				'mindmap',
+			]) {
+				expect(simpleMermaidStringTest(word)).toBe(false)
+			}
+		})
+
+		it('rejects a bare keyword with trailing whitespace', () => {
+			expect(simpleMermaidStringTest('  timeline  ')).toBe(false)
+			expect(simpleMermaidStringTest('graph\n')).toBe(false)
+		})
+
+		it('rejects hyphenated words that start with a keyword', () => {
+			for (const word of [
+				'kanban-board',
+				'gantt-chart',
+				'timeline-view',
+				'graph-paper',
+				'block-party',
+			]) {
+				expect(simpleMermaidStringTest(word)).toBe(false)
+			}
+		})
+
+		it('rejects words that merely start with a keyword', () => {
+			expect(simpleMermaidStringTest('information about the project')).toBe(false)
+			expect(simpleMermaidStringTest('graphql query')).toBe(false)
+			expect(simpleMermaidStringTest('pier review')).toBe(false)
 		})
 	})
 })

--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
@@ -12,8 +12,16 @@
  * pulling in the heavy mermaid library.
  */
 const FRONTMATTER_REGEX = /^-{3}\s*[\n\r]([\s\S]*?)[\n\r]-{3}\s*[\n\r]+/
+
+/**
+ * A diagram keyword at the start of the text, optionally followed by a known
+ * variant suffix (`-beta`, `-v2`). The trailing `(?![\w-])` is a word boundary
+ * that rejects keywords glued to more text: "kanban-board", "gantt-chart" and
+ * "information" do not match, while "sankey-beta" and "graph LR" do. Group 1 is
+ * the keyword, group 2 the variant suffix (if any).
+ */
 const DIAGRAM_KEYWORD_REGEX =
-	/^\s*(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|gitGraph|mindmap|timeline|sankey|xychart|block|quadrantChart|requirement|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|packet|kanban|architecture|treemap|radar|info)/
+	/^\s*(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|gitGraph|mindmap|timeline|sankey|xychart|block|quadrantChart|requirement|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|packet|kanban|architecture|treemap|radar|info)(-beta|-v\d+)?(?![\w-])/
 
 /**
  * Leading ```mermaid (or longer run) fence, closed by the first line that ends
@@ -42,5 +50,19 @@ export function stripMarkdownMermaidFence(text: string): string {
 }
 
 export function simpleMermaidStringTest(text: string): boolean {
-	return DIAGRAM_KEYWORD_REGEX.test(stripMermaidBoilerplate(stripMarkdownMermaidFence(text)))
+	const unfenced = stripMarkdownMermaidFence(text)
+	const cleaned = stripMermaidBoilerplate(unfenced).trim()
+	const match = cleaned.match(DIAGRAM_KEYWORD_REGEX)
+	if (!match) return false
+
+	// Inside an explicit ```mermaid fence the user has declared their intent, so a
+	// bare keyword is enough. Otherwise we require some evidence of an actual
+	// diagram beyond the keyword itself: either a recognized variant suffix
+	// (e.g. "sankey-beta") or additional content after the keyword. This stops
+	// common words like "timeline" or "info" from being treated as diagrams.
+	if (unfenced !== text) return true
+
+	const hasVariantSuffix = !!match[2]
+	const remainder = cleaned.slice(match[0].length).trim()
+	return hasVariantSuffix || remainder.length > 0
 }


### PR DESCRIPTION
In order to stop common English words from being rendered as broken mermaid diagrams on tldraw.com, this PR tightens the mermaid detection heuristic in `simpleMermaidStringTest`. Pasting words like "timeline", "kanban-board", or "info" previously matched a mermaid diagram keyword as a bare prefix and was sent to the mermaid renderer instead of being inserted as a plain text shape (#8481).

The detection regex matched diagram keywords with no word boundary and no structural validation, so:

1. **No word boundary** — "kanban-board" matched because "kanban" is a prefix.
2. **No structural validation** — a single word like "timeline" matched even though a real diagram has content after the keyword.

This PR addresses both:

- Adds a trailing `(?![\w-])` word-boundary lookahead so keywords glued to more text no longer match: "kanban-board", "gantt-chart", "information", "graphql".
- Requires evidence of an actual diagram beyond the bare keyword — either a recognized variant suffix (e.g. `sankey-beta`, `stateDiagram-v2`) or additional diagram content after the keyword.
- Keeps explicit ` ```mermaid ` fences permissive: a bare keyword inside a fence the user has labelled as mermaid is still detected, since intent is clear.

### Change type

- [x] `bugfix`

### Test plan

1. Go to tldraw.com.
2. Copy the word "timeline" (or "kanban-board", "info") and paste it onto the canvas — it should appear as a plain text shape, not a diagram.
3. Paste a real diagram (e.g. `timeline\n  title History` or a ` ```mermaid ` fenced diagram) — it should still render as a mermaid diagram.

- [x] Unit tests

### Release notes

- Fix mermaid detection on tldraw.com so common words like "timeline", "kanban-board", and "info" paste as plain text instead of being rendered as broken diagrams.
