### PR TITLE
chore(ci): bump CI Node to 24.17.0 for June 2026 security release

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Setup Node.js Environment
       uses: actions/setup-node@v6
       with:
-        node-version: 24.13.1
+        node-version: 24.17.0
 
     - name: Restore node_modules cache
       uses: actions/cache@v5
@@ -25,9 +25,9 @@ runs:
           .yarn/cache
           .yarn/unplugged
           .yarn/install-state.gz
-        key: ${{ runner.os }}-node-24.13.1-yarn-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/patches/*') }}
+        key: ${{ runner.os }}-node-24.17.0-yarn-${{ hashFiles('yarn.lock', '.yarnrc.yml', '.yarn/patches/*') }}
         restore-keys: |
-          ${{ runner.os }}-node-24.13.1-yarn-
+          ${{ runner.os }}-node-24.17.0-yarn-
 
     - name: Install dependencies
       run: yarn install --immutable


### PR DESCRIPTION
In order to keep the CI/build runtime current with the [June 2026 Node.js security releases](https://nodejs.org/en/blog/vulnerability/june-2026-security-releases), this bumps the Node version used by the shared `setup` action from `24.13.1` to `24.17.0` — the patched 24.x release (dated 2026-06-17, flagged `security`) — and updates the two cache-key references that pin the version alongside it.

Scope notes:

- **Build/CI runtime only.** The published `engines` field is unaffected (that's a separate concern — see #9098, which sets it to the `require(esm)` feature floor). `engines` is advisory and isn't the right place to chase security patch levels.
- **Not a fix for an exposure in tldraw.** The CVEs in this release are in Node's TLS/hostname-verification, HTTP/HTTP2/proxy, WebCrypto, and `--permission` subsystems. The SDK is browser code, tldraw.com's server side runs on Cloudflare workerd (not Node), and Node only runs at build/CI time here — so we don't believe tldraw is impacted. This is just keeping the build runtime patched.

### Change type

- [x] `other`

### Test plan

- CI runs green on Node 24.17.0.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +3 / -3    |
