### PR TITLE
docs: state no-contributions policy and direct users to issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,13 @@
 # Contributing
 
-We are **not accepting contributions** to [tldraw](https://github.com/tldraw/tldraw) at this time. Pull requests from external contributors will be automatically closed.
+We are **not accepting contributions** to [tldraw](https://github.com/tldraw/tldraw) at this time. Pull requests are turned off for this repository.
 
 For more details on this policy, see [this issue](https://github.com/tldraw/tldraw/issues/7695).
 
 ## Create an issue instead
 
 If you have found a bug, have a feature request, or want to suggest a change, please [create an issue](https://github.com/tldraw/tldraw/issues/new/choose). Issues are the best place to discuss proposed changes with the team, and we read every one.
+
+If a code example would help the discussion, fork the repository and link to your branch in the issue.
 
 Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around community culture.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,11 @@
 # Contributing
 
-Thank you for your interest in contributing to [tldraw](https://github.com/tldraw/tldraw)! We welcome any contributions to the code base and the documentation.
-
-## Create an Issue!
-
-Before submitting a pull request, it is **strongly recommended** to [create an issue](https://github.com/tldraw/tldraw/issues/new/choose) first to discuss your proposed changes. This will help us to make sure that your changes are aligned with the project goals and that you are not duplicating work that is already in progress.
-
-If you are not sure whether your changes are needed, feel free to create an issue anyway and we can discuss it there. Once we have agreed on the changes, you can start working on them.
-
-## Making Changes
-
-We are currently **not accepting pull requests from external contributors**. Pull requests will be automatically closed. This is a temporary policy until GitHub provides better tools for managing contributions.
+We are **not accepting contributions** to [tldraw](https://github.com/tldraw/tldraw) at this time. Pull requests from external contributors will be automatically closed.
 
 For more details on this policy, see [this issue](https://github.com/tldraw/tldraw/issues/7695).
 
-Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around contributor culture.
+## Create an issue instead
+
+If you have found a bug, have a feature request, or want to suggest a change, please [create an issue](https://github.com/tldraw/tldraw/issues/new/choose). Issues are the best place to discuss proposed changes with the team, and we read every one.
+
+Please also see our [Code of Conduct](https://github.com/tldraw/tldraw/blob/main/CODE_OF_CONDUCT.md) for our expectations around community culture.

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ yarn dev
 
 ## Contributing
 
-See our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md) to learn about contributing to tldraw.
+We are not accepting contributions at this time. If you've found a bug or have a feature request, please [create an issue](https://github.com/tldraw/tldraw/issues/new/choose) and we can discuss it there. See our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md) for details.
 
 ## License
 

--- a/apps/bemo-worker/README.md
+++ b/apps/bemo-worker/README.md
@@ -41,7 +41,7 @@ The bemo worker does several things like handling bookmark unfurling, asset uplo
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -34,7 +34,7 @@ A section looks like this:
 {
 	"id": "community",
 	"title": "Community",
-	"description": "Guides for contributing to tldraw's open source project.",
+	"description": "Community resources for tldraw.",
 	"categories": []
 }
 ```
@@ -148,7 +148,7 @@ When developing the docs, any change to the `content` folder will cause the page
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/apps/docs/content/community/contributing.mdx
+++ b/apps/docs/content/community/contributing.mdx
@@ -6,8 +6,6 @@ date: 3/22/2023
 order: 1
 ---
 
-Interested in contributing to the project?
+tldraw's source code is available on GitHub at [github.com/tldraw/tldraw](https://github.com/tldraw/tldraw). While you can read the code, we are not accepting external contributions.
 
-You can find tldraw's source code on GitHub at [github.com/tldraw/tldraw](https://github.com/tldraw/tldraw). See our [Contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md) for more information.
-
-To contribute translations to the project, please see our [translations guide](/community/translations).
+The best way to help improve tldraw is to share your feedback. To report a bug or request a feature, [open an issue](https://github.com/tldraw/tldraw/issues) on GitHub or let us know on [Discord](https://discord.tldraw.com/?utm_source=docs&utm_medium=organic&utm_campaign=sociallink). If a code example would help the discussion, fork the repository and link to your branch in the issue.

--- a/apps/dotcom/asset-upload-worker/README.md
+++ b/apps/dotcom/asset-upload-worker/README.md
@@ -16,7 +16,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/apps/dotcom/client/README.md
+++ b/apps/dotcom/client/README.md
@@ -10,7 +10,7 @@ See our:
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/apps/dotcom/image-resize-worker/README.md
+++ b/apps/dotcom/image-resize-worker/README.md
@@ -16,7 +16,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/apps/dotcom/sync-worker/README.md
+++ b/apps/dotcom/sync-worker/README.md
@@ -27,7 +27,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/apps/examples/README.md
+++ b/apps/examples/README.md
@@ -10,7 +10,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -95,7 +95,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/apps/vscode/editor/README.md
+++ b/apps/vscode/editor/README.md
@@ -4,7 +4,7 @@ This folder contains the React app used by the tldraw VS Code extension.
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/apps/vscode/extension/README.md
+++ b/apps/vscode/extension/README.md
@@ -37,7 +37,7 @@ To install from a `.vsix` file:
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/internal/apps-script/README.md
+++ b/internal/apps-script/README.md
@@ -4,7 +4,7 @@ This is an experimental/in-development library to create add-ons for Google Meet
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/internal/health-worker/README.md
+++ b/internal/health-worker/README.md
@@ -16,7 +16,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -8,7 +8,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/dotcom-shared/README.md
+++ b/packages/dotcom-shared/README.md
@@ -4,7 +4,7 @@ This is a small packaged used by [apps/dotcom](https://github.com/tldraw/tldraw/
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -20,7 +20,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/mermaid/README.md
+++ b/packages/mermaid/README.md
@@ -197,7 +197,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/namespaced-tldraw/README.md
+++ b/packages/namespaced-tldraw/README.md
@@ -18,7 +18,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/state-react/README.md
+++ b/packages/state-react/README.md
@@ -10,7 +10,7 @@ A `DOCS.md` file is included alongside this README in the published package, wit
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -273,7 +273,7 @@ Looking for more examples? Check out:
 
 ## Contributing
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -343,7 +343,7 @@ A diff describing the changes to a collection.
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/sync-core/README.md
+++ b/packages/sync-core/README.md
@@ -22,7 +22,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -22,7 +22,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -60,7 +60,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/tlschema/README.md
+++ b/packages/tlschema/README.md
@@ -84,7 +84,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -8,7 +8,7 @@ A `DOCS.md` file is included alongside this README in the published package, wit
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -36,7 +36,7 @@ A `DOCS.md` file is included alongside this README in the published package, wit
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## License
 

--- a/packages/worker-shared/README.md
+++ b/packages/worker-shared/README.md
@@ -16,7 +16,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/branching-chat/README.md
+++ b/templates/branching-chat/README.md
@@ -124,7 +124,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/chat/README.md
+++ b/templates/chat/README.md
@@ -64,7 +64,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/nextjs/README.md
+++ b/templates/nextjs/README.md
@@ -29,7 +29,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/shader/README.md
+++ b/templates/shader/README.md
@@ -144,7 +144,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/simple-server-example/README.md
+++ b/templates/simple-server-example/README.md
@@ -22,7 +22,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/socketio-server-example/README.md
+++ b/templates/socketio-server-example/README.md
@@ -22,7 +22,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/sync-cloudflare/README.md
+++ b/templates/sync-cloudflare/README.md
@@ -108,7 +108,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/vite/README.md
+++ b/templates/vite/README.md
@@ -29,7 +29,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/vue/README.md
+++ b/templates/vue/README.md
@@ -31,7 +31,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 

--- a/templates/workflow/README.md
+++ b/templates/workflow/README.md
@@ -67,7 +67,7 @@ You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?a
 
 ## Contribution
 
-Please see our [contributing guide](https://github.com/tldraw/tldraw/blob/main/CONTRIBUTING.md). Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
+Found a bug? Please [submit an issue](https://github.com/tldraw/tldraw/issues/new).
 
 ## Community
 


### PR DESCRIPTION
In order to make our contribution policy clear everywhere it's mentioned, this PR rewrites CONTRIBUTING.md to lead with the no-contributions policy and sweeps the rest of the repo for language that invites contributions. Relates to #7695.

- `CONTRIBUTING.md` now states up front that we are not accepting contributions and that pull requests are turned off for the repository. It directs people to create an issue to report bugs or discuss proposed changes, and to fork the repo and link to a branch in the issue if a code example would help the discussion.
- The docs site's community contributing page says the same.
- The root README's contributing section now points to issues instead of inviting contributions.
- The shared "Contribution" boilerplate in package, app, and template READMEs no longer invites readers to the contributing guide; it now just links to the issue tracker, matching the pattern already used in `packages/create-tldraw`.
- The docs site README's sample section description no longer describes tldraw as an open source project.

All changes are README, Markdown, and MDX files only.

Note: `apps/docs/content/community/contributing.mdx` is also rewritten in #9091; the wording here matches that PR plus the fork guidance, so whichever merges second will have a trivial conflict.

### Change type

- [x] `other`

### Test plan

Documentation-only change; no manual testing steps.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Core code     | +15 / -15  |
| Documentation | +12 / -18  |
| Apps          | +10 / -10  |
| Templates     | +10 / -10  |

Core code and apps rows are README files within those directories; no source code is changed.

