### PR TITLE
fix(dotcom): keep the home workspace file list correct

### DIFF
--- a/apps/dotcom/client/e2e/tests/sharing-live.scenario.spec.ts
+++ b/apps/dotcom/client/e2e/tests/sharing-live.scenario.spec.ts
@@ -84,6 +84,39 @@ test.describe('live sharing scenarios', () => {
 		await expect(member.page.getByTestId('tools.draw')).not.toBeVisible({ timeout: 10000 })
 	})
 
+	test('opening a guest file does not trap the member outside their home after they join its workspace', async ({
+		owner,
+		member,
+		scenario,
+	}) => {
+		// owner makes a workspace with a (shared) file owned by that workspace, plus an invite.
+		const { workspaceName, fileName, inviteUrl } = await scenario.createPendingWorkspaceInvite({
+			owner,
+			member,
+		})
+		const fileUrl = owner.page.url() // owner is left viewing the workspace file, which is shared
+
+		// member opens that file via its link while NOT a member of the workspace: it gets mirrored
+		// into their home as a guest file (visible in their sidebar).
+		await member.goto(fileUrl)
+		await member.editor.ensureSidebarOpen()
+		await member.sidebar.expectFileVisible(fileName)
+
+		// member then accepts the invite and joins the workspace.
+		await member.goto(inviteUrl)
+		await member.editor.ensureSidebarOpen()
+		await member.workspaceInviteDialog.acceptInvitation()
+		await member.waitForMutationResolution()
+		await member.sidebar.expectWorkspaceVisible(workspaceName)
+
+		// Now switching to the home workspace must stay there. The file is owned by a workspace the
+		// member belongs to, so it must not be listed in home: before the fix it was, and opening it
+		// re-activated the workspace, so the member could never get back to their home.
+		await member.sidebar.switchToHomeWorkspace()
+		await member.sidebar.expectActiveHomeWorkspace()
+		await member.sidebar.expectFileNotVisible(fileName)
+	})
+
 	test('unshare removes visitor access while the file is open', async ({
 		owner,
 		visitor,

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -434,8 +434,25 @@ export class TldrawApp {
 		const membership = this.getWorkspaceMembership(workspaceId)
 		if (!membership) return []
 
-		const pinned = membership.groupFiles.filter((f) => f.index !== null)
-		const unpinned = membership.groupFiles.filter((f) => f.index === null)
+		// Decide which of the membership's group_file rows actually belong in this list.
+		// A file owned by this workspace always belongs. A non-home workspace lists only the
+		// files it owns. The home workspace additionally lists legacy files (no owning group)
+		// and "guest files" — shared files the user opened that are owned by a workspace they
+		// are NOT a member of. It must NOT list a file owned by a workspace the user IS a
+		// member of: that's a mislinked row (a guest file whose workspace was later joined, or
+		// a workspace's welcome file mirrored during the create-workspace race), and opening it
+		// from home would bounce the user into that workspace. Guarding here keeps such rows out
+		// of the list even before they're cleaned up.
+		const homeWorkspaceId = this.getHomeWorkspaceId()
+		const groupFiles = membership.groupFiles.filter((f) => {
+			const owningGroupId = f.file.owningGroupId
+			if (owningGroupId === workspaceId) return true
+			if (workspaceId !== homeWorkspaceId) return false
+			return owningGroupId == null || !this.getWorkspaceMembership(owningGroupId)
+		})
+
+		const pinned = groupFiles.filter((f) => f.index !== null)
+		const unpinned = groupFiles.filter((f) => f.index === null)
 
 		const lastOrdering = this.lastWorkspaceFileOrderings.get(workspaceId)
 		const retainedOrdering =

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -629,8 +629,9 @@ export class TldrawApp {
 		if (this.isWorkspacesMigrated()) {
 			// Count only files the workspace actually owns — not guest files (shared files the
 			// user opened) or mislinked rows that getWorkspaceFilesSorted hides. Counting those
-			// would let the limit fire on files the user can neither see nor remove, and would
-			// disagree with the server's own limit check (assertNotMaxFiles counts owningGroupId).
+			// would let the limit fire on files the user can neither see nor remove. For migrated
+			// users createFile runs no server-side file-limit check, so this is the only gate;
+			// scoping it to owned files keeps it to what the user can actually manage.
 			const membership = this.getWorkspaceMembership(workspaceId)
 			if (!membership) return true
 			const nonDeletedCount = membership.groupFiles.filter(

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -627,10 +627,15 @@ export class TldrawApp {
 
 	private canCreateNewFile(workspaceId: string) {
 		if (this.isWorkspacesMigrated()) {
-			// For migrated users, count non-deleted files in the home workspace
+			// Count only files the workspace actually owns — not guest files (shared files the
+			// user opened) or mislinked rows that getWorkspaceFilesSorted hides. Counting those
+			// would let the limit fire on files the user can neither see nor remove, and would
+			// disagree with the server's own limit check (assertNotMaxFiles counts owningGroupId).
 			const membership = this.getWorkspaceMembership(workspaceId)
 			if (!membership) return true
-			const nonDeletedCount = membership.groupFiles.filter((gf) => !gf.file.isDeleted).length
+			const nonDeletedCount = membership.groupFiles.filter(
+				(gf) => !gf.file.isDeleted && gf.file.owningGroupId === workspaceId
+			).length
 			return nonDeletedCount < this.config.maxNumberOfFiles
 		} else {
 			// For unmigrated users, count non-deleted files owned by the user

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -504,6 +504,32 @@ describe('file creation', () => {
 			})
 		)
 	})
+
+	it('migrated user can create file in their home workspace without a group_user row', async () => {
+		// The home workspace (id === userId) is implicitly owned, so it may have no
+		// group_user row. createFile must still allow it — otherwise an empty home is
+		// un-switchable, since selecting it creates-then-opens a file. Regression test:
+		// authorize via getRole (home => owner), not a raw group_user lookup.
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [],
+			file_state: [],
+			group: [makeGroup({ id: userId })],
+			group_user: [], // no explicit home membership row
+			group_file: [],
+		}
+		const { tx } = createMockTx(s)
+		const m = createMutators(userId)
+		await expectValid(() =>
+			m.createFile(tx, {
+				fileId: 'file_aaaa11112222bbbb',
+				workspaceId: userId, // home workspace
+				name: 'New File',
+				time: Date.now(),
+				createSource: null,
+			})
+		)
+	})
 })
 
 describe('file_state mutations', () => {
@@ -613,6 +639,58 @@ describe('onEnterFile', () => {
 		await m.onEnterFile(tx, { fileId, time: Date.now() })
 		// Should NOT create a new group_file since it's already in user's group
 		expect(s.group_file.length).toBe(1)
+	})
+
+	it("mirrors another group's shared file into home as a guest file", async () => {
+		// Opening a shared file owned by a group the user is NOT a member of links it into
+		// their home group, which is what surfaces it as a "guest file" in the sidebar.
+		const otherGroup = 'group_other123456789'
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [makeFile({ id: fileId, owningGroupId: otherGroup, shared: true })],
+			file_state: [],
+			group: [makeGroup({ id: userId }), makeGroup({ id: otherGroup })],
+			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })], // home only
+			group_file: [makeGroupFile({ fileId, groupId: otherGroup })],
+		}
+		const { tx } = createMockTx(s, { location: 'server' })
+		const m = createMutators(userId)
+		await m.onEnterFile(tx, { fileId, time: Date.now() })
+		expect((s.group_file as TlaGroupFile[]).some((gf) => gf.groupId === userId)).toBe(true)
+	})
+
+	it('does not mirror a file the user already has via a group they belong to', async () => {
+		const workspaceId = 'group_workspace1234ab'
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [makeFile({ id: fileId, owningGroupId: workspaceId, shared: true })],
+			file_state: [],
+			group: [makeGroup({ id: userId }), makeGroup({ id: workspaceId })],
+			group_user: [
+				makeGroupUser({ userId, groupId: userId, role: 'owner' }),
+				makeGroupUser({ userId, groupId: workspaceId, role: 'member' }),
+			],
+			group_file: [makeGroupFile({ fileId, groupId: workspaceId })],
+		}
+		const { tx } = createMockTx(s, { location: 'server' })
+		const m = createMutators(userId)
+		await m.onEnterFile(tx, { fileId, time: Date.now() })
+		expect((s.group_file as TlaGroupFile[]).some((gf) => gf.groupId === userId)).toBe(false)
+	})
+
+	it('mirrors a group-less (legacy) file into home so it stays findable', async () => {
+		const s = {
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			file: [makeFile({ id: fileId, owningGroupId: null, ownerId: userId, shared: true })],
+			file_state: [],
+			group: [makeGroup({ id: userId })],
+			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
+			group_file: [],
+		}
+		const { tx } = createMockTx(s, { location: 'server' })
+		const m = createMutators(userId)
+		await m.onEnterFile(tx, { fileId, time: Date.now() })
+		expect((s.group_file as TlaGroupFile[]).some((gf) => gf.groupId === userId)).toBe(true)
 	})
 })
 

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -391,10 +391,14 @@ export function createMutators(userId: string) {
 			assertValidId(fileId)
 			assertValidId(workspaceId)
 			assert(name.trim(), ZErrorCode.bad_request)
-			const hasWorkspaceAccess = await tx.run(
-				zql.group_user.where('userId', '=', userId).where('groupId', '=', workspaceId).one()
-			)
-			assert(hasWorkspaceAccess, ZErrorCode.forbidden)
+			// Authorize via getRole, not a raw group_user lookup: the home workspace
+			// (id === userId) is implicitly owned and may have no group_user row, yet
+			// the user must still be able to create files in it. A raw row check would
+			// reject that case, leaving an empty home un-switchable (selecting it from
+			// the switcher creates-then-opens a file, which silently fails). Every other
+			// workspace op already authorizes through getRole/can for the same reason.
+			const role = await getRole(tx, userId, workspaceId)
+			assert(can(role, 'addFiles'), ZErrorCode.forbidden)
 
 			// create file row, group_file row, file_state row
 			await tx.mutate.file.insert({
@@ -534,7 +538,11 @@ export function createMutators(userId: string) {
 			if (migrated) {
 				const workspaceFileRows = await tx.run(zql.group_file.where('fileId', '=', fileId))
 				const userWorkspaceMemberships = await tx.run(zql.group_user.where('userId', '=', userId))
-				// Only add to home group if not already in any of the user's groups
+				// Add a visited file to the user's home group unless it already belongs to one of
+				// their groups. This is what surfaces a shared file the user opened as a "guest
+				// file" in their sidebar. (Files owned by a workspace the user is a member of are
+				// not mirrored here — and the sidebar read path also filters out any that slip
+				// through, see getWorkspaceFilesSorted — so a workspace file never shows in home.)
 				if (
 					!userWorkspaceMemberships.some((g: TlaGroupUser) =>
 						workspaceFileRows.some((gf: TlaGroupFile) => gf.groupId === g.groupId)


### PR DESCRIPTION
## What

Fixes a cluster of "My files" bugs in the workspaces model that all trace to one root cause.

A shared file you open as a guest is mirrored into your home group — this is the intended **guest file** feature (the file shows in "My files" with a guest badge so you can find it again). But if that file is owned by a workspace you're a **member of**, it would show in "My files" yet open into that workspace — because the active workspace is derived from the file's `owningGroupId`. So clicking it (or switching to "My files", which opens the top file) bounced you into the workspace, and you could never get back to your home.

This happens when:

- you open a workspace's shared file as a guest, then later **join** that workspace, or
- a workspace's **welcome file** is mirrored into home during the create-workspace race.

It explains the reported symptoms: shared files and a "Welcome to your workspace" file showing in "My files", and clicking them teleporting the user into another workspace with no way back.

## Preview

https://pr-9270-preview-deploy.tldraw.com/

## Fixes

1. **Teleport / "can't get back to My files" — read-side filter (`getWorkspaceFilesSorted`).** For the home workspace, the sidebar now lists only files it owns, legacy files, and genuine guest files (owned by workspaces you're **not** a member of). A file owned by a workspace you **are** a member of is no longer listed in home, so it can't bounce you out. Guest-file mirroring (`onEnterFile`) is unchanged — guest files still appear as before. Filtering on read also fixes already-affected users on deploy, before any data cleanup.

2. **File-count limit consistency (`canCreateNewFile`).** It now counts only files the workspace actually owns (`owningGroupId === workspaceId`), not guest files or hidden/mislinked rows — matching the server's `assertNotMaxFiles`. Prevents "max files reached" firing on files the user can't see or remove.

3. **Empty home stays switchable (`createFile`).** Authorizes the home workspace via `getRole`/`can('addFiles')` instead of a raw `group_user` lookup. The home workspace (`id === userId`) is implicitly owned and may have no `group_user` row (e.g. before it syncs), so creating a file there could be rejected — leaving an empty home impossible to switch back to. This matches how every other workspace op already authorizes.

## How to verify

On the preview (https://pr-9270-preview-deploy.tldraw.com/), with two accounts:

1. **Account A:** create a workspace, add a file inside it, then copy that **file's share link** and the **workspace invite link**.
2. **Account B (incognito):** open the **file share link** → the file appears in "My files" with a guest badge.
3. **Account B:** open the **workspace invite link** and accept it (you're now a member of the workspace).
4. **Account B:** click **"My files"** → you stay in "My files".

Before the fix, step 4 bounced you into the workspace (you couldn't get back to "My files").

## Testing

- New scenario test — `opening a guest file does not trap the member outside their home after they join its workspace` (`sharing-live.scenario.spec.ts`). It fails on the unfixed code (the member is teleported into the workspace) and passes here.
- Unit tests in `mutators.test.ts` cover `createFile` home authorization and `onEnterFile` guest / member / legacy mirroring.
- `yarn typecheck`, lint, and the full dotcom e2e suite pass.
