### PR TITLE
docs: add documentation links to package READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ yarn
 yarn dev
 ```
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
+From 5.1.x onward, published packages also include a `DOCS.md` file with the appropriate docs-site content and a generated `RELEASE_NOTES.md` file with versioned release notes. If you or your coding agent need release notes for your installed version specifically, check these files alongside the source in your `node_modules` folder.
+
 ## Community
 
 - [Discord](https://discord.tldraw.com/?utm_source=github&utm_medium=readme&utm_campaign=sociallink) — questions, feedback, and discussion

--- a/packages/assets/README.md
+++ b/packages/assets/README.md
@@ -2,6 +2,12 @@
 
 This package contains assets that are used by tldraw, including icons and fonts.
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 ## Distributions
 
 You can find tldraw on npm [here](https://www.npmjs.com/package/@tldraw/tldraw?activeTab=versions).

--- a/packages/create-tldraw/README.md
+++ b/packages/create-tldraw/README.md
@@ -56,6 +56,12 @@ This will add a template entry for any workspace in the repo which has a `packag
 }
 ```
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 ## License
 
 This project is part of the tldraw SDK. It is provided under the [tldraw SDK license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).

--- a/packages/driver/README.md
+++ b/packages/driver/README.md
@@ -114,6 +114,12 @@ These methods work in page coordinates and handle the screen-space conversion in
 | ----------- | -------------------------------------------- |
 | `dispose()` | Remove side-effect handlers. Call when done. |
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 ## License
 
 See [LICENSE.md](../../LICENSE.md).

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -4,6 +4,12 @@ The core editor and composable parts for tldraw. [Click here](https://tldraw.dev
 
 You might be more interested in the general package [tldraw](https://github.com/tldraw/tldraw/tree/main/packages/tldraw) instead of using this package directly.
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 ## License
 
 This project is part of the tldraw SDK. It is provided under the [tldraw SDK license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).

--- a/packages/mermaid/README.md
+++ b/packages/mermaid/README.md
@@ -183,6 +183,12 @@ The `mermaid` dependency is roughly 2 MB. The paste handler above already lazy-l
 
 See the [Mermaid diagrams example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/use-cases/hundred-mermaids) in the examples app for a runnable demo that renders many diagram types at once. Run it locally with `yarn dev` from the repo root and visit `localhost:5420`.
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 ## License
 
 This project is part of the tldraw SDK. It is provided under the [tldraw SDK license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).

--- a/packages/namespaced-tldraw/README.md
+++ b/packages/namespaced-tldraw/README.md
@@ -2,6 +2,12 @@
 
 This package is kept around for legacy purposes. It just tracks the normal `tldraw` package. Please install that one instead.
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 ## License
 
 This project is part of the tldraw SDK. It is provided under the [tldraw SDK license](https://github.com/tldraw/tldraw/blob/main/LICENSE.md).

--- a/packages/state-react/README.md
+++ b/packages/state-react/README.md
@@ -6,6 +6,10 @@ To learn more about this check out the [Signia library's React bindings](https:/
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## Contribution

--- a/packages/state/README.md
+++ b/packages/state/README.md
@@ -6,6 +6,10 @@
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## Why @tldraw/state?

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -6,6 +6,10 @@
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 # Usage

--- a/packages/sync-core/README.md
+++ b/packages/sync-core/README.md
@@ -4,6 +4,10 @@ This project contains core functionality for [tldraw sync](https://tldraw.dev/do
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## License

--- a/packages/sync/README.md
+++ b/packages/sync/README.md
@@ -4,6 +4,10 @@ This project contains source code for [tldraw sync](https://tldraw.dev/docs/sync
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## License

--- a/packages/tldraw/README.md
+++ b/packages/tldraw/README.md
@@ -32,6 +32,14 @@ export default function () {
 
 Visit [tldraw.dev](https://tldraw.dev) to learn more.
 
+## Documentation
+
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
+From 5.1.x onward, this package also includes a `DOCS.md` file with the appropriate docs-site content and a generated `RELEASE_NOTES.md` file with versioned release notes. If you or your coding agent need release notes for your installed version specifically, check these files alongside the source in your `node_modules` folder.
+
 ## Who's using tldraw
 
 The tldraw SDK powers canvas experiences in products from [Google](https://about.google), [Shopify](https://www.shopify.com), [BlackRock](https://www.blackrock.com), [Autodesk](https://blogs.autodesk.com/forma/2024/06/20/forma-board-collaborative-tool-for-architects/), [ClickUp](https://tldraw.dev/blog/clickup), [Replit](https://docs.replit.com/replitai/canvas), [Google Stitch](https://stitch.withgoogle.com), [Luma](https://lumalabs.ai/dream-machine), [Runway](https://runwayml.com), [Padlet](https://tldraw.dev/blog/padlet), [Mobbin](https://tldraw.dev/blog/mobbin), [Jam](https://tldraw.dev/blog/jam), [Craft](https://support.craft.do/en/write-and-edit/whiteboards), [Honeycomb](https://www.honeycomb.io/platform/canvas), [SchoolAI](https://schoolai.com/products/powerups), [Brisk](https://www.briskteaching.com/post/boost-whiteboard), and many more. See our [showcase](https://tldraw.dev/showcase) for case studies.

--- a/packages/tlschema/README.md
+++ b/packages/tlschema/README.md
@@ -4,6 +4,10 @@ Type definitions, schema migrations, and other type metadata for the tldraw edit
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## Records

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -4,6 +4,10 @@ Utility functions used by tldraw.
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## Contribution

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -32,6 +32,10 @@ queryValidator.validate(request.query)
 
 ## Documentation
 
+Documentation for the most recent release can be found on [tldraw.dev/docs](https://tldraw.dev/docs), including [reference docs](https://tldraw.dev/reference/editor/Editor). Our release notes can be found [here](https://tldraw.dev/releases).
+
+For more agent-friendly docs, see our [LLMs.txt](https://tldraw.dev/llms.txt).
+
 A `DOCS.md` file is included alongside this README in the published package, with detailed API documentation and usage examples.
 
 ## Contribution


### PR DESCRIPTION
In order to make our documentation easier to find for both humans and coding agents browsing GitHub, npm, or `node_modules`, this PR adds a "Documentation" section to the root README and each published package README. The section links to [tldraw.dev/docs](https://tldraw.dev/docs), the [reference docs](https://tldraw.dev/reference/editor/Editor), the [release notes](https://tldraw.dev/releases), and our agent-friendly [llms.txt](https://tldraw.dev/llms.txt). The root README and the `tldraw` package README also note that from 5.1.x onward, published packages include a `DOCS.md` file and a generated `RELEASE_NOTES.md` file with versioned content.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +84 / -0   |
