### PR TITLE
refactor(dotcom): reuse SDK CSS tokens

### DIFF
--- a/apps/dotcom/client/src/pages/admin.module.css
+++ b/apps/dotcom/client/src/pages/admin.module.css
@@ -60,7 +60,7 @@
 	height: 32px;
 	padding: 0 12px;
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	background-color: var(--tl-color-selected-contrast);
 	color: var(--tl-color-text-0);
 	font-family: var(--tla-font-ui);
@@ -84,7 +84,7 @@
 	font-weight: 500;
 	padding: 8px 12px;
 	background-color: var(--tla-color-secondary);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	border: 1px solid var(--tl-color-danger);
 }
 
@@ -94,7 +94,7 @@
 	font-weight: 500;
 	padding: 8px 12px;
 	background-color: var(--tla-color-secondary);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	border: 1px solid var(--tl-color-success);
 }
 
@@ -115,7 +115,7 @@
 .dataDisplay {
 	background-color: var(--tl-color-low);
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	padding: 16px;
 	font-family: 'IBMPlexMono', monospace;
 	font-size: 11px;
@@ -139,7 +139,7 @@
 	padding: 16px;
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 }
 
 .downloadContainer {
@@ -155,7 +155,7 @@
 	padding: 16px;
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-danger);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 }
 
 .deleteContainer {
@@ -174,7 +174,7 @@
 	padding: 16px;
 	background-color: var(--tl-color-low);
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 }
 
 .progressLog h5 {
@@ -195,7 +195,7 @@
 	color: var(--tl-color-text-0);
 	background-color: var(--tl-color-selected-contrast);
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	padding: 8px;
 }
 
@@ -230,7 +230,7 @@
 	padding: 16px;
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 }
 
 .summaryGrid {
@@ -268,7 +268,7 @@
 	padding: 16px;
 	background-color: var(--tl-color-panel);
 	border: 1px solid var(--tl-color-primary);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	margin-top: 16px;
 }
 

--- a/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaAnonDotDevLink/TlaAnonDotDevLink.module.css
@@ -80,7 +80,7 @@
 	}
 
 	.anonDotDevLink:has(a:hover)::after {
-		background-color: var(--tl-color-hover);
+		background-color: var(--tl-color-muted-2);
 	}
 }
 

--- a/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaButton/button.module.css
@@ -6,7 +6,7 @@
 	background: none;
 	outline: none;
 	color: var(--tl-color-text-0);
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 	cursor: pointer;
 	display: flex;
 	flex-direction: row;
@@ -69,7 +69,6 @@
 
 .primary {
 	background-color: var(--tl-color-primary);
-	box-shadow: var(--tla-shadow-primary-highlight);
 	color: var(--tl-color-selected-contrast);
 }
 
@@ -148,5 +147,5 @@
 .tlaButton:focus-visible {
 	outline: 2px solid var(--tl-color-focus);
 	outline-offset: 2px;
-	border-radius: var(--tla-radius-2);
+	border-radius: var(--tl-radius-1);
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -37,7 +37,7 @@
 	width: 100%;
 	height: 100%;
 	z-index: 99;
-	background-color: var(--tla-color-overlay);
+	background-color: var(--tl-color-overlay);
 	display: none;
 }
 

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -19,9 +19,6 @@
 
 /* Variables */
 :root {
-	/* Border radii */
-	--tla-radius-1: 2px;
-	--tla-radius-2: 4px;
 	/* Fonts */
 	--tla-font-ui:
 		'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu,
@@ -51,8 +48,6 @@
 	--tla-color-secondary-hover: hsl(0, 0%, 93.5%);
 	--tla-color-secondary-border: hsl(0, 0%, 80%);
 	/* Shadows */
-	/* --tla-shadow-primary-highlight: inset 0px 4px 2px -4px hsl(214, 94%, 94%),
-		inset 4px 4px 4px -6px hsl(214, 94%, 100%); */
 	--tla-shadow-1: 0px 1px 2px hsl(0, 0%, 0%, 25%), 0px 1px 3px hsl(0, 0%, 0%, 9%);
 	--tla-shadow-2:
 		0px 0px 2px hsl(0, 0%, 0%, 16%), 0px 2px 3px hsl(0, 0%, 0%, 24%),
@@ -75,8 +70,6 @@
 	--tla-color-secondary-hover: hsl(0, 0%, 22%);
 	--tla-color-secondary-border: hsl(0, 0%, 25%);
 	/* Shadows */
-	/* --tla-shadow-primary-highlight: inset 0px 1px 1px -1px hsl(214, 94%, 72%),
-		inset 4px 4px 4px -6px hsl(214, 94%, 80%); */
 	--tla-shadow-1:
 		0px 1px 2px hsl(0, 0%, 0%, 16.1%), 0px 1px 3px hsl(0, 0%, 0%, 22%),
 		inset 0px 0px 0px 1px var(--tl-color-panel);

--- a/apps/dotcom/client/src/tla/styles/tla.css
+++ b/apps/dotcom/client/src/tla/styles/tla.css
@@ -40,7 +40,6 @@
 
 .tla-theme__light {
 	--tla-color-sidebar: hsl(0, 0%, 99%);
-	--tla-color-overlay: hsla(240, 16%, 2%, 30%);
 	--tla-color-inactive: hsl(204, 4%, 55%);
 	--tla-color-inactive-hover: hsl(204, 4%, 59%);
 	--tla-color-primary-hover: hsl(214, 84%, 58%);
@@ -62,7 +61,6 @@
 
 .tla-theme__dark {
 	--tla-color-sidebar: hsl(0, 0%, 5%);
-	--tla-color-overlay: hsla(240, 0%, 0%, 81%);
 	--tla-color-inactive: hsl(204, 4%, 45%);
 	--tla-color-inactive-hover: hsl(204, 4%, 49%);
 	--tla-color-primary-hover: hsl(214, 84%, 50%);

--- a/apps/dotcom/client/src/tla/themes/ui-themes.ts
+++ b/apps/dotcom/client/src/tla/themes/ui-themes.ts
@@ -2,10 +2,9 @@ import { DEFAULT_THEME, TLTheme } from 'tldraw'
 
 /**
  * CSS variable overrides for one color mode. `tl` retints the editor canvas
- * wrapper (`.tl-container`); `tla` retints tldraw.com app shell colors. When
- * exported, `tla` is stripped down to keys that do not resolve through shared
- * `tl-color-*` tokens. Applied as inline styles at runtime and cleared when
- * switching back to the default theme.
+ * wrapper (`.tl-container`); `tla` retints tldraw.com app shell colors. Applied
+ * as inline styles at runtime and cleared when switching back to the default
+ * theme.
  */
 export interface UIThemeVariant {
 	tl: Record<string, string>
@@ -20,17 +19,6 @@ interface UITheme {
 	light: UIThemeVariant
 	dark: UIThemeVariant
 }
-
-const TLA_COLOR_KEYS_TO_OMIT = new Set([
-	'tla-color-panel',
-	'tla-color-text',
-	'tla-color-text-1',
-	'tla-color-cta-hover',
-	'tla-color-primary',
-	'tla-color-focus',
-	'tla-color-accent-3',
-	'tla-color-warning',
-])
 
 const THEMES: UITheme[] = [
 	{
@@ -78,7 +66,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#eee8d5',
-				'tla-color-overlay': 'hsla(192, 100%, 11%, 0.3)',
 				'tla-color-inactive': '#93a1a1',
 				'tla-color-inactive-hover': '#839496',
 				'tla-color-primary-hover': '#2d99e8',
@@ -127,7 +114,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#00212b',
-				'tla-color-overlay': 'hsla(192, 100%, 5%, 0.81)',
 				'tla-color-inactive': '#586e75',
 				'tla-color-inactive-hover': '#657b83',
 				'tla-color-primary-hover': '#2d99e8',
@@ -182,7 +168,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#ededea',
-				'tla-color-overlay': 'hsla(231, 15%, 18%, 0.3)',
 				'tla-color-inactive': '#6272a4',
 				'tla-color-inactive-hover': '#7283b5',
 				'tla-color-primary-hover': '#c9a5fa',
@@ -231,7 +216,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#21222c',
-				'tla-color-overlay': 'hsla(231, 15%, 10%, 0.81)',
 				'tla-color-inactive': '#6272a4',
 				'tla-color-inactive-hover': '#7283b5',
 				'tla-color-primary-hover': '#bd93f9',
@@ -286,7 +270,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#e5e9f0',
-				'tla-color-overlay': 'hsla(220, 16%, 22%, 0.3)',
 				'tla-color-inactive': '#7b88a1',
 				'tla-color-inactive-hover': '#8c97ae',
 				'tla-color-primary-hover': '#6b8db5',
@@ -335,7 +318,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#272d38',
-				'tla-color-overlay': 'hsla(220, 16%, 12%, 0.81)',
 				'tla-color-inactive': '#7b88a1',
 				'tla-color-inactive-hover': '#8c97ae',
 				'tla-color-primary-hover': '#88c0d0',
@@ -390,7 +372,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f0f0ec',
-				'tla-color-overlay': 'hsla(70, 8%, 15%, 0.3)',
 				'tla-color-inactive': '#8f908a',
 				'tla-color-inactive-hover': '#9e9f9a',
 				'tla-color-primary-hover': '#77ddf1',
@@ -439,7 +420,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#1e1f1a',
-				'tla-color-overlay': 'hsla(70, 8%, 8%, 0.81)',
 				'tla-color-inactive': '#75715e',
 				'tla-color-inactive-hover': '#8a8578',
 				'tla-color-primary-hover': '#66d9ef',
@@ -494,7 +474,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f2e5bc',
-				'tla-color-overlay': 'hsla(0, 0%, 16%, 0.3)',
 				'tla-color-inactive': '#928374',
 				'tla-color-inactive-hover': '#a39485',
 				'tla-color-primary-hover': '#539698',
@@ -543,7 +522,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#1d2021',
-				'tla-color-overlay': 'hsla(0, 0%, 8%, 0.81)',
 				'tla-color-inactive': '#928374',
 				'tla-color-inactive-hover': '#a39485',
 				'tla-color-primary-hover': '#83a598',
@@ -598,7 +576,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#e6e9ef',
-				'tla-color-overlay': 'hsla(234, 16%, 35%, 0.3)',
 				'tla-color-inactive': '#9ca0b0',
 				'tla-color-inactive-hover': '#8c8fa2',
 				'tla-color-primary-hover': '#9548f5',
@@ -647,7 +624,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#181825',
-				'tla-color-overlay': 'hsla(240, 21%, 10%, 0.81)',
 				'tla-color-inactive': '#6c7086',
 				'tla-color-inactive-hover': '#7f849c',
 				'tla-color-primary-hover': '#cba6f7',
@@ -702,7 +678,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f0f0f0',
-				'tla-color-overlay': 'hsla(230, 8%, 24%, 0.3)',
 				'tla-color-inactive': '#a0a1a7',
 				'tla-color-inactive-hover': '#8c8d93',
 				'tla-color-primary-hover': '#5288f5',
@@ -751,7 +726,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#21252b',
-				'tla-color-overlay': 'hsla(220, 13%, 10%, 0.81)',
 				'tla-color-inactive': '#5c6370',
 				'tla-color-inactive-hover': '#6b727f',
 				'tla-color-primary-hover': '#61afef',
@@ -806,7 +780,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#cbccd1',
-				'tla-color-overlay': 'hsla(232, 25%, 27%, 0.3)',
 				'tla-color-inactive': '#9699a3',
 				'tla-color-inactive-hover': '#86898f',
 				'tla-color-primary-hover': '#8aacf8',
@@ -855,7 +828,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#16161e',
-				'tla-color-overlay': 'hsla(235, 24%, 10%, 0.81)',
 				'tla-color-inactive': '#565f89',
 				'tla-color-inactive-hover': '#6b7394',
 				'tla-color-primary-hover': '#7aa2f7',
@@ -910,7 +882,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f4ebd0',
-				'tla-color-overlay': 'hsla(195, 14%, 20%, 0.3)',
 				'tla-color-inactive': '#939f91',
 				'tla-color-inactive-hover': '#828e80',
 				'tla-color-primary-hover': '#3fb88b',
@@ -959,7 +930,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#272e33',
-				'tla-color-overlay': 'hsla(195, 14%, 12%, 0.81)',
 				'tla-color-inactive': '#7a8478',
 				'tla-color-inactive-hover': '#8a9488',
 				'tla-color-primary-hover': '#83c092',
@@ -1014,7 +984,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f6f8fa',
-				'tla-color-overlay': 'hsla(210, 13%, 16%, 0.3)',
 				'tla-color-inactive': '#656d76',
 				'tla-color-inactive-hover': '#57606a',
 				'tla-color-primary-hover': '#1177e5',
@@ -1063,7 +1032,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#010409',
-				'tla-color-overlay': 'hsla(215, 28%, 5%, 0.81)',
 				'tla-color-inactive': '#484f58',
 				'tla-color-inactive-hover': '#57606a',
 				'tla-color-primary-hover': '#58a6ff',
@@ -1118,7 +1086,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f2f0e5',
-				'tla-color-overlay': 'hsla(30, 5%, 10%, 0.3)',
 				'tla-color-inactive': '#878580',
 				'tla-color-inactive-hover': '#6f6e69',
 				'tla-color-primary-hover': '#286bb5',
@@ -1167,7 +1134,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#0b0a0a',
-				'tla-color-overlay': 'hsla(0, 0%, 4%, 0.81)',
 				'tla-color-inactive': '#575653',
 				'tla-color-inactive-hover': '#6f6e69',
 				'tla-color-primary-hover': '#4385be',
@@ -1222,7 +1188,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f0f0f0',
-				'tla-color-overlay': 'hsla(241, 16%, 29%, 0.3)',
 				'tla-color-inactive': '#989fb1',
 				'tla-color-inactive-hover': '#888fa0',
 				'tla-color-primary-hover': '#32b5aa',
@@ -1271,7 +1236,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#00101f',
-				'tla-color-overlay': 'hsla(207, 95%, 5%, 0.81)',
 				'tla-color-inactive': '#5f7e97',
 				'tla-color-inactive-hover': '#708ea5',
 				'tla-color-primary-hover': '#7fdbca',
@@ -1326,7 +1290,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#f0f0f0',
-				'tla-color-overlay': 'hsla(0, 0%, 0%, 0.3)',
 				'tla-color-inactive': '#555555',
 				'tla-color-inactive-hover': '#333333',
 				'tla-color-primary-hover': '#3333ff',
@@ -1375,7 +1338,6 @@ const THEMES: UITheme[] = [
 			},
 			tla: {
 				'tla-color-sidebar': '#000000',
-				'tla-color-overlay': 'hsla(0, 0%, 0%, 0.81)',
 				'tla-color-inactive': '#aaaaaa',
 				'tla-color-inactive-hover': '#cccccc',
 				'tla-color-primary-hover': '#00ff00',
@@ -1419,18 +1381,7 @@ function buildTLTheme(def: UITheme): TLTheme {
 	}
 }
 
-function minimizeTlaColors(variant: UIThemeVariant): UIThemeVariant {
-	return {
-		tl: variant.tl,
-		tla: Object.fromEntries(
-			Object.entries(variant.tla).filter(([key]) => !TLA_COLOR_KEYS_TO_OMIT.has(key))
-		),
-	}
-}
-
 export const UI_THEMES: Array<UITheme & { theme: TLTheme }> = THEMES.map((def) => ({
 	...def,
-	light: minimizeTlaColors(def.light),
-	dark: minimizeTlaColors(def.dark),
 	theme: buildTLTheme(def),
 }))

--- a/apps/dotcom/client/src/tla/themes/ui-themes.ts
+++ b/apps/dotcom/client/src/tla/themes/ui-themes.ts
@@ -22,28 +22,14 @@ interface UITheme {
 }
 
 const TLA_COLOR_KEYS_TO_OMIT = new Set([
-	'tla-color-canvas',
 	'tla-color-panel',
 	'tla-color-text',
 	'tla-color-text-1',
-	'tla-color-text-2',
-	'tla-color-text-3',
-	'tla-color-contrast',
-	'tla-color-low',
-	'tla-color-border',
-	'tla-color-hover-1',
-	'tla-color-hover-2',
-	'tla-color-hover-3',
-	'tla-color-cta',
 	'tla-color-cta-hover',
 	'tla-color-primary',
 	'tla-color-focus',
-	'tla-color-accent-1',
-	'tla-color-accent-2',
 	'tla-color-accent-3',
 	'tla-color-warning',
-	'tla-color-tooltip',
-	'tla-color-drop-zone',
 ])
 
 const THEMES: UITheme[] = [


### PR DESCRIPTION
In order to keep dotcom styling aligned with the SDK token set, this PR replaces near-match app-shell CSS variable references with existing `--tl-*` package variables and removes now-dead dotcom token metadata. It folds the dotcom `--tla-color-overlay` token onto the package `--tl-color-overlay`, drops the radius and shadow-highlight leftovers from `tla.css`, and deletes the `TLA_COLOR_KEYS_TO_OMIT` set in `ui-themes.ts` (and its filter), which had become a no-op once the color migration landed — none of the keys it listed appear in any theme block anymore.

### Change type

- [x] `other`

### Test plan

1. Run `git diff --check`.
2. Confirm no removed `--tla-*` token reads remain in `apps/dotcom/client/src/tla` (every `var(--tla-color-*)` still read resolves to a definition in `tla.css`).
3. Confirm no undefined `--color-warn`, `--tl-color-hover`, or `--tla-shadow-primary-highlight` reads remain.
4. Run `yarn format-current` and `yarn lint-current`.
5. Run `yarn dev-app` and visually inspect the dotcom app shell, sidebar, dialogs, share menu, buttons, drag/drop zones, and admin page in both themes.

Note: the collapsed-sidebar scrim now uses `--tl-color-overlay`, which is lighter than the old `--tla-color-overlay` in dark mode (50% vs 81% black). Worth confirming the dark-mode scrim still reads acceptably on a narrow viewport.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps | +17 / -90 |
