### PR TITLE
fix(tldraw): rely on grapheme segmenter to iterate over textContent

### DIFF
--- a/apps/examples/e2e/baselines/fps-baselines.json
+++ b/apps/examples/e2e/baselines/fps-baselines.json
@@ -1,135 +1,146 @@
 {
-	"baselines": {
-		"linux-1280x720": {
-			"rotate_shapes": {
-				"avgFps": 25,
-				"minFps": 8,
-				"maxFps": 58,
-				"timestamp": "2025-12-06T22:18:16.000Z",
-				"environment": {
-					"platform": "linux",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"drag_shapes": {
-				"avgFps": 54,
-				"minFps": 26,
-				"maxFps": 69,
-				"timestamp": "2025-07-21T14:28:04.232Z",
-				"environment": {
-					"platform": "linux",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"resize_shapes": {
-				"avgFps": 22,
-				"minFps": 18,
-				"maxFps": 67,
-				"timestamp": "2025-07-21T14:28:23.924Z",
-				"environment": {
-					"platform": "linux",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"canvas_panning": {
-				"avgFps": 38,
-				"minFps": 28,
-				"maxFps": 70,
-				"timestamp": "2025-07-21T14:28:13.302Z",
-				"environment": {
-					"platform": "linux",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"canvas_zooming": {
-				"avgFps": 41,
-				"minFps": 19,
-				"maxFps": 67,
-				"timestamp": "2025-07-21T14:28:23.924Z",
-				"environment": {
-					"platform": "linux",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			}
-		},
-		"darwin-1280x720": {
-			"rotate_shapes": {
-				"avgFps": 60,
-				"minFps": 47,
-				"maxFps": 65,
-				"timestamp": "2025-11-26T22:53:39.487Z",
-				"environment": {
-					"platform": "darwin",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"drag_shapes": {
-				"avgFps": 60,
-				"minFps": 48,
-				"maxFps": 67,
-				"timestamp": "2025-11-26T22:53:50.324Z",
-				"environment": {
-					"platform": "darwin",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"resize_shapes": {
-				"avgFps": 58,
-				"minFps": 49,
-				"maxFps": 71,
-				"timestamp": "2025-11-26T22:54:01.975Z",
-				"environment": {
-					"platform": "darwin",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"canvas_panning": {
-				"avgFps": 60,
-				"minFps": 49,
-				"maxFps": 70,
-				"timestamp": "2025-11-26T22:54:09.322Z",
-				"environment": {
-					"platform": "darwin",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			},
-			"canvas_zooming": {
-				"avgFps": 59,
-				"minFps": 35,
-				"maxFps": 63,
-				"timestamp": "2025-11-26T22:54:23.386Z",
-				"environment": {
-					"platform": "darwin",
-					"viewport": "1280x720",
-					"browser": "chromium"
-				}
-			}
-		},
-		"darwin-393x727": {
-			"drag_shapes": {
-				"avgFps": 60,
-				"minFps": 58,
-				"maxFps": 69,
-				"timestamp": "2025-11-26T22:54:24.557Z",
-				"environment": {
-					"platform": "darwin",
-					"viewport": "393x727",
-					"browser": "chromium"
-				}
-			}
-		}
-	},
-	"metadata": {
-		"lastUpdated": "2025-11-26T22:54:24.558Z",
-		"version": "1.0.0"
-	}
+  "baselines": {
+    "linux-1280x720": {
+      "rotate_shapes": {
+        "avgFps": 25,
+        "minFps": 8,
+        "maxFps": 58,
+        "timestamp": "2025-12-06T22:18:16.000Z",
+        "environment": {
+          "platform": "linux",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "drag_shapes": {
+        "avgFps": 54,
+        "minFps": 26,
+        "maxFps": 69,
+        "timestamp": "2025-07-21T14:28:04.232Z",
+        "environment": {
+          "platform": "linux",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "resize_shapes": {
+        "avgFps": 22,
+        "minFps": 18,
+        "maxFps": 67,
+        "timestamp": "2025-07-21T14:28:23.924Z",
+        "environment": {
+          "platform": "linux",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "canvas_panning": {
+        "avgFps": 38,
+        "minFps": 28,
+        "maxFps": 70,
+        "timestamp": "2025-07-21T14:28:13.302Z",
+        "environment": {
+          "platform": "linux",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "canvas_zooming": {
+        "avgFps": 41,
+        "minFps": 19,
+        "maxFps": 67,
+        "timestamp": "2025-07-21T14:28:23.924Z",
+        "environment": {
+          "platform": "linux",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      }
+    },
+    "darwin-1280x720": {
+      "rotate_shapes": {
+        "avgFps": 60,
+        "minFps": 47,
+        "maxFps": 65,
+        "timestamp": "2025-11-26T22:53:39.487Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "drag_shapes": {
+        "avgFps": 60,
+        "minFps": 48,
+        "maxFps": 67,
+        "timestamp": "2025-11-26T22:53:50.324Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "resize_shapes": {
+        "avgFps": 58,
+        "minFps": 49,
+        "maxFps": 71,
+        "timestamp": "2025-11-26T22:54:01.975Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "canvas_panning": {
+        "avgFps": 60,
+        "minFps": 49,
+        "maxFps": 70,
+        "timestamp": "2025-11-26T22:54:09.322Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "canvas_zooming": {
+        "avgFps": 59,
+        "minFps": 35,
+        "maxFps": 63,
+        "timestamp": "2025-11-26T22:54:23.386Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      },
+      "create_text_shapes": {
+        "avgFps": 117,
+        "minFps": 72,
+        "maxFps": 137,
+        "timestamp": "2026-06-22T09:19:08.333Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "1280x720",
+          "browser": "chromium"
+        }
+      }
+    },
+    "darwin-393x727": {
+      "drag_shapes": {
+        "avgFps": 60,
+        "minFps": 58,
+        "maxFps": 69,
+        "timestamp": "2025-11-26T22:54:24.557Z",
+        "environment": {
+          "platform": "darwin",
+          "viewport": "393x727",
+          "browser": "chromium"
+        }
+      }
+    }
+  },
+  "metadata": {
+    "lastUpdated": "2026-06-22T09:19:08.334Z",
+    "version": "1.0.0"
+  }
 }

--- a/apps/examples/e2e/fixtures/perf-utils.ts
+++ b/apps/examples/e2e/fixtures/perf-utils.ts
@@ -395,6 +395,104 @@ export class PerformanceTestSuite {
 		return this.finalizeTestResult('canvas_zooming', metrics, expectMinFps)
 	}
 
+	async testTextShapeCreation(
+		options: InteractionTestOptions = {}
+	): Promise<PerformanceTestResult> {
+		const { warmupMs = 500, measureMs = 10000, expectMinFps } = options
+
+		const { metrics } = await this.fpsTracker.measureInteraction(
+			async () => {
+				const page = this.getPage()
+
+				// Repeatedly create text shapes and frames during the measurement
+				// window. Each cycle deletes the previous batch so text layouts
+				// can't be cached, forcing TextManager.measureText /
+				// measureTextSpans to run every time. The samples mix ASCII with
+				// emoji ZWJ sequences, flags, and accents so the grapheme
+				// segmenter path is exercised. See
+				// https://github.com/tldraw/tldraw/issues/9112.
+				await page.evaluate(() => {
+					const editor = (window as any).editor
+					const tldrawApi = (window as any).tldrawApi
+					if (!editor || !tldrawApi) return
+
+					const textSamples = [
+						'Performance text measurement',
+						'Lorem ipsum dolor sit amet, consectetur adipiscing',
+						'Hello 👨‍👩‍👧 family',
+						'Flag 🇫🇷 with accents café résumé',
+						'Multi-line\ntext content\nwith line breaks',
+						'Emoji 👍🏽 skin tone modifier 🎉 party',
+					]
+
+					// Seeded RNG for reproducible layouts.
+					let seed = 9112
+					const next = () => {
+						seed = (seed * 9301 + 49297) % 233280
+						return seed / 233280
+					}
+					const range = (min: number, max: number) => Math.floor(next() * (max - min + 1)) + min
+					const choice = <T>(arr: T[]): T => arr[range(0, arr.length - 1)]
+					const sizes = ['s', 'm', 'l', 'xl']
+
+					let batch = 0
+					const createInterval = setInterval(() => {
+						const prev = editor.getCurrentPageShapes()
+						if (prev.length) {
+							editor.deleteShapes(prev.map((s: any) => s.id))
+						}
+
+						const shapes: any[] = []
+						for (let i = 0; i < 25; i++) {
+							const sample = `${choice(textSamples)} ${i}`
+							shapes.push({
+								id: `shape:text-${batch}-${i}`,
+								type: 'text',
+								x: range(0, 1600),
+								y: range(0, 1000),
+								props: {
+									richText: tldrawApi.toRichText(sample),
+									size: choice(sizes),
+									font: 'draw',
+								},
+							})
+						}
+						// Frames whose names end in emoji/accents exercise the
+						// title measurement path from the original bug report.
+						for (let i = 0; i < 5; i++) {
+							shapes.push({
+								id: `shape:frame-${batch}-${i}`,
+								type: 'frame',
+								x: range(0, 1600),
+								y: range(0, 1000),
+								props: { w: 320, h: 220, name: `Frame ${choice(textSamples)}` },
+							})
+						}
+
+						editor.createShapes(shapes)
+						batch++
+					}, 100)
+
+					;(window as any).__textCreateInterval = createInterval
+				})
+			},
+			{ warmupMs, measureMs }
+		)
+
+		// Stop the creation interval and clean up.
+		const page = this.getPage()
+		await page.evaluate(() => {
+			const interval = (window as any).__textCreateInterval
+			if (interval) {
+				clearInterval(interval)
+				delete (window as any).__textCreateInterval
+			}
+		})
+		await page.keyboard.press('Escape')
+
+		return this.finalizeTestResult('create_text_shapes', metrics, expectMinFps)
+	}
+
 	async runFullPerformanceTest(): Promise<PerformanceTestResult[]> {
 		const results: PerformanceTestResult[] = []
 
@@ -409,6 +507,7 @@ export class PerformanceTestSuite {
 		results.push(await this.testCanvasPanning())
 		await this.setupHeavyBoard()
 		results.push(await this.testCanvasZooming())
+		results.push(await this.testTextShapeCreation())
 
 		return results
 	}
@@ -491,6 +590,7 @@ export class PerformanceTestSuite {
 			{ name: 'resize_shapes', testFn: () => this.testShapeResizing() },
 			{ name: 'canvas_panning', testFn: () => this.testCanvasPanning() },
 			{ name: 'canvas_zooming', testFn: () => this.testCanvasZooming() },
+			{ name: 'create_text_shapes', testFn: () => this.testTextShapeCreation() },
 		]
 
 		for (const { name, testFn } of interactions) {

--- a/apps/examples/e2e/perf/test-perf.spec.ts
+++ b/apps/examples/e2e/perf/test-perf.spec.ts
@@ -135,6 +135,21 @@ test.describe('Performance Tests', () => {
 
 		testOutput(await perfSuite.testCanvasZooming())
 	})
+
+	test('Text Shape Creation Performance', async ({
+		page,
+		context,
+		request,
+		browserName,
+		isMobile,
+	}) => {
+		if (isMobile) return
+
+		// The scenario creates its own text shapes, so no heavy board is needed.
+		const perfSuite = await setupPerformanceTest({ page, context, request }, browserName)
+
+		testOutput(await perfSuite.testTextShapeCreation())
+	})
 })
 
 test.describe('Baseline Management', () => {

--- a/apps/examples/e2e/tests/test-text.spec.ts
+++ b/apps/examples/e2e/tests/test-text.spec.ts
@@ -250,6 +250,21 @@ test.describe('text measurement', () => {
 		expect(formatLines(spans)).toEqual([[' \n'], [' \n'], [' \n'], [' ']])
 	})
 
+	test('should keep emoji grapheme clusters together', async () => {
+		// 👨‍👩‍👧 is several code points joined by zero-width joiners; it must be
+		// measured as one grapheme so no code points get dropped from the span text.
+		const family = '\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}'
+		const spans = await page.evaluate<
+			{ text: string; box: BoxModel }[],
+			typeof measureTextSpansOptions
+		>(async (options) => {
+			const familyEmoji = '\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}'
+			return editor.textMeasure.measureTextSpans(`a${familyEmoji}b`, { ...options, width: 200 })
+		}, measureTextSpansOptions)
+
+		expect(formatLines(spans).flat().join('')).toBe(`a${family}b`)
+	})
+
 	test('for auto-font-sizing shapes, should do normal font size for text that does not have long words', async () => {
 		const shape = await page.evaluate(() => {
 			const id = 'shape:testShape' as TLShapeId

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -247,6 +247,67 @@ describe('TextManager', () => {
 			expect(result.spans).toHaveLength(0)
 		})
 
+		it('should skip characters that produce no layout rectangles', () => {
+			const RangeMock = global.Range as unknown as ReturnType<typeof vi.fn>
+			RangeMock.mockImplementationOnce(function () {
+				return {
+					setStart: vi.fn(),
+					setEnd: vi.fn(),
+					// simulate a browser returning no rects for a measured character,
+					// which previously crashed with "Cannot read properties of
+					// undefined (reading 'top')". See issue #9112.
+					getClientRects: vi.fn(() => []),
+				}
+			})
+
+			const mockTextNode = {
+				nodeType: 3, // TEXT_NODE
+				textContent: 'Hello',
+			}
+
+			const mockElementWithText = {
+				childNodes: [mockTextNode],
+				getBoundingClientRect: () => ({ left: 0, top: 0 }),
+			}
+
+			let result
+			expect(() => {
+				result = textManager.measureElementTextNodeSpans(mockElementWithText as any)
+			}).not.toThrow()
+
+			expect(result!.spans).toHaveLength(0)
+			expect(result!.didTruncate).toBe(false)
+		})
+
+		it('should measure grapheme clusters as a single unit', () => {
+			const startOffsets: number[] = []
+			const RangeMock = global.Range as unknown as ReturnType<typeof vi.fn>
+			RangeMock.mockImplementationOnce(function () {
+				return {
+					setStart: vi.fn((_node: any, offset: number) => startOffsets.push(offset)),
+					setEnd: vi.fn(),
+					getClientRects: vi.fn(() => [
+						{ width: 10, height: 16, left: 0, top: 0, right: 10, bottom: 16 },
+					]),
+				}
+			})
+
+			// 👨‍👩‍👧 is 5 code points (8 UTF-16 units) joined by zero-width joiners
+			const family = '\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}'
+			const mockTextNode = { nodeType: 3, textContent: `a${family}b` }
+			const mockElementWithText = {
+				childNodes: [mockTextNode],
+				getBoundingClientRect: () => ({ left: 0, top: 0 }),
+			}
+
+			const result = textManager.measureElementTextNodeSpans(mockElementWithText as any)
+
+			// the emoji is measured as one grapheme, so the index jumps over all 8 units
+			expect(startOffsets).toEqual([0, 1, 9])
+			// and its code points are kept together in the span text
+			expect(result.spans[0].text).toBe(`a${family}b`)
+		})
+
 		it('should handle truncation option', () => {
 			const mockTextNode = {
 				nodeType: 3, // TEXT_NODE

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -93,6 +93,10 @@ export interface TLMeasureTextSpanOpts {
 
 const spaceCharacterRegex = /\s/
 
+// Iterate by grapheme cluster (e.g. emoji sequences, flags, accented letters)
+// rather than by code point, so a single glyph is measured as one unit.
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+
 const initialDefaultStyles = Object.freeze({
 	'overflow-wrap': 'break-word',
 	'word-break': 'auto',
@@ -301,15 +305,24 @@ export class TextManager {
 		for (const childNode of element.childNodes) {
 			if (childNode.nodeType !== Node.TEXT_NODE) continue
 
-			for (const char of childNode.textContent ?? '') {
-				// place the range around the characters we're interested in
+			for (const { segment } of graphemeSegmenter.segment(childNode.textContent ?? '')) {
+				// place the range around the grapheme we're interested in
 				range.setStart(textNode, idx)
-				range.setEnd(textNode, idx + char.length)
+				range.setEnd(textNode, idx + segment.length)
 				// measure the range. some browsers return multiple rects for the
 				// first char in a new line - one for the line break, and one for
 				// the character itself. we're only interested in the character.
 				const rects = range.getClientRects()
-				const rect = rects[rects.length - 1]!
+				const rect = rects[rects.length - 1]
+
+				// some graphemes produce no layout rectangle (e.g. zero-width
+				// spaces or newlines). skip them rather than crashing, but keep
+				// advancing the index so later graphemes stay aligned.
+				// See https://github.com/tldraw/tldraw/issues/9112.
+				if (!rect) {
+					idx += segment.length
+					continue
+				}
 
 				// calculate the position of the character relative to the element
 				const top = rect.top + offsetY
@@ -317,7 +330,7 @@ export class TextManager {
 				const right = rect.right + offsetX
 				const isRTL = left < prevCharLeftForRTLTest
 
-				const isSpaceCharacter = spaceCharacterRegex.test(char)
+				const isSpaceCharacter = spaceCharacterRegex.test(segment)
 				if (
 					// If we're at a word boundary...
 					isSpaceCharacter !== prevCharWasSpaceCharacter ||
@@ -341,7 +354,7 @@ export class TextManager {
 					// start a new span
 					currentSpan = {
 						box: { x: left, y: top, w: rect.width, h: rect.height },
-						text: char,
+						text: segment,
 					}
 					prevCharLeftForRTLTest = left
 				} else {
@@ -352,16 +365,16 @@ export class TextManager {
 
 					// otherwise we just need to extend the current span with the next character
 					currentSpan.box.w = isRTL ? currentSpan.box.w + rect.width : right - currentSpan.box.x
-					currentSpan.text += char
+					currentSpan.text += segment
 				}
 
-				if (char === '\n') {
+				if (segment === '\n') {
 					prevCharLeftForRTLTest = 0
 				}
 
 				prevCharWasSpaceCharacter = isSpaceCharacter
 				prevCharTop = top
-				idx += char.length
+				idx += segment.length
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/9112

Error occurs when iterating over text elements that have returns no bounding boxes, this could be a case of some zero width character and/or some emojis that are composed of two characters in order to compose a grapheme.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`
### Test plan

1. Add a frame and give it a name ending in an emoji or accented character (e.g. "Hello 👨‍👩‍👧"). Hover the frame and confirm no console error and the title sizes correctly.
2. Add a text shape containing an emoji ZWJ sequence, a flag (🇫🇷), and an accented letter, then export the selection as SVG. Confirm the exported text keeps all glyphs intact (no dropped accents or broken emoji).
3. Confirm existing text wrapping, truncation, and multiline behavior is unchanged.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Improve text measurement by iterating over grapheme clusters instead of individual characters, fixing an occasional crash and keeping emoji, flags, and accented characters intact.