### PR TITLE
perf(tldraw): cache generated pattern fill defs across editor mounts

### DIFF
--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -109,6 +109,25 @@ const generateImage = (dpr: number, currentZoom: number, solid: string) => {
 	})
 }
 
+// Generating the pattern images is expensive (canvas draw + encode), but the result only depends
+// on the device pixel ratio, zoom level, and solid color. Cache the blobs at the module level so
+// the work is done once and reused across editor mounts and instances. Object URLs are still
+// created and revoked per-instance; only the underlying blobs are shared.
+const patternImageBlobCache = new Map<string, Promise<Blob>>()
+
+function getPatternImageBlob(dpr: number, zoom: number, solid: string): Promise<Blob> {
+	const key = `${dpr}_${zoom}_${solid}`
+	let blob = patternImageBlobCache.get(key)
+	if (!blob) {
+		blob = generateImage(dpr, zoom, solid)
+		// Don't keep a rejected promise around (e.g. the throwToBlob debug flag), so a later call
+		// can retry once the failure condition is gone.
+		blob.catch(() => patternImageBlobCache.delete(key))
+		patternImageBlobCache.set(key, blob)
+	}
+	return blob
+}
+
 const canvasBlob = (size: [number, number], fn: (ctx: CanvasRenderingContext2D) => void) => {
 	const canvas = getGlobalDocument().createElement('canvas')
 	canvas.width = size[0]
@@ -208,12 +227,12 @@ function usePattern() {
 
 		const promise = Promise.all(
 			getPatternLodsToGenerate(maxEffectiveZoom).flatMap<Promise<PatternDef>>((zoom) => [
-				generateImage(dpr, zoom, lightSolid).then((blob) => ({
+				getPatternImageBlob(dpr, zoom, lightSolid).then((blob) => ({
 					zoom,
 					theme: 'light',
 					url: URL.createObjectURL(blob),
 				})),
-				generateImage(dpr, zoom, darkSolid).then((blob) => ({
+				getPatternImageBlob(dpr, zoom, darkSolid).then((blob) => ({
 					zoom,
 					theme: 'dark',
 					url: URL.createObjectURL(blob),

--- a/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/defaultStyleDefs.tsx
@@ -74,7 +74,10 @@ const generateImage = (dpr: number, currentZoom: number, solid: string) => {
 		canvasEl.height = size
 
 		const ctx = canvasEl.getContext('2d')
-		if (!ctx) return
+		if (!ctx) {
+			reject()
+			return
+		}
 
 		ctx.fillStyle = solid
 		ctx.fillRect(0, 0, size, size)


### PR DESCRIPTION
🙇‍♂️ File this one under "things we should have done four years ago". Speeds up load time by 50-75ms on my M5 MacBook. Affects SDK as well as everything else.

---

https://github.com/user-attachments/assets/bc9d0642-73f6-4e77-821d-60549ec5f5b3

In order to avoid regenerating SVG hash-pattern fill defs on every editor mount, this PR caches the generated pattern images at the module level. The pattern images are produced in `usePattern` by drawing to a canvas and encoding a blob for every zoom LOD × theme (light/dark) — at high-zoom LODs the canvas can reach ~2048×2048, so the draw-and-encode work costs roughly 50ms and was repeated from scratch on each load.

The encoded output only depends on `(devicePixelRatio, zoom, solidColor)`, so a module-level `patternImageBlobCache` keyed by those values now stores the `Promise<Blob>` and reuses it across editor mounts and instances. Object URLs are still created and revoked per-instance exactly as before — only the immutable blobs are shared, so there is no risk of handing out a revoked URL. Rejected promises (e.g. the `throwToBlob` debug flag) are evicted from the cache so a later mount can retry.

### Change type

- [x] `improvement`

### Test plan

1. Open an editor and add a shape with a pattern fill.
2. Unmount and remount the editor (or mount a second editor instance).
3. Confirm pattern fills render correctly and the canvas pattern-generation work does not repeat.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Cache generated pattern fill defs so they are not regenerated on every editor mount, reducing editor load time.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +21 / -2   |
