### PR TITLE
improvement(dotcom): let owners demote themselves to admin

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
@@ -269,7 +269,7 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 										{member.userName}
 										{member.userId === app.getUser().id ? ` (${youMsg})` : ''}
 									</span>
-									{isOwner && member.userId !== app.getUser().id ? (
+									{isOwner && (member.userId !== app.getUser().id || ownersCount > 1) ? (
 										<MemberRoleSelect
 											value={member.role}
 											disabled={member.role === 'owner' && ownersCount <= 1}


### PR DESCRIPTION
Lets group owners demote themselves to admin from the group settings dialog, but only when the group has another owner. The role dropdown now appears on your own member row when `ownersCount > 1`; with a single owner you still see read-only role text.

The backend mutator `setGroupMemberRole` already permits self-targeting and blocks demoting the last owner, so this is a client-only change to surface the dropdown in the valid case.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a group with two owners.
2. Open group settings as one of the owners.
3. On your own row, change your role from Owner to Admin — succeeds.
4. With only one owner, confirm your own row shows read-only role text (no dropdown).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Group owners can now demote themselves to admin, as long as another owner remains.
