### PR TITLE
fix(dotcom): keep source tool highlighted when dragging from toolbar

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/useExtraToolDragIcons.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/useExtraToolDragIcons.ts
@@ -14,7 +14,7 @@ export function useExtraDragIconOverrides() {
 			tools(editor, tools) {
 				tools.select.onDragStart = function (source, info) {
 					onDragFromToolbarToCreateShape(editor, info, {
-						toolId: 'select',
+						maskedToolId: 'select',
 						createShape: (id) => {
 							const sizeStyle = editor.getStyleForNextShape(DefaultSizeStyle)
 							return editor.createShape({
@@ -38,7 +38,7 @@ export function useExtraDragIconOverrides() {
 
 				tools.hand.onDragStart = function (source, info) {
 					onDragFromToolbarToCreateShape(editor, info, {
-						toolId: 'hand',
+						maskedToolId: 'hand',
 						createShape: (id) => {
 							const sizeStyle = editor.getStyleForNextShape(DefaultSizeStyle)
 							return editor.createShape({
@@ -62,7 +62,7 @@ export function useExtraDragIconOverrides() {
 
 				tools.draw.onDragStart = function (source, info) {
 					onDragFromToolbarToCreateShape(editor, info, {
-						toolId: 'draw',
+						maskedToolId: 'draw',
 						createShape: (id) => {
 							const sizeStyle = editor.getStyleForNextShape(DefaultSizeStyle)
 							return editor.createShape({

--- a/apps/dotcom/client/src/tla/components/TlaEditor/useExtraToolDragIcons.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/useExtraToolDragIcons.ts
@@ -14,6 +14,7 @@ export function useExtraDragIconOverrides() {
 			tools(editor, tools) {
 				tools.select.onDragStart = function (source, info) {
 					onDragFromToolbarToCreateShape(editor, info, {
+						toolId: 'select',
 						createShape: (id) => {
 							const sizeStyle = editor.getStyleForNextShape(DefaultSizeStyle)
 							return editor.createShape({
@@ -37,6 +38,7 @@ export function useExtraDragIconOverrides() {
 
 				tools.hand.onDragStart = function (source, info) {
 					onDragFromToolbarToCreateShape(editor, info, {
+						toolId: 'hand',
 						createShape: (id) => {
 							const sizeStyle = editor.getStyleForNextShape(DefaultSizeStyle)
 							return editor.createShape({
@@ -60,6 +62,7 @@ export function useExtraDragIconOverrides() {
 
 				tools.draw.onDragStart = function (source, info) {
 					onDragFromToolbarToCreateShape(editor, info, {
+						toolId: 'draw',
 						createShape: (id) => {
 							const sizeStyle = editor.getStyleForNextShape(DefaultSizeStyle)
 							return editor.createShape({

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2953,6 +2953,7 @@ export function onDragFromToolbarToCreateShape(editor: Editor, info: TLPointerEv
 export interface OnDragFromToolbarToCreateShapesOpts {
     createShape(id: TLShapeId): void;
     onDragEnd?(id: TLShapeId): void;
+    toolId?: string;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2952,8 +2952,8 @@ export function onDragFromToolbarToCreateShape(editor: Editor, info: TLPointerEv
 // @public
 export interface OnDragFromToolbarToCreateShapesOpts {
     createShape(id: TLShapeId): void;
+    maskedToolId?: string;
     onDragEnd?(id: TLShapeId): void;
-    toolId?: string;
 }
 
 // @public (undocumented)

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -367,6 +367,12 @@ export interface OnDragFromToolbarToCreateShapesOpts {
 	 * Called once the drag interaction has finished.
 	 */
 	onDragEnd?(id: TLShapeId): void
+	/**
+	 * The id of the toolbar tool to keep highlighted while dragging. Defaults to the created shape's
+	 * type. Set this when the dragged shape's type differs from the tool it's dragged from — for
+	 * example, dragging a `draw` shape out from the select tool.
+	 */
+	toolId?: string
 }
 
 /**
@@ -405,5 +411,5 @@ export function onDragFromToolbarToCreateShape(
 		},
 	})
 
-	editor.getCurrentTool().setCurrentToolIdMask(shape.type)
+	editor.getCurrentTool().setCurrentToolIdMask(opts.toolId ?? shape.type)
 }

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -411,7 +411,5 @@ export function onDragFromToolbarToCreateShape(
 		},
 	})
 
-	if (opts.maskedToolId) {
-		editor.getCurrentTool().setCurrentToolIdMask(opts.maskedToolId)
-	}
+	editor.getCurrentTool().setCurrentToolIdMask(opts.maskedToolId ?? shape.type)
 }

--- a/packages/tldraw/src/lib/ui/hooks/useTools.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTools.tsx
@@ -372,7 +372,7 @@ export interface OnDragFromToolbarToCreateShapesOpts {
 	 * type. Set this when the dragged shape's type differs from the tool it's dragged from — for
 	 * example, dragging a `draw` shape out from the select tool.
 	 */
-	toolId?: string
+	maskedToolId?: string
 }
 
 /**
@@ -411,5 +411,7 @@ export function onDragFromToolbarToCreateShape(
 		},
 	})
 
-	editor.getCurrentTool().setCurrentToolIdMask(opts.toolId ?? shape.type)
+	if (opts.maskedToolId) {
+		editor.getCurrentTool().setCurrentToolIdMask(opts.maskedToolId)
+	}
 }

--- a/packages/tldraw/src/test/dragFromToolbar.test.ts
+++ b/packages/tldraw/src/test/dragFromToolbar.test.ts
@@ -1,0 +1,67 @@
+import { b64Vecs, TLPointerEventInfo } from '@tldraw/editor'
+import { onDragFromToolbarToCreateShape } from '../lib/ui/hooks/useTools'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+function dragInfo(): TLPointerEventInfo {
+	return {
+		type: 'pointer',
+		target: 'canvas',
+		name: 'pointer_move',
+		point: { x: 50, y: 50, z: 0.5 },
+		shiftKey: false,
+		altKey: false,
+		ctrlKey: false,
+		metaKey: false,
+		accelKey: false,
+		pointerId: 1,
+		button: 0,
+		isPen: false,
+	}
+}
+
+describe('onDragFromToolbarToCreateShape', () => {
+	it('masks the toolbar with the created shape type by default', () => {
+		onDragFromToolbarToCreateShape(editor, dragInfo(), {
+			createShape: (id) => editor.createShape({ id, type: 'geo' }),
+		})
+
+		// while dragging, the toolbar shows the dragged shape's tool as active
+		expect(editor.getCurrentToolId()).toBe('geo')
+	})
+
+	it('masks the toolbar with toolId when the shape type differs from the source tool', () => {
+		// reproduces #9221: dragging a `draw` shape out from the select tool should keep
+		// the select tool highlighted, not the draw (pen) tool.
+		onDragFromToolbarToCreateShape(editor, dragInfo(), {
+			toolId: 'select',
+			createShape: (id) =>
+				editor.createShape({
+					id,
+					type: 'draw',
+					props: {
+						segments: [
+							{
+								type: 'free',
+								path: b64Vecs.encodePoints([
+									{ x: 0, y: 0, z: 0.5 },
+									{ x: 10, y: 10, z: 0.5 },
+								]),
+							},
+						],
+					},
+				}),
+		})
+
+		expect(editor.getCurrentToolId()).toBe('select')
+	})
+})

--- a/packages/tldraw/src/test/dragFromToolbar.test.ts
+++ b/packages/tldraw/src/test/dragFromToolbar.test.ts
@@ -43,7 +43,7 @@ describe('onDragFromToolbarToCreateShape', () => {
 		// reproduces #9221: dragging a `draw` shape out from the select tool should keep
 		// the select tool highlighted, not the draw (pen) tool.
 		onDragFromToolbarToCreateShape(editor, dragInfo(), {
-			toolId: 'select',
+			maskedToolId: 'select',
 			createShape: (id) =>
 				editor.createShape({
 					id,


### PR DESCRIPTION
Dragging a doodle out of the cursor or hand toolbar buttons on tldraw.com would momentarily highlight the pen (draw) tool while the drag was happening, snapping back to the cursor on release.

Those buttons drag out `draw` shapes, and `onDragFromToolbarToCreateShape` masks the active tool with the *created shape's type* so the originating toolbar button stays highlighted during a drag. For built-in tools the shape type matches the button (geo→geo, note→note), but dotcom's `select`/`hand` overrides create `draw` shapes, so the mask became `'draw'` and the pencil lit up.

Fix: add an optional `maskedToolId` to `OnDragFromToolbarToCreateShapesOpts` that controls which tool stays highlighted during the drag, defaulting to the created shape's type (so existing callers are unchanged). The dotcom select/hand/draw drag tools now pass the button they're dragged from.

Fixes #9221

### API changes

- Added optional `maskedToolId` to `OnDragFromToolbarToCreateShapesOpts`. It sets which toolbar tool stays highlighted while dragging a shape from the toolbar, and defaults to the created shape's type when omitted.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On tldraw.com, drag the cursor or hand toolbar button out onto the canvas.
2. While dragging, the originating button (cursor/hand) stays highlighted — the pen tool no longer flashes selected.
3. On release, the cursor tool is selected as before.
4. Drag a built-in tool (e.g. geo or note) out from its button — that button stays highlighted during the drag.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +7 / -1    |
| Tests           | +67 / -0   |
| Automated files | +1 / -0    |
| Apps            | +3 / -0    |

### Release notes

- Fixed a bug where dragging a shape out of the cursor or hand toolbar buttons briefly selected the pen tool.
