### PR TITLE
impovement(tldraw): toggle editing when actions have the completeEditing flag

### DIFF
--- a/apps/docs/content/releases/next.mdx
+++ b/apps/docs/content/releases/next.mdx
@@ -24,6 +24,7 @@ This release simplifies multi-click handling down to a single double-click event
 
 ## Improvements
 
+- Actions that act on a shape as an object — duplicate, delete, group, align, distribute, rotate, flip, reorder, move to a new page, and similar — now end text editing before they run. Actions that change a shape's content or appearance, such as style changes, leave you editing. ([#0000](https://github.com/tldraw/tldraw/pull/0000))
 - Add a `shift+q` shortcut that copies the styles of the hovered shape and applies them to the next shapes you create. ([#9028](https://github.com/tldraw/tldraw/pull/9028))
 - Keep sync at full speed when the same multiplayer room is open in multiple tabs, windows, or devices — previously a room with no other users throttled network sync to once per second. ([#8988](https://github.com/tldraw/tldraw/pull/8988))
 - Include `DOCS.md` documentation in published npm packages, and a generated docs and release notes rollup in the `tldraw` package, so documentation is available when browsing package artifacts. ([#8503](https://github.com/tldraw/tldraw/pull/8503))

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4569,6 +4569,7 @@ export interface TLUiA11yContextType {
 export interface TLUiActionItem<TransationKey extends string = string, IconType extends string = string> {
     // (undocumented)
     checkbox?: boolean;
+    completeEditing?: boolean;
     // (undocumented)
     icon?: IconType | React_2.ReactElement;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -54,6 +54,13 @@ export interface TLUiActionItem<
 	readonlyOk?: boolean
 	checkbox?: boolean
 	isRequiredA11yAction?: boolean
+	/**
+	 * If true, any active text-editing session is ended before this action runs. Use this for
+	 * actions that treat a shape as an object (move, transform, restructure, remove, relocate).
+	 * Leave it off for actions that change a shape's content/appearance (style, formatting) or are
+	 * view-only, so the user can keep editing while using them.
+	 */
+	completeEditing?: boolean
 	onSelect(source: TLUiEventSource): Promise<void> | void
 }
 
@@ -155,6 +162,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 		const actionItems: TLUiActionItem<TLUiTranslationKey, TLUiIconType>[] = [
 			{
 				id: 'edit-link',
+				completeEditing: true,
 				label: 'action.edit-link',
 				icon: 'link',
 				onSelect(source) {
@@ -505,6 +513,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'duplicate',
+				completeEditing: true,
 				kbd: 'cmd+d,ctrl+d',
 				label: 'action.duplicate',
 				icon: 'duplicate',
@@ -552,6 +561,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'ungroup',
+				completeEditing: true,
 				label: 'action.ungroup',
 				kbd: 'cmd+shift+g,ctrl+shift+g',
 				icon: 'ungroup',
@@ -566,6 +576,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'group',
+				completeEditing: true,
 				label: 'action.group',
 				kbd: 'cmd+g,ctrl+g',
 				icon: 'group',
@@ -586,6 +597,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'frame-selection',
+				completeEditing: true,
 				label: 'action.frame-selection',
 				kbd: 'cmd+alt+g',
 				onSelect(source) {
@@ -645,6 +657,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'remove-frame',
+				completeEditing: true,
 				label: 'action.remove-frame',
 				onSelect(source) {
 					if (!canApplySelectionAction()) return
@@ -665,6 +678,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'fit-frame-to-content',
+				completeEditing: true,
 				label: 'action.fit-frame-to-content',
 				onSelect(source) {
 					if (!canApplySelectionAction()) return
@@ -679,6 +693,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'align-left',
+				completeEditing: true,
 				label: 'action.align-left',
 				kbd: 'alt+A',
 				icon: 'align-left',
@@ -697,6 +712,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'align-center-horizontal',
+				completeEditing: true,
 				label: {
 					default: 'action.align-center-horizontal',
 					['context-menu']: 'action.align-center-horizontal.short',
@@ -718,6 +734,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'align-right',
+				completeEditing: true,
 				label: 'action.align-right',
 				kbd: 'alt+D',
 				icon: 'align-right',
@@ -736,6 +753,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'align-center-vertical',
+				completeEditing: true,
 				label: {
 					default: 'action.align-center-vertical',
 					['context-menu']: 'action.align-center-vertical.short',
@@ -757,6 +775,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'align-top',
+				completeEditing: true,
 				label: 'action.align-top',
 				icon: 'align-top',
 				kbd: 'alt+W',
@@ -775,6 +794,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'align-bottom',
+				completeEditing: true,
 				label: 'action.align-bottom',
 				icon: 'align-bottom',
 				kbd: 'alt+S',
@@ -793,6 +813,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'distribute-horizontal',
+				completeEditing: true,
 				label: {
 					default: 'action.distribute-horizontal',
 					['context-menu']: 'action.distribute-horizontal.short',
@@ -814,6 +835,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'distribute-vertical',
+				completeEditing: true,
 				label: {
 					default: 'action.distribute-vertical',
 					['context-menu']: 'action.distribute-vertical.short',
@@ -835,6 +857,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'stretch-horizontal',
+				completeEditing: true,
 				label: {
 					default: 'action.stretch-horizontal',
 					['context-menu']: 'action.stretch-horizontal.short',
@@ -855,6 +878,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'stretch-vertical',
+				completeEditing: true,
 				label: {
 					default: 'action.stretch-vertical',
 					['context-menu']: 'action.stretch-vertical.short',
@@ -875,6 +899,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'flip-horizontal',
+				completeEditing: true,
 				label: {
 					default: 'action.flip-horizontal',
 					['context-menu']: 'action.flip-horizontal.short',
@@ -895,6 +920,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'flip-vertical',
+				completeEditing: true,
 				label: { default: 'action.flip-vertical', ['context-menu']: 'action.flip-vertical.short' },
 				kbd: 'shift+v',
 				onSelect(source) {
@@ -912,6 +938,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'pack',
+				completeEditing: true,
 				label: 'action.pack',
 				icon: 'pack',
 				onSelect(source) {
@@ -929,6 +956,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'stack-vertical',
+				completeEditing: true,
 				label: {
 					default: 'action.stack-vertical',
 					['context-menu']: 'action.stack-vertical.short',
@@ -949,6 +977,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'stack-horizontal',
+				completeEditing: true,
 				label: {
 					default: 'action.stack-horizontal',
 					['context-menu']: 'action.stack-horizontal.short',
@@ -969,6 +998,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'bring-to-front',
+				completeEditing: true,
 				label: 'action.bring-to-front',
 				kbd: ']',
 				icon: 'bring-to-front',
@@ -983,6 +1013,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'bring-forward',
+				completeEditing: true,
 				label: 'action.bring-forward',
 				icon: 'bring-forward',
 				kbd: 'alt+]',
@@ -997,6 +1028,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'send-backward',
+				completeEditing: true,
 				label: 'action.send-backward',
 				icon: 'send-backward',
 				kbd: 'alt+[',
@@ -1011,6 +1043,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'send-to-back',
+				completeEditing: true,
 				label: 'action.send-to-back',
 				icon: 'send-to-back',
 				kbd: '[',
@@ -1025,6 +1058,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'cut',
+				completeEditing: true,
 				label: 'action.cut',
 				kbd: 'cmd+x,ctrl+x',
 				onSelect(source) {
@@ -1150,6 +1184,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'delete',
+				completeEditing: true,
 				label: 'action.delete',
 				kbd: '⌫,del',
 				icon: 'trash',
@@ -1164,6 +1199,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'rotate-cw',
+				completeEditing: true,
 				label: 'action.rotate-cw',
 				icon: 'rotate-cw',
 				kbd: 'shift+.,shift+alt+.',
@@ -1186,6 +1222,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'rotate-ccw',
+				completeEditing: true,
 				label: 'action.rotate-ccw',
 				icon: 'rotate-ccw',
 				// omg double comma
@@ -1583,6 +1620,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'toggle-lock',
+				completeEditing: true,
 				label: 'action.toggle-lock',
 				kbd: 'shift+l',
 				onSelect(source) {
@@ -1594,6 +1632,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'move-to-new-page',
+				completeEditing: true,
 				label: 'context.pages.new-page',
 				onSelect(source) {
 					const newPageId = PageRecordType.createId()
@@ -1662,6 +1701,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'flatten-to-image',
+				completeEditing: true,
 				label: 'action.flatten-to-image',
 				kbd: 'shift+f',
 				onSelect: async (source) => {
@@ -1801,6 +1841,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'enlarge-shapes',
+				completeEditing: true,
 				label: 'a11y.enlarge-shape',
 				kbd: 'cmd+alt+shift+=,ctrl+alt+shift+=',
 				onSelect: async (source) => {
@@ -1811,6 +1852,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 			},
 			{
 				id: 'shrink-shapes',
+				completeEditing: true,
 				label: 'a11y.shrink-shape',
 				kbd: 'cmd+alt+shift+-,ctrl+alt+shift+-',
 				onSelect: async (source) => {
@@ -1961,11 +2003,35 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 
 		const actions = makeActions(actionItems)
 
-		if (overrides) {
-			return overrides(editor, actions, helpers)
+		const finalActions = overrides ? overrides(editor, actions, helpers) : actions
+
+		// For actions flagged with `completeEditing`, end any active text-editing session before
+		// the action runs. Doing it here (after overrides) keeps the exit logic in one place and
+		// applies it to custom and overridden actions too. Clearing `editingShapeId` alone does not
+		// leave the `select.editing_shape` state, so we transition the tool out as well.
+		const wrappedActions: TLUiActionsContextType = {}
+		for (const [id, action] of Object.entries(finalActions)) {
+			if (!action.completeEditing) {
+				wrappedActions[id] = action
+				continue
+			}
+			const onSelect = action.onSelect
+			wrappedActions[id] = {
+				...action,
+				onSelect(source) {
+					// `editor.complete()` is the canonical way to finish an editing session: it
+					// leaves the `select.editing_shape` state and clears the editing shape.
+					if (editor.isIn('select.editing_shape')) {
+						editor.complete()
+					} else if (editor.getEditingShapeId()) {
+						editor.setEditingShape(null)
+					}
+					return onSelect(source)
+				},
+			}
 		}
 
-		return actions
+		return wrappedActions
 	}, [
 		helpers,
 		_editor,

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -517,6 +517,34 @@ describe('When pressing enter on a selected shape', () => {
 	})
 })
 
+describe('When undo/redo restores an invalid editing shape', () => {
+	// Regression: https://github.com/tldraw/tldraw/issues/9113
+	// Setting the editing shape is not recorded in history, but clearing it on delete is.
+	// When create + edit + delete of the same shape collapse into a single history entry,
+	// the shape's add/remove cancel out while the editingShapeId update survives. Undoing
+	// then restores editingShapeId pointing at a shape that no longer exists, which used to
+	// crash with "Entered editing state without an editing shape". The editor must never
+	// enter the editing state without a valid editing shape.
+	it('does not crash when undo restores editingShapeId for a deleted shape', () => {
+		const id = createShapeId()
+		editor.markHistoryStoppingPoint('start')
+		editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+		editor.setEditingShape(id)
+		editor.deleteShapes([id])
+
+		expect(() => editor.undo()).not.toThrow()
+
+		editor.expectToBeIn('select.idle')
+		expect(editor.getEditingShapeId()).toBe(null)
+		expect(editor.getShape(id)).toBeUndefined()
+
+		// Redoing back through the same history entry must also stay safe.
+		expect(() => editor.redo()).not.toThrow()
+		editor.expectToBeIn('select.idle')
+		expect(editor.getEditingShapeId()).toBe(null)
+	})
+})
+
 // it('selects the child of a group', () => {
 //   const id1 = createShapeId()
 //   const id2 = createShapeId()

--- a/packages/tldraw/src/test/ui/completeEditing.test.tsx
+++ b/packages/tldraw/src/test/ui/completeEditing.test.tsx
@@ -1,0 +1,158 @@
+import { Editor, TLShapeId, createShapeId } from '@tldraw/editor'
+import { useEffect } from 'react'
+import { Tldraw } from '../../lib/Tldraw'
+import { TLUiActionsContextType, useActions } from '../../lib/ui/context/actions'
+import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
+
+// Actions that treat a shape as an object (move, transform, restructure, remove, relocate)
+// should end the text-editing interaction before they run.
+const ACTIONS_THAT_END_EDITING = [
+	// lifecycle / structure
+	'duplicate',
+	'delete',
+	'cut',
+	'group',
+	'ungroup',
+	'frame-selection',
+	'remove-frame',
+	'fit-frame-to-content',
+	'flatten-to-image',
+	'move-to-new-page',
+	// transform
+	'rotate-cw',
+	'rotate-ccw',
+	'flip-horizontal',
+	'flip-vertical',
+	'stretch-horizontal',
+	'stretch-vertical',
+	'pack',
+	'enlarge-shapes',
+	'shrink-shapes',
+	// arrange
+	'align-left',
+	'align-center-horizontal',
+	'align-right',
+	'align-center-vertical',
+	'align-top',
+	'align-bottom',
+	'distribute-horizontal',
+	'distribute-vertical',
+	'stack-vertical',
+	'stack-horizontal',
+	'bring-to-front',
+	'bring-forward',
+	'send-backward',
+	'send-to-back',
+	// other
+	'toggle-lock',
+	'edit-link',
+] as const
+
+// Actions that change the shape's content/appearance or are view-only should NOT end editing,
+// so you can (for example) recolor or zoom while still editing text.
+const ACTIONS_THAT_KEEP_EDITING = [
+	'toggle-auto-size',
+	'select-white-color',
+	'zoom-to-selection',
+	'copy',
+] as const
+
+function ActionsCapturer({ onCapture }: { onCapture(actions: TLUiActionsContextType): void }) {
+	const actions = useActions()
+	useEffect(() => {
+		onCapture(actions)
+	}, [actions, onCapture])
+	return null
+}
+
+let editor: Editor
+let actions: TLUiActionsContextType
+
+// Render a fresh editor for each test. Editing state is reactive tool-state, and reusing one
+// editor across cases let a leaked `editing_shape` state make guards pass for the wrong reason.
+beforeEach(async () => {
+	let captured: TLUiActionsContextType | null = null
+	const result = await renderTldrawComponentWithEditor(
+		(onMount) => (
+			<Tldraw onMount={onMount}>
+				<ActionsCapturer onCapture={(a) => (captured = a)} />
+			</Tldraw>
+		),
+		{ waitForPatterns: false }
+	)
+	editor = result.editor
+	actions = captured!
+})
+
+function startEditingGeoShape(): TLShapeId {
+	const id = createShapeId()
+	editor.createShape({ id, type: 'geo', x: 0, y: 0, props: { w: 100, h: 100 } })
+	editor.setEditingShape(id)
+	return id
+}
+
+function runAction(id: string) {
+	try {
+		// Some actions have side effects (clipboard, rasterizing to an image) that don't fully
+		// work under jsdom. We only assert whether editing was exited, which happens up front.
+		const result = actions[id].onSelect('unknown')
+		if (result && typeof (result as Promise<void>).then === 'function') {
+			;(result as Promise<void>).catch(() => {})
+		}
+	} catch {
+		// ignore action side-effect errors; we only care about the editing state
+	}
+}
+
+describe('completeEditing on actions', () => {
+	it('starts in the editing state for the test fixture', () => {
+		const id = startEditingGeoShape()
+		expect(editor.getEditingShapeId()).toBe(id)
+		expect(editor.isIn('select.editing_shape')).toBe(true)
+	})
+
+	it('exits editing when duplicating while editing', () => {
+		const id = startEditingGeoShape()
+		expect(editor.getEditingShapeId()).toBe(id)
+
+		runAction('duplicate')
+
+		expect(editor.getEditingShapeId()).toBe(null)
+		expect(editor.isIn('select.editing_shape')).toBe(false)
+	})
+
+	describe('actions that should end editing', () => {
+		it.each(ACTIONS_THAT_END_EDITING)('%s ends editing', (id) => {
+			startEditingGeoShape()
+			expect(editor.getEditingShapeId()).not.toBe(null)
+
+			runAction(id)
+
+			expect(editor.getEditingShapeId()).toBe(null)
+			expect(editor.isIn('select.editing_shape')).toBe(false)
+		})
+	})
+
+	describe('actions that should keep editing', () => {
+		it.each(ACTIONS_THAT_KEEP_EDITING)('%s keeps editing', (id) => {
+			const editingId = startEditingGeoShape()
+			expect(editor.getEditingShapeId()).toBe(editingId)
+			expect(editor.isIn('select.editing_shape')).toBe(true)
+
+			runAction(id)
+
+			expect(editor.getEditingShapeId()).toBe(editingId)
+			expect(editor.isIn('select.editing_shape')).toBe(true)
+		})
+	})
+
+	it('does not crash on undo after duplicating while editing', () => {
+		const id = startEditingGeoShape()
+		editor.markHistoryStoppingPoint('duplicate')
+		runAction('duplicate')
+		expect(editor.getEditingShapeId()).toBe(null)
+
+		expect(() => editor.undo()).not.toThrow()
+		expect(editor.getShape(id)).not.toBe(undefined)
+	})
+})

--- a/packages/tlschema/src/records/TLPageState.ts
+++ b/packages/tlschema/src/records/TLPageState.ts
@@ -212,7 +212,11 @@ export const InstancePageStateRecordType = createRecordType<TLInstancePageState>
 		ephemeralKeys: {
 			pageId: false,
 			selectedShapeIds: false,
-			editingShapeId: false,
+			// editingShapeId is set with `history: 'ignore'`, so entering the editing
+			// state is never undoable. Marking it ephemeral keeps undo/redo from
+			// reapplying a stale editingShapeId (e.g. after a shape it pointed at was
+			// deleted), which could leave the editor pointing at a missing shape.
+			editingShapeId: true,
 			croppingShapeId: false,
 			meta: false,
 


### PR DESCRIPTION
Some actions such as duplicate leave the users still in editing mode, when pressing undo they end up removing the text they were actually editing.

This PR is a follow-up to https://github.com/tldraw/tldraw/pull/9260 and implements a boolean flag for actions to automatically buck out of editing mode. 

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a geo shape
2. Enter editing mode
3. type some text
4. press on "duplicate"
5. do an undo

=> the undo should remove the newly created shape 

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Implements "completeEditing" flag for actions that end the editing of a shape.
