### PR TITLE
feat(frame): hint shapes that will be enclosed while drag-creating a frame

### DIFF
--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeTool.ts
@@ -1,4 +1,4 @@
-import { BaseBoxShapeTool, TLShape, TLShapeId } from '@tldraw/editor'
+import { BaseBoxShapeTool, Editor, TLShape, TLShapeId } from '@tldraw/editor'
 
 /** @public */
 export class FrameShapeTool extends BaseBoxShapeTool {
@@ -9,29 +9,7 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 	override onCreate(shape: TLShape | null): void {
 		if (!shape) return
 
-		const bounds = this.editor.getShapePageBounds(shape)!
-		const shapesToAddToFrame: TLShapeId[] = []
-		const ancestorIds = this.editor.getShapeAncestors(shape).map((shape) => shape.id)
-
-		this.editor.getSortedChildIdsForParent(shape.parentId).map((siblingShapeId) => {
-			const siblingShape = this.editor.getShape(siblingShapeId)
-			if (!siblingShape) return
-			// We don't want to frame the frame itself
-			if (siblingShape.id === shape.id) return
-			if (siblingShape.isLocked) return
-
-			const pageShapeBounds = this.editor.getShapePageBounds(siblingShape)
-			if (!pageShapeBounds) return
-
-			// Frame shape encloses page shape
-			if (bounds.contains(pageShapeBounds)) {
-				if (canEnclose(siblingShape, ancestorIds, shape)) {
-					shapesToAddToFrame.push(siblingShape.id)
-				}
-			}
-		})
-
-		this.editor.reparentShapes(shapesToAddToFrame, shape.id)
+		this.editor.reparentShapes(getEnclosedShapeIds(this.editor, shape), shape.id)
 
 		if (this.editor.getInstanceState().isToolLocked) {
 			this.editor.setCurrentTool('frame')
@@ -39,6 +17,39 @@ export class FrameShapeTool extends BaseBoxShapeTool {
 			this.editor.setCurrentTool('select.idle')
 		}
 	}
+}
+
+/**
+ * Get the ids of the sibling shapes that a frame would enclose at its current page bounds.
+ *
+ * @internal
+ */
+export function getEnclosedShapeIds(editor: Editor, shape: TLShape): TLShapeId[] {
+	const bounds = editor.getShapePageBounds(shape)
+	if (!bounds) return []
+
+	const enclosedShapeIds: TLShapeId[] = []
+	const ancestorIds = editor.getShapeAncestors(shape).map((shape) => shape.id)
+
+	editor.getSortedChildIdsForParent(shape.parentId).map((siblingShapeId) => {
+		const siblingShape = editor.getShape(siblingShapeId)
+		if (!siblingShape) return
+		// We don't want to frame the frame itself
+		if (siblingShape.id === shape.id) return
+		if (siblingShape.isLocked) return
+
+		const pageShapeBounds = editor.getShapePageBounds(siblingShape)
+		if (!pageShapeBounds) return
+
+		// Frame shape encloses page shape
+		if (bounds.contains(pageShapeBounds)) {
+			if (canEnclose(siblingShape, ancestorIds, shape)) {
+				enclosedShapeIds.push(siblingShape.id)
+			}
+		}
+	})
+
+	return enclosedShapeIds
 }
 
 /** @internal */

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -19,6 +19,7 @@ import {
 	isAccelKey,
 	kickoutOccludedShapes,
 } from '@tldraw/editor'
+import { getEnclosedShapeIds } from '../../../shapes/frame/FrameShapeTool'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
 
 export type ResizingInfo = TLPointerEventInfo & {
@@ -440,6 +441,27 @@ export class Resizing extends StateNode {
 				}
 			}
 		}
+
+		this.updateEnclosureHints()
+	}
+
+	// While drag-creating a frame, hint the sibling shapes that would become its children on pointer up
+	private updateEnclosureHints() {
+		if (!this.info.isCreating) return
+
+		const shape = this.editor.getOnlySelectedShape()
+		if (!shape || !this.editor.isShapeOfType(shape, 'frame')) return
+
+		const hintingShapeIds = getEnclosedShapeIds(this.editor, shape)
+		const prevHintingShapeIds = this.editor.getHintingShapeIds()
+		if (
+			hintingShapeIds.length === prevHintingShapeIds.length &&
+			hintingShapeIds.every((id, i) => id === prevHintingShapeIds[i])
+		) {
+			return
+		}
+
+		this.editor.setHintingShapes(hintingShapeIds)
 	}
 
 	// ---
@@ -486,6 +508,9 @@ export class Resizing extends StateNode {
 		this.editor.setCursor({ type: 'default', rotation: 0 })
 		this.editor.snaps.clearIndicators()
 		setBatchLabelSizeCache(this.editor, null)
+		if (this.info.isCreating && this.editor.getHintingShapeIds().length > 0) {
+			this.editor.setHintingShapes([])
+		}
 	}
 
 	private _createSnapshot() {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -156,6 +156,78 @@ describe('creating frames', () => {
 		expect(parent).toBe('page:page')
 	})
 
+	it('hints the shapes that would be enclosed while drag-creating a frame', () => {
+		const boxA = createRect({ pos: [10, 10], size: [20, 20] })
+		const boxB = createRect({ pos: [60, 60], size: [20, 20] })
+
+		editor.setCurrentTool('frame')
+		editor.pointerDown(0, 0)
+
+		// The drag rectangle encloses box A only
+		editor.pointerMove(40, 40)
+		expect(editor.getHintingShapeIds()).toEqual([boxA])
+
+		// Grown to enclose both boxes
+		editor.pointerMove(100, 100)
+		expect(editor.getHintingShapeIds()).toEqual([boxA, boxB])
+
+		// Shrunk back to enclose box A only
+		editor.pointerMove(40, 40)
+		expect(editor.getHintingShapeIds()).toEqual([boxA])
+
+		// On pointer up, the hints clear and the hinted shape becomes a child of the frame
+		editor.pointerUp(40, 40)
+		expect(editor.getHintingShapeIds()).toHaveLength(0)
+		const frameId = editor.getOnlySelectedShape()!.id
+		expect(editor.getShape(boxA)?.parentId).toBe(frameId)
+		expect(editor.getShape(boxB)?.parentId).toBe(editor.getCurrentPageId())
+	})
+
+	it('does not hint shapes that are only partially enclosed', () => {
+		createRect({ pos: [10, 10], size: [20, 20] })
+
+		editor.setCurrentTool('frame')
+		editor.pointerDown(0, 0)
+		editor.pointerMove(20, 20)
+		expect(editor.getHintingShapeIds()).toHaveLength(0)
+	})
+
+	it('does not hint locked shapes', () => {
+		const rectId = createRect({ pos: [10, 10], size: [20, 20] })
+		editor.updateShape({ id: rectId, type: 'geo', isLocked: true })
+
+		editor.setCurrentTool('frame')
+		editor.pointerDown(0, 0)
+		editor.pointerMove(100, 100)
+		expect(editor.getHintingShapeIds()).toHaveLength(0)
+	})
+
+	it('clears the hints when the drag is cancelled', () => {
+		createRect({ pos: [10, 10], size: [20, 20] })
+
+		editor.setCurrentTool('frame')
+		editor.pointerDown(0, 0)
+		editor.pointerMove(100, 100)
+		expect(editor.getHintingShapeIds()).toHaveLength(1)
+
+		editor.cancel()
+		expect(editor.getHintingShapeIds()).toHaveLength(0)
+	})
+
+	it('clears the hints between successive frame creations when tool locked', () => {
+		editor.updateInstanceState({ isToolLocked: true })
+		createRect({ pos: [10, 10], size: [20, 20] })
+
+		editor.setCurrentTool('frame')
+		editor.pointerDown(0, 0)
+		editor.pointerMove(100, 100)
+		expect(editor.getHintingShapeIds()).toHaveLength(1)
+		editor.pointerUp(100, 100)
+
+		expect(editor.getCurrentToolId()).toBe('frame')
+		expect(editor.getHintingShapeIds()).toHaveLength(0)
+	})
+
 	it('can snap', () => {
 		editor.createShapes([
 			{ type: 'geo', id: ids.boxA, x: 0, y: 0, props: { w: 50, h: 50, fill: 'solid' } },


### PR DESCRIPTION
In order to make the frame tool's containment behavior discoverable, this PR shows live selection-style indicators on the shapes that will become children of a new frame while it is being dragged out. Previously, shapes silently became children of the frame on pointer up with no feedback during the drag. Closes #8846.

Because the frame tool hands the live drag off to `select.resizing` (via `BaseBoxShapeTool`'s `Pointing` state), the hinting runs in the select tool's `Resizing` state: when resizing a shape that is being created and is a frame, it computes the sibling shapes that would be enclosed at the current bounds and feeds them to `editor.setHintingShapes()`, which the indicator overlay already renders with a thicker stroke. The enclosure predicate is extracted from `FrameShapeTool.onCreate` into a shared internal helper, `getEnclosedShapeIds`, so the live hints and the final reparenting always agree. Hints update in both directions as the drag rectangle grows and shrinks, skip locked shapes and partially-overlapped shapes, and clear on pointer up, cancel, and between successive creations in tool-locked mode.


https://github.com/user-attachments/assets/1077057b-c9a8-4ae9-97e0-c7ebec7d1d63



### Change type

- [x] `improvement`

### Test plan

1. Create a few shapes on the canvas
2. Select the frame tool and drag out a frame over them
3. Shapes fully enclosed by the drag rectangle show a thicker indicator outline, updating live as the rectangle grows and shrinks
4. On pointer up, the indicators clear and exactly the hinted shapes become children of the frame
5. Pressing Escape mid-drag clears the indicators
6. Locked shapes and partially-overlapped shapes are never hinted

- [x] Unit tests

### Release notes

- Frame tool now shows live indicators on the shapes that will be enclosed by a frame while it is being drawn.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +60 / -24  |
| Tests     | +72 / -0   |