### PR TITLE
fix(sync): report SERVER_TOO_OLD when client runs a newer schema

### DIFF
--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -838,6 +838,28 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		this.broadcastPatch(diff)
 	}
 
+	/**
+	 * Work out whether a client we can't reconcile schemas with is running a newer or older SDK
+	 * than us.
+	 */
+	private getVersionMismatchReason(theirSchema: SerializedSchema) {
+		const ourSchema = this.serializedSchema
+
+		if (theirSchema.schemaVersion > ourSchema.schemaVersion) {
+			return TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+		}
+
+		if (theirSchema.schemaVersion === 2 && ourSchema.schemaVersion === 2) {
+			for (const [sequenceId, theirVersion] of Object.entries(theirSchema.sequences)) {
+				const ourVersion = ourSchema.sequences[sequenceId]
+				if (ourVersion === undefined || theirVersion > ourVersion) {
+					return TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+				}
+			}
+		}
+		return TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
+	}
+
 	private handleConnectRequest(
 		session: RoomSession<R, SessionMeta>,
 		message: Extract<TLSocketClientSentEvent<R>, { type: 'connect' }>
@@ -874,8 +896,13 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			return
 		}
 		const migrations = this.schema.getMigrationsSince(message.schema)
-		// if the client's store is at a different version to ours, we can't support them
-		if (!migrations.ok || migrations.value.some((m) => m.scope !== 'record' || !m.down)) {
+		if (!migrations.ok) {
+			this.rejectSession(session.sessionId, this.getVersionMismatchReason(message.schema))
+			return
+		}
+		// The client's schema is older than ours, but we can't migrate our data down to their
+		// version (a migration isn't record-scoped or has no down migration), so they're too old.
+		if (migrations.value.some((m) => m.scope !== 'record' || !m.down)) {
 			this.rejectSession(session.sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 			return
 		}

--- a/packages/sync-core/src/test/TLSyncRoom.test.ts
+++ b/packages/sync-core/src/test/TLSyncRoom.test.ts
@@ -845,6 +845,48 @@ describe('23. Connect handshake (HS)', () => {
 		)
 	})
 
+	it('rejects a client running a newer schema with SERVER_TOO_OLD, not CLIENT_TOO_OLD', () => {
+		// Regression test for #6169
+		// A client running a newer SDK than the server: its schema has a sequence version higher
+		// than anything this server knows about. The server can't reconcile it, but the server is
+		// the one that's behind, so it should report SERVER_TOO_OLD (not CLIENT_TOO_OLD).
+		const serializedSchema = schema.serialize()
+		const newerSerializedSchema: SerializedSchemaV2 = {
+			schemaVersion: 2,
+			sequences: {
+				...serializedSchema.sequences,
+				'com.tldraw.shape.arrow': 999,
+			},
+		}
+
+		const { room } = makeRoom()
+		const socket = makeSocket()
+
+		room.handleNewSession({
+			sessionId: 'newer-client-session',
+			socket,
+			meta: undefined,
+			isReadonly: false,
+		})
+
+		room.handleMessage('newer-client-session', {
+			connectRequestId: 'connect-1',
+			lastServerClock: 0,
+			protocolVersion: getTlsyncProtocolVersion(),
+			schema: newerSerializedSchema,
+			type: 'connect',
+		})
+
+		// Session should not be connected - it was rejected due to incompatible schema
+		expect(room.sessions.get('newer-client-session')?.state).not.toBe(RoomSessionState.Connected)
+
+		// Socket should be closed with SERVER_TOO_OLD, since the client is on a newer version
+		expect(socket.close).toHaveBeenCalledWith(
+			TLSyncErrorCloseEventCode,
+			TLSyncErrorCloseEventReason.SERVER_TOO_OLD
+		)
+	})
+
 	it('[HS4] handles a client with lastServerClock greater than the current documentClock', () => {
 		const { room } = makeRoom({ snapshot: makeSnapshot(records, { documentClock: 10 }) })
 

--- a/packages/sync-core/src/test/upgradeDowngrade.test.ts
+++ b/packages/sync-core/src/test/upgradeDowngrade.test.ts
@@ -482,9 +482,9 @@ it('[HS3] when the client is too new it cannot connect', () => {
 
 	expect(v2_socket.close).toHaveBeenCalledWith(
 		4099,
-		// this should really be 'serverTooOld' but our schema format is a bit too loose to
-		// accurately determine that now.
-		TLSyncErrorCloseEventReason.CLIENT_TOO_OLD
+		// the client is on a newer schema than the server, so from its perspective the server is
+		// the one that's too old.
+		TLSyncErrorCloseEventReason.SERVER_TOO_OLD
 	)
 })
 


### PR DESCRIPTION
In order to give developers an accurate error when their tldraw client and sync server are on mismatched versions, this PR makes the server report `SERVER_TOO_OLD` (instead of always `CLIENT_TOO_OLD`) when the client is actually running a newer schema than the server. Closes #6169.

Previously, when the server couldn't reconcile a client's schema (`getMigrationsSince` returned an error), it always rejected the session with `CLIENT_TOO_OLD` — even when the server was the one running the older SDK. The connect handshake now inspects the schemas: if the client's `schemaVersion`, or any of its sequence versions, is ahead of the server's, the session is rejected with `SERVER_TOO_OLD`; otherwise it stays `CLIENT_TOO_OLD`.

The pre-existing "older client we can't migrate down to" case (a migration isn't record-scoped or has no `down` migration) still reports `CLIENT_TOO_OLD`.

### Change type

- [x] `bugfix`

### Test plan

1. Run a newer `tldraw` client (e.g. 3.12) against an older `@tldraw/sync` server (e.g. 3.7).
2. Observe the client now receives `SERVER_TOO_OLD` instead of `CLIENT_TOO_OLD`.

- [x] Unit tests

### Release notes

- Fix sync version-mismatch handshake reporting `CLIENT_TOO_OLD` when the server is actually the one running an older version; it now correctly reports `SERVER_TOO_OLD`.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +29 / -2   |
| Tests     | +42 / -0   |
