### PR TITLE
fix(editor): keep zoom level when yeeting camera after a right-click pan

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11341,7 +11341,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 									// Don't pass right-click panning events to the state chart
 									// as it causes unintended shape selection on release
 									if (slideSpeed > 0) {
-										this.slideCamera({ speed: slideSpeed, direction: slideDirection })
+										this.slideCamera({
+											speed: slideSpeed,
+											direction: { x: slideDirection.x, y: slideDirection.y, z: 0 },
+										})
 									}
 									this._selectedShapeIdsAtPointerDown = []
 									this._didCaptureSelectionAtPointerDown = false

--- a/packages/tldraw/src/test/rightClickPanning.test.ts
+++ b/packages/tldraw/src/test/rightClickPanning.test.ts
@@ -1,3 +1,4 @@
+import { Vec } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
 describe('with rightClickPanning enabled (default)', () => {
@@ -15,6 +16,16 @@ describe('with rightClickPanning enabled (default)', () => {
 		editor.expectCameraToBe(100, 100, 1)
 		editor.pointerUp(200, 200, { button: 2 })
 		expect(editor.inputs.getIsPanning()).toBe(false)
+	})
+
+	it('does not zoom when momentum panning on release', () => {
+		editor.pointerDown(100, 100, { button: 2 })
+		editor.pointerMove(200, 200)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		editor.inputs.setPointerVelocity(new Vec(1, 1))
+		editor.pointerUp(200, 200, { button: 2 }).forceTick()
+
+		expect(editor.getCamera().z).toBe(1)
 	})
 
 	it('does not pan on a static right-click', () => {


### PR DESCRIPTION
In order to stop fast right-click pans from zooming the camera to 800% on release, this PR passes a sanitized direction (`z: 0`) to `slideCamera` in the right-mouse-button pointer-up path. The raw pointer-velocity `Vec` was being passed directly, and `Vec.z` defaults to 1 because it doubles as pen pressure; since #7858, `slideCamera` interprets `direction.z` as a zoom direction, so the inertia fling multiplied the zoom every tick until it hit the max-zoom clamp. The left and middle button paths already sanitize the direction this way; this brings the right-click path in line. Closes #9138. The underlying hazard of `Vec.z` carrying different meanings across APIs is tracked separately in #9146.

### Change type

- [x] `bugfix`

### Test plan

1. Open any tldraw canvas.
2. Right-click and drag quickly to pan, then release while still moving.
3. The camera glides to a stop at the same zoom level instead of jumping to 800%.
4. Slow right-click pans and left/middle button (spacebar) pans behave as before.

- [x] Unit tests

### Release notes

- Fixed a bug where releasing a fast right-click pan zoomed the camera to the maximum zoom level.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -1    |
| Tests     | +11 / -0   |