### PR TITLE
fix(examples): blur canvas when pointing into sidebar

### DIFF
--- a/apps/examples/src/exampleTldraw.tsx
+++ b/apps/examples/src/exampleTldraw.tsx
@@ -1,0 +1,24 @@
+import type { Editor } from '@tldraw/editor'
+import { useCallback } from 'react'
+import { Tldraw as TldrawBase, type TldrawProps } from '../../../packages/tldraw/src/lib/Tldraw'
+import { isExampleSiteSidebarRoute, wireExampleSiteFocus } from './wireExampleSiteFocus'
+
+export function Tldraw(props: TldrawProps) {
+	const { onMount, autoFocus, ...rest } = props
+	const manageFocus = isExampleSiteSidebarRoute()
+
+	const handleMount = useCallback(
+		(editor: Editor) => {
+			const teardownFocus = manageFocus ? wireExampleSiteFocus(editor) : undefined
+			const teardownOnMount = onMount?.(editor)
+
+			return () => {
+				teardownFocus?.()
+				teardownOnMount?.()
+			}
+		},
+		[onMount, manageFocus]
+	)
+
+	return <TldrawBase {...rest} autoFocus={manageFocus ? false : autoFocus} onMount={handleMount} />
+}

--- a/apps/examples/src/wireExampleSiteFocus.ts
+++ b/apps/examples/src/wireExampleSiteFocus.ts
@@ -1,0 +1,27 @@
+import type { Editor } from '@tldraw/editor'
+
+const SIDEBAR_SELECTOR = '.example__sidebar'
+
+export function isExampleSiteSidebarRoute() {
+	const path = window.location.pathname
+	return path !== '/develop' && path !== '/end-to-end' && !path.endsWith('/full')
+}
+
+/** Wire sidebar/canvas focus using plain DOM class selectors. */
+export function wireExampleSiteFocus(editor: Editor) {
+	if (!isExampleSiteSidebarRoute()) return () => {}
+
+	const container = editor.getContainer()
+	const sidebar = document.querySelector(SIDEBAR_SELECTOR)
+
+	const blur = () => editor.blur()
+	const focus = () => editor.focus()
+
+	sidebar?.addEventListener('pointerenter', blur)
+	container.addEventListener('pointerenter', focus)
+
+	return () => {
+		sidebar?.removeEventListener('pointerenter', blur)
+		container.removeEventListener('pointerenter', focus)
+	}
+}

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -72,8 +72,31 @@ const TLDRAW_BEMO_URL_STRING =
 				? `https://pr-${PR_NUMBER}-demo.tldraw.xyz`
 				: undefined
 
+const TLDRAW_INDEX = path.resolve(__dirname, '../../packages/tldraw/src/index.ts')
+const EXAMPLE_TLDRAW_IMPORT = path
+	.relative(path.dirname(TLDRAW_INDEX), path.join(__dirname, 'src/exampleTldraw.tsx'))
+	.replace(/\\/g, '/')
+	.replace(/\.tsx$/, '')
+
+/** Swap the SDK Tldraw export for the examples-site wrapper (sidebar focus). */
+function exampleTldrawPlugin(): Plugin {
+	return {
+		name: 'example-tldraw',
+		enforce: 'pre',
+		transform(code, id) {
+			const filePath = id.split('?')[0]
+			if (path.resolve(filePath) !== TLDRAW_INDEX) return
+
+			return code.replace(
+				"export { Tldraw, type TLComponents, type TldrawBaseProps, type TldrawProps } from './lib/Tldraw'",
+				`export { Tldraw } from '${EXAMPLE_TLDRAW_IMPORT}'\nexport { type TLComponents, type TldrawBaseProps, type TldrawProps } from './lib/Tldraw'`
+			)
+		},
+	}
+}
+
 export default defineConfig(({ mode }) => ({
-	plugins: [spaFallbackPlugin(), react(), exampleReadmePlugin()],
+	plugins: [spaFallbackPlugin(), react(), exampleTldrawPlugin(), exampleReadmePlugin()],
 	root: path.join(__dirname, 'src'),
 	publicDir: path.join(__dirname, 'public'),
 	build: {


### PR DESCRIPTION
This is a quick spike to fix the example pages when user click inside the sidebar and the editor isnot blurred.
This was raised in https://github.com/tldraw/tldraw/issues/9127 and it's not really a bug but it raises suspicions this is one when the responsibility of focusing / blurring the editor is left to the consumer of the SDK

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Go to any example
2. Add a shape
3. keep that shape selected
4. select text in the sidebar
5. copy it 
6. paste it into the canvas

The pasted text should be what was selected in the sidebar, not the JSON of a shape or the shape itself

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed examples focusing/blurring the canvas when interacting with the sidebar