### PR TITLE
refactor(dotcom): use --tl-space tokens for matching spacing values

### DIFF
--- a/apps/dotcom/client/src/pages/admin.module.css
+++ b/apps/dotcom/client/src/pages/admin.module.css
@@ -40,19 +40,19 @@
 	padding: 24px 32px;
 	display: flex;
 	flex-direction: column;
-	gap: 32px;
+	gap: var(--tl-space-8);
 	overflow: auto;
 }
 
 .adminSection {
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	gap: var(--tl-space-5);
 }
 
 .searchContainer {
 	display: flex;
-	gap: 12px;
+	gap: var(--tl-space-4);
 	align-items: center;
 }
 
@@ -100,7 +100,7 @@
 
 .userActions {
 	display: flex;
-	gap: 12px;
+	gap: var(--tl-space-4);
 	align-items: center;
 }
 
@@ -116,7 +116,7 @@
 	background-color: var(--tl-color-low);
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tl-radius-1);
-	padding: 16px;
+	padding: var(--tl-space-5);
 	font-family: 'IBMPlexMono', monospace;
 	font-size: 11px;
 	line-height: 1.4;
@@ -129,14 +129,14 @@
 .fileOperations {
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	gap: var(--tl-space-5);
 }
 
 .fileOperation {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
-	padding: 16px;
+	gap: var(--tl-space-4);
+	padding: var(--tl-space-5);
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tl-radius-1);
@@ -144,15 +144,15 @@
 
 .downloadContainer {
 	display: flex;
-	gap: 12px;
+	gap: var(--tl-space-4);
 	align-items: center;
 }
 
 .dangerZone {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
-	padding: 16px;
+	gap: var(--tl-space-4);
+	padding: var(--tl-space-5);
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-danger);
 	border-radius: var(--tl-radius-1);
@@ -160,7 +160,7 @@
 
 .deleteContainer {
 	display: flex;
-	gap: 12px;
+	gap: var(--tl-space-4);
 	align-items: center;
 }
 
@@ -171,7 +171,7 @@
 /* Progress Log */
 .progressLog {
 	margin-top: 16px;
-	padding: 16px;
+	padding: var(--tl-space-5);
 	background-color: var(--tl-color-low);
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tl-radius-1);
@@ -196,7 +196,7 @@
 	background-color: var(--tl-color-selected-contrast);
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tl-radius-1);
-	padding: 8px;
+	padding: var(--tl-space-3);
 }
 
 .logEntry {
@@ -215,7 +215,7 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
+	gap: var(--tl-space-4);
 }
 
 .copyButton {
@@ -227,7 +227,7 @@
 
 /* User Summary */
 .userSummary {
-	padding: 16px;
+	padding: var(--tl-space-5);
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tl-radius-1);
@@ -236,13 +236,13 @@
 .summaryGrid {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-	gap: 12px;
+	gap: var(--tl-space-4);
 }
 
 .summaryItem {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: var(--tl-space-2);
 }
 
 .fieldLabel {
@@ -264,8 +264,8 @@
 .migrationSection {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
-	padding: 16px;
+	gap: var(--tl-space-4);
+	padding: var(--tl-space-5);
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-primary);
 	border-radius: var(--tl-radius-1);
@@ -275,15 +275,15 @@
 /* Stats Display */
 .statsContainer {
 	display: flex;
-	gap: 16px;
-	padding: 12px;
+	gap: var(--tl-space-5);
+	padding: var(--tl-space-4);
 	flex-wrap: wrap;
 }
 
 .statItem {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: var(--tl-space-2);
 }
 
 .statLabel {
@@ -302,7 +302,7 @@
 /* Count Container */
 .countContainer {
 	display: flex;
-	gap: 12px;
+	gap: var(--tl-space-4);
 	align-items: center;
 }
 
@@ -314,7 +314,7 @@
 /* Config Container */
 .configContainer {
 	display: flex;
-	gap: 16px;
+	gap: var(--tl-space-5);
 	flex-wrap: wrap;
 }
 
@@ -330,20 +330,20 @@
 .featureFlagsContainer {
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	gap: var(--tl-space-5);
 	margin-top: 16px;
 }
 
 .featureFlagItem {
 	display: flex;
 	align-items: center;
-	gap: 12px;
+	gap: var(--tl-space-4);
 }
 
 .featureFlagLabel {
 	display: flex;
 	align-items: center;
-	gap: 8px;
+	gap: var(--tl-space-3);
 	cursor: pointer;
 	min-width: 200px;
 }

--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
@@ -4,7 +4,7 @@
 	right: max(var(--tl-space-2), env(safe-area-inset-right));
 	z-index: calc(var(--tl-layer-watermark) + 1);
 	height: 36px;
-	padding: 2px;
+	padding: var(--tl-space-1);
 }
 
 .anonDotDevLink > div {
@@ -38,7 +38,7 @@
 	position: relative;
 	display: flex;
 	align-items: center;
-	gap: 4px;
+	gap: var(--tl-space-2);
 	height: 100%;
 	padding: 0 8px;
 	color: inherit;

--- a/apps/dotcom/client/src/tla/components/TlaFileError/TlaFileError.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaFileError/TlaFileError.module.css
@@ -6,7 +6,7 @@
 	justify-content: center;
 	height: 100%;
 	text-align: center;
-	gap: 20px;
+	gap: var(--tl-space-6);
 }
 
 .content {

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/file-share-menu.module.css
@@ -13,7 +13,7 @@
 	height: 100%;
 	overflow: hidden;
 	border-radius: 4px;
-	padding: 8px;
+	padding: var(--tl-space-3);
 	border: 1px solid var(--tl-color-divider);
 	background-color: var(--tl-color-panel);
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -226,7 +226,7 @@
 .sidebar[data-workspaces='true'] .sidebarTopRow {
 	height: 44px;
 	padding: 3px 8px 0px 4px;
-	gap: 8px;
+	gap: var(--tl-space-3);
 }
 
 /* Workspace link */
@@ -466,7 +466,7 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	gap: 4px;
+	gap: var(--tl-space-2);
 	color: var(--tl-color-text-3);
 }
 
@@ -782,7 +782,7 @@
 }
 
 .sidebarSearchEmpty {
-	padding: 8px;
+	padding: var(--tl-space-3);
 	color: var(--tl-color-text-3);
 }
 
@@ -844,7 +844,7 @@
 	flex-direction: row;
 	align-items: center;
 	justify-content: flex-start;
-	gap: 8px;
+	gap: var(--tl-space-3);
 	position: relative;
 	pointer-events: none;
 	z-index: 2;
@@ -881,7 +881,7 @@
 	justify-content: flex-start;
 	padding: 0px 8px 0px calc(8px + var(--tla-sidebar-group-item-padding-left, 0px));
 	outline-offset: -2px;
-	gap: 8px;
+	gap: var(--tl-space-3);
 	position: relative;
 }
 

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteDialog.module.css
@@ -52,7 +52,7 @@
 	border: none;
 	color: var(--tl-color-text-3);
 	cursor: pointer;
-	padding: 8px;
+	padding: var(--tl-space-3);
 	height: 32px;
 }
 

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
@@ -10,7 +10,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	gap: 8px;
+	gap: var(--tl-space-3);
 	padding: 0 24px 24px;
 	width: 300px;
 }

--- a/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
@@ -58,7 +58,7 @@
 .authCtaButton img {
 	width: 22px;
 	height: 22px;
-	padding: 4px;
+	padding: var(--tl-space-2);
 	z-index: 2;
 	background-color: var(--tl-color-selected-contrast);
 	border-radius: 100%;
@@ -187,7 +187,7 @@
 .authOtpBoxes {
 	display: grid;
 	grid-template-columns: repeat(6, 40px);
-	gap: 8px;
+	gap: var(--tl-space-3);
 }
 
 .authOtpBox {

--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -70,7 +70,7 @@
 }
 
 .cookieText {
-	padding: 8px;
+	padding: var(--tl-space-3);
 	padding-bottom: 12px;
 	font-size: 12px;
 	color: var(--tl-color-text-0);
@@ -83,14 +83,14 @@
 
 .cookieButtonsRow {
 	display: flex;
-	gap: 4px;
+	gap: var(--tl-space-2);
 	justify-content: space-between;
 	flex-wrap: wrap;
 }
 
 .cookieButtons {
 	display: flex;
-	gap: 4px;
+	gap: var(--tl-space-2);
 	flex-wrap: wrap;
 	justify-content: space-between;
 }

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -1,8 +1,8 @@
 .menuSection {
 	display: flex;
-	padding: 12px;
+	padding: var(--tl-space-4);
 	flex-direction: column;
-	gap: 12px;
+	gap: var(--tl-space-4);
 }
 
 .menuSection:nth-of-type(n + 2) {
@@ -12,7 +12,7 @@
 .menuControlGroup {
 	display: flex;
 	flex-direction: column;
-	gap: 4px;
+	gap: var(--tl-space-2);
 }
 
 .menuControlGroup + .menuControlGroup {
@@ -109,7 +109,7 @@
 	display: flex;
 	align-items: center;
 	height: 24px;
-	gap: 4px;
+	gap: var(--tl-space-2);
 	justify-content: flex-end;
 	cursor: pointer;
 	padding-left: 2px;
@@ -154,8 +154,8 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 	position: relative;
 	display: flex;
 	align-items: center;
-	padding: 8px;
-	gap: 4px;
+	padding: var(--tl-space-3);
+	gap: var(--tl-space-2);
 	cursor: pointer;
 	z-index: 1;
 	margin-bottom: -4px;
@@ -210,7 +210,7 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 
 .menuSelectSeparator {
 	height: 1px;
-	margin: 4px;
+	margin: var(--tl-space-2);
 	background-color: var(--tl-color-divider);
 }
 
@@ -334,7 +334,7 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 	position: relative;
 	overflow-x: auto;
 	flex: 1;
-	--tab-padding: 12px;
+	--tab-padding: var(--tl-space-4);
 	--line-height: 2px;
 }
 


### PR DESCRIPTION
In order to route spacing through the shared scale instead of hardcoded pixels, this PR replaces single-value `padding` / `margin` / `gap` declarations that exactly match a `--tl-space-*` rung with the corresponding token, across the dotcom client CSS modules (52 declarations in 10 files). Part of #9197 (design-system consistency, #9189).

Because each token resolves to the same pixel value it replaced (e.g. `8px` = `var(--tl-space-3)`), there is **no visual change** — this is a pure refactor.

Deliberately left for follow-up:
- **Off-scale values** (`6px`, `10px`, `24px`) — no matching rung; they need the scale decision discussed in #9197.
- **Multi-value shorthands** (e.g. the bespoke auth/dialog card paddings) — left as-is.
- **`button.module.css` / `cta-button.module.css`** — skipped to avoid conflicts with the in-flight button PR #9205.

### Change type

- [x] `improvement`

### Test plan

No visual change is expected — every substituted token equals its previous pixel value. A reviewer can confirm there is no layout difference versus production in the affected areas (sidebar, dialogs, menus, invite/auth dialogs, admin panel).

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +52 / -52  |
