### PR TITLE
fix(dotcom): tighten mermaid detection for common words

### DIFF
--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
@@ -1,7 +1,7 @@
 import { simpleMermaidStringTest, stripMarkdownMermaidFence } from './simpleMermaidStringTest'
 
 describe('simpleMermaidStringTest', () => {
-	describe('bare keywords', () => {
+	describe('diagram keywords with content', () => {
 		const keywords = [
 			['flowchart', 'flowchart TD\n  A --> B'],
 			['graph', 'graph LR\n  A --> B'],
@@ -18,19 +18,19 @@ describe('simpleMermaidStringTest', () => {
 			['sankey', 'sankey-beta'],
 			['xychart', 'xychart-beta'],
 			['block', 'block-beta'],
-			['quadrantChart', 'quadrantChart'],
-			['requirement', 'requirement test_req'],
+			['quadrantChart', 'quadrantChart\n  title Reach vs Engagement'],
+			['requirement', 'requirement\n  test_req {\n    id: 1\n  }'],
 			['C4Context', 'C4Context\n  Person(user, "User")'],
-			['C4Container', 'C4Container'],
-			['C4Component', 'C4Component'],
-			['C4Dynamic', 'C4Dynamic'],
-			['C4Deployment', 'C4Deployment'],
+			['C4Container', 'C4Container\n  Container(web, "Web")'],
+			['C4Component', 'C4Component\n  Component(c, "Component")'],
+			['C4Dynamic', 'C4Dynamic\n  rel(a, b, "uses")'],
+			['C4Deployment', 'C4Deployment\n  Node(n, "Node")'],
 			['packet', 'packet-beta'],
-			['kanban', 'kanban'],
+			['kanban', 'kanban\n  todo[Todo]'],
 			['architecture', 'architecture-beta'],
 			['treemap', 'treemap-beta'],
 			['radar', 'radar-beta'],
-			['info', 'info'],
+			['info', 'info\n  showInfo'],
 		] as const
 
 		for (const [keyword, input] of keywords) {
@@ -109,6 +109,13 @@ describe('simpleMermaidStringTest', () => {
 			].join('\n')
 			expect(simpleMermaidStringTest(text)).toBe(true)
 		})
+
+		it('detects a bare keyword inside an explicit mermaid fence', () => {
+			// Inside a ```mermaid fence the user has declared intent, so a bare
+			// keyword that would otherwise be rejected is still treated as mermaid.
+			expect(simpleMermaidStringTest('```mermaid\ntimeline\n```')).toBe(true)
+			expect(simpleMermaidStringTest('```mermaid\nkanban\n```')).toBe(true)
+		})
 	})
 
 	describe('negative cases', () => {
@@ -145,6 +152,57 @@ describe('simpleMermaidStringTest', () => {
 		it('rejects a fence label that is not lowercase mermaid', () => {
 			const text = '```MERMAID\npie\n  "A" : 1\n```'
 			expect(simpleMermaidStringTest(text)).toBe(false)
+		})
+
+		it('rejects a bare keyword that is also a common word', () => {
+			for (const word of [
+				'timeline',
+				'graph',
+				'pie',
+				'block',
+				'info',
+				'kanban',
+				'journey',
+				'requirement',
+				'mindmap',
+			]) {
+				expect(simpleMermaidStringTest(word)).toBe(false)
+			}
+		})
+
+		it('rejects a bare keyword with trailing whitespace', () => {
+			expect(simpleMermaidStringTest('  timeline  ')).toBe(false)
+			expect(simpleMermaidStringTest('graph\n')).toBe(false)
+		})
+
+		it('rejects hyphenated words that start with a keyword', () => {
+			for (const word of [
+				'kanban-board',
+				'gantt-chart',
+				'timeline-view',
+				'graph-paper',
+				'block-party',
+			]) {
+				expect(simpleMermaidStringTest(word)).toBe(false)
+			}
+		})
+
+		it('rejects words that merely start with a keyword', () => {
+			expect(simpleMermaidStringTest('information about the project')).toBe(false)
+			expect(simpleMermaidStringTest('graphql query')).toBe(false)
+			expect(simpleMermaidStringTest('pier review')).toBe(false)
+		})
+
+		it('rejects single-line prose that starts with a keyword', () => {
+			for (const phrase of [
+				'graph paper is nice',
+				'pie in the sky',
+				'block party',
+				'journey home',
+				'info about the release',
+			]) {
+				expect(simpleMermaidStringTest(phrase)).toBe(false)
+			}
 		})
 	})
 })

--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.test.ts
@@ -204,6 +204,17 @@ describe('simpleMermaidStringTest', () => {
 				expect(simpleMermaidStringTest(phrase)).toBe(false)
 			}
 		})
+
+		it('rejects multi-line prose that starts with a keyword', () => {
+			for (const phrase of [
+				'journey home\nto my heart',
+				'pie in\nthe sky',
+				'graph paper\nis nice to draw on',
+				'block party\nthis weekend',
+			]) {
+				expect(simpleMermaidStringTest(phrase)).toBe(false)
+			}
+		})
 	})
 })
 

--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
@@ -63,9 +63,17 @@ export function simpleMermaidStringTest(text: string): boolean {
 	// clear diagram signal on its own.
 	if (match[2]) return true
 
-	// Otherwise require multi-line diagram structure: a line break followed by
-	// real content. This rejects single-line prose like "graph paper" or
-	// "pie in the sky" while still accepting "graph LR\n  A --> B".
+	// Otherwise require multi-line diagram structure. Real diagrams put the type
+	// keyword on its own line, optionally followed by a flowchart direction
+	// ("graph LR") or a pie modifier ("pie title ..."). The keyword line must
+	// match that shape and be followed by a body line. This rejects prose that
+	// merely starts with a keyword and trails into more text, whether on one
+	// line ("pie in the sky") or several ("journey home\nto my heart"), while
+	// still accepting "graph LR\n  A --> B" and "journey\n  title My day".
 	const remainder = cleaned.slice(match[0].length)
+	const keywordLine = remainder.match(/^[^\n\r]*/)![0].trim()
+	const isDiagramKeywordLine =
+		keywordLine === '' || /^(?:TB|TD|BT|RL|LR|title\b|showData\b)/i.test(keywordLine)
+	if (!isDiagramKeywordLine) return false
 	return /[\n\r]\s*\S/.test(remainder)
 }

--- a/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
+++ b/apps/dotcom/client/src/components/SneakyMermaidHandler/simpleMermaidStringTest.ts
@@ -12,8 +12,16 @@
  * pulling in the heavy mermaid library.
  */
 const FRONTMATTER_REGEX = /^-{3}\s*[\n\r]([\s\S]*?)[\n\r]-{3}\s*[\n\r]+/
+
+/**
+ * A diagram keyword at the start of the text, optionally followed by a known
+ * variant suffix (`-beta`, `-v2`). The trailing `(?![\w-])` is a word boundary
+ * that rejects keywords glued to more text: "kanban-board", "gantt-chart" and
+ * "information" do not match, while "sankey-beta" and "graph LR" do. Group 1 is
+ * the keyword, group 2 the variant suffix (if any).
+ */
 const DIAGRAM_KEYWORD_REGEX =
-	/^\s*(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|gitGraph|mindmap|timeline|sankey|xychart|block|quadrantChart|requirement|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|packet|kanban|architecture|treemap|radar|info)/
+	/^\s*(flowchart|graph|sequenceDiagram|classDiagram|stateDiagram|erDiagram|journey|gantt|pie|gitGraph|mindmap|timeline|sankey|xychart|block|quadrantChart|requirement|C4Context|C4Container|C4Component|C4Dynamic|C4Deployment|packet|kanban|architecture|treemap|radar|info)(-beta|-v\d+)?(?![\w-])/
 
 /**
  * Leading ```mermaid (or longer run) fence, closed by the first line that ends
@@ -42,5 +50,22 @@ export function stripMarkdownMermaidFence(text: string): string {
 }
 
 export function simpleMermaidStringTest(text: string): boolean {
-	return DIAGRAM_KEYWORD_REGEX.test(stripMermaidBoilerplate(stripMarkdownMermaidFence(text)))
+	const unfenced = stripMarkdownMermaidFence(text)
+	const cleaned = stripMermaidBoilerplate(unfenced).trim()
+	const match = cleaned.match(DIAGRAM_KEYWORD_REGEX)
+	if (!match) return false
+
+	// An explicit ```mermaid fence means the user has declared their intent, so
+	// a bare keyword inside it is enough.
+	if (unfenced !== text) return true
+
+	// A recognized variant suffix (e.g. "sankey-beta", "stateDiagram-v2") is a
+	// clear diagram signal on its own.
+	if (match[2]) return true
+
+	// Otherwise require multi-line diagram structure: a line break followed by
+	// real content. This rejects single-line prose like "graph paper" or
+	// "pie in the sky" while still accepting "graph LR\n  A --> B".
+	const remainder = cleaned.slice(match[0].length)
+	return /[\n\r]\s*\S/.test(remainder)
 }


### PR DESCRIPTION
In order to stop common English words and phrases from being rendered as broken mermaid diagrams on tldraw.com, this PR tightens the mermaid detection heuristic in `simpleMermaidStringTest`. Pasting text like "timeline", "kanban-board", "info", or "graph paper" previously matched a mermaid diagram keyword as a bare prefix and was routed to the mermaid renderer instead of being inserted as a plain text shape (closes #8481).

The detection regex matched diagram keywords with no word boundary and no structural validation, so:

1. **No word boundary** — "kanban-board" matched because "kanban" is a prefix.
2. **No structural validation** — a single word like "timeline", or a phrase like "graph paper", matched even though a real diagram has structure beyond the bare keyword.

This PR addresses both:

- Adds a trailing `(?![\w-])` word-boundary lookahead so keywords glued to more text no longer match: "kanban-board", "gantt-chart", "information", "graphql".
- Requires evidence of an actual diagram for unfenced text — either a recognized variant suffix (e.g. `sankey-beta`, `stateDiagram-v2`) or a line break followed by real content. This rejects single-line prose such as "graph paper is nice" or "pie in the sky" while still accepting `graph LR\n  A --> B`.
- Keeps explicit ` ```mermaid ` fences permissive: a bare keyword inside a fence the user has labelled as mermaid is still detected, since intent is clear.

### Change type

- [x] `bugfix`

### Test plan

1. Go to tldraw.com.
2. Copy a common word or phrase ("timeline", "kanban-board", "info", "graph paper") and paste it onto the canvas — it should appear as a plain text shape, not a diagram.
3. Paste a real diagram (e.g. `timeline` followed by `  title History`, or a ` ```mermaid ` fenced diagram) — it should still render as a mermaid diagram.

- [x] Unit tests

### Release notes

- Fix mermaid detection on tldraw.com so common words and phrases like "timeline", "kanban-board", "info", and "graph paper" paste as plain text instead of being rendered as broken diagrams.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +27 / -2   |
| Tests   | +67 / -9   |
