### PR TITLE
fix: treat empty-array rich text as an empty label

### DIFF
--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
@@ -182,6 +182,48 @@ describe('Resizing geo shapes with labels', () => {
 	})
 })
 
+describe('Geo shapes with programmatically-authored empty rich text', () => {
+	const geoId = createShapeId('geo')
+
+	function getGeo() {
+		return editor.getShape<TLGeoShape>(geoId)!
+	}
+
+	// An empty paragraph can be encoded two equally-valid ways. The interactive
+	// editor emits the first (no `content` key); programmatic authoring (snapshot
+	// load, agents emitting tldraw JSON) commonly emits the second (`content: []`).
+	// Both mean "no label", so neither should grow the shape to fit a phantom line.
+	const emptyForms = [
+		{
+			label: 'paragraph with no content key (toRichText output)',
+			richText: toRichText(''),
+		},
+		{
+			label: 'paragraph with empty content array',
+			richText: {
+				type: 'doc',
+				content: [{ type: 'paragraph', attrs: { dir: 'auto' }, content: [] }],
+			} as TLGeoShape['props']['richText'],
+		},
+	]
+
+	for (const { label, richText } of emptyForms) {
+		test(`does not grow height for an empty label: ${label}`, () => {
+			editor.createShapes([
+				{
+					id: geoId,
+					type: 'geo',
+					props: { w: 110, h: 24, geo: 'rectangle', size: 's', richText },
+				},
+			])
+
+			const geo = getGeo()
+			expect(geo.props.h).toBe(24)
+			expect(geo.props.growY).toBe(0)
+		})
+	}
+})
+
 describe('GeoShapeUtil.configure with customGeoTypes', () => {
 	// Snapshot the built-in geo values so we can clean up any custom keys added
 	// during these tests. `GeoShapeUtil.configure({ customGeoTypes })` mutates

--- a/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
+++ b/packages/tldraw/src/lib/shapes/geo/GeoShapeUtil.test.tsx
@@ -205,6 +205,10 @@ describe('Geo shapes with programmatically-authored empty rich text', () => {
 				content: [{ type: 'paragraph', attrs: { dir: 'auto' }, content: [] }],
 			} as TLGeoShape['props']['richText'],
 		},
+		{
+			label: 'doc with empty content array',
+			richText: { type: 'doc', content: [] } as TLGeoShape['props']['richText'],
+		},
 	]
 
 	for (const { label, richText } of emptyForms) {

--- a/packages/tldraw/src/lib/utils/text/richText.test.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.test.ts
@@ -1,0 +1,31 @@
+import { TLRichText, toRichText } from '@tldraw/editor'
+import { isEmptyRichText } from './richText'
+
+describe('isEmptyRichText', () => {
+	it('treats a paragraph with no content key as empty (interactive editor output)', () => {
+		expect(isEmptyRichText(toRichText(''))).toBe(true)
+	})
+
+	it('treats a paragraph with an empty content array as empty (programmatic authoring)', () => {
+		const richText: TLRichText = {
+			type: 'doc',
+			content: [{ type: 'paragraph', attrs: { dir: 'auto' }, content: [] }],
+		}
+		expect(isEmptyRichText(richText)).toBe(true)
+	})
+
+	it('treats a paragraph with text as non-empty', () => {
+		expect(isEmptyRichText(toRichText('Hello'))).toBe(false)
+	})
+
+	it('treats multiple paragraphs as non-empty', () => {
+		const richText: TLRichText = {
+			type: 'doc',
+			content: [
+				{ type: 'paragraph', content: [] },
+				{ type: 'paragraph', content: [] },
+			],
+		}
+		expect(isEmptyRichText(richText)).toBe(false)
+	})
+})

--- a/packages/tldraw/src/lib/utils/text/richText.test.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.test.ts
@@ -14,6 +14,11 @@ describe('isEmptyRichText', () => {
 		expect(isEmptyRichText(richText)).toBe(true)
 	})
 
+	it('treats a doc with an empty content array as empty (hand-authored / importer form)', () => {
+		const richText: TLRichText = { type: 'doc', content: [] }
+		expect(isEmptyRichText(richText)).toBe(true)
+	})
+
 	it('treats a paragraph with text as non-empty', () => {
 		expect(isEmptyRichText(toRichText('Hello'))).toBe(false)
 	})

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -107,11 +107,14 @@ export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: T
 const plainTextFromRichTextCache = new WeakCache<TLRichText, string>()
 
 export function isEmptyRichText(richText: TLRichText) {
+	// An empty document has no text. It can be encoded several equally-valid ways:
+	// an empty `content` array at the doc level, or a single paragraph whose own
+	// `content` is missing or an empty array. The interactive editor emits the
+	// single-paragraph / missing-`content` form; programmatic authoring (snapshot
+	// loads, and agents/importers emitting tldraw JSON) commonly emits the
+	// empty-array forms. Treat them all as empty.
+	if (richText.content.length === 0) return true
 	if (richText.content.length === 1) {
-		// An empty paragraph can be encoded as either a missing `content` key or an
-		// empty `content` array. The interactive editor emits the former; programmatic
-		// authoring (snapshot load, agents emitting tldraw JSON) often emits the latter.
-		// Both mean "no text", so treat them the same.
 		const node = richText.content[0] as any
 		if (!node.content || node.content.length === 0) return true
 	}

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -108,7 +108,12 @@ const plainTextFromRichTextCache = new WeakCache<TLRichText, string>()
 
 export function isEmptyRichText(richText: TLRichText) {
 	if (richText.content.length === 1) {
-		if (!(richText.content[0] as any).content) return true
+		// An empty paragraph can be encoded as either a missing `content` key or an
+		// empty `content` array. The interactive editor emits the former; programmatic
+		// authoring (snapshot load, agents emitting tldraw JSON) often emits the latter.
+		// Both mean "no text", so treat them the same.
+		const node = richText.content[0] as any
+		if (!node.content || node.content.length === 0) return true
 	}
 	return false
 }


### PR DESCRIPTION
### The problem

Geo, note, and arrow shapes share `isEmptyRichText` to decide whether a shape carries a label. An empty document has more than one valid encoding, and the predicate only recognised one of them:

- `{ doc, content: [{ paragraph }] }` — paragraph with no `content` key (what the interactive editor emits via `toRichText('')`) → correctly treated as empty.
- `{ doc, content: [{ paragraph, content: [] }] }` — paragraph-level empty array → **mis-read as having a label** (an empty array is truthy).
- `{ doc, content: [] }` — doc-level empty array → **also mis-read** (`content.length` is 0, so it never entered the predicate's `length === 1` branch).

A shape mis-classified this way runs label measurement on an empty paragraph and grows via `growY` to fit text that isn't there. Verified live (size `s`, base `h` 24):

| encoding | growY | rendered height |
|---|---|---|
| canonical `{ content: [{ paragraph }] }` | 0 | 24 |
| paragraph-level `content: []` | 32.3 | 56.3 (a full phantom line) |
| doc-level `content: []` | 8 | 32 (mild but real) |

### The fix

Treat all empty encodings as empty in the shared predicate — short-circuit on an empty doc, and on a single paragraph whose own `content` is missing or empty. Read-side only: the stored data was always valid rich text, so there's no migration; old and new documents are interpreted correctly from this commit on. Fixed at the chokepoint, so geo + note + arrow are corrected by one change.

### Reproduction

Run in any tldraw editor's console (each rectangle is authored with an empty label, exactly as programmatic/agent JSON emits it):

```js
const mk = (richText, x) => editor.createShape({
  type: 'geo', x, y: 100,
  props: { w: 110, h: 24, geo: 'rectangle', size: 's', richText },
})
mk({ type: 'doc', content: [{ type: 'paragraph' }] }, 0)                                  // canonical → stays 24
mk({ type: 'doc', content: [{ type: 'paragraph', attrs: { dir: 'auto' }, content: [] }] }, 200) // grows
mk({ type: 'doc', content: [] }, 400)                                                     // grows
```

Before this PR the second and third rectangles render taller than the first; after, all three stay at the authored height. (`editor.getShape(id).props.growY` logs non-zero before, `0` after.)

### Why this happens in practice — field survey

The interactive editor can only ever produce the canonical form (ProseMirror's serializer omits empty `content`). The empty-array forms come from rich text authored **outside** that serializer — hand-written object literals, importers, and AI/LLM tools emitting tldraw JSON. This pattern is real and already in the wild:

- **tldraw itself** — `packages/sync-core/src/test/TLSyncRoom.test.ts` uses `richText: { type: 'doc', content: [] }` as a fixture. Even internally, the doc-level empty array is the "obvious" hand-written form.
- **Custom `getDefaultProps`** — [`tldraw-for-cp`](https://github.com/temmie-950807/tldraw-for-cp/blob/main/src/tools/layout/ElementShapeUtil.tsx) ships `richText: { type: "doc", content: [] }` as a custom shape's default, so *every* instance carries the empty-array form.
- **Sanitizers** — [`MindBitsComposer`](https://github.com/Evolui-Tecnologia-MVP-Proto/MindBitsComposer/blob/main/client/src/pages/plugins/vector-graph-plugin.tsx) has a `sanitizeRichText()` that normalizes empty/invalid rich text to `{ doc, content: [{ paragraph, attrs: { dir: 'auto' }, content: [] }] }` and applies it to every shape — a cleanup routine that produces the exact buggy form.
- **AI-to-tldraw tools** — [`openOii`](https://github.com/Xeron2000/openOii/blob/main/frontend/app/components/canvas/InfiniteCanvas.tsx) writes `richText: { type: "doc", content: [] }` on shape creation; [`canvas-copilot`](https://github.com/allebee/canvas-copilot/blob/main/FRONTEND_STORAGE_GUIDE.md) instructs the model directly: `// Empty text → { type: "doc", content: [] }`, so the model emits the bad form at runtime.

The structural point: the heaviest producers (importers, LLM tools) generate the JSON at **runtime**, so the bad pattern lives in users' saved documents rather than in source code — which is why it has gone unreported despite being common, and why the symptom (a subtly oversized shape) is hard to attribute. No symptom reports were found in tldraw issues/discussions.

### Tests

- `richText.test.ts` — predicate coverage for all three empty forms (missing-content, paragraph-level `[]`, doc-level `[]`); text and multi-paragraph stay non-empty.
- `GeoShapeUtil.test.tsx` — integration regression asserting none of the empty forms grow the shape (`h` stays 24, `growY` stays 0). The paragraph-level case grew `growY` to 26 before the fix.

Verified locally: geo + predicate (19 tests), note + arrow (75 tests), and `yarn api-check` all pass. No public API change.

Closes #9282
