### PR TITLE
feat(tldraw): add showAttribution option to note shape util

### DIFF
--- a/apps/docs/content/sdk-features/attribution.mdx
+++ b/apps/docs/content/sdk-features/attribution.mdx
@@ -91,6 +91,14 @@ Attribution is opt-in per shape type. Each shape util decides what to track and 
 
 The built-in note shape tracks who first added text. When a user types in an empty note, `NoteShapeUtil` sets the `textFirstEditedBy` prop to the current user's ID via `editor.getAttributionUserId()`. Subsequent edits by other users don't change this value. Clearing the text resets it to `null`. The note renders the first editor's name as a small label in the corner.
 
+To hide this label, configure the note shape util with `showAttribution: false`:
+
+```tsx
+import { NoteShapeUtil } from 'tldraw'
+
+const NoteUtil = NoteShapeUtil.configure({ showAttribution: false })
+```
+
 ## Reading attribution
 
 The [Editor](?) provides three methods for working with attribution. These methods check the `TLUserStore` first, then fall back to `user:` records in the store:

--- a/apps/docs/content/sdk-features/note-shape.mdx
+++ b/apps/docs/content/sdk-features/note-shape.mdx
@@ -108,9 +108,10 @@ The note's text color is determined by its `labelColor` property. When set to `'
 
 Notes support the following configuration options:
 
-| Option       | Type                  | Default  | Description                                                       |
-| ------------ | --------------------- | -------- | ----------------------------------------------------------------- |
-| `resizeMode` | `'none'` \| `'scale'` | `'none'` | How the note resizes. Set to `'scale'` for manual resize handles. |
+| Option            | Type                  | Default  | Description                                                                                     |
+| ----------------- | --------------------- | -------- | ----------------------------------------------------------------------------------------------- |
+| `resizeMode`      | `'none'` \| `'scale'` | `'none'` | How the note resizes. Set to `'scale'` for manual resize handles.                               |
+| `showAttribution` | `boolean`             | `true`   | Whether to show the "first edited by" attribution badge on the note. Set to `false` to hide it. |
 
 By default, notes can't be manually resized—they only grow based on text content. To allow user resizing with locked aspect ratio:
 

--- a/apps/examples/src/examples/configuration/configure-shape-util/ConfigureShapeUtilExample.tsx
+++ b/apps/examples/src/examples/configuration/configure-shape-util/ConfigureShapeUtilExample.tsx
@@ -5,8 +5,8 @@ const shapeUtils = [
 	// Enable colors for frame shapes
 	FrameShapeUtil.configure({ showColors: true }),
 
-	// Enable resizing for note shapes
-	NoteShapeUtil.configure({ resizeMode: 'scale' }),
+	// Enable resizing for note shapes, and hide the author attribution badge
+	NoteShapeUtil.configure({ resizeMode: 'scale', showAttribution: false }),
 ]
 
 export default function ConfigureShapeUtilExample() {

--- a/apps/examples/src/examples/configuration/configure-shape-util/README.md
+++ b/apps/examples/src/examples/configuration/configure-shape-util/README.md
@@ -20,4 +20,4 @@ Change the behavior of built-in shapes by setting their options.
 
 Some of the builtin tldraw shapes can be customized to behave differently based on your needs. This is done via the `ShapeUtil.configure` function which returns a new version of the shape's util class with custom options specified.
 
-You can see a shape's options by looking at the `options` property of its `ShapeUtil`. For example, the note shape's options are listed at [`NoteShapeOptions`](https://tldraw.dev/reference/tldraw/NoteShapeOptions). In this example the note shape's options are modified so the note scales as text is added.
+You can see a shape's options by looking at the `options` property of its `ShapeUtil`. For example, the note shape's options are listed at [`NoteShapeOptions`](https://tldraw.dev/reference/tldraw/NoteShapeOptions). In this example the note shape's options are modified so the note scales as text is added, and so the author attribution badge is hidden.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2807,6 +2807,7 @@ export interface NonePathBuilderOpts extends BasePathBuilderOpts {
 // @public (undocumented)
 export interface NoteShapeOptions extends ShapeOptionsWithDisplayValues<TLNoteShape, NoteShapeUtilDisplayValues> {
     resizeMode: 'none' | 'scale';
+    showAttribution: boolean;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -102,6 +102,12 @@ export interface NoteShapeOptions extends ShapeOptionsWithDisplayValues<
 	 * but you can set it to be user-resizable using scale.
 	 */
 	resizeMode: 'none' | 'scale'
+
+	/**
+	 * Whether to show the attribution (the display name of the user who first edited the note's text)
+	 * in the corner of the note. Defaults to `true`.
+	 */
+	showAttribution: boolean
 }
 
 /** @public */
@@ -112,6 +118,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 	override options: NoteShapeOptions = {
 		resizeMode: 'none',
+		showAttribution: true,
 		getDefaultDisplayValues(_editor, shape, theme, colorMode): NoteShapeUtilDisplayValues {
 			const { color, labelColor, font, size, align, verticalAlign } = shape.props
 			const colors = theme.colors[colorMode]
@@ -345,15 +352,16 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		const isReadyForEditing = useIsReadyForEditing(this.editor, shape.id)
 		const isEmpty = isEmptyRichText(richText)
 
+		const showAttribution = this.options.showAttribution
 		const attribution = useValue(
 			'attribution',
 			() => {
-				if (!textFirstEditedBy || isEmpty) return null
+				if (!showAttribution || !textFirstEditedBy || isEmpty) return null
 				const name = this.editor.getAttributionDisplayName(textFirstEditedBy)
 				if (!name) return null
 				return { short: name.split(' ')[0], full: name }
 			},
-			[textFirstEditedBy, isEmpty, this.editor]
+			[showAttribution, textFirstEditedBy, isEmpty, this.editor]
 		)
 
 		return (
@@ -462,7 +470,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 
 		const { textFirstEditedBy } = shape.props
 		const attributionFirstName =
-			textFirstEditedBy && !isEmptyRichText(shape.props.richText)
+			this.options.showAttribution && textFirstEditedBy && !isEmptyRichText(shape.props.richText)
 				? this.editor.getAttributionDisplayName(textFirstEditedBy)?.split(' ')[0]
 				: null
 		const attributionName = attributionFirstName


### PR DESCRIPTION
In order to let SDK consumers turn off the note shape's authorship badge, this PR adds a `showAttribution` option to `NoteShapeUtil`. The note shape renders the display name of the user who first edited its text in the corner (and in SVG exports); previously this was always on. The new option defaults to `true`, so existing behavior is unchanged, and it can be disabled via `NoteShapeUtil.configure({ showAttribution: false })`.

### Component props

| Option | Type | Description |
| --- | --- | --- |
| `showAttribution` | `boolean` | Whether to show the attribution (display name of the user who first edited the note's text) in the corner of the note. Defaults to `true`. |

### Example

```ts
import { NoteShapeUtil, Tldraw } from 'tldraw'

const shapeUtils = [NoteShapeUtil.configure({ showAttribution: false })]

export default function App() {
	return <Tldraw shapeUtils={shapeUtils} />
}
```

The existing "Shape options" example (`apps/examples/src/examples/configuration/configure-shape-util`) is extended to demonstrate the option.

### Change type

- [x] `api`

### Test plan

1. Add a note shape and edit its text in a multiplayer or signed-in context so attribution appears.
2. Confirm the attribution name shows in the note corner and in SVG/PNG exports by default.
3. Configure `NoteShapeUtil.configure({ showAttribution: false })` and confirm the attribution no longer renders on canvas or in exports.

- [x] Unit tests

### Release notes

- Add a `showAttribution` option to `NoteShapeUtil` to hide or show the note's text attribution.

### API changes

- Added `showAttribution` to `NoteShapeOptions`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +11 / -3   |
| Automated files | +1 / -0    |
| Documentation   | +15 / -6   |
