### PR TITLE
fix(dotcom): name the file/workspace in delete confirmation dialogs

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -239,20 +239,6 @@
       "value": "Editor"
     }
   ],
-  "371ce8cf11": [
-    {
-      "type": 0,
-      "value": "Are you sure you want to forget "
-    },
-    {
-      "type": 1,
-      "value": "fileName"
-    },
-    {
-      "type": 0,
-      "value": "?"
-    }
-  ],
   "375396d6e5": [
     {
       "type": 0,
@@ -305,6 +291,26 @@
     {
       "type": 0,
       "value": "Get help on Discord"
+    }
+  ],
+  "454aad3b3c": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "fileName"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "?"
     }
   ],
   "46137245cd": [
@@ -723,6 +729,26 @@
       "value": "."
     }
   ],
+  "81666c6e4a": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to forget "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "fileName"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
   "858ba4765e": [
     {
       "type": 0,
@@ -803,6 +829,26 @@
       "value": "Rename"
     }
   ],
+  "90646db02d": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "workspaceName"
+        }
+      ],
+      "type": 8,
+      "value": "strong"
+    },
+    {
+      "type": 0,
+      "value": "? This action cannot be undone."
+    }
+  ],
   "95aacd4d4a": [
     {
       "type": 0,
@@ -819,20 +865,6 @@
     {
       "type": 0,
       "value": "This month"
-    }
-  ],
-  "97a9bd4350": [
-    {
-      "type": 0,
-      "value": "Are you sure you want to delete "
-    },
-    {
-      "type": 1,
-      "value": "workspaceName"
-    },
-    {
-      "type": 0,
-      "value": "? This action cannot be undone."
     }
   ],
   "985a4b720f": [
@@ -1375,20 +1407,6 @@
     {
       "type": 0,
       "value": "Account menu"
-    }
-  ],
-  "ecfced1d96": [
-    {
-      "type": 0,
-      "value": "Are you sure you want to delete "
-    },
-    {
-      "type": 1,
-      "value": "fileName"
-    },
-    {
-      "type": 0,
-      "value": "?"
     }
   ],
   "ed53713239": [

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -117,12 +117,6 @@
       "value": "Export as"
     }
   ],
-  "1764571547": [
-    {
-      "type": 0,
-      "value": "Are you sure you want to delete this workspace? This action cannot be undone."
-    }
-  ],
   "181b90f889": [
     {
       "type": 0,
@@ -245,6 +239,20 @@
       "value": "Editor"
     }
   ],
+  "371ce8cf11": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to forget "
+    },
+    {
+      "type": 1,
+      "value": "fileName"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
   "375396d6e5": [
     {
       "type": 0,
@@ -321,12 +329,6 @@
     {
       "type": 0,
       "value": "Pin file"
-    }
-  ],
-  "4908687e50": [
-    {
-      "type": 0,
-      "value": "Are you sure you want to forget this file?"
     }
   ],
   "49ee308734": [
@@ -817,6 +819,20 @@
     {
       "type": 0,
       "value": "This month"
+    }
+  ],
+  "97a9bd4350": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete "
+    },
+    {
+      "type": 1,
+      "value": "workspaceName"
+    },
+    {
+      "type": 0,
+      "value": "? This action cannot be undone."
     }
   ],
   "985a4b720f": [
@@ -1361,6 +1377,20 @@
       "value": "Account menu"
     }
   ],
+  "ecfced1d96": [
+    {
+      "type": 0,
+      "value": "Are you sure you want to delete "
+    },
+    {
+      "type": 1,
+      "value": "fileName"
+    },
+    {
+      "type": 0,
+      "value": "?"
+    }
+  ],
   "ed53713239": [
     {
       "type": 0,
@@ -1445,12 +1475,6 @@
     {
       "type": 0,
       "value": "Are you sure you want to leave this workspace?"
-    }
-  ],
-  "fd1be3efcf": [
-    {
-      "type": 0,
-      "value": "Are you sure you want to delete this file?"
     }
   ],
   "fed5ec05eb": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -110,9 +110,6 @@
   "344a7f427f": {
     "translation": "Editor"
   },
-  "371ce8cf11": {
-    "translation": "Are you sure you want to forget {fileName}?"
-  },
   "375396d6e5": {
     "translation": "Remove member"
   },
@@ -139,6 +136,9 @@
   },
   "44db318ee5": {
     "translation": "Get help on Discord"
+  },
+  "454aad3b3c": {
+    "translation": "Are you sure you want to delete <strong>{fileName}</strong>?"
   },
   "46137245cd": {
     "translation": "Thanks for helping us improve tldraw!"
@@ -329,6 +329,9 @@
   "815e116a2e": {
     "translation": "Have a bug, issue, or idea for tldraw? Let us know! Fill out this form and we will follow up over email if needed. You can also <discord>chat with us on Discord</discord> or <github>submit an issue on GitHub</github>."
   },
+  "81666c6e4a": {
+    "translation": "Are you sure you want to forget <strong>{fileName}</strong>?"
+  },
   "858ba4765e": {
     "translation": "Member"
   },
@@ -365,6 +368,9 @@
   "904a830405": {
     "translation": "Rename"
   },
+  "90646db02d": {
+    "translation": "Are you sure you want to delete <strong>{workspaceName}</strong>? This action cannot be undone."
+  },
   "95aacd4d4a": {
     "translation": "Sign in with Google"
   },
@@ -373,9 +379,6 @@
   },
   "96165d6df5": {
     "translation": "This month"
-  },
-  "97a9bd4350": {
-    "translation": "Are you sure you want to delete {workspaceName}? This action cannot be undone."
   },
   "985a4b720f": {
     "translation": "Terms of Use"
@@ -593,9 +596,6 @@
   },
   "ec611e9a08": {
     "translation": "Account menu"
-  },
-  "ecfced1d96": {
-    "translation": "Are you sure you want to delete {fileName}?"
   },
   "ed53713239": {
     "translation": "i18n: Accented"

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -56,9 +56,6 @@
   "13ddd375ad": {
     "translation": "Export as"
   },
-  "1764571547": {
-    "translation": "Are you sure you want to delete this workspace? This action cannot be undone."
-  },
   "181b90f889": {
     "translation": "Create file"
   },
@@ -113,6 +110,9 @@
   "344a7f427f": {
     "translation": "Editor"
   },
+  "371ce8cf11": {
+    "translation": "Are you sure you want to forget {fileName}?"
+  },
   "375396d6e5": {
     "translation": "Remove member"
   },
@@ -151,9 +151,6 @@
   },
   "47f493a590": {
     "translation": "Pin file"
-  },
-  "4908687e50": {
-    "translation": "Are you sure you want to forget this file?"
   },
   "49ee308734": {
     "translation": "Name"
@@ -377,6 +374,9 @@
   "96165d6df5": {
     "translation": "This month"
   },
+  "97a9bd4350": {
+    "translation": "Are you sure you want to delete {workspaceName}? This action cannot be undone."
+  },
   "985a4b720f": {
     "translation": "Terms of Use"
   },
@@ -594,6 +594,9 @@
   "ec611e9a08": {
     "translation": "Account menu"
   },
+  "ecfced1d96": {
+    "translation": "Are you sure you want to delete {fileName}?"
+  },
   "ed53713239": {
     "translation": "i18n: Accented"
   },
@@ -629,9 +632,6 @@
   },
   "fc9d47046b": {
     "translation": "Are you sure you want to leave this workspace?"
-  },
-  "fd1be3efcf": {
-    "translation": "Are you sure you want to delete this file?"
   },
   "fed5ec05eb": {
     "translation": "Copied link"

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -67,9 +67,15 @@ export function TlaDeleteFileDialog({
 			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
 				<>
 					{isOwner ? (
-						<F defaultMessage="Are you sure you want to delete {fileName}?" values={{ fileName }} />
+						<F
+							defaultMessage="Are you sure you want to delete <strong>{fileName}</strong>?"
+							values={{ fileName, strong: (chunks) => <strong>{chunks}</strong> }}
+						/>
 					) : (
-						<F defaultMessage="Are you sure you want to forget {fileName}?" values={{ fileName }} />
+						<F
+							defaultMessage="Are you sure you want to forget <strong>{fileName}</strong>?"
+							values={{ fileName, strong: (chunks) => <strong>{chunks}</strong> }}
+						/>
 					)}
 				</>
 			</TldrawUiDialogBody>

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaDeleteFileDialog.tsx
@@ -8,6 +8,7 @@ import {
 	TldrawUiDialogFooter,
 	TldrawUiDialogHeader,
 	TldrawUiDialogTitle,
+	useValue,
 } from 'tldraw'
 import { routes } from '../../../routeDefs'
 import { useApp } from '../../hooks/useAppState'
@@ -30,6 +31,7 @@ export function TlaDeleteFileDialog({
 	const auth = useAuth()
 
 	const isOwner = useHasFileAdminRights(fileId)
+	const fileName = useValue('file name', () => app.getFileName(fileId), [fileId, app])
 
 	const handleDelete = async () => {
 		const token = await auth.getToken()
@@ -65,9 +67,9 @@ export function TlaDeleteFileDialog({
 			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
 				<>
 					{isOwner ? (
-						<F defaultMessage="Are you sure you want to delete this file?" />
+						<F defaultMessage="Are you sure you want to delete {fileName}?" values={{ fileName }} />
 					) : (
-						<F defaultMessage="Are you sure you want to forget this file?" />
+						<F defaultMessage="Are you sure you want to forget {fileName}?" values={{ fileName }} />
 					)}
 				</>
 			</TldrawUiDialogBody>

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -209,7 +209,10 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 				<ConfirmDialog
 					title={<F defaultMessage="Delete workspace" />}
 					description={
-						<F defaultMessage="Are you sure you want to delete this workspace? This action cannot be undone." />
+						<F
+							defaultMessage="Are you sure you want to delete {workspaceName}? This action cannot be undone."
+							values={{ workspaceName: workspace.name || namePlaceholderMsg }}
+						/>
 					}
 					confirmLabel={<F defaultMessage="Delete" />}
 					cancelLabel={<F defaultMessage="Cancel" />}

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -210,8 +210,11 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 					title={<F defaultMessage="Delete workspace" />}
 					description={
 						<F
-							defaultMessage="Are you sure you want to delete {workspaceName}? This action cannot be undone."
-							values={{ workspaceName: workspace.name || namePlaceholderMsg }}
+							defaultMessage="Are you sure you want to delete <strong>{workspaceName}</strong>? This action cannot be undone."
+							values={{
+								workspaceName: workspace.name || namePlaceholderMsg,
+								strong: (chunks) => <strong>{chunks}</strong>,
+							}}
 						/>
 					}
 					confirmLabel={<F defaultMessage="Delete" />}


### PR DESCRIPTION
In order to make file and workspace deletion less ambiguous, this PR includes the name of the item being deleted in the confirmation dialogs. Previously the dialogs read generic copy like "Are you sure you want to delete this file?", which gave no confirmation of which file or workspace was about to be deleted.

The file delete/forget dialog now reads "Are you sure you want to delete {fileName}?" (and the "forget" variant for non-owners), and the delete-workspace confirmation reads "Are you sure you want to delete {workspaceName}? This action cannot be undone." Unnamed workspaces fall back to the existing name placeholder. This matches the existing pattern already used when removing a workspace member.

### Change type

- [x] `improvement`

### Test plan

1. Open a file's menu and click Delete (or Forget as a non-owner); confirm the dialog names the file.
2. Open a workspace's settings and click Delete workspace; confirm the dialog names the workspace.

### Release notes

- Show the file or workspace name in delete confirmation dialogs on tldraw.com.
