### PR TITLE
perf(tldraw): cache fill-pattern tiles across editor instances

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { clearPatternImageUrlCacheForTests, getOrCreatePatternImageUrl } from './defaultStyleDefs'
+
+describe('getOrCreatePatternImageUrl cache', () => {
+	beforeEach(() => {
+		clearPatternImageUrlCacheForTests()
+		// jsdom may not implement createObjectURL; stub it so the cache can resolve.
+		;(URL as any).createObjectURL = vi.fn(() => 'blob:mock')
+	})
+
+	const makeGenerator = () => vi.fn(() => Promise.resolve(new Blob()))
+
+	it('generates each (dpr, zoom, solid) tile at most once', async () => {
+		const generate = makeGenerator()
+		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		expect(generate).toHaveBeenCalledTimes(1)
+	})
+
+	it('returns the same promise for a repeated key', () => {
+		const generate = makeGenerator()
+		const first = getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		const second = getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		expect(second).toBe(first)
+	})
+
+	it('generates separately for different solid colors (theme correctness)', async () => {
+		const generate = makeGenerator()
+		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		await getOrCreatePatternImageUrl(2, 4, '#000000', generate)
+		expect(generate).toHaveBeenCalledTimes(2)
+	})
+
+	it('generates separately for different dpr and zoom', async () => {
+		const generate = makeGenerator()
+		await getOrCreatePatternImageUrl(1, 4, '#ffffff', generate)
+		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		await getOrCreatePatternImageUrl(2, 8, '#ffffff', generate)
+		expect(generate).toHaveBeenCalledTimes(3)
+	})
+})

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
@@ -1,11 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import {
-	clearPatternImageUrlCacheForTests,
-	getOrCreatePatternImageUrl,
-	PATTERN_IMAGE_CACHE_MAX,
-} from './defaultStyleDefs'
-
-const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0))
+import { clearPatternImageUrlCacheForTests, getOrCreatePatternImageUrl } from './defaultStyleDefs'
 
 describe('getOrCreatePatternImageUrl cache', () => {
 	beforeEach(() => {
@@ -56,43 +50,5 @@ describe('getOrCreatePatternImageUrl cache', () => {
 		// returning the cached rejection
 		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
 		expect(generate).toHaveBeenCalledTimes(2)
-	})
-
-	it('evicts least-recently-used tiles past the cap and revokes their URLs', async () => {
-		const revoke = vi.fn()
-		;(URL as any).revokeObjectURL = revoke
-		const generate = makeGenerator()
-
-		// Fill one past the cap with distinct solid colors (simulating runtime theme churn).
-		for (let i = 0; i <= PATTERN_IMAGE_CACHE_MAX; i++) {
-			await getOrCreatePatternImageUrl(2, 4, `#color${i}`, generate)
-		}
-		await flushMicrotasks()
-
-		// The oldest entry was evicted and its object URL revoked to free the blob.
-		expect(revoke).toHaveBeenCalledTimes(1)
-
-		// Requesting the evicted (oldest) color regenerates rather than hitting the cache.
-		generate.mockClear()
-		await getOrCreatePatternImageUrl(2, 4, '#color0', generate)
-		expect(generate).toHaveBeenCalledTimes(1)
-	})
-
-	it('keeps recently-used tiles in the cache when evicting under churn', async () => {
-		;(URL as any).revokeObjectURL = vi.fn()
-		const generate = makeGenerator()
-
-		// Insert color0 first, then keep using it while churning through new colors.
-		await getOrCreatePatternImageUrl(2, 4, '#color0', generate)
-		for (let i = 1; i <= PATTERN_IMAGE_CACHE_MAX; i++) {
-			await getOrCreatePatternImageUrl(2, 4, `#color${i}`, generate)
-			await getOrCreatePatternImageUrl(2, 4, '#color0', generate) // touch it to keep it fresh
-		}
-		await flushMicrotasks()
-
-		// color0 stays cached because it was recently used; the next request reuses it.
-		generate.mockClear()
-		await getOrCreatePatternImageUrl(2, 4, '#color0', generate)
-		expect(generate).not.toHaveBeenCalled()
 	})
 })

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
@@ -1,5 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { clearPatternImageUrlCacheForTests, getOrCreatePatternImageUrl } from './defaultStyleDefs'
+import {
+	clearPatternImageUrlCacheForTests,
+	getOrCreatePatternImageUrl,
+	PATTERN_IMAGE_CACHE_MAX,
+} from './defaultStyleDefs'
+
+const flushMicrotasks = () => new Promise((resolve) => setTimeout(resolve, 0))
 
 describe('getOrCreatePatternImageUrl cache', () => {
 	beforeEach(() => {
@@ -50,5 +56,43 @@ describe('getOrCreatePatternImageUrl cache', () => {
 		// returning the cached rejection
 		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
 		expect(generate).toHaveBeenCalledTimes(2)
+	})
+
+	it('evicts least-recently-used tiles past the cap and revokes their URLs', async () => {
+		const revoke = vi.fn()
+		;(URL as any).revokeObjectURL = revoke
+		const generate = makeGenerator()
+
+		// Fill one past the cap with distinct solid colors (simulating runtime theme churn).
+		for (let i = 0; i <= PATTERN_IMAGE_CACHE_MAX; i++) {
+			await getOrCreatePatternImageUrl(2, 4, `#color${i}`, generate)
+		}
+		await flushMicrotasks()
+
+		// The oldest entry was evicted and its object URL revoked to free the blob.
+		expect(revoke).toHaveBeenCalledTimes(1)
+
+		// Requesting the evicted (oldest) color regenerates rather than hitting the cache.
+		generate.mockClear()
+		await getOrCreatePatternImageUrl(2, 4, '#color0', generate)
+		expect(generate).toHaveBeenCalledTimes(1)
+	})
+
+	it('keeps recently-used tiles in the cache when evicting under churn', async () => {
+		;(URL as any).revokeObjectURL = vi.fn()
+		const generate = makeGenerator()
+
+		// Insert color0 first, then keep using it while churning through new colors.
+		await getOrCreatePatternImageUrl(2, 4, '#color0', generate)
+		for (let i = 1; i <= PATTERN_IMAGE_CACHE_MAX; i++) {
+			await getOrCreatePatternImageUrl(2, 4, `#color${i}`, generate)
+			await getOrCreatePatternImageUrl(2, 4, '#color0', generate) // touch it to keep it fresh
+		}
+		await flushMicrotasks()
+
+		// color0 stays cached because it was recently used; the next request reuses it.
+		generate.mockClear()
+		await getOrCreatePatternImageUrl(2, 4, '#color0', generate)
+		expect(generate).not.toHaveBeenCalled()
 	})
 })

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.test.ts
@@ -38,4 +38,17 @@ describe('getOrCreatePatternImageUrl cache', () => {
 		await getOrCreatePatternImageUrl(2, 8, '#ffffff', generate)
 		expect(generate).toHaveBeenCalledTimes(3)
 	})
+
+	it('does not cache a failed generation, so a later request retries', async () => {
+		const generate = vi
+			.fn()
+			.mockReturnValueOnce(Promise.reject(new Error('boom')))
+			.mockReturnValue(Promise.resolve(new Blob()))
+
+		await expect(getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)).rejects.toThrow('boom')
+		// the rejected entry is evicted, so the next request regenerates rather than
+		// returning the cached rejection
+		await getOrCreatePatternImageUrl(2, 4, '#ffffff', generate)
+		expect(generate).toHaveBeenCalledTimes(2)
+	})
 })

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -116,17 +116,19 @@ const generateImage = (dpr: number, currentZoom: number, solid: string) => {
 // in apps that remount the editor to switch documents that cost is paid on every switch. Caching
 // the resulting object URLs keeps the work to at most once per (dpr, zoom, color).
 //
-// The key space is bounded in normal use: `zoom` is a small set of power-of-two LODs, `dpr` is a
-// handful of device/zoom values, and `solid` is the theme's solid colors (two for the default
-// light/dark theme). The one way it can grow without limit is an app that varies the theme's solid
-// color at runtime (themes are runtime-customizable), which would add a new entry - and a retained
-// object URL - per distinct color. To stay bounded regardless, the cache evicts least-recently-used
-// tiles past a cap and revokes their object URLs. The cap far exceeds any single theme's
-// (dpr x LOD) tiles, so eviction only happens under runtime theme churn, where the evicted tiles
-// belong to stale themes no longer on screen.
-/** @internal */
-export const PATTERN_IMAGE_CACHE_MAX = 256
+// The cache is intentionally uncapped and does not revoke its object URLs. The URLs are shared
+// across editor instances and referenced by live <image> elements, so there is no safe moment to
+// revoke a tile without reference counting it (an LRU cap can't tell "least recently requested"
+// from "still on screen", and would revoke active tiles). In practice the key space is small and
+// bounded: `zoom` is a handful of power-of-two LODs, `dpr` is a few device/zoom values, and `solid`
+// is the theme's solid colors (two for the default light/dark theme). Shape colors are NOT part of
+// the key - the tile is a monochrome hatch tinted by the theme solid, and a shape's own color is
+// applied as a separate fill in PatternFill - so a document with thousands of distinct colors adds
+// no tiles. The only way the cache can grow without bound is an app that varies the theme's solid
+// color at runtime; if that ever matters, the fix is to reference-count the URLs so they can be
+// revoked once no editor references them.
 const patternImageUrlCache = new Map<string, Promise<string>>()
+
 /**
  * Returns a cached object URL for a pattern tile, generating it on first request. The
  * `generate` parameter is a seam for tests; production callers use the default.
@@ -139,32 +141,16 @@ export function getOrCreatePatternImageUrl(
 	generate: (dpr: number, zoom: number, solid: string) => Promise<Blob> = generateImage
 ): Promise<string> {
 	const key = `${dpr}_${zoom}_${solid}`
-	const existing = patternImageUrlCache.get(key)
-	if (existing) {
-		// Refresh recency so frequently-used tiles aren't the ones evicted by the cap below.
-		patternImageUrlCache.delete(key)
-		patternImageUrlCache.set(key, existing)
-		return existing
+	let url = patternImageUrlCache.get(key)
+	if (!url) {
+		url = generate(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
+		// Don't cache failures: if generation rejects (e.g. toBlob returns null), drop the
+		// entry so a later request can retry rather than being stuck with a rejected promise.
+		url.catch(() => {
+			if (patternImageUrlCache.get(key) === url) patternImageUrlCache.delete(key)
+		})
+		patternImageUrlCache.set(key, url)
 	}
-
-	const url = generate(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
-	// Don't cache failures: if generation rejects (e.g. toBlob returns null), drop the
-	// entry so a later request can retry rather than being stuck with a rejected promise.
-	url.catch(() => {
-		if (patternImageUrlCache.get(key) === url) patternImageUrlCache.delete(key)
-	})
-	patternImageUrlCache.set(key, url)
-
-	// Evict the least-recently-used tiles if the cache grows past the cap, revoking their object
-	// URLs so the backing blobs are freed (see the note above - only reachable via runtime theme
-	// color churn).
-	while (patternImageUrlCache.size > PATTERN_IMAGE_CACHE_MAX) {
-		const oldestKey = patternImageUrlCache.keys().next().value!
-		const oldest = patternImageUrlCache.get(oldestKey)
-		patternImageUrlCache.delete(oldestKey)
-		oldest?.then((u) => URL.revokeObjectURL(u)).catch(() => {})
-	}
-
 	return url
 }
 

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -111,19 +111,37 @@ const generateImage = (dpr: number, currentZoom: number, solid: string) => {
 
 // Pattern-fill tiles are a pure function of (dpr, zoom LOD, solid color), so each one can be
 // generated once and reused for the lifetime of the page. Generating a tile rasterizes a canvas
-// and encodes it with `canvas.toBlob`, which is expensive — on mobile Safari the full set of LODs
+// and encodes it with `canvas.toBlob`, which is expensive - on mobile Safari the full set of LODs
 // can take over a second. Without this cache, every editor that mounts regenerates the whole set;
 // in apps that remount the editor to switch documents that cost is paid on every switch. Caching
 // the resulting object URLs keeps the work to at most once per (dpr, zoom, color).
 const patternImageUrlCache = new Map<string, Promise<string>>()
-function getOrCreatePatternImageUrl(dpr: number, zoom: number, solid: string): Promise<string> {
+/**
+ * Returns a cached object URL for a pattern tile, generating it on first request. The
+ * `generate` parameter is a seam for tests; production callers use the default.
+ * @internal
+ */
+export function getOrCreatePatternImageUrl(
+	dpr: number,
+	zoom: number,
+	solid: string,
+	generate: (dpr: number, zoom: number, solid: string) => Promise<Blob> = generateImage
+): Promise<string> {
 	const key = `${dpr}_${zoom}_${solid}`
 	let url = patternImageUrlCache.get(key)
 	if (!url) {
-		url = generateImage(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
+		url = generate(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
 		patternImageUrlCache.set(key, url)
 	}
 	return url
+}
+
+/**
+ * Clears the pattern-tile cache. Only intended for tests.
+ * @internal
+ */
+export function clearPatternImageUrlCacheForTests() {
+	patternImageUrlCache.clear()
 }
 
 const canvasBlob = (size: [number, number], fn: (ctx: CanvasRenderingContext2D) => void) => {

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -109,6 +109,23 @@ const generateImage = (dpr: number, currentZoom: number, solid: string) => {
 	})
 }
 
+// Pattern-fill tiles are a pure function of (dpr, zoom LOD, solid color), so each one can be
+// generated once and reused for the lifetime of the page. Generating a tile rasterizes a canvas
+// and encodes it with `canvas.toBlob`, which is expensive — on mobile Safari the full set of LODs
+// can take over a second. Without this cache, every editor that mounts regenerates the whole set;
+// in apps that remount the editor to switch documents that cost is paid on every switch. Caching
+// the resulting object URLs keeps the work to at most once per (dpr, zoom, color).
+const patternImageUrlCache = new Map<string, Promise<string>>()
+function getOrCreatePatternImageUrl(dpr: number, zoom: number, solid: string): Promise<string> {
+	const key = `${dpr}_${zoom}_${solid}`
+	let url = patternImageUrlCache.get(key)
+	if (!url) {
+		url = generateImage(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
+		patternImageUrlCache.set(key, url)
+	}
+	return url
+}
+
 const canvasBlob = (size: [number, number], fn: (ctx: CanvasRenderingContext2D) => void) => {
 	const canvas = getGlobalDocument().createElement('canvas')
 	canvas.width = size[0]
@@ -208,15 +225,15 @@ function usePattern() {
 
 		const promise = Promise.all(
 			getPatternLodsToGenerate(maxEffectiveZoom).flatMap<Promise<PatternDef>>((zoom) => [
-				generateImage(dpr, zoom, lightSolid).then((blob) => ({
+				getOrCreatePatternImageUrl(dpr, zoom, lightSolid).then((url) => ({
 					zoom,
 					theme: 'light',
-					url: URL.createObjectURL(blob),
+					url,
 				})),
-				generateImage(dpr, zoom, darkSolid).then((blob) => ({
+				getOrCreatePatternImageUrl(dpr, zoom, darkSolid).then((url) => ({
 					zoom,
 					theme: 'dark',
-					url: URL.createObjectURL(blob),
+					url,
 				})),
 			])
 		)
@@ -230,11 +247,8 @@ function usePattern() {
 		return () => {
 			isCancelled = true
 			setIsReady(false)
-			promise.then((patterns) => {
-				for (const { url } of patterns) {
-					URL.revokeObjectURL(url)
-				}
-			})
+			// The object URLs are cached and shared across editor instances, so we must not
+			// revoke them here — they are reused by later mounts and kept for the page lifetime.
 		}
 	}, [dpr, maxEffectiveZoom, editor])
 

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -115,6 +115,17 @@ const generateImage = (dpr: number, currentZoom: number, solid: string) => {
 // can take over a second. Without this cache, every editor that mounts regenerates the whole set;
 // in apps that remount the editor to switch documents that cost is paid on every switch. Caching
 // the resulting object URLs keeps the work to at most once per (dpr, zoom, color).
+//
+// The key space is bounded in normal use: `zoom` is a small set of power-of-two LODs, `dpr` is a
+// handful of device/zoom values, and `solid` is the theme's solid colors (two for the default
+// light/dark theme). The one way it can grow without limit is an app that varies the theme's solid
+// color at runtime (themes are runtime-customizable), which would add a new entry - and a retained
+// object URL - per distinct color. To stay bounded regardless, the cache evicts least-recently-used
+// tiles past a cap and revokes their object URLs. The cap far exceeds any single theme's
+// (dpr x LOD) tiles, so eviction only happens under runtime theme churn, where the evicted tiles
+// belong to stale themes no longer on screen.
+/** @internal */
+export const PATTERN_IMAGE_CACHE_MAX = 256
 const patternImageUrlCache = new Map<string, Promise<string>>()
 /**
  * Returns a cached object URL for a pattern tile, generating it on first request. The
@@ -128,16 +139,32 @@ export function getOrCreatePatternImageUrl(
 	generate: (dpr: number, zoom: number, solid: string) => Promise<Blob> = generateImage
 ): Promise<string> {
 	const key = `${dpr}_${zoom}_${solid}`
-	let url = patternImageUrlCache.get(key)
-	if (!url) {
-		url = generate(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
-		// Don't cache failures: if generation rejects (e.g. toBlob returns null), drop the
-		// entry so a later request can retry rather than being stuck with a rejected promise.
-		url.catch(() => {
-			if (patternImageUrlCache.get(key) === url) patternImageUrlCache.delete(key)
-		})
-		patternImageUrlCache.set(key, url)
+	const existing = patternImageUrlCache.get(key)
+	if (existing) {
+		// Refresh recency so frequently-used tiles aren't the ones evicted by the cap below.
+		patternImageUrlCache.delete(key)
+		patternImageUrlCache.set(key, existing)
+		return existing
 	}
+
+	const url = generate(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
+	// Don't cache failures: if generation rejects (e.g. toBlob returns null), drop the
+	// entry so a later request can retry rather than being stuck with a rejected promise.
+	url.catch(() => {
+		if (patternImageUrlCache.get(key) === url) patternImageUrlCache.delete(key)
+	})
+	patternImageUrlCache.set(key, url)
+
+	// Evict the least-recently-used tiles if the cache grows past the cap, revoking their object
+	// URLs so the backing blobs are freed (see the note above - only reachable via runtime theme
+	// color churn).
+	while (patternImageUrlCache.size > PATTERN_IMAGE_CACHE_MAX) {
+		const oldestKey = patternImageUrlCache.keys().next().value!
+		const oldest = patternImageUrlCache.get(oldestKey)
+		patternImageUrlCache.delete(oldestKey)
+		oldest?.then((u) => URL.revokeObjectURL(u)).catch(() => {})
+	}
+
 	return url
 }
 

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -131,6 +131,11 @@ export function getOrCreatePatternImageUrl(
 	let url = patternImageUrlCache.get(key)
 	if (!url) {
 		url = generate(dpr, zoom, solid).then((blob) => URL.createObjectURL(blob))
+		// Don't cache failures: if generation rejects (e.g. toBlob returns null), drop the
+		// entry so a later request can retry rather than being stuck with a rejected promise.
+		url.catch(() => {
+			if (patternImageUrlCache.get(key) === url) patternImageUrlCache.delete(key)
+		})
 		patternImageUrlCache.set(key, url)
 	}
 	return url


### PR DESCRIPTION
**Draft.** Real-performance fix found by profiling a mobile file-open on tldraw.com; verify on the preview/simulator.

## Problem
Opening a file on tldraw.com pauses for seconds on mobile. A Safari sampling profile of one file tap (iOS Simulator, screenshots disabled) attributes **~66% of the entire interaction to `canvas.toBlob`** — ~2.3s. The caller is `usePattern` in `defaultStyleDefs.tsx`: it generates the hatch fill-pattern tiles in a mount effect, rasterizing a canvas and encoding each tile with `toBlob`, once per zoom LOD and theme, with the largest LODs being big retina-sized canvases.

The tiles lived in component state and the object URLs were revoked on unmount, so every editor that mounts regenerates the whole set. tldraw.com remounts the editor on every file switch (`key={fileSlug}`), so this cost is paid on every open — and on mobile Safari `toBlob` is slow enough to block the main thread for over a second.

## Fix
The tiles are a pure function of `(dpr, zoom LOD, solid color)`, so cache the generated object URLs in a module-level map and stop revoking them. Each tile is encoded at most once per page; remounting the editor (or a theme/dpr that's been seen before) reuses the cached tiles. The cache key includes the solid color so custom themes stay correct.

## Expected effect
- First editor mount in a session: unchanged (tiles still generate once).
- Every subsequent file open / editor remount: `toBlob` time drops to ~0 — removing the dominant cost of the tap.

## Verification
- Re-trace a file open on the preview/simulator: the `toBlob` self-time should be present on the first open and gone on the second.
- `getSvgString` pattern export test passes; typecheck and API report unchanged (cache helpers are module-private).

## Follow-ups (not in this PR)
- The first open still pays the full generation. Generating only the LODs actually needed (rather than all up to `maxEffectiveZoom`) would cut that too.
- Reusing the editor instance across file switches would remove the remaining mount costs (font-face setup, text measurement) and the document-hydration stall.

## Why it was this way (and why dropping the revoke is safe)

This isn't a case of caching being rejected — it was never needed under the original assumptions, which then drifted:

- **#1636 (Jun 2023)** introduced the tiles as a *fixed* set of 6 small zoom levels, generated once per mount, with **no `revokeObjectURL`**. For the normal "one editor for the life of the page" case that's perfectly reasonable — nothing to cache.
- **#3801 (May 2024) "fix pattern fill lods"** made the LOD set *dynamic* (camera options broke the hardcoded 1–6 range) and put `maxZoom` in the effect deps, so the effect could now regenerate at runtime. The `revokeObjectURL` cleanup was added **here**, as memory hygiene for that regeneration case — not as a stance against caching.
- **#8441** later scaled the effective zoom to the worst-case `maxZoom/minZoom` ratio, which is what pushed the top LODs up to 2048²–4096² canvases — the expensive tiles arrived in a separate change.
- Remounting the editor per document is an app-level decision (tldraw.com keys the editor by file), invisible to the SDK.

So the cost emerged from the *composition* of three individually-reasonable changes, not a single mistake.

**On removing the revoke:** its original job was cleaning up orphaned URLs when the effect regenerated on a `dpr`/`maxZoom`/theme change. With the cache those URLs are no longer orphaned — they're retained keyed by `(dpr, zoom, solid)` and reused if those inputs recur (e.g. toggling dark mode back). So this is intentional retention, not a leak, and the growth is bounded to the small set of distinct `(dpr, zoom, solid)` combinations seen in a session (a handful of small encoded PNG blobs).


## Why generate at runtime (not at build time)?

The tiles can't be baked at build time because all three of their inputs only exist at runtime — the cache key is literally `(dpr, zoom, solid)`: device pixel ratio (the user's display), the theme `solid` colors (runtime-customizable since the theme system in #8410), and the LOD count (derived from configurable camera `zoomSteps`, per #3801). As an SDK embedded by arbitrary apps, none of those are known at the SDK's build time, and the tiles are transient in-memory object URLs (never persisted), so baking them would freeze customizable assumptions and add bundle weight for something cheaply derivable on demand. The remaining levers are this cache (kills repeat cost) and lazy/capped LODs (first-open cost) — tracked as follow-ups, not in this PR.
