### PR TITLE
fix(dotcom): keep workspace switcher open when reopened mid-switch

### DIFF
--- a/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
@@ -33,6 +33,41 @@ test.describe('workspaces', () => {
 			await page.keyboard.press('Escape')
 		})
 
+		test('reopening the switcher right after switching keeps it open', async ({
+			page,
+			sidebar,
+		}) => {
+			// Regression test for the workspace switcher dismissing itself when reopened
+			// mid-switch. Selecting a workspace navigates immediately, but the target
+			// file's canvas loads asynchronously and (deep links are on for the file
+			// route) rewrites the URL with a `?d=` param once its editor mounts. The
+			// switcher's open state used to be scoped to the active file editor's
+			// context, so when the outgoing editor was disposed as the incoming canvas
+			// loaded, it cleared the just-reopened switcher's menu state.
+			const workspaceName = getRandomName()
+			await sidebar.createWorkspace(workspaceName)
+
+			const trigger = page.getByTestId('tla-workspace-switcher')
+			const homeItem = page.getByTestId('tla-workspace-switcher-home')
+
+			// Begin switching back to Home; the selection closes the menu.
+			await sidebar.openWorkspaceSwitcher()
+			await homeItem.click()
+			await expect(homeItem).toBeHidden()
+
+			// Reopen immediately, before the incoming canvas has finished loading. Use a
+			// single click, not sidebar.openWorkspaceSwitcher(), whose retry loop would
+			// mask a dismissal by simply reopening the menu.
+			await trigger.click()
+			await expect(homeItem).toBeVisible()
+
+			// The switcher must stay open while the incoming canvas finishes loading and
+			// rewrites the URL with `?d=` — that load is what used to dismiss it.
+			await page.waitForURL(/[?&]d=/, { timeout: 15000 })
+			await sidebar.expectActiveWorkspace('Home')
+			await expect(homeItem).toBeVisible()
+		})
+
 		test('create file button creates in the active workspace', async ({ sidebar }) => {
 			const workspaceName = getRandomName()
 			const file1 = getRandomName()

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
 import { CSSProperties, ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { uniqueId, useDialogs, useMenuIsOpen, useValue } from 'tldraw'
+import { uniqueId, useDialogs, useGlobalMenuIsOpen, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useActiveWorkspaceId } from '../../../hooks/useActiveWorkspaceId'
 import { useApp } from '../../../hooks/useAppState'
@@ -49,7 +49,12 @@ export function TlaSidebarWorkspaceSwitcher() {
 		[app, activeWorkspaceId]
 	)
 
-	const [isOpen, onOpenChange] = useMenuIsOpen('sidebar-workspace-switcher')
+	// Use a stable, editor-independent menu id. useMenuIsOpen would suffix the id
+	// with the active file editor's contextId, but the sidebar receives that editor
+	// via globalEditor and it is replaced on every file/workspace switch. That made
+	// the switcher's open state churn with — and get cleared by the dispose of — the
+	// outgoing editor, so reopening it mid-switch auto-dismissed once the new canvas loaded.
+	const [isOpen, onOpenChange] = useGlobalMenuIsOpen('sidebar-workspace-switcher')
 	const switchToWorkspace = useSwitchToWorkspace()
 	const handleCreateWorkspace = useCreateWorkspaceDialog()
 	const createWorkspaceLbl = useMsg(messages.createWorkspace)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
 import { CSSProperties, ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { uniqueId, useDialogs, useGlobalMenuIsOpen, useValue } from 'tldraw'
+import { uniqueId, useDialogs, useGlobalMenuIsOpen, useMaybeEditor, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useActiveWorkspaceId } from '../../../hooks/useActiveWorkspaceId'
 import { useApp } from '../../../hooks/useAppState'
@@ -54,7 +54,19 @@ export function TlaSidebarWorkspaceSwitcher() {
 	// via globalEditor and it is replaced on every file/workspace switch. That made
 	// the switcher's open state churn with — and get cleared by the dispose of — the
 	// outgoing editor, so reopening it mid-switch auto-dismissed once the new canvas loaded.
-	const [isOpen, onOpenChange] = useGlobalMenuIsOpen('sidebar-workspace-switcher')
+	// We still complete any in-progress canvas interaction on open (the one useful side
+	// effect useMenuIsOpen gave us) by running it against the current editor, without
+	// scoping the menu state itself to that editor.
+	const editor = useMaybeEditor()
+	const [isOpen, onOpenChange] = useGlobalMenuIsOpen(
+		'sidebar-workspace-switcher',
+		useCallback(
+			(nextIsOpen: boolean) => {
+				if (nextIsOpen) editor?.complete()
+			},
+			[editor]
+		)
+	)
 	const switchToWorkspace = useSwitchToWorkspace()
 	const handleCreateWorkspace = useCreateWorkspaceDialog()
 	const createWorkspaceLbl = useMsg(messages.createWorkspace)

--- a/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
+++ b/apps/dotcom/client/src/tla/layouts/TlaSidebarLayout/TlaSidebarLayout.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, useCallback, useLayoutEffect, useRef } from 'react'
-import { clamp, tltime, useMenuIsOpen, useQuickReactor } from 'tldraw'
+import { clamp, tltime, useGlobalMenuIsOpen, useQuickReactor } from 'tldraw'
 import { TlaSidebarToggle } from '../../components/TlaSidebar/components/TlaSidebarToggle'
 import { TlaSidebarToggleMobile } from '../../components/TlaSidebar/components/TlaSidebarToggleMobile'
 import { TlaSidebar } from '../../components/TlaSidebar/TlaSidebar'
@@ -28,7 +28,8 @@ export function TlaSidebarLayout({
 }) {
 	const isSidebarOpen = useIsSidebarOpen()
 	const isSidebarOpenMobile = useIsSidebarOpenMobile()
-	const [isWorkspaceSwitcherOpen] = useMenuIsOpen('sidebar-workspace-switcher')
+	// Must match the stable id used by TlaSidebarWorkspaceSwitcher (see note there).
+	const [isWorkspaceSwitcherOpen] = useGlobalMenuIsOpen('sidebar-workspace-switcher')
 
 	usePreventAccidentalDrops()
 


### PR DESCRIPTION
In order to fix #9228, this PR stops the sidebar workspace switcher from dismissing itself when reopened during a workspace switch.

Selecting a workspace navigates immediately, but the target file's canvas loads asynchronously and (deep links are on for the file route) rewrites the URL with a `?d=` param once its editor mounts. The switcher stored its open/closed state via `useMenuIsOpen`, which scopes the menu id to the active file editor's `contextId`. The sidebar receives that editor through `globalEditor`/`EditorContext`, and the editor instance is replaced on every workspace/file switch (`TlaEditor` remounts on `fileSlug`). So when the outgoing editor was disposed as the incoming canvas loaded, its `clearOpenMenus()` cleared the menu state for its context — the same key the just-reopened switcher was using — and, separately, the `globalEditor` flip changed the menu id out from under the open dropdown. Either way the dropdown closed on its own.

The switcher is a sidebar-level control whose lifetime spans editor remounts, so its open state should not be tied to any per-file editor. This switches both the switcher and the layout that reads it to `useGlobalMenuIsOpen` with a stable, editor-independent id. Outside-click dismissal is unchanged: the dropdown's Radix `modal` dismissable layer still closes it on any outside pointer-down, including canvas clicks.

This also addresses the root cause behind several retry-loop workarounds in the dotcom e2e `Sidebar` page object (added to tolerate "a settling re-render dismissed the menu"); those are left in place here and can be simplified separately.

### Change type

- [x] `bugfix`

### Test plan

1. On tldraw.com, be in a workspace with at least one other workspace available in the switcher.
2. Open the workspace switcher and select a different workspace.
3. While the new canvas is still loading, immediately reopen the workspace switcher.
4. Confirm it stays open (previously it dismissed itself once the canvas finished loading).

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Fix the tldraw.com sidebar workspace switcher dismissing itself when reopened right after switching workspaces.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +35 / -0   |
| Apps    | +10 / -4   |
