### PR TITLE
chore(templates): bump better-sqlite3 to v12 for Node 26 support

### DIFF
--- a/templates/simple-server-example/package.json
+++ b/templates/simple-server-example/package.json
@@ -35,7 +35,7 @@
 		"@tldraw/sync": "workspace:*",
 		"@tldraw/sync-core": "workspace:*",
 		"@vitejs/plugin-react": "^6.0.1",
-		"better-sqlite3": "^11.8.1",
+		"better-sqlite3": "^12.10.0",
 		"fastify": "^5.8.1",
 		"itty-router": "^5.0.18",
 		"react": "^19.2.1",

--- a/templates/socketio-server-example/package.json
+++ b/templates/socketio-server-example/package.json
@@ -33,7 +33,7 @@
 		"@tldraw/sync": "workspace:*",
 		"@tldraw/sync-core": "workspace:*",
 		"@vitejs/plugin-react": "^6.0.1",
-		"better-sqlite3": "^11.8.1",
+		"better-sqlite3": "^12.10.0",
 		"express": "^5.1.0",
 		"react": "^19.2.1",
 		"react-dom": "^19.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12156,7 +12156,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@types/ws": "npm:^8.18.1"
     "@vitejs/plugin-react": "npm:^6.0.1"
-    better-sqlite3: "npm:^11.8.1"
+    better-sqlite3: "npm:^12.10.0"
     concurrently: "npm:^9.1.2"
     fastify: "npm:^5.8.1"
     itty-router: "npm:^5.0.18"
@@ -12185,7 +12185,7 @@ __metadata:
     "@types/react-dom": "npm:^19.2.3"
     "@types/ws": "npm:^8.18.1"
     "@vitejs/plugin-react": "npm:^6.0.1"
-    better-sqlite3: "npm:^11.8.1"
+    better-sqlite3: "npm:^12.10.0"
     concurrently: "npm:^9.1.2"
     express: "npm:^5.1.0"
     lazyrepo: "npm:0.0.0-alpha.27"
@@ -15778,14 +15778,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^11.8.1":
-  version: 11.10.0
-  resolution: "better-sqlite3@npm:11.10.0"
+"better-sqlite3@npm:^12.10.0":
+  version: 12.10.0
+  resolution: "better-sqlite3@npm:12.10.0"
   dependencies:
     bindings: "npm:^1.5.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
-  checksum: 10/5e4c7437c4fe6033335a79c82974d7ab29f33c51c36f48b73e87e087d21578468575de1c56a7badd4f76f17255e25abefddaeacf018e5eeb9e0cb8d6e3e4a5e1
+  checksum: 10/99e213e78f15a7f40d5cb666b56781223a6b83ffc317c93846e2b63b694592978c1e3762e81afd6ce851e0e3c24ebc9d0c42341158ea93c8a39987e5e19602f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In order to let the server templates build and run on current Node.js, this PR bumps `better-sqlite3` from `^11.8.1` to `^12.10.0` in the two server templates. The `11.10.0` native addon cannot compile against Node 26's V8 (it uses removed APIs like `Object::GetPrototype`, `Context::GetIsolate`, and `PropertyCallbackInfo::This`) and ships no Node 26 prebuilt binary, so `yarn install` fails with a `node-gyp` build error. `better-sqlite3@12` ships prebuilt binaries for Node 24/25/26 and builds cleanly.

The only breaking change across the 11 → 12 line is dropping EOL Node.js 18 (`engines` is now `20.x || 22.x || 23.x || 24.x || 25.x || 26.x`), which is already below this repo's `node: ^20.0.0` requirement. There are no JavaScript API changes, and the templates only use basic `prepare`/`run`/`get`/`exec`, so no code changes are needed.

### Change type

- [x] `other` (chore — template dependency bump)

### Test plan

1. With Node 24/26 active, run `yarn dev-template simple-server-example`.
2. Run `yarn dev-template socketio-server-example`.
3. Confirm the server starts and persists rooms via better-sqlite3 without a build error.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Templates      | +2 / -2    |
| Config/tooling | +6 / -6    |

### Release notes

- Bump `better-sqlite3` to v12 in the server templates so they install and run on Node 24+ (including Node 26).
