### PR TITLE
feat(dotcom): enroll new users in groups frontend by default

### DIFF
--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -146,7 +146,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								exportPadding: true,
 								createdAt: now,
 								updatedAt: now,
-								flags: 'groups_backend',
+								flags: 'groups_backend,groups_frontend',
 							})
 							.execute()
 						await tx

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -287,7 +287,7 @@ export function createMutators(userId: string) {
 		init: async (tx: Tx, { user, time }: { user: TlaUser; time: number }) => {
 			assert(user.id === userId, ZErrorCode.forbidden)
 			time = ensureSensibleTimestamp(time)
-			await tx.mutate.user.insert({ ...user, flags: 'groups_backend' })
+			await tx.mutate.user.insert({ ...user, flags: 'groups_backend,groups_frontend' })
 			await tx.mutate.group.insert({
 				id: userId,
 				name: user.name,


### PR DESCRIPTION
In order to enable the groups UI for everyone, this PR makes new users enrolled in the groups frontend by default. New users were already created with the `groups_backend` flag; they now also get `groups_frontend`, so the groups UI (gated by `useHasFlag('groups_frontend')`) is on for every newly created user.

This only affects newly created users — existing users keep their stored flags.

### Change type

- [x] `feature`

### Test plan

1. Create a new user account.
2. Confirm the groups UI (workspace switcher / groups in the sidebar) is available without manual admin enrollment.

### Release notes

- Enroll new users in the groups frontend by default.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +1 / -1    |
| Core code | +1 / -1  |
