### PR TITLE
ci: don't fail update-snapshots when there are no changes

### DIFF
--- a/.github/workflows/playwright-update-snapshots.yml
+++ b/.github/workflows/playwright-update-snapshots.yml
@@ -71,6 +71,10 @@ jobs:
           git config --global user.name 'huppy-bot[bot]'
           git config --global user.email '128400622+huppy-bot[bot]@users.noreply.github.com'
           git add -A
+          if git diff --cached --quiet; then
+            echo 'No snapshot changes to commit.'
+            exit 0
+          fi
           git commit --no-verify -m '[automated] update snapshots'
           git add -A && git reset --hard HEAD # we sometimes get a dirty tree because husky makes changes for some reason
           git pull --rebase


### PR DESCRIPTION
The `update-snapshots` workflow regenerates Playwright snapshots and commits them via huppy-bot. When a run produces no snapshot changes, the `git commit` step failed with `nothing to commit, working tree clean` (exit 1), so the workflow reported a red ✗ even though nothing was wrong — there was simply nothing to update.

This guards the commit step: if nothing is staged, it logs a message and exits 0 instead of attempting an empty commit. Runs that do produce snapshot changes still commit and push as before.

## Code changes

| File | +/- |
| --- | --- |
| `.github/workflows/playwright-update-snapshots.yml` | +4 / −0 |

## Test plan

- A label-triggered run with no snapshot diffs now completes green instead of failing on the empty commit.
- A run that does produce snapshot changes still commits and pushes (the guard only short-circuits the empty case).