### PR TITLE
fix(dotcom): align sidebar rename input with file label

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -940,8 +940,11 @@
 }
 
 .sidebarFileListItemRenameInput {
-	height: 36px;
-	align-self: flex-start;
+	/* Size by the line box and let the 36px wrapper center it, the same way the
+	   file label is centered in its row. Giving the input an explicit 36px
+	   height makes it center its text internally, which rounds ~1px lower than
+	   the label and shifts the name down when entering rename mode. */
+	height: auto;
 	flex: 1 1 auto;
 	white-space: nowrap;
 	overflow: hidden;


### PR DESCRIPTION
In order to stop a file name from jumping ~1px vertically when you start renaming it in the sidebar, this PR sizes the inline rename input by its line box instead of giving it an explicit 36px height.

The input had `height: 36px`, so the underlying `.tlui-input` flex box centered its text internally, which rounds ~1px lower than the file label (which sizes by its line box). The result was a small downward shift when entering rename mode. Now the input sizes to its content and the surrounding 36px wrapper centers it via `align-items: center`, exactly how the label is centered in its row. This is the same fix previously applied to the sidebar search field in #9243.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw.com and look at the file list in the sidebar.
2. Double-click a file (or use the file menu → Rename) to enter rename mode.
3. Confirm the file name does not shift up or down when the input appears, and does not shift back when you commit or cancel.

### Release notes

- Fix a 1px vertical shift of the file name when renaming a file in the sidebar.