### PR TITLE
Show following indicator border in front of UI panels

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -12,9 +12,8 @@
 	 * (which creates its own stacking context at z-index 300), so their
 	 * z-indices are relative to the layout, not the container.
 	 *
-	 * cursor and following-indicator are rendered inside canvas-in-front
-	 * (stacking context at z-index 250), so their z-indices are relative
-	 * to that context.
+	 * cursor is rendered inside canvas-in-front (stacking context at
+	 * z-index 250), so their z-indices are relative to that context.
 	 */
 	--tl-layer-above: 1;
 	--tl-layer-focused-input: 10;
@@ -24,7 +23,6 @@
 	--tl-layer-toasts: 650;
 	--tl-layer-cursor: 700;
 	--tl-layer-header-footer: 999;
-	--tl-layer-following-indicator: 1000;
 }
 
 /* Button */
@@ -1043,7 +1041,7 @@
 	left: 8px;
 }
 
-/* 
+/*
  * focusing skip-to-main-content hide top ui buttons to make sure we avoid
  * z-index clashes on hover (see issue #8328)
  */
@@ -2181,7 +2179,6 @@ tldraw? probably.
 	inset: 0px;
 	border-width: 2px;
 	border-style: solid;
-	z-index: var(--tl-layer-following-indicator);
 	pointer-events: none;
 }
 

--- a/packages/tldraw/src/lib/ui/TldrawUi.tsx
+++ b/packages/tldraw/src/lib/ui/TldrawUi.tsx
@@ -123,6 +123,7 @@ const TldrawUiContent = React.memo(function TldrawUI() {
 		Toasts,
 		Dialogs,
 		A11y,
+		FollowingIndicator,
 	} = useTldrawUiComponents()
 
 	useEditorEvents()
@@ -235,6 +236,7 @@ const TldrawUiContent = React.memo(function TldrawUI() {
 					</div>
 				</>
 			)}
+			{FollowingIndicator && <FollowingIndicator />}
 			{Toasts && <Toasts />}
 			{Dialogs && <Dialogs />}
 		</div>
@@ -243,15 +245,13 @@ const TldrawUiContent = React.memo(function TldrawUI() {
 
 /** @public @react */
 export function TldrawUiInFrontOfTheCanvas() {
-	const { RichTextToolbar, ImageToolbar, VideoToolbar, CursorChatBubble, FollowingIndicator } =
-		useTldrawUiComponents()
+	const { RichTextToolbar, ImageToolbar, VideoToolbar, CursorChatBubble } = useTldrawUiComponents()
 
 	return (
 		<>
 			{RichTextToolbar && <RichTextToolbar />}
 			{ImageToolbar && <ImageToolbar />}
 			{VideoToolbar && <VideoToolbar />}
-			{FollowingIndicator && <FollowingIndicator />}
 			{CursorChatBubble && <CursorChatBubble />}
 		</>
 	)


### PR DESCRIPTION
Fixed #8821 - the following indicator border in `packages/tldraw/src/lib/ui/TldrawUi.tsx` was moved out of `TldrawUiInFrontOfTheCanvas()` and added together with the `Toasts` and `Dialogs` components. Removed dead code relating to the `--tl-layer-following-indicator` CSS variable.

<img width="271" height="122" alt="image" src="https://github.com/user-attachments/assets/ae75eb0c-f70b-416e-b993-4afbd415670c" />


### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Unclear about testing processes - would like advice from others regarding this please.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- The following indicator border is no longer hidden beneath UI panels.