### PR TITLE
fix(tldraw): keep selection handles visible while pressing a handle

### DIFF
--- a/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
@@ -97,6 +97,7 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 			'select.pointing_selection',
 			'select.pointing_shape',
 			'select.pointing_resize_handle',
+			'select.pointing_rotate_handle',
 			'select.resizing',
 			'select.crop.idle',
 			'select.crop.pointing_crop',
@@ -495,6 +496,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 				'select.idle',
 				'select.pointing_selection',
 				'select.pointing_shape',
+				'select.pointing_resize_handle',
+				'select.pointing_rotate_handle',
 				'select.crop.idle'
 			) &&
 			!isChangingStyle &&
@@ -552,7 +555,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 					'select.crop.idle',
 					'select.crop.pointing_crop',
 					'select.crop.pointing_crop_handle',
-					'select.pointing_resize_handle'
+					'select.pointing_resize_handle',
+					'select.pointing_rotate_handle'
 				)) ||
 			(showSelectionBounds &&
 				editor.isIn('select.resizing') &&

--- a/packages/tldraw/src/test/overlays/SelectionForegroundOverlayUtil.test.ts
+++ b/packages/tldraw/src/test/overlays/SelectionForegroundOverlayUtil.test.ts
@@ -189,6 +189,48 @@ describe('SelectionForegroundOverlayUtil', () => {
 			expect(idsSet.has('selection_fg:bottom_right')).toBe(true)
 		})
 
+		it('keeps resize handles while pressing a resize edge', () => {
+			editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+			editor.select(ids.box1)
+			editor.pointerDownOnHandle('top')
+			expect(editor.getPath()).toBe('select.pointing_resize_handle')
+
+			const util =
+				editor.overlays.getOverlayUtil<SelectionForegroundOverlayUtil>('selection_foreground')
+			const idsSet = new Set(util.getOverlays().map((o) => o.id))
+			expect(idsSet.has('selection_fg:top_left')).toBe(true)
+			expect(idsSet.has('selection_fg:top_right')).toBe(true)
+			expect(idsSet.has('selection_fg:bottom_left')).toBe(true)
+			expect(idsSet.has('selection_fg:bottom_right')).toBe(true)
+
+			// Once an actual resize begins, the handles hide
+			editor.pointerMoveBy(0, -30)
+			expect(editor.getPath()).toBe('select.resizing')
+			expect(util.getOverlays()).toEqual([])
+		})
+
+		it('keeps resize handles while pressing a rotate handle', () => {
+			editor.updateInstanceState({ isCoarsePointer: false })
+			editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+			editor.select(ids.box1)
+			editor.pointerDownOnHandle('top_left_rotate')
+			expect(editor.getPath()).toBe('select.pointing_rotate_handle')
+
+			const util =
+				editor.overlays.getOverlayUtil<SelectionForegroundOverlayUtil>('selection_foreground')
+			expect(util.isActive()).toBe(true)
+			const idsSet = new Set(util.getOverlays().map((o) => o.id))
+			expect(idsSet.has('selection_fg:top_left')).toBe(true)
+			expect(idsSet.has('selection_fg:top_right')).toBe(true)
+			expect(idsSet.has('selection_fg:bottom_left')).toBe(true)
+			expect(idsSet.has('selection_fg:bottom_right')).toBe(true)
+
+			// Once an actual rotation begins, the selection foreground hides
+			editor.pointerMoveBy(-30, -30)
+			expect(editor.getPath()).toBe('select.rotating')
+			expect(util.isActive()).toBe(false)
+		})
+
 		it('hides edge handles on coarse pointer', () => {
 			editor.updateInstanceState({ isCoarsePointer: true })
 			editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])


### PR DESCRIPTION
In order to keep the selection UI stable on pointer-down, this PR keeps the selection foreground visible while a resize or rotate handle is being pressed. Previously, pressing a resize edge or corner immediately hid the corner handles (leaving only the outline), and pressing a rotate handle hid the entire selection foreground, outline included. The handle states (`select.pointing_resize_handle`, `select.pointing_rotate_handle`) were missing from the `isActive`, `shouldDisplayControls`, and `shouldDisplayBox` predicates in `SelectionForegroundOverlayUtil`, while the crop equivalents were already included. The selection foreground still hides once an actual resize or rotation begins.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape.
2. Press and hold a resize edge or corner without moving — the corner handles and outline stay visible.
3. Press and hold a rotate handle without moving — the selection foreground stays visible.
4. Drag to resize or rotate — the handles hide as before.

- [x] Unit tests

### Release notes

- Fix selection handles disappearing when pressing (but not yet dragging) a resize edge, resize corner, or rotate handle.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -1    |
| Tests     | +42 / -0   |