### PR TITLE
refactor(dotcom): use ExternalLink for external links in dialogs

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaDebug.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaDebug.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { memo } from 'react'
 import { ExampleDialog, TldrawUiMenuItem, useDialogs } from 'tldraw'
+import { ExternalLink } from '../ExternalLink/ExternalLink'
 
 export function A11yAudit() {
 	const { addDialog } = useDialogs()
@@ -74,11 +75,7 @@ export const A11yResultTable = memo(({ results }: { results: any }) => {
 								))}
 							</td>
 							<td>
-								{issue.helpUrl ? (
-									<a href={issue.helpUrl} target="_blank" rel="noopener noreferrer">
-										More info
-									</a>
-								) : null}
+								{issue.helpUrl ? <ExternalLink to={issue.helpUrl}>More info</ExternalLink> : null}
 							</td>
 						</tr>
 					))}

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaLegalAcceptance.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaLegalAcceptance.tsx
@@ -4,6 +4,7 @@ import { useCallback, useRef, useState } from 'react'
 import { TldrawUiDialogBody, TldrawUiDialogHeader, TldrawUiDialogTitle } from 'tldraw'
 import { useAnalyticsConsent } from '../../hooks/useAnalyticsConsent'
 import { F } from '../../utils/i18n'
+import { ExternalLink } from '../ExternalLink/ExternalLink'
 import { TlaMenuSwitch } from '../tla-menu/tla-menu'
 import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
 import { TlaLogo } from '../TlaLogo/TlaLogo'
@@ -74,16 +75,8 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 					<F
 						defaultMessage="Before you start, please accept our <tos>terms of use</tos> and <privacy>privacy policy</privacy>."
 						values={{
-							tos: (chunks) => (
-								<a href="/tos.html" target="_blank" rel="noopener noreferrer">
-									{chunks}
-								</a>
-							),
-							privacy: (chunks) => (
-								<a href="/privacy.html" target="_blank" rel="noopener noreferrer">
-									{chunks}
-								</a>
-							),
+							tos: (chunks) => <ExternalLink to="/tos.html">{chunks}</ExternalLink>,
+							privacy: (chunks) => <ExternalLink to="/privacy.html">{chunks}</ExternalLink>,
 						}}
 					/>
 				</p>
@@ -94,11 +87,7 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 							<F
 								defaultMessage="Allow <cookies>analytics</cookies> to help us improve tldraw."
 								values={{
-									cookies: (chunks) => (
-										<a href="/cookies.html" target="_blank" rel="noopener noreferrer">
-											{chunks}
-										</a>
-									),
+									cookies: (chunks) => <ExternalLink to="/cookies.html">{chunks}</ExternalLink>,
 								}}
 							/>
 						</span>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaManageCookiesDialog.tsx
@@ -7,6 +7,7 @@ import {
 } from 'tldraw'
 import { useAnalyticsConsent } from '../../hooks/useAnalyticsConsent'
 import { F } from '../../utils/i18n'
+import { ExternalLink } from '../ExternalLink/ExternalLink'
 import {
 	TlaMenuControl,
 	TlaMenuControlGroup,
@@ -35,11 +36,7 @@ export function TlaManageCookiesDialog() {
 						<F
 							defaultMessage="We use cookies to keep you logged in, to sync your files, and to collect analytics to help us improve tldraw."
 							values={{
-								a: (chunks) => (
-									<a href={COOKIE_POLICY_URL} target="_blank" rel="noreferrer">
-										{chunks}
-									</a>
-								),
+								a: (chunks) => <ExternalLink to={COOKIE_POLICY_URL}>{chunks}</ExternalLink>,
 							}}
 						/>
 					</p>
@@ -71,11 +68,7 @@ export function TlaManageCookiesDialog() {
 						<F
 							defaultMessage="Read our <a>cookie policy</a> to learn more."
 							values={{
-								a: (chunks) => (
-									<a href={COOKIE_POLICY_URL} target="_blank" rel="noreferrer">
-										{chunks}
-									</a>
-								),
+								a: (chunks) => <ExternalLink to={COOKIE_POLICY_URL}>{chunks}</ExternalLink>,
 							}}
 						/>
 					</p>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaSignInDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from 'tldraw'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
 import { setRedirectOnSignIn } from '../../utils/redirect'
+import { ExternalLink } from '../ExternalLink/ExternalLink'
 import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
 import { TlaLogo } from '../TlaLogo/TlaLogo'
 import styles from './auth.module.css'
@@ -266,14 +267,14 @@ function TlaEnterEmailStep({
 				</TlaCtaButton>
 
 				<p className={styles.authTermsOfUse}>
-					<a href="/tos.html" target="_blank" rel="noopener noreferrer">
+					<ExternalLink to="/tos.html">
 						<F defaultMessage="Terms of Use" />
-					</a>
+					</ExternalLink>
 					{/* eslint-disable-next-line tldraw/jsx-no-literals */}
 					{' · '}
-					<a href="/privacy.html" target="_blank" rel="noopener noreferrer">
+					<ExternalLink to="/privacy.html">
 						<F defaultMessage="Privacy Policy" />
-					</a>
+					</ExternalLink>
 				</p>
 			</form>
 		</>


### PR DESCRIPTION
In order to stop re-implementing `target="_blank"` / `rel="noopener noreferrer"` on every external link and keep them consistent, this PR replaces raw `<a>` anchors with the shared `ExternalLink` component across four dotcom dialogs: legal acceptance, manage cookies, sign-in, and the a11y debug table. `ExternalLink` already encapsulates the target/rel boilerplate and is the established pattern for external links in the app. Closes #9198 (part of the design-system consistency tracking issue #9189).

`IFrameProtector` keeps its raw anchor as a documented exception: it sits outside the `tla` subsystem and `ExternalLink` (a react-router `Link`) would require router context that this low-level iframe guard cannot assume.

### Change type

- [x] `improvement`

### Test plan

A `dotcom-preview-please` preview is requested for this PR. On the preview:

1. Open the sign-in dialog and click **Terms of Use** and **Privacy Policy** — each opens the static page in a new tab.
2. Open **Manage cookies** and click the **cookie policy** links — each opens `/cookies.html` in a new tab.
3. Trigger the legal acceptance dialog and click the terms / privacy / analytics links.
4. Confirm the links still render inline within their surrounding sentences (they are embedded in i18n rich-text chunks).

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +14 / -34  |
