### PR TITLE
fix(editor): treat ctrl+click as right-click on macOS

### DIFF
--- a/packages/driver/src/lib/Driver.ts
+++ b/packages/driver/src/lib/Driver.ts
@@ -217,7 +217,7 @@ export class Driver {
 		} else if (options === undefined) {
 			options = { target: 'canvas' }
 		}
-		return {
+		const info = {
 			name: 'pointer_down',
 			type: 'pointer',
 			pointerId: 1,
@@ -232,6 +232,12 @@ export class Driver {
 			...options,
 			...modifiers,
 		} as TLPointerEventInfo
+
+		if (tlenv.isDarwin && info.button === 0 && info.ctrlKey && !info.metaKey) {
+			info.button = 2
+		}
+
+		return info
 	}
 
 	/**

--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -6,7 +6,7 @@ import { useEditor } from '../hooks/useEditor'
 import { Vec } from '../primitives/Vec'
 import { releasePointerCapture, setPointerCapture } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
-import { getRightClickLikeButton } from '../utils/pointer'
+import { getPointerEventButton } from '../utils/pointer'
 
 /**
  * When a menu is open, this component prevents the user from interacting with the canvas.
@@ -69,7 +69,7 @@ export function MenuClickCapture() {
 
 	const handlePointerDown = useCallback(
 		(e: PointerEvent) => {
-			const button = getRightClickLikeButton(e)
+			const button = getPointerEventButton(e)
 			if (button !== 0 && button !== 2) return
 
 			flushSync(() => setIsPointing(true))
@@ -151,7 +151,7 @@ export function MenuClickCapture() {
 				target: 'canvas',
 				name: 'pointer_up',
 				...getPointerInfo(editor, e),
-				button: rPointerState.current.button === 2 ? 2 : getRightClickLikeButton(e),
+				button: rPointerState.current.button === 2 ? 2 : getPointerEventButton(e),
 			})
 
 			if (isStaticRightClick && editor.options.rightClickPanning) {

--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -6,6 +6,7 @@ import { useEditor } from '../hooks/useEditor'
 import { Vec } from '../primitives/Vec'
 import { releasePointerCapture, setPointerCapture } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
+import { getRightClickLikeButton } from '../utils/pointer'
 
 /**
  * When a menu is open, this component prevents the user from interacting with the canvas.
@@ -68,18 +69,19 @@ export function MenuClickCapture() {
 
 	const handlePointerDown = useCallback(
 		(e: PointerEvent) => {
-			if (e.button !== 0 && e.button !== 2) return
+			const button = getRightClickLikeButton(e)
+			if (button !== 0 && button !== 2) return
 
 			flushSync(() => setIsPointing(true))
 			setPointerCapture(e.currentTarget, e)
 			rPointerState.current = {
 				isDown: true,
 				isDragging: false,
-				button: e.button,
+				button,
 				start: new Vec(e.clientX, e.clientY),
 			}
 
-			if (e.button === 2) {
+			if (button === 2) {
 				if (!editor.options.rightClickPanning) {
 					// Right-click panning off: close the open menu and swallow the native
 					// contextmenu that would otherwise briefly open a new one (causing a flash).
@@ -141,13 +143,15 @@ export function MenuClickCapture() {
 
 	const handlePointerUp = useCallback(
 		(e: PointerEvent) => {
-			const isStaticRightClick = e.button === 2 && !rPointerState.current.isDragging
+			const isStaticRightClick =
+				rPointerState.current.button === 2 && !rPointerState.current.isDragging
 
 			editor.dispatch({
 				type: 'pointer',
 				target: 'canvas',
 				name: 'pointer_up',
 				...getPointerInfo(editor, e),
+				button: rPointerState.current.button === 2 ? 2 : getRightClickLikeButton(e),
 			})
 
 			if (isStaticRightClick && editor.options.rightClickPanning) {

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -8,6 +8,7 @@ import {
 	setPointerCapture,
 } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
+import { getRightClickLikeButton, isRightClickLikeEvent } from '../utils/pointer'
 import { useEditor } from './useEditor'
 
 export function useCanvasEvents() {
@@ -17,12 +18,16 @@ export function useCanvasEvents() {
 
 	const events = useMemo(
 		function canvasEvents() {
+			let isRightClickLikePointerDown = false
+
 			function onPointerDown(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
+				const button = getRightClickLikeButton(e)
+				isRightClickLikePointerDown = button === 2
 
 				// With right-click panning disabled, fire right_click on press and let the
 				// native contextmenu through so the menu opens at the pointer-down location.
-				if (e.button === 2 && !editor.options.rightClickPanning) {
+				if (button === 2 && !editor.options.rightClickPanning) {
 					editor.dispatch({
 						type: 'pointer',
 						target: 'canvas',
@@ -32,7 +37,7 @@ export function useCanvasEvents() {
 					return
 				}
 
-				if (e.button !== 0 && e.button !== 1 && e.button !== 2 && e.button !== 5) return
+				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
 				setPointerCapture(e.currentTarget, e)
 
@@ -46,12 +51,13 @@ export function useCanvasEvents() {
 
 			function onPointerUp(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
-				if (e.button !== 0 && e.button !== 1 && e.button !== 2 && e.button !== 5) return
+				const button = isRightClickLikePointerDown ? 2 : getRightClickLikeButton(e)
+				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
 				const rightClickPanning = editor.options.rightClickPanning
 				// Check before dispatch (which resets isPanning)
 				const wasRightClickPanning =
-					rightClickPanning && e.button === 2 && editor.inputs.getIsPanning()
+					rightClickPanning && button === 2 && editor.inputs.getIsPanning()
 
 				releasePointerCapture(e.currentTarget, e)
 
@@ -60,10 +66,11 @@ export function useCanvasEvents() {
 					target: 'canvas',
 					name: 'pointer_up',
 					...getPointerInfo(editor, e),
+					button,
 				})
 
 				// Static right-click: fire contextmenu at the pointer-up location
-				if (rightClickPanning && e.button === 2 && !wasRightClickPanning) {
+				if (rightClickPanning && button === 2 && !wasRightClickPanning) {
 					const contextMenuEvent = new PointerEvent('contextmenu', {
 						bubbles: true,
 						clientX: e.clientX,
@@ -76,6 +83,7 @@ export function useCanvasEvents() {
 					})
 					e.currentTarget.dispatchEvent(contextMenuEvent)
 				}
+				isRightClickLikePointerDown = false
 			}
 
 			function onPointerEnter(e: React.PointerEvent) {
@@ -171,16 +179,15 @@ export function useCanvasEvents() {
 				// Synthetic events — our own dispatch from onPointerUp, or tests using
 				// fireEvent.contextMenu — pass through so Radix can open the menu.
 				if (!e.nativeEvent.isTrusted) return
-				// Only suppress the native browser contextmenu when it follows a real
-				// right-click (button=2 with no ctrl modifier). For those, our pointer
-				// handling has already decided what to do (either we'll dispatch a
-				// synthetic contextmenu on pointerup to open the menu at the release
-				// position, or we panned and don't want a menu at all).
+				// Only suppress the native browser contextmenu when it follows a
+				// right-click-like event. For those, our pointer handling has already
+				// decided what to do (either we'll dispatch a synthetic contextmenu on
+				// pointerup to open the menu at the release position, or we panned and
+				// don't want a menu at all).
 				//
 				// Other contextmenu sources must reach Radix so the menu opens:
-				// - ctrl+click on macOS (button=0, or button=2 with ctrlKey=true)
 				// - long-press on touch devices (button=0, pointerType=touch)
-				if (e.button !== 2 || e.ctrlKey) return
+				if (!isRightClickLikeEvent(e)) return
 				preventDefault(e)
 			}
 

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -8,7 +8,7 @@ import {
 	setPointerCapture,
 } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
-import { getRightClickLikeButton, isRightClickLikeEvent } from '../utils/pointer'
+import { getPointerEventButton, isSecondaryClickEvent } from '../utils/pointer'
 import { useEditor } from './useEditor'
 
 export function useCanvasEvents() {
@@ -18,12 +18,12 @@ export function useCanvasEvents() {
 
 	const events = useMemo(
 		function canvasEvents() {
-			let isRightClickLikePointerDown = false
+			let isSecondaryClickPointerDown = false
 
 			function onPointerDown(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
-				const button = getRightClickLikeButton(e)
-				isRightClickLikePointerDown = button === 2
+				const button = getPointerEventButton(e)
+				isSecondaryClickPointerDown = button === 2
 
 				// With right-click panning disabled, fire right_click on press and let the
 				// native contextmenu through so the menu opens at the pointer-down location.
@@ -51,7 +51,7 @@ export function useCanvasEvents() {
 
 			function onPointerUp(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
-				const button = isRightClickLikePointerDown ? 2 : getRightClickLikeButton(e)
+				const button = isSecondaryClickPointerDown ? 2 : getPointerEventButton(e)
 				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
 				const rightClickPanning = editor.options.rightClickPanning
@@ -83,7 +83,7 @@ export function useCanvasEvents() {
 					})
 					e.currentTarget.dispatchEvent(contextMenuEvent)
 				}
-				isRightClickLikePointerDown = false
+				isSecondaryClickPointerDown = false
 			}
 
 			function onPointerEnter(e: React.PointerEvent) {
@@ -180,14 +180,14 @@ export function useCanvasEvents() {
 				// fireEvent.contextMenu — pass through so Radix can open the menu.
 				if (!e.nativeEvent.isTrusted) return
 				// Only suppress the native browser contextmenu when it follows a
-				// right-click-like event. For those, our pointer handling has already
+				// secondary click. For those, our pointer handling has already
 				// decided what to do (either we'll dispatch a synthetic contextmenu on
 				// pointerup to open the menu at the release position, or we panned and
 				// don't want a menu at all).
 				//
 				// Other contextmenu sources must reach Radix so the menu opens:
 				// - long-press on touch devices (button=0, pointerType=touch)
-				if (!isRightClickLikeEvent(e)) return
+				if (!isSecondaryClickEvent(e)) return
 				preventDefault(e)
 			}
 

--- a/packages/editor/src/lib/utils/getPointerInfo.ts
+++ b/packages/editor/src/lib/utils/getPointerInfo.ts
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { Editor } from '../editor/Editor'
 import { isAccelKey } from './keyboard'
+import { getRightClickLikeButton } from './pointer'
 
 /** @public */
 export function getPointerInfo(editor: Editor, e: React.PointerEvent | PointerEvent) {
@@ -18,7 +19,7 @@ export function getPointerInfo(editor: Editor, e: React.PointerEvent | PointerEv
 		metaKey: e.metaKey,
 		accelKey: isAccelKey(e),
 		pointerId: e.pointerId,
-		button: e.button,
+		button: getRightClickLikeButton(e),
 		isPen: e.pointerType === 'pen',
 	}
 }

--- a/packages/editor/src/lib/utils/getPointerInfo.ts
+++ b/packages/editor/src/lib/utils/getPointerInfo.ts
@@ -1,7 +1,7 @@
 import type React from 'react'
 import { Editor } from '../editor/Editor'
 import { isAccelKey } from './keyboard'
-import { getRightClickLikeButton } from './pointer'
+import { getPointerEventButton } from './pointer'
 
 /** @public */
 export function getPointerInfo(editor: Editor, e: React.PointerEvent | PointerEvent) {
@@ -19,7 +19,7 @@ export function getPointerInfo(editor: Editor, e: React.PointerEvent | PointerEv
 		metaKey: e.metaKey,
 		accelKey: isAccelKey(e),
 		pointerId: e.pointerId,
-		button: getRightClickLikeButton(e),
+		button: getPointerEventButton(e),
 		isPen: e.pointerType === 'pen',
 	}
 }

--- a/packages/editor/src/lib/utils/pointer.test.ts
+++ b/packages/editor/src/lib/utils/pointer.test.ts
@@ -1,0 +1,48 @@
+import { tlenv } from '../globals/environment'
+import { TestEditor } from '../test/TestEditor'
+import { getPointerInfo } from './getPointerInfo'
+import { isSecondaryClickEvent } from './pointer'
+
+const originalIsDarwin = tlenv.isDarwin
+
+afterEach(() => {
+	tlenv.isDarwin = originalIsDarwin
+})
+
+describe('isSecondaryClickEvent', () => {
+	it('treats ctrl + left-click as a secondary click on macOS', () => {
+		tlenv.isDarwin = true
+		expect(isSecondaryClickEvent({ button: 0, ctrlKey: true, metaKey: false })).toBe(true)
+	})
+
+	it('does not treat ctrl + left-click as a secondary click off macOS', () => {
+		tlenv.isDarwin = false
+		expect(isSecondaryClickEvent({ button: 0, ctrlKey: true, metaKey: false })).toBe(false)
+	})
+})
+
+describe('ctrl + left-click on macOS fires as a right-click (regression)', () => {
+	// Regression test for https://github.com/tldraw/tldraw/issues/8217
+	// On macOS, a ctrl + left-click should be treated as a right-click
+	let editor: TestEditor
+
+	beforeEach(() => {
+		editor = new TestEditor()
+	})
+
+	afterEach(() => {
+		editor.dispose()
+	})
+
+	it('reports button 2 in the dispatched pointer info on macOS', () => {
+		tlenv.isDarwin = true
+		const event = new PointerEvent('pointerdown', { button: 0, ctrlKey: true })
+		expect(getPointerInfo(editor, event).button).toBe(2)
+	})
+
+	it('stays button 0 for the same gesture off macOS', () => {
+		tlenv.isDarwin = false
+		const event = new PointerEvent('pointerdown', { button: 0, ctrlKey: true })
+		expect(getPointerInfo(editor, event).button).toBe(0)
+	})
+})

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -1,11 +1,18 @@
 import { tlenv } from '../globals/environment'
 
 /** @internal */
-export function isRightClickLikeEvent(e: { button: number; ctrlKey: boolean; metaKey: boolean }) {
+interface PointerLike {
+	button: number
+	ctrlKey: boolean
+	metaKey: boolean
+}
+
+/** @internal */
+export function isSecondaryClickEvent(e: PointerLike) {
 	return e.button === 2 || (tlenv.isDarwin && e.button === 0 && e.ctrlKey && !e.metaKey)
 }
 
 /** @internal */
-export function getRightClickLikeButton(e: { button: number; ctrlKey: boolean; metaKey: boolean }) {
-	return isRightClickLikeEvent(e) ? 2 : e.button
+export function getPointerEventButton(e: PointerLike) {
+	return isSecondaryClickEvent(e) ? 2 : e.button
 }

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -1,0 +1,11 @@
+import { tlenv } from '../globals/environment'
+
+/** @internal */
+export function isRightClickLikeEvent(e: { button: number; ctrlKey: boolean; metaKey: boolean }) {
+	return e.button === 2 || (tlenv.isDarwin && e.button === 0 && e.ctrlKey && !e.metaKey)
+}
+
+/** @internal */
+export function getRightClickLikeButton(e: { button: number; ctrlKey: boolean; metaKey: boolean }) {
+	return isRightClickLikeEvent(e) ? 2 : e.button
+}

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -2188,6 +2188,19 @@ describe('control pointing', () => {
 		// ...and expect menu to be open, but that's a native thing
 	})
 
+	it('selects locked shapes on ctrl click when on a mac', () => {
+		tlenv.isDarwin = true
+
+		editor.createShape({ id: ids.box4, type: 'geo', x: 600, isLocked: true })
+
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.keyDown('Control')
+		editor.pointerMove(650, 50) // inside of locked box 4
+		editor.pointerDown()
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box4])
+	})
+
 	it('selects on ctrl click when on a pc or other device', () => {
 		tlenv.isDarwin = false
 


### PR DESCRIPTION
👩: this is a broad fix to #8217, and instead of targeting it specifically, makes the ctrl left click path on mac get treated as a right click everywhere
this also fixes behavior like right clicking on locked shapes as mentioned in #8217, but also right click to pan, which didn't work with ctrl+left, and also ctrl+left clicking while a context menu was already open, which would previously close the context menu instead of opening a new one in the place of the mouse pointer

---

In order to make ctrl+click behave like a real right-click on macOS, this PR normalizes ctrl+left-click (button `0` with `ctrlKey` and no `metaKey`) to button `2` throughout the editor's pointer handling. Previously this combination was treated as a plain left click, so ctrl+clicking a locked shape didn't select it or open the context menu the way a right-click does. Closes #8217.

A shared `getRightClickLikeButton` / `isRightClickLikeEvent` helper (`packages/editor/src/lib/utils/pointer.ts`) centralizes the macOS check, and it's applied consistently across the canvas pointer events, the menu click-capture component, the pointer-info builder, and the native context-menu suppression path. The test `Driver` applies the same normalization so drivers reproduce macOS behavior. The fix is scoped to the macOS ctrl+click path; touch long-press handling is unchanged.

### Change type

- [x] `bugfix`

### Test plan

1. On macOS, lock a shape on the canvas.
2. Hold Ctrl and left-click the locked shape.
3. The shape is selected and the context menu opens, matching a real right-click.
4. Repeat with an unlocked shape, and with right-click panning both enabled and disabled, to confirm no regressions.

- [x] Unit tests

### Release notes

- Fix ctrl+click on macOS not selecting locked shapes or opening the context menu; it now behaves like a right-click.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +47 / -18  |
| Tests          | +13 / -0   |
