### PR TITLE
feat(dotcom): let owners remove group members

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -189,10 +189,22 @@
       "value": "Please try refreshing the page."
     }
   ],
+  "33d8b74c4b": [
+    {
+      "type": 0,
+      "value": "You no longer have access to this file."
+    }
+  ],
   "344a7f427f": [
     {
       "type": 0,
       "value": "Editor"
+    }
+  ],
+  "375396d6e5": [
+    {
+      "type": 0,
+      "value": "Remove member"
     }
   ],
   "3bc7d6ea2f": [
@@ -365,6 +377,20 @@
     {
       "type": 0,
       "value": "PNG"
+    }
+  ],
+  "55a172e10a": [
+    {
+      "type": 0,
+      "value": "Remove "
+    },
+    {
+      "type": 1,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " from this group?"
     }
   ],
   "5677e381d2": [
@@ -917,6 +943,12 @@
     {
       "type": 0,
       "value": "Anyone with the link"
+    }
+  ],
+  "a701366b38": [
+    {
+      "type": 0,
+      "value": "Access removed"
     }
   ],
   "a768caa988": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -92,8 +92,14 @@
   "335defdafe": {
     "translation": "Please try refreshing the page."
   },
+  "33d8b74c4b": {
+    "translation": "You no longer have access to this file."
+  },
   "344a7f427f": {
     "translation": "Editor"
+  },
+  "375396d6e5": {
+    "translation": "Remove member"
   },
   "3bc7d6ea2f": {
     "translation": "Continue with email"
@@ -175,6 +181,9 @@
   },
   "55505ba281": {
     "translation": "PNG"
+  },
+  "55a172e10a": {
+    "translation": "Remove {name} from this group?"
   },
   "5677e381d2": {
     "translation": "We use analytics cookies to make tldraw better."
@@ -412,6 +421,9 @@
   },
   "a6cc403d56": {
     "translation": "Anyone with the link"
+  },
+  "a701366b38": {
+    "translation": "Access removed"
   },
   "a768caa988": {
     "translation": "Analytics"

--- a/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/GroupSettingsDialog.tsx
@@ -46,6 +46,8 @@ const messages = defineMessages({
 	},
 	leaveAction: { defaultMessage: 'Leave group' },
 	deleteAction: { defaultMessage: 'Delete group' },
+	removeMember: { defaultMessage: 'Remove member' },
+	confirmRemoveMember: { defaultMessage: 'Remove {name} from this group?' },
 })
 
 interface GroupSettingsDialogProps {
@@ -64,6 +66,7 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 	const ownerMsg = useMsg(messages.owner)
 	const memberMsg = useMsg(messages.member)
 	const youMsg = useMsg(messages.you)
+	const removeMemberMsg = useMsg(messages.removeMember)
 
 	// Get group data
 	const groupMembership = useValue('groupMembership', () => app.getGroupMembership(groupId), [
@@ -132,6 +135,14 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 		}
 	}
 
+	const handleRemoveMember = async (targetUserId: string) => {
+		try {
+			await app.z.mutate.removeGroupMember({ groupId, targetUserId }).client
+		} catch (error) {
+			console.error('Error removing member:', error)
+		}
+	}
+
 	const openLeaveConfirmDialog = () => {
 		addDialog({
 			component: ({ onClose }) => (
@@ -158,6 +169,22 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 					cancelLabel={<F {...messages.cancel} />}
 					confirmType="danger"
 					onConfirm={handleDeleteGroup}
+					onClose={onClose}
+				/>
+			),
+		})
+	}
+
+	const openRemoveMemberConfirmDialog = (member: { userId: string; userName: string }) => {
+		addDialog({
+			component: ({ onClose }) => (
+				<ConfirmDialog
+					title={<F {...messages.removeMember} />}
+					description={<F {...messages.confirmRemoveMember} values={{ name: member.userName }} />}
+					confirmLabel={<F {...messages.removeMember} />}
+					cancelLabel={<F {...messages.cancel} />}
+					confirmType="danger"
+					onConfirm={() => handleRemoveMember(member.userId)}
 					onClose={onClose}
 				/>
 			),
@@ -294,6 +321,16 @@ export function GroupSettingsDialog({ groupId, onClose }: GroupSettingsDialogPro
 										/>
 									) : (
 										<span className={styles.memberRole}>{roleLabels[member.role]}</span>
+									)}
+									{can(role, 'editMembers') && member.userId !== app.getUser().id && (
+										<button
+											type="button"
+											className={styles.removeMemberButton}
+											aria-label={removeMemberMsg}
+											onClick={() => openRemoveMemberConfirmDialog(member)}
+										>
+											<TlaIcon icon="cross-2" />
+										</button>
 									)}
 								</div>
 							))}

--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -289,6 +289,22 @@
 	font-size: 12px;
 }
 
+.removeMemberButton {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 4px;
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--tla-color-text-3);
+	border-radius: var(--tl-radius-1);
+}
+.removeMemberButton:hover {
+	color: var(--tla-color-text-1);
+	background-color: var(--tla-color-hover-2);
+}
+
 .dangerZoneActions {
 	display: flex;
 	flex-direction: column;

--- a/apps/dotcom/client/src/tla/hooks/useGroupFileAccessGuard.ts
+++ b/apps/dotcom/client/src/tla/hooks/useGroupFileAccessGuard.ts
@@ -15,37 +15,46 @@ const messages = defineMessages({
  * group-owned file they're viewing — e.g. an owner removes them from the group,
  * or the group is deleted out from under them.
  *
- * `getFile` resolves a group file through the user's synced memberships, so it
- * reactively becomes null the moment their `group_user` row disappears. The
- * guard only fires once access has been confirmed (`hadAccessRef`), so it never
- * trips during the initial sync — when the file legitimately isn't loaded yet —
- * nor for shared files that were never opened through a membership.
+ * The signal is losing *membership*, not the file going away. We remember the
+ * group a file belongs to (keyed to its slug, so navigating between files never
+ * trips it) and only redirect once that file is no longer visible *and* we're no
+ * longer a member of its group. Deleting the file you're on, or any other reason
+ * the file disappears while your membership stands, is left to the normal flows.
  */
 export function useGroupFileAccessGuard(app: TldrawApp | null | undefined, fileSlug: string) {
 	const navigate = useNavigate()
-	const hadAccessRef = useRef(false)
+	const lastSeenRef = useRef<{ fileSlug: string; groupId: string } | null>(null)
 
 	const lostAccessTitle = useMsg(messages.lostAccessTitle)
 	const lostAccessDescription = useMsg(messages.lostAccessDescription)
 
-	// The group this file belongs to, as seen through our own memberships.
-	const owningGroupId = useValue(
-		'owningGroupForCurrentFile',
-		() => app?.getFile(fileSlug)?.owningGroupId ?? null,
+	const lostAccess = useValue(
+		'lostGroupFileAccess',
+		() => {
+			if (!app) return false
+			const file = app.getFile(fileSlug)
+			if (file?.owningGroupId) {
+				// We can still see the file through one of our memberships.
+				lastSeenRef.current = { fileSlug, groupId: file.owningGroupId }
+				return false
+			}
+			// The file isn't visible. Only treat this as lost access if we'd seen it
+			// through a group membership for *this* file and that membership is gone.
+			const lastSeen = lastSeenRef.current
+			return (
+				!!lastSeen && lastSeen.fileSlug === fileSlug && !app.getGroupMembership(lastSeen.groupId)
+			)
+		},
 		[app, fileSlug]
 	)
 
 	useEffect(() => {
-		if (owningGroupId) {
-			hadAccessRef.current = true
-		} else if (hadAccessRef.current) {
-			hadAccessRef.current = false
-			app?.toasts?.addToast({
-				severity: 'info',
-				title: lostAccessTitle,
-				description: lostAccessDescription,
-			})
-			navigate(routes.tlaRoot())
-		}
-	}, [owningGroupId, app, navigate, lostAccessTitle, lostAccessDescription])
+		if (!lostAccess) return
+		app?.toasts?.addToast({
+			severity: 'info',
+			title: lostAccessTitle,
+			description: lostAccessDescription,
+		})
+		navigate(routes.tlaRoot())
+	}, [lostAccess, app, navigate, lostAccessTitle, lostAccessDescription])
 }

--- a/apps/dotcom/client/src/tla/hooks/useGroupFileAccessGuard.ts
+++ b/apps/dotcom/client/src/tla/hooks/useGroupFileAccessGuard.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useValue } from 'tldraw'
+import { routes } from '../../routeDefs'
+import { TldrawApp } from '../app/TldrawApp'
+import { defineMessages, useMsg } from '../utils/i18n'
+
+const messages = defineMessages({
+	lostAccessTitle: { defaultMessage: 'Access removed' },
+	lostAccessDescription: { defaultMessage: 'You no longer have access to this file.' },
+})
+
+/**
+ * Send the signed-in user back to their files when they lose access to the
+ * group-owned file they're viewing — e.g. an owner removes them from the group,
+ * or the group is deleted out from under them.
+ *
+ * `getFile` resolves a group file through the user's synced memberships, so it
+ * reactively becomes null the moment their `group_user` row disappears. The
+ * guard only fires once access has been confirmed (`hadAccessRef`), so it never
+ * trips during the initial sync — when the file legitimately isn't loaded yet —
+ * nor for shared files that were never opened through a membership.
+ */
+export function useGroupFileAccessGuard(app: TldrawApp | null | undefined, fileSlug: string) {
+	const navigate = useNavigate()
+	const hadAccessRef = useRef(false)
+
+	const lostAccessTitle = useMsg(messages.lostAccessTitle)
+	const lostAccessDescription = useMsg(messages.lostAccessDescription)
+
+	// The group this file belongs to, as seen through our own memberships.
+	const owningGroupId = useValue(
+		'owningGroupForCurrentFile',
+		() => app?.getFile(fileSlug)?.owningGroupId ?? null,
+		[app, fileSlug]
+	)
+
+	useEffect(() => {
+		if (owningGroupId) {
+			hadAccessRef.current = true
+		} else if (hadAccessRef.current) {
+			hadAccessRef.current = false
+			app?.toasts?.addToast({
+				severity: 'info',
+				title: lostAccessTitle,
+				description: lostAccessDescription,
+			})
+			navigate(routes.tlaRoot())
+		}
+	}, [owningGroupId, app, navigate, lostAccessTitle, lostAccessDescription])
+}

--- a/apps/dotcom/client/src/tla/pages/file.tsx
+++ b/apps/dotcom/client/src/tla/pages/file.tsx
@@ -4,6 +4,7 @@ import { useParams, useRouteError } from 'react-router-dom'
 import { TlaEditor } from '../components/TlaEditor/TlaEditor'
 import { TlaFileError } from '../components/TlaFileError/TlaFileError'
 import { useMaybeApp } from '../hooks/useAppState'
+import { useGroupFileAccessGuard } from '../hooks/useGroupFileAccessGuard'
 import { ReadyWrapper } from '../hooks/useIsReady'
 import { TlaAnonLayout } from '../layouts/TlaAnonLayout/TlaAnonLayout'
 import { TlaSidebarLayout } from '../layouts/TlaSidebarLayout/TlaSidebarLayout'
@@ -37,6 +38,10 @@ export function Component({ error }: { error?: unknown }) {
 			app.ensureFileVisibleInSidebar(fileSlug)
 		}
 	}, [app, fileSlug])
+
+	// Navigate away if we lose access to a group file while viewing it — e.g. an
+	// owner removes us from the group, or the group is deleted.
+	useGroupFileAccessGuard(app, fileSlug)
 
 	if (!userId) {
 		return (

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -793,6 +793,94 @@ describe('membership', () => {
 		await m.leaveGroup(tx, { groupId })
 		expect(s.group_user.find((gu) => gu.userId === userId)).toBeUndefined()
 	})
+
+	it('owner can remove a member', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'owner' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await m.removeGroupMember(tx, { groupId, targetUserId: memberId })
+		expect(s.group_user.find((gu) => gu.userId === memberId)).toBeUndefined()
+	})
+
+	it('member cannot remove a member', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'member' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await expectForbidden(() => m.removeGroupMember(tx, { groupId, targetUserId: memberId }))
+		expect(s.group_user.find((gu) => gu.userId === memberId)).toBeDefined()
+	})
+
+	it('cannot remove yourself (leave the group instead)', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'owner' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'owner' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await expectBadRequest(() => m.removeGroupMember(tx, { groupId, targetUserId: userId }))
+		expect(s.group_user.find((gu) => gu.userId === userId)).toBeDefined()
+	})
+
+	it('owner can remove another owner when more than one owner', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [
+				makeGroupUser({ userId, groupId, role: 'owner' }),
+				makeGroupUser({ userId: memberId, groupId, role: 'owner' }),
+			],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await m.removeGroupMember(tx, { groupId, targetUserId: memberId })
+		expect(s.group_user.find((gu) => gu.userId === memberId)).toBeUndefined()
+	})
+
+	it('cannot remove a user who is not a member', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: groupId })],
+			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await expectBadRequest(() =>
+			m.removeGroupMember(tx, { groupId, targetUserId: 'user_notamember1234ab' })
+		)
+	})
 })
 
 describe('file operations across groups', () => {

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -644,6 +644,37 @@ export function createMutators(userId: string) {
 			assert(!isOnlyOwner, ZErrorCode.forbidden)
 			await tx.mutate.group_user.delete({ userId, groupId })
 		},
+		removeGroupMember: async (
+			tx: Tx,
+			{ groupId, targetUserId }: { groupId: string; targetUserId: string }
+		) => {
+			await assertUserHasFlag(tx, userId, 'groups_backend')
+			assert(groupId, ZErrorCode.bad_request)
+			assert(targetUserId, ZErrorCode.bad_request)
+
+			const role = await getRole(tx, userId, groupId)
+			assert(can(role, 'editMembers'), ZErrorCode.forbidden)
+
+			// Removing yourself goes through leaveGroup, which owns the last-owner invariant.
+			assert(targetUserId !== userId, ZErrorCode.bad_request)
+
+			// Target must be a member.
+			const targetMembership = await tx.run(
+				zql.group_user.where('userId', '=', targetUserId).where('groupId', '=', groupId).one()
+			)
+			assert(targetMembership, ZErrorCode.bad_request)
+
+			// Invariant (not a capability): a group must always keep at least one
+			// owner, so the last owner can't be removed — the group must be deleted instead.
+			if (targetMembership.role === 'owner') {
+				const owners = await tx.run(
+					zql.group_user.where('groupId', '=', groupId).where('role', '=', 'owner')
+				)
+				assert(owners.length > 1, ZErrorCode.forbidden)
+			}
+
+			await tx.mutate.group_user.delete({ userId: targetUserId, groupId })
+		},
 		deleteGroup: async (tx: Tx, { id }: { id: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)


### PR DESCRIPTION
In order to let group owners manage who's in their group, this PR adds the ability to remove a member from a group. It's part of the broader groups effort (#8859).

Members with the `editMembers` capability (currently owners) get an × button next to each other member's role in the group settings dialog. Clicking it opens a danger confirmation; confirming calls a new `removeGroupMember` mutator. The mutator enforces the `editMembers` capability and the "a group always keeps at least one owner" invariant, so the last owner can't be removed (the group must be deleted instead). You can't remove yourself this way — that path stays `leaveGroup`.

Removing a member who is currently viewing one of the group's files would otherwise leave them stranded on a file they can no longer access until they reconnect. To handle that, a small reactive guard (`useGroupFileAccessGuard`) watches the file the user is viewing and navigates them back to their files with a toast the moment their access disappears. This also covers the existing case of a group being deleted out from under other members.

### Concepts

| Term | Type | Meaning |
| --- | --- | --- |
| `removeGroupMember` | Zero mutator | Deletes a `group_user` row for a target member; requires `editMembers` and won't remove the last owner |
| `useGroupFileAccessGuard` | React hook | Navigates the viewer away (with a toast) when they lose access to the group file they're on |

### Change type

- [x] `feature`

### Test plan

1. As an owner of a group with at least one other member, open **Group settings**.
2. Confirm an × button appears next to each other member (but not next to yourself).
3. Click ×, confirm the dialog — the member is removed from the list.
4. As a non-owner (member), confirm no × button is shown.
5. Confirm the last owner cannot be removed.
6. As a member viewing one of the group's files, have an owner remove you — confirm you're navigated back to your files with an "Access removed" toast.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Group owners can now remove members from a group in group settings.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +31 / -0   |
| Tests           | +88 / -0   |
| Automated files | +44 / -0   |
| Apps            | +109 / -0  |
