### PR TITLE
security(deps): bump vite, drop lodash.pick, dedupe lockfile

### DIFF
--- a/apps/analytics/package.json
+++ b/apps/analytics/package.json
@@ -20,7 +20,7 @@
 		"@cloudflare/workers-types": "^4.20260302.0",
 		"@types/js-cookie": "^3.0.6",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"vitest": "^4.1.7",
 		"wrangler": "^4.75.0"
 	}

--- a/apps/dotcom/client/package.json
+++ b/apps/dotcom/client/package.json
@@ -52,7 +52,6 @@
 		"classnames": "^2.5.1",
 		"idb": "^7.1.1",
 		"intl-messageformat": "^11.1.2",
-		"lodash.pick": "^4.4.0",
 		"posthog-js": "^1.281.0",
 		"qrcode": "^1.5.4",
 		"radix-ui": "^1.4.2",
@@ -72,7 +71,6 @@
 		"@playwright/test": "^1.58.2",
 		"@sentry/cli": "^2.41.1",
 		"@tldraw/validate": "workspace:*",
-		"@types/lodash.pick": "^4.4.9",
 		"@types/md5": "^2.3.5",
 		"@types/node": "^22.15.31",
 		"@types/qrcode": "^1.5.5",
@@ -88,7 +86,7 @@
 		"lazyrepo": "0.0.0-alpha.27",
 		"pg": "^8.13.1",
 		"regexgen": "^1.3.0",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"vitest": "^4.1.7",
 		"ws": "^8.18.0"
 	}

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -41,7 +41,6 @@ import {
 	throttle,
 	uniqueId,
 } from '@tldraw/utils'
-import pick from 'lodash.pick'
 import { useNavigate } from 'react-router-dom'
 import {
 	Atom,
@@ -497,7 +496,9 @@ export class TldrawApp {
 		userPreferences: computed('user prefs', () => {
 			const user = this.getUser()
 			return {
-				...(pick(user, UserPreferencesKeys) as TLUserPreferences),
+				...(Object.fromEntries(
+					UserPreferencesKeys.map((key) => [key, user[key]])
+				) as unknown as TLUserPreferences),
 				id: this.userId,
 			}
 		}),

--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -73,7 +73,7 @@
 		"tldraw": "workspace:*",
 		"topojson-client": "^3.1.0",
 		"us-atlas": "^3.0.1",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	},
 	"devDependencies": {
 		"@types/d3-geo": "^3.1.0",

--- a/apps/mcp-app/package.json
+++ b/apps/mcp-app/package.json
@@ -35,7 +35,7 @@
 		"tldraw": "workspace:*",
 		"tsx": "^4.19.2",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"vite-plugin-singlefile": "^2.3.2",
 		"wrangler": "^4.75.0"
 	}

--- a/templates/agent/package.json
+++ b/templates/agent/package.json
@@ -51,6 +51,6 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	}
 }

--- a/templates/branching-chat/package.json
+++ b/templates/branching-chat/package.json
@@ -46,6 +46,6 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	}
 }

--- a/templates/image-pipeline/package.json
+++ b/templates/image-pipeline/package.json
@@ -41,7 +41,7 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"wrangler": "^4.75.0"
 	}
 }

--- a/templates/shader/package.json
+++ b/templates/shader/package.json
@@ -37,6 +37,6 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	}
 }

--- a/templates/simple-server-example/package.json
+++ b/templates/simple-server-example/package.json
@@ -43,7 +43,7 @@
 		"react-router-dom": "^6.28.2",
 		"tldraw": "workspace:*",
 		"unfurl.js": "^6.4.0",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"ws": "^8.18.0"
 	}
 }

--- a/templates/socketio-server-example/package.json
+++ b/templates/socketio-server-example/package.json
@@ -42,6 +42,6 @@
 		"socket.io-client": "^4.8.1",
 		"tldraw": "workspace:*",
 		"unfurl.js": "^6.4.0",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	}
 }

--- a/templates/sync-cloudflare/package.json
+++ b/templates/sync-cloudflare/package.json
@@ -45,7 +45,7 @@
 		"@vitejs/plugin-react": "^6.0.1",
 		"concurrently": "^9.1.2",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"wrangler": "^4.75.0"
 	}
 }

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -36,6 +36,6 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	}
 }

--- a/templates/vue/package.json
+++ b/templates/vue/package.json
@@ -33,7 +33,7 @@
 		"@vitejs/plugin-react": "^6.0.1",
 		"@vitejs/plugin-vue": "^6.0.5",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1",
+		"vite": "^8.0.16",
 		"vite-plugin-vue-devtools": "^8.1.0",
 		"vue-tsc": "^3.0.1"
 	}

--- a/templates/workflow/package.json
+++ b/templates/workflow/package.json
@@ -39,6 +39,6 @@
 		"@types/react-dom": "^19.2.3",
 		"@vitejs/plugin-react": "^6.0.1",
 		"typescript": "^5.8.3",
-		"vite": "^8.0.1"
+		"vite": "^8.0.16"
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7116,10 +7116,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.132.0":
-  version: 0.132.0
-  resolution: "@oxc-project/types@npm:0.132.0"
-  checksum: 10/e0694a3c24746006ad774a1cab34efac3ccad5b519234063bcde17e9afe3475680749357e9f90164a222326414cb9510da1b8da350edc0cd35612fd05147c218
+"@oxc-project/types@npm:=0.133.0":
+  version: 0.133.0
+  resolution: "@oxc-project/types@npm:0.133.0"
+  checksum: 10/de44f653a9e0c0267309122f1f184120c6869af4382218a6bf4a320c5150743eb00b5e8641b04917666281995ed0fe6381561922a48a28082a75bb122acf3ac6
   languageName: node
   linkType: hard
 
@@ -9488,9 +9488,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.2"
+"@rolldown/binding-android-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -9502,9 +9502,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.2"
+"@rolldown/binding-darwin-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -9516,9 +9516,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.2"
+"@rolldown/binding-darwin-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -9530,9 +9530,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.2"
+"@rolldown/binding-freebsd-x64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -9544,9 +9544,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.2"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -9558,9 +9558,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.2"
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -9572,23 +9572,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.2"
+"@rolldown/binding-linux-arm64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.2"
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.2"
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -9600,9 +9600,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.2"
+"@rolldown/binding-linux-x64-gnu@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -9614,9 +9614,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.2"
+"@rolldown/binding-linux-x64-musl@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -9628,9 +9628,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.2"
+"@rolldown/binding-openharmony-arm64@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -9644,9 +9644,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.2"
+"@rolldown/binding-wasm32-wasi@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.3"
   dependencies:
     "@emnapi/core": "npm:1.10.0"
     "@emnapi/runtime": "npm:1.10.0"
@@ -9662,9 +9662,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.2"
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -9676,9 +9676,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.2":
-  version: 1.0.2
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.2"
+"@rolldown/binding-win32-x64-msvc@npm:1.0.3":
+  version: 1.0.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -11700,7 +11700,7 @@ __metadata:
     js-cookie: "npm:^3.0.5"
     posthog-js: "npm:^1.281.0"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     vitest: "npm:^4.1.7"
     wrangler: "npm:^4.75.0"
   languageName: unknown
@@ -12047,7 +12047,7 @@ __metadata:
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.8.3"
     unfurl.js: "npm:^6.4.0"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     ws: "npm:^8.18.0"
   languageName: unknown
   linkType: soft
@@ -12077,7 +12077,7 @@ __metadata:
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.8.3"
     unfurl.js: "npm:^6.4.0"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
   languageName: unknown
   linkType: soft
 
@@ -13028,15 +13028,6 @@ __metadata:
   dependencies:
     "@types/lodash": "npm:*"
   checksum: 10/233580e3bb72a482c0deb5f40cc0e4585d2fec5b3eedbbb6b2b7b19f35ceb29efb6cb374209780280f9961104dacf469d3a41011e350b0cfd3dc70ff431685d7
-  languageName: node
-  linkType: hard
-
-"@types/lodash.pick@npm:^4.4.9":
-  version: 4.4.9
-  resolution: "@types/lodash.pick@npm:4.4.9"
-  dependencies:
-    "@types/lodash": "npm:*"
-  checksum: 10/007c298133b5bc2157f13d6641b139d2782b4af7b6a942cc4b1a427c6ebc6020e46b32ee2e782607389b0c63a5211d51152606424fdfe25f3eeac8afea0bdf02
   languageName: node
   linkType: hard
 
@@ -18627,7 +18618,6 @@ __metadata:
     "@tldraw/sync-core": "workspace:*"
     "@tldraw/utils": "workspace:*"
     "@tldraw/validate": "workspace:*"
-    "@types/lodash.pick": "npm:^4.4.9"
     "@types/md5": "npm:^2.3.5"
     "@types/node": "npm:^22.15.31"
     "@types/qrcode": "npm:^1.5.5"
@@ -18646,7 +18636,6 @@ __metadata:
     json5: "npm:^2.2.3"
     kysely: "npm:^0.28.12"
     lazyrepo: "npm:0.0.0-alpha.27"
-    lodash.pick: "npm:^4.4.0"
     pg: "npm:^8.13.1"
     posthog-js: "npm:^1.281.0"
     qrcode: "npm:^1.5.4"
@@ -18660,7 +18649,7 @@ __metadata:
     react-router-dom: "npm:^6.28.2"
     regexgen: "npm:^1.3.0"
     tldraw: "workspace:*"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     vitest: "npm:^4.1.7"
     ws: "npm:^8.18.0"
   languageName: unknown
@@ -19998,7 +19987,7 @@ __metadata:
     topojson-client: "npm:^3.1.0"
     us-atlas: "npm:^3.0.1"
     vfile-matter: "npm:^5.0.0"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     webdriverio: "npm:^9.0.0"
   languageName: unknown
   linkType: soft
@@ -23853,13 +23842,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.pick@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "lodash.pick@npm:4.4.0"
-  checksum: 10/5a76778aa1c245ce081d19c5a625a44cdf4853f421c8789ec962cb5d73dd21be7cf11ae3bc2123ff5f432326ed0176d674d22ca6e0e8f9eaba5b74b00f632c12
-  languageName: node
-  linkType: hard
-
 "lodash.pickby@npm:^4.6.0":
   version: 4.6.0
   resolution: "lodash.pickby@npm:4.6.0"
@@ -24250,7 +24232,7 @@ __metadata:
     tldraw: "workspace:*"
     tsx: "npm:^4.19.2"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     vite-plugin-singlefile: "npm:^2.3.2"
     wrangler: "npm:^4.75.0"
     zod: "npm:^4.1.8"
@@ -29354,26 +29336,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.2":
-  version: 1.0.2
-  resolution: "rolldown@npm:1.0.2"
+"rolldown@npm:1.0.3":
+  version: 1.0.3
+  resolution: "rolldown@npm:1.0.3"
   dependencies:
-    "@oxc-project/types": "npm:=0.132.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.2"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.2"
-    "@rolldown/binding-darwin-x64": "npm:1.0.2"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.2"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.2"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.2"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.2"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.2"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.2"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.2"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.2"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.2"
+    "@oxc-project/types": "npm:=0.133.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.3"
+    "@rolldown/binding-darwin-x64": "npm:1.0.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.3"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.3"
     "@rolldown/pluginutils": "npm:^1.0.0"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
@@ -29408,7 +29390,7 @@ __metadata:
       optional: true
   bin:
     rolldown: ./bin/cli.mjs
-  checksum: 10/2e51f0b2332eef4001262dad360886ca11376558ce270fbddad6182870395200b123ad75d412e60cb4328650d1df2cb74ae374e79edf930c030bfb693c9b1891
+  checksum: 10/4dbe2c055104c47c15c051b713068cf4660acd473841904d3f7118f730922b2e498176610a45826cbc1ffe36842a29a076385d3bfcd5acb0f7ef8ad06b8feefb
   languageName: node
   linkType: hard
 
@@ -31390,13 +31372,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16, tinyglobby@npm:^0.2.9":
-  version: 0.2.16
-  resolution: "tinyglobby@npm:0.2.16"
+"tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.17, tinyglobby@npm:^0.2.9":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
-  checksum: 10/5c2c41b572ada38449e7c86a5fe034f204a1dbba577225a761a14f29f48dc3f2fc0d81a6c56fcc67c5a742cc3aa9fb5e2ca18dbf22b610b0bc0e549b34d5a0f8
+  checksum: 10/f85e8a217d675c3f78d5f0ad25ea4557e7e023ed13ddc2b014da10bd0312eea53a34cd52356af07ccdff777f1243012547656282a4ca70936f68bf5065fbaa71
   languageName: node
   linkType: hard
 
@@ -31444,7 +31426,7 @@ __metadata:
     react-markdown: "npm:^10.1.0"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     wrangler: "npm:^4.75.0"
     zod: "npm:^4.1.8"
   languageName: unknown
@@ -31468,7 +31450,7 @@ __metadata:
     react-dom: "npm:^19.2.1"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     wrangler: "npm:^4.75.0"
     zod: "npm:^4.1.8"
   languageName: unknown
@@ -31510,7 +31492,7 @@ __metadata:
     react-dom: "npm:^19.2.1"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     wrangler: "npm:^4.75.0"
   languageName: unknown
   linkType: soft
@@ -31541,7 +31523,7 @@ __metadata:
     react-dom: "npm:^19.2.1"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
   languageName: unknown
   linkType: soft
 
@@ -31564,7 +31546,7 @@ __metadata:
     react-router-dom: "npm:^6.28.2"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     wrangler: "npm:^4.75.0"
   languageName: unknown
   linkType: soft
@@ -31580,7 +31562,7 @@ __metadata:
     react-dom: "npm:^19.2.1"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
   languageName: unknown
   linkType: soft
 
@@ -31632,7 +31614,7 @@ __metadata:
     react-dom: "npm:^19.2.1"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
     vite-plugin-vue-devtools: "npm:^8.1.0"
     vue: "npm:^3.5.17"
     vue-tsc: "npm:^3.0.1"
@@ -31652,7 +31634,7 @@ __metadata:
     react-dom: "npm:^19.2.1"
     tldraw: "workspace:*"
     typescript: "npm:^5.8.3"
-    vite: "npm:^8.0.1"
+    vite: "npm:^8.0.16"
   languageName: unknown
   linkType: soft
 
@@ -32976,16 +32958,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.0.1":
-  version: 8.0.14
-  resolution: "vite@npm:8.0.14"
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0, vite@npm:^8.0.16":
+  version: 8.0.16
+  resolution: "vite@npm:8.0.16"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
     picomatch: "npm:^4.0.4"
     postcss: "npm:^8.5.15"
-    rolldown: "npm:1.0.2"
-    tinyglobby: "npm:^0.2.16"
+    rolldown: "npm:1.0.3"
+    tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
     "@vitejs/devtools": ^0.1.18
@@ -33029,7 +33011,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10/3747c9b9dabdfa5b840630c39b2c764afb3c3762816f3148afe7d516edc1889b60b666adeb4e98761c26fb8ed5ba3a9770df5c0450443daf4cdfac110bc6df1c
+  checksum: 10/a5d91d26f6110672a292a06ca161af9a58279fe9d27106c8c0afb725a942b0b47091c440c3b1e7ebc8e0fe901f64ac6a2ffee3cdae2f899339686dbecd0c0266
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Addresses the actionable findings from a socket.dev dependency scan of `main`. Most of the scan was noise; this PR fixes the items worth acting on.

### Changes

- **vite `^8.0.1` → `^8.0.16`** across apps and templates. Picks up the fix for CVE-2026-53571 (CVSS 8.2) and CVE-2026-53632. `yarn dedupe` pulls the remaining transitive vite range up to 8.0.16 as well.
- **Drop `lodash.pick`** (and `@types/lodash.pick`) from the dotcom client. The package is deprecated and flagged for CVE-2020-8203 (prototype pollution, highest EPSS in the scan). Its single usage in `TldrawApp.ts` is replaced with an inline `Object.fromEntries` over the known `UserPreferencesKeys` — behavior-equivalent since `user` is a full `TlaUser`.
- **`yarn dedupe`** to collapse duplicate transitive packages (lockfile shrinks ~110 lines).

### Deliberately not included

- **A blanket `tar` override.** The vulnerable `tar@6.2.1` is pulled only by `cacache`, `node-gyp`, and `sqlite3`, all of which require the tar **v6** API. The CVEs are only fixed in v7, so a resolution forcing v7 risks breaking native module builds. This is build/install-time tooling, not shipped runtime, so it's left for a dedicated change.
- **The ~60 `obfuscatedFile` supply-chain warnings.** These are false positives — socket flags minified bundles in well-known packages (pdfjs-dist, mermaid, next, webpack, svgo, etc.). Recommend dismissing the category in socket.
- Remaining transitive CVEs in dev/build tooling, which `yarn dedupe` resolves where a fixed version already exists in the tree.

### Change type

- [x] `other`

## Test plan

- `yarn typecheck` passes.
- `yarn lint-current` and `yarn format-current` clean.
- Pre-commit hooks pass.