### PR TITLE
fix(editor): let InputsManager own its frame subscription

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2198,6 +2198,8 @@ export class InputsManager {
     get currentPagePoint(): Vec;
     // @deprecated (undocumented)
     get currentScreenPoint(): Vec;
+    // @internal (undocumented)
+    dispose(): void;
     getAccelKey(): boolean;
     getAltKey(): boolean;
     getCtrlKey(): boolean;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -409,9 +409,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this._tickManager = new TickManager(this)
 		this.disposables.add(() => this._tickManager.dispose())
 		this.disposables.add(() => {
-			// Reset camera state to 'idle' so the store isn't left stuck at 'moving'
-			// when tick events stop (e.g. React strict mode disposes while camera is moving)
-			this.off('tick', this._decayCameraStateTimeout)
 			this._setCameraState('idle')
 		})
 
@@ -419,6 +416,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.disposables.add(() => this.fonts.dispose())
 
 		this.inputs = new InputsManager(this)
+		this.disposables.add(() => this.inputs.dispose())
 		this.performance = new PerformanceManager(this)
 		this.disposables.add(() => this.performance.dispose())
 		this.collaborators = new CollaboratorsManager(this)
@@ -1179,6 +1177,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.store.dispose()
 		this.isDisposed = true
 		this.emit('dispose')
+		this.removeAllListeners()
 	}
 
 	/* ------------------ Themes (shadowing the theme manager) ------------------ */

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.test.ts
@@ -1,0 +1,61 @@
+import { createTLStore } from '../../../config/createTLStore'
+import { Editor } from '../../Editor'
+
+function createTestEditor() {
+	const store = createTLStore({})
+	store.ensureStoreIsUsable()
+	return new Editor({
+		store,
+		bindingUtils: [],
+		shapeUtils: [],
+		getContainer: () => document.createElement('div'),
+		tools: [],
+	})
+}
+
+describe('InputsManager', () => {
+	let editor: Editor
+
+	beforeEach(() => {
+		editor = createTestEditor()
+	})
+
+	afterEach(() => {
+		editor.dispose()
+	})
+
+	it('updates pointer velocity on frame events', () => {
+		const point = editor.inputs.getCurrentScreenPoint()
+		point.x = 0
+		point.y = 0
+		editor.emit('frame', 16)
+
+		point.x = 100
+		point.y = 0
+		editor.emit('frame', 16)
+
+		expect(editor.inputs.getPointerVelocity().len()).toBeGreaterThan(0)
+	})
+
+	it('stops updating pointer velocity after dispose', () => {
+		const point = editor.inputs.getCurrentScreenPoint()
+		point.x = 0
+		point.y = 0
+		editor.emit('frame', 16)
+
+		point.x = 100
+		point.y = 0
+		editor.emit('frame', 16)
+
+		const velocityBeforeDispose = editor.inputs.getPointerVelocity().clone()
+		expect(velocityBeforeDispose.len()).toBeGreaterThan(0)
+
+		editor.inputs.dispose()
+
+		point.x = 200
+		point.y = 0
+		editor.emit('frame', 16)
+
+		expect(editor.inputs.getPointerVelocity()).toEqual(velocityBeforeDispose)
+	})
+})

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -1,6 +1,7 @@
 import { atom, computed, unsafe__withoutCapture } from '@tldraw/state'
 import { AtomSet } from '@tldraw/store'
 import { TLINSTANCE_ID, TLPOINTER_ID } from '@tldraw/tlschema'
+import { bind } from '@tldraw/utils'
 import { INTERNAL_POINTER_IDS } from '../../../constants'
 import { Vec } from '../../../primitives/Vec'
 import { isAccelKey } from '../../../utils/keyboard'
@@ -12,7 +13,19 @@ const POINTER_VELOCITY_REFERENCE_SMOOTHING = 0.5
 
 /** @public */
 export class InputsManager {
-	constructor(private readonly editor: Editor) {}
+	constructor(private readonly editor: Editor) {
+		this.editor.on('frame', this._onFrame)
+	}
+
+	/** @internal */
+	dispose() {
+		this.editor.off('frame', this._onFrame)
+	}
+
+	@bind
+	private _onFrame(elapsed: number) {
+		this.updatePointerVelocity(elapsed)
+	}
 
 	private _originPagePoint = atom<Vec>('originPagePoint', new Vec())
 	/**
@@ -120,8 +133,7 @@ export class InputsManager {
 	}
 
 	/**
-	 * Normally you shouldn't need to set the pointer velocity directly, this is set by the tick manager.
-	 * However, this is currently used in tests to fake pointer velocity.
+	 * Normally you shouldn't need to set the pointer velocity directly. Used in tests to fake pointer velocity.
 	 * @param pointerVelocity - The pointer velocity.
 	 * @internal
 	 */
@@ -460,7 +472,7 @@ export class InputsManager {
 	private _velocityPrevPoint = new Vec()
 
 	/**
-	 * Update the pointer velocity based on elapsed time. Called by the tick manager.
+	 * Update the pointer velocity based on elapsed time. Called each frame.
 	 * @param elapsed - The time elapsed since the last tick in milliseconds.
 	 * @internal
 	 */

--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.test.ts
@@ -1,5 +1,4 @@
 import { Mock, Mocked, vi } from 'vitest'
-import { Vec } from '../../../primitives/Vec'
 import { Editor } from '../../Editor'
 import { TickManager } from './TickManager'
 
@@ -21,17 +20,6 @@ describe('TickManager', () => {
 	let tickManager: TickManager
 	let mockEmit: Mock
 	let mockDisposablesAdd: Mock
-	let mockInputs: {
-		_currentScreenPoint: Vec
-		getCurrentScreenPoint(): Vec
-		currentScreenPoint: Vec
-		setCurrentScreenPoint(value: Vec): void
-		_pointerVelocity: Vec
-		getPointerVelocity(): Vec
-		pointerVelocity: Vec
-		setPointerVelocity(value: Vec): void
-		updatePointerVelocity(elapsed: number): void
-	}
 
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -52,39 +40,11 @@ describe('TickManager', () => {
 		mockEmit = vi.fn()
 		mockDisposablesAdd = vi.fn()
 
-		// Create a mock inputs object with getters and setters
-		mockInputs = {
-			_currentScreenPoint: new Vec(100, 100),
-			getCurrentScreenPoint() {
-				return this._currentScreenPoint
-			},
-			get currentScreenPoint() {
-				return this.getCurrentScreenPoint()
-			},
-			setCurrentScreenPoint(value: Vec) {
-				this._currentScreenPoint = value
-			},
-			_pointerVelocity: new Vec(0, 0),
-			getPointerVelocity() {
-				return this._pointerVelocity
-			},
-			get pointerVelocity() {
-				return this.getPointerVelocity()
-			},
-			setPointerVelocity(value: Vec) {
-				this._pointerVelocity = value
-			},
-			updatePointerVelocity(_elapsed: number) {
-				// Mock implementation - no-op for tests
-			},
-		}
-
 		editor = {
 			emit: mockEmit,
 			disposables: {
 				add: mockDisposablesAdd,
 			},
-			inputs: mockInputs as unknown as Editor['inputs'],
 		} as unknown as Mocked<Editor>
 
 		tickManager = new TickManager(editor)

--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
@@ -40,7 +40,6 @@ export class TickManager {
 		const elapsed = now - this.now
 		this.now = now
 
-		this.editor.inputs.updatePointerVelocity(elapsed)
 		this.editor.emit('frame', elapsed)
 		this.editor.emit('tick', elapsed)
 		this.cancelRaf = throttleToNextFrame(this.tick)

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -783,9 +783,6 @@ describe('snapping with multiple shapes', () => {
 })
 
 describe('Snap-between behavior', () => {
-	beforeEach(() => {
-		editor?.dispose()
-	})
 	it('snaps a shape horizontally between two others', () => {
 		// ┌─────┐               ┌─────┐
 		// │     │               │     │
@@ -1160,9 +1157,6 @@ describe('Snap-between behavior', () => {
 })
 
 describe('Snap-next-to behavior', () => {
-	beforeEach(() => {
-		editor?.dispose()
-	})
 	it('snaps a shape to the left of two others, matching the gap size', () => {
 		// ┌───┐
 		// │ X │


### PR DESCRIPTION
Closes #8892 (partial — focused fix; no `EditorManager` base class or full manager sweep).

I've had some more ideas for a suitable way to keep having the Editor being the event emitter bus with every "managers" owning their events, it has been spiked in https://github.com/tldraw/tldraw/pull/9204 

## Summary

- `InputsManager` now subscribes to the editor's `frame` event and tears down its own listener in `dispose()`.
- `TickManager` no longer hard-codes `editor.inputs.updatePointerVelocity()`; it only drives the clock and emits `frame` / `tick`.
- `Editor.dispose()` calls `removeAllListeners()` after emitting `dispose`, and the strict-mode camera workaround is simplified to `_setCameraState('idle')` only.

## Why

Issue #8892 flagged asymmetric lifecycle: `TickManager` drove updates but didn't own the listeners they triggered. This moves pointer velocity into a normal frame subscription owned by `InputsManager`, and centralizes dispose-time listener cleanup on the editor.

The load-bearing strict-mode fix is resetting persisted `cameraState` to `'idle'` when the editor is disposed — leftover tick listeners on a dead editor instance were never the real bug.

## Test plan

- [x] `cd packages/editor && yarn test run TickManager InputsManager`
- [x] `cd packages/tldraw && yarn test run HandTool Editor setCamera`
- [x] `yarn workspace @tldraw/editor build-api` (no public API change on `InputsManager`)

### API changes

- No public API changes for SDK consumers.
- Added `@internal` `InputsManager.dispose()` to the API report. This is an editor lifecycle hook; do not call it from app code — use `editor.dispose()` instead.
- `Editor.dispose()` now removes all event listeners after emitting `dispose`. Custom `editor.on(...)` handlers are cleared when the editor is torn down (expected for a disposed instance).

### Release notes

- Fix camera state getting stuck at `moving` when the editor is disposed during camera movement (e.g. React strict mode with a shared store).