### PR TITLE
perf(editor): batch rotation updates for multiple shapes

### DIFF
--- a/packages/editor/src/lib/utils/rotation.ts
+++ b/packages/editor/src/lib/utils/rotation.ts
@@ -70,59 +70,61 @@ export function applyRotationToSnapshotShapes({
 }) {
 	const { initialPageCenter, shapeSnapshots } = snapshot
 
-	editor.updateShapes(
-		shapeSnapshots.map(({ shape, initialPagePoint }) => {
-			// We need to both rotate each shape individually and rotate the shapes
-			// around the pivot point (the average center of all rotating shapes.)
+	// Calculate all rotation and position partials
+	const positionAndRotationPartials = shapeSnapshots.map(({ shape, initialPagePoint }) => {
+		// We need to both rotate each shape individually and rotate the shapes
+		// around the pivot point (the average center of all rotating shapes.)
 
-			const parentTransform = isShapeId(shape.parentId)
-				? editor.getShapePageTransform(shape.parentId)!
-				: Mat.Identity()
+		const parentTransform = isShapeId(shape.parentId)
+			? editor.getShapePageTransform(shape.parentId)!
+			: Mat.Identity()
 
-			const newPagePoint = Vec.RotWith(initialPagePoint, centerOverride ?? initialPageCenter, delta)
+		const newPagePoint = Vec.RotWith(initialPagePoint, centerOverride ?? initialPageCenter, delta)
 
-			const newLocalPoint = Mat.applyToPoint(
-				// use the current parent transform in case it has moved/resized since the start
-				// (e.g. if rotating a shape at the edge of a group)
-				Mat.Inverse(parentTransform),
-				newPagePoint
-			)
-			const newRotation = canonicalizeRotation(shape.rotation + delta)
+		const newLocalPoint = Mat.applyToPoint(
+			// use the current parent transform in case it has moved/resized since the start
+			// (e.g. if rotating a shape at the edge of a group)
+			Mat.Inverse(parentTransform),
+			newPagePoint
+		)
+		const newRotation = canonicalizeRotation(shape.rotation + delta)
 
-			return {
-				id: shape.id,
-				type: shape.type,
-				x: newLocalPoint.x,
-				y: newLocalPoint.y,
-				rotation: newRotation,
-			}
-		})
-	)
+		return {
+			id: shape.id,
+			type: shape.type,
+			x: newLocalPoint.x,
+			y: newLocalPoint.y,
+			rotation: newRotation,
+		} as TLShapePartial
+	})
 
-	// Handle change
+	// Collect callback changes based on the new shapes that will exist after position/rotation update
+	const callbackPartials: TLShapePartial[] = []
 
-	const changes: TLShapePartial[] = []
-
-	shapeSnapshots.forEach(({ shape }) => {
-		const current = editor.getShape(shape.id)
-		if (!current) return
+	shapeSnapshots.forEach(({ shape }, index) => {
 		const util = editor.getShapeUtil(shape)
 
 		if (stage === 'start' || stage === 'one-off') {
 			const changeStart = util.onRotateStart?.(shape)
-			if (changeStart) changes.push(changeStart)
+			if (changeStart) callbackPartials.push(changeStart)
 		}
 
-		const changeUpdate = util.onRotate?.(shape, current)
-		if (changeUpdate) changes.push(changeUpdate)
+		// For onRotate callback, we need to pass the updated shape
+		// Create a temporary shape with the new rotation/position to get the updated state
+		const updatedShapePartial = positionAndRotationPartials[index]
+		const tempUpdatedShape = { ...shape, ...updatedShapePartial }
+		const changeUpdate = util.onRotate?.(shape, tempUpdatedShape as TLShape)
+		if (changeUpdate) callbackPartials.push(changeUpdate)
 
 		if (stage === 'end' || stage === 'one-off') {
-			const changeEnd = util.onRotateEnd?.(shape, current)
-			if (changeEnd) changes.push(changeEnd)
+			const changeEnd = util.onRotateEnd?.(shape, tempUpdatedShape as TLShape)
+			if (changeEnd) callbackPartials.push(changeEnd)
 		}
 	})
 
-	if (changes.length > 0) {
-		editor.updateShapes(changes)
+	// Batch all updates together: position/rotation + callbacks
+	const allPartials = [...positionAndRotationPartials, ...callbackPartials]
+	if (allPartials.length > 0) {
+		editor.updateShapes(allPartials)
 	}
 }

--- a/packages/tldraw/src/test/rotating.test.ts
+++ b/packages/tldraw/src/test/rotating.test.ts
@@ -327,3 +327,38 @@ describe('Edge cases', () => {
 			.expectToBeIn('select.idle')
 	})
 })
+
+describe('Rotation batching', () => {
+	it('batches rotation updates for multiple shapes in a single updateShapes call', () => {
+		// Create additional shapes
+		editor.createShape({
+			type: 'geo',
+			x: 400,
+			y: 400,
+			props: { w: 100, h: 100 },
+		})
+
+		const shapes = editor.getLastCreatedShapes(3)
+		const shapeIds = shapes.map((s) => s.id)
+		editor.select(...shapeIds)
+
+		// Get the rotate handle position
+		const handlePoint = editor.getSelectionHandlePagePoint('top_right_rotate')
+
+		// Start rotating from a rotate handle
+		editor.pointerDown(handlePoint.x, handlePoint.y)
+		// Move the pointer significantly to create a rotation
+		editor.pointerMove(handlePoint.x + 100, handlePoint.y + 100)
+
+		// Verify all shapes rotated correctly
+		const rotations = shapeIds.map((id) => editor.getShape(id)!.rotation)
+		// All shapes should have the same rotation since they were selected together
+		expect(rotations[0]).toBe(rotations[1])
+		expect(rotations[1]).toBe(rotations[2])
+		// And the rotation should be non-zero
+		expect(rotations[0]).not.toBe(0)
+
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+})


### PR DESCRIPTION
## Summary

Refactor rotation update logic to batch all updates (position, rotation, and callback-driven changes) into a single `updateShapes` call when rotating multiple shapes together. This reduces intermediate shape updates and improves performance.

The rotation callbacks (`onRotate`, `onRotateStart`, `onRotateEnd`) now receive the shape with the new rotation and position applied, so they can make decisions based on the updated state rather than the pre-rotation state.

## Changes

- **perf(editor): batch rotation updates** — Consolidates position/rotation updates and callback-driven changes into a single `updateShapes` call, reducing the number of store transactions
- **test(tldraw): add rotation batching test** — Verifies that multiple shapes rotate correctly when batched together

## Testing

Added a test case that creates multiple shapes, selects them, rotates them together, and verifies:
- All shapes have the same rotation (they were rotated around a common center)
- The rotation is non-zero (the rotation actually occurred)
- The editor returns to `select.idle` state after rotation completes