### PR TITLE
fix(tldraw): render note attribution as HTML in SVG export

### DIFF
--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -1,9 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import {
 	Box,
-	DefaultFontFamilies,
 	EMPTY_ARRAY,
-	Editor,
 	Group2d,
 	IndexKey,
 	Rectangle2d,
@@ -461,13 +459,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		})
 
 		const { textFirstEditedBy } = shape.props
-		const attributionFirstName =
+		const attributionName =
 			textFirstEditedBy && !isEmptyRichText(shape.props.richText)
-				? this.editor.getAttributionDisplayName(textFirstEditedBy)?.split(' ')[0]
+				? (this.editor.getAttributionDisplayName(textFirstEditedBy)?.split(' ')[0] ?? null)
 				: null
-		const attributionName = attributionFirstName
-			? truncateAttributionForSvg(this.editor, attributionFirstName, dv.noteWidth)
-			: null
 
 		return (
 			<>
@@ -494,17 +489,26 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 					showTextOutline={false}
 				/>
 				{attributionName && (
-					<text
-						x={dv.noteWidth - 8}
-						y={bounds.h - 6}
-						textAnchor="end"
-						fontFamily={DefaultFontFamilies['sans']}
-						fontSize={11}
-						fill={dv.labelColor}
-						opacity={0.6}
+					<foreignObject
+						x={0}
+						y={0}
+						width={dv.noteWidth}
+						height={bounds.h}
+						className="tl-export-embed-styles"
 					>
-						{attributionName}
-					</text>
+						<div style={{ position: 'relative', width: '100%', height: '100%' }}>
+							<div
+								className="tl-note__attribution"
+								style={{
+									fontSize: 11,
+									color: dv.labelColor,
+									opacity: 0.6,
+								}}
+							>
+								{attributionName}
+							</div>
+						</div>
+					</foreignObject>
 				)}
 			</>
 		)
@@ -737,27 +741,6 @@ function useNoteKeydownHandler(id: TLShapeId) {
 
 function getNoteHeight(shape: TLNoteShape, noteHeight: number) {
 	return (noteHeight + shape.props.growY) * shape.props.scale
-}
-
-// Matches `.tl-note__attribution { max-width: 60% }` so SVG export truncates the same way.
-const ATTRIBUTION_MAX_WIDTH_RATIO = 0.6
-
-function truncateAttributionForSvg(editor: Editor, name: string, noteWidth: number) {
-	if (process.env.NODE_ENV === 'test') return name
-	const spans = editor.textMeasure.measureTextSpans(name, {
-		fontSize: 11,
-		fontFamily: DefaultFontFamilies['sans'],
-		textAlign: 'end',
-		width: noteWidth * ATTRIBUTION_MAX_WIDTH_RATIO,
-		height: 16,
-		padding: 0,
-		lineHeight: 1,
-		fontStyle: 'normal',
-		fontWeight: 'normal',
-		overflow: 'truncate-ellipsis',
-	})
-	if (spans.length === 0) return name
-	return spans.map((s) => s.text).join('')
 }
 
 function getNoteShadow(id: string, rotation: number, scale: number) {


### PR DESCRIPTION
In order to fix sticky note attribution text rendering larger and blurrier in PNG/SVG exports than on the live canvas, this PR renders the attribution as HTML inside a `<foreignObject>` instead of as a native SVG `<text>` element. Closes #8941.

The note body text was already exported through `RichTextSVG`, which wraps HTML in a `<foreignObject>` so the rasterized output uses the exact same layout and font metrics as the live DOM. The attribution was the only element exported as a native SVG `<text>`, which the browser's SVG text engine lays out and antialiases with different metrics — that mismatch was the degradation. Rendering it through a `foreignObject` with the existing `tl-note__attribution` class makes the export match the DOM.

Because the `foreignObject` now applies the real `.tl-note__attribution` CSS (`max-width: 60%; overflow: hidden; text-overflow: ellipsis`), ellipsis truncation happens natively and identically to the canvas, so the manual `truncateAttributionForSvg` text-measurement helper is no longer needed and has been removed.

### Change type

- [x] `bugfix`

### Test plan

1. Open a sticky note and type some text so the attribution (first name) appears in the bottom-right.
2. Copy the note as PNG (or export to PNG/SVG) and compare the pasted result against the original.
3. Confirm the attribution text is crisp and the same size/weight as on canvas, at both `scale = 1` and a resized note (`scale ≠ 1`).
4. Use a long attribution name and confirm it truncates with an ellipsis the same way as on the canvas.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +21 / -38  |

### Release notes

- Fix sticky note attribution text rendering larger and blurrier than the canvas when a note is exported or copied as a PNG.
