### PR TITLE
docs(examples): add multiplayer platformer example

### DIFF
--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
@@ -1,0 +1,378 @@
+import { useSyncDemo } from '@tldraw/sync'
+import { useEffect, useRef } from 'react'
+import { Box, Editor, TLComponents, Tldraw, TldrawUiButton, useEditor } from 'tldraw'
+import 'tldraw/tldraw.css'
+import { type Box as Collider, type PlayerMotion, stepPlayer } from './physics'
+import './multiplayer-platformer.css'
+import { PLAYER_TYPE, PlayerShape, PlayerShapeUtil } from './PlayerShape'
+
+// [1]
+const customShapeUtils = [PlayerShapeUtil]
+
+// [2]
+interface Terrain {
+	x: number
+	y: number
+	w: number
+	h: number
+	color: 'grey' | 'blue' | 'orange' | 'green'
+}
+
+const LEVEL: Terrain[] = [
+	{ x: -200, y: 560, w: 2000, h: 160, color: 'grey' }, // floor
+	{ x: 60, y: 500, w: 140, h: 60, color: 'grey' }, // step by the spawn
+	{ x: 280, y: 430, w: 220, h: 30, color: 'blue' },
+	{ x: 600, y: 320, w: 200, h: 30, color: 'blue' },
+	{ x: 760, y: 180, w: 120, h: 120, color: 'orange' }, // floating crate
+	{ x: 960, y: 410, w: 200, h: 30, color: 'blue' },
+	{ x: 1220, y: 360, w: 70, h: 200, color: 'grey' }, // pillar
+	{ x: 1360, y: 470, w: 220, h: 30, color: 'green' },
+]
+
+const SPAWN = { x: 90, y: 120 }
+// Anything that falls below this has left the level — send it back to the spawn.
+const VOID_Y = 1300
+const LEVEL_VIEW = new Box(-60, 100, 1380, 640)
+// How long an owner can be missing from presence before we remove their player.
+// The grace period rides out brief disconnects and the moment right after
+// joining, before peer presence has finished syncing.
+const DESPAWN_GRACE_MS = 3000
+
+// [3]
+function getMyPlayer(editor: Editor): PlayerShape | undefined {
+	const ownerId = editor.user.getRecordId()
+	return editor
+		.getCurrentPageShapes()
+		.find((s): s is PlayerShape => s.type === PLAYER_TYPE && s.props.ownerId === ownerId)
+}
+
+// [4]
+function setupLevel(editor: Editor) {
+	if (editor.getCurrentPageShapes().length === 0) {
+		editor.createShapes(
+			LEVEL.map((t) => ({
+				type: 'geo' as const,
+				x: t.x,
+				y: t.y,
+				props: {
+					geo: 'rectangle' as const,
+					w: t.w,
+					h: t.h,
+					color: t.color,
+					fill: 'solid' as const,
+				},
+			}))
+		)
+	}
+
+	if (!getMyPlayer(editor)) {
+		// Offset each new arrival so players don't spawn directly on top of one another.
+		const playerCount = editor.getCurrentPageShapes().filter((s) => s.type === PLAYER_TYPE).length
+		editor.createShape<PlayerShape>({
+			type: PLAYER_TYPE,
+			x: SPAWN.x + playerCount * 60,
+			y: SPAWN.y,
+			props: {
+				ownerId: editor.user.getRecordId(),
+				name: editor.user.getName(),
+				color: editor.user.getColor(),
+			},
+		})
+	}
+
+	editor.zoomToBounds(LEVEL_VIEW, { inset: 32, immediate: true })
+}
+
+// [5]
+const LEFT_KEYS = new Set(['arrowleft', 'a'])
+const RIGHT_KEYS = new Set(['arrowright', 'd'])
+const JUMP_KEYS = new Set(['arrowup', 'w', ' ', 'spacebar'])
+
+function isGameKey(key: string) {
+	return LEFT_KEYS.has(key) || RIGHT_KEYS.has(key) || JUMP_KEYS.has(key)
+}
+
+// [6]
+function PlatformerEngine() {
+	const editor = useEditor()
+	const pressed = useRef(new Set<string>())
+	const jumpRequested = useRef(false)
+	const motion = useRef<PlayerMotion>({ vy: 0, grounded: false })
+
+	useEffect(() => {
+		setupLevel(editor)
+
+		// [7]
+		// Remove the player of any collaborator who has left the room. We seed
+		// everyone who already has a player as "present" so that, just after we
+		// join, their players survive until peer presence has synced.
+		const lastSeenPresent = new Map<string, number>()
+		const joinedAt = Date.now()
+		for (const shape of editor.getCurrentPageShapes()) {
+			if (shape.type === PLAYER_TYPE) lastSeenPresent.set(shape.props.ownerId, joinedAt)
+		}
+		const reconcilePlayers = () => {
+			const now = Date.now()
+			// getCollaborators() is the set of connected peers (presence records), not
+			// the activity-filtered set — so a player standing still isn't treated as
+			// gone. Our own id is always present.
+			const present = new Set<string>(editor.getCollaborators().map((c) => c.userId))
+			present.add(editor.user.getRecordId())
+			for (const id of present) lastSeenPresent.set(id, now)
+			const departed = editor
+				.getCurrentPageShapes()
+				.filter(
+					(s) =>
+						s.type === PLAYER_TYPE &&
+						!present.has(s.props.ownerId) &&
+						now - (lastSeenPresent.get(s.props.ownerId) ?? now) > DESPAWN_GRACE_MS
+				)
+			if (departed.length === 0) return
+			editor.run(() => editor.deleteShapes(departed.map((s) => s.id)), { history: 'ignore' })
+		}
+		const despawnInterval = window.setInterval(reconcilePlayers, 1000)
+
+		// [8]
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.metaKey || e.ctrlKey || e.altKey) return
+			if (editor.getEditingShapeId()) return
+			const target = e.target as HTMLElement | null
+			if (
+				target?.isContentEditable ||
+				target?.tagName === 'INPUT' ||
+				target?.tagName === 'TEXTAREA'
+			) {
+				return
+			}
+			const key = e.key.toLowerCase()
+			if (!isGameKey(key)) return
+
+			// Claim these keys for the game. We listen in the capture phase, which
+			// runs before tldraw's own handlers, and stop propagation so the editor
+			// never sees them — otherwise space would pan, the arrows would nudge the
+			// selection, and W/A/S/D would switch tools. preventDefault stops the page
+			// from scrolling. Every other key still reaches the editor, so undo,
+			// copy/paste, and the rest keep working.
+			e.preventDefault()
+			e.stopPropagation()
+
+			if (JUMP_KEYS.has(key)) {
+				// Edge-triggered: one key press is one jump, so holding the key
+				// doesn't auto-bounce when you land.
+				if (!e.repeat) jumpRequested.current = true
+			} else {
+				pressed.current.add(key)
+			}
+		}
+
+		const onKeyUp = (e: KeyboardEvent) => {
+			const key = e.key.toLowerCase()
+			if (!isGameKey(key)) return
+			e.stopPropagation()
+			pressed.current.delete(key)
+		}
+
+		// Don't get stuck running when the tab loses focus mid-stride.
+		const onBlur = () => {
+			pressed.current.clear()
+			jumpRequested.current = false
+		}
+
+		// [9]
+		const onTick = (elapsedMs: number) => {
+			const me = getMyPlayer(editor)
+			if (!me) return
+
+			// While I'm dragging my own player, let the drag place it and pause
+			// physics so gravity doesn't fight the pointer.
+			if (editor.isIn('select.translating') && editor.getSelectedShapeIds().includes(me.id)) {
+				motion.current.vy = 0
+				return
+			}
+
+			// Clamp dt so a backgrounded tab doesn't teleport the player on resume.
+			const dt = Math.min(elapsedMs, 50) / 1000
+
+			// [10]
+			const colliders: Collider[] = []
+			for (const shape of editor.getCurrentPageShapes()) {
+				if (shape.id === me.id) continue
+				const bounds = editor.getShapePageBounds(shape.id)
+				if (bounds) colliders.push({ x: bounds.x, y: bounds.y, w: bounds.w, h: bounds.h })
+			}
+
+			const left = [...pressed.current].some((k) => LEFT_KEYS.has(k))
+			const right = [...pressed.current].some((k) => RIGHT_KEYS.has(k))
+			const input = { left, right, jump: jumpRequested.current }
+			jumpRequested.current = false
+
+			const result = stepPlayer(
+				{ x: me.x, y: me.y, w: me.props.w, h: me.props.h },
+				motion.current,
+				input,
+				colliders,
+				dt
+			)
+			motion.current = { vy: result.vy, grounded: result.grounded }
+
+			let { x, y } = result.box
+			if (y > VOID_Y) {
+				x = SPAWN.x
+				y = SPAWN.y
+				motion.current = { vy: 0, grounded: false }
+			}
+
+			const facing = result.facing ?? me.props.facing
+			const moved = Math.abs(x - me.x) > 0.01 || Math.abs(y - me.y) > 0.01
+			const turned = facing !== me.props.facing
+			if (!moved && !turned) return
+
+			// [11]
+			editor.run(
+				() => {
+					editor.updateShape<PlayerShape>({
+						id: me.id,
+						type: PLAYER_TYPE,
+						x,
+						y,
+						props: turned ? { facing } : undefined,
+					})
+				},
+				{ history: 'ignore' }
+			)
+		}
+
+		window.addEventListener('keydown', onKeyDown, { capture: true })
+		window.addEventListener('keyup', onKeyUp, { capture: true })
+		window.addEventListener('blur', onBlur)
+		editor.on('tick', onTick)
+
+		return () => {
+			window.clearInterval(despawnInterval)
+			window.removeEventListener('keydown', onKeyDown, { capture: true })
+			window.removeEventListener('keyup', onKeyUp, { capture: true })
+			window.removeEventListener('blur', onBlur)
+			editor.off('tick', onTick)
+		}
+	}, [editor])
+
+	return null
+}
+
+// [12]
+function Hud() {
+	const editor = useEditor()
+	const respawn = () => {
+		const me = getMyPlayer(editor)
+		if (!me) return
+		editor.run(
+			() =>
+				editor.updateShape<PlayerShape>({ id: me.id, type: PLAYER_TYPE, x: SPAWN.x, y: SPAWN.y }),
+			{ history: 'ignore' }
+		)
+	}
+	return (
+		<div className="platformer-hud">
+			<strong className="platformer-hud__title">Multiplayer platformer</strong>
+			<span>
+				<kbd>A</kbd>
+				<kbd>D</kbd> / <kbd>←</kbd>
+				<kbd>→</kbd> move · <kbd>space</kbd> jump
+			</span>
+			<span className="platformer-hud__hint">
+				Everything is just a shape — drag the ground, blocks, and players to rebuild the level.
+			</span>
+			<TldrawUiButton type="normal" onClick={respawn}>
+				Respawn
+			</TldrawUiButton>
+		</div>
+	)
+}
+
+const components: TLComponents = {
+	TopPanel: Hud,
+}
+
+export default function MultiplayerPlatformerExample({ roomId }: { roomId: string }) {
+	// [13]
+	const store = useSyncDemo({ roomId, shapeUtils: customShapeUtils })
+	return (
+		<div className="tldraw__editor">
+			<Tldraw store={store} shapeUtils={customShapeUtils} components={components}>
+				<PlatformerEngine />
+			</Tldraw>
+		</div>
+	)
+}
+
+/*
+This example turns the canvas into a shared 2D platformer. Every collaborator
+gets a player they drive with the keyboard, but the level itself — floor,
+platforms, crates, and the players — is made of ordinary tldraw shapes that
+anyone can still select, drag, resize, and delete.
+
+[1]
+Our custom player shape util. We pass it to both `useSyncDemo` and `<Tldraw>` so
+the synced store and the editor agree on how to validate and render the shape.
+
+[2]
+The level is a plain list of rectangles. We turn them into normal `geo` shapes,
+so there's nothing special about them — they're just the things the player
+collides with.
+
+[3]
+Find the player belonging to the current user. Each player shape is tagged with
+its owner's id, and we only ever simulate our own.
+
+[4]
+On mount we build the level if the room is empty (the first visitor lays it out;
+everyone else receives it over sync) and add our own player if we don't already
+have one. Using the user's id as the owner means reloading reuses the same
+player rather than spawning duplicates.
+
+[5]
+Key sets for the two control schemes: WASD and the arrow keys, plus space to
+jump.
+
+[6]
+The engine. It owns the keyboard state and the per-frame simulation. It renders
+nothing — it just reads input and writes the player's position back to the
+store.
+
+[7]
+When a collaborator leaves, their player should go too. `getCollaborators()`
+gives us the connected peers (it tracks presence records, not activity, so an
+idle player isn't mistaken for an absent one); any player whose owner isn't in
+that set — plus our own id — has left. We poll on an interval rather than react
+instantly so a brief disconnect, or the gap between joining and presence
+syncing, doesn't delete a player that's about to reappear (the grace period).
+
+[8]
+We listen for keys on the window in the capture phase, which runs before
+tldraw's own handlers, and call `stopPropagation` on the game keys so the editor
+never sees them. That's how we stop space from panning, the arrow keys from
+nudging the selection, and W/A/S/D from switching tools, without disabling those
+shortcuts elsewhere. Typing into a shape's text or an input is left alone.
+
+[9]
+The game loop runs on the editor's `tick` event. We only simulate our own
+player; everyone else's positions arrive over sync. While we're dragging our own
+player we pause physics so the drag wins.
+
+[10]
+Collision is checked against the page-space bounding box of every other shape.
+Because they're just bounding boxes, rotated shapes collide as their upright
+box — fine for a demo, and it keeps the maths simple.
+
+[11]
+Position updates run with `history: 'ignore'` so the physics don't fill up the
+undo stack. A resting player settles to the same spot every frame, so it stops
+emitting updates (and sync traffic) once it's standing still.
+
+[12]
+A small heads-up display with the controls and a respawn button.
+
+[13]
+`useSyncDemo` connects to tldraw's hosted demo sync server. It's only for
+prototyping — rooms are wiped after a day.
+*/

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
@@ -183,9 +183,15 @@ function PlatformerEngine() {
 			const me = getMyPlayer(editor)
 			if (!me) return
 
-			// While I'm dragging my own player, let the drag place it and pause
-			// physics so gravity doesn't fight the pointer.
-			if (editor.isIn('select.translating') && editor.getSelectedShapeIds().includes(me.id)) {
+			// While I'm actively manipulating my own player — dragging, resizing, or
+			// rotating it — pause physics so gravity doesn't fight the pointer. It
+			// resumes from rest once the interaction finishes.
+			const manipulatingMe =
+				editor.getSelectedShapeIds().includes(me.id) &&
+				(editor.isIn('select.translating') ||
+					editor.isIn('select.resizing') ||
+					editor.isIn('select.rotating'))
+			if (manipulatingMe) {
 				motion.current.vy = 0
 				return
 			}
@@ -356,8 +362,8 @@ shortcuts elsewhere. Typing into a shape's text or an input is left alone.
 
 [9]
 The game loop runs on the editor's `tick` event. We only simulate our own
-player; everyone else's positions arrive over sync. While we're dragging our own
-player we pause physics so the drag wins.
+player; everyone else's positions arrive over sync. While we're dragging,
+resizing, or rotating our own player we pause physics so the interaction wins.
 
 [10]
 Collision is checked against the page-space bounding box of every other shape.

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
@@ -2,7 +2,7 @@ import { useSyncDemo } from '@tldraw/sync'
 import { useEffect, useRef } from 'react'
 import { Box, Editor, TLComponents, Tldraw, TldrawUiButton, useEditor } from 'tldraw'
 import 'tldraw/tldraw.css'
-import { type Box as Collider, type PlayerMotion, stepPlayer } from './physics'
+import { type Collider, type PlayerMotion, stepPlayer } from './physics'
 import './multiplayer-platformer.css'
 import { PLAYER_TYPE, PlayerShape, PlayerShapeUtil } from './PlayerShape'
 
@@ -97,7 +97,7 @@ function PlatformerEngine() {
 	const editor = useEditor()
 	const pressed = useRef(new Set<string>())
 	const jumpRequested = useRef(false)
-	const motion = useRef<PlayerMotion>({ vy: 0, grounded: false })
+	const motion = useRef<PlayerMotion>({ vx: 0, vy: 0, grounded: false })
 
 	useEffect(() => {
 		setupLevel(editor)
@@ -192,7 +192,7 @@ function PlatformerEngine() {
 					editor.isIn('select.resizing') ||
 					editor.isIn('select.rotating'))
 			if (manipulatingMe) {
-				motion.current.vy = 0
+				motion.current = { vx: 0, vy: 0, grounded: motion.current.grounded }
 				return
 			}
 
@@ -203,8 +203,15 @@ function PlatformerEngine() {
 			const colliders: Collider[] = []
 			for (const shape of editor.getCurrentPageShapes()) {
 				if (shape.id === me.id) continue
-				const bounds = editor.getShapePageBounds(shape.id)
-				if (bounds) colliders.push({ x: bounds.x, y: bounds.y, w: bounds.w, h: bounds.h })
+				const geometry = editor.getShapeGeometry(shape)
+				// Open shapes (lines, arrows) have no interior to stand on — skip them.
+				if (!geometry.isClosed) continue
+				const transform = editor.getShapePageTransform(shape)
+				const vertices = geometry.vertices.map((v) => {
+					const page = transform.applyToPoint(v)
+					return { x: page.x, y: page.y }
+				})
+				if (vertices.length >= 3) colliders.push({ vertices })
 			}
 
 			const left = [...pressed.current].some((k) => LEFT_KEYS.has(k))
@@ -219,13 +226,13 @@ function PlatformerEngine() {
 				colliders,
 				dt
 			)
-			motion.current = { vy: result.vy, grounded: result.grounded }
+			motion.current = { vx: result.vx, vy: result.vy, grounded: result.grounded }
 
 			let { x, y } = result.box
 			if (y > VOID_Y) {
 				x = SPAWN.x
 				y = SPAWN.y
-				motion.current = { vy: 0, grounded: false }
+				motion.current = { vx: 0, vy: 0, grounded: false }
 			}
 
 			const facing = result.facing ?? me.props.facing
@@ -366,9 +373,13 @@ player; everyone else's positions arrive over sync. While we're dragging,
 resizing, or rotating our own player we pause physics so the interaction wins.
 
 [10]
-Collision is checked against the page-space bounding box of every other shape.
-Because they're just bounding boxes, rotated shapes collide as their upright
-box — fine for a demo, and it keeps the maths simple.
+Each collider is a shape's real outline — its geometry vertices mapped into page
+space via the shape's transform — not its bounding box. So a rotated rectangle
+collides as a rotated rectangle, and the player can land on a tilted shape and
+slide down it. We skip open shapes (lines, arrows) since they have no interior to
+stand on. Collision is solved with SAT in `physics.ts`: exact for convex shapes
+(rectangles, triangles), approximate for the many-sided polygons used for
+ellipses, and rough for concave shapes.
 
 [11]
 Position updates run with `history: 'ignore'` so the physics don't fill up the

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/MultiplayerPlatformerExample.tsx
@@ -157,8 +157,8 @@ function PlatformerEngine() {
 			e.stopPropagation()
 
 			if (JUMP_KEYS.has(key)) {
-				// Edge-triggered: one key press is one jump, so holding the key
-				// doesn't auto-bounce when you land.
+				// One press, one jump (ignore auto-repeat) — it fires next tick if we're
+				// on the ground, otherwise it's ignored.
 				if (!e.repeat) jumpRequested.current = true
 			} else {
 				pressed.current.add(key)
@@ -219,16 +219,19 @@ function PlatformerEngine() {
 			const input = { left, right, jump: jumpRequested.current }
 			jumpRequested.current = false
 
-			const result = stepPlayer(
-				{ x: me.x, y: me.y, w: me.props.w, h: me.props.h },
-				motion.current,
-				input,
-				colliders,
-				dt
-			)
+			// The player is its own rotated outline, so its hitbox matches what you
+			// see even after you spin the character around.
+			const playerTransform = editor.getShapePageTransform(me)
+			const playerVertices = editor.getShapeGeometry(me).vertices.map((v) => {
+				const page = playerTransform.applyToPoint(v)
+				return { x: page.x, y: page.y }
+			})
+
+			const result = stepPlayer(playerVertices, motion.current, input, colliders, dt)
 			motion.current = { vx: result.vx, vy: result.vy, grounded: result.grounded }
 
-			let { x, y } = result.box
+			let x = me.x + result.dx
+			let y = me.y + result.dy
 			if (y > VOID_Y) {
 				x = SPAWN.x
 				y = SPAWN.y
@@ -376,8 +379,10 @@ resizing, or rotating our own player we pause physics so the interaction wins.
 Each collider is a shape's real outline — its geometry vertices mapped into page
 space via the shape's transform — not its bounding box. So a rotated rectangle
 collides as a rotated rectangle, and the player can land on a tilted shape and
-slide down it. We skip open shapes (lines, arrows) since they have no interior to
-stand on. Collision is solved with SAT in `physics.ts`: exact for convex shapes
+slide down it. The player is passed through the same path (its own rotated
+outline), so its hitbox matches what you see even after you rotate the character.
+We skip open shapes (lines, arrows) since they have no interior to stand on.
+Collision is solved with SAT in `physics.ts`: exact for convex shapes
 (rectangles, triangles), approximate for the many-sided polygons used for
 ellipses, and rough for concave shapes.
 

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/PlayerShape.tsx
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/PlayerShape.tsx
@@ -1,0 +1,90 @@
+import { BaseBoxShapeUtil, HTMLContainer, T, TLShape } from 'tldraw'
+
+export const PLAYER_TYPE = 'player'
+
+// [1]
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[PLAYER_TYPE]: {
+			w: number
+			h: number
+			ownerId: string
+			name: string
+			color: string
+			facing: 'left' | 'right'
+		}
+	}
+}
+
+// [2]
+export type PlayerShape = TLShape<typeof PLAYER_TYPE>
+
+// [3]
+export class PlayerShapeUtil extends BaseBoxShapeUtil<PlayerShape> {
+	static override type = PLAYER_TYPE
+	static override props = {
+		w: T.positiveNumber,
+		h: T.positiveNumber,
+		ownerId: T.string,
+		name: T.string,
+		color: T.string,
+		facing: T.literalEnum('left', 'right'),
+	}
+
+	override getDefaultProps(): PlayerShape['props'] {
+		return { w: 44, h: 56, ownerId: '', name: 'Player', color: '#7b66dc', facing: 'right' }
+	}
+
+	// [4]
+	override component(shape: PlayerShape) {
+		const { color, name, facing } = shape.props
+		// Shift the pupils toward the direction of travel so it's clear which way
+		// each player is facing. The pupil is 46% of the eye wide, so these two
+		// offsets leave it the same 6% gap from the eye edge whichever way it looks.
+		const pupil = facing === 'right' ? '48%' : '6%'
+		return (
+			<HTMLContainer className="platformer-player">
+				{/* Only show a name tag for players whose owner actually has a name set. */}
+				{name.trim() !== '' && <div className="platformer-player__name">{name}</div>}
+				<div className="platformer-player__body" style={{ backgroundColor: color }}>
+					<div className="platformer-player__eye">
+						<div className="platformer-player__pupil" style={{ left: pupil }} />
+					</div>
+					<div className="platformer-player__eye">
+						<div className="platformer-player__pupil" style={{ left: pupil }} />
+					</div>
+				</div>
+			</HTMLContainer>
+		)
+	}
+
+	// [5]
+	override getIndicatorPath(shape: PlayerShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+/*
+[1]
+Register the player shape's props with tldraw's global type map so the rest of
+the SDK knows about them.
+
+[2]
+Define the shape type from its string type, the same way the built-in shapes do.
+
+[3]
+The shape util. We extend BaseBoxShapeUtil, which gives the player box geometry,
+resize handles, and hit-testing for free — everything needed for it to behave
+like a normal, draggable shape. The physics that move it live outside the util,
+in the example's game loop.
+
+[4]
+The rendered avatar: a coloured body with two googly eyes. The body colour and
+name come from the controlling user's tldraw identity, so each collaborator's
+character matches their cursor.
+
+[5]
+The selection indicator drawn when the shape is selected.
+*/

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/README.md
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/README.md
@@ -17,7 +17,8 @@ Everything in the level — the floor, platforms, crates, and the player charact
 This example shows how to:
 
 - Define a custom `player` shape that's still a normal, movable shape via `BaseBoxShapeUtil`.
-- Run a per-frame game loop on the editor's `tick` event, applying gravity and axis-aligned collision detection.
+- Run a per-frame game loop on the editor's `tick` event, applying gravity and collision detection.
+- Collide against each shape's real geometry (`editor.getShapeGeometry`) rather than its bounding box, using SAT so the player can land on a rotated shape and slide down it.
 - Read keyboard input without breaking tldraw's own shortcuts, by marking the game keys as handled before the editor sees them (space, the arrow keys, and W/A/S/D all have default behaviors otherwise).
 - Combine custom physics with `useSyncDemo`: each client simulates only its own player and writes its position to the store, while everyone else's players arrive over sync.
 - Despawn a collaborator's player when they leave, by reconciling player shapes against `editor.getCollaborators()` (with a short grace period so brief disconnects don't remove a player that's about to reappear).

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/README.md
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/README.md
@@ -1,0 +1,25 @@
+---
+title: Multiplayer platformer
+component: ./MultiplayerPlatformerExample.tsx
+priority: 6
+keywords: [game, platformer, physics, gravity, collision, jump, keyboard, sync, multiplayer]
+multiplayer: true
+---
+
+Turn the canvas into a shared 2D platformer where every collaborator drives their own player.
+
+---
+
+The canvas becomes a side-scrolling platformer level. Each collaborator gets a player they control with the arrow keys or WASD, and space to jump. Open the example in two windows (or share the room link) to play together.
+
+Everything in the level — the floor, platforms, crates, and the player characters themselves — is an ordinary tldraw shape. You can select, drag, resize, and delete any of it while the game runs, so you can rebuild the level under your own feet.
+
+This example shows how to:
+
+- Define a custom `player` shape that's still a normal, movable shape via `BaseBoxShapeUtil`.
+- Run a per-frame game loop on the editor's `tick` event, applying gravity and axis-aligned collision detection.
+- Read keyboard input without breaking tldraw's own shortcuts, by marking the game keys as handled before the editor sees them (space, the arrow keys, and W/A/S/D all have default behaviors otherwise).
+- Combine custom physics with `useSyncDemo`: each client simulates only its own player and writes its position to the store, while everyone else's players arrive over sync.
+- Despawn a collaborator's player when they leave, by reconciling player shapes against `editor.getCollaborators()` (with a short grace period so brief disconnects don't remove a player that's about to reappear).
+
+Position updates use `history: 'ignore'` so the simulation doesn't fill the undo stack, and a player at rest stops emitting updates so an idle game produces no sync traffic.

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/multiplayer-platformer.css
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/multiplayer-platformer.css
@@ -1,0 +1,96 @@
+/* The player avatar. The container is sized to the shape by tldraw; we draw the
+   body inside it and hang the name tag above. */
+.platformer-player__body {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 16%;
+	/* Fixed radius so the corners stay round on a narrow player instead of
+	   stretching into ellipses the way a percentage radius would. */
+	border-radius: 12px;
+	box-shadow:
+		inset 0 -6px 0 rgba(0, 0, 0, 0.18),
+		inset 0 0 0 2px rgba(0, 0, 0, 0.12),
+		0 3px 6px rgba(0, 0, 0, 0.2);
+	/* Let the body receive the pointer so it shows the move cursor and can be
+	   grabbed like any other shape. */
+	pointer-events: all;
+}
+
+.platformer-player__eye {
+	position: relative;
+	/* aspect-ratio keeps the eye a circle regardless of the body's proportions. */
+	width: 26%;
+	aspect-ratio: 1;
+	background: #fff;
+	border-radius: 50%;
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.12);
+}
+
+.platformer-player__pupil {
+	position: absolute;
+	top: 27%;
+	width: 46%;
+	aspect-ratio: 1;
+	background: #1d1d1d;
+	border-radius: 50%;
+	transition: left 0.08s ease-out;
+}
+
+.platformer-player__name {
+	position: absolute;
+	bottom: 100%;
+	left: 50%;
+	transform: translateX(-50%);
+	margin-bottom: 6px;
+	padding: 2px 8px;
+	max-width: 160px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 12px;
+	font-weight: 600;
+	color: #1d1d1d;
+	background: rgba(255, 255, 255, 0.92);
+	border-radius: 999px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+	pointer-events: none;
+}
+
+/* Heads-up display in the top panel slot. */
+.platformer-hud {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	margin: 8px;
+	padding: 8px 12px;
+	background: var(--color-panel);
+	border-radius: 10px;
+	box-shadow: var(--shadow-2);
+	font-size: 12px;
+	color: var(--color-text);
+	pointer-events: all;
+}
+
+.platformer-hud__title {
+	font-size: 13px;
+}
+
+.platformer-hud__hint {
+	color: var(--color-text-3);
+}
+
+.platformer-hud kbd {
+	display: inline-block;
+	min-width: 16px;
+	margin: 0 1px;
+	padding: 1px 5px;
+	text-align: center;
+	font-family: inherit;
+	font-size: 11px;
+	background: var(--color-muted-2);
+	border-radius: 4px;
+	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+}

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/physics.ts
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/physics.ts
@@ -1,10 +1,21 @@
-// The level is made of ordinary tldraw shapes, so a "collider" is just the
-// page-space bounding box of any shape that isn't the player we're simulating.
+export interface Vec2 {
+	x: number
+	y: number
+}
+
+// The player is always an upright box.
 export interface Box {
 	x: number
 	y: number
 	w: number
 	h: number
+}
+
+// A collider is the page-space outline of any shape that isn't the player. We
+// keep the full polygon (not just a bounding box) so the player can land on and
+// slide down rotated shapes.
+export interface Collider {
+	vertices: Vec2[]
 }
 
 export type Facing = 'left' | 'right'
@@ -16,9 +27,10 @@ export interface PlayerInput {
 }
 
 export interface PlayerMotion {
-	// Only vertical velocity needs to persist between frames — horizontal speed
-	// is read straight from the keys each tick. `grounded` is remembered so a
-	// jump can only take off from the ground.
+	// The full velocity persists between frames now: gravity feeds `vy`, and the
+	// horizontal `vx` carries momentum so a player keeps sliding down a slope
+	// after we've redirected their fall along the surface.
+	vx: number
 	vy: number
 	grounded: boolean
 }
@@ -32,107 +44,174 @@ export const PLATFORMER_PHYSICS = {
 	jumpSpeed: 820,
 	// terminal velocity, so a long fall can't tunnel straight through the floor
 	maxFallSpeed: 2000,
-}
-
-// Treat touching-but-not-overlapping as "not colliding". Without this, a player
-// resting exactly on the floor would be considered inside it during the
-// horizontal pass and get shoved sideways out of the ground.
-const EPSILON = 0.01
-
-function intersects(a: Box, b: Box) {
-	return (
-		a.x + a.w > b.x + EPSILON &&
-		b.x + b.w > a.x + EPSILON &&
-		a.y + a.h > b.y + EPSILON &&
-		b.y + b.h > a.y + EPSILON
-	)
+	// Horizontal speed kept per frame while standing still on flat ground; below
+	// this much it snaps to zero for a clean stop. Slopes ignore this (gravity
+	// keeps re-feeding the slide), so only flat ground actually brakes.
+	groundFriction: 0.6,
+	// A contact normal counts as standable ground when it points up by at least
+	// this much (1 = straight up). 0.5 ≈ slopes up to 60°.
+	standableUp: 0.5,
+	// ...and as flat-enough-to-brake ground when it points up by at least this
+	// much, so the player rests on flat ground but slides on anything tilted.
+	flatUp: 0.95,
+	// Resolve passes per tick. A few passes settle corners and stacked contacts
+	// without leaving the player jittering between two colliders.
+	resolveIterations: 4,
 }
 
 export interface StepResult {
 	box: Box
+	vx: number
 	vy: number
 	grounded: boolean
 	facing: Facing | null
 }
 
-// Advance the player by `dt` seconds. We resolve one axis at a time — move
-// horizontally and push out of anything we hit, then move vertically and do the
-// same. Resolving the axes separately is the classic way to get dependable
-// platformer collisions out of axis-aligned boxes.
+// Advance the player by `dt` seconds: apply input and gravity, move, then push
+// out of every collider along its surface normal. Cancelling only the
+// into-surface part of the velocity is what turns a fall into a slide.
 export function stepPlayer(
 	player: Box,
 	motion: PlayerMotion,
 	input: PlayerInput,
-	colliders: Box[],
+	colliders: Collider[],
 	dt: number
 ): StepResult {
 	const box: Box = { ...player }
+	let vx = motion.vx
 	let vy = motion.vy
 	let facing: Facing | null = null
 
-	// A jump only takes off when we were standing on something last frame.
+	// A jump takes off when we were standing on something last frame.
 	if (input.jump && motion.grounded) {
 		vy = -PLATFORMER_PHYSICS.jumpSpeed
 	}
 
-	// Horizontal speed comes straight from the keys — no momentum keeps the
-	// controls feeling tight.
-	let vx = 0
+	// Holding a direction sets the horizontal speed outright (tight controls);
+	// with no key held we keep whatever momentum we have, so slides continue.
 	if (input.left) {
-		vx -= PLATFORMER_PHYSICS.moveSpeed
+		vx = -PLATFORMER_PHYSICS.moveSpeed
 		facing = 'left'
-	}
-	if (input.right) {
-		vx += PLATFORMER_PHYSICS.moveSpeed
+	} else if (input.right) {
+		vx = PLATFORMER_PHYSICS.moveSpeed
 		facing = 'right'
 	}
 
 	// Gravity, clamped to a terminal velocity.
 	vy = Math.min(vy + PLATFORMER_PHYSICS.gravity * dt, PLATFORMER_PHYSICS.maxFallSpeed)
 
-	// --- horizontal pass ---
+	// Move, then resolve.
 	box.x += vx * dt
-	for (const c of colliders) {
-		if (!intersects(box, c)) continue
-		if (vx > 0) {
-			box.x = c.x - box.w
-		} else if (vx < 0) {
-			box.x = c.x + c.w
-		} else {
-			// A collider was dragged sideways into a stationary player — pop us
-			// out whichever side is closer.
-			const pushLeft = box.x + box.w - c.x
-			const pushRight = c.x + c.w - box.x
-			box.x = pushLeft < pushRight ? c.x - box.w : c.x + c.w
-		}
-	}
-
-	// --- vertical pass ---
 	box.y += vy * dt
+
 	let grounded = false
-	for (const c of colliders) {
-		if (!intersects(box, c)) continue
-		if (vy > 0) {
-			// Falling onto something: land on top of it.
-			box.y = c.y - box.h
-			vy = 0
-			grounded = true
-		} else if (vy < 0) {
-			// Rising into something: bonk our head and start coming back down.
-			box.y = c.y + c.h
-			vy = 0
-		} else {
-			// A collider was dragged vertically into a stationary player.
-			const pushUp = box.y + box.h - c.y
-			const pushDown = c.y + c.h - box.y
-			if (pushUp < pushDown) {
-				box.y = c.y - box.h
+	// The flattest ground we're touching (most upward normal), so we know whether
+	// to brake (flat) or let the player slide (tilted).
+	let groundUp = 0
+	for (let pass = 0; pass < PLATFORMER_PHYSICS.resolveIterations; pass++) {
+		for (const collider of colliders) {
+			const hit = collide(box, collider.vertices)
+			if (!hit) continue
+			// Push out of the surface.
+			box.x += hit.nx * hit.depth
+			box.y += hit.ny * hit.depth
+			// Remove only the velocity heading into the surface; the part running
+			// along it is kept, which is the slide.
+			const into = vx * hit.nx + vy * hit.ny
+			if (into < 0) {
+				vx -= into * hit.nx
+				vy -= into * hit.ny
+			}
+			// In page space y points down, so an upward normal has negative y.
+			const up = -hit.ny
+			if (up > PLATFORMER_PHYSICS.standableUp) {
 				grounded = true
-			} else {
-				box.y = c.y + c.h
+				groundUp = Math.max(groundUp, up)
 			}
 		}
 	}
 
-	return { box, vy, grounded, facing }
+	// Brake to a stop on flat ground when there's no input. On a slope we skip
+	// this so gravity can keep the player sliding.
+	if (grounded && groundUp > PLATFORMER_PHYSICS.flatUp && !input.left && !input.right) {
+		vx *= PLATFORMER_PHYSICS.groundFriction
+		if (Math.abs(vx) < 1) vx = 0
+	}
+
+	return { box, vx, vy, grounded, facing }
+}
+
+// Separating Axis Theorem between the upright player box and a convex polygon.
+// Returns the minimum push-out normal and depth, or null if they don't overlap.
+// It's exact for convex shapes (rectangles, rotated rectangles, triangles) and
+// a close approximation for the many-sided polygons tldraw uses for ellipses.
+function collide(box: Box, poly: Vec2[]): { nx: number; ny: number; depth: number } | null {
+	const boxVerts: Vec2[] = [
+		{ x: box.x, y: box.y },
+		{ x: box.x + box.w, y: box.y },
+		{ x: box.x + box.w, y: box.y + box.h },
+		{ x: box.x, y: box.y + box.h },
+	]
+
+	// Candidate separating axes: the box's two axes plus every polygon edge normal.
+	const axes: Vec2[] = [
+		{ x: 1, y: 0 },
+		{ x: 0, y: 1 },
+	]
+	for (let i = 0; i < poly.length; i++) {
+		const a = poly[i]
+		const b = poly[(i + 1) % poly.length]
+		const ex = b.x - a.x
+		const ey = b.y - a.y
+		const len = Math.hypot(ex, ey)
+		if (len === 0) continue
+		axes.push({ x: -ey / len, y: ex / len })
+	}
+
+	let minOverlap = Infinity
+	let nx = 0
+	let ny = 0
+	for (const axis of axes) {
+		const a = project(boxVerts, axis)
+		const b = project(poly, axis)
+		const overlap = Math.min(a.max, b.max) - Math.max(a.min, b.min)
+		if (overlap <= 0) return null // found a gap — no collision
+		if (overlap < minOverlap) {
+			minOverlap = overlap
+			nx = axis.x
+			ny = axis.y
+		}
+	}
+
+	// Point the normal from the polygon toward the player so we push out, not in.
+	const polyCenter = centroid(poly)
+	const boxCenterX = box.x + box.w / 2
+	const boxCenterY = box.y + box.h / 2
+	if ((boxCenterX - polyCenter.x) * nx + (boxCenterY - polyCenter.y) * ny < 0) {
+		nx = -nx
+		ny = -ny
+	}
+
+	return { nx, ny, depth: minOverlap }
+}
+
+function project(verts: Vec2[], axis: Vec2) {
+	let min = Infinity
+	let max = -Infinity
+	for (const v of verts) {
+		const p = v.x * axis.x + v.y * axis.y
+		if (p < min) min = p
+		if (p > max) max = p
+	}
+	return { min, max }
+}
+
+function centroid(verts: Vec2[]): Vec2 {
+	let x = 0
+	let y = 0
+	for (const v of verts) {
+		x += v.x
+		y += v.y
+	}
+	return { x: x / verts.length, y: y / verts.length }
 }

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/physics.ts
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/physics.ts
@@ -3,17 +3,9 @@ export interface Vec2 {
 	y: number
 }
 
-// The player is always an upright box.
-export interface Box {
-	x: number
-	y: number
-	w: number
-	h: number
-}
-
-// A collider is the page-space outline of any shape that isn't the player. We
-// keep the full polygon (not just a bounding box) so the player can land on and
-// slide down rotated shapes.
+// Both the player and every obstacle are passed in as convex polygons of
+// page-space points, so the player collides with each shape's real outline —
+// including its own, once it's been rotated.
 export interface Collider {
 	vertices: Vec2[]
 }
@@ -27,9 +19,9 @@ export interface PlayerInput {
 }
 
 export interface PlayerMotion {
-	// The full velocity persists between frames now: gravity feeds `vy`, and the
-	// horizontal `vx` carries momentum so a player keeps sliding down a slope
-	// after we've redirected their fall along the surface.
+	// The full velocity persists between frames: gravity feeds `vy`, and `vx`
+	// carries momentum so a player keeps sliding down a slope after we've
+	// redirected their fall along the surface.
 	vx: number
 	vy: number
 	grounded: boolean
@@ -44,15 +36,11 @@ export const PLATFORMER_PHYSICS = {
 	jumpSpeed: 820,
 	// terminal velocity, so a long fall can't tunnel straight through the floor
 	maxFallSpeed: 2000,
-	// Horizontal speed kept per frame while standing still on flat ground; below
-	// this much it snaps to zero for a clean stop. Slopes ignore this (gravity
-	// keeps re-feeding the slide), so only flat ground actually brakes.
-	groundFriction: 0.6,
 	// A contact normal counts as standable ground when it points up by at least
 	// this much (1 = straight up). 0.5 ≈ slopes up to 60°.
 	standableUp: 0.5,
-	// ...and as flat-enough-to-brake ground when it points up by at least this
-	// much, so the player rests on flat ground but slides on anything tilted.
+	// ...and as flat-enough-to-stop-on when it points up by at least this much,
+	// so the player halts on flat ground but keeps sliding on anything tilted.
 	flatUp: 0.95,
 	// Resolve passes per tick. A few passes settle corners and stacked contacts
 	// without leaving the player jittering between two colliders.
@@ -60,7 +48,9 @@ export const PLATFORMER_PHYSICS = {
 }
 
 export interface StepResult {
-	box: Box
+	// Net page-space displacement to apply to the player this tick.
+	dx: number
+	dy: number
 	vx: number
 	vy: number
 	grounded: boolean
@@ -69,15 +59,15 @@ export interface StepResult {
 
 // Advance the player by `dt` seconds: apply input and gravity, move, then push
 // out of every collider along its surface normal. Cancelling only the
-// into-surface part of the velocity is what turns a fall into a slide.
+// into-surface part of the velocity is what turns a fall into a slide. The
+// player is a polygon too, so a rotated player collides as a rotated box.
 export function stepPlayer(
-	player: Box,
+	playerVertices: Vec2[],
 	motion: PlayerMotion,
 	input: PlayerInput,
 	colliders: Collider[],
 	dt: number
 ): StepResult {
-	const box: Box = { ...player }
 	let vx = motion.vx
 	let vy = motion.vy
 	let facing: Facing | null = null
@@ -100,21 +90,32 @@ export function stepPlayer(
 	// Gravity, clamped to a terminal velocity.
 	vy = Math.min(vy + PLATFORMER_PHYSICS.gravity * dt, PLATFORMER_PHYSICS.maxFallSpeed)
 
-	// Move, then resolve.
-	box.x += vx * dt
-	box.y += vy * dt
+	// Work on a copy of the player polygon, tracking the net displacement so the
+	// caller can move the shape by it.
+	const verts = playerVertices.map((v) => ({ x: v.x, y: v.y }))
+	let dx = 0
+	let dy = 0
+	const move = (tx: number, ty: number) => {
+		for (const v of verts) {
+			v.x += tx
+			v.y += ty
+		}
+		dx += tx
+		dy += ty
+	}
+
+	move(vx * dt, vy * dt)
 
 	let grounded = false
 	// The flattest ground we're touching (most upward normal), so we know whether
-	// to brake (flat) or let the player slide (tilted).
+	// to stop (flat) or let the player slide (tilted).
 	let groundUp = 0
 	for (let pass = 0; pass < PLATFORMER_PHYSICS.resolveIterations; pass++) {
 		for (const collider of colliders) {
-			const hit = collide(box, collider.vertices)
+			const hit = collide(verts, collider.vertices)
 			if (!hit) continue
 			// Push out of the surface.
-			box.x += hit.nx * hit.depth
-			box.y += hit.ny * hit.depth
+			move(hit.nx * hit.depth, hit.ny * hit.depth)
 			// Remove only the velocity heading into the surface; the part running
 			// along it is kept, which is the slide.
 			const into = vx * hit.nx + vy * hit.ny
@@ -131,50 +132,29 @@ export function stepPlayer(
 		}
 	}
 
-	// Brake to a stop on flat ground when there's no input. On a slope we skip
-	// this so gravity can keep the player sliding.
+	// Stop dead on flat ground when there's no input — no icy glide. On a slope
+	// we skip this so gravity keeps the player sliding.
 	if (grounded && groundUp > PLATFORMER_PHYSICS.flatUp && !input.left && !input.right) {
-		vx *= PLATFORMER_PHYSICS.groundFriction
-		if (Math.abs(vx) < 1) vx = 0
+		vx = 0
 	}
 
-	return { box, vx, vy, grounded, facing }
+	return { dx, dy, vx, vy, grounded, facing }
 }
 
-// Separating Axis Theorem between the upright player box and a convex polygon.
-// Returns the minimum push-out normal and depth, or null if they don't overlap.
-// It's exact for convex shapes (rectangles, rotated rectangles, triangles) and
-// a close approximation for the many-sided polygons tldraw uses for ellipses.
-function collide(box: Box, poly: Vec2[]): { nx: number; ny: number; depth: number } | null {
-	const boxVerts: Vec2[] = [
-		{ x: box.x, y: box.y },
-		{ x: box.x + box.w, y: box.y },
-		{ x: box.x + box.w, y: box.y + box.h },
-		{ x: box.x, y: box.y + box.h },
-	]
-
-	// Candidate separating axes: the box's two axes plus every polygon edge normal.
-	const axes: Vec2[] = [
-		{ x: 1, y: 0 },
-		{ x: 0, y: 1 },
-	]
-	for (let i = 0; i < poly.length; i++) {
-		const a = poly[i]
-		const b = poly[(i + 1) % poly.length]
-		const ex = b.x - a.x
-		const ey = b.y - a.y
-		const len = Math.hypot(ex, ey)
-		if (len === 0) continue
-		axes.push({ x: -ey / len, y: ex / len })
-	}
-
+// Separating Axis Theorem between two convex polygons. Returns the minimum
+// push-out normal (pointing from `b` toward `a`) and depth, or null if they
+// don't overlap. Exact for convex shapes (rectangles, rotated rectangles,
+// triangles), a close approximation for the many-sided polygons tldraw uses for
+// ellipses, and rough for concave shapes.
+function collide(a: Vec2[], b: Vec2[]): { nx: number; ny: number; depth: number } | null {
+	const axes = [...edgeNormals(a), ...edgeNormals(b)]
 	let minOverlap = Infinity
 	let nx = 0
 	let ny = 0
 	for (const axis of axes) {
-		const a = project(boxVerts, axis)
-		const b = project(poly, axis)
-		const overlap = Math.min(a.max, b.max) - Math.max(a.min, b.min)
+		const pa = project(a, axis)
+		const pb = project(b, axis)
+		const overlap = Math.min(pa.max, pb.max) - Math.max(pa.min, pb.min)
 		if (overlap <= 0) return null // found a gap — no collision
 		if (overlap < minOverlap) {
 			minOverlap = overlap
@@ -183,16 +163,29 @@ function collide(box: Box, poly: Vec2[]): { nx: number; ny: number; depth: numbe
 		}
 	}
 
-	// Point the normal from the polygon toward the player so we push out, not in.
-	const polyCenter = centroid(poly)
-	const boxCenterX = box.x + box.w / 2
-	const boxCenterY = box.y + box.h / 2
-	if ((boxCenterX - polyCenter.x) * nx + (boxCenterY - polyCenter.y) * ny < 0) {
+	// Point the normal from b toward a so we push the player out, not in.
+	const ca = centroid(a)
+	const cb = centroid(b)
+	if ((ca.x - cb.x) * nx + (ca.y - cb.y) * ny < 0) {
 		nx = -nx
 		ny = -ny
 	}
 
 	return { nx, ny, depth: minOverlap }
+}
+
+function edgeNormals(verts: Vec2[]): Vec2[] {
+	const normals: Vec2[] = []
+	for (let i = 0; i < verts.length; i++) {
+		const a = verts[i]
+		const b = verts[(i + 1) % verts.length]
+		const ex = b.x - a.x
+		const ey = b.y - a.y
+		const len = Math.hypot(ex, ey)
+		if (len === 0) continue
+		normals.push({ x: -ey / len, y: ex / len })
+	}
+	return normals
 }
 
 function project(verts: Vec2[], axis: Vec2) {

--- a/apps/examples/src/examples/collaboration/multiplayer-platformer/physics.ts
+++ b/apps/examples/src/examples/collaboration/multiplayer-platformer/physics.ts
@@ -1,0 +1,138 @@
+// The level is made of ordinary tldraw shapes, so a "collider" is just the
+// page-space bounding box of any shape that isn't the player we're simulating.
+export interface Box {
+	x: number
+	y: number
+	w: number
+	h: number
+}
+
+export type Facing = 'left' | 'right'
+
+export interface PlayerInput {
+	left: boolean
+	right: boolean
+	jump: boolean
+}
+
+export interface PlayerMotion {
+	// Only vertical velocity needs to persist between frames — horizontal speed
+	// is read straight from the keys each tick. `grounded` is remembered so a
+	// jump can only take off from the ground.
+	vy: number
+	grounded: boolean
+}
+
+export const PLATFORMER_PHYSICS = {
+	// page units per second
+	moveSpeed: 360,
+	// page units per second, per second
+	gravity: 2400,
+	// initial upward speed of a jump
+	jumpSpeed: 820,
+	// terminal velocity, so a long fall can't tunnel straight through the floor
+	maxFallSpeed: 2000,
+}
+
+// Treat touching-but-not-overlapping as "not colliding". Without this, a player
+// resting exactly on the floor would be considered inside it during the
+// horizontal pass and get shoved sideways out of the ground.
+const EPSILON = 0.01
+
+function intersects(a: Box, b: Box) {
+	return (
+		a.x + a.w > b.x + EPSILON &&
+		b.x + b.w > a.x + EPSILON &&
+		a.y + a.h > b.y + EPSILON &&
+		b.y + b.h > a.y + EPSILON
+	)
+}
+
+export interface StepResult {
+	box: Box
+	vy: number
+	grounded: boolean
+	facing: Facing | null
+}
+
+// Advance the player by `dt` seconds. We resolve one axis at a time — move
+// horizontally and push out of anything we hit, then move vertically and do the
+// same. Resolving the axes separately is the classic way to get dependable
+// platformer collisions out of axis-aligned boxes.
+export function stepPlayer(
+	player: Box,
+	motion: PlayerMotion,
+	input: PlayerInput,
+	colliders: Box[],
+	dt: number
+): StepResult {
+	const box: Box = { ...player }
+	let vy = motion.vy
+	let facing: Facing | null = null
+
+	// A jump only takes off when we were standing on something last frame.
+	if (input.jump && motion.grounded) {
+		vy = -PLATFORMER_PHYSICS.jumpSpeed
+	}
+
+	// Horizontal speed comes straight from the keys — no momentum keeps the
+	// controls feeling tight.
+	let vx = 0
+	if (input.left) {
+		vx -= PLATFORMER_PHYSICS.moveSpeed
+		facing = 'left'
+	}
+	if (input.right) {
+		vx += PLATFORMER_PHYSICS.moveSpeed
+		facing = 'right'
+	}
+
+	// Gravity, clamped to a terminal velocity.
+	vy = Math.min(vy + PLATFORMER_PHYSICS.gravity * dt, PLATFORMER_PHYSICS.maxFallSpeed)
+
+	// --- horizontal pass ---
+	box.x += vx * dt
+	for (const c of colliders) {
+		if (!intersects(box, c)) continue
+		if (vx > 0) {
+			box.x = c.x - box.w
+		} else if (vx < 0) {
+			box.x = c.x + c.w
+		} else {
+			// A collider was dragged sideways into a stationary player — pop us
+			// out whichever side is closer.
+			const pushLeft = box.x + box.w - c.x
+			const pushRight = c.x + c.w - box.x
+			box.x = pushLeft < pushRight ? c.x - box.w : c.x + c.w
+		}
+	}
+
+	// --- vertical pass ---
+	box.y += vy * dt
+	let grounded = false
+	for (const c of colliders) {
+		if (!intersects(box, c)) continue
+		if (vy > 0) {
+			// Falling onto something: land on top of it.
+			box.y = c.y - box.h
+			vy = 0
+			grounded = true
+		} else if (vy < 0) {
+			// Rising into something: bonk our head and start coming back down.
+			box.y = c.y + c.h
+			vy = 0
+		} else {
+			// A collider was dragged vertically into a stationary player.
+			const pushUp = box.y + box.h - c.y
+			const pushDown = c.y + c.h - box.y
+			if (pushUp < pushDown) {
+				box.y = c.y - box.h
+				grounded = true
+			} else {
+				box.y = c.y + c.h
+			}
+		}
+	}
+
+	return { box, vy, grounded, facing }
+}


### PR DESCRIPTION
In order to demonstrate real-time multiplayer, a custom shape, and a per-frame game loop together, this PR adds a "Multiplayer platformer" example. The canvas becomes a shared 2D platformer level where each collaborator controls a player with WASD/arrow keys and space to jump. The floor, platforms, crates, and the players themselves are all ordinary tldraw shapes, so anyone can select, drag, resize, and delete them while the game runs.

Each client runs gravity and axis-aligned collision detection for its own player only and writes the result to the synced store; every other player's position arrives over `useSyncDemo`. Position updates use `history: 'ignore'` so the physics don't pollute the undo stack, and a resting player stops emitting updates so an idle game produces no sync traffic. Game keys are claimed with a window capture-phase listener that stops propagation, so space doesn't pan, the arrows don't nudge, and W/A/S/D don't switch tools. When a collaborator leaves, their player is despawned by reconciling player shapes against `editor.getCollaborators()`, with a short grace period so brief disconnects don't remove a player that's about to reappear.

### New examples

- `collaboration/multiplayer-platformer` — a shared 2D platformer with per-player gravity, AABB collision, keyboard controls, and despawn-on-leave.

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev` and open `localhost:5420/multiplayer-platformer`.
2. Click the canvas, then move with A/D or ←/→ and jump with space — the player should fall under gravity, land on platforms, and be blocked by walls.
3. Drag the floor, platforms, and players around; physics should keep working against the moved shapes.
4. Open the room in a second window (Copy link) — each window controls its own player. Close one window and its player should disappear from the other after a few seconds.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add a multiplayer platformer example showing a custom shape, a game loop with gravity and collision, keyboard input, and tldraw sync.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +822 / -0  |
