### PR TITLE
fix(tldraw): fix collaborators not being updated as they just joined

### DIFF
--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.test.ts
@@ -129,4 +129,18 @@ describe(CollaboratorsManager, () => {
 
 		expect(manager.getVisibleCollaborators()).toHaveLength(1)
 	})
+
+	it('shows newly-joined collaborators that have not recorded any activity yet', () => {
+		// A peer who has joined but not moved their pointer broadcasts the default
+		// `lastActivityTimestamp` of 0. They should still be treated as active so
+		// they appear in the people menu / face pile. See issue #9017.
+		const zero = createPresence('zero')
+		zero.lastActivityTimestamp = 0
+		const nullish = createPresence('nullish')
+		nullish.lastActivityTimestamp = null
+		const { editor } = createEditor([zero, nullish])
+		const manager = new CollaboratorsManager(editor)
+
+		expect(manager.getVisibleCollaborators()).toHaveLength(2)
+	})
 })

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
@@ -93,9 +93,12 @@ export class CollaboratorsManager {
 		return collaborators.filter((presence) => {
 			const { lastActivityTimestamp, userId, chatMessage } = presence
 
-			// Treat a missing `lastActivityTimestamp` as "active right now" (elapsed = 0)
-			// so newly-joined peers aren't immediately classified as idle/inactive.
-			const elapsed = Math.max(0, now - (lastActivityTimestamp ?? now))
+			// Treat a missing or zero `lastActivityTimestamp` as "active right now"
+			// (elapsed = 0) so newly-joined peers aren't immediately classified as
+			// idle/inactive. The broadcast default for peers who haven't moved their
+			// pointer yet is `0` (e.g. someone on a touch device who joins and just
+			// watches), so a plain `?? now` would leave them hidden. See issue #9017.
+			const elapsed = lastActivityTimestamp ? Math.max(0, now - lastActivityTimestamp) : 0
 
 			if (elapsed > collaboratorInactiveTimeoutMs) {
 				// Inactive: If they're inactive, only show if we're following them or they're highlighted


### PR DESCRIPTION
Should close https://github.com/tldraw/tldraw/issues/9017

Newly added collaborator does not appear until they've actually "moved" on the canvas, this is mostly likely to be picked up on tablet (and normally… phones) as users are not spending their time moving fingers on the screen (is dirty)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

On ipad, or desktop

1. Open tldraw
2. Do a doodely diddle
3. share it with yourself
4. open link BUT DONT TOUCHY THE SCREENY
5. check other room -> should see user 

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug in the `CollaboratorsManager` where we're not displaying user who just joined until they interact with the board. 