### PR TITLE
fix(tldraw): make dialog and menu dismissal layer-aware via Radix

### DIFF
--- a/apps/dotcom/client/e2e/tests/smoke/sharing.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/sharing.spec.ts
@@ -42,6 +42,32 @@ test.describe('signed in user on own file', () => {
 		expect(await shareMenu.publishTabPage.isVisible()).toBe(true)
 	})
 
+	test('a select inside the menu closes without closing the menu', async ({ page, shareMenu }) => {
+		await shareMenu.open()
+		await shareMenu.exportTabButton.click()
+		await expect(shareMenu.exportTabPage).toBeVisible()
+
+		const themeSelect = page.locator('#tla-export-theme-select')
+
+		// Selecting an option closes the select but leaves the share menu open.
+		await themeSelect.click()
+		await expect(page.getByRole('listbox')).toBeVisible()
+		await page.getByRole('option').last().click()
+		await expect(page.getByRole('listbox')).toHaveCount(0)
+		await expect(shareMenu.exportTabPage).toBeVisible()
+
+		// Re-clicking the open select's trigger also closes only the select. The trigger
+		// is non-interactive while the select is open (Radix disables outside pointer
+		// events), so click its position directly rather than via the locator.
+		await themeSelect.click()
+		await expect(page.getByRole('listbox')).toBeVisible()
+		const box = await themeSelect.boundingBox()
+		if (!box) throw new Error('theme select not found')
+		await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2)
+		await expect(page.getByRole('listbox')).toHaveCount(0)
+		await expect(shareMenu.exportTabPage).toBeVisible()
+	})
+
 	test('can unshare and reshare', async ({ page, browser, shareMenu }) => {
 		// Copy the link to the current file
 		await shareMenu.open()

--- a/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
@@ -63,7 +63,10 @@ test.describe('workspaces', () => {
 			await expect(homeItem).toBeVisible()
 		})
 
-		test('dismissing the switcher does not click a file underneath', async ({ page, sidebar }) => {
+		test('clicking a file while the switcher is open closes it and opens that file', async ({
+			page,
+			sidebar,
+		}) => {
 			const file1 = getRandomName()
 			const file2 = getRandomName()
 			const file3 = getRandomName()
@@ -74,93 +77,74 @@ test.describe('workspaces', () => {
 			await sidebar.expectFileActive(file3)
 
 			await sidebar.openWorkspaceSwitcher()
-			const overlay = page.getByTestId('tla-workspace-switcher-overlay')
-			await expect(overlay).toBeVisible()
+			const homeItem = page.getByTestId('tla-workspace-switcher-home')
+			await expect(homeItem).toBeVisible()
 
-			const target = await page.evaluate(() => {
-				const overlay = document.querySelector<HTMLElement>(
-					'[data-testid="tla-workspace-switcher-overlay"]'
-				)
-				if (!overlay) throw new Error('Missing workspace switcher overlay')
+			// Clicking a file link while the switcher is open should both dismiss the switcher
+			// and open that file — letting the click fall through to the sidebar is intended.
+			const menuBox = await page.locator('[role="menu"]').boundingBox()
+			if (!menuBox) throw new Error('Missing workspace switcher menu')
 
+			const target = await page.evaluate((menuBottom) => {
 				const links = Array.from(
 					document.querySelectorAll<HTMLElement>('[data-element="file-link"]')
 				)
-				for (const link of links.reverse()) {
+				for (const link of links) {
 					if (link.dataset.active === 'true') continue
-
 					const rect = link.getBoundingClientRect()
-					const x = rect.left + rect.width / 2
-					const y = rect.top + rect.height / 2
-					if (
-						!document
-							.elementFromPoint(x, y)
-							?.closest('[data-testid="tla-workspace-switcher-overlay"]')
-					) {
-						continue
-					}
-
+					// Pick a link below the open menu so the click lands on the link, not the menu.
+					if (rect.top < menuBottom) continue
 					return {
 						name: link.querySelector('[data-testid*="-name"]')?.textContent?.trim() ?? '',
-						x,
-						y,
+						x: rect.left + rect.width / 2,
+						y: rect.top + rect.height / 2,
 					}
 				}
 
-				throw new Error('Could not find a file link behind the workspace switcher overlay')
-			})
+				throw new Error('Could not find a non-active file link below the switcher menu')
+			}, menuBox.y + menuBox.height)
 
-			await page.evaluate(({ x, y }) => {
-				const overlay = document.querySelector<HTMLElement>(
-					'[data-testid="tla-workspace-switcher-overlay"]'
-				)
-				if (!overlay) throw new Error('Missing workspace switcher overlay')
+			await page.mouse.click(target.x, target.y)
 
-				overlay.dispatchEvent(
-					new PointerEvent('pointerdown', {
-						bubbles: true,
-						cancelable: true,
-						clientX: x,
-						clientY: y,
-						pointerId: 1,
-						pointerType: 'touch',
-						isPrimary: true,
-					})
-				)
-			}, target)
+			await expect(homeItem).toBeHidden()
+			await sidebar.expectFileActive(target.name)
+		})
 
-			await expect(overlay).toBeVisible()
+		test('closing the mobile sidebar closes open sidebar menus', async ({ page, sidebar }) => {
+			const fileName = getRandomName()
+			await sidebar.createNewDocument(fileName)
 
-			await page.evaluate(({ x, y }) => {
-				const target = document.elementFromPoint(x, y)
-				target?.dispatchEvent(
-					new PointerEvent('pointerup', {
-						bubbles: true,
-						cancelable: true,
-						clientX: x,
-						clientY: y,
-						pointerId: 1,
-						pointerType: 'touch',
-						isPrimary: true,
-					})
-				)
-				target?.dispatchEvent(
-					new MouseEvent('click', {
-						bubbles: true,
-						cancelable: true,
-						clientX: x,
-						clientY: y,
-					})
-				)
-			}, target)
+			await page.setViewportSize({ width: 390, height: 844 })
 
-			await expect(overlay).toBeHidden()
-			await sidebar.expectFileActive(file3)
-			await sidebar.expectFileNotActive(target.name)
+			const mobileToggle = page.getByTestId('tla-sidebar-toggle-mobile')
+			const mobileOverlay = page.getByTestId('tla-sidebar-overlay-mobile')
+			const closeMobileSidebar = async () => {
+				await mobileOverlay.click({ position: { x: 380, y: 422 } })
+				await expect(mobileOverlay).toBeHidden()
+			}
 
+			await expect(mobileToggle).toBeVisible()
+			await mobileToggle.click()
+			await expect(mobileOverlay).toBeVisible()
+
+			// The sidebar only CSS-hides (it doesn't unmount), so an open menu would otherwise
+			// stay open behind it. Closing the mobile sidebar must close the workspace switcher...
 			await sidebar.openWorkspaceSwitcher()
-			await page.getByTestId('tla-workspace-switcher').click()
+			await expect(page.getByTestId('tla-workspace-switcher-home')).toBeVisible()
+			await closeMobileSidebar()
 			await expect(page.getByTestId('tla-workspace-switcher-home')).toBeHidden()
+
+			// ...and a file's context menu.
+			await mobileToggle.click()
+			await expect(mobileOverlay).toBeVisible()
+
+			const fileLink = sidebar.getFileByName(fileName)
+			await fileLink.hover()
+			await fileLink.getByRole('button').click()
+			await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
+
+			await closeMobileSidebar()
+			await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeHidden()
 		})
 
 		test('clicking the canvas closes the workspace switcher without reaching the canvas', async ({
@@ -194,41 +178,6 @@ test.describe('workspaces', () => {
 					return editor.getSelectedShapeIds()
 				})
 			).toEqual([shapeId])
-		})
-
-		test('closing the mobile sidebar closes open sidebar menus', async ({ page, sidebar }) => {
-			const fileName = getRandomName()
-			await sidebar.createNewDocument(fileName)
-
-			await page.setViewportSize({ width: 390, height: 844 })
-
-			const mobileToggle = page.getByTestId('tla-sidebar-toggle-mobile')
-			const mobileOverlay = page.getByTestId('tla-sidebar-overlay-mobile')
-			const closeMobileSidebar = async () => {
-				await mobileOverlay.click({ position: { x: 380, y: 422 } })
-				await expect(mobileOverlay).toBeHidden()
-			}
-
-			await expect(mobileToggle).toBeVisible()
-			await mobileToggle.click()
-			await expect(mobileOverlay).toBeVisible()
-
-			await sidebar.openWorkspaceSwitcher()
-			await expect(page.getByTestId('tla-workspace-switcher-home')).toBeVisible()
-
-			await closeMobileSidebar()
-			await expect(page.getByTestId('tla-workspace-switcher-home')).toBeHidden()
-
-			await mobileToggle.click()
-			await expect(mobileOverlay).toBeVisible()
-
-			const fileLink = sidebar.getFileByName(fileName)
-			await fileLink.hover()
-			await fileLink.getByRole('button').click()
-			await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeVisible()
-
-			await closeMobileSidebar()
-			await expect(page.getByRole('menuitem', { name: 'Rename' })).toBeHidden()
 		})
 
 		test('create file button creates in the active workspace', async ({ sidebar }) => {

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -30,6 +30,7 @@ import { copyTextToClipboard } from '../../utils/copy'
 import { defineMessages, useMsg } from '../../utils/i18n'
 import { CreateWorkspaceDialog } from '../dialogs/CreateWorkspaceDialog'
 import { TlaDeleteFileDialog } from '../dialogs/TlaDeleteFileDialog'
+import { TLA_MENU_POSITION } from '../tla-menu/tla-menu'
 import { editorMessages } from '../TlaEditor/editor-messages'
 import { downloadAppFile } from '../TlaEditor/useFileEditorOverrides'
 
@@ -83,7 +84,15 @@ export function TlaFileMenu({
 		<TldrawUiDropdownMenuRoot id={`file-menu-${fileId}-${source}-${id}`}>
 			<TldrawUiMenuContextProvider type="menu" sourceId="dialog">
 				<TldrawUiDropdownMenuTrigger>{trigger}</TldrawUiDropdownMenuTrigger>
-				<TldrawUiDropdownMenuContent side="bottom" align="end" alignOffset={-16} sideOffset={4}>
+				{/* Sidebar menus hang ~8px over the sidebar's right edge, so they keep the shared
+				    side/collision offsets but override alignOffset (the default is tuned for the
+				    share/select menus, which would leave these looking inset). */}
+				<TldrawUiDropdownMenuContent
+					side="bottom"
+					align="end"
+					{...TLA_MENU_POSITION}
+					alignOffset={-16}
+				>
 					{children ?? fileItemsWhenNoChildren}
 				</TldrawUiDropdownMenuContent>
 			</TldrawUiMenuContextProvider>

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/TlaFileShareMenu.tsx
@@ -1,17 +1,12 @@
 import { ReactNode, useCallback } from 'react'
-import {
-	TldrawUiPopover,
-	TldrawUiPopoverContent,
-	TldrawUiPopoverTrigger,
-	preventDefault,
-	useValue,
-} from 'tldraw'
+import { TldrawUiPopover, TldrawUiPopoverContent, TldrawUiPopoverTrigger, useValue } from 'tldraw'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { useHasFileAdminRights } from '../../hooks/useIsFileOwner'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { F } from '../../utils/i18n'
 import { getLocalSessionState, updateLocalSessionState } from '../../utils/local-session-state'
 import {
+	TLA_MENU_POSITION,
 	TlaMenuTabsPage,
 	TlaMenuTabsRoot,
 	TlaMenuTabsTab,
@@ -83,66 +78,63 @@ export function TlaFileShareMenu({
 	// todo: replace disabled tabs for signed out users with "sign in to do X" content
 
 	return (
-		<div onPointerDown={preventDefault}>
-			<TldrawUiPopover id={`share-${fileId}-${source}`}>
-				<TldrawUiPopoverTrigger>{children}</TldrawUiPopoverTrigger>
+		<TldrawUiPopover id={`share-${fileId}-${source}`}>
+			<TldrawUiPopoverTrigger>{children}</TldrawUiPopoverTrigger>
 
-				<TldrawUiPopoverContent
-					side="bottom"
-					align="end"
-					alignOffset={-2}
-					sideOffset={4}
-					autoFocusFirstButton={false}
-				>
-					<div className={styles.fileShareMenu}>
-						<TlaMenuTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
-							<TlaMenuTabsTabs>
-								{/* Disable share when on a scratchpad file */}
-								{okTabs.share && (
-									<TlaMenuTabsTab id="share" data-testid="tla-share-tab-button-share">
-										<F defaultMessage="Invite" />
-									</TlaMenuTabsTab>
-								)}
-								{okTabs['anon-share'] && (
-									<TlaMenuTabsTab id="anon-share" data-testid="tla-share-tab-button-anon-share">
-										<F defaultMessage="Share" />
-									</TlaMenuTabsTab>
-								)}
-								{/* Always show export */}
-								<TlaMenuTabsTab id="export" data-testid="tla-share-tab-button-export">
-									<F defaultMessage="Export" />
+			<TldrawUiPopoverContent
+				side="bottom"
+				align="end"
+				{...TLA_MENU_POSITION}
+				autoFocusFirstButton={false}
+			>
+				<div className={styles.fileShareMenu}>
+					<TlaMenuTabsRoot activeTab={tabToShowAsActive} onTabChange={handleTabChange}>
+						<TlaMenuTabsTabs>
+							{/* Disable share when on a scratchpad file */}
+							{okTabs.share && (
+								<TlaMenuTabsTab id="share" data-testid="tla-share-tab-button-share">
+									<F defaultMessage="Invite" />
 								</TlaMenuTabsTab>
-								{/* Show publish tab when there's a file and either the context is a published file or the user owns the file */}
-								{okTabs.publish && (
-									<TlaMenuTabsTab id="publish" data-testid="tla-share-tab-button-publish">
-										<F defaultMessage="Publish" />
-									</TlaMenuTabsTab>
-								)}
-							</TlaMenuTabsTabs>
-							{okTabs.share && fileId && (
-								// We have a file and we're authenticated
-								<TlaMenuTabsPage id="share" data-testid="tla-share-tab-page-share">
-									<TlaInviteTab fileId={fileId} />
-								</TlaMenuTabsPage>
 							)}
 							{okTabs['anon-share'] && (
-								<TlaMenuTabsPage id="anon-share" data-testid="tla-share-tab-page-anon-share">
-									<TlaAnonCopyLinkTab />
-								</TlaMenuTabsPage>
+								<TlaMenuTabsTab id="anon-share" data-testid="tla-share-tab-button-anon-share">
+									<F defaultMessage="Share" />
+								</TlaMenuTabsTab>
 							)}
-							<TlaMenuTabsPage id="export" data-testid="tla-share-tab-page-export">
-								<TlaExportTab />
+							{/* Always show export */}
+							<TlaMenuTabsTab id="export" data-testid="tla-share-tab-button-export">
+								<F defaultMessage="Export" />
+							</TlaMenuTabsTab>
+							{/* Show publish tab when there's a file and either the context is a published file or the user owns the file */}
+							{okTabs.publish && (
+								<TlaMenuTabsTab id="publish" data-testid="tla-share-tab-button-publish">
+									<F defaultMessage="Publish" />
+								</TlaMenuTabsTab>
+							)}
+						</TlaMenuTabsTabs>
+						{okTabs.share && fileId && (
+							// We have a file and we're authenticated
+							<TlaMenuTabsPage id="share" data-testid="tla-share-tab-page-share">
+								<TlaInviteTab fileId={fileId} />
 							</TlaMenuTabsPage>
-							{/* Only show the publish tab if the file is owned by the user */}
-							{okTabs.publish && file && (
-								<TlaMenuTabsPage id="publish" data-testid="tla-share-tab-page-publish">
-									<TlaPublishTab file={file} />
-								</TlaMenuTabsPage>
-							)}
-						</TlaMenuTabsRoot>
-					</div>
-				</TldrawUiPopoverContent>
-			</TldrawUiPopover>
-		</div>
+						)}
+						{okTabs['anon-share'] && (
+							<TlaMenuTabsPage id="anon-share" data-testid="tla-share-tab-page-anon-share">
+								<TlaAnonCopyLinkTab />
+							</TlaMenuTabsPage>
+						)}
+						<TlaMenuTabsPage id="export" data-testid="tla-share-tab-page-export">
+							<TlaExportTab />
+						</TlaMenuTabsPage>
+						{/* Only show the publish tab if the file is owned by the user */}
+						{okTabs.publish && file && (
+							<TlaMenuTabsPage id="publish" data-testid="tla-share-tab-page-publish">
+								<TlaPublishTab file={file} />
+							</TlaMenuTabsPage>
+						)}
+					</TlaMenuTabsRoot>
+				</div>
+			</TldrawUiPopoverContent>
+		</TldrawUiPopover>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -1,5 +1,5 @@
 import { memo, useCallback, useEffect } from 'react'
-import { tlmenus } from 'tldraw'
+import { tlmenus, useMaybeEditor } from 'tldraw'
 import { useActiveWorkspaceId } from '../../hooks/useActiveWorkspaceId'
 import { useHasFlag } from '../../hooks/useHasFlag'
 import { useTldrFileDrop } from '../../hooks/useTldrFileDrop'
@@ -26,6 +26,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 	const isSidebarOpen = useIsSidebarOpen()
 	const isSidebarOpenMobile = useIsSidebarOpenMobile()
 	const trackEvent = useTldrawAppUiEvents()
+	const editor = useMaybeEditor()
 
 	useEffect(() => {
 		function handleKeyDown(e: KeyboardEvent) {
@@ -44,12 +45,17 @@ export const TlaSidebar = memo(function TlaSidebar() {
 	}, [trackEvent])
 
 	const handleOverlayClick = useCallback(() => {
-		// The sidebar only hides (CSS transform), it doesn't unmount, so its open menus
-		// (workspace switcher, file menus) would otherwise stay open behind the closed
-		// sidebar. Clear them as the mobile sidebar closes.
-		tlmenus.clearOpenMenus()
+		// The sidebar only hides (CSS transform), it doesn't unmount, so its portaled menus
+		// (workspace switcher, file/user menus) would otherwise stay open over the canvas once the
+		// sidebar is closed. Close them — scoped to this editor's menus plus the global switcher id.
+		// The scope matters: open SDK dialogs register in the same tlmenus registry under the 'tla'
+		// context, and an arg-less clearOpenMenus() would evict them while they stay mounted, leaving
+		// the editor's menu-gated behavior (canvas click-capture, shortcuts, clipboard guards)
+		// thinking nothing is open.
+		if (editor) tlmenus.clearOpenMenus(editor.contextId)
+		tlmenus.deleteOpenMenu('sidebar-workspace-switcher')
 		updateLocalSessionState(() => ({ isSidebarOpenMobile: false }))
-	}, [])
+	}, [editor])
 
 	const { onDrop, onDragOver, onDragEnter, onDragLeave } = useTldrFileDrop()
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -44,6 +44,9 @@ export const TlaSidebar = memo(function TlaSidebar() {
 	}, [trackEvent])
 
 	const handleOverlayClick = useCallback(() => {
+		// The sidebar only hides (CSS transform), it doesn't unmount, so its open menus
+		// (workspace switcher, file menus) would otherwise stay open behind the closed
+		// sidebar. Clear them as the mobile sidebar closes.
 		tlmenus.clearOpenMenus()
 		updateLocalSessionState(() => ({ isSidebarOpenMobile: false }))
 	}, [])

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -8,6 +8,7 @@ import {
 	TldrawUiTooltip,
 	isEqual,
 	preventDefault,
+	useContainer,
 	useMaybeEditor,
 	useMenuIsOpen,
 	useValue,
@@ -96,6 +97,7 @@ export function TlaSidebarFileLink({
 	}
 
 	const [_, handleOpenChange] = useMenuIsOpen(`file-context-menu-${fileId}`)
+	const container = useContainer()
 
 	return (
 		<_ContextMenu.Root onOpenChange={handleOpenChange} modal={false}>
@@ -114,19 +116,21 @@ export function TlaSidebarFileLink({
 					className={className}
 				/>
 			</_ContextMenu.Trigger>
-			<_ContextMenu.Content className="tlui-menu tlui-scrollable">
-				{/* Don't show the context menu on mobile */}
-				{!isMobile && (
-					<TldrawUiMenuContextProvider type="context-menu" sourceId="context-menu">
-						<FileItems
-							source="sidebar-context-menu"
-							fileId={fileId}
-							onRenameAction={handleRenameAction}
-							workspaceId={workspaceId}
-						/>
-					</TldrawUiMenuContextProvider>
-				)}
-			</_ContextMenu.Content>
+			<_ContextMenu.Portal container={container}>
+				<_ContextMenu.Content className="tlui-menu tlui-scrollable">
+					{/* Don't show the context menu on mobile */}
+					{!isMobile && (
+						<TldrawUiMenuContextProvider type="context-menu" sourceId="context-menu">
+							<FileItems
+								source="sidebar-context-menu"
+								fileId={fileId}
+								onRenameAction={handleRenameAction}
+								workspaceId={workspaceId}
+							/>
+						</TldrawUiMenuContextProvider>
+					)}
+				</_ContextMenu.Content>
+			</_ContextMenu.Portal>
 		</_ContextMenu.Root>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarUserSettingsMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarUserSettingsMenu.tsx
@@ -22,6 +22,7 @@ import {
 	ThemeSubmenu,
 	UserManualMenuItem,
 } from '../../menu-items/menu-items'
+import { TLA_MENU_POSITION } from '../../tla-menu/tla-menu'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import styles from '../sidebar.module.css'
 
@@ -70,7 +71,13 @@ export function TlaUserSettingsMenu() {
 						</div>
 					</TldrawUiButton>
 				</TldrawUiDropdownMenuTrigger>
-				<TldrawUiDropdownMenuContent side="bottom" align="end" alignOffset={-18} sideOffset={4}>
+				{/* Hang ~8px over the sidebar's right edge (see TlaFileMenu) rather than inset. */}
+				<TldrawUiDropdownMenuContent
+					side="bottom"
+					align="end"
+					{...TLA_MENU_POSITION}
+					alignOffset={-18}
+				>
 					{user && (
 						<>
 							<TldrawUiMenuGroup id="files">

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceActions.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceActions.tsx
@@ -32,9 +32,6 @@ export function TlaSidebarWorkspaceActions({ workspaceId }: { workspaceId: strin
 			component: ({ onClose }) => (
 				<WorkspaceSettingsDialog workspaceId={workspaceId} onClose={onClose} />
 			),
-			// The dialog contains nested TlaMenuSelect popups; interacting with one
-			// would otherwise register as a background click and dismiss the dialog.
-			preventBackgroundClose: true,
 		})
 		trackEvent('open-share-menu', { source: 'sidebar' })
 	}, [addDialog, workspaceId, trackEvent])

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -3,13 +3,21 @@ import classNames from 'classnames'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
 import { ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { uniqueId, useDialogs, useGlobalMenuIsOpen, useMaybeEditor, useValue } from 'tldraw'
+import {
+	uniqueId,
+	useContainer,
+	useDialogs,
+	useGlobalMenuIsOpen,
+	useMaybeEditor,
+	useValue,
+} from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useActiveWorkspaceId } from '../../../hooks/useActiveWorkspaceId'
 import { useApp } from '../../../hooks/useAppState'
 import { getIsCoarsePointer } from '../../../utils/getIsCoarsePointer'
 import { defineMessages, useMsg } from '../../../utils/i18n'
 import { CreateWorkspaceDialog } from '../../dialogs/CreateWorkspaceDialog'
+import { TLA_MENU_POSITION } from '../../tla-menu/tla-menu'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import styles from '../sidebar.module.css'
 
@@ -75,29 +83,12 @@ export function TlaSidebarWorkspaceSwitcher() {
 	const switchToWorkspace = useSwitchToWorkspace()
 	const handleCreateWorkspace = useCreateWorkspaceDialog()
 	const createWorkspaceLbl = useMsg(messages.createWorkspace)
+	const container = useContainer()
 
 	return (
 		<div className={styles.sidebarSection}>
-			{isOpen && (
-				<div
-					className={styles.sidebarWorkspaceSwitcherOverlay}
-					data-testid="tla-workspace-switcher-overlay"
-					onPointerDown={(e) => {
-						e.stopPropagation()
-					}}
-					onPointerUp={(e) => {
-						e.stopPropagation()
-					}}
-					onClick={(e) => {
-						e.preventDefault()
-						e.stopPropagation()
-						onOpenChange(false)
-					}}
-				/>
-			)}
 			<div className={styles.sidebarWorkspaceSwitcherRoot}>
-				{/* Modal doesn't really work for us here because other elements have explicit pointer-events on. Thus the switcher overlay.*/}
-				<_DropdownMenu.Root open={isOpen} onOpenChange={onOpenChange} modal>
+				<_DropdownMenu.Root open={isOpen} onOpenChange={onOpenChange}>
 					<_DropdownMenu.Trigger asChild>
 						<button
 							className={classNames(
@@ -116,50 +107,53 @@ export function TlaSidebarWorkspaceSwitcher() {
 							<TlaIcon icon="chevron-up-down" className={styles.sidebarWorkspaceSwitcherChevrons} />
 						</button>
 					</_DropdownMenu.Trigger>
-					<_DropdownMenu.Content
-						className={classNames('tlui-menu', styles.sidebarWorkspaceSwitcherMenu)}
-						side="bottom"
-						align="start"
-						sideOffset={4}
-						alignOffset={-4}
-						collisionPadding={8}
-						// Switching workspaces mounts a new canvas that steals focus as it loads.
-						// Ignore that focus shift while still allowing real outside pointer clicks
-						// (for example, clicking the canvas) to dismiss the switcher.
-						onFocusOutside={(e) => e.preventDefault()}
-					>
-						<WorkspaceSwitcherItem
-							isActive={isHome}
-							onSelect={() => switchToWorkspace(homeWorkspaceId)}
-							testId="tla-workspace-switcher-home"
+					<_DropdownMenu.Portal container={container}>
+						<_DropdownMenu.Content
+							className={classNames('tlui-menu', styles.sidebarWorkspaceSwitcherMenu)}
+							side="bottom"
+							align="start"
+							{...TLA_MENU_POSITION}
+							// When the switcher closes because another menu is opening (e.g. a file's
+							// "…" menu), don't restore focus to our trigger — that focus shift would
+							// dismiss the just-opened menu, making it flash. A plain Escape/outside
+							// close (no other menu open) still restores focus for keyboard users.
+							onCloseAutoFocus={(e) => {
+								if (editor?.menus.hasAnyOpenMenus()) e.preventDefault()
+							}}
 						>
-							{homeWorkspaceName ?? myWorkspaceLbl}
-						</WorkspaceSwitcherItem>
-						{workspaces.map((g) => (
 							<WorkspaceSwitcherItem
-								key={`workspace-${g.group.id}`}
-								isActive={g.group.id === activeWorkspaceId}
-								onSelect={() => switchToWorkspace(g.group.id)}
+								isActive={isHome}
+								onSelect={() => switchToWorkspace(homeWorkspaceId)}
+								testId="tla-workspace-switcher-home"
 							>
-								{g.group.name}
+								{homeWorkspaceName ?? myWorkspaceLbl}
 							</WorkspaceSwitcherItem>
-						))}
-						<_DropdownMenu.Separator className={styles.sidebarWorkspaceSwitcherSeparator} />
-						<_DropdownMenu.Item
-							className={classNames(
-								styles.sidebarWorkspaceSwitcherItem,
-								styles.sidebarWorkspaceSwitcherItemCreate,
-								'tla-text_ui__regular'
-							)}
-							onSelect={handleCreateWorkspace}
-							data-testid="tla-create-workspace-menu-item"
-						>
-							<span className={styles.sidebarWorkspaceSwitcherItemLabel}>
-								<TlaIcon icon="plus" />
-								<span className={styles.sidebarTruncatedText}>{createWorkspaceLbl}</span>
-							</span>
-						</_DropdownMenu.Item>
-					</_DropdownMenu.Content>
+							{workspaces.map((g) => (
+								<WorkspaceSwitcherItem
+									key={`workspace-${g.group.id}`}
+									isActive={g.group.id === activeWorkspaceId}
+									onSelect={() => switchToWorkspace(g.group.id)}
+								>
+									{g.group.name}
+								</WorkspaceSwitcherItem>
+							))}
+							<_DropdownMenu.Separator className={styles.sidebarWorkspaceSwitcherSeparator} />
+							<_DropdownMenu.Item
+								className={classNames(
+									styles.sidebarWorkspaceSwitcherItem,
+									styles.sidebarWorkspaceSwitcherItemCreate,
+									'tla-text_ui__regular'
+								)}
+								onSelect={handleCreateWorkspace}
+								data-testid="tla-create-workspace-menu-item"
+							>
+								<span className={styles.sidebarWorkspaceSwitcherItemLabel}>
+									<TlaIcon icon="plus" />
+									<span className={styles.sidebarTruncatedText}>{createWorkspaceLbl}</span>
+								</span>
+							</_DropdownMenu.Item>
+						</_DropdownMenu.Content>
+					</_DropdownMenu.Portal>
 				</_DropdownMenu.Root>
 			</div>
 		</div>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -540,18 +540,26 @@
 }
 
 .sidebarWorkspaceSwitcherMenu {
-	min-width: max(260px, calc(var(--tla-sidebar-width) - 4px));
-	max-width: calc(var(--tla-sidebar-width) - 4px);
+	/* Width is enforced on the popper wrapper below. Use --radix-popper-anchor-width (the
+	   trigger width, which Radix sets on the portaled wrapper) — NOT --tla-sidebar-width,
+	   which is declared on the sidebar layout and does NOT reach this menu once it's portaled
+	   out into the editor container. The trigger spans the sidebar minus its 2×12px padding,
+	   so +24px brings it back to the full sidebar width (so the picker hangs ~8px over the
+	   edge). The wrapper is sized below; stretch the panel to fill it (it would otherwise
+	   hug the workspace names). Cap it so long names truncate rather than grow past it. */
+	width: 100%;
+	max-width: max(260px, calc(var(--radix-popper-anchor-width) + 24px));
 	max-height: 70vh;
 	overflow-y: auto;
 	padding: 2px 0px;
 }
 
-.sidebarWorkspaceSwitcherOverlay {
-	position: fixed;
-	inset: 0;
-	z-index: calc(var(--tl-layer-menus) - 1);
-	pointer-events: all;
+/* Like the select dropdown, popper writes `min-width: max-content` inline on the wrapper, so it
+   hugs its content; widen it to the trigger width here. !important is unavoidable: an inline
+   style outranks every selector, so it is the only way to override it. (A DropdownMenu is always
+   popper-positioned, so unlike the select there is no item-aligned alternative to weigh.) */
+:global([data-radix-popper-content-wrapper]):has(> .sidebarWorkspaceSwitcherMenu) {
+	min-width: max(260px, calc(var(--radix-popper-anchor-width) + 24px)) !important;
 }
 
 .sidebarWorkspaceSwitcherRoot {

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -407,7 +407,6 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 															id={`workspace-member-role-${member.userId}`}
 															label={roleLabels[member.role]}
 															value={member.role}
-															usePortal
 															options={memberRoleOptions}
 															// Everyone — including yourself — can be removed; it's disabled when
 															// removal would leave the workspace without an owner. On your own

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -125,28 +125,29 @@
 	opacity: 0;
 }
 
-/* need to target the parent div, ugh, can't target via a className */
-div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
-	position: absolute !important;
-	top: 17px;
-	right: -8px;
-	left: auto !important;
-	z-index: 2 !important;
-}
-
 .menuSelectContent {
-	/* Match the layer `.tlui-dialog__overlay` renders at — it reuses
-	   --tl-layer-canvas-overlays — so the portaled (popper) dropdown isn't hidden
-	   behind a containing dialog. A lower z-index would lose: both the dialog and
-	   the select portal into the same container as siblings, so they compete in one
-	   stacking context; at equal z-index the dropdown wins only because it mounts
-	   later. Radix copies this z-index onto its popper wrapper, so setting it on the
-	   content (not the wrapper, which Radix styles inline) avoids needing
-	   !important. Harmless inline (item-aligned), where the wrapper's z-index governs. */
+	/* The dropdown portals into the editor container as a sibling of any containing
+	   dialog/popover, so they share one stacking context. Match the canvas-overlays
+	   layer the dialog/popover use so the dropdown isn't hidden behind them. Radix
+	   copies this z-index onto its popper wrapper, so setting it on the content (not
+	   the wrapper, which Radix styles inline) avoids needing !important. */
 	z-index: var(--tl-layer-canvas-overlays);
 	border-radius: var(--tl-radius-3);
 	background-color: var(--tl-color-panel);
 	box-shadow: var(--tl-shadow-3);
+}
+
+/* This select uses `position="popper"` (drops below the trigger, end-aligned, with our shared
+   offsets) instead of Radix's default `position="item-aligned"`. Both modes cost a CSS override,
+   just in a different spot: item-aligned sizes itself to the trigger for free but overlays the
+   trigger and ignores side/align/offsets (so it needs CSS to place it below); popper places it
+   correctly but writes `min-width: max-content` inline on its wrapper, so it hugs the option
+   text. We pick popper — placement consistency with the other tla menus — and pay its tax here.
+   !important is not a shortcut: an inline style outranks every selector and @layer, so it is the
+   only way to widen the (class-less) wrapper. Reuses Radix's own --radix-popper-anchor-width;
+   the +1.5rem restores the checkmark offset the old item-aligned layout had. */
+:global([data-radix-popper-content-wrapper]):has(> .menuSelectContent) {
+	min-width: calc(var(--radix-popper-anchor-width) + 1.5rem) !important;
 }
 
 .menuSelectOption {

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -7,8 +7,6 @@ import {
 	ReactNode,
 	useCallback,
 	useContext,
-	useEffect,
-	useState,
 } from 'react'
 import { TldrawUiButton, TldrawUiIcon, TldrawUiTooltip, useContainer } from 'tldraw'
 import { defineMessages, useMsg } from '../../utils/i18n'
@@ -18,6 +16,18 @@ import styles from './menu.module.css'
 const messages = defineMessages({
 	help: { defaultMessage: 'Help' },
 })
+
+/**
+ * Shared positioning for tla dropdowns, popovers, and selects so they sit consistently
+ * relative to their triggers. Spread onto a Radix/SDK content element (e.g.
+ * `{...TLA_MENU_POSITION}`); tweak here to adjust every tla menu at once. `side` and
+ * `align` stay per-menu since they depend on the trigger's placement.
+ */
+export const TLA_MENU_POSITION = {
+	sideOffset: 4,
+	alignOffset: -4,
+	collisionPadding: 4,
+} as const
 
 // Used to section areas of the menu, ie links vs snapshots
 export function TlaMenuSection({ children }: { children: ReactNode }) {
@@ -114,7 +124,6 @@ export function TlaMenuSelect<T extends string>({
 	onChange,
 	options,
 	actions,
-	usePortal,
 	'data-testid': dataTestId,
 }: {
 	id: string
@@ -134,12 +143,8 @@ export function TlaMenuSelect<T extends string>({
 		// Shown on hover when the action is disabled (e.g. why it can't be used).
 		tooltip?: ReactNode
 	}[]
-	// When set, render the dropdown in a portal (popper-positioned) so it isn't
-	// clipped by / doesn't overflow a constrained container like a modal dialog.
-	usePortal?: boolean
 	'data-testid'?: string
 }) {
-	const [isOpen, setIsOpen] = useState(false)
 	const container = useContainer()
 	const handleChange = useCallback(
 		(value: string) => {
@@ -153,45 +158,9 @@ export function TlaMenuSelect<T extends string>({
 		[actions, onChange]
 	)
 
-	const handleOpenChange = (open: boolean) => {
-		setIsOpen(open)
-	}
-
-	useEffect(() => {
-		if (!isOpen) return
-		// Close the select menu when the user clicks outside of it
-		// This is a workaround for an issue in Radix Select when combined with a popper menu.
-		const handlePointerDown = (event: MouseEvent) => {
-			const target = event.target as HTMLElement
-			if (!target.closest(`.${styles.menuSelectContent}`)) {
-				setIsOpen(false)
-			}
-		}
-
-		document.body.addEventListener('pointerdown', handlePointerDown, { capture: true })
-		return () => {
-			document.body.removeEventListener('pointerdown', handlePointerDown, { capture: true })
-		}
-	}, [isOpen])
-
 	return (
-		<div
-			className={styles.menuSelectWrapper}
-			// Stop clicks from reaching ancestor handlers (e.g. a background-dismiss),
-			// but use the bubble phase, not capture: Radix Select opens on `click` for
-			// touch/pen input (it only opens on `pointerdown` for mouse). Capturing here
-			// would swallow that click before it reaches the trigger, so the menu would
-			// never open on iOS. Bubbling lets the trigger handle the click first.
-			onClick={(e) => {
-				e.stopPropagation()
-			}}
-		>
-			<_Select.Root
-				open={isOpen}
-				value={value}
-				onOpenChange={handleOpenChange}
-				onValueChange={handleChange}
-			>
+		<div className={styles.menuSelectWrapper}>
+			<_Select.Root value={value} onValueChange={handleChange}>
 				<_Select.Trigger
 					id={id}
 					className={styles.menuSelectTrigger}
@@ -206,14 +175,13 @@ export function TlaMenuSelect<T extends string>({
 						<TlaIcon icon="chevron-down" className={styles.menuSelectChevron} />
 					</_Select.Icon>
 				</_Select.Trigger>
-				<TlaSelectPortal usePortal={usePortal} container={container}>
+				<_Select.Portal container={container}>
 					<_Select.Content
 						className={styles.menuSelectContent}
-						position={usePortal ? 'popper' : undefined}
-						side={usePortal ? 'bottom' : undefined}
-						align={usePortal ? 'end' : undefined}
-						sideOffset={usePortal ? 4 : undefined}
-						collisionPadding={usePortal ? 4 : undefined}
+						position="popper"
+						side="bottom"
+						align="end"
+						{...TLA_MENU_POSITION}
 					>
 						<_Select.Viewport>
 							{options.map((option) => (
@@ -257,25 +225,10 @@ export function TlaMenuSelect<T extends string>({
 							)}
 						</_Select.Viewport>
 					</_Select.Content>
-				</TlaSelectPortal>
+				</_Select.Portal>
 			</_Select.Root>
 		</div>
 	)
-}
-
-function TlaSelectPortal({
-	usePortal,
-	container,
-	children,
-}: {
-	usePortal?: boolean
-	container: HTMLElement
-	children: ReactNode
-}) {
-	if (usePortal) {
-		return <_Select.Portal container={container}>{children}</_Select.Portal>
-	}
-	return <>{children}</>
 }
 
 /* --------------------- Switch --------------------- */

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -230,7 +230,7 @@
 
 /** Buttons/A tags */
 .tla:has(.tl-container__focused:not(.tl-container__no-focus-ring))
-	:is(nav, .tlui-menu, .tlui-popover__content, .tlui-dialog__overlay)
+	:is(nav, .tlui-menu, .tlui-popover__content, .tlui-dialog__content)
 	button:not(.tla-button-text):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) button:not(.tlui-button):focus-visible,
 .tl-container__focused:not(.tl-container__no-focus-ring) .tlui-layout__top a:focus-visible {

--- a/apps/examples/e2e/tests/test-dialogs.spec.ts
+++ b/apps/examples/e2e/tests/test-dialogs.spec.ts
@@ -1,0 +1,107 @@
+import { expect, type Page } from '@playwright/test'
+import test from '../fixtures/fixtures'
+
+const content = (page: Page) => page.locator('.tlui-dialog__content')
+const selectContent = (page: Page) => page.getByTestId('dialog-select.content')
+
+// Click the dialog backdrop at a point that is outside the centered content.
+async function clickBackdrop(page: Page) {
+	const box = await content(page).boundingBox()
+	if (!box) throw new Error('Could not find dialog content')
+	// Midpoint of the left-hand backdrop, vertically aligned with the content.
+	await page.mouse.click(Math.max(5, box.x / 2), box.y + box.height / 2)
+}
+
+test.describe('dialogs', () => {
+	// These exercise backdrop/drag dismissal, which is desktop pointer behaviour.
+	test.skip(({ isMobile }) => isMobile, 'Dialog dismissal is tested with a desktop pointer')
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('http://localhost:5420/toasts-and-dialogs')
+		await page.waitForSelector('.tl-canvas')
+	})
+
+	test('a backdrop click dismisses a normal dialog', async ({ page }) => {
+		await page.getByTestId('show-dialog').click()
+		await expect(content(page)).toBeVisible()
+
+		await clickBackdrop(page)
+		await expect(content(page)).toHaveCount(0)
+	})
+
+	test('escape dismisses a dialog', async ({ page }) => {
+		await page.getByTestId('show-dialog').click()
+		await expect(content(page)).toBeVisible()
+
+		await page.keyboard.press('Escape')
+		await expect(content(page)).toHaveCount(0)
+	})
+
+	test('a press that starts inside the content and ends on the backdrop does not dismiss', async ({
+		page,
+	}) => {
+		await page.getByTestId('show-dialog').click()
+		await expect(content(page)).toBeVisible()
+
+		const box = await content(page).boundingBox()
+		if (!box) throw new Error('Could not find dialog content')
+		// Press down inside the content (e.g. selecting text)...
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+		await page.mouse.down()
+		// ...drag out onto the backdrop and release.
+		await page.mouse.move(Math.max(5, box.x / 2), box.y + box.height / 2, { steps: 5 })
+		await page.mouse.up()
+
+		await expect(content(page)).toBeVisible()
+	})
+
+	test('an open select inside a modal is dismissed before the dialog', async ({ page }) => {
+		await page.getByTestId('show-dialog-with-select').click()
+		await expect(content(page)).toBeVisible()
+
+		// Open the select; its listbox portals into the container.
+		await page.getByTestId('dialog-select.trigger').click()
+		await expect(selectContent(page)).toBeVisible()
+
+		// The first outside click closes only the select; the dialog stays open.
+		await clickBackdrop(page)
+		await expect(selectContent(page)).toHaveCount(0)
+		await expect(content(page)).toBeVisible()
+
+		// A second outside click then closes the dialog.
+		await clickBackdrop(page)
+		await expect(content(page)).toHaveCount(0)
+	})
+})
+
+test.describe('stacked dialogs', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('http://localhost:5420/toasts-and-dialogs')
+		await page.waitForSelector('.tl-canvas')
+	})
+
+	// Stacked modal dialogs must stay interactive — including the topmost dialog's controls
+	// on a touchscreen. Making lower stacked dialogs non-modal previously left the nested
+	// dialog unresponsive to taps on mobile, so this runs on mobile as well as desktop.
+	test('a nested dialog stacks over its parent and stays interactive', async ({
+		page,
+		isMobile,
+	}) => {
+		const act = (testId: string) =>
+			isMobile ? page.getByTestId(testId).tap() : page.getByTestId(testId).click()
+
+		await act('show-nested-dialog')
+		await expect(page.getByTestId('dialog-parent')).toBeVisible()
+
+		await act('dialog-parent.open-nested')
+		await expect(page.getByTestId('dialog-nested')).toBeVisible()
+		// Opening the nested dialog must not collapse the parent.
+		await expect(page.getByTestId('dialog-parent')).toBeVisible()
+
+		// The topmost dialog's control must respond (taps included): closing it leaves the
+		// parent open underneath.
+		await act('dialog-nested.confirm')
+		await expect(page.getByTestId('dialog-nested')).toHaveCount(0)
+		await expect(page.getByTestId('dialog-parent')).toBeVisible()
+	})
+})

--- a/apps/examples/src/examples/layout/external-dialog/external-dialog.css
+++ b/apps/examples/src/examples/layout/external-dialog/external-dialog.css
@@ -1,3 +1,4 @@
-.tlui-dialog__overlay {
+.tlui-dialog__overlay,
+.tlui-dialog__positioner {
 	position: fixed;
 }

--- a/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -1,3 +1,5 @@
+import { Select as _Select } from 'radix-ui'
+import { useState } from 'react'
 import {
 	TLComponents,
 	Tldraw,
@@ -8,6 +10,7 @@ import {
 	TldrawUiDialogFooter,
 	TldrawUiDialogHeader,
 	TldrawUiDialogTitle,
+	useContainer,
 	useDialogs,
 	useToasts,
 } from 'tldraw'
@@ -47,6 +50,94 @@ function MySimpleDialog({ onClose }: { onClose(): void }) {
 	)
 }
 
+// [3]
+function MyDialogWithSelect({ onClose }: { onClose(): void }) {
+	const container = useContainer()
+	const [value, setValue] = useState('a')
+	return (
+		<>
+			<TldrawUiDialogHeader>
+				<TldrawUiDialogTitle>Dialog with a select</TldrawUiDialogTitle>
+				<TldrawUiDialogCloseButton />
+			</TldrawUiDialogHeader>
+			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
+				<p>A select opened inside a modal is its own dismissable layer.</p>
+				<_Select.Root value={value} onValueChange={setValue}>
+					<_Select.Trigger
+						data-testid="dialog-select.trigger"
+						style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+					>
+						<_Select.Value />
+						<_Select.Icon>▾</_Select.Icon>
+					</_Select.Trigger>
+					<_Select.Portal container={container}>
+						<_Select.Content
+							data-testid="dialog-select.content"
+							position="popper"
+							sideOffset={4}
+							style={{
+								backgroundColor: 'var(--tl-color-panel)',
+								boxShadow: 'var(--tl-shadow-3)',
+								borderRadius: 'var(--tl-radius-2)',
+								padding: 4,
+								zIndex: 'var(--tl-layer-canvas-overlays)',
+							}}
+						>
+							<_Select.Viewport>
+								{['a', 'b', 'c'].map((v) => (
+									<_Select.Item
+										key={v}
+										value={v}
+										data-testid={`dialog-select.item-${v}`}
+										style={{ padding: '4px 8px', cursor: 'pointer' }}
+									>
+										<_Select.ItemText>Option {v}</_Select.ItemText>
+									</_Select.Item>
+								))}
+							</_Select.Viewport>
+						</_Select.Content>
+					</_Select.Portal>
+				</_Select.Root>
+			</TldrawUiDialogBody>
+			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+				<TldrawUiButton type="primary" onClick={onClose}>
+					<TldrawUiButtonLabel>Done</TldrawUiButtonLabel>
+				</TldrawUiButton>
+			</TldrawUiDialogFooter>
+		</>
+	)
+}
+
+// [4] A dialog that opens a second dialog, so the two stack. Stacked dialogs stay modal,
+// so each one — including the topmost — keeps its own controls interactive (taps included).
+function MyNestedDialog({ onClose }: { onClose(): void }) {
+	const { addDialog } = useDialogs()
+	return (
+		<div data-testid="dialog-parent" style={{ padding: 16 }}>
+			<h2>Parent dialog</h2>
+			<p>Opens another dialog on top of itself.</p>
+			<button
+				data-testid="dialog-parent.open-nested"
+				onClick={() => addDialog({ component: MyConfirmDialog })}
+			>
+				Open nested dialog
+			</button>
+			<button onClick={onClose}>Close</button>
+		</div>
+	)
+}
+
+function MyConfirmDialog({ onClose }: { onClose(): void }) {
+	return (
+		<div data-testid="dialog-nested" style={{ padding: 16 }}>
+			<h2>Nested dialog</h2>
+			<button data-testid="dialog-nested.confirm" onClick={onClose}>
+				Confirm
+			</button>
+		</div>
+	)
+}
+
 const CustomSharePanel = () => {
 	const { addToast } = useToasts()
 	const { addDialog } = useDialogs()
@@ -61,6 +152,7 @@ const CustomSharePanel = () => {
 				Show toast
 			</button>
 			<button
+				data-testid="show-dialog"
 				onClick={() => {
 					addDialog({
 						component: MyDialog,
@@ -86,12 +178,48 @@ const CustomSharePanel = () => {
 			>
 				Show simple dialog
 			</button>
+			<button
+				data-testid="show-dialog-with-select"
+				onClick={() => {
+					addDialog({
+						component: MyDialogWithSelect,
+						onClose() {
+							// You can do something after the dialog is closed
+							void null
+						},
+					})
+				}}
+			>
+				Show dialog with select
+			</button>
 		</div>
+	)
+}
+
+// Rendered in front of the canvas rather than in the SharePanel, which overflows
+// off-screen on mobile — so the stacked-dialog demo stays reachable on a touchscreen.
+function StackedDialogLauncher() {
+	const { addDialog } = useDialogs()
+	return (
+		<button
+			data-testid="show-nested-dialog"
+			style={{
+				position: 'absolute',
+				top: '50%',
+				left: 8,
+				transform: 'translateY(-50%)',
+				pointerEvents: 'all',
+			}}
+			onClick={() => addDialog({ component: MyNestedDialog })}
+		>
+			Show nested dialog
+		</button>
 	)
 }
 
 const components: TLComponents = {
 	SharePanel: CustomSharePanel,
+	InFrontOfTheCanvas: StackedDialogLauncher,
 }
 
 export default function ToastsDialogsExample() {
@@ -104,8 +232,8 @@ export default function ToastsDialogsExample() {
 
 /*
 
-To control toasts and dialogs your app, you can use the `useToasts` and `useDialogs` hooks. 
-These hooks give you access to functions which allow you to add, remove and clear toasts 
+To control toasts and dialogs your app, you can use the `useToasts` and `useDialogs` hooks.
+These hooks give you access to functions which allow you to add, remove and clear toasts
 and dialogs.
 
 Dialogs are especially customisable, allowing you to pass in a custom component to render
@@ -113,10 +241,15 @@ as the dialog content. Alternatively, you can use the `ExampleDialog` component 
 provided by the library.
 
 [1]
-The tldraw library provides a set of components that you can use to build your dialogs. 
-The `onClose` function passed to the dialog component runs when the dialog closes or 
+The tldraw library provides a set of components that you can use to build your dialogs.
+The `onClose` function passed to the dialog component runs when the dialog closes or
 is dismissed, but you can also call it from buttons to close the dialog.
 
 [2]
 ...or you can build your own dialog component!
+
+[3]
+Dialogs can contain their own popups, like a select menu. Because tldraw's dialog uses
+Radix's dismissable layers, clicking outside an open select closes just the select and
+leaves the dialog open — a second outside click then closes the dialog.
 */

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4225,7 +4225,7 @@ export function TldrawUiDialogTitle({ className, children, style }: TLUiDialogTi
 export function TldrawUiDropdownMenuCheckboxItem({ children, onSelect, ...rest }: TLUiDropdownMenuCheckboxItemProps): JSX.Element;
 
 // @public (undocumented)
-export function TldrawUiDropdownMenuContent({ className, side, align, sideOffset, alignOffset, children }: TLUiDropdownMenuContentProps): JSX.Element;
+export function TldrawUiDropdownMenuContent({ className, side, align, sideOffset, alignOffset, collisionPadding, children }: TLUiDropdownMenuContentProps): JSX.Element;
 
 // @public (undocumented)
 export function TldrawUiDropdownMenuGroup({ className, children }: TLUiDropdownMenuGroupProps): JSX.Element;
@@ -4318,7 +4318,7 @@ export interface TldrawUiOrientationProviderProps {
 export function TldrawUiPopover({ id, children, onOpenChange, open, className }: TLUiPopoverProps): JSX.Element;
 
 // @public (undocumented)
-export function TldrawUiPopoverContent({ side, children, align, sideOffset, alignOffset, disableEscapeKeyDown, autoFocusFirstButton }: TLUiPopoverContentProps): JSX.Element;
+export function TldrawUiPopoverContent({ side, children, align, sideOffset, alignOffset, collisionPadding, disableEscapeKeyDown, autoFocusFirstButton }: TLUiPopoverContentProps): JSX.Element;
 
 // @public (undocumented)
 export function TldrawUiPopoverTrigger({ children }: TLUiPopoverTriggerProps): JSX.Element;
@@ -4862,6 +4862,8 @@ export interface TLUiDropdownMenuContentProps {
     children: ReactNode;
     // (undocumented)
     className?: string;
+    // (undocumented)
+    collisionPadding?: number;
     // (undocumented)
     id?: string;
     // (undocumented)
@@ -5483,6 +5485,7 @@ export interface TLUiPopoverContentProps {
     autoFocusFirstButton?: boolean;
     // (undocumented)
     children: React_3.ReactNode;
+    collisionPadding?: number;
     // (undocumented)
     disableEscapeKeyDown?: boolean;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1693,8 +1693,17 @@ tldraw? probably.
 	height: 100%;
 	z-index: var(--tl-layer-canvas-overlays);
 	background-color: var(--tl-color-overlay);
-	pointer-events: all;
 	animation: tl-fade-in 0.12s ease-out;
+}
+
+.tlui-dialog__positioner {
+	position: absolute;
+	top: 0px;
+	left: 0px;
+	width: 100%;
+	height: 100%;
+	z-index: var(--tl-layer-canvas-overlays);
+	pointer-events: all;
 	display: grid;
 	place-items: center;
 	overflow-y: auto;

--- a/packages/tldraw/src/lib/ui/components/Dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/components/Dialogs.tsx
@@ -1,18 +1,12 @@
 import { useContainer, useValue } from '@tldraw/editor'
 import { Dialog as _Dialog } from 'radix-ui'
-import { memo, useCallback, useRef } from 'react'
+import { memo, useCallback } from 'react'
 import { TLUiDialog, useDialogs } from '../context/dialogs'
 import { useDirection } from '../hooks/useTranslation/useTranslation'
 
 /** @internal */
-const TldrawUiDialog = ({
-	id,
-	component: ModalContent,
-	preventBackgroundClose,
-	isModal,
-}: TLUiDialog & { isModal: boolean }) => {
+const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }: TLUiDialog) => {
 	const { removeDialog } = useDialogs()
-	const mouseDownInsideContentRef = useRef(false)
 
 	const container = useContainer()
 	const dir = useDirection()
@@ -27,40 +21,32 @@ const TldrawUiDialog = ({
 	)
 
 	return (
-		<_Dialog.Root onOpenChange={handleOpenChange} defaultOpen modal={isModal}>
+		<_Dialog.Root onOpenChange={handleOpenChange} defaultOpen>
 			<_Dialog.Portal container={container}>
-				<_Dialog.Overlay
-					dir={dir}
-					className="tlui-dialog__overlay"
-					onClick={(e) => {
-						// We pressed mouse down inside the content of the dialog then moved the mouse
-						// outside it and let go of the mouse button. This should not close the dialog.
-						if (mouseDownInsideContentRef.current) return
-						// only close if the click is on the overlay itself, ignore bubbling clicks
-						if (!preventBackgroundClose && e.target === e.currentTarget) handleOpenChange(false)
-					}}
-				>
+				{/* Radix renders the scrim and content as siblings. The positioner sits on
+				    top of the scrim and centers the content, scrolling and padding it when
+				    it's taller than the viewport. */}
+				<_Dialog.Overlay dir={dir} className="tlui-dialog__overlay" />
+				<div dir={dir} className="tlui-dialog__positioner">
 					<_Dialog.Content
 						dir={dir}
 						className="tlui-dialog__content"
 						aria-describedby={undefined}
-						onMouseDown={() => (mouseDownInsideContentRef.current = true)}
-						onMouseUp={() => (mouseDownInsideContentRef.current = false)}
 						onInteractOutside={(e) => {
-							mouseDownInsideContentRef.current = false
+							// Radix's dismissable layers are layer-aware: an interaction outside the
+							// topmost layer dismisses only that layer — an open select, or a dialog
+							// stacked on top — leaving lower layers open. onInteractOutside fires for
+							// both a pointer press and a focus shift outside the dialog; opt out of both
+							// when the dialog asks to stay open on background interactions (escape still
+							// closes it).
 							if (preventBackgroundClose) {
 								e.preventDefault()
 							}
 						}}
 					>
-						<ModalContent
-							onClose={() => {
-								mouseDownInsideContentRef.current = false
-								handleOpenChange(false)
-							}}
-						/>
+						<ModalContent onClose={() => handleOpenChange(false)} />
 					</_Dialog.Content>
-				</_Dialog.Overlay>
+				</div>
 			</_Dialog.Portal>
 		</_Dialog.Root>
 	)
@@ -70,11 +56,11 @@ const TldrawUiDialog = ({
 export const DefaultDialogs = memo(function DefaultDialogs() {
 	const { dialogs } = useDialogs()
 	const dialogsArray = useValue('dialogs', () => dialogs.get(), [dialogs])
-	// Only the topmost dialog should be modal. Stacking multiple modal Radix
-	// dialogs makes lower ones intercept pointer/touch events (via their own
-	// focus traps and scroll-locking), which leaves a nested dialog unresponsive
-	// to taps on mobile.
-	return dialogsArray.map((dialog, i) => (
-		<TldrawUiDialog key={dialog.id} {...dialog} isModal={i === dialogsArray.length - 1} />
-	))
+	// Every stacked dialog stays modal (Radix's default). That's what keeps dismiss
+	// layer-aware: a background press or escape closes only the topmost layer, because
+	// Radix's focus-scope stack pauses lower dialogs rather than dismissing them. Don't
+	// make a lower dialog non-modal to work around anything — without a focus scope it
+	// dismisses on the focus shift when a nested dialog or select opens, collapsing the
+	// whole stack.
+	return dialogsArray.map((dialog) => <TldrawUiDialog key={dialog.id} {...dialog} />)
 })

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiDropdownMenu.tsx
@@ -68,6 +68,7 @@ export interface TLUiDropdownMenuContentProps {
 	align?: 'start' | 'center' | 'end'
 	sideOffset?: number
 	alignOffset?: number
+	collisionPadding?: number
 	children: ReactNode
 }
 
@@ -78,6 +79,7 @@ export function TldrawUiDropdownMenuContent({
 	align = 'start',
 	sideOffset = 8,
 	alignOffset = 8,
+	collisionPadding = 4,
 	children,
 }: TLUiDropdownMenuContentProps) {
 	const container = useContainer()
@@ -90,7 +92,7 @@ export function TldrawUiDropdownMenuContent({
 				sideOffset={sideOffset}
 				align={align}
 				alignOffset={alignOffset}
-				collisionPadding={4}
+				collisionPadding={collisionPadding}
 			>
 				{children}
 			</_DropdownMenu.Content>

--- a/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/TldrawUiPopover.tsx
@@ -47,6 +47,11 @@ export interface TLUiPopoverContentProps {
 	align?: 'start' | 'center' | 'end'
 	alignOffset?: number
 	sideOffset?: number
+	/**
+	 * Minimum distance to keep between the popover and the viewport edge before it
+	 * shifts to stay in view. Defaults to Radix's `0`.
+	 */
+	collisionPadding?: number
 	disableEscapeKeyDown?: boolean
 	autoFocusFirstButton?: boolean
 }
@@ -58,6 +63,7 @@ export function TldrawUiPopoverContent({
 	align = 'center',
 	sideOffset = 8,
 	alignOffset = 0,
+	collisionPadding,
 	disableEscapeKeyDown = false,
 	autoFocusFirstButton = true,
 }: TLUiPopoverContentProps) {
@@ -83,6 +89,7 @@ export function TldrawUiPopoverContent({
 				sideOffset={sideOffset}
 				align={align}
 				alignOffset={alignOffset}
+				collisionPadding={collisionPadding}
 				dir={dir}
 				ref={ref}
 				onOpenAutoFocus={handleOpenAutoFocus}

--- a/packages/tldraw/src/test/ui/Dialogs.test.tsx
+++ b/packages/tldraw/src/test/ui/Dialogs.test.tsx
@@ -1,0 +1,256 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { Select as _Select } from 'radix-ui'
+import { TLComponents, Tldraw } from '../../lib/Tldraw'
+import { useDialogs } from '../../lib/ui/context/dialogs'
+import { renderTldrawComponent } from '../testutils/renderTldrawComponent'
+
+// jsdom doesn't implement scrollIntoView, which Radix Select calls when it opens.
+Element.prototype.scrollIntoView ??= () => {}
+
+function DialogWithSelect({ onClose }: { onClose(): void }) {
+	return (
+		<div data-testid="dialog-inner">
+			<_Select.Root defaultValue="a">
+				<_Select.Trigger data-testid="select-trigger">
+					<_Select.Value />
+				</_Select.Trigger>
+				<_Select.Portal>
+					<_Select.Content data-testid="select-content">
+						<_Select.Viewport>
+							<_Select.Item value="a" data-testid="select-a">
+								<_Select.ItemText>A</_Select.ItemText>
+							</_Select.Item>
+							<_Select.Item value="b" data-testid="select-b">
+								<_Select.ItemText>B</_Select.ItemText>
+							</_Select.Item>
+						</_Select.Viewport>
+					</_Select.Content>
+				</_Select.Portal>
+			</_Select.Root>
+			<button data-testid="dialog-close" onClick={onClose}>
+				Close
+			</button>
+		</div>
+	)
+}
+
+function OpenDialogButton({ preventBackgroundClose }: { preventBackgroundClose?: boolean }) {
+	const { addDialog } = useDialogs()
+	return (
+		<button
+			data-testid="open-dialog"
+			onClick={() => addDialog({ component: DialogWithSelect, preventBackgroundClose })}
+		>
+			open
+		</button>
+	)
+}
+
+// A confirm-style dialog opened from inside another dialog (e.g. the dotcom workspace
+// settings dialog's regenerate/leave/delete confirmations).
+function NestedConfirmDialog({ onClose }: { onClose(): void }) {
+	return (
+		<div data-testid="nested-dialog">
+			<button data-testid="nested-confirm" onClick={onClose}>
+				Confirm
+			</button>
+		</div>
+	)
+}
+
+function DialogThatOpensNested({ onClose }: { onClose(): void }) {
+	const { addDialog } = useDialogs()
+	return (
+		<div data-testid="parent-dialog">
+			<button
+				data-testid="open-nested"
+				onClick={() => addDialog({ component: NestedConfirmDialog })}
+			>
+				open nested
+			</button>
+			<button data-testid="parent-close" onClick={onClose}>
+				Close
+			</button>
+		</div>
+	)
+}
+
+function OpenParentDialogButton() {
+	const { addDialog } = useDialogs()
+	return (
+		<button
+			data-testid="open-parent"
+			onClick={() => addDialog({ component: DialogThatOpensNested })}
+		>
+			open parent
+		</button>
+	)
+}
+
+function renderWithParentDialog() {
+	const components: TLComponents = {
+		SharePanel: () => <OpenParentDialogButton />,
+	}
+	return renderTldrawComponent(<Tldraw components={components} />, { waitForPatterns: false })
+}
+
+function renderWithDialog(opts: { preventBackgroundClose?: boolean } = {}) {
+	const components: TLComponents = {
+		SharePanel: () => <OpenDialogButton preventBackgroundClose={opts.preventBackgroundClose} />,
+	}
+	return renderTldrawComponent(<Tldraw components={components} />, { waitForPatterns: false })
+}
+
+// A full press on the dialog backdrop. Radix dismisses on pointer-down, but we fire the
+// whole sequence so a layer-blind click handler (the bug this guards against) would be caught.
+function pressBackdrop() {
+	const el = document.querySelector('.tlui-dialog__positioner')
+	if (!el) throw new Error('dialog positioner (backdrop) not found')
+	fireEvent.pointerDown(el, { pointerType: 'mouse' })
+	fireEvent.pointerUp(el, { pointerType: 'mouse' })
+	fireEvent.click(el)
+}
+
+// Press the backdrop of the topmost dialog (the last positioner in the DOM) — used when
+// dialogs are stacked, so the press lands on the layer that should dismiss first.
+function pressTopBackdrop() {
+	const positioners = document.querySelectorAll('.tlui-dialog__positioner')
+	const el = positioners[positioners.length - 1]
+	if (!el) throw new Error('dialog positioner (backdrop) not found')
+	fireEvent.pointerDown(el, { pointerType: 'mouse' })
+	fireEvent.pointerUp(el, { pointerType: 'mouse' })
+	fireEvent.click(el)
+}
+
+it('dismisses a select opened inside a modal before the modal itself', async () => {
+	await renderWithDialog()
+
+	fireEvent.click(screen.getByTestId('open-dialog'))
+	await screen.findByTestId('dialog-inner')
+
+	// Open the select.
+	fireEvent.pointerDown(screen.getByTestId('select-trigger'), { button: 0, pointerType: 'mouse' })
+	await screen.findByTestId('select-content')
+
+	// A press on the dialog backdrop closes only the select; the dialog stays open.
+	pressBackdrop()
+	expect(screen.queryByTestId('select-content')).toBeNull()
+	expect(screen.queryByTestId('dialog-inner')).not.toBeNull()
+
+	// A second press on the backdrop then closes the dialog.
+	pressBackdrop()
+	expect(screen.queryByTestId('dialog-inner')).toBeNull()
+})
+
+it('dismisses a normal dialog on a backdrop press', async () => {
+	await renderWithDialog()
+
+	fireEvent.click(screen.getByTestId('open-dialog'))
+	await screen.findByTestId('dialog-inner')
+
+	pressBackdrop()
+	expect(screen.queryByTestId('dialog-inner')).toBeNull()
+})
+
+it('does not dismiss when a press starts inside the content and ends on the backdrop', async () => {
+	await renderWithDialog()
+
+	fireEvent.click(screen.getByTestId('open-dialog'))
+	await screen.findByTestId('dialog-inner')
+
+	// A press that starts inside the content (e.g. selecting text)...
+	fireEvent.pointerDown(screen.getByTestId('dialog-inner'), { pointerType: 'mouse' })
+	// ...and is released on the backdrop should not dismiss the dialog, since Radix
+	// dismisses on pointer-down and the press began inside the content.
+	const el = document.querySelector('.tlui-dialog__positioner')!
+	fireEvent.pointerUp(el, { pointerType: 'mouse' })
+	fireEvent.click(el)
+
+	expect(screen.queryByTestId('dialog-inner')).not.toBeNull()
+})
+
+it('dismisses a dialog on escape', async () => {
+	await renderWithDialog()
+
+	fireEvent.click(screen.getByTestId('open-dialog'))
+	await screen.findByTestId('dialog-inner')
+
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('dialog-inner')).toBeNull()
+})
+
+it('escape dismisses one stacked layer at a time: the select first, then the dialog', async () => {
+	await renderWithDialog()
+
+	fireEvent.click(screen.getByTestId('open-dialog'))
+	await screen.findByTestId('dialog-inner')
+
+	fireEvent.pointerDown(screen.getByTestId('select-trigger'), { button: 0, pointerType: 'mouse' })
+	await screen.findByTestId('select-content')
+
+	// The first escape closes only the select (the topmost layer); the dialog stays.
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('select-content')).toBeNull()
+	expect(screen.queryByTestId('dialog-inner')).not.toBeNull()
+
+	// The second escape then closes the dialog.
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('dialog-inner')).toBeNull()
+})
+
+it('keeps a preventBackgroundClose dialog open on a backdrop press but still closes on escape', async () => {
+	await renderWithDialog({ preventBackgroundClose: true })
+
+	fireEvent.click(screen.getByTestId('open-dialog'))
+	await screen.findByTestId('dialog-inner')
+
+	// A backdrop press is ignored...
+	pressBackdrop()
+	expect(screen.queryByTestId('dialog-inner')).not.toBeNull()
+
+	// ...but escape still dismisses the dialog.
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('dialog-inner')).toBeNull()
+})
+
+it('backdrop presses dismiss stacked dialogs one layer at a time', async () => {
+	await renderWithParentDialog()
+
+	fireEvent.click(screen.getByTestId('open-parent'))
+	await screen.findByTestId('parent-dialog')
+
+	fireEvent.click(screen.getByTestId('open-nested'))
+	await screen.findByTestId('nested-dialog')
+
+	// Opening the nested dialog (which stacks on top and grabs focus) must not dismiss
+	// the parent — the dialogs stack rather than collapsing together.
+	expect(screen.queryByTestId('parent-dialog')).not.toBeNull()
+
+	// A backdrop press closes only the topmost (nested) dialog; the parent stays open.
+	pressTopBackdrop()
+	expect(screen.queryByTestId('nested-dialog')).toBeNull()
+	expect(screen.queryByTestId('parent-dialog')).not.toBeNull()
+
+	// A second backdrop press then closes the parent.
+	pressTopBackdrop()
+	expect(screen.queryByTestId('parent-dialog')).toBeNull()
+})
+
+it('escape dismisses a nested dialog before its parent', async () => {
+	await renderWithParentDialog()
+
+	fireEvent.click(screen.getByTestId('open-parent'))
+	await screen.findByTestId('parent-dialog')
+
+	fireEvent.click(screen.getByTestId('open-nested'))
+	await screen.findByTestId('nested-dialog')
+
+	// The first escape closes only the nested dialog; the parent stays.
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('nested-dialog')).toBeNull()
+	expect(screen.queryByTestId('parent-dialog')).not.toBeNull()
+
+	// The second escape then closes the parent.
+	fireEvent.keyDown(document.body, { key: 'Escape' })
+	expect(screen.queryByTestId('parent-dialog')).toBeNull()
+})


### PR DESCRIPTION
Two nested-dismissable-layer bugs (#9264, #9134) where a popup opened inside another dismissable container dismissed the container too on the first outside click — both from hand-rolled dismiss logic that bypassed Radix's layer-aware "light dismiss". Fixing them turned into a broader cleanup of dotcom's selects and menus so they lean on Radix (layer-aware dismiss + portals) instead of carrying hand-rolled workarounds.

### SDK dialogs (#9264)

The dialog dismissed via an `onClick` on the overlay that closed on any backdrop click, ignoring Radix's layer stack — so a select opened inside a modal closed the whole modal on the first outside click. That handler dates to #2497 (Jan 2024), where Radix's native dismiss wasn't firing for reasons never found and flagged "revisit later"; on `radix-ui` 1.4.2 it works, so it's gone. The content now sits beside the overlay (Radix's standard sibling structure) with a positioner preserving the centring/scroll/padding, and dismissal is layer-aware (an open select/popover consumes the first outside press; a second closes the dialog). Escape still closes; drag-out (press inside, release outside) no longer dismisses, since Radix is pointer-down based. Stacked dialogs stay modal so a backdrop press / Escape closes one layer at a time. `preventBackgroundClose` is kept only on the legacy read-only modal.

### dotcom selects & menus (#9134 + cleanup)

- **`TlaMenuSelect`**: removed the capture-phase `document.body` pointerdown listener (the cause of #9134 — it closed the select synchronously and de-registered its Radix layer before the popover's own dismiss handler ran, taking the popover down too) and the `stopPropagation` guard. Made the open state **uncontrolled** (it was only controlled to feed that listener). Now **always portals** with Radix popper positioning, dropping the inline-vs-portal `usePortal` split and the hand-rolled CSS positioning override.
- **Share menu**: removed the `<div onPointerDown={preventDefault}>` wrapper — vestigial since the menu moved from a Radix DropdownMenu (#5459's context) to a Popover.
- **Sidebar**: portaled the file context menu, the workspace switcher, and the user-settings menu into the editor container via `useContainer()`, consistent with the SDK's own dialogs/menus.

### Sidebar menu dismissal + positioning

- The workspace switcher and the sidebar "…" / user-settings menus stay **non-modal** (Radix's default), so they cross-dismiss natively — opening one closes the other. The switcher → file-menu **flash** (opening a second menu used to dismiss it, because the modal switcher restored focus to its trigger and that focus shift tore down the just-opened non-modal menu) is fixed with a guarded `onCloseAutoFocus`: it skips restoring focus to the trigger *only when another menu is already opening*, while a plain Escape / outside-click close still restores focus for keyboard users.
- **Note vs #9330:** after coordinating with Steve, this PR deliberately keeps the **non-modal** switcher rather than #9330's `modal` + click-swallow overlay. When this lands after #9330 it replaces that overlay with the non-modal + `onCloseAutoFocus` approach. (No-click-through is intentionally not pursued here — for these controlled menus it needs the overlay or an uncontrolled refactor, both out of scope.)
- Menu offsets are centralised in a shared `TLA_MENU_POSITION` constant (`sideOffset` / `alignOffset` / `collisionPadding`), spread onto the select and share popover. The sidebar dropdowns override `alignOffset` so they hang ~8px over the sidebar's right edge.
- Dropdown **width**: the portaled select and switcher menus are sized off the popper wrapper's `--radix-popper-anchor-width` with `!important` (Radix sets an inline `min-width: max-content` on the wrapper, so the size must be forced there), because `--tla-sidebar-width` is declared on the sidebar layout and doesn't reach the portaled menu.
- `tlmenus.clearOpenMenus()` is called when the mobile sidebar closes, so portaled menus don't linger behind the CSS-hidden sidebar.

### Test plan

Covered by automated tests:

- `packages/tldraw/src/test/ui/Dialogs.test.tsx` (jsdom) and `apps/examples/e2e/tests/test-dialogs.spec.ts` (browser) — dialog dismiss + stacked-escape one layer at a time
- `apps/dotcom/client/e2e/tests/smoke/sharing.spec.ts` — share menu select dismiss
- `apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts` — switcher (incl. the focus-steal regression and clicking a file with it open) and the file context menu (move / delete / rename)

Also reproduced and verified by hand against a local dotcom + the toasts/dialogs example.

- [x] Unit tests
- [x] End to end tests

### API changes

- Added optional `collisionPadding?: number` to `TldrawUiPopoverContent` (`TLUiPopoverContentProps`) — forwarded to the Radix popover content; defaults to Radix's `0`.
- Added optional `collisionPadding?: number` to `TldrawUiDropdownMenuContent` (`TLUiDropdownMenuContentProps`) — defaults to `4` (the value it previously hardcoded), so no change for existing consumers.

### Change type

- [x] `bugfix`

### Release notes

- Fix modal dialogs being dismissed when you closed a select or popover opened inside them; the inner popup now closes on its own first.

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +43 / -40   |
| Tests           | +444 / -71  |
| Automated files | +5 / -2     |
| Documentation   | +139 / -5   |
| Apps            | +195 / -234 |

### Follow-ups (not in this PR)

- Converge the select and dropdown/menu **styling** onto a single shared base (the switcher already builds on `tlui-menu`; `TlaMenuSelect` carries its own duplicate panel/row CSS). Keep them as separate primitives (Select vs DropdownMenu), share the look.
- Consider whether dotcom's `TlaMenuSelect` needs to exist at all, or can lean on the SDK's existing `TldrawUiSelect` (same portaled-select-into-container pattern).
