### PR TITLE
refactor(dotcom): tokenize divider colour and remove dead modal CSS

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -226,13 +226,6 @@
 	gap: 8px;
 }
 
-.helpIcon {
-	width: 16px;
-	height: 16px;
-	color: #666;
-	cursor: help;
-}
-
 .disabledIcon {
 	width: 16px;
 	height: 16px;
@@ -253,7 +246,7 @@
 .divider {
 	margin: 12px 0;
 	border: none;
-	border-top: 1px solid #e0e0e0;
+	border-top: 1px solid var(--tla-color-border);
 }
 
 .membersList {
@@ -308,37 +301,6 @@
 }
 .inlineButton:hover {
 	text-decoration: underline;
-}
-
-.modalOverlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background-color: rgba(0, 0, 0, 0.5);
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	z-index: 1000;
-}
-
-.modalContent {
-	background-color: white;
-	padding: 24px;
-	border-radius: 8px;
-	max-width: 400px;
-	text-align: center;
-}
-
-.modalMessage {
-	margin-bottom: 16px;
-}
-
-.modalActions {
-	display: flex;
-	gap: 8px;
-	justify-content: center;
 }
 
 .copyInviteLinkIconRight {


### PR DESCRIPTION
In order to reduce hardcoded colours in the dotcom client (part of #9199, design-system consistency #9189), this PR resolves three of the colour holes in `dialogs.module.css`:

- `.divider` now uses `var(--tla-color-border)` instead of `#e0e0e0`. This also fixes a latent bug: the hardcoded value did not adapt to dark mode (a bright divider on a dark background); the token has a dark-mode variant.
- The dead `.helpIcon` block (`#666`) and the dead `.modalOverlay` / `.modalContent` / `.modalMessage` / `.modalActions` blocks (`rgba(0, 0, 0, 0.5)`) are removed. All are unreferenced (the only `modalContent`/`modalActions` usages are in `MaybeForceUserRefresh`, which has its own module), so the colours are resolved by deleting the dead code rather than tokenizing it.

Two hardcoded colours are intentionally **left**, because neither has a matching token and remapping would change their appearance:
- `.disabledIcon` `#ccc` — the semantically-right token (`--tla-color-inactive`) is noticeably darker.
- `.dropCursorLine` `rgba(0, 122, 255, 0.7)` — an iOS-blue selection cursor; `--tla-color-drop-zone` is a dark near-transparent tint, and `cta`/`primary` are different solid blues.

### Change type

- [x] `improvement`

### Test plan

A `dotcom-preview-please` preview is requested.

1. Open a dialog that uses a divider (e.g. **Workspace settings**) and confirm the divider line looks unchanged in light mode and renders correctly (not over-bright) in **dark mode**.
2. The removed CSS was unused, so there should be no other visual change.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +1 / -39   |
