### PR TITLE
feat(dotcom): admin action to enroll a user in groups

### DIFF
--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -716,7 +716,7 @@ function EnrollUserInGroups({
 
 			const result = await res.json()
 			const parts: string[] = []
-			if (result.backendMigrated) parts.push(`migrated data (files: ${result.files_migrated})`)
+			if (result.backendMigrated) parts.push('migrated to groups backend')
 			if (result.frontendGranted) parts.push('granted groups UI')
 			onSuccessMessage(
 				parts.length ? `Enrolled in groups: ${parts.join(', ')}` : 'User was already fully enrolled'

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -6,7 +6,7 @@ import {
 	userHasFlag,
 	ZStoreData,
 } from '@tldraw/dotcom-shared'
-import { RefObject, useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { fetch } from 'tldraw'
 import { sentryReleaseName } from '../../sentry-release-name'
@@ -225,12 +225,10 @@ export function Component() {
 							</TlaButton>
 						</div>
 						<EnrollUserInGroups
-							inputRef={inputRef}
+							user={data.user[0] as TlaUser}
 							onSuccess={loadData}
 							onError={setError}
 							onSuccessMessage={setSuccessMessage}
-							hasBackend={userHasFlag((data.user[0] as TlaUser).flags, 'groups_backend')}
-							hasFrontend={userHasFlag((data.user[0] as TlaUser).flags, 'groups_frontend')}
 						/>
 						<StructuredDataDisplay data={data} />
 					</section>
@@ -669,34 +667,28 @@ function DownloadTldrFile({ legacy }: { legacy: boolean }) {
 }
 
 function EnrollUserInGroups({
-	inputRef,
+	user,
 	onSuccess,
 	onError,
 	onSuccessMessage,
-	hasBackend,
-	hasFrontend,
 }: {
-	inputRef: RefObject<HTMLInputElement | null>
+	user: TlaUser
 	onSuccess(): void
 	onError(error: string): void
 	onSuccessMessage(message: string): void
-	hasBackend: boolean
-	hasFrontend: boolean
 }) {
 	const [isEnrolling, setIsEnrolling] = useState(false)
 	const [isUnenrolling, setIsUnenrolling] = useState(false)
+	// Derive status and the target id from the loaded user, not the live search
+	// box, so the action always matches the status shown above it.
+	const hasBackend = userHasFlag(user.flags, 'groups_backend')
+	const hasFrontend = userHasFlag(user.flags, 'groups_frontend')
 	const fullyEnrolled = hasBackend && hasFrontend
 
 	const handleEnroll = useCallback(async () => {
-		const q = inputRef.current?.value?.trim() ?? ''
-		if (!q) {
-			onError('Please enter an email or ID')
-			return
-		}
-
 		if (
 			!window.confirm(
-				`Enroll user "${q}" in the groups feature? This grants groups_backend (migrating their data if needed) and groups_frontend (the groups UI).`
+				`Enroll ${user.email} in the groups feature? This grants groups_backend (migrating their data if needed) and groups_frontend (the groups UI).`
 			)
 		) {
 			return
@@ -706,9 +698,10 @@ function EnrollUserInGroups({
 		onError('')
 
 		try {
-			const res = await fetch(`/api/app/admin/user/enroll_groups?${new URLSearchParams({ q })}`, {
-				method: 'POST',
-			})
+			const res = await fetch(
+				`/api/app/admin/user/enroll_groups?${new URLSearchParams({ q: user.id })}`,
+				{ method: 'POST' }
+			)
 
 			if (!res.ok) {
 				onError(res.statusText + ': ' + (await res.text()))
@@ -731,18 +724,12 @@ function EnrollUserInGroups({
 		} finally {
 			setIsEnrolling(false)
 		}
-	}, [inputRef, onError, onSuccess, onSuccessMessage])
+	}, [user.id, user.email, onError, onSuccess, onSuccessMessage])
 
 	const handleUnenroll = useCallback(async () => {
-		const q = inputRef.current?.value?.trim() ?? ''
-		if (!q) {
-			onError('Please enter an email or ID')
-			return
-		}
-
 		if (
 			!window.confirm(
-				`Remove user "${q}" from the groups UI? This clears the groups_frontend flag (their data stays migrated).`
+				`Remove ${user.email} from the groups UI? This clears the groups_frontend flag (their data stays migrated).`
 			)
 		) {
 			return
@@ -752,9 +739,10 @@ function EnrollUserInGroups({
 		onError('')
 
 		try {
-			const res = await fetch(`/api/app/admin/user/unenroll_groups?${new URLSearchParams({ q })}`, {
-				method: 'POST',
-			})
+			const res = await fetch(
+				`/api/app/admin/user/unenroll_groups?${new URLSearchParams({ q: user.id })}`,
+				{ method: 'POST' }
+			)
 
 			if (!res.ok) {
 				onError(res.statusText + ': ' + (await res.text()))
@@ -773,7 +761,7 @@ function EnrollUserInGroups({
 		} finally {
 			setIsUnenrolling(false)
 		}
-	}, [inputRef, onError, onSuccess, onSuccessMessage])
+	}, [user.id, user.email, onError, onSuccess, onSuccessMessage])
 
 	return (
 		<div className={styles.migrationSection}>

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -224,12 +224,13 @@ export function Component() {
 								Force Reboot
 							</TlaButton>
 						</div>
-						<MigrateUserToGroups
+						<EnrollUserInGroups
 							inputRef={inputRef}
 							onSuccess={loadData}
 							onError={setError}
 							onSuccessMessage={setSuccessMessage}
-							didMigrate={userHasFlag((data.user[0] as TlaUser).flags, 'groups_backend')}
+							hasBackend={userHasFlag((data.user[0] as TlaUser).flags, 'groups_backend')}
+							hasFrontend={userHasFlag((data.user[0] as TlaUser).flags, 'groups_frontend')}
 						/>
 						<StructuredDataDisplay data={data} />
 					</section>
@@ -667,22 +668,25 @@ function DownloadTldrFile({ legacy }: { legacy: boolean }) {
 	)
 }
 
-function MigrateUserToGroups({
+function EnrollUserInGroups({
 	inputRef,
 	onSuccess,
 	onError,
 	onSuccessMessage,
-	didMigrate,
+	hasBackend,
+	hasFrontend,
 }: {
 	inputRef: RefObject<HTMLInputElement | null>
 	onSuccess(): void
 	onError(error: string): void
 	onSuccessMessage(message: string): void
-	didMigrate: boolean
+	hasBackend: boolean
+	hasFrontend: boolean
 }) {
-	const [isMigrating, setIsMigrating] = useState(false)
+	const [isEnrolling, setIsEnrolling] = useState(false)
+	const fullyEnrolled = hasBackend && hasFrontend
 
-	const handleMigrate = useCallback(async () => {
+	const handleEnroll = useCallback(async () => {
 		const q = inputRef.current?.value?.trim() ?? ''
 		if (!q) {
 			onError('Please enter an email or ID')
@@ -691,17 +695,17 @@ function MigrateUserToGroups({
 
 		if (
 			!window.confirm(
-				`Are you sure you want to migrate user "${q}" to the groups backend? This action cannot be undone.`
+				`Enroll user "${q}" in the groups feature? This grants groups_backend (migrating their data if needed) and groups_frontend (the groups UI).`
 			)
 		) {
 			return
 		}
 
-		setIsMigrating(true)
+		setIsEnrolling(true)
 		onError('')
 
 		try {
-			const res = await fetch(`/api/app/admin/user/migrate?${new URLSearchParams({ q })}`, {
+			const res = await fetch(`/api/app/admin/user/enroll_groups?${new URLSearchParams({ q })}`, {
 				method: 'POST',
 			})
 
@@ -711,30 +715,38 @@ function MigrateUserToGroups({
 			}
 
 			const result = await res.json()
+			const parts: string[] = []
+			if (result.backendMigrated) parts.push(`migrated data (files: ${result.files_migrated})`)
+			if (result.frontendGranted) parts.push('granted groups UI')
 			onSuccessMessage(
-				`User migrated successfully! Files: ${result.files_migrated}, Pinned: ${result.pinned_files_migrated}`
+				parts.length ? `Enrolled in groups: ${parts.join(', ')}` : 'User was already fully enrolled'
 			)
 			onSuccess()
 		} catch (err) {
-			onError(err instanceof Error ? err.message : 'Migration failed')
+			onError(err instanceof Error ? err.message : 'Enrollment failed')
 		} finally {
-			setIsMigrating(false)
+			setIsEnrolling(false)
 		}
 	}, [inputRef, onError, onSuccess, onSuccessMessage])
 
-	return didMigrate ? null : (
+	return (
 		<div className={styles.migrationSection}>
-			<h4 className="tla-text_ui__medium">Migrate User to Groups Backend</h4>
+			<h4 className="tla-text_ui__medium">Groups enrollment</h4>
 			<p className="tla-text_ui__small">
-				Migrate this user from the legacy file_state model to the new groups model.
+				groups_backend: {hasBackend ? '✓ enrolled' : '✗ not enrolled'} · groups_frontend:{' '}
+				{hasFrontend ? '✓ enrolled' : '✗ not enrolled'}
+			</p>
+			<p className="tla-text_ui__small">
+				Enroll this user in the groups feature: migrates their data to the groups model if needed
+				and shows the groups UI.
 			</p>
 			<TlaButton
-				onClick={handleMigrate}
+				onClick={handleEnroll}
 				variant="primary"
-				disabled={isMigrating}
-				isLoading={isMigrating}
+				disabled={isEnrolling}
+				isLoading={isEnrolling}
 			>
-				{isMigrating ? 'Migrating...' : 'Migrate to Groups'}
+				{isEnrolling ? 'Enrolling…' : fullyEnrolled ? 'Re-run enrollment' : 'Enroll in groups'}
 			</TlaButton>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -715,11 +715,14 @@ function EnrollUserInGroups({
 			}
 
 			const result = await res.json()
-			const parts: string[] = []
-			if (result.backendMigrated) parts.push('migrated to groups backend')
-			if (result.frontendGranted) parts.push('granted groups UI')
+			const changes = [
+				result.backendMigrated && 'migrated to groups backend',
+				result.frontendGranted && 'granted groups UI',
+			].filter(Boolean)
 			onSuccessMessage(
-				parts.length ? `Enrolled in groups: ${parts.join(', ')}` : 'User was already fully enrolled'
+				changes.length
+					? `Enrolled in groups: ${changes.join(', ')}`
+					: 'User was already fully enrolled'
 			)
 			onSuccess()
 		} catch (err) {

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -746,10 +746,10 @@ function EnrollUserInGroups({
 			<TlaButton
 				onClick={handleEnroll}
 				variant="primary"
-				disabled={isEnrolling}
+				disabled={isEnrolling || fullyEnrolled}
 				isLoading={isEnrolling}
 			>
-				{isEnrolling ? 'Enrolling…' : fullyEnrolled ? 'Re-run enrollment' : 'Enroll in groups'}
+				Enroll in groups
 			</TlaButton>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -684,6 +684,7 @@ function EnrollUserInGroups({
 	hasFrontend: boolean
 }) {
 	const [isEnrolling, setIsEnrolling] = useState(false)
+	const [isUnenrolling, setIsUnenrolling] = useState(false)
 	const fullyEnrolled = hasBackend && hasFrontend
 
 	const handleEnroll = useCallback(async () => {
@@ -732,6 +733,48 @@ function EnrollUserInGroups({
 		}
 	}, [inputRef, onError, onSuccess, onSuccessMessage])
 
+	const handleUnenroll = useCallback(async () => {
+		const q = inputRef.current?.value?.trim() ?? ''
+		if (!q) {
+			onError('Please enter an email or ID')
+			return
+		}
+
+		if (
+			!window.confirm(
+				`Remove user "${q}" from the groups UI? This clears the groups_frontend flag (their data stays migrated).`
+			)
+		) {
+			return
+		}
+
+		setIsUnenrolling(true)
+		onError('')
+
+		try {
+			const res = await fetch(`/api/app/admin/user/unenroll_groups?${new URLSearchParams({ q })}`, {
+				method: 'POST',
+			})
+
+			if (!res.ok) {
+				onError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+
+			const result = await res.json()
+			onSuccessMessage(
+				result.frontendRemoved
+					? 'Removed from the groups UI'
+					: 'User was not enrolled in the groups UI'
+			)
+			onSuccess()
+		} catch (err) {
+			onError(err instanceof Error ? err.message : 'Unenroll failed')
+		} finally {
+			setIsUnenrolling(false)
+		}
+	}, [inputRef, onError, onSuccess, onSuccessMessage])
+
 	return (
 		<div className={styles.migrationSection}>
 			<h4 className="tla-text_ui__medium">Groups enrollment</h4>
@@ -743,14 +786,24 @@ function EnrollUserInGroups({
 				Enroll this user in the groups feature: migrates their data to the groups model if needed
 				and shows the groups UI.
 			</p>
-			<TlaButton
-				onClick={handleEnroll}
-				variant="primary"
-				disabled={isEnrolling || fullyEnrolled}
-				isLoading={isEnrolling}
-			>
-				Enroll in groups
-			</TlaButton>
+			<div className={styles.userActions}>
+				<TlaButton
+					onClick={handleEnroll}
+					variant="primary"
+					disabled={isEnrolling || isUnenrolling || fullyEnrolled}
+					isLoading={isEnrolling}
+				>
+					Enroll in groups
+				</TlaButton>
+				<TlaButton
+					onClick={handleUnenroll}
+					variant="secondary"
+					disabled={isEnrolling || isUnenrolling || !hasFrontend}
+					isLoading={isUnenrolling}
+				>
+					Unenroll from groups UI
+				</TlaButton>
+			</div>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
@@ -24,6 +24,11 @@
 	-webkit-font-smoothing: antialiased;
 }
 
+.tlaButton:disabled {
+	cursor: not-allowed;
+	opacity: 0.5;
+}
+
 .tlaButton > .spinner {
 	position: absolute;
 	top: calc(50% - 20px);
@@ -123,15 +128,15 @@
 }
 
 @media (hover: hover) {
-	.primary:hover {
+	.primary:not(:disabled):hover {
 		background-color: var(--tla-color-primary-hover);
 	}
 
-	.secondary:hover {
+	.secondary:not(:disabled):hover {
 		background-color: var(--tla-color-secondary-hover);
 	}
 
-	.cta:hover {
+	.cta:not(:disabled):hover {
 		background-color: var(--tla-color-primary-hover);
 	}
 

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -17,6 +17,7 @@ import {
 	ZErrorCode,
 	ZServerSentPacket,
 	createMutators,
+	parseFlags,
 	schema,
 } from '@tldraw/dotcom-shared'
 import {
@@ -24,7 +25,14 @@ import {
 	TLSyncErrorCloseEventCode,
 	TLSyncErrorCloseEventReason,
 } from '@tldraw/sync-core'
-import { ExecutionQueue, IndexKey, assert, mapObjectMapValues, sleep } from '@tldraw/utils'
+import {
+	ExecutionQueue,
+	IndexKey,
+	assert,
+	mapObjectMapValues,
+	sleep,
+	uniqueId,
+} from '@tldraw/utils'
 import { createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
@@ -801,6 +809,56 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		this.log.debug('migration complete, user rebooted')
 
 		return result.rows[0]
+	}
+
+	/**
+	 * Enroll a user in the groups feature so they can actually see and use it.
+	 * Ensures both flags:
+	 *   - groups_backend: migrate the user's data into the groups model if needed
+	 *     (the SQL function is idempotent and returns early if already migrated).
+	 *   - groups_frontend: the flag that shows the groups UI (otherwise only granted
+	 *     when a user accepts a group invite).
+	 * Then reboots the user so the new flags/data take effect.
+	 */
+	async admin_enrollInGroups(userId: string) {
+		this.userId ??= userId
+
+		// 1. Ensure the data model is migrated.
+		const migration = await sql<{
+			files_migrated: number
+			pinned_files_migrated: number
+			flag_added: boolean
+		}>`SELECT * FROM migrate_user_to_groups(${userId}, ${uniqueId()})`.execute(this.db)
+
+		// 2. Ensure the groups UI flag is present (read flags after the migration,
+		// which may have just added groups_backend).
+		const row = await this.db
+			.selectFrom('user')
+			.where('id', '=', userId)
+			.select('flags')
+			.executeTakeFirst()
+		const flags = parseFlags(row?.flags)
+		let frontendGranted = false
+		if (!flags.includes('groups_frontend')) {
+			flags.push('groups_frontend')
+			await this.db
+				.updateTable('user')
+				.set({ flags: flags.join(',') })
+				.where('id', '=', userId)
+				.execute()
+			frontendGranted = true
+		}
+
+		// 3. Reboot so the user picks up the new flags and migrated data.
+		await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
+		await this.cache?.reboot({ delay: false, source: 'admin', hard: true })
+
+		return {
+			backendMigrated: migration.rows[0]?.flag_added ?? false,
+			frontendGranted,
+			files_migrated: migration.rows[0]?.files_migrated ?? 0,
+			pinned_files_migrated: migration.rows[0]?.pinned_files_migrated ?? 0,
+		}
 	}
 
 	async admin_forceHardReboot(userId: string) {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -856,6 +856,37 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		return { backendMigrated, frontendGranted }
 	}
 
+	/**
+	 * Unenroll a user from the groups UI by clearing the groups_frontend flag.
+	 * Leaves groups_backend (the data model) in place — this just hides the groups
+	 * UI again, which is handy for testing the enrollment flow. Reboots the user so
+	 * the change takes effect.
+	 */
+	async admin_unenrollFromGroups(userId: string) {
+		this.userId ??= userId
+
+		const row = await this.db
+			.selectFrom('user')
+			.where('id', '=', userId)
+			.select('flags')
+			.executeTakeFirst()
+		const flags = parseFlags(row?.flags)
+		const nextFlags = flags.filter((flag) => flag !== 'groups_frontend')
+		const frontendRemoved = nextFlags.length !== flags.length
+		if (frontendRemoved) {
+			await this.db
+				.updateTable('user')
+				.set({ flags: nextFlags.join(',') })
+				.where('id', '=', userId)
+				.execute()
+		}
+
+		await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
+		await this.cache?.reboot({ delay: false, source: 'admin', hard: true })
+
+		return { frontendRemoved }
+	}
+
 	async admin_forceHardReboot(userId: string) {
 		if (this.cache) {
 			await this.cache?.reboot({ hard: true, delay: false, source: 'admin' })

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -823,12 +823,12 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	async admin_enrollInGroups(userId: string) {
 		this.userId ??= userId
 
-		// 1. Ensure the data model is migrated.
-		const migration = await sql<{
-			files_migrated: number
-			pinned_files_migrated: number
+		// 1. Ensure the data model is migrated. The SQL function is idempotent:
+		// flag_added is false (and nothing changes) when the user is already migrated.
+		const { rows } = await sql<{
 			flag_added: boolean
 		}>`SELECT * FROM migrate_user_to_groups(${userId}, ${uniqueId()})`.execute(this.db)
+		const backendMigrated = rows[0]?.flag_added ?? false
 
 		// 2. Ensure the groups UI flag is present (read flags after the migration,
 		// which may have just added groups_backend).
@@ -853,12 +853,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
 		await this.cache?.reboot({ delay: false, source: 'admin', hard: true })
 
-		return {
-			backendMigrated: migration.rows[0]?.flag_added ?? false,
-			frontendGranted,
-			files_migrated: migration.rows[0]?.files_migrated ?? 0,
-			pinned_files_migrated: migration.rows[0]?.pinned_files_migrated ?? 0,
-		}
+		return { backendMigrated, frontendGranted }
 	}
 
 	async admin_forceHardReboot(userId: string) {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -64,6 +64,16 @@ export const adminRoutes = createRouter<Environment>()
 		const result = await user.admin_migrateToGroups(userRow.id, uniqueId())
 		return json(result)
 	})
+	.post('/app/admin/user/enroll_groups', async (res, env) => {
+		const q = res.query['q']
+		if (typeof q !== 'string') {
+			return new Response('Missing query param', { status: 400 })
+		}
+		const userRow = await requireUser(env, q)
+		const user = getUserDurableObject(env, userRow.id)
+		const result = await user.admin_enrollInGroups(userRow.id)
+		return json(result)
+	})
 	.get('/app/admin/unmigrated_users_count', async (_res, env) => {
 		const pg = createPostgresConnectionPool(env, '/app/admin/unmigrated_users_count')
 		return json({ count: await getNumUnmigratedUsers(pg) })

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -74,6 +74,16 @@ export const adminRoutes = createRouter<Environment>()
 		const result = await user.admin_enrollInGroups(userRow.id)
 		return json(result)
 	})
+	.post('/app/admin/user/unenroll_groups', async (res, env) => {
+		const q = res.query['q']
+		if (typeof q !== 'string') {
+			return new Response('Missing query param', { status: 400 })
+		}
+		const userRow = await requireUser(env, q)
+		const user = getUserDurableObject(env, userRow.id)
+		const result = await user.admin_unenrollFromGroups(userRow.id)
+		return json(result)
+	})
 	.get('/app/admin/unmigrated_users_count', async (_res, env) => {
 		const pg = createPostgresConnectionPool(env, '/app/admin/unmigrated_users_count')
 		return json({ count: await getNumUnmigratedUsers(pg) })


### PR DESCRIPTION
In order to let an admin turn the groups experience on for a specific user, this PR adds an "Enroll in groups" action to the `/admin` page that grants both groups flags. Closes #9062.

The page previously only had a single-user "Migrate to Groups" control that was hidden unless you'd searched a user lacking `groups_backend`, and it only granted `groups_backend` — never `groups_frontend`, the flag that actually shows the groups UI (otherwise only granted on accepting a group invite). So there was no usable way to enroll a specific user into the groups experience.

This replaces that control with an always-visible (per found user) "Groups enrollment" block that shows the user's current `groups_backend` / `groups_frontend` status and an "Enroll in groups" button. The button calls a new admin endpoint `POST /app/admin/user/enroll_groups` (behind the existing `@tldraw.com` admin gate), which runs `admin_enrollInGroups`: migrate the data model if needed (idempotent `migrate_user_to_groups`) and add `groups_frontend`, then reboot the user so it takes effect. It reports what changed and is safe to re-run. The existing batch migration and `POST /app/admin/user/migrate` are unchanged.

### Change type

- [x] `improvement`

### Test plan

1. Sign in to a local/staging dotcom with an `@tldraw.com` account and open `/admin`.
2. Enter a user's email or id → **Find User**.
3. In **User Data**, the **Groups enrollment** block shows `groups_backend ✓/✗ · groups_frontend ✓/✗`.
4. For a user lacking `groups_frontend` (e.g. a freshly created account — new users get `groups_backend` by default but not `groups_frontend`), click **Enroll in groups** → confirm. The status flips to both ✓, and the groups UI appears for that user on their next load.
5. Re-running on an already-enrolled user reports "already fully enrolled" (idempotent).

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +101 / -21 |
