### PR TITLE
fix(dotcom): make TlaMenuSelect open on iOS

### DIFF
--- a/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
+++ b/apps/dotcom/client/src/tla/components/tla-menu/menu.module.css
@@ -108,7 +108,7 @@
 	position: relative;
 	display: flex;
 	align-items: center;
-	height: 36px;
+	height: 24px;
 	gap: 4px;
 	justify-content: flex-end;
 	cursor: pointer;

--- a/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
+++ b/apps/dotcom/client/src/tla/components/tla-menu/tla-menu.tsx
@@ -177,7 +177,12 @@ export function TlaMenuSelect<T extends string>({
 	return (
 		<div
 			className={styles.menuSelectWrapper}
-			onClickCapture={(e) => {
+			// Stop clicks from reaching ancestor handlers (e.g. a background-dismiss),
+			// but use the bubble phase, not capture: Radix Select opens on `click` for
+			// touch/pen input (it only opens on `pointerdown` for mouse). Capturing here
+			// would swallow that click before it reaches the trigger, so the menu would
+			// never open on iOS. Bubbling lets the trigger handle the click first.
+			onClick={(e) => {
 				e.stopPropagation()
 			}}
 		>


### PR DESCRIPTION
In order to make the workspace member-role selects (and other `TlaMenuSelect` menus) usable on iOS, this PR fixes the wrapper that was swallowing the trigger click. Radix Select opens its dropdown on `click` for touch and pen input, but only on `pointerdown` for mouse. The `TlaMenuSelect` wrapper called `stopPropagation()` in the capture phase, so the click was stopped before it could descend to the trigger — harmless on desktop (already opened on `pointerdown`) but on iOS it meant the menu never opened and the control looked dead. Moving the guard to the bubble phase lets the trigger handle the click first, then still stops the click from reaching ancestor handlers (e.g. a background dismiss).

This also tightens the menu select trigger height from 36px to 24px.

### Change type

- [x] `bugfix`

### Test plan

1. On an iOS device or Simulator, open the workspace settings dialog.
2. Tap a member's role select.
3. Confirm the dropdown opens and options can be selected.
4. Confirm desktop mouse behaviour is unchanged.

### Release notes

- Fix workspace settings selects not opening on iOS.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +7 / -2    |
