### PR TITLE
refactor(dotcom): use TlaButton for error-page action buttons

### DIFF
--- a/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,7 @@
 import { Component, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import translationsEnJson from '../../../public/tla/locales-compiled/en.json'
+import { TlaButton } from '../../tla/components/TlaButton/TlaButton'
 import { F, IntlProvider } from '../../tla/utils/i18n'
 import { isInIframe } from '../../utils/iFrame'
 
@@ -81,7 +82,11 @@ export class RefreshErrorBoundary extends Component<
 			return (
 				<ErrorPage
 					messages={this.props.messages}
-					cta={<button onClick={() => window.location.reload()}>{this.props.messages.cta}</button>}
+					cta={
+						<TlaButton variant="primary" onClick={() => window.location.reload()}>
+							{this.props.messages.cta}
+						</TlaButton>
+					}
 				/>
 			)
 		}

--- a/apps/dotcom/client/src/components/StoreErrorScreen.tsx
+++ b/apps/dotcom/client/src/components/StoreErrorScreen.tsx
@@ -1,4 +1,5 @@
 import { TLRemoteSyncError, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
+import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 import { ErrorPage } from './ErrorPage/ErrorPage'
 import LoginRedirectPage from './LoginRedirectPage/LoginRedirectPage'
 
@@ -24,7 +25,11 @@ export function StoreErrorScreen({ error }: { error: Error }) {
 							header: 'Refresh the page',
 							para1: 'You need to update to the latest version of tldraw to continue.',
 						}}
-						cta={<button onClick={() => window.location.reload()}>Refresh</button>}
+						cta={
+							<TlaButton variant="primary" onClick={() => window.location.reload()}>
+								Refresh
+							</TlaButton>
+						}
 					/>
 				)
 			}

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -30,6 +30,7 @@ import { globalEditor } from '../../utils/globalEditor'
 import { TlaCookieConsent } from '../components/dialogs/TlaCookieConsent'
 import { TlaLegalAcceptance } from '../components/dialogs/TlaLegalAcceptance'
 import { MaybeForceUserRefresh } from '../components/MaybeForceUserRefresh/MaybeForceUserRefresh'
+import { TlaButton } from '../components/TlaButton/TlaButton'
 import { components } from '../components/TlaEditor/TlaEditor'
 import { WorkspaceInviteHandler } from '../components/WorkspaceInviteHandler'
 import { AppStateProvider, useMaybeApp } from '../hooks/useAppState'
@@ -282,9 +283,9 @@ function SignedInProvider({
 						para1: intl.formatMessage(appMessages.clerkUnavailablePara),
 					}}
 					cta={
-						<button onClick={() => window.location.reload()}>
+						<TlaButton variant="primary" onClick={() => window.location.reload()}>
 							{intl.formatMessage(appMessages.refresh)}
-						</button>
+						</TlaButton>
 					}
 				/>
 			)


### PR DESCRIPTION
In order to start replacing raw `<button>` elements with the shared `TlaButton` (part of the design-system consistency effort), this PR converts the reload/refresh action buttons on the shared `ErrorPage` from unstyled raw `<button>`s to `TlaButton variant="primary"`. These were the cleanest conversions in the audit for #9190: they have no existing styling, and `TlaButton` depends only on its bundled CSS and global tokens (no React providers), so it is safe in `ErrorPage`'s intentionally provider-independent context (offline, sync failure, Clerk timeout). Part of #9190.

The remaining raw buttons in #9190 turned out to carry bespoke CSS (cookie consent, sidebar, workspace-settings inline buttons, etc.) that needs reconciling with `TlaButton` variants — that is really #9193's consolidation work — or are intentionally raw (the mobile sidebar overlay, the file-name width-setters). Those are out of scope here.

### Change type

- [x] `improvement`

### Test plan

A `dotcom-preview-please` preview is requested. The affected buttons only appear on error screens, so they take some effort to reach. In each case the reload/refresh button should now render as a styled primary button instead of a browser-default `<button>`:

1. **`StoreErrorScreen`** — shown on certain sync errors (e.g. a client-too-old close reason renders the "Refresh" button).
2. **`RefreshErrorBoundary` (`ErrorPage`)** — shown when a React error boundary catches an error; the refresh CTA uses this.
3. **Clerk-unavailable fallback (`TlaRootProviders`)** — shown if Clerk fails to load within the timeout; the refresh button uses this.

Confirm the button is styled (primary fill, correct hover) and still reloads the page on click.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +15 / -4   |
