### PR TITLE
perf(dotcom): cache auth tokens for file navigation

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -73,6 +73,7 @@ import { MULTIPLAYER_SERVER, ZERO_SERVER } from '../../utils/config'
 import { multiplayerAssetStore } from '../../utils/multiplayerAssetStore'
 import { getScratchPersistenceKey } from '../../utils/scratch-persistence-key'
 import { TLAppUiContextType } from '../utils/app-ui-events'
+import type { TlaGetToken } from '../utils/authTokenCache'
 import { getDateFormat } from '../utils/dates'
 import { FeatureFlags } from '../utils/FeatureFlagPoller'
 import { createIntl, defineMessages, setupCreateIntl } from '../utils/i18n'
@@ -134,7 +135,7 @@ export class TldrawApp {
 	private readonly useProperZero: boolean
 	private readonly abortController = new AbortController()
 	readonly disposables: (() => void)[] = [() => this.abortController.abort(), () => this.z.close()]
-	private getToken: () => Promise<string | undefined>
+	private getToken: TlaGetToken
 
 	changes: Map<Atom<any, unknown>, any> = new Map()
 	changesFlushed = null as null | ReturnType<typeof promiseWithResolve>
@@ -179,7 +180,7 @@ export class TldrawApp {
 	private constructor(
 		public readonly userId: string,
 		initialToken: string | undefined,
-		getToken: () => Promise<string | undefined>,
+		getToken: TlaGetToken,
 		onClientTooOld: () => void,
 		trackEvent: TLAppUiContextType,
 		navigate: ReturnType<typeof useNavigate>,
@@ -210,7 +211,7 @@ export class TldrawApp {
 			})
 			this.z = z
 			const refreshToken = () =>
-				getToken().then((token) => {
+				getToken({ forceRefresh: true }).then((token) => {
 					if (token) {
 						z.connection.connect({ auth: token })
 						return true
@@ -259,7 +260,7 @@ export class TldrawApp {
 						sessionId,
 						protocolVersion: String(Z_PROTOCOL_VERSION),
 					})
-					const token = await getToken()
+					const token = await getToken({ minTimeToExpiryMs: 10_000 })
 					params.set('accessToken', token || 'no-token-found')
 					return `${MULTIPLAYER_SERVER}/app/${userId}/connect?${params}`
 				},
@@ -267,6 +268,13 @@ export class TldrawApp {
 				onClientTooOld: () => onClientTooOld(),
 				trackEvent,
 			}) as unknown as Zero<TlaSchema, TlaMutators, ZeroContext>
+			const TOKEN_REFRESH_INTERVAL = 50_000
+			const refreshInterval = setInterval(() => {
+				getToken({ forceRefresh: true }).catch((err) => {
+					console.error('Failed to proactively refresh auth token:', err)
+				})
+			}, TOKEN_REFRESH_INTERVAL)
+			this.disposables.push(() => clearInterval(refreshInterval))
 		}
 
 		this.user$ = this.signalizeQuery('user signal', this.userQuery())
@@ -292,7 +300,7 @@ export class TldrawApp {
 	async preload() {
 		if (this.useProperZero) {
 			// Ensure user exists in DB before Zero can query
-			const token = await this.getToken()
+			const token = await this.getToken({ minTimeToExpiryMs: 10_000 })
 			if (!token) {
 				throw new Error('No auth token available for init')
 			} else {
@@ -972,11 +980,15 @@ export class TldrawApp {
 		this.updateFileState(fileId, { lastVisitAt: Date.now() })
 	}
 
+	getAuthToken() {
+		return this.getToken({ minTimeToExpiryMs: 10_000 })
+	}
+
 	static async create(opts: {
 		userId: string
 		email?: string | null
 		flags: FeatureFlags
-		getToken(): Promise<string | undefined>
+		getToken: TlaGetToken
 		onClientTooOld(): void
 		trackEvent: TLAppUiContextType
 		navigate: ReturnType<typeof useNavigate>
@@ -987,7 +999,8 @@ export class TldrawApp {
 
 		const { id: _id, name: _name, color, ...restOfPreferences } = getUserPreferences()
 		// Get initial token before creating Zero instance
-		const initialToken = await opts.getToken()
+		const initialToken = await opts.getToken({ minTimeToExpiryMs: 10_000 })
+		if (!initialToken) throw new Error('no token')
 		const app = new TldrawApp(
 			opts.userId,
 			initialToken,

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import { assertExists, atom } from 'tldraw'
 import { TldrawApp } from '../app/TldrawApp'
 import { useTldrawAppUiEvents } from '../utils/app-ui-events'
+import { createCachedTokenGetter } from '../utils/authTokenCache'
 import {
 	DEFAULT_FLAGS,
 	FeatureFlags,
@@ -52,16 +53,12 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 				flags = await fetchFlagsWithTimeout()
 			}
 			if (didCancel) return
-			const token = await auth.getToken()
-			if (!token) throw new Error('no token')
+			const getToken = createCachedTokenGetter(() => auth.getToken({ leewayInSeconds: 10 }))
 			const { app } = await TldrawApp.create({
 				userId: auth.userId,
 				email: user.primaryEmailAddress?.emailAddress,
 				flags,
-				getToken: async () => {
-					const token = await auth.getToken()
-					return token || undefined
-				},
+				getToken,
 				onClientTooOld: () => {
 					isClientTooOld$.set(true)
 				},

--- a/apps/dotcom/client/src/tla/hooks/useUser.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useUser.tsx
@@ -19,7 +19,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
 	// and was causing downstream react components to remount unnecessarily and lose state.
 	// I tracked it down to being useAuth().has which was being updated randomly for some reason.
 	// Destructuring the bits we need here fixes the issue as they seem to be stable.
-	const { getToken, isSignedIn, isLoaded: isAuthLoaded } = useAuth()
+	const { isSignedIn, isLoaded: isAuthLoaded } = useAuth()
 
 	// app can be null during hot reloading sometimes?
 	const app = useMaybeApp()
@@ -37,12 +37,12 @@ export function UserProvider({ children }: { children: ReactNode }) {
 				user?.primaryEmailAddress?.verification.status === 'verified' &&
 				user.primaryEmailAddress.emailAddress.endsWith('@tldraw.com'),
 			getToken: async () => {
-				const token = await getToken()
+				const token = await app.getAuthToken()
 				assert(token)
 				return token
 			},
 		}
-	}, [getToken, isSignedIn, user, app])
+	}, [isSignedIn, user, app])
 
 	if (!isLoaded || !isAuthLoaded || !app) {
 		return (

--- a/apps/dotcom/client/src/tla/utils/authTokenCache.ts
+++ b/apps/dotcom/client/src/tla/utils/authTokenCache.ts
@@ -1,0 +1,79 @@
+const DEFAULT_MIN_TIME_TO_EXPIRY_MS = 5_000
+const BACKGROUND_REFRESH_TIME_TO_EXPIRY_MS = 30_000
+const FALLBACK_TOKEN_TTL_MS = 30_000
+
+interface CachedToken {
+	token: string
+	expiresAt: number
+}
+
+export interface GetCachedTokenOptions {
+	forceRefresh?: boolean
+	minTimeToExpiryMs?: number
+}
+
+export type TlaGetToken = (options?: GetCachedTokenOptions) => Promise<string | undefined>
+
+export function createCachedTokenGetter(
+	getToken: () => Promise<string | null | undefined>
+): TlaGetToken {
+	let cachedToken: CachedToken | null = null
+	let pendingRefresh: Promise<string | undefined> | null = null
+
+	function refreshToken() {
+		if (!pendingRefresh) {
+			pendingRefresh = (async () => {
+				const token = await getToken()
+				if (!token) {
+					cachedToken = null
+					return undefined
+				}
+
+				cachedToken = {
+					token,
+					expiresAt: getTokenExpiresAt(token),
+				}
+				return token
+			})().finally(() => {
+				pendingRefresh = null
+			})
+		}
+		return pendingRefresh
+	}
+
+	return async function getCachedToken({
+		forceRefresh = false,
+		minTimeToExpiryMs = DEFAULT_MIN_TIME_TO_EXPIRY_MS,
+	}: GetCachedTokenOptions = {}) {
+		const timeToExpiryMs = cachedToken ? cachedToken.expiresAt - Date.now() : 0
+		if (!forceRefresh && cachedToken && timeToExpiryMs > minTimeToExpiryMs) {
+			if (timeToExpiryMs < BACKGROUND_REFRESH_TIME_TO_EXPIRY_MS) {
+				void refreshToken().catch((err) => {
+					console.warn('[Auth] Failed to refresh cached token:', err)
+				})
+			}
+			return cachedToken.token
+		}
+
+		return refreshToken()
+	}
+}
+
+function getTokenExpiresAt(token: string) {
+	const fallbackExpiresAt = Date.now() + FALLBACK_TOKEN_TTL_MS
+	try {
+		const payload = token.split('.')[1]
+		if (!payload) return fallbackExpiresAt
+
+		const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+		const padding = (4 - (normalized.length % 4)) % 4
+		const decoded = globalThis.atob(normalized + '='.repeat(padding))
+		const parsed = JSON.parse(decoded) as { exp?: unknown }
+		if (typeof parsed.exp === 'number' && Number.isFinite(parsed.exp)) {
+			return parsed.exp * 1000
+		}
+	} catch {
+		// Fall back to a short TTL if Clerk ever changes token shape.
+	}
+	return fallbackExpiresAt
+}

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -40,24 +40,24 @@ export async function getAuth(request: IRequest, env: Environment): Promise<Sign
 	const clerk = getClerkClient(env)
 	const authorizedParties = getAuthorizedParties(env)
 
-	const state = await clerk.authenticateRequest(request, { authorizedParties })
-	if (state.isSignedIn) return state.toAuth() as SignedInAuth
-
 	// we can't send headers with websockets, so for those connections we need to pass the token in
 	// the query string. `authenticateRequest` only works with headers/cookies though, so we need to
 	// copy the query string into the headers.
-	const cloned = new Request(request.url, { headers: request.headers })
-	const url = new URL(cloned.url)
-	if (!cloned.headers.has('Authorization')) {
-		if (url.searchParams.has('accessToken')) {
-			cloned.headers.set('Authorization', `Bearer ${url.searchParams.get('accessToken')}`)
-		} else {
-			return null
-		}
+	const url = new URL(request.url)
+	let requestToAuthenticate: Request = request
+	const accessToken = url.searchParams.get('accessToken')
+	if (!request.headers.has('Authorization') && accessToken !== null) {
+		const headers = new Headers(request.headers)
+		headers.set('Authorization', `Bearer ${accessToken}`)
+		requestToAuthenticate = new Request(request.url, { method: request.method, headers })
 	}
 
-	const res = await clerk.authenticateRequest(cloned, { authorizedParties })
+	const res = await clerk.authenticateRequest(requestToAuthenticate, { authorizedParties })
 	if (!res.isSignedIn) {
+		if (requestToAuthenticate !== request && request.headers.has('Cookie')) {
+			const cookieRes = await clerk.authenticateRequest(request, { authorizedParties })
+			if (cookieRes.isSignedIn) return cookieRes.toAuth() as SignedInAuth
+		}
 		return null
 	}
 


### PR DESCRIPTION
🙇‍♂️ I noticed that every navigation was paying 150ms for an auth round trip to Clerk. This PR is an attempt to prevent that by holding on to the auth token.

---

In order to avoid making signed-in file navigation wait on repeated Clerk token retrieval, this PR adds a shared auth token cache for the dotcom app and uses it for file sync and asset token access. It also normalizes WebSocket `accessToken` query params before worker-side Clerk authentication so the common file-join path does one authenticate pass, with a cookie fallback only when the query-token attempt fails.

### Change type

- [x] `improvement`

### Test plan

1. `yarn workspace dotcom lint`
2. `yarn workspace @tldraw/dotcom-worker lint`
3. `yarn typecheck`

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve signed-in file navigation by reusing recently refreshed auth tokens.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps | +117 / -28 |