### PR TITLE
refactor(dotcom): rename groups to workspaces in the backend

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -61,7 +61,7 @@ export class Database {
 		if (!id) throw new Error('User not found')
 
 		// Call the migration function
-		await sql`SELECT * FROM migrate_user_to_groups(${id}, ${inviteSecret})`.execute(db)
+		await sql`SELECT * FROM migrate_user_to_workspaces(${id}, ${inviteSecret})`.execute(db)
 	}
 
 	/**

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -13,9 +13,9 @@ import {
 	TlaFileState,
 	TlaFileStatePartial,
 	TlaFlags,
-	TlaGroup,
-	TlaGroupFile,
-	TlaGroupUser,
+	TlaWorkspace,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 	TlaMutators,
 	TlaSchema,
 	TlaUser,
@@ -131,10 +131,10 @@ export class TldrawApp {
 	private readonly user$: Signal<TlaUser | undefined>
 	private readonly fileStates$: Signal<(TlaFileState & { file: TlaFile })[]>
 	private readonly workspaceMemberships$: Signal<
-		(TlaGroupUser & {
-			group: TlaGroup
-			groupFiles: Array<TlaGroupFile & { file: TlaFile }>
-			groupMembers: Array<TlaGroupUser>
+		(TlaWorkspaceUser & {
+			workspace: TlaWorkspace
+			workspaceFiles: Array<TlaWorkspaceFile & { file: TlaFile }>
+			workspaceMembers: Array<TlaWorkspaceUser>
 		})[]
 	>
 
@@ -410,7 +410,7 @@ export class TldrawApp {
 
 	/**
 	 * Check if the user has been migrated to the new workspaces-based data model.
-	 * Users with the 'groups_backend' flag use group_file for access control and pinning.
+	 * Users with the 'groups_backend' flag use workspace_file for access control and pinning.
 	 * Users without the flag use the legacy file_state-based approach.
 	 */
 	isWorkspacesMigrated() {
@@ -432,15 +432,15 @@ export class TldrawApp {
 	}
 
 	getWorkspaceMembership(workspaceId: string) {
-		return this.workspaceMemberships$.get().find((g) => g.groupId === workspaceId)
+		return this.workspaceMemberships$.get().find((m) => m.workspaceId === workspaceId)
 	}
 
 	getWorkspaceFilesSorted(workspaceId: string) {
 		const membership = this.getWorkspaceMembership(workspaceId)
 		if (!membership) return []
 
-		const pinned = membership.groupFiles.filter((f) => f.index !== null)
-		const unpinned = membership.groupFiles.filter((f) => f.index === null)
+		const pinned = membership.workspaceFiles.filter((f) => f.index !== null)
+		const unpinned = membership.workspaceFiles.filter((f) => f.index === null)
 
 		const lastOrdering = this.lastWorkspaceFileOrderings.get(workspaceId)
 		const retainedOrdering =
@@ -561,7 +561,7 @@ export class TldrawApp {
 			}
 
 			// if the file is in a workspace we have access to, we don't want to show it in my files
-			if (myWorkspaceMemberships.some((g) => g.groupFiles.some((gf) => gf.fileId === fileId))) {
+			if (myWorkspaceMemberships.some((m) => m.workspaceFiles.some((wf) => wf.fileId === fileId))) {
 				continue
 			}
 
@@ -618,7 +618,7 @@ export class TldrawApp {
 			// For migrated users, count non-deleted files in the home workspace
 			const membership = this.getWorkspaceMembership(workspaceId)
 			if (!membership) return true
-			const nonDeletedCount = membership.groupFiles.filter((gf) => !gf.file.isDeleted).length
+			const nonDeletedCount = membership.workspaceFiles.filter((wf) => !wf.file.isDeleted).length
 			return nonDeletedCount < this.config.maxNumberOfFiles
 		} else {
 			// For unmigrated users, count non-deleted files owned by the user
@@ -794,8 +794,8 @@ export class TldrawApp {
 		if (this.isWorkspacesMigrated()) {
 			return (
 				this.getWorkspaceMemberships()
-					.find((g) => g.groupFiles.some((gf) => gf.fileId === fileId))
-					?.groupFiles.find((gf) => gf.fileId === fileId)?.file ?? null
+					.find((m) => m.workspaceFiles.some((wf) => wf.fileId === fileId))
+					?.workspaceFiles.find((wf) => wf.fileId === fileId)?.file ?? null
 			)
 		}
 		return this.getUserOwnFiles().find((f) => f.id === fileId) ?? null
@@ -805,8 +805,8 @@ export class TldrawApp {
 		const file = this.getFile(fileId)
 		if (!file) return false
 		if (file.ownerId) return file.ownerId === this.userId
-		if (file.owningGroupId) {
-			const role = this.getWorkspaceMembership(file.owningGroupId)?.role
+		if (file.owningWorkspaceId) {
+			const role = this.getWorkspaceMembership(file.owningWorkspaceId)?.role
 			return can(role, 'accessFiles')
 		}
 		return false
@@ -1159,9 +1159,9 @@ export class TldrawApp {
 		// The home workspace can't be invited to.
 		if (workspaceId === this.getHomeWorkspaceId()) return false
 		const membership = this.getWorkspaceMembership(workspaceId)
-		if (!membership?.group.inviteSecret) return false
+		if (!membership?.workspace.inviteSecret) return false
 
-		const inviteText = `${location.origin}/invite/${membership.group.inviteSecret}`
+		const inviteText = `${location.origin}/invite/${membership.workspace.inviteSecret}`
 		navigator.clipboard.writeText(inviteText)
 
 		if (showToast) {

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -3,10 +3,10 @@ import {
 	OptimisticAppStore,
 	TlaFile,
 	TlaFileState,
-	TlaGroup,
-	TlaGroupFile,
-	TlaGroupUser,
 	TlaSchema,
+	TlaWorkspace,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 	ZClientSentMessage,
 	ZErrorCode,
 	ZServerSentMessage,
@@ -300,27 +300,29 @@ export class Zero {
 			)
 		}
 
-		if (tableName === 'group_user' && ast.related?.length) {
+		if (tableName === 'workspace_user' && ast.related?.length) {
 			rows = rows.map((row) => {
-				const groupUser = row as TlaGroupUser
-				const group = data.group.find((g: TlaGroup) => g.id === groupUser.groupId)
-				const groupFiles = compact(
-					data.group_file
-						.filter((gf: TlaGroupFile) => gf.groupId === groupUser.groupId)
-						.map((gf: TlaGroupFile) => {
-							const file = data.file.find((f: TlaFile) => f.id === gf.fileId)
+				const workspaceUser = row as TlaWorkspaceUser
+				const workspace = data.workspace.find(
+					(w: TlaWorkspace) => w.id === workspaceUser.workspaceId
+				)
+				const workspaceFiles = compact(
+					data.workspace_file
+						.filter((wf: TlaWorkspaceFile) => wf.workspaceId === workspaceUser.workspaceId)
+						.map((wf: TlaWorkspaceFile) => {
+							const file = data.file.find((f: TlaFile) => f.id === wf.fileId)
 							if (!file) return null
-							return { ...gf, file }
+							return { ...wf, file }
 						})
 				)
-				const groupMembers = data.group_user.filter(
-					(gu: TlaGroupUser) => gu.groupId === groupUser.groupId
+				const workspaceMembers = data.workspace_user.filter(
+					(wu: TlaWorkspaceUser) => wu.workspaceId === workspaceUser.workspaceId
 				)
 				return {
-					...groupUser,
-					group,
-					groupFiles,
-					groupMembers,
+					...workspaceUser,
+					workspace,
+					workspaceFiles,
+					workspaceMembers,
 				}
 			})
 		}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyFileDropHandler.tsx
@@ -22,7 +22,7 @@ export const SneakyTldrawFileDropHandler = memo(function SneakyTldrawFileDropHan
 			const tldrawFiles = files.filter((file) => file.name.endsWith('.tldr'))
 			if (tldrawFiles.length > 0) {
 				const currentFile = fileId ? app.getFile(fileId) : null
-				const workspaceId = currentFile?.owningGroupId ?? undefined
+				const workspaceId = currentFile?.owningWorkspaceId ?? undefined
 				await app.uploadTldrFiles(
 					tldrawFiles,
 					(fileId) => {

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -124,9 +124,9 @@ export function FileItems({
 
 	// A file lives in exactly one workspace. The "Move to" menu only offers the workspaces
 	// it can move to — every workspace except the current one and the home workspace
-	const currentWorkspaceId = file?.owningGroupId ?? app.getHomeWorkspaceId()
+	const currentWorkspaceId = file?.owningWorkspaceId ?? app.getHomeWorkspaceId()
 	const moveToWorkspaces = workspaceMemberships.filter(
-		(g) => g.groupId !== app.getHomeWorkspaceId() && g.groupId !== currentWorkspaceId
+		(m) => m.workspaceId !== app.getHomeWorkspaceId() && m.workspaceId !== currentWorkspaceId
 	)
 
 	const handleCopyLinkClick = useCallback(() => {
@@ -258,12 +258,15 @@ export function FileItems({
 							<TldrawUiMenuGroup id="my-workspaces">
 								{moveToWorkspaces.map((membership) => (
 									<TldrawUiMenuItem
-										key={membership.groupId}
-										label={membership.group.name}
-										id={`workspace-${membership.groupId}`}
+										key={membership.workspaceId}
+										label={membership.workspace.name}
+										id={`workspace-${membership.workspaceId}`}
 										readonlyOk
 										onSelect={() => {
-											app.z.mutate.moveFileToWorkspace({ fileId, workspaceId: membership.groupId })
+											app.z.mutate.moveFileToWorkspace({
+												fileId,
+												workspaceId: membership.workspaceId,
+											})
 										}}
 									/>
 								))}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRecentFilesNew.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRecentFilesNew.tsx
@@ -54,13 +54,13 @@ export function TlaSidebarRecentFilesNew() {
 		[app, activeWorkspaceId]
 	)
 
-	const workspaceName = isHome ? <F defaultMessage="My files" /> : membership?.group.name
+	const workspaceName = isHome ? <F defaultMessage="My files" /> : membership?.workspace.name
 
 	// The header names which space's files are shown. Without any workspaces
 	// there is nothing to disambiguate, so it's omitted.
 	const hasWorkspaces = useValue(
 		'has workspaces',
-		() => app.getWorkspaceMemberships().some((m) => m.groupId !== homeWorkspaceId),
+		() => app.getWorkspaceMemberships().some((m) => m.workspaceId !== homeWorkspaceId),
 		[app, homeWorkspaceId]
 	)
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceList.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceList.tsx
@@ -28,7 +28,7 @@ export function TlaSidebarWorkspaceList() {
 		() => app.getWorkspaceMemberships(),
 		[app]
 	)
-	const workspaces = workspaceMemberships.filter((g) => g.groupId !== homeWorkspaceId)
+	const workspaces = workspaceMemberships.filter((m) => m.workspaceId !== homeWorkspaceId)
 
 	return (
 		<div className={styles.sidebarWorkspaceList}>
@@ -36,11 +36,11 @@ export function TlaSidebarWorkspaceList() {
 				workspaceId={homeWorkspaceId}
 				label={<F defaultMessage="My files" />}
 			/>
-			{workspaces.map((g) => (
+			{workspaces.map((m) => (
 				<TlaSidebarWorkspaceListItem
-					key={`workspace-${g.group.id}`}
-					workspaceId={g.group.id}
-					label={g.group.name}
+					key={`workspace-${m.workspace.id}`}
+					workspaceId={m.workspace.id}
+					label={m.workspace.name}
 				/>
 			))}
 			<TlaSidebarCreateWorkspaceButton />

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -77,12 +77,12 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	if (!workspaceMembership) return null
 	// The home workspace has no settings to manage.
 	if (workspaceId === app.getHomeWorkspaceId()) return null
-	const workspace = workspaceMembership.group
-	const currentUser = workspaceMembership.groupMembers.find(
+	const workspace = workspaceMembership.workspace
+	const currentUser = workspaceMembership.workspaceMembers.find(
 		(member) => member.userId === app.getUser().id
 	)
 	const role = currentUser?.role
-	const ownersCount = workspaceMembership.groupMembers.filter((m) => m.role === 'owner').length
+	const ownersCount = workspaceMembership.workspaceMembers.filter((m) => m.role === 'owner').length
 	// Leaving is allowed for everyone except the last owner — a workspace invariant
 	// (it must always keep at least one owner), not a capability.
 	const canLeave = role !== 'owner' || ownersCount > 1
@@ -110,7 +110,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const handleLeaveWorkspace = async () => {
 		try {
 			const isCurrentlyOnAFileInThisWorkspace =
-				currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
+				currentFileId && app.getFile(currentFileId)?.owningWorkspaceId === workspaceId
 			await app.z.mutate.leaveWorkspace({ workspaceId }).client
 			onClose()
 			if (isCurrentlyOnAFileInThisWorkspace) {
@@ -125,7 +125,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const handleDeleteWorkspace = async () => {
 		try {
 			const isCurrentlyOnAFileInThisWorkspace =
-				currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
+				currentFileId && app.getFile(currentFileId)?.owningWorkspaceId === workspaceId
 			await app.z.mutate.deleteWorkspace({ id: workspaceId }).client
 			onClose()
 			if (isCurrentlyOnAFileInThisWorkspace) {
@@ -258,11 +258,11 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 						<F {...messages.members} />{' '}
 						<span className={styles.memberCount}>
 							{/* eslint-disable-next-line tldraw/jsx-no-literals */}
-							{`(${workspaceMembership.groupMembers.length})`}
+							{`(${workspaceMembership.workspaceMembers.length})`}
 						</span>
 					</label>
 					<div className={styles.membersList}>
-						{[...workspaceMembership.groupMembers]
+						{[...workspaceMembership.workspaceMembers]
 							.sort((a, b) => {
 								const currentId = app.getUser().id
 								if (a.userId === currentId && b.userId !== currentId) return -1

--- a/apps/dotcom/client/src/tla/hooks/useActiveWorkspaceId.ts
+++ b/apps/dotcom/client/src/tla/hooks/useActiveWorkspaceId.ts
@@ -18,8 +18,8 @@ export function useActiveWorkspaceId() {
 		() => {
 			if (fileSlug) {
 				const file = app.getFile(fileSlug)
-				if (file?.owningGroupId && app.getWorkspaceMembership(file.owningGroupId)) {
-					return file.owningGroupId
+				if (file?.owningWorkspaceId && app.getWorkspaceMembership(file.owningWorkspaceId)) {
+					return file.owningWorkspaceId
 				}
 			}
 			return app.getHomeWorkspaceId()

--- a/apps/dotcom/client/src/tla/hooks/useIsFileOwner.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsFileOwner.tsx
@@ -12,8 +12,8 @@ export function useHasFileAdminRights(fileId?: string): boolean {
 			const file = app?.getFile(fileId)
 			if (!file) return false
 			if (file.ownerId) return file.ownerId === app.userId
-			if (file.owningGroupId) {
-				const role = app.getWorkspaceMembership(file.owningGroupId)?.role
+			if (file.owningWorkspaceId) {
+				const role = app.getWorkspaceMembership(file.owningWorkspaceId)?.role
 				return can(role, 'accessFiles')
 			}
 			return false

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -636,18 +636,18 @@ export class TLFileDurableObject extends DurableObject {
 				}
 				rateLimitTimer.report('on_request_rate_limit')
 
-				// Check if user has owner access (directly or via group membership)
+				// Check if user has owner access (directly or via workspace membership)
 				let hasOwnerAccess = false
 				if (file.ownerId && file.ownerId === auth?.userId) {
 					hasOwnerAccess = true
-				} else if (file.owningGroupId && auth?.userId) {
-					// Check the user can access the owning group's files
-					const groupCheckTimer = this.timer()
-					const role = await getRole(this.db, auth.userId, file.owningGroupId)
+				} else if (file.owningWorkspaceId && auth?.userId) {
+					// Check the user can access the owning workspace's files
+					const workspaceCheckTimer = this.timer()
+					const role = await getRole(this.db, auth.userId, file.owningWorkspaceId)
 					if (can(role, 'accessFiles')) {
 						hasOwnerAccess = true
 					}
-					groupCheckTimer.report('on_request_group_check')
+					workspaceCheckTimer.report('on_request_workspace_check')
 				}
 
 				if (!hasOwnerAccess) {
@@ -755,8 +755,8 @@ export class TLFileDurableObject extends DurableObject {
 		let hasOwnerAccess = false
 		if (file.ownerId && file.ownerId === auth?.userId) {
 			hasOwnerAccess = true
-		} else if (file.owningGroupId && auth?.userId) {
-			const role = await getRole(this.db, auth.userId, file.owningGroupId)
+		} else if (file.owningWorkspaceId && auth?.userId) {
+			const role = await getRole(this.db, auth.userId, file.owningWorkspaceId)
 			if (can(role, 'accessFiles')) {
 				hasOwnerAccess = true
 			}
@@ -1580,7 +1580,7 @@ export class TLFileDurableObject extends DurableObject {
 			if (file.ownerId && session.meta.userId === file.ownerId) continue
 
 			const canAccessFiles = async () => {
-				const role = await getRole(this.db, session.meta.userId, file.owningGroupId)
+				const role = await getRole(this.db, session.meta.userId, file.owningWorkspaceId)
 				return can(role, 'accessFiles')
 			}
 

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -136,7 +136,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 	private readonly wal2jsonPlugin = new SafeWal2JsonPlugin({
 		addTables:
-			'public.user,public.file,public.file_state,public.user_mutation_number,public.replicator_boot_id,public.group,public.group_user,public.group_file',
+			'public.user,public.file,public.file_state,public.user_mutation_number,public.replicator_boot_id,public.workspace,public.workspace_user,public.workspace_file',
 	})
 
 	private readonly db: Kysely<DB>

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -150,7 +150,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 							})
 							.execute()
 						await tx
-							.insertInto('group')
+							.insertInto('workspace')
 							.values({
 								id,
 								name: clerkUser.fullName ?? '',
@@ -161,10 +161,10 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 							})
 							.execute()
 						await tx
-							.insertInto('group_user')
+							.insertInto('workspace_user')
 							.values({
 								userId: id,
-								groupId: id,
+								workspaceId: id,
 								createdAt: now,
 								updatedAt: now,
 								role: 'owner',
@@ -542,7 +542,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			await client.query('BEGIN', [])
 
 			// Acquire shared advisory lock to coordinate with migration
-			// This will wait if migrate_user_to_groups is running (which uses exclusive lock)
+			// This will wait if migrate_user_to_workspaces is running (which uses exclusive lock)
 			// but won't block other mutations (which also use shared locks)
 			// Lock will be automatically released when transaction ends
 			await client.query('SELECT pg_advisory_xact_lock_shared(hashtext($1))', [this.userId])
@@ -743,22 +743,22 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				.where('id', '=', userId)
 				.execute()
 
-			// Get all groups the user is a member of and delete them
-			// CASCADE will automatically delete group_user, group_file, and owned files
-			const userGroups = await tx
-				.selectFrom('group_user')
+			// Get all workspaces the user is a member of and delete them
+			// CASCADE will automatically delete workspace_user, workspace_file, and owned files
+			const userWorkspaces = await tx
+				.selectFrom('workspace_user')
 				.where('userId', '=', userId)
-				.select('groupId')
+				.select('workspaceId')
 				.execute()
-			const groupIds = userGroups.map((g) => g.groupId)
+			const workspaceIds = userWorkspaces.map((w) => w.workspaceId)
 
-			if (groupIds.length > 0) {
-				await tx.deleteFrom('group').where('id', 'in', groupIds).execute()
+			if (workspaceIds.length > 0) {
+				await tx.deleteFrom('workspace').where('id', 'in', workspaceIds).execute()
 			}
 
-			// Re-create the home group
+			// Re-create the home workspace
 			await tx
-				.insertInto('group')
+				.insertInto('workspace')
 				.values({
 					id: userId,
 					name: '',
@@ -770,10 +770,10 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 				.onConflict((oc) => oc.doNothing())
 				.execute()
 			await tx
-				.insertInto('group_user')
+				.insertInto('workspace_user')
 				.values({
 					userId: userId,
-					groupId: userId,
+					workspaceId: userId,
 					createdAt: Date.now(),
 					updatedAt: Date.now(),
 					role: 'owner',
@@ -786,7 +786,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		})
 
 		// Drop the stale user snapshot so the reboot pulls fresh post-reset state
-		// instead of resurrecting deleted files and groups.
+		// instead of resurrecting deleted files and workspaces.
 		await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
 		await this.cache?.reboot({ delay: false, source: 'admin', hard: true })
 	}
@@ -795,13 +795,13 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		console.error('admin_migrateToGroups', userId, inviteSecret)
 		this.userId ??= userId
 
-		this.log.debug('migrating to groups', userId, inviteSecret)
+		this.log.debug('migrating to workspaces', userId, inviteSecret)
 		// Call the Postgres migration function
 		const result = await sql<{
 			files_migrated: number
 			pinned_files_migrated: number
 			flag_added: boolean
-		}>`SELECT * FROM migrate_user_to_groups(${userId}, ${inviteSecret})`.execute(this.db)
+		}>`SELECT * FROM migrate_user_to_workspaces(${userId}, ${inviteSecret})`.execute(this.db)
 		console.error('admin_migrateToGroups result', result.rows)
 
 		this.log.debug('migration result', result.rows[0])
@@ -815,12 +815,12 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	}
 
 	/**
-	 * Enroll a user in the groups feature so they can actually see and use it.
+	 * Enroll a user in the workspaces feature so they can actually see and use it.
 	 * Ensures both flags:
-	 *   - groups_backend: migrate the user's data into the groups model if needed
+	 *   - groups_backend: migrate the user's data into the workspaces model if needed
 	 *     (the SQL function is idempotent and returns early if already migrated).
-	 *   - groups_frontend: the flag that shows the groups UI (otherwise only granted
-	 *     when a user accepts a group invite).
+	 *   - groups_frontend: the flag that shows the workspaces UI (otherwise only granted
+	 *     when a user accepts a workspace invite).
 	 * Then reboots the user so the new flags/data take effect.
 	 */
 	async admin_enrollInGroups(userId: string) {
@@ -830,10 +830,10 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		// flag_added is false (and nothing changes) when the user is already migrated.
 		const { rows } = await sql<{
 			flag_added: boolean
-		}>`SELECT * FROM migrate_user_to_groups(${userId}, ${uniqueId()})`.execute(this.db)
+		}>`SELECT * FROM migrate_user_to_workspaces(${userId}, ${uniqueId()})`.execute(this.db)
 		const backendMigrated = rows[0]?.flag_added ?? false
 
-		// 2. Ensure the groups UI flag is present (read flags after the migration,
+		// 2. Ensure the workspaces UI flag is present (read flags after the migration,
 		// which may have just added groups_backend).
 		const row = await this.db
 			.selectFrom('user')
@@ -860,10 +860,10 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 	}
 
 	/**
-	 * Unenroll a user from the groups UI by clearing the groups_frontend flag.
-	 * Leaves groups_backend (the data model) in place — this just hides the groups
-	 * UI again, which is handy for testing the enrollment flow. Reboots the user so
-	 * the change takes effect.
+	 * Unenroll a user from the workspaces UI by clearing the groups_frontend flag.
+	 * Leaves groups_backend (the data model) in place — this just hides the
+	 * workspaces UI again, which is handy for testing the enrollment flow. Reboots
+	 * the user so the change takes effect.
 	 */
 	async admin_unenrollFromGroups(userId: string) {
 		this.userId ??= userId

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -4,11 +4,11 @@ import {
 	OptimisticAppStore,
 	TlaFile,
 	TlaFileState,
-	TlaGroup,
-	TlaGroupFile,
-	TlaGroupUser,
 	TlaRow,
 	TlaUser,
+	TlaWorkspace,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 	ZEvent,
 	ZRowUpdate,
 	ZServerSentPacket,
@@ -91,7 +91,7 @@ type BootState =
 			lastSequenceNumber: number
 	  }
 
-const stateVersion = 4
+const stateVersion = 5
 interface StateSnapshot {
 	version: number
 	initialData: ZStoreData
@@ -123,9 +123,9 @@ interface LegacyZStoreDataV3 {
 	file: TlaFile[]
 	file_state: TlaFileState[]
 	user: TlaUser[]
-	group: TlaGroup[]
-	group_user: TlaGroupUser[]
-	group_file: TlaGroupFile[]
+	group: TlaWorkspace[]
+	group_user: (Omit<TlaWorkspaceUser, 'workspaceId'> & { groupId: string })[]
+	group_file: (Omit<TlaWorkspaceFile, 'workspaceId'> & { groupId: string })[]
 	lsn: string
 }
 
@@ -172,8 +172,13 @@ function migrateStateSnapshot(snapshot: any) {
 			group: data.group,
 			group_user: data.group_user,
 			group_file: data.group_file,
-		} satisfies ZStoreData
+		} satisfies LegacyZStoreDataV3
 	}
+
+	// Version 5 renamed the group tables/columns to workspace. There is no v4 → v5
+	// data migration: the replicator forces a full refetch as part of the rename
+	// deploy anyway, so v4 snapshots are discarded (loadInitialDataFromR2 returns
+	// null on version mismatch) and rebuilt from postgres.
 }
 
 const MUTATION_COMMIT_TIMEOUT = 10_000
@@ -332,9 +337,9 @@ export class UserDataSyncer {
 			user: [],
 			file: [],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 			lsn: '0/0',
 			mutationNumber: 0,
 		}
@@ -347,9 +352,9 @@ export class UserDataSyncer {
 				initialData.user = []
 				initialData.file = []
 				initialData.file_state = []
-				initialData.group = []
-				initialData.group_user = []
-				initialData.group_file = []
+				initialData.workspace = []
+				initialData.workspace_user = []
+				initialData.workspace_file = []
 
 				await this.db.transaction().execute(async (tx) => {
 					const result = await tx.executeQuery(CompiledQuery.raw(fetchEverythingSql, [this.userId]))
@@ -444,26 +449,26 @@ export class UserDataSyncer {
 				lastSequenceNumber: resumeData.lastSequenceNumber,
 			}))
 		) {
-			// TODO: investigate how this returns without group_user, or suck that 'group_user is not iterable'
+			// TODO: investigate how this returns without workspace_user, or suck that 'workspace_user is not iterable'
 			const initialData = this.store.getCommittedData()!
 			const topicSubscriptions: TopicSubscriptionTree = {}
-			const groupFileIds = new Set()
-			for (const group_user of initialData.group_user) {
-				topicSubscriptions[`group:${group_user.groupId}`] = {}
+			const workspaceFileIds = new Set()
+			for (const workspace_user of initialData.workspace_user) {
+				topicSubscriptions[`workspace:${workspace_user.workspaceId}`] = {}
 			}
-			for (const group_file of initialData.group_file) {
-				groupFileIds.add(group_file.fileId)
-				let subgraph = topicSubscriptions[`group:${group_file.groupId}`]
+			for (const workspace_file of initialData.workspace_file) {
+				workspaceFileIds.add(workspace_file.fileId)
+				let subgraph = topicSubscriptions[`workspace:${workspace_file.workspaceId}`]
 				if (typeof subgraph !== 'object') {
 					subgraph = {}
-					topicSubscriptions[`group:${group_file.groupId}`] = subgraph
+					topicSubscriptions[`workspace:${workspace_file.workspaceId}`] = subgraph
 				}
 
-				subgraph[`file:${group_file.fileId}`] = 1
+				subgraph[`file:${workspace_file.fileId}`] = 1
 			}
 
 			for (const file_state of initialData.file_state) {
-				if (groupFileIds.has(file_state.fileId)) continue
+				if (workspaceFileIds.has(file_state.fileId)) continue
 				topicSubscriptions[`file:${file_state.fileId}`] = 1
 			}
 
@@ -515,9 +520,9 @@ export class UserDataSyncer {
 				event.table !== 'user' &&
 				event.table !== 'file' &&
 				event.table !== 'file_state' &&
-				event.table !== 'group' &&
-				event.table !== 'group_user' &&
-				event.table !== 'group_file'
+				event.table !== 'workspace' &&
+				event.table !== 'workspace_user' &&
+				event.table !== 'workspace_file'
 			) {
 				throw new Error(`Unhandled table: ${event.table}`)
 			}

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -388,55 +388,59 @@ async function performUserDeletion(
 ) {
 	const pg = createPostgresConnectionPool(env, '/app/admin/delete_user')
 
-	// Step 1: Find all groups the user is the only owner of
-	// This includes their home group (group.id = user.id) and any other groups they solely own
-	sendProgress?.('groups', 'Finding groups to delete...')
+	// Step 1: Find all workspaces the user is the only owner of
+	// This includes their home workspace (workspace.id = user.id) and any other workspaces they solely own
+	sendProgress?.('workspaces', 'Finding workspaces to delete...')
 
-	// Get all groups where this user is an owner
-	const userOwnedGroupMemberships = await pg
-		.selectFrom('group_user')
+	// Get all workspaces where this user is an owner
+	const userOwnedWorkspaceMemberships = await pg
+		.selectFrom('workspace_user')
 		.where('userId', '=', userRow.id)
 		.where('role', '=', 'owner')
-		.select('groupId')
+		.select('workspaceId')
 		.execute()
 
-	const groupsToDelete: string[] = []
+	const workspacesToDelete: string[] = []
 
-	for (const membership of userOwnedGroupMemberships) {
-		// Check if this user is the only owner of this group
+	for (const membership of userOwnedWorkspaceMemberships) {
+		// Check if this user is the only owner of this workspace
 		const ownerCount = await pg
-			.selectFrom('group_user')
-			.where('groupId', '=', membership.groupId)
+			.selectFrom('workspace_user')
+			.where('workspaceId', '=', membership.workspaceId)
 			.where('role', '=', 'owner')
 			.select((eb) => eb.fn.countAll().as('count'))
 			.executeTakeFirst()
 
 		if (ownerCount && Number(ownerCount.count) === 1) {
-			groupsToDelete.push(membership.groupId)
+			workspacesToDelete.push(membership.workspaceId)
 		}
 	}
 
-	sendProgress?.('groups', `Found ${groupsToDelete.length} groups to delete`, {
-		groupCount: groupsToDelete.length,
-		groupIds: groupsToDelete,
+	sendProgress?.('workspaces', `Found ${workspacesToDelete.length} workspaces to delete`, {
+		workspaceCount: workspacesToDelete.length,
+		workspaceIds: workspacesToDelete,
 	})
 
-	// Step 2: Soft delete groups (the cleanup_deleted_group_trigger will soft delete their files)
-	if (groupsToDelete.length > 0) {
-		sendProgress?.('groups', 'Soft deleting groups...')
-		await pg.updateTable('group').set('isDeleted', true).where('id', 'in', groupsToDelete).execute()
+	// Step 2: Soft delete workspaces (the cleanup_deleted_workspace_trigger will soft delete their files)
+	if (workspacesToDelete.length > 0) {
+		sendProgress?.('workspaces', 'Soft deleting workspaces...')
+		await pg
+			.updateTable('workspace')
+			.set('isDeleted', true)
+			.where('id', 'in', workspacesToDelete)
+			.execute()
 	}
 
 	// Step 3: Get all files to hard delete
 	const filesToDelete = new Map<string, TlaFile>()
 
-	if (groupsToDelete.length > 0) {
-		const groupFiles = await pg
+	if (workspacesToDelete.length > 0) {
+		const workspaceFiles = await pg
 			.selectFrom('file')
-			.where('owningGroupId', 'in', groupsToDelete)
+			.where('owningWorkspaceId', 'in', workspacesToDelete)
 			.selectAll()
 			.execute()
-		for (const file of groupFiles) {
+		for (const file of workspaceFiles) {
 			filesToDelete.set(file.id, file)
 		}
 	}
@@ -446,7 +450,7 @@ async function performUserDeletion(
 	})
 
 	// Allow time for soft deletes to propagate
-	if (groupsToDelete.length > 0 || filesToDelete.size > 0) {
+	if (workspacesToDelete.length > 0 || filesToDelete.size > 0) {
 		await sleep(3000)
 	}
 
@@ -458,7 +462,7 @@ async function performUserDeletion(
 
 	sendProgress?.('database', 'Cleaning up database records...')
 
-	// Step 5: Hard delete groups and user in a transaction
+	// Step 5: Hard delete workspaces and user in a transaction
 	await pg.transaction().execute(async (tx) => {
 		// Clean up tables that don't have CASCADE delete constraints
 		await tx.deleteFrom('user_mutation_number').where('userId', '=', userRow.id).execute()
@@ -466,12 +470,12 @@ async function performUserDeletion(
 		// Clean up assets that reference this user (nullable foreign key)
 		await tx.deleteFrom('asset').where('userId', '=', userRow.id).execute()
 
-		// Remove user from all groups they're a member of (including ones they don't solely own)
-		await tx.deleteFrom('group_user').where('userId', '=', userRow.id).execute()
+		// Remove user from all workspaces they're a member of (including ones they don't solely own)
+		await tx.deleteFrom('workspace_user').where('userId', '=', userRow.id).execute()
 
-		// Hard delete the groups (this will cascade delete group_user and group_file entries)
-		if (groupsToDelete.length > 0) {
-			await tx.deleteFrom('group').where('id', 'in', groupsToDelete).execute()
+		// Hard delete the workspaces (this will cascade delete workspace_user and workspace_file entries)
+		if (workspacesToDelete.length > 0) {
+			await tx.deleteFrom('workspace').where('id', 'in', workspacesToDelete).execute()
 		}
 
 		// Delete the user row (this will cascade delete any remaining related records)
@@ -580,7 +584,7 @@ async function startUserMigration(
 					files_migrated: number
 					pinned_files_migrated: number
 					flag_added: boolean
-				}>`SELECT * FROM migrate_user_to_groups(${userRow.id}, ${uniqueId()})`.execute(pg)
+				}>`SELECT * FROM migrate_user_to_workspaces(${userRow.id}, ${uniqueId()})`.execute(pg)
 				await user.admin_forceHardReboot(userRow.id)
 
 				successCount++

--- a/apps/dotcom/sync-worker/src/fetchEverythingSql.snap.ts
+++ b/apps/dotcom/sync-worker/src/fetchEverythingSql.snap.ts
@@ -6,12 +6,12 @@ WITH
   legacy_my_own_files AS (SELECT * FROM public."file" WHERE "ownerId" = $1 AND "isDeleted" = false),
   my_file_states AS (SELECT * FROM public."file_state" WHERE "userId" = $1),
   legacy_files_shared_with_me AS (SELECT f.* FROM my_file_states ufs JOIN public."file" f ON f.id = ufs."fileId" WHERE ufs."isFileOwner" = false AND f.shared = true),
-  my_group_ids AS (SELECT "groupId" FROM public."group_user" WHERE "userId" = $1),
-  my_groups AS (SELECT g.* FROM my_group_ids mg JOIN public."group" g ON g.id = mg."groupId" WHERE g."isDeleted" = false),
-  all_group_users AS (SELECT ug.* FROM my_groups mg JOIN public."group_user" ug ON ug."groupId" = mg."id"),
-  group_file_ownership AS (SELECT fg.* FROM my_groups mg JOIN public."group_file" fg ON fg."groupId" = mg."id"),
-  group_files AS (SELECT f.* FROM group_file_ownership gfo JOIN public."file" f ON f.id = gfo."fileId"),
-  all_files AS (SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from group_files)
+  my_workspace_ids AS (SELECT "workspaceId" FROM public."workspace_user" WHERE "userId" = $1),
+  my_workspaces AS (SELECT w.* FROM my_workspace_ids mw JOIN public."workspace" w ON w.id = mw."workspaceId" WHERE w."isDeleted" = false),
+  all_workspace_users AS (SELECT uw.* FROM my_workspaces mw JOIN public."workspace_user" uw ON uw."workspaceId" = mw."id"),
+  workspace_file_ownership AS (SELECT fw.* FROM my_workspaces mw JOIN public."workspace_file" fw ON fw."workspaceId" = mw."id"),
+  workspace_files AS (SELECT f.* FROM workspace_file_ownership wfo JOIN public."file" f ON f.id = wfo."fileId"),
+  all_files AS (SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from workspace_files)
 SELECT
   'user' as "table",
   "allowAnalyticsCookie"::boolean as "0",
@@ -93,7 +93,7 @@ SELECT
   "ownerAvatar"::text as "17",
   "ownerId"::text as "18",
   "ownerName"::text as "19",
-  "owningGroupId"::text as "20",
+  "owningWorkspaceId"::text as "20",
   "publishedSlug"::text as "21",
   "sharedLinkType"::text as "22",
   "thumbnail"::text as "23",
@@ -101,7 +101,7 @@ SELECT
 FROM all_files
 UNION ALL
 SELECT
-  'group_file' as "table",
+  'workspace_file' as "table",
   null::boolean as "0",
   null::boolean as "1",
   null::boolean as "2",
@@ -117,8 +117,8 @@ SELECT
   null::bigint as "12",
   null::bigint as "13",
   "fileId"::text as "14",
-  "groupId"::text as "15",
-  "index"::text as "16",
+  "index"::text as "15",
+  "workspaceId"::text as "16",
   null::text as "17",
   null::text as "18",
   null::text as "19",
@@ -127,10 +127,10 @@ SELECT
   null::text as "22",
   null::text as "23",
   null::text as "24"
-FROM group_file_ownership
+FROM workspace_file_ownership
 UNION ALL
 SELECT
-  'group' as "table",
+  'workspace' as "table",
   "isDeleted"::boolean as "0",
   null::boolean as "1",
   null::boolean as "2",
@@ -156,10 +156,10 @@ SELECT
   null::text as "22",
   null::text as "23",
   null::text as "24"
-FROM my_groups
+FROM my_workspaces
 UNION ALL
 SELECT
-  'group_user' as "table",
+  'workspace_user' as "table",
   null::boolean as "0",
   null::boolean as "1",
   null::boolean as "2",
@@ -174,18 +174,18 @@ SELECT
   "updatedAt"::bigint as "11",
   null::bigint as "12",
   null::bigint as "13",
-  "groupId"::text as "14",
-  "index"::text as "15",
-  "role"::text as "16",
-  "userColor"::text as "17",
-  "userId"::text as "18",
-  "userName"::text as "19",
+  "index"::text as "14",
+  "role"::text as "15",
+  "userColor"::text as "16",
+  "userId"::text as "17",
+  "userName"::text as "18",
+  "workspaceId"::text as "19",
   null::text as "20",
   null::text as "21",
   null::text as "22",
   null::text as "23",
   null::text as "24"
-FROM all_group_users
+FROM all_workspace_users
 UNION ALL
 SELECT
   'user_mutation_number' as "table",
@@ -298,19 +298,19 @@ export const columnNamesByAlias = {
 		'17': 'ownerAvatar',
 		'18': 'ownerId',
 		'19': 'ownerName',
-		'20': 'owningGroupId',
+		'20': 'owningWorkspaceId',
 		'21': 'publishedSlug',
 		'22': 'sharedLinkType',
 		'23': 'thumbnail',
 	},
-	group_file: {
+	workspace_file: {
 		'10': 'createdAt',
 		'11': 'updatedAt',
 		'14': 'fileId',
-		'15': 'groupId',
-		'16': 'index',
+		'15': 'index',
+		'16': 'workspaceId',
 	},
-	group: {
+	workspace: {
 		'0': 'isDeleted',
 		'10': 'createdAt',
 		'11': 'updatedAt',
@@ -318,15 +318,15 @@ export const columnNamesByAlias = {
 		'15': 'inviteSecret',
 		'16': 'name',
 	},
-	group_user: {
+	workspace_user: {
 		'10': 'createdAt',
 		'11': 'updatedAt',
-		'14': 'groupId',
-		'15': 'index',
-		'16': 'role',
-		'17': 'userColor',
-		'18': 'userId',
-		'19': 'userName',
+		'14': 'index',
+		'15': 'role',
+		'16': 'userColor',
+		'17': 'userId',
+		'18': 'userName',
+		'19': 'workspaceId',
 	},
 	user_mutation_number: {
 		'10': 'mutationNumber',

--- a/apps/dotcom/sync-worker/src/fetchEverythingSql.test.ts
+++ b/apps/dotcom/sync-worker/src/fetchEverythingSql.test.ts
@@ -47,38 +47,38 @@ const withs = [
 	{
 		alias: 'legacy_files_shared_with_me',
 		// Legacy access control via file_state for non-migrated users
-		// Migrated users (with 'groups_backend' flag) have shared files in their home group via group_file
+		// Migrated users (with 'groups_backend' flag) have shared files in their home workspace via workspace_file
 		expression:
 			'SELECT f.* FROM my_file_states ufs JOIN public."file" f ON f.id = ufs."fileId" WHERE ufs."isFileOwner" = false AND f.shared = true',
 	},
 	{
-		alias: 'my_group_ids',
-		expression: 'SELECT "groupId" FROM public."group_user" WHERE "userId" = $1',
+		alias: 'my_workspace_ids',
+		expression: 'SELECT "workspaceId" FROM public."workspace_user" WHERE "userId" = $1',
 	},
 	{
-		alias: 'my_groups',
+		alias: 'my_workspaces',
 		expression:
-			'SELECT g.* FROM my_group_ids mg JOIN public."group" g ON g.id = mg."groupId" WHERE g."isDeleted" = false',
+			'SELECT w.* FROM my_workspace_ids mw JOIN public."workspace" w ON w.id = mw."workspaceId" WHERE w."isDeleted" = false',
 	},
 	{
-		alias: 'all_group_users',
+		alias: 'all_workspace_users',
 		expression:
-			'SELECT ug.* FROM my_groups mg JOIN public."group_user" ug ON ug."groupId" = mg."id"',
+			'SELECT uw.* FROM my_workspaces mw JOIN public."workspace_user" uw ON uw."workspaceId" = mw."id"',
 	},
 	{
-		alias: 'group_file_ownership',
+		alias: 'workspace_file_ownership',
 		expression:
-			'SELECT fg.* FROM my_groups mg JOIN public."group_file" fg ON fg."groupId" = mg."id"',
+			'SELECT fw.* FROM my_workspaces mw JOIN public."workspace_file" fw ON fw."workspaceId" = mw."id"',
 	},
 	{
-		alias: 'group_files',
+		alias: 'workspace_files',
 		expression:
-			'SELECT f.* FROM group_file_ownership gfo JOIN public."file" f ON f.id = gfo."fileId"',
+			'SELECT f.* FROM workspace_file_ownership wfo JOIN public."file" f ON f.id = wfo."fileId"',
 	},
 	{
 		alias: 'all_files',
 		expression:
-			'SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from group_files',
+			'SELECT * from legacy_my_own_files UNION SELECT * from legacy_files_shared_with_me UNION SELECT * from workspace_files',
 	},
 ] as const satisfies WithClause[]
 
@@ -109,19 +109,19 @@ const selects: SelectClause[] = [
 		columns: makeColumnStuff(schema.tables.file),
 	},
 	{
-		from: 'group_file_ownership',
-		outputTableName: 'group_file',
-		columns: makeColumnStuff(schema.tables.group_file),
+		from: 'workspace_file_ownership',
+		outputTableName: 'workspace_file',
+		columns: makeColumnStuff(schema.tables.workspace_file),
 	},
 	{
-		from: 'my_groups',
-		outputTableName: 'group',
-		columns: makeColumnStuff(schema.tables.group),
+		from: 'my_workspaces',
+		outputTableName: 'workspace',
+		columns: makeColumnStuff(schema.tables.workspace),
 	},
 	{
-		from: 'all_group_users',
-		outputTableName: 'group_user',
-		columns: makeColumnStuff(schema.tables.group_user),
+		from: 'all_workspace_users',
+		outputTableName: 'workspace_user',
+		columns: makeColumnStuff(schema.tables.workspace_user),
 	},
 	{
 		from: 'public."user_mutation_number"',

--- a/apps/dotcom/sync-worker/src/replicator/ChangeCollator.ts
+++ b/apps/dotcom/sync-worker/src/replicator/ChangeCollator.ts
@@ -1,12 +1,12 @@
 import {
 	TlaFile,
 	TlaFileState,
-	TlaGroup,
-	TlaGroupFile,
-	TlaGroupUser,
 	TlaRow,
 	TlaUser,
 	TlaUserMutationNumber,
+	TlaWorkspace,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 } from '@tldraw/dotcom-shared'
 import { exhaustiveSwitchError } from '@tldraw/utils'
 import { DurableObject } from 'cloudflare:workers'
@@ -55,12 +55,18 @@ export function getTopics(row: TlaRow, event: ReplicationEvent): Topic[] {
 		}
 		case 'user_mutation_number':
 			return [`user:${(row as any as TlaUserMutationNumber).userId}`]
-		case 'group':
-			return [`group:${(row as TlaGroup).id}`]
-		case 'group_user':
-			return [`group:${(row as TlaGroupUser).groupId}`, `user:${(row as TlaGroupUser).userId}`]
-		case 'group_file':
-			return [`group:${(row as TlaGroupFile).groupId}`, `file:${(row as TlaGroupFile).fileId}`]
+		case 'workspace':
+			return [`workspace:${(row as TlaWorkspace).id}`]
+		case 'workspace_user':
+			return [
+				`workspace:${(row as TlaWorkspaceUser).workspaceId}`,
+				`user:${(row as TlaWorkspaceUser).userId}`,
+			]
+		case 'workspace_file':
+			return [
+				`workspace:${(row as TlaWorkspaceFile).workspaceId}`,
+				`file:${(row as TlaWorkspaceFile).fileId}`,
+			]
 		default: {
 			exhaustiveSwitchError(event.table)
 			return [] // just in case
@@ -107,7 +113,7 @@ export function buildTopicsString(changes: ChangeV2[]): string {
  *
  * Uses the subscription graph to determine which users should receive
  * each change. For example, if a file changes, it finds all users who
- * subscribe to that file (directly or through groups) and queues the
+ * subscribe to that file (directly or through workspaces) and queues the
  * change for delivery to them.
  */
 export class LiveChangeCollator implements ChangeCollator {
@@ -130,7 +136,7 @@ export class LiveChangeCollator implements ChangeCollator {
 	 * Uses recursive SQL to traverse the subscription graph and find all
 	 * users connected to these topics through any number of hops.
 	 *
-	 * Example: user:alice -> group:dev -> file:doc1
+	 * Example: user:alice -> workspace:dev -> file:doc1
 	 * When file:doc1 changes, alice gets notified even though she's not directly subscribed.
 	 */
 	private getSubscribersToTopics(topics: Topic[]): string[] {
@@ -159,7 +165,7 @@ export class LiveChangeCollator implements ChangeCollator {
 				-- Direct subscriptions to any of the target topics
 				SELECT fromTopic FROM topic_subscription WHERE toTopic IN (${placeholders})
 				UNION
-				-- Transitive subscriptions (users -> groups -> topics)
+				-- Transitive subscriptions (users -> workspaces -> topics)
 				SELECT ts.fromTopic 
 				FROM topic_subscription ts
 				JOIN subscribers s ON ts.toTopic = s.fromTopic

--- a/apps/dotcom/sync-worker/src/replicator/Subscription.ts
+++ b/apps/dotcom/sync-worker/src/replicator/Subscription.ts
@@ -1,4 +1,4 @@
-import { TlaFileState, TlaGroupFile, TlaGroupUser, TlaRow } from '@tldraw/dotcom-shared'
+import { TlaFileState, TlaRow, TlaWorkspaceFile, TlaWorkspaceUser } from '@tldraw/dotcom-shared'
 import { ReplicationEvent, Topic } from './replicatorTypes'
 
 /**
@@ -57,36 +57,36 @@ export function getSubscriptionChanges(changes: Array<{ row: TlaRow; event: Repl
 				}
 				break
 			}
-			case 'group_user': {
-				const userGroup = change.row as TlaGroupUser
-				const userTopic: Topic = `user:${userGroup.userId}`
-				const groupTopic: Topic = `group:${userGroup.groupId}`
+			case 'workspace_user': {
+				const userWorkspace = change.row as TlaWorkspaceUser
+				const userTopic: Topic = `user:${userWorkspace.userId}`
+				const workspaceTopic: Topic = `workspace:${userWorkspace.workspaceId}`
 				if (change.event.command === 'insert') {
-					// User joins a group - create subscription from user to group
-					newSubscriptions.push({ fromTopic: userTopic, toTopic: groupTopic })
+					// User joins a workspace - create subscription from user to workspace
+					newSubscriptions.push({ fromTopic: userTopic, toTopic: workspaceTopic })
 				} else if (change.event.command === 'delete') {
-					// User leaves a group - remove subscription from user to group
-					removedSubscriptions.push({ fromTopic: userTopic, toTopic: groupTopic })
+					// User leaves a workspace - remove subscription from user to workspace
+					removedSubscriptions.push({ fromTopic: userTopic, toTopic: workspaceTopic })
 				}
 				break
 			}
-			case 'group_file': {
-				const fileGroup = change.row as TlaGroupFile
-				const fileTopic: Topic = `file:${fileGroup.fileId}`
-				const groupTopic: Topic = `group:${fileGroup.groupId}`
+			case 'workspace_file': {
+				const fileWorkspace = change.row as TlaWorkspaceFile
+				const fileTopic: Topic = `file:${fileWorkspace.fileId}`
+				const workspaceTopic: Topic = `workspace:${fileWorkspace.workspaceId}`
 				if (change.event.command === 'insert') {
-					// File is added to group - create subscription from group to file
-					newSubscriptions.push({ fromTopic: groupTopic, toTopic: fileTopic })
+					// File is added to workspace - create subscription from workspace to file
+					newSubscriptions.push({ fromTopic: workspaceTopic, toTopic: fileTopic })
 				} else if (change.event.command === 'delete') {
-					// File is removed from group - remove subscription from group to file
-					removedSubscriptions.push({ fromTopic: groupTopic, toTopic: fileTopic })
+					// File is removed from workspace - remove subscription from workspace to file
+					removedSubscriptions.push({ fromTopic: workspaceTopic, toTopic: fileTopic })
 				}
 				break
 			}
 			// IMPORTANT: If you make changes to this function, we might need to add a replicator migration
 			// to update the history table's subscription changes columns.
 			default:
-				// Only file_state, group_user, and group_file changes affect subscriptions
+				// Only file_state, workspace_user, and workspace_file changes affect subscriptions
 				break
 		}
 	}

--- a/apps/dotcom/sync-worker/src/replicator/getResumeType.test.ts
+++ b/apps/dotcom/sync-worker/src/replicator/getResumeType.test.ts
@@ -32,7 +32,7 @@ function createMockFileChange(fileId: string, ownerId: string, _lsn: string): Ch
 			isEmpty: false,
 			isDeleted: false,
 			createSource: 'test',
-			owningGroupId: null,
+			owningWorkspaceId: null,
 		},
 		previous: {
 			id: fileId,
@@ -51,7 +51,7 @@ function createMockFileChange(fileId: string, ownerId: string, _lsn: string): Ch
 			isEmpty: false,
 			isDeleted: false,
 			createSource: 'test',
-			owningGroupId: null,
+			owningWorkspaceId: null,
 		},
 		topics: [`user:${ownerId}`, `file:${fileId}`],
 	}
@@ -349,7 +349,7 @@ describe.skip('getResumeType Performance Tests', () => {
 				isEmpty: Math.random() > 0.95, // 5% chance of being empty
 				isDeleted: command === 'delete',
 				createSource: 'test',
-				owningGroupId: null,
+				owningWorkspaceId: null,
 			},
 			previous:
 				command === 'update'

--- a/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.test.ts
+++ b/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.test.ts
@@ -58,6 +58,9 @@ describe('replicatorMigrations', () => {
 			    "name": "sqlite_stat1",
 			  },
 			  {
+			    "name": "sqlite_stat4",
+			  },
+			  {
 			    "name": "history",
 			  },
 			  {
@@ -142,7 +145,7 @@ describe('replicatorMigrations', () => {
 			await migrate(sqlStorage as any, logger as any)
 
 			migrations = sqlStorage.exec('SELECT id FROM migrations ORDER BY id').toArray()
-			expect(migrations).toHaveLength(8) // All migrations should be applied
+			expect(migrations).toHaveLength(9) // All migrations should be applied
 
 			// Should not duplicate existing migrations
 			const migrationCounts = sqlStorage

--- a/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.ts
+++ b/apps/dotcom/sync-worker/src/replicator/replicatorMigrations.ts
@@ -169,6 +169,28 @@ const migrations: Migration[] = [
 		// so we need to regenerate the subscription changes for all existing history rows
 		fn: _updateHistorySubscriptions,
 	},
+	{
+		id: '008_rename_group_topics_to_workspace',
+		// The postgres data model renamed group → workspace (zero-cache migration
+		// 035), which changes the table names, the groupId/owningGroupId column
+		// names, and the `group:` topic prefix. History rows store serialized
+		// changes under the old names, which new code can't replay, so drop them
+		// and force every user DO to re-register and refetch from postgres:
+		//  * empty history → getResumeType returns 'reboot' for any stale lsn
+		//  * no active_user rows → resumeSequence fails, forcing re-registration
+		//  * null lsn → registerUser waits for the first post-boot commit, whose
+		//    lsn is newer than any user's stale lsn
+		// Re-registration re-seeds each user's topic_subscription edges with
+		// `workspace:` topics; rewrite the existing rows anyway so edges for users
+		// who don't reconnect soon don't linger with a dead prefix.
+		sql: `
+			DELETE FROM history;
+			DELETE FROM active_user;
+			UPDATE topic_subscription SET fromTopic = 'workspace:' || substr(fromTopic, 7) WHERE fromTopic LIKE 'group:%';
+			UPDATE topic_subscription SET toTopic = 'workspace:' || substr(toTopic, 7) WHERE toTopic LIKE 'group:%';
+			UPDATE meta SET lsn = NULL;
+		`,
+	},
 ]
 
 function _updateHistorySubscriptions(sqlite: SqlStorage) {

--- a/apps/dotcom/sync-worker/src/replicator/replicatorTypes.ts
+++ b/apps/dotcom/sync-worker/src/replicator/replicatorTypes.ts
@@ -1,16 +1,16 @@
 import { TlaFile, TlaRow } from '@tldraw/dotcom-shared'
 import { stringEnum } from '@tldraw/utils'
 
-export type Topic = `user:${string}` | `file:${string}` | `group:${string}`
+export type Topic = `user:${string}` | `file:${string}` | `workspace:${string}`
 
 export const replicatedTables = stringEnum(
 	'user',
 	'file',
 	'file_state',
 	'user_mutation_number',
-	'group',
-	'group_user',
-	'group_file'
+	'workspace',
+	'workspace_user',
+	'workspace_file'
 )
 export type ReplicatedTable = keyof typeof replicatedTables
 

--- a/apps/dotcom/sync-worker/src/replicator/test-helpers.ts
+++ b/apps/dotcom/sync-worker/src/replicator/test-helpers.ts
@@ -89,7 +89,7 @@ export function createMockFile(
 		id: fileId,
 		name: overrides.name || `Test Document ${fileId}`,
 		ownerId,
-		owningGroupId: null,
+		owningWorkspaceId: null,
 		ownerName: `Owner ${ownerId}`,
 		ownerAvatar: '',
 		thumbnail: '',

--- a/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
@@ -34,25 +34,25 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 				)
 			}
 
-			// Check if user is already a member of this group (with row lock to prevent race conditions)
+			// Check if user is already a member of this workspace (with row lock to prevent race conditions)
 			const existingMember = await tx
-				.selectFrom('group_user')
+				.selectFrom('workspace_user')
 				.select('userId')
-				.where('groupId', '=', workspace.id)
+				.where('workspaceId', '=', workspace.id)
 				.where('userId', '=', auth.userId)
 				.executeTakeFirst()
 
 			if (existingMember) {
 				return Response.json({
 					error: false,
-					message: 'You are already a member of this group',
+					message: 'You are already a member of this workspace',
 					workspaceId: workspace.id,
 					workspaceName: workspace.name,
 					alreadyMember: true,
 				} satisfies AcceptInviteResponseBody)
 			}
 
-			// Get the user's information for the group_user record
+			// Get the user's information for the workspace_user record
 			const user = await tx
 				.selectFrom('user')
 				.select(['name', 'color', 'flags'])
@@ -72,7 +72,7 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 				return Response.json(
 					{
 						error: true,
-						message: 'User is not migrated to the groups model',
+						message: 'User is not migrated to the workspaces model',
 					} satisfies AcceptInviteResponseBody,
 					{ status: 400 }
 				)
@@ -89,30 +89,30 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 					.execute()
 			}
 
-			// Get the lowest index to place new group at the top
-			const lowestIndexGroup = await sql<{
+			// Get the lowest index to place new workspace at the top
+			const lowestIndexWorkspace = await sql<{
 				index: string
 				// kysely doesn't support 'collate' in the query builder, so we have to use raw sql
 				// collate "C" makes it use straight up byte comparison instead of lexicographic comparison
-			}>`select index from group_user where "userId" = ${auth.userId} order by index collate "C" asc limit 1`.execute(
+			}>`select index from workspace_user where "userId" = ${auth.userId} order by index collate "C" asc limit 1`.execute(
 				tx
 			)
 
-			// Use tldraw's fractional indexing to place new group at the top
+			// Use tldraw's fractional indexing to place new workspace at the top
 			let index: IndexKey
-			if (!lowestIndexGroup.rows[0]) {
-				// First group gets 'a1'
+			if (!lowestIndexWorkspace.rows[0]) {
+				// First workspace gets 'a1'
 				index = 'a1' as IndexKey
 			} else {
 				// Generate a new index below the current lowest (to place at top)
-				index = getIndexBelow(lowestIndexGroup.rows[0].index as IndexKey)
+				index = getIndexBelow(lowestIndexWorkspace.rows[0].index as IndexKey)
 			}
 
-			// Add user to the group
+			// Add user to the workspace
 			await tx
-				.insertInto('group_user')
+				.insertInto('workspace_user')
 				.values({
-					groupId: workspace.id,
+					workspaceId: workspace.id,
 					userId: auth.userId,
 					userColor: user.color || '#000000',
 					userName: user.name,
@@ -125,7 +125,7 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 
 			return Response.json({
 				error: false,
-				message: 'Successfully joined the group',
+				message: 'Successfully joined the workspace',
 				workspaceId: workspace.id,
 				workspaceName: workspace.name,
 				success: true,

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -81,7 +81,7 @@ export async function requireWriteAccessToFile(
 		const file = await db
 			.selectFrom('file')
 			.select('ownerId')
-			.select('owningGroupId')
+			.select('owningWorkspaceId')
 			.select('shared')
 			.select('sharedLinkType')
 			.where('id', '=', roomId)
@@ -96,9 +96,9 @@ export async function requireWriteAccessToFile(
 			return
 		}
 
-		// If the file is owned by a group, check the user can access its files
-		if (file.owningGroupId) {
-			const role = await getRole(db, auth.userId, file.owningGroupId)
+		// If the file is owned by a workspace, check the user can access its files
+		if (file.owningWorkspaceId) {
+			const role = await getRole(db, auth.userId, file.owningWorkspaceId)
 			if (can(role, 'accessFiles')) {
 				return
 			}

--- a/apps/dotcom/sync-worker/src/utils/tla/getJoinableWorkspaceFromInvite.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getJoinableWorkspaceFromInvite.ts
@@ -4,15 +4,15 @@ import { Kysely } from 'kysely'
 /**
  * Resolve the workspace an invite token points to, or null if the token can't
  * be used to join: it's unknown/expired, the workspace is deleted, or it's a
- * home workspace (group id === its owner's user id), which is private. Callers
- * treat null as an invalid token.
+ * home workspace (workspace id === its owner's user id), which is private.
+ * Callers treat null as an invalid token.
  */
 export async function getJoinableWorkspaceFromInvite(
 	db: Kysely<DB>,
 	token: string
 ): Promise<{ id: string; name: string } | null> {
 	const workspace = await db
-		.selectFrom('group')
+		.selectFrom('workspace')
 		.select(['id', 'name', 'isDeleted'])
 		.where('inviteSecret', '=', token)
 		.executeTakeFirst()

--- a/apps/dotcom/sync-worker/src/utils/tla/getRole.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getRole.ts
@@ -2,20 +2,20 @@ import { DB, Role } from '@tldraw/dotcom-shared'
 import { Kysely } from 'kysely'
 
 /**
- * Resolve a user's role in a group from the database, or null if they aren't a
- * member. The sync-worker's counterpart to the mutators' getRole; compose it
- * with `can`, e.g. `can(await getRole(db, userId, groupId), 'accessFiles')`.
+ * Resolve a user's role in a workspace from the database, or null if they
+ * aren't a member. The sync-worker's counterpart to the mutators' getRole;
+ * compose it with `can`, e.g. `can(await getRole(db, userId, workspaceId), 'accessFiles')`.
  */
 export async function getRole(
 	db: Kysely<DB>,
 	userId: string | null | undefined,
-	groupId: string | null | undefined
+	workspaceId: string | null | undefined
 ): Promise<Role | null> {
-	if (!userId || !groupId) return null
+	if (!userId || !workspaceId) return null
 	const member = await db
-		.selectFrom('group_user')
+		.selectFrom('workspace_user')
 		.select('role')
-		.where('groupId', '=', groupId)
+		.where('workspaceId', '=', workspaceId)
 		.where('userId', '=', userId)
 		.executeTakeFirst()
 	return member?.role ?? null

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -276,7 +276,7 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 			const file = await db
 				.selectFrom('file')
 				.where('id', '=', fileId)
-				.select(['ownerId', 'owningGroupId', 'shared', 'sharedLinkType'])
+				.select(['ownerId', 'owningWorkspaceId', 'shared', 'sharedLinkType'])
 				.executeTakeFirst()
 			if (!file) return { ok: false, error: 'File not found' }
 
@@ -294,8 +294,8 @@ export default class Worker extends WorkerEntrypoint<Environment> {
 				// owner
 			} else if (isSharedEdit) {
 				// shared for editing
-			} else if (userId && file.owningGroupId) {
-				const role = await getRole(db, userId, file.owningGroupId)
+			} else if (userId && file.owningWorkspaceId) {
+				const role = await getRole(db, userId, file.owningWorkspaceId)
 				if (!can(role, 'accessFiles')) {
 					return { ok: false, error: 'Forbidden' }
 				}

--- a/apps/dotcom/zero-cache/delete_file_states.test.ts
+++ b/apps/dotcom/zero-cache/delete_file_states.test.ts
@@ -5,17 +5,19 @@ import pg from 'pg'
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Focused integration test for the `delete_file_states` trigger that cleans up
-// guest file_state rows and guest home-group file links (group_file rows) when a
-// file is unshared (shared: true -> false).
+// guest file_state rows and guest home-workspace file links (workspace_file
+// rows) when a file is unshared (shared: true -> false).
 //
-// Regression coverage for: unsharing a group-owned file (ownerId NULL,
-// owningGroupId set) used to leave guest file_states behind, because the original
-// trigger keyed on `OLD."ownerId" != "userId"` and `NULL != x` is NULL in SQL.
-// Visiting a shared file also links it into the visitor's home group via a
-// group_file row (home group id == user id) — that link is what puts the file in
-// their recent files, and nothing cleaned it up either, so the file name lingered
-// in an ex-guest's recent files after access was revoked.
-// See migration 034_fix_unshare_group_file_cleanup.sql.
+// Regression coverage for: unsharing a workspace-owned file (ownerId NULL,
+// owningWorkspaceId set) used to leave guest file_states behind, because the
+// original trigger keyed on `OLD."ownerId" != "userId"` and `NULL != x` is NULL
+// in SQL. Visiting a shared file also links it into the visitor's home workspace
+// via a workspace_file row (home workspace id == user id) — that link is what
+// puts the file in their recent files, and nothing cleaned it up either, so the
+// file name lingered in an ex-guest's recent files after access was revoked.
+// See migration 034_fix_unshare_group_file_cleanup.sql (the fix, under the old
+// group naming) and 035_rename_groups_to_workspaces.sql (the current
+// definition).
 //
 // This talks to a real postgres (the trigger is plpgsql, so fakes can't exercise
 // it). It is opt-in: set ZERO_CACHE_TEST_POSTGRES_URL (local dev stack:
@@ -37,12 +39,26 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 const DIRNAME = dirname(fileURLToPath(import.meta.url))
 const CONNECTION_STRING = process.env.ZERO_CACHE_TEST_POSTGRES_URL
 
-// The real, shipped function body. We load it from the migration file so the test
-// exercises exactly what runs in production rather than a hand-copied duplicate.
-const FIXED_FUNCTION_SQL = readFileSync(
-	join(DIRNAME, 'migrations', '034_fix_unshare_group_file_cleanup.sql'),
+// The real, shipped function body. We extract it from the migration file so the
+// test exercises exactly what runs in production rather than a hand-copied
+// duplicate. 035 re-creates the function (fixed in 034) against the renamed
+// workspace tables, alongside unrelated rename DDL that can't run against this
+// test's minimal schema — hence the extraction instead of executing the file.
+const MIGRATION_035_SQL = readFileSync(
+	join(DIRNAME, 'migrations', '035_rename_groups_to_workspaces.sql'),
 	'utf8'
 )
+const FIXED_FUNCTION_SQL = (() => {
+	const match = MIGRATION_035_SQL.match(
+		/CREATE OR REPLACE FUNCTION delete_file_states\(\)[\s\S]*?\$\$ LANGUAGE plpgsql;/
+	)
+	if (!match) {
+		throw new Error(
+			'delete_file_states() definition not found in 035_rename_groups_to_workspaces.sql'
+		)
+	}
+	return match[0]
+})()
 
 // The original (buggy) function body, kept here so we can prove the bug exists and
 // that the fix is what closes it.
@@ -64,32 +80,32 @@ const schemaName = `tldraw_test_${process.pid}`
 // which we (re)create first). Dropping `file` CASCADE also drops the trigger.
 // Fully qualified so it cannot touch `public` no matter what session it runs on.
 const SCHEMA_SQL = `
-DROP TABLE IF EXISTS "${schemaName}"."file_state", "${schemaName}"."group_file", "${schemaName}"."file", "${schemaName}"."group_user", "${schemaName}"."group" CASCADE;
-CREATE TABLE "${schemaName}"."group" (
+DROP TABLE IF EXISTS "${schemaName}"."file_state", "${schemaName}"."workspace_file", "${schemaName}"."file", "${schemaName}"."workspace_user", "${schemaName}"."workspace" CASCADE;
+CREATE TABLE "${schemaName}"."workspace" (
   "id" TEXT PRIMARY KEY
 );
-CREATE TABLE "${schemaName}"."group_user" (
+CREATE TABLE "${schemaName}"."workspace_user" (
   "userId" TEXT NOT NULL,
-  "groupId" TEXT NOT NULL,
-  PRIMARY KEY ("userId", "groupId")
+  "workspaceId" TEXT NOT NULL,
+  PRIMARY KEY ("userId", "workspaceId")
 );
 CREATE TABLE "${schemaName}"."file" (
   "id" TEXT PRIMARY KEY,
   "ownerId" TEXT,
-  "owningGroupId" TEXT,
+  "owningWorkspaceId" TEXT,
   "shared" BOOLEAN NOT NULL,
   -- mirror the production XOR invariant so the test seed stays realistic
-  CHECK (("ownerId" IS NULL) != ("owningGroupId" IS NULL))
+  CHECK (("ownerId" IS NULL) != ("owningWorkspaceId" IS NULL))
 );
 CREATE TABLE "${schemaName}"."file_state" (
   "userId" TEXT NOT NULL,
   "fileId" TEXT NOT NULL,
   PRIMARY KEY ("userId", "fileId")
 );
-CREATE TABLE "${schemaName}"."group_file" (
+CREATE TABLE "${schemaName}"."workspace_file" (
   "fileId" TEXT NOT NULL,
-  "groupId" TEXT NOT NULL,
-  PRIMARY KEY ("fileId", "groupId")
+  "workspaceId" TEXT NOT NULL,
+  PRIMARY KEY ("fileId", "workspaceId")
 );
 CREATE TRIGGER file_shared_update
 AFTER UPDATE OF shared ON "${schemaName}"."file"
@@ -153,47 +169,47 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 	})
 
 	async function seed() {
-		// group g1 with an owner and a member; guest is NOT a member
-		await client.query(`INSERT INTO "${schemaName}"."group" ("id") VALUES ('g1')`)
+		// workspace w1 with an owner and a member; guest is NOT a member
+		await client.query(`INSERT INTO "${schemaName}"."workspace" ("id") VALUES ('w1')`)
 		await client.query(
-			`INSERT INTO "${schemaName}"."group_user" ("userId", "groupId") VALUES ('uOwner', 'g1'), ('uMember', 'g1')`
+			`INSERT INTO "${schemaName}"."workspace_user" ("userId", "workspaceId") VALUES ('uOwner', 'w1'), ('uMember', 'w1')`
 		)
 
-		// group-owned shared file: ownerId NULL, owningGroupId set
+		// workspace-owned shared file: ownerId NULL, owningWorkspaceId set
 		await client.query(
-			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningGroupId", "shared") VALUES ('fGroup', NULL, 'g1', true)`
+			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningWorkspaceId", "shared") VALUES ('fWorkspace', NULL, 'w1', true)`
 		)
-		// legacy user-owned shared file: ownerId set, owningGroupId NULL
+		// legacy user-owned shared file: ownerId set, owningWorkspaceId NULL
 		await client.query(
-			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningGroupId", "shared") VALUES ('fLegacy', 'uOwner', NULL, true)`
+			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningWorkspaceId", "shared") VALUES ('fLegacy', 'uOwner', NULL, true)`
 		)
 		// a shared file we will NOT unshare, as a control
 		await client.query(
-			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningGroupId", "shared") VALUES ('fControl', 'uOwner', NULL, true)`
+			`INSERT INTO "${schemaName}"."file" ("id", "ownerId", "owningWorkspaceId", "shared") VALUES ('fControl', 'uOwner', NULL, true)`
 		)
 
 		// everyone has a file_state on every file
-		for (const fileId of ['fGroup', 'fLegacy', 'fControl']) {
+		for (const fileId of ['fWorkspace', 'fLegacy', 'fControl']) {
 			await client.query(
 				`INSERT INTO "${schemaName}"."file_state" ("userId", "fileId") VALUES ('uOwner', $1), ('uMember', $1), ('uGuest', $1)`,
 				[fileId]
 			)
 		}
 
-		// group_file rows: the owning group's own row for fGroup, plus home-group
-		// file links (home group id == user id) created by visiting a shared file
+		// workspace_file rows: the owning workspace's own row for fWorkspace, plus home-workspace
+		// file links (home workspace id == user id) created by visiting a shared file
 		await client.query(
-			`INSERT INTO "${schemaName}"."group_file" ("fileId", "groupId") VALUES
-				('fGroup', 'g1'),
-				('fGroup', 'uMember'),
-				('fGroup', 'uGuest'),
+			`INSERT INTO "${schemaName}"."workspace_file" ("fileId", "workspaceId") VALUES
+				('fWorkspace', 'w1'),
+				('fWorkspace', 'uMember'),
+				('fWorkspace', 'uGuest'),
 				('fLegacy', 'uOwner'),
 				('fLegacy', 'uGuest'),
 				('fControl', 'uGuest')`
 		)
 	}
 
-	// Unsharing fires the trigger, whose body reads `file_state` and `group_user`
+	// Unsharing fires the trigger, whose body reads `file_state` and `workspace_user`
 	// unqualified — resolved via search_path at execution time — so the UPDATE
 	// must run with the test schema pinned.
 	async function unshare(fileId: string) {
@@ -211,32 +227,32 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 	}
 
 	async function linksFor(fileId: string): Promise<string[]> {
-		const res = await client.query<{ groupId: string }>(
-			`SELECT "groupId" FROM "${schemaName}"."group_file" WHERE "fileId" = $1 ORDER BY "groupId"`,
+		const res = await client.query<{ workspaceId: string }>(
+			`SELECT "workspaceId" FROM "${schemaName}"."workspace_file" WHERE "fileId" = $1 ORDER BY "workspaceId"`,
 			[fileId]
 		)
-		return res.rows.map((r) => r.groupId)
+		return res.rows.map((r) => r.workspaceId)
 	}
 
-	describe('with the fixed function (migration 034)', () => {
+	describe('with the fixed function (migrations 034/035)', () => {
 		beforeEach(async () => {
 			await inTestSchema(FIXED_FUNCTION_SQL)
 			await client.query(SCHEMA_SQL)
 			await seed()
 		})
 
-		it('removes the guest state but keeps group members when a group-owned file is unshared', async () => {
-			await unshare('fGroup')
-			// owner + member of the owning group keep access; guest is cleaned up
-			expect(await statesFor('fGroup')).toEqual(['uMember', 'uOwner'])
+		it('removes the guest state but keeps workspace members when a workspace-owned file is unshared', async () => {
+			await unshare('fWorkspace')
+			// owner + member of the owning workspace keep access; guest is cleaned up
+			expect(await statesFor('fWorkspace')).toEqual(['uMember', 'uOwner'])
 		})
 
-		it('removes the guest file link but keeps the owning group row and member links', async () => {
-			await unshare('fGroup')
-			// the file still lives in its owning group, and the member keeps their
-			// home-group link (they retain access); the guest's link is cleaned up
+		it('removes the guest file link but keeps the owning workspace row and member links', async () => {
+			await unshare('fWorkspace')
+			// the file still lives in its owning workspace, and the member keeps their
+			// home-workspace link (they retain access); the guest's link is cleaned up
 			// so the file stops showing in their recent files
-			expect(await linksFor('fGroup')).toEqual(['g1', 'uMember'])
+			expect(await linksFor('fWorkspace')).toEqual(['uMember', 'w1'])
 		})
 
 		it('removes the guest state but keeps the owner when a legacy file is unshared', async () => {
@@ -250,7 +266,7 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 		})
 
 		it('leaves still-shared files untouched', async () => {
-			await unshare('fGroup')
+			await unshare('fWorkspace')
 			expect(await statesFor('fControl')).toEqual(['uGuest', 'uMember', 'uOwner'])
 			expect(await linksFor('fControl')).toEqual(['uGuest'])
 		})
@@ -263,16 +279,16 @@ describeMaybe('delete_file_states trigger (unshare cleanup)', () => {
 			await seed()
 		})
 
-		it('demonstrates the bug: group-owned guest state survives because ownerId is NULL', async () => {
-			await unshare('fGroup')
+		it('demonstrates the bug: workspace-owned guest state survives because ownerId is NULL', async () => {
+			await unshare('fWorkspace')
 			// NULL != "userId" is NULL, so the old DELETE matched nothing: the guest lingers
-			expect(await statesFor('fGroup')).toEqual(['uGuest', 'uMember', 'uOwner'])
-			// and the old function never touched group_file at all, so the guest's
-			// home-group link (their recent-files entry) survived too
-			expect(await linksFor('fGroup')).toEqual(['g1', 'uGuest', 'uMember'])
+			expect(await statesFor('fWorkspace')).toEqual(['uGuest', 'uMember', 'uOwner'])
+			// and the old function never touched workspace_file at all, so the guest's
+			// home-workspace link (their recent-files entry) survived too
+			expect(await linksFor('fWorkspace')).toEqual(['uGuest', 'uMember', 'w1'])
 		})
 
-		it('still works for legacy files (so the regression is group-specific)', async () => {
+		it('still works for legacy files (so the regression is workspace-specific)', async () => {
 			await unshare('fLegacy')
 			expect(await statesFor('fLegacy')).toEqual(['uOwner'])
 		})

--- a/apps/dotcom/zero-cache/migrations/035_rename_groups_to_workspaces.sql
+++ b/apps/dotcom/zero-cache/migrations/035_rename_groups_to_workspaces.sql
@@ -1,0 +1,397 @@
+-- Rename the groups data model to workspaces.
+--
+-- The UI already calls groups "workspaces"; this finishes the rename at the data
+-- layer: tables (group → workspace, group_user → workspace_user, group_file →
+-- workspace_file), columns ("groupId" → "workspaceId", file."owningGroupId" →
+-- "owningWorkspaceId"), and the indexes, constraints, triggers, and functions
+-- named after them.
+--
+-- Intentionally NOT renamed:
+--   * the user.flags values 'groups_backend' / 'groups_frontend' — they are
+--     persisted per-user rollout markers, and rewriting them buys nothing
+--     structurally while racing against the not-yet-deployed sync-worker;
+--   * migrate_user_to_groups keeps a thin compatibility wrapper (see the end of
+--     this file) because the previous sync-worker deployment calls it by name
+--     until the new worker ships a few minutes after this migration runs.
+--
+-- Table renames keep their OIDs, so publication membership (zero_data), FK
+-- relationships, grants, and trigger bindings all follow automatically. plpgsql
+-- function bodies are stored as text, so every function that mentions a renamed
+-- table or column is re-created below with the new names.
+
+------------------------
+--- TABLES & COLUMNS ---
+------------------------
+
+ALTER TABLE public."group" RENAME TO "workspace";
+ALTER TABLE public."group_user" RENAME TO "workspace_user";
+ALTER TABLE public."group_file" RENAME TO "workspace_file";
+
+ALTER TABLE public."workspace_user" RENAME COLUMN "groupId" TO "workspaceId";
+ALTER TABLE public."workspace_file" RENAME COLUMN "groupId" TO "workspaceId";
+ALTER TABLE public."file" RENAME COLUMN "owningGroupId" TO "owningWorkspaceId";
+
+-----------------------------
+--- INDEXES & CONSTRAINTS ---
+-----------------------------
+
+-- Renaming a table or column does not rename the objects named after it.
+
+ALTER INDEX public."group_inviteSecret_idx" RENAME TO "workspace_inviteSecret_idx";
+ALTER INDEX public."file_owning_group_id_idx" RENAME TO "file_owning_workspace_id_idx";
+-- from 031_group_id_indexes.sql
+ALTER INDEX public."group_user_group_id_idx" RENAME TO "workspace_user_workspace_id_idx";
+ALTER INDEX public."group_file_group_id_idx" RENAME TO "workspace_file_workspace_id_idx";
+
+ALTER TABLE public."workspace" RENAME CONSTRAINT "group_pkey" TO "workspace_pkey";
+ALTER TABLE public."workspace_user" RENAME CONSTRAINT "group_user_pkey" TO "workspace_user_pkey";
+ALTER TABLE public."workspace_user" RENAME CONSTRAINT "group_user_userId_fkey" TO "workspace_user_userId_fkey";
+ALTER TABLE public."workspace_user" RENAME CONSTRAINT "group_user_groupId_fkey" TO "workspace_user_workspaceId_fkey";
+-- re-created under this name by 033_rename_group_admin_role_to_member.sql
+ALTER TABLE public."workspace_user" RENAME CONSTRAINT "group_user_role_check" TO "workspace_user_role_check";
+ALTER TABLE public."workspace_file" RENAME CONSTRAINT "group_file_pkey" TO "workspace_file_pkey";
+ALTER TABLE public."workspace_file" RENAME CONSTRAINT "group_file_fileId_fkey" TO "workspace_file_fileId_fkey";
+ALTER TABLE public."workspace_file" RENAME CONSTRAINT "group_file_groupId_fkey" TO "workspace_file_workspaceId_fkey";
+ALTER TABLE public."file" RENAME CONSTRAINT "file_owningGroupId_fkey" TO "file_owningWorkspaceId_fkey";
+
+----------------
+--- TRIGGERS ---
+----------------
+
+ALTER TRIGGER "update_group_user_details_trigger" ON public."user" RENAME TO "update_workspace_user_details_trigger";
+ALTER TRIGGER "set_group_user_details_trigger" ON public."workspace_user" RENAME TO "set_workspace_user_details_trigger";
+ALTER TRIGGER "update_file_group_details_trigger" ON public."workspace" RENAME TO "update_file_workspace_details_trigger";
+ALTER TRIGGER "cleanup_deleted_group_trigger" ON public."workspace" RENAME TO "cleanup_deleted_workspace_trigger";
+ALTER TRIGGER "cleanup_group_user_file_states_trigger" ON public."workspace_user" RENAME TO "cleanup_workspace_user_file_states_trigger";
+ALTER TRIGGER "update_group_timestamp_trigger" ON public."workspace" RENAME TO "update_workspace_timestamp_trigger";
+ALTER TRIGGER "update_group_user_timestamp_trigger" ON public."workspace_user" RENAME TO "update_workspace_user_timestamp_trigger";
+ALTER TRIGGER "update_group_file_timestamp_trigger" ON public."workspace_file" RENAME TO "update_workspace_file_timestamp_trigger";
+ALTER TRIGGER "update_home_group_name_trigger" ON public."user" RENAME TO "update_home_workspace_name_trigger";
+ALTER TRIGGER "initialize_home_group_name_trigger" ON public."workspace" RENAME TO "initialize_home_workspace_name_trigger";
+ALTER TRIGGER "validate_group_file_association_trigger" ON public."workspace_file" RENAME TO "validate_workspace_file_association_trigger";
+
+-----------------
+--- FUNCTIONS ---
+-----------------
+
+-- Rename first so the trigger bindings (which reference functions by OID)
+-- follow, then re-create the bodies with the new table/column names. The
+-- update_*_timestamp functions only touch NEW."updatedAt", so the rename alone
+-- is enough for them.
+
+ALTER FUNCTION update_group_user_details() RENAME TO update_workspace_user_details;
+ALTER FUNCTION set_group_user_details() RENAME TO set_workspace_user_details;
+ALTER FUNCTION update_file_group_details() RENAME TO update_file_workspace_details;
+ALTER FUNCTION cleanup_deleted_group() RENAME TO cleanup_deleted_workspace;
+ALTER FUNCTION cleanup_group_user_file_states() RENAME TO cleanup_workspace_user_file_states;
+ALTER FUNCTION update_group_timestamp() RENAME TO update_workspace_timestamp;
+ALTER FUNCTION update_group_user_timestamp() RENAME TO update_workspace_user_timestamp;
+ALTER FUNCTION update_group_file_timestamp() RENAME TO update_workspace_file_timestamp;
+ALTER FUNCTION update_home_group_name() RENAME TO update_home_workspace_name;
+ALTER FUNCTION initialize_home_group_name() RENAME TO initialize_home_workspace_name;
+ALTER FUNCTION validate_group_file_association() RENAME TO validate_workspace_file_association;
+
+-- When the user's name or color is updated, update the userName and userColor
+-- columns in the workspace_user table
+CREATE OR REPLACE FUNCTION update_workspace_user_details() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE "workspace_user"
+  SET "userName" = NEW.name,
+      "userColor" = COALESCE(NEW.color, '#000000')
+  WHERE "userId" = NEW.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- When a workspace_user is inserted or updated, update the userName and
+-- userColor columns
+CREATE OR REPLACE FUNCTION set_workspace_user_details() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE "workspace_user"
+  SET "userName" = u."name",
+      "userColor" = COALESCE(u."color", '#000000')
+  FROM public."user" u
+  WHERE u."id" = NEW."userId" AND "workspace_user"."userId" = NEW."userId" AND "workspace_user"."workspaceId" = NEW."workspaceId";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Update file owner details when the owning workspace's name changes, keeping
+-- the denormalized ownerName field in sync
+CREATE OR REPLACE FUNCTION update_file_workspace_details() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE "file"
+  SET "ownerName" = NEW.name,
+      "ownerAvatar" = ''
+  WHERE "owningWorkspaceId" = NEW.id;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Set file owner details when file ownership changes. Handles both user
+-- ownership and workspace ownership.
+CREATE OR REPLACE FUNCTION set_file_owner_details() RETURNS TRIGGER AS $$
+BEGIN
+  -- If the file is owned by a user, set user details
+  IF NEW."ownerId" IS NOT NULL THEN
+    UPDATE "file"
+    SET "ownerName" = u."name",
+        "ownerAvatar" = u."avatar"
+    FROM public."user" u
+    WHERE u."id" = NEW."ownerId" AND "file"."id" = NEW."id";
+  END IF;
+
+  -- If the file is owned by a workspace, set workspace details
+  IF NEW."owningWorkspaceId" IS NOT NULL THEN
+    UPDATE "file"
+    SET "ownerName" = w."name",
+        "ownerAvatar" = ''
+    FROM public."workspace" w
+    WHERE w."id" = NEW."owningWorkspaceId" AND "file"."id" = NEW."id";
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Clean up related records when a file is marked as deleted
+CREATE OR REPLACE FUNCTION cleanup_deleted_file() RETURNS TRIGGER AS $$
+BEGIN
+  -- Delete any file states for this file
+  DELETE FROM "file_state"
+  WHERE "fileId" = NEW."id";
+
+  -- Delete any workspace file associations for this file
+  DELETE FROM "workspace_file"
+  WHERE "fileId" = NEW."id";
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Clean up workspace associations when a workspace is marked as deleted
+CREATE OR REPLACE FUNCTION cleanup_deleted_workspace() RETURNS TRIGGER AS $$
+BEGIN
+  -- Delete all workspace_user associations for this workspace
+  DELETE FROM "workspace_user"
+  WHERE "workspaceId" = NEW."id";
+
+  -- Delete all workspace_file associations for this workspace
+  DELETE FROM "workspace_file"
+  WHERE "workspaceId" = NEW."id";
+
+  -- Mark all files owned by this workspace as deleted
+  UPDATE "file"
+  SET "isDeleted" = true
+  WHERE "owningWorkspaceId" = NEW."id";
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Clean up file states when a user leaves a workspace. This removes access to
+-- non-shared files that are owned by the workspace the user just left.
+CREATE OR REPLACE FUNCTION cleanup_workspace_user_file_states() RETURNS TRIGGER AS $$
+BEGIN
+  -- Delete file_state records for files that are:
+  -- 1. Owned by the workspace the user just left (OLD.workspaceId)
+  -- 2. Not shared (so the user no longer has access)
+  DELETE FROM "file_state"
+  WHERE "userId" = OLD."userId"
+    AND "fileId" IN (
+      SELECT "id" FROM "file"
+      WHERE "owningWorkspaceId" = OLD."workspaceId"
+        AND "shared" = false
+    );
+
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Sync home workspace name with user name on update
+CREATE OR REPLACE FUNCTION update_home_workspace_name() RETURNS TRIGGER AS $$
+BEGIN
+  -- Update the workspace name where the workspace id matches the user id (home workspace)
+  UPDATE "workspace"
+  SET "name" = NEW.name
+  WHERE "id" = NEW.id;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Initialize a home workspace's name from the user's name on creation
+CREATE OR REPLACE FUNCTION initialize_home_workspace_name() RETURNS TRIGGER AS $$
+BEGIN
+  -- If there's a user with the same id as the workspace, update the workspace name to match
+  UPDATE "workspace"
+  SET "name" = u."name"
+  FROM public."user" u
+  WHERE u."id" = NEW."id" AND "workspace"."id" = NEW."id";
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Validate workspace_file associations: the file must be shared or owned by the
+-- workspace, preventing links to private files the workspace doesn't own
+CREATE OR REPLACE FUNCTION validate_workspace_file_association() RETURNS TRIGGER AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM "file" f
+    WHERE f."id" = NEW."fileId"
+      AND (f."shared" = true OR f."owningWorkspaceId" = NEW."workspaceId")
+  ) THEN
+    RAISE EXCEPTION 'Cannot link file to workspace: file must be shared or owned by the workspace';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Clean up guest access when a file is unshared (shared: true -> false), for
+-- both ownership models (see 034_fix_unshare_group_file_cleanup.sql):
+--   * file_state: delete states for anyone who isn't the legacy owner
+--     (NULL-safe) or a current member of the owning workspace;
+--   * workspace_file: delete the file's links except the owning workspace's own
+--     row and home-workspace links of users who keep access (the legacy owner /
+--     owning-workspace members).
+CREATE OR REPLACE FUNCTION delete_file_states() RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.shared = TRUE AND NEW.shared = FALSE THEN
+    DELETE FROM file_state fs
+    WHERE fs."fileId" = OLD.id
+      -- not the legacy owner (IS DISTINCT FROM is NULL-safe, so a NULL ownerId
+      -- never accidentally protects a guest the way `!=` did)
+      AND OLD."ownerId" IS DISTINCT FROM fs."userId"
+      -- not a current member of the owning workspace (no-op for legacy files,
+      -- where owningWorkspaceId is NULL and the subquery returns nothing)
+      AND NOT EXISTS (
+        SELECT 1 FROM workspace_user wu
+        WHERE wu."workspaceId" = OLD."owningWorkspaceId"
+          AND wu."userId" = fs."userId"
+      );
+
+    DELETE FROM workspace_file wf
+    WHERE wf."fileId" = OLD.id
+      -- never the owning workspace's own row: that's where the file lives
+      AND wf."workspaceId" IS DISTINCT FROM OLD."owningWorkspaceId"
+      -- not the legacy owner's home-workspace link (home workspace id == user id)
+      AND wf."workspaceId" IS DISTINCT FROM OLD."ownerId"
+      -- not a home-workspace link of a current owning-workspace member (no-op
+      -- for legacy files, where owningWorkspaceId is NULL and the subquery
+      -- returns nothing)
+      AND NOT EXISTS (
+        SELECT 1 FROM workspace_user wu
+        WHERE wu."workspaceId" = OLD."owningWorkspaceId"
+          AND wu."userId" = wf."workspaceId"
+      );
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Migration function to move a user from the legacy file_state-based model to
+-- the workspace_file-based model. Renamed from migrate_user_to_groups; the
+-- 'groups_backend' flag value is unchanged because it's persisted in user rows.
+-- Usage: SELECT migrate_user_to_workspaces('user-id-here', 'invite-secret');
+ALTER FUNCTION migrate_user_to_groups(TEXT, TEXT) RENAME TO migrate_user_to_workspaces;
+
+CREATE OR REPLACE FUNCTION migrate_user_to_workspaces(target_user_id TEXT, invite_secret TEXT)
+RETURNS TABLE (
+    files_migrated INTEGER,
+    pinned_files_migrated INTEGER,
+    flag_added BOOLEAN
+) AS $$
+DECLARE
+    v_files_migrated INTEGER := 0;
+    v_pinned_files_migrated INTEGER := 0;
+    v_current_flags TEXT;
+    v_file_record RECORD;
+    v_now BIGINT := EXTRACT(EPOCH FROM NOW()) * 1000;
+    v_lock_key BIGINT;
+BEGIN
+    -- Check if user exists
+    IF NOT EXISTS (SELECT 1 FROM public."user" WHERE id = target_user_id) THEN
+      RAISE EXCEPTION 'User % does not exist', target_user_id;
+    END IF;
+
+    -- Check if user already has the migrated flag
+    SELECT flags INTO v_current_flags FROM public."user" WHERE id = target_user_id;
+    IF v_current_flags LIKE '%groups_backend%' THEN
+      RAISE NOTICE 'User % already has the migrated flag, skipping migration', target_user_id;
+      RETURN QUERY SELECT 0, 0, FALSE;
+      RETURN;
+    END IF;
+
+    -- Acquire an advisory lock based on the user ID to prevent mutations during migration
+    -- Convert user ID string to a bigint for the lock key using hashtext
+    -- Using xact lock so it's automatically released when transaction ends
+    v_lock_key := hashtext(target_user_id);
+    RAISE NOTICE 'Acquiring advisory lock % for user %', v_lock_key, target_user_id;
+    PERFORM pg_advisory_xact_lock(v_lock_key);
+
+    -- Lock acquired, now we can safely migrate
+    RAISE NOTICE 'Lock acquired, starting migration for user %', target_user_id;
+
+    -- Create a home workspace for the user
+    INSERT INTO public."workspace" ("id", "name", "createdAt", "updatedAt", "isDeleted", "inviteSecret")
+    VALUES (target_user_id, target_user_id, v_now, v_now, FALSE, invite_secret)
+    ON CONFLICT DO NOTHING;
+
+    -- Make the user a member of the home workspace
+    INSERT INTO public."workspace_user" ("userId", "workspaceId", "createdAt", "updatedAt", "role", "index", "userName", "userColor")
+    VALUES (target_user_id, target_user_id, v_now, v_now, 'owner', 'a1', '', '')
+    ON CONFLICT DO NOTHING;
+
+    -- For any files owned by the user, change the owningWorkspaceId to the home workspace and set the ownerId to null
+    UPDATE public."file"
+    SET "owningWorkspaceId" = target_user_id,
+        "ownerId" = NULL
+    WHERE "ownerId" = target_user_id;
+
+    -- For any files that the user has access to, create a workspace_file entry in the home workspace
+    INSERT INTO public."workspace_file" ("fileId", "workspaceId", "createdAt", "updatedAt")
+    SELECT fs."fileId", target_user_id, COALESCE(fs."firstVisitAt", f."createdAt", v_now), COALESCE(fs."lastEditAt", fs."firstVisitAt", f."updatedAt", f."createdAt", v_now)
+    FROM public."file_state" fs JOIN public."file" f ON fs."fileId" = f."id"
+    WHERE fs."userId" = target_user_id
+    ON CONFLICT DO NOTHING;
+
+    -- Update indexes for the workspace_file entries
+    UPDATE public."workspace_file" wf
+    SET "index" = 'a' || fs.i::text
+    FROM (
+      SELECT "fileId", ROW_NUMBER() over (ORDER BY COALESCE("lastEditAt", "firstVisitAt", 0) DESC) AS i
+      FROM public."file_state"
+      WHERE "userId" = target_user_id
+        AND "isPinned" = TRUE
+    ) AS fs
+    WHERE wf."fileId" = fs."fileId" AND wf."workspaceId" = target_user_id;
+
+    -- Add the 'groups_backend' flag to the user (historical flag value, see above)
+    IF v_current_flags IS NULL OR v_current_flags = '' THEN
+        UPDATE public."user" SET flags = 'groups_backend' WHERE id = target_user_id;
+    ELSE
+        UPDATE public."user" SET flags = v_current_flags || ' groups_backend' WHERE id = target_user_id;
+    END IF;
+
+    RAISE NOTICE 'Successfully migrated user % to the workspaces model. Files: %, Pinned: %',
+                 target_user_id, v_files_migrated, v_pinned_files_migrated;
+
+    RETURN QUERY SELECT v_files_migrated, v_pinned_files_migrated, TRUE;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Compatibility wrapper: the sync-worker deployment that is live while this
+-- migration runs still calls migrate_user_to_groups (the new worker deploys a
+-- few minutes later). Safe to drop in a future migration.
+CREATE OR REPLACE FUNCTION migrate_user_to_groups(target_user_id TEXT, invite_secret TEXT)
+RETURNS TABLE (
+    files_migrated INTEGER,
+    pinned_files_migrated INTEGER,
+    flag_added BOOLEAN
+) AS $$
+BEGIN
+    RETURN QUERY SELECT * FROM migrate_user_to_workspaces(target_user_id, invite_secret);
+END;
+$$ LANGUAGE plpgsql;

--- a/internal/scripts/dotcom/copy-random-files-to-staging.ts
+++ b/internal/scripts/dotcom/copy-random-files-to-staging.ts
@@ -114,11 +114,11 @@ async function copyFilesToStaging(fileIds: string[]) {
 					isEmpty: false,
 					isDeleted: false,
 					createSource: null,
-					owningGroupId: null,
+					owningWorkspaceId: null,
 				}
 
 				const insertQuery = `
-					INSERT INTO file (id, name, "ownerId", "ownerName", "ownerAvatar", thumbnail, shared, "sharedLinkType", published, "lastPublished", "publishedSlug", "createdAt", "updatedAt", "isEmpty", "isDeleted", "owningGroupId")
+					INSERT INTO file (id, name, "ownerId", "ownerName", "ownerAvatar", thumbnail, shared, "sharedLinkType", published, "lastPublished", "publishedSlug", "createdAt", "updatedAt", "isEmpty", "isDeleted", "owningWorkspaceId")
 					VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 				`
 				await stagingClient.query(insertQuery, [
@@ -137,7 +137,7 @@ async function copyFilesToStaging(fileIds: string[]) {
 					testFile.updatedAt,
 					testFile.isEmpty,
 					testFile.isDeleted,
-					testFile.owningGroupId,
+					testFile.owningWorkspaceId,
 				])
 
 				copiedIds.push(newId)

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -5,9 +5,9 @@ import { FILE_PREFIX, PUBLISH_PREFIX } from './routes'
 import {
 	TlaFile,
 	TlaFileState,
-	TlaGroup,
-	TlaGroupFile,
-	TlaGroupUser,
+	TlaWorkspace,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 	TlaSchema,
 	TlaUser,
 } from './tlaSchema'
@@ -49,7 +49,7 @@ function makeFile(overrides: Partial<TlaFile> & { id: string }): TlaFile {
 	return {
 		name: 'Untitled',
 		ownerId: null,
-		owningGroupId: null,
+		owningWorkspaceId: null,
 		ownerName: '',
 		ownerAvatar: '',
 		thumbnail: '',
@@ -67,9 +67,9 @@ function makeFile(overrides: Partial<TlaFile> & { id: string }): TlaFile {
 	}
 }
 
-function makeGroupUser(
-	overrides: Partial<TlaGroupUser> & { userId: string; groupId: string }
-): TlaGroupUser {
+function makeWorkspaceUser(
+	overrides: Partial<TlaWorkspaceUser> & { userId: string; workspaceId: string }
+): TlaWorkspaceUser {
 	return {
 		createdAt: 1,
 		updatedAt: 1,
@@ -81,9 +81,9 @@ function makeGroupUser(
 	}
 }
 
-function makeGroupFile(
-	overrides: Partial<TlaGroupFile> & { fileId: string; groupId: string }
-): TlaGroupFile {
+function makeWorkspaceFile(
+	overrides: Partial<TlaWorkspaceFile> & { fileId: string; workspaceId: string }
+): TlaWorkspaceFile {
 	return {
 		createdAt: 1,
 		updatedAt: 1,
@@ -92,9 +92,9 @@ function makeGroupFile(
 	}
 }
 
-function makeGroup(overrides: Partial<TlaGroup> & { id: string }): TlaGroup {
+function makeWorkspace(overrides: Partial<TlaWorkspace> & { id: string }): TlaWorkspace {
 	return {
-		name: 'Test Group',
+		name: 'Test Workspace',
 		inviteSecret: null,
 		isDeleted: false,
 		createdAt: 1,
@@ -122,18 +122,18 @@ interface TableStore {
 	user: TlaUser[]
 	file: TlaFile[]
 	file_state: TlaFileState[]
-	group: TlaGroup[]
-	group_user: TlaGroupUser[]
-	group_file: TlaGroupFile[]
+	workspace: TlaWorkspace[]
+	workspace_user: TlaWorkspaceUser[]
+	workspace_file: TlaWorkspaceFile[]
 }
 
 const TABLE_PKS: Record<keyof TableStore, string[]> = {
 	user: ['id'],
 	file: ['id'],
 	file_state: ['userId', 'fileId'],
-	group: ['id'],
-	group_user: ['userId', 'groupId'],
-	group_file: ['fileId', 'groupId'],
+	workspace: ['id'],
+	workspace_user: ['userId', 'workspaceId'],
+	workspace_file: ['fileId', 'workspaceId'],
 }
 
 /**
@@ -267,7 +267,7 @@ function createMockTx(
 				if (sql.includes('count(*)') && sql.includes('"file"')) {
 					const userId = params[0]
 					const count = store.file.filter(
-						(f) => !f.isDeleted && (f.ownerId === userId || f.owningGroupId === userId)
+						(f) => !f.isDeleted && (f.ownerId === userId || f.owningWorkspaceId === userId)
 					).length
 					return [{ count: String(count) }]
 				}
@@ -324,9 +324,9 @@ describe('user mutations', () => {
 			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		})
 		const m = createMutators(userId)
 		await expectValid(() => m.user.update(tx, { id: userId, name: 'New Name' }))
@@ -338,9 +338,9 @@ describe('user mutations', () => {
 			user: [makeUser({ id: userId }), makeUser({ id: otherId })],
 			file: [],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		})
 		const m = createMutators(userId)
 		await expectForbidden(() => m.user.update(tx, { id: otherId, name: 'Hacked' }))
@@ -351,9 +351,9 @@ describe('user mutations', () => {
 			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		})
 		const m = createMutators(userId)
 		await expectForbidden(() => m.user.update(tx, { id: userId, email: 'evil@evil.com' }))
@@ -364,9 +364,9 @@ describe('user mutations', () => {
 			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		})
 		const m = createMutators(userId)
 		// flags is NOT in immutableColumns.user, so this should succeed
@@ -378,22 +378,22 @@ describe('user mutations', () => {
 
 describe('file mutations', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 
 	function baseStore() {
 		return {
 			user: [makeUser({ id: userId })],
 			file: [] as TlaFile[],
 			file_state: [] as TlaFileState[],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
-			group_file: [] as TlaGroupFile[],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'member' })],
+			workspace_file: [] as TlaWorkspaceFile[],
 		}
 	}
 
 	it('workspace member can update file', async () => {
 		const s = baseStore()
-		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })
+		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })
 		s.file.push(f)
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -405,11 +405,11 @@ describe('file mutations', () => {
 		const s = baseStore()
 		const f = makeFile({
 			id: 'file_aaaa11112222bbbb',
-			owningGroupId: groupId,
+			owningWorkspaceId: workspaceId,
 			shared: true,
 		})
 		s.file.push(f)
-		// otherId is NOT in the group
+		// otherId is NOT in the workspace
 		const { tx } = createMockTx(s)
 		const m = createMutators(otherId)
 		await expectForbidden(() => m.file.update(tx, { id: f.id, name: 'Hacked' }))
@@ -417,27 +417,27 @@ describe('file mutations', () => {
 
 	it('cannot change immutable field (ownerId)', async () => {
 		const s = baseStore()
-		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })
+		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })
 		s.file.push(f)
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() => m.file.update(tx, { id: f.id, ownerId: 'evil' }))
 	})
 
-	it('cannot change immutable field (owningGroupId)', async () => {
+	it('cannot change immutable field (owningWorkspaceId)', async () => {
 		const s = baseStore()
-		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })
+		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })
 		s.file.push(f)
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
-			m.file.update(tx, { id: f.id, owningGroupId: 'evil_group_1234567' })
+			m.file.update(tx, { id: f.id, owningWorkspaceId: 'evil_workspace_12345' })
 		)
 	})
 
 	it('cannot change immutable field (isDeleted)', async () => {
 		const s = baseStore()
-		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })
+		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })
 		s.file.push(f)
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -447,7 +447,11 @@ describe('file mutations', () => {
 	it('unrelated user cannot update file', async () => {
 		const strangerId = 'user_stranger12345678'
 		const s = baseStore()
-		const f = makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId, shared: false })
+		const f = makeFile({
+			id: 'file_aaaa11112222bbbb',
+			owningWorkspaceId: workspaceId,
+			shared: false,
+		})
 		s.file.push(f)
 		const { tx } = createMockTx(s)
 		const m = createMutators(strangerId)
@@ -457,23 +461,23 @@ describe('file mutations', () => {
 
 describe('file creation', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 
 	it('migrated user can create file in own workspace', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectValid(() =>
 			m.createFile(tx, {
 				fileId: 'file_aaaa11112222bbbb',
-				workspaceId: groupId,
+				workspaceId: workspaceId,
 				name: 'New File',
 				time: Date.now(),
 				createSource: null,
@@ -482,21 +486,21 @@ describe('file creation', () => {
 	})
 
 	it('migrated user cannot create file in another workspace', async () => {
-		const otherGroup = 'group_other123456789'
+		const otherWorkspace = 'workspace_other123456789'
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId }), makeGroup({ id: otherGroup })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId }), makeWorkspace({ id: otherWorkspace })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
 			m.createFile(tx, {
 				fileId: 'file_aaaa11112222bbbb',
-				workspaceId: otherGroup,
+				workspaceId: otherWorkspace,
 				name: 'Nope',
 				time: Date.now(),
 				createSource: null,
@@ -507,17 +511,17 @@ describe('file creation', () => {
 
 describe('file_state mutations', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 	const fileId = 'file_aaaa11112222bbbb'
 
 	it('user can update own file_state', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: fileId, owningGroupId: groupId, shared: true })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceId, shared: true })],
 			file_state: [makeFileState({ userId, fileId })],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -528,11 +532,11 @@ describe('file_state mutations', () => {
 		const otherId = 'user_other1234567890'
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: fileId, owningGroupId: groupId })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceId })],
 			file_state: [makeFileState({ userId: otherId, fileId })],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -544,16 +548,16 @@ describe('file_state mutations', () => {
 	it('server cannot update file_state for inaccessible file', async () => {
 		const inaccessibleFile = makeFile({
 			id: 'file_inaccessible12345',
-			owningGroupId: groupId,
+			owningWorkspaceId: workspaceId,
 			shared: false,
 		})
 		const s = {
 			user: [makeUser({ id: userId })],
 			file: [inaccessibleFile],
 			file_state: [makeFileState({ userId, fileId: inaccessibleFile.id })],
-			group: [makeGroup({ id: groupId })],
-			group_user: [], // userId NOT a member
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [], // userId NOT a member
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -565,17 +569,17 @@ describe('file_state mutations', () => {
 
 describe('onEnterFile', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 	const fileId = 'file_aaaa11112222bbbb'
 
 	it('user with access can enter file', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: fileId, owningGroupId: groupId })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceId })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [makeGroupFile({ fileId, groupId })],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId })],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -587,31 +591,31 @@ describe('onEnterFile', () => {
 	it('user without access cannot enter file', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: fileId, owningGroupId: groupId, shared: false })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceId, shared: false })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [], // not a member
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [], // not a member
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
 		await expectForbidden(() => m.onEnterFile(tx, { fileId, time: Date.now() }))
 	})
 
-	it('entering file already in workspace does not create duplicate group_file', async () => {
+	it('entering file already in workspace does not create duplicate workspace_file', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: fileId, owningGroupId: groupId, shared: true })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceId, shared: true })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [makeGroupFile({ fileId, groupId })],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId })],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
 		await m.onEnterFile(tx, { fileId, time: Date.now() })
-		// Should NOT create a new group_file since it's already in user's group
-		expect(s.group_file.length).toBe(1)
+		// Should NOT create a new workspace_file since it's already in user's workspace
+		expect(s.workspace_file.length).toBe(1)
 	})
 })
 
@@ -623,87 +627,87 @@ describe('workspace mutations', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		const groupId = 'group_new123456789ab'
-		await m.createWorkspace(tx, { id: groupId, name: 'My Group' })
-		expect(s.group.length).toBe(1)
-		expect(s.group_user.length).toBe(1)
-		expect((s.group_user as TlaGroupUser[])[0]?.role).toBe('owner')
+		const workspaceId = 'workspace_new123456789ab'
+		await m.createWorkspace(tx, { id: workspaceId, name: 'My Workspace' })
+		expect(s.workspace.length).toBe(1)
+		expect(s.workspace_user.length).toBe(1)
+		expect((s.workspace_user as TlaWorkspaceUser[])[0]?.role).toBe('owner')
 	})
 
 	it('owner can update workspace name', async () => {
-		const groupId = 'group_aaa11112222bbb'
+		const workspaceId = 'workspace_aaa11112222bbb'
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'owner' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectValid(() => m.updateWorkspace(tx, { id: groupId, name: 'Renamed' }))
+		await expectValid(() => m.updateWorkspace(tx, { id: workspaceId, name: 'Renamed' }))
 	})
 
 	it('member cannot update workspace name', async () => {
-		const groupId = 'group_aaa11112222bbb'
+		const workspaceId = 'workspace_aaa11112222bbb'
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'member' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectForbidden(() => m.updateWorkspace(tx, { id: groupId, name: 'Renamed' }))
+		await expectForbidden(() => m.updateWorkspace(tx, { id: workspaceId, name: 'Renamed' }))
 	})
 
 	it('owner can delete workspace', async () => {
-		const groupId = 'group_aaa11112222bbb'
+		const workspaceId = 'workspace_aaa11112222bbb'
 		const fileId = 'file_aaaa11112222bbbb'
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupId })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceId })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
-			group_file: [makeGroupFile({ fileId, groupId })],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'owner' })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.deleteWorkspace(tx, { id: groupId })
-		expect(s.group[0]?.isDeleted).toBe(true)
+		await m.deleteWorkspace(tx, { id: workspaceId })
+		expect(s.workspace[0]?.isDeleted).toBe(true)
 		expect(s.file[0]?.isDeleted).toBe(true)
-		expect(s.group_file.length).toBe(0)
+		expect(s.workspace_file.length).toBe(0)
 	})
 
 	it('non-owner cannot delete workspace', async () => {
-		const groupId = 'group_aaa11112222bbb'
+		const workspaceId = 'workspace_aaa11112222bbb'
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'member' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectForbidden(() => m.deleteWorkspace(tx, { id: groupId }))
+		await expectForbidden(() => m.deleteWorkspace(tx, { id: workspaceId }))
 	})
 })
 
 describe('membership', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 	const memberId = 'user_member12345678ab'
 
 	it('owner can set member roles', async () => {
@@ -711,21 +715,21 @@ describe('membership', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [
-				makeGroupUser({ userId, groupId, role: 'owner' }),
-				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [
+				makeWorkspaceUser({ userId, workspaceId, role: 'owner' }),
+				makeWorkspaceUser({ userId: memberId, workspaceId, role: 'member' }),
 			],
-			group_file: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await m.setWorkspaceMemberRole(tx, {
-			workspaceId: groupId,
+			workspaceId: workspaceId,
 			targetUserId: memberId,
 			role: 'owner',
 		})
-		expect(s.group_user.find((gu) => gu.userId === memberId)?.role).toBe('owner')
+		expect(s.workspace_user.find((gu) => gu.userId === memberId)?.role).toBe('owner')
 	})
 
 	it('member cannot set member roles', async () => {
@@ -733,17 +737,21 @@ describe('membership', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [
-				makeGroupUser({ userId, groupId, role: 'member' }),
-				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [
+				makeWorkspaceUser({ userId, workspaceId, role: 'member' }),
+				makeWorkspaceUser({ userId: memberId, workspaceId, role: 'member' }),
 			],
-			group_file: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
-			m.setWorkspaceMemberRole(tx, { workspaceId: groupId, targetUserId: memberId, role: 'owner' })
+			m.setWorkspaceMemberRole(tx, {
+				workspaceId: workspaceId,
+				targetUserId: memberId,
+				role: 'owner',
+			})
 		)
 	})
 
@@ -752,17 +760,21 @@ describe('membership', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [
-				makeGroupUser({ userId, groupId, role: 'owner' }),
-				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [
+				makeWorkspaceUser({ userId, workspaceId, role: 'owner' }),
+				makeWorkspaceUser({ userId: memberId, workspaceId, role: 'member' }),
 			],
-			group_file: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
-			m.setWorkspaceMemberRole(tx, { workspaceId: groupId, targetUserId: userId, role: 'member' })
+			m.setWorkspaceMemberRole(tx, {
+				workspaceId: workspaceId,
+				targetUserId: userId,
+				role: 'member',
+			})
 		)
 	})
 
@@ -771,13 +783,13 @@ describe('membership', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'owner' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectForbidden(() => m.leaveWorkspace(tx, { workspaceId: groupId }))
+		await expectForbidden(() => m.leaveWorkspace(tx, { workspaceId: workspaceId }))
 	})
 
 	it('non-owner member can leave workspace', async () => {
@@ -785,99 +797,99 @@ describe('membership', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [
-				makeGroupUser({ userId: 'user_owner12345678ab', groupId, role: 'owner' }),
-				makeGroupUser({ userId, groupId, role: 'member' }),
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [
+				makeWorkspaceUser({ userId: 'user_owner12345678ab', workspaceId, role: 'owner' }),
+				makeWorkspaceUser({ userId, workspaceId, role: 'member' }),
 			],
-			group_file: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.leaveWorkspace(tx, { workspaceId: groupId })
-		expect(s.group_user.find((gu) => gu.userId === userId)).toBeUndefined()
+		await m.leaveWorkspace(tx, { workspaceId: workspaceId })
+		expect(s.workspace_user.find((gu) => gu.userId === userId)).toBeUndefined()
 	})
 })
 
 describe('file operations across workspaces', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupA = 'group_aaa11112222bbb'
-	const groupB = 'group_bbb11112222ccc'
+	const workspaceA = 'workspace_aaa11112222bbb'
+	const workspaceB = 'workspace_bbb11112222ccc'
 	const fileId = 'file_aaaa11112222bbbb'
 
 	it('member of both workspaces can move file between them', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [],
-			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
-			group_user: [
-				makeGroupUser({ userId, groupId: groupA }),
-				makeGroupUser({ userId, groupId: groupB }),
+			workspace: [makeWorkspace({ id: workspaceA }), makeWorkspace({ id: workspaceB })],
+			workspace_user: [
+				makeWorkspaceUser({ userId, workspaceId: workspaceA }),
+				makeWorkspaceUser({ userId, workspaceId: workspaceB }),
 			],
-			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId: workspaceA })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.moveFileToWorkspace(tx, { fileId, workspaceId: groupB })
-		expect(s.file[0]?.owningGroupId).toBe(groupB)
+		await m.moveFileToWorkspace(tx, { fileId, workspaceId: workspaceB })
+		expect(s.file[0]?.owningWorkspaceId).toBe(workspaceB)
 	})
 
 	it('member of source workspace only cannot move file to other workspace', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [],
-			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
-			group_user: [makeGroupUser({ userId, groupId: groupA })],
-			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			workspace: [makeWorkspace({ id: workspaceA }), makeWorkspace({ id: workspaceB })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: workspaceA })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId: workspaceA })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectForbidden(() => m.moveFileToWorkspace(tx, { fileId, workspaceId: groupB }))
+		await expectForbidden(() => m.moveFileToWorkspace(tx, { fileId, workspaceId: workspaceB }))
 	})
 
 	it('member of target workspace only cannot move file from other workspace', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [],
-			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
-			group_user: [makeGroupUser({ userId, groupId: groupB })],
-			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			workspace: [makeWorkspace({ id: workspaceA }), makeWorkspace({ id: workspaceB })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: workspaceB })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId: workspaceA })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectForbidden(() => m.moveFileToWorkspace(tx, { fileId, workspaceId: groupB }))
+		await expectForbidden(() => m.moveFileToWorkspace(tx, { fileId, workspaceId: workspaceB }))
 	})
 
 	it('member can remove file from workspace', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [makeFileState({ userId, fileId })],
-			group: [makeGroup({ id: groupA })],
-			group_user: [makeGroupUser({ userId, groupId: groupA, role: 'member' })],
-			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			workspace: [makeWorkspace({ id: workspaceA })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: workspaceA, role: 'member' })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId: workspaceA })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.removeFileFromWorkspace(tx, { fileId, workspaceId: groupA })
+		await m.removeFileFromWorkspace(tx, { fileId, workspaceId: workspaceA })
 		expect(s.file[0]?.isDeleted).toBe(true)
 	})
 
 	it('non-member cannot remove file from workspace', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [makeFileState({ userId, fileId })],
-			group: [makeGroup({ id: groupA })],
-			group_user: [],
-			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			workspace: [makeWorkspace({ id: workspaceA })],
+			workspace_user: [],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId: workspaceA })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await expectForbidden(() => m.removeFileFromWorkspace(tx, { fileId, workspaceId: groupA }))
+		await expectForbidden(() => m.removeFileFromWorkspace(tx, { fileId, workspaceId: workspaceA }))
 		expect(s.file[0]?.isDeleted).toBe(false)
 	})
 
@@ -885,45 +897,49 @@ describe('file operations across workspaces', () => {
 		// the file is owned by workspace B but linked into workspace A
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupB })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceB })],
 			file_state: [makeFileState({ userId, fileId })],
-			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
-			group_user: [makeGroupUser({ userId, groupId: groupA, role: 'owner' })],
-			group_file: [
-				makeGroupFile({ fileId, groupId: groupA }),
-				makeGroupFile({ fileId, groupId: groupB }),
+			workspace: [makeWorkspace({ id: workspaceA }), makeWorkspace({ id: workspaceB })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: workspaceA, role: 'owner' })],
+			workspace_file: [
+				makeWorkspaceFile({ fileId, workspaceId: workspaceA }),
+				makeWorkspaceFile({ fileId, workspaceId: workspaceB }),
 			],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.removeFileFromWorkspace(tx, { fileId, workspaceId: groupA })
+		await m.removeFileFromWorkspace(tx, { fileId, workspaceId: workspaceA })
 		expect(s.file[0]?.isDeleted).toBe(false)
-		expect(s.group_file.some((gf) => gf.groupId === groupA)).toBe(false)
-		expect(s.group_file.some((gf) => gf.groupId === groupB)).toBe(true)
+		expect(s.workspace_file.some((gf) => gf.workspaceId === workspaceA)).toBe(false)
+		expect(s.workspace_file.some((gf) => gf.workspaceId === workspaceB)).toBe(true)
 	})
 
 	it('drag move operation moves the file to the target workspace', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [],
-			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
-			group_user: [
-				makeGroupUser({ userId, groupId: groupA }),
-				makeGroupUser({ userId, groupId: groupB }),
+			workspace: [makeWorkspace({ id: workspaceA }), makeWorkspace({ id: workspaceB })],
+			workspace_user: [
+				makeWorkspaceUser({ userId, workspaceId: workspaceA }),
+				makeWorkspaceUser({ userId, workspaceId: workspaceB }),
 			],
-			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			workspace_file: [makeWorkspaceFile({ fileId, workspaceId: workspaceA })],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await m.handleFileDragOperation(tx, {
 			fileId,
-			workspaceId: groupA,
-			operation: { move: { targetId: groupB } },
+			workspaceId: workspaceA,
+			operation: { move: { targetId: workspaceB } },
 		})
-		expect(s.file[0]?.owningGroupId).toBe(groupB)
-		expect(s.group_file.some((gf) => gf.groupId === groupB && gf.fileId === fileId)).toBe(true)
-		expect(s.group_file.some((gf) => gf.groupId === groupA && gf.fileId === fileId)).toBe(false)
+		expect(s.file[0]?.owningWorkspaceId).toBe(workspaceB)
+		expect(
+			s.workspace_file.some((gf) => gf.workspaceId === workspaceB && gf.fileId === fileId)
+		).toBe(true)
+		expect(
+			s.workspace_file.some((gf) => gf.workspaceId === workspaceA && gf.fileId === fileId)
+		).toBe(false)
 	})
 
 	it('drag reorder pins the file above the insert target', async () => {
@@ -931,26 +947,30 @@ describe('file operations across workspaces', () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [
-				makeFile({ id: fileId, owningGroupId: groupA }),
-				makeFile({ id: otherFileId, owningGroupId: groupA }),
+				makeFile({ id: fileId, owningWorkspaceId: workspaceA }),
+				makeFile({ id: otherFileId, owningWorkspaceId: workspaceA }),
 			],
 			file_state: [],
-			group: [makeGroup({ id: groupA })],
-			group_user: [makeGroupUser({ userId, groupId: groupA })],
-			group_file: [
-				makeGroupFile({ fileId, groupId: groupA }),
-				makeGroupFile({ fileId: otherFileId, groupId: groupA, index: 'a1' as IndexKey }),
+			workspace: [makeWorkspace({ id: workspaceA })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: workspaceA })],
+			workspace_file: [
+				makeWorkspaceFile({ fileId, workspaceId: workspaceA }),
+				makeWorkspaceFile({
+					fileId: otherFileId,
+					workspaceId: workspaceA,
+					index: 'a1' as IndexKey,
+				}),
 			],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await m.handleFileDragOperation(tx, {
 			fileId,
-			workspaceId: groupA,
+			workspaceId: workspaceA,
 			operation: { reorder: { insertBeforeId: otherFileId, indicatorY: 0 } },
 		})
-		const moved = s.group_file.find((gf) => gf.fileId === fileId)
-		const target = s.group_file.find((gf) => gf.fileId === otherFileId)
+		const moved = s.workspace_file.find((gf) => gf.fileId === fileId)
+		const target = s.workspace_file.find((gf) => gf.fileId === otherFileId)
 		expect(moved?.index).toBeTruthy()
 		expect(moved!.index! < target!.index!).toBe(true)
 	})
@@ -958,16 +978,18 @@ describe('file operations across workspaces', () => {
 	it('drag with an empty operation unpins the file', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
-			file: [makeFile({ id: fileId, owningGroupId: groupA })],
+			file: [makeFile({ id: fileId, owningWorkspaceId: workspaceA })],
 			file_state: [],
-			group: [makeGroup({ id: groupA })],
-			group_user: [makeGroupUser({ userId, groupId: groupA })],
-			group_file: [makeGroupFile({ fileId, groupId: groupA, index: 'a1' as IndexKey })],
+			workspace: [makeWorkspace({ id: workspaceA })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: workspaceA })],
+			workspace_file: [
+				makeWorkspaceFile({ fileId, workspaceId: workspaceA, index: 'a1' as IndexKey }),
+			],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.handleFileDragOperation(tx, { fileId, workspaceId: groupA, operation: {} })
-		expect(s.group_file.find((gf) => gf.fileId === fileId)?.index).toBe(null)
+		await m.handleFileDragOperation(tx, { fileId, workspaceId: workspaceA, operation: {} })
+		expect(s.workspace_file.find((gf) => gf.fileId === fileId)?.index).toBe(null)
 	})
 
 	it('pinning in a workspace computes the index against that workspace, not home', async () => {
@@ -976,31 +998,39 @@ describe('file operations across workspaces', () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [
-				makeFile({ id: fileId, owningGroupId: groupA }),
-				makeFile({ id: otherFileId, owningGroupId: groupA }),
-				makeFile({ id: homePinnedId, owningGroupId: userId }),
+				makeFile({ id: fileId, owningWorkspaceId: workspaceA }),
+				makeFile({ id: otherFileId, owningWorkspaceId: workspaceA }),
+				makeFile({ id: homePinnedId, owningWorkspaceId: userId }),
 			],
 			file_state: [],
-			group: [makeGroup({ id: groupA }), makeGroup({ id: userId })],
-			group_user: [
-				makeGroupUser({ userId, groupId: groupA }),
-				makeGroupUser({ userId, groupId: userId }),
+			workspace: [makeWorkspace({ id: workspaceA }), makeWorkspace({ id: userId })],
+			workspace_user: [
+				makeWorkspaceUser({ userId, workspaceId: workspaceA }),
+				makeWorkspaceUser({ userId, workspaceId: userId }),
 			],
-			group_file: [
-				makeGroupFile({ fileId, groupId: groupA }),
+			workspace_file: [
+				makeWorkspaceFile({ fileId, workspaceId: workspaceA }),
 				// an already-pinned sibling in the same workspace
-				makeGroupFile({ fileId: otherFileId, groupId: groupA, index: 'a1' as IndexKey }),
+				makeWorkspaceFile({
+					fileId: otherFileId,
+					workspaceId: workspaceA,
+					index: 'a1' as IndexKey,
+				}),
 				// a pinned file in the home workspace with the same index; it must not
 				// influence (or collide with) the new pin's index
-				makeGroupFile({ fileId: homePinnedId, groupId: userId, index: 'a1' as IndexKey }),
+				makeWorkspaceFile({ fileId: homePinnedId, workspaceId: userId, index: 'a1' as IndexKey }),
 			],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		await m.pinFile(tx, { fileId, workspaceId: groupA })
+		await m.pinFile(tx, { fileId, workspaceId: workspaceA })
 
-		const pinned = s.group_file.find((gf) => gf.fileId === fileId && gf.groupId === groupA)
-		const sibling = s.group_file.find((gf) => gf.fileId === otherFileId && gf.groupId === groupA)
+		const pinned = s.workspace_file.find(
+			(gf) => gf.fileId === fileId && gf.workspaceId === workspaceA
+		)
+		const sibling = s.workspace_file.find(
+			(gf) => gf.fileId === otherFileId && gf.workspaceId === workspaceA
+		)
 		expect(pinned?.index).toBeTruthy()
 		// new pin goes above the workspace's existing pinned sibling
 		expect(pinned!.index! < sibling!.index!).toBe(true)
@@ -1011,19 +1041,19 @@ describe('home workspace special case', () => {
 	const userId = 'user_aaaa11112222bbbb'
 
 	it('home workspace shortcut passes membership check', async () => {
-		// createFile with groupId === userId should pass the membership check
-		// even without a group_user row, because of the userId === groupId shortcut
+		// createFile with workspaceId === userId should pass the membership check
+		// even without a workspace_user row, because of the userId === workspaceId shortcut
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: userId })],
-			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: userId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: userId, role: 'owner' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
-		// This exercises the userId === groupId shortcut in assertUserIsGroupMember
+		// This exercises the userId === workspaceId shortcut in assertUserIsWorkspaceMember
 		await expectValid(() =>
 			m.createFile(tx, {
 				fileId: 'file_home123456789ab',
@@ -1035,14 +1065,16 @@ describe('home workspace special case', () => {
 		)
 	})
 
-	// The home workspace (group id === userId) can't be renamed, invited to, left,
+	// The home workspace (workspace id === userId) can't be renamed, invited to, left,
 	// deleted, or have its members managed.
 	function homeState(extra?: { secondOwnerId?: string }) {
-		const group_user: TlaGroupUser[] = [makeGroupUser({ userId, groupId: userId, role: 'owner' })]
+		const workspace_user: TlaWorkspaceUser[] = [
+			makeWorkspaceUser({ userId, workspaceId: userId, role: 'owner' }),
+		]
 		const user = [makeUser({ id: userId, flags: 'groups_backend' })]
 		if (extra?.secondOwnerId) {
-			group_user.push(
-				makeGroupUser({ userId: extra.secondOwnerId, groupId: userId, role: 'owner' })
+			workspace_user.push(
+				makeWorkspaceUser({ userId: extra.secondOwnerId, workspaceId: userId, role: 'owner' })
 			)
 			user.push(makeUser({ id: extra.secondOwnerId, flags: 'groups_backend' }))
 		}
@@ -1050,9 +1082,9 @@ describe('home workspace special case', () => {
 			user,
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: userId })],
-			group_user,
-			group_file: [],
+			workspace: [makeWorkspace({ id: userId })],
+			workspace_user,
+			workspace_file: [],
 		} satisfies TableStore
 	}
 
@@ -1085,7 +1117,9 @@ describe('home workspace special case', () => {
 		const targetId = 'user_target123456789'
 		const s = homeState()
 		s.user.push(makeUser({ id: targetId, flags: 'groups_backend' }))
-		s.group_user.push(makeGroupUser({ userId: targetId, groupId: userId, role: 'member' }))
+		s.workspace_user.push(
+			makeWorkspaceUser({ userId: targetId, workspaceId: userId, role: 'member' })
+		)
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
@@ -1096,22 +1130,22 @@ describe('home workspace special case', () => {
 
 describe('regenerateWorkspaceInviteSecret', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 
 	it('member can regenerate invite secret', async () => {
 		const s = {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId, inviteSecret: 'old_secret_1234567' })],
-			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId, inviteSecret: 'old_secret_1234567' })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId, role: 'member' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
-		await m.regenerateWorkspaceInviteSecret(tx, { id: groupId })
+		await m.regenerateWorkspaceInviteSecret(tx, { id: workspaceId })
 		// inviteSecret should have changed
-		expect(s.group[0]?.inviteSecret).not.toBe('old_secret_1234567')
+		expect(s.workspace[0]?.inviteSecret).not.toBe('old_secret_1234567')
 	})
 
 	it('non-member cannot regenerate invite secret', async () => {
@@ -1120,59 +1154,59 @@ describe('regenerateWorkspaceInviteSecret', () => {
 			user: [makeUser({ id: nonMemberId, flags: 'groups_backend' })],
 			file: [],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			// No group_user for nonMemberId — not a member at all
-			group_user: [],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			// No workspace_user for nonMemberId — not a member at all
+			workspace_user: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(nonMemberId)
-		await expectForbidden(() => m.regenerateWorkspaceInviteSecret(tx, { id: groupId }))
+		await expectForbidden(() => m.regenerateWorkspaceInviteSecret(tx, { id: workspaceId }))
 	})
 })
 
 describe('immutable column bypass attempts', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 
 	it('cannot change file.ownerId to self', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })],
+			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() => m.file.update(tx, { id: 'file_aaaa11112222bbbb', ownerId: userId }))
 	})
 
-	it('cannot change file.owningGroupId', async () => {
+	it('cannot change file.owningWorkspaceId', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })],
+			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
 		await expectForbidden(() =>
-			m.file.update(tx, { id: 'file_aaaa11112222bbbb', owningGroupId: 'evil_group_12345' })
+			m.file.update(tx, { id: 'file_aaaa11112222bbbb', owningWorkspaceId: 'evil_workspace_1234' })
 		)
 	})
 
 	it('cannot set isDeleted:true', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })],
+			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1182,11 +1216,13 @@ describe('immutable column bypass attempts', () => {
 	it('cannot set isDeleted:false (falsy value still blocked)', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId, isDeleted: false })],
+			file: [
+				makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId, isDeleted: false }),
+			],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1198,11 +1234,13 @@ describe('immutable column bypass attempts', () => {
 	it('cannot update file_state for inaccessible file on server', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_secret12345678', owningGroupId: groupId, shared: false })],
+			file: [
+				makeFile({ id: 'file_secret12345678', owningWorkspaceId: workspaceId, shared: false }),
+			],
 			file_state: [makeFileState({ userId, fileId: 'file_secret12345678' })],
-			group: [makeGroup({ id: groupId })],
-			group_user: [], // not a member
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [], // not a member
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1214,11 +1252,11 @@ describe('immutable column bypass attempts', () => {
 	it('cannot change immutable file_state field (firstVisitAt)', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningGroupId: groupId })],
+			file: [makeFile({ id: 'file_aaaa11112222bbbb', owningWorkspaceId: workspaceId })],
 			file_state: [makeFileState({ userId, fileId: 'file_aaaa11112222bbbb', firstVisitAt: 1 })],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1234,17 +1272,19 @@ describe('immutable column bypass attempts', () => {
 
 describe('file access control logic', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const groupId = 'group_aaa11112222bbb'
+	const workspaceId = 'workspace_aaa11112222bbb'
 
 	it('non-member can enter shared file (read access)', async () => {
 		const otherId = 'user_other1234567890'
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_shared123456789', owningGroupId: groupId, shared: true })],
+			file: [
+				makeFile({ id: 'file_shared123456789', owningWorkspaceId: workspaceId, shared: true }),
+			],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId: otherId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId: otherId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1255,11 +1295,13 @@ describe('file access control logic', () => {
 	it('cannot enter deleted file', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
-			file: [makeFile({ id: 'file_deleted1234567a', owningGroupId: groupId, isDeleted: true })],
+			file: [
+				makeFile({ id: 'file_deleted1234567a', owningWorkspaceId: workspaceId, isDeleted: true }),
+			],
 			file_state: [],
-			group: [makeGroup({ id: groupId })],
-			group_user: [makeGroupUser({ userId, groupId })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1268,21 +1310,21 @@ describe('file access control logic', () => {
 		)
 	})
 
-	it('cannot enter file with neither ownerId nor owningGroupId', async () => {
+	it('cannot enter file with neither ownerId nor owningWorkspaceId', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],
 			file: [
 				makeFile({
 					id: 'file_orphan12345678a',
 					ownerId: null,
-					owningGroupId: null,
+					owningWorkspaceId: null,
 					shared: false,
 				}),
 			],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1295,16 +1337,18 @@ describe('file access control logic', () => {
 describe('cross-user isolation', () => {
 	const userA = 'user_aaaa11112222bbbb'
 	const userB = 'user_bbbb22223333cccc'
-	const groupA = 'group_aaa11112222bbb'
+	const workspaceA = 'workspace_aaa11112222bbb'
 
 	it('user A files never accessible to unrelated user B', async () => {
 		const s = {
 			user: [makeUser({ id: userA }), makeUser({ id: userB })],
-			file: [makeFile({ id: 'file_userA123456789a', owningGroupId: groupA, shared: false })],
+			file: [
+				makeFile({ id: 'file_userA123456789a', owningWorkspaceId: workspaceA, shared: false }),
+			],
 			file_state: [],
-			group: [makeGroup({ id: groupA })],
-			group_user: [makeGroupUser({ userId: userA, groupId: groupA })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: workspaceA })],
+			workspace_user: [makeWorkspaceUser({ userId: userA, workspaceId: workspaceA })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const mB = createMutators(userB)
@@ -1319,19 +1363,19 @@ describe('cross-user isolation', () => {
 
 describe('createFile from source (duplicate) access control', () => {
 	const userId = 'user_aaaa11112222bbbb'
-	const otherGroup = 'group_other123456789'
+	const otherWorkspace = 'workspace_other123456789'
 	const sourceId = 'file_source123456789'
 	const newFileId = 'file_dup1234567890ab'
 
-	// migrated user whose target group is their home group (groupId === userId)
+	// migrated user whose target workspace is their home workspace (workspaceId === userId)
 	function baseStore(sourceFile: TlaFile) {
 		return {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [sourceFile],
 			file_state: [],
-			group: [makeGroup({ id: userId }), makeGroup({ id: otherGroup })],
-			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: userId }), makeWorkspace({ id: otherWorkspace })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: userId, role: 'owner' })],
+			workspace_file: [],
 		}
 	}
 
@@ -1346,7 +1390,7 @@ describe('createFile from source (duplicate) access control', () => {
 	}
 
 	it('can duplicate a file shared with you', async () => {
-		const s = baseStore(makeFile({ id: sourceId, owningGroupId: otherGroup, shared: true }))
+		const s = baseStore(makeFile({ id: sourceId, owningWorkspaceId: otherWorkspace, shared: true }))
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
 		await expectValid(() => duplicate(m, tx, `${FILE_PREFIX}/${sourceId}`))
@@ -1354,8 +1398,8 @@ describe('createFile from source (duplicate) access control', () => {
 	})
 
 	it('can duplicate your own file', async () => {
-		// source owned by the user's home group → accessible as a member
-		const s = baseStore(makeFile({ id: sourceId, owningGroupId: userId, shared: false }))
+		// source owned by the user's home workspace → accessible as a member
+		const s = baseStore(makeFile({ id: sourceId, owningWorkspaceId: userId, shared: false }))
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
 		await expectValid(() => duplicate(m, tx, `${FILE_PREFIX}/${sourceId}`))
@@ -1363,7 +1407,9 @@ describe('createFile from source (duplicate) access control', () => {
 
 	it('cannot duplicate a file you cannot access (e.g. access revoked, shared:false)', async () => {
 		// the core bug: source no longer shared and user is not owner/member
-		const s = baseStore(makeFile({ id: sourceId, owningGroupId: otherGroup, shared: false }))
+		const s = baseStore(
+			makeFile({ id: sourceId, owningWorkspaceId: otherWorkspace, shared: false })
+		)
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
 		await expectForbidden(() => duplicate(m, tx, `${FILE_PREFIX}/${sourceId}`))
@@ -1376,9 +1422,9 @@ describe('createFile from source (duplicate) access control', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [] as TlaFile[],
 			file_state: [],
-			group: [makeGroup({ id: userId })],
-			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: userId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: userId, role: 'owner' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1390,9 +1436,9 @@ describe('createFile from source (duplicate) access control', () => {
 			user: [makeUser({ id: userId, flags: '' })],
 			file: [makeFile({ id: sourceId, ownerId: 'user_someoneElse1234', shared: false })],
 			file_state: [],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1406,9 +1452,9 @@ describe('createFile from source (duplicate) access control', () => {
 			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [] as TlaFile[],
 			file_state: [],
-			group: [makeGroup({ id: userId })],
-			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
-			group_file: [],
+			workspace: [makeWorkspace({ id: userId })],
+			workspace_user: [makeWorkspaceUser({ userId, workspaceId: userId, role: 'owner' })],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1431,9 +1477,9 @@ describe('legacy file creation (insertWithFileState removed as a mutator)', () =
 			user: [makeUser({ id: userId, flags: '' })],
 			file: [] as TlaFile[],
 			file_state: [] as TlaFileState[],
-			group: [],
-			group_user: [],
-			group_file: [],
+			workspace: [],
+			workspace_user: [],
+			workspace_file: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -20,11 +20,11 @@ import {
 	TlaFileState,
 	TlaFileStatePartial,
 	TlaFlags,
-	TlaGroupFile,
-	TlaGroupUser,
 	TlaSchema,
 	TlaUser,
 	TlaUserPartial,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 } from './tlaSchema'
 import { ZErrorCode } from './types'
 
@@ -94,10 +94,10 @@ async function assertNotMaxFiles(tx: Transaction<TlaSchema>, userId: string) {
 		const files = await tx.run(zql.file)
 		const count = files.filter((f: TlaFile) => {
 			if (f.isDeleted) return false
-			// For migrated users, count files owned by their home group
+			// For migrated users, count files owned by their home workspace
 			// For unmigrated users, count files owned directly by userId
 			if (migrated) {
-				return f.owningGroupId === userId
+				return f.owningWorkspaceId === userId
 			} else {
 				return f.ownerId === userId
 			}
@@ -105,10 +105,10 @@ async function assertNotMaxFiles(tx: Transaction<TlaSchema>, userId: string) {
 		assert(count < MAX_NUMBER_OF_FILES, ZErrorCode.max_files_reached)
 	} else {
 		// On the server, don't fetch all files because we don't need them
-		// Check both ownerId and owningGroupId to handle both migration states
+		// Check both ownerId and owningWorkspaceId to handle both migration states
 		const rows = Array.from(
 			await tx.dbTransaction.query(
-				`select count(*) from "file" where "isDeleted" = false and ("ownerId" = $1 OR "owningGroupId" = $1)`,
+				`select count(*) from "file" where "isDeleted" = false and ("ownerId" = $1 OR "owningWorkspaceId" = $1)`,
 				[userId]
 			)
 		) as { count: string }[]
@@ -129,13 +129,13 @@ async function getRole(
 	// A user's personal/home workspace has an id equal to their userId; they own it.
 	if (workspaceId === userId) return 'owner'
 	const workspaceUser = await tx.run(
-		zql.group_user.where('userId', '=', userId).where('groupId', '=', workspaceId).one()
+		zql.workspace_user.where('userId', '=', userId).where('workspaceId', '=', workspaceId).one()
 	)
 	return workspaceUser?.role ?? null
 }
 
 /**
- * The home workspace (group id === its owner's user id) is private: it can't be
+ * The home workspace (workspace id === its owner's user id) is private: it can't be
  * invited to, renamed, left, deleted, or have its members managed. Throw if
  * `workspaceId` is a home workspace, i.e. a user exists with a matching id.
  */
@@ -174,12 +174,12 @@ async function assertUserCanAccessFileInternal(
 	if (file.ownerId) {
 		// Legacy model: user must own the file
 		assert(file.ownerId === userId, ZErrorCode.forbidden)
-	} else if (file.owningGroupId) {
+	} else if (file.owningWorkspaceId) {
 		// New model: user must be a member of the owning workspace
-		const role = await getRole(tx, userId, file.owningGroupId)
+		const role = await getRole(tx, userId, file.owningWorkspaceId)
 		assert(can(role, 'accessFiles'), ZErrorCode.forbidden)
 	} else {
-		// File has neither ownerId nor owningGroupId - invalid state
+		// File has neither ownerId nor owningWorkspaceId - invalid state
 		assert(false, ZErrorCode.bad_request)
 	}
 }
@@ -188,7 +188,7 @@ async function assertUserCanAccessFileInternal(
  * Check if a user can access (read) a file.
  * A user can access a file if:
  * - They own it (legacy model: file.ownerId matches userId)
- * - They are a member of the owning workspace (new model: user is in file.owningGroupId)
+ * - They are a member of the owning workspace (new model: user is in file.owningWorkspaceId)
  * - The file is shared (regardless of ownership model)
  */
 async function assertUserCanAccessFile(tx: Transaction<TlaSchema>, userId: string, file: TlaFile) {
@@ -199,7 +199,7 @@ async function assertUserCanAccessFile(tx: Transaction<TlaSchema>, userId: strin
  * Check if a user can update (write to) a file.
  * A user can update a file if:
  * - They own it (legacy model: file.ownerId matches userId)
- * - They are a member of the owning workspace (new model: user is in file.owningGroupId)
+ * - They are a member of the owning workspace (new model: user is in file.owningWorkspaceId)
  * Note: Sharing only grants read access, not write access
  */
 async function assertUserCanUpdateFile(tx: Transaction<TlaSchema>, userId: string, file: TlaFile) {
@@ -286,7 +286,7 @@ export function createMutators(userId: string) {
 			assert(user.id === userId, ZErrorCode.forbidden)
 			time = ensureSensibleTimestamp(time)
 			await tx.mutate.user.insert({ ...user, flags: 'groups_backend' })
-			await tx.mutate.group.insert({
+			await tx.mutate.workspace.insert({
 				id: userId,
 				name: user.name,
 				createdAt: time,
@@ -294,9 +294,9 @@ export function createMutators(userId: string) {
 				isDeleted: false,
 				inviteSecret: null,
 			})
-			await tx.mutate.group_user.insert({
+			await tx.mutate.workspace_user.insert({
 				userId,
-				groupId: userId,
+				workspaceId: userId,
 				createdAt: time,
 				updatedAt: time,
 				role: 'owner',
@@ -355,7 +355,7 @@ export function createMutators(userId: string) {
 					id: fileId,
 					name,
 					ownerId: userId,
-					owningGroupId: null,
+					owningWorkspaceId: null,
 					ownerName: '',
 					ownerAvatar: '',
 					thumbnail: '',
@@ -389,16 +389,16 @@ export function createMutators(userId: string) {
 			assertValidId(workspaceId)
 			assert(name.trim(), ZErrorCode.bad_request)
 			const hasWorkspaceAccess = await tx.run(
-				zql.group_user.where('userId', '=', userId).where('groupId', '=', workspaceId).one()
+				zql.workspace_user.where('userId', '=', userId).where('workspaceId', '=', workspaceId).one()
 			)
 			assert(hasWorkspaceAccess, ZErrorCode.forbidden)
 
-			// create file row, group_file row, file_state row
+			// create file row, workspace_file row, file_state row
 			await tx.mutate.file.insert({
 				id: fileId,
 				name,
 				ownerId: null,
-				owningGroupId: workspaceId,
+				owningWorkspaceId: workspaceId,
 				ownerName: '',
 				ownerAvatar: '',
 				thumbnail: '',
@@ -413,9 +413,9 @@ export function createMutators(userId: string) {
 				isDeleted: false,
 				createSource,
 			})
-			await tx.mutate.group_file.insert({
+			await tx.mutate.workspace_file.insert({
 				fileId,
-				groupId: workspaceId,
+				workspaceId: workspaceId,
 				createdAt: time,
 				updatedAt: time,
 				index: null,
@@ -444,20 +444,24 @@ export function createMutators(userId: string) {
 			const migrated = await isMigratedToWorkspaces(tx, userId)
 
 			if (migrated) {
-				// Migrated users: pinned files are group_file rows with a non-null index.
+				// Migrated users: pinned files are workspace_file rows with a non-null index.
 				// New pins go above the workspace's current top pinned file.
 				let indexToUse = index
 				if (indexToUse == null) {
-					const allWorkspaceFiles = await tx.run(zql.group_file.where('groupId', '=', workspaceId))
-					const otherPinnedFiles = allWorkspaceFiles.filter((gf: TlaGroupFile) => gf.index !== null)
+					const allWorkspaceFiles = await tx.run(
+						zql.workspace_file.where('workspaceId', '=', workspaceId)
+					)
+					const otherPinnedFiles = allWorkspaceFiles.filter(
+						(gf: TlaWorkspaceFile) => gf.index !== null
+					)
 
 					otherPinnedFiles.sort(sortByMaybeIndex)
 					indexToUse = getIndexBelow(otherPinnedFiles[0]?.index) ?? ('a1' as IndexKey)
 				}
 
-				await tx.mutate.group_file.update({
+				await tx.mutate.workspace_file.update({
 					fileId,
-					groupId: workspaceId,
+					workspaceId: workspaceId,
 					index: indexToUse,
 				})
 			} else {
@@ -476,9 +480,9 @@ export function createMutators(userId: string) {
 			const migrated = await isMigratedToWorkspaces(tx, userId)
 
 			if (migrated) {
-				await tx.mutate.group_file.update({
+				await tx.mutate.workspace_file.update({
 					fileId,
-					groupId: workspaceId,
+					workspaceId: workspaceId,
 					index: null,
 				})
 			} else {
@@ -509,8 +513,8 @@ export function createMutators(userId: string) {
 			assert(file, ZErrorCode.bad_request)
 
 			await tx.mutate.file_state.delete({ fileId, userId })
-			await tx.mutate.group_file.delete({ fileId, groupId: workspaceId })
-			if (file.owningGroupId === workspaceId) {
+			await tx.mutate.workspace_file.delete({ fileId, workspaceId: workspaceId })
+			if (file.owningWorkspaceId === workspaceId) {
 				await tx.mutate.file.update({ id: fileId, isDeleted: true })
 			}
 		},
@@ -529,17 +533,19 @@ export function createMutators(userId: string) {
 
 			const migrated = await isMigratedToWorkspaces(tx, userId)
 			if (migrated) {
-				const workspaceFileRows = await tx.run(zql.group_file.where('fileId', '=', fileId))
-				const userWorkspaceMemberships = await tx.run(zql.group_user.where('userId', '=', userId))
-				// Only add to home group if not already in any of the user's groups
+				const workspaceFileRows = await tx.run(zql.workspace_file.where('fileId', '=', fileId))
+				const userWorkspaceMemberships = await tx.run(
+					zql.workspace_user.where('userId', '=', userId)
+				)
+				// Only add to the home workspace if not already in any of the user's workspaces
 				if (
-					!userWorkspaceMemberships.some((g: TlaGroupUser) =>
-						workspaceFileRows.some((gf: TlaGroupFile) => gf.groupId === g.groupId)
+					!userWorkspaceMemberships.some((g: TlaWorkspaceUser) =>
+						workspaceFileRows.some((gf: TlaWorkspaceFile) => gf.workspaceId === g.workspaceId)
 					)
 				) {
-					await tx.mutate.group_file.insert({
+					await tx.mutate.workspace_file.insert({
 						fileId,
-						groupId: userId,
+						workspaceId: userId,
 						createdAt: time,
 						updatedAt: time,
 						index: null,
@@ -552,13 +558,13 @@ export function createMutators(userId: string) {
 			assertValidId(id)
 
 			// Enforce the workspace limit before creating anything.
-			const existingWorkspaces = await tx.run(zql.group_user.where('userId', '=', userId))
+			const existingWorkspaces = await tx.run(zql.workspace_user.where('userId', '=', userId))
 			assert(
 				existingWorkspaces.length < MAX_NUMBER_OF_WORKSPACES,
 				ZErrorCode.max_workspaces_reached
 			)
 
-			await tx.mutate.group.insert({
+			await tx.mutate.workspace.insert({
 				id,
 				name,
 				inviteSecret: tx.location === 'server' ? uniqueId() : null,
@@ -580,9 +586,9 @@ export function createMutators(userId: string) {
 				index = getIndexBelow(lowest)
 			}
 
-			await tx.mutate.group_user.insert({
+			await tx.mutate.workspace_user.insert({
 				userId,
-				groupId: id,
+				workspaceId: id,
 				// these are set by the trigger
 				userName: '',
 				userColor: '#000000',
@@ -600,7 +606,7 @@ export function createMutators(userId: string) {
 			const role = await getRole(tx, userId, id)
 			assert(can(role, 'editWorkspace'), ZErrorCode.forbidden)
 
-			await tx.mutate.group.update({ id, name: name.trim() })
+			await tx.mutate.workspace.update({ id, name: name.trim() })
 		},
 		regenerateWorkspaceInviteSecret: async (tx: Tx, { id }: { id: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
@@ -611,7 +617,7 @@ export function createMutators(userId: string) {
 			assert(can(role, 'manageInvites'), ZErrorCode.forbidden)
 
 			if (tx.location === 'server') {
-				await tx.mutate.group.update({ id, inviteSecret: uniqueId() })
+				await tx.mutate.workspace.update({ id, inviteSecret: uniqueId() })
 			}
 		},
 		setWorkspaceMemberRole: async (
@@ -633,24 +639,27 @@ export function createMutators(userId: string) {
 
 			// Target must be a member
 			const targetMembership = await tx.run(
-				zql.group_user.where('userId', '=', targetUserId).where('groupId', '=', workspaceId).one()
+				zql.workspace_user
+					.where('userId', '=', targetUserId)
+					.where('workspaceId', '=', workspaceId)
+					.one()
 			)
 			assert(targetMembership, ZErrorCode.bad_request)
 
 			if (targetMembership.role === targetRole) return
 
-			// Invariant (not a capability): a group must always keep at least one
+			// Invariant (not a capability): a workspace must always keep at least one
 			// owner, so the last owner can't be demoted away from owner.
 			if (targetMembership.role === 'owner' && targetRole !== 'owner') {
 				const owners = await tx.run(
-					zql.group_user.where('groupId', '=', workspaceId).where('role', '=', 'owner')
+					zql.workspace_user.where('workspaceId', '=', workspaceId).where('role', '=', 'owner')
 				)
 				assert(owners.length > 1, ZErrorCode.forbidden)
 			}
 
-			await tx.mutate.group_user.update({
+			await tx.mutate.workspace_user.update({
 				userId: targetUserId,
-				groupId: workspaceId,
+				workspaceId: workspaceId,
 				role: targetRole,
 			})
 		},
@@ -659,13 +668,13 @@ export function createMutators(userId: string) {
 			assert(workspaceId, ZErrorCode.bad_request)
 			await assertNotHomeWorkspace(tx, workspaceId)
 			const owners = await tx.run(
-				zql.group_user.where('groupId', '=', workspaceId).where('role', '=', 'owner')
+				zql.workspace_user.where('workspaceId', '=', workspaceId).where('role', '=', 'owner')
 			)
 			const isOnlyOwner = owners.length === 1 && owners[0].userId === userId
-			// Invariant (not a capability): a group must always keep at least one
-			// owner, so the last owner can't leave — they must delete the group instead.
+			// Invariant (not a capability): a workspace must always keep at least one
+			// owner, so the last owner can't leave — they must delete the workspace instead.
 			assert(!isOnlyOwner, ZErrorCode.forbidden)
-			await tx.mutate.group_user.delete({ userId, groupId: workspaceId })
+			await tx.mutate.workspace_user.delete({ userId, workspaceId: workspaceId })
 		},
 		deleteWorkspace: async (tx: Tx, { id }: { id: string }) => {
 			await assertUserHasFlag(tx, userId, 'groups_backend')
@@ -675,23 +684,23 @@ export function createMutators(userId: string) {
 			assert(can(role, 'deleteWorkspace'), ZErrorCode.forbidden)
 
 			// Delete all workspace files
-			const workspaceFileRows = await tx.run(zql.group_file.where('groupId', '=', id))
+			const workspaceFileRows = await tx.run(zql.workspace_file.where('workspaceId', '=', id))
 			for (const workspaceFile of workspaceFileRows) {
-				await tx.mutate.group_file.delete({ fileId: workspaceFile.fileId, groupId: id })
+				await tx.mutate.workspace_file.delete({ fileId: workspaceFile.fileId, workspaceId: id })
 			}
 
 			// Mark all files owned by this workspace as deleted
-			const files = await tx.run(zql.file.where('owningGroupId', '=', id))
+			const files = await tx.run(zql.file.where('owningWorkspaceId', '=', id))
 			for (const file of files) {
 				await tx.mutate.file.update({ id: file.id, isDeleted: true })
 			}
 
-			await tx.mutate.group.update({ id: id, isDeleted: true })
-			// TODO: test that this works on the client and that the groups and group_users are removed
+			await tx.mutate.workspace.update({ id: id, isDeleted: true })
+			// TODO: test that this works on the client and that the workspaces and workspace_users are removed
 			// from the user's durable object state.
 			// ALSO TODO: add special case for isDeleted becoming false in user data syncer to trigger a hard reboot
 			if (tx.location !== 'server') {
-				await tx.mutate.group_user.delete({ userId, groupId: id })
+				await tx.mutate.workspace_user.delete({ userId, workspaceId: id })
 			}
 		},
 		moveFileToWorkspace: async (
@@ -706,31 +715,31 @@ export function createMutators(userId: string) {
 			assert(file, ZErrorCode.bad_request)
 
 			// No-op if file is already in the target workspace
-			if (file.owningGroupId === workspaceId) {
+			if (file.owningWorkspaceId === workspaceId) {
 				return
 			}
 
 			// User must be allowed to take the file out of its current workspace and
 			// to add files to the destination workspace.
-			const fromRole = await getRole(tx, userId, file.owningGroupId)
+			const fromRole = await getRole(tx, userId, file.owningWorkspaceId)
 			assert(can(fromRole, 'removeFiles'), ZErrorCode.forbidden)
 			const toRole = await getRole(tx, userId, workspaceId)
 			assert(can(toRole, 'addFiles'), ZErrorCode.forbidden)
 
-			// Remove file from current group association if it exists
-			if (file.owningGroupId) {
-				await tx.mutate.group_file.delete({ fileId, groupId: file.owningGroupId })
+			// Remove file from current workspace association if it exists
+			if (file.owningWorkspaceId) {
+				await tx.mutate.workspace_file.delete({ fileId, workspaceId: file.owningWorkspaceId })
 			}
 
-			// Transfer file ownership from user to group
+			// Transfer file ownership from user to workspace
 			await tx.mutate.file.update({
 				id: fileId,
-				owningGroupId: workspaceId,
+				owningWorkspaceId: workspaceId,
 				updatedAt: Date.now(),
 			})
-			await tx.mutate.group_file.insert({
+			await tx.mutate.workspace_file.insert({
 				fileId,
-				groupId: workspaceId,
+				workspaceId: workspaceId,
 				createdAt: Date.now(),
 				updatedAt: Date.now(),
 				index: null,
@@ -757,23 +766,23 @@ export function createMutators(userId: string) {
 				const finalRole = await getRole(tx, userId, finalWorkspaceId)
 				assert(can(finalRole, 'addFiles'), ZErrorCode.forbidden)
 			}
-			const isFileLink = file.owningGroupId !== workspaceId
+			const isFileLink = file.owningWorkspaceId !== workspaceId
 
 			// Execute move operation first (if any)
 			if (finalWorkspaceId !== workspaceId) {
-				// Move to specific group
+				// Move to specific workspace
 				if (isFileLink) {
-					await tx.mutate.group_file.delete({ fileId, groupId: workspaceId })
+					await tx.mutate.workspace_file.delete({ fileId, workspaceId: workspaceId })
 					const existing = await tx.run(
-						zql.group_file
+						zql.workspace_file
 							.where('fileId', '=', fileId)
-							.where('groupId', '=', finalWorkspaceId)
+							.where('workspaceId', '=', finalWorkspaceId)
 							.one()
 					)
 					if (!existing) {
-						await tx.mutate.group_file.insert({
+						await tx.mutate.workspace_file.insert({
 							fileId,
-							groupId: finalWorkspaceId,
+							workspaceId: finalWorkspaceId,
 							createdAt: Date.now(),
 							updatedAt: Date.now(),
 						})
@@ -789,7 +798,7 @@ export function createMutators(userId: string) {
 				if (insertBeforeId === null) {
 					// insert at end
 					const lastPinnedFile = (
-						await tx.run(zql.group_file.where('groupId', '=', finalWorkspaceId))
+						await tx.run(zql.workspace_file.where('workspaceId', '=', finalWorkspaceId))
 					)
 						.filter((f) => f.index !== null)
 						.sort(sortByMaybeIndex)
@@ -799,7 +808,9 @@ export function createMutators(userId: string) {
 					}
 				} else {
 					// insert before specific file
-					const files = (await tx.run(zql.group_file.where('groupId', '=', finalWorkspaceId)))
+					const files = (
+						await tx.run(zql.workspace_file.where('workspaceId', '=', finalWorkspaceId))
+					)
 						.filter((f) => f.index !== null)
 						.sort(sortByMaybeIndex)
 					const targetIdx = files.findIndex((f) => f.fileId === insertBeforeId)
@@ -808,15 +819,15 @@ export function createMutators(userId: string) {
 
 					nextIndex = getIndexBetween(beforeIndex, afterIndex)
 				}
-				await tx.mutate.group_file.update({
+				await tx.mutate.workspace_file.update({
 					fileId,
-					groupId: finalWorkspaceId,
+					workspaceId: finalWorkspaceId,
 					index: nextIndex,
 				})
 			} else if (!operation.reorder) {
-				await tx.mutate.group_file.update({
+				await tx.mutate.workspace_file.update({
 					fileId,
-					groupId: finalWorkspaceId,
+					workspaceId: finalWorkspaceId,
 					index: null,
 					updatedAt: Date.now(),
 				})

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -28,13 +28,13 @@ export const queries = defineQueries({
 		zql.file_state.where('userId', '=', ctx.userId).related('file', (file) => file.one())
 	),
 
-	/** User's workspace memberships with related group, files, and members */
+	/** User's workspace memberships with related workspace, files, and members */
 	workspaceMemberships: defineQuery(({ ctx }) =>
-		zql.group_user
+		zql.workspace_user
 			.where('userId', '=', ctx.userId)
-			.related('group', (group) => group.one())
-			.related('groupFiles', (gf) => gf.related('file', (file) => file.one()))
-			.related('groupMembers')
+			.related('workspace', (workspace) => workspace.one())
+			.related('workspaceFiles', (wf) => wf.related('file', (file) => file.one()))
+			.related('workspaceMembers')
 	),
 })
 

--- a/packages/dotcom-shared/src/roles.ts
+++ b/packages/dotcom-shared/src/roles.ts
@@ -7,7 +7,7 @@ import { Capability } from './capabilities'
  * meaning of a role lives in exactly one place: the `roles` table below. Read a
  * role's list to see what it can do; edit the list, or add a role, to change it.
  *
- * The role is stored in the DB as a plain string (`group_user.role`);
+ * The role is stored in the DB as a plain string (`workspace_user.role`);
  * capabilities are never persisted — they're derived from that string here.
  */
 
@@ -30,7 +30,7 @@ const roles = {
 	],
 } satisfies Record<string, readonly Capability[]>
 
-/** A role a member can have in a workspace — the string stored in `group_user.role`. */
+/** A role a member can have in a workspace — the string stored in `workspace_user.role`. */
 export type Role = keyof typeof roles
 
 /**

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -64,7 +64,7 @@ export const file = table('file')
 		id: string(),
 		name: string(),
 		ownerId: string().optional(),
-		owningGroupId: string().optional(),
+		owningWorkspaceId: string().optional(),
 		ownerName: string(),
 		ownerAvatar: string(),
 		thumbnail: string(),
@@ -81,7 +81,7 @@ export const file = table('file')
 	})
 	.primaryKey('id')
 
-export const group = table('group')
+export const workspace = table('workspace')
 	.columns({
 		id: string(),
 		name: string(),
@@ -92,10 +92,10 @@ export const group = table('group')
 	})
 	.primaryKey('id')
 
-export const group_user = table('group_user')
+export const workspace_user = table('workspace_user')
 	.columns({
 		userId: string(),
-		groupId: string(),
+		workspaceId: string(),
 		createdAt: number(),
 		updatedAt: number(),
 		role: enumeration<Role>(),
@@ -103,17 +103,17 @@ export const group_user = table('group_user')
 		userColor: string(),
 		index: string<IndexKey>(),
 	})
-	.primaryKey('userId', 'groupId')
+	.primaryKey('userId', 'workspaceId')
 
-export const group_file = table('group_file')
+export const workspace_file = table('workspace_file')
 	.columns({
 		fileId: string(),
-		groupId: string(),
+		workspaceId: string(),
 		createdAt: number(),
 		updatedAt: number(),
 		index: string<IndexKey>().optional(),
 	})
-	.primaryKey('fileId', 'groupId')
+	.primaryKey('fileId', 'workspaceId')
 
 const fileRelationships = relationships(file, ({ one, many }) => ({
 	owner: one({
@@ -126,10 +126,10 @@ const fileRelationships = relationships(file, ({ one, many }) => ({
 		destField: ['fileId'],
 		destSchema: file_state,
 	}),
-	groupFiles: many({
+	workspaceFiles: many({
 		sourceField: ['id'],
 		destField: ['fileId'],
-		destSchema: group_file,
+		destSchema: workspace_file,
 	}),
 }))
 
@@ -146,57 +146,57 @@ const fileStateRelationships = relationships(file_state, ({ one }) => ({
 	}),
 }))
 
-const groupRelationships = relationships(group, ({ many }) => ({
-	groupMembers: many({
+const workspaceRelationships = relationships(workspace, ({ many }) => ({
+	workspaceMembers: many({
 		sourceField: ['id'],
-		destField: ['groupId'],
-		destSchema: group_user,
+		destField: ['workspaceId'],
+		destSchema: workspace_user,
 	}),
-	groupFiles: many({
+	workspaceFiles: many({
 		sourceField: ['id'],
-		destField: ['groupId'],
-		destSchema: group_file,
+		destField: ['workspaceId'],
+		destSchema: workspace_file,
 	}),
 }))
 
-const groupUserRelationships = relationships(group_user, ({ one, many }) => ({
+const workspaceUserRelationships = relationships(workspace_user, ({ one, many }) => ({
 	user: one({
 		sourceField: ['userId'],
 		destField: ['id'],
 		destSchema: user,
 	}),
-	group: one({
-		sourceField: ['groupId'],
+	workspace: one({
+		sourceField: ['workspaceId'],
 		destField: ['id'],
-		destSchema: group,
+		destSchema: workspace,
 	}),
-	groupFiles: many({
-		sourceField: ['groupId'],
-		destField: ['groupId'],
-		destSchema: group_file,
+	workspaceFiles: many({
+		sourceField: ['workspaceId'],
+		destField: ['workspaceId'],
+		destSchema: workspace_file,
 	}),
-	groupMembers: many({
-		sourceField: ['groupId'],
-		destField: ['groupId'],
-		destSchema: group_user,
+	workspaceMembers: many({
+		sourceField: ['workspaceId'],
+		destField: ['workspaceId'],
+		destSchema: workspace_user,
 	}),
 }))
 
-const groupFileRelationships = relationships(group_file, ({ one, many }) => ({
+const workspaceFileRelationships = relationships(workspace_file, ({ one, many }) => ({
 	file: one({
 		sourceField: ['fileId'],
 		destField: ['id'],
 		destSchema: file,
 	}),
-	group: one({
-		sourceField: ['groupId'],
+	workspace: one({
+		sourceField: ['workspaceId'],
 		destField: ['id'],
-		destSchema: group,
+		destSchema: workspace,
 	}),
-	groupMembers: many({
-		sourceField: ['groupId'],
-		destField: ['groupId'],
-		destSchema: group_user,
+	workspaceMembers: many({
+		sourceField: ['workspaceId'],
+		destField: ['workspaceId'],
+		destSchema: workspace_user,
 	}),
 }))
 
@@ -212,28 +212,34 @@ export type TlaUserPartial = Partial<TlaUser> & {
 	id: TlaUser['id']
 }
 
-export type TlaGroupPartial = Partial<TlaGroup> & {
-	id: TlaGroup['id']
+export type TlaWorkspacePartial = Partial<TlaWorkspace> & {
+	id: TlaWorkspace['id']
 }
 
-export type TlaGroupUserPartial = Partial<TlaGroupUser> & {
-	userId: TlaGroupUser['userId']
-	groupId: TlaGroupUser['groupId']
+export type TlaWorkspaceUserPartial = Partial<TlaWorkspaceUser> & {
+	userId: TlaWorkspaceUser['userId']
+	workspaceId: TlaWorkspaceUser['workspaceId']
 }
 
-export type TlaGroupFilePartial = Partial<TlaGroupFile> & {
-	fileId: TlaGroupFile['fileId']
-	groupId: TlaGroupFile['groupId']
+export type TlaWorkspaceFilePartial = Partial<TlaWorkspaceFile> & {
+	fileId: TlaWorkspaceFile['fileId']
+	workspaceId: TlaWorkspaceFile['workspaceId']
 }
 
-export type TlaRow = TlaFile | TlaFileState | TlaUser | TlaGroup | TlaGroupUser | TlaGroupFile
+export type TlaRow =
+	| TlaFile
+	| TlaFileState
+	| TlaUser
+	| TlaWorkspace
+	| TlaWorkspaceUser
+	| TlaWorkspaceFile
 export type TlaRowPartial =
 	| TlaFilePartial
 	| TlaFileStatePartial
 	| TlaUserPartial
-	| TlaGroupPartial
-	| TlaGroupUserPartial
-	| TlaGroupFilePartial
+	| TlaWorkspacePartial
+	| TlaWorkspaceUserPartial
+	| TlaWorkspaceFilePartial
 export interface TlaUserMutationNumber {
 	userId: string
 	mutationNumber: number
@@ -244,7 +250,7 @@ export const immutableColumns = {
 	file: new Set<keyof TlaFile>([
 		'ownerName',
 		'ownerAvatar',
-		'owningGroupId',
+		'owningWorkspaceId',
 		'publishedSlug',
 		'ownerId',
 		'thumbnail',
@@ -270,21 +276,21 @@ export interface DB {
 	file: TlaFile
 	file_state: TlaFileState
 	user: TlaUser
-	group: TlaGroup
-	group_user: TlaGroupUser
-	group_file: TlaGroupFile
+	workspace: TlaWorkspace
+	workspace_user: TlaWorkspaceUser
+	workspace_file: TlaWorkspaceFile
 	user_mutation_number: TlaUserMutationNumber
 	asset: TlaAsset
 }
 
 export const schema = createSchema({
-	tables: [user, file, file_state, group, group_user, group_file],
+	tables: [user, file, file_state, workspace, workspace_user, workspace_file],
 	relationships: [
 		fileRelationships,
 		fileStateRelationships,
-		groupRelationships,
-		groupUserRelationships,
-		groupFileRelationships,
+		workspaceRelationships,
+		workspaceUserRelationships,
+		workspaceFileRelationships,
 	],
 })
 
@@ -292,11 +298,14 @@ export type TlaSchema = typeof schema
 export type TlaUser = Row<typeof schema.tables.user>
 export type TlaFile = Row<typeof schema.tables.file>
 export type TlaFileState = Row<typeof schema.tables.file_state>
-export type TlaGroup = Row<typeof schema.tables.group>
-export type TlaGroupUser = Row<typeof schema.tables.group_user>
-export type TlaGroupFile = Row<typeof schema.tables.group_file>
+export type TlaWorkspace = Row<typeof schema.tables.workspace>
+export type TlaWorkspaceUser = Row<typeof schema.tables.workspace_user>
+export type TlaWorkspaceFile = Row<typeof schema.tables.workspace_file>
 
 // Permissions are now handled via Synced Queries in queries.ts
 
+// These flag values are persisted in user.flags rows from the original groups
+// rollout, so they keep the old "groups" naming even though the data model is
+// now named "workspace".
 export const TlaFlags = stringEnum('groups_backend', 'groups_frontend')
 export type TlaFlags = keyof typeof TlaFlags

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -3,12 +3,12 @@ import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaFile,
 	TlaFileState,
-	TlaGroup,
-	TlaGroupFile,
-	TlaGroupUser,
 	TlaRow,
 	TlaRowPartial,
 	TlaUser,
+	TlaWorkspace,
+	TlaWorkspaceFile,
+	TlaWorkspaceUser,
 } from './tlaSchema'
 
 export interface Snapshot {
@@ -119,9 +119,9 @@ export interface ZStoreData {
 	file: TlaFile[]
 	file_state: TlaFileState[]
 	user: TlaUser[]
-	group: TlaGroup[]
-	group_user: TlaGroupUser[]
-	group_file: TlaGroupFile[]
+	workspace: TlaWorkspace[]
+	workspace_user: TlaWorkspaceUser[]
+	workspace_file: TlaWorkspaceFile[]
 	lsn: string
 }
 
@@ -139,7 +139,13 @@ export interface ZRowDeleteOrUpdate {
 	event: 'update' | 'delete'
 }
 
-export type ZTable = 'file' | 'file_state' | 'user' | 'group' | 'group_user' | 'group_file'
+export type ZTable =
+	| 'file'
+	| 'file_state'
+	| 'user'
+	| 'workspace'
+	| 'workspace_user'
+	| 'workspace_file'
 
 export type ZEvent = 'insert' | 'update' | 'delete'
 
@@ -159,8 +165,8 @@ export type ZErrorCode = keyof typeof ZErrorCode
 
 // increment this to force clients to reload
 // e.g. if we make backwards-incompatible changes to the schema
-export const Z_PROTOCOL_VERSION = 3
-export const MIN_Z_PROTOCOL_VERSION = 3
+export const Z_PROTOCOL_VERSION = 4
+export const MIN_Z_PROTOCOL_VERSION = 4
 
 export type ZServerSentPacket =
 	| {


### PR DESCRIPTION
In order to finish the group → workspace rename started in the UI layer (#9107), this PR renames the dotcom backend data model: the Postgres tables `group`/`group_user`/`group_file` become `workspace`/`workspace_user`/`workspace_file`, the `groupId` and `file.owningGroupId` columns become `workspaceId` and `owningWorkspaceId`, and everything named after them follows — zero schema tables/relationships, `TlaGroup*` types, replicator topics, SQL functions, triggers, indexes, and constraints.

### Migrations

**Postgres (`035_rename_groups_to_workspaces.sql`)** renames the tables, columns, indexes, constraints, and triggers, and re-creates every plpgsql function whose body references a renamed table (function bodies are stored as text, so renames don't propagate into them). Table renames keep their OIDs, so the `zero_data` publication membership, FKs, and trigger bindings follow automatically. `migrate_user_to_groups` is renamed to `migrate_user_to_workspaces` with a thin compatibility wrapper kept under the old name, because the previous sync-worker deployment keeps calling it during the few minutes between the migration running and the new worker shipping (the deploy script runs migrations → zero → sync-worker → client, in that order).

**Replicator (sqlite migration `008_rename_group_topics_to_workspace`)** wipes `history` and `active_user` and nulls the stored lsn. History rows store serialized changes under the old table/column names and `group:` topic prefixes, which new code can't replay — so instead every user DO is forced to re-register and refetch from postgres through the existing sequence-break machinery. This also repairs any updates silently dropped during the deploy window, when the old worker's wal2json table filter no longer matches the renamed tables. Existing `topic_subscription` rows are rewritten from `group:` to `workspace:` so edges for users who don't reconnect promptly don't linger with a dead prefix.

**Stale sessions** are handled by bumping `Z_PROTOCOL_VERSION`/`MIN_Z_PROTOCOL_VERSION` to 4 (old clients get `CLIENT_TOO_OLD` and the refresh prompt) and bumping the user DO snapshot `stateVersion` to 5 (v4 R2 snapshots are discarded rather than migrated, since the forced refetch rebuilds them from postgres anyway).

### Intentionally not renamed

- The `user.flags` values `groups_backend`/`groups_frontend` — persisted per-user rollout markers, written from several code paths. Rewriting them races against the not-yet-deployed worker and buys nothing structurally.
- The admin enroll/unenroll routes and DO methods (`admin_enrollInGroups` etc.) that manage those flags.
- Historical migration files (023, 031, 033, 034) — applied history stays untouched.

### Verification

The full migration chain (000 → 035) was run against a scratch Postgres, then smoke-tested: `migrate_user_to_workspaces` and the `migrate_user_to_groups` wrapper migrate a legacy user correctly; the home-workspace name triggers, the unshare guest-cleanup trigger, and the workspace soft-delete cascade all fire correctly against the renamed tables. The opt-in `delete_file_states` suite (which now extracts the function definition from 035) passes against real Postgres.

### Change type

- [x] `other`

### Test plan

1. Existing coverage: dotcom-shared (77), sync-worker (123), dotcom client (133), zero-cache (14, incl. the real-Postgres trigger suite) all pass; `yarn typecheck` is clean.
2. `fetchEverythingSql.snap.ts` regenerated via `UPDATE_SNAPSHOTS=1`.

- [x] Unit tests

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +183 / -157 |
| Tests           | +469 / -404 |
| Automated files | +33 / -33   |
| Apps            | +668 / -229 |
| Config/tooling  | +3 / -3     |
