### PR TITLE
fix(editor): forgets previous touch interactions when entering pen mode

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11191,7 +11191,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 						inputs.setIsDragging(false)
 
 						// If pen mode is off but we're not already in pen mode, turn that on
-						if (!isPenMode && isPen) this.updateInstanceState({ isPenMode: true })
+						if (!isPenMode && isPen) {
+							this.updateInstanceState({ isPenMode: true })
+							// Once pen mode is on, touch input is ignored, so we discard the
+							// in-progress touch interaction .
+							this.interrupt()
+						}
 
 						// On devices with erasers (like the Surface Pen or Wacom Pen), button 5 is the eraser
 						if (info.button === STYLUS_ERASER_BUTTON) {

--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -1,4 +1,4 @@
-import { Vec } from '@tldraw/editor'
+import { TLDrawShape, Vec } from '@tldraw/editor'
 import { TestEditor } from '../TestEditor'
 
 let editor: TestEditor
@@ -26,4 +26,57 @@ it('ignores touch events while in pen mode', async () => {
 	})
 
 	expect(editor.getCurrentPageShapes().length).toBe(0)
+})
+
+describe('forgiving palm touches when entering pen mode', () => {
+	it('does not connect a palm touch to the stylus stroke', () => {
+		editor.setCurrentTool('draw')
+		expect(editor.getInstanceState().isPenMode).toBe(false)
+
+		// A palm rests on the canvas first (not a pen, pen mode is still off)
+		editor.pointerDown(100, 100, { isPen: false })
+		editor.expectToBeIn('draw.drawing')
+
+		// Then the stylus lands, which switches the editor into pen mode
+		editor.pointerDown(300, 300, { isPen: true })
+		expect(editor.getInstanceState().isPenMode).toBe(true)
+
+		// The stylus draws its stroke
+		editor.pointerMove(310, 310, { isPen: true })
+		editor.pointerMove(320, 320, { isPen: true })
+		editor.pointerUp(320, 320, { isPen: true })
+
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		const shape = editor.getCurrentPageShapes()[0] as TLDrawShape
+
+		// The stroke should begin where the stylus landed, not at the palm point.
+		const bounds = editor.getShapePageBounds(shape.id)!
+		expect(bounds.minX).toBeGreaterThan(200)
+		expect(bounds.minY).toBeGreaterThan(200)
+	})
+
+	it('forgives a palm touch that was already dragging before the stylus lands', () => {
+		editor.setCurrentTool('draw')
+
+		// A palm rests on the canvas and drags a little before the stylus arrives
+		editor.pointerDown(100, 100, { isPen: false })
+		editor.pointerMove(120, 120, { isPen: false })
+		editor.pointerMove(140, 140, { isPen: false })
+		editor.expectToBeIn('draw.drawing')
+
+		// The stylus lands, switching into pen mode and forgiving the palm stroke
+		editor.pointerDown(300, 300, { isPen: true })
+		expect(editor.getInstanceState().isPenMode).toBe(true)
+
+		editor.pointerMove(310, 310, { isPen: true })
+		editor.pointerMove(320, 320, { isPen: true })
+		editor.pointerUp(320, 320, { isPen: true })
+
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+		const shape = editor.getCurrentPageShapes()[0] as TLDrawShape
+
+		const bounds = editor.getShapePageBounds(shape.id)!
+		expect(bounds.minX).toBeGreaterThan(200)
+		expect(bounds.minY).toBeGreaterThan(200)
+	})
 })


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/9145

"On a tablet, before the editor has switched into pen mode, touching the canvas with your hand and then the stylus produces an unwanted line: as the editor detects the stylus and switches into pen mode, the draw stroke begins at the point where the hand was touching and connects to the stylus position, so the palm contact becomes the first point of the same stroke the stylus goes on to draw. The expected behavior is that the hand touch is treated as a palm and ignored, so the stroke begins only where the stylus is. Reported on tldraw.com on iPad, and SDK users have reported the same on both iPad and Android, so the fix belongs in the SDK rather than the app."

We simply cancel previous touches when entering pen mode.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Put a finger on touch screen
2. Bring the pen on the canvas
3. Start drawing

The drawing should start where the pen first hit the canvas, not from the previous finger touch.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug when user enter pen mode while a finger/hand is on the touch screen device. We cancel previous touches and the line starts where the pen first touched the screen.