### PR TITLE
fix(tldraw): restore double click on arrow handles to toggle arrowheads

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -270,13 +270,27 @@ export class Idle extends StateNode {
 			case 'canvas': {
 				const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 
-				// Check overlays first — if we hit a resize/rotate handle, re-dispatch
-				// as a selection event so onDoubleClickEdge / onDoubleClickCorner fire.
+				// Check overlays first — if we hit a shape handle, re-dispatch as a
+				// handle event so onDoubleClickHandle fires; if we hit a resize/rotate
+				// handle, re-dispatch as a selection event so onDoubleClickEdge /
+				// onDoubleClickCorner fire.
 				const hitOverlay = this.editor.overlays.getOverlayAtPoint(
 					currentPagePoint,
 					this.editor.options.hitTestMargin / this.editor.getZoomLevel()
 				)
 				if (hitOverlay) {
+					if (hitOverlay.type === 'shape_handle') {
+						const shape = this.editor.getShape(hitOverlay.props.shapeId as any)
+						if (shape) {
+							this.onDoubleClick({
+								...info,
+								target: 'handle',
+								shape,
+								handle: hitOverlay.props.handle as any,
+							})
+							return
+						}
+					}
 					const overlayType = hitOverlay.props.overlayType as string | undefined
 					if (
 						overlayType === 'resize_handle' ||

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -1,4 +1,11 @@
-import { IndexKey, ShapeUtil, TLFrameShape, createShapeId, toRichText } from '@tldraw/editor'
+import {
+	IndexKey,
+	ShapeUtil,
+	TLArrowShape,
+	TLFrameShape,
+	createShapeId,
+	toRichText,
+} from '@tldraw/editor'
 import { vi } from 'vitest'
 import { defaultHandleExternalTldrawContent } from '../lib/defaultExternalContentHandlers'
 import { defaultOverlayUtils } from '../lib/defaultOverlayUtils'
@@ -642,6 +649,34 @@ describe('When double clicking a selection handle that registers as a canvas eve
 
 		expect(spy).toHaveBeenCalledTimes(1)
 		expect(spy.mock.calls[0][1]).toMatchObject({ target: 'selection', handle: 'bottom_right' })
+	})
+
+	it('Routes a canvas-targeted double-click on an arrow handle to onDoubleClickHandle', () => {
+		const id = createShapeId()
+		overlayEditor
+			.createShapes([
+				{
+					id,
+					type: 'arrow',
+					x: 100,
+					y: 100,
+					props: { start: { x: 0, y: 0 }, end: { x: 100, y: 100 } },
+				},
+			])
+			.select(id)
+
+		expect(overlayEditor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('arrow')
+
+		// Double-click on the end handle without specifying target — defaults to
+		// target: 'canvas', the payload a real DOM double-click produces when the
+		// press lands on the handle overlay. This should toggle the arrowhead.
+		overlayEditor.doubleClick(200, 200)
+
+		expect(overlayEditor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('none')
+
+		overlayEditor.doubleClick(200, 200)
+
+		expect(overlayEditor.getShape<TLArrowShape>(id)!.props.arrowheadEnd).toBe('arrow')
 	})
 })
 


### PR DESCRIPTION
In order to restore the double-click-on-arrow-handle gesture that toggles the arrowhead on that end, this PR routes `shape_handle` overlay hits in `Idle.onDoubleClick` to a `target: 'handle'` event. Since the overlays refactoring, handle presses arrive as `target: 'canvas'` events and are hit-tested against overlays in code. `Idle.onPointerDown` already re-dispatched `shape_handle` overlay hits as handle events, but the double-click path only re-dispatched resize and rotate handle overlays, so a double click on an arrow handle fell through to the shape hit test and started editing the arrow's label instead of calling `ShapeUtil.onDoubleClickHandle`.

### Change type

- [x] `bugfix`

### Test plan

1. Create an arrow and select it.
2. Double click the end handle: the arrowhead should disappear.
3. Double click it again: the arrowhead should come back.
4. Double click the start handle: an arrowhead should appear on the start.

- [x] Unit tests

### Release notes

- Fixed a bug where double clicking an arrow handle no longer toggled the arrowhead on that end.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -2   |
| Tests     | +36 / -1   |