### PR TITLE
ui: dont add title attribute for menu items, its annoying

### DIFF
--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuCheckboxItem.tsx
@@ -60,7 +60,6 @@ export function TldrawUiMenuCheckboxItem<
 					dir={dir}
 					lang={lang}
 					className="tlui-button tlui-button__menu tlui-button__checkbox"
-					title={labelStr}
 					onSelect={(e) => {
 						onSelect?.(sourceId)
 						preventDefault(e)
@@ -89,7 +88,6 @@ export function TldrawUiMenuCheckboxItem<
 					className="tlui-button tlui-button__menu tlui-button__checkbox"
 					dir={dir}
 					lang={lang}
-					title={labelStr}
 					onSelect={(e) => {
 						onSelect(sourceId)
 						preventDefault(e)

--- a/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/primitives/menus/TldrawUiMenuSubmenu.tsx
@@ -50,7 +50,6 @@ export function TldrawUiMenuSubmenu<Translation extends string = string>({
 						id={`${sourceId}-sub.${id}-button`}
 						disabled={disabled}
 						label={labelStr!}
-						title={labelStr!}
 					/>
 					<TldrawUiDropdownMenuSubContent id={`${sourceId}-sub.${id}-content`} size={size}>
 						{children}


### PR DESCRIPTION


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Release notes

- ui: removes title attribute for menu items which were extraneous