### PR TITLE
test(dotcom): stabilize live-sharing scenario sync waits

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -291,19 +291,22 @@ export class Sidebar {
 
 	// Workspace-related methods
 
+	// A single attempt at opening the switcher: click only when it isn't already open, then confirm
+	// the menu content mounted (Home is always present). Callers that also act on a menu item should
+	// run this *inside* their own retry loop alongside that action — re-renders and navigation that
+	// fire while the app settles after a cross-client change can dismiss the menu between opening it
+	// and acting, so the open and the action have to be retried together, not in sequence.
+	private async ensureWorkspaceSwitcherOpen() {
+		const home = this.page.getByTestId('tla-workspace-switcher-home')
+		if (!(await home.isVisible())) {
+			await this.page.getByTestId('tla-workspace-switcher').click()
+		}
+		await expect(home).toBeVisible({ timeout: 2000 })
+	}
+
 	@step
 	async openWorkspaceSwitcher() {
-		// A single fire-and-forget click is unreliable: it can be lost to a re-render, and the menu
-		// closes on any outside pointer-down. Click only when it isn't already open, and retry until
-		// the menu content (Home is always present) is actually mounted, so callers can rely on the
-		// switcher being open rather than racing a click that may not have registered.
-		const home = this.page.getByTestId('tla-workspace-switcher-home')
-		await expect(async () => {
-			if (!(await home.isVisible())) {
-				await this.page.getByTestId('tla-workspace-switcher').click()
-			}
-			await expect(home).toBeVisible({ timeout: 2000 })
-		}).toPass({ timeout: 15000 })
+		await expect(() => this.ensureWorkspaceSwitcherOpen()).toPass({ timeout: 15000 })
 	}
 
 	@step
@@ -340,26 +343,29 @@ export class Sidebar {
 
 	@step
 	async expectWorkspaceVisible(name: string) {
-		// A workspace appears for a member via cross-client sync (e.g. after accepting an invite).
-		// Wait for the membership to land in the app's data layer first — that is the genuine,
-		// variable-latency sync gate — then open the switcher and assert the UI renders it. Keeping
-		// the slow wait off the dropdown avoids racing its open state, which can churn on re-render.
+		// Gate on cross-client sync at the data layer first — immune to dropdown churn — then assert
+		// the switcher renders the workspace. Re-open and re-check together: the membership can be
+		// fully synced (the member may even be active in the workspace) yet the assertion still fails
+		// because a settling re-render dismissed the menu, and a closed switcher has no link items.
 		await this.waitForWorkspaceMembershipSync(name, true)
-		await this.openWorkspaceSwitcher()
-		await expect(this.getWorkspaceLink(name)).toBeVisible({ timeout: 10000 })
+		await expect(async () => {
+			await this.ensureWorkspaceSwitcherOpen()
+			await expect(this.getWorkspaceLink(name)).toBeVisible({ timeout: 2000 })
+		}).toPass({ timeout: 20000 })
 		await this.page.keyboard.press('Escape')
 	}
 
 	@step
 	async expectWorkspaceNotVisible(name: string) {
 		// Workspace removal (member removed, workspace deleted) reaches an active member via
-		// cross-client sync too. Wait for the membership to leave the data layer before asserting the
-		// switcher no longer lists it, so the absence check can't race ahead of the sync.
+		// cross-client sync too. Wait for the membership to leave the data layer first, then confirm
+		// the switcher no longer lists it. Keep the menu open while checking (Home is always present)
+		// so the absence can't pass vacuously against a dropdown that closed under us mid-settle.
 		await this.waitForWorkspaceMembershipSync(name, false)
-		// openWorkspaceSwitcher only returns once the menu content is mounted (Home is always
-		// present), so the absence check below can't pass vacuously against an unopened dropdown.
-		await this.openWorkspaceSwitcher()
-		await expect(this.getWorkspaceLink(name)).not.toBeVisible()
+		await expect(async () => {
+			await this.ensureWorkspaceSwitcherOpen()
+			await expect(this.getWorkspaceLink(name)).toHaveCount(0)
+		}).toPass({ timeout: 20000 })
 		await this.page.keyboard.press('Escape')
 	}
 
@@ -393,8 +399,12 @@ export class Sidebar {
 
 	@step
 	async switchToWorkspace(name: string) {
-		await this.openWorkspaceSwitcher()
-		await this.getWorkspaceLink(name).click()
+		// Re-open and click together: a settling re-render can dismiss the menu between opening it and
+		// clicking the workspace, leaving the click waiting on an item that no longer exists.
+		await expect(async () => {
+			await this.ensureWorkspaceSwitcherOpen()
+			await this.getWorkspaceLink(name).click({ timeout: 2000 })
+		}).toPass({ timeout: 20000 })
 		await this.expectActiveWorkspace(name)
 	}
 

--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -293,7 +293,17 @@ export class Sidebar {
 
 	@step
 	async openWorkspaceSwitcher() {
-		await this.page.getByTestId('tla-workspace-switcher').click()
+		// A single fire-and-forget click is unreliable: it can be lost to a re-render, and the menu
+		// closes on any outside pointer-down. Click only when it isn't already open, and retry until
+		// the menu content (Home is always present) is actually mounted, so callers can rely on the
+		// switcher being open rather than racing a click that may not have registered.
+		const home = this.page.getByTestId('tla-workspace-switcher-home')
+		await expect(async () => {
+			if (!(await home.isVisible())) {
+				await this.page.getByTestId('tla-workspace-switcher').click()
+			}
+			await expect(home).toBeVisible({ timeout: 2000 })
+		}).toPass({ timeout: 15000 })
 	}
 
 	@step
@@ -346,10 +356,9 @@ export class Sidebar {
 		// cross-client sync too. Wait for the membership to leave the data layer before asserting the
 		// switcher no longer lists it, so the absence check can't race ahead of the sync.
 		await this.waitForWorkspaceMembershipSync(name, false)
+		// openWorkspaceSwitcher only returns once the menu content is mounted (Home is always
+		// present), so the absence check below can't pass vacuously against an unopened dropdown.
 		await this.openWorkspaceSwitcher()
-		// Wait for the dropdown to actually render (Home is always present)
-		// so the absence check below can't pass vacuously.
-		await expect(this.page.getByTestId('tla-workspace-switcher-home')).toBeVisible()
 		await expect(this.getWorkspaceLink(name)).not.toBeVisible()
 		await this.page.keyboard.press('Escape')
 	}
@@ -375,7 +384,11 @@ export class Sidebar {
 
 	@step
 	async expectActiveWorkspace(name: string) {
-		await expect(this.page.getByTestId('tla-active-workspace-name')).toHaveText(name)
+		// Switching workspaces navigates to (or creates) a file in the target before the active name
+		// updates, so allow the suite's cross-client budget rather than the default 5s.
+		await expect(this.page.getByTestId('tla-active-workspace-name')).toHaveText(name, {
+			timeout: 10000,
+		})
 	}
 
 	@step

--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -1,6 +1,12 @@
 import type { Locator, Page } from '@playwright/test'
 import { expect, step } from './tla-test'
 
+// Cross-client Zero sync (accepting an invite, being removed, a workspace being deleted) delivers
+// workspace-membership rows asynchronously and with variable latency on a busy CI machine. This is
+// the budget for the data-layer wait that actually gates on that sync; it is intentionally generous
+// while still bounded, so a genuine sync regression fails with a clear signal rather than hanging.
+const WORKSPACE_MEMBERSHIP_SYNC_TIMEOUT = 30_000
+
 export class Sidebar {
 	public readonly fileLink = '[data-element="file-link"]'
 
@@ -324,21 +330,47 @@ export class Sidebar {
 
 	@step
 	async expectWorkspaceVisible(name: string) {
+		// A workspace appears for a member via cross-client sync (e.g. after accepting an invite).
+		// Wait for the membership to land in the app's data layer first — that is the genuine,
+		// variable-latency sync gate — then open the switcher and assert the UI renders it. Keeping
+		// the slow wait off the dropdown avoids racing its open state, which can churn on re-render.
+		await this.waitForWorkspaceMembershipSync(name, true)
 		await this.openWorkspaceSwitcher()
-		// A workspace can appear via cross-client sync (e.g. after accepting an invite), which can
-		// take longer than the default assertion timeout on CI.
-		await expect(this.getWorkspaceLink(name)).toBeVisible({ timeout: 15000 })
+		await expect(this.getWorkspaceLink(name)).toBeVisible({ timeout: 10000 })
 		await this.page.keyboard.press('Escape')
 	}
 
 	@step
 	async expectWorkspaceNotVisible(name: string) {
+		// Workspace removal (member removed, workspace deleted) reaches an active member via
+		// cross-client sync too. Wait for the membership to leave the data layer before asserting the
+		// switcher no longer lists it, so the absence check can't race ahead of the sync.
+		await this.waitForWorkspaceMembershipSync(name, false)
 		await this.openWorkspaceSwitcher()
 		// Wait for the dropdown to actually render (Home is always present)
 		// so the absence check below can't pass vacuously.
 		await expect(this.page.getByTestId('tla-workspace-switcher-home')).toBeVisible()
 		await expect(this.getWorkspaceLink(name)).not.toBeVisible()
 		await this.page.keyboard.press('Escape')
+	}
+
+	/**
+	 * Poll the app's data layer until a workspace membership with the given name is present (or
+	 * absent). The membership backs the workspace switcher reactively via `getWorkspaceMemberships`,
+	 * so once it settles the UI follows immediately — this lets callers gate on cross-client sync
+	 * without depending on the dropdown being open at the moment the row arrives.
+	 */
+	private async waitForWorkspaceMembershipSync(name: string, present: boolean) {
+		await expect
+			.poll(
+				() =>
+					this.page.evaluate((workspaceName) => {
+						const memberships = (window as any).app?.getWorkspaceMemberships?.() ?? []
+						return memberships.some((m: any) => m?.group?.name === workspaceName)
+					}, name),
+				{ timeout: WORKSPACE_MEMBERSHIP_SYNC_TIMEOUT }
+			)
+			.toBe(present)
 	}
 
 	@step
@@ -409,12 +441,16 @@ export class Sidebar {
 
 	@step
 	async expectFileVisible(fileName: string) {
-		await expect(this.getFileByName(fileName)).toBeVisible()
+		// A file can appear in a member's list via cross-client sync (workspace files, shared guest
+		// files), so allow the same propagation budget the rest of the suite uses rather than the
+		// default 5s assertion timeout.
+		await expect(this.getFileByName(fileName)).toBeVisible({ timeout: 10000 })
 	}
 
 	@step
 	async expectFileNotVisible(fileName: string) {
-		await expect(this.getFileByName(fileName)).not.toBeVisible()
+		// File removal (deletion, losing workspace access) also propagates via cross-client sync.
+		await expect(this.getFileByName(fileName)).not.toBeVisible({ timeout: 10000 })
 	}
 
 	@step

--- a/apps/dotcom/client/e2e/tests/sharing-live.scenario.spec.ts
+++ b/apps/dotcom/client/e2e/tests/sharing-live.scenario.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from '../fixtures/scenario-test'
 
 // Live share and workspace membership scenarios.
-test.describe.configure({ mode: 'parallel' })
+//
+// These scenarios drive two browser contexts and assert on state that propagates between them via
+// Zero sync. The membership/file waits gate on the data layer first (see Sidebar), but the heavy
+// per-test setup plus genuinely variable cross-client sync latency on CI needs more than the default
+// 30s per-test budget, so raise it for the suite.
+test.describe.configure({ mode: 'parallel', timeout: 60_000 })
 
 test.describe('live sharing scenarios', () => {
 	test('owner and visitor see live edits through an edit link', async ({


### PR DESCRIPTION
In order to stop the live-sharing scenario e2e suite (`sharing-live.scenario.spec.ts`, added in #9187) flaking on CI, this PR replaces its fixed-timeout cross-client sync waits with a deterministic readiness signal and makes the workspace switcher open reliably. Closes #9214.

The flake (e.g. "member removal revokes the active member window without reload", but also workspace/file deletion, role changes, invite acceptance, and `ui` scenarios) timed out in setup. `expectWorkspaceVisible` opened the switcher dropdown once and waited for the workspace link to render — but that list is driven reactively by Zero sync via `getWorkspaceMemberships`, so the single wait was really gating on variable cross-client sync latency *through* a dropdown whose open state churns on re-render. A previous 5s→15s timeout bump didn't fix it; 2 of 11 surveyed CI runs exhausted all retries and went red.

The fix separates the two tangled concerns, then hardens the UI step:

- `waitForWorkspaceMembershipSync` polls `window.app.getWorkspaceMemberships()` until the workspace is present/absent — the genuine sync gate, immune to dropdown churn — bounded at 30s so a real sync regression still fails with a clear signal rather than hanging (this is the deterministic readiness signal from the issue's open question 1).
- `expectWorkspaceVisible` / `expectWorkspaceNotVisible` gate on that data first, then assert the UI.
- `openWorkspaceSwitcher` now ensures the dropdown is actually open: it clicks only when not already open and retries until the menu content is mounted. A first CI run on this branch confirmed the residual race was here — the data gate passed but a lost open-click left the link assertion waiting on a closed dropdown. This hardens every caller (`switchToWorkspace`, create-workspace, settings/invite flows) and the `ui` scenario suite, which share this page object.
- `expectFileVisible` / `expectFileNotVisible` and `expectActiveWorkspace` move off the bare 5s default onto the suite's established 10s cross-client propagation budget.
- The suite's per-test timeout is raised to 60s so the data-layer wait has headroom past the heavy two-context setup.

### Change type

- [x] `other`

### Test plan

This is test-infrastructure hardening; correctness is verified by the suite running green and non-flaky in CI. The bar is a clean pass on the **first** attempt (the dotcom e2e job retries twice), not a retry-rescued pass.

- [x] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +65 / -11  |