### PR TITLE
fix(tldraw): check active selection before tldraw selections

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -145,6 +145,16 @@ function areShortcutsDisabled(editor: Editor) {
 	)
 }
 
+/**
+ * Check if there's an active selection
+ *
+ * @internal
+ */
+function hasActiveTextSelection(editor: Editor) {
+	const selection = editor.getContainerWindow().getSelection()
+	return !!selection && !selection.isCollapsed && selection.toString().trim().length > 0
+}
+
 import { putPastedExternalContent } from './clipboard/putPastedContent'
 export { putPastedExternalContent } from './clipboard/putPastedContent'
 
@@ -869,7 +879,8 @@ export function useNativeClipboardEvents() {
 			if (
 				editor.getSelectedShapeIds().length === 0 ||
 				editor.getEditingShapeId() !== null ||
-				areShortcutsDisabled(editor)
+				areShortcutsDisabled(editor) ||
+				hasActiveTextSelection(editor)
 			) {
 				return
 			}
@@ -886,7 +897,8 @@ export function useNativeClipboardEvents() {
 			if (
 				editor.getSelectedShapeIds().length === 0 ||
 				editor.getEditingShapeId() !== null ||
-				areShortcutsDisabled(editor)
+				areShortcutsDisabled(editor) ||
+				hasActiveTextSelection(editor)
 			) {
 				return
 			}

--- a/packages/tldraw/src/test/ui/nativeClipboard.test.tsx
+++ b/packages/tldraw/src/test/ui/nativeClipboard.test.tsx
@@ -1,0 +1,124 @@
+import { act } from '@testing-library/react'
+import { createShapeId, Editor } from '@tldraw/editor'
+import { vi } from 'vitest'
+import { Tldraw } from '../../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+const ids = {
+	box1: createShapeId('box1'),
+}
+
+function mockClipboard() {
+	const write = vi.fn()
+	Object.assign(window.navigator, {
+		clipboard: {
+			write,
+			writeText: vi.fn(),
+		},
+	})
+	globalThis.ClipboardItem = vi.fn(function (payload: any) {
+		return payload
+	}) as any
+	return write
+}
+
+async function setupFocusedEditor() {
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+
+	act(() => {
+		editor.updateInstanceState({ isFocused: true })
+	})
+
+	return { editor }
+}
+
+function dispatchClipboardEvent(editor: Editor, type: 'copy' | 'cut') {
+	const doc = editor.getContainerDocument()
+	const event = new Event(type, { bubbles: true, cancelable: true })
+	doc.dispatchEvent(event)
+	return event
+}
+
+async function setupSelectedShape(editor: Editor) {
+	act(() => {
+		editor.createShapes([{ id: ids.box1, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } }])
+		editor.selectAll()
+	})
+}
+
+describe('useNativeClipboardEvents', () => {
+	it('copies selected shapes when there is no text selection', async () => {
+		const write = mockClipboard()
+		const { editor } = await setupFocusedEditor()
+		await setupSelectedShape(editor)
+
+		await act(async () => {
+			dispatchClipboardEvent(editor, 'copy')
+			await Promise.resolve()
+		})
+
+		expect(write).toHaveBeenCalled()
+	})
+
+	it('does not copy selected shapes when there is an active text selection', async () => {
+		const write = mockClipboard()
+		const { editor } = await setupFocusedEditor()
+		await setupSelectedShape(editor)
+
+		const getSelectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue({
+			isCollapsed: false,
+			toString: () => 'hello',
+		} as Selection)
+
+		const event = await act(async () => {
+			const e = dispatchClipboardEvent(editor, 'copy')
+			await Promise.resolve()
+			return e
+		})
+
+		expect(write).not.toHaveBeenCalled()
+		expect(event.defaultPrevented).toBe(false)
+
+		getSelectionSpy.mockRestore()
+	})
+
+	it('cuts selected shapes when there is no text selection', async () => {
+		const write = mockClipboard()
+		const { editor } = await setupFocusedEditor()
+		await setupSelectedShape(editor)
+
+		await act(async () => {
+			dispatchClipboardEvent(editor, 'cut')
+			await Promise.resolve()
+		})
+
+		expect(write).toHaveBeenCalled()
+		expect(editor.getCurrentPageShapeIds().has(ids.box1)).toBe(false)
+	})
+
+	it('does not cut selected shapes when there is an active text selection', async () => {
+		const write = mockClipboard()
+		const { editor } = await setupFocusedEditor()
+		await setupSelectedShape(editor)
+
+		const getSelectionSpy = vi.spyOn(window, 'getSelection').mockReturnValue({
+			isCollapsed: false,
+			toString: () => 'hello',
+		} as Selection)
+
+		const event = await act(async () => {
+			const e = dispatchClipboardEvent(editor, 'cut')
+			await Promise.resolve()
+			return e
+		})
+
+		expect(write).not.toHaveBeenCalled()
+		expect(event.defaultPrevented).toBe(false)
+		expect(editor.getCurrentPageShapeIds().has(ids.box1)).toBe(true)
+
+		getSelectionSpy.mockRestore()
+	})
+})


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/9127 where an active selections in the interface outside of the canvas is not copied because we do copy the selection shapes.

The easy fix for now seems to be checking wether or not we have some active text selections.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. go to examples
2. create a shape
3. select it
4. try and select some text in the examples left sidebar
5. copy 
6. paste it on the canvas

The text you see should be what you selected in the left sidebar, not the json of the currently selected shape 

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed an issue where active text selections cannot be copied/cut if we have selected shapes on a canvas