### PR TITLE
fix(dotcom): clean up dev-app and e2e processes on exit

### DIFF
--- a/apps/dotcom/client/e2e/global.teardown.ts
+++ b/apps/dotcom/client/e2e/global.teardown.ts
@@ -1,0 +1,24 @@
+/* eslint-disable no-console */
+import { spawnSync } from 'child_process'
+import path from 'path'
+
+/**
+ * In CI the Playwright `webServer` boots the full dotcom dev stack (`VITE_PREVIEW=1 yarn dev-app`),
+ * which includes the branch-scoped Docker postgres/pgbouncer containers. Playwright reaps the Node
+ * processes it spawned, but Docker containers are daemon-managed and survive that teardown, so they
+ * leak between runs. Run `yarn dev-app:clean` to remove them and the rest of the dev state.
+ *
+ * Gated to CI: locally `reuseExistingServer` means we are sharing the developer's own running stack,
+ * which we must not tear down.
+ */
+async function globalTeardown() {
+	if (!process.env.CI) return
+
+	const repoRoot = path.join(__dirname, '../../../../')
+	const result = spawnSync('yarn', ['dev-app:clean'], { cwd: repoRoot, stdio: 'inherit' })
+	if (result.error) {
+		console.warn(`Could not run yarn dev-app:clean: ${result.error.message}`)
+	}
+}
+
+export default globalTeardown

--- a/apps/dotcom/client/e2e/global.teardown.ts
+++ b/apps/dotcom/client/e2e/global.teardown.ts
@@ -18,6 +18,10 @@ async function globalTeardown() {
 	const result = spawnSync('yarn', ['dev-app:clean'], { cwd: repoRoot, stdio: 'inherit' })
 	if (result.error) {
 		console.warn(`Could not run yarn dev-app:clean: ${result.error.message}`)
+	} else if (result.status !== 0) {
+		console.warn(
+			`yarn dev-app:clean exited with ${result.signal ? `signal ${result.signal}` : `code ${result.status}`}; dev state may have leaked`
+		)
 	}
 }
 

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -21,6 +21,9 @@ dotenv.config({ path: path.resolve(__dirname, '.env.local') })
  */
 export default defineConfig({
 	testDir: './e2e',
+	// In CI the webServer below starts the full dotcom dev stack (including Docker). Tear it down
+	// afterwards so containers and ports do not leak between runs. No-op locally (reused server).
+	globalTeardown: process.env.CI ? require.resolve('./e2e/global.teardown.ts') : undefined,
 	// Run files in parallel, but tests within a file in sequence. This is important for certain
 	// tests that use shared system resources like the clipboard, which should all be kept in the
 	// same file.

--- a/apps/dotcom/client/scripts/dev-app.ts
+++ b/apps/dotcom/client/scripts/dev-app.ts
@@ -1,6 +1,6 @@
+import { spawn } from 'child_process'
 import { createServer } from 'net'
 import { pathToFileURL } from 'url'
-import { exec } from '../../../../internal/scripts/lib/exec'
 
 const CLIENT_PORT = 3000
 const SKIPPABLE_PROBE_ERROR_CODES = new Set(['EADDRNOTAVAIL', 'EAFNOSUPPORT'])
@@ -47,11 +47,32 @@ export function getViteArgs(command: 'dev' | 'preview', port = CLIENT_PORT) {
 async function main() {
 	await assertPortFree(CLIENT_PORT)
 
-	if (process.env.VITE_PREVIEW === '1') {
-		await exec('vite', getViteArgs('preview'))
-	} else {
-		await exec('vite', getViteArgs('dev'))
+	const args = getViteArgs(process.env.VITE_PREVIEW === '1' ? 'preview' : 'dev')
+	const child = spawn('vite', args, { stdio: 'inherit' })
+
+	// Forward termination signals to vite and make sure it is killed if this process exits for any
+	// other reason. Without this, an unclean exit (closed terminal, killed parent) leaves vite
+	// holding port 3000, which blocks the next `yarn dev-app`.
+	let shuttingDown = false
+	const stop = (signal: NodeJS.Signals) => {
+		if (shuttingDown) return
+		shuttingDown = true
+		if (!child.killed) child.kill(signal)
 	}
+	process.on('SIGINT', () => stop('SIGINT'))
+	process.on('SIGTERM', () => stop('SIGTERM'))
+	process.on('SIGHUP', () => stop('SIGHUP'))
+	process.on('exit', () => {
+		if (!child.killed) child.kill('SIGKILL')
+	})
+
+	child.once('error', (error) => {
+		console.error(error)
+		process.exit(1)
+	})
+	child.once('exit', (code, signal) => {
+		process.exit(signal ? 1 : (code ?? 0))
+	})
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/apps/dotcom/sync-worker/dev.ts
+++ b/apps/dotcom/sync-worker/dev.ts
@@ -35,3 +35,7 @@ child.once('error', (error) => {
 
 process.on('SIGINT', () => child.kill('SIGINT'))
 process.on('SIGTERM', () => child.kill('SIGTERM'))
+process.on('SIGHUP', () => child.kill('SIGHUP'))
+process.on('exit', () => {
+	if (!child.killed) child.kill('SIGKILL')
+})

--- a/apps/dotcom/zero-cache/dev.ts
+++ b/apps/dotcom/zero-cache/dev.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { ChildProcess, spawn } from 'child_process'
+import { ChildProcess, spawn, spawnSync } from 'child_process'
 import dotenv from 'dotenv'
 import pg from 'pg'
 import { DOTCOM_DEV_PORTS, DOTCOM_DEV_READINESS_TIMEOUT_MS, getDotcomDevEnv } from './dev-env'
@@ -25,17 +25,72 @@ function statusFromExit(code: number | null, signal: NodeJS.Signals | null) {
 	return signal ? `signal ${signal}` : `code ${code ?? 1}`
 }
 
+/** Collect every descendant PID of `pid` by walking the process tree with `pgrep -P`. */
+function descendantPids(pid: number): number[] {
+	const result = spawnSync('pgrep', ['-P', String(pid)], { encoding: 'utf8' })
+	const childPids = (result.stdout ?? '')
+		.split('\n')
+		.map((line) => Number(line.trim()))
+		.filter((n) => Number.isInteger(n) && n > 0)
+	return childPids.flatMap((childPid) => [childPid, ...descendantPids(childPid)])
+}
+
+function killChildren() {
+	// Reap the whole descendant tree, not just our direct children. The zero-cache dev server spawns
+	// worker subprocesses (change-streamer, replicator, syncer, ...) in their own process groups, so a
+	// terminal/group signal misses them and they orphan, holding port 4848. Walking by PID crosses
+	// those group boundaries. Collect PIDs before killing so the tree does not reparent out from under
+	// us, then SIGKILL deepest-first.
+	const descendants = descendantPids(process.pid).reverse()
+	for (const pid of descendants) {
+		try {
+			process.kill(pid, 'SIGKILL')
+		} catch {
+			// already gone
+		}
+	}
+	for (const child of [...children].reverse()) {
+		if (!child.killed) {
+			child.kill('SIGKILL')
+		}
+	}
+}
+
+function composeDown() {
+	// Bring the branch-scoped Docker stack down so its containers and ports (postgres, pgbouncer)
+	// are released when the orchestrator stops. SIGINT to the attached `compose up` alone can leave
+	// containers running if we were not stopped cleanly.
+	//
+	// We `dev-app` under lazyrepo, where Ctrl+C delivers SIGINT to the whole process group at once,
+	// so a blocking teardown here would race the group being torn down and never finish. Spawn the
+	// teardown detached (its own session, immune to that group signal) and unref it so it runs to
+	// completion after we exit. The postgres volume is kept (no --volumes) so local data survives a
+	// restart; `yarn dev-app:clean` removes it.
+	const child = spawn(
+		'docker',
+		[
+			'compose',
+			'--env-file',
+			env.dockerEnvFile,
+			'-f',
+			env.dockerComposeFile,
+			'--project-name',
+			env.composeProjectName,
+			'down',
+			'--remove-orphans',
+		],
+		{ cwd: env.zeroCacheDir, detached: true, stdio: 'ignore' }
+	)
+	child.unref()
+}
+
 function shutdown(code: number) {
 	if (shuttingDown) return
 	shuttingDown = true
 
-	for (const child of [...children].reverse()) {
-		if (!child.killed) {
-			child.kill('SIGINT')
-		}
-	}
-
-	setTimeout(() => process.exit(code), 500).unref()
+	killChildren()
+	composeDown()
+	process.exit(code)
 }
 
 function spawnManaged(
@@ -152,6 +207,14 @@ async function main() {
 
 	process.on('SIGINT', () => shutdown(0))
 	process.on('SIGTERM', () => shutdown(0))
+	process.on('SIGHUP', () => shutdown(0))
+	// Last-resort sync cleanup if we ever exit through a path that bypassed shutdown(). Keep this light
+	// (no subprocess spawning, which is unreliable from an 'exit' handler): just kill our direct children.
+	process.on('exit', () => {
+		for (const child of children) {
+			if (!child.killed) child.kill('SIGKILL')
+		}
+	})
 
 	spawnManaged(
 		'Docker compose',

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -78,6 +78,14 @@ class MiniflareMonitor {
 		}
 	}
 
+	/** Synchronously kill the wrangler process. Safe to call from signal and `exit` handlers. */
+	public dispose(): void {
+		if (this.process) {
+			this.process.kill('SIGTERM')
+			this.process = null
+		}
+	}
+
 	private _lockPromise?: Promise<() => Promise<void>>
 	private isLocked() {
 		return !!this._lockPromise
@@ -227,7 +235,7 @@ async function main() {
 	const port = getDevPort(process.argv.slice(2))
 	if (port != null) await ensurePortFreeOrExit(port)
 
-	new MiniflareMonitor('wrangler', [
+	const monitor = new MiniflareMonitor('wrangler', [
 		'dev',
 		'--env',
 		'dev',
@@ -237,9 +245,24 @@ async function main() {
 		'--var',
 		'IS_LOCAL:true',
 		...process.argv.slice(2),
-	]).start()
+	])
+	monitor.start()
 
 	new SizeReporter().start()
+
+	// Tear down wrangler (and its workerd child) when this process is asked to stop or exits. Without
+	// this the worker keeps holding its inspector/dev port after the parent goes away, blocking reruns.
+	let shuttingDown = false
+	const shutdown = () => {
+		if (shuttingDown) return
+		shuttingDown = true
+		monitor.dispose()
+		process.exit(0)
+	}
+	process.on('SIGINT', shutdown)
+	process.on('SIGTERM', shutdown)
+	process.on('SIGHUP', shutdown)
+	process.on('exit', () => monitor.dispose())
 }
 
 main()

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -79,9 +79,9 @@ class MiniflareMonitor {
 	}
 
 	/** Synchronously kill the wrangler process. Safe to call from signal and `exit` handlers. */
-	public dispose(): void {
+	public dispose(signal: NodeJS.Signals = 'SIGTERM'): void {
 		if (this.process) {
-			this.process.kill('SIGTERM')
+			this.process.kill(signal)
 			this.process = null
 		}
 	}
@@ -262,7 +262,9 @@ async function main() {
 	process.on('SIGINT', shutdown)
 	process.on('SIGTERM', shutdown)
 	process.on('SIGHUP', shutdown)
-	process.on('exit', () => monitor.dispose())
+	// Last resort if we exit through a path that bypassed shutdown(): SIGKILL so wrangler can't catch
+	// it and linger holding its dev port. The graceful SIGTERM is only for the signal path above.
+	process.on('exit', () => monitor.dispose('SIGKILL'))
 }
 
 main()


### PR DESCRIPTION
In order to stop the dotcom dev stack from leaving orphaned processes and Docker containers behind when it exits, this PR adds teardown handling to the dotcom dev scripts and the dotcom e2e suite. Previously, ending a `yarn dev-app` session (or a CI e2e run) could leave processes holding the fixed dev ports (3000, 8787, 4848, 9339, 7654) and Docker containers holding 6432/6543, which then made the next `yarn dev-app` fail on a port conflict.

Root cause: `yarn dev-app` runs under lazyrepo, which has no signal handling of its own, so on exit each script is responsible for tearing down what it spawned — and several did not. The zero-cache workers are the worst case: they run in their own process groups, so a terminal/group signal never reaches them and the zero CLI keeps holding port 4848.

What changed:

- **`dev-app.ts`** — run vite as a managed child and kill it on SIGINT/SIGTERM/SIGHUP/exit (was `exec`-ed with no handlers, so vite orphaned and held port 3000).
- **`internal/scripts/workers/dev.ts`** — add `MiniflareMonitor.dispose()` plus signal/exit handlers so wrangler and its `workerd` child are stopped (previously only killed on a segfault-triggered restart).
- **`sync-worker/dev.ts`** — add SIGHUP and exit handlers alongside the existing SIGINT/SIGTERM forwarding.
- **`zero-cache/dev.ts`** — on shutdown, reap the whole descendant process tree by PID (crossing the separate process groups the zero-cache workers live in) and run a detached `docker compose down --remove-orphans`.
- **dotcom e2e** — add a CI-only Playwright `globalTeardown` that runs `yarn dev-app:clean`. Playwright reaps the Node processes it spawned, but the Docker stack is daemon-managed and survives, so it leaked between runs. Gated to CI so a locally reused dev server is never torn down.

Known limitation: for interactive Ctrl+C the teardown is now much more reliable but still racy, because lazyrepo's wrapper layers (yarn → tsx → nodemon) can die and reparent their children to `launchd` before the orchestrator walks the tree. The deterministic guarantees remain the existing port guards (clear error on next start) and `yarn dev-app:clean` / `:clean:all`, plus the new CI e2e teardown.

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev-app` and confirm the stack starts (client on 3000, sync-worker 8787, zero 4848, workers 9339, migrations 7654, Docker on 6432/6543).
2. Stop it with Ctrl+C and confirm the Node dev ports are released and the next `yarn dev-app` starts without a port-in-use error.
3. Confirm the dotcom client unit tests still pass: `yarn workspace dotcom test run scripts/dev-app.test.ts`.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Tests           | +24 / -0   |
| Apps            | +102 / -11 |
| Config/tooling  | +25 / -2   |