### PR TITLE
fix(overlays): keep selection chrome consistent while pointing

### DIFF
--- a/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/SelectionForegroundOverlayUtil.ts
@@ -97,6 +97,7 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 			'select.pointing_selection',
 			'select.pointing_shape',
 			'select.pointing_resize_handle',
+			'select.pointing_rotate_handle',
 			'select.resizing',
 			'select.crop.idle',
 			'select.crop.pointing_crop',
@@ -495,6 +496,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 				'select.idle',
 				'select.pointing_selection',
 				'select.pointing_shape',
+				'select.pointing_resize_handle',
+				'select.pointing_rotate_handle',
 				'select.crop.idle'
 			) &&
 			!isChangingStyle &&
@@ -552,7 +555,8 @@ export class SelectionForegroundOverlayUtil extends OverlayUtil<TLSelectionForeg
 					'select.crop.idle',
 					'select.crop.pointing_crop',
 					'select.crop.pointing_crop_handle',
-					'select.pointing_resize_handle'
+					'select.pointing_resize_handle',
+					'select.pointing_rotate_handle'
 				)) ||
 			(showSelectionBounds &&
 				editor.isIn('select.resizing') &&

--- a/packages/tldraw/src/lib/overlays/ShapeHandleOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ShapeHandleOverlayUtil.ts
@@ -38,7 +38,9 @@ export class ShapeHandleOverlayUtil extends OverlayUtil<TLShapeHandleOverlay> {
 		const handles = editor.getShapeHandles(onlySelectedShape)
 		if (!handles) return false
 
-		if (editor.isInAny('select.idle', 'select.pointing_handle', 'select.pointing_shape')) {
+		// Not shown in select.pointing_shape: hiding handles on pointer down
+		// matches the arrow binding hint, which also waits for pointer up.
+		if (editor.isInAny('select.idle', 'select.pointing_handle')) {
 			return true
 		}
 

--- a/packages/tldraw/src/lib/overlays/ShapeIndicatorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/ShapeIndicatorOverlayUtil.ts
@@ -71,7 +71,9 @@ export class ShapeIndicatorOverlayUtil extends OverlayUtil<TLShapeIndicatorOverl
 			'select.scribble_brushing',
 			'select.pointing_shape',
 			'select.pointing_selection',
-			'select.pointing_handle'
+			'select.pointing_handle',
+			'select.pointing_resize_handle',
+			'select.pointing_rotate_handle'
 		)
 
 		if (!isChangingStyle && (isIdleOrEditing || isInSelectState)) {

--- a/packages/tldraw/src/test/overlays/SelectionForegroundOverlayUtil.test.ts
+++ b/packages/tldraw/src/test/overlays/SelectionForegroundOverlayUtil.test.ts
@@ -93,6 +93,22 @@ describe('SelectionForegroundOverlayUtil', () => {
 			expect(idsSet.has('selection_fg:bottom_right_rotate')).toBe(true)
 		})
 
+		it.each(['top_left', 'top', 'top_left_rotate'] as const)(
+			'keeps selection foreground overlays visible while pointing the %s handle',
+			(handle) => {
+				editor.updateInstanceState({ isCoarsePointer: false })
+				editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+				editor.select(ids.box1)
+				editor.pointerDown(0, 0, { target: 'selection', handle })
+
+				const overlays = editor.overlays.getCurrentOverlays()
+				const idsSet = new Set(overlays.map((o) => o.id))
+				expect(idsSet.has('selection_fg:top_left')).toBe(true)
+				expect(idsSet.has('selection_fg:top')).toBe(true)
+				expect(idsSet.has('selection_fg:top_left_rotate')).toBe(true)
+			}
+		)
+
 		it('includes mobile rotate handle for coarse pointer', () => {
 			editor.updateInstanceState({ isCoarsePointer: true })
 			editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 60, h: 60 } }])

--- a/packages/tldraw/src/test/overlays/ShapeHandleOverlayUtil.test.ts
+++ b/packages/tldraw/src/test/overlays/ShapeHandleOverlayUtil.test.ts
@@ -64,13 +64,13 @@ describe('ShapeHandleOverlayUtil', () => {
 			editor.pointerUp()
 		})
 
-		it('returns true in select.pointing_shape with a handle shape selected', () => {
+		it('returns false in select.pointing_shape with a handle shape selected', () => {
 			editor.createShapes([{ id: ids.line1, type: 'line', x: 120, y: 120 }])
 			const shape = editor.getShape(ids.line1)!
 			editor.pointerDown(shape.x + 1, shape.y + 1, { target: 'shape', shape })
 			editor.expectToBeIn('select.pointing_shape')
 			const util = editor.overlays.getOverlayUtil<ShapeHandleOverlayUtil>('shape_handle')
-			expect(util.isActive()).toBe(true)
+			expect(util.isActive()).toBe(false)
 			editor.pointerUp()
 		})
 

--- a/packages/tldraw/src/test/overlays/ShapeIndicatorOverlayUtil.test.ts
+++ b/packages/tldraw/src/test/overlays/ShapeIndicatorOverlayUtil.test.ts
@@ -1,0 +1,36 @@
+import { createShapeId } from '@tldraw/editor'
+import { defaultOverlayUtils } from '../../lib/defaultOverlayUtils'
+import { ShapeIndicatorOverlayUtil } from '../../lib/overlays/ShapeIndicatorOverlayUtil'
+import { TestEditor } from '../TestEditor'
+
+let editor: TestEditor
+
+const ids = {
+	box1: createShapeId('box1'),
+}
+
+beforeEach(() => {
+	editor = new TestEditor({ overlayUtils: defaultOverlayUtils })
+})
+
+describe('ShapeIndicatorOverlayUtil', () => {
+	describe('getOverlays', () => {
+		it.each(['top_left', 'top_left_rotate'] as const)(
+			'keeps selected shape indicators visible while pointing the %s selection handle',
+			(handle) => {
+				editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } }])
+				editor.select(ids.box1)
+				editor.pointerDown(0, 0, { target: 'selection', handle })
+
+				const util = editor.overlays.getOverlayUtil<ShapeIndicatorOverlayUtil>('shape_indicator')
+				expect(util.getOverlays()).toMatchObject([
+					{
+						id: 'shape_indicator',
+						type: 'shape_indicator',
+						props: { idsToDisplay: [ids.box1] },
+					},
+				])
+			}
+		)
+	})
+})


### PR DESCRIPTION
In order to keep selection chrome consistent while you point at selected shapes and selection handles, this PR aligns the relevant overlay visibility states.

Previously, when an arrow bound to two shapes was selected, pressing down on its body would immediately show endpoint handles, but the dashed binding preview line would only appear on pointer up or long press. The two overlays disagreed about `select.pointing_shape`, so the handles appeared without their accompanying preview line. This PR hides selected shape handles during that state so both overlays appear together on pointer up or when a long press promotes the gesture into translating.

This PR also keeps selected shape indicators visible while pointing resize and rotate selection handles. `ShapeIndicatorOverlayUtil` already handled the older `select.pointing_handle` state, but selection resize and rotate handles use `select.pointing_resize_handle` and `select.pointing_rotate_handle`, so indicators disappeared as soon as those handles were pressed.

### Change type

- [x] `bugfix`

### Test plan

1. Create an arrow bound to two shapes.
2. Select the arrow, then press and hold on its body.
3. While holding, no endpoint handles should be shown, matching the hidden dashed preview line.
4. Release, or long press to start translating; handles and the dashed preview should appear together.
5. Select a shape, then press a resize or rotate selection handle.
6. While holding the handle before dragging, the selected shape indicator should remain visible.

- [x] Unit tests

### Release notes

- Fix selected shape handles appearing on pointer down before the arrow binding preview.
- Fix selected shape indicators disappearing while pressing resize and rotate selection handles.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +11 / -3   |
| Tests     | +54 / -2   |