### PR TITLE
perf(tldraw): dedupe redundant icon preloads on editor mount

### DIFF
--- a/packages/tldraw/src/lib/ui/context/asset-urls.tsx
+++ b/packages/tldraw/src/lib/ui/context/asset-urls.tsx
@@ -21,16 +21,17 @@ export interface AssetUrlsProviderProps {
  */
 export function AssetUrlsProvider({ assetUrls, children }: AssetUrlsProviderProps) {
 	useEffect(() => {
-		for (const src of Object.values(assetUrls.icons)) {
+		// Many icon URLs point at the same sprite sheet and differ only by their
+		// `#fragment` identifier (e.g. `0_merged.svg#tool-arrow`). The fragment
+		// doesn't change the underlying resource, so preload each unique resource
+		// once rather than creating hundreds of redundant Image decodes.
+		const preloaded = new Set<string>()
+		for (const src of [...Object.values(assetUrls.icons), ...Object.values(assetUrls.embedIcons)]) {
 			if (!src) continue
 
-			const image = Image()
-			image.crossOrigin = 'anonymous'
-			image.src = src
-			image.decode().catch(noop)
-		}
-		for (const src of Object.values(assetUrls.embedIcons)) {
-			if (!src) continue
+			const resource = src.split('#')[0]
+			if (preloaded.has(resource)) continue
+			preloaded.add(resource)
 
 			const image = Image()
 			image.crossOrigin = 'anonymous'


### PR DESCRIPTION
In order to avoid hundreds of redundant `Image.decode()` calls when the editor mounts, this PR deduplicates icon preloads by their underlying resource. The `AssetUrlsProvider` effect preloads every icon URL, but all ~324 icon URLs point at the same SVG sprite sheet and differ only by their `#fragment` (e.g. `0_merged.svg#tool-arrow`). The fragment doesn't change the resource, so the effect was creating one `Image` and `decode()` per icon for what is really a single file. This was visible as repeated, slow work in `asset-urls.tsx` during editor load. The effect now strips the fragment and tracks preloaded resources in a `Set`, so each unique resource is decoded once. Embed icons (separate files) are unaffected and still preload individually.

### Change type

- [x] `improvement`

### Test plan

1. Load the editor and confirm icons render correctly (toolbar, menus, style panel).
2. In the Performance panel, record editor load and confirm the icon preload work in `asset-urls.tsx` no longer repeats per-icon.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Reduce redundant icon preloading work on editor mount by deduplicating sprite-sheet preloads.