### PR TITLE
chore(dotcom): allow parallel dev stacks per worktree

### DIFF
--- a/apps/dotcom/asset-upload-worker/package.json
+++ b/apps/dotcom/asset-upload-worker/package.json
@@ -9,7 +9,7 @@
 	},
 	"main": "src/index.ts",
 	"scripts": {
-		"dev": "yarn run -T tsx ../../../internal/scripts/workers/dev.ts --persist-to tmp-assets --inspector-port 9449",
+		"dev": "yarn run -T tsx ../zero-cache/run-dotcom-worker.ts assetUploadWorker --persist-to tmp-assets",
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test": "yarn run -T vitest --passWithNoTests",
 		"test-coverage": "yarn run -T vitest run --coverage --passWithNoTests",

--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -3,13 +3,16 @@ import { Page } from '@playwright/test'
 import { DB, userHasFlag } from '@tldraw/dotcom-shared'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import pg from 'pg'
+import { getDotcomDevPorts } from '../../../zero-cache/dev-env'
 import { OTHER_USERS, USERS } from '../consts'
 import { getStorageStateFileName } from './helpers'
 
+// e2e pins the dev stack to instance 0 (see playwright.config.ts), so its pgbouncer is on instance
+// 0's port.
 const db = new Kysely<DB>({
 	dialect: new PostgresDialect({
 		pool: new pg.Pool({
-			connectionString: 'postgresql://user:password@127.0.0.1:6432/postgres',
+			connectionString: `postgresql://user:password@127.0.0.1:${getDotcomDevPorts(0).pgbouncer}/postgres`,
 			application_name: 'migrate',
 			idleTimeoutMillis: 10_000,
 			max: 10,

--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -3,16 +3,17 @@ import { Page } from '@playwright/test'
 import { DB, userHasFlag } from '@tldraw/dotcom-shared'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import pg from 'pg'
-import { getDotcomDevPorts } from '../../../zero-cache/dev-env'
 import { OTHER_USERS, USERS } from '../consts'
 import { getStorageStateFileName } from './helpers'
 
-// e2e pins the dev stack to instance 0 (see playwright.config.ts), so its pgbouncer is on instance
-// 0's port.
+// e2e pins the dev stack to instance 0 (see playwright.config.ts), so pgbouncer is on instance 0's
+// port: DOTCOM_DEV_PORT_BASE (3000) + pgbouncer slot (6) = 3006. Keep in sync with
+// zero-cache/dev-env.ts (not imported here: that module uses import.meta and breaks Playwright's
+// CommonJS test transpile).
 const db = new Kysely<DB>({
 	dialect: new PostgresDialect({
 		pool: new pg.Pool({
-			connectionString: `postgresql://user:password@127.0.0.1:${getDotcomDevPorts(0).pgbouncer}/postgres`,
+			connectionString: 'postgresql://user:password@127.0.0.1:3006/postgres',
 			application_name: 'migrate',
 			idleTimeoutMillis: 10_000,
 			max: 10,

--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -116,7 +116,11 @@ export default defineConfig({
 
 	/* Run your local dev server before starting the tests */
 	webServer: {
-		command: process.env.CI ? 'VITE_PREVIEW=1 yarn dev-app' : 'yarn preview-app',
+		// Pin to dev instance 0 so the client is deterministically on localhost:3000, regardless of
+		// which instance this worktree would otherwise be allocated.
+		command: process.env.CI
+			? 'DOTCOM_DEV_INSTANCE=0 VITE_PREVIEW=1 yarn dev-app'
+			: 'DOTCOM_DEV_INSTANCE=0 yarn preview-app',
 		url: 'http://localhost:3000',
 		reuseExistingServer: !process.env.CI,
 		cwd: path.join(__dirname, '../../../'),

--- a/apps/dotcom/client/scripts/dev-app.ts
+++ b/apps/dotcom/client/scripts/dev-app.ts
@@ -1,8 +1,10 @@
 import { spawn } from 'child_process'
 import { createServer } from 'net'
 import { pathToFileURL } from 'url'
+import { getDotcomDevEnv } from '../../zero-cache/dev-env'
 
-const CLIENT_PORT = 3000
+// `yarn dev-app` exports DOTCOM_DEV_INSTANCE so each worktree's stack uses its own port block.
+const CLIENT_PORT = getDotcomDevEnv().ports.client
 const SKIPPABLE_PROBE_ERROR_CODES = new Set(['EADDRNOTAVAIL', 'EAFNOSUPPORT'])
 
 type PortProbe = (port: number, host: string) => Promise<void>

--- a/apps/dotcom/client/src/utils/csp.ts
+++ b/apps/dotcom/client/src/utils/csp.ts
@@ -76,9 +76,12 @@ export const csp = Object.keys(cspDirectives)
 export const cspDev = Object.keys(cspDirectives)
 	.filter((key) => key !== 'report-uri')
 	.map((directive) => {
-		const values = cspDirectives[directive]
+		const values = [...cspDirectives[directive]]
 		// We allow data: urls for frame-src to allow debugging SVG embeds in dev.
-		if (directive === 'frame-src') return `${directive} ${[...values, 'data:'].join(' ')}`
+		if (directive === 'frame-src') values.push('data:')
+		// Allow any localhost port so per-worktree dev stacks (which offset the worker ports) can
+		// reach their own zero/asset/usercontent workers without hardcoding each instance's ports.
+		if (directive === 'connect-src') values.push('http://localhost:*', 'http://127.0.0.1:*')
 		return `${directive} ${values.join(' ')}`
 	})
 	.join('; ')

--- a/apps/dotcom/client/vite.config.ts
+++ b/apps/dotcom/client/vite.config.ts
@@ -4,6 +4,7 @@ import formatjs from '@formatjs/unplugin/vite'
 import react from '@vitejs/plugin-react'
 import { config } from 'dotenv'
 import { defineConfig, Plugin } from 'vite'
+import { getDotcomDevPorts } from '../zero-cache/dev-env'
 import { getMultiplayerServerURL } from './scripts/multiplayer-server-url'
 import { zodLocalePlugin } from './scripts/vite-zod-locale-plugin.js'
 
@@ -12,6 +13,9 @@ export { getMultiplayerServerURL }
 config({
 	path: './.env.local',
 })
+
+// `yarn dev-app` exports DOTCOM_DEV_INSTANCE so each worktree's stack talks to its own workers.
+const devPorts = getDotcomDevPorts(Number(process.env.DOTCOM_DEV_INSTANCE) || 0)
 
 /**
  * Plugin to enable SPA fallback for vite preview.
@@ -88,12 +92,16 @@ export default defineConfig((env) => ({
 				.filter(([key]) => key.startsWith('NEXT_PUBLIC_'))
 				.map(([key, value]) => [`process.env.${key}`, JSON.stringify(value)])
 		),
-		'process.env.MULTIPLAYER_SERVER': urlOrLocalFallback(env.mode, getMultiplayerServerURL(), 8787),
-		'process.env.ZERO_SERVER': urlOrLocalFallback(env.mode, process.env.ZERO_SERVER, 4848),
+		'process.env.MULTIPLAYER_SERVER': urlOrLocalFallback(
+			env.mode,
+			getMultiplayerServerURL(),
+			devPorts.syncWorker
+		),
+		'process.env.ZERO_SERVER': urlOrLocalFallback(env.mode, process.env.ZERO_SERVER, devPorts.zero),
 		'process.env.USER_CONTENT_URL': urlOrLocalFallback(
 			env.mode,
 			process.env.USER_CONTENT_URL,
-			8789
+			devPorts.userContentWorker
 		),
 		'process.env.TLDRAW_ENV': JSON.stringify(process.env.TLDRAW_ENV ?? 'development'),
 		'process.env.TLDRAW_LICENSE': JSON.stringify(process.env.TLDRAW_LICENSE ?? ''),
@@ -107,7 +115,7 @@ export default defineConfig((env) => ({
 	server: {
 		proxy: {
 			'/api': {
-				target: getMultiplayerServerURL() || 'http://127.0.0.1:8787',
+				target: getMultiplayerServerURL() || `http://127.0.0.1:${devPorts.syncWorker}`,
 				rewrite: (path) => path.replace(/^\/api/, ''),
 				ws: false, // we talk to the websocket directly via workers.dev
 				// Useful for debugging proxy issues
@@ -135,7 +143,7 @@ export default defineConfig((env) => ({
 	preview: {
 		proxy: {
 			'/api': {
-				target: getMultiplayerServerURL() || 'http://127.0.0.1:8787',
+				target: getMultiplayerServerURL() || `http://127.0.0.1:${devPorts.syncWorker}`,
 				rewrite: (path) => path.replace(/^\/api/, ''),
 			},
 		},

--- a/apps/dotcom/dev-app.ts
+++ b/apps/dotcom/dev-app.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+import { spawn } from 'child_process'
+import { mkdirSync } from 'fs'
+import { buildDotcomDevEnv } from './zero-cache/dev-env'
+import { resolveDotcomDevInstance } from './zero-cache/dev-instance'
+
+// Resolve this worktree's dev instance once, then run the dotcom dev stack under lazyrepo with the
+// instance exported. Every dev task (client, workers, zero-cache) derives its ports and per-instance
+// Docker/Zero/Wrangler state from the instance, so one stack can run per worktree side by side.
+// `DOTCOM_DEV_INSTANCE` (set by the user) overrides the automatic assignment.
+const instance = resolveDotcomDevInstance({ allocate: true })
+const env = buildDotcomDevEnv({ instance })
+
+// Wrangler shares a global service-binding registry by default; point it at a per-instance dir so a
+// second stack's workers don't re-register the shared worker names and cross-wire the instances.
+mkdirSync(env.wranglerRegistryDir, { recursive: true })
+
+console.log(`Starting dotcom dev stack (instance ${instance}, ports ${env.portBlockStart}+):`)
+console.log(`  client       http://localhost:${env.ports.client}`)
+console.log(`  sync worker  http://localhost:${env.ports.syncWorker}`)
+console.log(`  zero         http://localhost:${env.ports.zero}`)
+console.log(`  postgres     127.0.0.1:${env.ports.postgres}`)
+console.log('')
+
+const child = spawn(
+	'yarn',
+	['lazy', 'run', 'dev', '--filter=apps/dotcom/*', '--filter=packages/tldraw'],
+	{
+		stdio: 'inherit',
+		env: {
+			...process.env,
+			LAZYREPO_PRETTY_OUTPUT: '0',
+			DOTCOM_DEV_INSTANCE: String(instance),
+			WRANGLER_REGISTRY_PATH: env.wranglerRegistryDir,
+		},
+	}
+)
+
+let shuttingDown = false
+const stop = (signal: NodeJS.Signals) => {
+	if (shuttingDown) return
+	shuttingDown = true
+	if (!child.killed) child.kill(signal)
+}
+process.on('SIGINT', () => stop('SIGINT'))
+process.on('SIGTERM', () => stop('SIGTERM'))
+process.on('SIGHUP', () => stop('SIGHUP'))
+process.on('exit', () => {
+	if (!child.killed) child.kill('SIGKILL')
+})
+
+child.once('error', (error) => {
+	console.error(error)
+	process.exit(1)
+})
+child.once('exit', (code, signal) => {
+	process.exit(signal ? 1 : (code ?? 0))
+})

--- a/apps/dotcom/image-resize-worker/package.json
+++ b/apps/dotcom/image-resize-worker/package.json
@@ -9,7 +9,7 @@
 	},
 	"main": "src/index.ts",
 	"scripts": {
-		"dev": "yarn run -T tsx ../../../internal/scripts/workers/dev.ts --inspector-port 9339",
+		"dev": "yarn run -T tsx ../zero-cache/run-dotcom-worker.ts imageResizeWorker",
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test": "yarn run -T vitest --passWithNoTests",
 		"test-coverage": "yarn run -T vitest run --coverage --passWithNoTests",

--- a/apps/dotcom/sync-worker/dev.ts
+++ b/apps/dotcom/sync-worker/dev.ts
@@ -6,6 +6,12 @@ const env = getDotcomDevEnv()
 
 console.log(`Wrangler state: ${env.wranglerPersistDir}`)
 
+const upstreamDb = `postgresql://user:password@127.0.0.1:${env.ports.postgres}/postgres`
+const pooledDb = `postgresql://user:password@127.0.0.1:${env.ports.pgbouncer}/postgres`
+
+// Pass this instance's serving and inspector ports explicitly, plus override the URLs and
+// connection strings that wrangler.toml's [env.dev] block points at fixed ports so they follow this
+// instance's block too.
 const child = spawn(
 	'yarn',
 	[
@@ -13,12 +19,22 @@ const child = spawn(
 		'-T',
 		'tsx',
 		'../../../internal/scripts/workers/dev.ts',
+		'--port',
+		String(env.ports.syncWorker),
+		'--inspector-port',
+		String(env.ports.syncWorkerInspector),
 		'--persist-to',
 		env.wranglerPersistDir,
 		'--var',
-		'ASSET_UPLOAD_ORIGIN:http://localhost:8788',
+		`ASSET_UPLOAD_ORIGIN:http://localhost:${env.ports.assetUploadWorker}`,
 		'--var',
-		'USER_CONTENT_URL:http://localhost:8789',
+		`USER_CONTENT_URL:http://localhost:${env.ports.userContentWorker}`,
+		'--var',
+		`MULTIPLAYER_SERVER:http://localhost:${env.ports.client}`,
+		'--var',
+		`BOTCOM_POSTGRES_CONNECTION_STRING:${upstreamDb}`,
+		'--var',
+		`BOTCOM_POSTGRES_POOLED_CONNECTION_STRING:${pooledDb}`,
 	],
 	{
 		cwd: env.syncWorkerDir,

--- a/apps/dotcom/tldrawusercontent-worker/package.json
+++ b/apps/dotcom/tldrawusercontent-worker/package.json
@@ -9,7 +9,7 @@
 	},
 	"main": "src/index.ts",
 	"scripts": {
-		"dev": "yarn run -T tsx ../../../internal/scripts/workers/dev.ts --inspector-port 9450",
+		"dev": "yarn run -T tsx ../zero-cache/run-dotcom-worker.ts userContentWorker",
 		"test": "yarn run -T vitest --passWithNoTests",
 		"test-ci": "yarn run -T vitest run --passWithNoTests",
 		"test-coverage": "yarn run -T vitest run --coverage --passWithNoTests",

--- a/apps/dotcom/zero-cache/.env
+++ b/apps/dotcom/zero-cache/.env
@@ -1,11 +1,13 @@
-VITE_PUBLIC_SERVER="http://localhost:4848"
-ZERO_UPSTREAM_DB="postgresql://user:password@127.0.0.1:6543/postgres"
-ZERO_CVR_DB="postgresql://user:password@127.0.0.1:6543/postgres"
-ZERO_CHANGE_DB="postgresql://user:password@127.0.0.1:6543/postgres"
-ZERO_REPLICA_FILE="/tmp/zstart_replica.db"
+# Port-bearing values are overridden per dev instance by zero-cache/dev-env.ts; these defaults match
+# instance 0 (see DOTCOM_DEV_PORT_SLOTS) for standalone use.
+VITE_PUBLIC_SERVER="http://localhost:3002"
+ZERO_UPSTREAM_DB="postgresql://user:password@127.0.0.1:3005/postgres"
+ZERO_CVR_DB="postgresql://user:password@127.0.0.1:3005/postgres"
+ZERO_CHANGE_DB="postgresql://user:password@127.0.0.1:3005/postgres"
+ZERO_REPLICA_FILE="/tmp/tldraw-dotcom-zero-dev.db"
 ZERO_APP_PUBLICATIONS="zero_data"
-ZERO_MUTATE_URL="http://localhost:8787/app/zero/mutate"
-ZERO_QUERY_URL="http://localhost:8787/app/zero/query"
+ZERO_MUTATE_URL="http://localhost:3001/app/zero/mutate"
+ZERO_QUERY_URL="http://localhost:3001/app/zero/query"
 ZERO_ENABLE_CRUD_MUTATIONS=false
 ZERO_LOG_LEVEL="info"
 ZERO_ENABLE_STARTUP_MESSAGE=0

--- a/apps/dotcom/zero-cache/dev-clean.ts
+++ b/apps/dotcom/zero-cache/dev-clean.ts
@@ -2,9 +2,10 @@
 import { spawnSync } from 'child_process'
 import { existsSync, readdirSync, rmSync } from 'fs'
 import { join } from 'path'
-import { getDotcomDevCleanAllTargets, getDotcomDevCleanTargets, getDotcomDevEnv } from './dev-env'
+import { buildDotcomDevEnv, getDotcomDevCleanAllTargets, getDotcomDevCleanTargets } from './dev-env'
+import { resolveDotcomDevInstance } from './dev-instance'
 
-const env = getDotcomDevEnv()
+const env = buildDotcomDevEnv({ instance: resolveDotcomDevInstance({ allocate: false }) })
 const targets = getDotcomDevCleanTargets(env)
 const allTargets = getDotcomDevCleanAllTargets(env)
 
@@ -103,6 +104,7 @@ function cleanCurrent() {
 	}
 	removePath(targets.schemaFile)
 	removePath(targets.wranglerPersistDir)
+	removePath(targets.wranglerRegistryDir)
 
 	console.log('')
 	console.log('Server-side dotcom dev state is clean.')
@@ -153,8 +155,11 @@ function cleanAll() {
 			(entry.endsWith('.db') || entry.endsWith('.db-shm') || entry.endsWith('.db-wal'))
 	)
 	removePath(allTargets.schemaFile)
-	removeMatchingPaths(allTargets.wranglerStateDir, (entry) =>
-		entry.startsWith(allTargets.wranglerPersistDirPrefix)
+	removeMatchingPaths(
+		allTargets.wranglerStateDir,
+		(entry) =>
+			entry.startsWith(allTargets.wranglerPersistDirPrefix) ||
+			entry.startsWith(allTargets.wranglerRegistryDirPrefix)
 	)
 
 	console.log('')

--- a/apps/dotcom/zero-cache/dev-doctor.ts
+++ b/apps/dotcom/zero-cache/dev-doctor.ts
@@ -2,14 +2,10 @@
 import { spawnSync } from 'child_process'
 import { existsSync, statSync } from 'fs'
 import { Socket } from 'net'
-import {
-	DOTCOM_DEV_PORTS,
-	getDotcomDevCleanTargets,
-	getDotcomDevEnv,
-	type DotcomDevEnv,
-} from './dev-env'
+import { buildDotcomDevEnv, getDotcomDevCleanTargets, type DotcomDevEnv } from './dev-env'
+import { resolveDotcomDevInstance } from './dev-instance'
 
-const env = getDotcomDevEnv()
+const env = buildDotcomDevEnv({ instance: resolveDotcomDevInstance({ allocate: false }) })
 const targets = getDotcomDevCleanTargets(env)
 
 function formatStatus(ok: boolean, detail?: string) {
@@ -69,16 +65,17 @@ function checkSchemaFreshness(devEnv: DotcomDevEnv) {
 }
 
 async function main() {
-	const postgresPort = await checkPort(DOTCOM_DEV_PORTS.postgres)
-	const pgbouncerPort = await checkPort(DOTCOM_DEV_PORTS.pgbouncer)
-	const migrations = await checkHttp(`http://localhost:${DOTCOM_DEV_PORTS.migrations}`, true)
-	const zero = await checkHttp(`http://localhost:${DOTCOM_DEV_PORTS.zero}/`, true)
-	const syncWorker = await checkHttp(`http://localhost:${DOTCOM_DEV_PORTS.syncWorker}/`, false)
+	const postgresPort = await checkPort(env.ports.postgres)
+	const pgbouncerPort = await checkPort(env.ports.pgbouncer)
+	const migrations = await checkHttp(`http://localhost:${env.ports.migrations}`, true)
+	const zero = await checkHttp(`http://localhost:${env.ports.zero}/`, true)
+	const syncWorker = await checkHttp(`http://localhost:${env.ports.syncWorker}/`, false)
 	const volume = checkDockerVolume(targets.postgresVolumeName)
 	const schema = checkSchemaFreshness(env)
 
 	console.log('Dotcom dev doctor')
 	console.log('')
+	console.log(`Instance: ${env.instance} (ports ${env.portBlockStart}+)`)
 	console.log(`Compose project: ${env.composeProjectName}`)
 	console.log(
 		`Postgres volume: ${env.postgresVolumeName} - ${formatStatus(volume.ok, volume.detail)}`
@@ -92,14 +89,14 @@ async function main() {
 	console.log(`Generated schema: ${env.schemaFile} - ${formatStatus(schema.ok, schema.detail)}`)
 	console.log('')
 	console.log('Ports and services')
-	console.log(`Postgres ${DOTCOM_DEV_PORTS.postgres}: ${formatStatus(postgresPort)}`)
-	console.log(`PgBouncer ${DOTCOM_DEV_PORTS.pgbouncer}: ${formatStatus(pgbouncerPort)}`)
+	console.log(`Postgres ${env.ports.postgres}: ${formatStatus(postgresPort)}`)
+	console.log(`PgBouncer ${env.ports.pgbouncer}: ${formatStatus(pgbouncerPort)}`)
 	console.log(
-		`Migrations ${DOTCOM_DEV_PORTS.migrations}: ${formatStatus(migrations.ok, migrations.detail)}`
+		`Migrations ${env.ports.migrations}: ${formatStatus(migrations.ok, migrations.detail)}`
 	)
-	console.log(`Zero ${DOTCOM_DEV_PORTS.zero}: ${formatStatus(zero.ok, zero.detail)}`)
+	console.log(`Zero ${env.ports.zero}: ${formatStatus(zero.ok, zero.detail)}`)
 	console.log(
-		`Sync worker ${DOTCOM_DEV_PORTS.syncWorker}: ${formatStatus(syncWorker.ok, syncWorker.detail)}`
+		`Sync worker ${env.ports.syncWorker}: ${formatStatus(syncWorker.ok, syncWorker.detail)}`
 	)
 	console.log('')
 	console.log('Suggested cleanup: yarn dev-app:clean')

--- a/apps/dotcom/zero-cache/dev-env.test.ts
+++ b/apps/dotcom/zero-cache/dev-env.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import {
 	DOTCOM_DEV_APP_READY_TIMEOUT_MS,
+	DOTCOM_DEV_INSTANCE_BLOCK_SIZE,
 	DOTCOM_DEV_MIGRATIONS_READY_TIMEOUT_MS,
+	DOTCOM_DEV_PORT_BASE,
 	DOTCOM_DEV_READINESS_TIMEOUT_MS,
 	buildDotcomDevEnv,
 	getDotcomDevCleanAllTargets,
 	getDotcomDevCleanTargets,
+	getDotcomDevPorts,
 } from './dev-env'
 
 describe('dotcom dev env', () => {
@@ -18,20 +21,65 @@ describe('dotcom dev env', () => {
 		)
 	})
 
-	it('uses fixed, branch-independent Zero and Docker values', () => {
-		const env = buildDotcomDevEnv({ repoRoot: '/repo' })
+	it('keeps the client on 3000 and the historical identifiers for instance 0', () => {
+		const env = buildDotcomDevEnv({ repoRoot: '/repo', instance: 0 })
 
+		expect(env.instance).toBe(0)
+		expect(env.portBlockStart).toBe(DOTCOM_DEV_PORT_BASE)
+		expect(env.ports.client).toBe(3000)
 		expect(env.composeProjectName).toBe('tldraw_dotcom_dev')
 		expect(env.postgresVolumeName).toBe('tldraw_dotcom_dev_tlapp_pgdata')
 		expect(env.zeroEnv).toMatchObject({
+			ZERO_PORT: String(env.ports.zero),
 			ZERO_REPLICA_FILE: '/tmp/tldraw-dotcom-zero-dev.db',
 			ZERO_NUM_SYNC_WORKERS: '1',
+			ZERO_UPSTREAM_DB: `postgresql://user:password@127.0.0.1:${env.ports.postgres}/postgres`,
+		})
+		expect(env.dockerEnv).toEqual({
+			TLAPP_POSTGRES_PORT: String(env.ports.postgres),
+			TLAPP_PGBOUNCER_PORT: String(env.ports.pgbouncer),
 		})
 		expect(env.wranglerPersistDir).toBe('/repo/apps/dotcom/sync-worker/.wrangler/state-dev')
+		expect(env.wranglerRegistryDir).toBe('/repo/apps/dotcom/sync-worker/.wrangler/registry-dev')
 	})
 
-	it('selects clean targets for the single dev stack', () => {
-		const env = buildDotcomDevEnv({ repoRoot: '/repo' })
+	it('gives each instance its own contiguous 100-port block and scopes every identifier', () => {
+		const env = buildDotcomDevEnv({ repoRoot: '/repo', instance: 1 })
+
+		expect(env.portBlockStart).toBe(DOTCOM_DEV_PORT_BASE + DOTCOM_DEV_INSTANCE_BLOCK_SIZE)
+		expect(env.ports.client).toBe(3100)
+		expect(env.ports.syncWorker).toBe(3101)
+		expect(env.ports.zero).toBe(3102)
+		expect(env.ports.postgres).toBe(3105)
+		expect(env.composeProjectName).toBe('tldraw_dotcom_dev1')
+		expect(env.postgresVolumeName).toBe('tldraw_dotcom_dev1_tlapp_pgdata')
+		expect(env.zeroReplicaFile).toBe('/tmp/tldraw-dotcom-zero-dev1.db')
+		expect(env.zeroEnv.ZERO_PORT).toBe('3102')
+		expect(env.dockerEnv.TLAPP_POSTGRES_PORT).toBe('3105')
+		expect(env.wranglerPersistDir).toBe('/repo/apps/dotcom/sync-worker/.wrangler/state-dev1')
+		expect(env.wranglerRegistryDir).toBe('/repo/apps/dotcom/sync-worker/.wrangler/registry-dev1')
+	})
+
+	it('leaves zero+1 and zero+2 free for the change-streamer and litestream', () => {
+		const ports = getDotcomDevPorts(0)
+		const reserved = [ports.zero + 1, ports.zero + 2]
+		const assigned = Object.values(ports)
+		expect(assigned.some((port) => reserved.includes(port))).toBe(false)
+	})
+
+	it('never lets two instances collide on a port', () => {
+		const a = Object.values(getDotcomDevPorts(0))
+		const b = Object.values(getDotcomDevPorts(1))
+		expect(a.some((port) => b.includes(port))).toBe(false)
+	})
+
+	it('rejects out-of-range instances', () => {
+		expect(() => buildDotcomDevEnv({ instance: -1 })).toThrow()
+		expect(() => buildDotcomDevEnv({ instance: 999 })).toThrow()
+	})
+
+	it('selects clean targets for the resolved instance', () => {
+		const env = buildDotcomDevEnv({ repoRoot: '/repo', instance: 0 })
 
 		expect(getDotcomDevCleanTargets(env)).toEqual({
 			composeProjectName: 'tldraw_dotcom_dev',
@@ -43,11 +91,12 @@ describe('dotcom dev env', () => {
 			],
 			schemaFile: '/repo/apps/dotcom/zero-cache/.schema.js',
 			wranglerPersistDir: '/repo/apps/dotcom/sync-worker/.wrangler/state-dev',
+			wranglerRegistryDir: '/repo/apps/dotcom/sync-worker/.wrangler/registry-dev',
 		})
 	})
 
 	it('selects clean-all target patterns that also cover legacy per-branch state', () => {
-		const env = buildDotcomDevEnv({ repoRoot: '/repo' })
+		const env = buildDotcomDevEnv({ repoRoot: '/repo', instance: 0 })
 
 		expect(getDotcomDevCleanAllTargets(env)).toEqual({
 			composeProjectNamePrefix: 'tldraw_dotcom_',
@@ -60,6 +109,7 @@ describe('dotcom dev env', () => {
 			schemaFile: '/repo/apps/dotcom/zero-cache/.schema.js',
 			wranglerStateDir: '/repo/apps/dotcom/sync-worker/.wrangler',
 			wranglerPersistDirPrefix: 'state',
+			wranglerRegistryDirPrefix: 'registry',
 		})
 	})
 })

--- a/apps/dotcom/zero-cache/dev-env.ts
+++ b/apps/dotcom/zero-cache/dev-env.ts
@@ -3,40 +3,100 @@ import { fileURLToPath } from 'url'
 
 const thisDir = dirname(fileURLToPath(import.meta.url))
 
-export const DOTCOM_DEV_PORTS = {
-	client: 3000,
-	postgres: 6543,
-	pgbouncer: 6432,
-	migrations: 7654,
-	zero: 4848,
-	syncWorker: 8787,
+// Each dev stack (one per git worktree) gets its own contiguous block of ports so multiple stacks
+// can run side by side. A service's port is:
+//
+//   DOTCOM_DEV_PORT_BASE + instance * DOTCOM_DEV_INSTANCE_BLOCK_SIZE + slot
+//
+// So instance 0 starts at 3000, instance 1 at 3100, instance 2 at 3200, and so on. The client (the
+// URL you open) sits at slot 0, so instance 0's client stays on the familiar localhost:3000.
+export const DOTCOM_DEV_PORT_BASE = 3000
+export const DOTCOM_DEV_INSTANCE_BLOCK_SIZE = 100
+export const DOTCOM_DEV_MAX_INSTANCES = 50
+
+// Slot of each service within an instance's block. Zero also binds `zero + 1` (change-streamer) and
+// `zero + 2` (litestream) - those follow `ZERO_PORT` automatically (see zero-cache normalize.ts) -
+// so slots 3 and 4 are deliberately left free next to `zero`. There is plenty of room in the block
+// (0..99) for new services.
+export const DOTCOM_DEV_PORT_SLOTS = {
+	client: 0,
+	syncWorker: 1,
+	zero: 2,
+	postgres: 5,
+	pgbouncer: 6,
+	migrations: 7,
+	imageResizeWorker: 8,
+	assetUploadWorker: 9,
+	userContentWorker: 10,
+	syncWorkerInspector: 11,
+	imageResizeWorkerInspector: 12,
+	assetUploadWorkerInspector: 13,
+	userContentWorkerInspector: 14,
 } as const
+
+export type DotcomDevPortName = keyof typeof DOTCOM_DEV_PORT_SLOTS
+export type DotcomDevPorts = Record<DotcomDevPortName, number>
 
 export const DOTCOM_DEV_READINESS_TIMEOUT_MS = 180_000
 export const DOTCOM_DEV_MIGRATIONS_READY_TIMEOUT_MS = DOTCOM_DEV_READINESS_TIMEOUT_MS * 2 + 60_000
 export const DOTCOM_DEV_APP_READY_TIMEOUT_MS =
 	DOTCOM_DEV_MIGRATIONS_READY_TIMEOUT_MS + DOTCOM_DEV_READINESS_TIMEOUT_MS * 2
 
-// The dotcom dev stack uses a single, fixed set of identifiers rather than per-branch ones. The
-// stack binds fixed host ports, so only one copy can run at a time anyway; fixed names mean your
-// local database and state persist across branch switches, and there are no per-branch stacks left
-// to orphan and fight over those ports.
-export const DOTCOM_DEV_COMPOSE_PROJECT = 'tldraw_dotcom_dev'
-export const DOTCOM_DEV_POSTGRES_VOLUME = `${DOTCOM_DEV_COMPOSE_PROJECT}_tlapp_pgdata`
-export const DOTCOM_DEV_ZERO_REPLICA_FILE = '/tmp/tldraw-dotcom-zero-dev.db'
-export const DOTCOM_DEV_WRANGLER_STATE_DIR = 'state-dev'
-
-// Identifiers for resources left behind by older dev setups (per-branch scoping and the original
-// `docker` compose project). `yarn dev-app` reconciles these on startup and `dev-app:clean:all`
-// removes them.
+// Each dev stack scopes its Docker, Zero, and Wrangler resources by an instance label so that
+// per-worktree stacks keep their own database, replica, and state. Instance 0 keeps the historical
+// `dev` identifiers, so the default stack's data and ports are unchanged.
 export const DOTCOM_DEV_DOCKER_PROJECT_PREFIX = 'tldraw_dotcom_'
 export const DOTCOM_DEV_POSTGRES_VOLUME_SUFFIX = '_tlapp_pgdata'
 export const DOTCOM_DEV_ZERO_REPLICA_FILE_PREFIX = 'tldraw-dotcom-zero-'
 export const DOTCOM_DEV_WRANGLER_STATE_PREFIX = 'state'
+export const DOTCOM_DEV_WRANGLER_REGISTRY_PREFIX = 'registry'
+
+// Identifiers for resources left behind by older dev setups (the original `docker` compose project).
+// `yarn dev-app:clean:all` removes these alongside any current per-instance state.
 export const DOTCOM_DEV_LEGACY_DOCKER_PROJECT_NAMES = ['docker']
 export const DOTCOM_DEV_LEGACY_POSTGRES_VOLUME_NAMES = ['docker_tlapp_pgdata']
 
+/** The instance-0 identifiers, kept for reference and backwards compatibility. */
+export const DOTCOM_DEV_COMPOSE_PROJECT = `${DOTCOM_DEV_DOCKER_PROJECT_PREFIX}dev`
+export const DOTCOM_DEV_POSTGRES_VOLUME = `${DOTCOM_DEV_COMPOSE_PROJECT}${DOTCOM_DEV_POSTGRES_VOLUME_SUFFIX}`
+export const DOTCOM_DEV_ZERO_REPLICA_FILE = `/tmp/${DOTCOM_DEV_ZERO_REPLICA_FILE_PREFIX}dev.db`
+
+/** The first port in an instance's block. */
+export function getDotcomDevPortBlockStart(instance: number) {
+	return DOTCOM_DEV_PORT_BASE + instance * DOTCOM_DEV_INSTANCE_BLOCK_SIZE
+}
+
+export function getDotcomDevPorts(instance: number): DotcomDevPorts {
+	const blockStart = getDotcomDevPortBlockStart(instance)
+	return Object.fromEntries(
+		Object.entries(DOTCOM_DEV_PORT_SLOTS).map(([name, slot]) => [name, blockStart + slot])
+	) as DotcomDevPorts
+}
+
+/** The label used to scope an instance's Docker, Zero, and Wrangler resources. */
+export function getDotcomDevInstanceLabel(instance: number) {
+	return instance === 0 ? 'dev' : `dev${instance}`
+}
+
+export function assertValidDotcomDevInstance(instance: number) {
+	if (!Number.isInteger(instance) || instance < 0 || instance >= DOTCOM_DEV_MAX_INSTANCES) {
+		throw new Error(
+			`Invalid dotcom dev instance "${instance}". Expected an integer in 0..${DOTCOM_DEV_MAX_INSTANCES - 1}.`
+		)
+	}
+	return instance
+}
+
+function readInstanceFromEnv() {
+	const raw = process.env.DOTCOM_DEV_INSTANCE
+	if (raw === undefined || raw === '') return 0
+	return assertValidDotcomDevInstance(Number(raw))
+}
+
 export interface DotcomDevEnv {
+	instance: number
+	portBlockStart: number
+	ports: DotcomDevPorts
 	repoRoot: string
 	dotcomDir: string
 	zeroCacheDir: string
@@ -47,9 +107,11 @@ export interface DotcomDevEnv {
 	postgresVolumeName: string
 	zeroReplicaFile: string
 	zeroEnv: Record<string, string>
+	dockerEnv: Record<string, string>
 	schemaFile: string
 	schemaSourceFile: string
 	wranglerPersistDir: string
+	wranglerRegistryDir: string
 	resetLocalStateUrl: string
 }
 
@@ -59,6 +121,7 @@ export interface DotcomDevCleanTargets {
 	zeroReplicaFiles: string[]
 	schemaFile: string
 	wranglerPersistDir: string
+	wranglerRegistryDir: string
 }
 
 export interface DotcomDevCleanAllTargets {
@@ -72,35 +135,76 @@ export interface DotcomDevCleanAllTargets {
 	schemaFile: string
 	wranglerStateDir: string
 	wranglerPersistDirPrefix: string
+	wranglerRegistryDirPrefix: string
 }
 
 export function buildDotcomDevEnv({
 	repoRoot = resolve(thisDir, '../../..'),
+	instance = readInstanceFromEnv(),
 }: {
 	repoRoot?: string
+	instance?: number
 } = {}): DotcomDevEnv {
+	assertValidDotcomDevInstance(instance)
+
 	const dotcomDir = join(repoRoot, 'apps/dotcom')
 	const zeroCacheDir = join(dotcomDir, 'zero-cache')
 	const syncWorkerDir = join(dotcomDir, 'sync-worker')
 
+	const ports = getDotcomDevPorts(instance)
+	const label = getDotcomDevInstanceLabel(instance)
+
+	const composeProjectName = `${DOTCOM_DEV_DOCKER_PROJECT_PREFIX}${label}`
+	const postgresVolumeName = `${composeProjectName}${DOTCOM_DEV_POSTGRES_VOLUME_SUFFIX}`
+	const zeroReplicaFile = `/tmp/${DOTCOM_DEV_ZERO_REPLICA_FILE_PREFIX}${label}.db`
+	const upstreamDb = `postgresql://user:password@127.0.0.1:${ports.postgres}/postgres`
+
 	return {
+		instance,
+		portBlockStart: getDotcomDevPortBlockStart(instance),
+		ports,
 		repoRoot,
 		dotcomDir,
 		zeroCacheDir,
 		syncWorkerDir,
 		dockerComposeFile: join(zeroCacheDir, 'docker/docker-compose.yml'),
 		dockerEnvFile: join(zeroCacheDir, '.env'),
-		composeProjectName: DOTCOM_DEV_COMPOSE_PROJECT,
-		postgresVolumeName: DOTCOM_DEV_POSTGRES_VOLUME,
-		zeroReplicaFile: DOTCOM_DEV_ZERO_REPLICA_FILE,
+		composeProjectName,
+		postgresVolumeName,
+		zeroReplicaFile,
 		zeroEnv: {
-			ZERO_REPLICA_FILE: DOTCOM_DEV_ZERO_REPLICA_FILE,
+			ZERO_PORT: String(ports.zero),
+			ZERO_REPLICA_FILE: zeroReplicaFile,
 			ZERO_NUM_SYNC_WORKERS: '1',
+			ZERO_UPSTREAM_DB: upstreamDb,
+			ZERO_CVR_DB: upstreamDb,
+			ZERO_CHANGE_DB: upstreamDb,
+			ZERO_MUTATE_URL: `http://localhost:${ports.syncWorker}/app/zero/mutate`,
+			ZERO_QUERY_URL: `http://localhost:${ports.syncWorker}/app/zero/query`,
+			VITE_PUBLIC_SERVER: `http://localhost:${ports.zero}`,
+		},
+		// Substituted into docker/docker-compose.yml so each instance publishes its own host ports.
+		dockerEnv: {
+			TLAPP_POSTGRES_PORT: String(ports.postgres),
+			TLAPP_PGBOUNCER_PORT: String(ports.pgbouncer),
 		},
 		schemaFile: join(zeroCacheDir, '.schema.js'),
 		schemaSourceFile: join(repoRoot, 'packages/dotcom-shared/src/tlaSchema.ts'),
-		wranglerPersistDir: join(syncWorkerDir, '.wrangler', DOTCOM_DEV_WRANGLER_STATE_DIR),
-		resetLocalStateUrl: `http://localhost:${DOTCOM_DEV_PORTS.client}/dev/reset-local-state`,
+		wranglerPersistDir: join(
+			syncWorkerDir,
+			'.wrangler',
+			`${DOTCOM_DEV_WRANGLER_STATE_PREFIX}-${label}`
+		),
+		// Per-instance Wrangler service-binding registry. Without this, instances share the global
+		// registry and a second stack's workers re-register the shared worker names (e.g.
+		// `dev-tldraw-multiplayer`), cross-wiring one instance's image/usercontent worker to another
+		// instance's sync worker.
+		wranglerRegistryDir: join(
+			syncWorkerDir,
+			'.wrangler',
+			`${DOTCOM_DEV_WRANGLER_REGISTRY_PREFIX}-${label}`
+		),
+		resetLocalStateUrl: `http://localhost:${ports.client}/dev/reset-local-state`,
 	}
 }
 
@@ -119,6 +223,7 @@ export function getDotcomDevCleanTargets(env: DotcomDevEnv): DotcomDevCleanTarge
 		],
 		schemaFile: env.schemaFile,
 		wranglerPersistDir: env.wranglerPersistDir,
+		wranglerRegistryDir: env.wranglerRegistryDir,
 	}
 }
 
@@ -134,5 +239,6 @@ export function getDotcomDevCleanAllTargets(env: DotcomDevEnv): DotcomDevCleanAl
 		schemaFile: env.schemaFile,
 		wranglerStateDir: join(env.syncWorkerDir, '.wrangler'),
 		wranglerPersistDirPrefix: DOTCOM_DEV_WRANGLER_STATE_PREFIX,
+		wranglerRegistryDirPrefix: DOTCOM_DEV_WRANGLER_REGISTRY_PREFIX,
 	}
 }

--- a/apps/dotcom/zero-cache/dev-instance.test.ts
+++ b/apps/dotcom/zero-cache/dev-instance.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveDotcomDevInstance } from './dev-instance'
+
+describe('resolveDotcomDevInstance', () => {
+	const original = process.env.DOTCOM_DEV_INSTANCE
+
+	afterEach(() => {
+		if (original === undefined) delete process.env.DOTCOM_DEV_INSTANCE
+		else process.env.DOTCOM_DEV_INSTANCE = original
+	})
+
+	it('uses DOTCOM_DEV_INSTANCE when set, without touching the registry', () => {
+		process.env.DOTCOM_DEV_INSTANCE = '2'
+		expect(resolveDotcomDevInstance({ allocate: true })).toBe(2)
+		expect(resolveDotcomDevInstance({ allocate: false })).toBe(2)
+	})
+
+	it('rejects an out-of-range DOTCOM_DEV_INSTANCE', () => {
+		process.env.DOTCOM_DEV_INSTANCE = '99'
+		expect(() => resolveDotcomDevInstance({ allocate: false })).toThrow()
+	})
+})

--- a/apps/dotcom/zero-cache/dev-instance.ts
+++ b/apps/dotcom/zero-cache/dev-instance.ts
@@ -1,0 +1,131 @@
+import { spawnSync } from 'child_process'
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from 'fs'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+import { assertValidDotcomDevInstance, DOTCOM_DEV_MAX_INSTANCES } from './dev-env'
+
+// A machine-global registry that maps a worktree's absolute path to a stable dev instance number.
+// Keeping it stable means each worktree keeps its own ports and database across restarts; keeping it
+// machine-global (rather than per-repo) means separate clones get distinct instances too.
+const REGISTRY_FILE = join(homedir(), '.tldraw', 'dotcom-dev-instances.json')
+const LOCK_DIR = `${REGISTRY_FILE}.lock`
+const LOCK_STALE_MS = 30_000
+const LOCK_TIMEOUT_MS = 10_000
+
+type Registry = Record<string, number>
+
+function sleepSync(ms: number) {
+	// Synchronous sleep with no dependencies, so the short lock-retry loop below stays simple.
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+}
+
+/** Resolve the current worktree's root, falling back to the process cwd outside a git checkout. */
+function getWorktreeKey() {
+	const result = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' })
+	const top = result.status === 0 ? result.stdout.trim() : ''
+	const path = top || process.cwd()
+	try {
+		return realpathSync(path)
+	} catch {
+		return path
+	}
+}
+
+function readRegistry(): Registry {
+	try {
+		const parsed = JSON.parse(readFileSync(REGISTRY_FILE, 'utf8'))
+		return parsed && typeof parsed === 'object' ? (parsed as Registry) : {}
+	} catch {
+		return {}
+	}
+}
+
+function writeRegistry(registry: Registry) {
+	mkdirSync(dirname(REGISTRY_FILE), { recursive: true })
+	writeFileSync(REGISTRY_FILE, `${JSON.stringify(registry, null, 2)}\n`)
+}
+
+/** Atomic mkdir-based lock, with stale-lock stealing so a crashed `dev-app` can't wedge allocation. */
+function withRegistryLock<T>(fn: () => T): T {
+	mkdirSync(dirname(LOCK_DIR), { recursive: true })
+	const start = Date.now()
+	for (;;) {
+		try {
+			mkdirSync(LOCK_DIR)
+			break
+		} catch (error: any) {
+			if (error?.code !== 'EEXIST') throw error
+			try {
+				if (Date.now() - statSync(LOCK_DIR).mtimeMs > LOCK_STALE_MS) {
+					rmSync(LOCK_DIR, { recursive: true, force: true })
+					continue
+				}
+			} catch {
+				// Lock vanished between our mkdir and stat; retry immediately.
+			}
+			if (Date.now() - start > LOCK_TIMEOUT_MS) {
+				throw new Error(`Timed out acquiring the dotcom dev instance lock at ${LOCK_DIR}.`)
+			}
+			sleepSync(100)
+		}
+	}
+	try {
+		return fn()
+	} finally {
+		rmSync(LOCK_DIR, { recursive: true, force: true })
+	}
+}
+
+/**
+ * Resolve the dev instance number for the current worktree.
+ *
+ * `DOTCOM_DEV_INSTANCE` always wins when set. Otherwise we look the worktree up in the shared
+ * registry; with `allocate`, a worktree we've never seen claims the lowest free instance and the
+ * choice is persisted so it's stable across runs. Without `allocate` (clean/doctor), an unregistered
+ * worktree resolves to the default instance 0 rather than reserving a slot.
+ */
+export function resolveDotcomDevInstance({ allocate }: { allocate: boolean }): number {
+	const fromEnv = process.env.DOTCOM_DEV_INSTANCE
+	if (fromEnv !== undefined && fromEnv !== '') {
+		return assertValidDotcomDevInstance(Number(fromEnv))
+	}
+
+	const worktree = getWorktreeKey()
+
+	if (!allocate) {
+		return readRegistry()[worktree] ?? 0
+	}
+
+	return withRegistryLock(() => {
+		const registry = readRegistry()
+		// Drop entries for worktrees that no longer exist so their instances can be reused.
+		for (const path of Object.keys(registry)) {
+			if (!existsSync(path)) delete registry[path]
+		}
+
+		if (registry[worktree] === undefined) {
+			const used = new Set(Object.values(registry))
+			let instance = 0
+			while (used.has(instance)) instance++
+			if (instance >= DOTCOM_DEV_MAX_INSTANCES) {
+				throw new Error(
+					`Too many concurrent dotcom dev stacks (max ${DOTCOM_DEV_MAX_INSTANCES}). ` +
+						`Stop one, run \`yarn dev-app:clean\` in a worktree you're done with, or set ` +
+						`DOTCOM_DEV_INSTANCE to reuse a slot.`
+				)
+			}
+			registry[worktree] = instance
+		}
+
+		writeRegistry(registry)
+		return registry[worktree]
+	})
+}

--- a/apps/dotcom/zero-cache/dev.ts
+++ b/apps/dotcom/zero-cache/dev.ts
@@ -2,25 +2,27 @@
 import { ChildProcess, spawn, spawnSync } from 'child_process'
 import dotenv from 'dotenv'
 import pg from 'pg'
-import { DOTCOM_DEV_PORTS, DOTCOM_DEV_READINESS_TIMEOUT_MS, getDotcomDevEnv } from './dev-env'
+import { DOTCOM_DEV_READINESS_TIMEOUT_MS, getDotcomDevEnv } from './dev-env'
 
 const env = getDotcomDevEnv()
 const dotEnv = dotenv.config({ path: env.dockerEnvFile }).parsed ?? {}
 const childEnv = {
 	...dotEnv,
 	...process.env,
-	// Fixed dev values intentionally win over shell vars for deterministic local state.
+	// Per-instance dev values intentionally win over shell vars for deterministic local state.
 	...env.zeroEnv,
+	...env.dockerEnv,
 }
 
 const children: ChildProcess[] = []
 let migrationsReady = false
 let shuttingDown = false
 
-// Host ports the Docker stack publishes (see docker/docker-compose.yml). Our own stack is reused
-// in place across runs, but a stack from an older per-branch setup will hold these ports and block
-// `docker compose up`, so we reconcile those away on startup.
-const DOCKER_PUBLISHED_PORTS = [DOTCOM_DEV_PORTS.pgbouncer, DOTCOM_DEV_PORTS.postgres]
+// Host ports this instance's Docker stack publishes (see docker/docker-compose.yml). Our own stack
+// is reused in place across runs, but a stack from an older per-branch setup will hold these ports
+// and block `docker compose up`, so we reconcile those away on startup. Sibling instances publish
+// different ports, so they are never disturbed.
+const DOCKER_PUBLISHED_PORTS = [env.ports.pgbouncer, env.ports.postgres]
 
 function delay(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))
@@ -209,7 +211,7 @@ function reconcileDockerStacks() {
 async function waitForPostgres() {
 	const connectionString =
 		childEnv.ZERO_UPSTREAM_DB ??
-		`postgresql://user:password@127.0.0.1:${DOTCOM_DEV_PORTS.postgres}/postgres`
+		`postgresql://user:password@127.0.0.1:${env.ports.postgres}/postgres`
 	const pool = new pg.Pool({ connectionString, max: 1 })
 	const deadline = Date.now() + DOTCOM_DEV_READINESS_TIMEOUT_MS
 	let attempts = 0
@@ -259,6 +261,7 @@ async function waitForHttpOk(url: string, label: string) {
 }
 
 async function main() {
+	console.log(`Dotcom dev instance: ${env.instance} (ports ${env.portBlockStart}+)`)
 	console.log(`Docker compose project: ${env.composeProjectName}`)
 	console.log(`Postgres volume: ${env.postgresVolumeName}`)
 	console.log(`Zero replica: ${env.zeroReplicaFile}`)
@@ -296,7 +299,7 @@ async function main() {
 	await runOnce('schema bundle', 'yarn', ['bundle-schema'])
 
 	spawnManaged('migrations', 'yarn', ['migrate', '--signal-success'])
-	await waitForHttpOk(`http://localhost:${DOTCOM_DEV_PORTS.migrations}`, 'migrations')
+	await waitForHttpOk(`http://localhost:${env.ports.migrations}`, 'migrations')
 	migrationsReady = true
 
 	spawnManaged('schema watch', 'yarn', ['bundle-schema:watch'])
@@ -311,8 +314,8 @@ async function main() {
 		'SIGINT',
 	])
 
-	await waitForHttpOk(`http://localhost:${DOTCOM_DEV_PORTS.zero}/`, 'Zero')
-	console.log(`Zero is ready at http://localhost:${DOTCOM_DEV_PORTS.zero}/`)
+	await waitForHttpOk(`http://localhost:${env.ports.zero}/`, 'Zero')
+	console.log(`Zero is ready at http://localhost:${env.ports.zero}/`)
 
 	await new Promise(() => {
 		// Keep the orchestration process alive while child processes run.

--- a/apps/dotcom/zero-cache/docker-compose.ts
+++ b/apps/dotcom/zero-cache/docker-compose.ts
@@ -24,6 +24,8 @@ const child = spawn(
 	{
 		cwd: env.zeroCacheDir,
 		stdio: 'inherit',
+		// Publish this instance's host ports (substituted into docker-compose.yml).
+		env: { ...process.env, ...env.dockerEnv },
 	}
 )
 

--- a/apps/dotcom/zero-cache/docker/docker-compose.yml
+++ b/apps/dotcom/zero-cache/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       timeout: 5s
       retries: 5
     ports:
-      - 6543:5432
+      - ${TLAPP_POSTGRES_PORT:-3005}:5432
     environment:
       POSTGRES_USER: user
       POSTGRES_DB: postgres
@@ -34,7 +34,7 @@ services:
     image: edoburu/pgbouncer:latest
     restart: always
     ports:
-      - "6432:6432"
+      - "${TLAPP_PGBOUNCER_PORT:-3006}:6432"
     environment:
       DATABASE_URL: postgres://user:password@zstart_postgres:5432/postgres
     volumes:

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -3,10 +3,13 @@ import { existsSync, readFileSync, readdirSync } from 'fs'
 import { createServer } from 'http'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import pg from 'pg'
+import { getDotcomDevEnv } from './dev-env'
+
+const devEnv = getDotcomDevEnv()
 
 const postgresConnectionString: string =
 	process.env.BOTCOM_POSTGRES_POOLED_CONNECTION_STRING ||
-	'postgresql://user:password@127.0.0.1:6543/postgres'
+	`postgresql://user:password@127.0.0.1:${devEnv.ports.postgres}/postgres`
 
 if (!postgresConnectionString) {
 	throw new Error('Missing BOTCOM_POSTGRES_POOLED_CONNECTION_STRING env var')
@@ -177,7 +180,7 @@ async function run() {
 			const s = createServer((_, res) => {
 				res.end('ok')
 			})
-			s.listen(7654)
+			s.listen(devEnv.ports.migrations)
 		} else {
 			process.exit(0)
 		}

--- a/apps/dotcom/zero-cache/run-dotcom-worker.ts
+++ b/apps/dotcom/zero-cache/run-dotcom-worker.ts
@@ -1,0 +1,45 @@
+/* eslint-disable no-console */
+import { spawn } from 'child_process'
+import { type DotcomDevPortName, getDotcomDevEnv } from './dev-env'
+
+// Runs a dotcom worker under the shared worker dev runner with this instance's serving and inspector
+// ports. Usage: `tsx ../zero-cache/run-dotcom-worker.ts <serviceKey> [extra wrangler args]`, run from
+// the worker's package directory. `serviceKey` is the worker's port name in dev-env (e.g.
+// `assetUploadWorker`); its inspector port is `<serviceKey>Inspector`.
+const [serviceKey, ...extraArgs] = process.argv.slice(2) as [DotcomDevPortName, ...string[]]
+const env = getDotcomDevEnv()
+
+const port = env.ports[serviceKey]
+const inspectorPort = env.ports[`${serviceKey}Inspector` as DotcomDevPortName]
+if (port == null || inspectorPort == null) {
+	throw new Error(`Unknown dotcom worker "${serviceKey}".`)
+}
+
+const child = spawn(
+	'yarn',
+	[
+		'run',
+		'-T',
+		'tsx',
+		'../../../internal/scripts/workers/dev.ts',
+		'--port',
+		String(port),
+		'--inspector-port',
+		String(inspectorPort),
+		...extraArgs,
+	],
+	{ env: process.env, stdio: 'inherit' }
+)
+
+child.once('exit', (code) => process.exit(code ?? 1))
+child.once('error', (error) => {
+	console.error(error)
+	process.exit(1)
+})
+
+process.on('SIGINT', () => child.kill('SIGINT'))
+process.on('SIGTERM', () => child.kill('SIGTERM'))
+process.on('SIGHUP', () => child.kill('SIGHUP'))
+process.on('exit', () => {
+	if (!child.killed) child.kill('SIGKILL')
+})

--- a/apps/dotcom/zero-cache/wait-for-dev-readiness.ts
+++ b/apps/dotcom/zero-cache/wait-for-dev-readiness.ts
@@ -1,9 +1,11 @@
 /* eslint-disable no-console */
 import {
 	DOTCOM_DEV_MIGRATIONS_READY_TIMEOUT_MS,
-	DOTCOM_DEV_PORTS,
 	DOTCOM_DEV_READINESS_TIMEOUT_MS,
+	getDotcomDevEnv,
 } from './dev-env'
+
+const { ports } = getDotcomDevEnv()
 
 function delay(ms: number) {
 	return new Promise((resolve) => setTimeout(resolve, ms))
@@ -43,19 +45,19 @@ async function waitForResponse({
 
 async function main() {
 	await waitForResponse({
-		url: `http://localhost:${DOTCOM_DEV_PORTS.migrations}`,
+		url: `http://localhost:${ports.migrations}`,
 		label: 'migrations',
 		timeoutMs: DOTCOM_DEV_MIGRATIONS_READY_TIMEOUT_MS,
 		requireOk: true,
 	})
 	await waitForResponse({
-		url: `http://localhost:${DOTCOM_DEV_PORTS.zero}/`,
+		url: `http://localhost:${ports.zero}/`,
 		label: 'Zero',
 		timeoutMs: DOTCOM_DEV_READINESS_TIMEOUT_MS,
 		requireOk: true,
 	})
 	await waitForResponse({
-		url: `http://localhost:${DOTCOM_DEV_PORTS.syncWorker}/`,
+		url: `http://localhost:${ports.syncWorker}/`,
 		label: 'sync worker',
 		timeoutMs: DOTCOM_DEV_READINESS_TIMEOUT_MS,
 		requireOk: false,

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -184,12 +184,7 @@ class SizeReporter {
 	}
 }
 
-function getDevPort(args: string[]): number | null {
-	const portIdx = args.findIndex((a) => a === '--port')
-	if (portIdx >= 0 && args[portIdx + 1]) {
-		const fromArg = Number(args[portIdx + 1])
-		return Number.isFinite(fromArg) ? fromArg : null
-	}
+function readWranglerDevPort(): number | null {
 	try {
 		const parsed = toml.parse(readFileSync(resolve(process.cwd(), 'wrangler.toml'), 'utf8'))
 		const port = parsed?.dev?.port
@@ -197,6 +192,16 @@ function getDevPort(args: string[]): number | null {
 	} catch {
 		return null
 	}
+}
+
+/** Read the numeric value of `flag <value>` from `args`, if present. */
+function readArgPort(args: string[], flag: string): number | null {
+	const idx = args.findIndex((a) => a === flag)
+	if (idx >= 0 && args[idx + 1] != null) {
+		const value = Number(args[idx + 1])
+		return Number.isFinite(value) ? value : null
+	}
+	return null
 }
 
 function probePortFree(port: number): Promise<void> {
@@ -209,17 +214,24 @@ function probePortFree(port: number): Promise<void> {
 	})
 }
 
-async function ensurePortFreeOrExit(port: number) {
+async function ensurePortFreeOrExit(port: number, what: 'serving' | 'inspector') {
 	try {
 		await probePortFree(port)
 	} catch (err: any) {
 		if (err?.code === 'EADDRINUSE') {
+			const detail =
+				what === 'inspector'
+					? `process is already listening on it. Wrangler would silently fail to bind its\n` +
+						`serving port — the worker would never come up, with no error in the log. This is\n` +
+						`usually another dev stack running on the same instance; give this one a different\n` +
+						`DOTCOM_DEV_INSTANCE (or run it from its own worktree).`
+					: `process is already listening on it. Wrangler would silently fall back to a random\n` +
+						`port, but the rest of the dev stack expects ${port} — so /api requests from the\n` +
+						`client would either 404 or hit the wrong worker.`
 			console.error(
-				`\n${kleur.red(kleur.bold(`✖ Port ${port} is already in use.`))}\n\n` +
-					`This worker (${kleur.cyan(process.cwd())}) needs port ${port}, but another\n` +
-					`process is already listening on it. Wrangler would silently fall back to a random\n` +
-					`port, but the rest of the dev stack expects ${port} — so /api requests from the\n` +
-					`client would either 404 or hit the wrong worker.\n\n` +
+				`\n${kleur.red(kleur.bold(`✖ ${what === 'inspector' ? 'Inspector port' : 'Port'} ${port} is already in use.`))}\n\n` +
+					`This worker (${kleur.cyan(process.cwd())}) needs ${what} port ${port}, but another\n` +
+					`${detail}\n\n` +
 					`Find what's holding it:\n` +
 					`  ${kleur.bold(`lsof -nP -iTCP:${port} -sTCP:LISTEN`)}\n\n` +
 					`Then stop that process and re-run.\n`
@@ -232,8 +244,18 @@ async function ensurePortFreeOrExit(port: number) {
 }
 
 async function main() {
-	const port = getDevPort(process.argv.slice(2))
-	if (port != null) await ensurePortFreeOrExit(port)
+	// The dotcom dev stack passes each worker an explicit per-instance `--port` and
+	// `--inspector-port` (see apps/dotcom/zero-cache/run-dotcom-worker.ts) so worktrees don't collide.
+	// Other workers (examples, bemo) just use their wrangler.toml port. Probe both ports up front:
+	// wrangler otherwise silently falls back to a random serving port, and a clashing inspector port
+	// makes the worker fail to bind with no error in the log.
+	const args = process.argv.slice(2)
+
+	const servingPort = readArgPort(args, '--port') ?? readWranglerDevPort()
+	if (servingPort != null) await ensurePortFreeOrExit(servingPort, 'serving')
+
+	const inspectorPort = readArgPort(args, '--inspector-port')
+	if (inspectorPort != null) await ensurePortFreeOrExit(inspectorPort, 'inspector')
 
 	const monitor = new MiniflareMonitor('wrangler', [
 		'dev',
@@ -244,7 +266,7 @@ async function main() {
 		'info',
 		'--var',
 		'IS_LOCAL:true',
-		...process.argv.slice(2),
+		...args,
 	])
 	monitor.start()
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"refresh-assets": "lazy refresh-assets",
 		"dev": "LAZYREPO_PRETTY_OUTPUT=0 lazy run dev --filter='apps/examples' --filter='packages/tldraw' --filter='apps/bemo-worker' --filter='apps/dotcom/image-resize-worker'",
 		"dev-vscode": "code ./apps/vscode/extension && lazy run dev --filter='apps/vscode/{extension,editor}'",
-		"dev-app": "LAZYREPO_PRETTY_OUTPUT=0 lazy run dev --filter='apps/dotcom/*' --filter='packages/tldraw'",
+		"dev-app": "yarn run -T tsx apps/dotcom/dev-app.ts",
 		"dev-app:clean": "yarn workspace @tldraw/zero-cache dev:clean",
 		"dev-app:clean:all": "yarn workspace @tldraw/zero-cache dev:clean:all",
 		"dev-app:doctor": "yarn workspace @tldraw/zero-cache dev:doctor",


### PR DESCRIPTION
In order to work on multiple dotcom features at once (e.g. several Claude sessions across git worktrees), this PR lets each worktree run its own `yarn dev-app` stack side by side. Closes #9061.

Today the dotcom dev stack is a singleton: every service binds a fixed port, so a second `yarn dev-app` collides — and the sync worker fails *silently* (it never binds its serving port, with no error in the log). This PR gives each dev instance its own contiguous block of ports plus its own Docker, Zero, and Wrangler state, so stacks don't fight over ports, database data, or service bindings.

### How it works

- **Ports**: each instance gets a 100-port block — a service's port is `3000 + instance * 100 + slot`, with a fixed slot per service (see `DOTCOM_DEV_PORT_SLOTS`). So instance 0 = 3000–3014, instance 1 = 3100–3114, etc. The client sits at slot 0, so **instance 0's client stays on `localhost:3000`** and existing e2e/Clerk/bookmarks are unaffected. Slots 3–4 are left free for Zero's change-streamer/litestream, which derive from `ZERO_PORT`.
- **Instance assignment**: stable per worktree. The first time a worktree runs `yarn dev-app` it claims the lowest free instance and records it in `~/.tldraw/dotcom-dev-instances.json` (a small locked registry), so its ports and database stay put across restarts. `DOTCOM_DEV_INSTANCE=<n>` overrides.
- **Isolated state**: per-instance Docker compose project + Postgres volume, Zero replica file, Wrangler `--persist-to` dir, and — importantly — a per-instance `WRANGLER_REGISTRY_PATH` so a second stack's workers don't re-register the shared worker names and cross-wire service bindings between instances.
- **Fail loud**: the shared worker runner now probes the inspector port too, turning the silent sync-worker hang into a clear "port in use" error. Non-dotcom workers (examples, bemo) are untouched.

### Change type

- [x] `other`

### Test plan

1. `yarn dev-app` in worktree A → instance 0, client at http://localhost:3000.
2. `yarn dev-app` in worktree B (with secrets copied in) → instance 1, client at http://localhost:3100. Both serve at once.
3. `yarn dev-app:doctor` in each prints its instance + ports; `yarn dev-app:clean` cleans only that instance.
4. `yarn e2e-dotcom` still targets `localhost:3000` (pinned to instance 0).

- [x] Unit tests
- [ ] End to end tests

> Note: I couldn't run a live dual-stack here (needs Docker + Clerk keys + a second worktree), so the end-to-end "two stacks serving simultaneously" still wants a local smoke test.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Tests          | +86 / -7   |
| Apps           | +468 / -85 |
| Config/tooling  | +38 / -16  |
