### PR TITLE
fix(editor): make arrows hoverable after binding-only changes

### DIFF
--- a/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
+++ b/packages/editor/src/lib/editor/managers/SpatialIndexManager/SpatialIndexManager.ts
@@ -46,6 +46,10 @@ export class SpatialIndexManager {
 
 	private createSpatialIndexComputed() {
 		const shapeHistory = this.editor.store.query.filterHistory('shape')
+		// Binding changes can move a shape's derived bounds (e.g. creating or
+		// deleting an arrow binding relocates the arrow's body) without
+		// touching any shape record, so they must also invalidate the index.
+		const bindingHistory = this.editor.store.query.filterHistory('binding')
 
 		return computed<number>('spatialIndex', (_prevValue, lastComputedEpoch) => {
 			if (isUninitialized(_prevValue)) {
@@ -53,8 +57,9 @@ export class SpatialIndexManager {
 			}
 
 			const shapeDiff = shapeHistory.getDiffSince(lastComputedEpoch)
+			const bindingDiff = bindingHistory.getDiffSince(lastComputedEpoch)
 
-			if (shapeDiff === RESET_VALUE) {
+			if (shapeDiff === RESET_VALUE || bindingDiff === RESET_VALUE) {
 				return this.rebuildAndBumpEpoch()
 			}
 
@@ -63,8 +68,10 @@ export class SpatialIndexManager {
 				return this.rebuildAndBumpEpoch()
 			}
 
-			if (shapeDiff.length === 0) return this._boundsEpoch
+			if (shapeDiff.length === 0 && bindingDiff.length === 0) return this._boundsEpoch
 
+			// A binding-only diff passes an empty shape diff: step 1 is a no-op
+			// and the step-2 sweep re-checks the indexed bounds of every shape.
 			if (this.processIncrementalUpdate(shapeDiff)) {
 				this._boundsEpoch++
 			}

--- a/packages/tldraw/src/test/spatialIndex.test.ts
+++ b/packages/tldraw/src/test/spatialIndex.test.ts
@@ -223,6 +223,138 @@ describe('SpatialIndexManager - step-2 transitive bounds sweep', () => {
 	})
 })
 
+describe('SpatialIndexManager - binding-only diffs', () => {
+	it('refreshes arrow bounds when bindings are created in a separate step from the shapes', () => {
+		// Regression: an arrow's bounds derive from its bindings, but a
+		// binding-only transaction contains no shape diff. If the index was
+		// queried between createShapes and createBindings (the hover side
+		// effect does this on every store change), the arrow stayed indexed
+		// at its unbound bounds and parts of the bound body were
+		// un-hoverable.
+		const boxAId = createShapeId('boxA')
+		const boxBId = createShapeId('boxB')
+		const arrowId = createShapeId('arrow')
+
+		editor.createShapes([
+			{ id: boxAId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100, fill: 'none' } },
+			{ id: boxBId, type: 'geo', x: 500, y: 0, props: { w: 100, h: 100, fill: 'none' } },
+			// The arrow's own terminals are far from the shapes it will be
+			// bound to, as happens when content is created via the API.
+			{
+				id: arrowId,
+				type: 'arrow',
+				x: 2000,
+				y: 2000,
+				props: { kind: 'arc', bend: -50, start: { x: 0, y: 0 }, end: { x: 100, y: 0 } },
+			},
+		])
+
+		const unboundBounds = editor.getShapePageBounds(arrowId)!
+
+		// Pull the spatial index so the arrow is indexed at its unbound
+		// bounds before the bindings exist.
+		expect(editor.getShapeIdsInsideBounds(unboundBounds).has(arrowId)).toBe(true)
+
+		editor.createBindings([
+			{
+				type: 'arrow',
+				fromId: arrowId,
+				toId: boxAId,
+				props: {
+					terminal: 'start',
+					isExact: false,
+					isPrecise: false,
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+				},
+			},
+			{
+				type: 'arrow',
+				fromId: arrowId,
+				toId: boxBId,
+				props: {
+					terminal: 'end',
+					isExact: false,
+					isPrecise: false,
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+				},
+			},
+		])
+
+		const boundBounds = editor.getShapePageBounds(arrowId)!
+		expect(boundBounds.equals(unboundBounds)).toBe(false)
+
+		// The index must reflect the bound bounds...
+		expect(editor.getShapeIdsInsideBounds(boundBounds).has(arrowId)).toBe(true)
+
+		// ...and the arrow must be hit-testable on its bound body.
+		const apex = { x: boundBounds.midX, y: boundBounds.minY + 1 }
+		expect(editor.getShapeAtPoint(apex, { hitInside: false, margin: 8 })?.id).toBe(arrowId)
+	})
+
+	it('ticks the epoch and refreshes arrow bounds when a binding update moves the arrow', () => {
+		const boxAId = createShapeId('boxA')
+		const boxBId = createShapeId('boxB')
+		const arrowId = createShapeId('arrow')
+
+		editor.createShapes([
+			{ id: boxAId, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100, fill: 'none' } },
+			{ id: boxBId, type: 'geo', x: 500, y: 500, props: { w: 100, h: 100, fill: 'none' } },
+			{
+				id: arrowId,
+				type: 'arrow',
+				x: 0,
+				y: 0,
+				props: { start: { x: 0, y: 0 }, end: { x: 100, y: 0 } },
+			},
+		])
+		editor.createBindings([
+			{
+				type: 'arrow',
+				fromId: arrowId,
+				toId: boxAId,
+				props: {
+					terminal: 'start',
+					isExact: false,
+					isPrecise: true,
+					normalizedAnchor: { x: 0, y: 0 },
+				},
+			},
+			{
+				type: 'arrow',
+				fromId: arrowId,
+				toId: boxBId,
+				props: {
+					terminal: 'end',
+					isExact: false,
+					isPrecise: true,
+					normalizedAnchor: { x: 0, y: 0 },
+				},
+			},
+		])
+
+		const boundsBefore = editor.getShapePageBounds(arrowId)!
+		const tracker = trackSpatialIndexInvalidations(editor, boundsBefore.clone())
+
+		// Move the end terminal across the target shape with a binding-only
+		// update; the arrow record itself is untouched.
+		const binding = editor
+			.getBindingsFromShape(arrowId, 'arrow')
+			.find((b) => b.props.terminal === 'end')!
+		editor.updateBinding({
+			...binding,
+			props: { ...binding.props, normalizedAnchor: { x: 0.5, y: 1 } },
+		})
+
+		const boundsAfter = editor.getShapePageBounds(arrowId)!
+		expect(boundsAfter.equals(boundsBefore)).toBe(false)
+		expect(tracker.delta).toBe(1)
+
+		const probe = probeOnlyInAfter(boundsBefore, boundsAfter)
+		expect(editor.getShapeIdsInsideBounds(probe).has(arrowId)).toBe(true)
+		tracker.stop()
+	})
+})
+
 describe('SpatialIndexManager - basic queries', () => {
 	it('returns shapes inside the queried bounds', () => {
 		const insideId = createShapeId('inside')


### PR DESCRIPTION
In order to make arrows hit-testable after their bindings change, this PR makes the spatial index react to binding record diffs. The index previously consumed only shape record history, so a binding-only transaction — `createBindings` called after `createShapes` (how API consumers and agent integrations create bound arrows), or an `updateBinding` that moves an arrow terminal — never re-checked indexed bounds. The arrow stayed indexed at its unbound bounds, and `getShapeAtPoint`'s broad phase filtered it out wherever the real body lay outside them: parts of the arrow could not be hovered or clicked, even though `Geometry2d.distanceToPoint` at those points was ~0. The staleness self-healed on the next shape record change, which made the bug intermittent and hard to pin down.

The fix consumes `filterHistory('binding')` alongside `filterHistory('shape')` in the spatial index computed. A binding-only diff now runs the incremental update, whose existing step-2 sweep re-checks every indexed shape's bounds and catches arrows moved by their bindings. A binding history reset triggers a full rebuild, matching the shape history behavior. Relates to #8882 (any future optimization of the step-2 sweep must keep binding diffs invalidating dependent arrow bounds).

Reproduced with a real document in the examples app: tracing the pointer along one arrow's rendered body found 63 of 81 positions dead (`getHoveredShapeId()` returned null), with the rbush holding the arrow's unbound bounds. After the fix, indexed bounds match real bounds exactly and every position along all arrows hovers the arrow.

### Change type

- [x] `bugfix`

### Test plan

1. In the examples app, run `editor.createShapes([...])` with two geo shapes and an arc arrow whose own terminals are far from both, hover the canvas once, then run `editor.createBindings([...])` binding the arrow between the shapes.
2. Hover along the full length of the rebound arrow body — every point should highlight the arrow.

- [x] Unit tests

### Release notes

- Fix arrows becoming partially un-hoverable and un-clickable when bindings were created or updated without a shape change (e.g. `createBindings` after `createShapes`).

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -2    |
| Tests     | +132 / -0  |