### PR TITLE
fix(dotcom): lock down the personal home workspace

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1156,6 +1156,8 @@ export class TldrawApp {
 
 	/** Returns false when there is no invite link to copy yet (e.g. right after creation). */
 	copyWorkspaceInvite(workspaceId: string, showToast = true): boolean {
+		// The home workspace can't be invited to.
+		if (workspaceId === this.getHomeWorkspaceId()) return false
 		const membership = this.getWorkspaceMembership(workspaceId)
 		if (!membership?.group.inviteSecret) return false
 

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -75,6 +75,8 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const navigate = useNavigate()
 
 	if (!workspaceMembership) return null
+	// The home workspace has no settings to manage.
+	if (workspaceId === app.getHomeWorkspaceId()) return null
 	const workspace = workspaceMembership.group
 	const currentUser = workspaceMembership.groupMembers.find(
 		(member) => member.userId === app.getUser().id

--- a/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
@@ -5,7 +5,7 @@ import { sql } from 'kysely'
 import { createPostgresConnectionPool } from '../../postgres'
 import { Environment } from '../../types'
 import { requireAuth } from '../../utils/tla/getAuth'
-import { getJoinableGroupFromInvite } from '../../utils/tla/getJoinableGroupFromInvite'
+import { getJoinableWorkspaceFromInvite } from '../../utils/tla/getJoinableWorkspaceFromInvite'
 
 export async function acceptInvite(request: IRequest, env: Environment): Promise<Response> {
 	const { token } = request.params
@@ -21,10 +21,10 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 
 	try {
 		return await db.transaction().execute(async (tx) => {
-			// First, validate the invite token and get group info
-			const group = await getJoinableGroupFromInvite(tx, token)
+			// First, validate the invite token and get workspace info
+			const workspace = await getJoinableWorkspaceFromInvite(tx, token)
 
-			if (!group) {
+			if (!workspace) {
 				return Response.json(
 					{
 						error: true,
@@ -38,7 +38,7 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 			const existingMember = await tx
 				.selectFrom('group_user')
 				.select('userId')
-				.where('groupId', '=', group.id)
+				.where('groupId', '=', workspace.id)
 				.where('userId', '=', auth.userId)
 				.executeTakeFirst()
 
@@ -46,8 +46,8 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 				return Response.json({
 					error: false,
 					message: 'You are already a member of this group',
-					workspaceId: group.id,
-					workspaceName: group.name,
+					workspaceId: workspace.id,
+					workspaceName: workspace.name,
 					alreadyMember: true,
 				} satisfies AcceptInviteResponseBody)
 			}
@@ -112,7 +112,7 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 			await tx
 				.insertInto('group_user')
 				.values({
-					groupId: group.id,
+					groupId: workspace.id,
 					userId: auth.userId,
 					userColor: user.color || '#000000',
 					userName: user.name,
@@ -126,8 +126,8 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 			return Response.json({
 				error: false,
 				message: 'Successfully joined the group',
-				workspaceId: group.id,
-				workspaceName: group.name,
+				workspaceId: workspace.id,
+				workspaceName: workspace.name,
 				success: true,
 			} satisfies AcceptInviteResponseBody)
 		})

--- a/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
@@ -37,6 +37,22 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 				)
 			}
 
+			// A home workspace (group id === owner's user id) can't be joined.
+			const homeOwner = await tx
+				.selectFrom('user')
+				.select('id')
+				.where('id', '=', group.id)
+				.executeTakeFirst()
+			if (homeOwner) {
+				return Response.json(
+					{
+						error: true,
+						message: 'Invalid or expired invite token',
+					} satisfies AcceptInviteResponseBody,
+					{ status: 404 }
+				)
+			}
+
 			// Check if user is already a member of this group (with row lock to prevent race conditions)
 			const existingMember = await tx
 				.selectFrom('group_user')

--- a/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
@@ -5,6 +5,7 @@ import { sql } from 'kysely'
 import { createPostgresConnectionPool } from '../../postgres'
 import { Environment } from '../../types'
 import { requireAuth } from '../../utils/tla/getAuth'
+import { getJoinableGroupFromInvite } from '../../utils/tla/getJoinableGroupFromInvite'
 
 export async function acceptInvite(request: IRequest, env: Environment): Promise<Response> {
 	const { token } = request.params
@@ -21,29 +22,9 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 	try {
 		return await db.transaction().execute(async (tx) => {
 			// First, validate the invite token and get group info
-			const group = await tx
-				.selectFrom('group')
-				.select(['id', 'name', 'isDeleted'])
-				.where('inviteSecret', '=', token)
-				.executeTakeFirst()
+			const group = await getJoinableGroupFromInvite(tx, token)
 
-			if (!group || group.isDeleted) {
-				return Response.json(
-					{
-						error: true,
-						message: 'Invalid or expired invite token',
-					} satisfies AcceptInviteResponseBody,
-					{ status: 404 }
-				)
-			}
-
-			// A home workspace (group id === owner's user id) can't be joined.
-			const homeOwner = await tx
-				.selectFrom('user')
-				.select('id')
-				.where('id', '=', group.id)
-				.executeTakeFirst()
-			if (homeOwner) {
+			if (!group) {
 				return Response.json(
 					{
 						error: true,

--- a/apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts
@@ -28,6 +28,22 @@ export async function getInviteInfo(request: IRequest, env: Environment): Promis
 			)
 		}
 
+		// A home workspace (group id === owner's user id) can't be joined.
+		const homeOwner = await db
+			.selectFrom('user')
+			.select('id')
+			.where('id', '=', group.id)
+			.executeTakeFirst()
+		if (homeOwner) {
+			return Response.json(
+				{
+					error: true,
+					message: 'Invalid or expired invite token',
+				} satisfies GetInviteInfoResponseBody,
+				{ status: 404 }
+			)
+		}
+
 		return Response.json({
 			error: false,
 			workspaceId: group.id,

--- a/apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts
@@ -2,7 +2,7 @@ import { GetInviteInfoResponseBody } from '@tldraw/dotcom-shared'
 import { IRequest } from 'itty-router'
 import { createPostgresConnectionPool } from '../../postgres'
 import { Environment } from '../../types'
-import { getJoinableGroupFromInvite } from '../../utils/tla/getJoinableGroupFromInvite'
+import { getJoinableWorkspaceFromInvite } from '../../utils/tla/getJoinableWorkspaceFromInvite'
 
 export async function getInviteInfo(request: IRequest, env: Environment): Promise<Response> {
 	const { token } = request.params
@@ -13,9 +13,9 @@ export async function getInviteInfo(request: IRequest, env: Environment): Promis
 	const db = createPostgresConnectionPool(env, 'getInviteInfo')
 
 	try {
-		const group = await getJoinableGroupFromInvite(db, token)
+		const workspace = await getJoinableWorkspaceFromInvite(db, token)
 
-		if (!group) {
+		if (!workspace) {
 			return Response.json(
 				{
 					error: true,
@@ -27,8 +27,8 @@ export async function getInviteInfo(request: IRequest, env: Environment): Promis
 
 		return Response.json({
 			error: false,
-			workspaceId: group.id,
-			workspaceName: group.name,
+			workspaceId: workspace.id,
+			workspaceName: workspace.name,
 			isValid: true,
 			inviteSecret: token,
 		} satisfies GetInviteInfoResponseBody)

--- a/apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getInviteInfo.ts
@@ -2,6 +2,7 @@ import { GetInviteInfoResponseBody } from '@tldraw/dotcom-shared'
 import { IRequest } from 'itty-router'
 import { createPostgresConnectionPool } from '../../postgres'
 import { Environment } from '../../types'
+import { getJoinableGroupFromInvite } from '../../utils/tla/getJoinableGroupFromInvite'
 
 export async function getInviteInfo(request: IRequest, env: Environment): Promise<Response> {
 	const { token } = request.params
@@ -12,29 +13,9 @@ export async function getInviteInfo(request: IRequest, env: Environment): Promis
 	const db = createPostgresConnectionPool(env, 'getInviteInfo')
 
 	try {
-		const group = await db
-			.selectFrom('group')
-			.select(['id', 'name', 'isDeleted'])
-			.where('inviteSecret', '=', token)
-			.executeTakeFirst()
+		const group = await getJoinableGroupFromInvite(db, token)
 
-		if (!group || group.isDeleted) {
-			return Response.json(
-				{
-					error: true,
-					message: 'Invalid or expired invite token',
-				} satisfies GetInviteInfoResponseBody,
-				{ status: 404 }
-			)
-		}
-
-		// A home workspace (group id === owner's user id) can't be joined.
-		const homeOwner = await db
-			.selectFrom('user')
-			.select('id')
-			.where('id', '=', group.id)
-			.executeTakeFirst()
-		if (homeOwner) {
+		if (!group) {
 			return Response.json(
 				{
 					error: true,

--- a/apps/dotcom/sync-worker/src/utils/tla/getJoinableGroupFromInvite.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getJoinableGroupFromInvite.ts
@@ -1,0 +1,30 @@
+import { DB } from '@tldraw/dotcom-shared'
+import { Kysely } from 'kysely'
+
+/**
+ * Resolve the group an invite token points to, or null if the token can't be
+ * used to join: it's unknown/expired, the group is deleted, or the group is a
+ * home workspace (group id === its owner's user id), which is private. Callers
+ * treat null as an invalid token.
+ */
+export async function getJoinableGroupFromInvite(
+	db: Kysely<DB>,
+	token: string
+): Promise<{ id: string; name: string } | null> {
+	const group = await db
+		.selectFrom('group')
+		.select(['id', 'name', 'isDeleted'])
+		.where('inviteSecret', '=', token)
+		.executeTakeFirst()
+	if (!group || group.isDeleted) return null
+
+	// A home workspace has the same id as its owning user.
+	const homeOwner = await db
+		.selectFrom('user')
+		.select('id')
+		.where('id', '=', group.id)
+		.executeTakeFirst()
+	if (homeOwner) return null
+
+	return { id: group.id, name: group.name }
+}

--- a/apps/dotcom/sync-worker/src/utils/tla/getJoinableWorkspaceFromInvite.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getJoinableWorkspaceFromInvite.ts
@@ -2,29 +2,29 @@ import { DB } from '@tldraw/dotcom-shared'
 import { Kysely } from 'kysely'
 
 /**
- * Resolve the group an invite token points to, or null if the token can't be
- * used to join: it's unknown/expired, the group is deleted, or the group is a
+ * Resolve the workspace an invite token points to, or null if the token can't
+ * be used to join: it's unknown/expired, the workspace is deleted, or it's a
  * home workspace (group id === its owner's user id), which is private. Callers
  * treat null as an invalid token.
  */
-export async function getJoinableGroupFromInvite(
+export async function getJoinableWorkspaceFromInvite(
 	db: Kysely<DB>,
 	token: string
 ): Promise<{ id: string; name: string } | null> {
-	const group = await db
+	const workspace = await db
 		.selectFrom('group')
 		.select(['id', 'name', 'isDeleted'])
 		.where('inviteSecret', '=', token)
 		.executeTakeFirst()
-	if (!group || group.isDeleted) return null
+	if (!workspace || workspace.isDeleted) return null
 
 	// A home workspace has the same id as its owning user.
 	const homeOwner = await db
 		.selectFrom('user')
 		.select('id')
-		.where('id', '=', group.id)
+		.where('id', '=', workspace.id)
 		.executeTakeFirst()
 	if (homeOwner) return null
 
-	return { id: group.id, name: group.name }
+	return { id: workspace.id, name: workspace.name }
 }

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -1048,12 +1048,12 @@ describe('home workspace special case', () => {
 		}
 		return {
 			user,
-			file: [] as TlaFile[],
-			file_state: [] as TlaFileState[],
+			file: [],
+			file_state: [],
 			group: [makeGroup({ id: userId })],
 			group_user,
-			group_file: [] as TlaGroupFile[],
-		}
+			group_file: [],
+		} satisfies TableStore
 	}
 
 	it('cannot rename home workspace', async () => {

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -1035,20 +1035,62 @@ describe('home workspace special case', () => {
 		)
 	})
 
-	it('home workspace shortcut passes ownership check', async () => {
-		// updateWorkspace with id === userId should pass assertUserIsWorkspaceOwner
-		// via the shortcut, even if there's no group_user row
-		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [],
-			file_state: [],
-			group: [makeGroup({ id: userId })],
-			group_user: [],
-			group_file: [],
+	// The home workspace (group id === userId) can't be renamed, invited to, left,
+	// deleted, or have its members managed.
+	function homeState(extra?: { secondOwnerId?: string }) {
+		const group_user: TlaGroupUser[] = [makeGroupUser({ userId, groupId: userId, role: 'owner' })]
+		const user = [makeUser({ id: userId, flags: 'groups_backend' })]
+		if (extra?.secondOwnerId) {
+			group_user.push(
+				makeGroupUser({ userId: extra.secondOwnerId, groupId: userId, role: 'owner' })
+			)
+			user.push(makeUser({ id: extra.secondOwnerId, flags: 'groups_backend' }))
 		}
+		return {
+			user,
+			file: [] as TlaFile[],
+			file_state: [] as TlaFileState[],
+			group: [makeGroup({ id: userId })],
+			group_user,
+			group_file: [] as TlaGroupFile[],
+		}
+	}
+
+	it('cannot rename home workspace', async () => {
+		const { tx } = createMockTx(homeState())
+		const m = createMutators(userId)
+		await expectForbidden(() => m.updateWorkspace(tx, { id: userId, name: 'My Home' }))
+	})
+
+	it('cannot regenerate invite secret on home workspace', async () => {
+		const { tx } = createMockTx(homeState(), { location: 'server' })
+		const m = createMutators(userId)
+		await expectForbidden(() => m.regenerateWorkspaceInviteSecret(tx, { id: userId }))
+	})
+
+	it('cannot delete home workspace', async () => {
+		const { tx } = createMockTx(homeState())
+		const m = createMutators(userId)
+		await expectForbidden(() => m.deleteWorkspace(tx, { id: userId }))
+	})
+
+	it('cannot leave home workspace, even with another owner', async () => {
+		// A second owner would normally allow leaving; the home guard blocks it anyway.
+		const { tx } = createMockTx(homeState({ secondOwnerId: 'user_second12345678' }))
+		const m = createMutators(userId)
+		await expectForbidden(() => m.leaveWorkspace(tx, { workspaceId: userId }))
+	})
+
+	it('cannot change member roles in home workspace', async () => {
+		const targetId = 'user_target123456789'
+		const s = homeState()
+		s.user.push(makeUser({ id: targetId, flags: 'groups_backend' }))
+		s.group_user.push(makeGroupUser({ userId: targetId, groupId: userId, role: 'member' }))
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectValid(() => m.updateWorkspace(tx, { id: userId, name: 'My Home' }))
+		await expectForbidden(() =>
+			m.setWorkspaceMemberRole(tx, { workspaceId: userId, targetUserId: targetId, role: 'owner' })
+		)
 	})
 })
 

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -134,6 +134,16 @@ async function getRole(
 	return workspaceUser?.role ?? null
 }
 
+/**
+ * The home workspace (group id === its owner's user id) is private: it can't be
+ * invited to, renamed, left, deleted, or have its members managed. Throw if
+ * `workspaceId` is a home workspace, i.e. a user exists with a matching id.
+ */
+async function assertNotHomeWorkspace(tx: Transaction<TlaSchema>, workspaceId: string) {
+	const user = await tx.run(zql.user.where('id', '=', workspaceId).one())
+	assert(!user, ZErrorCode.forbidden)
+}
+
 function assertValidId(id: string) {
 	assert(id.match(/^[a-zA-Z0-9_-]+$/), ZErrorCode.bad_request)
 	assert(id.length <= 32, ZErrorCode.bad_request)
@@ -586,6 +596,7 @@ export function createMutators(userId: string) {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
 			assert(name && name.trim(), ZErrorCode.bad_request)
+			await assertNotHomeWorkspace(tx, id)
 			const role = await getRole(tx, userId, id)
 			assert(can(role, 'editWorkspace'), ZErrorCode.forbidden)
 
@@ -594,6 +605,7 @@ export function createMutators(userId: string) {
 		regenerateWorkspaceInviteSecret: async (tx: Tx, { id }: { id: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
+			await assertNotHomeWorkspace(tx, id)
 
 			const role = await getRole(tx, userId, id)
 			assert(can(role, 'manageInvites'), ZErrorCode.forbidden)
@@ -614,6 +626,7 @@ export function createMutators(userId: string) {
 			assert(workspaceId, ZErrorCode.bad_request)
 			assert(targetUserId, ZErrorCode.bad_request)
 			assert(isRole(targetRole), ZErrorCode.bad_request)
+			await assertNotHomeWorkspace(tx, workspaceId)
 
 			const role = await getRole(tx, userId, workspaceId)
 			assert(can(role, 'editMembers'), ZErrorCode.forbidden)
@@ -644,6 +657,7 @@ export function createMutators(userId: string) {
 		leaveWorkspace: async (tx: Tx, { workspaceId }: { workspaceId: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(workspaceId, ZErrorCode.bad_request)
+			await assertNotHomeWorkspace(tx, workspaceId)
 			const owners = await tx.run(
 				zql.group_user.where('groupId', '=', workspaceId).where('role', '=', 'owner')
 			)
@@ -656,6 +670,7 @@ export function createMutators(userId: string) {
 		deleteWorkspace: async (tx: Tx, { id }: { id: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
+			await assertNotHomeWorkspace(tx, id)
 			const role = await getRole(tx, userId, id)
 			assert(can(role, 'deleteWorkspace'), ZErrorCode.forbidden)
 


### PR DESCRIPTION
In order to keep a user's home/personal workspace private, this PR enforces its special permissions server-side instead of only hiding them in the UI. The home workspace is the `group` row whose `id` equals the owning user's id; previously the only special-casing was `getRole()` treating the user as `owner`, which granted capabilities without restricting anything. Because the mutators re-run on the server as the authority, a crafted mutation could regenerate an invite secret, add members via an invite link, leave, delete, rename, or change roles in the home workspace — bypassing the sidebar UI that hid those actions.

This adds an `assertNotHomeWorkspace` guard (a home workspace is any group whose id matches an existing user id) to the `regenerateWorkspaceInviteSecret`, `updateWorkspace`, `deleteWorkspace`, `leaveWorkspace`, and `setWorkspaceMemberRole` mutators, and rejects home workspaces in the `acceptInvite` and `getInviteInfo` routes so an invite link can never resolve to one. Client-side defense-in-depth: `WorkspaceSettingsDialog` renders nothing for the home workspace and `copyWorkspaceInvite` refuses it.

### Change type

- [x] `bugfix`

### Test plan

1. Open the home workspace in the sidebar — confirm it has no workspace menu, settings, invite link, rename, leave, or delete.
2. Attempt each home-workspace mutation directly (regenerate invite, rename, delete, leave, change member role) — all are rejected by the server.
3. Visit an `/invite/<secret>` link that resolves to a home workspace — it is treated as invalid.

- [x] Unit tests

### Release notes

- Lock down the personal/home workspace: it can no longer be shared via an invite link, renamed, left, deleted, or have its members managed.

### Code changes

| Section    | LOC change |
| ---------- | ---------- |
| Core code  | +15 / -0   |
| Tests      | +52 / -10  |
| Apps       | +36 / -0   |
