### PR TITLE
feat(dotcom): seed new workspaces with a welcome file forked from a template

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -291,7 +291,7 @@ export class Sidebar {
 	}
 
 	@step
-	async createWorkspace(name: string, { dismissRename = true } = {}) {
+	async createWorkspace(name: string) {
 		// The standalone button is only shown while the user has no workspaces;
 		// after that, creating happens from the workspace switcher dropdown.
 		if (await this.createWorkspaceButton.isVisible()) {
@@ -308,14 +308,9 @@ export class Sidebar {
 		await this.page.getByRole('button', { name: 'Create workspace' }).click()
 		await this.mutationResolution()
 
-		// Creating a workspace switches to it, creates its first file, and
-		// starts renaming that file.
+		// Creating a workspace switches to it and opens its seeded welcome file. That file
+		// arrives named, so (unlike a blank file) there is no inline rename to dismiss.
 		await this.expectActiveWorkspace(name)
-		const renameInput = this.page.getByTestId('tla-sidebar-rename-input')
-		await expect(renameInput).toBeVisible()
-		if (dismissRename) {
-			await this.page.keyboard.press('Escape')
-		}
 	}
 
 	getWorkspaceLink(name: string) {

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -165,6 +165,12 @@
       "value": "Upload failed"
     }
   ],
+  "2a1167f869": [
+    {
+      "type": 0,
+      "value": "Welcome to your workspace"
+    }
+  ],
   "2c3ef76333": [
     {
       "type": 0,

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -80,6 +80,9 @@
   "299cb00a7a": {
     "translation": "Upload failed"
   },
+  "2a1167f869": {
+    "translation": "Welcome to your workspace"
+  },
   "2c3ef76333": {
     "translation": "My files"
   },

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -283,7 +283,9 @@ export function Component() {
 
 function WelcomeTemplate() {
 	const inputRef = useRef<HTMLInputElement>(null)
-	const [current, setCurrent] = useState(null as { fileId: string; publishedSlug: string } | null)
+	const [current, setCurrent] = useState(
+		null as { fileId: string; publishedSlug: string; live?: boolean } | null
+	)
 	const [isLoading, setIsLoading] = useState(true)
 	const [error, setError] = useState(null as string | null)
 	const [successMessage, setSuccessMessage] = useState(null as string | null)
@@ -376,7 +378,9 @@ function WelcomeTemplate() {
 					{isLoading
 						? 'Loading…'
 						: current
-							? `${current.fileId} (published slug ${current.publishedSlug})`
+							? `${current.fileId} (published slug ${current.publishedSlug})${
+									current.live ? '' : ' ⚠️ not published — new workspaces fall back to the default'
+								}`
 							: 'none — using the built-in default'}
 				</span>
 			</div>

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -254,6 +254,12 @@ export function Component() {
 					<FeatureFlags />
 				</section>
 
+				{/* Welcome Template Section */}
+				<section className={styles.adminSection}>
+					<h3 className="tla-text_ui__title">Welcome template</h3>
+					<WelcomeTemplate />
+				</section>
+
 				{/* File Operations Section */}
 				<section className={styles.adminSection}>
 					<h3 className="tla-text_ui__title">File Operations</h3>
@@ -271,6 +277,123 @@ export function Component() {
 					<DeleteUser />
 				</section>
 			</main>
+		</div>
+	)
+}
+
+function WelcomeTemplate() {
+	const inputRef = useRef<HTMLInputElement>(null)
+	const [current, setCurrent] = useState(null as { fileId: string; publishedSlug: string } | null)
+	const [isLoading, setIsLoading] = useState(true)
+	const [error, setError] = useState(null as string | null)
+	const [successMessage, setSuccessMessage] = useState(null as string | null)
+
+	const load = useCallback(async () => {
+		setIsLoading(true)
+		setError(null)
+		try {
+			const res = await fetch('/api/app/admin/welcome-template')
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			setCurrent(await res.json())
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to load welcome template')
+		} finally {
+			setIsLoading(false)
+		}
+	}, [])
+
+	useEffect(() => {
+		load()
+	}, [load])
+
+	const onSet = useCallback(async () => {
+		const fileId = inputRef.current?.value?.trim()
+		if (!fileId) {
+			setError('Please enter a published file ID')
+			return
+		}
+		setError(null)
+		setSuccessMessage(null)
+		try {
+			const res = await fetch('/api/app/admin/welcome-template', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ fileId }),
+			})
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			setCurrent(await res.json())
+			setSuccessMessage('Welcome template set ✨')
+			inputRef.current!.value = ''
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to set welcome template')
+		}
+	}, [])
+
+	const onClear = useCallback(async () => {
+		if (
+			!window.confirm('Clear the welcome template? New workspaces will use the built-in default.')
+		)
+			return
+		setError(null)
+		setSuccessMessage(null)
+		try {
+			const res = await fetch('/api/app/admin/welcome-template/clear', { method: 'POST' })
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			setCurrent(null)
+			setSuccessMessage('Welcome template cleared — using the built-in default')
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to clear welcome template')
+		}
+	}, [])
+
+	useEffect(() => {
+		if (successMessage) {
+			const timer = setTimeout(() => setSuccessMessage(null), 3000)
+			return () => clearTimeout(timer)
+		}
+	}, [successMessage])
+
+	return (
+		<div className={styles.fileOperation}>
+			<p className="tla-text_ui__regular">
+				The file new workspaces fork their first file from. Publish the file first, then set it here
+				by its file ID. Clear it to use the built-in default.
+			</p>
+			{error && <div className={styles.errorMessage}>{error}</div>}
+			{successMessage && <div className={styles.successMessage}>{successMessage}</div>}
+			<div className={styles.summaryItem}>
+				<span className={styles.fieldLabel}>Current:</span>
+				<span className={styles.fieldValue}>
+					{isLoading
+						? 'Loading…'
+						: current
+							? `${current.fileId} (published slug ${current.publishedSlug})`
+							: 'none — using the built-in default'}
+				</span>
+			</div>
+			<div className={styles.searchContainer}>
+				<input
+					type="text"
+					placeholder="Published file ID"
+					ref={inputRef}
+					className={styles.searchInput}
+				/>
+				<TlaButton onClick={onSet} variant="primary">
+					Set as welcome template
+				</TlaButton>
+				<TlaButton onClick={onClear} variant="secondary" disabled={!current}>
+					Clear
+				</TlaButton>
+			</div>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -10,6 +10,7 @@ import {
 	MAX_NUMBER_OF_FILES,
 	ROOM_PREFIX,
 	TlaFile,
+	WELCOME_CREATE_SOURCE,
 	TlaFileState,
 	TlaFileStatePartial,
 	TlaFlags,
@@ -327,6 +328,8 @@ export class TldrawApp {
 			defaultMessage:
 				'You have reached the maximum number of workspaces. You need to delete old workspaces before creating new ones.',
 		},
+		// the name of a workspace's seeded first (welcome) file
+		new_workspace_file_name: { defaultMessage: 'Welcome to your workspace' },
 		// toast title
 		mutation_error_toast_title: { defaultMessage: 'Error' },
 		// toast descriptions
@@ -643,6 +646,44 @@ export class TldrawApp {
 			)
 		}
 		return this.getFileState(fileId)?.isPinned ?? false
+	}
+
+	// A new workspace becomes visible in the sidebar (its `createWorkspace` mutation lands)
+	// before its first file does, so it briefly appears empty. Both the creation flow and an
+	// empty-workspace switch want to seed that first file; this tracks which workspaces have a
+	// seed in flight so the two paths (and rapid repeat clicks) don't create duplicates. The
+	// entry is added synchronously before the file mutation, so a racing caller sees it.
+	private readonly workspacesSeedingFirstFile = new Set<string>()
+
+	/**
+	 * Create the first file of an empty workspace, at most once per workspace even when the
+	 * creation flow and a switch to the (briefly) empty workspace race. The home workspace
+	 * gets a blank file; other workspaces get the seeded welcome file, whose content the sync
+	 * worker resolves from the welcome template (or a committed default). The welcome file
+	 * arrives named. Resolves to `null` when another caller is already seeding this workspace.
+	 */
+	async createWorkspaceFirstFile(
+		workspaceId: string
+	): Promise<Result<
+		{ fileId: string },
+		'max number of files reached' | 'mutation rejected'
+	> | null> {
+		if (this.workspacesSeedingFirstFile.has(workspaceId)) return null
+		this.workspacesSeedingFirstFile.add(workspaceId)
+		try {
+			const isHome = workspaceId === this.getHomeWorkspaceId()
+			return await this.createFile(
+				isHome
+					? { workspaceId }
+					: {
+							workspaceId,
+							name: this.getIntl().formatMessage(this.messages.new_workspace_file_name),
+							createSource: WELCOME_CREATE_SOURCE,
+						}
+			)
+		} finally {
+			this.workspacesSeedingFirstFile.delete(workspaceId)
+		}
 	}
 
 	async createFile({

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -650,40 +650,46 @@ export class TldrawApp {
 
 	// A new workspace becomes visible in the sidebar (its `createWorkspace` mutation lands)
 	// before its first file does, so it briefly appears empty. Both the creation flow and an
-	// empty-workspace switch want to seed that first file; this tracks which workspaces have a
-	// seed in flight so the two paths (and rapid repeat clicks) don't create duplicates. The
-	// entry is added synchronously before the file mutation, so a racing caller sees it.
-	private readonly workspacesSeedingFirstFile = new Set<string>()
+	// empty-workspace switch want to seed that first file; this single-flights the seed per
+	// workspace so concurrent callers (and rapid repeat clicks) share one creation — and all
+	// receive its result — rather than racing to create duplicates. Cleared once settled, so a
+	// workspace emptied later can be seeded again.
+	private readonly workspaceFirstFileSeeds = new Map<
+		string,
+		Promise<Result<{ fileId: string }, 'max number of files reached' | 'mutation rejected'>>
+	>()
 
 	/**
 	 * Create the first file of an empty workspace, at most once per workspace even when the
-	 * creation flow and a switch to the (briefly) empty workspace race. The home workspace
-	 * gets a blank file; other workspaces get the seeded welcome file, whose content the sync
-	 * worker resolves from the welcome template (or a committed default). The welcome file
-	 * arrives named. Resolves to `null` when another caller is already seeding this workspace.
+	 * creation flow and a switch to the (briefly) empty workspace race — concurrent callers
+	 * share the same in-flight creation and all get its result. The home workspace gets a blank
+	 * file; other workspaces get the seeded welcome file, whose content the sync worker
+	 * resolves from the welcome template (or a committed default). The welcome file arrives
+	 * named.
 	 */
-	async createWorkspaceFirstFile(
+	createWorkspaceFirstFile(
 		workspaceId: string
-	): Promise<Result<
-		{ fileId: string },
-		'max number of files reached' | 'mutation rejected'
-	> | null> {
-		if (this.workspacesSeedingFirstFile.has(workspaceId)) return null
-		this.workspacesSeedingFirstFile.add(workspaceId)
-		try {
-			const isHome = workspaceId === this.getHomeWorkspaceId()
-			return await this.createFile(
-				isHome
-					? { workspaceId }
-					: {
-							workspaceId,
-							name: this.getIntl().formatMessage(this.messages.new_workspace_file_name),
-							createSource: WELCOME_CREATE_SOURCE,
-						}
-			)
-		} finally {
-			this.workspacesSeedingFirstFile.delete(workspaceId)
-		}
+	): Promise<Result<{ fileId: string }, 'max number of files reached' | 'mutation rejected'>> {
+		const inFlight = this.workspaceFirstFileSeeds.get(workspaceId)
+		if (inFlight) return inFlight
+
+		const isHome = workspaceId === this.getHomeWorkspaceId()
+		const seed = this.createFile(
+			isHome
+				? { workspaceId }
+				: {
+						workspaceId,
+						name: this.getIntl().formatMessage(this.messages.new_workspace_file_name),
+						createSource: WELCOME_CREATE_SOURCE,
+					}
+		)
+		this.workspaceFirstFileSeeds.set(workspaceId, seed)
+		seed.finally(() => {
+			if (this.workspaceFirstFileSeeds.get(workspaceId) === seed) {
+				this.workspaceFirstFileSeeds.delete(workspaceId)
+			}
+		})
+		return seed
 	}
 
 	async createFile({
@@ -741,6 +747,8 @@ export class TldrawApp {
 
 		if (!createSource) {
 			analyticsSource = 'create-blank-file' // Default for button clicks
+		} else if (createSource === WELCOME_CREATE_SOURCE) {
+			analyticsSource = 'welcome'
 		} else if (createSource.startsWith(`${LOCAL_FILE_PREFIX}/`)) {
 			analyticsSource = 'slurp'
 		} else if (createSource.startsWith(`${FILE_PREFIX}/`)) {

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -684,6 +684,15 @@ export class TldrawApp {
 		return seed
 	}
 
+	/**
+	 * The in-flight welcome-file seed for a workspace, if one is still creating. The empty-workspace
+	 * open path uses this to await a just-created workspace's welcome file rather than racing it with
+	 * a duplicate blank file. Returns undefined once the seed settles (or if none was started).
+	 */
+	getPendingWorkspaceWelcomeFile(workspaceId: string) {
+		return this.workspaceWelcomeFileSeeds.get(workspaceId)
+	}
+
 	async createFile({
 		fileId = uniqueId(),
 		workspaceId = this.getHomeWorkspaceId(),

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -648,45 +648,37 @@ export class TldrawApp {
 		return this.getFileState(fileId)?.isPinned ?? false
 	}
 
-	// A new workspace becomes visible in the sidebar (its `createWorkspace` mutation lands)
-	// before its first file does, so it briefly appears empty. Both the creation flow and an
-	// empty-workspace switch want to seed that first file; this single-flights the seed per
-	// workspace so concurrent callers (and rapid repeat clicks) share one creation — and all
-	// receive its result — rather than racing to create duplicates. Cleared once settled, so a
-	// workspace emptied later can be seeded again.
-	private readonly workspaceFirstFileSeeds = new Map<
+	// A workspace's welcome file is seeded once, when the workspace is created. Its
+	// `createWorkspace` mutation lands before the file does, so the workspace briefly appears
+	// empty; this single-flights the seed per workspace so a double-submit (or any concurrent
+	// caller) shares one creation and all receive its result, rather than creating duplicates.
+	// Cleared once settled.
+	private readonly workspaceWelcomeFileSeeds = new Map<
 		string,
 		Promise<Result<{ fileId: string }, 'max number of files reached' | 'mutation rejected'>>
 	>()
 
 	/**
-	 * Create the first file of an empty workspace, at most once per workspace even when the
-	 * creation flow and a switch to the (briefly) empty workspace race — concurrent callers
-	 * share the same in-flight creation and all get its result. The home workspace gets a blank
-	 * file; other workspaces get the seeded welcome file, whose content the sync worker
-	 * resolves from the welcome template (or a committed default). The welcome file arrives
-	 * named.
+	 * Seed a newly-created workspace's welcome file: a named file whose content the sync worker
+	 * resolves from the welcome template (or a committed default). Called once at workspace
+	 * creation — not on later empty opens, which get a blank file (see useSwitchToWorkspace) —
+	 * and single-flighted so a double-submit shares the same creation.
 	 */
-	createWorkspaceFirstFile(
+	createWorkspaceWelcomeFile(
 		workspaceId: string
 	): Promise<Result<{ fileId: string }, 'max number of files reached' | 'mutation rejected'>> {
-		const inFlight = this.workspaceFirstFileSeeds.get(workspaceId)
+		const inFlight = this.workspaceWelcomeFileSeeds.get(workspaceId)
 		if (inFlight) return inFlight
 
-		const isHome = workspaceId === this.getHomeWorkspaceId()
-		const seed = this.createFile(
-			isHome
-				? { workspaceId }
-				: {
-						workspaceId,
-						name: this.getIntl().formatMessage(this.messages.new_workspace_file_name),
-						createSource: WELCOME_CREATE_SOURCE,
-					}
-		)
-		this.workspaceFirstFileSeeds.set(workspaceId, seed)
+		const seed = this.createFile({
+			workspaceId,
+			name: this.getIntl().formatMessage(this.messages.new_workspace_file_name),
+			createSource: WELCOME_CREATE_SOURCE,
+		})
+		this.workspaceWelcomeFileSeeds.set(workspaceId, seed)
 		seed.finally(() => {
-			if (this.workspaceFirstFileSeeds.get(workspaceId) === seed) {
-				this.workspaceFirstFileSeeds.delete(workspaceId)
+			if (this.workspaceWelcomeFileSeeds.get(workspaceId) === seed) {
+				this.workspaceWelcomeFileSeeds.delete(workspaceId)
 			}
 		})
 		return seed

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -282,15 +282,13 @@ function useSwitchToWorkspace() {
 				navigate(routes.tlaFile(files[0]!.fileId))
 				return
 			}
-			// Empty workspace: create its first file and open that, so selecting a workspace
-			// always lands you on a file within it. Non-home workspaces are seeded with the
-			// welcome file (named, so no inline rename); the home workspace gets a blank file
-			// to rename. createWorkspaceFirstFile single-flights per workspace, so a concurrent
-			// seed (or a rapid second click) shares the same creation and still resolves here.
-			const isHome = workspaceId === app.getHomeWorkspaceId()
-			const res = await app.createWorkspaceFirstFile(workspaceId)
+			// Empty workspace: create a blank file and open it, so selecting a workspace always
+			// lands you on a file within it. The welcome file is seeded only when a workspace is
+			// first created (see useCreateWorkspaceDialog), so an emptied workspace — like the
+			// home workspace — just gets a fresh blank file to rename, not another welcome doc.
+			const res = await app.createFile({ workspaceId })
 			if (res.ok) {
-				if (isHome && !getIsCoarsePointer()) {
+				if (!getIsCoarsePointer()) {
 					app.sidebarState.update((prev) => ({
 						...prev,
 						renameState: { fileId: res.value.fileId, workspaceId },
@@ -305,8 +303,8 @@ function useSwitchToWorkspace() {
 
 function useCreateWorkspaceDialog() {
 	const app = useApp()
+	const navigate = useNavigate()
 	const { addDialog } = useDialogs()
-	const switchToWorkspace = useSwitchToWorkspace()
 
 	return useCallback(() => {
 		addDialog({
@@ -321,10 +319,16 @@ function useCreateWorkspaceDialog() {
 							app.showMutationRejectionToast((e as Error).message as ZErrorCode)
 							return
 						}
-						await switchToWorkspace(id)
+						// Seed the workspace's welcome file once, here at creation, and open it
+						// directly (not via switchToWorkspace, whose empty-workspace path would
+						// otherwise create a blank file before the welcome file lands).
+						const res = await app.createWorkspaceWelcomeFile(id)
+						if (res.ok) {
+							navigate(routes.tlaFile(res.value.fileId))
+						}
 					}}
 				/>
 			),
 		})
-	}, [app, addDialog, switchToWorkspace])
+	}, [app, addDialog, navigate])
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -285,11 +285,11 @@ function useSwitchToWorkspace() {
 			// Empty workspace: create its first file and open that, so selecting a workspace
 			// always lands you on a file within it. Non-home workspaces are seeded with the
 			// welcome file (named, so no inline rename); the home workspace gets a blank file
-			// to rename. createWorkspaceFirstFile dedupes against a concurrent seed and returns
-			// null if one is already in flight.
+			// to rename. createWorkspaceFirstFile single-flights per workspace, so a concurrent
+			// seed (or a rapid second click) shares the same creation and still resolves here.
 			const isHome = workspaceId === app.getHomeWorkspaceId()
 			const res = await app.createWorkspaceFirstFile(workspaceId)
-			if (res?.ok) {
+			if (res.ok) {
 				if (isHome && !getIsCoarsePointer()) {
 					app.sidebarState.update((prev) => ({
 						...prev,

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -282,6 +282,18 @@ function useSwitchToWorkspace() {
 				navigate(routes.tlaFile(files[0]!.fileId))
 				return
 			}
+			// A workspace created moments ago may still be seeding its welcome file: the
+			// createWorkspace mutation lands before the file does, so it briefly appears empty.
+			// Await that in-flight seed and open its result rather than racing it with a duplicate
+			// blank file. (On seed failure we fall through to the blank-file path below.)
+			const pendingWelcome = app.getPendingWorkspaceWelcomeFile(workspaceId)
+			if (pendingWelcome) {
+				const seeded = await pendingWelcome
+				if (seeded.ok) {
+					navigate(routes.tlaFile(seeded.value.fileId))
+					return
+				}
+			}
 			// Empty workspace: create a blank file and open it, so selecting a workspace always
 			// lands you on a file within it. The welcome file is seeded only when a workspace is
 			// first created (see useCreateWorkspaceDialog), so an emptied workspace — like the
@@ -305,6 +317,7 @@ function useCreateWorkspaceDialog() {
 	const app = useApp()
 	const navigate = useNavigate()
 	const { addDialog } = useDialogs()
+	const switchToWorkspace = useSwitchToWorkspace()
 
 	return useCallback(() => {
 		addDialog({
@@ -325,10 +338,15 @@ function useCreateWorkspaceDialog() {
 						const res = await app.createWorkspaceWelcomeFile(id)
 						if (res.ok) {
 							navigate(routes.tlaFile(res.value.fileId))
+						} else {
+							// Seeding failed; still land the user in the new workspace rather than
+							// leaving them stranded. switchToWorkspace creates a blank file for the
+							// (now empty) workspace and opens it.
+							await switchToWorkspace(id)
 						}
 					}}
 				/>
 			),
 		})
-	}, [app, addDialog, navigate])
+	}, [app, addDialog, navigate, switchToWorkspace])
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -282,11 +282,15 @@ function useSwitchToWorkspace() {
 				navigate(routes.tlaFile(files[0]!.fileId))
 				return
 			}
-			// Empty workspace: create a file in it and open that, so selecting a
-			// workspace always lands you on a file within it.
-			const res = await app.createFile({ workspaceId })
-			if (res.ok) {
-				if (!getIsCoarsePointer()) {
+			// Empty workspace: create its first file and open that, so selecting a workspace
+			// always lands you on a file within it. Non-home workspaces are seeded with the
+			// welcome file (named, so no inline rename); the home workspace gets a blank file
+			// to rename. createWorkspaceFirstFile dedupes against a concurrent seed and returns
+			// null if one is already in flight.
+			const isHome = workspaceId === app.getHomeWorkspaceId()
+			const res = await app.createWorkspaceFirstFile(workspaceId)
+			if (res?.ok) {
+				if (isHome && !getIsCoarsePointer()) {
 					app.sidebarState.update((prev) => ({
 						...prev,
 						renameState: { fileId: res.value.fileId, workspaceId },

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -37,24 +37,18 @@ export function TlaDeleteFileDialog({
 		trackEvent('delete-file', { source: 'file-menu' })
 		await app.deleteOrForgetFile(fileId, workspaceId)
 
-		// Prefer staying within the workspace the file was deleted from: navigate to the
-		// top of its remaining files so the sidebar scrolls to the current workspace
-		// instead of jumping up to my files.
-		const workspaceFiles =
-			workspaceId === app.getHomeWorkspaceId() ? [] : app.getWorkspaceFilesSorted(workspaceId)
-		if (workspaceFiles.length > 0) {
-			navigate(routes.tlaFile(workspaceFiles[0].fileId))
+		// Stay in the workspace the file was deleted from: go to its most recent remaining
+		// file, or — if that was its last file — create a fresh blank file in it, the same
+		// "always land on a file" behavior as opening an empty workspace. (Home lists its files
+		// via getMyFiles rather than as a workspace.)
+		const isHome = workspaceId === app.getHomeWorkspaceId()
+		const remaining = isHome ? app.getMyFiles() : app.getWorkspaceFilesSorted(workspaceId)
+		if (remaining.length > 0) {
+			navigate(routes.tlaFile(remaining[0].fileId))
 		} else {
-			// Deleting from my files, or the workspace is now empty: fall back to my files,
-			// creating a new file if there are none.
-			const recentFiles = app.getMyFiles()
-			if (recentFiles.length === 0) {
-				const result = await app.createFile()
-				if (result.ok) {
-					navigate(routes.tlaFile(result.value.fileId))
-				}
-			} else {
-				navigate(routes.tlaFile(recentFiles[0].fileId))
+			const result = await app.createFile({ workspaceId })
+			if (result.ok) {
+				navigate(routes.tlaFile(result.value.fileId))
 			}
 		}
 		onClose()

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -905,7 +905,7 @@ export class TLFileDurableObject extends DurableObject {
 			// A new workspace's first file. Unlike the prefix/id sources below, this is a fixed
 			// marker the worker resolves to the welcome template's content (or a committed
 			// default) — see resolveWelcomeSnapshot.
-			data = await resolveWelcomeSnapshot(this.env)
+			data = await resolveWelcomeSnapshot(this.env, (e) => this.reportError(e))
 		} else {
 			const split = createSource?.split('/')
 			if (!split || split?.length !== 2) {

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -16,6 +16,7 @@ import {
 	SNAPSHOT_PREFIX,
 	TLCustomServerEvent,
 	TlaFile,
+	WELCOME_CREATE_SOURCE,
 	can,
 	type RoomOpenMode,
 } from '@tldraw/dotcom-shared'
@@ -71,6 +72,7 @@ import { getAuth, requireAdminAccess, requireWriteAccessToFile } from './utils/t
 import { getLegacyRoomData } from './utils/tla/getLegacyRoomData'
 import { getRole } from './utils/tla/getRole'
 import { isTestFile } from './utils/tla/isTestFile'
+import { resolveWelcomeSnapshot } from './welcome/resolveWelcomeSnapshot'
 
 const MAX_CONNECTIONS = 50
 
@@ -894,50 +896,59 @@ export class TLFileDurableObject extends DurableObject {
 
 	async handleFileCreateFromSource(): Promise<DBLoadResult> {
 		assert(this._fileRecordCache, 'we need to have a file record to create a file from source')
-		const split = this._fileRecordCache.createSource?.split('/')
-		if (!split || split?.length !== 2) {
-			throw ROOM_NOT_FOUND
-		}
+		const createSource = this._fileRecordCache.createSource
 
 		let data: RoomSnapshot | string | null | undefined = undefined
-		const [prefix, id] = split
 		const fetchTimer = this.timer()
-		switch (prefix) {
-			case FILE_PREFIX: {
-				// The source file's content is copied verbatim into this (user-owned)
-				// room. Read access to the source `id` is authorized upstream when the
-				// file record is created (see the `createFile` mutator), since that is
-				// where the requesting user's identity is known.
-				const awaitPersistTimer = this.timer()
-				await getRoomDurableObject(this.env, id).awaitPersist()
-				awaitPersistTimer.report('create_from_source_await_persist')
 
-				const r2FetchTimer = this.timer()
-				data = await this.r2.rooms
-					.get(getR2KeyForRoom({ slug: id, isApp: true }))
-					.then((r) => r?.text())
-				r2FetchTimer.report('create_from_source_r2_fetch')
-				break
+		if (createSource === WELCOME_CREATE_SOURCE) {
+			// A new workspace's first file. Unlike the prefix/id sources below, this is a fixed
+			// marker the worker resolves to the welcome template's content (or a committed
+			// default) — see resolveWelcomeSnapshot.
+			data = await resolveWelcomeSnapshot(this.env)
+		} else {
+			const split = createSource?.split('/')
+			if (!split || split?.length !== 2) {
+				throw ROOM_NOT_FOUND
 			}
-			case ROOM_PREFIX:
-				data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
-				break
-			case READ_ONLY_PREFIX:
-				data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
-				break
-			case READ_ONLY_LEGACY_PREFIX:
-				data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
-				break
-			case SNAPSHOT_PREFIX:
-				data = await getLegacyRoomData(this.env, id, 'snapshot')
-				break
-			case PUBLISH_PREFIX:
-				data = await getPublishedRoomSnapshot(this.env, id)
-				break
-			case LOCAL_FILE_PREFIX:
-				// create empty room, the client will populate it
-				data = DEFAULT_INITIAL_SNAPSHOT
-				break
+			const [prefix, id] = split
+			switch (prefix) {
+				case FILE_PREFIX: {
+					// The source file's content is copied verbatim into this (user-owned)
+					// room. Read access to the source `id` is authorized upstream when the
+					// file record is created (see the `createFile` mutator), since that is
+					// where the requesting user's identity is known.
+					const awaitPersistTimer = this.timer()
+					await getRoomDurableObject(this.env, id).awaitPersist()
+					awaitPersistTimer.report('create_from_source_await_persist')
+
+					const r2FetchTimer = this.timer()
+					data = await this.r2.rooms
+						.get(getR2KeyForRoom({ slug: id, isApp: true }))
+						.then((r) => r?.text())
+					r2FetchTimer.report('create_from_source_r2_fetch')
+					break
+				}
+				case ROOM_PREFIX:
+					data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
+					break
+				case READ_ONLY_PREFIX:
+					data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
+					break
+				case READ_ONLY_LEGACY_PREFIX:
+					data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
+					break
+				case SNAPSHOT_PREFIX:
+					data = await getLegacyRoomData(this.env, id, 'snapshot')
+					break
+				case PUBLISH_PREFIX:
+					data = await getPublishedRoomSnapshot(this.env, id)
+					break
+				case LOCAL_FILE_PREFIX:
+					// create empty room, the client will populate it
+					data = DEFAULT_INITIAL_SNAPSHOT
+					break
+			}
 		}
 		fetchTimer.report('create_from_source_fetch_total')
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -896,60 +896,9 @@ export class TLFileDurableObject extends DurableObject {
 
 	async handleFileCreateFromSource(): Promise<DBLoadResult> {
 		assert(this._fileRecordCache, 'we need to have a file record to create a file from source')
-		const createSource = this._fileRecordCache.createSource
 
-		let data: RoomSnapshot | string | null | undefined = undefined
 		const fetchTimer = this.timer()
-
-		if (createSource === WELCOME_CREATE_SOURCE) {
-			// A new workspace's first file. Unlike the prefix/id sources below, this is a fixed
-			// marker the worker resolves to the welcome template's content (or a committed
-			// default) — see resolveWelcomeSnapshot.
-			data = await resolveWelcomeSnapshot(this.env, (e) => this.reportError(e))
-		} else {
-			const split = createSource?.split('/')
-			if (!split || split?.length !== 2) {
-				throw ROOM_NOT_FOUND
-			}
-			const [prefix, id] = split
-			switch (prefix) {
-				case FILE_PREFIX: {
-					// The source file's content is copied verbatim into this (user-owned)
-					// room. Read access to the source `id` is authorized upstream when the
-					// file record is created (see the `createFile` mutator), since that is
-					// where the requesting user's identity is known.
-					const awaitPersistTimer = this.timer()
-					await getRoomDurableObject(this.env, id).awaitPersist()
-					awaitPersistTimer.report('create_from_source_await_persist')
-
-					const r2FetchTimer = this.timer()
-					data = await this.r2.rooms
-						.get(getR2KeyForRoom({ slug: id, isApp: true }))
-						.then((r) => r?.text())
-					r2FetchTimer.report('create_from_source_r2_fetch')
-					break
-				}
-				case ROOM_PREFIX:
-					data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
-					break
-				case READ_ONLY_PREFIX:
-					data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
-					break
-				case READ_ONLY_LEGACY_PREFIX:
-					data = await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
-					break
-				case SNAPSHOT_PREFIX:
-					data = await getLegacyRoomData(this.env, id, 'snapshot')
-					break
-				case PUBLISH_PREFIX:
-					data = await getPublishedRoomSnapshot(this.env, id)
-					break
-				case LOCAL_FILE_PREFIX:
-					// create empty room, the client will populate it
-					data = DEFAULT_INITIAL_SNAPSHOT
-					break
-			}
-		}
+		const data = await this.loadCreateSourceData(this._fileRecordCache.createSource)
 		fetchTimer.report('create_from_source_fetch_total')
 
 		if (!data) {
@@ -967,6 +916,58 @@ export class TLFileDurableObject extends DurableObject {
 		return {
 			snapshot,
 			roomSizeMB: roomObject ? roomObject.size / MB : 0,
+		}
+	}
+
+	/**
+	 * Resolve the seed content for a file's `createSource`, as a RoomSnapshot or its serialized
+	 * string. Returns undefined for an unknown source, which the caller turns into ROOM_NOT_FOUND.
+	 */
+	private async loadCreateSourceData(
+		createSource: string | null | undefined
+	): Promise<RoomSnapshot | string | null | undefined> {
+		// A new workspace's first file: a fixed marker (no prefix/id) the worker resolves to the
+		// welcome template's content, or a committed default — see resolveWelcomeSnapshot.
+		if (createSource === WELCOME_CREATE_SOURCE) {
+			return await resolveWelcomeSnapshot(this.env, (e) => this.reportError(e))
+		}
+
+		const split = createSource?.split('/')
+		if (!split || split.length !== 2) {
+			throw ROOM_NOT_FOUND
+		}
+		const [prefix, id] = split
+		switch (prefix) {
+			case FILE_PREFIX: {
+				// The source file's content is copied verbatim into this (user-owned) room. Read
+				// access to the source `id` is authorized upstream when the file record is created
+				// (see the `createFile` mutator), since that is where the user's identity is known.
+				const awaitPersistTimer = this.timer()
+				await getRoomDurableObject(this.env, id).awaitPersist()
+				awaitPersistTimer.report('create_from_source_await_persist')
+
+				const r2FetchTimer = this.timer()
+				const text = await this.r2.rooms
+					.get(getR2KeyForRoom({ slug: id, isApp: true }))
+					.then((r) => r?.text())
+				r2FetchTimer.report('create_from_source_r2_fetch')
+				return text
+			}
+			case ROOM_PREFIX:
+				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_WRITE)
+			case READ_ONLY_PREFIX:
+				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY)
+			case READ_ONLY_LEGACY_PREFIX:
+				return await getLegacyRoomData(this.env, id, ROOM_OPEN_MODE.READ_ONLY_LEGACY)
+			case SNAPSHOT_PREFIX:
+				return await getLegacyRoomData(this.env, id, 'snapshot')
+			case PUBLISH_PREFIX:
+				return await getPublishedRoomSnapshot(this.env, id)
+			case LOCAL_FILE_PREFIX:
+				// create empty room, the client will populate it
+				return DEFAULT_INITIAL_SNAPSHOT
+			default:
+				return undefined
 		}
 	}
 

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -345,7 +345,7 @@ export const adminRoutes = createRouter<Environment>()
 		const file = await pg
 			.selectFrom('file')
 			.where('id', '=', fileId)
-			.select(['id', 'published', 'publishedSlug'])
+			.select(['id', 'published', 'publishedSlug', 'isDeleted'])
 			.executeTakeFirst()
 		if (!file) throw new StatusError(404, `File not found: ${fileId}`)
 		if (!file.published) {
@@ -362,7 +362,10 @@ export const adminRoutes = createRouter<Environment>()
 					.doUpdateSet({ fileId: file.id, publishedSlug: file.publishedSlug, updatedAt })
 			)
 			.execute()
-		return json({ fileId: file.id, publishedSlug: file.publishedSlug, updatedAt })
+		// Return the same shape as GET, including `live`, so the admin UI doesn't flash the
+		// "not published" warning right after a successful set.
+		const live = !file.isDeleted && file.published
+		return json({ fileId: file.id, publishedSlug: file.publishedSlug, updatedAt, live })
 	})
 	// Clear the welcome template, reverting new workspaces to the committed default snapshot.
 	.post('/app/admin/welcome-template/clear', async (_res, env) => {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -318,6 +318,48 @@ export const adminRoutes = createRouter<Environment>()
 		assert(typeof fileSlug === 'string', 'fileSlug is required')
 		return await returnFileSnapshot(env, fileSlug, false)
 	})
+	// The current welcome template (the file new workspaces fork their first file from), or
+	// null when none is set and the committed default is used. See resolveWelcomeSnapshot.
+	.get('/app/admin/welcome-template', async (_res, env) => {
+		const pg = createPostgresConnectionPool(env, '/app/admin/welcome-template')
+		const row = await pg.selectFrom('welcome_template').selectAll().executeTakeFirst()
+		return json(row ?? null)
+	})
+	// Mark a published file as the welcome template. We store its publishedSlug, so the file
+	// must be published first; new workspaces then fork its published snapshot.
+	.post('/app/admin/welcome-template', async (req, env) => {
+		const { fileId } = (await req.json()) as { fileId?: unknown }
+		assert(typeof fileId === 'string' && fileId.length > 0, 'fileId (string) is required')
+
+		const pg = createPostgresConnectionPool(env, '/app/admin/welcome-template')
+		const file = await pg
+			.selectFrom('file')
+			.where('id', '=', fileId)
+			.select(['id', 'published', 'publishedSlug'])
+			.executeTakeFirst()
+		if (!file) throw new StatusError(404, `File not found: ${fileId}`)
+		if (!file.published) {
+			throw new StatusError(400, 'File must be published before it can be the welcome template')
+		}
+
+		const updatedAt = Date.now()
+		await pg
+			.insertInto('welcome_template')
+			.values({ id: true, fileId: file.id, publishedSlug: file.publishedSlug, updatedAt })
+			.onConflict((oc) =>
+				oc
+					.column('id')
+					.doUpdateSet({ fileId: file.id, publishedSlug: file.publishedSlug, updatedAt })
+			)
+			.execute()
+		return json({ fileId: file.id, publishedSlug: file.publishedSlug, updatedAt })
+	})
+	// Clear the welcome template, reverting new workspaces to the committed default snapshot.
+	.post('/app/admin/welcome-template/clear', async (_res, env) => {
+		const pg = createPostgresConnectionPool(env, '/app/admin/welcome-template')
+		await pg.deleteFrom('welcome_template').execute()
+		return json({ cleared: true })
+	})
 
 async function maybeHardDeleteLegacyFile({ id, env }: { id: string; env: Environment }) {
 	return await getRoomDurableObject(env, id).__admin__hardDeleteIfLegacy()

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -319,11 +319,21 @@ export const adminRoutes = createRouter<Environment>()
 		return await returnFileSnapshot(env, fileSlug, false)
 	})
 	// The current welcome template (the file new workspaces fork their first file from), or
-	// null when none is set and the committed default is used. See resolveWelcomeSnapshot.
+	// null when none is set and the committed default is used. Also reports whether the marked
+	// file is still live and published: the resolver silently falls back to the default if it
+	// isn't, so the admin needs to see a stale pointer rather than assume it's working. See
+	// resolveWelcomeSnapshot.
 	.get('/app/admin/welcome-template', async (_res, env) => {
 		const pg = createPostgresConnectionPool(env, '/app/admin/welcome-template')
 		const row = await pg.selectFrom('welcome_template').selectAll().executeTakeFirst()
-		return json(row ?? null)
+		if (!row) return json(null)
+		const file = await pg
+			.selectFrom('file')
+			.where('id', '=', row.fileId)
+			.select(['published', 'isDeleted'])
+			.executeTakeFirst()
+		const live = !!file && !file.isDeleted && file.published
+		return json({ ...row, live })
 	})
 	// Mark a published file as the welcome template. We store its publishedSlug, so the file
 	// must be published first; new workspaces then fork its published snapshot.

--- a/apps/dotcom/sync-worker/src/welcome/defaultWelcomeSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/welcome/defaultWelcomeSnapshot.ts
@@ -1,0 +1,2441 @@
+// The committed *default* welcome document — the fallback content a new workspace's first
+// file is seeded with when no file is marked as the welcome template (fresh dev/preview/prod,
+// before an admin has set one). Once a welcome template file is marked, its published
+// snapshot is used instead and this default is no longer consulted. Its canvas is a
+// three-panel comic in the brand's illustration style (the Downy/Cloudy/Penta characters)
+// covering shared visibility, inviting people, and moving files in.
+//
+// Stored pre-serialized as the JSON of a RoomSnapshot: the worker writes the string to R2
+// verbatim and parses a fresh snapshot per seed, so worker isolates don't pay object-graph
+// evaluation at cold start and no mutable snapshot object is shared between rooms.
+//
+// Schema migrations are handled for you: welcome.test.ts keeps this file baked at the
+// current schema, so when a migration touches these records the test fails and `yarn test -u`
+// re-bakes the literal below. Only redesigning the default canvas needs a manual re-export:
+// open a file in the app, build the content, run this in the console, and rebuild the
+// RoomSnapshot JSON between the backticks below ({ documentClock: 0,
+// tombstoneHistoryStartsAtClock: 0, schema, documents: records.map((state) => ({ state,
+// lastChangedClock: 0 })) }):
+//
+//   JSON.stringify({
+//     schema: editor.store.schema.serialize(),
+//     records: Object.values(editor.store.serialize('document')),
+//   })
+//
+// Keep only document/page/shape (and asset/binding) records: drop any `user` records and
+// reset any `textFirstEditedBy` props to null, since those carry the authoring user's
+// identity.
+//
+// Keep the content near the origin and inside roughly 1200×800 page units: new files open
+// at the default camera (no zoom-to-fit on first visit), so the canvas must fit a typical
+// editor viewport. welcome.test.ts asserts a coarse bounds envelope for this.
+export const defaultWelcomeSnapshotJson = `{
+	"documentClock": 0,
+	"tombstoneHistoryStartsAtClock": 0,
+	"schema": {
+		"schemaVersion": 2,
+		"sequences": {
+			"com.tldraw.store": 5,
+			"com.tldraw.asset": 1,
+			"com.tldraw.camera": 1,
+			"com.tldraw.document": 2,
+			"com.tldraw.instance": 26,
+			"com.tldraw.instance_page_state": 5,
+			"com.tldraw.page": 1,
+			"com.tldraw.instance_presence": 6,
+			"com.tldraw.pointer": 1,
+			"com.tldraw.shape": 4,
+			"com.tldraw.user": 1,
+			"com.tldraw.asset.image": 6,
+			"com.tldraw.asset.video": 5,
+			"com.tldraw.asset.bookmark": 2,
+			"com.tldraw.shape.arrow": 8,
+			"com.tldraw.shape.bookmark": 2,
+			"com.tldraw.shape.draw": 4,
+			"com.tldraw.shape.embed": 4,
+			"com.tldraw.shape.frame": 1,
+			"com.tldraw.shape.geo": 11,
+			"com.tldraw.shape.group": 0,
+			"com.tldraw.shape.highlight": 3,
+			"com.tldraw.shape.image": 5,
+			"com.tldraw.shape.line": 5,
+			"com.tldraw.shape.note": 12,
+			"com.tldraw.shape.text": 4,
+			"com.tldraw.shape.video": 4,
+			"com.tldraw.binding.arrow": 1
+		}
+	},
+	"documents": [
+		{
+			"state": {
+				"gridSize": 10,
+				"name": "",
+				"meta": {},
+				"id": "document:document",
+				"typeName": "document"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"meta": {},
+				"id": "page:page",
+				"name": "Page 1",
+				"index": "a1",
+				"typeName": "page"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 20.48764116032075,
+				"y": 26.174423770442814,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:-L-rqW6hOIhsA2_SCSPCv",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/Zq4AAAAAIKUAAAAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.685919876085497,
+					"scaleY": 0.685919876085497
+				},
+				"parentId": "shape:zUmcvvSq9SJRIp2EVqER9",
+				"index": "a2DpXERV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 42.01894326919903,
+				"y": 24.07841325368804,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:-fE8AbI7P8RrZUnn6eJ_m",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AAAKrwAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.6330585325466017,
+					"scaleY": 0.6330585325466017
+				},
+				"parentId": "shape:zf-Mv7lx75TSGVQj9sHiL",
+				"index": "a3cmBpLV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 0,
+				"y": 0,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:050ZbMAIJKFKLwHb-mf6P",
+				"type": "geo",
+				"props": {
+					"w": 63.99999999999999,
+					"h": 63.99999999999999,
+					"geo": "pentagon",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "m",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:CQ8CzKGPhFuNSzEC4d3ab",
+				"index": "a1",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 73.82291105580043,
+				"y": 0,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:1rO2bAZ391CFEbzKoowv6",
+				"type": "geo",
+				"props": {
+					"w": 234.44013758668294,
+					"h": 145.77951664952835,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a2aF7UQl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 37.02380880226292,
+				"y": 138.0214360546894,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:22ZHSc6AJqQ6TqO_7ZGtk",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/Zq4AAAAAIKUAAAAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.8924667937747233,
+					"scaleY": 0.8924667937747233
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aLraAcBV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 170.96922215977247,
+				"y": 116.46756237007344,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:2JMA1v5e8LGFopoj-Jt-A",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 16,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.3364459229094039,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "+"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aGbIUqHl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 117.01208622570164,
+				"y": 81.13756031653281,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:2l3d0eWP-tDRL06fmhxvH",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 42.18295291160777,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.31097065348041475,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Decision tree"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a8yccgpV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 79.54599236025433,
+				"y": 5.410601921338653,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:3KGPvZ2pt2z1gdK_xBRWH",
+				"type": "geo",
+				"props": {
+					"w": 234.44013758668294,
+					"h": 145.77951664952835,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "grey",
+					"labelColor": "black",
+					"fill": "fill",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a1",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 191.9707994749284,
+				"y": 81.13756031653281,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:3nexYcU3qY6zqK9DT_biT",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 72.51351959598657,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.31097065348041475,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Post-trip retrospective"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a9U3PFOl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 244.6909771827785,
+				"y": 116.25169607193538,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:7Z_63p4qBuOoM84rcKSzJ",
+				"type": "geo",
+				"props": {
+					"w": 8.66310155057614,
+					"h": 7.1408974770218245,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "light-blue",
+					"labelColor": "black",
+					"fill": "fill",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aBWz8dgl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 64.42399038780422,
+				"y": 133.3197530810348,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:9gLywTXosTnvnGBakdQMJ",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AAAKrwAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.8924667937747233,
+					"scaleY": 0.8924667937747233
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aMv78Izl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 119.89988068564571,
+				"y": 149.02961654903993,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:BVI4XEOQleQH51CqflJth",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 62.546875,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 1,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Visitor"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a6BTs",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 283.90000000000003,
+				"y": 227.20000000000005,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:CQ8CzKGPhFuNSzEC4d3ab",
+				"type": "group",
+				"parentId": "page:page",
+				"index": "aBSxrxxd",
+				"props": {},
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 20.4559253377397,
+				"y": 35.55394546015327,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:Cv5oAW4aUK9X4CrDOCXuK",
+				"type": "geo",
+				"props": {
+					"w": 150,
+					"h": 58,
+					"geo": "oval",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"content": [
+									{
+										"type": "text",
+										"text": "join us!"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a39PZ",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 229.3578740942399,
+				"y": 146.63332405285837,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:E2HCohGIwGnVBGJ6PHFGK",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 46.3671875,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 1,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "View"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a74I5",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 169.22570356512222,
+				"y": 56.3895825798966,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:E3A03YzLfa96lV9DLtSxN",
+				"type": "geo",
+				"props": {
+					"w": 8.66310155057614,
+					"h": 7.1408974770218245,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "light-blue",
+					"labelColor": "black",
+					"fill": "fill",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aDwNfQnV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 113.43809258290867,
+				"y": 113.48384916948817,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:EgL7rDXJh5Z520Z-LA7q-",
+				"type": "geo",
+				"props": {
+					"w": 196.67313508595362,
+					"h": 78.83573731273304,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "grey",
+					"labelColor": "black",
+					"fill": "fill",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a1",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 64.16205352262674,
+				"y": 35.6258760349715,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:FW0PLIPH5u3J7p9nYyRfR",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AAAKrwAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 1,
+					"scaleY": 1
+				},
+				"parentId": "shape:khK3znr8sfRGr3clmYOYD",
+				"index": "a6Pmy",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 32.216494505131834,
+				"y": 30.547902709481576,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:GZPCmIuEmRYzdHrBbT0wm",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/w60AAAAAAAAAAAAAwzEAAAAAuDIAAAAAezQAAAAAUjQAAAAARjUAAAAA2DcAAAAAfDgAAAAAPDoAAAAAzDoAAAAAuDoAAAAAsDkAAAAAIDkKrwAAsDkAtAAAuDiPtgAAEDg+tgAAEDgotAAAoDQYsgAAgCwYsQAAgDJ4sQAAQDMosAAAgC5wsQAAADCgrwAAADBwsQAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.6330585325466017,
+					"scaleY": 0.6330585325466017
+				},
+				"parentId": "shape:CQ8CzKGPhFuNSzEC4d3ab",
+				"index": "a4lLIJ5V",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 30.925528518676202,
+				"y": 29.570570413678865,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:I-Gb0qhsQUyQezyKx_r0x",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/w60AAAAAAAAAAAAAwzEAAAAAuDIAAAAAezQAAAAAUjQAAAAARjUAAAAA2DcAAAAAfDgAAAAAPDoAAAAAzDoAAAAAuDoAAAAAsDkAAAAAIDkKrwAAsDkAtAAAuDiPtgAAEDg+tgAAEDgotAAAoDQYsgAAgCwYsQAAgDJ4sQAAQDMosAAAgC5wsQAAADCgrwAAADBwsQAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.685919876085497,
+					"scaleY": 0.685919876085497
+				},
+				"parentId": "shape:zUmcvvSq9SJRIp2EVqER9",
+				"index": "a4OzCnsG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 283.6211366846151,
+				"y": 157.60647342079028,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:K24g9p3oTCU_sKK-ljYzt",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AACuKwAAZqp7LAAAHiUgKQAApDSkNAAAPTYpOAAAFTjNOAAAUjggOQAAhDekOAAAYDdQOAAAmDW4NgAAeDSoNAAAIDHAMgAAoC+ALwAAgC4ALwAAgCwALAAAoC8AIAAAgCqAqwAAYCwgsgAAIDFgtgAAIDIouAAAUDRUuAAAcDVQuAAAQDUWuAAAsDQUtgAAADKktAAAgC4otAAAgCxcswAAACkqtAAAgCwotAAAIDAKswAAACwfsQAAAC16sAAAQC18sAAAACmwqwAAgCp4rAAA"
+						}
+					],
+					"color": "black",
+					"fill": "fill",
+					"dash": "draw",
+					"size": "s",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 1,
+					"scaleY": 1
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a9C9Y",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 116.92510313578373,
+				"y": 33.954470457012235,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:KW5sCOVWT8OIO7C3t-eqP",
+				"type": "geo",
+				"props": {
+					"w": 65.00743355749368,
+					"h": 34.289976660978105,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a3dWzAll",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 119.89988068564571,
+				"y": 117.42636630728157,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:MnR6mvfdg2tLrps2N9XYx",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 77.0546875,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 1,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Member"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a50pA",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 283.6211366846151,
+				"y": 129.39872649695099,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:OSj7igfnIe4qod5JDKbhN",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AACuKwAAZqp7LAAAHiUgKQAApDSkNAAAPTYpOAAAFTjNOAAAUjggOQAAhDekOAAAYDdQOAAAmDW4NgAAeDSoNAAAIDHAMgAAoC+ALwAAgC4ALwAAgCwALAAAoC8AIAAAgCqAqwAAYCwgsgAAIDFgtgAAIDIouAAAUDRUuAAAcDVQuAAAQDUWuAAAsDQUtgAAADKktAAAgC4otAAAgCxcswAAACkqtAAAgCwotAAAIDAKswAAACwfsQAAAC16sAAAQC18sAAAACmwqwAAgCp4rAAA"
+						}
+					],
+					"color": "black",
+					"fill": "fill",
+					"dash": "draw",
+					"size": "s",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 1,
+					"scaleY": 1
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "aA2si",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 236.44389006068792,
+				"y": 118.42557712901908,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:P8uG1InpoIIoJTlONyETx",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 38.6953125,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 1,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Edit"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a81n3",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 116.92510313578373,
+				"y": 92.0715890357126,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:PEFQAwp47mNnzaI8iIdP3",
+				"type": "geo",
+				"props": {
+					"w": 65.00743355749368,
+					"h": 34.289976660978105,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a5pUlrcl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 191.9707994749284,
+				"y": 21.66474625267503,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:Pvsrw91tgj8EMAGL_2dFl",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 55.88097943788618,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.31097065348041475,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Packing checklist"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aAlLWB8V",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 41.546496558607714,
+				"y": 22.560868817835257,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:QAZCFvDMAVODbDygnqT2d",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AAAKrwAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.685919876085497,
+					"scaleY": 0.685919876085497
+				},
+				"parentId": "shape:zUmcvvSq9SJRIp2EVqER9",
+				"index": "a3WkZwUG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 78.30000000000003,
+				"y": 174.20000000000005,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:RmFnpn464VJGgAerQYJ-L",
+				"type": "geo",
+				"props": {
+					"w": 297,
+					"h": 135,
+					"geo": "rectangle",
+					"dash": "dashed",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "m",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a9DNdzxl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": -3.9810919323204246,
+				"y": -3.528128306754155,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:UZ5m5kCotziiYQfZ-HkPV",
+				"type": "geo",
+				"props": {
+					"w": 69.3440966554546,
+					"h": 69.3440966554546,
+					"geo": "cloud",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "m",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:zUmcvvSq9SJRIp2EVqER9",
+				"index": "a1",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 831.4069350265314,
+				"y": 135.6,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"type": "group",
+				"parentId": "page:page",
+				"index": "a9Ccg2CbG",
+				"props": {},
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 247.32470742095836,
+				"y": 115.80778402132839,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:XW5UeI8SerqvTasUA_SQ2",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 16,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.3364459229094039,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "+"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aFN7MErV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 5.186953606369684,
+				"y": 99.37473351190062,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:YyQVx-c86qBxpD2y9_seO",
+				"type": "geo",
+				"props": {
+					"w": 90.2252664880994,
+					"h": 90.2252664880994,
+					"geo": "pentagon",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "m",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aKQ8BYhV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 117.01208622570164,
+				"y": 21.66474625267503,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:Z28p3B2D-WZYYRgHfX0Qx",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 127.8515625,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.31097065348041475,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Regional map"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a7gn7GVV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 22.583017062143142,
+				"y": 27.41348470347515,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:_3XBj3lQ1P58b3KS5O6YW",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/Zq4AAAAAIKUAAAAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.6330585325466017,
+					"scaleY": 0.6330585325466017
+				},
+				"parentId": "shape:CQ8CzKGPhFuNSzEC4d3ab",
+				"index": "a2czFd7G",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 0,
+				"y": 20.38829590031247,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:auCO1XVHPFzUfQ-Aj-6cL",
+				"type": "geo",
+				"props": {
+					"w": 133.8700190662085,
+					"h": 56.296875,
+					"geo": "oval",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"content": [
+									{
+										"type": "text",
+										"text": "so tidy!"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aJgPf0wV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 191.9707994749284,
+				"y": 33.954470457012235,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:cnN9kMUMF8hnuBpHk30Xf",
+				"type": "geo",
+				"props": {
+					"w": 65.00743355749368,
+					"h": 34.289976660978105,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a4BsTzyG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 0,
+				"y": 0,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:d_GwLU7EuiCRhw5-_9NbQ",
+				"type": "geo",
+				"props": {
+					"w": 63.99999999999999,
+					"h": 63.99999999999999,
+					"geo": "arrow-down",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "m",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:zf-Mv7lx75TSGVQj9sHiL",
+				"index": "a1",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 245.14803944908397,
+				"y": 57.183055717597824,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:dj3jzSdVsrRN7YtVaOoLW",
+				"type": "geo",
+				"props": {
+					"w": 8.66310155057614,
+					"h": 7.1408974770218245,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "light-blue",
+					"labelColor": "black",
+					"fill": "fill",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aEzJuNyG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 171.85943380330207,
+				"y": 55.94567052928957,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:dyKIODH6_nJZ9CgPE2KIe",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 16,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.3364459229094039,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "+"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aHUjXyZG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": -2.2124460045648675,
+				"y": -2.409174463167915,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:ed7mZE16Bf4C_QJ8b0pqh",
+				"type": "geo",
+				"props": {
+					"w": 101.09649694246673,
+					"h": 101.09649694246673,
+					"geo": "cloud",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "m",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:khK3znr8sfRGr3clmYOYD",
+				"index": "a3FwHZWr",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 106.56978935951747,
+				"y": 106.10713802593091,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:gGS-H-NK9w5JBuR3R8WcG",
+				"type": "geo",
+				"props": {
+					"w": 196.67313508595362,
+					"h": 78.83573731273304,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "semi",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a2Akp",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": -3.7049877116837706,
+				"y": 76.82529397680992,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:khK3znr8sfRGr3clmYOYD",
+				"type": "group",
+				"parentId": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"index": "a4BhY",
+				"props": {},
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 168.33549192159262,
+				"y": 116.91147442068043,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:mH2XPHnZ6Iw9nWNI2dgS3",
+				"type": "geo",
+				"props": {
+					"w": 8.66310155057614,
+					"h": 7.1408974770218245,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "light-blue",
+					"labelColor": "black",
+					"fill": "fill",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aCMNm0pV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 191.9707994749284,
+				"y": 92.0715890357126,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:nTLlFG2LaOiC8Oi0TiY-v",
+				"type": "geo",
+				"props": {
+					"w": 65.00743355749368,
+					"h": 34.289976660978105,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "a6MUgS9l",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 22.583017062143142,
+				"y": 27.41348470347515,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:pCF8YfTHgwFDq6zEhLDxm",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/Zq4AAAAAIKUAAAAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.6330585325466017,
+					"scaleY": 0.6330585325466017
+				},
+				"parentId": "shape:zf-Mv7lx75TSGVQj9sHiL",
+				"index": "a263MQQV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 247.78176968726382,
+				"y": 56.73914366699083,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:pbPdvo9qFy8IBUYsYn-2Y",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "s",
+					"w": 16,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.3364459229094039,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "+"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aIJxo0cV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 50.60479426321217,
+				"y": 142.44024386526795,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:sFCD7m_vGHkJxk3o74PSL",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/w60AAAAAAAAAAAAAwzEAAAAAuDIAAAAAezQAAAAAUjQAAAAARjUAAAAA2DcAAAAAfDgAAAAAPDoAAAAAzDoAAAAAuDoAAAAAsDkAAAAAIDkKrwAAsDkAtAAAuDiPtgAAEDg+tgAAEDgotAAAoDQYsgAAgCwYsQAAgDJ4sQAAQDMosAAAgC5wsQAAADCgrwAAADBwsQAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.8924667937747233,
+					"scaleY": 0.8924667937747233
+				},
+				"parentId": "shape:WCD0ezbfYvyJ8CeEZXA6-",
+				"index": "aNPhaJZV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 452.5027105731176,
+				"y": 132.88041351777883,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:tvjW5PV-VXtHI6E-6o_IL",
+				"type": "group",
+				"parentId": "page:page",
+				"index": "aC93CFfV",
+				"props": {},
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 42.01894326919904,
+				"y": 24.07841325368804,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:vHnjFG_eyxWrewzR1UHSN",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/AAAKrwAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.6330585325466017,
+					"scaleY": 0.6330585325466017
+				},
+				"parentId": "shape:CQ8CzKGPhFuNSzEC4d3ab",
+				"index": "a3KpYESV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 48.67778428035788,
+				"y": 45.845293550392626,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:vrxr5RlbjJVGWvirc_wVt",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/w60AAAAAAAAAAAAAwzEAAAAAuDIAAAAAezQAAAAAUjQAAAAARjUAAAAA2DcAAAAAfDgAAAAAPDoAAAAAzDoAAAAAuDoAAAAAsDkAAAAAIDkKrwAAsDkAtAAAuDiPtgAAEDg+tgAAEDgotAAAoDQYsgAAgCwYsQAAgDJ4sQAAQDMosAAAgC5wsQAAADCgrwAAADBwsQAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 1,
+					"scaleY": 1
+				},
+				"parentId": "shape:khK3znr8sfRGr3clmYOYD",
+				"index": "a84NN",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 32.216494505131834,
+				"y": 30.547902709481576,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:wcMDn17H3_o3g0WN8gkuj",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/w60AAAAAAAAAAAAAwzEAAAAAuDIAAAAAezQAAAAAUjQAAAAARjUAAAAA2DcAAAAAfDgAAAAAPDoAAAAAzDoAAAAAuDoAAAAAsDkAAAAAIDkKrwAAsDkAtAAAuDiPtgAAEDg+tgAAEDgotAAAoDQYsgAAgCwYsQAAgDJ4sQAAQDMosAAAgC5wsQAAADCgrwAAADBwsQAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 0.6330585325466017,
+					"scaleY": 0.6330585325466017
+				},
+				"parentId": "shape:zf-Mv7lx75TSGVQj9sHiL",
+				"index": "a4kgKzMl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 63.60000000000001,
+				"y": 363,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-caption-1",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "m",
+					"w": 480,
+					"font": "draw",
+					"textAlign": "middle",
+					"autoSize": false,
+					"scale": 0.68,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "A workspace is a "
+									},
+									{
+										"type": "text",
+										"text": "shared space",
+										"marks": [
+											{
+												"type": "bold"
+											}
+										]
+									},
+									{
+										"type": "text",
+										"text": " for your team. Everyone in it can see and edit its files."
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a5NzSpwl",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 444.40000000000003,
+				"y": 363,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-caption-2",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "m",
+					"w": 480,
+					"font": "draw",
+					"textAlign": "middle",
+					"autoSize": false,
+					"scale": 0.68,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Invite your team",
+										"marks": [
+											{
+												"type": "bold"
+											}
+										]
+									},
+									{
+										"type": "text",
+										"text": " with an invite link from the workspace menu in the sidebar. Shared it by accident? Revoke it there too."
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a6k2uplV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 825.2,
+				"y": 363,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-caption-3",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "m",
+					"w": 480,
+					"font": "draw",
+					"textAlign": "middle",
+					"autoSize": false,
+					"scale": 0.68,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"attrs": {
+									"dir": "auto"
+								},
+								"content": [
+									{
+										"type": "text",
+										"text": "Move files in",
+										"marks": [
+											{
+												"type": "bold"
+											}
+										]
+									},
+									{
+										"type": "text",
+										"text": " by dragging them onto this workspace in the sidebar, or with a file's 'Move to' menu."
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a7gskqfV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 50,
+				"y": 121.60000000000001,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-panel-1",
+				"type": "geo",
+				"props": {
+					"w": 353.6,
+					"h": 217.60000000000002,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a2ZtKrvV",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 430.8,
+				"y": 121.60000000000001,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-panel-2",
+				"type": "geo",
+				"props": {
+					"w": 353.6,
+					"h": 217.60000000000002,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a3QUhZVG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 811.6,
+				"y": 121.60000000000001,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-panel-3",
+				"type": "geo",
+				"props": {
+					"w": 353.6,
+					"h": 217.60000000000002,
+					"geo": "rectangle",
+					"dash": "draw",
+					"growY": 0,
+					"url": "",
+					"scale": 1,
+					"color": "black",
+					"labelColor": "black",
+					"fill": "none",
+					"size": "s",
+					"font": "draw",
+					"align": "middle",
+					"verticalAlign": "middle",
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph"
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a4RkZS6V",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 85.32000000000002,
+				"y": 151.67812500000005,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-team-label",
+				"type": "text",
+				"props": {
+					"color": "grey",
+					"size": "s",
+					"w": 8,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.68,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"content": [
+									{
+										"type": "text",
+										"text": "your team"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "aEhzhZxG",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 50,
+				"y": 40,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:welcome-title",
+				"type": "text",
+				"props": {
+					"color": "black",
+					"size": "xl",
+					"w": 8,
+					"font": "draw",
+					"textAlign": "start",
+					"autoSize": true,
+					"scale": 0.68,
+					"richText": {
+						"type": "doc",
+						"content": [
+							{
+								"type": "paragraph",
+								"content": [
+									{
+										"type": "text",
+										"text": "Welcome to your workspace"
+									}
+								]
+							}
+						]
+					}
+				},
+				"parentId": "page:page",
+				"index": "a1gDbS5V",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 33.46042767316371,
+				"y": 40.8940641697576,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:yWwE7jyYSu8YpiIJREQWQ",
+				"type": "draw",
+				"props": {
+					"segments": [
+						{
+							"type": "free",
+							"path": "AAAAAAAAAAAAAAA/Zq4AAAAAIKUAAAAA"
+						}
+					],
+					"color": "black",
+					"fill": "semi",
+					"dash": "draw",
+					"size": "m",
+					"isComplete": true,
+					"isClosed": false,
+					"isPen": false,
+					"scale": 1,
+					"scaleX": 1,
+					"scaleY": 1
+				},
+				"parentId": "shape:khK3znr8sfRGr3clmYOYD",
+				"index": "a4dinZcw",
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 195.99233782418597,
+				"y": 227.20000000000005,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:zUmcvvSq9SJRIp2EVqER9",
+				"type": "group",
+				"parentId": "page:page",
+				"index": "aC3YXLOg",
+				"props": {},
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		},
+		{
+			"state": {
+				"x": 105.70000000000006,
+				"y": 227.20000000000005,
+				"rotation": 0,
+				"isLocked": false,
+				"opacity": 1,
+				"meta": {},
+				"id": "shape:zf-Mv7lx75TSGVQj9sHiL",
+				"type": "group",
+				"parentId": "page:page",
+				"index": "aEFs9aY8",
+				"props": {},
+				"typeName": "shape"
+			},
+			"lastChangedClock": 0
+		}
+	]
+}`

--- a/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.test.ts
+++ b/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.test.ts
@@ -17,7 +17,10 @@ const { getPublishedRoomSnapshot } = await import('../routes/tla/getPublishedFil
 const env = {} as Environment
 const defaultSnapshot = JSON.parse(defaultWelcomeSnapshotJson) as RoomSnapshot
 
-// Stub the Kysely chain `pool.selectFrom('welcome_template').select(...).executeTakeFirst()`.
+const destroy = vi.fn(async () => {})
+
+// Stub the Kysely chain `pool.selectFrom('welcome_template').select(...).executeTakeFirst()`
+// plus `pool.destroy()`.
 function mockWelcomeTemplateRow(row: { publishedSlug: string } | undefined | (() => never)) {
 	vi.mocked(createPostgresConnectionPool).mockReturnValue({
 		selectFrom: () => ({
@@ -25,20 +28,24 @@ function mockWelcomeTemplateRow(row: { publishedSlug: string } | undefined | (()
 				executeTakeFirst: async () => (typeof row === 'function' ? row() : row),
 			}),
 		}),
+		destroy,
 	} as any)
 }
 
 afterEach(() => vi.clearAllMocks())
 
 describe('resolveWelcomeSnapshot', () => {
-	it('uses the committed default when no welcome template is set', async () => {
+	it('uses the committed default — silently — when no welcome template is set', async () => {
+		const reportError = vi.fn()
 		mockWelcomeTemplateRow(undefined)
-		const result = await resolveWelcomeSnapshot(env)
+		const result = await resolveWelcomeSnapshot(env, reportError)
 		expect(result).toEqual(defaultSnapshot)
 		expect(getPublishedRoomSnapshot).not.toHaveBeenCalled()
+		expect(reportError).not.toHaveBeenCalled()
 	})
 
 	it('forks the flagged template’s published snapshot when one is set', async () => {
+		const reportError = vi.fn()
 		const published: RoomSnapshot = {
 			documentClock: 0,
 			tombstoneHistoryStartsAtClock: 0,
@@ -48,34 +55,47 @@ describe('resolveWelcomeSnapshot', () => {
 		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
 		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(published)
 
-		const result = await resolveWelcomeSnapshot(env)
+		const result = await resolveWelcomeSnapshot(env, reportError)
 		expect(getPublishedRoomSnapshot).toHaveBeenCalledWith(env, 'pub_abc')
 		expect(result).toBe(published)
+		expect(reportError).not.toHaveBeenCalled()
 	})
 
-	it('falls back to the default when the published snapshot can’t be read', async () => {
+	it('falls back to the default AND reports when a set template’s snapshot throws', async () => {
+		const reportError = vi.fn()
 		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
-		vi.mocked(getPublishedRoomSnapshot).mockRejectedValue(new Error('not found'))
-		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
+		vi.mocked(getPublishedRoomSnapshot).mockRejectedValue(new Error('not published'))
+		expect(await resolveWelcomeSnapshot(env, reportError)).toEqual(defaultSnapshot)
+		expect(reportError).toHaveBeenCalledOnce()
 	})
 
-	it('falls back to the default when the published snapshot is missing', async () => {
+	it('falls back to the default AND reports when a set template has no published snapshot', async () => {
+		const reportError = vi.fn()
 		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
 		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(undefined)
-		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
+		expect(await resolveWelcomeSnapshot(env, reportError)).toEqual(defaultSnapshot)
+		expect(reportError).toHaveBeenCalledOnce()
 	})
 
-	it('falls back to the default when the lookup itself throws (e.g. table absent)', async () => {
+	it('falls back to the default AND reports when the pointer lookup throws', async () => {
+		const reportError = vi.fn()
 		mockWelcomeTemplateRow(() => {
 			throw new Error('relation "welcome_template" does not exist')
 		})
-		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
+		expect(await resolveWelcomeSnapshot(env, reportError)).toEqual(defaultSnapshot)
 		expect(getPublishedRoomSnapshot).not.toHaveBeenCalled()
+		expect(reportError).toHaveBeenCalledOnce()
 	})
 
-	it('always returns a usable snapshot (has documents)', async () => {
+	it('destroys the Postgres pool on every path (DO hibernation hygiene)', async () => {
 		mockWelcomeTemplateRow(undefined)
-		const result = await resolveWelcomeSnapshot(env)
-		expect(result.documents.length).toBeGreaterThan(0)
+		await resolveWelcomeSnapshot(env)
+		expect(destroy).toHaveBeenCalledOnce()
+	})
+
+	it('works without a reportError callback', async () => {
+		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
+		vi.mocked(getPublishedRoomSnapshot).mockRejectedValue(new Error('boom'))
+		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
 	})
 })

--- a/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.test.ts
+++ b/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.test.ts
@@ -1,0 +1,81 @@
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Environment } from '../types'
+import { defaultWelcomeSnapshotJson } from './defaultWelcomeSnapshot'
+import { resolveWelcomeSnapshot } from './resolveWelcomeSnapshot'
+
+vi.mock('../postgres', () => ({
+	createPostgresConnectionPool: vi.fn(),
+}))
+vi.mock('../routes/tla/getPublishedFile', () => ({
+	getPublishedRoomSnapshot: vi.fn(),
+}))
+
+const { createPostgresConnectionPool } = await import('../postgres')
+const { getPublishedRoomSnapshot } = await import('../routes/tla/getPublishedFile')
+
+const env = {} as Environment
+const defaultSnapshot = JSON.parse(defaultWelcomeSnapshotJson) as RoomSnapshot
+
+// Stub the Kysely chain `pool.selectFrom('welcome_template').select(...).executeTakeFirst()`.
+function mockWelcomeTemplateRow(row: { publishedSlug: string } | undefined | (() => never)) {
+	vi.mocked(createPostgresConnectionPool).mockReturnValue({
+		selectFrom: () => ({
+			select: () => ({
+				executeTakeFirst: async () => (typeof row === 'function' ? row() : row),
+			}),
+		}),
+	} as any)
+}
+
+afterEach(() => vi.clearAllMocks())
+
+describe('resolveWelcomeSnapshot', () => {
+	it('uses the committed default when no welcome template is set', async () => {
+		mockWelcomeTemplateRow(undefined)
+		const result = await resolveWelcomeSnapshot(env)
+		expect(result).toEqual(defaultSnapshot)
+		expect(getPublishedRoomSnapshot).not.toHaveBeenCalled()
+	})
+
+	it('forks the flagged template’s published snapshot when one is set', async () => {
+		const published: RoomSnapshot = {
+			documentClock: 0,
+			tombstoneHistoryStartsAtClock: 0,
+			schema: defaultSnapshot.schema,
+			documents: [{ state: { id: 'sentinel' } as any, lastChangedClock: 0 }],
+		}
+		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(published)
+
+		const result = await resolveWelcomeSnapshot(env)
+		expect(getPublishedRoomSnapshot).toHaveBeenCalledWith(env, 'pub_abc')
+		expect(result).toBe(published)
+	})
+
+	it('falls back to the default when the published snapshot can’t be read', async () => {
+		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
+		vi.mocked(getPublishedRoomSnapshot).mockRejectedValue(new Error('not found'))
+		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
+	})
+
+	it('falls back to the default when the published snapshot is missing', async () => {
+		mockWelcomeTemplateRow({ publishedSlug: 'pub_abc' })
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(undefined)
+		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
+	})
+
+	it('falls back to the default when the lookup itself throws (e.g. table absent)', async () => {
+		mockWelcomeTemplateRow(() => {
+			throw new Error('relation "welcome_template" does not exist')
+		})
+		expect(await resolveWelcomeSnapshot(env)).toEqual(defaultSnapshot)
+		expect(getPublishedRoomSnapshot).not.toHaveBeenCalled()
+	})
+
+	it('always returns a usable snapshot (has documents)', async () => {
+		mockWelcomeTemplateRow(undefined)
+		const result = await resolveWelcomeSnapshot(env)
+		expect(result.documents.length).toBeGreaterThan(0)
+	})
+})

--- a/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.ts
@@ -7,31 +7,36 @@ import { defaultWelcomeSnapshotJson } from './defaultWelcomeSnapshot'
 /**
  * The content a new workspace's first file is seeded with (createSource 'welcome'): the
  * published snapshot of the file currently marked as the welcome template, or a committed
- * default when none is marked or the marked one can't be loaded (fresh env, deploy skew,
- * unpublished, missing R2). Always resolves — the default guarantees a usable file.
+ * default when none is marked or the marked one can't be loaded. Always resolves — the
+ * default guarantees a usable file.
+ *
+ * Falling back is deliberate, but a template that is *set yet unreadable* (unpublished,
+ * missing R2, transient DB error) is a misconfiguration, not the fresh-env no-template case,
+ * so it is reported via `reportError` while still degrading to the default. `reportError` is
+ * the calling Durable Object's error reporter; the no-template case is silent.
  */
-export async function resolveWelcomeSnapshot(env: Environment): Promise<RoomSnapshot> {
-	const slug = await getWelcomeTemplateSlug(env)
-	if (slug) {
-		try {
-			const published = await getPublishedRoomSnapshot(env, slug)
+export async function resolveWelcomeSnapshot(
+	env: Environment,
+	reportError?: (e: unknown) => void
+): Promise<RoomSnapshot> {
+	// Runs inside a Durable Object, so destroy the pool to avoid an idle connection holding
+	// the DO awake (see TLPostgresPool in postgres.ts).
+	const pg = createPostgresConnectionPool(env, 'resolveWelcomeSnapshot')
+	try {
+		const row = await pg.selectFrom('welcome_template').select('publishedSlug').executeTakeFirst()
+		if (row?.publishedSlug) {
+			const published = await getPublishedRoomSnapshot(env, row.publishedSlug)
 			if (published) return published
-		} catch {
-			// fall through to the committed default
+			// A template is configured but its published snapshot is gone — flag it, don't
+			// silently serve the default as if nothing were set.
+			reportError?.(new Error(`welcome template ${row.publishedSlug} has no published snapshot`))
 		}
+	} catch (e) {
+		// A configured template that fails to load, or a DB error reading the pointer — report
+		// it; only a genuinely-absent template should fall back silently.
+		reportError?.(e)
+	} finally {
+		await pg.destroy()
 	}
 	return JSON.parse(defaultWelcomeSnapshotJson) as RoomSnapshot
-}
-
-async function getWelcomeTemplateSlug(env: Environment): Promise<string | null> {
-	try {
-		const row = await createPostgresConnectionPool(env, 'resolveWelcomeSnapshot')
-			.selectFrom('welcome_template')
-			.select('publishedSlug')
-			.executeTakeFirst()
-		return row?.publishedSlug ?? null
-	} catch {
-		// no row / table missing → use the committed default
-		return null
-	}
 }

--- a/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/welcome/resolveWelcomeSnapshot.ts
@@ -1,0 +1,37 @@
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { createPostgresConnectionPool } from '../postgres'
+import { getPublishedRoomSnapshot } from '../routes/tla/getPublishedFile'
+import { Environment } from '../types'
+import { defaultWelcomeSnapshotJson } from './defaultWelcomeSnapshot'
+
+/**
+ * The content a new workspace's first file is seeded with (createSource 'welcome'): the
+ * published snapshot of the file currently marked as the welcome template, or a committed
+ * default when none is marked or the marked one can't be loaded (fresh env, deploy skew,
+ * unpublished, missing R2). Always resolves — the default guarantees a usable file.
+ */
+export async function resolveWelcomeSnapshot(env: Environment): Promise<RoomSnapshot> {
+	const slug = await getWelcomeTemplateSlug(env)
+	if (slug) {
+		try {
+			const published = await getPublishedRoomSnapshot(env, slug)
+			if (published) return published
+		} catch {
+			// fall through to the committed default
+		}
+	}
+	return JSON.parse(defaultWelcomeSnapshotJson) as RoomSnapshot
+}
+
+async function getWelcomeTemplateSlug(env: Environment): Promise<string | null> {
+	try {
+		const row = await createPostgresConnectionPool(env, 'resolveWelcomeSnapshot')
+			.selectFrom('welcome_template')
+			.select('publishedSlug')
+			.executeTakeFirst()
+		return row?.publishedSlug ?? null
+	} catch {
+		// no row / table missing → use the committed default
+		return null
+	}
+}

--- a/apps/dotcom/sync-worker/src/welcome/welcome.test.ts
+++ b/apps/dotcom/sync-worker/src/welcome/welcome.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { createTLSchema } from '@tldraw/tlschema'
+import { describe, expect, it } from 'vitest'
+import { defaultWelcomeSnapshotJson } from './defaultWelcomeSnapshot'
+
+const SNAPSHOT_FILE = fileURLToPath(new URL('./defaultWelcomeSnapshot.ts', import.meta.url))
+
+describe('defaultWelcomeSnapshotJson', () => {
+	const snapshot = JSON.parse(defaultWelcomeSnapshotJson) as RoomSnapshot
+
+	it('parses into a room snapshot', () => {
+		expect(snapshot).toMatchObject({ documentClock: 0, tombstoneHistoryStartsAtClock: 0 })
+		expect(snapshot.schema).toBeDefined()
+		expect(Array.isArray(snapshot.documents)).toBe(true)
+		for (const doc of snapshot.documents) {
+			expect(doc).toMatchObject({ lastChangedClock: 0 })
+			expect(doc.state.id).toBeDefined()
+		}
+	})
+
+	// The default is baked at the schema version current when it was exported, and is loaded
+	// into a room verbatim. Rather than just check that it still migrates, keep the baked file
+	// itself migrated up to head: this test migrates and revalidates every record, re-anchors
+	// the stored schema, re-embeds the JSON into the literal, and asserts it matches the file
+	// on disk. A schema change that touches these records fails this test; run `yarn test -u`
+	// to re-bake defaultWelcomeSnapshot.ts (it rewrites only the literal, not the header).
+	// Changing the default canvas content is a separate manual re-export — see the file header.
+	it('defaultWelcomeSnapshot.ts is baked at the current schema (run `yarn test -u` to re-bake)', async () => {
+		const schema = createTLSchema()
+		expect(snapshot.documents.length).toBeGreaterThan(0)
+		const documents = snapshot.documents.map(({ state, lastChangedClock }) => {
+			const migrated = schema.migratePersistedRecord(state as any, snapshot.schema!, 'up')
+			if (migrated.type !== 'success') throw new Error(`record ${state.id} failed to migrate`)
+			schema.types[migrated.value.typeName].validate(migrated.value)
+			return { state: migrated.value, lastChangedClock }
+		})
+		const rebaked = { ...snapshot, schema: schema.serialize(), documents }
+
+		// embed the pretty-printed JSON back into the literal, escaped for ` and ${ }
+		const json = JSON.stringify(rebaked, null, '\t')
+			.replace(/\\/g, '\\\\')
+			.replace(/`/g, '\\`')
+			.replace(/\$\{/g, '\\${')
+		const regenerated = readFileSync(SNAPSHOT_FILE, 'utf8').replace(
+			/export const defaultWelcomeSnapshotJson = `[\s\S]*`\n?$/,
+			'export const defaultWelcomeSnapshotJson = `' + json + '`\n'
+		)
+		await expect(regenerated).toMatchFileSnapshot(SNAPSHOT_FILE)
+	})
+
+	it('parents every shape to the single page through groups, without cycles', () => {
+		const records = snapshot.documents.map((d) => d.state)
+		const documents = records.filter((r) => r.typeName === 'document')
+		const pages = records.filter((r) => r.typeName === 'page')
+		const shapes = records.filter((r) => r.typeName === 'shape') as any[]
+		expect(documents).toHaveLength(1)
+		expect(pages).toHaveLength(1)
+		expect(shapes.length).toBeGreaterThan(0)
+		const shapesById = new Map(shapes.map((s) => [s.id, s]))
+		for (const shape of shapes) {
+			// walk the parent chain to the page; intermediate parents must be group shapes
+			const visited = new Set<string>([shape.id])
+			let current = shape
+			while (current.parentId !== pages[0].id) {
+				expect(visited.has(current.parentId), `${shape.id} parent chain has no cycle`).toBe(false)
+				visited.add(current.parentId)
+				const parent = shapesById.get(current.parentId)
+				expect(parent, `${shape.id} ancestor ${current.parentId} exists`).toBeDefined()
+				expect(parent.type, `${shape.id} ancestor ${parent.id} is a group`).toBe('group')
+				current = parent
+			}
+		}
+	})
+
+	// New files open at the default camera (there is no zoom-to-fit on first visit), so the
+	// canvas content must sit near the origin and fit a typical editor viewport. Record x/y
+	// is a coarse proxy for shape bounds, but it catches a re-export from the wrong part of
+	// a canvas, which would present new users with an apparently empty file.
+	it('keeps content near the origin so the default camera shows it', () => {
+		const records = snapshot.documents.map((d) => d.state)
+		const pageId = records.find((r) => r.typeName === 'page')!.id
+		const topLevelShapes = records.filter(
+			(r) => r.typeName === 'shape' && (r as any).parentId === pageId
+		) as any[]
+		expect(topLevelShapes.length).toBeGreaterThan(0)
+		for (const shape of topLevelShapes) {
+			expect(shape.x, `${shape.id} x within the first viewport`).toBeGreaterThan(-100)
+			expect(shape.x, `${shape.id} x within the first viewport`).toBeLessThan(1300)
+			expect(shape.y, `${shape.id} y within the first viewport`).toBeGreaterThan(-100)
+			expect(shape.y, `${shape.id} y within the first viewport`).toBeLessThan(900)
+		}
+	})
+
+	// The default is stamped into every user's new workspace, so it must not carry the
+	// authoring user's identity (see the regeneration notes in defaultWelcomeSnapshot.ts).
+	it('contains no authoring user identity', () => {
+		const records = snapshot.documents.map((d) => d.state)
+		expect(records.filter((r) => r.typeName === 'user')).toHaveLength(0)
+		for (const record of records) {
+			const props = (record as any).props
+			if (props && 'textFirstEditedBy' in props) {
+				expect(props.textFirstEditedBy, `${record.id} textFirstEditedBy`).toBeNull()
+			}
+		}
+	})
+})

--- a/apps/dotcom/zero-cache/migrations/035_welcome_template.sql
+++ b/apps/dotcom/zero-cache/migrations/035_welcome_template.sql
@@ -1,0 +1,14 @@
+-- Points at the file whose published snapshot seeds a new workspace's first file (the
+-- "welcome template"). Set by an admin action; read by the sync worker when it materializes
+-- a file created with createSource 'welcome'. When no row is present (fresh env, before an
+-- admin has marked one) the worker falls back to a committed default snapshot.
+--
+-- Singleton: the boolean primary key only permits id = TRUE, so there is at most one row.
+-- Deliberately NOT added to the Zero publication — this is worker-side config, not client
+-- sync state, so the client never replicates it.
+CREATE TABLE welcome_template (
+  id BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (id = TRUE),
+  "fileId" VARCHAR NOT NULL,
+  "publishedSlug" VARCHAR NOT NULL,
+  "updatedAt" BIGINT NOT NULL
+);

--- a/packages/dotcom-shared/src/constants.ts
+++ b/packages/dotcom-shared/src/constants.ts
@@ -2,3 +2,13 @@ export const MAX_NUMBER_OF_FILES = 200
 export const MAX_NUMBER_OF_WORKSPACES = 20
 
 export const ROOM_SIZE_LIMIT_MB = 25
+
+/**
+ * `createSource` value for a new workspace's first file. The sync worker resolves it to the
+ * current welcome template's published snapshot (or a committed default if none is set),
+ * forking that content into the new file. Unlike the other `createSource` prefixes this is a
+ * fixed marker with no id — the worker decides which file is the welcome template — so the
+ * client never needs to know the template's slug and an admin can retarget it without a
+ * client change.
+ */
+export const WELCOME_CREATE_SOURCE = 'welcome'

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -266,6 +266,17 @@ export interface TlaAsset {
 	userId: string | null
 }
 
+/**
+ * The welcome-template pointer (see migration 035). Worker-side config only — not a Zero
+ * table (absent from `createSchema` below), so it never replicates to clients.
+ */
+export interface TlaWelcomeTemplate {
+	id: boolean
+	fileId: string
+	publishedSlug: string
+	updatedAt: number
+}
+
 export interface DB {
 	file: TlaFile
 	file_state: TlaFileState
@@ -275,6 +286,7 @@ export interface DB {
 	group_file: TlaGroupFile
 	user_mutation_number: TlaUserMutationNumber
 	asset: TlaAsset
+	welcome_template: TlaWelcomeTemplate
 }
 
 export const schema = createSchema({


### PR DESCRIPTION
In order to give new workspaces a welcoming first file instead of a blank canvas — and to make that content editable without a deploy — this PR seeds a new workspace's first file by forking a "welcome template". When a workspace is created (behind the `groups_frontend` flag), its first file is seeded by passing a fixed `createSource: 'welcome'`, which the sync worker resolves: it forks the published snapshot of the file currently marked as the welcome template, falling back to a committed default snapshot when none is set or it can't be read (fresh env, deploy skew, unpublished). An admin marks any published file as the template. The file is ordinary — renameable, editable, deletable — and "My files" keeps its blank first file.

Relates to #9143.

> [!NOTE]
> Draft + alternative approach. This is the fork/publish alternative to #9142, which seeds the same welcome content from a `RoomSnapshot` baked into the sync worker. The trade-off: #9142 ships the content in the worker bundle (identical everywhere, no data setup, but editing means re-exporting and re-deploying); this PR makes the welcome content a real published file an admin can edit and re-publish live, with a committed default so it still works everywhere out of the box. Opening both for comparison — only one should land.

How it works:

- **`createSource: 'welcome'`** (`WELCOME_CREATE_SOURCE` in `dotcom-shared`) is a fixed, slug-less marker — the client never knows which file is the template, so an admin can retarget it without a client change. `TLFileDurableObject.handleFileCreateFromSource` special-cases it before the prefix/id split.
- **Resolution** (`resolveWelcomeSnapshot`): read the `welcome_template` pointer, fork that file's published snapshot via the existing `getPublishedRoomSnapshot`, else the committed default. A template that is *set but unreadable* is reported (Sentry) rather than silently serving the default; a genuinely-absent template is silent.
- **`welcome_template`** (migration `035`) is a singleton Postgres table, deliberately outside the Zero publication — worker-side config, never replicated to clients.
- **Admin**: `/app/admin/welcome-template` GET/POST/clear (admin-gated) + a "Welcome template" section in the admin panel. Setting requires the file be published; the panel warns if the current template is no longer live.
- **Seeding** is single-flighted per workspace, so a creation flow and a workspace switch can't create duplicates and all callers get the result. The committed default reuses a self-rebaking snapshot test that keeps it migrated to the current schema.

### Change type

- [x] `feature`

### Test plan

Preview deploy: https://pr-9203-preview-deploy.tldraw.com/

**Setup**

1. Open the preview and sign in; enrol yourself in groups via `/admin` (the `groups_frontend` flag).

**Default (no template set)**

2. Create a workspace and open it → its first file is "Welcome to your workspace" with the default welcome canvas; no inline-rename prompt.
3. Empty "My files" and open it → still a blank, date-named file with the rename prompt.

**Admin template + fork**

4. Create a file, give it distinct content, and **publish** it.
5. In `/admin` → Welcome template, set it by file ID.
6. Create another workspace → its welcome file is a fork of that published file's content.
7. Unpublish/delete that file → `/admin` shows the template is no longer live; new workspaces fall back to the default.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +22 / -0    |
| Tests           | +209 / -0   |
| Automated files | +9 / -0     |
| Apps            | +2784 / -44 |

### Release notes

- Add a welcome file to new workspaces: creating a workspace opens a "Welcome to your workspace" canvas (forked from an admin-set template, or a built-in default). Deleting it, or opening an already-empty workspace, gives a blank file as before.

