### PR TITLE
fix(analytics): remove deprecated public prop from vercel.json

### DIFF
--- a/apps/analytics/vercel.json
+++ b/apps/analytics/vercel.json
@@ -1,6 +1,5 @@
 {
 	"version": 2,
-	"public": true,
 	"ignoreCommand": "bash ../../internal/scripts/vercel/should-build-analytics.sh",
 	"installCommand": "yarn workspaces focus @tldraw/analytics @tldraw/monorepo config",
 	"buildCommand": "yarn build",


### PR DESCRIPTION
In order to unblock the analytics Vercel deploy check on PRs, this PR removes the top-level `"public": true` property from `apps/analytics/vercel.json`.

Vercel's strict `vercel.json` schema (`https://openapi.vercel.sh/vercel.json`) sets `additionalProperties: false` and no longer includes `public`, so deploy-time validation rejected it as an unexpected property and failed the analytics build on every PR. The property had been present since #6089.

Removing it changes no behavior: `public` is a [documented no-op](https://vercel.com/docs/project-configuration/vercel-json#public) ("This option is deprecated and no longer enables public access to deployment source or build logs"). The analytics proxy's CORS handling comes entirely from the `headers` block, which is untouched.

### Change type

- [x] `other`

### Test plan

1. Open this PR and confirm the analytics Vercel deploy check passes (no `vercel.json` validation error).

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +0 / -1    |
