### PR TITLE
chore: add dev server launch config

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,23 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "examples",
+			"runtimeExecutable": "yarn",
+			"runtimeArgs": ["dev"],
+			"port": 5420
+		},
+		{
+			"name": "dotcom-app",
+			"runtimeExecutable": "yarn",
+			"runtimeArgs": ["dev-app"],
+			"port": 3000
+		},
+		{
+			"name": "docs",
+			"runtimeExecutable": "yarn",
+			"runtimeArgs": ["dev-docs"],
+			"port": 3001
+		}
+	]
+}


### PR DESCRIPTION
Adds a `.claude/launch.json` describing the repo's main dev servers so they can be started consistently from tooling. No application or build behavior changes.

The config maps each server to its root `yarn` command and port:

| Server | Command | Port |
|---|---|---|
| examples | `yarn dev` | 5420 |
| dotcom-app | `yarn dev-app` | 3000 |
| docs | `yarn dev-docs` | 3001 |

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

- This only adds a config file; no runtime code is affected.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Internal: add dev server launch config.
