### PR TITLE
fix(dotcom): show an empty state when a group invite link has expired

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -69,6 +69,12 @@
       "value": "File menu"
     }
   ],
+  "0c4383617a": [
+    {
+      "type": 0,
+      "value": "Something went wrong loading this invite. Please try again."
+    }
+  ],
   "0d1f2bb523": [
     {
       "type": 0,
@@ -679,6 +685,12 @@
       "value": "You are already a member of this workspace"
     }
   ],
+  "88bf6ab42c": [
+    {
+      "type": 0,
+      "value": "This invite link has expired"
+    }
+  ],
   "8ad4303b83": [
     {
       "type": 0,
@@ -1177,6 +1189,12 @@
       "value": "App debug flags"
     }
   ],
+  "e0aa021e21": [
+    {
+      "type": 0,
+      "value": "OK"
+    }
+  ],
   "e0c88179b3": [
     {
       "type": 0,
@@ -1229,6 +1247,12 @@
     {
       "type": 0,
       "value": "Cancel"
+    }
+  ],
+  "eb1e2b0542": [
+    {
+      "type": 0,
+      "value": "Ask the workspace owner for a new one."
     }
   ],
   "ebfe9ce86e": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -32,6 +32,9 @@
   "0b9a4cde72": {
     "translation": "File menu"
   },
+  "0c4383617a": {
+    "translation": "Something went wrong loading this invite. Please try again."
+  },
   "0d1f2bb523": {
     "translation": "Send feedback"
   },
@@ -314,6 +317,9 @@
   "87fdb09de6": {
     "translation": "You are already a member of this workspace"
   },
+  "88bf6ab42c": {
+    "translation": "This invite link has expired"
+  },
   "8ad4303b83": {
     "translation": "No thanks"
   },
@@ -513,6 +519,9 @@
   "dfdb78a4e4": {
     "translation": "App debug flags"
   },
+  "e0aa021e21": {
+    "translation": "OK"
+  },
   "e0c88179b3": {
     "translation": "Invite members"
   },
@@ -539,6 +548,9 @@
   },
   "ea4788705e": {
     "translation": "Cancel"
+  },
+  "eb1e2b0542": {
+    "translation": "Ask the workspace owner for a new one."
   },
   "ebfe9ce86e": {
     "translation": "Yesterday"

--- a/apps/dotcom/client/src/tla/components/WorkspaceInviteHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/WorkspaceInviteHandler.tsx
@@ -13,9 +13,11 @@ import { hasNotAcceptedLegal } from '../utils/auth'
 import { defineMessages, useMsg } from '../utils/i18n'
 import { SESSION_STORAGE_KEYS } from '../utils/session-storage'
 import { TlaInviteDialog } from './dialogs/TlaInviteDialog'
+import { TlaInviteExpiredDialog } from './dialogs/TlaInviteExpiredDialog'
 
 const workspaceInviteMessages = defineMessages({
 	alreadyMember: { defaultMessage: 'You are already a member of this workspace' },
+	error: { defaultMessage: 'Something went wrong loading this invite. Please try again.' },
 })
 
 export function WorkspaceInviteHandler() {
@@ -24,6 +26,7 @@ export function WorkspaceInviteHandler() {
 	const { addToast } = useToasts()
 	const app = useMaybeApp()
 	const alreadyMemberMsg = useMsg(workspaceInviteMessages.alreadyMember)
+	const errorMsg = useMsg(workspaceInviteMessages.error)
 
 	const { user } = useClerkUser()
 
@@ -43,7 +46,15 @@ export function WorkspaceInviteHandler() {
 				.then((res) => res.json())
 				.then((data: GetInviteInfoResponseBody) => {
 					if (data.error) {
-						// Invalid invite token, ignore
+						// The invite link is no longer valid: the owner has regenerated it
+						// (re-roll) or the workspace is gone. Show a dedicated empty-state
+						// instead of failing silently. (A toast is unreliable here: it is
+						// added during the /invite -> / -> file route transition and gets
+						// dismissed near-instantly at the default duration, so the dialog
+						// is the surface that reliably reaches the user.)
+						dialogs.addDialog({
+							component: ({ onClose }) => <TlaInviteExpiredDialog onClose={onClose} />,
+						})
 						return
 					}
 
@@ -63,10 +74,29 @@ export function WorkspaceInviteHandler() {
 					})
 				})
 				.catch(() => {
-					// Error fetching invite, ignore
+					// Genuine network/parse failure (not a 404, which resolves and is
+					// handled above). No dialog competes here, so a toast is the right
+					// surface — keepOpen so it survives the route transition rather than
+					// being dismissed before the user sees it.
+					addToast({
+						id: 'workspace-invite-error',
+						severity: 'error',
+						title: errorMsg,
+						keepOpen: true,
+					})
 				})
 		}
-	}, [auth.isLoaded, auth.userId, auth.isSignedIn, dialogs, app, user, addToast, alreadyMemberMsg])
+	}, [
+		auth.isLoaded,
+		auth.userId,
+		auth.isSignedIn,
+		dialogs,
+		app,
+		user,
+		addToast,
+		alreadyMemberMsg,
+		errorMsg,
+	])
 
 	return null
 }

--- a/apps/dotcom/client/src/tla/components/WorkspaceInviteHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/WorkspaceInviteHandler.tsx
@@ -41,20 +41,35 @@ export function WorkspaceInviteHandler() {
 		if (storedToken) {
 			deleteFromSessionStorage(SESSION_STORAGE_KEYS.WORKSPACE_INVITE_TOKEN)
 
+			const showError = () =>
+				addToast({
+					id: 'workspace-invite-error',
+					severity: 'error',
+					title: errorMsg,
+					keepOpen: true,
+				})
+
 			// Fetch invite info from API
 			fetch(`/api/app/invite/${storedToken}`)
-				.then((res) => res.json())
-				.then((data: GetInviteInfoResponseBody) => {
-					if (data.error) {
-						// The invite link is no longer valid: the owner has regenerated it
-						// (re-roll) or the workspace is gone. Show a dedicated empty-state
-						// instead of failing silently. (A toast is unreliable here: it is
-						// added during the /invite -> / -> file route transition and gets
-						// dismissed near-instantly at the default duration, so the dialog
-						// is the surface that reliably reaches the user.)
+				.then(async (res) => {
+					// 404 means the invite no longer resolves (link regenerated or workspace
+					// gone) — the only case that warrants the expired empty-state. Other
+					// failures (400, 500) are errors, not expired links.
+					if (res.status === 404) {
 						dialogs.addDialog({
 							component: ({ onClose }) => <TlaInviteExpiredDialog onClose={onClose} />,
 						})
+						return
+					}
+
+					if (!res.ok) {
+						showError()
+						return
+					}
+
+					const data: GetInviteInfoResponseBody = await res.json()
+					if (data.error) {
+						showError()
 						return
 					}
 
@@ -73,18 +88,7 @@ export function WorkspaceInviteHandler() {
 						component: ({ onClose }) => <TlaInviteDialog inviteInfo={data} onClose={onClose} />,
 					})
 				})
-				.catch(() => {
-					// Genuine network/parse failure (not a 404, which resolves and is
-					// handled above). No dialog competes here, so a toast is the right
-					// surface — keepOpen so it survives the route transition rather than
-					// being dismissed before the user sees it.
-					addToast({
-						id: 'workspace-invite-error',
-						severity: 'error',
-						title: errorMsg,
-						keepOpen: true,
-					})
-				})
+				.catch(showError)
 		}
 	}, [
 		auth.isLoaded,

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
@@ -15,9 +15,11 @@
 	width: 300px;
 }
 
-.header {
+.dialogBody .header {
+	flex: 0 0 auto;
 	font-size: 16px;
 	font-weight: 600;
+	color: var(--tl-color-text-1);
 	margin: 8px 0 0;
 }
 

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
@@ -32,15 +32,4 @@
 .okButton {
 	margin-top: 8px;
 	width: 100%;
-	height: 32px;
-	background-color: var(--tla-color-cta);
-	color: var(--tla-color-contrast);
-	border: none;
-	border-radius: var(--tl-radius-1);
-	font-weight: 500;
-	cursor: pointer;
-}
-
-.okButton:hover {
-	background-color: var(--tla-color-cta-hover);
 }

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
@@ -1,0 +1,44 @@
+.dialogHeader {
+	height: 40px;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+.dialogBody {
+	text-align: center;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 8px;
+	padding: 0 24px 24px;
+	width: 300px;
+}
+
+.header {
+	font-size: 16px;
+	font-weight: 600;
+	margin: 8px 0 0;
+}
+
+.message {
+	font-size: 12px;
+	color: var(--tl-color-text-3);
+	margin: 0;
+}
+
+.okButton {
+	margin-top: 8px;
+	width: 100%;
+	height: 32px;
+	background-color: var(--tla-color-cta);
+	color: var(--tla-color-contrast);
+	border: none;
+	border-radius: var(--tl-radius-1);
+	font-weight: 500;
+	cursor: pointer;
+}
+
+.okButton:hover {
+	background-color: var(--tla-color-cta-hover);
+}

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.tsx
@@ -6,6 +6,7 @@ import {
 } from 'tldraw'
 import { sadFaceIcon } from '../../../components/ErrorPage/ErrorPage'
 import { F } from '../../utils/i18n'
+import { TlaButton } from '../TlaButton/TlaButton'
 import styles from './TlaInviteExpiredDialog.module.css'
 
 export function TlaInviteExpiredDialog({ onClose }: { onClose(): void }) {
@@ -22,9 +23,9 @@ export function TlaInviteExpiredDialog({ onClose }: { onClose(): void }) {
 				<p className={styles.message}>
 					<F defaultMessage="Ask the workspace owner for a new one." />
 				</p>
-				<button className={styles.okButton} onClick={onClose}>
+				<TlaButton variant="cta" className={styles.okButton} onClick={onClose}>
 					<F defaultMessage="OK" />
-				</button>
+				</TlaButton>
 			</TldrawUiDialogBody>
 		</>
 	)

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.tsx
@@ -12,16 +12,13 @@ export function TlaInviteExpiredDialog({ onClose }: { onClose(): void }) {
 	return (
 		<>
 			<TldrawUiDialogHeader className={styles.dialogHeader}>
-				<TldrawUiDialogTitle>
-					<span />
-				</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
 			<TldrawUiDialogBody className={styles.dialogBody}>
 				{sadFaceIcon}
-				<h1 className={styles.header}>
+				<TldrawUiDialogTitle className={styles.header}>
 					<F defaultMessage="This invite link has expired" />
-				</h1>
+				</TldrawUiDialogTitle>
 				<p className={styles.message}>
 					<F defaultMessage="Ask the workspace owner for a new one." />
 				</p>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.tsx
@@ -1,0 +1,34 @@
+import {
+	TldrawUiDialogBody,
+	TldrawUiDialogCloseButton,
+	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
+} from 'tldraw'
+import { sadFaceIcon } from '../../../components/ErrorPage/ErrorPage'
+import { F } from '../../utils/i18n'
+import styles from './TlaInviteExpiredDialog.module.css'
+
+export function TlaInviteExpiredDialog({ onClose }: { onClose(): void }) {
+	return (
+		<>
+			<TldrawUiDialogHeader className={styles.dialogHeader}>
+				<TldrawUiDialogTitle>
+					<span />
+				</TldrawUiDialogTitle>
+				<TldrawUiDialogCloseButton />
+			</TldrawUiDialogHeader>
+			<TldrawUiDialogBody className={styles.dialogBody}>
+				{sadFaceIcon}
+				<h1 className={styles.header}>
+					<F defaultMessage="This invite link has expired" />
+				</h1>
+				<p className={styles.message}>
+					<F defaultMessage="Ask the workspace owner for a new one." />
+				</p>
+				<button className={styles.okButton} onClick={onClose}>
+					<F defaultMessage="OK" />
+				</button>
+			</TldrawUiDialogBody>
+		</>
+	)
+}


### PR DESCRIPTION
In order to stop a regenerated group invite link from failing silently, this PR shows a dedicated empty-state when someone follows an expired link. Closes #9077.

A group invite link works for any number of users until the owner regenerates ("refreshes") it from group settings, which is effectively a re-roll: the old link's secret no longer matches any group. Previously, a new user who followed the stale link hit a silent failure — `GroupInviteHandler` fetched the invite info, got a `404 { error: true }`, and `return`ed without telling the user anything. Genuine network failures in the same handler were also swallowed in the `.catch`.

Now an expired/invalid link shows a `TlaInviteExpiredDialog` empty-state (sad-face panel mirroring the existing "you don't have access to this file" state: "This invite link has expired" / "Ask the group owner for a new one."), and a real network/parse failure surfaces an error toast instead of being ignored.

A note on why the empty-state is a dialog rather than a toast (the issue's original framing): the handler runs while the app is mid-navigation (`/invite/:token → / → /f/:file`), and a toast added during that transition is dismissed at its default 4s duration before the user can read it. The dialog isn't on a duration timer, so it reliably reaches the user. The `.catch` toast uses `keepOpen: true` for the same reason.

### Change type

- [x] `bugfix`

### Test plan

1. Open the preview deploy at https://pr-9080-preview-deploy.tldraw.com/ and sign in.
2. Turn on the groups flag for your account: go to https://pr-9080-preview-deploy.tldraw.com/admin, search for your email, and enrol yourself in groups.
3. Create a group, open group settings, and copy the invite link.
4. Click "refresh" in group settings to regenerate the link (this invalidates the link you just copied).
5. Open an incognito window and paste the **original** (now stale) invite link.
6. Confirm an empty-state dialog appears: "This invite link has expired" / "Ask the group owner for a new one." (Previously: nothing happened.)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Show an empty state when a user follows an expired group invite link, instead of silently failing to join.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Apps            | +111 / -3  |
| Automated files | +36 / -0   |


<img width="1624" height="1061" alt="Screenshot 2026-06-09 at 12 14 46" src="https://github.com/user-attachments/assets/bc756045-b4ca-4fc1-9d55-e272fbfa99b1" />
