### PR TITLE
fix(dotcom): reap the live process tree when dev-app stops

### DIFF
--- a/apps/dotcom/client/scripts/dev-app.ts
+++ b/apps/dotcom/client/scripts/dev-app.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'child_process'
 import { createServer } from 'net'
 import { pathToFileURL } from 'url'
+import { killProcessTree } from '../../../../internal/scripts/lib/kill-tree'
 
 const CLIENT_PORT = 3000
 const SKIPPABLE_PROBE_ERROR_CODES = new Set(['EADDRNOTAVAIL', 'EAFNOSUPPORT'])
@@ -50,27 +51,29 @@ async function main() {
 	const args = getViteArgs(process.env.VITE_PREVIEW === '1' ? 'preview' : 'dev')
 	const child = spawn('vite', args, { stdio: 'inherit' })
 
-	// Forward termination signals to vite and make sure it is killed if this process exits for any
-	// other reason. Without this, an unclean exit (closed terminal, killed parent) leaves vite
-	// holding port 3000, which blocks the next `yarn dev-app`.
+	// On shutdown, reap vite *and its children* (esbuild/optimizer helpers) by walking the PID tree
+	// and killing deepest-first. This runs in the signal handler, while the tree is still alive —
+	// not on `exit` — because once vite exits its helpers reparent to launchd and a `pgrep` walk from
+	// us can no longer find them, so they would orphan and keep holding port 3000.
 	let shuttingDown = false
-	const stop = (signal: NodeJS.Signals) => {
+	const shutdown = () => {
 		if (shuttingDown) return
 		shuttingDown = true
-		if (!child.killed) child.kill(signal)
+		killProcessTree(process.pid)
+		process.exit(0)
 	}
-	process.on('SIGINT', () => stop('SIGINT'))
-	process.on('SIGTERM', () => stop('SIGTERM'))
-	process.on('SIGHUP', () => stop('SIGHUP'))
-	process.on('exit', () => {
-		if (!child.killed) child.kill('SIGKILL')
-	})
+	process.on('SIGINT', shutdown)
+	process.on('SIGTERM', shutdown)
+	process.on('SIGHUP', shutdown)
+	// Backstop for any exit path that bypassed the signal handler.
+	process.on('exit', () => killProcessTree(process.pid))
 
 	child.once('error', (error) => {
 		console.error(error)
 		process.exit(1)
 	})
 	child.once('exit', (code, signal) => {
+		if (shuttingDown) return
 		process.exit(signal ? 1 : (code ?? 0))
 	})
 }

--- a/apps/dotcom/client/scripts/kill-tree.test.ts
+++ b/apps/dotcom/client/scripts/kill-tree.test.ts
@@ -1,0 +1,114 @@
+import { spawn } from 'child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { killProcessTree } from '../../../../internal/scripts/lib/kill-tree'
+
+// `killProcessTree` lives in internal/scripts/lib, but only apps/** and packages/** are wired into
+// the root vitest config, so its regression test lives here alongside dev-app.test.ts (the dotcom
+// dev script that depends on it).
+
+// A process that records its own pid, optionally spawns one more level below itself, then idles.
+// Running `node nest.cjs <depth> <pidfile>` builds a chain `depth` levels deep so we can prove the
+// reap crosses more than one wrapper layer (the real tree is orchestrator → yarn → tsx → wrangler →
+// workerd).
+const NEST_SCRIPT = `
+const { spawn } = require('child_process')
+const { appendFileSync } = require('fs')
+const depth = Number(process.argv[2])
+const pidfile = process.argv[3]
+appendFileSync(pidfile, process.pid + '\\n')
+if (depth > 0) {
+	spawn(process.execPath, [__filename, String(depth - 1), pidfile], { stdio: 'ignore' })
+}
+setInterval(() => {}, 1 << 30)
+`
+
+let dir: string
+let pidfile: string
+let scriptPath: string
+let spawned: number[] = []
+
+function isAlive(pid: number) {
+	try {
+		process.kill(pid, 0)
+		return true
+	} catch {
+		return false
+	}
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000) {
+	const deadline = Date.now() + timeoutMs
+	while (Date.now() < deadline) {
+		if (predicate()) return
+		await new Promise((r) => setTimeout(r, 25))
+	}
+	throw new Error('timed out waiting for condition')
+}
+
+function recordedPids() {
+	try {
+		return readFileSync(pidfile, 'utf8')
+			.split('\n')
+			.map((l) => Number(l.trim()))
+			.filter((n) => Number.isInteger(n) && n > 0)
+	} catch {
+		return []
+	}
+}
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), 'kill-tree-'))
+	pidfile = join(dir, 'pids.txt')
+	scriptPath = join(dir, 'nest.cjs')
+	writeFileSync(scriptPath, NEST_SCRIPT)
+	writeFileSync(pidfile, '')
+	spawned = []
+})
+
+afterEach(() => {
+	// Clean up anything the test left alive so a failure can't leak processes.
+	for (const pid of [...spawned, ...recordedPids()]) {
+		try {
+			process.kill(pid, 'SIGKILL')
+		} catch {
+			// already gone
+		}
+	}
+	rmSync(dir, { recursive: true, force: true })
+})
+
+describe('killProcessTree', () => {
+	it('reaps the whole descendant tree while leaving the root alive', async () => {
+		// root → child → grandchild (3 processes total).
+		const root = spawn(process.execPath, [scriptPath, '2', pidfile], { stdio: 'ignore' })
+		spawned.push(root.pid!)
+
+		await waitFor(() => recordedPids().length === 3)
+		const [rootPid, childPid, grandchildPid] = recordedPids()
+		expect(rootPid).toBe(root.pid)
+		expect(isAlive(childPid)).toBe(true)
+		expect(isAlive(grandchildPid)).toBe(true)
+
+		killProcessTree(rootPid)
+
+		// The descendants (child and grandchild) are reaped; the root is intentionally left alone so a
+		// caller can finish its own shutdown and exit.
+		await waitFor(() => !isAlive(childPid) && !isAlive(grandchildPid))
+		expect(isAlive(childPid)).toBe(false)
+		expect(isAlive(grandchildPid)).toBe(false)
+		expect(isAlive(rootPid)).toBe(true)
+	})
+
+	it('does nothing when the pid has no descendants', async () => {
+		// A leaf process (depth 0) with no children: the reap should be a no-op and leave it running.
+		const leaf = spawn(process.execPath, [scriptPath, '0', pidfile], { stdio: 'ignore' })
+		spawned.push(leaf.pid!)
+
+		await waitFor(() => recordedPids().length === 1)
+		expect(() => killProcessTree(leaf.pid!)).not.toThrow()
+		expect(isAlive(leaf.pid!)).toBe(true)
+	})
+})

--- a/apps/dotcom/sync-worker/dev.ts
+++ b/apps/dotcom/sync-worker/dev.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import { spawn } from 'child_process'
+import { killProcessTree } from '../../../internal/scripts/lib/kill-tree'
 import { getDotcomDevEnv } from '../zero-cache/dev-env'
 
 const env = getDotcomDevEnv()
@@ -27,15 +28,29 @@ const child = spawn(
 	}
 )
 
-child.once('exit', (code) => process.exit(code ?? 1))
+// On shutdown, reap the whole subtree while it is still alive. The direct child is a
+// `yarn run -T tsx …` wrapper, so just signalling it would let the tsx → node → wrangler → workerd
+// processes beneath it reparent to launchd and keep holding the dev port. Walking by PID,
+// deepest-first, crosses those wrapper boundaries. We do this in the signal handler (not on `exit`)
+// so the tree is still enumerable.
+let shuttingDown = false
+const shutdown = () => {
+	if (shuttingDown) return
+	shuttingDown = true
+	killProcessTree(process.pid)
+	process.exit(0)
+}
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
+process.on('SIGHUP', shutdown)
+// Backstop for any exit path that bypassed the signal handler.
+process.on('exit', () => killProcessTree(process.pid))
+
+child.once('exit', (code) => {
+	if (shuttingDown) return
+	process.exit(code ?? 1)
+})
 child.once('error', (error) => {
 	console.error(error)
 	process.exit(1)
-})
-
-process.on('SIGINT', () => child.kill('SIGINT'))
-process.on('SIGTERM', () => child.kill('SIGTERM'))
-process.on('SIGHUP', () => child.kill('SIGHUP'))
-process.on('exit', () => {
-	if (!child.killed) child.kill('SIGKILL')
 })

--- a/apps/dotcom/zero-cache/dev.ts
+++ b/apps/dotcom/zero-cache/dev.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
-import { ChildProcess, spawn, spawnSync } from 'child_process'
+import { spawn, spawnSync } from 'child_process'
 import dotenv from 'dotenv'
 import pg from 'pg'
+import { killProcessTree } from '../../../internal/scripts/lib/kill-tree'
 import { DOTCOM_DEV_PORTS, DOTCOM_DEV_READINESS_TIMEOUT_MS, getDotcomDevEnv } from './dev-env'
 
 const env = getDotcomDevEnv()
@@ -13,7 +14,6 @@ const childEnv = {
 	...env.zeroEnv,
 }
 
-const children: ChildProcess[] = []
 let migrationsReady = false
 let shuttingDown = false
 
@@ -30,35 +30,12 @@ function statusFromExit(code: number | null, signal: NodeJS.Signals | null) {
 	return signal ? `signal ${signal}` : `code ${code ?? 1}`
 }
 
-/** Collect every descendant PID of `pid` by walking the process tree with `pgrep -P`. */
-function descendantPids(pid: number): number[] {
-	const result = spawnSync('pgrep', ['-P', String(pid)], { encoding: 'utf8' })
-	const childPids = (result.stdout ?? '')
-		.split('\n')
-		.map((line) => Number(line.trim()))
-		.filter((n) => Number.isInteger(n) && n > 0)
-	return childPids.flatMap((childPid) => [childPid, ...descendantPids(childPid)])
-}
-
 function killChildren() {
-	// Reap the whole descendant tree, not just our direct children. The zero-cache dev server spawns
-	// worker subprocesses (change-streamer, replicator, syncer, ...) in their own process groups, so a
-	// terminal/group signal misses them and they orphan, holding port 4848. Walking by PID crosses
-	// those group boundaries. Collect PIDs before killing so the tree does not reparent out from under
-	// us, then SIGKILL deepest-first.
-	const descendants = descendantPids(process.pid).reverse()
-	for (const pid of descendants) {
-		try {
-			process.kill(pid, 'SIGKILL')
-		} catch {
-			// already gone
-		}
-	}
-	for (const child of [...children].reverse()) {
-		if (!child.killed) {
-			child.kill('SIGKILL')
-		}
-	}
+	// Reap the whole descendant tree, not just our direct children, and do it here on the shutdown
+	// path while the tree is still alive. The zero-cache dev server spawns worker subprocesses
+	// (change-streamer, replicator, syncer, ...) in their own process groups, so a terminal/group
+	// signal misses them and they orphan, holding port 4848.
+	killProcessTree(process.pid)
 }
 
 function composeDown() {
@@ -110,7 +87,6 @@ function spawnManaged(
 		env: childEnv,
 		stdio: 'inherit',
 	})
-	children.push(child)
 
 	child.once('error', (error) => {
 		if (shuttingDown) return
@@ -266,13 +242,11 @@ async function main() {
 	process.on('SIGINT', () => shutdown(0))
 	process.on('SIGTERM', () => shutdown(0))
 	process.on('SIGHUP', () => shutdown(0))
-	// Last-resort sync cleanup if we ever exit through a path that bypassed shutdown(). Keep this light
-	// (no subprocess spawning, which is unreliable from an 'exit' handler): just kill our direct children.
-	process.on('exit', () => {
-		for (const child of children) {
-			if (!child.killed) child.kill('SIGKILL')
-		}
-	})
+	// Backstop if we ever exit through a path that bypassed shutdown(). `killProcessTree` only uses
+	// `spawnSync`, which is synchronous and so runs to completion in an 'exit' handler — unlike the
+	// async `spawn` in composeDown(), which an 'exit' handler would not wait for, so that stays on the
+	// shutdown() path only.
+	process.on('exit', () => killProcessTree(process.pid))
 
 	reconcileDockerStacks()
 

--- a/apps/dotcom/zero-cache/dev.ts
+++ b/apps/dotcom/zero-cache/dev.ts
@@ -242,11 +242,15 @@ async function main() {
 	process.on('SIGINT', () => shutdown(0))
 	process.on('SIGTERM', () => shutdown(0))
 	process.on('SIGHUP', () => shutdown(0))
-	// Backstop if we ever exit through a path that bypassed shutdown(). `killProcessTree` only uses
-	// `spawnSync`, which is synchronous and so runs to completion in an 'exit' handler — unlike the
-	// async `spawn` in composeDown(), which an 'exit' handler would not wait for, so that stays on the
-	// shutdown() path only.
-	process.on('exit', () => killProcessTree(process.pid))
+	// Backstop only for exits that bypassed shutdown() (e.g. the port-preflight `process.exit(1)`,
+	// which runs before any children spawn). `killProcessTree` uses `spawnSync`, which is synchronous
+	// and so runs to completion in an 'exit' handler. We must NOT reap once shutdown() has run: it
+	// spawns the detached `docker compose down` teardown, which is a child of this process until we
+	// exit, so reaping the tree here would SIGKILL it mid-teardown and leak the Docker ports. The
+	// live-tree reap for the shutdown() path already happened in killChildren(), before composeDown().
+	process.on('exit', () => {
+		if (!shuttingDown) killProcessTree(process.pid)
+	})
 
 	reconcileDockerStacks()
 

--- a/internal/scripts/lib/kill-tree.ts
+++ b/internal/scripts/lib/kill-tree.ts
@@ -1,0 +1,40 @@
+import { spawnSync } from 'child_process'
+
+/**
+ * Collect every descendant PID of `pid` by walking the process tree with `pgrep -P`.
+ *
+ * Returned breadth-first (direct children first, deepest descendants last). Callers that SIGKILL
+ * the tree should reverse this so they kill deepest-first.
+ */
+export function descendantPids(pid: number): number[] {
+	const result = spawnSync('pgrep', ['-P', String(pid)], { encoding: 'utf8' })
+	const childPids = (result.stdout ?? '')
+		.split('\n')
+		.map((line) => Number(line.trim()))
+		.filter((n) => Number.isInteger(n) && n > 0)
+	return childPids.flatMap((childPid) => [childPid, ...descendantPids(childPid)])
+}
+
+/**
+ * SIGKILL `pid` and its entire descendant tree.
+ *
+ * Our dev orchestrators spawn children through wrapper layers (`yarn run -T tsx …`) and processes
+ * that fork their own grandchildren (vite → esbuild, wrangler → workerd, zero-cache → worker
+ * subprocesses). `child.kill()` only signals the direct child, and SIGKILL is uncatchable and does
+ * not cascade — so killing a wrapper or parent just orphans everything beneath it, leaving processes
+ * that keep holding the fixed dev ports. Walking by PID crosses those wrapper and process-group
+ * boundaries.
+ *
+ * Collect the PIDs up front so the tree does not reparent out from under us while we kill, then
+ * SIGKILL deepest-first. The root `pid` itself is left alone so the caller can finish its own
+ * shutdown and exit. Safe to call from signal and synchronous `exit` handlers.
+ */
+export function killProcessTree(pid: number) {
+	for (const target of descendantPids(pid).reverse()) {
+		try {
+			process.kill(target, 'SIGKILL')
+		} catch {
+			// already gone
+		}
+	}
+}

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -6,6 +6,7 @@ import kleur from 'kleur'
 import { lock } from 'proper-lockfile'
 import stripAnsi from 'strip-ansi'
 import * as toml from 'toml'
+import { killProcessTree } from '../lib/kill-tree'
 
 const lockfileName = __dirname
 
@@ -74,14 +75,6 @@ class MiniflareMonitor {
 		if (this.isLocked()) await this.release()
 		if (this.process) {
 			this.process.kill()
-			this.process = null
-		}
-	}
-
-	/** Synchronously kill the wrangler process. Safe to call from signal and `exit` handlers. */
-	public dispose(signal: NodeJS.Signals = 'SIGTERM'): void {
-		if (this.process) {
-			this.process.kill(signal)
 			this.process = null
 		}
 	}
@@ -235,7 +228,7 @@ async function main() {
 	const port = getDevPort(process.argv.slice(2))
 	if (port != null) await ensurePortFreeOrExit(port)
 
-	const monitor = new MiniflareMonitor('wrangler', [
+	new MiniflareMonitor('wrangler', [
 		'dev',
 		'--env',
 		'dev',
@@ -245,26 +238,27 @@ async function main() {
 		'--var',
 		'IS_LOCAL:true',
 		...process.argv.slice(2),
-	])
-	monitor.start()
+	]).start()
 
 	new SizeReporter().start()
 
-	// Tear down wrangler (and its workerd child) when this process is asked to stop or exits. Without
-	// this the worker keeps holding its inspector/dev port after the parent goes away, blocking reruns.
+	// On shutdown, reap the whole subtree while it is still alive. wrangler spawns workerd as a child
+	// and the size reporter spawns esbuild through a `yarn run -T` wrapper, so just signalling our
+	// direct children would let those grandchildren reparent to launchd and keep holding the dev port.
+	// Walking by PID, deepest-first, crosses those wrapper and process boundaries. We do this in the
+	// signal handler (not on `exit`) so the tree is still enumerable.
 	let shuttingDown = false
 	const shutdown = () => {
 		if (shuttingDown) return
 		shuttingDown = true
-		monitor.dispose()
+		killProcessTree(process.pid)
 		process.exit(0)
 	}
 	process.on('SIGINT', shutdown)
 	process.on('SIGTERM', shutdown)
 	process.on('SIGHUP', shutdown)
-	// Last resort if we exit through a path that bypassed shutdown(): SIGKILL so wrangler can't catch
-	// it and linger holding its dev port. The graceful SIGTERM is only for the signal path above.
-	process.on('exit', () => monitor.dispose('SIGKILL'))
+	// Backstop for any exit path that bypassed the signal handler.
+	process.on('exit', () => killProcessTree(process.pid))
 }
 
 main()


### PR DESCRIPTION
Follow-up to #9226.

That PR added per-script teardown so `yarn dev-app` stops leaving orphaned processes and Docker containers behind. It helped, but node/worker processes could still linger after quitting (and switching branches), which is what motivated this fix.

### Two problems

**1. Only zero-cache reaped its descendant tree.** The other scripts signalled their **direct** child only — and each of those is either a wrapper or a process that forks its own grandchildren:

| Script | Direct child | What leaked |
| --- | --- | --- |
| `client/scripts/dev-app.ts` | `vite` | vite's esbuild/optimizer helpers |
| `sync-worker/dev.ts` | `yarn run -T tsx …` wrapper | the tsx → node → wrangler → workerd subtree |
| `internal/scripts/workers/dev.ts` | `wrangler` / esbuild wrapper | workerd, esbuild watcher |

`SIGKILL` is uncatchable and does not cascade, so killing the parent just orphaned the grandchildren — they reparent to `launchd` and keep holding the fixed dev ports.

**2. The reap ran in the `exit` handler — too late.** In the dominant Ctrl+C path the direct child exits *before* the `exit` handler runs, and its children have already reparented to pid 1, so a `pgrep -P` walk from us finds nothing. I verified this with a minimal harness reproducing the exact topology:

```
[signal] descendantPids(parent) = [<child>, <grandchild>]   <- tree still alive
[exit]   descendantPids(parent) = []                         <- what the old reap saw
>>> grandchild LEAKED (reparented to pid 1)
```

Reaping the **live** tree on the signal path instead cleans it up.

### What changed

- Factor zero-cache's descendant-tree walk into a shared `killProcessTree` helper (`internal/scripts/lib/kill-tree.ts`).
- Have every dev orchestrator reap the tree on the **signal/shutdown path** while it is still alive, killing deepest-first so nothing reparents out from under us. This is the pattern zero-cache already used, now applied consistently across `dev-app`, `sync-worker`, and the workers dev script.
- `killProcessTree` remains as the synchronous `exit` backstop. It only uses `spawnSync`, which runs to completion in an `exit` handler — unlike the async `spawn` in zero-cache's `composeDown()`, which stays on the `shutdown()` path only. This also reconciles the previously contradictory zero-cache `exit`-handler comment.
- Removed now-redundant tracking (`MiniflareMonitor.dispose()`, zero-cache's `children` array) in favour of the single tree reap.

### Validation

- Minimal harness reproducing the orchestrator → wrapper → grandchild topology: confirmed the old `exit`-handler reap is a no-op (grandchild leaks) and the live-tree signal-path reap cleans it up.
- Added a regression test (`kill-tree.test.ts`) that spawns a real three-level process tree and asserts the descendants are reaped while the root survives. Stable across repeated runs.
- `yarn workspace dotcom test run scripts/` (6 tests) passes; `yarn typecheck` and lint clean.

### Test plan

1. `yarn dev-app`, confirm the stack starts (client 3000, sync-worker 8787, zero 4848, workers 9339, migrations 7654, Docker 6432/6543).
2. Ctrl+C, then confirm no stray `vite`/`workerd`/`wrangler`/zero processes remain (`lsof -nP -iTCP:3000,8787,4848,9339 -sTCP:LISTEN`) and the next `yarn dev-app` starts without a port-in-use error.

- [x] Unit tests