### PR TITLE
fix(dotcom): dotcom followups, theme tokens, auth dialog width, and iOS input zoom

### DIFF
--- a/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
@@ -63,6 +63,106 @@ test.describe('workspaces', () => {
 			await expect(homeItem).toBeVisible()
 		})
 
+		test('dismissing the switcher does not click a file underneath', async ({ page, sidebar }) => {
+			const file1 = getRandomName()
+			const file2 = getRandomName()
+			const file3 = getRandomName()
+
+			await sidebar.createNewDocument(file1)
+			await sidebar.createNewDocument(file2)
+			await sidebar.createNewDocument(file3)
+			await sidebar.expectFileActive(file3)
+
+			await sidebar.openWorkspaceSwitcher()
+			const overlay = page.getByTestId('tla-workspace-switcher-overlay')
+			await expect(overlay).toBeVisible()
+
+			const target = await page.evaluate(() => {
+				const overlay = document.querySelector<HTMLElement>(
+					'[data-testid="tla-workspace-switcher-overlay"]'
+				)
+				if (!overlay) throw new Error('Missing workspace switcher overlay')
+
+				const links = Array.from(
+					document.querySelectorAll<HTMLElement>('[data-element="file-link"]')
+				)
+				for (const link of links.reverse()) {
+					if (link.dataset.active === 'true') continue
+
+					const rect = link.getBoundingClientRect()
+					const x = rect.left + rect.width / 2
+					const y = rect.top + rect.height / 2
+					if (
+						!document
+							.elementFromPoint(x, y)
+							?.closest('[data-testid="tla-workspace-switcher-overlay"]')
+					) {
+						continue
+					}
+
+					return {
+						name: link.querySelector('[data-testid*="-name"]')?.textContent?.trim() ?? '',
+						x,
+						y,
+					}
+				}
+
+				throw new Error('Could not find a file link behind the workspace switcher overlay')
+			})
+
+			await page.evaluate(({ x, y }) => {
+				const overlay = document.querySelector<HTMLElement>(
+					'[data-testid="tla-workspace-switcher-overlay"]'
+				)
+				if (!overlay) throw new Error('Missing workspace switcher overlay')
+
+				overlay.dispatchEvent(
+					new PointerEvent('pointerdown', {
+						bubbles: true,
+						cancelable: true,
+						clientX: x,
+						clientY: y,
+						pointerId: 1,
+						pointerType: 'touch',
+						isPrimary: true,
+					})
+				)
+			}, target)
+
+			await expect(overlay).toBeVisible()
+
+			await page.evaluate(({ x, y }) => {
+				const target = document.elementFromPoint(x, y)
+				target?.dispatchEvent(
+					new PointerEvent('pointerup', {
+						bubbles: true,
+						cancelable: true,
+						clientX: x,
+						clientY: y,
+						pointerId: 1,
+						pointerType: 'touch',
+						isPrimary: true,
+					})
+				)
+				target?.dispatchEvent(
+					new MouseEvent('click', {
+						bubbles: true,
+						cancelable: true,
+						clientX: x,
+						clientY: y,
+					})
+				)
+			}, target)
+
+			await expect(overlay).toBeHidden()
+			await sidebar.expectFileActive(file3)
+			await sidebar.expectFileNotActive(target.name)
+
+			await sidebar.openWorkspaceSwitcher()
+			await page.getByTestId('tla-workspace-switcher').click()
+			await expect(page.getByTestId('tla-workspace-switcher-home')).toBeHidden()
+		})
+
 		test('create file button creates in the active workspace', async ({ sidebar }) => {
 			const workspaceName = getRandomName()
 			const file1 = getRandomName()

--- a/apps/dotcom/client/src/pages/admin.module.css
+++ b/apps/dotcom/client/src/pages/admin.module.css
@@ -4,7 +4,7 @@
 	height: 100vh;
 	overflow: auto;
 	background-color: var(--tla-color-sidebar);
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	font-family: var(--tla-font-ui);
 	max-width: 100vw;
 }
@@ -31,7 +31,7 @@
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 	font-size: 11px;
 	font-weight: 500;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 	word-break: break-all;
 }
 
@@ -62,7 +62,7 @@
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tla-radius-2);
 	background-color: var(--tl-color-selected-contrast);
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	font-family: var(--tla-font-ui);
 	font-size: 12px;
 	font-weight: 500;
@@ -120,7 +120,7 @@
 	font-family: 'IBMPlexMono', monospace;
 	font-size: 11px;
 	line-height: 1.4;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	overflow: auto;
 	max-height: 400px;
 	user-select: text;
@@ -181,7 +181,7 @@
 	margin: 0 0 12px 0;
 	font-size: 12px;
 	font-weight: 600;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 	text-transform: uppercase;
 	letter-spacing: 0.5px;
 }
@@ -192,7 +192,7 @@
 	font-family: 'IBMPlexMono', monospace;
 	font-size: 11px;
 	line-height: 1.4;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	background-color: var(--tl-color-selected-contrast);
 	border: 1px solid var(--tl-color-divider);
 	border-radius: var(--tla-radius-2);
@@ -256,7 +256,7 @@
 .fieldValue {
 	font-size: 12px;
 	font-weight: 500;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	word-break: break-word;
 }
 
@@ -296,7 +296,7 @@
 .statValue {
 	font-size: 16px;
 	font-weight: 600;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 /* Count Container */
@@ -308,7 +308,7 @@
 
 .countDisplay {
 	font-size: 12px;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 }
 
 /* Config Container */

--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
@@ -9,7 +9,7 @@
 
 .anonDotDevLink > div {
 	font-size: 12px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	pointer-events: all;
 	display: flex;
 	align-items: center;
@@ -17,7 +17,7 @@
 	width: 100%;
 	height: 100%;
 	background-color: var(--tl-color-background);
-	border: 1px solid var(--tl-color-text-1);
+	border: 1px solid var(--tl-color-text-0);
 	border-radius: 2px;
 }
 
@@ -29,7 +29,7 @@
 	right: 4px;
 	bottom: -4px;
 	border-radius: 2px;
-	border: 1px dashed var(--tl-color-text-1);
+	border: 1px dashed var(--tl-color-text-0);
 	z-index: -1;
 	pointer-events: none;
 }

--- a/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
@@ -5,7 +5,7 @@
 	padding: 0px 12px;
 	background: none;
 	outline: none;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	border-radius: var(--tla-radius-2);
 	cursor: pointer;
 	display: flex;
@@ -84,7 +84,7 @@
 .secondary {
 	background-color: var(--tla-color-secondary);
 	border: 1px solid var(--tla-color-secondary-border);
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .iconRight {

--- a/apps/dotcom/client/src/tla/components/TlaCtaButton/cta-button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaCtaButton/cta-button.module.css
@@ -60,7 +60,7 @@
 }
 
 .ctaButtonSecondary {
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 }
 
 .ctaButtonSecondary::after {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/top.module.css
@@ -1,7 +1,7 @@
 /* ------------------- Top left panel ------------------- */
 
 .topLeftOfflineLogo {
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	margin-top: -4px;
 	padding: 4px 8px 4px 10px;
 	height: 40px;
@@ -24,7 +24,7 @@
 	max-width: 100%;
 	min-width: 0px;
 	overflow: hidden;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .topLeftPanelButtons {
@@ -110,7 +110,7 @@ button.topLeftInputNameWidthSetter {
 	pointer-events: all;
 	height: 100%;
 	min-width: 0px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .topLeftInputWrapper > div:nth-of-type(1) {
@@ -125,7 +125,7 @@ button.topLeftInputNameWidthSetter {
 	padding: 0px 12px 1px 12px;
 	height: 100%;
 	font-weight: 800;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .topLeftInputWrapper input:focus-visible {
@@ -188,7 +188,7 @@ button.topLeftInputNameWidthSetter {
 
 @media (hover: hover) {
 	.topLeftMainMenuTrigger:hover {
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 
 	.topLeftMainMenuTrigger:hover::after {
@@ -235,7 +235,7 @@ button.topLeftInputNameWidthSetter {
 	position: relative;
 	cursor: pointer;
 	z-index: 1;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .topRightAnonShareButton::before {

--- a/apps/dotcom/client/src/tla/components/TlaLogo/logo.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaLogo/logo.module.css
@@ -2,7 +2,7 @@
 	display: flex;
 	position: relative;
 	flex-shrink: 0;
-	background-color: var(--tl-color-text-1);
+	background-color: var(--tl-color-text-0);
 	height: 19px;
 	width: 70px;
 	z-index: 1;

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
@@ -1,17 +1,10 @@
-import { ExternalLink } from '../../ExternalLink/ExternalLink'
 import { TlaLogo } from '../../TlaLogo/TlaLogo'
 import styles from '../sidebar.module.css'
 
 export function TlaSidebarWorkspaceLink() {
 	return (
-		<ExternalLink
-			to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=top-left-logo"
-			eventName="sidebar-logo-clicked"
-			aria-label="tldraw.dev"
-			className={styles.sidebarWorkspaceButton}
-			data-testid="tla-sidebar-workspace-link"
-		>
+		<div className={styles.sidebarWorkspaceButton} data-testid="tla-sidebar-workspace-link">
 			<TlaLogo data-testid="tla-sidebar-logo-icon" />
-		</ExternalLink>
+		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -75,7 +75,14 @@ export function TlaSidebarWorkspaceSwitcher() {
 			{isOpen && (
 				<div
 					className={styles.sidebarWorkspaceSwitcherOverlay}
+					data-testid="tla-workspace-switcher-overlay"
 					onPointerDown={(e) => {
+						e.stopPropagation()
+					}}
+					onPointerUp={(e) => {
+						e.stopPropagation()
+					}}
+					onClick={(e) => {
 						e.preventDefault()
 						e.stopPropagation()
 						onOpenChange(false)
@@ -113,6 +120,8 @@ export function TlaSidebarWorkspaceSwitcher() {
 						// loads. Without this the focus shift would dismiss the switcher mid-
 						// switch. The open state is driven externally (useGlobalMenuIsOpen), so
 						// the menu still closes via the trigger, the overlay, or Escape.
+						onPointerDownOutside={(e) => e.preventDefault()}
+						onInteractOutside={(e) => e.preventDefault()}
 						onFocusOutside={(e) => e.preventDefault()}
 					>
 						<WorkspaceSwitcherItem

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -136,11 +136,11 @@
 	}
 
 	.hoverable {
-		color: var(--tl-color-text-1);
+		color: var(--tl-color-text-0);
 	}
 	.hoverable[data-active='true'],
 	.hoverable:hover {
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 }
 
@@ -153,7 +153,7 @@
 	cursor: pointer;
 	width: 40px;
 	height: 40px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -352,7 +352,7 @@
 	background: none;
 	border: none;
 	cursor: pointer;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	padding: 0px 8px;
 	text-align: left;
 	text-decoration: none;
@@ -405,7 +405,7 @@
 
 .sidebarUserSettingsAvatarIcon {
 	flex: 0 0 auto;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	margin-inline-end: 6px;
 }
 
@@ -414,7 +414,7 @@
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarUserSettingsIcon {
@@ -431,7 +431,7 @@
 
 @media (hover: hover) {
 	.sidebarUserSettingsTrigger:hover {
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 
 	.sidebarUserSettingsIcon {
@@ -439,7 +439,7 @@
 	}
 
 	.sidebarUserSettingsTrigger:hover .sidebarUserSettingsIcon {
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 }
 
@@ -507,7 +507,7 @@
 	background: none;
 	border: none;
 	cursor: pointer;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	padding: 0px 8px;
 	text-align: left;
 	min-width: 0;
@@ -565,7 +565,7 @@
 	align-items: center;
 	height: 40px;
 	padding: 0px 12px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	cursor: pointer;
 	outline: none;
 	min-width: 0;
@@ -646,7 +646,7 @@
 	background: none;
 	border: none;
 	cursor: pointer;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	padding: 0px 8px;
 	text-align: left;
 }
@@ -674,13 +674,14 @@
 	cursor: pointer;
 	padding: 0px 8px;
 	text-align: left;
+	color: var(--tl-color-text-0);
 }
 
 .sidebarActionButton span[role='img'] {
 	width: 15px;
 	height: 15px;
 	position: relative;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarActionButtonLabel {
@@ -709,7 +710,7 @@
 	flex: 0 0 auto;
 	/* Match the file rows below so the clear button lines up with their menu triggers. */
 	padding: 0px 4px 0px 8px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarSearch::before {
@@ -732,7 +733,7 @@
 	z-index: 1;
 	height: 15px;
 	width: 15px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarSearchInput {
@@ -746,7 +747,7 @@
 	background: none;
 	border: none;
 	padding: 0px;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	position: relative;
 	z-index: 1;
 }
@@ -768,7 +769,7 @@
 	flex: 0 0 auto;
 	z-index: 3;
 	cursor: pointer;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarSearchClear:after {
@@ -832,7 +833,7 @@
 
 .sidebarFileListItem[data-active='true'][data-enhanced-a11y-mode='true'] {
 	border-radius: 4px;
-	outline: 2px solid var(--tl-color-text);
+	outline: 2px solid var(--tl-color-text-0);
 	outline-offset: -2px;
 }
 
@@ -860,7 +861,7 @@
 }
 
 .sidebar[data-workspaces='true'] .sidebarFileListItemLabel {
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 /* The selected file reads as the current one with a heavier weight. */
@@ -871,7 +872,7 @@
 /* The portion of a file name that matches the active search query. */
 .sidebarFileListItemLabelMatch {
 	font-weight: 700;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarFileListItemRenameInputWrapper {
@@ -989,7 +990,7 @@
 	}
 
 	.sidebarFileListItemMenuTrigger:hover {
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 }
 
@@ -1017,7 +1018,7 @@
 	background: none;
 	pointer-events: all;
 	cursor: pointer;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .sidebarFileSectionTitleText {

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteDialog.module.css
@@ -57,5 +57,5 @@
 }
 
 .declineButton:hover {
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 }

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaInviteExpiredDialog.module.css
@@ -19,7 +19,7 @@
 	flex: 0 0 auto;
 	font-size: 16px;
 	font-weight: 600;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 	margin: 8px 0 0;
 }
 

--- a/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
@@ -1,6 +1,6 @@
 /* Auth Dialog Container */
 .authContainer {
-	width: 450px;
+	width: 360px;
 	max-width: 95vw;
 	overflow-y: auto;
 }
@@ -96,7 +96,7 @@
 .authLabel {
 	font-size: 12px;
 	font-weight: 500;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 }
 
 .authInput {
@@ -158,7 +158,7 @@
 	gap: var(--tl-space-4);
 	cursor: pointer;
 	font-size: 12px;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 	line-height: 1.5;
 }
 
@@ -278,11 +278,6 @@
 
 	.authCtaButton {
 		height: 36px;
-	}
-
-	.authBody {
-		gap: 24px;
-		padding: 8px 16px 24px 32px;
 	}
 
 	.authCtaButton img {

--- a/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/dialogs.module.css
@@ -73,7 +73,7 @@
 	padding: 8px;
 	padding-bottom: 12px;
 	font-size: 12px;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 	line-height: 1.4;
 }
 
@@ -111,7 +111,7 @@
 
 .cookieAcceptButton {
 	color: var(--tla-color-sidebar);
-	background-color: var(--tl-color-text);
+	background-color: var(--tl-color-text-0);
 	overflow: hidden;
 	position: relative;
 }
@@ -155,7 +155,7 @@
 @media (hover: hover) {
 	.cookieAcceptButton:hover {
 		color: var(--tla-color-sidebar);
-		background-color: var(--tl-color-text);
+		background-color: var(--tl-color-text-0);
 	}
 }
 
@@ -231,7 +231,7 @@
 	margin: 8px 0 0;
 	text-align: center;
 	text-wrap: balance;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .membersList {
@@ -319,7 +319,7 @@
 	cursor: pointer;
 	font-size: 12px;
 	font-weight: 500;
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	text-align: left;
 	height: 36px;
 }

--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -74,7 +74,7 @@
 @media (hover: hover) {
 	.menuInfoTrigger:not(:disabled):hover {
 		z-index: 1;
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 
 	.menuInfoTrigger:not(:disabled):hover::after {
@@ -83,7 +83,7 @@
 }
 
 .menuLabel {
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -347,7 +347,7 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 	display: flex;
 	align-items: center;
 	padding: var(--tab-padding);
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 }
 
 .menuTabsTab::after {
@@ -359,7 +359,7 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 	right: var(--tab-padding);
 	height: var(--line-height);
 	z-index: 3;
-	background-color: var(--tl-color-text);
+	background-color: var(--tl-color-text-0);
 	visibility: hidden;
 }
 
@@ -368,7 +368,7 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 }
 
 .menuTabsTab[data-active='true'] {
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	/* active tab in front of peers */
 	z-index: 2;
 }
@@ -385,7 +385,7 @@ div:has(> .menuSelectContent):not([data-radix-popper-content-wrapper]) {
 
 @media (hover: hover) {
 	.menuTabsTab:not(:disabled):hover {
-		color: var(--tl-color-text);
+		color: var(--tl-color-text-0);
 	}
 }
 

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames'
-import React, { PropsWithChildren, ReactNode, useCallback, useContext, useEffect } from 'react'
-import { Spinner } from 'tldraw'
+import React, { PropsWithChildren, ReactNode, useCallback, useContext } from 'react'
 import styles from './useIsReady.module.css'
 
 /*
@@ -25,19 +24,11 @@ export function ReadyWrapper({
 }: PropsWithChildren<{ loadingScreen?: ReactNode }>) {
 	const parent = useContext(ReadyContext)
 	const [isReady, _setIsReady] = React.useState(false)
-	const [showSpinner, setShowSpinner] = React.useState(false)
 	const hasLoadingScreen = !!loadingScreen
 	const setIsReady = useCallback(async () => {
 		_setIsReady(true)
 	}, [])
-	useEffect(() => {
-		const timeout = setTimeout(() => {
-			setShowSpinner(true)
-		}, 500)
-		return () => {
-			clearTimeout(timeout)
-		}
-	}, [])
+
 	if (!parent.isRoot) {
 		// already wrapped at a higher level
 		return children
@@ -65,11 +56,6 @@ export function ReadyWrapper({
 				{!isReady && hasLoadingScreen && (
 					<div className={styles.loadingScreen} inert aria-hidden="true">
 						{loadingScreen}
-					</div>
-				)}
-				{!isReady && (
-					<div className={classNames(styles.spinner, showSpinner && styles.showSpinner)}>
-						<Spinner />
 					</div>
 				)}
 			</div>

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -6,6 +6,17 @@
 	box-sizing: border-box;
 }
 
+/* On iOS, Safari zooms into any focused form field whose computed font-size is
+   below 16px. Bump form fields to 16px on iOS to prevent that. This only affects
+   iOS rendering; other platforms keep their smaller sizes. */
+@supports (-webkit-touch-callout: none) {
+	.tla input,
+	.tla textarea,
+	.tla select {
+		font-size: 16px;
+	}
+}
+
 /* Variables */
 :root {
 	/* Border radii */
@@ -27,7 +38,7 @@
 	height: 100%;
 	font-family: var(--tla-font-ui);
 	background-color: var(--tla-color-sidebar);
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .tla-theme__light {
@@ -97,7 +108,7 @@
 	position: relative;
 	top: 1px;
 	font-family: var(--tla-font-ui);
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 }
 
 .tla-text_ui__small {
@@ -126,7 +137,7 @@
 	font-size: 24px;
 	line-height: 1.3;
 	font-family: var(--tla-font-ui);
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	text-rendering: optimizeLegibility;
 }
 

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -214,13 +214,13 @@ a {
 .board-history__month-header {
 	font-size: 16px;
 	font-weight: 600;
-	color: var(--tl-color-text-1);
+	color: var(--tl-color-text-0);
 	margin: 0 0 8px 0;
 	padding: 0;
 }
 
 .board-history__list a {
-	color: var(--tl-color-text);
+	color: var(--tl-color-text-0);
 	text-decoration: none;
 	padding: 8px 0;
 	display: block;

--- a/packages/tldraw/src/lib/ui/components/Dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/components/Dialogs.tsx
@@ -5,7 +5,12 @@ import { TLUiDialog, useDialogs } from '../context/dialogs'
 import { useDirection } from '../hooks/useTranslation/useTranslation'
 
 /** @internal */
-const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }: TLUiDialog) => {
+const TldrawUiDialog = ({
+	id,
+	component: ModalContent,
+	preventBackgroundClose,
+	isModal,
+}: TLUiDialog & { isModal: boolean }) => {
 	const { removeDialog } = useDialogs()
 	const mouseDownInsideContentRef = useRef(false)
 
@@ -22,7 +27,7 @@ const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }:
 	)
 
 	return (
-		<_Dialog.Root onOpenChange={handleOpenChange} defaultOpen>
+		<_Dialog.Root onOpenChange={handleOpenChange} defaultOpen modal={isModal}>
 			<_Dialog.Portal container={container}>
 				<_Dialog.Overlay
 					dir={dir}
@@ -65,5 +70,11 @@ const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }:
 export const DefaultDialogs = memo(function DefaultDialogs() {
 	const { dialogs } = useDialogs()
 	const dialogsArray = useValue('dialogs', () => dialogs.get(), [dialogs])
-	return dialogsArray.map((dialog) => <TldrawUiDialog key={dialog.id} {...dialog} />)
+	// Only the topmost dialog should be modal. Stacking multiple modal Radix
+	// dialogs makes lower ones intercept pointer/touch events (via their own
+	// focus traps and scroll-locking), which leaves a nested dialog unresponsive
+	// to taps on mobile.
+	return dialogsArray.map((dialog, i) => (
+		<TldrawUiDialog key={dialog.id} {...dialog} isModal={i === dialogsArray.length - 1} />
+	))
 })


### PR DESCRIPTION
In order to clean up a few rough edges on tldraw.com, this PR bundles three small dotcom fixes:

- **Theme tokens** — standardize text colors on `--tl-color-text-0` across the sidebar, top panel, menus, dialogs, buttons, and admin page. Several rules referenced `--tl-color-text` and `--tl-color-text-1`, which led to inconsistent text contrast.
- **Auth dialog** — narrow the auth dialog from 450px to 360px and drop a redundant mobile `.authBody` override so the layout reads better.
- **iOS input zoom** — bump form fields to 16px on iOS only (gated behind `@supports (-webkit-touch-callout: none)`) so Safari no longer zooms in when a text field is focused.

### Change type

- [x] `bugfix`

### Test plan

1. On iOS Safari, focus the sidebar search input (and other text fields) and confirm the page no longer zooms in.
2. Open the auth dialog and confirm it renders at the narrower width on desktop and mobile.
3. Check the sidebar, top panel, menus, dialogs, and admin page for consistent text color in light and dark themes.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix iOS Safari zooming in when focusing text fields on tldraw.com.
- Standardize text colors and narrow the auth dialog.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +76 / -69  |
