### PR TITLE
fix(editor): handle text spans with no layout rects

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -247,6 +247,38 @@ describe('TextManager', () => {
 			expect(result.spans).toHaveLength(0)
 		})
 
+		it('should skip characters that produce no layout rectangles', () => {
+			const RangeMock = global.Range as unknown as ReturnType<typeof vi.fn>
+			RangeMock.mockImplementationOnce(function () {
+				return {
+					setStart: vi.fn(),
+					setEnd: vi.fn(),
+					// simulate a browser returning no rects for a measured character,
+					// which previously crashed with "Cannot read properties of
+					// undefined (reading 'top')". See issue #9112.
+					getClientRects: vi.fn(() => []),
+				}
+			})
+
+			const mockTextNode = {
+				nodeType: 3, // TEXT_NODE
+				textContent: 'Hello',
+			}
+
+			const mockElementWithText = {
+				childNodes: [mockTextNode],
+				getBoundingClientRect: () => ({ left: 0, top: 0 }),
+			}
+
+			let result
+			expect(() => {
+				result = textManager.measureElementTextNodeSpans(mockElementWithText as any)
+			}).not.toThrow()
+
+			expect(result!.spans).toHaveLength(0)
+			expect(result!.didTruncate).toBe(false)
+		})
+
 		it('should handle truncation option', () => {
 			const mockTextNode = {
 				nodeType: 3, // TEXT_NODE

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -309,7 +309,17 @@ export class TextManager {
 				// first char in a new line - one for the line break, and one for
 				// the character itself. we're only interested in the character.
 				const rects = range.getClientRects()
-				const rect = rects[rects.length - 1]!
+				const rect = rects[rects.length - 1]
+
+				// some characters produce no layout rectangles in some browsers
+				// (e.g. zero-width or combining characters). skip them rather than
+				// crashing, but keep advancing the index so later characters stay
+				// aligned with their text node offsets.
+				// See https://github.com/tldraw/tldraw/issues/9112.
+				if (!rect) {
+					idx += char.length
+					continue
+				}
 
 				// calculate the position of the character relative to the element
 				const top = rect.top + offsetY


### PR DESCRIPTION
In order to stop text measurement from intermittently crashing, this PR makes span measurement tolerate characters that report no layout rectangles. While measuring text spans (e.g. frame title sizes computed during shape geometry calculation), `Range.getClientRects()` can return an empty list for certain characters in some browsers. The previous code read `rects[rects.length - 1]` (i.e. `rects[-1]` → `undefined`) and then threw `TypeError: Cannot read properties of undefined (reading 'top')`. This surfaced on stock browsers (Chrome, Edge) as ~680 Sentry events across ~480 users since March 2025. Now we skip those characters while still advancing the text-node index so later characters stay aligned.

Closes #9112

### Change type

- [x] `bugfix`

### Test plan

1. Measure text spans where a character produces no layout rectangles (covered by the new unit test).

- [x] Unit tests

### Release notes

- Fix an intermittent crash in text measurement when a measured character produced no layout rectangles.

Made with [Cursor](https://cursor.com)