### PR TITLE
test(dotcom): fail e2e fast when dev server does not start

### DIFF
--- a/apps/dotcom/client/playwright.config.ts
+++ b/apps/dotcom/client/playwright.config.ts
@@ -7,8 +7,11 @@ const scenarioTestMatch = /.*\.scenario\.spec\.ts/
 // scenario runner. See e2e/README.md.
 const smokeTestMatch = /tests\/smoke\/.*\.spec\.ts/
 
-// Must cover `DOTCOM_DEV_APP_READY_TIMEOUT_MS` in zero-cache/dev-env.ts plus a Vite startup buffer.
-const CI_WEB_SERVER_TIMEOUT_MS = 840_000
+// Fail fast if the dev stack does not come up: not a single test runs until http://localhost:3000
+// responds, so a stuck server otherwise burns CI minutes. The dotcom server should boot well within
+// this. If a CI cold start ever legitimately needs longer, raise this (and the readiness budgets in
+// zero-cache/dev-env.ts) rather than reverting to a multi-minute stuck wait.
+const CI_WEB_SERVER_TIMEOUT_MS = 180_000
 
 /**
  * Read environment variables from file.


### PR DESCRIPTION
In order to stop burning GitHub Actions minutes when the dotcom dev stack fails to start, this PR reduces the Playwright `webServer` startup timeout in CI from `840_000`ms (14 min) to `180_000`ms (3 min). That timeout is how long Playwright waits for `http://localhost:3000` to respond before any test runs; on a stuck or broken stack it previously sat idle for ~14 minutes before failing. The dotcom server should boot well within 3 minutes, so this aborts a hung run quickly instead.

The old value was derived to cover the dev stack's internal per-stage readiness budgets in `zero-cache/dev-env.ts` (~13 min worst case). Those internal budgets are left unchanged: they gate individual stages (Postgres, migrations, Zero cache, sync worker) and govern the local dev experience, and a genuinely failing stage already throws and exits quickly. The 3-min cap now bounds the whole `yarn dev-app` command in CI. Trade-off: if a CI cold start ever legitimately needs more than 3 minutes, the e2e job will fail at that mark — the fix then is to bump this value to a measured number, not restore 14 minutes.

### Change type

- [x] `improvement`

### Test plan

- A healthy CI e2e run should start tests exactly as before.
- A run where the dev server never comes up should now abort at ~3 min instead of ~14 min.

- [ ] Unit tests
- [x] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +5 / -2    |