### PR TITLE
improvement(tldraw): hide back to content when focusing back to canvas

### DIFF
--- a/packages/tldraw/src/lib/ui/components/A11y.tsx
+++ b/packages/tldraw/src/lib/ui/components/A11y.tsx
@@ -13,6 +13,7 @@ import {
 import { memo, MouseEvent, useCallback, useEffect, useRef } from 'react'
 import { useA11y } from '../context/a11y'
 import { useTranslation } from '../hooks/useTranslation/useTranslation'
+import { suppressBackToContent } from './HelperButtons/BackToContent'
 import { TldrawUiButton } from './primitives/Button/TldrawUiButton'
 
 export function SkipToMainContent() {
@@ -27,6 +28,7 @@ export function SkipToMainContent() {
 			const shapes = editor.getCurrentPageShapesInReadingOrder()
 			if (!shapes.length) return
 			editor.setSelectedShapes([shapes[0].id])
+			suppressBackToContent(editor, editor.options.animationMediumMs)
 			editor.zoomToSelectionIfOffscreen(256, {
 				animation: {
 					duration: editor.options.animationMediumMs,

--- a/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
@@ -1,7 +1,24 @@
-import { useEditor, useQuickReactor } from '@tldraw/editor'
+import { Editor, EditorAtom, useEditor, useQuickReactor } from '@tldraw/editor'
 import { useRef, useState } from 'react'
 import { useActions } from '../../context/actions'
 import { TldrawUiMenuActionItem } from '../primitives/menus/TldrawUiMenuActionItem'
+
+const backToContentSuppressed = new EditorAtom('backToContentSuppressed', () => false)
+
+/**
+ * Hide the "back to content" helper button right away, regardless of where the
+ * camera currently is. This is used when the user has explicitly chosen to
+ * navigate back to the content (e.g. via the "move focus to canvas" button): the
+ * button should disappear on intent rather than waiting for the camera animation
+ * to physically bring a shape back into the viewport. The button falls back to
+ * its normal reactive logic after `durationMs`, by which point the camera has
+ * arrived and the content is visible.
+ * @internal
+ */
+export function suppressBackToContent(editor: Editor, durationMs: number) {
+	backToContentSuppressed.set(editor, true)
+	editor.timers.setTimeout(() => backToContentSuppressed.set(editor, false), durationMs)
+}
 
 export function BackToContent() {
 	const editor = useEditor()
@@ -15,10 +32,12 @@ export function BackToContent() {
 		'toggle showback to content',
 		() => {
 			const showBackToContentPrev = rIsShowing.current
-			const shapeIds = editor.getCurrentPageShapeIds()
 			let showBackToContentNow = false
-			if (shapeIds.size) {
-				showBackToContentNow = shapeIds.size === editor.getNotVisibleShapes().size
+			if (!backToContentSuppressed.get(editor)) {
+				const shapeIds = editor.getCurrentPageShapeIds()
+				if (shapeIds.size) {
+					showBackToContentNow = shapeIds.size === editor.getNotVisibleShapes().size
+				}
 			}
 
 			if (showBackToContentPrev !== showBackToContentNow) {

--- a/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
@@ -4,6 +4,7 @@ import { useActions } from '../../context/actions'
 import { TldrawUiMenuActionItem } from '../primitives/menus/TldrawUiMenuActionItem'
 
 const backToContentSuppressed = new EditorAtom('backToContentSuppressed', () => false)
+const suppressTimeout = new EditorAtom<number | null>('backToContentSuppressTimeout', () => null)
 
 /**
  * Hide the "back to content" helper button right away, regardless of where the
@@ -17,7 +18,15 @@ const backToContentSuppressed = new EditorAtom('backToContentSuppressed', () => 
  */
 export function suppressBackToContent(editor: Editor, durationMs: number) {
 	backToContentSuppressed.set(editor, true)
-	editor.timers.setTimeout(() => backToContentSuppressed.set(editor, false), durationMs)
+	// Cancel any pending timeout so an earlier (shorter) timer can't clear the
+	// suppression while a newer camera animation is still running.
+	const pending = suppressTimeout.get(editor)
+	if (pending !== null) clearTimeout(pending)
+	const id = editor.timers.setTimeout(() => {
+		backToContentSuppressed.set(editor, false)
+		suppressTimeout.set(editor, null)
+	}, durationMs)
+	suppressTimeout.set(editor, id)
 }
 
 export function BackToContent() {


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8328 

The fix in https://github.com/tldraw/tldraw/pull/8334 surfaced a rather unpleasant visual issue that occur once the user tabulate and press enter: the "back to canvas" stays visible during the animate. 

This PR fixes that by forcing the button to hide once the "focus" button is pressed.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape
2. Go far far, really far (on the left, on the right, where you want, you do you)
3. Press tab
4. Press enter

=> The "back to content" button is not visible during the animation

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Small visual improvement with the "focus canvas" a11y behaviour, we hide the "back to canvas"  button during the animation that pan back to the first created shape 