### PR TITLE
fix(tldraw): correct fill dropdown trigger tooltip

### DIFF
--- a/apps/examples/e2e/fixtures/menus/StylePanel.ts
+++ b/apps/examples/e2e/fixtures/menus/StylePanel.ts
@@ -4,6 +4,7 @@ export class StylePanel {
 	readonly stylesArray: string[]
 	readonly colors: { [key: string]: Locator }
 	readonly fill: { [key: string]: Locator }
+	readonly fillExtra: Locator
 	readonly dash: { [key: string]: Locator }
 	readonly size: { [key: string]: Locator }
 	readonly font: { [key: string]: Locator }
@@ -39,6 +40,7 @@ export class StylePanel {
 			semi: this.page.getByTestId('style.fill.semi'),
 			solid: this.page.getByTestId('style.fill.solid'),
 		}
+		this.fillExtra = this.page.getByTestId('style.fill-extra')
 		this.dash = {
 			draw: this.page.getByTestId('style.dash.draw'),
 			dashed: this.page.getByTestId('style.dash.dashed'),

--- a/apps/examples/e2e/tests/test-style-panel.spec.ts
+++ b/apps/examples/e2e/tests/test-style-panel.spec.ts
@@ -31,6 +31,23 @@ test.describe('Style selection behaviour', () => {
 		await stylePanel.isActive(blue)
 	})
 
+	test('the fill dropdown trigger tooltip describes the dropdown, not the current fill', async ({
+		isMobile,
+		stylePanel,
+		toolbar,
+	}) => {
+		const { solid } = stylePanel.fill
+		if (isMobile) {
+			await toolbar.mobileStylesButton.click()
+		}
+
+		// when the current fill lives outside the dropdown (the default "none", or "solid"),
+		// the trigger tooltip should just name the style, not a value the dropdown can't show
+		await expect(stylePanel.fillExtra).toHaveAttribute('aria-label', 'Fill')
+		await solid.click()
+		await expect(stylePanel.fillExtra).toHaveAttribute('aria-label', 'Fill')
+	})
+
 	test('selecting a style changes the style of the shapes', async ({
 		page,
 		stylePanel,

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -73,10 +73,17 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 
 	const stylePanelName = msg(`style-panel.${stylePanelType}` as TLUiTranslationKey)
 
+	// The current value isn't always present in this dropdown's items (for example the fill
+	// dropdown only holds the "extra" fills, so a "solid" selection lives elsewhere). When the
+	// selected value isn't one of these items, describe what the dropdown opens rather than a
+	// value it can't show.
+	const valueInItems = value.type !== 'mixed' && items.some((item) => item.value === value.value)
 	const titleStr =
 		value.type === 'mixed'
 			? msg('style-panel.mixed')
-			: stylePanelName + ' — ' + msg(`${uiType}-style.${value.value}` as TLUiTranslationKey)
+			: valueInItems
+				? stylePanelName + ' — ' + msg(`${uiType}-style.${value.value}` as TLUiTranslationKey)
+				: stylePanelName
 	const labelStr = label ? msg(label) : ''
 
 	const popoverId = `style panel ${id}`


### PR DESCRIPTION
In order to stop the fill dropdown trigger from showing a misleading tooltip, this PR makes the trigger describe what the dropdown opens instead of the currently selected value. Closes #8955.

The fill style panel shows the main fills (`none`, `semi`, `solid`) as buttons and the extra fills (`pattern`, `lined fill`, `fill`) behind a dropdown trigger. The trigger's tooltip was always built from the current selection, so hovering it with a main fill selected showed something like "Fill — Solid" — a value that isn't even in that dropdown.

Now the tooltip only names the selected value when that value is actually one of the dropdown's items; otherwise it just shows the style name ("Fill"). This mirrors the existing icon logic, which already falls back to the first item when the current value isn't in the dropdown. Standalone dropdown pickers (geo, spline, arrowhead kind) always hold the current value, so their tooltips are unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape with a fill (or set the fill to `none`, `semi`, or `solid`).
2. Hover the fill dropdown trigger (the last item in the fill row).
3. The tooltip reads "Fill", not the name of the currently selected fill.
4. Open the dropdown and select an extra fill (e.g. pattern); the trigger tooltip then reads "Fill — Pattern".

- [x] End to end tests

### Release notes

- Fix the fill style dropdown trigger showing a misleading tooltip for the currently selected fill.
