### PR TITLE
perf(editor): cache resolved font faces across editor instances

### DIFF
--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
@@ -9,7 +9,7 @@ import {
 import { IndexKey } from '@tldraw/utils'
 import { Mock, Mocked, vi } from 'vitest'
 import { Editor } from '../../Editor'
-import { FontManager } from './FontManager'
+import { clearFontFaceCacheForTests, FontManager } from './FontManager'
 
 // Mock the Editor class
 vi.mock('../../Editor')
@@ -73,6 +73,7 @@ describe('FontManager', () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks()
+		clearFontFaceCacheForTests()
 
 		mockAssetUrls = {
 			'test-font.woff2': 'https://example.com/fonts/test-font.woff2',
@@ -312,6 +313,28 @@ describe('FontManager', () => {
 			}
 
 			await expect(fontManager.ensureFontIsLoaded(minimalFont)).resolves.toBeUndefined()
+		})
+	})
+
+	describe('findOrCreateFontFace caching', () => {
+		it('reuses a font face across manager instances instead of recreating it on remount', async () => {
+			const font = createMockFont()
+			await fontManager.ensureFontIsLoaded(font)
+			expect(global.FontFace).toHaveBeenCalledTimes(1)
+
+			// A fresh manager on the same document simulates an editor remount.
+			const remounted = new FontManager(editor, mockAssetUrls)
+			await remounted.ensureFontIsLoaded(font)
+
+			// The per-document cache lets the second manager reuse the existing face
+			// rather than re-scanning document.fonts and creating a new one.
+			expect(global.FontFace).toHaveBeenCalledTimes(1)
+		})
+
+		it('creates separate font faces for fonts with different descriptors', async () => {
+			await fontManager.ensureFontIsLoaded(createMockFont({ weight: 'normal' }))
+			await fontManager.ensureFontIsLoaded(createMockFont({ weight: 'bold' }))
+			expect(global.FontFace).toHaveBeenCalledTimes(2)
 		})
 	})
 })

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -145,7 +145,26 @@ export class FontManager {
 	}
 
 	private findOrCreateFontFace(font: TLFontFace) {
-		const fonts = this.editor.getContainerDocument().fonts
+		const containerDocument = this.editor.getContainerDocument()
+
+		// `findOrCreateFontFace` runs for every font on every editor mount, and a fresh
+		// editor (e.g. switching documents) gets a fresh FontManager with no memory of the
+		// previous one. The dedup below is an O(n) scan of the document's whole FontFaceSet,
+		// so without a cache that scan re-ran on every mount (measurably expensive on mobile
+		// Safari). Cache the resolved FontFace per document so repeated lookups - and
+		// remounts - are O(1). Keyed per document for cross-window embedding.
+		let cache = fontFaceCacheByDocument.get(containerDocument)
+		if (!cache) {
+			cache = new Map()
+			fontFaceCacheByDocument.set(containerDocument, cache)
+		}
+		const key = getFontFaceCacheKey(font)
+		const cached = cache.get(key)
+		if (cached) return cached
+
+		const fonts = containerDocument.fonts
+		// On a cache miss we still scan once, so font faces added outside this manager
+		// (e.g. preloaded fonts) are reused rather than duplicated.
 		for (const existing of fonts) {
 			if (
 				existing.family === font.family &&
@@ -153,6 +172,7 @@ export class FontManager {
 					([key, defaultValue]) => existing[key] === (font[key] ?? defaultValue)
 				)
 			) {
+				cache.set(key, existing)
 				return existing
 			}
 		}
@@ -164,6 +184,7 @@ export class FontManager {
 		})
 
 		fonts.add(instance)
+		cache.set(key, instance)
 
 		return instance
 	}
@@ -204,4 +225,28 @@ const defaultFontFaceDescriptors = {
 	ascentOverride: 'normal',
 	descentOverride: 'normal',
 	lineGapOverride: 'normal',
+}
+
+// A FontFace is fully determined by its family and descriptors, so resolved faces can be
+// cached per document and reused across FontManager instances (e.g. editor remounts),
+// turning the per-lookup FontFaceSet scan into an O(1) map lookup. Faces are never removed
+// from `document.fonts` (FontManager.dispose leaves them), so the cache stays valid for the
+// document's lifetime. Keyed per document for cross-window embedding.
+let fontFaceCacheByDocument = new WeakMap<Document, Map<string, FontFace>>()
+
+function getFontFaceCacheKey(font: TLFontFace): string {
+	return JSON.stringify([
+		font.family,
+		...objectMapEntries(defaultFontFaceDescriptors).map(
+			([key, defaultValue]) => font[key] ?? defaultValue
+		),
+	])
+}
+
+/**
+ * Resets the per-document font-face cache. Only intended for tests.
+ * @internal
+ */
+export function clearFontFaceCacheForTests() {
+	fontFaceCacheByDocument = new WeakMap()
 }


### PR DESCRIPTION
## Problem
After the pattern-tile cache (#9320), profiling a tldraw.com file open on the iOS Simulator showed the next-biggest cost was `findOrCreateFontFace` — ~385 ms, attributed to `next@native` iterating the document's `FontFaceSet`. Crucially this was on a *warm* open (the pattern `toBlob` was already ~0), so it's a per-mount cost, not first-load.

Root cause: `findOrCreateFontFace` deduplicates font faces with an O(n) scan of `document.fonts` on every lookup. It runs for each font on every editor mount, and a fresh editor (e.g. switching documents on tldraw.com, which remounts the editor) gets a fresh `FontManager` with no memory of the previous one — so the scan re-runs every mount.

The trace ruled out recreation: the `FontFace` constructor was ~11 ms, `load()` ~0 ms, and there were zero font-file network requests — faces are *reused*, just found via a slow scan.

## Fix
Cache resolved font faces in a per-document `Map` (keyed by family + descriptors), shared across `FontManager` instances, so repeated lookups and remounts are O(1). On a cache miss the existing `document.fonts` scan still runs once, so faces added outside the manager (preloaded fonts) are still reused rather than duplicated. Keyed per document for cross-window embedding; faces are never removed from `document.fonts`, so the cache stays valid for the document's lifetime.

## Tests
`FontManager.test.ts`: a fresh manager on the same document reuses the existing face instead of recreating it (the remount regression), and fonts with different descriptors get distinct faces. The cross-document cache has a test-only reset. All 22 tests pass; typecheck clean; no public-API change (the reset helper is `@internal` and not re-exported).

## Verification
Re-trace a file open on the simulator: `findOrCreateFontFace`'s scan cost should be present on the first open and ~0 on subsequent opens.

## Context
This is a sibling to #9320 (pattern-tile cache) — same symptom (per-mount cost on tldraw.com file switches), different root cause: patterns had the wrong lifetime (per-instance state); fonts had the wrong data structure (O(n) scan vs O(1) lookup).