### PR TITLE
fix(dotcom): apply the warning class for TlaButton variant="warning"

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaButton/TlaButton.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaButton/TlaButton.tsx
@@ -43,6 +43,7 @@ export const TlaButton = forwardRef<
 					[styles.cta]: variant === 'cta',
 					[styles.primary]: variant === 'primary',
 					[styles.secondary]: variant === 'secondary',
+					[styles.warning]: variant === 'warning',
 					[styles.ghost]: ghost,
 					[styles.big]: big,
 				},


### PR DESCRIPTION
In order to fix a button variant that silently did nothing, this PR makes `TlaButton`'s `classNames` apply `styles.warning` when `variant="warning"`. The variant was typed and used (four call sites in the admin panel) but never applied its class, so it rendered with no warning treatment. Closes #9207 (found while folding `TlaCtaButton`, part of the design-system consistency effort #9189).

### Change type

- [x] `bugfix`

### Test plan

A `dotcom-preview-please` preview is requested. The affected buttons are in the admin panel (`/admin`), so a reviewer with admin access can check that the warning-variant buttons now render with the warning treatment (secondary background + warning-coloured text):

1. The user "Reboot" action button (previously rendered as a plain button — now styled as a warning).
2. The "Delete (cannot be undone)" and related delete buttons (previously only had their own warning border via `className`; now they also get the variant's warning fill).

This is admin-only internal tooling, so there is no public user-facing impact.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +1 / -0    |
