### PR TITLE
fix(dotcom): close mobile sidebar before loading the tapped file

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarFileLink.tsx
@@ -162,6 +162,7 @@ export function TlaSidebarFileLinkInner({
 	className?: string
 }) {
 	const trackEvent = useTldrawAppUiEvents()
+	const navigate = useNavigate()
 	const linkRef = useRef<HTMLAnchorElement | null>(null)
 	const app = useApp()
 	const isSidebarOpenMobile = useIsSidebarOpenMobile()
@@ -262,7 +263,30 @@ export function TlaSidebarFileLinkInner({
 						setPreventScrollOnNavigation(true)
 					}
 					if (isSidebarOpenMobile) {
-						toggleMobileSidebar(false)
+						// On mobile the sidebar overlays the file, so opening one should
+						// close it. Opening a file is expensive — the editor tears down and
+						// remounts — and that work runs synchronously in this click handler,
+						// which blocks the sidebar from closing until it finishes (~1s),
+						// making the menu look stuck open. For a plain tap, close the sidebar
+						// and defer navigation until after the close has painted, so the menu
+						// snaps shut immediately and the file loads after. Modifier and
+						// non-primary clicks fall through to the native link (e.g. new tab).
+						const isPlainNavigation =
+							!isActive &&
+							event.button === 0 &&
+							!event.ctrlKey &&
+							!event.metaKey &&
+							!event.shiftKey &&
+							!event.altKey
+						if (isPlainNavigation) {
+							preventDefault(event)
+							toggleMobileSidebar(false)
+							// Two frames: the first paints the closed sidebar, the second
+							// starts the expensive navigation once that paint has landed.
+							requestAnimationFrame(() => requestAnimationFrame(() => navigate(href)))
+						} else {
+							toggleMobileSidebar(false)
+						}
 					}
 					trackEvent('click-file-link', { source: 'sidebar' })
 				}}


### PR DESCRIPTION
**Draft.** Targeted perceptual fix for the mobile sidebar file-tap delay, backed by a Safari Timeline trace from the iOS Simulator.

## Problem
On mobile, tapping a file in the sidebar pauses ~1s before the menu closes and the file loads — both happen together after the wait.

## What the trace showed
A Safari Web Inspector Timeline of one file tap on the iOS Simulator:
- `click` fires and the handler **blocks the main thread for ~1106ms** — `navigate` is dispatched 4ms in, and the rest is React unmounting the previous file's editor and mounting the new one(s) synchronously.
- The sidebar close only paints *after* that 1.1s block ends.
- A second ~1.2s block follows (`message` handler ~1181ms + a ~1272ms rendering frame) as the synced document hydrates and first-paints.

So the "menu stuck open" pause is the navigation work running synchronously inside the click handler, blocking the (cheap) sidebar close from painting. This is not the WebKit tap delay (taps showed normal ~100–185ms `pointerdown`→`click`), so the earlier `touch-action` attempt was dropped.

## Fix
For a plain tap, close the sidebar and defer navigation by two animation frames so the close paints first, then the expensive navigation runs. The menu snaps shut immediately; the file loads after. Modifier and non-primary clicks still use the native link, preserving open-in-new-tab.

Two frames are needed because `navigate` runs synchronously in the click handler: a single rAF fires before the next paint and would re-block the close, and `flushSync` commits the DOM without yielding a paint before `navigate`.

## Scope / follow-ups
This is a perceptual fix — the menu closes instantly, but tap-to-file-visible stays ~3s because the editor still tears down and remounts and the document still hydrates. Reducing that absolute time is separate, larger work:
- the loading placeholder is a second full `<Tldraw>` instance (`TlaEditor.tsx` `TlaEditorLoadingPlaceholder`) mounted alongside the real one — a cheaper skeleton would remove one of two concurrent editor instantiations;
- the editor is keyed by `fileSlug` so every switch fully remounts it instead of reusing the instance.

## Test plan (iOS Simulator)
- Open the sidebar, tap a file: the menu should close immediately rather than after ~1s.
- Verify open-in-new-tab still works (long-press / modifier where applicable).