### PR TITLE
fix(tldraw): don't re-enter label editing on cmd+enter

### DIFF
--- a/apps/examples/e2e/tests/test-a11y-style-panel-navigation.spec.ts
+++ b/apps/examples/e2e/tests/test-a11y-style-panel-navigation.spec.ts
@@ -102,10 +102,7 @@ test.describe('A11y Style Panel Navigation', () => {
 		expect(finalText).toBe('Updated Label')
 	})
 
-	// Failing! This is failing because the keyboard event isn't being picked up while editing the rich
-	// text. In practice the behavior does work, so this is a problem with the test or the way that we're
-	// dispatching the event.
-	test.fail('in a geo shape, cmd+enter returns focus to the canvas', async ({ page, isMobile }) => {
+	test('in a geo shape, cmd+enter returns focus to the canvas', async ({ page, isMobile }) => {
 		if (isMobile) {
 			test.skip()
 		}
@@ -115,21 +112,19 @@ test.describe('A11y Style Panel Navigation', () => {
 		await page.mouse.click(200, 200)
 		await page.keyboard.press('v') // Select tool
 
-		// press enter
+		// press enter to start editing the label
 		await page.keyboard.press('Enter')
 
-		expect(await isFocusedOnRichTextEditor(page)).toBe(true)
+		// the editor is in the editing state with the rich text editor focused. Focus is
+		// asynchronous, so poll rather than asserting immediately.
+		await expect.poll(() => page.evaluate(() => editor.isIn('select.editing_shape'))).toBe(true)
+		await expect.poll(() => isFocusedOnRichTextEditor(page)).toBe(true)
 
-		// expect editor to be in the editing state
-		expect(await page.evaluate(() => editor.isIn('select.editing_shape'))).toBe(true)
-
-		// dispatch cmd+enter to the active element
+		// cmd+enter completes editing and returns focus to the canvas
 		await page.keyboard.press('ControlOrMeta+Enter')
-		await page.waitForTimeout(100)
 
-		expect(await page.evaluate(() => editor.isIn('select.editing_shape'))).toBe(false)
-
-		expect(await isFocusedOnCanvas(page)).toBe(true)
+		await expect.poll(() => page.evaluate(() => editor.isIn('select.editing_shape'))).toBe(false)
+		await expect.poll(() => isFocusedOnCanvas(page)).toBe(true)
 	})
 
 	test('in a note shape, cmd+enter creates the next shape and does not focus on the style panel', async ({

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -652,6 +652,11 @@ export class Idle extends StateNode {
 	override onKeyUp(info: TLKeyboardEventInfo) {
 		switch (info.key) {
 			case 'Enter': {
+				// cmd/ctrl+enter never starts editing: while a shape is selected it focuses the style
+				// panel (the "adjust shape styles" shortcut), and while editing a label it completes
+				// editing and returns focus to the canvas. Only a plain Enter begins editing.
+				if (info.accelKey) break
+
 				// Because Enter onKeyDown can happen outside the canvas (but then focus the canvas potentially),
 				// we need to check if the canvas was initially selecting something before continuing.
 				if (!this.selectedShapesOnKeyDown.length) return


### PR DESCRIPTION
In order to make cmd+enter reliably finish editing a shape's label, this PR stops the select tool from re-entering editing immediately after it exits.

While editing a geo shape's label, cmd/ctrl+enter calls `editor.complete()`, which exits editing and returns focus to the canvas. But the same keydown then bubbles to the editor's container listener and is dispatched to the idle state, which re-arms `selectedShapesOnKeyDown`; the following Enter keyup is handled by `Idle.onKeyUp` and starts editing again. The result is intermittent — sometimes focus stays on the canvas, sometimes it bounces straight back into the label editor.

cmd/ctrl+enter is never an "edit" gesture: when idle it focuses the style panel (the "adjust shape styles" shortcut), and while editing it completes editing. The fix guards the idle Enter keyup against the accelerator key so only a plain Enter begins editing.

The e2e test that covers this (`in a geo shape, cmd+enter returns focus to the canvas`) was previously wrapped in `test.fail`, with a note that the behaviour worked in practice but the test didn't. The body actually passes on CI most of the time, so `test.fail` reported those runs as failures — the source of the intermittent red on `main`. With the behaviour fixed, the test is un-skipped and now polls for the settled editing/focus state instead of asserting immediately after the key press.

Note: a few of the other tests in the same file can still flake under heavy parallel load due to unrelated immediate-assertion focus/typing races; stabilising those is left as a follow-up.

### Change type

- [x] `bugfix`

### Test plan

1. Create a geo shape (e.g. a rectangle) and select it.
2. Press Enter to edit its label and type some text.
3. Press cmd/ctrl+enter.
4. Focus returns to the canvas and the shape is no longer being edited — it does not bounce back into the label editor.

- [x] End to end tests

### Release notes

- Fix cmd/ctrl+enter not reliably returning focus to the canvas when finishing editing a shape's label.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -0    |
| Tests     | +9 / -14   |