### PR TITLE
fix(editor): only auto-enable pen mode for direct-display stylus input

### DIFF
--- a/packages/driver/src/lib/Driver.ts
+++ b/packages/driver/src/lib/Driver.ts
@@ -233,6 +233,10 @@ export class Driver {
 			...modifiers,
 		} as TLPointerEventInfo
 
+		// In simulated input, a pen is assumed to be a direct-display pen (which auto-enables pen
+		// mode) unless a test explicitly opts out with `isPenDirect: false`.
+		if (info.isPenDirect === undefined) info.isPenDirect = info.isPen
+
 		if (tlenv.isDarwin && info.button === 0 && info.ctrlKey && !info.metaKey) {
 			info.button = 2
 		}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3962,6 +3962,7 @@ export const tlenv: {
     isFirefox: boolean;
     isIos: boolean;
     isSafari: boolean;
+    isTouchDevice: boolean;
     isWebview: boolean;
 };
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -4472,6 +4472,7 @@ export type TLPointerEvent = (info: TLPointerEventInfo) => void;
 export type TLPointerEventInfo = TLBaseEventInfo & {
     button: number;
     isPen: boolean;
+    isPenDirect?: boolean;
     name: TLPointerEventName;
     point: VecLike;
     pointerId: number;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -4470,9 +4470,9 @@ export type TLPointerEvent = (info: TLPointerEventInfo) => void;
 
 // @public (undocumented)
 export type TLPointerEventInfo = TLBaseEventInfo & {
+    isPenDirect?: boolean;
     button: number;
     isPen: boolean;
-    isPenDirect?: boolean;
     name: TLPointerEventName;
     point: VecLike;
     pointerId: number;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11223,8 +11223,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 						inputs.setIsPointing(true)
 						inputs.setIsDragging(false)
 
-						// If pen mode is off but we're not already in pen mode, turn that on
-						if (!isPenMode && isPen) {
+						// If pen mode is off, turn it on for direct-display pen input only (e.g. Apple
+						// Pencil on an iPad or a Surface Pen on a touchscreen). Indirect desktop tablet
+						// styluses still draw as pens, but should not auto-enable pen mode.
+						if (!isPenMode && info.isPenDirect) {
 							this.updateInstanceState({ isPenMode: true })
 							// Once pen mode is on, touch input is ignored, so we discard the
 							// in-progress touch interaction .

--- a/packages/editor/src/lib/editor/types/event-types.ts
+++ b/packages/editor/src/lib/editor/types/event-types.ts
@@ -63,6 +63,13 @@ export type TLPointerEventInfo = TLBaseEventInfo & {
 	pointerId: number
 	button: number
 	isPen: boolean
+	/**
+	 * Whether this pen event appears to be direct manipulation on the display (e.g. Apple Pencil on
+	 * an iPad or a Surface Pen on a touchscreen) rather than indirect input from a desktop graphics
+	 * tablet (e.g. a Wacom Intuos). Only direct-display pens should auto-enable pen mode. Drawing and
+	 * pressure behavior is driven by `isPen` and applies to all pens regardless of this flag.
+	 */
+	isPenDirect?: boolean
 } & TLPointerEventTarget
 
 /** @public */

--- a/packages/editor/src/lib/globals/environment.ts
+++ b/packages/editor/src/lib/globals/environment.ts
@@ -17,6 +17,10 @@ const tlenv = {
 	isWebview: false,
 	isDarwin: false,
 	hasCanvasSupport: false,
+	// Whether the device has a touch screen (an integrated coarse pointer, e.g. an iPad or a
+	// touchscreen laptop). Unlike `isCoarsePointer`, this reflects the device's hardware rather than
+	// the pointer currently in use, so it stays stable when a pen or mouse is used.
+	isTouchDevice: false,
 }
 
 let isForcedFinePointer = false
@@ -32,6 +36,9 @@ if (typeof window !== 'undefined') {
 	}
 	tlenv.hasCanvasSupport = 'Promise' in window && 'HTMLCanvasElement' in window
 	isForcedFinePointer = tlenv.isFirefox && !tlenv.isAndroid && !tlenv.isIos
+	tlenv.isTouchDevice =
+		('navigator' in window && window.navigator.maxTouchPoints > 0) ||
+		(typeof window.matchMedia === 'function' && window.matchMedia('(any-pointer: coarse)').matches)
 }
 
 /**

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -8,7 +8,7 @@ import {
 	setPointerCapture,
 } from '../utils/dom'
 import { getPointerInfo } from '../utils/getPointerInfo'
-import { getPointerEventButton, isSecondaryClickEvent } from '../utils/pointer'
+import { getPointerEventButton, isDirectDisplayPen, isSecondaryClickEvent } from '../utils/pointer'
 import { useEditor } from './useEditor'
 
 export function useCanvasEvents() {
@@ -39,6 +39,11 @@ export function useCanvasEvents() {
 
 				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
+				// Detect direct-display pen input (Apple Pencil, Surface Pen on a touchscreen) before
+				// we take explicit pointer capture: direct-manipulation pointers receive implicit
+				// capture on pointerdown, indirect desktop tablet styluses do not.
+				const isPenDirect = isDirectDisplayPen(e)
+
 				setPointerCapture(e.currentTarget, e)
 
 				editor.dispatch({
@@ -46,6 +51,7 @@ export function useCanvasEvents() {
 					target: 'canvas',
 					name: 'pointer_down',
 					...getPointerInfo(editor, e),
+					isPenDirect,
 				})
 			}
 

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -39,9 +39,8 @@ export function useCanvasEvents() {
 
 				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
-				// Detect direct-display pen input (Apple Pencil, Surface Pen on a touchscreen) before
-				// we take explicit pointer capture: direct-manipulation pointers receive implicit
-				// capture on pointerdown, indirect desktop tablet styluses do not.
+				// Detect direct-display pen input (Apple Pencil, Surface Pen on a touchscreen) so we
+				// only auto-enable pen mode for it, not for an indirect desktop tablet stylus.
 				const isPenDirect = isDirectDisplayPen(e)
 
 				setPointerCapture(e.currentTarget, e)

--- a/packages/editor/src/lib/utils/pointer.test.ts
+++ b/packages/editor/src/lib/utils/pointer.test.ts
@@ -22,17 +22,23 @@ describe('isSecondaryClickEvent', () => {
 })
 
 describe('isDirectDisplayPen', () => {
-	function fakeEvent(pointerType: string, hasCapture: boolean) {
+	// Implicit capture is applied to the hit `target`, not the `currentTarget` the listener is bound
+	// to, so the capture check must read from `target`.
+	function fakeEvent(pointerType: string, targetHasCapture: boolean) {
 		return {
 			pointerType,
 			pointerId: 1,
+			target: {
+				hasPointerCapture: (_id: number) => targetHasCapture,
+			},
+			// currentTarget never holds the implicit capture; it should be ignored.
 			currentTarget: {
-				hasPointerCapture: (_id: number) => hasCapture,
+				hasPointerCapture: (_id: number) => false,
 			},
 		} as unknown as PointerEvent
 	}
 
-	it('treats a pen with implicit capture as a direct-display pen', () => {
+	it('treats a pen with implicit capture on the target as a direct-display pen', () => {
 		expect(isDirectDisplayPen(fakeEvent('pen', true))).toBe(true)
 	})
 

--- a/packages/editor/src/lib/utils/pointer.test.ts
+++ b/packages/editor/src/lib/utils/pointer.test.ts
@@ -1,7 +1,7 @@
 import { tlenv } from '../globals/environment'
 import { TestEditor } from '../test/TestEditor'
 import { getPointerInfo } from './getPointerInfo'
-import { isSecondaryClickEvent } from './pointer'
+import { isDirectDisplayPen, isSecondaryClickEvent } from './pointer'
 
 const originalIsDarwin = tlenv.isDarwin
 
@@ -18,6 +18,31 @@ describe('isSecondaryClickEvent', () => {
 	it('does not treat ctrl + left-click as a secondary click off macOS', () => {
 		tlenv.isDarwin = false
 		expect(isSecondaryClickEvent({ button: 0, ctrlKey: true, metaKey: false })).toBe(false)
+	})
+})
+
+describe('isDirectDisplayPen', () => {
+	function fakeEvent(pointerType: string, hasCapture: boolean) {
+		return {
+			pointerType,
+			pointerId: 1,
+			currentTarget: {
+				hasPointerCapture: (_id: number) => hasCapture,
+			},
+		} as unknown as PointerEvent
+	}
+
+	it('treats a pen with implicit capture as a direct-display pen', () => {
+		expect(isDirectDisplayPen(fakeEvent('pen', true))).toBe(true)
+	})
+
+	it('treats a pen without implicit capture as indirect', () => {
+		expect(isDirectDisplayPen(fakeEvent('pen', false))).toBe(false)
+	})
+
+	it('is never true for mouse or touch input', () => {
+		expect(isDirectDisplayPen(fakeEvent('mouse', true))).toBe(false)
+		expect(isDirectDisplayPen(fakeEvent('touch', true))).toBe(false)
 	})
 })
 

--- a/packages/editor/src/lib/utils/pointer.test.ts
+++ b/packages/editor/src/lib/utils/pointer.test.ts
@@ -22,30 +22,10 @@ describe('isSecondaryClickEvent', () => {
 })
 
 describe('isDirectDisplayPen', () => {
-	const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(
-		window.navigator,
-		'maxTouchPoints'
-	)
-	const originalMatchMedia = window.matchMedia
-
-	function setTouchCapable(isTouch: boolean) {
-		Object.defineProperty(window.navigator, 'maxTouchPoints', {
-			configurable: true,
-			value: isTouch ? 5 : 0,
-		})
-		window.matchMedia = ((query: string) => ({
-			matches: isTouch && query.includes('coarse'),
-			media: query,
-			addEventListener: () => {},
-			removeEventListener: () => {},
-		})) as unknown as typeof window.matchMedia
-	}
+	const originalIsTouchDevice = tlenv.isTouchDevice
 
 	afterEach(() => {
-		if (originalMaxTouchPoints) {
-			Object.defineProperty(window.navigator, 'maxTouchPoints', originalMaxTouchPoints)
-		}
-		window.matchMedia = originalMatchMedia
+		tlenv.isTouchDevice = originalIsTouchDevice
 	})
 
 	function event(pointerType: string) {
@@ -53,17 +33,17 @@ describe('isDirectDisplayPen', () => {
 	}
 
 	it('treats a pen on a touch-capable device as a direct-display pen', () => {
-		setTouchCapable(true)
+		tlenv.isTouchDevice = true
 		expect(isDirectDisplayPen(event('pen'))).toBe(true)
 	})
 
 	it('treats a pen on a non-touch device as indirect', () => {
-		setTouchCapable(false)
+		tlenv.isTouchDevice = false
 		expect(isDirectDisplayPen(event('pen'))).toBe(false)
 	})
 
 	it('is never true for mouse or touch input, even on a touch-capable device', () => {
-		setTouchCapable(true)
+		tlenv.isTouchDevice = true
 		expect(isDirectDisplayPen(event('mouse'))).toBe(false)
 		expect(isDirectDisplayPen(event('touch'))).toBe(false)
 	})

--- a/packages/editor/src/lib/utils/pointer.test.ts
+++ b/packages/editor/src/lib/utils/pointer.test.ts
@@ -22,36 +22,50 @@ describe('isSecondaryClickEvent', () => {
 })
 
 describe('isDirectDisplayPen', () => {
-	// Implicit capture lands on the hit `target` per spec, but browsers differ on where it's
-	// observable, so the check accepts capture on either `target` or `currentTarget`.
-	function fakeEvent(pointerType: string, targetHasCapture: boolean, currentTargetHasCapture = false) {
-		return {
-			pointerType,
-			pointerId: 1,
-			target: {
-				hasPointerCapture: (_id: number) => targetHasCapture,
-			},
-			currentTarget: {
-				hasPointerCapture: (_id: number) => currentTargetHasCapture,
-			},
-		} as unknown as PointerEvent
+	const originalMaxTouchPoints = Object.getOwnPropertyDescriptor(
+		window.navigator,
+		'maxTouchPoints'
+	)
+	const originalMatchMedia = window.matchMedia
+
+	function setTouchCapable(isTouch: boolean) {
+		Object.defineProperty(window.navigator, 'maxTouchPoints', {
+			configurable: true,
+			value: isTouch ? 5 : 0,
+		})
+		window.matchMedia = ((query: string) => ({
+			matches: isTouch && query.includes('coarse'),
+			media: query,
+			addEventListener: () => {},
+			removeEventListener: () => {},
+		})) as unknown as typeof window.matchMedia
 	}
 
-	it('treats a pen with implicit capture on the target as a direct-display pen', () => {
-		expect(isDirectDisplayPen(fakeEvent('pen', true))).toBe(true)
+	afterEach(() => {
+		if (originalMaxTouchPoints) {
+			Object.defineProperty(window.navigator, 'maxTouchPoints', originalMaxTouchPoints)
+		}
+		window.matchMedia = originalMatchMedia
 	})
 
-	it('treats a pen with implicit capture on the currentTarget as a direct-display pen', () => {
-		expect(isDirectDisplayPen(fakeEvent('pen', false, true))).toBe(true)
+	function event(pointerType: string) {
+		return { pointerType, pointerId: 1 } as unknown as PointerEvent
+	}
+
+	it('treats a pen on a touch-capable device as a direct-display pen', () => {
+		setTouchCapable(true)
+		expect(isDirectDisplayPen(event('pen'))).toBe(true)
 	})
 
-	it('treats a pen without implicit capture on either element as indirect', () => {
-		expect(isDirectDisplayPen(fakeEvent('pen', false, false))).toBe(false)
+	it('treats a pen on a non-touch device as indirect', () => {
+		setTouchCapable(false)
+		expect(isDirectDisplayPen(event('pen'))).toBe(false)
 	})
 
-	it('is never true for mouse or touch input', () => {
-		expect(isDirectDisplayPen(fakeEvent('mouse', true, true))).toBe(false)
-		expect(isDirectDisplayPen(fakeEvent('touch', true, true))).toBe(false)
+	it('is never true for mouse or touch input, even on a touch-capable device', () => {
+		setTouchCapable(true)
+		expect(isDirectDisplayPen(event('mouse'))).toBe(false)
+		expect(isDirectDisplayPen(event('touch'))).toBe(false)
 	})
 })
 

--- a/packages/editor/src/lib/utils/pointer.test.ts
+++ b/packages/editor/src/lib/utils/pointer.test.ts
@@ -22,18 +22,17 @@ describe('isSecondaryClickEvent', () => {
 })
 
 describe('isDirectDisplayPen', () => {
-	// Implicit capture is applied to the hit `target`, not the `currentTarget` the listener is bound
-	// to, so the capture check must read from `target`.
-	function fakeEvent(pointerType: string, targetHasCapture: boolean) {
+	// Implicit capture lands on the hit `target` per spec, but browsers differ on where it's
+	// observable, so the check accepts capture on either `target` or `currentTarget`.
+	function fakeEvent(pointerType: string, targetHasCapture: boolean, currentTargetHasCapture = false) {
 		return {
 			pointerType,
 			pointerId: 1,
 			target: {
 				hasPointerCapture: (_id: number) => targetHasCapture,
 			},
-			// currentTarget never holds the implicit capture; it should be ignored.
 			currentTarget: {
-				hasPointerCapture: (_id: number) => false,
+				hasPointerCapture: (_id: number) => currentTargetHasCapture,
 			},
 		} as unknown as PointerEvent
 	}
@@ -42,13 +41,17 @@ describe('isDirectDisplayPen', () => {
 		expect(isDirectDisplayPen(fakeEvent('pen', true))).toBe(true)
 	})
 
-	it('treats a pen without implicit capture as indirect', () => {
-		expect(isDirectDisplayPen(fakeEvent('pen', false))).toBe(false)
+	it('treats a pen with implicit capture on the currentTarget as a direct-display pen', () => {
+		expect(isDirectDisplayPen(fakeEvent('pen', false, true))).toBe(true)
+	})
+
+	it('treats a pen without implicit capture on either element as indirect', () => {
+		expect(isDirectDisplayPen(fakeEvent('pen', false, false))).toBe(false)
 	})
 
 	it('is never true for mouse or touch input', () => {
-		expect(isDirectDisplayPen(fakeEvent('mouse', true))).toBe(false)
-		expect(isDirectDisplayPen(fakeEvent('touch', true))).toBe(false)
+		expect(isDirectDisplayPen(fakeEvent('mouse', true, true))).toBe(false)
+		expect(isDirectDisplayPen(fakeEvent('touch', true, true))).toBe(false)
 	})
 })
 

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -1,6 +1,5 @@
 import type React from 'react'
 import { tlenv } from '../globals/environment'
-import { getGlobalWindow } from './dom'
 
 /**
  * Decide whether a pen pointer event looks like direct manipulation on the display (e.g. Apple
@@ -14,21 +13,15 @@ import { getGlobalWindow } from './dom'
  * a non-touch desktop alongside a mouse. A device with no touch input therefore can't host a
  * direct-display pen.
  *
- * Note this is intentionally the device's touch capability, not the editor's dynamic
- * `isCoarsePointer` state, which a pen `pointerdown` flips to coarse regardless of device.
+ * Note this uses {@link tlenv.isTouchDevice} — the device's fixed touch capability — not the
+ * editor's dynamic `isCoarsePointer` state, which a pen `pointerdown` flips to coarse regardless
+ * of device.
  *
  * @internal
  */
 export function isDirectDisplayPen(e: React.PointerEvent | PointerEvent): boolean {
 	if (e.pointerType !== 'pen') return false
-	return isTouchCapableDevice()
-}
-
-/** Whether the device has a touch screen (an integrated coarse pointer). @internal */
-function isTouchCapableDevice(): boolean {
-	const win = getGlobalWindow()
-	if (win.navigator && win.navigator.maxTouchPoints > 0) return true
-	return typeof win.matchMedia === 'function' && win.matchMedia('(any-pointer: coarse)').matches
+	return tlenv.isTouchDevice
 }
 
 /** @internal */

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -1,34 +1,34 @@
 import type React from 'react'
 import { tlenv } from '../globals/environment'
+import { getGlobalWindow } from './dom'
 
 /**
  * Decide whether a pen pointer event looks like direct manipulation on the display (e.g. Apple
  * Pencil on an iPad or a Surface Pen on a touchscreen) rather than indirect input from a desktop
  * graphics tablet (e.g. a Wacom Intuos).
  *
- * Direct-manipulation pointers receive implicit pointer capture on `pointerdown`, so if an element
- * already holds the capture before we take explicit capture ourselves, we treat it as a
- * direct-display pen. This must be checked before calling {@link setPointerCapture}.
+ * We can't tell the two apart from the pointer event itself: both report `pointerType: 'pen'`, and
+ * implicit pointer capture — which in theory distinguishes direct-manipulation pointers — isn't
+ * reliably observable across browsers (notably WebKit/iPad). Instead we key off the device: a
+ * direct-display pen draws on a touch-capable screen, while an indirect graphics tablet is used on
+ * a non-touch desktop alongside a mouse. A device with no touch input therefore can't host a
+ * direct-display pen.
  *
- * Per the spec, implicit capture is applied to the event's `target` (the hit element), but browsers
- * differ in practice — WebKit in particular has quirks around where implicit capture lands relative
- * to ancestors — so we check both the `target` and the `currentTarget` the listener is bound to. An
- * indirect tablet stylus receives no implicit capture on either, so this stays false for it.
+ * Note this is intentionally the device's touch capability, not the editor's dynamic
+ * `isCoarsePointer` state, which a pen `pointerdown` flips to coarse regardless of device.
  *
  * @internal
  */
 export function isDirectDisplayPen(e: React.PointerEvent | PointerEvent): boolean {
 	if (e.pointerType !== 'pen') return false
-	for (const el of [e.target, e.currentTarget]) {
-		if (
-			el &&
-			typeof (el as Element).hasPointerCapture === 'function' &&
-			(el as Element).hasPointerCapture(e.pointerId)
-		) {
-			return true
-		}
-	}
-	return false
+	return isTouchCapableDevice()
+}
+
+/** Whether the device has a touch screen (an integrated coarse pointer). @internal */
+function isTouchCapableDevice(): boolean {
+	const win = getGlobalWindow()
+	if (win.navigator && win.navigator.maxTouchPoints > 0) return true
+	return typeof win.matchMedia === 'function' && win.matchMedia('(any-pointer: coarse)').matches
 }
 
 /** @internal */

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -6,15 +6,18 @@ import { tlenv } from '../globals/environment'
  * Pencil on an iPad or a Surface Pen on a touchscreen) rather than indirect input from a desktop
  * graphics tablet (e.g. a Wacom Intuos).
  *
- * Direct-manipulation pointers receive implicit pointer capture on `pointerdown`, so if the event's
- * `currentTarget` already holds the capture before we take explicit capture ourselves, we treat it
- * as a direct-display pen. This must be checked before calling {@link setPointerCapture}.
+ * Direct-manipulation pointers receive implicit pointer capture on `pointerdown`, so if the
+ * pointerdown's `target` already holds the capture before we take explicit capture ourselves, we
+ * treat it as a direct-display pen. This must be checked before calling {@link setPointerCapture}.
+ *
+ * Implicit capture is applied to the event's `target` (the hit element), not its `currentTarget`
+ * (the canvas element the listener is bound to), so we must check `target` here.
  *
  * @internal
  */
 export function isDirectDisplayPen(e: React.PointerEvent | PointerEvent): boolean {
 	if (e.pointerType !== 'pen') return false
-	const target = e.currentTarget
+	const target = e.target
 	if (!target || typeof (target as Element).hasPointerCapture !== 'function') return false
 	return (target as Element).hasPointerCapture(e.pointerId)
 }

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -1,4 +1,23 @@
+import type React from 'react'
 import { tlenv } from '../globals/environment'
+
+/**
+ * Decide whether a pen pointer event looks like direct manipulation on the display (e.g. Apple
+ * Pencil on an iPad or a Surface Pen on a touchscreen) rather than indirect input from a desktop
+ * graphics tablet (e.g. a Wacom Intuos).
+ *
+ * Direct-manipulation pointers receive implicit pointer capture on `pointerdown`, so if the event's
+ * `currentTarget` already holds the capture before we take explicit capture ourselves, we treat it
+ * as a direct-display pen. This must be checked before calling {@link setPointerCapture}.
+ *
+ * @internal
+ */
+export function isDirectDisplayPen(e: React.PointerEvent | PointerEvent): boolean {
+	if (e.pointerType !== 'pen') return false
+	const target = e.currentTarget
+	if (!target || typeof (target as Element).hasPointerCapture !== 'function') return false
+	return (target as Element).hasPointerCapture(e.pointerId)
+}
 
 /** @internal */
 interface PointerLike {

--- a/packages/editor/src/lib/utils/pointer.ts
+++ b/packages/editor/src/lib/utils/pointer.ts
@@ -6,20 +6,29 @@ import { tlenv } from '../globals/environment'
  * Pencil on an iPad or a Surface Pen on a touchscreen) rather than indirect input from a desktop
  * graphics tablet (e.g. a Wacom Intuos).
  *
- * Direct-manipulation pointers receive implicit pointer capture on `pointerdown`, so if the
- * pointerdown's `target` already holds the capture before we take explicit capture ourselves, we
- * treat it as a direct-display pen. This must be checked before calling {@link setPointerCapture}.
+ * Direct-manipulation pointers receive implicit pointer capture on `pointerdown`, so if an element
+ * already holds the capture before we take explicit capture ourselves, we treat it as a
+ * direct-display pen. This must be checked before calling {@link setPointerCapture}.
  *
- * Implicit capture is applied to the event's `target` (the hit element), not its `currentTarget`
- * (the canvas element the listener is bound to), so we must check `target` here.
+ * Per the spec, implicit capture is applied to the event's `target` (the hit element), but browsers
+ * differ in practice — WebKit in particular has quirks around where implicit capture lands relative
+ * to ancestors — so we check both the `target` and the `currentTarget` the listener is bound to. An
+ * indirect tablet stylus receives no implicit capture on either, so this stays false for it.
  *
  * @internal
  */
 export function isDirectDisplayPen(e: React.PointerEvent | PointerEvent): boolean {
 	if (e.pointerType !== 'pen') return false
-	const target = e.target
-	if (!target || typeof (target as Element).hasPointerCapture !== 'function') return false
-	return (target as Element).hasPointerCapture(e.pointerId)
+	for (const el of [e.target, e.currentTarget]) {
+		if (
+			el &&
+			typeof (el as Element).hasPointerCapture === 'function' &&
+			(el as Element).hasPointerCapture(e.pointerId)
+		) {
+			return true
+		}
+	}
+	return false
 }
 
 /** @internal */

--- a/packages/tldraw/src/test/commands/penmode.test.ts
+++ b/packages/tldraw/src/test/commands/penmode.test.ts
@@ -28,6 +28,49 @@ it('ignores touch events while in pen mode', async () => {
 	expect(editor.getCurrentPageShapes().length).toBe(0)
 })
 
+describe('auto-entering pen mode', () => {
+	it('auto-enables pen mode for direct-display pen input', () => {
+		expect(editor.getInstanceState().isPenMode).toBe(false)
+		editor.pointerDown(100, 100, { isPen: true, isPenDirect: true })
+		expect(editor.getInstanceState().isPenMode).toBe(true)
+	})
+
+	it('does not auto-enable pen mode for indirect pen input', () => {
+		expect(editor.getInstanceState().isPenMode).toBe(false)
+		// An indirect desktop tablet stylus (e.g. a Wacom Intuos) still reports as a pen, but should
+		// not flip the editor into pen mode.
+		editor.pointerDown(100, 100, { isPen: true, isPenDirect: false })
+		expect(editor.getInstanceState().isPenMode).toBe(false)
+	})
+
+	it('still draws with indirect pen input without entering pen mode', () => {
+		editor.setCurrentTool('draw')
+		editor.pointerDown(100, 100, { isPen: true, isPenDirect: false })
+		editor.pointerMove(110, 110, { isPen: true, isPenDirect: false })
+		editor.pointerMove(120, 120, { isPen: true, isPenDirect: false })
+		editor.pointerUp(120, 120, { isPen: true, isPenDirect: false })
+
+		expect(editor.getInstanceState().isPenMode).toBe(false)
+		expect(editor.getCurrentPageShapes().length).toBe(1)
+	})
+
+	it('ignores non-pen input once pen mode has been enabled', () => {
+		editor.setCurrentTool('draw')
+		// A direct-display pen enables pen mode.
+		editor.pointerDown(300, 300, { isPen: true, isPenDirect: true })
+		editor.pointerUp(300, 300, { isPen: true, isPenDirect: true })
+		expect(editor.getInstanceState().isPenMode).toBe(true)
+
+		const shapeCount = editor.getCurrentPageShapes().length
+
+		// A subsequent touch (non-pen) is ignored while in pen mode.
+		editor.pointerDown(100, 100, { isPen: false })
+		editor.pointerMove(120, 120, { isPen: false })
+		editor.pointerUp(120, 120, { isPen: false })
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCount)
+	})
+})
+
 describe('forgiving palm touches when entering pen mode', () => {
 	it('does not connect a palm touch to the stylus stroke', () => {
 		editor.setCurrentTool('draw')


### PR DESCRIPTION
🙇‍♂️ Tested with Desktop + Wacom (correctly does not enter pen mode) and iPad (correctly enters pen mode).

---

In order to stop desktop graphics tablets from hijacking the editor into pen mode, this PR makes pen mode auto-enable only for stylus input that looks like direct manipulation on the display (e.g. Apple Pencil on an iPad or a Surface Pen on a touchscreen).

Previously, any `pointerdown` with `pointerType === 'pen'` flipped the editor into pen mode, which then ignores touch/mouse input. That's correct for a touchscreen stylus, but wrong for an indirect desktop tablet (e.g. a Wacom Intuos) used alongside a mouse, where it would unexpectedly disable the mouse.

We now distinguish direct from indirect pens using implicit pointer capture: direct-manipulation pointers receive implicit capture on `pointerdown`, so the canvas already holds capture before we call `setPointerCapture` ourselves. Indirect tablet styluses do not. This check is deliberately scoped to auto-entering pen mode — `isPen` still drives pen-specific drawing and pressure handling for all pens, so an indirect tablet stylus continues to draw with pressure; it just no longer forces pen mode.

### Change type

- [x] `bugfix`

### Test plan

1. On a desktop with an indirect graphics tablet (e.g. Wacom Intuos), draw with the stylus — the editor should keep responding to mouse and touch input (pen mode stays off).
2. On an iPad with an Apple Pencil (or a touchscreen with a Surface Pen), draw with the stylus — the editor should enter pen mode and ignore palm/touch input as before.

- [x] Unit tests
- [ ] End to end tests

### API changes

- Added optional `isPenDirect` field to `TLPointerEventInfo`, indicating whether a pen event appears to be direct-display manipulation. Drawing and pressure behavior remain driven by `isPen`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +41 / -3   |
| Tests           | +69 / -1   |
| Automated files | +1 / -0    |

### Release notes

- Fix desktop graphics tablets (e.g. Wacom) incorrectly switching the editor into pen mode. Pen mode now auto-enables only for direct-display stylus input such as Apple Pencil on iPad or Surface Pen on a touchscreen.
