### PR TITLE
fix(dotcom): hide Move to submenu for linked files

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -240,7 +240,7 @@ export function FileItems({
 				)}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="file-delete">
-				{workspacesEnabled && (
+				{workspacesEnabled && hasAdminRights && (
 					<TldrawUiMenuSubmenu id="move-to-workspace" label={'Move to'} size="small">
 						<TldrawUiMenuGroup id="workspaces">
 							<TldrawUiMenuCheckboxItem


### PR DESCRIPTION
In order to avoid showing a control that does nothing, this PR hides the "Move to" submenu in the sidebar file menu for linked files — files the user doesn't own but has visited, which appear in "My workspace" and cannot be moved to another workspace.

Previously the "Move to" submenu rendered for every file when workspaces were enabled. For a linked file, picking a destination workspace dispatched `moveFileToWorkspace`, which the server rejects because the user lacks `removeFiles` permission on the file's owning workspace. The menu options looked actionable but silently did nothing.

The submenu is now gated on `hasAdminRights` (from `useHasFileAdminRights`), the same check already used for the rename item and the delete-vs-forget label. Linked files return `false` here, so the three owner-only actions are now consistently hidden together.

### Change type

- [x] `bugfix`

### Test plan

1. Enable workspaces (`groups_frontend`).
2. Visit a file shared by another user so it appears under "My workspace" as a linked/guest file.
3. Open that file's menu in the sidebar and confirm there is no "Move to" submenu (and the action is "Forget", not "Delete").
4. Open the menu for a file you own and confirm "Move to" still appears and works.

### Release notes

- Hide the "Move to" submenu for linked files in the sidebar, since they can't be moved to another workspace.
