### PR TITLE
fix(dotcom): guard against group_file rows with no synced file

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -126,7 +126,7 @@ export class TldrawApp {
 	private readonly workspaceMemberships$: Signal<
 		(TlaGroupUser & {
 			group: TlaGroup
-			groupFiles: Array<TlaGroupFile & { file: TlaFile }>
+			groupFiles: Array<TlaGroupFile & { file: TlaFile | undefined }>
 			groupMembers: Array<TlaGroupUser>
 		})[]
 	>
@@ -444,7 +444,12 @@ export class TldrawApp {
 		// from home would bounce the user into that workspace. Guarding here keeps such rows out
 		// of the list even before they're cleaned up.
 		const homeWorkspaceId = this.getHomeWorkspaceId()
-		const groupFiles = membership.groupFiles.filter((f) => {
+		const groupFiles = membership.groupFiles.filter((f): f is TlaGroupFile & { file: TlaFile } => {
+			// A group_file row can outlive (or arrive before) its file: the file may be deleted,
+			// not yet synced, or filtered out server-side because the user can no longer read it.
+			// The `file` relationship is a nullable Zero `.one()`, so guard before dereferencing.
+			// The type predicate narrows `file` to non-undefined for the rest of the function.
+			if (!f.file) return false
 			const owningGroupId = f.file.owningGroupId
 			if (owningGroupId === workspaceId) return true
 			if (workspaceId !== homeWorkspaceId) return false
@@ -635,7 +640,7 @@ export class TldrawApp {
 			const membership = this.getWorkspaceMembership(workspaceId)
 			if (!membership) return true
 			const nonDeletedCount = membership.groupFiles.filter(
-				(gf) => !gf.file.isDeleted && gf.file.owningGroupId === workspaceId
+				(gf) => gf.file && !gf.file.isDeleted && gf.file.owningGroupId === workspaceId
 			).length
 			return nonDeletedCount < this.config.maxNumberOfFiles
 		} else {

--- a/apps/dotcom/client/src/tla/app/getWorkspaceFilesSorted.test.ts
+++ b/apps/dotcom/client/src/tla/app/getWorkspaceFilesSorted.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { TldrawApp } from './TldrawApp'
+
+// `getWorkspaceFilesSorted` reads only these four members off `this`, so we can drive the real
+// method (and the sibling methods it calls) against a lightweight stub instead of constructing a
+// full TldrawApp, which needs Zero, Clerk, and a router.
+function createAppStub(memberships: any[], userId = 'user:home') {
+	const app = Object.create(TldrawApp.prototype)
+	Object.assign(app, {
+		userId,
+		workspaceMemberships$: { get: () => memberships },
+		fileStates$: { get: () => [] },
+		lastWorkspaceFileOrderings: new Map(),
+	})
+	return app as TldrawApp
+}
+
+function makeFile(overrides: Partial<any> = {}) {
+	return {
+		id: 'file:1',
+		owningGroupId: null,
+		isDeleted: false,
+		createdAt: 1000,
+		updatedAt: 1000,
+		...overrides,
+	}
+}
+
+function makeMembership(groupId: string, groupFiles: any[]) {
+	return { groupId, groupFiles }
+}
+
+describe('getWorkspaceFilesSorted', () => {
+	it('drops group_file rows whose file is missing instead of crashing', () => {
+		const homeId = 'user:home'
+		const ownedFile = makeFile({ id: 'file:owned', owningGroupId: homeId })
+		// A group_file row can outlive (or arrive before) its file when the file is deleted, not yet
+		// synced, or filtered out server-side. The orphan is listed first so a regressed guard would
+		// throw inside the filter at the exact line that crashed in production.
+		const membership = makeMembership(homeId, [
+			{ fileId: 'file:orphan', groupId: homeId, index: null, file: undefined },
+			{ fileId: 'file:owned', groupId: homeId, index: null, file: ownedFile },
+		])
+		const app = createAppStub([membership], homeId)
+
+		const result = app.getWorkspaceFilesSorted(homeId)
+
+		expect(result.map((r) => r.fileId)).toEqual(['file:owned'])
+	})
+
+	it('returns an empty list when every group_file row is orphaned', () => {
+		const homeId = 'user:home'
+		const membership = makeMembership(homeId, [
+			{ fileId: 'file:a', groupId: homeId, index: null, file: undefined },
+			{ fileId: 'file:b', groupId: homeId, index: null, file: undefined },
+		])
+		const app = createAppStub([membership], homeId)
+
+		expect(app.getWorkspaceFilesSorted(homeId)).toEqual([])
+	})
+})


### PR DESCRIPTION
### The problem

The workspace sidebar can crash the whole app on the proper-Zero backend:

```
TypeError: Cannot read properties of undefined (reading 'owningGroupId')
  at getWorkspaceFilesSorted (TldrawApp.ts)
```

`getWorkspaceFilesSorted` reads `f.file.owningGroupId` for every `group_file` row, assuming the `file` is always there. The `workspaceMemberships` query joins `file` as a Zero `.one()` relationship, which resolves to `undefined` when the referenced `file` row isn't in the client's synced data. A `group_file` row can be present without its `file` when:

- the file was deleted, leaving a dangling join row,
- the join row synced before its file row, or
- the file is filtered out server-side because the user can no longer read it.

Any of these throws inside the sidebar's reactive derive and takes down the component tree. The declared type `groupFiles: Array<TlaGroupFile & { file: TlaFile }>` asserted `file` was always present, so the compiler never flagged the access.

This only affects the proper-Zero path. The legacy `ZeroPolyfill` already drops orphan rows at the source (`compact()` + `if (!file) return null`), so the guard was effectively lost when proper Zero took over the same shape. Introduced in #9270.

### The change

- Make the type honest: `file: TlaFile | undefined`.
- Drop orphan rows in `getWorkspaceFilesSorted` via a type-guard predicate, so the non-undefined narrowing flows into `pinned`/`unpinned` and the rest of the function with no scattered `!` assertions.
- Guard the `canCreateNewFile` file-limit count the same way.

### Testing

Added `getWorkspaceFilesSorted.test.ts`, which drives the real method against a membership whose first row is an orphan (`file: undefined`). Without the guard it reproduces the exact production crash; with it, the orphan is excluded and the owned file is returned. `yarn typecheck` passes (the honest type surfaced two more access sites, fixed by the type guard).