### PR TITLE
spike: fix(editor): keep bound arrows stable when deleting a shape is…

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1330,6 +1330,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getIsFocused(): boolean;
     // (undocumented)
     getIsReadonly(): boolean;
+    getIsReplayingHistory(): boolean;
     // @internal
     getMarkIdMatching(idSubstring: string): null | string;
     getNearestAdjacentShape(shapes: TLShape[], currentShapeId: TLShapeId, direction: 'down' | 'left' | 'right' | 'up'): TLShapeId;
@@ -2155,6 +2156,8 @@ export class HistoryManager<R extends UnknownRecord> {
     getNumUndos(): number;
     // @internal (undocumented)
     _isInBatch: boolean;
+    // @internal
+    _isInUndoRedo: boolean;
     // @internal (undocumented)
     _mark(id: string): void;
     // (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -697,16 +697,22 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						deletedShapeIds.add(shape.id)
 
+						// When re-applying a recorded diff during undo/redo, the diff already contains
+						// the result of isolation (e.g. an arrow's frozen terminal and bend). Running
+						// the isolation callbacks again would recompute from the already-modified
+						// shape and overwrite the recorded values, so we skip them during replay.
+						const isInUndoRedo = this.getIsReplayingHistory()
+
 						const deleteBindingIds: TLBindingId[] = []
 						for (const binding of this.getBindingsInvolvingShape(shape)) {
 							invalidBindingTypes.add(binding.type)
 							deleteBindingIds.push(binding.id)
 							const util = this.getBindingUtil(binding)
 							if (binding.fromId === shape.id) {
-								util.onBeforeIsolateToShape?.({ binding, removedShape: shape })
+								if (!isInUndoRedo) util.onBeforeIsolateToShape?.({ binding, removedShape: shape })
 								util.onBeforeDeleteFromShape?.({ binding, shape })
 							} else {
-								util.onBeforeIsolateFromShape?.({ binding, removedShape: shape })
+								if (!isInUndoRedo) util.onBeforeIsolateFromShape?.({ binding, removedShape: shape })
 								util.onBeforeDeleteToShape?.({ binding, shape })
 							}
 						}
@@ -1511,6 +1517,32 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	getCanRedo() {
 		return this.canRedo()
+	}
+
+	/**
+	 * Whether the editor is currently replaying a recorded change as part of an undo or redo.
+	 *
+	 * While this is true, the recorded history diff is authoritative: it already contains the
+	 * result of any side effects that ran when the change first happened. Side effects that perform
+	 * a one-shot, non-idempotent transform (for example, "freezing" an arrow's terminal when the
+	 * shape it points to is deleted) should not run again during replay, otherwise they recompute
+	 * from the already-updated state and drift away from the recorded values.
+	 *
+	 * @example
+	 * ```ts
+	 * class MyBindingUtil extends BindingUtil<MyBinding> {
+	 *     override onBeforeIsolateToShape({ binding }: BindingOnShapeIsolateOptions<MyBinding>) {
+	 *         // the recorded diff already holds the isolated result, so don't recompute it
+	 *         if (this.editor.getIsReplayingHistory()) return
+	 *         // ...otherwise bake in the current geometry
+	 *     }
+	 * }
+	 * ```
+	 *
+	 * @public
+	 */
+	getIsReplayingHistory() {
+		return this.history._isInUndoRedo
 	}
 
 	clearHistory() {

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -82,6 +82,15 @@ export class HistoryManager<R extends UnknownRecord> {
 	/** @internal */
 	_isInBatch = false
 
+	/**
+	 * Whether we're currently re-applying a recorded diff as part of an undo or redo. While this is
+	 * true, the recorded diff is authoritative, so consistency side effects (such as the binding
+	 * isolation callbacks) should not recompute and overwrite the recorded values.
+	 *
+	 * @internal
+	 */
+	_isInUndoRedo = false
+
 	batch(fn: () => void, opts?: TLHistoryBatchOptions) {
 		const previousState = this.state
 
@@ -177,7 +186,12 @@ export class HistoryManager<R extends UnknownRecord> {
 				return this
 			}
 
-			this.store.applyDiff(diffToUndo, { ignoreEphemeralKeys: true })
+			this._isInUndoRedo = true
+			try {
+				this.store.applyDiff(diffToUndo, { ignoreEphemeralKeys: true })
+			} finally {
+				this._isInUndoRedo = false
+			}
 			this.store.ensureStoreIsUsable()
 			this.stacks.set({ undos, redos })
 		} finally {
@@ -225,7 +239,12 @@ export class HistoryManager<R extends UnknownRecord> {
 				}
 			}
 
-			this.store.applyDiff(diffToRedo, { ignoreEphemeralKeys: true })
+			this._isInUndoRedo = true
+			try {
+				this.store.applyDiff(diffToRedo, { ignoreEphemeralKeys: true })
+			} finally {
+				this._isInUndoRedo = false
+			}
 			this.store.ensureStoreIsUsable()
 			this.stacks.set({ undos, redos })
 		} finally {

--- a/packages/tldraw/src/test/commands/deleteShapes.test.ts
+++ b/packages/tldraw/src/test/commands/deleteShapes.test.ts
@@ -1,4 +1,4 @@
-import { createBindingId, createShapeId } from '@tldraw/editor'
+import { createBindingId, createShapeId, TLArrowShape } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { getArrowBindings } from '../../lib/shapes/arrow/shared'
 import { TestEditor } from '../TestEditor'
@@ -173,5 +173,28 @@ describe('When deleting arrows', () => {
 		editor.undo()
 		expect(bindings().start).toBeDefined()
 		expect(bindings().end).toBeDefined()
+	})
+
+	it('Recalculates a bent arrow the same way on redo as on the original delete', () => {
+		// Give the arrow a bend so deleting a bound shape has to recompute its arc.
+		editor.updateShape({ id: ids.arrow1, type: 'arrow', props: { bend: 60 } })
+
+		editor.markHistoryStoppingPoint('before deleting')
+		editor.deleteShapes([ids.box2])
+
+		const afterDelete = editor.getShape<TLArrowShape>(ids.arrow1)!.props
+		expect(bindings().end).toBeUndefined()
+
+		editor.undo()
+		expect(bindings().end).toBeDefined()
+		expect(editor.getShape<TLArrowShape>(ids.arrow1)!.props.bend).toBe(60)
+
+		editor.redo()
+		const afterRedo = editor.getShape<TLArrowShape>(ids.arrow1)!.props
+		expect(bindings().end).toBeUndefined()
+		// redo must reproduce the exact frozen terminal and bend from the original delete,
+		// not recompute a drifted value
+		expect(afterRedo.end).toEqual(afterDelete.end)
+		expect(afterRedo.bend).toEqual(afterDelete.bend)
 	})
 })


### PR DESCRIPTION
### this is a spike in order to get a better understanding of the problem in https://github.com/tldraw/tldraw/pull/8283 and eventually help out with it. 

When a shape that a curved arrow points to is deleted, the arrow's terminal
and bend are "frozen" so the arrow stays put. This freeze runs in the
`onBeforeIsolateFromShape` binding callback and recomputes the arc from the
arrow's current geometry — a one-shot, non-idempotent transform.

Undo/redo replays the recorded diff and also re-runs store side effects. On
redo, the diff already restored the frozen terminal and bend, but the isolation
callback ran again on top of those already-frozen values, recomputed a
different arc, and overwrote the recorded result. The arrow ended up in a
different place than it did on the original delete.

The recorded diff is authoritative during replay, so we now skip the binding
isolation callbacks while undoing/redoing. This applies to every binding type,
not just arrows.

Also exposes `editor.getIsReplayingHistory()` so authors of custom bindings and
shapes can guard their own one-shot transforms against the same drift.

### Test plan

- New regression test in `deleteShapes.test.ts`: a bent arrow bound to two
  shapes recomputes identically on redo as on the original delete, and undo
  restores the original bend.
- `packages/editor` and `packages/tldraw` test suites, `yarn typecheck`, and
  `yarn api-check` pass.