### PR TITLE
docs: add customer list to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ tldraw provides a feature-complete infinite canvas engine designed to be the fou
 
 ## Who's using tldraw
 
-The tldraw SDK powers canvas experiences in products from Google, Shopify, BlackRock, Autodesk, ClickUp, Replit, Google Stitch, Luma, Runway, Padlet, Mobbin, Jam, Craft, Honeycomb, SchoolAI, Brisk, CADChat, bigpi, Genio, Pollination, Legendkeeper, Matilda workspace, Aries, AlAI, Dirac, and many more.
+The tldraw SDK powers canvas experiences in products from [Google](https://about.google), [Shopify](https://www.shopify.com), [BlackRock](https://www.blackrock.com), [Autodesk](https://blogs.autodesk.com/forma/2024/06/20/forma-board-collaborative-tool-for-architects/), [ClickUp](https://tldraw.dev/blog/clickup), [Replit](https://docs.replit.com/replitai/canvas), [Google Stitch](https://stitch.withgoogle.com), [Luma](https://lumalabs.ai/app), [Runway](https://runwayml.com), [Padlet](https://tldraw.dev/blog/padlet), [Mobbin](https://tldraw.dev/blog/mobbin), [Jam](https://tldraw.dev/blog/jam), [Craft](https://support.craft.do/en/write-and-edit/whiteboards), [Honeycomb](https://www.honeycomb.io/platform/canvas), [SchoolAI](https://schoolai.com/products/powerups), [Brisk](https://www.briskteaching.com/post/boost-whiteboard), [CADChat](https://cadchat.com), [bigpi](https://www.bigpi.ai), [Genio](https://genio.co), [Pollination](https://www.pollination.solutions), [Legendkeeper](https://www.legendkeeper.com), [Matilda](https://www.matilda.io), [Aries](https://aries.com/infinite), [Alai](https://getalai.com), [Dirac](https://www.diracinc.com), and many more.
 
 See our [showcase](https://tldraw.dev/showcase) for case studies on how teams build with tldraw.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ tldraw provides a feature-complete infinite canvas engine designed to be the fou
 - **DOM canvas** — web rendering supports anything the browser supports, including embedded websites from YouTube, Figma, GitHub, [and more](https://tldraw.dev/sdk-features/embed-shape)
 - **Broad support** — works in any browser across desktop, touch screens, tablets, and mobile devices
 
+## Who's using tldraw
+
+The tldraw SDK powers canvas experiences in products from Google, Shopify, BlackRock, Autodesk, ClickUp, Replit, Google Stitch, Luma, Runway, Padlet, Mobbin, Jam, Craft, Honeycomb, SchoolAI, Brisk, CADChat, bigpi, Genio, Pollination, Legendkeeper, Matilda workspace, Aries, AlAI, Dirac, and many more.
+
+See our [showcase](https://tldraw.dev/showcase) for case studies on how teams build with tldraw.
+
 ## Quick start
 
 Install the tldraw package:

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -32,6 +32,10 @@ export default function () {
 
 Visit [tldraw.dev](https://tldraw.dev) to learn more.
 
+## Who's using tldraw
+
+The tldraw SDK powers canvas experiences in products from Google, Shopify, BlackRock, Autodesk, ClickUp, Replit, Google Stitch, Luma, Runway, Padlet, Mobbin, Jam, Craft, Honeycomb, SchoolAI, Brisk, CADChat, bigpi, Genio, Pollination, Legendkeeper, Matilda workspace, Aries, AlAI, Dirac, and many more. See our [showcase](https://tldraw.dev/showcase) for case studies.
+
 ## Documentation
 
 The published package includes a generated `DOCS.md` file with the docs-site content and a generated `RELEASE_NOTES.md` file with versioned release notes.

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -34,11 +34,7 @@ Visit [tldraw.dev](https://tldraw.dev) to learn more.
 
 ## Who's using tldraw
 
-The tldraw SDK powers canvas experiences in products from Google, Shopify, BlackRock, Autodesk, ClickUp, Replit, Google Stitch, Luma, Runway, Padlet, Mobbin, Jam, Craft, Honeycomb, SchoolAI, Brisk, CADChat, bigpi, Genio, Pollination, Legendkeeper, Matilda workspace, Aries, AlAI, Dirac, and many more. See our [showcase](https://tldraw.dev/showcase) for case studies.
-
-## Documentation
-
-The published package includes a generated `DOCS.md` file with the docs-site content and a generated `RELEASE_NOTES.md` file with versioned release notes.
+The tldraw SDK powers canvas experiences in products from [Google](https://about.google), [Shopify](https://www.shopify.com), [BlackRock](https://www.blackrock.com), [Autodesk](https://blogs.autodesk.com/forma/2024/06/20/forma-board-collaborative-tool-for-architects/), [ClickUp](https://tldraw.dev/blog/clickup), [Replit](https://docs.replit.com/replitai/canvas), [Google Stitch](https://stitch.withgoogle.com), [Luma](https://lumalabs.ai/dream-machine), [Runway](https://runwayml.com), [Padlet](https://tldraw.dev/blog/padlet), [Mobbin](https://tldraw.dev/blog/mobbin), [Jam](https://tldraw.dev/blog/jam), [Craft](https://support.craft.do/en/write-and-edit/whiteboards), [Honeycomb](https://www.honeycomb.io/platform/canvas), [SchoolAI](https://schoolai.com/products/powerups), [Brisk](https://www.briskteaching.com/post/boost-whiteboard), and many more. See our [showcase](https://tldraw.dev/showcase) for case studies.
 
 ## Package development
 


### PR DESCRIPTION
In order to show social proof for the SDK, this PR adds a "Who's using tldraw" section to the root README and the `tldraw` package README. The section lists the customers from the tldraw.dev logo marquee (all covered by marketing agreements), with each name linking to the most tldraw-specific page available: our case studies for ClickUp, Padlet, Mobbin, and Jam; feature announcements or product pages for the tldraw-powered surface where one exists (Autodesk Forma Board, Replit Design Canvas, Google Stitch, Luma, Honeycomb Canvas, SchoolAI Doodleboard, Brisk Boost Whiteboard, Craft whiteboards); and company homepages for the rest. The root README carries the full list of 25; the package README a shorter list of highlights.

### Change type

- [x] `other`

### Test plan

1. View the rendered READMEs on the branch and check the new section reads well.
2. Click through the customer links.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +8 / -2    |
