### PR TITLE
fix(arrows): delete frame-bound arrows when the frame is deleted

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -12,6 +12,7 @@ import { BaseFrameLikeShapeUtil } from '@tldraw/editor';
 import { BindingOnChangeOptions } from '@tldraw/editor';
 import { BindingOnCreateOptions } from '@tldraw/editor';
 import { BindingOnShapeChangeOptions } from '@tldraw/editor';
+import { BindingOnShapeDeleteOptions } from '@tldraw/editor';
 import { BindingOnShapeIsolateOptions } from '@tldraw/editor';
 import { BindingUtil } from '@tldraw/editor';
 import { Box } from '@tldraw/editor';
@@ -234,6 +235,8 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
     onAfterChangeToShape({ binding, shapeBefore, shapeAfter, reason }: BindingOnShapeChangeOptions<TLArrowBinding>): void;
     // (undocumented)
     onAfterCreate({ binding }: BindingOnCreateOptions<TLArrowBinding>): void;
+    // (undocumented)
+    onBeforeDeleteToShape({ binding, shape }: BindingOnShapeDeleteOptions<TLArrowBinding>): void;
     // (undocumented)
     onBeforeIsolateFromShape({ binding }: BindingOnShapeIsolateOptions<TLArrowBinding>): void;
     // (undocumented)

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -2,6 +2,7 @@ import {
 	BindingOnChangeOptions,
 	BindingOnCreateOptions,
 	BindingOnShapeChangeOptions,
+	BindingOnShapeDeleteOptions,
 	BindingOnShapeIsolateOptions,
 	BindingUtil,
 	Editor,
@@ -103,6 +104,29 @@ export class ArrowBindingUtil extends BindingUtil<TLArrowBinding> {
 			arrow,
 			terminal: binding.props.terminal,
 		})
+	}
+
+	// When a frame is deleted, delete an arrow bound to it on both ends *only if the arrow
+	// sits inside the frame*. Such an arrow is part of the frame's contents, like any shape
+	// drawn inside it, so it goes with the frame. An arrow that is bound to the frame but
+	// routes outside it is a connector that happens to use the frame, so it is isolated and
+	// survives instead. The arrow stays parented to the page either way, so it is never
+	// clipped to the frame's bounds.
+	override onBeforeDeleteToShape({
+		binding,
+		shape,
+	}: BindingOnShapeDeleteOptions<TLArrowBinding>): void {
+		if (!this.editor.isShapeOfType(shape, 'frame')) return
+		const arrow = this.editor.getShape<TLArrowShape>(binding.fromId)
+		if (!arrow) return
+		const { start, end } = getArrowBindings(this.editor, arrow)
+		if (start?.toId !== shape.id || end?.toId !== shape.id) return
+
+		const frameBounds = this.editor.getShapePageBounds(shape)
+		const arrowBounds = this.editor.getShapePageBounds(arrow)
+		if (frameBounds && arrowBounds && frameBounds.contains(arrowBounds)) {
+			this.editor.deleteShape(arrow.id)
+		}
 	}
 }
 

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -691,6 +691,128 @@ describe('frame shapes', () => {
 		expect(arrow.parentId).toBe(editor.getCurrentPageId())
 	})
 
+	it('deletes an arrow bound to the frame on both ends and sitting inside the frame', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(200, 200).pointerUp(200, 200)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		// Draw an arrow across empty space within the frame, so both terminals
+		// bind to the frame shape itself rather than to any child.
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(130, 130).pointerMove(170, 170).pointerUp(170, 170)
+
+		const arrow = editor.getOnlySelectedShape()! as TLArrowShape
+		const bindings = getArrowBindings(editor, arrow)
+
+		expect(bindings.start).toMatchObject({ toId: frameId })
+		expect(bindings.end).toMatchObject({ toId: frameId })
+
+		// The arrow stays parented to the page (not the frame) so it is never clipped.
+		expect(arrow.parentId).toBe(editor.getCurrentPageId())
+
+		// It sits inside the frame, so it is part of the frame's contents and is deleted with it.
+		editor.deleteShapes([frameId])
+		expect(editor.getShape(frameId)).toBeUndefined()
+		expect(editor.getShape(arrow.id)).toBeUndefined()
+	})
+
+	it('keeps an arrow bound to the frame on both ends when the arrow routes outside the frame', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(200, 200).pointerUp(200, 200)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(130, 130).pointerMove(170, 170).pointerUp(170, 170)
+		const arrow = editor.getOnlySelectedShape()! as TLArrowShape
+
+		// Bow the arrow well outside the frame's bounds while keeping both bindings.
+		editor.updateShapes([{ id: arrow.id, type: 'arrow', props: { bend: 200 } }])
+
+		const bindings = getArrowBindings(editor, arrow)
+		expect(bindings.start).toMatchObject({ toId: frameId })
+		expect(bindings.end).toMatchObject({ toId: frameId })
+
+		// Sanity check: the arrow now extends beyond the frame.
+		const frameBounds = editor.getShapePageBounds(frameId)!
+		const arrowBounds = editor.getShapePageBounds(arrow.id)!
+		expect(frameBounds.contains(arrowBounds)).toBe(false)
+
+		// Because it routes outside the frame, it is a connector that uses the frame, not
+		// frame content — so it is isolated rather than deleted.
+		editor.deleteShapes([frameId])
+		expect(editor.getShape(frameId)).toBeUndefined()
+		expect(editor.getShape(arrow.id)).toBeDefined()
+	})
+
+	it('keeps an arrow bound to the frame on only one end when the frame is deleted', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(200, 200).pointerUp(200, 200)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		// Draw an arrow that starts inside the frame (bound to it) and ends outside it.
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(150, 150).pointerMove(300, 300).pointerUp(300, 300)
+
+		const arrow = editor.getOnlySelectedShape()! as TLArrowShape
+		const bindings = getArrowBindings(editor, arrow)
+
+		expect(bindings.start).toMatchObject({ toId: frameId })
+		expect(bindings.end).toBeUndefined()
+
+		// Only one end depends on the frame, so the arrow is isolated, not deleted.
+		editor.deleteShapes([frameId])
+		expect(editor.getShape(frameId)).toBeUndefined()
+		expect(editor.getShape(arrow.id)).toBeDefined()
+	})
+
+	it('arrows with both ends bound to a non-frame shape survive its deletion', () => {
+		// A geo shape is not a frame, so a self-loop arrow on it should not be deleted
+		// when the shape is deleted — it is isolated and left on the page.
+		editor.setCurrentTool('geo')
+		editor
+			.pointerDown(100, 100)
+			.pointerMove(200, 200)
+			.pointerUp(200, 200)
+			.setStyleForSelectedShapes(DefaultFillStyle, 'solid')
+			.setStyleForNextShapes(DefaultFillStyle, 'solid')
+		const boxId = editor.getOnlySelectedShape()!.id
+
+		// Draw an arrow that starts and ends on the same box.
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(130, 130).pointerMove(170, 170).pointerUp(170, 170)
+
+		const arrow = editor.getOnlySelectedShape()! as TLArrowShape
+		const bindings = getArrowBindings(editor, arrow)
+
+		expect(bindings.start).toMatchObject({ toId: boxId })
+		expect(bindings.end).toMatchObject({ toId: boxId })
+
+		// Deleting the box unbinds the arrow but leaves it on the page.
+		editor.deleteShapes([boxId])
+		expect(editor.getShape(boxId)).toBeUndefined()
+		expect(editor.getShape(arrow.id)).toBeDefined()
+	})
+
+	it('restores both the frame and its deleted arrow with a single undo', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(200, 200).pointerUp(200, 200)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(130, 130).pointerMove(170, 170).pointerUp(170, 170)
+		const arrowId = editor.getOnlySelectedShape()!.id
+
+		editor.markHistoryStoppingPoint()
+		editor.deleteShapes([frameId])
+		expect(editor.getShape(frameId)).toBeUndefined()
+		expect(editor.getShape(arrowId)).toBeUndefined()
+
+		// The cascade delete happens in the same history batch, so one undo brings both back.
+		editor.undo()
+		expect(editor.getShape(frameId)).toBeDefined()
+		expect(editor.getShape(arrowId)).toBeDefined()
+	})
+
 	it('can be edited', () => {
 		editor.setCurrentTool('frame')
 		editor.pointerDown(100, 100).pointerMove(200, 200).pointerUp(200, 200)


### PR DESCRIPTION
In order to stop a frame deletion from leaving an orphaned arrow behind, this PR deletes an arrow that is bound to a frame on both ends and sits inside that frame when the frame is deleted. Closes #8978.

When an arrow is drawn across empty frame space, both terminals bind to the frame shape itself (not to any child). `reparentArrow` parents such an arrow to the page (`findCommonAncestor` of the same shape returns `undefined`, so the `?? parentPageId` fallback applies), and `deleteShapes` only removes a frame's descendants — so the page-parented arrow was never deleted and survived as an orphan. This is inconsistent with how everything else inside a frame behaves: a shape drawn inside a frame becomes a child and is deleted with it.

The fix adds `ArrowBindingUtil.onBeforeDeleteToShape`. When a frame is deleted, an arrow bound to it on both handles is deleted too — but only if the arrow sits inside the frame's bounds. Such an arrow is part of the frame's contents. An arrow bound to the frame but routed outside it is a connector that happens to use the frame, so it is isolated and survives. The arrow stays parented to the page either way (it is never reparented into the frame), so it is never clipped to the frame's bounds. Arrows bound to the frame on only one end, or bound to a non-frame shape, are isolated as before.

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame.
2. With the arrow tool, draw an arrow from one empty area inside the frame to another empty area, so both ends bind to the frame.
3. Delete the frame — the arrow is deleted with it. Undo restores both.
4. Repeat, then bend the arrow so it routes outside the frame: deleting the frame now leaves the arrow.
5. Draw an arrow from inside the frame to a point outside it (one end bound): deleting the frame leaves the arrow.
6. Repeat step 2 with a rectangle instead of a frame (self-loop arrow): deleting the rectangle leaves the arrow.

- [x] Unit tests
- [ ] End to end tests

### API changes

- Added `ArrowBindingUtil.onBeforeDeleteToShape()`, which deletes an arrow bound to a frame on both handles and contained within it when the frame is deleted.

### Release notes

- Fix an arrow with both ends bound to a frame being left behind when the frame is deleted.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +24 / -0   |
| Tests           | +122 / -0  |
| Automated files | +3 / -0    |
