### PR TITLE
fix(tldraw): end hand tool pan when a second touch starts a pinch

### DIFF
--- a/packages/tldraw/src/lib/tools/HandTool/childStates/Dragging.ts
+++ b/packages/tldraw/src/lib/tools/HandTool/childStates/Dragging.ts
@@ -15,8 +15,21 @@ export class Dragging extends StateNode {
 		this.update()
 	}
 
+	override onPointerDown() {
+		// A second touch resets the input origin to the new pointer, so continuing
+		// the pan would snap the camera. Yield before the pinch begins; the pan
+		// does not resume when the pinch ends.
+		this.parent.transition('idle')
+	}
+
 	override onPointerUp() {
 		this.complete()
+	}
+
+	override onInterrupt() {
+		// A pinch interrupts when it starts (without a preceding pointer_down on
+		// some inputs, like Safari trackpads), so end the pan here too.
+		this.parent.transition('idle')
 	}
 
 	override onCancel() {

--- a/packages/tldraw/src/test/HandTool.test.ts
+++ b/packages/tldraw/src/test/HandTool.test.ts
@@ -208,4 +208,49 @@ describe('When in the dragging state', () => {
 		editor.cancel()
 		editor.expectToBeIn('hand.idle')
 	})
+
+	it('Returns to the idle state on interrupt', () => {
+		editor.setCurrentTool('hand')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('hand.dragging')
+		editor.interrupt()
+		editor.expectToBeIn('hand.idle')
+	})
+
+	it('Ends the pan when a second touch starts, without jumping the camera', () => {
+		editor.setCurrentTool('hand')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('hand.dragging')
+		expect(editor.getCamera()).toMatchObject({ x: 50, y: 50 })
+
+		// A second finger lands far from the first, resetting the input origin.
+		editor.pointerDown(200, 0)
+		editor.expectToBeIn('hand.idle')
+
+		// Movement before pinch_start arrives no longer pans the camera.
+		editor.pointerMove(210, 10)
+		expect(editor.getCamera()).toMatchObject({ x: 50, y: 50 })
+	})
+
+	it('Does not resume the pan after a pinch ends', () => {
+		editor.setCurrentTool('hand')
+		editor.pointerDown(50, 50)
+		editor.pointerMove(100, 100)
+		editor.expectToBeIn('hand.dragging')
+
+		// A second finger lands and starts a pinch.
+		editor.pointerDown(200, 0)
+		editor.expectToBeIn('hand.idle')
+		editor.pinchStart(150, 50, 1, 0, 0, 0)
+		editor.pinchTo(150, 50, 2, 0, 0, 0)
+		editor.pinchEnd(150, 50, 2, 0, 0, 0)
+		editor.expectToBeIn('hand.idle')
+
+		// Moving the remaining finger does not pan the camera.
+		const { x, y } = editor.getCamera()
+		editor.pointerMove(120, 120)
+		expect(editor.getCamera()).toMatchObject({ x, y })
+	})
 })


### PR DESCRIPTION
In order to stop the camera from jumping when a one-finger pan turns into a two-finger pinch with the hand tool, this PR makes the hand tool's dragging state end the pan as soon as a second pointer goes down or the gesture is interrupted. Closes #9181.

When a second finger lands, its `pointer_down` resets the input origin to the new finger's position, so the next `pointer_move` made `Dragging.update()` compute a near-zero delta and snap the camera back toward the camera position captured at pan start. The new `onPointerDown` handler yields to idle before that can happen, and the new `onInterrupt` handler covers pinches that begin without a preceding `pointer_down` (such as Safari trackpad gestures, which `pinch_start` interrupts). The pan does not resume after the pinch ends; the user starts a new pan with the remaining finger.

### Change type

- [x] `bugfix`

### Test plan

1. On a touch device, select the hand tool.
2. Pan the canvas with one finger.
3. While panning, place a second finger and pinch to zoom.
4. Verify the camera transitions smoothly from pan to zoom with no jump.
5. Lift one finger and verify the pan does not resume until a new single-finger pan begins.

- [x] Unit tests

### Release notes

- Fixed the camera jumping when a one-finger pan with the hand tool transitions into a two-finger pinch zoom.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +13 / -0   |
| Tests     | +45 / -0   |