### PR TITLE
fix(tldraw): keep pasted text on screen when pasting at cursor

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -546,8 +546,40 @@ export async function defaultHandleExternalTextContent(
 		autoSize = true
 	}
 
-	if (p.y - h / 2 < editor.getViewportPageBounds().minY + 40) {
-		p.y = editor.getViewportPageBounds().minY + 40 + h / 2
+	const vpb = editor.getViewportPageBounds()
+	const PADDING = 40
+	const availableWidth = vpb.width - PADDING * 2
+
+	// If the text is wider than the space available on screen, squeeze it horizontally to fit.
+	let didSqueeze = false
+	if (w > availableWidth) {
+		const resized = editor.textMeasure.measureHtml(htmlToMeasure, {
+			...TEXT_PROPS,
+			lineHeight: theme.lineHeight,
+			fontFamily: getFontFamily(theme, defaultProps.font),
+			fontSize: theme.fontSize * FONT_SIZES[defaultProps.size],
+			maxWidth: availableWidth,
+		})
+		w = resized.w
+		h = resized.h
+		autoSize = false
+		align = isRtl ? 'end' : 'start'
+		didSqueeze = true
+	}
+
+	// Offset horizontally to keep the text on screen.
+	if (p.x - w / 2 < vpb.minX + PADDING) {
+		p.x = vpb.minX + PADDING + w / 2
+	} else if (p.x + w / 2 > vpb.maxX - PADDING) {
+		p.x = vpb.maxX - PADDING - w / 2
+	}
+
+	// Vertically, always offset down so the top stays visible.
+	// Offset up when the text wasn't squeezed
+	if (p.y - h / 2 < vpb.minY + PADDING) {
+		p.y = vpb.minY + PADDING + h / 2
+	} else if (!didSqueeze && p.y + h / 2 > vpb.maxY - PADDING) {
+		p.y = vpb.maxY - PADDING - h / 2
 	}
 
 	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -522,9 +522,13 @@ export async function defaultHandleExternalTextContent(
 		maxWidth: null,
 	})
 
-	const vpb = editor.getViewportPageBounds()
-	const padding = 40 / editor.getZoomLevel()
-	const maxWidth = vpb.width - padding * 2
+	// Wrap the text if it's wider than the viewport, but don't let
+	// it wrap narrower than the viewport would be at 100% zoom.
+	const padding = 40
+	const maxWidth = Math.max(
+		editor.getViewportPageBounds().width - (padding * 2) / editor.getZoomLevel(),
+		editor.getViewportScreenBounds().width - padding * 2
+	)
 
 	if (rawSize.w > maxWidth) {
 		// The text is wider than the viewport, so wrap it to fit on screen.
@@ -546,21 +550,8 @@ export async function defaultHandleExternalTextContent(
 		autoSize = true
 	}
 
-	// Offset horizontally to keep the text within the viewport.
-	if (p.x - w / 2 < vpb.minX + padding) {
-		p.x = vpb.minX + padding + w / 2
-	} else if (p.x + w / 2 > vpb.maxX - padding) {
-		p.x = vpb.maxX - padding - w / 2
-	}
-
-	// Offset up or down vertically to keep the text within the viewport,
-	// but don't let the top cross the top safe zone.
-	const topSafe = vpb.minY + padding
-	const bottomSafe = vpb.maxY - padding
-	if (p.y - h / 2 < topSafe) {
-		p.y = topSafe + h / 2
-	} else if (p.y + h / 2 > bottomSafe) {
-		p.y = Math.max(bottomSafe - h / 2, topSafe + h / 2)
+	if (p.y - h / 2 < editor.getViewportPageBounds().minY + 40) {
+		p.y = editor.getViewportPageBounds().minY + 40 + h / 2
 	}
 
 	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -522,18 +522,18 @@ export async function defaultHandleExternalTextContent(
 		maxWidth: null,
 	})
 
-	const minWidth = Math.min(
-		isMultiLine ? editor.getViewportPageBounds().width * 0.9 : 920,
-		Math.max(200, editor.getViewportPageBounds().width * 0.9)
-	)
+	const vpb = editor.getViewportPageBounds()
+	const padding = 40 / editor.getZoomLevel()
+	const maxWidth = vpb.width - padding * 2
 
-	if (rawSize.w > minWidth) {
+	if (rawSize.w > maxWidth) {
+		// The text is wider than the viewport, so wrap it to fit on screen.
 		const shrunkSize = editor.textMeasure.measureHtml(htmlToMeasure, {
 			...TEXT_PROPS,
 			lineHeight: theme.lineHeight,
 			fontFamily: getFontFamily(theme, defaultProps.font),
 			fontSize: theme.fontSize * FONT_SIZES[defaultProps.size],
-			maxWidth: minWidth,
+			maxWidth,
 		})
 		w = shrunkSize.w
 		h = shrunkSize.h
@@ -546,40 +546,21 @@ export async function defaultHandleExternalTextContent(
 		autoSize = true
 	}
 
-	const vpb = editor.getViewportPageBounds()
-	const PADDING = 40
-	const availableWidth = vpb.width - PADDING * 2
-
-	// If the text is wider than the space available on screen, squeeze it horizontally to fit.
-	let didSqueeze = false
-	if (w > availableWidth) {
-		const resized = editor.textMeasure.measureHtml(htmlToMeasure, {
-			...TEXT_PROPS,
-			lineHeight: theme.lineHeight,
-			fontFamily: getFontFamily(theme, defaultProps.font),
-			fontSize: theme.fontSize * FONT_SIZES[defaultProps.size],
-			maxWidth: availableWidth,
-		})
-		w = resized.w
-		h = resized.h
-		autoSize = false
-		align = isRtl ? 'end' : 'start'
-		didSqueeze = true
+	// Offset horizontally to keep the text within the viewport.
+	if (p.x - w / 2 < vpb.minX + padding) {
+		p.x = vpb.minX + padding + w / 2
+	} else if (p.x + w / 2 > vpb.maxX - padding) {
+		p.x = vpb.maxX - padding - w / 2
 	}
 
-	// Offset horizontally to keep the text on screen.
-	if (p.x - w / 2 < vpb.minX + PADDING) {
-		p.x = vpb.minX + PADDING + w / 2
-	} else if (p.x + w / 2 > vpb.maxX - PADDING) {
-		p.x = vpb.maxX - PADDING - w / 2
-	}
-
-	// Vertically, always offset down so the top stays visible.
-	// Offset up when the text wasn't squeezed
-	if (p.y - h / 2 < vpb.minY + PADDING) {
-		p.y = vpb.minY + PADDING + h / 2
-	} else if (!didSqueeze && p.y + h / 2 > vpb.maxY - PADDING) {
-		p.y = vpb.maxY - PADDING - h / 2
+	// Offset up or down vertically to keep the text within the viewport,
+	// but don't let the top cross the top safe zone.
+	const topSafe = vpb.minY + padding
+	const bottomSafe = vpb.maxY - padding
+	if (p.y - h / 2 < topSafe) {
+		p.y = topSafe + h / 2
+	} else if (p.y + h / 2 > bottomSafe) {
+		p.y = Math.max(bottomSafe - h / 2, topSafe + h / 2)
 	}
 
 	const newPoint = maybeSnapToGrid(new Vec(p.x - w / 2, p.y - h / 2), editor)


### PR DESCRIPTION
In order to keep text pasted at the cursor on screen, this PR offsets external text content in every direction rather than only nudging it down from the top edge. When pasted text is too wide for the viewport, it's now squeezed to the safe-zone width and offset to stay fully visible — previously it was scaled to fit but left partly off-screen, producing the strange behavior shown below.

This doesn't address the second point in the issue (pasting into an existing text box), which I think is intended behavior.

Relates to #6645.

**Before** (doesn't offset from the left, right, or bottom)

https://github.com/user-attachments/assets/5bb5c91e-a9c4-451b-9e28-021b43eb5379

**After**

https://github.com/user-attachments/assets/725304c5-6bfb-4327-ad4c-975d1bbd00e8

### Change type

- [x] `bugfix`

### Test plan

1. Turn on "paste at cursor" in preferences.
2. Copy ~300 words of text.
3. Move the cursor near each edge of the canvas and paste — the text should stay fully on screen each time.
4. Copy text wider than the viewport and paste — it should squeeze to fit the safe zone and stay on screen.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Keep text pasted at the cursor fully on screen by offsetting it in all directions, and squeeze over-wide pasted text to fit the viewport.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +34 / -2   |
