### PR TITLE
fix(dotcom): auto-scroll sidebar while dragging a file

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -73,7 +73,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 				{/* The workspace list is fixed; only the file list below it scrolls. */}
 				{workspacesEnabled && <TlaSidebarWorkspaceList />}
 				{workspacesEnabled && <div className={styles.sidebarDivider} />}
-				<div className={styles.sidebarContent}>
+				<div className={styles.sidebarContent} data-sidebar-scroll-container>
 					<div className={styles.sidebarContentInner}>
 						{workspacesEnabled ? <TlaSidebarRecentFilesNew /> : <TlaSidebarRecentFiles />}
 					</div>

--- a/apps/dotcom/client/src/tla/hooks/useDragTracking.ts
+++ b/apps/dotcom/client/src/tla/hooks/useDragTracking.ts
@@ -60,6 +60,44 @@ function findHoveredWorkspaceId(
 	)
 }
 
+// Auto-scroll the sidebar while dragging when the pointer nears the top or
+// bottom edge of the scroll container. These mirror the page menu's drag
+// scrolling (see DefaultPageMenu) so the two pieces of UI behave the same.
+// AUTO_SCROLL_ZONE is how far from the edge the auto-scroll begins;
+// RAMP_DISTANCE is how far past that point it takes to reach max speed.
+const AUTO_SCROLL_ZONE = 16
+const AUTO_SCROLL_RAMP_DISTANCE = 48
+const MIN_AUTO_SCROLL_SPEED = 1
+const MAX_AUTO_SCROLL_SPEED = 6
+
+// Scrolls the sidebar container by one frame's worth of auto-scroll when the
+// pointer is within AUTO_SCROLL_ZONE of an edge, ramping the speed up the
+// further past the edge the pointer goes. Reorder/move targets are recomputed
+// on the next frame from fresh element rects, so no offset bookkeeping is
+// needed here — the native drag image follows the cursor on its own.
+function tickAutoScroll(container: HTMLElement, mousePosition: { y: number }) {
+	const rect = container.getBoundingClientRect()
+	const fromTop = mousePosition.y - rect.top
+	const fromBottom = rect.bottom - mousePosition.y
+	const maxScroll = container.scrollHeight - container.clientHeight
+
+	const overshootTop = AUTO_SCROLL_ZONE - fromTop
+	const overshootBottom = AUTO_SCROLL_ZONE - fromBottom
+
+	let dy = 0
+	if (overshootTop > 0 && container.scrollTop > 0) {
+		const t = Math.min(1, overshootTop / AUTO_SCROLL_RAMP_DISTANCE)
+		dy = -Math.ceil(MIN_AUTO_SCROLL_SPEED + (MAX_AUTO_SCROLL_SPEED - MIN_AUTO_SCROLL_SPEED) * t)
+	} else if (overshootBottom > 0 && container.scrollTop < maxScroll) {
+		const t = Math.min(1, overshootBottom / AUTO_SCROLL_RAMP_DISTANCE)
+		dy = Math.ceil(MIN_AUTO_SCROLL_SPEED + (MAX_AUTO_SCROLL_SPEED - MIN_AUTO_SCROLL_SPEED) * t)
+	}
+
+	if (dy !== 0) {
+		container.scrollTop = Math.max(0, Math.min(maxScroll, container.scrollTop + dy))
+	}
+}
+
 // This adds a little bit of an offset to the indicator
 // so it doesn't hug the top or bottom edge of the adjacent
 // item too closely if it's at the top or bottom of the list.
@@ -175,6 +213,7 @@ export function useDragTracking() {
 			const workspaceElements = document.querySelectorAll('[data-drop-target-id^="workspace:"]')
 			const homeWorkspaceId = app.getHomeWorkspaceId()
 			const myFilesElement = document.querySelector(`[data-drop-target-id="${homeWorkspaceId}"]`)
+			const scrollContainer = document.querySelector<HTMLElement>('[data-sidebar-scroll-container]')
 
 			assert(myFilesElement, 'myFilesElement not found')
 
@@ -225,6 +264,12 @@ export function useDragTracking() {
 			// Start the measurement loop
 			const onFrame = () => {
 				if (!cleanupRef.current) return
+
+				// Auto-scroll the sidebar when the pointer nears an edge so the
+				// list keeps moving even though native drag suppresses scrolling.
+				if (scrollContainer) {
+					tickAutoScroll(scrollContainer, mousePosition)
+				}
 
 				// Update bounding boxes for all drop targets
 				// Detect operations and update app state

--- a/apps/dotcom/client/src/tla/hooks/useDragTracking.ts
+++ b/apps/dotcom/client/src/tla/hooks/useDragTracking.ts
@@ -258,7 +258,15 @@ export function useDragTracking() {
 				}
 			}
 
+			// The `drag` event is throttled well below the animation-frame rate,
+			// so on its own it leaves `mousePosition` stale between frames — the
+			// auto-scroll loop would keep scrolling for several frames after the
+			// pointer has already left the edge zone. `dragover` fires as the
+			// pointer moves across elements, refreshing the position within about
+			// a frame of leaving the zone. We only read coordinates here (no
+			// preventDefault), so this doesn't affect drop handling.
 			window.addEventListener('drag', handleMouseMove)
+			window.addEventListener('dragover', handleMouseMove)
 			let animationFrame = 0
 
 			// Start the measurement loop
@@ -306,6 +314,7 @@ export function useDragTracking() {
 				cleanupRef.current = null
 				cancelAnimationFrame(animationFrame)
 				window.removeEventListener('drag', handleMouseMove)
+				window.removeEventListener('dragover', handleMouseMove)
 				window.removeEventListener('dragend', onDone)
 				window.removeEventListener('pointerup', onDone)
 				window.removeEventListener('blur', onDone)


### PR DESCRIPTION
In order to let users scroll the sidebar file list while dragging a file, this PR adds edge auto-scroll to the sidebar's drag tracking. The sidebar uses the native HTML5 drag-and-drop API, which suppresses normal scrolling, so when a dragged file reached the top or bottom of an overflowing list the list stayed put and you couldn't reach the rest of it. The fix reuses the page menu's auto-scroll approach — same edge zone, ramp distance, and min/max speed as `DefaultPageMenu` — inside the drag tracking's existing `requestAnimationFrame` loop, aligning the two pieces of UI as requested. Closes #8972.

Because the loop re-detects drop targets from fresh element rects every frame and the browser's native drag image follows the cursor on its own, the only addition needed was a guarded `tickAutoScroll(container, mousePosition)` call plus a `data-sidebar-scroll-container` marker so the drag hook can resolve the scroll element (consistent with the drag subsystem's existing `data-*` contract).

### Preview

Test it on the live preview deploy: **https://pr-9071-preview-deploy.tldraw.com/**

(This URL is stable across commits — it always points at the latest build of this PR.)

### Change type

- [x] `bugfix`

### Test plan

1. Open the preview deploy at https://pr-9071-preview-deploy.tldraw.com/ and sign in.
2. Turn on the groups flag for your account: go to https://pr-9071-preview-deploy.tldraw.com/admin, search for your email, and enrol yourself in groups.
3. Create a number of files to fill up the sidebar so the file list overflows.
4. Start dragging a file and hold it near the top or bottom edge of the list.
5. The list auto-scrolls, with speed ramping up the closer the pointer is to the edge, matching the page menu's behavior.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the sidebar not scrolling while dragging a file; the file list now auto-scrolls when a dragged file reaches the top or bottom edge.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +46 / -1   |
