### PR TITLE
perf(utils): inline fractional indexing and speed up index key generation

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -43,7 +43,6 @@
 		"lint": "yarn run -T tsx ../../internal/scripts/lint.ts"
 	},
 	"dependencies": {
-		"jittered-fractional-indexing": "^1.0.0",
 		"lodash.isequal": "^4.5.0",
 		"lodash.isequalwith": "^4.4.0",
 		"lodash.throttle": "^4.1.1",

--- a/packages/utils/src/lib/fractionalIndexing.test.ts
+++ b/packages/utils/src/lib/fractionalIndexing.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest'
+import {
+	generateNJitteredKeysBetween,
+	generateNKeysBetween,
+	validateOrderKey,
+} from './fractionalIndexing'
+
+// Single-key helper: the non-jittered generator with n=1.
+const keyBetween = (a: string | null, b: string | null) => generateNKeysBetween(a, b, 1)[0]
+
+describe('fractionalIndexing', () => {
+	// Golden vectors from the upstream `fractional-indexing` README. These pin the
+	// exact base-62 output, proving the vendored/specialized core stays
+	// byte-for-byte compatible with the original library.
+	describe('generateKeyBetween (golden vectors)', () => {
+		it.each([
+			[null, null, 'a0'],
+			['a0', null, 'a1'],
+			['a1', null, 'a2'],
+			[null, 'a0', 'Zz'],
+			['a0', 'a1', 'a0V'],
+			['a1', 'a2', 'a1V'],
+		])('between %o and %o is %o', (a, b, expected) => {
+			expect(keyBetween(a, b)).toBe(expected)
+		})
+	})
+
+	describe('generateNKeysBetween (golden vectors)', () => {
+		it.each<[string | null, string | null, number, string[]]>([
+			[null, null, 2, ['a0', 'a1']],
+			['a1', null, 2, ['a2', 'a3']],
+			[null, 'a0', 2, ['Zy', 'Zz']],
+			['a0', 'a1', 2, ['a0G', 'a0V']],
+			[null, null, 5, ['a0', 'a1', 'a2', 'a3', 'a4']],
+		])('%o keys between %o and %o', (a, b, n, expected) => {
+			expect(generateNKeysBetween(a, b, n)).toEqual(expected)
+		})
+
+		it('returns an empty array for n = 0', () => {
+			expect(generateNKeysBetween(null, null, 0)).toEqual([])
+		})
+	})
+
+	describe('errors', () => {
+		it('throws when a >= b', () => {
+			expect(() => keyBetween('a1', 'a0')).toThrow()
+			expect(() => keyBetween('a0', 'a0')).toThrow()
+		})
+
+		it('throws on invalid input keys', () => {
+			expect(() => keyBetween('a00', null)).toThrow() // trailing zero
+			expect(() => keyBetween('', null)).toThrow()
+			expect(() => keyBetween('foo', null)).toThrow()
+		})
+	})
+
+	describe('validateOrderKey', () => {
+		it.each(['a0', 'a1', 'a0V', 'Zz', 'a0G', 'b127'])('accepts %s', (key) => {
+			expect(() => validateOrderKey(key)).not.toThrow()
+		})
+
+		it.each([
+			'', // empty
+			'a', // integer part too short
+			'1', // invalid head
+			'a00', // trailing zero in fraction
+			'foo', // invalid head
+			'A' + '0'.repeat(26), // the reserved smallest-integer key
+		])('rejects %o', (key) => {
+			expect(() => validateOrderKey(key)).toThrow()
+		})
+	})
+
+	// Invariant tests: independent of exact output, these catch ordering or
+	// digit-mapping regressions across the whole alphabet (e.g. a bad charCode
+	// offset in digitIndex, or carry/borrow bugs when integers roll over).
+	describe('invariants', () => {
+		it('generateNKeysBetween yields strictly increasing, valid, in-bounds keys', () => {
+			const keys = generateNKeysBetween('a0', 'a1', 200)
+			expect(keys).toHaveLength(200)
+			let prev = 'a0'
+			for (const key of keys) {
+				expect(() => validateOrderKey(key)).not.toThrow()
+				expect(key > prev).toBe(true)
+				expect(key < 'a1').toBe(true)
+				prev = key
+			}
+		})
+
+		it('stays ordered while repeatedly inserting after the last key (integer carries)', () => {
+			// 200 sequential keys force the integer part to roll over many digits,
+			// exercising incrementInteger across the full base-62 alphabet.
+			let key = keyBetween(null, null)
+			let prev = ''
+			for (let i = 0; i < 200; i++) {
+				expect(() => validateOrderKey(key)).not.toThrow()
+				expect(key > prev).toBe(true)
+				prev = key
+				key = keyBetween(key, null)
+			}
+		})
+
+		it('stays ordered while repeatedly inserting before the first key (integer borrows)', () => {
+			let key = keyBetween(null, null)
+			let next = 'zzzzz'
+			for (let i = 0; i < 200; i++) {
+				expect(() => validateOrderKey(key)).not.toThrow()
+				expect(key < next).toBe(true)
+				next = key
+				key = keyBetween(null, key)
+			}
+		})
+
+		it('generateNJitteredKeysBetween yields ordered, valid, in-bounds, distinct keys', () => {
+			const keys = generateNJitteredKeysBetween('a0', 'a5', 100)
+			expect(keys).toHaveLength(100)
+			expect(new Set(keys).size).toBe(100)
+			let prev = 'a0'
+			for (const key of keys) {
+				expect(() => validateOrderKey(key)).not.toThrow()
+				expect(key > prev).toBe(true)
+				expect(key < 'a5').toBe(true)
+				prev = key
+			}
+		})
+
+		it('jittered keys land strictly between their neighbours', () => {
+			const a = keyBetween(null, null)
+			const b = keyBetween(a, null)
+			for (let i = 0; i < 50; i++) {
+				const mid = generateNJitteredKeysBetween(a, b, 1)[0]
+				expect(mid > a).toBe(true)
+				expect(mid < b).toBe(true)
+				expect(() => validateOrderKey(mid)).not.toThrow()
+			}
+		})
+	})
+})

--- a/packages/utils/src/lib/fractionalIndexing.ts
+++ b/packages/utils/src/lib/fractionalIndexing.ts
@@ -1,0 +1,275 @@
+// Fractional indexing, specialized to tldraw's needs.
+//
+// This is a vendored and trimmed version of the `fractional-indexing` (by
+// arv@rocicorp.dev) and `jittered-fractional-indexing` (by
+// github@nathanhleung.com) packages, both released under CC0-1.0 (public
+// domain). See https://observablehq.com/@dgreensp/implementing-fractional-indexing
+// for the original algorithm.
+//
+// We only ever use the default base-62 alphabet, so the `digits` parameter has
+// been specialized away. This lets us hoist the per-call allocations that the
+// upstream `validateOrderKey` made (notably `digits[0].repeat(26)`) into module
+// constants, and skip redundant re-validation inside the jitter loop, which are
+// both on hot paths (every index generation and every IndexKey validation).
+
+// Digits must be in ascending character-code order.
+const DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+const ZERO = DIGITS[0] // '0'
+const LARGEST_DIGIT = DIGITS[DIGITS.length - 1] // 'z'
+// The reserved "smallest integer" key, which has no valid predecessor.
+const SMALLEST_INTEGER = 'A' + ZERO.repeat(26)
+// Number of random bisections used to spread concurrently-generated keys apart,
+// reducing the chance of collisions when multiple clients insert into the same
+// gap at once. Each bit costs one extra key generation and ~0.17 characters of
+// key length, so this trades collision resistance against compute and key size.
+// 16 keeps collisions below ~0.1% even for ~10 simultaneous same-position
+// inserts, which is ample headroom for real multiplayer use.
+const JITTER_BITS = 16
+
+function getIntegerLength(head: string): number {
+	if (head >= 'a' && head <= 'z') {
+		return head.charCodeAt(0) - 'a'.charCodeAt(0) + 2
+	} else if (head >= 'A' && head <= 'Z') {
+		return 'Z'.charCodeAt(0) - head.charCodeAt(0) + 2
+	}
+	throw new Error('invalid order key head: ' + head)
+}
+
+function getIntegerPart(key: string): string {
+	const integerPartLength = getIntegerLength(key[0])
+	if (integerPartLength > key.length) {
+		throw new Error('invalid order key: ' + key)
+	}
+	return key.slice(0, integerPartLength)
+}
+
+// Map a base-62 digit to its value. Faster than DIGITS.indexOf() (which scans
+// the alphabet) on the hot key-generation path. DIGITS is in char-code order:
+// '0'-'9' -> 0-9, 'A'-'Z' -> 10-35, 'a'-'z' -> 36-61.
+function digitIndex(char: string): number {
+	const code = char.charCodeAt(0)
+	if (code <= 57) return code - 48
+	if (code <= 90) return code - 55
+	return code - 61
+}
+
+/**
+ * Throws if `key` is not a canonical order key. Allocation-free in the common
+ * case: no `repeat`/`slice` per call.
+ */
+export function validateOrderKey(key: string): void {
+	if (key === SMALLEST_INTEGER) {
+		throw new Error('invalid order key: ' + key)
+	}
+	// getIntegerPart throws if the first character is bad or the key is too short.
+	const i = getIntegerPart(key)
+	// The fractional part (everything after the integer part) must not end in the
+	// smallest digit, as a trailing zero is a non-canonical representation.
+	if (key.length > i.length && key[key.length - 1] === ZERO) {
+		throw new Error('invalid order key: ' + key)
+	}
+}
+
+// `a` may be empty string, `b` is null or non-empty string.
+// `a < b` lexicographically if `b` is non-null. No trailing zeros allowed.
+function midpoint(a: string, b: string | null): string {
+	if (b != null && a >= b) {
+		throw new Error(a + ' >= ' + b)
+	}
+	if (a.slice(-1) === ZERO || (b && b.slice(-1) === ZERO)) {
+		throw new Error('trailing zero')
+	}
+	if (b) {
+		// Remove the longest common prefix, padding `a` with zeros as we go. We
+		// don't need to pad `b`, because it can't end before `a` while traversing
+		// the common prefix.
+		let n = 0
+		while ((a[n] || ZERO) === b[n]) {
+			n++
+		}
+		if (n > 0) {
+			return b.slice(0, n) + midpoint(a.slice(n), b.slice(n))
+		}
+	}
+	// First digits (or lack of digit) are different.
+	const digitA = a ? digitIndex(a[0]) : 0
+	const digitB = b != null ? digitIndex(b[0]) : DIGITS.length
+	if (digitB - digitA > 1) {
+		const midDigit = Math.round(0.5 * (digitA + digitB))
+		return DIGITS[midDigit]
+	}
+	// First digits are consecutive.
+	if (b && b.length > 1) {
+		return b.slice(0, 1)
+	}
+	// `b` is null or has length 1 (a single digit). The first digit of `a` is the
+	// previous digit to `b`, or the largest digit if `b` is null.
+	return DIGITS[digitA] + midpoint(a.slice(1), null)
+}
+
+// May return null, as there is a largest integer.
+function incrementInteger(x: string): string | null {
+	const [head, ...digs] = x.split('')
+	let carry = true
+	for (let i = digs.length - 1; carry && i >= 0; i--) {
+		const d = digitIndex(digs[i]) + 1
+		if (d === DIGITS.length) {
+			digs[i] = ZERO
+		} else {
+			digs[i] = DIGITS[d]
+			carry = false
+		}
+	}
+	if (carry) {
+		if (head === 'Z') return 'a' + ZERO
+		if (head === 'z') return null
+		const h = String.fromCharCode(head.charCodeAt(0) + 1)
+		if (h > 'a') {
+			digs.push(ZERO)
+		} else {
+			digs.pop()
+		}
+		return h + digs.join('')
+	}
+	return head + digs.join('')
+}
+
+// May return null, as there is a smallest integer.
+function decrementInteger(x: string): string | null {
+	const [head, ...digs] = x.split('')
+	let borrow = true
+	for (let i = digs.length - 1; borrow && i >= 0; i--) {
+		const d = digitIndex(digs[i]) - 1
+		if (d === -1) {
+			digs[i] = LARGEST_DIGIT
+		} else {
+			digs[i] = DIGITS[d]
+			borrow = false
+		}
+	}
+	if (borrow) {
+		if (head === 'a') return 'Z' + LARGEST_DIGIT
+		if (head === 'A') return null
+		const h = String.fromCharCode(head.charCodeAt(0) - 1)
+		if (h < 'Z') {
+			digs.push(LARGEST_DIGIT)
+		} else {
+			digs.pop()
+		}
+		return h + digs.join('')
+	}
+	return head + digs.join('')
+}
+
+// Generate a key strictly between `a` and `b`, without validating the inputs.
+// `a`/`b` are order keys or null (START/END). `a < b` if both are non-null.
+function keyBetweenUnchecked(a: string | null, b: string | null): string {
+	if (a != null && b != null && a >= b) {
+		throw new Error(a + ' >= ' + b)
+	}
+	if (a == null) {
+		if (b == null) return 'a' + ZERO
+		const ib = getIntegerPart(b)
+		const fb = b.slice(ib.length)
+		if (ib === SMALLEST_INTEGER) {
+			return ib + midpoint('', fb)
+		}
+		if (ib < b) return ib
+		const res = decrementInteger(ib)
+		if (res == null) throw new Error('cannot decrement any more')
+		return res
+	}
+	if (b == null) {
+		const ia = getIntegerPart(a)
+		const fa = a.slice(ia.length)
+		const i = incrementInteger(ia)
+		return i == null ? ia + midpoint(fa, null) : i
+	}
+	const ia = getIntegerPart(a)
+	const fa = a.slice(ia.length)
+	const ib = getIntegerPart(b)
+	const fb = b.slice(ib.length)
+	if (ia === ib) {
+		return ia + midpoint(fa, fb)
+	}
+	const i = incrementInteger(ia)
+	if (i == null) throw new Error('cannot increment any more')
+	if (i < b) return i
+	return ia + midpoint(fa, null)
+}
+
+// Generate `n` keys between `a` and `b`, without validating the inputs.
+// Intermediate keys are valid by construction, so they're never re-validated.
+function nKeysBetweenUnchecked(a: string | null, b: string | null, n: number): string[] {
+	if (n === 0) return []
+	if (n === 1) return [keyBetweenUnchecked(a, b)]
+	if (b == null) {
+		let c = keyBetweenUnchecked(a, b)
+		const result = [c]
+		for (let i = 0; i < n - 1; i++) {
+			c = keyBetweenUnchecked(c, b)
+			result.push(c)
+		}
+		return result
+	}
+	if (a == null) {
+		let c = keyBetweenUnchecked(a, b)
+		const result = [c]
+		for (let i = 0; i < n - 1; i++) {
+			c = keyBetweenUnchecked(a, c)
+			result.push(c)
+		}
+		result.reverse()
+		return result
+	}
+	const mid = Math.floor(n / 2)
+	const c = keyBetweenUnchecked(a, b)
+	return [...nKeysBetweenUnchecked(a, c, mid), c, ...nKeysBetweenUnchecked(c, b, n - mid - 1)]
+}
+
+// Bisect `[low, high]` JITTER_BITS times, following a random walk, so that keys
+// generated concurrently land in different sub-ranges. `low`/`high` must already
+// be valid (or null); the intermediate midpoints are valid by construction.
+function jitterBetween(low: string | null, high: string | null): string {
+	let mid = keyBetweenUnchecked(low, high)
+	for (let i = 0; i < JITTER_BITS; i++) {
+		if (Math.random() < 0.5) {
+			low = mid
+		} else {
+			high = mid
+		}
+		mid = keyBetweenUnchecked(low, high)
+	}
+	return mid
+}
+
+/**
+ * Generate `n` jittered keys evenly spaced between `a` and `b`. Inputs are
+ * validated once; everything downstream is generated, hence trusted.
+ */
+export function generateNJitteredKeysBetween(
+	a: string | null,
+	b: string | null,
+	n: number
+): string[] {
+	if (n === 0) return []
+	if (a != null) validateOrderKey(a)
+	if (b != null) validateOrderKey(b)
+	const keys = nKeysBetweenUnchecked(a, b, n + 1)
+	const result = new Array<string>(n)
+	for (let i = 0; i < n; i++) {
+		result[i] = jitterBetween(keys[i], keys[i + 1])
+	}
+	return result
+}
+
+/**
+ * Generate `n` keys evenly spaced between `a` and `b`, without jitter. Used in
+ * tests for deterministic output.
+ */
+export function generateNKeysBetween(a: string | null, b: string | null, n: number): string[] {
+	if (n === 0) return []
+	if (a != null) validateOrderKey(a)
+	if (b != null) validateOrderKey(b)
+	return nKeysBetweenUnchecked(a, b, n)
+}

--- a/packages/utils/src/lib/reordering.ts
+++ b/packages/utils/src/lib/reordering.ts
@@ -1,11 +1,11 @@
-import { generateKeyBetween, generateNKeysBetween } from 'jittered-fractional-indexing'
-
-const generateNKeysBetweenWithNoJitter = (a: string | null, b: string | null, n: number) => {
-	return generateNKeysBetween(a, b, n, { jitterBits: 0 })
-}
+import {
+	generateNJitteredKeysBetween,
+	generateNKeysBetween,
+	validateOrderKey,
+} from './fractionalIndexing'
 
 const generateKeysFn =
-	process.env.NODE_ENV === 'test' ? generateNKeysBetweenWithNoJitter : generateNKeysBetween
+	process.env.NODE_ENV === 'test' ? generateNKeysBetween : generateNJitteredKeysBetween
 
 /**
  * A string made up of an integer part followed by a fraction part. The fraction point consists of
@@ -30,7 +30,7 @@ export const ZERO_INDEX_KEY = 'a0' as IndexKey
  */
 export function validateIndexKey(index: string): asserts index is IndexKey {
 	try {
-		generateKeyBetween(index, null)
+		validateOrderKey(index)
 	} catch {
 		throw new Error('invalid index: ' + index)
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12220,7 +12220,6 @@ __metadata:
     "@types/lodash.isequalwith": "npm:^4.4.9"
     "@types/lodash.throttle": "npm:^4.1.9"
     "@types/lodash.uniq": "npm:^4.5.9"
-    jittered-fractional-indexing: "npm:^1.0.0"
     lazyrepo: "npm:0.0.0-alpha.27"
     lodash.isequal: "npm:^4.5.0"
     lodash.isequalwith: "npm:^4.4.0"
@@ -20701,13 +20700,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fractional-indexing@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "fractional-indexing@npm:3.2.0"
-  checksum: 10/9c35f80cd3c9c40d22ae245f23d6fa4da77b0a0296b35a7af46c06b7f7cd57ea5db676df88cdce9e268424622c7910b1550052de2819d23b44c2005958e1ac03
-  languageName: node
-  linkType: hard
-
 "framer-motion@npm:^11.18.2":
   version: 11.18.2
   resolution: "framer-motion@npm:11.18.2"
@@ -22876,15 +22868,6 @@ __metadata:
   bin:
     jiti: lib/jiti-cli.mjs
   checksum: 10/6d75a8dbd61dbee031aa0937fabb748ff8ddf370b971958cc704f5cf26b4c5bdc9dcd0563059b2627a2bd41d946fa0bc64f912fdc8981ca7945a9d63c74ad0f9
-  languageName: node
-  linkType: hard
-
-"jittered-fractional-indexing@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "jittered-fractional-indexing@npm:1.0.0"
-  dependencies:
-    fractional-indexing: "npm:^3.2.0"
-  checksum: 10/fa479654ec02629638cf9284e459682d3593ced2d4f7791636465d0546a16d1a57cac4d98754d7ac9244d4c98c7340ccaea4a546d9db71d670e39738ec481b63
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
🙇‍♂️ The fractional indexing libraries we were using were doing silly things. I was never really happy that we moved to an external lib for this, it's a small thing and we benefit from just using the parts that we need and improving those.

**What's changed?**

This PR vendors a trimmed, base-62-specialized version of `fractional-indexing` and `jittered-fractional-indexing` (both CC0-1.0 public domain) into `packages/utils`, replacing the `jittered-fractional-indexing` dependency. tldraw only ever uses the default base-62 alphabet, so specializing away the `digits` parameter lets us hoist per-call allocations and remove redundant work on hot paths:

- `validateIndexKey` (run on every IndexKey validation) now validates directly instead of generating and discarding a jittered key, which previously ran the full key generator ~31 times per call.
- The jitter loop validates its two inputs once instead of re-validating both endpoints on every bisection.
- `validateOrderKey` is allocation-free (no per-call `repeat`/`slice`), and digit lookups use char-code arithmetic instead of scanning the 62-character alphabet.
- Jitter is reduced from 30 to 16 bits, which shortens every generated key by ~3 characters and roughly halves per-key generation work.

**What prompted the change?**

Index keys are generated and validated constantly — on every shape insert, reorder, and record validation — so this is a genuine hot path. The dependency's `validateOrderKey` allocated a fresh 26-character string on every call, and `validateIndexKey` was generating and throwing away a fully jittered key just to check validity. Inlining the library lets us cut that waste and drop a third-party dependency at the same time.

**What do I need to know?**

The public API of `@tldraw/utils` is unchanged (`getIndices*`, `getIndexBetween`, `validateIndexKey`, etc. keep their signatures); the vendored core is internal. Reducing jitter from 30 to 16 bits keeps collision probability below ~0.1% even for ~10 simultaneous inserts into the same gap, and existing keys stay valid — only newly generated keys are affected.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests

The existing reordering and validation suites pass unchanged. A new `fractionalIndexing.test.ts` pins byte-for-byte compatibility against the upstream library's published vectors and adds ordering/validity invariants across the full base-62 alphabet (integer carry/borrow, jittered and non-jittered generators).

### Release notes

- Removed the `jittered-fractional-indexing` dependency and sped up index key generation and validation. Newly generated index keys are slightly shorter.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +282 / -7  |
| Tests          | +138 / -0  |
| Config/tooling | +0 / -18   |