### PR TITLE
fix(dotcom): remove editor load animations (fade-in and loading spinners)

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -79,37 +79,12 @@ interface TlaEditorProps {
 	deepLinks?: boolean
 }
 
-/**
- * An empty, non-interactive tldraw editor shown immediately while the real file
- * connects and syncs. It renders the full editor chrome (toolbar, menus, panels)
- * over its own ephemeral empty store, so the UI pops in instantly and only the
- * document content fills in once synced. It never autofocuses, and the
- * ReadyWrapper overlay disables pointer events so nothing here is interactive.
- */
-function TlaEditorLoadingPlaceholder() {
-	const app = useMaybeApp()
-	return (
-		<TlaEditorWrapper>
-			<Tldraw
-				className="tla-editor"
-				licenseKey={getLicenseKey()}
-				assetUrls={assetUrls}
-				// Match the user's theme so the placeholder doesn't flash light/dark.
-				user={app?.tlUser}
-				autoFocus={false}
-				components={components}
-				options={{ actionShortcutsLocation: 'toolbar' }}
-			/>
-		</TlaEditorWrapper>
-	)
-}
-
 export function TlaEditor(props: TlaEditorProps) {
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
 		<>
 			<SneakySetDocumentTitle />
-			<ReadyWrapper key={props.fileSlug} loadingScreen={<TlaEditorLoadingPlaceholder />}>
+			<ReadyWrapper key={props.fileSlug}>
 				<TlaEditorInner {...props} key={props.fileSlug} />
 			</ReadyWrapper>
 		</>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -68,6 +68,9 @@ export const components: TLComponents = {
 	SharePanel: TlaEditorSharePanel,
 	Dialogs: null,
 	Toasts: null,
+	// No loading screen on tla editors: the chrome and placeholder appear
+	// instantly, so a spinner would only flash before the content cuts in.
+	LoadingScreen: null,
 }
 
 interface TlaEditorProps {
@@ -75,12 +78,6 @@ interface TlaEditorProps {
 	isEmbed?: boolean
 	deepLinks?: boolean
 }
-
-// Components for the inert placeholder editor shown while the real file syncs.
-// Same UI as the real editor (toolbar, menus, panels) so the chrome appears
-// instantly, plus a nulled loading screen to avoid a flash of its own spinner
-// before the (instant) empty local store finishes loading.
-const placeholderComponents: TLComponents = { ...components, LoadingScreen: null }
 
 /**
  * An empty, non-interactive tldraw editor shown immediately while the real file
@@ -100,7 +97,7 @@ function TlaEditorLoadingPlaceholder() {
 				// Match the user's theme so the placeholder doesn't flash light/dark.
 				user={app?.tlUser}
 				autoFocus={false}
-				components={placeholderComponents}
+				components={components}
 				options={{ actionShortcutsLocation: 'toolbar' }}
 			/>
 		</TlaEditorWrapper>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -68,8 +68,8 @@ export const components: TLComponents = {
 	SharePanel: TlaEditorSharePanel,
 	Dialogs: null,
 	Toasts: null,
-	// No loading screen on tla editors: the chrome and placeholder appear
-	// instantly, so a spinner would only flash before the content cuts in.
+	// No loading screen on tla editors: the editor only mounts once it's ready,
+	// so a spinner would only flash before the content appears.
 	LoadingScreen: null,
 }
 

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
@@ -13,23 +13,9 @@
 .innerContainer {
 	flex-grow: 1;
 	height: 100%;
-	transition: opacity 0.12s ease-in;
 }
 
 .innerContainer:not(.isReady) {
-	opacity: 0;
-}
-
-.spinner {
-	transition: opacity 1s ease-in;
-	position: absolute;
-	inset: 0;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-}
-
-.spinner:not(.showSpinner) {
 	opacity: 0;
 }
 
@@ -53,15 +39,10 @@
 }
 
 /*
- * Fade just the file content in once the editor is ready, leaving the main UI,
- * background, and grid untouched so they line up with the placeholder.
+ * Keep just the file content hidden until the editor is ready, then hard-cut it
+ * in (no fade), leaving the main UI, background, and grid untouched so they line
+ * up with the placeholder.
  */
-.withLoadingScreen .innerContainer :global(.tl-shapes),
-.withLoadingScreen .innerContainer :global(.tl-canvas-overlays),
-.withLoadingScreen .innerContainer :global(.tl-canvas__in-front) {
-	transition: opacity 0.2s ease-in;
-}
-
 .withLoadingScreen .innerContainer:not(.isReady) :global(.tl-shapes),
 .withLoadingScreen .innerContainer:not(.isReady) :global(.tl-canvas-overlays),
 .withLoadingScreen .innerContainer:not(.isReady) :global(.tl-canvas__in-front) {

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.module.css
@@ -18,33 +18,3 @@
 .innerContainer:not(.isReady) {
 	opacity: 0;
 }
-
-.loadingScreen {
-	position: absolute;
-	inset: 0;
-	/* The placeholder editor is purely visual: never let it receive input. */
-	pointer-events: none;
-}
-
-/*
- * When a placeholder editor is shown during loading there's already an editor on
- * screen, so the real editor hard-cuts in rather than fading.
- */
-.withLoadingScreen .innerContainer {
-	transition: none;
-}
-
-.withLoadingScreen .innerContainer:not(.isReady) {
-	opacity: 1;
-}
-
-/*
- * Keep just the file content hidden until the editor is ready, then hard-cut it
- * in (no fade), leaving the main UI, background, and grid untouched so they line
- * up with the placeholder.
- */
-.withLoadingScreen .innerContainer:not(.isReady) :global(.tl-shapes),
-.withLoadingScreen .innerContainer:not(.isReady) :global(.tl-canvas-overlays),
-.withLoadingScreen .innerContainer:not(.isReady) :global(.tl-canvas__in-front) {
-	opacity: 0;
-}

--- a/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useIsReady.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { PropsWithChildren, ReactNode, useCallback, useContext } from 'react'
+import React, { PropsWithChildren, useCallback, useContext } from 'react'
 import styles from './useIsReady.module.css'
 
 /*
@@ -18,13 +18,9 @@ export function useSetIsReady() {
 	return React.useContext(ReadyContext).setIsReady
 }
 
-export function ReadyWrapper({
-	children,
-	loadingScreen,
-}: PropsWithChildren<{ loadingScreen?: ReactNode }>) {
+export function ReadyWrapper({ children }: PropsWithChildren) {
 	const parent = useContext(ReadyContext)
 	const [isReady, _setIsReady] = React.useState(false)
-	const hasLoadingScreen = !!loadingScreen
 	const setIsReady = useCallback(async () => {
 		_setIsReady(true)
 	}, [])
@@ -36,28 +32,13 @@ export function ReadyWrapper({
 
 	return (
 		<ReadyContext.Provider value={{ isReady, setIsReady, isRoot: false }}>
-			<div
-				className={classNames(
-					styles.container,
-					isReady && styles.isReady,
-					// There's already an editor (the placeholder) on screen, so the real
-					// editor hard-cuts in instead of fading.
-					hasLoadingScreen && styles.withLoadingScreen
-				)}
-			>
+			<div className={classNames(styles.container, isReady && styles.isReady)}>
 				<div
 					className={classNames(styles.innerContainer, isReady && styles.isReady)}
 					inert={!isReady}
 				>
 					{children}
 				</div>
-				{/* While loading, show the inert placeholder editor (if provided) with
-				    the spinner layered in front of it. */}
-				{!isReady && hasLoadingScreen && (
-					<div className={styles.loadingScreen} inert aria-hidden="true">
-						{loadingScreen}
-					</div>
-				)}
 			</div>
 		</ReadyContext.Provider>
 	)

--- a/apps/dotcom/client/src/tla/hooks/useUser.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useUser.tsx
@@ -1,7 +1,7 @@
 import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
 import type { UserResource } from '@clerk/types'
 import { ReactNode, createContext, useContext, useMemo } from 'react'
-import { DefaultSpinner, LoadingScreen, assert, useShallowObjectIdentity } from 'tldraw'
+import { assert, useShallowObjectIdentity } from 'tldraw'
 import { useMaybeApp } from './useAppState'
 
 interface TldrawUser {
@@ -45,13 +45,8 @@ export function UserProvider({ children }: { children: ReactNode }) {
 	}, [getToken, isSignedIn, user, app])
 
 	if (!isLoaded || !isAuthLoaded || !app) {
-		return (
-			<div className="tldraw__editor">
-				<LoadingScreen>
-					<DefaultSpinner />
-				</LoadingScreen>
-			</div>
-		)
+		// Render a blank editor surface while auth loads, with no spinner or fade.
+		return <div className="tldraw__editor" />
 	}
 
 	return <UserContext.Provider value={value}>{children}</UserContext.Provider>


### PR DESCRIPTION
In order to make tldraw.com files open without any animated loading state, this PR removes the editor load animations from the dotcom tla app: the fade-in shroud and the loading screens that show a spinner. The editor chrome and placeholder already appear instantly, so these animations only flashed a spinner and faded content in before the real document hard-cut in. This is scoped entirely to `apps/dotcom/client/src/tla/` — the tldraw SDK (`packages/editor`, `packages/tldraw`) is unchanged, so the default `LoadingScreen`, `DefaultSpinner`, and `.tl-loading` fade are untouched for SDK consumers.

What changed:

- Set `LoadingScreen: null` on the shared tla `components` object, so the file editor, local editor, and root-providers editor mount with no SDK spinner or fade. The placeholder editor's now-redundant override was folded away.
- The auth gate in `useUser` no longer renders a `<LoadingScreen>` with a `<DefaultSpinner>`; it renders a blank editor surface while auth loads.
- Removed the fade-in transitions from the `useIsReady` shroud (page and file-content opacity fades) and deleted a dead `.spinner` fade rule. Content now hard-cuts in once the editor is ready.

Relates to #9249

### Change type

- [x] `improvement`

### Test plan

1. Open a file on tldraw.com (and a local file at `/`): the editor and its content appear with no fade-in and no spinner.
2. While signed-out/auth is loading, confirm no spinner shows — just a blank editor surface.
3. Confirm the SDK examples app still shows the default loading spinner and fade (SDK behavior unchanged).

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +10 / -37  |
