### PR TITLE
fix(dotcom): keep sidebar in current group when deleting a group file

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -450,6 +450,18 @@ export class Sidebar {
 		await expect(fileLink).toHaveAttribute('data-is-pinned', 'false')
 	}
 
+	@step
+	async expectFileActive(fileName: string) {
+		const fileLink = this.getFileByName(fileName)
+		await expect(fileLink).toHaveAttribute('data-active', 'true')
+	}
+
+	@step
+	async expectFileNotActive(fileName: string) {
+		const fileLink = this.getFileByName(fileName)
+		await expect(fileLink).toHaveAttribute('data-active', 'false')
+	}
+
 	async getFilesInGroup(groupName: string): Promise<string[]> {
 		const group = this.getGroup(groupName)
 		const fileLinks = group.locator('[data-element="file-link"]')

--- a/apps/dotcom/client/e2e/tests/groups.spec.ts
+++ b/apps/dotcom/client/e2e/tests/groups.spec.ts
@@ -328,6 +328,39 @@ test.describe('groups', () => {
 			await sidebar.expectFileVisible(file2)
 		})
 
+		test('deleting the active file in a group stays in the group', async ({
+			sidebar,
+			deleteFileDialog,
+		}) => {
+			const groupName = getRandomName()
+			const homeFile = getRandomName()
+			const file1 = getRandomName()
+			const file2 = getRandomName()
+
+			// A file in "my files" so we can tell if navigation jumps out of the group.
+			await sidebar.createNewDocument(homeFile)
+			await sidebar.expectFileVisible(homeFile)
+
+			await sidebar.createGroup(groupName)
+			await sidebar.expectGroupExpanded(groupName)
+			await sidebar.createFileInGroup(groupName, file1)
+			await sidebar.createFileInGroup(groupName, file2)
+
+			// file2 was created last, so it's the active file.
+			await sidebar.expectFileActive(file2)
+
+			await sidebar.deleteFileInGroup(file2)
+			await deleteFileDialog.expectIsVisible()
+			await deleteFileDialog.confirmDeletion()
+			await deleteFileDialog.expectIsNotVisible()
+			await sidebar.mutationResolution()
+
+			// We should land on the group's top remaining file, not jump to my files.
+			await sidebar.expectFileNotVisible(file2)
+			await sidebar.expectFileActive(file1)
+			await sidebar.expectFileNotActive(homeFile)
+		})
+
 		test('duplicate file', async ({ page, sidebar, editor }) => {
 			const groupName = getRandomName()
 			const file1 = getRandomName()

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -37,14 +37,26 @@ export function TlaDeleteFileDialog({
 		if (!token) throw new Error('No token')
 		trackEvent('delete-file', { source: 'file-menu' })
 		await app.deleteOrForgetFile(fileId, groupId)
-		const recentFiles = app.getMyFiles()
-		if (recentFiles.length === 0) {
-			const result = await app.createFile()
-			if (result.ok) {
-				navigate(routes.tlaFile(result.value.fileId))
-			}
+
+		// Prefer staying within the group the file was deleted from: navigate to the
+		// top of its remaining files so the sidebar scrolls to the current group
+		// instead of jumping up to my files.
+		const groupFiles = groupId === app.getHomeGroupId() ? [] : app.getGroupFilesSorted(groupId)
+		if (groupFiles.length > 0) {
+			app.ensureFileVisibleInSidebar(groupFiles[0].fileId)
+			navigate(routes.tlaFile(groupFiles[0].fileId))
 		} else {
-			navigate(routes.tlaFile(recentFiles[0].fileId))
+			// Deleting from my files, or the group is now empty: fall back to my files,
+			// creating a new file if there are none.
+			const recentFiles = app.getMyFiles()
+			if (recentFiles.length === 0) {
+				const result = await app.createFile()
+				if (result.ok) {
+					navigate(routes.tlaFile(result.value.fileId))
+				}
+			} else {
+				navigate(routes.tlaFile(recentFiles[0].fileId))
+			}
 		}
 		onClose()
 	}, [auth, app, fileId, groupId, onClose, navigate, trackEvent])


### PR DESCRIPTION
In order to keep the sidebar anchored to the group you're working in, this PR changes file deletion to stay within the current group. Previously, deleting a file from a group navigated to the top of "My files", which scrolled the sidebar to the top and opened an unrelated personal file. Now we navigate to the top of the deleted file's group, falling back to "My files" only when the group has no remaining files. Closes #8974.

### How it works

The sidebar has no direct "scroll to group" behavior — scrolling is a side effect of which file is active. Each file link calls `scrollIntoView({ block: 'nearest' })` when it becomes the active file (the one in the URL). Previously, deleting a group file navigated to the top of "My files", so that link became active and scrolled the sidebar up and out of the group. Navigating to the group's top remaining file instead makes a file *inside the group* active, so the sidebar reveals it in place and stays anchored to the group.

A couple of details for reviewers unfamiliar with this code:

- `block: 'nearest'` means "top of current group" is really "reveal the group's top file" with minimal scrolling — it matches the rest of the sidebar's active-file navigation rather than pinning the group header to the top of the viewport.
- `ensureFileVisibleInSidebar` is load-bearing: it expands the group so the active link exists in the DOM before we navigate. Without it the scroll would no-op when the group is collapsed (for example, deleting from the editor's file menu while the sidebar group is closed).

### Change type

- [x] `bugfix`

### Test plan

1. Enable groups and create a group with two or more files.
2. Open one of the files in the group.
3. Delete a file from the group.
4. The sidebar should stay scrolled to the current group and open the top remaining file in that group, rather than jumping up to "My files".
5. Delete the last file in the group — navigation should fall back to "My files" (creating a new file if there are none).

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Fix the sidebar jumping to "My files" when deleting a file from a group; it now stays in the current group.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +45 / -0   |
| Apps    | +19 / -7   |
