### PR TITLE
feat(dotcom): show an inert editor placeholder while files load

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -76,12 +76,43 @@ interface TlaEditorProps {
 	deepLinks?: boolean
 }
 
+// Components for the inert placeholder editor shown while the real file syncs.
+// Same UI as the real editor (toolbar, menus, panels) so the chrome appears
+// instantly, plus a nulled loading screen to avoid a flash of its own spinner
+// before the (instant) empty local store finishes loading.
+const placeholderComponents: TLComponents = { ...components, LoadingScreen: null }
+
+/**
+ * An empty, non-interactive tldraw editor shown immediately while the real file
+ * connects and syncs. It renders the full editor chrome (toolbar, menus, panels)
+ * over its own ephemeral empty store, so the UI pops in instantly and only the
+ * document content fills in once synced. It never autofocuses, and the
+ * ReadyWrapper overlay disables pointer events so nothing here is interactive.
+ */
+function TlaEditorLoadingPlaceholder() {
+	const app = useMaybeApp()
+	return (
+		<TlaEditorWrapper>
+			<Tldraw
+				className="tla-editor"
+				licenseKey={getLicenseKey()}
+				assetUrls={assetUrls}
+				// Match the user's theme so the placeholder doesn't flash light/dark.
+				user={app?.tlUser}
+				autoFocus={false}
+				components={placeholderComponents}
+				options={{ actionShortcutsLocation: 'toolbar' }}
+			/>
+		</TlaEditorWrapper>
+	)
+}
+
 export function TlaEditor(props: TlaEditorProps) {
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
 		<>
 			<SneakySetDocumentTitle />
-			<ReadyWrapper key={props.fileSlug}>
+			<ReadyWrapper key={props.fileSlug} loadingScreen={<TlaEditorLoadingPlaceholder />}>
 				<TlaEditorInner {...props} key={props.fileSlug} />
 			</ReadyWrapper>
 		</>

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
@@ -51,3 +51,19 @@
 .withLoadingScreen .innerContainer:not(.isReady) {
 	opacity: 1;
 }
+
+/*
+ * Fade just the file content in once the editor is ready, leaving the main UI,
+ * background, and grid untouched so they line up with the placeholder.
+ */
+.withLoadingScreen .innerContainer :global(.tl-shapes),
+.withLoadingScreen .innerContainer :global(.tl-canvas-overlays),
+.withLoadingScreen .innerContainer :global(.tl-canvas__in-front) {
+	transition: opacity 0.2s ease-in;
+}
+
+.withLoadingScreen .innerContainer:not(.isReady) :global(.tl-shapes),
+.withLoadingScreen .innerContainer:not(.isReady) :global(.tl-canvas-overlays),
+.withLoadingScreen .innerContainer:not(.isReady) :global(.tl-canvas__in-front) {
+	opacity: 0;
+}

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
@@ -32,3 +32,22 @@
 .spinner:not(.showSpinner) {
 	opacity: 0;
 }
+
+.loadingScreen {
+	position: absolute;
+	inset: 0;
+	/* The placeholder editor is purely visual: never let it receive input. */
+	pointer-events: none;
+}
+
+/*
+ * When a placeholder editor is shown during loading there's already an editor on
+ * screen, so the real editor hard-cuts in rather than fading.
+ */
+.withLoadingScreen .innerContainer {
+	transition: none;
+}
+
+.withLoadingScreen .innerContainer:not(.isReady) {
+	opacity: 1;
+}

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
@@ -26,6 +26,7 @@ export function ReadyWrapper({
 	const parent = useContext(ReadyContext)
 	const [isReady, _setIsReady] = React.useState(false)
 	const [showSpinner, setShowSpinner] = React.useState(false)
+	const hasLoadingScreen = !!loadingScreen
 	const setIsReady = useCallback(async () => {
 		_setIsReady(true)
 	}, [])
@@ -50,15 +51,22 @@ export function ReadyWrapper({
 					isReady && styles.isReady,
 					// There's already an editor (the placeholder) on screen, so the real
 					// editor hard-cuts in instead of fading.
-					loadingScreen && styles.withLoadingScreen
+					hasLoadingScreen && styles.withLoadingScreen
 				)}
 			>
-				<div className={classNames(styles.innerContainer, isReady && styles.isReady)}>
+				<div
+					className={classNames(styles.innerContainer, isReady && styles.isReady)}
+					inert={!isReady}
+				>
 					{children}
 				</div>
 				{/* While loading, show the inert placeholder editor (if provided) with
 				    the spinner layered in front of it. */}
-				{!isReady && loadingScreen && <div className={styles.loadingScreen}>{loadingScreen}</div>}
+				{!isReady && hasLoadingScreen && (
+					<div className={styles.loadingScreen} inert aria-hidden="true">
+						{loadingScreen}
+					</div>
+				)}
 				{!isReady && (
 					<div className={classNames(styles.spinner, showSpinner && styles.showSpinner)}>
 						<Spinner />

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { PropsWithChildren, useCallback, useContext, useEffect } from 'react'
+import React, { PropsWithChildren, ReactNode, useCallback, useContext, useEffect } from 'react'
 import { Spinner } from 'tldraw'
 import styles from './useIsReady.module.css'
 
@@ -19,7 +19,10 @@ export function useSetIsReady() {
 	return React.useContext(ReadyContext).setIsReady
 }
 
-export function ReadyWrapper({ children }: PropsWithChildren) {
+export function ReadyWrapper({
+	children,
+	loadingScreen,
+}: PropsWithChildren<{ loadingScreen?: ReactNode }>) {
 	const parent = useContext(ReadyContext)
 	const [isReady, _setIsReady] = React.useState(false)
 	const [showSpinner, setShowSpinner] = React.useState(false)
@@ -41,10 +44,21 @@ export function ReadyWrapper({ children }: PropsWithChildren) {
 
 	return (
 		<ReadyContext.Provider value={{ isReady, setIsReady, isRoot: false }}>
-			<div className={classNames(styles.container, isReady && styles.isReady)}>
+			<div
+				className={classNames(
+					styles.container,
+					isReady && styles.isReady,
+					// There's already an editor (the placeholder) on screen, so the real
+					// editor hard-cuts in instead of fading.
+					loadingScreen && styles.withLoadingScreen
+				)}
+			>
 				<div className={classNames(styles.innerContainer, isReady && styles.isReady)}>
 					{children}
 				</div>
+				{/* While loading, show the inert placeholder editor (if provided) with
+				    the spinner layered in front of it. */}
+				{!isReady && loadingScreen && <div className={styles.loadingScreen}>{loadingScreen}</div>}
 				{!isReady && (
 					<div className={classNames(styles.spinner, showSpinner && styles.showSpinner)}>
 						<Spinner />


### PR DESCRIPTION
In order to make switching files feel instant while keeping the editor chrome stable, this PR shows an inert editor placeholder as soon as a file opens, instead of showing a spinner on a blank screen. Previously the real editor only mounted once the sync connection completed, so clicking a sidebar file could show nothing but a spinner until the document loaded.

Now `ReadyWrapper` accepts an optional `loadingScreen`, and `TlaEditor` passes a `TlaEditorLoadingPlaceholder`: a visual-only `<Tldraw>` rendering the editor chrome (toolbar, menus, panels) over its own empty local store. The placeholder never autofocuses, and both the placeholder and not-yet-ready real editor are marked inert while loading, so they cannot receive focus or input. It matches the user's theme to avoid a light/dark flash. Once the real store reaches `synced-remote`, the placeholder unmounts and the real editor remains visible, with file-specific canvas content (shapes, overlays, and front-of-canvas content) fading in. The placeholder path is the only one that uses this content-only transition; the legacy and anon editor flows keep their existing fade-in.

### Change type

- [x] `improvement`

### Test plan

1. Sign in to tldraw.com and open a file from the sidebar.
2. Throttle the network in DevTools to lengthen the loading window.
3. Click between files and confirm an empty editor with chrome appears immediately, remains non-interactive while loading, and the document content fades in once connected.
4. Run `yarn workspace dotcom lint`.
5. Run `yarn typecheck`.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Show an editor placeholder immediately when opening a file on tldraw.com, so the canvas appears instantly and the document content fades in once it connects.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +93 / -5   |
