### PR TITLE
perf(editor): skip redundant history bookkeeping on every store change

### DIFF
--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -48,7 +48,11 @@ export class HistoryManager<R extends UnknownRecord> {
 			switch (this.state) {
 				case HistoryRecorderState.Recording:
 					this.pendingDiff.apply(entry.changes)
-					this.stacks.update(({ undos }) => ({ undos, redos: stack() }))
+					// this interceptor runs for every store change, so skip the update when the
+					// redo stack is already empty
+					if (this.stacks.get().redos.length > 0) {
+						this.stacks.update(({ undos }) => ({ undos, redos: stack() }))
+					}
 					break
 				case HistoryRecorderState.RecordingPreserveRedoStack:
 					this.pendingDiff.apply(entry.changes)
@@ -349,12 +353,26 @@ class PendingDiff<R extends UnknownRecord> {
 
 	apply(diff: RecordsDiff<R>) {
 		squashRecordDiffsMutable(this.diff, [diff])
-		this.isEmptyAtom.set(isRecordsDiffEmpty(this.diff))
+		// Recomputing emptiness from the accumulated diff is O(N) (for-in over a
+		// dictionary-mode object pays an O(N) key-collection prologue), and this runs on
+		// every history interceptor call — e.g. every input tick while resizing many
+		// shapes. Updates can never cancel out existing entries during a squash, so the
+		// full recompute is only needed when the incoming diff adds or removes records.
+		if (hasAnyKey(diff.added) || hasAnyKey(diff.removed)) {
+			this.isEmptyAtom.set(isRecordsDiffEmpty(this.diff))
+		} else if (this.isEmptyAtom.__unsafe__getWithoutCapture()) {
+			this.isEmptyAtom.set(!hasAnyKey(diff.updated))
+		}
 	}
 
 	debug() {
 		return { diff: this.diff, isEmpty: this.isEmpty() }
 	}
+}
+
+function hasAnyKey(obj: object) {
+	for (const _ in obj) return true
+	return false
 }
 
 type Stack<T> = StackItem<T> | EmptyStackItem<T>


### PR DESCRIPTION
In order to keep the history interceptor cheap during high-frequency interactions (it runs on every store change, e.g. every input tick while resizing many shapes), this PR skips two pieces of per-change bookkeeping in `HistoryManager` when they cannot have an effect. Split out from #9148; relates to #7943.

- While recording, the interceptor unconditionally replaced the redo stack with a fresh empty stack, triggering a reactive update per store change. It now only clears the stack when there is something to clear.
- `PendingDiff.apply` recomputed emptiness from the full accumulated diff on every call, which is O(N) in the number of pending records. Since updates can never cancel out existing entries during a squash, the full recompute is only needed when the incoming diff adds or removes records; pure-update diffs now derive emptiness incrementally.

### Benchmarks

Simulating a 60-tick gesture that updates 2000 records per tick through a real `Store` with a `HistoryManager` attached, against a store-only control (Node 24, Apple Silicon, median of 9 runs):

| Scenario | main | this PR |
| --- | --- | --- |
| HistoryManager overhead per 60-tick gesture | 18.6ms | 15.9ms |

Most of the remaining overhead is `squashRecordDiffsMutable` itself, which #9151 addresses; the two changes compound when combined.

### Change type

- [x] `improvement`

### Test plan

1. Resize or drag many shapes, then undo and redo; verify the document returns to the correct states.

- [x] Unit tests

### Release notes

- Improve history performance when many shapes change at once.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +20 / -2   |