### PR TITLE
spike(editor): introduce EditorManager base class for subscription lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,12 @@ Bindings:
 - Shape relationships use binding records and `BindingUtil` classes.
 - Arrows and other connected shapes should update through binding utilities, not ad hoc shape mutation.
 
+Managers:
+
+- Editor subsystems live in `packages/editor/src/lib/editor/managers/` as classes owned and disposed by the `Editor`.
+- A manager that subscribes to events or holds a resource should extend `EditorManager` and register its cleanup so it runs on `dispose()`: `addEditorEvent(event, fn)` for editor bus events, `_register(fn)` for everything else (store side effects, reactions, DOM listeners, child resources). Use `editor.timers` for timeouts/intervals/frames and `editor.disposables` for cleanup on the editor itself.
+- Don't extend `EditorManager` for managers with no teardown. See the `EditorManager` doc comment for the full decision guide.
+
 Store and schema:
 
 - Store changes should respect migrations, validators, and schema versioning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Bindings:
 Managers:
 
 - Editor subsystems live in `packages/editor/src/lib/editor/managers/` as classes owned and disposed by the `Editor`.
-- A manager that subscribes to events or holds a resource should extend `EditorManager` and register its cleanup so it runs on `dispose()`: `addEditorEvent(event, fn)` for editor bus events, `_register(fn)` for everything else (store side effects, reactions, DOM listeners, child resources). Use `editor.timers` for timeouts/intervals/frames and `editor.disposables` for cleanup on the editor itself.
+- A manager that subscribes to events or holds a resource should extend `EditorManager` and register its cleanup so it runs on `dispose()`: `addEditorEvent(event, fn)` for editor bus events, `register(fn)` for everything else (store side effects, reactions, DOM listeners, child resources). Use `editor.timers` for timeouts/intervals/frames and `editor.disposables` for cleanup on the editor itself.
 - Don't extend `EditorManager` for managers with no teardown. See the `EditorManager` doc comment for the full decision guide.
 
 Store and schema:

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1707,6 +1707,19 @@ export class EditorAtom<T> {
 // @public (undocumented)
 export const EditorContext: React_3.Context<Editor | null>;
 
+// @public
+export abstract class EditorManager {
+    constructor(editor: Editor);
+    protected addEditorEvent<E extends keyof TLEventMap>(event: E, fn: (...args: TLEventMap[E]) => void): void;
+    // (undocumented)
+    protected readonly disposables: Set<() => void>;
+    // @internal (undocumented)
+    dispose(): void;
+    // (undocumented)
+    protected readonly editor: Editor;
+    protected _register(dispose: () => void): () => void;
+}
+
 // @public (undocumented)
 export function EditorProvider({ editor, children }: EditorProviderProps): JSX.Element;
 
@@ -2200,7 +2213,7 @@ export type HTMLContainerProps = React_2.HTMLAttributes<HTMLDivElement>;
 export const inlineBase64AssetStore: TLAssetStore;
 
 // @public (undocumented)
-export class InputsManager {
+export class InputsManager extends EditorManager {
     constructor(editor: Editor);
     // @deprecated (undocumented)
     get accelKey(): boolean;
@@ -2215,8 +2228,6 @@ export class InputsManager {
     get currentPagePoint(): Vec;
     // @deprecated (undocumented)
     get currentScreenPoint(): Vec;
-    // @internal (undocumented)
-    dispose(): void;
     getAccelKey(): boolean;
     getAltKey(): boolean;
     getCtrlKey(): boolean;
@@ -3341,12 +3352,8 @@ export const Table: {
 };
 
 // @public (undocumented)
-export class TextManager {
+export class TextManager extends EditorManager {
     constructor(editor: Editor);
-    // (undocumented)
-    dispose(): void;
-    // (undocumented)
-    editor: Editor;
     measureElementTextNodeSpans(element: HTMLElement, { shouldTruncateToFirstLine }?: {
         shouldTruncateToFirstLine?: boolean;
     }): {
@@ -3387,14 +3394,12 @@ export class ThemeManager {
 }
 
 // @internal (undocumented)
-export class TickManager {
+export class TickManager extends EditorManager {
     constructor(editor: Editor);
     // (undocumented)
     cancelRaf?: (() => void) | null;
     // (undocumented)
     dispose(): void;
-    // (undocumented)
-    editor: Editor;
     // (undocumented)
     isPaused: boolean;
     // (undocumented)

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1717,7 +1717,7 @@ export abstract class EditorManager {
     dispose(): void;
     // (undocumented)
     protected readonly editor: Editor;
-    protected _register(dispose: () => void): () => void;
+    protected register(dispose: () => void): () => void;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -102,6 +102,7 @@ export { ClickManager, type TLClickState } from './lib/editor/managers/ClickMana
 export { EdgeScrollManager } from './lib/editor/managers/EdgeScrollManager/EdgeScrollManager'
 export { FontManager } from './lib/editor/managers/FontManager/FontManager'
 export { HistoryManager } from './lib/editor/managers/HistoryManager/HistoryManager'
+export { EditorManager } from './lib/editor/managers/EditorManager'
 export { InputsManager } from './lib/editor/managers/InputsManager/InputsManager'
 export {
 	ScribbleManager,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -891,7 +891,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.edgeScrollManager = new EdgeScrollManager(this)
 		this.focusManager = new FocusManager(this, autoFocus)
-		this.disposables.add(this.focusManager.dispose.bind(this.focusManager))
+		this.disposables.add(() => this.focusManager.dispose())
 
 		if (this.getInstanceState().followingUserId) {
 			this.stopFollowingUser()

--- a/packages/editor/src/lib/editor/managers/EditorManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/EditorManager.test.ts
@@ -12,7 +12,7 @@ class TestManager extends EditorManager {
 
 	cancelRaf = vi.fn()
 	startRaf() {
-		this._register(this.cancelRaf)
+		this.register(this.cancelRaf)
 	}
 }
 
@@ -38,7 +38,7 @@ describe('EditorManager', () => {
 		expect(off).toHaveBeenCalledWith('frame', manager.onTestEvent)
 	})
 
-	it('_register runs custom disposables on dispose', () => {
+	it('register runs custom disposables on dispose', () => {
 		manager.startRaf()
 		manager.dispose()
 		expect(manager.cancelRaf).toHaveBeenCalled()

--- a/packages/editor/src/lib/editor/managers/EditorManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/EditorManager.test.ts
@@ -1,0 +1,51 @@
+import { vi } from 'vitest'
+import type { Editor } from '../Editor'
+import { EditorManager } from './EditorManager'
+
+class TestManager extends EditorManager {
+	onTestEvent = vi.fn()
+
+	constructor(editor: Editor) {
+		super(editor)
+		this.addEditorEvent('frame', this.onTestEvent)
+	}
+
+	cancelRaf = vi.fn()
+	startRaf() {
+		this._register(this.cancelRaf)
+	}
+}
+
+describe('EditorManager', () => {
+	let on: ReturnType<typeof vi.fn>
+	let off: ReturnType<typeof vi.fn>
+	let editor: Editor
+	let manager: TestManager
+
+	beforeEach(() => {
+		on = vi.fn()
+		off = vi.fn()
+		editor = { on, off } as unknown as Editor
+		manager = new TestManager(editor)
+	})
+
+	it('addEditorEvent registers a listener on the editor', () => {
+		expect(on).toHaveBeenCalledWith('frame', manager.onTestEvent)
+	})
+
+	it('dispose removes registered editor listeners', () => {
+		manager.dispose()
+		expect(off).toHaveBeenCalledWith('frame', manager.onTestEvent)
+	})
+
+	it('_register runs custom disposables on dispose', () => {
+		manager.startRaf()
+		manager.dispose()
+		expect(manager.cancelRaf).toHaveBeenCalled()
+	})
+
+	it('dispose is safe to call twice', () => {
+		manager.dispose()
+		expect(() => manager.dispose()).not.toThrow()
+	})
+})

--- a/packages/editor/src/lib/editor/managers/EditorManager.ts
+++ b/packages/editor/src/lib/editor/managers/EditorManager.ts
@@ -12,10 +12,10 @@ import type { TLEventMap } from '../types/emit-types'
  * Register cleanup by what you're creating:
  *
  * - Editor bus event (`tick`, `frame`, `change`, …): {@link EditorManager.addEditorEvent}
- * - Store side effect (`editor.sideEffects.register…`): `this._register(disposer)`
- * - Reaction (`react(...)` from `@tldraw/state`): `this._register(react(...))`
- * - DOM listener: `this._register(() => el.removeEventListener(...))`
- * - Other resource (cache, index, child manager): `this._register(() => x.dispose())`
+ * - Store side effect (`editor.sideEffects.register…`): `this.register(disposer)`
+ * - Reaction (`react(...)` from `@tldraw/state`): `this.register(react(...))`
+ * - DOM listener: `this.register(() => el.removeEventListener(...))`
+ * - Other resource (cache, index, child manager): `this.register(() => x.dispose())`
  *
  * For timeouts, intervals, and animation frames prefer `editor.timers` (context-grouped
  * and auto-disposed) over raw `setTimeout`. For cleanup on the editor itself rather than a
@@ -35,7 +35,7 @@ export abstract class EditorManager {
 	 * Register a teardown function to run on `dispose()`. The universal way for a manager to
 	 * make a resource "see itself out". Returns the same function for convenience.
 	 */
-	protected _register(dispose: () => void): () => void {
+	protected register(dispose: () => void): () => void {
 		this.disposables.add(dispose)
 		return dispose
 	}
@@ -49,7 +49,7 @@ export abstract class EditorManager {
 		fn: (...args: TLEventMap[E]) => void
 	): void {
 		this.editor.on(event, fn as any)
-		this._register(() => this.editor.off(event, fn as any))
+		this.register(() => this.editor.off(event, fn as any))
 	}
 
 	/** @internal */

--- a/packages/editor/src/lib/editor/managers/EditorManager.ts
+++ b/packages/editor/src/lib/editor/managers/EditorManager.ts
@@ -1,0 +1,60 @@
+import type { Editor } from '../Editor'
+import type { TLEventMap } from '../types/emit-types'
+
+/**
+ * Base class for editor-attached managers that need to clean up after themselves.
+ *
+ * Extending `EditorManager` gives a manager one consistent teardown contract: register
+ * anything that needs undoing, and it runs automatically on `dispose()`. This keeps
+ * subscription lifecycle symmetric — whatever sets a thing up is what tears it down — so
+ * it can't be forgotten (the failure mode behind the strict-mode camera bug, #8892).
+ *
+ * Register cleanup by what you're creating:
+ *
+ * - Editor bus event (`tick`, `frame`, `change`, …): {@link EditorManager.addEditorEvent}
+ * - Store side effect (`editor.sideEffects.register…`): `this._register(disposer)`
+ * - Reaction (`react(...)` from `@tldraw/state`): `this._register(react(...))`
+ * - DOM listener: `this._register(() => el.removeEventListener(...))`
+ * - Other resource (cache, index, child manager): `this._register(() => x.dispose())`
+ *
+ * For timeouts, intervals, and animation frames prefer `editor.timers` (context-grouped
+ * and auto-disposed) over raw `setTimeout`. For cleanup on the editor itself rather than a
+ * manager, use `editor.disposables`.
+ *
+ * If a manager needs ordered teardown (e.g. pause a loop before cancelling it), override
+ * `dispose()` and call `super.dispose()` last — see `TickManager`.
+ *
+ * @public
+ */
+export abstract class EditorManager {
+	protected readonly disposables = new Set<() => void>()
+
+	constructor(protected readonly editor: Editor) {}
+
+	/**
+	 * Register a teardown function to run on `dispose()`. The universal way for a manager to
+	 * make a resource "see itself out". Returns the same function for convenience.
+	 */
+	protected _register(dispose: () => void): () => void {
+		this.disposables.add(dispose)
+		return dispose
+	}
+
+	/**
+	 * Subscribe to an editor bus event and register the matching unsubscribe, so the listener
+	 * is removed automatically on `dispose()`.
+	 */
+	protected addEditorEvent<E extends keyof TLEventMap>(
+		event: E,
+		fn: (...args: TLEventMap[E]) => void
+	): void {
+		this.editor.on(event, fn as any)
+		this._register(() => this.editor.off(event, fn as any))
+	}
+
+	/** @internal */
+	dispose(): void {
+		this.disposables.forEach((d) => d())
+		this.disposables.clear()
+	}
+}

--- a/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.test.ts
@@ -73,7 +73,8 @@ describe('FocusManager', () => {
 	describe('constructor', () => {
 		it('should initialize with editor reference', () => {
 			focusManager = new FocusManager(editor)
-			expect(focusManager.editor).toBe(editor)
+			expect(focusManager).toBeInstanceOf(FocusManager)
+			expect(editor.sideEffects.registerAfterChangeHandler).toHaveBeenCalled()
 		})
 
 		it('should register side effect listener for instance state changes', () => {

--- a/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
@@ -23,7 +23,7 @@ export class FocusManager extends EditorManager {
 				}
 			}
 		)
-		this._register(() => disposeSideEffectListener?.())
+		this.register(() => disposeSideEffectListener?.())
 
 		const currentFocusState = editor.getInstanceState().isFocused
 		if (autoFocus !== currentFocusState) {
@@ -34,7 +34,7 @@ export class FocusManager extends EditorManager {
 		const body = editor.getContainerDocument().body
 		body.addEventListener('keydown', this.handleKeyDown)
 		body.addEventListener('mousedown', this.handleMouseDown)
-		this._register(() => {
+		this.register(() => {
 			body.removeEventListener('keydown', this.handleKeyDown)
 			body.removeEventListener('mousedown', this.handleMouseDown)
 		})

--- a/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
+++ b/packages/editor/src/lib/editor/managers/FocusManager/FocusManager.ts
@@ -1,5 +1,6 @@
 import { bind } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
+import { EditorManager } from '../EditorManager'
 
 /**
  * A manager for ensuring correct focus across the editor.
@@ -10,14 +11,11 @@ import type { Editor } from '../../Editor'
  *
  * @internal
  */
-export class FocusManager {
-	private disposeSideEffectListener?: () => void
+export class FocusManager extends EditorManager {
+	constructor(editor: Editor, autoFocus?: boolean) {
+		super(editor)
 
-	constructor(
-		public editor: Editor,
-		autoFocus?: boolean
-	) {
-		this.disposeSideEffectListener = editor.sideEffects.registerAfterChangeHandler(
+		const disposeSideEffectListener = editor.sideEffects.registerAfterChangeHandler(
 			'instance',
 			(prev, next) => {
 				if (prev.isFocused !== next.isFocused) {
@@ -25,6 +23,7 @@ export class FocusManager {
 				}
 			}
 		)
+		this._register(() => disposeSideEffectListener?.())
 
 		const currentFocusState = editor.getInstanceState().isFocused
 		if (autoFocus !== currentFocusState) {
@@ -35,6 +34,10 @@ export class FocusManager {
 		const body = editor.getContainerDocument().body
 		body.addEventListener('keydown', this.handleKeyDown)
 		body.addEventListener('mousedown', this.handleMouseDown)
+		this._register(() => {
+			body.removeEventListener('keydown', this.handleKeyDown)
+			body.removeEventListener('mousedown', this.handleMouseDown)
+		})
 	}
 
 	/**
@@ -82,12 +85,5 @@ export class FocusManager {
 	blur({ blurContainer = true } = {}) {
 		this.editor.complete() // stop any interaction
 		if (blurContainer) this.editor.getContainer().blur() // blur the container
-	}
-
-	dispose() {
-		const body = this.editor.getContainerDocument().body
-		body.removeEventListener('keydown', this.handleKeyDown)
-		body.removeEventListener('mousedown', this.handleMouseDown)
-		this.disposeSideEffectListener?.()
 	}
 }

--- a/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
+++ b/packages/editor/src/lib/editor/managers/InputsManager/InputsManager.ts
@@ -7,19 +7,16 @@ import { Vec } from '../../../primitives/Vec'
 import { isAccelKey } from '../../../utils/keyboard'
 import type { Editor } from '../../Editor'
 import { TLPinchEventInfo, TLPointerEventInfo, TLWheelEventInfo } from '../../types/event-types'
+import { EditorManager } from '../EditorManager'
 
 const POINTER_VELOCITY_REFERENCE_INTERVAL_MS = 16
 const POINTER_VELOCITY_REFERENCE_SMOOTHING = 0.5
 
 /** @public */
-export class InputsManager {
-	constructor(private readonly editor: Editor) {
-		this.editor.on('frame', this._onFrame)
-	}
-
-	/** @internal */
-	dispose() {
-		this.editor.off('frame', this._onFrame)
+export class InputsManager extends EditorManager {
+	constructor(editor: Editor) {
+		super(editor)
+		this.addEditorEvent('frame', this._onFrame)
 	}
 
 	@bind
@@ -472,7 +469,7 @@ export class InputsManager {
 	private _velocityPrevPoint = new Vec()
 
 	/**
-	 * Update the pointer velocity based on elapsed time. Called each frame.
+	 * Update the pointer velocity based on elapsed time. Called by the tick manager.
 	 * @param elapsed - The time elapsed since the last tick in milliseconds.
 	 * @internal
 	 */

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -110,7 +110,6 @@ describe('TextManager', () => {
 	describe('constructor', () => {
 		it('should create a TextManager instance', () => {
 			expect(textManager).toBeInstanceOf(TextManager)
-			expect(textManager.editor).toBe(mockEditor)
 		})
 	})
 

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -1,6 +1,7 @@
 import { BoxModel, TLDefaultHorizontalAlignStyle } from '@tldraw/tlschema'
 import { objectMapKeys } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
+import { EditorManager } from '../EditorManager'
 
 /**
  * The whole-pixel line-height for a given font size and tldraw's unitless line-height
@@ -103,13 +104,21 @@ const initialDefaultStyles = Object.freeze({
 })
 
 /** @public */
-export class TextManager {
+export class TextManager extends EditorManager {
 	private elm: HTMLDivElement
 	private poolElms: PoolItem[] = []
 
-	constructor(public editor: Editor) {
+	constructor(editor: Editor) {
+		super(editor)
 		this.elm = this.createMeasurementEl()
 		this.editor.getContainer().appendChild(this.elm)
+		this._register(() => {
+			this.elm.remove()
+			for (const { el } of this.poolElms) {
+				el.remove()
+			}
+			this.poolElms.length = 0
+		})
 	}
 
 	private createMeasurementEl(): HTMLDivElement {
@@ -176,14 +185,6 @@ export class TextManager {
 			'overflow-wrap': opts.disableOverflowWrapBreaking ? 'normal' : 'break-word',
 			...opts.otherStyles,
 		}
-	}
-
-	dispose() {
-		this.elm.remove()
-		for (const { el } of this.poolElms) {
-			el.remove()
-		}
-		this.poolElms.length = 0
 	}
 
 	private ensurePoolSize(size: number) {

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -112,7 +112,7 @@ export class TextManager extends EditorManager {
 		super(editor)
 		this.elm = this.createMeasurementEl()
 		this.editor.getContainer().appendChild(this.elm)
-		this._register(() => {
+		this.register(() => {
 			this.elm.remove()
 			for (const { el } of this.poolElms) {
 				el.remove()

--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.test.ts
@@ -19,7 +19,6 @@ describe('TickManager', () => {
 	let editor: Mocked<Editor>
 	let tickManager: TickManager
 	let mockEmit: Mock
-	let mockDisposablesAdd: Mock
 
 	beforeEach(() => {
 		vi.clearAllMocks()
@@ -38,13 +37,9 @@ describe('TickManager', () => {
 		mockCancelAnimationFrame.mockImplementation(() => {})
 
 		mockEmit = vi.fn()
-		mockDisposablesAdd = vi.fn()
 
 		editor = {
 			emit: mockEmit,
-			disposables: {
-				add: mockDisposablesAdd,
-			},
 		} as unknown as Mocked<Editor>
 
 		tickManager = new TickManager(editor)
@@ -58,13 +53,8 @@ describe('TickManager', () => {
 
 	describe('constructor and initialization', () => {
 		it('should initialize with correct default values', () => {
-			expect(tickManager.editor).toBe(editor)
 			expect(tickManager.isPaused).toBe(false)
 			expect(tickManager.now).toBe(1000)
-		})
-
-		it('should add dispose method to editor disposables', () => {
-			expect(mockDisposablesAdd).toHaveBeenCalledWith(tickManager.dispose)
 		})
 
 		it('should start the tick loop on construction', () => {

--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
@@ -1,5 +1,6 @@
 import { throttleToNextFrame as _throttleToNextFrame, bind } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
+import { EditorManager } from '../EditorManager'
 
 const throttleToNextFrame =
 	typeof process !== 'undefined' && process.env.NODE_ENV === 'test'
@@ -13,9 +14,9 @@ const throttleToNextFrame =
 		: _throttleToNextFrame
 
 /** @internal */
-export class TickManager {
-	constructor(public editor: Editor) {
-		this.editor.disposables.add(this.dispose)
+export class TickManager extends EditorManager {
+	constructor(editor: Editor) {
+		super(editor)
 		this.start()
 	}
 
@@ -45,11 +46,10 @@ export class TickManager {
 		this.cancelRaf = throttleToNextFrame(this.tick)
 	}
 
-	// Clear the listener
 	@bind
 	dispose() {
 		this.isPaused = true
-
 		this.cancelRaf?.()
+		super.dispose()
 	}
 }

--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
@@ -46,7 +46,6 @@ export class TickManager extends EditorManager {
 		this.cancelRaf = throttleToNextFrame(this.tick)
 	}
 
-	@bind
 	dispose() {
 		this.isPaused = true
 		this.cancelRaf?.()


### PR DESCRIPTION
This spike establishes a consistent vocabulary for cleanup in editor-attached managers, addressing the lifecycle inconsistency behind [#8892](https://github.com/tldraw/tldraw/issues/8892): listeners and resources were set up in one place and torn down in another (or not at all), with every manager hand-rolling its own `dispose()`.

It adds a `@public` `EditorManager` base class and adopts it in the managers that actually own a subscription or resource. The goal is that engineers know what to reach for so anything they create sees itself out automatically.

## Concepts

| Term | Type | Meaning |
|------|------|---------|
| `EditorManager` | `@public` abstract class | Base for managers that hold an `Editor` ref and need lifecycle cleanup |
| `_register(fn)` | protected method | Register any teardown fn; runs on `dispose()` (VS Code `Disposable._register`) |
| `addEditorEvent(event, fn)` | protected method | Subscribe to a `TLEventMap` event via `editor.on` and auto-register the matching `off` |

## What to use to register cleanup

Register the "undo" next to the "do". The base picks up where the editor's existing registries leave off:

| You create | Register via | Cleaned up on |
|------------|--------------|---------------|
| editor bus listener (`tick`/`frame`/`change`…) | `this.addEditorEvent(event, fn)` | manager `dispose()` |
| store side effect (`editor.sideEffects.register…`) | `this._register(disposer)` | manager `dispose()` |
| reaction (`react(...)`) | `this._register(react(...))` | manager `dispose()` |
| DOM listener | `this._register(() => el.removeEventListener(...))` | manager `dispose()` |
| timeout / interval / frame | `editor.timers.setTimeout(ctx, …)` | context / editor dispose |
| other resource (cache, index, child) | `this._register(() => x.dispose())` | manager `dispose()` |
| cleanup on the editor itself | `editor.disposables.add(fn)` | `editor.dispose()` |

`addEditorEvent` is sugar over `_register` for the most footgun-prone case — bus subscriptions, the exact asymmetry behind #8892.

## Managers adopted

| Manager | Uses | Why |
|---------|------|-----|
| `InputsManager` | `addEditorEvent('frame', …)` | owns its pointer-velocity frame subscription |
| `FocusManager` | `_register` | side-effect handler + DOM keydown/mousedown listeners |
| `TextManager` | `_register` | measurement DOM nodes created in its constructor |
| `TickManager` | `dispose()` override + `super.dispose()` | needs ordered teardown (pause loop before cancelling RAF) |

## Deliberately not adopted

The pattern is opt-in by need, not mandated by category. Managers with no teardown (`ThemeManager`) or fully self-contained, well-named teardown (`SpatialIndexManager`) stay as plain classes — extending the base would add an inheritance hop for no cleanup benefit.

## Documentation

The disposable vocabulary is documented where engineers will look for it: a decision-guide doc comment on `EditorManager`, and a "Managers" note in `AGENTS.md` under Architecture notes.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests: `EditorManager`, `InputsManager`, `TickManager`, `FocusManager`, `TextManager`
- [x] Full `packages/editor` suite
- [x] `yarn typecheck`
- [x] `yarn api-check`

### API changes

- Adds `EditorManager` as a `@public` abstract class (required so the `@public` `InputsManager` can extend it; `_register` / `addEditorEvent` are `protected`, not consumer-facing).
- `InputsManager`, `TickManager`, `FocusManager`, and `TextManager` now extend `EditorManager`.
- `TextManager` no longer exposes its own public `dispose()` or `editor` field (now inherited; `dispose()` is `@internal`) — a minor public-surface reduction.

### Release notes

- Internal: introduce an `EditorManager` base class so editor managers share one teardown contract; no change to documented SDK behavior.