### PR TITLE
refactor(dotcom): derive membership signal types from the Zero queries

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -1,4 +1,4 @@
-import { Zero } from '@rocicorp/zero'
+import { QueryResultType, Zero } from '@rocicorp/zero'
 import { captureException } from '@sentry/react'
 import {
 	AcceptInviteResponseBody,
@@ -10,12 +10,9 @@ import {
 	ROOM_PREFIX,
 	TlaFile,
 	WELCOME_CREATE_SOURCE,
-	TlaFileState,
 	TlaFileStatePartial,
 	TlaFlags,
-	TlaGroup,
 	TlaGroupFile,
-	TlaGroupUser,
 	TlaMutators,
 	TlaSchema,
 	TlaUser,
@@ -122,13 +119,13 @@ export class TldrawApp {
 	readonly z: Zero<TlaSchema, TlaMutators, ZeroContext>
 
 	private readonly user$: Signal<TlaUser | undefined>
-	private readonly fileStates$: Signal<(TlaFileState & { file: TlaFile })[]>
+	// These signal types are derived from the query definitions in dotcom-shared rather than
+	// hand-written, so the shape (and the nullability of `.one()` joins like `file`) stays in
+	// sync with the queries automatically. A previous hand-written annotation claimed `file` was
+	// always present, which hid a production crash when a `.one()` join resolved to undefined.
+	private readonly fileStates$: Signal<QueryResultType<typeof queries.fileStates>>
 	private readonly workspaceMemberships$: Signal<
-		(TlaGroupUser & {
-			group: TlaGroup
-			groupFiles: Array<TlaGroupFile & { file: TlaFile | undefined }>
-			groupMembers: Array<TlaGroupUser>
-		})[]
+		QueryResultType<typeof queries.workspaceMemberships>
 	>
 
 	private readonly useProperZero: boolean
@@ -1229,10 +1226,10 @@ export class TldrawApp {
 	copyWorkspaceInvite(workspaceId: string, showToast = true): boolean {
 		// The home workspace can't be invited to.
 		if (workspaceId === this.getHomeWorkspaceId()) return false
-		const membership = this.getWorkspaceMembership(workspaceId)
-		if (!membership?.group.inviteSecret) return false
+		const group = this.getWorkspaceMembership(workspaceId)?.group
+		if (!group?.inviteSecret) return false
 
-		const inviteText = `${location.origin}/invite/${membership.group.inviteSecret}`
+		const inviteText = `${location.origin}/invite/${group.inviteSecret}`
 		navigator.clipboard.writeText(inviteText)
 
 		if (showToast) {

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -128,9 +128,10 @@ export function FileItems({
 	// labelled with its own name like any other workspace.
 	const currentWorkspaceId = file?.owningGroupId ?? app.getHomeWorkspaceId()
 	const homeWorkspaceName = workspaceMemberships.find((g) => g.groupId === app.getHomeWorkspaceId())
-		?.group.name
+		?.group?.name
 	const moveToWorkspaces = workspaceMemberships.filter(
-		(g) => g.groupId !== app.getHomeWorkspaceId()
+		(g): g is typeof g & { group: NonNullable<(typeof g)['group']> } =>
+			g.groupId !== app.getHomeWorkspaceId() && !!g.group
 	)
 
 	const handleCopyLinkClick = useCallback(() => {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -34,17 +34,23 @@ export function TlaSidebarWorkspaceSwitcher() {
 
 	const workspaces = useValue(
 		'workspaceMemberships',
-		() => app.getWorkspaceMemberships().filter((g) => g.groupId !== homeWorkspaceId),
+		() =>
+			app
+				.getWorkspaceMemberships()
+				.filter(
+					(g): g is typeof g & { group: NonNullable<(typeof g)['group']> } =>
+						g.groupId !== homeWorkspaceId && !!g.group
+				),
 		[app, homeWorkspaceId]
 	)
 	const activeWorkspaceName = useValue(
 		'active workspace name',
-		() => app.getWorkspaceMembership(activeWorkspaceId)?.group.name,
+		() => app.getWorkspaceMembership(activeWorkspaceId)?.group?.name,
 		[app, activeWorkspaceId]
 	)
 	const homeWorkspaceName = useValue(
 		'home workspace name',
-		() => app.getWorkspaceMembership(homeWorkspaceId)?.group.name,
+		() => app.getWorkspaceMembership(homeWorkspaceId)?.group?.name,
 		[app, homeWorkspaceId]
 	)
 


### PR DESCRIPTION
Follow-up to #9328, addressing @frolic's review: *"feels like this is a smell and that we should be able get the real result type from the query itself."*

### The smell

`fileStates$` and `workspaceMemberships$` had **hand-written** type annotations that mirrored the shape of their Zero queries (`packages/dotcom-shared/src/queries.ts`). That mirror is a second source of truth, and it had already drifted from reality: it declared `.one()` joins as always-present, which is exactly what hid the production crash fixed in #9328 (a `group_file` row whose `file` join resolved to `undefined`).

### The change

Derive both signal types straight from the query definitions:

```ts
private readonly fileStates$: Signal<QueryResultType<typeof queries.fileStates>>
private readonly workspaceMemberships$: Signal<QueryResultType<typeof queries.workspaceMemberships>>
```

Now the shape — and the nullability of every `.one()` join — stays in sync with the queries automatically. This whole class of bug becomes a compile error instead of a runtime crash.

### What it caught

Making the types honest surfaced **9 latent nullability errors across 3 files** — and none were about `file`. They were all the `group` join (also a `.one()`), which the hand-written type also falsely claimed was always present. So the original crash wasn't a one-off; the hand-written mirror was concealing the same bug for a second relationship.

Fixes per site:
- Drop group-less rows from the two workspace lists (workspace switcher, "move to" menu) via a type-guard filter — same pattern as the orphan-`file` fix, so downstream `.map` accesses narrow to non-null.
- Optional-chain the display reads (workspace names, invite secret).
- Remove three type imports (`TlaFileState`, `TlaGroup`, `TlaGroupUser`) that existed only to prop up the hand-written shapes.

### Testing

- `yarn typecheck` passes (the derivation resolves; the `getWorkspaceFilesSorted` type-guard from #9328 still composes with the derived element type).
- The `getWorkspaceFilesSorted` regression test from #9328 still passes.
- No behavior change for the common case; the only runtime difference is that a membership with an unsynced `group` is omitted from the workspace lists rather than crashing.