### PR TITLE
perf: batch shape updates when resizing many shapes

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1348,6 +1348,8 @@ export class Editor extends EventEmitter<TLEventMap> {
     _getReferencedUserIds(shapes: TLShape[]): Set<string>;
     getRenderingShapes(): TLRenderingShape[];
     getResizeScaleFactor(): number;
+    // @internal
+    getResizeShapePartial(shape: TLShape | TLShapeId, scale: VecLike, opts?: TLResizeShapeOptions): null | TLShapePartial;
     getRichTextEditor(): null | TiptapEditor;
     getSelectedShapeAtPoint(point: VecLike): TLShape | undefined;
     getSelectedShapeIds(): TLShapeId[];

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -8102,32 +8102,53 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	resizeShape(shape: TLShapeId | TLShape, scale: VecLike, opts: TLResizeShapeOptions = {}): this {
+		const partial = this.getResizeShapePartial(shape, scale, opts)
+		if (partial) this.updateShapes([partial])
+		return this
+	}
+
+	/**
+	 * Get the update for a resized shape without committing it to the store. Interactions that
+	 * resize many shapes at once use this to collect all of the updates and commit them in a
+	 * single batch. Returns null when there is nothing to update.
+	 *
+	 * Shapes that are rotated out of alignment with the scale axis cannot be resized with a
+	 * single update; those shapes are resized immediately (as `resizeShape` would do) and null
+	 * is returned.
+	 *
+	 * @internal
+	 */
+	getResizeShapePartial(
+		shape: TLShapeId | TLShape,
+		scale: VecLike,
+		opts: TLResizeShapeOptions = {}
+	): TLShapePartial | null {
 		const id = typeof shape === 'string' ? shape : shape.id
-		if (this.getIsReadonly()) return this
+		if (this.getIsReadonly()) return null
 
 		if (!Number.isFinite(scale.x)) scale = new Vec(1, scale.y)
 		if (!Number.isFinite(scale.y)) scale = new Vec(scale.x, 1)
 
 		const initialShape = opts.initialShape ?? this.getShape(id)
-		if (!initialShape) return this
+		if (!initialShape) return null
 
 		const scaleOrigin = opts.scaleOrigin ?? this.getShapePageBounds(id)?.center
-		if (!scaleOrigin) return this
+		if (!scaleOrigin) return null
 
 		const pageTransform = opts.initialPageTransform
 			? Mat.Cast(opts.initialPageTransform)
 			: this.getShapePageTransform(id)
-		if (!pageTransform) return this
+		if (!pageTransform) return null
 
 		const pageRotation = pageTransform.rotation()
 
-		if (pageRotation == null) return this
+		if (pageRotation == null) return null
 
 		const scaleAxisRotation = opts.scaleAxisRotation ?? pageRotation
 
 		const initialBounds = opts.initialBounds ?? this.getShapeGeometry(id).bounds
 
-		if (!initialBounds) return this
+		if (!initialBounds) return null
 
 		const isAspectRatioLocked =
 			opts.isAspectRatioLocked ?? this.getShapeUtil(initialShape).isAspectRatioLocked(initialShape)
@@ -8137,7 +8158,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// from whichever axis is being scaled the least, to avoid the shape getting bigger
 			// than the bounds of the selection
 			// const minScale = Math.min(Math.abs(scale.x), Math.abs(scale.y))
-			return this._resizeUnalignedShape(id, scale, {
+			this._resizeUnalignedShape(id, scale, {
 				...opts,
 				initialBounds,
 				scaleOrigin,
@@ -8146,6 +8167,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				isAspectRatioLocked,
 				initialShape,
 			})
+			return null
 		}
 
 		const util = this.getShapeUtil(initialShape)
@@ -8158,7 +8180,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 		}
 
-		let didResize = false
+		let workingShape: TLShape | null = null
 
 		if (util.onResize && util.canResize(initialShape)) {
 			// get the model changes from the shape util
@@ -8190,7 +8212,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			// need to adjust the shape's x and y points in case the parent has moved since start of resizing
 			const { x, y } = this.getPointInParentSpace(initialShape.id, initialPagePoint)
 
-			let workingShape = initialShape
+			workingShape = initialShape
 			if (!opts.skipStartAndEndCallbacks) {
 				workingShape = applyPartialToRecordWithProps(
 					initialShape,
@@ -8212,10 +8234,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 				}
 			)
 
-			if (resizedShape) {
-				didResize = true
-			}
-
 			workingShape = applyPartialToRecordWithProps(workingShape, {
 				id,
 				type: initialShape.type as any,
@@ -8231,40 +8249,47 @@ export class Editor extends EventEmitter<TLEventMap> {
 				)
 			}
 
-			this.updateShapes([workingShape])
+			if (resizedShape) {
+				return workingShape
+			}
 		}
 
-		if (!didResize) {
-			// reposition shape (rather than resizing it) based on where its resized center would be
+		// the shape was not resized by its util, so reposition it (rather than resizing it)
+		// based on where its resized center would be
 
-			const initialPageCenter = Mat.applyToPoint(pageTransform, initialBounds.center)
-			// get the model changes from the shape util
-			const newPageCenter = this._scalePagePoint(
-				initialPageCenter,
-				scaleOrigin,
-				scale,
-				scaleAxisRotation
-			)
+		const initialPageCenter = Mat.applyToPoint(pageTransform, initialBounds.center)
+		// get the model changes from the shape util
+		const newPageCenter = this._scalePagePoint(
+			initialPageCenter,
+			scaleOrigin,
+			scale,
+			scaleAxisRotation
+		)
 
-			const initialPageCenterInParentSpace = this.getPointInParentSpace(
-				initialShape.id,
-				initialPageCenter
-			)
-			const newPageCenterInParentSpace = this.getPointInParentSpace(initialShape.id, newPageCenter)
+		const initialPageCenterInParentSpace = this.getPointInParentSpace(
+			initialShape.id,
+			initialPageCenter
+		)
+		const newPageCenterInParentSpace = this.getPointInParentSpace(initialShape.id, newPageCenter)
 
-			const delta = Vec.Sub(newPageCenterInParentSpace, initialPageCenterInParentSpace)
-			// apply the changes to the model
-			this.updateShapes([
-				{
-					id,
-					type: initialShape.type as any,
-					x: initialShape.x + delta.x,
-					y: initialShape.y + delta.y,
-				},
-			])
+		const delta = Vec.Sub(newPageCenterInParentSpace, initialPageCenterInParentSpace)
+
+		if (workingShape) {
+			// the util's onResize ran but returned no change; keep the working update (which may
+			// include changes from onResizeStart / onResizeEnd) and reposition the shape
+			return {
+				...workingShape,
+				x: initialShape.x + delta.x,
+				y: initialShape.y + delta.y,
+			}
 		}
 
-		return this
+		return {
+			id,
+			type: initialShape.type as any,
+			x: initialShape.x + delta.x,
+			y: initialShape.y + delta.y,
+		}
 	}
 
 	/** @internal */

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Resizing.ts
@@ -17,6 +17,7 @@ import {
 	areAnglesCompatible,
 	compact,
 	isAccelKey,
+	isShapeId,
 	kickoutOccludedShapes,
 } from '@tldraw/editor'
 import { batchMeasureGeoLabels, setBatchLabelSizeCache } from '../../../shapes/geo/GeoShapeUtil'
@@ -214,24 +215,30 @@ export class Resizing extends StateNode {
 	}
 
 	private updateShapes() {
-		const altKey = this.editor.inputs.getAltKey()
-		const shiftKey = this.editor.inputs.getShiftKey()
 		const {
-			frames,
-			shapeSnapshots,
-			selectionBounds,
-			cursorHandleOffset,
-			selectedShapeIds,
-			selectionRotation,
-			canShapesDeform,
-		} = this.snapshot
+			editor,
+			info,
+			snapshot: {
+				frames,
+				shapeSnapshots,
+				selectionBounds,
+				cursorHandleOffset,
+				selectedShapeIds,
+				selectionRotation,
+				canShapesDeform,
+				initialSelectionPageBounds,
+				resizeLevels,
+			},
+		} = this
+		const altKey = editor.inputs.getAltKey()
+		const shiftKey = editor.inputs.getShiftKey()
 
 		let isAspectRatioLocked = shiftKey || !canShapesDeform
 
 		if (shapeSnapshots.size === 1) {
 			const onlySnapshot = [...shapeSnapshots.values()][0]!
-			if (this.editor.isShapeOfType(onlySnapshot.shape, 'text')) {
-				isAspectRatioLocked = !(this.info.handle === 'left' || this.info.handle === 'right')
+			if (editor.isShapeOfType(onlySnapshot.shape, 'text')) {
+				isAspectRatioLocked = !(info.handle === 'left' || info.handle === 'right')
 			}
 		}
 
@@ -268,32 +275,32 @@ export class Resizing extends StateNode {
 		//                            │
 		//                   cursorHandleOffset.x
 
-		const isHoldingAccel = isAccelKey(this.editor.inputs)
+		const isHoldingAccel = isAccelKey(editor.inputs)
 
-		const currentPagePoint = this.editor.inputs
+		const currentPagePoint = editor.inputs
 			.getCurrentPagePoint()
 			.clone()
 			.sub(cursorHandleOffset)
 			.sub(this.creationCursorOffset)
 
-		const originPagePoint = this.editor.inputs.getOriginPagePoint().clone().sub(cursorHandleOffset)
+		const originPagePoint = editor.inputs.getOriginPagePoint().clone().sub(cursorHandleOffset)
 
-		if (this.editor.getInstanceState().isGridMode && !isHoldingAccel) {
-			const { gridSize } = this.editor.getDocumentSettings()
+		if (editor.getInstanceState().isGridMode && !isHoldingAccel) {
+			const { gridSize } = editor.getDocumentSettings()
 			currentPagePoint.snapToGrid(gridSize)
 		}
 
-		const dragHandle = this.info.handle as SelectionCorner | SelectionEdge
+		const dragHandle = info.handle as SelectionCorner | SelectionEdge
 		const scaleOriginHandle = rotateSelectionHandle(dragHandle, Math.PI)
 
-		this.editor.snaps.clearIndicators()
+		editor.snaps.clearIndicators()
 
-		const shouldSnap = this.editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
+		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
 
 		if (shouldSnap && selectionRotation % HALF_PI === 0) {
-			const { nudge } = this.editor.snaps.shapeBounds.snapResizeShapes({
+			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
 				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
-				initialSelectionPageBounds: this.snapshot.initialSelectionPageBounds,
+				initialSelectionPageBounds: initialSelectionPageBounds,
 				handle: rotateSelectionHandle(dragHandle, selectionRotation),
 				isAspectRatioLocked,
 				isResizingFromCenter: altKey,
@@ -376,24 +383,38 @@ export class Resizing extends StateNode {
 			)
 		}
 
-		// Resize all shapes (onResize will use the batch cache for geo shapes when available)
-		for (const id of shapeSnapshots.keys()) {
-			const snapshot = shapeSnapshots.get(id)!
+		// Resize all shapes (onResize will use the batch cache for geo shapes when available).
+		// Collect the updates for each nesting level and commit them in a single batch, so that
+		// each pointer move pays the store's per-commit costs once per level rather than once per
+		// shape. Shapes that are rotated out of alignment with the selection can't be expressed
+		// as a single update; getResizeShapePartial resizes those immediately and returns null.
+		for (const level of resizeLevels) {
+			const changes: TLShapePartial[] = []
 
-			this.editor.resizeShape(id, scale, {
-				initialShape: snapshot.shape,
-				initialBounds: snapshot.bounds,
-				initialPageTransform: snapshot.pageTransform,
-				dragHandle,
-				mode:
-					selectedShapeIds.length === 1 && id === selectedShapeIds[0]
-						? 'resize_bounds'
-						: 'scale_shape',
-				scaleOrigin: scaleOriginPage,
-				isAspectRatioLocked,
-				scaleAxisRotation: selectionRotation,
-				skipStartAndEndCallbacks: true,
-			})
+			for (const id of level) {
+				const snapshot = shapeSnapshots.get(id)!
+
+				const change = editor.getResizeShapePartial(id, scale, {
+					initialShape: snapshot.shape,
+					initialBounds: snapshot.bounds,
+					initialPageTransform: snapshot.pageTransform,
+					dragHandle,
+					mode:
+						selectedShapeIds.length === 1 && id === selectedShapeIds[0]
+							? 'resize_bounds'
+							: 'scale_shape',
+					scaleOrigin: scaleOriginPage,
+					isAspectRatioLocked,
+					scaleAxisRotation: selectionRotation,
+					skipStartAndEndCallbacks: true,
+				})
+
+				if (change) changes.push(change)
+			}
+
+			if (changes.length > 0) {
+				editor.updateShapes(changes)
+			}
 		}
 
 		// If there's only one shape snapshot and it's a frame and the user is holding ctrl,
@@ -401,6 +422,8 @@ export class Resizing extends StateNode {
 		// the frame rather than resizing it.
 		if (isHoldingAccel) {
 			this.didHoldCommand = true
+
+			const childChanges: TLShapePartial[] = []
 
 			for (const { id, children } of frames) {
 				if (!children.length) continue
@@ -415,7 +438,7 @@ export class Resizing extends StateNode {
 
 				if (delta.x !== 0 || delta.y !== 0) {
 					for (const child of children) {
-						this.editor.updateShape({
+						childChanges.push({
 							id: child.id,
 							type: child.type,
 							x: child.x - delta.x,
@@ -424,20 +447,29 @@ export class Resizing extends StateNode {
 					}
 				}
 			}
+
+			if (childChanges.length > 0) {
+				this.editor.updateShapes(childChanges)
+			}
 		} else if (this.didHoldCommand) {
 			// If we're no longer holding the command key...
 			this.didHoldCommand = false
 
+			const childChanges: TLShapePartial[] = []
+
 			for (const { children } of frames) {
-				if (!children.length) continue
 				for (const child of children) {
-					this.editor.updateShape({
+					childChanges.push({
 						id: child.id,
 						type: child.type,
 						x: child.x,
 						y: child.y,
 					})
 				}
+			}
+
+			if (childChanges.length > 0) {
+				this.editor.updateShapes(childChanges)
 			}
 		}
 	}
@@ -455,30 +487,32 @@ export class Resizing extends StateNode {
 		isFlippedY: boolean
 		rotation: number
 	}) {
-		const nextCursor = { ...this.editor.getInstanceState().cursor }
+		const prevCursor = this.editor.getInstanceState().cursor
+		let nextCursorType = prevCursor.type
 
 		switch (dragHandle) {
 			case 'top_left':
 			case 'bottom_right': {
-				nextCursor.type = 'nwse-resize'
+				nextCursorType = 'nwse-resize'
 				if (isFlippedX !== isFlippedY) {
-					nextCursor.type = 'nesw-resize'
+					nextCursorType = 'nesw-resize'
 				}
 				break
 			}
 			case 'top_right':
 			case 'bottom_left': {
-				nextCursor.type = 'nesw-resize'
+				nextCursorType = 'nesw-resize'
 				if (isFlippedX !== isFlippedY) {
-					nextCursor.type = 'nwse-resize'
+					nextCursorType = 'nwse-resize'
 				}
 				break
 			}
 		}
 
-		nextCursor.rotation = rotation
+		// this runs on every pointer move, so skip the instance state update when nothing changed
+		if (nextCursorType === prevCursor.type && rotation === prevCursor.rotation) return
 
-		this.editor.setCursor(nextCursor)
+		this.editor.setCursor({ type: nextCursorType, rotation })
 	}
 
 	override onExit() {
@@ -568,6 +602,34 @@ export class Resizing extends StateNode {
 				!areAnglesCompatible(shape.pageRotation, selectionRotation) || shape.isAspectRatioLocked
 		)
 
+		// Group the shapes into levels of relative nesting so that each level can be resized in a
+		// single batched update. A shape whose ancestor is also resizing must commit after that
+		// ancestor, because its new position is computed against the parent's current transform.
+		// In the common case (no resizing shape is parented to another resizing shape) there is a
+		// single level, so each pointer move commits one update for all shapes.
+		const resizeLevels: TLShapeId[][] = []
+		const levelByShapeId = new Map<TLShapeId, number>()
+		const getLevel = (id: TLShapeId): number => {
+			const cached = levelByShapeId.get(id)
+			if (cached !== undefined) return cached
+			let level = 0
+			let parentId = editor.getShape(id)?.parentId
+			while (parentId && isShapeId(parentId)) {
+				if (shapeSnapshots.has(parentId)) {
+					level = getLevel(parentId) + 1
+					break
+				}
+				parentId = editor.getShape(parentId)?.parentId
+			}
+			levelByShapeId.set(id, level)
+			return level
+		}
+		for (const id of shapeSnapshots.keys()) {
+			const level = getLevel(id)
+			while (resizeLevels.length <= level) resizeLevels.push([])
+			resizeLevels[level].push(id)
+		}
+
 		return {
 			shapeSnapshots,
 			selectionBounds,
@@ -577,6 +639,7 @@ export class Resizing extends StateNode {
 			canShapesDeform,
 			initialSelectionPageBounds: this.editor.getSelectionPageBounds()!,
 			frames,
+			resizeLevels,
 		}
 	}
 }

--- a/packages/tldraw/src/test/resizing.test.ts
+++ b/packages/tldraw/src/test/resizing.test.ts
@@ -1,9 +1,11 @@
 import {
 	GapsSnapIndicator,
+	Mat,
 	PI,
 	PI2,
 	PointsSnapIndicator,
 	RotateCorner,
+	TLArrowShape,
 	TLGeoShape,
 	TLSelectionHandle,
 	TLShapeId,
@@ -16,6 +18,7 @@ import {
 	toRichText,
 } from '@tldraw/editor'
 import { vi } from 'vitest'
+import { getArrowBindings, getArrowTerminalsInArrowSpace } from '../lib/shapes/arrow/shared'
 import { NoteShapeUtil } from '../lib/shapes/note/NoteShapeUtil'
 import { createDrawSegments } from '../lib/utils/test-helpers'
 import { getSnapLines } from './getSnapLines'
@@ -864,6 +867,253 @@ describe('When resizing a shape with children', () => {
 		// B's model should have changed by the offset
 
 		expect(editor.getShape(ids.lineA)).toMatchSnapshot('draw shape after rotating')
+	})
+})
+
+describe('When resizing nested shapes', () => {
+	// A document with the common kinds of nesting: a geo shape on the page, a
+	// group of two geo shapes, a frame with a geo child, and arrows bound from
+	// the page shape to a group child and from a group child to the frame child.
+	//
+	//      0    100   200             500
+	//
+	//   0             ┌─group1─────────┐
+	//                 │ ┌─────┐        │
+	//                 │ │  A  │ ┌─────┐│
+	// 100             │ └─────┘ │  B  ││
+	// 200  ┌─────┐    └─────────┴─────┘│
+	//      │page │
+	// 300  └─────┘
+	// 400             ┌─frame1─────────┐
+	//                 │ ┌─────┐        │
+	//                 │ │  C  │        │
+	// 600             └─┴─────┴────────┘
+	const nestedIds = {
+		pageBox: createShapeId('pageBox'),
+		group1: createShapeId('group1'),
+		groupBoxA: createShapeId('groupBoxA'),
+		groupBoxB: createShapeId('groupBoxB'),
+		frame1: createShapeId('frame1'),
+		frameBox: createShapeId('frameBox'),
+		arrowPageToGroup: createShapeId('arrowPageToGroup'),
+		arrowGroupToFrame: createShapeId('arrowGroupToFrame'),
+	}
+
+	beforeEach(() => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		editor
+			.createShapes([
+				{ id: nestedIds.pageBox, type: 'geo', x: 0, y: 200, props: { w: 100, h: 100 } },
+				{ id: nestedIds.groupBoxA, type: 'geo', x: 200, y: 0, props: { w: 100, h: 100 } },
+				{ id: nestedIds.groupBoxB, type: 'geo', x: 400, y: 100, props: { w: 100, h: 100 } },
+				{ id: nestedIds.frame1, type: 'frame', x: 200, y: 400, props: { w: 300, h: 200 } },
+				{
+					id: nestedIds.frameBox,
+					type: 'geo',
+					parentId: nestedIds.frame1,
+					x: 50,
+					y: 50,
+					props: { w: 100, h: 100 },
+				},
+			])
+			.groupShapes([nestedIds.groupBoxA, nestedIds.groupBoxB], { groupId: nestedIds.group1 })
+			.createShapes([
+				{
+					id: nestedIds.arrowPageToGroup,
+					type: 'arrow',
+					x: 150,
+					y: 200,
+					props: { start: { x: 0, y: 0 }, end: { x: 50, y: -100 } },
+				},
+				{
+					id: nestedIds.arrowGroupToFrame,
+					type: 'arrow',
+					x: 450,
+					y: 250,
+					props: { start: { x: 0, y: 0 }, end: { x: -150, y: 250 } },
+				},
+			])
+			.createBindings([
+				{
+					type: 'arrow',
+					fromId: nestedIds.arrowPageToGroup,
+					toId: nestedIds.pageBox,
+					props: {
+						terminal: 'start',
+						isExact: false,
+						isPrecise: true,
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+					},
+				},
+				{
+					type: 'arrow',
+					fromId: nestedIds.arrowPageToGroup,
+					toId: nestedIds.groupBoxA,
+					props: {
+						terminal: 'end',
+						isExact: false,
+						isPrecise: true,
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+					},
+				},
+				{
+					type: 'arrow',
+					fromId: nestedIds.arrowGroupToFrame,
+					toId: nestedIds.groupBoxB,
+					props: {
+						terminal: 'start',
+						isExact: false,
+						isPrecise: true,
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+					},
+				},
+				{
+					type: 'arrow',
+					fromId: nestedIds.arrowGroupToFrame,
+					toId: nestedIds.frameBox,
+					props: {
+						terminal: 'end',
+						isExact: false,
+						isPrecise: true,
+						normalizedAnchor: { x: 0.5, y: 0.5 },
+					},
+				},
+			])
+			.selectNone()
+	})
+
+	const getArrowTerminalPagePoints = (arrowId: TLShapeId) => {
+		const arrow = editor.getShape<TLArrowShape>(arrowId)!
+		const bindings = getArrowBindings(editor, arrow)
+		const terminals = getArrowTerminalsInArrowSpace(editor, arrow, bindings)
+		const pageTransform = editor.getShapePageTransform(arrowId)!
+		return {
+			start: Mat.applyToPoint(pageTransform, terminals.start),
+			end: Mat.applyToPoint(pageTransform, terminals.end),
+		}
+	}
+
+	it('resizes the children of a group', () => {
+		editor
+			.select(nestedIds.group1)
+			// the group's page bounds are (200,0) -> (500,200); double them
+			.pointerDownOnHandle('bottom_right')
+			.pointerMove(800, 400)
+
+		expect(roundedPageBounds(nestedIds.group1)).toMatchObject({ x: 200, y: 0, w: 600, h: 400 })
+		expect(roundedPageBounds(nestedIds.groupBoxA)).toMatchObject({ x: 200, y: 0, w: 200, h: 200 })
+		expect(roundedPageBounds(nestedIds.groupBoxB)).toMatchObject({
+			x: 600,
+			y: 200,
+			w: 200,
+			h: 200,
+		})
+
+		// shapes outside of the group are unaffected
+		expect(roundedPageBounds(nestedIds.pageBox)).toMatchObject({ x: 0, y: 200, w: 100, h: 100 })
+		expect(roundedPageBounds(nestedIds.frameBox)).toMatchObject({ x: 250, y: 450, w: 100, h: 100 })
+	})
+
+	it('resizes the children of nested groups on every pointer move', () => {
+		const boxP = createShapeId('boxP')
+		const boxQ = createShapeId('boxQ')
+		const boxR = createShapeId('boxR')
+		const innerGroup = createShapeId('innerGroup')
+		const outerGroup = createShapeId('outerGroup')
+
+		editor
+			.selectAll()
+			.deleteShapes(editor.getSelectedShapeIds())
+			.createShapes([
+				{ id: boxP, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } },
+				{ id: boxQ, type: 'geo', x: 200, y: 200, props: { w: 100, h: 100 } },
+			])
+			.groupShapes([boxP, boxQ], { groupId: innerGroup })
+			.createShapes([{ id: boxR, type: 'geo', x: 400, y: 400, props: { w: 100, h: 100 } }])
+			.groupShapes([innerGroup, boxR], { groupId: outerGroup })
+			.select(outerGroup)
+
+		expect(roundedPageBounds(outerGroup)).toMatchObject({ x: 0, y: 0, w: 500, h: 500 })
+
+		// grow to double the size; each pointer move must update the outer
+		// group, then the inner group, then the innermost children, since each
+		// level's new position depends on its parent's committed transform
+		editor.pointerDownOnHandle('bottom_right').pointerMove(1000, 1000)
+
+		expect(roundedPageBounds(outerGroup)).toMatchObject({ x: 0, y: 0, w: 1000, h: 1000 })
+		expect(roundedPageBounds(innerGroup)).toMatchObject({ x: 0, y: 0, w: 600, h: 600 })
+		expect(roundedPageBounds(boxP)).toMatchObject({ x: 0, y: 0, w: 200, h: 200 })
+		expect(roundedPageBounds(boxQ)).toMatchObject({ x: 400, y: 400, w: 200, h: 200 })
+		expect(roundedPageBounds(boxR)).toMatchObject({ x: 800, y: 800, w: 200, h: 200 })
+
+		// then shrink to half the original size in the same gesture
+		editor.pointerMove(250, 250)
+
+		expect(roundedPageBounds(outerGroup)).toMatchObject({ x: 0, y: 0, w: 250, h: 250 })
+		expect(roundedPageBounds(innerGroup)).toMatchObject({ x: 0, y: 0, w: 150, h: 150 })
+		expect(roundedPageBounds(boxP)).toMatchObject({ x: 0, y: 0, w: 50, h: 50 })
+		expect(roundedPageBounds(boxQ)).toMatchObject({ x: 100, y: 100, w: 50, h: 50 })
+		expect(roundedPageBounds(boxR)).toMatchObject({ x: 200, y: 200, w: 50, h: 50 })
+
+		editor.pointerUp()
+
+		expect(roundedPageBounds(boxP)).toMatchObject({ x: 0, y: 0, w: 50, h: 50 })
+		expect(roundedPageBounds(boxQ)).toMatchObject({ x: 100, y: 100, w: 50, h: 50 })
+		expect(roundedPageBounds(boxR)).toMatchObject({ x: 200, y: 200, w: 50, h: 50 })
+	})
+
+	it('keeps arrows bound to shapes inside a resized group', () => {
+		editor
+			.select(nestedIds.group1)
+			.pointerDownOnHandle('bottom_right')
+			.pointerMove(800, 400)
+			.pointerUp()
+
+		const bindings = getArrowBindings(
+			editor,
+			editor.getShape<TLArrowShape>(nestedIds.arrowPageToGroup)!
+		)
+		expect(bindings.start).toMatchObject({ toId: nestedIds.pageBox })
+		expect(bindings.end).toMatchObject({ toId: nestedIds.groupBoxA })
+
+		const terminals = getArrowTerminalPagePoints(nestedIds.arrowPageToGroup)
+		// the start terminal stays at the center of the unselected page shape
+		expect(terminals.start).toCloselyMatchObject({ x: 50, y: 250 })
+		// the end terminal follows the center of the resized group child
+		expect(terminals.end).toCloselyMatchObject({ x: 300, y: 100 })
+	})
+
+	it('resizes a mixed selection of page, group, and frame shapes', () => {
+		editor
+			.selectAll()
+			// the selection's page bounds are (0,0) -> (500,600); double them
+			.pointerDownOnHandle('bottom_right')
+			.pointerMove(1000, 1200)
+			.pointerUp()
+
+		expect(roundedPageBounds(nestedIds.pageBox)).toMatchObject({ x: 0, y: 400, w: 200, h: 200 })
+		expect(roundedPageBounds(nestedIds.group1)).toMatchObject({ x: 400, y: 0, w: 600, h: 400 })
+		expect(roundedPageBounds(nestedIds.groupBoxA)).toMatchObject({ x: 400, y: 0, w: 200, h: 200 })
+		expect(roundedPageBounds(nestedIds.groupBoxB)).toMatchObject({
+			x: 800,
+			y: 200,
+			w: 200,
+			h: 200,
+		})
+		expect(roundedPageBounds(nestedIds.frame1)).toMatchObject({ x: 400, y: 800, w: 600, h: 400 })
+
+		// the frame's child is not resized; it keeps its position within the frame
+		expect(editor.getShape(nestedIds.frameBox)).toMatchObject({ x: 50, y: 50 })
+		expect(roundedPageBounds(nestedIds.frameBox)).toMatchObject({ x: 450, y: 850, w: 100, h: 100 })
+
+		// the arrow terminals follow the shapes they are bound to
+		const pageToGroup = getArrowTerminalPagePoints(nestedIds.arrowPageToGroup)
+		expect(pageToGroup.start).toCloselyMatchObject({ x: 100, y: 500 })
+		expect(pageToGroup.end).toCloselyMatchObject({ x: 500, y: 100 })
+
+		const groupToFrame = getArrowTerminalPagePoints(nestedIds.arrowGroupToFrame)
+		expect(groupToFrame.start).toCloselyMatchObject({ x: 900, y: 300 })
+		expect(groupToFrame.end).toCloselyMatchObject({ x: 500, y: 900 })
 	})
 })
 


### PR DESCRIPTION
🙇‍♂️ Previously, when we resized shapes we would call `updateShapes([shape])` separately for each shape. Now we do it in `updateShapes` runs batched by parent depth (usually one big batch unless groups or frames are selected). Given the extra work done in `updateShapes`, this is a lot faster and more efficient. The main change is generating the changes that would occur, then committing them all at once. The difficult part (which we missed when we first implemented this feature) was solving the relationship between resized parents and children, which prevents a single batch; and which our good friend solved by separating the batch by depth levels.

---

In order to keep the canvas responsive when resizing many shapes at once, this PR makes the `Resizing` tool commit all of its per-tick shape updates in batches instead of one store transaction per shape. Split out from #9148; relates to #7943.

- The `Resizing` tool committed each shape's resize as its own `updateShapes` call, paying the store's per-commit costs (validation, diff capture, reactive flush) once per shape per pointer tick. It now collects partials via a new internal `Editor.getResizeShapePartial` and commits them in a single batch per tick. Shapes that are rotated out of alignment with the selection can't be expressed as a single update; those keep the old immediate path.
- When a resizing shape is parented to another resizing shape, its new position must be computed against the parent's committed transform. The snapshot now groups shapes into nesting levels and commits one batch per level; in the common case there is a single level.
- The frame-children compensation paths (holding and releasing the accel key) similarly batched their per-child `updateShape` calls.
- The resize cursor was rebuilt and set on every pointer move; it now skips the instance-state update when the cursor type and rotation are unchanged.

### Benchmarks

Resizing 2000 selected geo shapes by their bottom-right selection handle in a headless `TestEditor`, measuring 20 pointer-move ticks after warmup (Node 24, Apple Silicon, jsdom test environment, 3 runs each):

| Scenario | main | this PR | |
| --- | --- | --- | --- |
| Resize tick over 2000 shapes | ~65ms / tick | ~14.3ms / tick | 4.5x |

With the companion PRs #9150, #9151, and #9152 also applied, the same benchmark measures ~12.9ms per tick (5x vs main overall). Absolute numbers are from the test environment and overstate production costs, but the ratio reflects the removed per-shape commit overhead.

### Change type

- [x] `improvement`

### Test plan

1. Create a large number of shapes (e.g. 2000).
2. Select all and resize via a corner or edge handle; the interaction should stay smooth.
3. Undo and redo the resize; verify the document returns to the correct states.
4. Resize a frame while holding the accel key and verify children stay in place, including after releasing the key mid-gesture.
5. Resize a selection containing a group with rotated children and verify shapes resize correctly.

- [x] Unit tests

### API changes

- Added internal `Editor.getResizeShapePartial()`, which returns the update for a resized shape without committing it, so interactions can batch many resizes into one store transaction.

### Release notes

- Improve performance when resizing many shapes at once.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +177 / -89 |
| Automated files | +2 / -0    |