### PR TITLE
fix(dotcom): archive vercel deploy to stay under the 15k file limit

### DIFF
--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -906,9 +906,16 @@ async function deploySpa(): Promise<{ deploymentUrl: string; inspectUrl: string 
 	// both 'staging' and 'production' are deployed to vercel as 'production' deploys
 	// in separate 'projects'
 	const prod = env.TLDRAW_ENV !== 'preview'
-	const out = await vercelCli('deploy', ['--yes', '--prebuilt', ...(prod ? ['--prod'] : [])], {
-		pwd: dotcom,
-	})
+	// Upload the prebuilt output as a single tarball. We serve the .js.map files rather than
+	// stripping them, which pushes the deploy past Vercel's 15,000-individual-file upload limit;
+	// archiving sidesteps that limit.
+	const out = await vercelCli(
+		'deploy',
+		['--yes', '--prebuilt', '--archive=tgz', ...(prod ? ['--prod'] : [])],
+		{
+			pwd: dotcom,
+		}
+	)
 
 	const previewURL = out.match(/Preview: (https:\/\/\S*)/)?.[1]
 	const inspectUrl = out.match(/Inspect: (https:\/\/\S*)/)?.[1]


### PR DESCRIPTION
In order to unblock the staging deploy, this PR adds `--archive=tgz` to the `vercel deploy` command in the dotcom deploy script. Relates to #9327.

#9327 stopped stripping `.js.map` files from the client deploy (so deployed builds are debuggable in devtools), which was the right call — but the extra files pushed the prebuilt output to 15,237 files, over Vercel's 15,000-individual-file upload limit, and the "Deploy dotcom to staging" job has failed on every `main` push since:

```
Error: Invalid request: `files` should NOT have more than 15000 items, received 15237.
Try using `--archive=tgz` to limit the amount of files you upload.
```

Archiving uploads the output as a single tarball instead of as individual files, so the per-file count limit no longer applies, while keeping the source maps that #9327 intentionally ships. This is exactly the workaround Vercel's own error message recommends. The change applies to staging, production, and PR preview deploys (all go through `deploySpa()`).

### Change type

- [x] `bugfix`

### Test plan

1. Merge and confirm the "Deploy dotcom to staging" job succeeds on the next `main` push, with the Vercel step reporting an archived upload rather than the 15,000-file error.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +10 / -3   |
