### PR TITLE
fix(dotcom): constrain sidebar logo hit area

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceLink.tsx
@@ -1,10 +1,19 @@
+import { ExternalLink } from '../../ExternalLink/ExternalLink'
 import { TlaLogo } from '../../TlaLogo/TlaLogo'
 import styles from '../sidebar.module.css'
 
 export function TlaSidebarWorkspaceLink() {
 	return (
-		<div className={styles.sidebarWorkspaceButton} data-testid="tla-sidebar-workspace-link">
-			<TlaLogo data-testid="tla-sidebar-logo-icon" />
+		<div className={styles.sidebarWorkspaceButton}>
+			<ExternalLink
+				to="https://tldraw.dev?utm_source=dotcom&utm_medium=organic&utm_campaign=top-left-logo"
+				eventName="sidebar-logo-clicked"
+				aria-label="tldraw.dev"
+				className={styles.sidebarWorkspaceLogoLink}
+				data-testid="tla-sidebar-workspace-link"
+			>
+				<TlaLogo data-testid="tla-sidebar-logo-icon" />
+			</ExternalLink>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -246,6 +246,20 @@
 	padding-bottom: 1px;
 }
 
+.sidebarWorkspaceLogoLink {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: center;
+	color: inherit;
+	text-decoration: none;
+}
+
+.sidebarWorkspaceLogoLink:focus-visible {
+	border-radius: var(--tla-radius-1);
+	outline: 2px solid var(--tl-color-focus);
+	outline-offset: 4px;
+}
+
 /* In the workspaces layout the logo is 16px tall, with its mark centered on
    the same vertical axis as the action-row icons below. */
 .sidebar[data-workspaces='true'] .sidebarWorkspaceButton {


### PR DESCRIPTION
In order to keep the tldraw.com sidebar logo hit area aligned with the visible logo, this PR moves the external link onto the logo-sized child while leaving the top-row spacer in place. The create-file button alignment is preserved, but the logo link no longer stretches across the row. Closes #9277.

### Change type

- [x] `bugfix`

### Test plan

1. Open the tldraw.com sidebar with workspaces enabled.
2. Hover or focus the logo area.
3. Confirm only the logo-sized area is clickable/focusable and the create-file button remains aligned.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the tldraw.com sidebar logo link hit area extending past the logo.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +25 / -2   |
