### PR TITLE
feat(dotcom): add pink to the color palette

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -737,6 +737,12 @@
       "value": "Check your email for a verification code."
     }
   ],
+  "8dc5344bc0": [
+    {
+      "type": 0,
+      "value": "Pink"
+    }
+  ],
   "8eb2c00e96": [
     {
       "type": 0,

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -329,6 +329,9 @@
   "8c2d3d730c": {
     "translation": "Check your email for a verification code."
   },
+  "8dc5344bc0": {
+    "translation": "Pink"
+  },
   "8eb2c00e96": {
     "translation": "Shared with you"
   },

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -24,6 +24,7 @@ import {
 	ZErrorCode,
 	Z_PROTOCOL_VERSION,
 	ZeroContext,
+	createDotcomTLSchema,
 	createMutators,
 	parseFlags,
 	queries,
@@ -57,7 +58,6 @@ import {
 	atom,
 	computed,
 	createTLCurrentUser,
-	createTLSchema,
 	dataUrlToFile,
 	defaultUserPreferences,
 	getUserPreferences,
@@ -1087,7 +1087,7 @@ export class TldrawApp {
 	) {
 		const json = await file.text()
 		const parseFileResult = parseTldrawJsonFile({
-			schema: createTLSchema(),
+			schema: createDotcomTLSchema(),
 			json,
 		})
 

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -43,6 +43,7 @@ import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
+import { themes } from '../../utils/themes'
 import { TlaAnonDotDevLink } from '../TlaAnonDotDevLink/TlaAnonDotDevLink'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
@@ -223,6 +224,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		}, [fileSlug, hasUser, getUserToken]),
 		assets,
 		users,
+		themes,
 		onCustomMessageReceived: useCallback((message: TLCustomServerEvent) => {
 			trackEvent(message.type)
 		}, []),
@@ -283,6 +285,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				className="tla-editor"
 				licenseKey={getLicenseKey()}
 				store={store}
+				themes={themes}
 				assetUrls={assetUrls}
 				user={app?.tlUser}
 				onMount={handleMount}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/editor-messages.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/editor-messages.ts
@@ -6,4 +6,5 @@ export const editorMessages = defineMessages({
 	downloadFile: { defaultMessage: 'Download' },
 	copyToMyfiles: { defaultMessage: 'Copy to my files' },
 	anonymousUser: { defaultMessage: 'Guest user' },
+	pinkColor: { defaultMessage: 'Pink' },
 })

--- a/apps/dotcom/client/src/tla/components/TlaEditor/useFileEditorOverrides.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/useFileEditorOverrides.ts
@@ -56,6 +56,7 @@ export function useFileEditorOverrides({ fileSlug }: { fileSlug?: string }) {
 			translations: {
 				en: {
 					'people-menu.anonymous-user': intl.formatMessage(messages.anonymousUser),
+					'color-style.pink': intl.formatMessage(messages.pinkColor),
 				},
 			},
 			actions(editor, actions) {

--- a/apps/dotcom/client/src/tla/utils/importFromUrl.ts
+++ b/apps/dotcom/client/src/tla/utils/importFromUrl.ts
@@ -1,4 +1,5 @@
-import { createTLSchema, fetch, parseTldrawJsonFile } from 'tldraw'
+import { createDotcomTLSchema } from '@tldraw/dotcom-shared'
+import { fetch, parseTldrawJsonFile } from 'tldraw'
 import type { TldrawApp } from '../app/TldrawApp'
 
 export async function importFromUrl(
@@ -15,7 +16,7 @@ export async function importFromUrl(
 		const json = await res.text()
 		const parseResult = parseTldrawJsonFile({
 			json,
-			schema: createTLSchema(),
+			schema: createDotcomTLSchema(),
 		})
 		if (!parseResult.ok) {
 			return { ok: false, error: 'URL did not point to a valid tldraw file' }

--- a/apps/dotcom/client/src/tla/utils/themes.ts
+++ b/apps/dotcom/client/src/tla/utils/themes.ts
@@ -1,0 +1,16 @@
+import { PINK_DARK, PINK_LIGHT } from '@tldraw/dotcom-shared'
+import { DEFAULT_THEME, TLTheme, TLThemes } from 'tldraw'
+
+// The full theme used by the dotcom editor: the default palette plus the custom
+// "pink" color. We spread DEFAULT_THEME so every built-in color stays present —
+// passing themes to `useSync` runs `registerColorsFromThemes`, which removes any
+// color that isn't in the theme it's given.
+export const themes: Partial<TLThemes> = {
+	default: {
+		...DEFAULT_THEME,
+		colors: {
+			light: { ...DEFAULT_THEME.colors.light, pink: PINK_LIGHT } as TLTheme['colors']['light'],
+			dark: { ...DEFAULT_THEME.colors.dark, pink: PINK_DARK } as TLTheme['colors']['dark'],
+		},
+	},
+}

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -16,6 +16,7 @@ import {
 	SNAPSHOT_PREFIX,
 	TLCustomServerEvent,
 	TlaFile,
+	createDotcomTLSchema,
 	type RoomOpenMode,
 } from '@tldraw/dotcom-shared'
 import {
@@ -31,14 +32,7 @@ import {
 	type PersistedRoomSnapshotForSupabase,
 	type SessionStateSnapshot,
 } from '@tldraw/sync-core'
-import {
-	TLAsset,
-	TLAssetId,
-	TLDOCUMENT_ID,
-	TLDocument,
-	TLRecord,
-	createTLSchema,
-} from '@tldraw/tlschema'
+import { TLAsset, TLAssetId, TLDOCUMENT_ID, TLDocument, TLRecord } from '@tldraw/tlschema'
 import {
 	ExecutionQueue,
 	assert,
@@ -162,7 +156,7 @@ export class TLFileDurableObject extends DurableObject {
 						this.triggerPersist()
 					})
 					storage.transaction((txn) => {
-						createTLSchema().migrateStorage(txn)
+						createDotcomTLSchema().migrateStorage(txn)
 					})
 					return storage
 				})
@@ -187,6 +181,7 @@ export class TLFileDurableObject extends DurableObject {
 			this._room = this.getStorage().then(async (storage) => {
 				const room = new TLSocketRoom<TLRecord, SessionMeta>({
 					storage,
+					schema: createDotcomTLSchema(),
 					clientTimeout: Infinity,
 					onSessionSnapshot: (sessionId, snapshot) => {
 						const ws = this.sessionIdToWs.get(sessionId)
@@ -513,7 +508,7 @@ export class TLFileDurableObject extends DurableObject {
 			await this.r2.rooms.put(roomKey, dataText)
 			const storage = await this.getStorage()
 			storage.transaction((txn) => {
-				loadSnapshotIntoStorage(txn, createTLSchema(), JSON.parse(dataText))
+				loadSnapshotIntoStorage(txn, createDotcomTLSchema(), JSON.parse(dataText))
 			})
 
 			this.maybeAssociateFileAssets()

--- a/apps/dotcom/sync-worker/src/routes/tla/createFiles.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/createFiles.ts
@@ -1,6 +1,5 @@
-import { CreateFilesRequestBody } from '@tldraw/dotcom-shared'
+import { CreateFilesRequestBody, createDotcomTLSchema } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { createTLSchema } from '@tldraw/tlschema'
 import { uniqueId } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../../r2'
@@ -30,7 +29,7 @@ export async function createFiles(request: IRequest, env: Environment): Promise<
 
 		// Create the new snapshot
 		const snapshot: RoomSnapshot = {
-			schema: createTLSchema().serialize(),
+			schema: createDotcomTLSchema().serialize(),
 			clock: 0,
 			documents: Object.values(snapshotResult.value).map((r) => ({
 				state: r,

--- a/apps/dotcom/sync-worker/src/utils/validateSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/utils/validateSnapshot.ts
@@ -1,5 +1,6 @@
+import { createDotcomTLSchema } from '@tldraw/dotcom-shared'
 import { SerializedSchema, SerializedStore } from '@tldraw/store'
-import { TLRecord, createTLSchema } from '@tldraw/tlschema'
+import { TLRecord } from '@tldraw/tlschema'
 import { Result, objectMapEntries } from '@tldraw/utils'
 
 interface SnapshotRequestBody {
@@ -7,7 +8,7 @@ interface SnapshotRequestBody {
 	snapshot: SerializedStore<TLRecord>
 }
 
-const schema = createTLSchema()
+const schema = createDotcomTLSchema()
 export function validateSnapshot(
 	body: SnapshotRequestBody
 ): Result<SerializedStore<TLRecord>, string> {

--- a/packages/dotcom-shared/src/customColors.ts
+++ b/packages/dotcom-shared/src/customColors.ts
@@ -1,0 +1,90 @@
+import {
+	DefaultColorStyle,
+	TLDefaultColor,
+	TLDefaultColorStyle,
+	TLThemes,
+	createTLSchema,
+	registerColorsFromThemes,
+} from '@tldraw/tlschema'
+
+// Teach TypeScript about the custom color name. This augmentation applies
+// wherever this module is part of the compilation (client and worker).
+declare module '@tldraw/tlschema' {
+	interface TLThemeDefaultColors {
+		pink: TLDefaultColor
+	}
+}
+
+// The custom color names dotcom adds on top of the built-in palette.
+const DOTCOM_CUSTOM_COLORS = ['pink'] as const satisfies TLDefaultColorStyle[]
+
+// Color values for the custom "pink" palette entry, in both light and dark
+// variants. These are only used for client-side rendering; the worker never
+// needs them, but they live here so client and worker share one source of truth
+// for the color name.
+export const PINK_LIGHT: TLDefaultColor = {
+	solid: '#e91e8c',
+	semi: '#fce4f2',
+	pattern: '#f06baf',
+	fill: '#e91e8c',
+	linedFill: '#fce4f2',
+	frameHeadingStroke: '#e91e8c',
+	frameHeadingFill: '#fce4f2',
+	frameStroke: '#e91e8c',
+	frameFill: '#fce4f2',
+	frameText: '#e91e8c',
+	noteFill: '#fce4f2',
+	noteText: '#e91e8c',
+	highlightSrgb: '#e91e8c',
+	highlightP3: '#e91e8c',
+}
+
+export const PINK_DARK: TLDefaultColor = {
+	solid: '#f06baf',
+	semi: '#3d1a2e',
+	pattern: '#e91e8c',
+	fill: '#f06baf',
+	linedFill: '#3d1a2e',
+	frameHeadingStroke: '#f06baf',
+	frameHeadingFill: '#3d1a2e',
+	frameStroke: '#f06baf',
+	frameFill: '#3d1a2e',
+	frameText: '#f06baf',
+	noteFill: '#3d1a2e',
+	noteText: '#f06baf',
+	highlightSrgb: '#f06baf',
+	highlightP3: '#f06baf',
+}
+
+/**
+ * Register dotcom's custom color names into the global color and label-color
+ * style enums, so the schema validators accept them. Uses
+ * `registerColorsFromThemes` (the only public API that covers the label-color
+ * enum too), feeding it a palette built from the currently-registered colors
+ * plus our custom ones — this adds the custom colors without removing the
+ * built-ins, and needs no real theme values, so it runs on the worker without
+ * pulling in the editor's theme defaults. Idempotent.
+ */
+export function registerDotcomColors() {
+	// registerColorsFromThemes only inspects which palette keys hold an object;
+	// the values are irrelevant to registration (the client supplies the real
+	// values for rendering). PINK_LIGHT is reused here purely as a stand-in.
+	const names = new Set<TLDefaultColorStyle>([
+		...(DefaultColorStyle.values as TLDefaultColorStyle[]),
+		...DOTCOM_CUSTOM_COLORS,
+	])
+	const palette = Object.fromEntries([...names].map((name) => [name, PINK_LIGHT]))
+	registerColorsFromThemes({
+		default: { colors: { light: palette, dark: palette } },
+	} as unknown as TLThemes)
+}
+
+/**
+ * Build a `TLSchema` with dotcom's custom colors registered. Use this anywhere
+ * dotcom would otherwise call `createTLSchema()` directly, so the schema's
+ * validators accept the custom colors on both the client and the sync worker.
+ */
+export function createDotcomTLSchema() {
+	registerDotcomColors()
+	return createTLSchema()
+}

--- a/packages/dotcom-shared/src/index.ts
+++ b/packages/dotcom-shared/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable tldraw/no-export-star */
 export * from './constants'
+export * from './customColors'
 export { default as getLicenseKey } from './license'
 export * from './mutators'
 export * from './OptimisticAppStore'


### PR DESCRIPTION
In order to add a custom "pink" color to tldraw.com, this PR registers the new color on both the client and the sync worker so that shapes using it pass validation everywhere. Relates to #9026.

Custom colors are added to a runtime style-prop enum, not a special record format — shapes store only the color *name* (`pink`), and the sync worker re-validates every incoming record against its own schema. The client already registers theme colors automatically when you pass `themes` to `useSync`/`<Tldraw>`, but the worker builds its schema independently, so a synced `pink` shape would otherwise be rejected with `INVALID_RECORD`. This PR registers the color on both sides through one shared module.

### Concepts

| Term | Where | Meaning |
| --- | --- | --- |
| `PINK_LIGHT` / `PINK_DARK` | `dotcom-shared` | The pink color values for the light/dark palettes (client rendering only) |
| `registerDotcomColors()` | `dotcom-shared` | Registers dotcom's custom color names into the global color and label-color enums |
| `createDotcomTLSchema()` | `dotcom-shared` | `createTLSchema()` with dotcom's custom colors registered first; used everywhere dotcom built a schema directly |
| `themes` | client | Full theme (defaults + pink), passed to `useSync` (registration + store schema) and `<Tldraw>` (rendering + palette) |

### Change type

- [x] `feature`

### Test plan

1. Open a file on tldraw.com.
2. Select the pink color and add a sticky note (and a geo shape).
3. Confirm the shapes render pink and there is no `sync error INVALID_RECORD` / page crash.
4. Reload the page and confirm the pink shapes persist.
5. Open the same file in a second tab/client and confirm the pink shapes sync.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Area | Net LOC |
| --- | --- |
| `packages/dotcom-shared` (shared color module + export) | +91 |
| `apps/dotcom/sync-worker` (register on server schemas + room) | +15 |
| `apps/dotcom/client` (themes, palette label, import schemas) | +30 |
| Generated locales | +9 |

### Release notes

- Add a pink color to the tldraw.com palette.
