### PR TITLE
test(dotcom): catch duplicate or non-contiguous zero-cache migration numbers

### DIFF
--- a/apps/dotcom/zero-cache/validateMigrationFilenames.test.ts
+++ b/apps/dotcom/zero-cache/validateMigrationFilenames.test.ts
@@ -1,0 +1,43 @@
+import { readdirSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { describe, expect, it } from 'vitest'
+import { validateMigrationFilenames } from './validateMigrationFilenames'
+
+const migrationsDir = fileURLToPath(new URL('./migrations', import.meta.url))
+
+describe('validateMigrationFilenames', () => {
+	it('passes for the migrations checked into this package', () => {
+		const filenames = readdirSync(migrationsDir)
+		expect(() => validateMigrationFilenames(filenames)).not.toThrow()
+	})
+
+	it('accepts a clean contiguous sequence', () => {
+		expect(() =>
+			validateMigrationFilenames(['000_seed.sql', '001_a.sql', '002_b.sql'])
+		).not.toThrow()
+	})
+
+	it('throws on a duplicate number', () => {
+		expect(() => validateMigrationFilenames(['000_seed.sql', '001_a.sql', '001_b.sql'])).toThrow(
+			/Duplicate migration number 001/
+		)
+	})
+
+	it('throws on a gap in the sequence', () => {
+		expect(() => validateMigrationFilenames(['000_seed.sql', '002_b.sql'])).toThrow(/missing 001/)
+	})
+
+	it('throws when the sequence does not start at 000', () => {
+		expect(() => validateMigrationFilenames(['001_a.sql'])).toThrow(/must start at 000/)
+	})
+
+	it('throws on a malformed filename', () => {
+		expect(() => validateMigrationFilenames(['1_a.sql'])).toThrow(/must match/)
+	})
+
+	it('allows explicitly grandfathered duplicate numbers', () => {
+		expect(() =>
+			validateMigrationFilenames(['000_seed.sql', '001_a.sql', '001_b.sql'], new Set([1]))
+		).not.toThrow()
+	})
+})

--- a/apps/dotcom/zero-cache/validateMigrationFilenames.ts
+++ b/apps/dotcom/zero-cache/validateMigrationFilenames.ts
@@ -1,0 +1,64 @@
+// Migration numbers are chosen by hand, so two concurrent PRs can pick the same
+// one. The filenames differ, so git merges both cleanly and `main` ends up with
+// a duplicate. This throws on duplicate or non-contiguous numbers; CI runs it
+// against the post-merge tree, catching the collision before it lands.
+
+// Numbers duplicated before this check existed. Don't add to this list.
+export const GRANDFATHERED_DUPLICATE_NUMBERS: ReadonlySet<number> = new Set([27])
+
+function pad(n: number) {
+	return String(n).padStart(3, '0')
+}
+
+export function validateMigrationFilenames(
+	filenames: string[],
+	allowedDuplicates: ReadonlySet<number> = GRANDFATHERED_DUPLICATE_NUMBERS
+) {
+	const filesByNumber = new Map<number, string[]>()
+	for (const filename of filenames) {
+		const match = filename.match(/^(\d{3})_.+\.sql$/)
+		if (!match) {
+			throw new Error(
+				`Migration filename "${filename}" must match "NNN_description.sql" (a three-digit number, for example "032_add_thing.sql").`
+			)
+		}
+		const number = Number(match[1])
+		const existing = filesByNumber.get(number)
+		if (existing) {
+			existing.push(filename)
+		} else {
+			filesByNumber.set(number, [filename])
+		}
+	}
+
+	if (filesByNumber.size === 0) {
+		throw new Error('No migrations found.')
+	}
+
+	const numbers = [...filesByNumber.keys()].sort((a, b) => a - b)
+
+	// Numbers must be unique.
+	for (const number of numbers) {
+		const files = filesByNumber.get(number)!
+		if (files.length > 1 && !allowedDuplicates.has(number)) {
+			throw new Error(
+				`Duplicate migration number ${pad(number)}: ${[...files].sort().join(', ')}. ` +
+					`Each migration must use a unique number — bump one of them to the next free number.`
+			)
+		}
+	}
+
+	// Numbers must be contiguous starting at 000.
+	if (numbers[0] !== 0) {
+		throw new Error(`Migrations must start at 000, but the lowest number is ${pad(numbers[0])}.`)
+	}
+	for (let i = 1; i < numbers.length; i++) {
+		const prev = numbers[i - 1]
+		const curr = numbers[i]
+		if (curr !== prev + 1) {
+			throw new Error(
+				`Migration numbers must be contiguous: missing ${pad(prev + 1)} (jumps from ${pad(prev)} to ${pad(curr)}).`
+			)
+		}
+	}
+}

--- a/apps/dotcom/zero-cache/vitest.config.ts
+++ b/apps/dotcom/zero-cache/vitest.config.ts
@@ -1,0 +1,12 @@
+/// <reference types="vitest" />
+import { mergeConfig } from 'vitest/config'
+import baseConfig from '../../../internal/config/vitest/node-preset'
+
+// Node env; source lives at the package root, not `src/`, so widen the include.
+export default mergeConfig(baseConfig, {
+	test: {
+		environment: 'node',
+		include: ['**/*.test.ts'],
+		exclude: ['**/node_modules/**', 'docker/**', '_archive/**'],
+	},
+})


### PR DESCRIPTION
In order to stop two concurrent PRs from each picking the same zero-cache migration number and silently colliding on `main`, this PR adds a check that validates the migration filenames in `apps/dotcom/zero-cache/migrations/`. Migration numbers are chosen by hand and the filenames differ, so git merges two same-numbered migrations cleanly and `main` ends up with a duplicate. The check throws on duplicate or non-contiguous numbers and runs as a vitest test under `yarn test-ci`. Because CI checks out the post-merge tree (both `pull_request` and the `merge_group` queue), the collision is caught when the second PR is merged rather than after it lands. Closes #9075.

The existing duplicate `027` on `main` is grandfathered in via `GRANDFATHERED_DUPLICATE_NUMBERS` so the check passes today; new migrations must use a unique, contiguous number.

### Change type

- [x] `other` (CI/tooling, test)

### Test plan

1. From `apps/dotcom/zero-cache`, run `yarn test run` — passes against the real migrations directory.
2. Create a colliding file: `cp migrations/031_group_id_indexes.sql migrations/031_dupe.sql`, rerun — fails with "Duplicate migration number 031". Remove it.
3. Rename a file to create a gap: `mv migrations/031_*.sql migrations/033_*.sql`, rerun — fails with "missing 032". Revert.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Tests          | +43 / -0   |
| Apps           | +64 / -0   |
| Config/tooling | +12 / -0   |