### PR TITLE
test(examples): preload fonts before export-snapshot layout

### DIFF
--- a/apps/examples/e2e/fixtures/fixtures.ts
+++ b/apps/examples/e2e/fixtures/fixtures.ts
@@ -93,6 +93,7 @@ const test = base.extend<Fixtures>({
 				resetMockShapeIds: true,
 				createMermaidDiagram: true,
 				toRichText: true,
+				preloadFonts: true,
 				markAllArrowBindings: true,
 				b64VecsEncodePoints: true,
 			},

--- a/apps/examples/e2e/tests/export-snapshots.spec.tsx
+++ b/apps/examples/e2e/tests/export-snapshots.spec.tsx
@@ -967,13 +967,18 @@ interface SnapshotWithoutJsx {
 test.describe('Export snapshots', () => {
 	const snapshotsToTest = Object.entries(snapshots)
 
-	test.beforeEach(async ({ page, context }) => {
+	test.beforeEach(async ({ page, context, api }) => {
 		const url = page.url()
 		if (!url.includes('end-to-end')) {
 			await setup({ page, context } as any)
 		} else {
 			await hardResetEditor(page)
 		}
+		// These snapshots lay shapes out by their measured bounds, and text is measured from
+		// the loaded font - so load the fonts before anything is measured. Otherwise a shape
+		// can be measured with fallback-font metrics, which shifts the layout and the export's
+		// size and makes the screenshot diff flaky.
+		await api.preloadFonts()
 	})
 
 	for (const [name, snapshotWithJsx] of snapshotsToTest) {
@@ -988,7 +993,7 @@ test.describe('Export snapshots', () => {
 				)
 
 				await page.evaluate(
-					async ({
+					({
 						colorScheme,
 						name,
 						snapshot,
@@ -1064,13 +1069,6 @@ test.describe('Export snapshots', () => {
 
 							y = bottom + 40
 						}
-
-						// Wait for every font used on the page to finish loading before exporting.
-						// Text geometry - and therefore the export's bounding box - is measured from
-						// the loaded font; while a font is still loading the shapes fall back to
-						// system-font metrics, which gives the export a slightly different size and
-						// makes the screenshot diff flaky.
-						await editor.fonts.loadRequiredFontsForCurrentPage()
 
 						tldrawApi.markAllArrowBindings()
 						editor.selectAll()

--- a/apps/examples/src/misc/EndToEndApi.tsx
+++ b/apps/examples/src/misc/EndToEndApi.tsx
@@ -7,6 +7,7 @@ export interface EndToEndApi {
 	resetMockShapeIds(): void
 	createMermaidDiagram(definition: string): Promise<void>
 	toRichText(text: string): TLRichText
+	preloadFonts(): Promise<void>
 	markAllArrowBindings(): void
 	b64VecsEncodePoints(points: VecModel[]): string
 }

--- a/apps/examples/src/misc/end-to-end.tsx
+++ b/apps/examples/src/misc/end-to-end.tsx
@@ -6,6 +6,7 @@ import {
 	TLShape,
 	Tldraw,
 	VecModel,
+	allDefaultFontFaces,
 	b64Vecs,
 	createShapeId,
 	exportAs,
@@ -161,6 +162,13 @@ function SneakyExportButton() {
 				})
 			},
 			toRichText: (text: string) => toRichText(text),
+			preloadFonts: async () => {
+				// Load every default font face up front. Text geometry is measured from the
+				// loaded font, so anything that measures a shape before its font loads (e.g.
+				// laying out shapes by their measured bounds) would otherwise get fallback-font
+				// metrics until the real font swaps in.
+				await Promise.all(allDefaultFontFaces.map((font) => editor.fonts.ensureFontIsLoaded(font)))
+			},
 			b64VecsEncodePoints: (points: VecModel[]) => b64Vecs.encodePoints(points),
 			markAllArrowBindings: () => {
 				const markRadius = 3


### PR DESCRIPTION
In order to actually fix the flaky `Export snapshots › Text rendering` screenshot test, this PR loads the default fonts before the snapshot tests measure anything. It follows up [#9332](https://github.com/tldraw/tldraw/pull/9332), which awaited fonts before the export call but left the test flaky - the failure just moved between the `(light)` and `(dark)` variants.

### Root cause

The failure is a size mismatch (`Expected an image 2063px by 678px, received 2045px by 677px`), and the fonts are rendered correctly in both the passing and failing images - so it isn't a render-time fallback. The diff is a cumulative horizontal drift: each column sits a little further left than the baseline, clipping ~18px off the right edge.

The export's size comes from the test's own column-packing layout, and that layout is computed *during* shape creation. Each column's `x` advance is `getShapePageBounds()` of an auto-sized mono title shape, and a text shape's geometry is measured from its loaded font. So positioning a title before its font has loaded packs that column with fallback-font metrics; on Linux the monospace fallback differs from `tldraw_mono`, the per-column error accumulates, and the whole layout drifts narrower. Awaiting fonts *after* the layout (as #9332 did) can't help - the shapes are already placed.

This isn't really canvas-specific: it's the ordinary "web fonts load asynchronously, and text measurement depends on which font is loaded" problem. It only shows up here because the test reads exact measurements synchronously while laying shapes out, and then asserts on the pixel size of the result.

### Fix

Load the default fonts before the test measures anything. A new `api.preloadFonts()` helper (`allDefaultFontFaces` + the public `FontManager.ensureFontIsLoaded`) runs in the snapshot `beforeEach`, so every measurement - layout and export alike - is taken with the final font metrics. Because `defaultAddFontsFromNode` resolves to those same `DefaultFontFaces` instances, preloading them is exactly what the shapes go on to use.

Two alternatives were rejected:

- **Awaiting fonts only before export** (#9332) - too late; the layout is already computed.
- **A two-pass "create everything, then lay out"** - `Editor.createShapes` auto-parents a positioned shape into any frame under its point, so creating all the test cases at once captures unrelated shapes into the `#5020` frame and corrupts the layout.

### Evidence

Replicating the column-packing with the `draw` font (whose macOS fallback metrics differ a lot, unlike `tldraw_mono`) and the font response delayed:

| Layout | Width (fonts delayed) | Drift |
| --- | --- | --- |
| Reference (fonts loaded) | 1376.75 | — |
| Measure-during-loop (current behaviour) | 1173.45 | −203px |
| Preload-then-measure (this PR) | 1376.75 | 0.00 |

With the fix, under a forced 6s font-load delay, `Text rendering` exports at a stable 2042×678 and `Regressions` at 353×653 (their loaded-font sizes) on every run, and the output is byte-identical across repeated runs.

### Change type

- [x] `bugfix`

### Test plan

1. `cd apps/examples && yarn e2e -g "Text rendering|Regressions" --project=chromium` - the exports are now a deterministic size regardless of font-load timing.
2. Full `export-snapshots.spec.tsx` suite still exports every snapshot group without error.

- [ ] Unit tests
- [x] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +17 / -9   |
