### PR TITLE
chore: reduce /issue slop

### DIFF
--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -17,6 +17,22 @@ At the top of the issue, include the user's original description verbatim. Annot
 ---
 ```
 
+## Underspecified issues
+
+Many issues arrive as a one-liner, and the original text may be everything the creator has in their head. Your job is to add useful context, not to invent a specification they never gave. A wrong inference is worse than an open question: it sends an implementer with less context down the wrong path while reading like settled scope.
+
+Throughout investigation and research, keep two things separate:
+
+- **Codebase facts** — a file does X, this code path runs on Y. You confirm these by reading; state them plainly.
+- **Intent and scope** — what the creator wants, which behavior is correct, what the fix should be. This is inference; never present it as fact.
+
+Gate how far you expand on your confidence in the intent:
+
+- **High confidence (≥95%)** that the original text has one clear reading and the codebase confirms it: expand normally — describe the problem, root cause, and a concrete approach.
+- **Anything less:** do not commit to a single interpretation. Capture what's ambiguous as open questions and lay out the possible approaches with their tradeoffs, so the creator can come back and specify. Add the `More Info Needed` label.
+
+When in doubt, prefer questions over assumptions. This drives step 2 (assess specification), step 4 (open questions in the body), and step 9 (verified-vs-inferred research); format the body per `../write-issue/SKILL.md`.
+
 ## Workflow
 
 1. Gather context:
@@ -27,12 +43,13 @@ At the top of the issue, include the user's original description verbatim. Annot
    - Search for relevant files, functions, or patterns mentioned in the description.
    - Identify likely affected packages, apps, or examples.
    - Note obvious causes, related issues, or existing code paths.
+   - Assess how well-specified the issue is (see underspecified issues above). Note where the original text has more than one reasonable reading.
 3. For visual bugs, identify a reproduction target when possible:
    - Examples app: `localhost:5420` from `yarn dev`.
    - tldraw.com app: `localhost:3000` from `yarn dev-app`.
    - Docs site: `localhost:3001` from `yarn dev-docs`.
    - If screenshots are useful but not feasible locally, ask the user for screenshots and specific reproduction details.
-4. Write the issue title and body using `../write-issue/SKILL.md`.
+4. Write the issue title and body using `../write-issue/SKILL.md`. Keep the original text verbatim at the top. If the issue is underspecified, add a short `## Open questions` section to the body listing what the creator needs to clarify, and add the `More Info Needed` label.
 5. Create the issue:
 
 ```bash
@@ -44,10 +61,11 @@ gh issue create --repo tldraw/tldraw --title "..." --body "..."
    - `Improve developer resources` for examples, documentation, comments, starter kits, and `npm create tldraw`.
    - `Improve automations` for GitHub Actions, review bots, CI/CD, and automation work.
 8. Share the issue URL with the user immediately after creation.
-9. Do deeper research after creation:
-   - Identify relevant files and line numbers.
-   - Explain the root cause for bugs.
-   - Summarize architecture context and related code.
+9. Do deeper research after creation. Structure the findings so a reader can tell verified facts from inference:
+   - **What I found** (verified) — relevant files and line numbers, code paths, architecture context, related code, and the root cause for bugs you can confirm.
+   - **Interpretation** — how you are reading the original text, and exactly where it is ambiguous.
+   - **Possible approaches** — when the intent is clear (≥95%), one recommended approach. When it is not, two or three options with their tradeoffs, not a single confident pick.
+   - **Open questions** — what the creator should answer to unblock implementation (mirror or expand the body's open questions).
    - Note edge cases, testing needs, and likely implementation risks.
 10. Add the research as an issue comment:
 
@@ -58,5 +76,5 @@ gh issue comment <issue-number> --repo tldraw/tldraw --body "..."
 ## Rules
 
 - Always create the issue before doing deep research so the user can track it.
-- Follow `../write-issue/SKILL.md` for all issue content standards.
-- Do not include AI attribution in issue titles, bodies, comments, or metadata.
+- Never present inferred intent as fact — when unsure, capture open questions and alternative approaches instead of guessing.
+- Follow `../write-issue/SKILL.md` for all content standards, including issue types, labels, and AI attribution.

--- a/skills/take/SKILL.md
+++ b/skills/take/SKILL.md
@@ -42,7 +42,9 @@ Read the full issue and comments. Identify:
 - Technical notes and affected files.
 - Relevant discussion or clarifications.
 
-If the issue lacks detail, explore the codebase before deciding whether implementation is safe.
+Check whether the issue is underspecified: a `More Info Needed` label, an "Open questions" section, listed alternative approaches, or original text that does not pin down the intended behavior. See the underspecified-issues standard in `../write-issue/SKILL.md`.
+
+If it is underspecified, do not guess past the open questions. Explore the codebase to see whether the intent is in fact unambiguous. If it is not, surface the open questions to the user and confirm the intended behavior and approach before implementing — picking the wrong interpretation here is exactly the failure to avoid.
 
 ### 3. Assign the issue
 
@@ -103,7 +105,7 @@ End with:
 
 ## Rules
 
-- Ask the user when requirements are unclear.
+- Ask the user when requirements are unclear. Resolve an underspecified issue's open questions before implementing — do not guess past them.
 - Do not guess at unspecified product behavior.
 - Keep the implementation scoped to the issue.
 - Never include AI attribution in commits, issues, or PRs.

--- a/skills/write-issue/SKILL.md
+++ b/skills/write-issue/SKILL.md
@@ -90,6 +90,15 @@ Use sparingly (1-2 per issue) for metadata, not categorization.
 3. Suggested approach
 4. Which example category it belongs to
 
+### Underspecified issues
+
+When an issue is underspecified, keep the original text verbatim and add:
+
+- **Open questions** - a short list of what the creator must clarify before the issue is actionable.
+- **Possible approaches** - when more than one reasonable interpretation or path exists, list them with their tradeoffs instead of committing to one.
+
+Add the `More Info Needed` label. Judging whether an issue is underspecified is part of the `issue` workflow.
+
 ## Triage workflow
 
 ### New issues
@@ -111,3 +120,4 @@ Use sparingly (1-2 per issue) for metadata, not categorization.
 
 - Never include AI attribution unless the issue directly relates to AI tooling
 - Never use title case for descriptions - use sentence case
+- Never present inferred intent as fact — flag inferences as inferences


### PR DESCRIPTION
In order to stop the `issue` skill from filling underspecified one-liner issues with confident-but-wrong inferences, this PR adds a confidence gate to the issue-creation workflow. The original text is always preserved verbatim; the agent only expands an issue into a single problem statement and solution when it's ≥95% confident of the intent. Below that bar it captures open questions and lays out the possible approaches with their tradeoffs, so the original creator can come back and specify — rather than sending a downstream implementer with less context down the wrong path.

It also splits ownership cleanly between the paired skills, so the same guidance no longer lives in two places:

- `issue` (workflow) owns the *judgment* — when an issue is underspecified and how confident to be before expanding it — and structures its research comment so verified codebase facts are distinguishable from inferred intent.
- `write-issue` (standards) owns only the *body format* — the open-questions / possible-approaches sections and the `More Info Needed` label.
- `take` now detects an underspecified issue (the label, an open-questions section, vague text) and surfaces those questions to confirm intent before implementing, instead of guessing past them.

### Change type

- [x] `improvement`

### Test plan

These are agent skill instructions (markdown), so there is nothing to execute. Verified by reading:

- `issue` no longer commits to a single interpretation below the confidence bar; it records open questions plus approaches and adds `More Info Needed`.
- `take` pauses on an underspecified issue and confirms intent before implementing.
- No skill refers to itself; cross-references stay skill → other-skill, matching the existing `pr` / `write-pr` pattern.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +39 / -9   |
