### PR TITLE
other(dotcom): disable zero-cache startup message in dev

### DIFF
--- a/apps/dotcom/zero-cache/.env
+++ b/apps/dotcom/zero-cache/.env
@@ -8,4 +8,5 @@ ZERO_MUTATE_URL="http://localhost:8787/app/zero/mutate"
 ZERO_QUERY_URL="http://localhost:8787/app/zero/query"
 ZERO_ENABLE_CRUD_MUTATIONS=false
 ZERO_LOG_LEVEL="info"
+ZERO_ENABLE_STARTUP_MESSAGE=0
 DO_NOT_TRACK=1


### PR DESCRIPTION
In order to stop the Zero Cloud promo banner from printing on every local zero-cache startup, this PR sets `ZERO_ENABLE_STARTUP_MESSAGE=0` in the dev `.env`, alongside the existing `DO_NOT_TRACK` opt-out.

### Change type

- [x] `other`

### Test plan

1. Run the zero-cache dev server (`yarn dev` in `apps/dotcom/zero-cache`).
2. Confirm the "Cloud Zero is now available" startup message no longer prints.
