### PR TITLE
perf: improve performance when resizing many shapes

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1348,6 +1348,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     _getReferencedUserIds(shapes: TLShape[]): Set<string>;
     getRenderingShapes(): TLRenderingShape[];
     getResizeScaleFactor(): number;
+    // @internal
+    getResizeShapePartial(shape: TLShape | TLShapeId, scale: VecLike, opts?: TLResizeShapeOptions): null | TLShapePartial;
     getRichTextEditor(): null | TiptapEditor;
     getSelectedShapeAtPoint(point: VecLike): TLShape | undefined;
     getSelectedShapeIds(): TLShapeId[];

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8102,32 +8102,53 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	resizeShape(shape: TLShapeId | TLShape, scale: VecLike, opts: TLResizeShapeOptions = {}): this {
+		const partial = this.getResizeShapePartial(shape, scale, opts)
+		if (partial) this.updateShapes([partial])
+		return this
+	}
+
+	/**
+	 * Get the update for a resized shape without committing it to the store. Interactions that
+	 * resize many shapes at once use this to collect all of the updates and commit them in a
+	 * single batch. Returns null when there is nothing to update.
+	 *
+	 * Shapes that are rotated out of alignment with the scale axis cannot be resized with a
+	 * single update; those shapes are resized immediately (as `resizeShape` would do) and null
+	 * is returned.
+	 *
+	 * @internal
+	 */
+	getResizeShapePartial(
+		shape: TLShapeId | TLShape,
+		scale: VecLike,
+		opts: TLResizeShapeOptions = {}
+	): TLShapePartial | null {
 		const id = typeof shape === 'string' ? shape : shape.id
-		if (this.getIsReadonly()) return this
+		if (this.getIsReadonly()) return null
 
 		if (!Number.isFinite(scale.x)) scale = new Vec(1, scale.y)
 		if (!Number.isFinite(scale.y)) scale = new Vec(scale.x, 1)
 
 		const initialShape = opts.initialShape ?? this.getShape(id)
-		if (!initialShape) return this
+		if (!initialShape) return null
 
 		const scaleOrigin = opts.scaleOrigin ?? this.getShapePageBounds(id)?.center
-		if (!scaleOrigin) return this
+		if (!scaleOrigin) return null
 
 		const pageTransform = opts.initialPageTransform
 			? Mat.Cast(opts.initialPageTransform)
 			: this.getShapePageTransform(id)
-		if (!pageTransform) return this
+		if (!pageTransform) return null
 
 		const pageRotation = pageTransform.rotation()
 
-		if (pageRotation == null) return this
+		if (pageRotation == null) return null
 
 		const scaleAxisRotation = opts.scaleAxisRotation ?? pageRotation
 
 		const initialBounds = opts.initialBounds ?? this.getShapeGeometry(id).bounds
 
-		if (!initialBounds) return this
+		if (!initialBounds) return null
 
 		const isAspectRatioLocked =
 			opts.isAspectRatioLocked ?? this.getShapeUtil(initialShape).isAspectRatioLocked(initialShape)
@@ -8137,7 +8158,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// from whichever axis is being scaled the least, to avoid the shape getting bigger
 			// than the bounds of the selection
 			// const minScale = Math.min(Math.abs(scale.x), Math.abs(scale.y))
-			return this._resizeUnalignedShape(id, scale, {
+			this._resizeUnalignedShape(id, scale, {
 				...opts,
 				initialBounds,
 				scaleOrigin,
@@ -8146,6 +8167,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				isAspectRatioLocked,
 				initialShape,
 			})
+			return null
 		}
 
 		const util = this.getShapeUtil(initialShape)
@@ -8158,7 +8180,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 		}
 
-		let didResize = false
+		let workingShape: TLShape | null = null
 
 		if (util.onResize && util.canResize(initialShape)) {
 			// get the model changes from the shape util
@@ -8190,7 +8212,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// need to adjust the shape's x and y points in case the parent has moved since start of resizing
 			const { x, y } = this.getPointInParentSpace(initialShape.id, initialPagePoint)
 
-			let workingShape = initialShape
+			workingShape = initialShape
 			if (!opts.skipStartAndEndCallbacks) {
 				workingShape = applyPartialToRecordWithProps(
 					initialShape,
@@ -8212,10 +8234,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 				}
 			)
 
-			if (resizedShape) {
-				didResize = true
-			}
-
 			workingShape = applyPartialToRecordWithProps(workingShape, {
 				id,
 				type: initialShape.type as any,
@@ -8231,40 +8249,47 @@ export class Editor extends EventEmitter<TLEventMap> {
 				)
 			}
 
-			this.updateShapes([workingShape])
+			if (resizedShape) {
+				return workingShape
+			}
 		}
 
-		if (!didResize) {
-			// reposition shape (rather than resizing it) based on where its resized center would be
+		// the shape was not resized by its util, so reposition it (rather than resizing it)
+		// based on where its resized center would be
 
-			const initialPageCenter = Mat.applyToPoint(pageTransform, initialBounds.center)
-			// get the model changes from the shape util
-			const newPageCenter = this._scalePagePoint(
-				initialPageCenter,
-				scaleOrigin,
-				scale,
-				scaleAxisRotation
-			)
+		const initialPageCenter = Mat.applyToPoint(pageTransform, initialBounds.center)
+		// get the model changes from the shape util
+		const newPageCenter = this._scalePagePoint(
+			initialPageCenter,
+			scaleOrigin,
+			scale,
+			scaleAxisRotation
+		)
 
-			const initialPageCenterInParentSpace = this.getPointInParentSpace(
-				initialShape.id,
-				initialPageCenter
-			)
-			const newPageCenterInParentSpace = this.getPointInParentSpace(initialShape.id, newPageCenter)
+		const initialPageCenterInParentSpace = this.getPointInParentSpace(
+			initialShape.id,
+			initialPageCenter
+		)
+		const newPageCenterInParentSpace = this.getPointInParentSpace(initialShape.id, newPageCenter)
 
-			const delta = Vec.Sub(newPageCenterInParentSpace, initialPageCenterInParentSpace)
-			// apply the changes to the model
-			this.updateShapes([
-				{
-					id,
-					type: initialShape.type as any,
-					x: initialShape.x + delta.x,
-					y: initialShape.y + delta.y,
-				},
-			])
+		const delta = Vec.Sub(newPageCenterInParentSpace, initialPageCenterInParentSpace)
+
+		if (workingShape) {
+			// the util's onResize ran but returned no change; keep the working update (which may
+			// include changes from onResizeStart / onResizeEnd) and reposition the shape
+			return {
+				...workingShape,
+				x: initialShape.x + delta.x,
+				y: initialShape.y + delta.y,
+			}
 		}
 
-		return this
+		return {
+			id,
+			type: initialShape.type as any,
+			x: initialShape.x + delta.x,
+			y: initialShape.y + delta.y,
+		}
 	}
 
 	/** @internal */

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -48,7 +48,11 @@ export class HistoryManager<R extends UnknownRecord> {
 			switch (this.state) {
 				case HistoryRecorderState.Recording:
 					this.pendingDiff.apply(entry.changes)
-					this.stacks.update(({ undos }) => ({ undos, redos: stack() }))
+					// this interceptor runs for every store change, so skip the update when the
+					// redo stack is already empty
+					if (this.stacks.get().redos.length > 0) {
+						this.stacks.update(({ undos }) => ({ undos, redos: stack() }))
+					}
 					break
 				case HistoryRecorderState.RecordingPreserveRedoStack:
 					this.pendingDiff.apply(entry.changes)
@@ -349,12 +353,26 @@ class PendingDiff<R extends UnknownRecord> {
 
 	apply(diff: RecordsDiff<R>) {
 		squashRecordDiffsMutable(this.diff, [diff])
-		this.isEmptyAtom.set(isRecordsDiffEmpty(this.diff))
+		// Recomputing emptiness from the accumulated diff is O(N) (for-in over a
+		// dictionary-mode object pays an O(N) key-collection prologue), and this runs on
+		// every history interceptor call — e.g. every input tick while resizing many
+		// shapes. Updates can never cancel out existing entries during a squash, so the
+		// full recompute is only needed when the incoming diff adds or removes records.
+		if (hasAnyKey(diff.added) || hasAnyKey(diff.removed)) {
+			this.isEmptyAtom.set(isRecordsDiffEmpty(this.diff))
+		} else if (this.isEmptyAtom.__unsafe__getWithoutCapture()) {
+			this.isEmptyAtom.set(!hasAnyKey(diff.updated))
+		}
 	}
 
 	debug() {
 		return { diff: this.diff, isEmpty: this.isEmpty() }
 	}
+}
+
+function hasAnyKey(obj: object) {
+	for (const _ in obj) return true
+	return false
 }
 
 type Stack<T> = StackItem<T> | EmptyStackItem<T>

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -1,4 +1,3 @@
-import { objectMapEntries } from '@tldraw/utils'
 import { IdOf, UnknownRecord } from './BaseRecord'
 
 /**
@@ -107,11 +106,16 @@ export function reverseRecordsDiff(diff: RecordsDiff<any>) {
  * @public
  */
 export function isRecordsDiffEmpty<T extends UnknownRecord>(diff: RecordsDiff<T>) {
-	return (
-		Object.keys(diff.added).length === 0 &&
-		Object.keys(diff.updated).length === 0 &&
-		Object.keys(diff.removed).length === 0
-	)
+	return !hasAnyKey(diff.added) && !hasAnyKey(diff.updated) && !hasAnyKey(diff.removed)
+}
+
+// Cheaper than Object.keys().length, but note that for-in still pays an O(N)
+// key-collection prologue on dictionary-mode objects (which diffs become once keys
+// are deleted from them) — avoid calling this on large diffs in per-frame hot paths.
+/** @internal */
+export function hasAnyKey(obj: object) {
+	for (const _ in obj) return true
+	return false
 }
 
 /**
@@ -203,9 +207,22 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 	target: RecordsDiff<T>,
 	diffs: RecordsDiff<T>[]
 ): void {
+	// This runs on every history interceptor call — e.g. once per input tick while
+	// resizing N shapes, with N entries in diff.updated — so the updated loop must not
+	// allocate per entry. We use for-in instead of Object.entries, mutate the target's
+	// existing [from, to] tuples in place, and skip delete calls against collections we
+	// know are empty. In-place tuple mutation is safe because the target exclusively
+	// owns its updated tuples: they are always created here (never shared with a source
+	// diff), and sources are never mutated.
 	for (const diff of diffs) {
-		for (const [id, value] of objectMapEntries(diff.added)) {
-			if (target.removed[id]) {
+		// target.removed can only lose entries before the removed loop below, so a
+		// stale `true` is harmless (extra no-op deletes).
+		const targetHasRemoved = hasAnyKey(target.removed)
+
+		for (const _id in diff.added) {
+			const id = _id as IdOf<T>
+			const value = diff.added[id]
+			if (targetHasRemoved && target.removed[id]) {
 				const original = target.removed[id]
 				delete target.removed[id]
 				if (original !== value) {
@@ -216,24 +233,32 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 			}
 		}
 
-		for (const [id, [_from, to]] of objectMapEntries(diff.updated)) {
-			if (target.added[id]) {
+		// the added loop above may have inserted into target.added
+		const targetHasAdded = hasAnyKey(target.added)
+
+		for (const _id in diff.updated) {
+			const id = _id as IdOf<T>
+			const to = diff.updated[id][1]
+			if (targetHasAdded && target.added[id]) {
 				target.added[id] = to
 				delete target.updated[id]
-				delete target.removed[id]
+				if (targetHasRemoved) delete target.removed[id]
 				continue
 			}
-			if (target.updated[id]) {
-				target.updated[id] = [target.updated[id][0], to]
-				delete target.removed[id]
+			const existing = target.updated[id]
+			if (existing) {
+				existing[1] = to
+				if (targetHasRemoved) delete target.removed[id]
 				continue
 			}
 
-			target.updated[id] = diff.updated[id]
-			delete target.removed[id]
+			// copy the tuple so the target owns it and can mutate it in place later
+			target.updated[id] = [diff.updated[id][0], to]
+			if (targetHasRemoved) delete target.removed[id]
 		}
 
-		for (const [id, value] of objectMapEntries(diff.removed)) {
+		for (const _id in diff.removed) {
+			const id = _id as IdOf<T>
 			// the same record was added in this diff sequence, just drop it
 			if (target.added[id]) {
 				delete target.added[id]
@@ -241,7 +266,7 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 				target.removed[id] = target.updated[id][0]
 				delete target.updated[id]
 			} else {
-				target.removed[id] = value
+				target.removed[id] = diff.removed[id]
 			}
 		}
 	}

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -14,7 +14,7 @@ import {
 import { AtomMap } from './AtomMap'
 import { IdOf, RecordId, UnknownRecord } from './BaseRecord'
 import { devFreeze } from './devFreeze'
-import { RecordsDiff, squashRecordDiffs } from './RecordsDiff'
+import { hasAnyKey, RecordsDiff, squashRecordDiffs } from './RecordsDiff'
 import { RecordScope } from './RecordType'
 import { StoreQueries } from './StoreQueries'
 import { SerializedSchema, StoreSchema } from './StoreSchema'
@@ -573,11 +573,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			updated: filterEntries(change.updated, (_, r) => this.scopedTypes[scope].has(r[1].typeName)),
 			removed: filterEntries(change.removed, (_, r) => this.scopedTypes[scope].has(r.typeName)),
 		}
-		if (
-			Object.keys(result.added).length === 0 &&
-			Object.keys(result.updated).length === 0 &&
-			Object.keys(result.removed).length === 0
-		) {
+		if (!hasAnyKey(result.added) && !hasAnyKey(result.updated) && !hasAnyKey(result.removed)) {
 			return null
 		}
 		return result
@@ -1328,7 +1324,9 @@ function squashHistoryEntries<T extends UnknownRecord>(
 	return devFreeze(
 		chunked.map((chunk) => ({
 			source: chunk[0].source,
-			changes: squashRecordDiffs(chunk.map((e) => e.changes)),
+			// a single-entry chunk needs no squashing — skip the O(N) copy of its diff
+			changes:
+				chunk.length === 1 ? chunk[0].changes : squashRecordDiffs(chunk.map((e) => e.changes)),
 		}))
 	)
 }

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -12,7 +12,6 @@ import {
 	exhaustiveSwitchError,
 	isEqual,
 	objectMapEntries,
-	structuredClone,
 	uniqueId,
 } from '@tldraw/utils'
 import {
@@ -853,10 +852,11 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		// in offline mode, we only accumulate in speculativeChanges
 		if (!this.isConnectedToRoom) return
 		if (!this.unsentChanges.nextDiff) {
-			this.unsentChanges.nextDiff = structuredClone(change)
-		} else {
-			squashRecordDiffsMutable(this.unsentChanges.nextDiff, [change])
+			this.unsentChanges.nextDiff = { added: {} as any, updated: {} as any, removed: {} as any }
 		}
+		// records are immutable, so sharing their references with `change` is fine — the
+		// squash gives nextDiff its own containers and tuples without deep-cloning records
+		squashRecordDiffsMutable(this.unsentChanges.nextDiff, [change])
 		this.sendUnsentChanges()
 	}
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -17,6 +17,7 @@ import {
 	areAnglesCompatible,
 	compact,
 	isAccelKey,
+	isShapeId,
 	kickoutOccludedShapes,
 } from '@tldraw/editor'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -214,24 +215,30 @@ export class Resizing extends StateNode {
 	}
 
 	private updateShapes() {
-		const altKey = this.editor.inputs.getAltKey()
-		const shiftKey = this.editor.inputs.getShiftKey()
 		const {
-			frames,
-			shapeSnapshots,
-			selectionBounds,
-			cursorHandleOffset,
-			selectedShapeIds,
-			selectionRotation,
-			canShapesDeform,
-		} = this.snapshot
+			editor,
+			info,
+			snapshot: {
+				frames,
+				shapeSnapshots,
+				selectionBounds,
+				cursorHandleOffset,
+				selectedShapeIds,
+				selectionRotation,
+				canShapesDeform,
+				initialSelectionPageBounds,
+				resizeLevels,
+			},
+		} = this
+		const altKey = editor.inputs.getAltKey()
+		const shiftKey = editor.inputs.getShiftKey()
 
 		let isAspectRatioLocked = shiftKey || !canShapesDeform
 
 		if (shapeSnapshots.size === 1) {
 			const onlySnapshot = [...shapeSnapshots.values()][0]!
-			if (this.editor.isShapeOfType(onlySnapshot.shape, 'text')) {
-				isAspectRatioLocked = !(this.info.handle === 'left' || this.info.handle === 'right')
+			if (editor.isShapeOfType(onlySnapshot.shape, 'text')) {
+				isAspectRatioLocked = !(info.handle === 'left' || info.handle === 'right')
 			}
 		}
 
@@ -268,32 +275,32 @@ export class Resizing extends StateNode {
 		//                            │
 		//                   cursorHandleOffset.x
 
-		const isHoldingAccel = isAccelKey(this.editor.inputs)
+		const isHoldingAccel = isAccelKey(editor.inputs)
 
-		const currentPagePoint = this.editor.inputs
+		const currentPagePoint = editor.inputs
 			.getCurrentPagePoint()
 			.clone()
 			.sub(cursorHandleOffset)
 			.sub(this.creationCursorOffset)
 
-		const originPagePoint = this.editor.inputs.getOriginPagePoint().clone().sub(cursorHandleOffset)
+		const originPagePoint = editor.inputs.getOriginPagePoint().clone().sub(cursorHandleOffset)
 
-		if (this.editor.getInstanceState().isGridMode && !isHoldingAccel) {
-			const { gridSize } = this.editor.getDocumentSettings()
+		if (editor.getInstanceState().isGridMode && !isHoldingAccel) {
+			const { gridSize } = editor.getDocumentSettings()
 			currentPagePoint.snapToGrid(gridSize)
 		}
 
-		const dragHandle = this.info.handle as SelectionCorner | SelectionEdge
+		const dragHandle = info.handle as SelectionCorner | SelectionEdge
 		const scaleOriginHandle = rotateSelectionHandle(dragHandle, Math.PI)
 
-		this.editor.snaps.clearIndicators()
+		editor.snaps.clearIndicators()
 
-		const shouldSnap = this.editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
+		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
 
 		if (shouldSnap && selectionRotation % HALF_PI === 0) {
-			const { nudge } = this.editor.snaps.shapeBounds.snapResizeShapes({
+			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
 				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
-				initialSelectionPageBounds: this.snapshot.initialSelectionPageBounds,
+				initialSelectionPageBounds: initialSelectionPageBounds,
 				handle: rotateSelectionHandle(dragHandle, selectionRotation),
 				isAspectRatioLocked,
 				isResizingFromCenter: altKey,
@@ -376,24 +383,38 @@ export class Resizing extends StateNode {
 			)
 		}
 
-		// Resize all shapes (onResize will use the batch cache for geo shapes when available)
-		for (const id of shapeSnapshots.keys()) {
-			const snapshot = shapeSnapshots.get(id)!
+		// Resize all shapes (onResize will use the batch cache for geo shapes when available).
+		// Collect the updates for each nesting level and commit them in a single batch, so that
+		// each pointer move pays the store's per-commit costs once per level rather than once per
+		// shape. Shapes that are rotated out of alignment with the selection can't be expressed
+		// as a single update; getResizeShapePartial resizes those immediately and returns null.
+		for (const level of resizeLevels) {
+			const changes: TLShapePartial[] = []
 
-			this.editor.resizeShape(id, scale, {
-				initialShape: snapshot.shape,
-				initialBounds: snapshot.bounds,
-				initialPageTransform: snapshot.pageTransform,
-				dragHandle,
-				mode:
-					selectedShapeIds.length === 1 && id === selectedShapeIds[0]
-						? 'resize_bounds'
-						: 'scale_shape',
-				scaleOrigin: scaleOriginPage,
-				isAspectRatioLocked,
-				scaleAxisRotation: selectionRotation,
-				skipStartAndEndCallbacks: true,
-			})
+			for (const id of level) {
+				const snapshot = shapeSnapshots.get(id)!
+
+				const change = editor.getResizeShapePartial(id, scale, {
+					initialShape: snapshot.shape,
+					initialBounds: snapshot.bounds,
+					initialPageTransform: snapshot.pageTransform,
+					dragHandle,
+					mode:
+						selectedShapeIds.length === 1 && id === selectedShapeIds[0]
+							? 'resize_bounds'
+							: 'scale_shape',
+					scaleOrigin: scaleOriginPage,
+					isAspectRatioLocked,
+					scaleAxisRotation: selectionRotation,
+					skipStartAndEndCallbacks: true,
+				})
+
+				if (change) changes.push(change)
+			}
+
+			if (changes.length > 0) {
+				editor.updateShapes(changes)
+			}
 		}
 
 		// If there's only one shape snapshot and it's a frame and the user is holding ctrl,
@@ -401,6 +422,8 @@ export class Resizing extends StateNode {
 		// the frame rather than resizing it.
 		if (isHoldingAccel) {
 			this.didHoldCommand = true
+
+			const childChanges: TLShapePartial[] = []
 
 			for (const { id, children } of frames) {
 				if (!children.length) continue
@@ -415,7 +438,7 @@ export class Resizing extends StateNode {
 
 				if (delta.x !== 0 || delta.y !== 0) {
 					for (const child of children) {
-						this.editor.updateShape({
+						childChanges.push({
 							id: child.id,
 							type: child.type,
 							x: child.x - delta.x,
@@ -424,20 +447,29 @@ export class Resizing extends StateNode {
 					}
 				}
 			}
+
+			if (childChanges.length > 0) {
+				this.editor.updateShapes(childChanges)
+			}
 		} else if (this.didHoldCommand) {
 			// If we're no longer holding the command key...
 			this.didHoldCommand = false
 
+			const childChanges: TLShapePartial[] = []
+
 			for (const { children } of frames) {
-				if (!children.length) continue
 				for (const child of children) {
-					this.editor.updateShape({
+					childChanges.push({
 						id: child.id,
 						type: child.type,
 						x: child.x,
 						y: child.y,
 					})
 				}
+			}
+
+			if (childChanges.length > 0) {
+				this.editor.updateShapes(childChanges)
 			}
 		}
 	}
@@ -455,30 +487,32 @@ export class Resizing extends StateNode {
 		isFlippedY: boolean
 		rotation: number
 	}) {
-		const nextCursor = { ...this.editor.getInstanceState().cursor }
+		const prevCursor = this.editor.getInstanceState().cursor
+		let nextCursorType = prevCursor.type
 
 		switch (dragHandle) {
 			case 'top_left':
 			case 'bottom_right': {
-				nextCursor.type = 'nwse-resize'
+				nextCursorType = 'nwse-resize'
 				if (isFlippedX !== isFlippedY) {
-					nextCursor.type = 'nesw-resize'
+					nextCursorType = 'nesw-resize'
 				}
 				break
 			}
 			case 'top_right':
 			case 'bottom_left': {
-				nextCursor.type = 'nesw-resize'
+				nextCursorType = 'nesw-resize'
 				if (isFlippedX !== isFlippedY) {
-					nextCursor.type = 'nwse-resize'
+					nextCursorType = 'nwse-resize'
 				}
 				break
 			}
 		}
 
-		nextCursor.rotation = rotation
+		// this runs on every pointer move, so skip the instance state update when nothing changed
+		if (nextCursorType === prevCursor.type && rotation === prevCursor.rotation) return
 
-		this.editor.setCursor(nextCursor)
+		this.editor.setCursor({ type: nextCursorType, rotation })
 	}
 
 	override onExit() {
@@ -568,6 +602,34 @@ export class Resizing extends StateNode {
 				!areAnglesCompatible(shape.pageRotation, selectionRotation) || shape.isAspectRatioLocked
 		)
 
+		// Group the shapes into levels of relative nesting so that each level can be resized in a
+		// single batched update. A shape whose ancestor is also resizing must commit after that
+		// ancestor, because its new position is computed against the parent's current transform.
+		// In the common case (no resizing shape is parented to another resizing shape) there is a
+		// single level, so each pointer move commits one update for all shapes.
+		const resizeLevels: TLShapeId[][] = []
+		const levelByShapeId = new Map<TLShapeId, number>()
+		const getLevel = (id: TLShapeId): number => {
+			const cached = levelByShapeId.get(id)
+			if (cached !== undefined) return cached
+			let level = 0
+			let parentId = editor.getShape(id)?.parentId
+			while (parentId && isShapeId(parentId)) {
+				if (shapeSnapshots.has(parentId)) {
+					level = getLevel(parentId) + 1
+					break
+				}
+				parentId = editor.getShape(parentId)?.parentId
+			}
+			levelByShapeId.set(id, level)
+			return level
+		}
+		for (const id of shapeSnapshots.keys()) {
+			const level = getLevel(id)
+			while (resizeLevels.length <= level) resizeLevels.push([])
+			resizeLevels[level].push(id)
+		}
+
 		return {
 			shapeSnapshots,
 			selectionBounds,
@@ -577,6 +639,7 @@ export class Resizing extends StateNode {
 			canShapesDeform,
 			initialSelectionPageBounds: this.editor.getSelectionPageBounds()!,
 			frames,
+			resizeLevels,
 		}
 	}
 }

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -166,15 +166,14 @@ export class ValidationError extends Error {
 	}
 }
 
-function prefixError<T>(path: string | number, fn: () => T): T {
-	try {
-		return fn()
-	} catch (err) {
-		if (err instanceof ValidationError) {
-			throw new ValidationError(err.rawMessage, [path, ...err.path])
-		}
-		throw new ValidationError((err as Error).toString(), [path])
+// Rethrows a validation error with a path prefix. Validation paths use this in a plain
+// try/catch (rather than wrapping the work in a callback) so that the success path
+// allocates no closure.
+function rethrowPrefixed(path: string | number, err: unknown): never {
+	if (err instanceof ValidationError) {
+		throw new ValidationError(err.rawMessage, [path, ...err.path])
 	}
+	throw new ValidationError((err as Error).toString(), [path])
 }
 
 function typeToString(value: unknown): string {
@@ -487,7 +486,13 @@ export class Validator<T> implements Validatable<T> {
 	check(nameOrCheckFn: string | ((value: T) => void), checkFn?: (value: T) => void): Validator<T> {
 		if (typeof nameOrCheckFn === 'string') {
 			return this.refine((value) => {
-				prefixError(`(check ${nameOrCheckFn})`, () => checkFn!(value))
+				// build the check-name error prefix only on failure so the success path
+				// allocates no string or closure
+				try {
+					checkFn!(value)
+				} catch (err) {
+					rethrowPrefixed(`(check ${nameOrCheckFn})`, err)
+				}
 				return value
 			})
 		} else {
@@ -523,18 +528,11 @@ export class ArrayOfValidator<T> extends Validator<T[]> {
 			(value) => {
 				const arr = array.validate(value)
 				for (let i = 0; i < arr.length; i++) {
-					if (IS_DEV) {
-						prefixError(i, () => itemValidator.validate(arr[i]))
-					} else {
-						// Production: inline error handling to avoid closure overhead
-						try {
-							itemValidator.validate(arr[i])
-						} catch (err) {
-							if (err instanceof ValidationError) {
-								throw new ValidationError(err.rawMessage, [i, ...err.path])
-							}
-							throw new ValidationError((err as Error).toString(), [i])
-						}
+					// inline error handling to avoid closure overhead on the success path
+					try {
+						itemValidator.validate(arr[i])
+					} catch (err) {
+						rethrowPrefixed(i, err)
 					}
 				}
 				return arr as T[]
@@ -551,17 +549,10 @@ export class ArrayOfValidator<T> extends Validator<T[]> {
 					const item = arr[i]
 					if (i >= knownGoodValue.length) {
 						isDifferent = true
-						if (IS_DEV) {
-							prefixError(i, () => itemValidator.validate(item))
-						} else {
-							try {
-								itemValidator.validate(item)
-							} catch (err) {
-								if (err instanceof ValidationError) {
-									throw new ValidationError(err.rawMessage, [i, ...err.path])
-								}
-								throw new ValidationError((err as Error).toString(), [i])
-							}
+						try {
+							itemValidator.validate(item)
+						} catch (err) {
+							rethrowPrefixed(i, err)
 						}
 						continue
 					}
@@ -569,28 +560,16 @@ export class ArrayOfValidator<T> extends Validator<T[]> {
 					if (Object.is(knownGoodValue[i], item)) {
 						continue
 					}
-					if (IS_DEV) {
-						const checkedItem = prefixError(i, () =>
-							itemValidator.validateUsingKnownGoodVersion!(knownGoodValue[i], item)
+					try {
+						const checkedItem = itemValidator.validateUsingKnownGoodVersion!(
+							knownGoodValue[i],
+							item
 						)
 						if (!Object.is(checkedItem, knownGoodValue[i])) {
 							isDifferent = true
 						}
-					} else {
-						try {
-							const checkedItem = itemValidator.validateUsingKnownGoodVersion!(
-								knownGoodValue[i],
-								item
-							)
-							if (!Object.is(checkedItem, knownGoodValue[i])) {
-								isDifferent = true
-							}
-						} catch (err) {
-							if (err instanceof ValidationError) {
-								throw new ValidationError(err.rawMessage, [i, ...err.path])
-							}
-							throw new ValidationError((err as Error).toString(), [i])
-						}
+					} catch (err) {
+						rethrowPrefixed(i, err)
 					}
 				}
 
@@ -673,34 +652,34 @@ export class ObjectValidator<Shape extends object> extends Validator<Shape> {
 		},
 		private readonly shouldAllowUnknownProperties = false
 	) {
+		// Cache the config keys and validators once so each validation iterates flat arrays
+		// instead of walking the config object with a hasOwnProperty check per key per call.
+		const configKeys: string[] = []
+		const configValidators: Validatable<unknown>[] = []
+		for (const [key, validator] of Object.entries(config)) {
+			configKeys.push(key)
+			configValidators.push(validator as Validatable<unknown>)
+		}
+
 		super(
 			(object) => {
 				if (typeof object !== 'object' || object === null) {
 					throw new ValidationError(`Expected object, got ${typeToString(object)}`)
 				}
 
-				for (const key in config) {
-					if (!hasOwnProperty(config, key)) continue
-					const validator = config[key as keyof typeof config]
-					if (IS_DEV) {
-						prefixError(key, () => {
-							;(validator as Validatable<unknown>).validate(getOwnProperty(object, key))
-						})
-					} else {
-						// Production: inline error handling to avoid closure overhead
-						try {
-							;(validator as Validatable<unknown>).validate(getOwnProperty(object, key))
-						} catch (err) {
-							if (err instanceof ValidationError) {
-								throw new ValidationError(err.rawMessage, [key, ...err.path])
-							}
-							throw new ValidationError((err as Error).toString(), [key])
-						}
+				for (let i = 0; i < configKeys.length; i++) {
+					const key = configKeys[i]
+					try {
+						configValidators[i].validate(getOwnProperty(object, key))
+					} catch (err) {
+						rethrowPrefixed(key, err)
 					}
 				}
 
 				if (!shouldAllowUnknownProperties) {
-					for (const key of Object.keys(object)) {
+					// for...in instead of Object.keys() to avoid the key array allocation
+					for (const key in object) {
+						if (!hasOwnProperty(object, key)) continue
 						if (!hasOwnProperty(config, key)) {
 							throw new ValidationError(`Unexpected property`, [key])
 						}
@@ -720,57 +699,45 @@ export class ObjectValidator<Shape extends object> extends Validator<Shape> {
 
 				let isDifferent = false
 
-				for (const key in config) {
-					if (!hasOwnProperty(config, key)) continue
-					const validator = config[key as keyof typeof config]
+				for (let i = 0; i < configKeys.length; i++) {
+					const key = configKeys[i]
 					const prev = getOwnProperty(knownGoodValue, key)
 					const next = getOwnProperty(newValue, key)
 					// sneaky quick check here to avoid the prefix + validator overhead
 					if (Object.is(prev, next)) {
 						continue
 					}
-					if (IS_DEV) {
-						const checked = prefixError(key, () => {
-							const validatable = validator as Validatable<unknown>
-							if (validatable.validateUsingKnownGoodVersion) {
-								return validatable.validateUsingKnownGoodVersion(prev, next)
-							} else {
-								return validatable.validate(next)
-							}
-						})
+					try {
+						const validator = configValidators[i]
+						const checked = validator.validateUsingKnownGoodVersion
+							? validator.validateUsingKnownGoodVersion(prev, next)
+							: validator.validate(next)
 						if (!Object.is(checked, prev)) {
 							isDifferent = true
 						}
-					} else {
-						try {
-							const validatable = validator as Validatable<unknown>
-							const checked = validatable.validateUsingKnownGoodVersion
-								? validatable.validateUsingKnownGoodVersion(prev, next)
-								: validatable.validate(next)
-							if (!Object.is(checked, prev)) {
-								isDifferent = true
-							}
-						} catch (err) {
-							if (err instanceof ValidationError) {
-								throw new ValidationError(err.rawMessage, [key, ...err.path])
-							}
-							throw new ValidationError((err as Error).toString(), [key])
-						}
+					} catch (err) {
+						rethrowPrefixed(key, err)
 					}
 				}
 
 				if (!shouldAllowUnknownProperties) {
-					for (const key of Object.keys(newValue)) {
+					// for...in instead of Object.keys() to avoid the key array allocation
+					for (const key in newValue) {
+						if (!hasOwnProperty(newValue, key)) continue
 						if (!hasOwnProperty(config, key)) {
 							throw new ValidationError(`Unexpected property`, [key])
 						}
 					}
 				}
 
-				for (const key of Object.keys(knownGoodValue)) {
-					if (!hasOwnProperty(newValue, key)) {
-						isDifferent = true
-						break
+				if (!isDifferent) {
+					// this loop only detects removed keys, so skip it once a difference is known
+					for (const key in knownGoodValue) {
+						if (!hasOwnProperty(knownGoodValue, key)) continue
+						if (!hasOwnProperty(newValue, key)) {
+							isDifferent = true
+							break
+						}
 					}
 				}
 
@@ -874,35 +841,45 @@ export class UnionValidator<
 			(input) => {
 				this.expectObject(input)
 
-				const { matchingSchema, variant } = this.getMatchingSchemaAndVariant(input)
+				const matchingSchema = this.getMatchingSchema(input)
 				if (matchingSchema === undefined) {
-					return this.unknownValueValidation(input, variant)
+					return this.unknownValueValidation(input, this.getVariant(input))
 				}
 
-				return prefixError(`(${key} = ${variant})`, () => matchingSchema.validate(input))
+				// build the `(key = variant)` error prefix only on failure so the success path
+				// allocates no string or closure
+				try {
+					return matchingSchema.validate(input)
+				} catch (err) {
+					rethrowPrefixed(`(${key} = ${this.getVariant(input)})`, err)
+				}
 			},
 			(prevValue, newValue) => {
 				// Note: Object.is check is already done by base Validator class
 				this.expectObject(newValue)
 				this.expectObject(prevValue)
 
-				const { matchingSchema, variant } = this.getMatchingSchemaAndVariant(newValue)
+				const matchingSchema = this.getMatchingSchema(newValue)
 				if (matchingSchema === undefined) {
-					return this.unknownValueValidation(newValue, variant)
+					return this.unknownValueValidation(newValue, this.getVariant(newValue))
 				}
 
-				if (getOwnProperty(prevValue, key) !== getOwnProperty(newValue, key)) {
-					// the type has changed so bail out and do a regular validation
-					return prefixError(`(${key} = ${variant})`, () => matchingSchema.validate(newValue))
-				}
+				// build the `(key = variant)` error prefix only on failure so the success path
+				// allocates no string or closure
+				try {
+					if (getOwnProperty(prevValue, key) !== getOwnProperty(newValue, key)) {
+						// the type has changed so bail out and do a regular validation
+						return matchingSchema.validate(newValue)
+					}
 
-				return prefixError(`(${key} = ${variant})`, () => {
 					if (matchingSchema.validateUsingKnownGoodVersion) {
 						return matchingSchema.validateUsingKnownGoodVersion(prevValue, newValue)
 					} else {
 						return matchingSchema.validate(newValue)
 					}
-				})
+				} catch (err) {
+					rethrowPrefixed(`(${key} = ${this.getVariant(newValue)})`, err)
+				}
 			}
 		)
 	}
@@ -913,10 +890,14 @@ export class UnionValidator<
 		}
 	}
 
-	private getMatchingSchemaAndVariant(object: object): {
-		matchingSchema: Validatable<any> | undefined
-		variant: string
-	} {
+	private getVariant(object: object): string {
+		return getOwnProperty(object, this.key) as unknown as string
+	}
+
+	// Returns the matching schema for the object's variant, or undefined if the variant is
+	// unknown. The variant itself is only needed on cold paths (unknown variants and errors),
+	// so this avoids allocating a `{ matchingSchema, variant }` result per validation.
+	private getMatchingSchema(object: object): Validatable<any> | undefined {
 		const variant = getOwnProperty(object, this.key)! as string & keyof Config
 		if (!this.useNumberKeys && typeof variant !== 'string') {
 			throw new ValidationError(
@@ -933,8 +914,7 @@ export class UnionValidator<
 			}
 		}
 
-		const matchingSchema = hasOwnProperty(this.config, variant) ? this.config[variant] : undefined
-		return { matchingSchema, variant }
+		return hasOwnProperty(this.config, variant) ? this.config[variant] : undefined
 	}
 
 	/**
@@ -994,22 +974,12 @@ export class DictValidator<Key extends string, Value> extends Validator<Record<K
 				// Use for...in instead of Object.entries() to avoid array allocation
 				for (const key in object) {
 					if (!hasOwnProperty(object, key)) continue
-					if (IS_DEV) {
-						prefixError(key, () => {
-							keyValidator.validate(key)
-							valueValidator.validate((object as Record<string, unknown>)[key])
-						})
-					} else {
-						// Production: inline error handling to avoid closure overhead
-						try {
-							keyValidator.validate(key)
-							valueValidator.validate((object as Record<string, unknown>)[key])
-						} catch (err) {
-							if (err instanceof ValidationError) {
-								throw new ValidationError(err.rawMessage, [key, ...err.path])
-							}
-							throw new ValidationError((err as Error).toString(), [key])
-						}
+					// inline error handling to avoid closure overhead on the success path
+					try {
+						keyValidator.validate(key)
+						valueValidator.validate((object as Record<string, unknown>)[key])
+					} catch (err) {
+						rethrowPrefixed(key, err)
 					}
 				}
 
@@ -1033,21 +1003,11 @@ export class DictValidator<Key extends string, Value> extends Validator<Record<K
 
 					if (!hasOwnProperty(knownGoodValue, key)) {
 						isDifferent = true
-						if (IS_DEV) {
-							prefixError(key, () => {
-								keyValidator.validate(key)
-								valueValidator.validate(next)
-							})
-						} else {
-							try {
-								keyValidator.validate(key)
-								valueValidator.validate(next)
-							} catch (err) {
-								if (err instanceof ValidationError) {
-									throw new ValidationError(err.rawMessage, [key, ...err.path])
-								}
-								throw new ValidationError((err as Error).toString(), [key])
-							}
+						try {
+							keyValidator.validate(key)
+							valueValidator.validate(next)
+						} catch (err) {
+							rethrowPrefixed(key, err)
 						}
 						continue
 					}
@@ -1059,31 +1019,15 @@ export class DictValidator<Key extends string, Value> extends Validator<Record<K
 						continue
 					}
 
-					if (IS_DEV) {
-						const checked = prefixError(key, () => {
-							if (valueValidator.validateUsingKnownGoodVersion) {
-								return valueValidator.validateUsingKnownGoodVersion(prev as Value, next)
-							} else {
-								return valueValidator.validate(next)
-							}
-						})
+					try {
+						const checked = valueValidator.validateUsingKnownGoodVersion
+							? valueValidator.validateUsingKnownGoodVersion(prev as Value, next)
+							: valueValidator.validate(next)
 						if (!Object.is(checked, prev)) {
 							isDifferent = true
 						}
-					} else {
-						try {
-							const checked = valueValidator.validateUsingKnownGoodVersion
-								? valueValidator.validateUsingKnownGoodVersion(prev as Value, next)
-								: valueValidator.validate(next)
-							if (!Object.is(checked, prev)) {
-								isDifferent = true
-							}
-						} catch (err) {
-							if (err instanceof ValidationError) {
-								throw new ValidationError(err.rawMessage, [key, ...err.path])
-							}
-							throw new ValidationError((err as Error).toString(), [key])
-						}
+					} catch (err) {
+						rethrowPrefixed(key, err)
 					}
 				}
 
@@ -1536,12 +1480,21 @@ function isValidJson(value: any): value is JsonValue {
 		return true
 	}
 
+	// plain loops instead of .every() / Object.values() — this runs for every record on
+	// full validation (e.g. document load), so avoid the closure and array allocations
 	if (Array.isArray(value)) {
-		return value.every(isValidJson)
+		for (let i = 0; i < value.length; i++) {
+			if (!isValidJson(value[i])) return false
+		}
+		return true
 	}
 
 	if (isPlainObject(value)) {
-		return Object.values(value).every(isValidJson)
+		for (const key in value) {
+			if (!hasOwnProperty(value, key)) continue
+			if (!isValidJson(value[key])) return false
+		}
+		return true
 	}
 
 	return false
@@ -1760,16 +1713,23 @@ export function model<T extends { readonly id: string }>(
 ): Validator<T> {
 	return new Validator(
 		(value) => {
-			return prefixError(name, () => validator.validate(value))
+			// plain try/catch so the success path allocates no closure
+			try {
+				return validator.validate(value)
+			} catch (err) {
+				rethrowPrefixed(name, err)
+			}
 		},
 		(prevValue, newValue) => {
-			return prefixError(name, () => {
+			try {
 				if (validator.validateUsingKnownGoodVersion) {
 					return validator.validateUsingKnownGoodVersion(prevValue, newValue)
 				} else {
 					return validator.validate(newValue)
 				}
-			})
+			} catch (err) {
+				rethrowPrefixed(name, err)
+			}
 		}
 	)
 }

--- a/packages/validate/src/lib/validation.ts
+++ b/packages/validate/src/lib/validation.ts
@@ -1542,7 +1542,9 @@ export const jsonValue: Validator<JsonValue> = new Validator<JsonValue>(
 			return isDifferent ? (newValue as JsonValue) : knownGoodValue
 		} else if (isPlainObject(knownGoodValue) && isPlainObject(newValue)) {
 			let isDifferent = false
-			for (const key of Object.keys(newValue)) {
+			// for...in instead of Object.keys() to avoid the key array allocation
+			for (const key in newValue) {
+				if (!hasOwnProperty(newValue, key)) continue
 				if (!hasOwnProperty(knownGoodValue, key)) {
 					isDifferent = true
 					jsonValue.validate(newValue[key])
@@ -1558,10 +1560,14 @@ export const jsonValue: Validator<JsonValue> = new Validator<JsonValue>(
 					isDifferent = true
 				}
 			}
-			for (const key of Object.keys(knownGoodValue)) {
-				if (!hasOwnProperty(newValue, key)) {
-					isDifferent = true
-					break
+			if (!isDifferent) {
+				// this loop only detects removed keys, so skip it once a difference is known
+				for (const key in knownGoodValue) {
+					if (!hasOwnProperty(knownGoodValue, key)) continue
+					if (!hasOwnProperty(newValue, key)) {
+						isDifferent = true
+						break
+					}
 				}
 			}
 			return isDifferent ? (newValue as JsonValue) : knownGoodValue


### PR DESCRIPTION
In order to keep the canvas responsive when resizing thousands of shapes at once, this PR removes the per-tick bottlenecks across the resize interaction, the history system, the store's change pipeline, validation, and sync. Relates to #7943.

Profiling a 2000-shape resize showed most of the frame budget going to O(N) work and allocations that ran on every pointer tick:

- The `Resizing` tool committed each shape's resize as its own `updateShapes` call. It now collects partials via a new internal `Editor.getResizeShapePartial` and commits them in a single batch per tick. Rotated-out-of-alignment shapes keep the old immediate path.
- `HistoryManager`'s pending diff recomputed emptiness from the full accumulated diff on every store change. Since updates can never cancel existing entries during a squash, it now derives emptiness incrementally and only does the full check when a diff adds or removes records. It also skips clearing the redo stack when the stack is already empty.
- `squashRecordDiffsMutable` allocated per entry per tick (`Object.entries` pair arrays, a fresh `[from, to]` tuple per updated record, unconditional deletes against empty collections). The hot loop is now allocation-free: `for…in` iteration, in-place tuple mutation (the target copies tuples on first insert so it exclusively owns them), and emptiness-guarded deletes. In a micro-benchmark of a 2000-shape, 60-tick gesture this is 3.5x faster on average and removes a 10ms worst-case GC tick.
- `isRecordsDiffEmpty` and `Store.filterChangesByScope` used `Object.keys(...).length === 0`, which materializes every key to compare against zero. Both now use an early-exit `for…in` check.
- `squashHistoryEntries` squash-copied every same-source chunk on each frame flush even when the chunk held a single entry; single-entry chunks now pass through untouched.
- `TLSyncClient.push` deep-cloned the first diff of each send window via `structuredClone` just to get an owned accumulator. It now squashes into a fresh empty diff: owned containers and tuples, shared record references. Records are immutable by construction (`devFreeze` on every store write), and every consumer of the unsent diff (`getNetworkDiff`, the rebase replay via `applyObjectDiff`) is read-only or copy-on-write.
- `ObjectValidator` walked its config object with a `hasOwnProperty` check per key per validation and allocated a closure per property for error prefixing. It now iterates a cached entries array and uses a plain try/catch with a shared rethrow helper.

### Change type

- [x] `improvement`

### Test plan

1. Create a large number of shapes (e.g. 2000).
2. Select all and resize via a corner or edge handle; the interaction should stay smooth.
3. Undo and redo the resize; verify the document returns to the correct states.
4. Repeat in a multiplayer room and verify changes sync correctly, including resizing while offline and reconnecting.

- [x] Unit tests

### Release notes

- Improve performance when resizing many shapes at once.

### API changes

- Added internal `Editor.getResizeShapePartial()`, which returns the update for a resized shape without committing it, so interactions can batch many resizes into one store transaction.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +396 / -301 |
| Automated files | +2 / -0    |
