### PR TITLE
fix(tldraw): restore redo shortcut after undo on the same physical key

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -155,11 +155,21 @@ export function useKeyboardShortcuts() {
 				if (!reg.onKeyDown) continue
 				for (const p of reg.parsed) {
 					if (matchesEvent(e, p)) {
-						const prev = code ? heldKeyRegistrations.get(code) : undefined
-						// The held key already triggered a different shortcut; don't fall back to
-						// this one (or anything else) just because a modifier was released.
-						if (prev && prev !== reg) return
-						if (code) heldKeyRegistrations.set(code, reg)
+						if (code) {
+							// We only guard auto-repeat events. A fresh keypress (`e.repeat` is
+							// false) is always free to trigger whatever it matches, even on the same
+							// physical key — e.g. cmd+z (undo) then cmd+shift+z (redo), where macOS
+							// swallows the `z` keyup while cmd stays held, so we can't rely on keyup
+							// to clear the previous registration.
+							if (e.repeat) {
+								const prev = heldKeyRegistrations.get(code)
+								// The held key already triggered a different shortcut; don't fall back
+								// to this one (or anything else) just because a modifier was released.
+								if (prev && prev !== reg) return
+							} else {
+								heldKeyRegistrations.set(code, reg)
+							}
+						}
 						reg.onKeyDown(e)
 						break
 					}

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -1,5 +1,5 @@
 import { act } from '@testing-library/react'
-import { Editor } from '@tldraw/editor'
+import { createShapeId, Editor } from '@tldraw/editor'
 import { useEffect } from 'react'
 import { Tldraw } from '../../lib/Tldraw'
 import { useActions } from '../../lib/ui/context/actions'
@@ -178,5 +178,30 @@ describe('keyboard shortcuts with a held key', () => {
 		// A fresh plain `q` press now works rather than being blocked by a stale entry.
 		keydown(editor, { key: 'q', code: 'KeyQ' })
 		expect(editor.getInstanceState().isToolLocked).toBe(true)
+	})
+
+	// Regression test for #9099: redo (cmd+shift+z) stopped firing after an undo (cmd+z) on
+	// macOS, where the browser swallows the `z` keyup while cmd stays held. The held-key
+	// tracking from #9099 never got cleared, so the stale undo registration blocked the redo
+	// on the same physical `KeyZ`. A fresh keypress must always be free to trigger its match.
+	it('fires redo after undo on the same physical key when the keyup is swallowed (cmd held)', async () => {
+		const { editor } = await setupFocusedEditor()
+
+		const id = createShapeId()
+		act(() => {
+			editor.markHistoryStoppingPoint()
+			editor.createShape({ id, type: 'geo', x: 0, y: 0 })
+		})
+		expect(editor.getCurrentPageShapeIds().has(id)).toBe(true)
+
+		// cmd+z undoes the shape creation. On macOS the `z` keyup is never delivered while cmd
+		// stays held, so we deliberately don't dispatch it.
+		keydown(editor, { key: 'z', code: 'KeyZ', metaKey: true })
+		expect(editor.getCurrentPageShapeIds().has(id)).toBe(false)
+
+		// Adding shift and pressing z again is a fresh keypress (not an auto-repeat), so it must
+		// trigger redo rather than being blocked by the stale undo registration on `KeyZ`.
+		keydown(editor, { key: 'z', code: 'KeyZ', metaKey: true, shiftKey: true })
+		expect(editor.getCurrentPageShapeIds().has(id)).toBe(true)
 	})
 })


### PR DESCRIPTION
In order to fix the redo shortcut regressing on macOS, this PR changes the held-key fallback guard added in #9099 so it only applies to auto-repeat keydowns.

#9099 tracked which registration each physically-held key (keyed by `event.code`) first triggered, and cleared that tracking on `keyup`. But macOS swallows the `keyup` for non-modifier keys while `cmd` is held. So after `cmd+z` (undo), the stale undo registration for `KeyZ` was never cleared, and the next `cmd+shift+z` (redo) — which lands on the same physical `KeyZ` — was suppressed as an "adjacent shortcut" and never fired. Redo silently did nothing.

The fix only guards auto-repeat (`event.repeat`) keydowns, which is the actual case #9099 targeted (holding `q` and releasing shift produces auto-repeat `q` events). A fresh keypress is always free to trigger whatever it matches, even on the same physical key, so `cmd+z` then `cmd+shift+z` works regardless of whether the intervening `keyup` was delivered. Holding `shift+q` and releasing shift still does not fall back to plain `q`.

### Change type

- [x] `bugfix`

### Test plan

1. On macOS, draw something and make a couple of edits.
2. Hold `cmd` and press `z` to undo.
3. Keeping `cmd` held, press `shift+z` to redo.
4. Confirm redo fires (it previously did nothing).

- [x] Unit tests

### Release notes

- Fix redo (`cmd+shift+z`) not firing after an undo (`cmd+z`) on macOS when cmd is kept held.
