### PR TITLE
fix(dotcom): scope sidebar drag-image compositing hack to pressed rows

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -532,8 +532,6 @@
 
 .sidebarFileListItem {
 	background-color: transparent;
-	/* Chrome hack to enable the drag image to have a transparent background */
-	opacity: 0.999;
 	position: relative;
 	width: 100%;
 	display: flex;
@@ -545,6 +543,15 @@
 
 .sidebar[data-workspaces='true'] .sidebarFileListItem {
 	padding: 0px 4px 0px 8px;
+}
+
+/* Chrome hack: promote the pressed row to its own compositing layer so the
+   native drag image keeps a transparent background. :active fires on
+   mousedown, before dragstart takes the snapshot, so the layer exists in
+   time. translateZ(0) promotes without touching opacity, so there's no
+   color shift at all. */
+.sidebarFileListItem:active {
+	transform: translateZ(0);
 }
 
 .sidebarFileListItem[data-active='true'][data-enhanced-a11y-mode='true'] {


### PR DESCRIPTION
In order to make every sidebar row render the same hover color, this PR removes the always-on `opacity: 0.999` Chrome drag-image hack from `.sidebarFileListItem` and replaces it with a `transform: translateZ(0)` that only applies while a row is pressed (`:active`). Closes #8811, supersedes #8929.

The old hack kept file rows permanently in their own compositing layer, so the shared `--tla-color-hover-1` tint rasterized slightly differently on file and workspace rows than on the user settings row. The layer is only actually needed at the moment Chrome snapshots the native drag image, and `:active` fires on mousedown — always before `dragstart` — so the layer exists in time. Using a transform instead of opacity means the promotion itself causes no color shift either.

Verified by sampling the composited pixels in the running app: file rows and the user settings row now match exactly in both themes — `rgb(245,245,245)` on light hover, `rgb(13,13,13)` idle and `rgb(20,20,20)` hover on dark.

### Change type

- [x] `bugfix`

### Test plan

1. Hover a file row, a workspace row, and the user settings row — all should show the same hover tint, in light and dark mode.
2. In Chrome, drag a file row — the drag ghost should still have a transparent background (no opaque box behind the row).
3. Check the row doesn't visibly shift on mousedown.

### Release notes

- Fix a subtle hover color mismatch between sidebar file rows and the user settings row on tldraw.com.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +9 / -2    |