### PR TITLE
feat(dotcom): improve member management in workspace settings

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -75,6 +75,12 @@
       "value": "Send feedback"
     }
   ],
+  "1063e38cb5": [
+    {
+      "type": 0,
+      "value": "Remove"
+    }
+  ],
   "110a4b01be": [
     {
       "type": 0,
@@ -187,6 +193,12 @@
     {
       "type": 0,
       "value": "Editor"
+    }
+  ],
+  "375396d6e5": [
+    {
+      "type": 0,
+      "value": "Remove member"
     }
   ],
   "3bc7d6ea2f": [
@@ -1351,6 +1363,20 @@
     {
       "type": 0,
       "value": "Copied link"
+    }
+  ],
+  "ff2fefd3c6": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to remove "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " from this workspace?"
     }
   ],
   "ffcd73e997": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -35,6 +35,9 @@
   "0d1f2bb523": {
     "translation": "Send feedback"
   },
+  "1063e38cb5": {
+    "translation": "Remove"
+  },
   "110a4b01be": {
     "translation": "Publish"
   },
@@ -91,6 +94,9 @@
   },
   "344a7f427f": {
     "translation": "Editor"
+  },
+  "375396d6e5": {
+    "translation": "Remove member"
   },
   "3bc7d6ea2f": {
     "translation": "Continue with email"
@@ -593,6 +599,9 @@
   },
   "fed5ec05eb": {
     "translation": "Copied link"
+  },
+  "ff2fefd3c6": {
+    "translation": "Are you sure you want to remove {name} from this workspace?"
   },
   "ffcd73e997": {
     "translation": "Import file…"

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceMenu.tsx
@@ -75,6 +75,10 @@ export function WorkspaceMenuContent({ workspaceId }: { workspaceId: string }) {
 			component: ({ onClose }) => (
 				<WorkspaceSettingsDialog workspaceId={workspaceId} onClose={onClose} />
 			),
+			// The role picker is a Radix select; opening it inside the modal trips the
+			// dialog's outside-interaction dismissal. Closing happens via the close
+			// button or Escape instead.
+			preventBackgroundClose: true,
 		})
 		trackEvent('open-share-menu', { source: 'sidebar' })
 	}, [addDialog, workspaceId, trackEvent])

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -47,6 +47,11 @@ const messages = defineMessages({
 	},
 	leaveAction: { defaultMessage: 'Leave workspace' },
 	deleteAction: { defaultMessage: 'Delete workspace' },
+	removeMember: { defaultMessage: 'Remove' },
+	removeAction: { defaultMessage: 'Remove member' },
+	confirmRemove: {
+		defaultMessage: 'Are you sure you want to remove {name} from this workspace?',
+	},
 })
 
 interface WorkspaceSettingsDialogProps {
@@ -65,6 +70,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const ownerMsg = useMsg(messages.owner)
 	const memberMsg = useMsg(messages.member)
 	const youMsg = useMsg(messages.you)
+	const removeMemberMsg = useMsg(messages.removeMember)
 
 	// Get workspace data
 	const workspaceMembership = useValue(
@@ -169,6 +175,31 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 					cancelLabel={<F {...messages.cancel} />}
 					confirmType="danger"
 					onConfirm={handleDeleteWorkspace}
+					onClose={onClose}
+				/>
+			),
+		})
+	}
+
+	const handleRemoveMember = async (targetUserId: string) => {
+		try {
+			await app.z.mutate.removeWorkspaceMember({ workspaceId, targetUserId }).client
+		} catch (error) {
+			console.error('Error removing member:', error)
+			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		}
+	}
+
+	const openRemoveConfirmDialog = (member: { userId: string; userName: string }) => {
+		addDialog({
+			component: ({ onClose }) => (
+				<ConfirmDialog
+					title={<F {...messages.removeAction} />}
+					description={<F {...messages.confirmRemove} values={{ name: member.userName }} />}
+					confirmLabel={<F {...messages.removeAction} />}
+					cancelLabel={<F {...messages.cancel} />}
+					confirmType="danger"
+					onConfirm={() => handleRemoveMember(member.userId)}
 					onClose={onClose}
 				/>
 			),
@@ -303,6 +334,18 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 												value={member.role}
 												usePortal
 												options={roleOptions}
+												actions={
+													member.userId === app.getUser().id
+														? undefined
+														: [
+																{
+																	id: 'remove',
+																	label: removeMemberMsg,
+																	destructive: true,
+																	onSelect: () => openRemoveConfirmDialog(member),
+																},
+															]
+												}
 												onChange={async (value) => {
 													if (value === member.role) return
 													try {

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -87,6 +87,8 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const canLeave = role !== 'owner' || ownersCount > 1
 	const canEditMembers = can(role, 'editMembers')
 	const roleLabels: Record<Role, string> = { owner: ownerMsg, member: memberMsg }
+	// Owners sort above members; within a role the current user is pinned to the top.
+	const roleOrder: Record<Role, number> = { owner: 0, member: 1 }
 	const roleOptions = (Object.keys(roleLabels) as Role[]).map((value) => ({
 		value,
 		label: roleLabels[value],
@@ -269,8 +271,10 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 						{[...workspaceMembership.groupMembers]
 							.sort((a, b) => {
 								const currentId = app.getUser().id
-								if (a.userId === currentId && b.userId !== currentId) return -1
-								if (b.userId === currentId && a.userId !== currentId) return 1
+								// Owners first, then members; within a role, pin the current user to the top.
+								if (a.role !== b.role) return roleOrder[a.role] - roleOrder[b.role]
+								if (a.userId === currentId) return -1
+								if (b.userId === currentId) return 1
 								return 0
 							})
 							.map((member) => {

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -17,6 +17,7 @@ import { routes } from '../../../routeDefs'
 import { useApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
+import { TlaMenuSelect } from '../tla-menu/tla-menu'
 import { TlaButton } from '../TlaButton/TlaButton'
 import { TlaIcon } from '../TlaIcon/TlaIcon'
 import { ConfirmDialog } from './ConfirmDialog'
@@ -84,7 +85,12 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	// Leaving is allowed for everyone except the last owner — a workspace invariant
 	// (it must always keep at least one owner), not a capability.
 	const canLeave = role !== 'owner' || ownersCount > 1
+	const canEditMembers = can(role, 'editMembers')
 	const roleLabels: Record<Role, string> = { owner: ownerMsg, member: memberMsg }
+	const roleOptions = (Object.keys(roleLabels) as Role[]).map((value) => ({
+		value,
+		label: roleLabels[value],
+	}))
 
 	const handleCopyInviteLink = async () => {
 		if (copiedInviteLink) return
@@ -267,46 +273,52 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 								if (b.userId === currentId && a.userId !== currentId) return 1
 								return 0
 							})
-							.map((member) => (
-								<div key={member.userId} className={styles.memberItem}>
-									<div
-										className={styles.memberAvatar}
-										style={{
-											backgroundColor: member.userColor || '#ff6b35',
-										}}
-									>
-										{member.userName.charAt(0).toUpperCase()}
-									</div>
-									<span className={styles.memberName}>
-										{member.userName}
-										{member.userId === app.getUser().id ? ` (${youMsg})` : ''}
-									</span>
-									{can(role, 'editMembers') &&
-									(member.userId !== app.getUser().id || ownersCount > 1) ? (
-										<MemberRoleSelect
-											value={member.role}
-											disabled={member.role === 'owner' && ownersCount <= 1}
-											labels={roleLabels}
-											onChange={async (value) => {
-												if (value === member.role) return
-												if (member.role === 'owner' && value !== 'owner' && ownersCount <= 1) return
-												try {
-													await app.z.mutate.setWorkspaceMemberRole({
-														workspaceId,
-														targetUserId: member.userId,
-														role: value,
-													}).client
-												} catch (err) {
-													console.error('Failed to change member role', err)
-													app.showMutationRejectionToast((err as Error).message as ZErrorCode)
-												}
+							.map((member) => {
+								// Roles are shown to everyone; only editMembers holders can change them,
+								// and never their own role while they're the sole owner.
+								const canEditThisRole =
+									canEditMembers && (member.userId !== app.getUser().id || ownersCount > 1)
+								return (
+									<div key={member.userId} className={styles.memberItem}>
+										<div
+											className={styles.memberAvatar}
+											style={{
+												backgroundColor: member.userColor || '#ff6b35',
 											}}
-										/>
-									) : (
-										<span className={styles.memberRole}>{roleLabels[member.role]}</span>
-									)}
-								</div>
-							))}
+										>
+											{member.userName.charAt(0).toUpperCase()}
+										</div>
+										<span className={styles.memberName}>
+											{member.userName}
+											{member.userId === app.getUser().id ? ` (${youMsg})` : ''}
+										</span>
+										{canEditThisRole ? (
+											<TlaMenuSelect
+												id={`workspace-member-role-${member.userId}`}
+												label={roleLabels[member.role]}
+												value={member.role}
+												usePortal
+												options={roleOptions}
+												onChange={async (value) => {
+													if (value === member.role) return
+													try {
+														await app.z.mutate.setWorkspaceMemberRole({
+															workspaceId,
+															targetUserId: member.userId,
+															role: value,
+														}).client
+													} catch (err) {
+														console.error('Failed to change member role', err)
+														app.showMutationRejectionToast((err as Error).message as ZErrorCode)
+													}
+												}}
+											/>
+										) : (
+											<span className={styles.memberRole}>{roleLabels[member.role]}</span>
+										)}
+									</div>
+								)
+							})}
 					</div>
 				</div>
 
@@ -333,35 +345,5 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 				{/* Confirmation handled via tldraw dialogs */}
 			</TldrawUiDialogBody>
 		</_Tooltip.Provider>
-	)
-}
-
-function MemberRoleSelect({
-	value,
-	onChange,
-	disabled,
-	labels,
-}: {
-	value: Role
-	onChange(v: Role): void
-	disabled?: boolean
-	labels: Record<Role, string>
-}) {
-	return (
-		<div className={styles.selectWrapper}>
-			<TlaIcon icon="chevron-down" className={styles.menuSelectChevron} />
-			<select
-				className={styles.select}
-				value={value}
-				disabled={disabled}
-				onChange={(e) => onChange(e.currentTarget.value as Role)}
-			>
-				{Object.entries(labels).map(([roleValue, label]) => (
-					<option key={roleValue} value={roleValue}>
-						{label}
-					</option>
-				))}
-			</select>
-		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -341,42 +341,6 @@
 	justify-content: center;
 }
 
-.selectWrapper {
-	display: flex;
-	position: relative;
-}
-
-.select {
-	display: inline-block;
-	appearance: none;
-	outline: none;
-	border: none;
-	padding: 4px 20px 4px 8px;
-	cursor: pointer;
-	position: relative;
-}
-
-.select:disabled {
-	cursor: default;
-}
-
-.selectWrapper:hover::after {
-	content: '';
-	pointer-events: none;
-	display: flex;
-	position: absolute;
-	inset: 0px -6px 0px 0px;
-	background-color: var(--tla-color-hover-2);
-	border-radius: var(--tl-radius-1);
-}
-
-.menuSelectChevron {
-	position: absolute !important;
-	right: 0 !important;
-	top: 50% !important;
-	transform: translateY(-50%) !important;
-}
-
 .copyInviteLinkIconRight {
 	right: 12.5px !important;
 }

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -223,6 +223,16 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 	display: none;
 }
 
+.menuSelectSeparator {
+	height: 1px;
+	margin: 4px;
+	background-color: var(--tl-color-divider);
+}
+
+.menuSelectOptionDestructive {
+	color: var(--tl-color-danger);
+}
+
 [data-radix-focus-guard] {
 	inset: 0;
 }

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -137,7 +137,7 @@
 }
 
 /* need to target the parent div, ugh, can't target via a className */
-div:has(> .menuSelectContent) {
+div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 	position: absolute !important;
 	top: 17px;
 	right: -8px;
@@ -146,12 +146,22 @@ div:has(> .menuSelectContent) {
 }
 
 .menuSelectContent {
+	/* Match the layer `.tlui-dialog__overlay` renders at — it reuses
+	   --tl-layer-canvas-overlays — so the portaled (popper) dropdown isn't hidden
+	   behind a containing dialog. A lower z-index would lose: both the dialog and
+	   the select portal into the same container as siblings, so they compete in one
+	   stacking context; at equal z-index the dropdown wins only because it mounts
+	   later. Radix copies this z-index onto its popper wrapper, so setting it on the
+	   content (not the wrapper, which Radix styles inline) avoids needing
+	   !important. Harmless inline (item-aligned), where the wrapper's z-index governs. */
+	z-index: var(--tl-layer-canvas-overlays);
 	border-radius: var(--tl-radius-3);
 	background-color: var(--tl-color-panel);
 	box-shadow: var(--tl-shadow-3);
 }
 
 .menuSelectOption {
+	white-space: nowrap;
 	position: relative;
 	display: flex;
 	align-items: center;

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -105,6 +105,7 @@ export function TlaMenuSelect<T extends string>({
 	disabled,
 	onChange,
 	options,
+	actions,
 	usePortal,
 	'data-testid': dataTestId,
 }: {
@@ -114,6 +115,9 @@ export function TlaMenuSelect<T extends string>({
 	disabled?: boolean
 	onChange(value: T): void
 	options: { value: T; label: ReactNode }[]
+	// Extra actions shown in their own section below the options (e.g. a
+	// destructive "remove"). Selecting one runs its onSelect instead of onChange.
+	actions?: { id: string; label: ReactNode; onSelect(): void; destructive?: boolean }[]
 	// When set, render the dropdown in a portal (popper-positioned) so it isn't
 	// clipped by / doesn't overflow a constrained container like a modal dialog.
 	usePortal?: boolean
@@ -123,9 +127,14 @@ export function TlaMenuSelect<T extends string>({
 	const container = useContainer()
 	const handleChange = useCallback(
 		(value: string) => {
+			const action = actions?.find((a) => a.id === value)
+			if (action) {
+				action.onSelect()
+				return
+			}
 			onChange(value as T)
 		},
-		[onChange]
+		[actions, onChange]
 	)
 
 	const handleOpenChange = (open: boolean) => {
@@ -198,6 +207,23 @@ export function TlaMenuSelect<T extends string>({
 									<_Select.ItemText>{option.label}</_Select.ItemText>
 								</_Select.Item>
 							))}
+							{actions && actions.length > 0 && (
+								<>
+									<_Select.Separator className={styles.menuSelectSeparator} />
+									{actions.map((action) => (
+										<_Select.Item
+											key={action.id}
+											className={classNames(
+												styles.menuSelectOption,
+												action.destructive && styles.menuSelectOptionDestructive
+											)}
+											value={action.id}
+										>
+											<_Select.ItemText>{action.label}</_Select.ItemText>
+										</_Select.Item>
+									))}
+								</>
+							)}
 						</_Select.Viewport>
 					</_Select.Content>
 				</TlaSelectPortal>

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -10,7 +10,7 @@ import {
 	useEffect,
 	useState,
 } from 'react'
-import { TldrawUiButton, TldrawUiIcon, TldrawUiTooltip } from 'tldraw'
+import { TldrawUiButton, TldrawUiIcon, TldrawUiTooltip, useContainer } from 'tldraw'
 import { defineMessages, useMsg } from '../../utils/i18n'
 import { TlaIcon } from '../TlaIcon/TlaIcon'
 import styles from './menu.module.css'
@@ -105,6 +105,7 @@ export function TlaMenuSelect<T extends string>({
 	disabled,
 	onChange,
 	options,
+	usePortal,
 	'data-testid': dataTestId,
 }: {
 	id: string
@@ -113,9 +114,13 @@ export function TlaMenuSelect<T extends string>({
 	disabled?: boolean
 	onChange(value: T): void
 	options: { value: T; label: ReactNode }[]
+	// When set, render the dropdown in a portal (popper-positioned) so it isn't
+	// clipped by / doesn't overflow a constrained container like a modal dialog.
+	usePortal?: boolean
 	'data-testid'?: string
 }) {
 	const [isOpen, setIsOpen] = useState(false)
+	const container = useContainer()
 	const handleChange = useCallback(
 		(value: string) => {
 			onChange(value as T)
@@ -171,25 +176,49 @@ export function TlaMenuSelect<T extends string>({
 						<TlaIcon icon="chevron-down" className={styles.menuSelectChevron} />
 					</_Select.Icon>
 				</_Select.Trigger>
-				<_Select.Content className={styles.menuSelectContent}>
-					<_Select.Viewport>
-						{options.map((option) => (
-							<_Select.Item
-								key={option.value}
-								className={styles.menuSelectOption}
-								value={option.value}
-							>
-								<_Select.ItemIndicator>
-									<TlaIcon icon="check" />
-								</_Select.ItemIndicator>
-								<_Select.ItemText>{option.label}</_Select.ItemText>
-							</_Select.Item>
-						))}
-					</_Select.Viewport>
-				</_Select.Content>
+				<TlaSelectPortal usePortal={usePortal} container={container}>
+					<_Select.Content
+						className={styles.menuSelectContent}
+						position={usePortal ? 'popper' : undefined}
+						side={usePortal ? 'bottom' : undefined}
+						align={usePortal ? 'end' : undefined}
+						sideOffset={usePortal ? 4 : undefined}
+						collisionPadding={usePortal ? 4 : undefined}
+					>
+						<_Select.Viewport>
+							{options.map((option) => (
+								<_Select.Item
+									key={option.value}
+									className={styles.menuSelectOption}
+									value={option.value}
+								>
+									<_Select.ItemIndicator>
+										<TlaIcon icon="check" />
+									</_Select.ItemIndicator>
+									<_Select.ItemText>{option.label}</_Select.ItemText>
+								</_Select.Item>
+							))}
+						</_Select.Viewport>
+					</_Select.Content>
+				</TlaSelectPortal>
 			</_Select.Root>
 		</div>
 	)
+}
+
+function TlaSelectPortal({
+	usePortal,
+	container,
+	children,
+}: {
+	usePortal?: boolean
+	container: HTMLElement
+	children: ReactNode
+}) {
+	if (usePortal) {
+		return <_Select.Portal container={container}>{children}</_Select.Portal>
+	}
+	return <>{children}</>
 }
 
 /* --------------------- Switch --------------------- */

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -797,6 +797,62 @@ describe('membership', () => {
 		await m.leaveWorkspace(tx, { workspaceId: groupId })
 		expect(s.group_user.find((gu) => gu.userId === userId)).toBeUndefined()
 	})
+
+	it('owner can remove a member', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'owner' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await m.removeWorkspaceMember(tx, { workspaceId: groupId, targetUserId: memberId })
+		expect(s.group_user.find((gu) => gu.userId === memberId)).toBeUndefined()
+	})
+
+	it('member cannot remove members', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'member' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await expectForbidden(() =>
+			m.removeWorkspaceMember(tx, { workspaceId: groupId, targetUserId: memberId })
+		)
+	})
+
+	it('cannot remove the last owner', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'owner' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await expectForbidden(() =>
+			m.removeWorkspaceMember(tx, { workspaceId: groupId, targetUserId: userId })
+		)
+	})
 })
 
 describe('file operations across workspaces', () => {

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -641,6 +641,34 @@ export function createMutators(userId: string) {
 				role: targetRole,
 			})
 		},
+		removeWorkspaceMember: async (
+			tx: Tx,
+			{ workspaceId, targetUserId }: { workspaceId: string; targetUserId: string }
+		) => {
+			await assertUserHasFlag(tx, userId, 'groups_backend')
+			assert(workspaceId, ZErrorCode.bad_request)
+			assert(targetUserId, ZErrorCode.bad_request)
+
+			const role = await getRole(tx, userId, workspaceId)
+			assert(can(role, 'editMembers'), ZErrorCode.forbidden)
+
+			// Target must be a member
+			const targetMembership = await tx.run(
+				zql.group_user.where('userId', '=', targetUserId).where('groupId', '=', workspaceId).one()
+			)
+			assert(targetMembership, ZErrorCode.bad_request)
+
+			// Invariant (not a capability): a group must always keep at least one
+			// owner, so the last owner can't be removed.
+			if (targetMembership.role === 'owner') {
+				const owners = await tx.run(
+					zql.group_user.where('groupId', '=', workspaceId).where('role', '=', 'owner')
+				)
+				assert(owners.length > 1, ZErrorCode.forbidden)
+			}
+
+			await tx.mutate.group_user.delete({ userId: targetUserId, groupId: workspaceId })
+		},
 		leaveWorkspace: async (tx: Tx, { workspaceId }: { workspaceId: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(workspaceId, ZErrorCode.bad_request)


### PR DESCRIPTION
In order to improve member management in workspace settings, this PR reworks the members list and the role picker. Closes #9131.

**Members list**

- Sorted by role (owners first, then members), with the current user pinned to the top of their own role group. For example, a member sees:

  ```
  Owner 1
  Owner 2
  Member 1 (you)
  Member 2
  Member 3
  ```

- Every member's role is shown to everyone as a read-only label; changing a role still requires the `editMembers` capability.

**Role picker**

- Migrated from a bespoke native `<select>` to the shared Radix `TlaMenuSelect` used elsewhere in the app, for consistency and accessibility. This fixes the role dropdown rendering as an unstyled native `select` in Firefox and brings it in line with the app's other selects.
- Members with `editMembers` get a separate, destructive section in the picker to **remove another member** from the workspace; selecting it asks for confirmation. Hidden on your own row — use "Leave workspace" there.
- Opening the picker no longer dismisses the settings modal.

**Cleanup**

- Dropped the redundant client-side last-owner guards on the picker; that invariant is enforced server-side in the mutators.

### Change type

- [x] `improvement`

### Test plan

1. As a **member**: owners are listed first, then members, with you pinned to the top of the members.
2. As an **owner**: you appear at the top of the owners; the role picker is the standard app dropdown (keyboard accessible, check on the current role, and properly styled in Firefox).
3. Every member's role label is visible; only members with `editMembers` get the editable picker.
4. As an **owner**, open another member's picker → "Remove from workspace" (in its own section) → confirm → the member is removed. Confirm the last owner can't be removed.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Workspace settings: members are grouped by role (owners first) with you pinned to the top of your role; the role picker is now consistent and keyboard-accessible (and no longer falls back to a native dropdown in Firefox); members who can edit members can remove others from the workspace.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +28 / -0   |
| Tests           | +56 / -0   |
| Automated files | +35 / -0   |
| Apps            | +140 / -108 |


An an owner:
<img width="431" height="551" alt="image" src="https://github.com/user-attachments/assets/119f7021-40d1-460c-9171-e23875f9259c" />

As a member:
<img width="426" height="533" alt="image" src="https://github.com/user-attachments/assets/ee1d008d-6e9d-41f9-b133-7d35685b8f1d" />
