### PR TITLE
feat(dotcom): refine workspaces sidebar design (experimental)

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -196,7 +196,7 @@ export class Sidebar {
 	async pinFromFileMenu(index: number) {
 		const fileLink = this.getFileLink('today', index)
 		await this.openFileMenu(fileLink)
-		await this.page.getByRole('menuitem', { name: 'Pin' }).click()
+		await this.page.getByRole('menuitem', { name: 'Add pin' }).click()
 		await this.mutationResolution()
 	}
 
@@ -204,7 +204,7 @@ export class Sidebar {
 	async unpinFromFileMenu(index: number) {
 		const fileLink = this.getFileLink('pinned', index)
 		await this.openFileMenu(fileLink)
-		await this.page.getByRole('menuitem', { name: 'Unpin' }).click()
+		await this.page.getByRole('menuitem', { name: 'Remove pin' }).click()
 		await this.mutationResolution()
 	}
 
@@ -458,14 +458,14 @@ export class Sidebar {
 	@step
 	async pinFile(fileName: string) {
 		await this.openFileMenuByName(fileName)
-		await this.page.getByRole('menuitem', { name: 'Pin' }).click()
+		await this.page.getByRole('menuitem', { name: 'Add pin' }).click()
 		await this.mutationResolution()
 	}
 
 	@step
 	async unpinFile(fileName: string) {
 		await this.openFileMenuByName(fileName)
-		await this.page.getByRole('menuitem', { name: 'Unpin' }).click()
+		await this.page.getByRole('menuitem', { name: 'Remove pin' }).click()
 		await this.mutationResolution()
 	}
 

--- a/apps/dotcom/client/e2e/tests/workspaces.spec.ts
+++ b/apps/dotcom/client/e2e/tests/workspaces.spec.ts
@@ -2,11 +2,10 @@ import { getRandomName, openNewTab } from '../fixtures/helpers'
 import { expect, test } from '../fixtures/tla-test'
 
 // The sidebar has a workspace switcher dropdown at the top ("Home" + the
-// user's workspaces + a create item), action rows for the active non-home
-// workspace (new board, invite teammates, workspace settings), and the active
-// workspace's files below. Switching to a workspace opens its top file — first pinned,
-// otherwise most recent (creating one if it's empty) — and creating a
-// workspace switches to it.
+// user's workspaces + a create item), action rows for the active workspace,
+// and the active workspace's files below. Switching to a workspace opens its
+// top file: first pinned, otherwise most recent (creating one if it's empty).
+// Creating a workspace switches to it.
 test.describe('workspaces', () => {
 	test.beforeEach(async ({ database, editor }) => {
 		await database.migrateUser()

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -105,6 +105,12 @@
       "value": "Try the tldraw SDK"
     }
   ],
+  "13348442cc": [
+    {
+      "type": 0,
+      "value": "Search"
+    }
+  ],
   "13ddd375ad": [
     {
       "type": 0,
@@ -617,6 +623,12 @@
     {
       "type": 0,
       "value": "Download"
+    }
+  ],
+  "8030793ce3": [
+    {
+      "type": 0,
+      "value": "New workspace"
     }
   ],
   "815e116a2e": [

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -99,12 +99,6 @@
       "value": "Publish"
     }
   ],
-  "12a6766ba1": [
-    {
-      "type": 0,
-      "value": "Unpin file"
-    }
-  ],
   "12c8a9838c": [
     {
       "type": 0,
@@ -145,6 +139,12 @@
     {
       "type": 0,
       "value": "Today"
+    }
+  ],
+  "1ef22651a0": [
+    {
+      "type": 0,
+      "value": "Add pin"
     }
   ],
   "21f66c9c00": [
@@ -283,12 +283,6 @@
     {
       "type": 0,
       "value": "tldraw"
-    }
-  ],
-  "47f493a590": [
-    {
-      "type": 0,
-      "value": "Pin file"
     }
   ],
   "4908687e50": [
@@ -1069,6 +1063,12 @@
     {
       "type": 0,
       "value": "Invite"
+    }
+  ],
+  "c753a20c76": [
+    {
+      "type": 0,
+      "value": "Remove pin"
     }
   ],
   "c7d7403714": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -50,6 +50,9 @@
   "12c8a9838c": {
     "translation": "Try the tldraw SDK"
   },
+  "13348442cc": {
+    "translation": "Search"
+  },
   "13ddd375ad": {
     "translation": "Export as"
   },
@@ -301,6 +304,9 @@
   },
   "801ab24683": {
     "translation": "Download"
+  },
+  "8030793ce3": {
+    "translation": "New workspace"
   },
   "815e116a2e": {
     "translation": "Have a bug, issue, or idea for tldraw? Let us know! Fill out this form and we will follow up over email if needed. You can also <discord>chat with us on Discord</discord> or <github>submit an issue on GitHub</github>."

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -47,9 +47,6 @@
   "110a4b01be": {
     "translation": "Publish"
   },
-  "12a6766ba1": {
-    "translation": "Unpin file"
-  },
   "12c8a9838c": {
     "translation": "Try the tldraw SDK"
   },
@@ -70,6 +67,9 @@
   },
   "1dd1c5fb7f": {
     "translation": "Today"
+  },
+  "1ef22651a0": {
+    "translation": "Add pin"
   },
   "21f66c9c00": {
     "translation": "Workspace name"
@@ -139,9 +139,6 @@
   },
   "47839e47a5": {
     "translation": "tldraw"
-  },
-  "47f493a590": {
-    "translation": "Pin file"
   },
   "4908687e50": {
     "translation": "Are you sure you want to forget this file?"
@@ -473,6 +470,9 @@
   },
   "c6a00f137b": {
     "translation": "Invite"
+  },
+  "c753a20c76": {
+    "translation": "Remove pin"
   },
   "c7d7403714": {
     "translation": "New board"

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -62,6 +62,7 @@ export function TlaFileMenu({
 	workspaceId,
 	onRenameAction,
 	trigger,
+	contentClassName,
 }: {
 	children?: ReactNode
 	source: TLAppUiEventSource
@@ -69,6 +70,7 @@ export function TlaFileMenu({
 	workspaceId: string | null
 	onRenameAction(): void
 	trigger: ReactNode
+	contentClassName?: string
 }) {
 	const id = useId()
 	const fileItemsWhenNoChildren = (
@@ -83,7 +85,13 @@ export function TlaFileMenu({
 		<TldrawUiDropdownMenuRoot id={`file-menu-${fileId}-${source}-${id}`}>
 			<TldrawUiMenuContextProvider type="menu" sourceId="dialog">
 				<TldrawUiDropdownMenuTrigger>{trigger}</TldrawUiDropdownMenuTrigger>
-				<TldrawUiDropdownMenuContent side="bottom" align="start" alignOffset={0} sideOffset={0}>
+				<TldrawUiDropdownMenuContent
+					side="bottom"
+					align="start"
+					alignOffset={0}
+					sideOffset={0}
+					className={contentClassName}
+				>
 					{children ?? fileItemsWhenNoChildren}
 				</TldrawUiDropdownMenuContent>
 			</TldrawUiMenuContextProvider>
@@ -122,12 +130,10 @@ export function FileItems({
 		[app]
 	)
 
-	// A file lives in exactly one workspace. The "Move to" menu only offers the workspaces
-	// it can move to — every workspace except the current one and the home workspace
+	// A file lives in exactly one workspace. The "Move to" menu shows every workspace
+	// with the current workspace checked, matching the workspace switcher.
 	const currentWorkspaceId = file?.owningGroupId ?? app.getHomeWorkspaceId()
-	const moveToWorkspaces = workspaceMemberships.filter(
-		(g) => g.groupId !== app.getHomeWorkspaceId() && g.groupId !== currentWorkspaceId
-	)
+	const otherWorkspaces = workspaceMemberships.filter((g) => g.groupId !== app.getHomeWorkspaceId())
 
 	const handleCopyLinkClick = useCallback(() => {
 		const url = routes.tlaFile(fileId, { asUrl: true })
@@ -238,31 +244,33 @@ export function FileItems({
 			<TldrawUiMenuGroup id="file-delete">
 				{workspacesEnabled && (
 					<TldrawUiMenuSubmenu id="move-to-workspace" label={'Move to'} size="small">
-						{currentWorkspaceId !== app.getHomeWorkspaceId() && (
-							<TldrawUiMenuGroup id="my-files">
-								<TldrawUiMenuItem
-									key="my-files"
-									label={myFilesMsg}
-									id="my-files"
-									readonlyOk
-									onSelect={() => {
-										app.z.mutate.moveFileToWorkspace({
-											fileId,
-											workspaceId: app.getHomeWorkspaceId(),
-										})
-									}}
-								/>
-							</TldrawUiMenuGroup>
-						)}
-						{moveToWorkspaces.length > 0 && (
+						<TldrawUiMenuGroup id="my-files">
+							<TldrawUiMenuItem
+								key="my-files"
+								label={myFilesMsg}
+								id="my-files"
+								readonlyOk
+								iconLeft={currentWorkspaceId === app.getHomeWorkspaceId() ? 'check' : 'none'}
+								onSelect={() => {
+									if (currentWorkspaceId === app.getHomeWorkspaceId()) return
+									app.z.mutate.moveFileToWorkspace({
+										fileId,
+										workspaceId: app.getHomeWorkspaceId(),
+									})
+								}}
+							/>
+						</TldrawUiMenuGroup>
+						{otherWorkspaces.length > 0 && (
 							<TldrawUiMenuGroup id="my-workspaces">
-								{moveToWorkspaces.map((membership) => (
+								{otherWorkspaces.map((membership) => (
 									<TldrawUiMenuItem
 										key={membership.groupId}
 										label={membership.group.name}
 										id={`workspace-${membership.groupId}`}
 										readonlyOk
+										iconLeft={membership.groupId === currentWorkspaceId ? 'check' : 'none'}
 										onSelect={() => {
+											if (membership.groupId === currentWorkspaceId) return
 											app.z.mutate.moveFileToWorkspace({ fileId, workspaceId: membership.groupId })
 										}}
 									/>

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -41,8 +41,8 @@ const messages = defineMessages({
 	forget: { defaultMessage: 'Forget' },
 	rename: { defaultMessage: 'Rename' },
 	copy: { defaultMessage: 'Copy' },
-	pin: { defaultMessage: 'Pin file' },
-	unpin: { defaultMessage: 'Unpin file' },
+	pin: { defaultMessage: 'Add pin' },
+	unpin: { defaultMessage: 'Remove pin' },
 	myFiles: { defaultMessage: 'My files' },
 })
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -116,7 +116,13 @@ export function TlaSidebarFileLink({
 					className={className}
 				/>
 			</_ContextMenu.Trigger>
-			<_ContextMenu.Content className="tlui-menu tlui-scrollable">
+			<_ContextMenu.Content
+				className={classNames(
+					'tlui-menu tlui-scrollable',
+					styles.sidebarDropdownMenu,
+					'tla-sidebar-file-menu'
+				)}
+			>
 				{/* Don't show the context menu on mobile */}
 				{!isMobile && (
 					<TldrawUiMenuContextProvider type="context-menu" sourceId="context-menu">

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLinkMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLinkMenu.tsx
@@ -1,3 +1,4 @@
+import classNames from 'classnames'
 import { TldrawUiButton } from 'tldraw'
 import { useMsg } from '../../../utils/i18n'
 import { TlaFileMenu } from '../../TlaFileMenu/TlaFileMenu'
@@ -22,6 +23,7 @@ export function TlaSidebarFileLinkMenu({
 			workspaceId={workspaceId}
 			source="sidebar"
 			onRenameAction={onRenameAction}
+			contentClassName={classNames(styles.sidebarDropdownMenu, 'tla-sidebar-file-menu')}
 			trigger={
 				<TldrawUiButton
 					type="icon"

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarUserSettingsMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarUserSettingsMenu.tsx
@@ -71,7 +71,7 @@ export function TlaUserSettingsMenu() {
 						</>
 					)}
 					<TldrawUiMenuGroup id="legal">
-						<UserManualMenuItem icon={false} />
+						<UserManualMenuItem icon="question-circle" />
 						<LegalSummaryMenuItem />
 						<CookieConsentMenuItem />
 					</TldrawUiMenuGroup>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -97,8 +97,8 @@ export function TlaSidebarWorkspaceSwitcher() {
 							side="bottom"
 							align="start"
 							sideOffset={4}
-							alignOffset={-4}
-							collisionPadding={8}
+							alignOffset={-6}
+							collisionPadding={0}
 						>
 							<WorkspaceSwitcherItem
 								isActive={isHome}
@@ -135,12 +135,16 @@ export function TlaSidebarWorkspaceSwitcher() {
 					</_DropdownMenu.Root>
 				</div>
 			</div>
-			<div className={styles.sidebarDivider} />
-			<TlaSidebarWorkspaceActions
-				workspaceId={activeWorkspaceId}
-				isHome={isHome}
-				onCreateWorkspace={handleCreateWorkspace}
-			/>
+			{(!isHome || workspaces.length === 0) && (
+				<>
+					<div className={styles.sidebarDivider} />
+					<TlaSidebarWorkspaceActions
+						workspaceId={activeWorkspaceId}
+						isHome={isHome}
+						onCreateWorkspace={handleCreateWorkspace}
+					/>
+				</>
+			)}
 		</>
 	)
 }
@@ -178,7 +182,7 @@ function WorkspaceSwitcherItem({
 
 /**
  * The action rows shown below the workspace switcher. Home shows file and
- * workspace creation actions; public workspaces add invite and settings.
+ * workspace creation actions; created workspaces show invite and settings.
  */
 function TlaSidebarWorkspaceActions({
 	workspaceId,
@@ -223,23 +227,25 @@ function TlaSidebarWorkspaceActions({
 
 	return (
 		<div className={styles.sidebarSection}>
-			<TlaSidebarActionButton
-				icon="edit-strong"
-				// edit-strong fills its 15px box while the other action icons draw
-				// 12px art inside it; scale it down so they optically match.
-				iconStyle={{ width: 12, height: 12, margin: 0 }}
-				label={newBoardLbl}
-				onClick={handleCreateFile}
-				testId="tla-sidebar-new-board"
-			/>
-			<TlaSidebarActionButton icon="search" label={searchLbl} />
 			{isHome ? (
-				<TlaSidebarActionButton
-					icon="plus"
-					label={newWorkspaceLbl}
-					onClick={onCreateWorkspace}
-					testId="tla-create-workspace"
-				/>
+				<>
+					<TlaSidebarActionButton
+						icon="edit-strong"
+						// edit-strong fills its 15px box while the other action icons draw
+						// 12px art inside it; scale it down so they optically match.
+						iconStyle={{ width: 12, height: 12, margin: 0 }}
+						label={newBoardLbl}
+						onClick={handleCreateFile}
+						testId="tla-sidebar-new-board"
+					/>
+					<TlaSidebarActionButton icon="search" label={searchLbl} />
+					<TlaSidebarActionButton
+						icon="plus"
+						label={newWorkspaceLbl}
+						onClick={onCreateWorkspace}
+						testId="tla-create-workspace"
+					/>
+				</>
 			) : (
 				<>
 					<TlaSidebarActionButton

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -19,17 +19,19 @@ import styles from '../sidebar.module.css'
 const messages = defineMessages({
 	home: { defaultMessage: 'Home' },
 	createWorkspace: { defaultMessage: 'Create workspace' },
+	newWorkspace: { defaultMessage: 'New workspace' },
 	newBoard: { defaultMessage: 'New board' },
+	search: { defaultMessage: 'Search' },
 	inviteTeammates: { defaultMessage: 'Invite teammates' },
 	workspaceSettings: { defaultMessage: 'Workspace settings' },
 })
 
 /**
  * The fixed top region of the sidebar: a dropdown for switching between the
- * home workspace and the user's other workspaces, followed by action rows
- * when a non-home workspace is active. Selecting a workspace opens its top
- * file (first pinned file, otherwise the most recent one), which makes it
- * active (the active workspace is derived from the open file).
+ * home workspace and the user's other workspaces, followed by action rows for
+ * the active workspace. Selecting a workspace opens its top file (first
+ * pinned file, otherwise the most recent one) and makes it active (the active
+ * workspace is derived from the open file).
  */
 export function TlaSidebarWorkspaceSwitcher() {
 	const app = useApp()
@@ -114,6 +116,7 @@ export function TlaSidebarWorkspaceSwitcher() {
 									{g.group.name}
 								</WorkspaceSwitcherItem>
 							))}
+							<_DropdownMenu.Separator className={styles.sidebarWorkspaceSwitcherSeparator} />
 							<_DropdownMenu.Item
 								className={classNames(
 									styles.sidebarWorkspaceSwitcherItem,
@@ -131,26 +134,13 @@ export function TlaSidebarWorkspaceSwitcher() {
 						</_DropdownMenu.Content>
 					</_DropdownMenu.Root>
 				</div>
-				{workspaces.length === 0 && (
-					<button
-						className={classNames(
-							styles.sidebarCreateWorkspaceButton,
-							styles.hoverable,
-							'tla-text_ui__regular'
-						)}
-						onClick={handleCreateWorkspace}
-						data-testid="tla-create-workspace"
-					>
-						{createWorkspaceLbl}
-					</button>
-				)}
 			</div>
-			{!isHome && (
-				<>
-					<div className={styles.sidebarDivider} />
-					<TlaSidebarWorkspaceActions workspaceId={activeWorkspaceId} />
-				</>
-			)}
+			<div className={styles.sidebarDivider} />
+			<TlaSidebarWorkspaceActions
+				workspaceId={activeWorkspaceId}
+				isHome={isHome}
+				onCreateWorkspace={handleCreateWorkspace}
+			/>
 		</>
 	)
 }
@@ -178,22 +168,34 @@ function WorkspaceSwitcherItem({
 			onSelect={onSelect}
 			data-testid={testId}
 		>
+			<span className={styles.sidebarWorkspaceSwitcherItemCheck}>
+				{isActive ? <TlaIcon icon="check" /> : null}
+			</span>
 			<span className={styles.sidebarWorkspaceSwitcherItemLabel}>{children}</span>
 		</_DropdownMenu.Item>
 	)
 }
 
 /**
- * The action rows shown below the workspace switcher when a non-home
- * workspace is active: creating a new board in it, copying the workspace
- * invite link, and opening the workspace settings.
+ * The action rows shown below the workspace switcher. Home shows file and
+ * workspace creation actions; public workspaces add invite and settings.
  */
-function TlaSidebarWorkspaceActions({ workspaceId }: { workspaceId: string }) {
+function TlaSidebarWorkspaceActions({
+	workspaceId,
+	isHome,
+	onCreateWorkspace,
+}: {
+	workspaceId: string
+	isHome: boolean
+	onCreateWorkspace(): void
+}) {
 	const app = useApp()
 	const { addDialog } = useDialogs()
 	const trackEvent = useTldrawAppUiEvents()
 	const handleCreateFile = useHandleSidebarCreateFile()
 	const newBoardLbl = useMsg(messages.newBoard)
+	const searchLbl = useMsg(messages.search)
+	const newWorkspaceLbl = useMsg(messages.newWorkspace)
 	const inviteTeammatesLbl = useMsg(messages.inviteTeammates)
 	const settingsLbl = useMsg(messages.workspaceSettings)
 
@@ -230,18 +232,30 @@ function TlaSidebarWorkspaceActions({ workspaceId }: { workspaceId: string }) {
 				onClick={handleCreateFile}
 				testId="tla-sidebar-new-board"
 			/>
-			<TlaSidebarActionButton
-				icon="invite"
-				label={inviteTeammatesLbl}
-				onClick={handleCopyInviteLink}
-				testId="tla-sidebar-invite-teammates"
-			/>
-			<TlaSidebarActionButton
-				icon="settings"
-				label={settingsLbl}
-				onClick={handleSettings}
-				testId="tla-sidebar-workspace-settings"
-			/>
+			<TlaSidebarActionButton icon="search" label={searchLbl} />
+			{isHome ? (
+				<TlaSidebarActionButton
+					icon="plus"
+					label={newWorkspaceLbl}
+					onClick={onCreateWorkspace}
+					testId="tla-create-workspace"
+				/>
+			) : (
+				<>
+					<TlaSidebarActionButton
+						icon="invite"
+						label={inviteTeammatesLbl}
+						onClick={handleCopyInviteLink}
+						testId="tla-sidebar-invite-teammates"
+					/>
+					<TlaSidebarActionButton
+						icon="settings"
+						label={settingsLbl}
+						onClick={handleSettings}
+						testId="tla-sidebar-workspace-settings"
+					/>
+				</>
+			)}
 		</div>
 	)
 }
@@ -256,16 +270,40 @@ function TlaSidebarActionButton({
 	icon: string
 	iconStyle?: CSSProperties
 	label: string
-	onClick(): void
-	testId: string
+	onClick?(): void
+	testId?: string
 }) {
+	const iconEl =
+		icon === 'search' ? (
+			<span className={styles.sidebarSearchIcon} aria-hidden="true" />
+		) : (
+			<TlaIcon icon={icon} style={iconStyle} />
+		)
+
+	if (!onClick) {
+		return (
+			<div
+				className={classNames(
+					styles.sidebarActionButton,
+					styles.sidebarActionButtonStatic,
+					'tla-text_ui__regular'
+				)}
+				aria-hidden="true"
+				data-testid={testId}
+			>
+				{iconEl}
+				<span className={styles.sidebarActionButtonLabel}>{label}</span>
+			</div>
+		)
+	}
+
 	return (
 		<button
 			className={classNames(styles.sidebarActionButton, styles.hoverable, 'tla-text_ui__regular')}
 			onClick={onClick}
 			data-testid={testId}
 		>
-			<TlaIcon icon={icon} style={iconStyle} />
+			{iconEl}
 			<span className={styles.sidebarActionButtonLabel}>{label}</span>
 		</button>
 	)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -588,7 +588,7 @@
 	max-width: calc(var(--tla-sidebar-width) - 4px);
 	max-height: 70vh;
 	overflow-y: auto;
-	padding: 2px 0px;
+	padding: 4px 0px;
 }
 
 .sidebarWorkspaceSwitcherOverlay {
@@ -607,8 +607,9 @@
 	position: relative;
 	display: flex;
 	align-items: center;
-	height: 40px;
-	padding: 0px 12px;
+	height: 34px;
+	padding: 0px 8px;
+	gap: 6px;
 	color: var(--tla-color-text-1);
 	cursor: pointer;
 	outline: none;
@@ -616,27 +617,10 @@
 	z-index: 1;
 }
 
-.sidebarWorkspaceSwitcherMenu > * {
-	margin-top: -4px;
-	margin-bottom: -4px;
-}
-
-.sidebarWorkspaceSwitcherMenu > *:hover {
-	z-index: 2;
-}
-
-.sidebarWorkspaceSwitcherMenu > *:nth-of-type(1) {
-	margin-top: 0px;
-}
-
-.sidebarWorkspaceSwitcherMenu > *:nth-last-of-type(1) {
-	margin-bottom: 0px;
-}
-
 .sidebarWorkspaceSwitcherItem::after {
 	content: '';
 	position: absolute;
-	inset: 4px 6px;
+	inset: 1px 6px;
 	opacity: 0;
 	pointer-events: none;
 	border-radius: 4px;
@@ -644,12 +628,23 @@
 
 .sidebarWorkspaceSwitcherItem[data-highlighted]::after {
 	opacity: 1;
-	background-color: var(--tla-color-hover-1);
+	background-color: var(--tla-color-hover-2);
 }
 
-.sidebarWorkspaceSwitcherItem[data-highlighted]::after {
-	opacity: 1;
-	background-color: var(--tla-color-hover-2);
+.sidebarWorkspaceSwitcherItemCheck {
+	position: relative;
+	z-index: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 12px;
+	height: 12px;
+	flex: 0 0 auto;
+}
+
+.sidebarWorkspaceSwitcherItemCheck span[role='img'] {
+	width: 12px;
+	height: 12px;
 }
 
 .sidebarWorkspaceSwitcherItemLabel {
@@ -668,21 +663,14 @@
 	color: var(--tla-color-text-3);
 }
 
-.sidebarCreateWorkspaceButton {
-	position: relative;
-	display: flex;
-	align-items: center;
-	height: 32px;
-	background: none;
-	border: none;
-	cursor: pointer;
-	color: var(--tla-color-text-3);
-	padding: 0px 8px;
-	text-align: left;
+.sidebarWorkspaceSwitcherItemCreate .sidebarWorkspaceSwitcherItemLabel {
+	padding-left: 2px;
 }
 
-.sidebarCreateWorkspaceButton:focus-visible {
-	outline-offset: -2px;
+.sidebarWorkspaceSwitcherSeparator {
+	height: 1px;
+	margin: 4px 0px;
+	background-color: var(--tl-color-divider, rgba(232, 232, 232, 1));
 }
 
 /* 36px rows whose hover highlight is 32px tall (the .hoverable::after insets
@@ -703,11 +691,50 @@
 	text-align: left;
 }
 
+.sidebarActionButtonStatic {
+	cursor: default;
+}
+
 /* The outline icons draw 12px art centered in a 15px box; pull the box in so
    the art lines up with the design's 12px icon grid. */
 .sidebarActionButton > span[role='img'] {
 	flex-shrink: 0;
 	margin: -1.5px;
+}
+
+.sidebarSearchIcon {
+	position: relative;
+	display: inline-flex;
+	width: 12px;
+	height: 12px;
+	flex: 0 0 auto;
+	margin: 0;
+	color: inherit;
+}
+
+.sidebarSearchIcon::before {
+	content: '';
+	position: absolute;
+	top: 1px;
+	left: 1px;
+	width: 7px;
+	height: 7px;
+	border: 1.5px solid currentColor;
+	border-radius: 50%;
+	box-sizing: border-box;
+}
+
+.sidebarSearchIcon::after {
+	content: '';
+	position: absolute;
+	right: 1px;
+	bottom: 1px;
+	width: 5px;
+	height: 1.5px;
+	border-radius: 999px;
+	background: currentColor;
+	transform: rotate(45deg);
+	transform-origin: right center;
 }
 
 .sidebarActionButtonLabel {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -19,7 +19,7 @@
    design; the rules below must not leak to users without the flag. */
 .sidebar[data-workspaces='true'] {
 	padding: 0 0 4px 0;
-	border-right: 1px solid var(--tl-color-low, rgba(237, 240, 242, 1));
+	border-right: 1px solid var(--tla-color-border);
 }
 
 :global(.tl-container[dir='rtl']) .sidebar {
@@ -253,8 +253,9 @@
    92px. */
 .sidebar[data-workspaces='true'] .sidebarTopRow {
 	height: 44px;
-	padding: 3px 8px 0px 4px;
-	gap: 8px;
+	justify-content: space-between;
+	padding: 3px 6px 0px 18px;
+	gap: 0px;
 }
 
 /* Workspace link */
@@ -277,12 +278,15 @@
 /* In the workspaces layout the logo is 16px tall, with its mark centered on
    the same vertical axis as the action-row icons below. */
 .sidebar[data-workspaces='true'] .sidebarWorkspaceButton {
-	padding-left: 15.3px;
+	flex: 0 0 auto;
+	height: 41px;
+	padding: 0;
+	background-color: transparent;
 }
 
 .sidebar[data-workspaces='true'] .sidebarWorkspaceButton span[role='img'] {
 	height: 16px;
-	width: 59px;
+	width: 62px;
 }
 
 .sidebarWorkspaceButtonLabel {
@@ -323,6 +327,17 @@
 	left: -8px;
 }
 
+.sidebar[data-workspaces='true'] .sidebarCreateFileButton {
+	right: auto;
+	min-width: 36px;
+	width: 36px;
+	height: 36px;
+}
+
+:global(.tl-container[dir='rtl']) .sidebar[data-workspaces='true'] .sidebarCreateFileButton {
+	left: auto;
+}
+
 .sidebarCreateFileButton::after {
 	display: block;
 	content: '';
@@ -336,6 +351,15 @@
 	z-index: 0;
 	visibility: hidden;
 	background-color: var(--tla-color-hover-1);
+}
+
+.sidebar[data-workspaces='true'] .sidebarCreateFileButton::after {
+	inset: 2px;
+}
+
+.sidebar[data-workspaces='true'] .sidebarCreateFileButton span[role='img'] {
+	width: 12px;
+	height: 12px;
 }
 
 .sidebarCreateFileButton:focus-visible {
@@ -400,9 +424,31 @@
 	text-decoration: none;
 }
 
+.sidebar[data-workspaces='true'] .sidebarFeedbackButton,
+.sidebar[data-workspaces='true'] .sidebarUserSettingsTrigger,
+.sidebar[data-workspaces='true'] .sidebarUserSettingsName,
+.sidebar[data-workspaces='true'] .sidebarWorkspaceSwitcherTrigger,
+.sidebar[data-workspaces='true'] .sidebarWorkspaceSwitcherLabel,
+.sidebar[data-workspaces='true'] .sidebarWorkspaceSwitcherItem,
+.sidebar[data-workspaces='true'] .sidebarActionButton,
+.sidebar[data-workspaces='true'] .sidebarActionButtonLabel,
+.sidebar[data-workspaces='true'] .sidebarFeedbackButtonLabel,
+.sidebar[data-workspaces='true'] .sidebarFileListItemLabel {
+	font-size: 12px;
+	line-height: 1;
+	font-weight: 500;
+}
+
 .sidebarFeedbackButton > span[role='img'] {
 	flex-shrink: 0;
 	margin: -1.5px;
+}
+
+.sidebar[data-workspaces='true'] .sidebarFeedbackButton > span[role='img'],
+.sidebar[data-workspaces='true'] .sidebarFeedbackButton > :global(.tlui-icon) {
+	width: 12px;
+	height: 12px;
+	margin: 0;
 }
 
 .sidebarFeedbackButtonLabel {
@@ -466,6 +512,16 @@
 	color: var(--tla-color-text-3);
 }
 
+.sidebar[data-workspaces='true'] .sidebarUserSettingsIcon {
+	visibility: visible;
+	color: var(--tla-color-text-1);
+}
+
+.sidebar[data-workspaces='true'] .sidebarUserSettingsIcon span[role='img'] {
+	width: 12px;
+	height: 12px;
+}
+
 @media (hover: hover) {
 	.sidebarUserSettingsTrigger:hover {
 		color: var(--tla-color-text-1);
@@ -474,6 +530,11 @@
 	.sidebarUserSettingsIcon {
 		color: var(--tla-color-text-3);
 		visibility: hidden;
+	}
+
+	.sidebar[data-workspaces='true'] .sidebarUserSettingsIcon {
+		color: var(--tla-color-text-1);
+		visibility: visible;
 	}
 
 	.sidebarUserSettingsTrigger:hover .sidebarUserSettingsIcon {
@@ -496,6 +557,10 @@
 	margin-top: 8px;
 }
 
+.sidebar[data-workspaces='true'] .sidebarFileSectionWrapper {
+	margin-top: 6px;
+}
+
 .sidebarFileSection {
 	position: relative;
 	background: var(--tla-color-sidebar);
@@ -516,7 +581,14 @@
 
 .sidebar[data-workspaces='true'] .sidebarFileSectionTitle {
 	padding: 0px 8px;
-	font-weight: 500;
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 19.2px;
+}
+
+.sidebar[data-workspaces='true'] .sidebarFileSectionTitle > span[role='img'] {
+	width: 12px;
+	height: 12px;
 }
 
 /* ----------------------------- Shared section ----------------------------- */
@@ -583,12 +655,17 @@
 	z-index: 1;
 }
 
+.sidebar[data-workspaces='true'] .sidebarWorkspaceSwitcherChevrons {
+	width: 12px;
+	height: 12px;
+}
+
 .sidebarWorkspaceSwitcherMenu {
-	min-width: calc(var(--tla-sidebar-width) - 4px);
-	max-width: calc(var(--tla-sidebar-width) - 4px);
+	min-width: var(--tla-sidebar-width);
+	max-width: var(--tla-sidebar-width);
 	max-height: 70vh;
 	overflow-y: auto;
-	padding: 4px 0px;
+	padding: 2px 0px;
 }
 
 .sidebarWorkspaceSwitcherOverlay {
@@ -607,8 +684,8 @@
 	position: relative;
 	display: flex;
 	align-items: center;
-	height: 34px;
-	padding: 0px 8px;
+	height: 36px;
+	padding: 0px 12px;
 	gap: 6px;
 	color: var(--tla-color-text-1);
 	cursor: pointer;
@@ -620,7 +697,7 @@
 .sidebarWorkspaceSwitcherItem::after {
 	content: '';
 	position: absolute;
-	inset: 1px 6px;
+	inset: 2px 4px;
 	opacity: 0;
 	pointer-events: none;
 	border-radius: 4px;
@@ -660,17 +737,125 @@
 }
 
 .sidebarWorkspaceSwitcherItemCreate {
-	color: var(--tla-color-text-3);
+	color: var(--tla-color-text-1);
 }
 
 .sidebarWorkspaceSwitcherItemCreate .sidebarWorkspaceSwitcherItemLabel {
-	padding-left: 2px;
+	padding-left: 0px;
+}
+
+.sidebarWorkspaceSwitcherItemLabel span[role='img'] {
+	width: 12px;
+	height: 12px;
 }
 
 .sidebarWorkspaceSwitcherSeparator {
+	height: 4px;
+	margin: 0px;
+	display: flex;
+	align-items: center;
+	background-color: transparent;
+}
+
+.sidebarWorkspaceSwitcherSeparator::after {
+	content: '';
+	width: 100%;
 	height: 1px;
-	margin: 4px 0px;
-	background-color: var(--tl-color-divider, rgba(232, 232, 232, 1));
+	background-color: var(--tla-color-border);
+}
+
+/* Sidebar dropdowns use the compact 36px menu rows from the Figma sidebar spec. */
+.sidebarDropdownMenu,
+:global(body:has(.tla-sidebar-file-menu) [data-testid$='move-to-workspace-content']) {
+	min-width: 101px;
+	padding: 2px 0px;
+	border-radius: 9px;
+	background-color: var(--tla-color-sidebar);
+	box-shadow: var(--tla-shadow-2);
+	color: var(--tla-color-text-1);
+}
+
+:global(body:has(.tla-sidebar-file-menu) [data-testid$='move-to-workspace-content']) {
+	min-width: 144px;
+}
+
+.sidebarDropdownMenu :global(.tlui-menu__group),
+:global(
+	body:has(.tla-sidebar-file-menu) [data-testid$='move-to-workspace-content'] .tlui-menu__group
+) {
+	border-bottom: none;
+}
+
+.sidebarDropdownMenu :global(.tlui-menu__group + .tlui-menu__group),
+:global(
+	body:has(.tla-sidebar-file-menu)
+		[data-testid$='move-to-workspace-content']
+		.tlui-menu__group
+		+ .tlui-menu__group
+) {
+	margin-top: 2px;
+	padding-top: 2px;
+	border-top: 1px solid var(--tla-color-border);
+}
+
+.sidebarDropdownMenu :global(.tlui-button__menu),
+:global(
+	body:has(.tla-sidebar-file-menu) [data-testid$='move-to-workspace-content'] .tlui-button__menu
+) {
+	height: 36px;
+	min-height: 36px;
+	margin-top: 0px;
+	padding: 0px 12px;
+	gap: 6px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1;
+	color: var(--tla-color-text-1);
+}
+
+.sidebarDropdownMenu :global(.tlui-button__menu)::after,
+:global(
+	body:has(.tla-sidebar-file-menu) [data-testid$='move-to-workspace-content'] .tlui-button__menu
+)::after {
+	inset: 2px 4px;
+	border-radius: 4px;
+	background-color: var(--tla-color-hover-1);
+}
+
+.sidebarDropdownMenu :global(.tlui-button__menu[data-highlighted])::after,
+.sidebarDropdownMenu :global(.tlui-menu__submenu__trigger[data-state='open'])::after,
+:global(
+	body:has(.tla-sidebar-file-menu)
+		[data-testid$='move-to-workspace-content']
+		.tlui-button__menu[data-highlighted]
+)::after {
+	opacity: 1;
+	background: var(--tla-color-hover-1);
+}
+
+.sidebarDropdownMenu :global(.tlui-button__menu > .tlui-icon),
+.sidebarDropdownMenu :global(.tlui-button__menu span[role='img']),
+.sidebarDropdownMenu :global(.tlui-icon__placeholder),
+:global(
+	body:has(.tla-sidebar-file-menu)
+		[data-testid$='move-to-workspace-content']
+		.tlui-button__menu
+		> .tlui-icon
+),
+:global(
+	body:has(.tla-sidebar-file-menu)
+		[data-testid$='move-to-workspace-content']
+		.tlui-button__menu
+		span[role='img']
+),
+:global(
+	body:has(.tla-sidebar-file-menu)
+		[data-testid$='move-to-workspace-content']
+		.tlui-button__menu
+		.tlui-icon__placeholder
+) {
+	width: 12px;
+	height: 12px;
 }
 
 /* 36px rows whose hover highlight is 32px tall (the .hoverable::after insets
@@ -700,6 +885,12 @@
 .sidebarActionButton > span[role='img'] {
 	flex-shrink: 0;
 	margin: -1.5px;
+}
+
+.sidebar[data-workspaces='true'] .sidebarActionButton > span[role='img'] {
+	width: 12px;
+	height: 12px;
+	margin: 0;
 }
 
 .sidebarSearchIcon {
@@ -833,13 +1024,20 @@
 }
 
 .sidebarFileListItemRenameInputWrapper {
+	box-sizing: border-box;
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
+	width: 100%;
+	height: 36px;
 	padding: 0px 8px 0px calc(8px + var(--tla-sidebar-group-item-padding-left, 0px));
 	outline-offset: -2px;
 	gap: 8px;
 	position: relative;
+}
+
+.sidebar[data-workspaces='true'] .sidebarFileListItemRenameInputWrapper {
+	padding: 0px 4px 0px 8px;
 }
 
 .sidebarFileListItemRenameInputWrapper::before {
@@ -856,14 +1054,23 @@
 }
 
 .sidebarFileListItemRenameInput {
+	box-sizing: border-box;
 	height: 36px;
+	max-height: 36px;
 	align-self: flex-start;
 	flex: 1 1 auto;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	padding: 0px;
 	position: relative;
 	z-index: 1;
+}
+
+.sidebar[data-workspaces='true'] .sidebarFileListItemRenameInput {
+	font-size: 12px;
+	line-height: 1;
+	font-weight: 500;
 }
 
 .sidebarFileListItemButton {
@@ -907,6 +1114,11 @@
 
 .sidebarFileListItemMenuTrigger:after {
 	content: none;
+}
+
+.sidebar[data-workspaces='true'] .sidebarFileListItemMenuTrigger span[role='img'] {
+	width: 12px;
+	height: 12px;
 }
 
 .sidebarFileListItemMenuTrigger:focus-visible {

--- a/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
+++ b/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
@@ -291,13 +291,13 @@ export function CookieConsentMenuItem() {
 	)
 }
 
-export function UserManualMenuItem({ icon = true }: { icon?: boolean } = {}) {
+export function UserManualMenuItem({ icon = 'manual' }: { icon?: string | false } = {}) {
 	const openAndTrack = useOpenUrlAndTrack('main-menu')
 	return (
 		<TldrawUiMenuItem
 			id="user-manual"
 			label={useMsg(messages.getHelp)}
-			iconLeft={icon ? 'manual' : undefined}
+			iconLeft={icon || undefined}
 			readonlyOk
 			onSelect={() => {
 				openAndTrack('https://tldraw.notion.site/support')

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -15,7 +15,7 @@ import {
 import styles from './sidebar-layout.module.css'
 
 const MIN_SIDEBAR_WIDTH = 150
-const DEF_SIDEBAR_WIDTH = 260
+const DEF_SIDEBAR_WIDTH = 264
 const MAX_SIDEBAR_WIDTH = 500
 
 export function TlaSidebarLayout({

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/sidebar-layout.module.css
@@ -1,5 +1,5 @@
 .layout {
-	--tla-sidebar-width: 260px;
+	--tla-sidebar-width: 264px;
 	position: absolute;
 	top: 0px;
 	left: 0px;

--- a/apps/dotcom/client/src/tla/utils/local-session-state.ts
+++ b/apps/dotcom/client/src/tla/utils/local-session-state.ts
@@ -59,7 +59,7 @@ const defaultSessionState: TldrawAppSessionState = {
 		exportBackground: true,
 		exportPadding: false,
 	},
-	sidebarWidth: 260,
+	sidebarWidth: 264,
 }
 
 let prev: TldrawAppSessionState = { ...defaultSessionState }


### PR DESCRIPTION
In order to bring the tldraw.com sidebar in line with the workspaces Figma spec, this PR refines the sidebar's top region, action rows, and dropdown menus. All changes sit behind the existing `workspaces` flag.

- The home workspace now shows new board, search, and new workspace action rows; created workspaces keep their invite and settings rows. Workspace rows in the switcher get a check mark for the active workspace.
- The file menu, file context menu, and "Move to" submenu are restyled to the compact 36px menu spec. "Move to" now lists every workspace with the current one checked, instead of hiding the current and home workspaces.
- Icon sizing is tidied to the 12px grid across the sidebar, the user settings menu gets a help icon, and the default sidebar width bumps from 260px to 264px.
- Pin menu labels change from "Pin file" / "Unpin file" to "Add pin" / "Remove pin".

### Change type

- [x] `improvement`

### Test plan

1. Enable the workspaces flag and open the sidebar.
2. Confirm the home workspace shows new board, search, and new workspace actions, and that other workspaces show invite and settings.
3. Open the switcher and confirm the active workspace is checked.
4. Open a file menu and the "Move to" submenu; confirm all workspaces appear with the current one checked, and that menus match the compact styling.

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Refine the tldraw.com sidebar design behind the workspaces flag: home and workspace action rows, checked active workspace, restyled dropdown menus, and "Add pin" / "Remove pin" labels.

### Code changes

| Section         | LOC change   |
| --------------- | ------------ |
| Apps            | +436 / -131  |
| Tests           | +8 / -9      |
| Automated files | +22 / -10    |
