### PR TITLE
fix(sync): drop malformed websocket messages

### DIFF
--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -410,6 +410,25 @@ describe('ClientWebSocketAdapter', () => {
 			expect(onMessage).toHaveBeenCalledWith({ type: 'message', data: 'hello' })
 		})
 
+		it('[CW7] drops malformed JSON messages without closing the socket', async () => {
+			const warnOnceMock = vi.mocked(warnOnce)
+			const onMessage = vi.fn()
+			adapter.onReceiveMessage(onMessage)
+
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			warnOnceMock.mockClear()
+
+			connectedServerSocket.send('{ "type": "message",')
+			connectedServerSocket.send('{ "type": "message", "data": "hello" }')
+
+			await waitFor(() => onMessage.mock.calls.length === 1)
+			expect(onMessage).toHaveBeenCalledWith({ type: 'message', data: 'hello' })
+			expect(adapter.connectionStatus).toBe('online')
+			expect(warnOnceMock).toHaveBeenCalledWith(
+				'Received malformed WebSocket message. Dropping message.'
+			)
+		})
+
 		it('[CW7] stops delivering messages after unsubscribe', async () => {
 			const onMessage = vi.fn()
 			const unsubscribe = adapter.onReceiveMessage(onMessage)

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -212,7 +212,13 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 				this._ws === ws,
 				"sockets must only be orphaned when they are CLOSING or CLOSED, so they can't receive messages"
 			)
-			const parsed = JSON.parse(ev.data.toString())
+			let parsed: TLSocketServerSentEvent<TLRecord>
+			try {
+				parsed = JSON.parse(ev.data.toString())
+			} catch {
+				warnOnce('Received malformed WebSocket message. Dropping message.')
+				return
+			}
 			this.messageListeners.forEach((cb) => cb(parsed))
 		}
 


### PR DESCRIPTION
In order to prevent malformed WebSocket frames from taking down sync clients, this PR catches JSON parse failures in `ClientWebSocketAdapter` and drops the bad message. Valid later messages continue to be delivered normally. Closes #9119.

### Change type

- [x] `bugfix`

### Test plan

1. Send malformed JSON to a `ClientWebSocketAdapter` socket.
2. Confirm the adapter stays online and does not notify message listeners.
3. Send a valid JSON message afterwards and confirm it is delivered.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix sync clients crashing when a malformed WebSocket message is received.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -1    |
| Tests     | +19 / -0   |
