### PR TITLE
fix(tldraw): don't select style on release over a different section

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelButtonPicker.tsx
@@ -123,6 +123,11 @@ function StylePanelButtonPickerInlineInner<T extends string>(
 		}
 
 		const handleButtonPointerUp = (e: React.PointerEvent<HTMLButtonElement>) => {
+			// Only apply on release if the scrub started in this picker. Otherwise
+			// releasing over a different style section selects that section's
+			// option, even though scrubbing can't cross sections. See #9223.
+			if (!rPointing.current) return
+
 			const { id } = e.currentTarget.dataset
 			if (value.type === 'shared' && value.value === id) return
 


### PR DESCRIPTION
Styles in the style panel (e.g. color) can be scrubbed by pressing and dragging across the options. Scrubbing is intentionally scoped to a single section — dragging from colors over to dash styles won't select anything mid-drag. But releasing the pointer over a button in a *different* section still selected that section's option, which shouldn't happen.

Each style section is a separate `StylePanelButtonPicker` instance with its own `rPointing` ref. `handleButtonPointerEnter` already early-returns when `!rPointing.current`, which is what prevents mid-scrub selection across sections. `handleButtonPointerUp` had no such guard and applied the value of whatever button was under the pointer on release. This adds the same `rPointing.current` guard so a release only applies in the picker where the scrub started.

The window-level `pointerup` cleanup runs after React's synthetic handler, so the flag is still set during a legitimate release — normal click and same-section scrub-release behavior is unchanged.

Fixes #9223

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Select a shape and open the style panel.
2. Press on a color, drag down over the dash/fill style buttons, and release over one of them.
3. The dash/fill style should not change; only the color you released over within the color section applies.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where releasing the pointer over a different style section after scrubbing would select that section's option.
