### PR TITLE
fix(mermaid): load mermaid lazily so @tldraw/mermaid works in CommonJS

### DIFF
--- a/packages/mermaid/src/createMermaidDiagram.ts
+++ b/packages/mermaid/src/createMermaidDiagram.ts
@@ -1,6 +1,5 @@
 let nextMermaidId = 0
 
-import mermaid from 'mermaid'
 import type { FlowDB } from 'mermaid/dist/diagrams/flowchart/flowDb.d.ts'
 import type { FlowEdge, FlowSubGraph, FlowVertex } from 'mermaid/dist/diagrams/flowchart/types.js'
 import type { MindmapDB } from 'mermaid/dist/diagrams/mindmap/mindmapDb.d.ts'
@@ -56,6 +55,13 @@ export async function createMermaidDiagram(
 	text: string,
 	options: MermaidDiagramOptions = {}
 ): Promise<void> {
+	// load mermaid lazily: it's a large, ESM-only dependency only needed when a
+	// diagram is actually created. a dynamic import() works from CommonJS (unlike
+	// a static import, which compiles to require(<esm>) and throws
+	// ERR_REQUIRE_ESM on Node <20.19, Jest, and ts-node) and avoids pulling
+	// mermaid in when @tldraw/mermaid is merely imported.
+	const mermaid = (await import('mermaid')).default
+
 	mermaid.initialize({
 		...MERMAID_CONFIG,
 		...(options.mermaidConfig ?? {}),


### PR DESCRIPTION
`@tldraw/mermaid` depends on `mermaid`, which is ESM-only. The static `import mermaid from 'mermaid'` at the top of `createMermaidDiagram.ts` compiles to `require("mermaid")` in the package's `dist-cjs` build, and `require()` of an ES module throws `ERR_REQUIRE_ESM` for CommonJS consumers on Node 20.0–20.18 (the repo floor is `^20.0.0`) and trips up Jest and ts-node — the same failure class as [#7905](https://github.com/tldraw/tldraw/pull/7905).

`createMermaidDiagram()` is already `async` and `mermaid` is only referenced inside it (every other `mermaid` import is `import type`, erased at build), so it can be loaded with a dynamic `import()`:

```ts
// before — top-level; compiles to require("mermaid") in dist-cjs
import mermaid from 'mermaid'

// after — loaded the first time a diagram is created
const mermaid = (await import('mermaid')).default
```

esbuild keeps `import()` as a real dynamic import (it doesn't downlevel to `require`), so no `require(<esm>)` ends up in the CJS build — `@tldraw/mermaid` becomes requirable from CommonJS regardless of how a consumer imports it.

It also helps bundling slightly, but only for consumers who import `@tldraw/mermaid` **statically** at their module top level: for them mermaid (and its large d3/dagre tree) moves out of the main bundle into a chunk loaded on the first `createMermaidDiagram()` call. Consumers who already `await import('@tldraw/mermaid')` — the recommended pattern, and what `SneakyMermaidHandler` and the examples do — already have mermaid in a lazy chunk, so their bundle is unchanged.

Self-contained and independent of the broader ESM-only-in-CJS efforts in #9050 (build-level inlining) and #9098 (Node engine bump, which makes `require('mermaid')` work natively on Node ≥20.19 / 22.12).

### Change type

- [x] `bugfix`

### Test plan

1. `cd packages/mermaid && yarn build`.
2. `packages/mermaid/dist-cjs/createMermaidDiagram.js` contains `await import("mermaid")` and no `require("mermaid")` (mermaid stays external in both builds).
3. The 53 mermaid tests pass (`cd packages/mermaid && yarn test run`); typecheck passes.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- `@tldraw/mermaid` now loads its ESM-only `mermaid` dependency lazily, so the package is requirable from CommonJS (and mermaid only loads when a diagram is created).

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -1    |
