### PR TITLE
fix(dotcom): serve source maps instead of stripping them from the deploy

### DIFF
--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -1,7 +1,6 @@
 import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs'
 import { T } from '@tldraw/validate'
 import { config } from 'dotenv'
-import { glob } from 'fast-glob'
 import json5 from 'json5'
 import regexgen from 'regexgen'
 import { exec } from '../../../../internal/scripts/lib/exec'
@@ -53,7 +52,10 @@ async function build() {
 	await exec('rm', ['-rf', '.vercel/output'])
 	mkdirSync('.vercel/output', { recursive: true })
 	await exec('cp', ['-r', 'dist', '.vercel/output/static'])
-	await exec('rm', ['-rf', ...glob.sync('.vercel/output/static/**/*.js.map')])
+	// We serve the .js.map files publicly. The client source is open at tldraw/tldraw, so
+	// there's nothing to hide, and serving the maps lets anyone debugging a deployed build get
+	// real names and lines in devtools without going through Sentry. Sentry still gets its own
+	// copy via the upload step, which reads from dist/assets before this point.
 
 	// Add fonts to preload into index.html
 	const assetsList = readdirSync('dist/assets')
@@ -92,7 +94,9 @@ async function build() {
 
 	const multiplayerServerUrl = getMultiplayerServerURL() ?? 'http://localhost:8787'
 
-	const assetsToCache = assetsList.filter((f) => !f.endsWith('.js.map')).map((f) => `/assets/${f}`)
+	// Includes the .js.map files: they're content-hashed like the chunks they describe, so they're
+	// safe to cache immutably, and we now serve them rather than stripping them from the deploy.
+	const assetsToCache = assetsList.map((f) => `/assets/${f}`)
 	// need to batch these because Vercel's route limit is 4096 characters
 	const assetsBatches: string[][] = []
 	for (let i = 0; i < assetsToCache.length; i += 50) {


### PR DESCRIPTION
In order to make deployed tldraw.com builds debuggable in browser devtools and stop the source-map 404s, this PR stops stripping `.js.map` files from the client deploy and serves them publicly. Closes #9322.

The client build generated source maps, uploaded them to Sentry, then deleted the `.js.map` files from the deployed assets — while leaving the `//# sourceMappingURL` comments in the shipped JS. That produced a 404 for every map and left browser devtools unable to symbolicate deployed builds. The usual reason to hide source maps is to keep source private, which does not apply here since the client source is public in this repo. Sentry upload is unaffected: it reads from `dist/assets` before the strip step.

### Change type

- [x] `bugfix`

### Test plan

1. From the preview deploy, open devtools → Network, reload, and confirm `*.js.map` requests return 200 rather than 404.
2. Open a minified stack frame in devtools and confirm it symbolicates to real names and lines.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +7 / -3    |
