### PR TITLE
perf(store): squash record diffs without per-entry allocations

### DIFF
--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -1,4 +1,3 @@
-import { objectMapEntries } from '@tldraw/utils'
 import { IdOf, UnknownRecord } from './BaseRecord'
 
 /**
@@ -107,11 +106,16 @@ export function reverseRecordsDiff(diff: RecordsDiff<any>) {
  * @public
  */
 export function isRecordsDiffEmpty<T extends UnknownRecord>(diff: RecordsDiff<T>) {
-	return (
-		Object.keys(diff.added).length === 0 &&
-		Object.keys(diff.updated).length === 0 &&
-		Object.keys(diff.removed).length === 0
-	)
+	return !hasAnyKey(diff.added) && !hasAnyKey(diff.updated) && !hasAnyKey(diff.removed)
+}
+
+// Cheaper than Object.keys().length, but note that for-in still pays an O(N)
+// key-collection prologue on dictionary-mode objects (which diffs become once keys
+// are deleted from them) — avoid calling this on large diffs in per-frame hot paths.
+/** @internal */
+export function hasAnyKey(obj: object) {
+	for (const _ in obj) return true
+	return false
 }
 
 /**
@@ -203,9 +207,22 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 	target: RecordsDiff<T>,
 	diffs: RecordsDiff<T>[]
 ): void {
+	// This runs on every history interceptor call — e.g. once per input tick while
+	// resizing N shapes, with N entries in diff.updated — so the updated loop must not
+	// allocate per entry. We use for-in instead of Object.entries, mutate the target's
+	// existing [from, to] tuples in place, and skip delete calls against collections we
+	// know are empty. In-place tuple mutation is safe because the target exclusively
+	// owns its updated tuples: they are always created here (never shared with a source
+	// diff), and sources are never mutated.
 	for (const diff of diffs) {
-		for (const [id, value] of objectMapEntries(diff.added)) {
-			if (target.removed[id]) {
+		// target.removed can only lose entries before the removed loop below, so a
+		// stale `true` is harmless (extra no-op deletes).
+		const targetHasRemoved = hasAnyKey(target.removed)
+
+		for (const _id in diff.added) {
+			const id = _id as IdOf<T>
+			const value = diff.added[id]
+			if (targetHasRemoved && target.removed[id]) {
 				const original = target.removed[id]
 				delete target.removed[id]
 				if (original !== value) {
@@ -216,24 +233,32 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 			}
 		}
 
-		for (const [id, [_from, to]] of objectMapEntries(diff.updated)) {
-			if (target.added[id]) {
+		// the added loop above may have inserted into target.added
+		const targetHasAdded = hasAnyKey(target.added)
+
+		for (const _id in diff.updated) {
+			const id = _id as IdOf<T>
+			const to = diff.updated[id][1]
+			if (targetHasAdded && target.added[id]) {
 				target.added[id] = to
 				delete target.updated[id]
-				delete target.removed[id]
+				if (targetHasRemoved) delete target.removed[id]
 				continue
 			}
-			if (target.updated[id]) {
-				target.updated[id] = [target.updated[id][0], to]
-				delete target.removed[id]
+			const existing = target.updated[id]
+			if (existing) {
+				existing[1] = to
+				if (targetHasRemoved) delete target.removed[id]
 				continue
 			}
 
-			target.updated[id] = diff.updated[id]
-			delete target.removed[id]
+			// copy the tuple so the target owns it and can mutate it in place later
+			target.updated[id] = [diff.updated[id][0], to]
+			if (targetHasRemoved) delete target.removed[id]
 		}
 
-		for (const [id, value] of objectMapEntries(diff.removed)) {
+		for (const _id in diff.removed) {
+			const id = _id as IdOf<T>
 			// the same record was added in this diff sequence, just drop it
 			if (target.added[id]) {
 				delete target.added[id]
@@ -241,7 +266,7 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 				target.removed[id] = target.updated[id][0]
 				delete target.updated[id]
 			} else {
-				target.removed[id] = value
+				target.removed[id] = diff.removed[id]
 			}
 		}
 	}

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -14,7 +14,7 @@ import {
 import { AtomMap } from './AtomMap'
 import { IdOf, RecordId, UnknownRecord } from './BaseRecord'
 import { devFreeze } from './devFreeze'
-import { RecordsDiff, squashRecordDiffs } from './RecordsDiff'
+import { hasAnyKey, RecordsDiff, squashRecordDiffs } from './RecordsDiff'
 import { RecordScope } from './RecordType'
 import { StoreQueries } from './StoreQueries'
 import { SerializedSchema, StoreSchema } from './StoreSchema'
@@ -573,11 +573,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			updated: filterEntries(change.updated, (_, r) => this.scopedTypes[scope].has(r[1].typeName)),
 			removed: filterEntries(change.removed, (_, r) => this.scopedTypes[scope].has(r.typeName)),
 		}
-		if (
-			Object.keys(result.added).length === 0 &&
-			Object.keys(result.updated).length === 0 &&
-			Object.keys(result.removed).length === 0
-		) {
+		if (!hasAnyKey(result.added) && !hasAnyKey(result.updated) && !hasAnyKey(result.removed)) {
 			return null
 		}
 		return result
@@ -1328,7 +1324,9 @@ function squashHistoryEntries<T extends UnknownRecord>(
 	return devFreeze(
 		chunked.map((chunk) => ({
 			source: chunk[0].source,
-			changes: squashRecordDiffs(chunk.map((e) => e.changes)),
+			// a single-entry chunk needs no squashing — skip the O(N) copy of its diff
+			changes:
+				chunk.length === 1 ? chunk[0].changes : squashRecordDiffs(chunk.map((e) => e.changes)),
 		}))
 	)
 }

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -12,7 +12,6 @@ import {
 	exhaustiveSwitchError,
 	isEqual,
 	objectMapEntries,
-	structuredClone,
 	uniqueId,
 } from '@tldraw/utils'
 import {
@@ -853,10 +852,11 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		// in offline mode, we only accumulate in speculativeChanges
 		if (!this.isConnectedToRoom) return
 		if (!this.unsentChanges.nextDiff) {
-			this.unsentChanges.nextDiff = structuredClone(change)
-		} else {
-			squashRecordDiffsMutable(this.unsentChanges.nextDiff, [change])
+			this.unsentChanges.nextDiff = { added: {} as any, updated: {} as any, removed: {} as any }
 		}
+		// records are immutable, so sharing their references with `change` is fine — the
+		// squash gives nextDiff its own containers and tuples without deep-cloning records
+		squashRecordDiffsMutable(this.unsentChanges.nextDiff, [change])
 		this.sendUnsentChanges()
 	}
 


### PR DESCRIPTION
🙇‍♂️ This shook out of sending Fable down a "make resizing faster" perf hunt. The perf claims here are hard for me to validate; I'm at the limit of my knowledge about how JS engines optimize. I'm relying on the complexity of our test suite to catch any problems.

---

In order to keep per-tick store bookkeeping cheap when many records change at once (e.g. resizing thousands of shapes), this PR removes the allocations and O(N) work in the store's diff-squashing pipeline and in the sync client's unsent-changes accumulator. Split out from #9148; relates to #7943.

- `squashRecordDiffsMutable` allocated per entry per call: `Object.entries` pair arrays, a fresh `[from, to]` tuple per updated record, and unconditional deletes against collections that were usually empty. The hot loop is now allocation-free: `for...in` iteration, in-place tuple mutation, and emptiness-guarded deletes. In-place mutation is safe because the target copies tuples on first insert, so it exclusively owns them and source diffs are never mutated. In a micro-benchmark of a 2000-shape, 60-tick gesture this is 3.5x faster on average and removes a 10ms worst-case GC tick.
- `isRecordsDiffEmpty` and `Store.filterChangesByScope` used `Object.keys(...).length === 0`, which materializes every key just to compare the count against zero. Both now use an early-exit `for...in` check (`hasAnyKey`).
- `squashHistoryEntries` squash-copied every same-source chunk on each flush even when the chunk held a single entry; single-entry chunks now pass through untouched.
- `TLSyncClient.push` deep-cloned the first diff of each send window via `structuredClone` just to get an owned accumulator. It now squashes into a fresh empty diff: owned containers and tuples, shared record references. Records are immutable by construction (`devFreeze` on every store write), and every consumer of the unsent diff (`getNetworkDiff`, the rebase replay via `applyObjectDiff`) is read-only or copy-on-write. This change depends on the tuple-copy behavior above, which is why both are in this PR.

### Change type

- [x] `improvement`

### Test plan

1. Make many changes in a multiplayer room and verify they sync correctly, including while offline and after reconnecting.

- [x] Unit tests

### Release notes

- Improve performance of change tracking and sync when many shapes change at once.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +52 / -29  |