### PR TITLE
build: make CommonJS builds safe against ESM-only deps, upgrade rbush to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,3 +98,8 @@ jobs:
         # the sed pipe makes sure that github annotations come through without
         # turbo's prefix
         run: "yarn build-package | sed -E 's/^.*? ::/::/'"
+
+      - name: Smoke test CJS output
+        # fail if a published dist-cjs build require()s an ESM-only dependency
+        # that isn't inlined (would throw ERR_REQUIRE_ESM for CJS consumers)
+        run: yarn check-cjs

--- a/internal/scripts/build-package.ts
+++ b/internal/scripts/build-package.ts
@@ -1,12 +1,23 @@
 import { copyFileSync, existsSync } from 'fs'
 import path from 'path'
 import { pathToFileURL } from 'url'
-import { build } from 'esbuild'
+import { build, type BuildOptions, type Plugin } from 'esbuild'
 import { glob } from 'glob'
 import kleur from 'kleur'
 import rimraf from 'rimraf'
 import { addJsExtensions } from './lib/add-extensions'
 import { readJsonIfExists } from './lib/file'
+
+/**
+ * Allowlist of ESM-only dependencies to inline into the CommonJS build output.
+ * We dual-publish CJS + ESM with `bundle: false`, so a dependency normally stays
+ * external as a `require("x")` in the CJS output. That breaks CJS consumers when
+ * `x` is ESM-only (`require` of an ES module throws on Node <20.19, and trips up
+ * Jest/ts-node). Bundling these deps into the CJS output keeps the CJS path
+ * working. The ESM build still leaves them external so ESM consumers resolve
+ * them natively and keep dedup/tree-shaking.
+ */
+const ESM_ONLY = new Set(['rbush', 'jittered-fractional-indexing', 'nanoevents'])
 
 interface LibraryInfo {
 	name: string
@@ -44,10 +55,16 @@ async function buildPackage({ sourcePackageDir }: { sourcePackageDir: string }) 
 	const packageVersion = packageJson.version
 	if (typeof packageVersion !== 'string') throw new Error('package.json version is not a string')
 
+	// allowlisted ESM-only deps that this package actually depends on. Only these
+	// get inlined into the CJS build; every other package keeps the plain
+	// `bundle: false` path with byte-for-byte identical output.
+	const inlineDeps = Object.keys(packageJson.dependencies ?? {}).filter((dep) => ESM_ONLY.has(dep))
+
 	// build CommonJS files to /dist-cjs
 	await buildLibrary({
 		sourceFiles,
 		sourcePackageDir,
+		inlineDeps,
 		info: {
 			name: packageName,
 			version: packageVersion,
@@ -59,6 +76,7 @@ async function buildPackage({ sourcePackageDir }: { sourcePackageDir: string }) 
 	await buildLibrary({
 		sourceFiles,
 		sourcePackageDir,
+		inlineDeps,
 		info: {
 			name: packageName,
 			version: packageVersion,
@@ -82,10 +100,12 @@ async function buildLibrary({
 	sourceFiles,
 	sourcePackageDir,
 	info,
+	inlineDeps,
 }: {
 	sourceFiles: string[]
 	sourcePackageDir: string
 	info: LibraryInfo
+	inlineDeps: string[]
 }) {
 	const dirName = `dist-${info.moduleSystem}`
 	const outdir = path.join(sourcePackageDir, dirName)
@@ -104,16 +124,29 @@ async function buildLibrary({
 	define['globalThis.TLDRAW_LIBRARY_MODULES'] = JSON.stringify(info.moduleSystem)
 	define['globalThis.TLDRAW_LIBRARY_IS_BUILD'] = JSON.stringify(true)
 
+	// Only the CJS build inlines allowlisted ESM-only deps, and only when this
+	// package actually depends on one. Every other build keeps the original
+	// `bundle: false` path so its output stays byte-for-byte identical.
+	const shouldInlineEsmDeps = info.moduleSystem === 'cjs' && inlineDeps.length > 0
+	const bundleOptions: BuildOptions = shouldInlineEsmDeps
+		? {
+				bundle: true,
+				plugins: [createCjsInlinePlugin(inlineDeps)],
+				// preserve the inlined deps' license notices in dist-cjs
+				legalComments: 'linked',
+			}
+		: { bundle: false }
+
 	const res = await build({
 		entryPoints: sourceFiles,
 		outdir,
 		format: info.moduleSystem,
 		outExtension: info.moduleSystem === 'esm' ? { '.js': '.mjs' } : undefined,
-		bundle: false,
 		platform: 'neutral',
 		sourcemap: true,
 		target: 'es2022',
 		define,
+		...bundleOptions,
 	})
 
 	if (info.moduleSystem === 'esm') {
@@ -124,6 +157,59 @@ async function buildLibrary({
 		console.error(kleur.red('Build failed with errors:'))
 		console.error(res.errors)
 		throw new Error('esm build failed')
+	}
+}
+
+/**
+ * Returns the package name for a bare import specifier, handling scoped names
+ * and subpath imports. e.g. `rbush` -> `rbush`, `rbush/foo` -> `rbush`,
+ * `@scope/name/sub` -> `@scope/name`.
+ */
+function getPackageName(specifier: string): string {
+	if (specifier.startsWith('@')) {
+		const [scope, name] = specifier.split('/')
+		return `${scope}/${name}`
+	}
+	return specifier.split('/')[0]
+}
+
+/**
+ * esbuild plugin for the bundled CJS pass. It inlines the allowlisted ESM-only
+ * deps (and their transitive deps) into the output while keeping our own
+ * per-file source mirror and all other deps external.
+ */
+function createCjsInlinePlugin(inlineDeps: string[]): Plugin {
+	const inlineSet = new Set(inlineDeps)
+	return {
+		name: 'tldraw-cjs-inline-esm-deps',
+		setup(pluginBuild) {
+			pluginBuild.onResolve({ filter: /.*/ }, (args) => {
+				// let esbuild resolve the entry points themselves.
+				if (args.kind === 'entry-point') return null
+
+				// we're inside an allowlisted dep's own subtree: bundle everything
+				// transitively. rbush v4 depends on quickselect, which is also
+				// ESM-only, so leaving it external would just move the bug down a
+				// level.
+				if (args.importer.includes('node_modules')) return null
+
+				// from here on the importer is our own source.
+
+				// keep relative imports external so we don't inline sibling source
+				// files into each entry point and collapse the per-file mirror.
+				if (args.path.startsWith('.')) {
+					return { path: args.path, external: true }
+				}
+
+				// bundle bare specifiers for allowlisted deps into the CJS output.
+				if (inlineSet.has(getPackageName(args.path))) {
+					return null
+				}
+
+				// every other bare specifier stays external.
+				return { path: args.path, external: true }
+			})
+		},
 	}
 }
 

--- a/internal/scripts/check-cjs.ts
+++ b/internal/scripts/check-cjs.ts
@@ -1,0 +1,197 @@
+import { execFile } from 'child_process'
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from 'fs'
+import { builtinModules } from 'module'
+import { tmpdir } from 'os'
+import path from 'path'
+import { glob } from 'glob'
+import { REPO_ROOT } from './lib/file'
+import { nicelog } from './lib/nicelog'
+
+/**
+ * Smoke test for the published CommonJS builds. tldraw dual-publishes CJS + ESM,
+ * and the package build keeps dependencies external as `require("x")` in the CJS
+ * output (see `build-package.ts`). When `x` is ESM-only, that `require(<esm>)`
+ * throws `ERR_REQUIRE_ESM` for CJS consumers on Node 20.0-20.18 (the repo floor
+ * is `^20.0.0`; `require(esm)` only landed in 20.19 / 22.12) and breaks Jest and
+ * ts-node.
+ *
+ * This script scans each package's `dist-cjs` build for the external deps it
+ * `require()`s and checks each one under strict CommonJS resolution
+ * (`node --no-experimental-require-module`, which reinstates the
+ * `ERR_REQUIRE_ESM` throw even on newer Node). It fails on any ESM-only dep that
+ * leaks into a CJS build. Fix a leak by inlining the dep (add it to `ESM_ONLY`
+ * in `build-package.ts`) or by loading it via a dynamic `import()`.
+ */
+
+// Error codes Node throws when CommonJS `require()`s an ES module.
+const ESM_REQUIRE_ERROR_CODES = new Set(['ERR_REQUIRE_ESM', 'ERR_REQUIRE_ASYNC_MODULE'])
+
+interface RequireCandidate {
+	packageName: string
+	packageDir: string
+	specifier: string
+	files: Set<string>
+}
+
+/** Package name for a bare specifier, handling scoped names and subpaths. */
+function getPackageName(specifier: string): string {
+	if (specifier.startsWith('@')) return specifier.split('/').slice(0, 2).join('/')
+	return specifier.split('/')[0]
+}
+
+/** Names of every workspace package, so we skip our own dual-built deps. */
+function getWorkspacePackageNames(): Set<string> {
+	const names = new Set<string>()
+	for (const dir of readdirSync(path.join(REPO_ROOT, 'packages'))) {
+		const manifest = path.join(REPO_ROOT, 'packages', dir, 'package.json')
+		if (!existsSync(manifest)) continue
+		const name = JSON.parse(readFileSync(manifest, 'utf8')).name
+		if (typeof name === 'string') names.add(name)
+	}
+	return names
+}
+
+/** Bare `require("x")` specifiers in a built CJS file (ignores `require.resolve`). */
+function extractRequireSpecifiers(code: string): Set<string> {
+	const specifiers = new Set<string>()
+	const re = /\brequire\(\s*["']([^"']+)["']\s*\)/g
+	let match
+	while ((match = re.exec(code))) specifiers.add(match[1])
+	return specifiers
+}
+
+/** Collect every external dep `require()`d from any package's `dist-cjs`. */
+function collectRequireCandidates(): Map<string, RequireCandidate> {
+	const workspaceNames = getWorkspacePackageNames()
+	const builtins = new Set(builtinModules)
+	const candidates = new Map<string, RequireCandidate>()
+
+	for (const distCjsDir of glob.sync('packages/*/dist-cjs', { cwd: REPO_ROOT, absolute: true })) {
+		const packageDir = path.dirname(distCjsDir)
+		const packageName = JSON.parse(readFileSync(path.join(packageDir, 'package.json'), 'utf8')).name
+
+		for (const file of glob.sync('**/*.js', { cwd: distCjsDir, absolute: true })) {
+			const code = readFileSync(file, 'utf8')
+			for (const specifier of extractRequireSpecifiers(code)) {
+				if (specifier.startsWith('.') || specifier.startsWith('node:')) continue
+				const name = getPackageName(specifier)
+				if (builtins.has(specifier) || builtins.has(name)) continue
+				if (workspaceNames.has(name)) continue
+
+				const key = `${packageName} ${specifier}`
+				let candidate = candidates.get(key)
+				if (!candidate) {
+					candidate = { packageName, packageDir, specifier, files: new Set() }
+					candidates.set(key, candidate)
+				}
+				candidate.files.add(path.relative(REPO_ROOT, file))
+			}
+		}
+	}
+
+	return candidates
+}
+
+/**
+ * Strict-`require()` each candidate in a child `node` process with
+ * `require(esm)` support disabled, returning the error code (if any) per id.
+ */
+async function strictRequire(
+	items: { id: number; base: string; specifier: string }[]
+): Promise<Map<number, string | null>> {
+	const codes = new Map<number, string | null>()
+	if (items.length === 0) return codes
+
+	const outDir = mkdtempSync(path.join(tmpdir(), 'check-cjs-'))
+	const outFile = path.join(outDir, 'result.json')
+
+	// runs as plain CommonJS (node -e defaults to CJS), so require(esm) throws.
+	const harness = `
+		const { createRequire } = require('module')
+		const { writeFileSync } = require('fs')
+		const items = JSON.parse(process.argv[1])
+		const outFile = process.argv[2]
+		const results = []
+		for (const item of items) {
+			let code = null
+			try {
+				createRequire(item.base)(item.specifier)
+			} catch (error) {
+				code = error && error.code ? error.code : 'ERROR'
+			}
+			results.push({ id: item.id, code })
+		}
+		writeFileSync(outFile, JSON.stringify(results))
+	`
+
+	// Node 20.19+ / 22.12+ allow require(esm) by default, so we disable it to get
+	// the faithful ERR_REQUIRE_ESM throw. Older Node throws anyway and doesn't
+	// recognize the flag, so only pass it when it's supported.
+	const strictFlags = process.allowedNodeEnvironmentFlags.has('--no-experimental-require-module')
+		? ['--no-experimental-require-module']
+		: []
+
+	try {
+		await new Promise<void>((resolve, reject) => {
+			execFile(
+				'node',
+				[...strictFlags, '-e', harness, JSON.stringify(items), outFile],
+				{ cwd: REPO_ROOT, maxBuffer: 32 * 1024 * 1024 },
+				(error) => {
+					if (existsSync(outFile)) resolve()
+					else reject(error ?? new Error('check-cjs harness produced no output'))
+				}
+			)
+		})
+		for (const result of JSON.parse(readFileSync(outFile, 'utf8'))) {
+			codes.set(result.id, result.code)
+		}
+	} finally {
+		rmSync(outDir, { recursive: true, force: true })
+	}
+
+	return codes
+}
+
+async function main() {
+	const candidates = collectRequireCandidates()
+	const candidateList = [...candidates.values()]
+	nicelog(
+		`Checking ${candidateList.length} external require() targets across packages/*/dist-cjs for ESM-only leaks...`
+	)
+
+	const items = candidateList.map((candidate, id) => ({
+		id,
+		base: path.join(candidate.packageDir, 'dist-cjs', 'index.js'),
+		specifier: candidate.specifier,
+	}))
+	const codes = await strictRequire(items)
+
+	const leaks = candidateList.filter((_, id) => {
+		const code = codes.get(id)
+		return code != null && ESM_REQUIRE_ERROR_CODES.has(code)
+	})
+
+	if (leaks.length > 0) {
+		console.error(`\nFound ${leaks.length} ESM-only dependency leak(s) in the CJS build:\n`)
+		for (const leak of leaks) {
+			console.error(`  ${leak.packageName} require()s ESM-only "${leak.specifier}"`)
+			for (const file of [...leak.files].sort()) console.error(`    - ${file}`)
+		}
+		console.error(
+			`\nThese throw ERR_REQUIRE_ESM for CJS consumers (Node <20.19, Jest, ts-node).` +
+				`\nFix each one by either:` +
+				`\n  - inlining it: add its package name to ESM_ONLY in internal/scripts/build-package.ts` +
+				`\n    (route multi-site deps through a vendor shim first, like the no-tiptap-default-import rule), or` +
+				`\n  - loading it lazily with a dynamic import() from an async call site.\n`
+		)
+		process.exit(1)
+	}
+
+	nicelog('No ESM-only dependency leaks in the CJS build.')
+}
+
+main().catch((error) => {
+	console.error(error)
+	process.exit(1)
+})

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"profile-tsserver": "tsx internal/scripts/profile-tsserver.ts",
 		"check-packages": "tsx internal/scripts/check-packages.ts",
 		"check-circular-deps": "tsx internal/scripts/check-circular-deps.ts",
+		"check-cjs": "tsx internal/scripts/check-cjs.ts",
 		"update-pr-template": "tsx internal/scripts/update-pr-template.ts",
 		"generate-test-licenses": "tsx internal/scripts/generate-test-licenses.ts",
 		"api-check": "lazy api-check",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -60,7 +60,7 @@
 		"eventemitter3": "^4.0.7",
 		"idb": "^7.1.1",
 		"is-plain-object": "^5.0.0",
-		"rbush": "^3.0.1"
+		"rbush": "^4.0.1"
 	},
 	"peerDependencies": {
 		"react": "^18.2.0 || ^19.2.1",
@@ -71,7 +71,7 @@
 		"@testing-library/dom": "^10.0.0",
 		"@testing-library/react": "^16.0.0",
 		"@types/benchmark": "^2.1.5",
-		"@types/rbush": "^3.0.0",
+		"@types/rbush": "^4.0.0",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",
 		"@types/wicg-file-system-access": "^2020.9.8",

--- a/packages/mermaid/src/createMermaidDiagram.ts
+++ b/packages/mermaid/src/createMermaidDiagram.ts
@@ -1,6 +1,5 @@
 let nextMermaidId = 0
 
-import mermaid from 'mermaid'
 import type { FlowDB } from 'mermaid/dist/diagrams/flowchart/flowDb.d.ts'
 import type { FlowEdge, FlowSubGraph, FlowVertex } from 'mermaid/dist/diagrams/flowchart/types.js'
 import type { MindmapDB } from 'mermaid/dist/diagrams/mindmap/mindmapDb.d.ts'
@@ -56,6 +55,12 @@ export async function createMermaidDiagram(
 	text: string,
 	options: MermaidDiagramOptions = {}
 ): Promise<void> {
+	// load mermaid lazily so @tldraw/mermaid stays requirable from CommonJS:
+	// mermaid is ESM-only, and a static `import` would compile to `require(<esm>)`
+	// in the CJS build (throws ERR_REQUIRE_ESM on Node <20.19, Jest, ts-node). a
+	// dynamic import() works from CJS and only loads mermaid when this runs.
+	const mermaid = (await import('mermaid')).default
+
 	mermaid.initialize({
 		...MERMAID_CONFIG,
 		...(options.mermaidConfig ?? {}),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12015,7 +12015,7 @@ __metadata:
     "@tldraw/utils": "workspace:*"
     "@tldraw/validate": "workspace:*"
     "@types/benchmark": "npm:^2.1.5"
-    "@types/rbush": "npm:^3.0.0"
+    "@types/rbush": "npm:^4.0.0"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@types/wicg-file-system-access": "npm:^2020.9.8"
@@ -12026,7 +12026,7 @@ __metadata:
     idb: "npm:^7.1.1"
     is-plain-object: "npm:^5.0.0"
     lazyrepo: "npm:0.0.0-alpha.27"
-    rbush: "npm:^3.0.1"
+    rbush: "npm:^4.0.1"
     react: "npm:^19.2.1"
     react-dom: "npm:^19.2.1"
     resize-observer-polyfill: "npm:^1.5.1"
@@ -13378,10 +13378,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/rbush@npm:^3.0.0":
-  version: 3.0.4
-  resolution: "@types/rbush@npm:3.0.4"
-  checksum: 10/3f3b723f0f2542c7e2d493286c81177f3f2850c944c2f5d3296c86e02d4c206a447be7c982b23b82b95da9a2adc210d07cf870c1564f68b58eaa46d43073e013
+"@types/rbush@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@types/rbush@npm:4.0.0"
+  checksum: 10/ee37c7fa322a83af4e754180022253b7e2bbbb853c9a6d8ffce1ea1e59bbb0eef3a347e2f37934bb1afa4d40ea2ea44409d7cee751cb8ac8dbded13dc9160a64
   languageName: node
   linkType: hard
 
@@ -27232,10 +27232,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"quickselect@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "quickselect@npm:2.0.0"
-  checksum: 10/ed2e78431050d223fb75da20ee98011aef1a03f7cb04e1a32ee893402e640be3cfb76d72e9dbe01edf3bb457ff6a62e5c2d85748424d1aa531f6ba50daef098c
+"quickselect@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "quickselect@npm:3.0.0"
+  checksum: 10/8f72bedb8bb14bce5c3767c55f567bc296fa3ca9d98ba385e3867e434463bc633feee1eddf3dfec17914b7e88feeb08c7b313cf47114a8ff11bf964f77f51cfc
   languageName: node
   linkType: hard
 
@@ -27361,12 +27361,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rbush@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "rbush@npm:3.0.1"
+"rbush@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "rbush@npm:4.0.1"
   dependencies:
-    quickselect: "npm:^2.0.0"
-  checksum: 10/489e2e7d9889888ad533518f194e3ab7cc19b1f1365a38ee99fbdda542a47f41cda7dc89870180050f4d04ea402e9ff294e1d767d03c0f1694e0028b7609eec9
+    quickselect: "npm:^3.0.0"
+  checksum: 10/8db2f9b464ee31cbb13237e762140c27f4de517a470d1639f840cc606b1f917f64f6273178b2f07c93d95c44cc068cc0c25c84ad40c4a483404e60d17c054eec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In order to safely consume modern ESM-only leaf dependencies without breaking CommonJS consumers, this PR adds selective CJS bundling to the package build, uses it to upgrade `rbush` from v3 to v4 in `@tldraw/editor`, adds a CI smoke test that catches ESM-only dependency leaks in the published CJS builds, and fixes every leak it found.

tldraw dual-publishes CJS + ESM, and the package build (`internal/scripts/build-package.ts`) runs esbuild with `bundle: false`, so dependencies stay external as `require("x")` in the CJS output. When `x` is ESM-only, that leaks a `require(<esm>)` into the published CJS build, which throws `ERR_REQUIRE_ESM` on Node 20.0–20.18 (the repo floor is `^20.0.0`; `require(esm)` only landed in 20.19 / 22.12) and breaks Jest and ts-node. This already bit us once: [#7905](https://github.com/tldraw/tldraw/pull/7905) downgraded `rbush` v4 → v3 because v4 went ESM-only. This PR makes v4 safe for CJS, effectively reversing that downgrade.

## How it works

A narrow allowlist (`ESM_ONLY` — `rbush`, `jittered-fractional-indexing`, `nanoevents`) controls which ESM-only deps get inlined into the CommonJS build.

- **Asymmetric externals.** The ESM build is unchanged (`bundle: false`), so allowlisted deps stay external and ESM consumers resolve them natively, keeping dedup and tree-shaking. Only the CJS build inlines them.
- **Gated per package.** `buildPackage` computes which allowlisted deps are in the package's own `dependencies`. Bundling turns on only for the CJS pass, and only when that list is non-empty. Every other package keeps the exact `bundle: false` path — verified that an unaffected package's `dist-cjs` is byte-for-byte identical before and after this change.
- **The esbuild plugin.** When bundling the CJS pass, an `onResolve` plugin leaves entry points to esbuild, inlines allowlisted bare specifiers and everything reachable from them (any importer inside `node_modules` is bundled), keeps relative imports external so the per-file source mirror is preserved instead of collapsed into each entry, and keeps every other bare dep external.
- **Transitive bundling.** An inlined dep's own deps are inlined too: `rbush` pulls in `quickselect` and `jittered-fractional-indexing` pulls in `fractional-indexing` — both also ESM-only. Inlining only the top dep while leaving `require("quickselect")`/`require("fractional-indexing")` external would just move the bug down a level, so the plugin bundles the whole reachable subtree. License notices for the inlined deps are preserved via esbuild `legalComments: 'linked'` in `dist-cjs`.

## CJS smoke test (CI)

`yarn check-cjs` (`internal/scripts/check-cjs.ts`) runs in the CI build job after `build-package`. It scans every `packages/*/dist-cjs` build for the external deps it `require()`s and strict-requires each under `node --no-experimental-require-module`, which reinstates the `ERR_REQUIRE_ESM` throw even on modern Node (where `require(esm)` is otherwise allowed by default). It fails on any ESM-only dep that leaks into a CJS build — the general version of #7905's smoke check, with no hardcoded dep list.

The check found four leaks (rbush plus three latent, pre-existing ones). **All are fixed in this PR**, so the check guards a fully clean tree:

| Package | ESM-only dep | Fix |
| --- | --- | --- |
| `@tldraw/editor` | `rbush@4` (+ `quickselect`) | inlined (`ESM_ONLY`) |
| `@tldraw/utils` | `jittered-fractional-indexing` (+ `fractional-indexing`) | inlined (`ESM_ONLY`) |
| `@tldraw/sync-core` | `nanoevents` | inlined (`ESM_ONLY`) |
| `@tldraw/mermaid` | `mermaid@11` | dynamic `import()` (see below) |

## Inline vs dynamic import

The three small, sync-used deps (`rbush`, `jittered-fractional-indexing`, `nanoevents`) are **inlined** — they're used synchronously (rbush is even a base class), so they must be present at module-eval time, and their trees are tiny pure JS that bundle cleanly under `platform: 'neutral'`.

`mermaid` is **not** inlined. Inlining it fails outright (78 esbuild errors — its tree, e.g. chevrotain/lodash-es, can't resolve under `platform: 'neutral'`), and it's huge and lazily used. Instead `createMermaidDiagram()` (already `async`) loads it with a dynamic `import('mermaid')`. `import()` works from CommonJS, and esbuild keeps it as a real dynamic import (it doesn't downlevel to `require`), so mermaid stays external — no multi-MB blob, dedup preserved — and only loads when a diagram is actually created (so `require('@tldraw/mermaid')` no longer pulls mermaid in at all).

## Follow-up before allowlisting more deps

Each dep inlined here is a single import site, so adding it to `ESM_ONLY` was safe directly. For any **future** dep imported across many files, we should first route it through a single "vendor shim" import site and guard it with a lint rule — the same pattern as the existing `no-tiptap-default-import` rule — so an ESM-only dep can't be imported somewhere that bypasses the CJS inlining.

### Change type

- [x] `improvement`

### Test plan

1. `yarn build-package`.
2. `yarn check-cjs` passes (no ESM-only `require` leaks in any `dist-cjs`), and correctly fails if a new ESM-only leak is introduced.
3. Allowlisted deps stay external in ESM: e.g. `rbush` appears as `import RBush from "rbush"` in `packages/editor/dist-esm`, not inlined.
4. CJS load smoke test (mirrors #7905): requiring the built `RBushIndex` from a CommonJS context constructs and queries the index with no `ERR_REQUIRE_ESM`.
5. `@tldraw/mermaid`: `dist-cjs/createMermaidDiagram.js` contains `await import("mermaid")` and no `require("mermaid")`; the 53 mermaid tests pass.
6. Regression: an unaffected package's `dist-cjs` output is byte-for-byte identical before and after the build-script change.
7. `yarn typecheck`, `yarn api-check`, `yarn lint-current`, and the spatial index tests (`packages/tldraw/src/test/spatialIndex.test.ts`, `getCulledShapes.test.tsx`) all pass.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +6 / -1    |
| Config/tooling | +308 / -19 |
