### PR TITLE
fix(tldraw): drag a selected hollow shape that overlaps a filled shape behind it

### DIFF
--- a/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
@@ -8,16 +8,30 @@ export function getHitShapeOnCanvasPointerDown(
 	const zoomLevel = editor.getZoomLevel()
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
-	return (
-		// hovered shape at point
-		editor.getShapeAtPoint(currentPagePoint, {
-			hitInside: false,
-			hitLabels,
-			hitLocked: editor.options.selectLockedShapes,
-			margin: editor.options.hitTestMargin / zoomLevel,
-			renderingOnly: true,
-		}) ??
-		// selected shape at point
-		editor.getSelectedShapeAtPoint(currentPagePoint)
-	)
+	// The shape whose geometry is under the pointer. For hollow shapes this skips
+	// the interior, so a point inside a hollow shape can resolve to a filled shape
+	// sitting behind it.
+	const hitShape = editor.getShapeAtPoint(currentPagePoint, {
+		hitInside: false,
+		hitLabels,
+		hitLocked: editor.options.selectLockedShapes,
+		margin: editor.options.hitTestMargin / zoomLevel,
+		renderingOnly: true,
+	})
+
+	// A selected shape under the pointer (tested with hitInside, so a hollow
+	// selected shape's interior counts) should win over a shape behind it. This
+	// keeps a selected hollow shape grabbable even when a filled shape sits behind
+	// it. We only prefer it when it's in front of (or there is no) other hit shape,
+	// so clicking a shape stacked on top of the selection still selects that shape.
+	const selectedShapeAtPoint = editor.getSelectedShapeAtPoint(currentPagePoint)
+	if (selectedShapeAtPoint) {
+		if (!hitShape) return selectedShapeAtPoint
+		const sorted = editor.getCurrentPageShapesSorted()
+		if (sorted.indexOf(selectedShapeAtPoint) >= sorted.indexOf(hitShape)) {
+			return selectedShapeAtPoint
+		}
+	}
+
+	return hitShape
 }

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -1185,6 +1185,53 @@ describe('when selecting behind selection', () => {
 	})
 })
 
+describe('when a selected hollow shape overlaps a filled shape behind it', () => {
+	beforeEach(() => {
+		editor
+			.createShapes([
+				// large filled shape behind
+				{ id: ids.box1, type: 'geo', x: 0, y: 0, props: { w: 300, h: 300, fill: 'solid' } },
+				// smaller hollow shape in front, interior over the filled shape
+				{ id: ids.box2, type: 'geo', x: 50, y: 50, props: { w: 100, h: 100, fill: 'none' } },
+			])
+			.select(ids.box2)
+	})
+
+	it('keeps the hollow shape selected on pointer down inside it (does not fall through to the filled shape)', () => {
+		editor.pointerMove(100, 100) // inside box2's interior, over box1
+		// the hollow interior isn't a hit target, so box1 is what's hovered
+		expect(editor.getHoveredShapeId()).toBe(ids.box1)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+	})
+
+	it('translates the selected hollow shape when dragged from its interior', () => {
+		editor.pointerMove(100, 100) // inside box2's interior, over box1
+		editor.pointerDown()
+		editor.pointerMove(150, 150) // drag
+		editor.expectToBeIn('select.translating')
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+		expect(editor.getShape(ids.box2)).toMatchObject({ x: 100, y: 100 })
+	})
+
+	it('still selects a filled shape stacked in front of the selection', () => {
+		// box3 is filled and created last, so it sits in front of the selected box2
+		editor.createShape({
+			id: ids.box3,
+			type: 'geo',
+			x: 75,
+			y: 75,
+			props: { w: 40, h: 40, fill: 'solid' },
+		})
+		editor.pointerMove(95, 95) // inside box3, also inside box2's interior
+		expect(editor.getHoveredShapeId()).toBe(ids.box3)
+		editor.pointerDown()
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+	})
+})
+
 for (const key of ['Shift', 'Control']) {
 	describe('when additive+selecting', () => {
 		beforeEach(() => {


### PR DESCRIPTION
## What
<img width="2562" height="1442" alt="2026-06-18 at 14 54 27 - Cyan Partridge" src="https://github.com/user-attachments/assets/0c40fba4-884d-433f-9941-ceda3f10cab9" />

<img width="2562" height="1442" alt="2026-06-18 at 14 52 34 - Plum Guanaco" src="https://github.com/user-attachments/assets/44b723a4-107b-4970-95d1-dd0c685b99dc" />

Fixes a case where an already-selected hollow (no-fill) shape couldn't be dragged from its interior when it overlapped a filled shape sitting behind it. Pointing down inside the hollow shape's interior resolved to the filled shape, deselecting the hollow one.

Closes #8733

## Why it happened

`getHitShapeOnCanvasPointerDown` returned:

```ts
editor.getShapeAtPoint(point, { hitInside: false, ... }) ?? editor.getSelectedShapeAtPoint(point)
```

`getShapeAtPoint({ hitInside: false })` skips a hollow shape's interior, so a point inside the hollow shape resolves to the filled shape behind it. Because of the `??`, the `getSelectedShapeAtPoint` fallback only fired when *nothing* was hit — so it never rescued the hollow-over-filled case. The wrong shape then flowed into `PointingShape`, which committed the selection to the filled shape.

## The fix

Prefer a *selected* shape under the pointer (tested with `hitInside`, so a hollow interior counts) over a shape behind it — but only when the selected shape is in front of, or there is no, other hit shape (z-order check via `getCurrentPageShapesSorted`). That keeps a selected hollow shape grabbable from its interior while still letting a shape stacked *on top* of the selection win a click.

Fixing it in the helper (rather than in `PointingShape`) corrects the input for all of its callers — `Idle`, `EditingShape`, and `Crop` — at the point where "what's under the pointer" is actually decided.

## Tests

Added a `selection-omnibus` describe block covering:
- pointer down inside a selected hollow shape keeps it selected (doesn't fall through to the filled shape behind)
- dragging from the interior translates the hollow shape
- a filled shape stacked *in front* of the selection still wins a click (guards against over-capture)

All 158 selection-omnibus tests pass.