### PR TITLE
fix(dotcom): normalize create workspace dialog title and button

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Sidebar.ts
+++ b/apps/dotcom/client/e2e/fixtures/Sidebar.ts
@@ -327,7 +327,7 @@ export class Sidebar {
 		await expect(input).toBeVisible()
 		await input.fill(name)
 
-		await this.page.getByRole('button', { name: 'Create workspace' }).click()
+		await this.page.getByRole('button', { name: 'Create', exact: true }).click()
 		await this.mutationResolution()
 
 		// Creating a workspace switches to it and opens its seeded welcome file. That file

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -425,12 +425,6 @@
       "value": "PNG"
     }
   ],
-  "5638176be5": [
-    {
-      "type": 0,
-      "value": "Create a workspace"
-    }
-  ],
   "5677e381d2": [
     {
       "type": 0,
@@ -531,6 +525,12 @@
     {
       "type": 0,
       "value": "Enter your email address"
+    }
+  ],
+  "686e697538": [
+    {
+      "type": 0,
+      "value": "Create"
     }
   ],
   "694f82ed9d": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -191,9 +191,6 @@
   "55505ba281": {
     "translation": "PNG"
   },
-  "5638176be5": {
-    "translation": "Create a workspace"
-  },
   "5677e381d2": {
     "translation": "We use analytics cookies to make tldraw better."
   },
@@ -244,6 +241,9 @@
   },
   "6832ac5936": {
     "translation": "Enter your email address"
+  },
+  "686e697538": {
+    "translation": "Create"
   },
   "694f82ed9d": {
     "translation": "Delete workspace"

--- a/apps/dotcom/client/src/tla/components/dialogs/CreateWorkspaceDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/CreateWorkspaceDialog.tsx
@@ -51,7 +51,7 @@ export function CreateWorkspaceDialog({ onClose, onCreate }: CreateWorkspaceDial
 		<>
 			<TldrawUiDialogHeader>
 				<TldrawUiDialogTitle>
-					<F defaultMessage="Create a workspace" />
+					<F defaultMessage="Create workspace" />
 				</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
@@ -80,7 +80,7 @@ export function CreateWorkspaceDialog({ onClose, onCreate }: CreateWorkspaceDial
 					<F defaultMessage="Cancel" />
 				</TldrawUiButton>
 				<TldrawUiButton type="primary" onClick={handleCreate}>
-					<F defaultMessage="Create workspace" />
+					<F defaultMessage="Create" />
 				</TldrawUiButton>
 			</TldrawUiDialogFooter>
 		</>

--- a/apps/dotcom/user-manual.md
+++ b/apps/dotcom/user-manual.md
@@ -26,7 +26,7 @@ If you already have a workspace, click the workspace switcher at the top of the 
 
 Enter a workspace name.
 
-Click **Create workspace**.
+Click **Create**.
 
 tldraw creates the workspace, makes you the owner, creates a welcome file, and opens that file.
 


### PR DESCRIPTION
In order to keep the workspace dialogs consistent, this PR normalizes the create workspace dialog so its title is a descriptive action ("Create workspace") and its confirm button is a bare verb ("Create"). Previously the title had a stray article ("Create a workspace") and the button repeated the noun ("Create workspace"). Every other workspace dialog already follows this convention (Manage workspace, Leave workspace / Leave, Delete workspace / Delete, Regenerate invite link / Regenerate, Remove member / Remove).

The i18n source and compiled message catalogs were regenerated with `yarn workspace dotcom build-i18n` (the message IDs are content-hashed, so changing the copy shifts them), and the e2e fixture and user manual were updated to match the new button label.

### Change type

- [x] `improvement`

### Test plan

1. Open the workspace switcher in the sidebar and choose to create a workspace.
2. Confirm the dialog title reads "Create workspace" and the primary button reads "Create".

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Normalize the create workspace dialog title and button to match the other workspace dialogs.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Tests           | +1 / -1    |
| Automated files | +9 / -9    |
| Apps            | +3 / -3    |