### PR TITLE
test(examples): wait for fonts before export-snapshot capture

### DIFF
--- a/apps/examples/e2e/tests/export-snapshots.spec.tsx
+++ b/apps/examples/e2e/tests/export-snapshots.spec.tsx
@@ -988,7 +988,7 @@ test.describe('Export snapshots', () => {
 				)
 
 				await page.evaluate(
-					({
+					async ({
 						colorScheme,
 						name,
 						snapshot,
@@ -1064,6 +1064,13 @@ test.describe('Export snapshots', () => {
 
 							y = bottom + 40
 						}
+
+						// Wait for every font used on the page to finish loading before exporting.
+						// Text geometry - and therefore the export's bounding box - is measured from
+						// the loaded font; while a font is still loading the shapes fall back to
+						// system-font metrics, which gives the export a slightly different size and
+						// makes the screenshot diff flaky.
+						await editor.fonts.loadRequiredFontsForCurrentPage()
 
 						tldrawApi.markAllArrowBindings()
 						editor.selectAll()


### PR DESCRIPTION
In order to fix the intermittently-failing `Export snapshots › Text rendering (dark)` e2e test on `main`, this PR makes the export-snapshot test wait for fonts to finish loading before it captures the export.

### Root cause

The failure is a size mismatch, not pixel noise: `Expected an image 2063px by 678px, received 2045px by 677px`. An export's bounding box is computed synchronously from each shape's geometry (`getSvgJsx` → `getShapeMaskedPageBounds`), and a text shape's geometry is measured from its **loaded** font (`sizeCache` in `TextShapeUtil` tracks font-load state via `editor.fonts.trackFontsForShape`). The test created its shapes and exported immediately, without awaiting the fonts those shapes request. When a font is still loading, the shape falls back to system-font metrics, so the laid-out text — and therefore the whole export — comes out a slightly different size.

This raced on CI: the `(dark)` variant always runs right after `(light)` leaves the page on a `file://` screenshot URL, forcing a fresh navigation. Running warm and fast, it reached the export before the lazily-requested fonts had loaded, exporting at the fallback size and failing the comparison on dimensions. It is intermittent (failure / failure / success on `main`), which is the signature of a timing race rather than a deterministic rendering regression.

The fix mirrors what the editor itself does on mount (`TldrawEditor.tsx` awaits `loadRequiredFontsForCurrentPage`) and what `TldrawImage` does before rendering — the test was just missing the equivalent wait for the shapes it adds after mount. No re-baselining: the committed baseline (2063×678) already is the loaded-font size; the fix makes the test deterministically produce it.

### Evidence

Driving the real export pipeline with the font response delayed (the CI condition), the exported SVG's own `width` attribute is **713px** when the export runs before fonts load versus **833px** once `loadRequiredFontsForCurrentPage()` is awaited — a font-metric size swing, gone once fonts are awaited. After the fix, the `Text rendering` export is a stable size on every run, including under a forced multi-second font-load delay.

### Change type

- [x] `bugfix`

### Test plan

1. Run `cd apps/examples && yarn e2e -g "Text rendering" --project=chromium` repeatedly; the export is now a deterministic size rather than intermittently falling back.
2. Run the full `export-snapshots.spec.tsx` suite to confirm every snapshot group still exports without error.

- [ ] Unit tests
- [x] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +8 / -1    |
