### PR TITLE
fix(tlschema): make editingShapeId ephemeral so undo/redo can't restore a deleted editing shape

### DIFF
--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -517,6 +517,34 @@ describe('When pressing enter on a selected shape', () => {
 	})
 })
 
+describe('When undo/redo restores an invalid editing shape', () => {
+	// Regression: https://github.com/tldraw/tldraw/issues/9113
+	// Setting the editing shape is not recorded in history, but clearing it on delete is.
+	// When create + edit + delete of the same shape collapse into a single history entry,
+	// the shape's add/remove cancel out while the editingShapeId update survives. Undoing
+	// then restores editingShapeId pointing at a shape that no longer exists, which used to
+	// crash with "Entered editing state without an editing shape". The editor must never
+	// enter the editing state without a valid editing shape.
+	it('does not crash when undo restores editingShapeId for a deleted shape', () => {
+		const id = createShapeId()
+		editor.markHistoryStoppingPoint('start')
+		editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+		editor.setEditingShape(id)
+		editor.deleteShapes([id])
+
+		expect(() => editor.undo()).not.toThrow()
+
+		editor.expectToBeIn('select.idle')
+		expect(editor.getEditingShapeId()).toBe(null)
+		expect(editor.getShape(id)).toBeUndefined()
+
+		// Redoing back through the same history entry must also stay safe.
+		expect(() => editor.redo()).not.toThrow()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getEditingShapeId()).toBe(null)
+	})
+})
+
 // it('selects the child of a group', () => {
 //   const id1 = createShapeId()
 //   const id2 = createShapeId()

--- a/packages/tlschema/src/records/TLPageState.ts
+++ b/packages/tlschema/src/records/TLPageState.ts
@@ -212,7 +212,11 @@ export const InstancePageStateRecordType = createRecordType<TLInstancePageState>
 		ephemeralKeys: {
 			pageId: false,
 			selectedShapeIds: false,
-			editingShapeId: false,
+			// editingShapeId is set with `history: 'ignore'`, so entering the editing
+			// state is never undoable. Marking it ephemeral keeps undo/redo from
+			// reapplying a stale editingShapeId (e.g. after a shape it pointed at was
+			// deleted), which could leave the editor pointing at a missing shape.
+			editingShapeId: true,
 			croppingShapeId: false,
 			meta: false,
 


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/9113

In order to stop undo/redo from crashing the editor, this PR makes the select tool refuse to enter its editing state without a valid editing shape.

Setting the editing shape is not recorded in history (`setEditingShape` runs with `history: 'ignore'`), but the cleanup that clears `editingShapeId` when a shape is deleted *is* recorded. When a shape is created, edited, and deleted within a single history entry, the shape's add/remove cancel out during squashing while the `editingShapeId` change survives. Undoing then restores `editingShapeId` pointing at a shape that no longer exists. The `instance_page_state.afterChange` side effect reacted to that by transitioning into `select.editing_shape`, and `EditingShape.onEnter` threw `Entered editing state without an editing shape`, crashing the app. This is SDK behavior in the select tool, so it affected SDK consumers as well as tldraw.com (~860 events from 60 users since February 2024).

This PR fixes it at the source: in `defaultSideEffects`, before entering the editing state in response to an `editingShapeId` change, it resolves the editing shape. If the shape doesn't exist, it clears the stale `editingShapeId` and stays put instead of transitioning into `select.editing_shape`. This covers every store-driven path (undo/redo, snapshot load, remote sync, programmatic writes), which are the only ways a stale id can appear. `EditingShape.onEnter` keeps its `throw` as an invariant assertion — with this guard it can no longer be reached without a valid editing shape.

### Change type

- [x] `bugfix`

### Test plan

1. Create a shape, begin editing it, and delete it within a single undo step.
2. Press undo, then redo.
3. The editor stays in `select.idle` and does not crash.

- [x] Unit tests

### Release notes

- Fix a crash that could occur when undo or redo restored an editing state for a shape that no longer exists.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -4   |
| Tests     | +28 / -0   |