### PR TITLE
ci(mcp-app): auto-deploy on push to production

### DIFF
--- a/.github/workflows/deploy-mcp-app.yml
+++ b/.github/workflows/deploy-mcp-app.yml
@@ -1,6 +1,13 @@
 name: Deploy MCP app
 
 on:
+  # Auto-deploy whenever production is updated, keeping the public MCP worker on
+  # the same commit and SDK build as production dotcom. Only production triggers a
+  # deploy: there is no staging worker, so a push to main must not overwrite the
+  # shared `tldraw-mcp-app` worker.
+  push:
+    branches:
+      - production
   workflow_dispatch:
     inputs:
       target:
@@ -12,7 +19,7 @@ env:
   CI: 1
   PRINT_GITHUB_ANNOTATIONS: 1
   TLDRAW_ENV: production
-  TARGET: ${{ github.event.inputs.target }}
+  TARGET: ${{ github.event.inputs.target || github.ref_name }}
 
 defaults:
   run:


### PR DESCRIPTION
In order to keep the public MCP worker (`tldraw-mcp-app`) on the same commit and SDK build as production dotcom without a manual step, this PR makes `deploy-mcp-app.yml` auto-deploy on every push to the `production` branch, mirroring how the VS Code extension auto-publishes via its `push` trigger.

Previously the workflow was `workflow_dispatch`-only, so it never ran automatically (despite #8587's description, the auto-trigger was never wired up). This adds a `push` trigger scoped to `production` and keeps the manual `workflow_dispatch`. `TARGET` now falls back to `github.ref_name` so the checkout ref resolves for both event types.

Production only: the MCP app is a single Cloudflare worker with no staging environment, so a push to `main` must not overwrite the shared `tldraw-mcp-app` worker. (This is why it does not also trigger on `main` like the VS Code extension, which has a separate staging pre-release channel.)

### Change type

- [x] `other`

### Test plan

1. Confirm `MCP_APP_TLDRAW_LICENSE_KEY` and the Cloudflare secrets are available to the `deploy-production` environment.
2. After merge, push to `production` (or wait for a production release) and confirm the **Deploy MCP app** workflow runs automatically and the worker serves the new bundle.
3. Confirm the manual **Deploy MCP app** workflow_dispatch still works.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +8 / -1    |
