### PR TITLE
perf(editor): avoid repeated useTransform layout effects

### DIFF
--- a/packages/editor/src/lib/hooks/useTransform.ts
+++ b/packages/editor/src/lib/hooks/useTransform.ts
@@ -10,6 +10,9 @@ export function useTransform(
 	rotate?: number,
 	additionalOffset?: VecLike
 ) {
+	const additionalOffsetX = additionalOffset?.x
+	const additionalOffsetY = additionalOffset?.y
+
 	useLayoutEffect(() => {
 		const elm = ref.current
 		if (!elm) return
@@ -22,9 +25,9 @@ export function useTransform(
 		if (rotate !== undefined) {
 			trans += ` rotate(${rotate}rad)`
 		}
-		if (additionalOffset) {
-			trans += ` translate(${additionalOffset.x}px, ${additionalOffset.y}px)`
+		if (additionalOffsetX !== undefined && additionalOffsetY !== undefined) {
+			trans += ` translate(${additionalOffsetX}px, ${additionalOffsetY}px)`
 		}
 		elm.style.transform = trans
-	})
+	}, [additionalOffsetX, additionalOffsetY, ref, rotate, scale, x, y])
 }


### PR DESCRIPTION
In order to avoid applying DOM transforms after every render, this PR adds a dependency array to `useTransform` based on the actual transform values. The optional offset is split into scalar dependencies so fresh offset object literals do not force the effect to rerun unnecessarily. Closes #8234.

### Change type

- [x] `improvement`

### Test plan

1. Render a component using `useTransform`.
2. Confirm the transform style is still applied from `x`, `y`, `scale`, `rotate`, and `additionalOffset`.
3. Confirm the effect only reruns when those values change.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Improve `useTransform` so it only applies styles when transform values change.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -3    |
