### PR TITLE
fix(dotcom): guard zero-cache migrations against blocking column backfills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Store and schema:
 
 - Store changes should respect migrations, validators, and schema versioning.
 - Schema-affecting changes usually need updates in `packages/tlschema` and focused migration tests.
-- When adding a column to a Zero-replicated table (`apps/dotcom/zero-cache/migrations`), add it nullable with no default, backfill values in batches, then set the default / NOT NULL in a later migration. A single `ADD COLUMN ... NOT NULL DEFAULT` forces a blocking replica backfill that hides the column from view-syncers and holds the Postgres replication slot open until it finishes. `validateMigrationContents` (a unit test) enforces this for new migrations; a column on a table Zero does not replicate can opt out with a `-- zero-cache:allow-add-column-default <reason>` comment.
+- When adding a column to a Zero-replicated table (`apps/dotcom/zero-cache/migrations`), add it nullable with no default, backfill values in batches, then set the default / NOT NULL in a later migration. A single `ADD COLUMN ... NOT NULL DEFAULT` forces a blocking replica backfill that hides the column from view-syncers and holds the Postgres replication slot open until it finishes. `validateMigrationContents` (a unit test) enforces this for new migrations; a column on a table Zero does not replicate can opt out with a `-- zero-cache:allow-add-column-default <reason>` line comment.
 
 ## Where to work
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Store and schema:
 
 - Store changes should respect migrations, validators, and schema versioning.
 - Schema-affecting changes usually need updates in `packages/tlschema` and focused migration tests.
+- When adding a column to a Zero-replicated table (`apps/dotcom/zero-cache/migrations`), add it nullable with no default, backfill values in batches, then set the default / NOT NULL in a later migration. A single `ADD COLUMN ... NOT NULL DEFAULT` forces a blocking replica backfill that hides the column from view-syncers and holds the Postgres replication slot open until it finishes. The migration runner enforces this.
 
 ## Where to work
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Store and schema:
 
 - Store changes should respect migrations, validators, and schema versioning.
 - Schema-affecting changes usually need updates in `packages/tlschema` and focused migration tests.
-- When adding a column to a Zero-replicated table (`apps/dotcom/zero-cache/migrations`), add it nullable with no default, backfill values in batches, then set the default / NOT NULL in a later migration. A single `ADD COLUMN ... NOT NULL DEFAULT` forces a blocking replica backfill that hides the column from view-syncers and holds the Postgres replication slot open until it finishes. The migration runner enforces this.
+- When adding a column to a Zero-replicated table (`apps/dotcom/zero-cache/migrations`), add it nullable with no default, backfill values in batches, then set the default / NOT NULL in a later migration. A single `ADD COLUMN ... NOT NULL DEFAULT` forces a blocking replica backfill that hides the column from view-syncers and holds the Postgres replication slot open until it finishes. `validateMigrationContents` (a unit test) enforces this for new migrations; a column on a table Zero does not replicate can opt out with a `-- zero-cache:allow-add-column-default <reason>` comment.
 
 ## Where to work
 

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -137,19 +137,6 @@ async function migrate(summary: string[], dryRun: boolean) {
 						`Migration ${migration} contains a transaction block. Migrations run in transactions, so you don't need to include them in the migration file.`
 					)
 				}
-				// Adding a column WITH a DEFAULT forces the current Zero version to re-copy
-				// the whole column into its replica before the column becomes visible to
-				// the view-syncers. That backfill holds the Postgres replication slot open
-				// (WAL accumulates) and, if client code ships before it finishes, clients
-				// hit SchemaVersionNotSupported. Use expand/contract instead: add the column
-				// nullable with no default (visible immediately), backfill values in batches,
-				// then set the default / NOT NULL in a later migration. Remove this guard once
-				// Zero is upgraded to a version that applies scalar defaults without a backfill.
-				if (/\bADD\s+COLUMN\b[^;]*\bDEFAULT\b/is.test(migrationSql)) {
-					throw new Error(
-						`Migration ${migration} adds a column with a DEFAULT, which triggers a blocking column backfill in Zero's replica: the new column stays invisible to view-syncers until the backfill finishes and the replication slot is held open meanwhile. Split it — add the column nullable with no default, backfill values in batches, then set the default / NOT NULL in a separate migration.`
-					)
-				}
 				await sql.raw(migrationSql).execute(tx)
 				await sql`INSERT INTO migrations.applied_migrations (filename) VALUES (${migration})`.execute(
 					tx

--- a/apps/dotcom/zero-cache/migrate.ts
+++ b/apps/dotcom/zero-cache/migrate.ts
@@ -137,6 +137,19 @@ async function migrate(summary: string[], dryRun: boolean) {
 						`Migration ${migration} contains a transaction block. Migrations run in transactions, so you don't need to include them in the migration file.`
 					)
 				}
+				// Adding a column WITH a DEFAULT forces the current Zero version to re-copy
+				// the whole column into its replica before the column becomes visible to
+				// the view-syncers. That backfill holds the Postgres replication slot open
+				// (WAL accumulates) and, if client code ships before it finishes, clients
+				// hit SchemaVersionNotSupported. Use expand/contract instead: add the column
+				// nullable with no default (visible immediately), backfill values in batches,
+				// then set the default / NOT NULL in a later migration. Remove this guard once
+				// Zero is upgraded to a version that applies scalar defaults without a backfill.
+				if (/\bADD\s+COLUMN\b[^;]*\bDEFAULT\b/is.test(migrationSql)) {
+					throw new Error(
+						`Migration ${migration} adds a column with a DEFAULT, which triggers a blocking column backfill in Zero's replica: the new column stays invisible to view-syncers until the backfill finishes and the replication slot is held open meanwhile. Split it — add the column nullable with no default, backfill values in batches, then set the default / NOT NULL in a separate migration.`
+					)
+				}
 				await sql.raw(migrationSql).execute(tx)
 				await sql`INSERT INTO migrations.applied_migrations (filename) VALUES (${migration})`.execute(
 					tx

--- a/apps/dotcom/zero-cache/validateMigrationContents.test.ts
+++ b/apps/dotcom/zero-cache/validateMigrationContents.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync, readdirSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { describe, expect, it } from 'vitest'
+import { validateMigrationContents } from './validateMigrationContents'
+
+const migrationsDir = fileURLToPath(new URL('./migrations', import.meta.url))
+
+function readMigrations() {
+	return readdirSync(migrationsDir)
+		.filter((filename) => filename.endsWith('.sql'))
+		.map((filename) => ({
+			filename,
+			sql: readFileSync(`${migrationsDir}/${filename}`, 'utf8'),
+		}))
+}
+
+const bad = 'ALTER TABLE "group" ADD COLUMN "x" boolean NOT NULL DEFAULT true;'
+
+describe('validateMigrationContents', () => {
+	it('passes for the migrations checked into this package', () => {
+		expect(() => validateMigrationContents(readMigrations())).not.toThrow()
+	})
+
+	it('throws on a new migration that adds a column with a DEFAULT', () => {
+		expect(() => validateMigrationContents([{ filename: '999_bad.sql', sql: bad }])).toThrow(
+			/adds a column with a DEFAULT/
+		)
+	})
+
+	it('allows the expand step: a nullable column with no default', () => {
+		expect(() =>
+			validateMigrationContents([
+				{ filename: '999_expand.sql', sql: 'ALTER TABLE "group" ADD COLUMN "x" boolean;' },
+			])
+		).not.toThrow()
+	})
+
+	it('allows the contract steps: setting default / not null on an existing column', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_contract.sql',
+					sql:
+						'ALTER TABLE "group" ALTER COLUMN "x" SET DEFAULT true;\n' +
+						'ALTER TABLE "group" ALTER COLUMN "x" SET NOT NULL;',
+				},
+			])
+		).not.toThrow()
+	})
+
+	it('ignores the pattern when it only appears in a comment', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_comment.sql',
+					sql:
+						'-- deliberately NOT using ADD COLUMN ... DEFAULT here\n' +
+						'ALTER TABLE "group" ADD COLUMN "x" boolean;',
+				},
+			])
+		).not.toThrow()
+	})
+
+	it('lets a migration opt out for a table Zero does not replicate', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_optout.sql',
+					sql:
+						'-- zero-cache:allow-add-column-default paddle_transactions is not replicated\n' +
+						'ALTER TABLE "paddle_transactions" ADD COLUMN "x" int NOT NULL DEFAULT 0;',
+				},
+			])
+		).not.toThrow()
+	})
+
+	it('still allows grandfathered migrations to use a default', () => {
+		expect(() =>
+			validateMigrationContents([{ filename: '037_x.sql', sql: bad }], new Set([37]))
+		).not.toThrow()
+	})
+})

--- a/apps/dotcom/zero-cache/validateMigrationContents.test.ts
+++ b/apps/dotcom/zero-cache/validateMigrationContents.test.ts
@@ -27,10 +27,62 @@ describe('validateMigrationContents', () => {
 		)
 	})
 
+	it('throws on the multi-line ADD COLUMN ... DEFAULT shape (as real migration 037 used)', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_multiline.sql',
+					sql: 'ALTER TABLE "group"\nADD COLUMN "x" BOOLEAN NOT NULL DEFAULT true;',
+				},
+			])
+		).toThrow(/adds a column with a DEFAULT/)
+	})
+
+	it('throws when COLUMN is omitted (ADD <name> ... DEFAULT)', () => {
+		expect(() =>
+			validateMigrationContents([
+				{ filename: '999_nocolumn.sql', sql: 'ALTER TABLE "group" ADD "x" boolean DEFAULT true;' },
+			])
+		).toThrow(/adds a column with a DEFAULT/)
+	})
+
+	it('is case-insensitive', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_lower.sql',
+					sql: 'alter table "group" add column "x" boolean default true;',
+				},
+			])
+		).toThrow(/adds a column with a DEFAULT/)
+	})
+
+	it('names the offending migration when it is among several', () => {
+		expect(() =>
+			validateMigrationContents([
+				{ filename: '998_ok.sql', sql: 'ALTER TABLE "group" ADD COLUMN "a" boolean;' },
+				{ filename: '999_bad.sql', sql: bad },
+			])
+		).toThrow(/999_bad\.sql/)
+	})
+
 	it('allows the expand step: a nullable column with no default', () => {
 		expect(() =>
 			validateMigrationContents([
 				{ filename: '999_expand.sql', sql: 'ALTER TABLE "group" ADD COLUMN "x" boolean;' },
+			])
+		).not.toThrow()
+	})
+
+	it('allows a separate ADD and SET DEFAULT in one migration (semicolon boundary)', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_expand_then_default.sql',
+					sql:
+						'ALTER TABLE "group" ADD COLUMN "x" boolean;\n' +
+						'ALTER TABLE "group" ALTER COLUMN "x" SET DEFAULT true;',
+				},
 			])
 		).not.toThrow()
 	})
@@ -48,13 +100,26 @@ describe('validateMigrationContents', () => {
 		).not.toThrow()
 	})
 
-	it('ignores the pattern when it only appears in a comment', () => {
+	it('ignores the pattern in a line comment', () => {
 		expect(() =>
 			validateMigrationContents([
 				{
-					filename: '999_comment.sql',
+					filename: '999_line_comment.sql',
 					sql:
 						'-- deliberately NOT using ADD COLUMN ... DEFAULT here\n' +
+						'ALTER TABLE "group" ADD COLUMN "x" boolean;',
+				},
+			])
+		).not.toThrow()
+	})
+
+	it('ignores the pattern in a block comment', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_block_comment.sql',
+					sql:
+						'/* historically this was\n   ADD COLUMN "x" boolean DEFAULT true; */\n' +
 						'ALTER TABLE "group" ADD COLUMN "x" boolean;',
 				},
 			])
@@ -74,9 +139,48 @@ describe('validateMigrationContents', () => {
 		).not.toThrow()
 	})
 
-	it('still allows grandfathered migrations to use a default', () => {
+	it('requires a reason on the opt-out marker', () => {
 		expect(() =>
-			validateMigrationContents([{ filename: '037_x.sql', sql: bad }], new Set([37]))
+			validateMigrationContents([
+				{
+					filename: '999_optout_noreason.sql',
+					sql: '-- zero-cache:allow-add-column-default\n' + bad,
+				},
+			])
+		).toThrow(/adds a column with a DEFAULT/)
+	})
+
+	it('does not treat the marker as an opt-out unless it is a line comment', () => {
+		expect(() =>
+			validateMigrationContents([
+				{
+					filename: '999_optout_notcomment.sql',
+					sql:
+						`INSERT INTO log (note) VALUES ('zero-cache:allow-add-column-default here');\n` + bad,
+				},
+			])
+		).toThrow(/adds a column with a DEFAULT/)
+	})
+
+	it('inspects a .sql file even when its name is malformed', () => {
+		expect(() => validateMigrationContents([{ filename: 'weird.sql', sql: bad }])).toThrow(
+			/adds a column with a DEFAULT/
+		)
+	})
+
+	it('skips non-.sql files', () => {
+		expect(() => validateMigrationContents([{ filename: 'README.md', sql: bad }])).not.toThrow()
+	})
+
+	it('allows a grandfathered migration to use a default (default set)', () => {
+		expect(() =>
+			validateMigrationContents([{ filename: '006_add_file_soft_delete.sql', sql: bad }])
+		).not.toThrow()
+	})
+
+	it('allows a grandfathered migration via an explicit set', () => {
+		expect(() =>
+			validateMigrationContents([{ filename: '999_x.sql', sql: bad }], new Set(['999_x.sql']))
 		).not.toThrow()
 	})
 })

--- a/apps/dotcom/zero-cache/validateMigrationContents.ts
+++ b/apps/dotcom/zero-cache/validateMigrationContents.ts
@@ -1,0 +1,60 @@
+// Adding a column WITH a DEFAULT is not a metadata-only change for Zero: the
+// replication-manager re-copies the whole column into its replica before the
+// column becomes visible to the view-syncers, and holds the Postgres
+// replication slot open while it backfills. If client code that expects the
+// column ships before the backfill finishes, clients hit
+// SchemaVersionNotSupported (the cause of the inviteLinkEnabled incident). New
+// migrations must use expand/contract instead: add the column nullable with no
+// default (visible immediately), backfill values in batches, then set the
+// default / NOT NULL in a later migration. CI runs this against the migrations
+// to stop a new one reintroducing the pattern.
+//
+// Remove this check once Zero is upgraded to a version that applies scalar
+// defaults without a full-column backfill.
+
+// Migrations that added a column with a DEFAULT before this check existed. They
+// have already been applied everywhere, so they only need to keep replaying
+// cleanly on fresh databases. Don't add to this list — new migrations must use
+// the expand/contract pattern.
+export const GRANDFATHERED_DEFAULT_BACKFILL: ReadonlySet<number> = new Set([
+	6, 7, 8, 9, 19, 20, 22, 26, 27, 29, 30, 37,
+])
+
+// A migration can opt out when the column is on a table Zero does not replicate
+// (not in the `zero_data` publication), so no replica backfill happens. Add it
+// as a SQL comment with a reason, e.g.
+// `-- zero-cache:allow-add-column-default paddle_transactions is not replicated`.
+const OPT_OUT_MARKER = 'zero-cache:allow-add-column-default'
+
+const ADD_COLUMN_WITH_DEFAULT = /\bADD\s+COLUMN\b[^;]*\bDEFAULT\b/is
+
+function stripSqlComments(sql: string) {
+	return sql
+		.replace(/\/\*[\s\S]*?\*\//g, ' ') // block comments
+		.replace(/--[^\n]*/g, ' ') // line comments
+}
+
+export function validateMigrationContents(
+	migrations: { filename: string; sql: string }[],
+	grandfathered: ReadonlySet<number> = GRANDFATHERED_DEFAULT_BACKFILL
+) {
+	for (const { filename, sql } of migrations) {
+		const match = filename.match(/^(\d{3})_.+\.sql$/)
+		// Filename shape is validated separately; skip anything that isn't a migration.
+		if (!match) continue
+		if (grandfathered.has(Number(match[1]))) continue
+		// The marker lives in a comment, so check the raw SQL before stripping comments.
+		if (sql.includes(OPT_OUT_MARKER)) continue
+		if (ADD_COLUMN_WITH_DEFAULT.test(stripSqlComments(sql))) {
+			throw new Error(
+				`Migration "${filename}" adds a column with a DEFAULT. On the current Zero version ` +
+					`this triggers a blocking replica backfill: the new column stays invisible to the ` +
+					`view-syncers until it finishes, and the Postgres replication slot is held open ` +
+					`meanwhile (the inviteLinkEnabled incident). Use expand/contract instead — add the ` +
+					`column nullable with no default, backfill values in batches, then set the default / ` +
+					`NOT NULL in a later migration. If the column is on a table Zero does not replicate, ` +
+					`add a "-- ${OPT_OUT_MARKER} <reason>" comment to opt out.`
+			)
+		}
+	}
+}

--- a/apps/dotcom/zero-cache/validateMigrationContents.ts
+++ b/apps/dotcom/zero-cache/validateMigrationContents.ts
@@ -6,27 +6,46 @@
 // SchemaVersionNotSupported (the cause of the inviteLinkEnabled incident). New
 // migrations must use expand/contract instead: add the column nullable with no
 // default (visible immediately), backfill values in batches, then set the
-// default / NOT NULL in a later migration. CI runs this against the migrations
-// to stop a new one reintroducing the pattern.
+// default / NOT NULL in a later migration — or, for a column on a table Zero
+// does not replicate, opt out with the marker below. A unit test runs this over
+// the checked-in migrations to stop a new one reintroducing the pattern.
 //
 // Remove this check once Zero is upgraded to a version that applies scalar
 // defaults without a full-column backfill.
 
 // Migrations that added a column with a DEFAULT before this check existed. They
-// have already been applied everywhere, so they only need to keep replaying
-// cleanly on fresh databases. Don't add to this list — new migrations must use
-// the expand/contract pattern.
-export const GRANDFATHERED_DEFAULT_BACKFILL: ReadonlySet<number> = new Set([
-	6, 7, 8, 9, 19, 20, 22, 26, 27, 29, 30, 37,
+// predate the guard and only need to keep replaying cleanly on fresh databases.
+// Don't add to this list — new migrations must use the expand/contract pattern.
+export const GRANDFATHERED_DEFAULT_BACKFILL: ReadonlySet<string> = new Set([
+	'006_add_file_soft_delete.sql',
+	'007_update_file_owner_details.sql',
+	'008_add_pinned.sql',
+	'009_add_allow_analytics_cookie.sql',
+	'019_add_keyboard_shortcuts_pref.sql',
+	'020_add_show_ui_labels_pref.sql',
+	'022_add_input_mode_preference.sql',
+	'026_fairy_usage_tracking.sql',
+	'027_fairy_invite_description.sql',
+	'029_fairy_weekly_limit.sql',
+	'030_add_zoom_direction_preference.sql',
+	'037_add_group_invite_link_enabled.sql',
 ])
 
 // A migration can opt out when the column is on a table Zero does not replicate
-// (not in the `zero_data` publication), so no replica backfill happens. Add it
-// as a SQL comment with a reason, e.g.
+// (not in the `zero_data` publication), so no replica backfill happens. The
+// marker must be its own line comment with a reason, e.g.
 // `-- zero-cache:allow-add-column-default paddle_transactions is not replicated`.
 const OPT_OUT_MARKER = 'zero-cache:allow-add-column-default'
+// The marker, a reason, and everything else must be on one line comment, so the
+// separators are non-newline whitespace — otherwise a reason-less marker would
+// match the SQL on the next line and opt out without a reason.
+const OPT_OUT_LINE = new RegExp(`^[ \\t]*--[ \\t]*${OPT_OUT_MARKER}[ \\t]+\\S`, 'm')
 
-const ADD_COLUMN_WITH_DEFAULT = /\bADD\s+COLUMN\b[^;]*\bDEFAULT\b/is
+// Matches `ADD [COLUMN] ... DEFAULT` within a single statement (`[^;]*` stops at
+// the next `;`). Matching is lexical and statement-coarse: a multi-column `ADD`
+// where any column has a DEFAULT trips it, and the `DEFAULT` keyword inside a
+// string literal would too. Split the statement or use the opt-out marker.
+const ADD_COLUMN_WITH_DEFAULT = /\bADD\s+(?:COLUMN\s+)?[^;]*\bDEFAULT\b/is
 
 function stripSqlComments(sql: string) {
 	return sql
@@ -36,15 +55,14 @@ function stripSqlComments(sql: string) {
 
 export function validateMigrationContents(
 	migrations: { filename: string; sql: string }[],
-	grandfathered: ReadonlySet<number> = GRANDFATHERED_DEFAULT_BACKFILL
+	grandfathered: ReadonlySet<string> = GRANDFATHERED_DEFAULT_BACKFILL
 ) {
 	for (const { filename, sql } of migrations) {
-		const match = filename.match(/^(\d{3})_.+\.sql$/)
-		// Filename shape is validated separately; skip anything that isn't a migration.
-		if (!match) continue
-		if (grandfathered.has(Number(match[1]))) continue
+		// Only `.sql` files are migrations; the runner ignores everything else.
+		if (!filename.endsWith('.sql')) continue
+		if (grandfathered.has(filename)) continue
 		// The marker lives in a comment, so check the raw SQL before stripping comments.
-		if (sql.includes(OPT_OUT_MARKER)) continue
+		if (OPT_OUT_LINE.test(sql)) continue
 		if (ADD_COLUMN_WITH_DEFAULT.test(stripSqlComments(sql))) {
 			throw new Error(
 				`Migration "${filename}" adds a column with a DEFAULT. On the current Zero version ` +
@@ -53,7 +71,7 @@ export function validateMigrationContents(
 					`meanwhile (the inviteLinkEnabled incident). Use expand/contract instead — add the ` +
 					`column nullable with no default, backfill values in batches, then set the default / ` +
 					`NOT NULL in a later migration. If the column is on a table Zero does not replicate, ` +
-					`add a "-- ${OPT_OUT_MARKER} <reason>" comment to opt out.`
+					`add a "-- ${OPT_OUT_MARKER} <reason>" line comment to opt out.`
 			)
 		}
 	}


### PR DESCRIPTION
In order to prevent the deploy-time outage we hit with `group.inviteLinkEnabled`, this PR adds a test that rejects new zero-cache migrations using `ADD COLUMN ... DEFAULT`, and documents the expand/contract pattern to use instead. Relates to #9031 (the Supabase DDL schema-change hooks this builds on).

### Background

On the current Zero version (`@rocicorp/zero` 1.6.1), adding a column **with a default** is not a metadata-only change for Zero: the replication-manager re-copies the new column across every existing row into its replica before the column becomes visible to the view-syncers. While that backfill runs it holds the Postgres replication slot open, so WAL accumulates.

In the `inviteLinkEnabled` incident, the client bundle (which expected the column) shipped before the backfill finished, so the view-syncers were still serving the old schema and clients got `SchemaVersionNotSupported` → the "this version of tldraw is no longer supported / please reload" dialog. It self-healed once the backfill completed (replication lag fell from ~355k back to baseline), but during the window it also drove the replication-lag/WAL alerts.

### What this does

- Adds `validateMigrationContents` and a unit test that fails when a migration uses `ADD COLUMN ... DEFAULT`, pointing authors to the expand/contract pattern: add the column nullable with no default (visible immediately, so client code can ship right away), backfill values in batches, then set the default / NOT NULL in a later migration.
- The check inspects migration **contents** statically rather than running inside the migration runner, so it never blocks historical migrations replaying on a fresh database (local dev, new preview environments). Existing `ADD COLUMN ... DEFAULT` migrations are grandfathered by number, SQL comments are stripped before matching, and a column on a table Zero does not replicate can opt out with a `-- zero-cache:allow-add-column-default <reason>` marker.
- Documents the convention in `AGENTS.md`.

The check is a version-gated stopgap: Rocicorp confirmed a newer Zero applies scalar defaults instantly with no backfill. Once we upgrade past 1.6.1, the check (and the grandfather list) can be removed — the code comment notes this.

### Change type

- [x] `other`

### Test plan

1. `cd apps/dotcom/zero-cache && yarn test run validateMigrationContents.test.ts` — passes (includes a check that all migrations currently in the package are clean).
2. The test covers: a new `ADD COLUMN ... DEFAULT` is rejected; the expand step (nullable, no default) and contract steps (`ALTER COLUMN ... SET DEFAULT` / `SET NOT NULL`) pass; the pattern inside a comment is ignored; the opt-out marker is honored; grandfathered migrations are allowed.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +60 / -0   |
| Tests          | +82 / -0   |
| Config/tooling | +1 / -0    |