### PR TITLE
refactor(dotcom): rename group admin role to member

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -699,6 +699,12 @@
       "value": "."
     }
   ],
+  "858ba4765e": [
+    {
+      "type": 0,
+      "value": "Member"
+    }
+  ],
   "85a082de1b": [
     {
       "type": 0,
@@ -1275,12 +1281,6 @@
     {
       "type": 0,
       "value": "Legal summary"
-    }
-  ],
-  "e3afed0047": [
-    {
-      "type": 0,
-      "value": "Admin"
     }
   ],
   "e404559826": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -314,6 +314,9 @@
   "815e116a2e": {
     "translation": "Have a bug, issue, or idea for tldraw? Let us know! Fill out this form and we will follow up over email if needed. You can also <discord>chat with us on Discord</discord> or <github>submit an issue on GitHub</github>."
   },
+  "858ba4765e": {
+    "translation": "Member"
+  },
   "85a082de1b": {
     "translation": "Please refresh the page to get the latest version of tldraw."
   },
@@ -548,9 +551,6 @@
   },
   "e2ae80a510": {
     "translation": "Legal summary"
-  },
-  "e3afed0047": {
-    "translation": "Admin"
   },
   "e404559826": {
     "translation": "Terms of service"

--- a/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
@@ -33,7 +33,7 @@ const messages = defineMessages({
 	copyInviteLink: { defaultMessage: 'Copy invite link' },
 	members: { defaultMessage: 'Members' },
 	owner: { defaultMessage: 'Owner' },
-	admin: { defaultMessage: 'Admin' },
+	member: { defaultMessage: 'Member' },
 	you: { defaultMessage: 'you' },
 	dangerZone: { defaultMessage: 'Danger zone' },
 	leaveGroup: { defaultMessage: 'Leave group…' },
@@ -62,7 +62,7 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 
 	const namePlaceholderMsg = useMsg(messages.namePlaceholder)
 	const ownerMsg = useMsg(messages.owner)
-	const adminMsg = useMsg(messages.admin)
+	const memberMsg = useMsg(messages.member)
 	const youMsg = useMsg(messages.you)
 
 	// Get group data
@@ -83,7 +83,7 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 	// Leaving is allowed for everyone except the last owner — a group invariant
 	// (it must always keep at least one owner), not a capability.
 	const canLeave = role !== 'owner' || ownersCount > 1
-	const roleLabels: Record<Role, string> = { owner: ownerMsg, admin: adminMsg }
+	const roleLabels: Record<Role, string> = { owner: ownerMsg, member: memberMsg }
 
 	const handleCopyInviteLink = async () => {
 		if (copiedInviteLink) return

--- a/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
@@ -119,7 +119,7 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 					userId: auth.userId,
 					userColor: user.color || '#000000',
 					userName: user.name,
-					role: 'admin',
+					role: 'member',
 					index,
 					createdAt: Date.now(),
 					updatedAt: Date.now(),

--- a/apps/dotcom/zero-cache/migrations/033_rename_group_admin_role_to_member.sql
+++ b/apps/dotcom/zero-cache/migrations/033_rename_group_admin_role_to_member.sql
@@ -1,0 +1,13 @@
+-- Rename the non-owner group role from 'admin' to 'member'.
+-- The 'admin' label was misleading: the role confers no admin-level
+-- capabilities, it's a standard group member.
+
+-- Drop the existing CHECK constraint. It was created as an inline column
+-- constraint in 023_groups.sql, so Postgres auto-named it "group_user_role_check".
+ALTER TABLE public."group_user" DROP CONSTRAINT IF EXISTS "group_user_role_check";
+
+-- Rewrite existing rows to the new role value.
+UPDATE public."group_user" SET "role" = 'member' WHERE "role" = 'admin';
+
+-- Re-add the CHECK constraint with the new allowed values.
+ALTER TABLE public."group_user" ADD CONSTRAINT "group_user_role_check" CHECK ("role" IN ('member', 'owner'));

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -73,7 +73,7 @@ function makeGroupUser(
 	return {
 		createdAt: 1,
 		updatedAt: 1,
-		role: 'admin',
+		role: 'member',
 		userName: 'Test',
 		userColor: '#000',
 		index: 'a1' as IndexKey,
@@ -386,7 +386,7 @@ describe('file mutations', () => {
 			file: [] as TlaFile[],
 			file_state: [] as TlaFileState[],
 			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'admin' })],
+			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [] as TlaGroupFile[],
 		}
 	}
@@ -651,14 +651,14 @@ describe('group mutations', () => {
 		await expectValid(() => m.updateGroup(tx, { id: groupId, name: 'Renamed' }))
 	})
 
-	it('admin cannot update group name', async () => {
+	it('member cannot update group name', async () => {
 		const groupId = 'group_aaa11112222bbb'
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'admin' })],
+			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
 		}
 		const { tx } = createMockTx(s)
@@ -692,7 +692,7 @@ describe('group mutations', () => {
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'admin' })],
+			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
 		}
 		const { tx } = createMockTx(s)
@@ -714,7 +714,7 @@ describe('membership', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [
 				makeGroupUser({ userId, groupId, role: 'owner' }),
-				makeGroupUser({ userId: memberId, groupId, role: 'admin' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
 		}
@@ -724,15 +724,15 @@ describe('membership', () => {
 		expect(s.group_user.find((gu) => gu.userId === memberId)?.role).toBe('owner')
 	})
 
-	it('admin cannot set member roles', async () => {
+	it('member cannot set member roles', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
 			group_user: [
-				makeGroupUser({ userId, groupId, role: 'admin' }),
-				makeGroupUser({ userId: memberId, groupId, role: 'admin' }),
+				makeGroupUser({ userId, groupId, role: 'member' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
 		}
@@ -743,7 +743,7 @@ describe('membership', () => {
 		)
 	})
 
-	it('cannot demote last owner to admin', async () => {
+	it('cannot demote last owner to member', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
@@ -751,14 +751,14 @@ describe('membership', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [
 				makeGroupUser({ userId, groupId, role: 'owner' }),
-				makeGroupUser({ userId: memberId, groupId, role: 'admin' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
-			m.setGroupMemberRole(tx, { groupId, targetUserId: userId, role: 'admin' })
+			m.setGroupMemberRole(tx, { groupId, targetUserId: userId, role: 'member' })
 		)
 	})
 
@@ -784,7 +784,7 @@ describe('membership', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [
 				makeGroupUser({ userId: 'user_owner12345678ab', groupId, role: 'owner' }),
-				makeGroupUser({ userId, groupId, role: 'admin' }),
+				makeGroupUser({ userId, groupId, role: 'member' }),
 			],
 			group_file: [],
 		}
@@ -847,13 +847,13 @@ describe('file operations across groups', () => {
 		await expectForbidden(() => m.moveFileToGroup(tx, { fileId, groupId: groupB }))
 	})
 
-	it('admin can remove file from group', async () => {
+	it('member can remove file from group', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [makeFile({ id: fileId, owningGroupId: groupA })],
 			file_state: [makeFileState({ userId, fileId })],
 			group: [makeGroup({ id: groupA })],
-			group_user: [makeGroupUser({ userId, groupId: groupA, role: 'admin' })],
+			group_user: [makeGroupUser({ userId, groupId: groupA, role: 'member' })],
 			group_file: [makeGroupFile({ fileId, groupId: groupA })],
 		}
 		const { tx } = createMockTx(s)
@@ -959,13 +959,13 @@ describe('regenerateGroupInviteSecret', () => {
 	const userId = 'user_aaaa11112222bbbb'
 	const groupId = 'group_aaa11112222bbb'
 
-	it('admin can regenerate invite secret', async () => {
+	it('member can regenerate invite secret', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId, inviteSecret: 'old_secret_1234567' })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'admin' })],
+			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
@@ -976,18 +976,18 @@ describe('regenerateGroupInviteSecret', () => {
 	})
 
 	it('non-member cannot regenerate invite secret', async () => {
-		const nonAdminId = 'user_nonadmin1234567'
+		const nonMemberId = 'user_nonmember123456'
 		const s = {
-			user: [makeUser({ id: nonAdminId, flags: 'groups_backend' })],
+			user: [makeUser({ id: nonMemberId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
-			// No group_user for nonAdminId — not a member at all
+			// No group_user for nonMemberId — not a member at all
 			group_user: [],
 			group_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
-		const m = createMutators(nonAdminId)
+		const m = createMutators(nonMemberId)
 		await expectForbidden(() => m.regenerateGroupInviteSecret(tx, { id: groupId }))
 	})
 })

--- a/packages/dotcom-shared/src/roles.test.ts
+++ b/packages/dotcom-shared/src/roles.test.ts
@@ -24,29 +24,29 @@ describe('can', () => {
 		}
 	})
 
-	it('grants admins the non-administrative capabilities only', () => {
-		const adminCapabilities = capabilities.filter((capability) => can('admin', capability))
-		expect(adminCapabilities).toEqual(['accessFiles', 'addFiles', 'removeFiles', 'manageInvites'])
+	it('grants members the non-administrative capabilities only', () => {
+		const memberCapabilities = capabilities.filter((capability) => can('member', capability))
+		expect(memberCapabilities).toEqual(['accessFiles', 'addFiles', 'removeFiles', 'manageInvites'])
 	})
 
-	it('denies admins the administrative capabilities', () => {
-		expect(can('admin', 'editGroup')).toBe(false)
-		expect(can('admin', 'editMembers')).toBe(false)
-		expect(can('admin', 'deleteGroup')).toBe(false)
+	it('denies members the administrative capabilities', () => {
+		expect(can('member', 'editGroup')).toBe(false)
+		expect(can('member', 'editMembers')).toBe(false)
+		expect(can('member', 'deleteGroup')).toBe(false)
 	})
 
-	it("admins' capabilities are a subset of owners'", () => {
+	it("members' capabilities are a subset of owners'", () => {
 		for (const capability of capabilities) {
-			if (can('admin', capability)) {
+			if (can('member', capability)) {
 				expect(can('owner', capability)).toBe(true)
 			}
 		}
 	})
 
 	it('denies unknown, empty, or missing roles every capability', () => {
-		// `member` is included deliberately: the rename from `admin` is still
-		// pending, so it is not yet a valid role.
-		const notRoles = [null, undefined, '', 'member', 'nope', 'OWNER', 'toString', '__proto__']
+		// `admin` is included deliberately: it was renamed to `member`, so it is no
+		// longer a valid role.
+		const notRoles = [null, undefined, '', 'admin', 'nope', 'OWNER', 'toString', '__proto__']
 		for (const role of notRoles) {
 			for (const capability of capabilities) {
 				expect(can(role, capability)).toBe(false)
@@ -58,11 +58,11 @@ describe('can', () => {
 describe('isRole', () => {
 	it('accepts known role strings', () => {
 		expect(isRole('owner')).toBe(true)
-		expect(isRole('admin')).toBe(true)
+		expect(isRole('member')).toBe(true)
 	})
 
 	it('rejects unknown, empty, or missing values', () => {
-		for (const value of [null, undefined, '', 'member', 'nope', 'toString', '__proto__']) {
+		for (const value of [null, undefined, '', 'admin', 'nope', 'toString', '__proto__']) {
 			expect(isRole(value)).toBe(false)
 		}
 	})

--- a/packages/dotcom-shared/src/roles.ts
+++ b/packages/dotcom-shared/src/roles.ts
@@ -9,22 +9,16 @@ import { Capability } from './capabilities'
  *
  * The role is stored in the DB as a plain string (`group_user.role`);
  * capabilities are never persisted — they're derived from that string here.
- *
- * NOTE: `'admin'` is in the process of being renamed to `'member'`. No
- * authorization logic branches on that name — the only role literals left in
- * logic are the last-owner invariant, which checks `'owner'` (not renamed). So
- * the rename is relabeling this key, the `acceptInvite` default, the display
- * labels, and a data migration of stored values.
  */
 
 /**
  * What each role can do — the single source of truth. The role name is the key,
  * and {@link Role} is derived from these keys. Today the only difference between
- * `admin` and `owner` is the three administrative capabilities at the end of the
+ * `member` and `owner` is the three administrative capabilities at the end of the
  * owner list.
  */
 const roles = {
-	admin: ['accessFiles', 'addFiles', 'removeFiles', 'manageInvites'],
+	member: ['accessFiles', 'addFiles', 'removeFiles', 'manageInvites'],
 	owner: [
 		'accessFiles',
 		'addFiles',


### PR DESCRIPTION
In order to make the group role label match what it actually represents, this PR renames the non-owner group role from `admin` to `member`. The role confers no admin-level capabilities — it's a standard group member — so the old "Admin" label was misleading. Closes #9014.

This builds on the capabilities abstraction from #9067: authorization asks `can(role, capability)` and never branches on the role name, so the rename is purely a relabel plus a data migration — no authorization logic changes.

What changes:

- **Role definition** (`roles.ts`) — the `admin` key in the `roles` capability table becomes `member`. `Role` is derived from these keys, so the `group_user.role` enum in `tlaSchema.ts` and every `Role`-typed call site update for free.
- **Sync worker** — accepting a group invite now assigns `role: 'member'`.
- **Client UI** — the members list and role dropdown show "Member" (the dropdown is data-driven from the role → label map, so only the label and the map key change).
- **Database** — migration `033` drops the `group_user` role check constraint, rewrites existing `admin` rows to `member`, then re-adds the constraint allowing `('member', 'owner')`.

Because the new check constraint rejects `'admin'`, the migration should run as part of the deploy that ships this change. In the `deploy-dotcom` flow migrations run before the sync worker is deployed, so existing rows are rewritten and the constraint swapped before any new code writes `'member'`. Groups is behind the `groups_backend` / `groups_frontend` flags and was added recently, so little data has accumulated.

### Change type

- [x] `improvement`

### Test plan

1. Open a group's settings dialog as the owner.
2. Confirm the members list shows "Member" (not "Admin") next to non-owner members.
3. Confirm the role dropdown offers "Owner" and "Member".
4. Change a member's role to Owner and back; confirm it persists.
5. Accept a group invite as a new user; confirm they join as a member.

- [x] Unit tests
- [ ] End to end tests

`roles.test.ts` covers the role → capability matrix and `isRole` under the new name; `mutators.test.ts` group tests run against `member` fixtures.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +2 / -8    |
| Tests           | +35 / -35  |
| Automated files | +9 / -9    |
| Apps            | +17 / -4   |
