### PR TITLE
fix(tldraw): add missing keyboard shortcuts to shortcuts dialog

### DIFF
--- a/packages/tldraw/src/lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialogContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialogContent.tsx
@@ -12,8 +12,10 @@ export function DefaultKeyboardShortcutsDialogContent() {
 			<TldrawUiMenuGroup label="shortcuts-dialog.tools" id="tools">
 				<TldrawUiMenuActionItem actionId="toggle-tool-lock" />
 				<TldrawUiMenuActionItem actionId="insert-media" />
+				<TldrawUiMenuActionItem actionId="insert-embed" />
 				<TldrawUiMenuToolItem toolId="select" />
 				<TldrawUiMenuToolItem toolId="draw" />
+				<TldrawUiMenuToolItem toolId="highlight" />
 				<TldrawUiMenuToolItem toolId="eraser" />
 				<TldrawUiMenuToolItem toolId="hand" />
 				<TldrawUiMenuToolItem toolId="rectangle" />
@@ -43,11 +45,13 @@ export function DefaultKeyboardShortcutsDialogContent() {
 				<TldrawUiMenuActionItem actionId="redo" />
 				<TldrawUiMenuActionItem actionId="cut" />
 				<TldrawUiMenuActionItem actionId="copy" />
+				<TldrawUiMenuActionItem actionId="copy-as-png" />
 				<TldrawUiMenuActionItem actionId="copy-hovered-styles" />
 				<TldrawUiMenuActionItem actionId="paste" />
 				<TldrawUiMenuActionItem actionId="select-all" />
 				<TldrawUiMenuActionItem actionId="delete" />
 				<TldrawUiMenuActionItem actionId="duplicate" />
+				<TldrawUiMenuActionItem actionId="print" />
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup label="shortcuts-dialog.view" id="view">
 				<TldrawUiMenuActionItem actionId="select-zoom-tool" />
@@ -72,6 +76,9 @@ export function DefaultKeyboardShortcutsDialogContent() {
 				<TldrawUiMenuActionItem actionId="send-to-back" />
 				<TldrawUiMenuActionItem actionId="group" />
 				<TldrawUiMenuActionItem actionId="ungroup" />
+				<TldrawUiMenuActionItem actionId="frame-selection" />
+				<TldrawUiMenuActionItem actionId="flatten-to-image" />
+				<TldrawUiMenuActionItem actionId="toggle-lock" />
 				<TldrawUiMenuActionItem actionId="flip-horizontal" />
 				<TldrawUiMenuActionItem actionId="flip-vertical" />
 				<TldrawUiMenuActionItem actionId="align-top" />
@@ -80,6 +87,8 @@ export function DefaultKeyboardShortcutsDialogContent() {
 				<TldrawUiMenuActionItem actionId="align-left" />
 				<TldrawUiMenuActionItem actionId="align-center-horizontal" />
 				<TldrawUiMenuActionItem actionId="align-right" />
+				<TldrawUiMenuActionItem actionId="distribute-horizontal" />
+				<TldrawUiMenuActionItem actionId="distribute-vertical" />
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup label="shortcuts-dialog.text-formatting" id="text">
 				<TldrawUiMenuItem

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -2,6 +2,8 @@ import { act } from '@testing-library/react'
 import { createShapeId, Editor } from '@tldraw/editor'
 import { useEffect } from 'react'
 import { Tldraw } from '../../lib/Tldraw'
+import { DefaultKeyboardShortcutsDialogContent } from '../../lib/ui/components/KeyboardShortcutsDialog/DefaultKeyboardShortcutsDialogContent'
+import { TldrawUiMenuContextProvider } from '../../lib/ui/components/primitives/menus/TldrawUiMenuContext'
 import { useActions } from '../../lib/ui/context/actions'
 import {
 	getHotkeysStringFromKbd,
@@ -17,6 +19,36 @@ import {
 // These kbds are intentionally not registered in the shortcut registry, they're handled by
 // useNativeClipboardEvents / the upload asset action instead. See SKIP_KBDS in useKeyboardShortcuts.
 const SKIP_KBDS = ['copy', 'cut', 'paste', 'asset']
+
+// Shortcuts that have a kbd but intentionally don't get their own row in the default keyboard
+// shortcuts dialog. If you add a shortcut that should be visible to users, add it to
+// DefaultKeyboardShortcutsDialogContent instead of this list.
+const NOT_IN_SHORTCUTS_DIALOG = new Set([
+	// Opening the shortcuts dialog is covered by the a11y "Open keyboard shortcuts" row.
+	'open-kbd-shortcuts',
+	// Covered by the a11y "Open context menu" row.
+	'a11y-open-context-menu',
+	// Cursor-targeted variants of zoom in/out that share a label with the rows already shown.
+	'zoom-in-on-cursor',
+	'zoom-out-on-cursor',
+	// Rotation is covered by the a11y "Rotate shape" rows.
+	'rotate-cw',
+	'rotate-ccw',
+	// Cursor-targeted paste variants of the paste row already shown.
+	'paste-at-cursor',
+	'paste-plain-text-at-cursor',
+	// Style-picking shortcuts that aren't surfaced in the dialog.
+	'select-white-color',
+	'select-fill-fill',
+	'select-fill-lined-fill',
+	// Re-selects the last geo tool; covered by the rectangle/ellipse tool rows.
+	'select-geo-tool',
+	// Page navigation shortcuts without dialog labels.
+	'change-page-prev',
+	'change-page-next',
+	// Only rendered when collaboration UI is enabled, which is off in this test.
+	'open-cursor-chat',
+])
 
 interface ShortcutEntry {
 	id: string
@@ -88,6 +120,33 @@ describe('default keyboard shortcuts', () => {
 			.map(([combo, ids]) => `${combo} -> ${ids.join(', ')}`)
 
 		expect(collisions).toEqual([])
+	})
+
+	it('lists every shortcut in the keyboard shortcuts dialog (or marks it as intentionally omitted)', async () => {
+		let entries: ShortcutEntry[] = []
+		const rendered = await renderTldrawComponent(
+			<Tldraw>
+				<ShortcutCapturer onCapture={(captured) => (entries = captured)} />
+				<TldrawUiMenuContextProvider type="keyboard-shortcuts" sourceId="kbd">
+					<DefaultKeyboardShortcutsDialogContent />
+				</TldrawUiMenuContextProvider>
+			</Tldraw>,
+			{ waitForPatterns: false }
+		)
+
+		// The raw ids (without the `action.`/`tool.` prefix) rendered as rows in the dialog.
+		const idsInDialog = new Set(
+			[...rendered.container.querySelectorAll('[data-testid^="kbd."]')].map((el) =>
+				el.getAttribute('data-testid')!.slice('kbd.'.length)
+			)
+		)
+		expect(idsInDialog.size).toBeGreaterThan(0)
+
+		const missing = entries
+			.map((entry) => entry.id.replace(/^(action|tool)\./, ''))
+			.filter((id) => !idsInDialog.has(id) && !NOT_IN_SHORTCUTS_DIALOG.has(id))
+
+		expect(missing).toEqual([])
 	})
 })
 


### PR DESCRIPTION
In order to keep the keyboard shortcuts dialog in sync with the shortcuts the editor actually handles, this PR adds the shortcuts that had a keybinding but were missing from the dialog. This follows up on #7399 (copy as PNG), which added the shortcut but never listed it, and covers the other gaps noted in #9087 (flatten, toggle locked, and more).

Added rows:

- Tools: insert embed (`cmd+i`), highlight tool (`shift+d`)
- Edit: copy as PNG (`cmd+shift+c`), print (`cmd+p`)
- Transform: frame selection (`cmd+alt+g`), flatten (`shift+f`), toggle locked (`shift+l`), distribute horizontally (`alt+shift+h`), distribute vertically (`alt+shift+v`)

A few shortcuts are intentionally left out and are now documented in the new test's `NOT_IN_SHORTCUTS_DIALOG` list: cursor-targeted zoom/paste variants and rotation (duplicates of rows already shown or covered by the accessibility group), style-picking shortcuts, geo-tool re-select, page navigation (no dialog labels), and cursor chat (only shown with collaboration UI enabled).

A test now fails if a shortcut gains a keybinding without being added to the dialog or to that intentional-omission list, so the dialog can't silently drift again.

Closes #9087

### Change type

- [x] `improvement`

### Test plan

1. Open the editor and press the keyboard shortcuts shortcut (`cmd+alt+/`).
2. Confirm the new rows appear: insert embed, highlight, copy as PNG, print, frame selection, flatten, toggle locked, distribute horizontally/vertically.

- [x] Unit tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -0    |
| Tests     | +59 / -0   |

### Release notes

- Add the missing keyboard shortcuts (copy as PNG, print, insert embed, highlight tool, frame selection, flatten, toggle locked, distribute horizontally/vertically) to the keyboard shortcuts dialog.
