### PR TITLE
refactor(dotcom): use TlaIcon for the iframe-warning external-link icon

### DIFF
--- a/apps/dotcom/client/src/components/IFrameProtector.tsx
+++ b/apps/dotcom/client/src/components/IFrameProtector.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useEffect } from 'react'
 import { useUrl } from '../hooks/useUrl'
+import { TlaIcon } from '../tla/components/TlaIcon/TlaIcon'
 import { trackEvent } from '../utils/analytics'
 import { getParentOrigin, isInIframe } from '../utils/iFrame'
 
@@ -64,20 +65,7 @@ export function IFrameProtector({
 				<div className="iframe-warning__container">
 					<a className="iframe-warning__link" href={url} rel="noopener noreferrer" target="_blank">
 						{'Visit this page on tldraw.com'}
-						<svg
-							width="15"
-							height="15"
-							viewBox="0 0 15 15"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<path
-								d="M3 2C2.44772 2 2 2.44772 2 3V12C2 12.5523 2.44772 13 3 13H12C12.5523 13 13 12.5523 13 12V8.5C13 8.22386 12.7761 8 12.5 8C12.2239 8 12 8.22386 12 8.5V12H3V3L6.5 3C6.77614 3 7 2.77614 7 2.5C7 2.22386 6.77614 2 6.5 2H3ZM12.8536 2.14645C12.9015 2.19439 12.9377 2.24964 12.9621 2.30861C12.9861 2.36669 12.9996 2.4303 13 2.497L13 2.5V2.50049V5.5C13 5.77614 12.7761 6 12.5 6C12.2239 6 12 5.77614 12 5.5V3.70711L6.85355 8.85355C6.65829 9.04882 6.34171 9.04882 6.14645 8.85355C5.95118 8.65829 5.95118 8.34171 6.14645 8.14645L11.2929 3H9.5C9.22386 3 9 2.77614 9 2.5C9 2.22386 9.22386 2 9.5 2H12.4999H12.5C12.5678 2 12.6324 2.01349 12.6914 2.03794C12.7504 2.06234 12.8056 2.09851 12.8536 2.14645Z"
-								fill="currentColor"
-								stroke="black"
-								strokeWidth=".5"
-							></path>
-						</svg>
+						<TlaIcon icon="external" inline />
 					</a>
 				</div>
 			</div>

--- a/apps/dotcom/client/src/tla/components/MaybeForceUserRefresh/MaybeForceUserRefresh.tsx
+++ b/apps/dotcom/client/src/tla/components/MaybeForceUserRefresh/MaybeForceUserRefresh.tsx
@@ -22,6 +22,9 @@ export function MaybeForceUserRefresh({ children }: { children: ReactNode }) {
 			>
 				{children}
 			</div>
+			{/* A custom overlay rather than TldrawUiDialog: it renders at the app-provider root
+			    to dim the whole app when the client is outdated — a context where the Radix-based
+			    dialog primitives and their UI-context hooks are not available. */}
 			{showModal ? (
 				<div className={styles.modal}>
 					<div className={styles.modalContent}>


### PR DESCRIPTION
In order to stop hand-maintaining an inline copy of the external-link icon, this PR replaces `IFrameProtector`'s inline `<svg>` with the shared `<TlaIcon icon="external" inline />`. The sprite already has that icon, and `TlaIcon` has no provider dependencies, so it is safe inside that low-dependency iframe guard.

It also documents why `MaybeForceUserRefresh` keeps a custom `position: fixed` overlay rather than `TldrawUiDialog`: it renders at the app-provider root to dim the whole app when the client is outdated, a context where the Radix portal and UI-context hooks (`useTranslation` / `useDirection`) are not available.

### Scope note

This PR originally also tokenized `.disabledIcon` (`#ccc`) and added a `--tla-color-drop-cursor` token for `.dropCursorLine`, but both have since been removed from `main` independently — the `.disabledIcon` block is gone, and `.dropCursorLine` was deleted in #9254 — so only the icon swap and the doc comment remain. The remaining colour and CSS items from this effort were resolved by #9326 (SDK token reuse) and #9261 (dead-code removal).

Part of the design-system consistency effort #9189 / #9199.

### Change type

- [x] `improvement`

### Test plan

A `dotcom-preview-please` preview is requested: https://pr-9217-preview-deploy.tldraw.com/

On the preview, embed a non-allowed tldraw room in an iframe so `IFrameProtector` shows its warning, and confirm the "Visit this page on tldraw.com" link still shows the external-link icon (now rendered via `TlaIcon`).

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +5 / -14   |
