### PR TITLE
feat(dotcom): track workspace lifecycle and membership analytics events

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -291,6 +291,7 @@ export function FileItems({
 														app.showMutationRejectionToast((e as Error).message as ZErrorCode)
 														return
 													}
+													trackEvent('create-workspace', { source })
 													try {
 														await app.z.mutate.moveFileToWorkspace({ fileId, workspaceId: id })
 															.client

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -7,6 +7,7 @@ import { uniqueId, useDialogs, useGlobalMenuIsOpen, useMaybeEditor, useValue } f
 import { routes } from '../../../../routeDefs'
 import { useActiveWorkspaceId } from '../../../hooks/useActiveWorkspaceId'
 import { useApp } from '../../../hooks/useAppState'
+import { useTldrawAppUiEvents } from '../../../utils/app-ui-events'
 import { getIsCoarsePointer } from '../../../utils/getIsCoarsePointer'
 import { defineMessages, useMsg } from '../../../utils/i18n'
 import { CreateWorkspaceDialog } from '../../dialogs/CreateWorkspaceDialog'
@@ -244,6 +245,7 @@ function useCreateWorkspaceDialog() {
 	const navigate = useNavigate()
 	const { addDialog } = useDialogs()
 	const switchToWorkspace = useSwitchToWorkspace()
+	const trackEvent = useTldrawAppUiEvents()
 
 	return useCallback(() => {
 		addDialog({
@@ -258,6 +260,7 @@ function useCreateWorkspaceDialog() {
 							app.showMutationRejectionToast((e as Error).message as ZErrorCode)
 							return
 						}
+						trackEvent('create-workspace', { source: 'sidebar' })
 						// Seed the workspace's welcome file once, here at creation, and open it
 						// directly (not via switchToWorkspace, whose empty-workspace path would
 						// otherwise create a blank file before the welcome file lands).
@@ -274,5 +277,5 @@ function useCreateWorkspaceDialog() {
 				/>
 			),
 		})
-	}, [app, addDialog, navigate, switchToWorkspace])
+	}, [app, addDialog, navigate, switchToWorkspace, trackEvent])
 }

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from 'tldraw'
 import { useApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
+import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
 import {
 	TlaMenuControl,
@@ -73,6 +74,7 @@ function useScrollbarWhenScrollable() {
 export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSettingsDialogProps) {
 	const app = useApp()
 	const { addDialog } = useDialogs()
+	const trackEvent = useTldrawAppUiEvents()
 	const [activeTab, setActiveTab] = useState('members')
 	const [copiedInviteLink, setCopiedInviteLink] = useState(false)
 
@@ -146,11 +148,13 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 
 	const handleToggleInviteLink = (enabled: boolean) => {
 		app.z.mutate.setWorkspaceInviteLinkEnabled({ id: workspaceId, enabled })
+		trackEvent('set-workspace-invite-link-enabled', { source: 'workspace-settings', enabled })
 	}
 
 	const handleRegenerateInviteLink = async () => {
 		try {
 			await app.z.mutate.regenerateWorkspaceInviteSecret({ id: workspaceId }).server
+			trackEvent('regenerate-workspace-invite-secret', { source: 'workspace-settings' })
 		} catch (error) {
 			console.error('Error regenerating invite link:', error)
 			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
@@ -162,6 +166,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 			const isCurrentlyOnAFileInThisWorkspace =
 				currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
 			await app.z.mutate.leaveWorkspace({ workspaceId }).client
+			trackEvent('leave-workspace', { source: 'workspace-settings' })
 			onClose()
 			if (isCurrentlyOnAFileInThisWorkspace) {
 				navigate('/')
@@ -177,6 +182,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 			const isCurrentlyOnAFileInThisWorkspace =
 				currentFileId && app.getFile(currentFileId)?.owningGroupId === workspaceId
 			await app.z.mutate.deleteWorkspace({ id: workspaceId }).client
+			trackEvent('delete-workspace', { source: 'workspace-settings' })
 			onClose()
 			if (isCurrentlyOnAFileInThisWorkspace) {
 				navigate('/')
@@ -190,6 +196,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	const handleRemoveMember = async (targetUserId: string) => {
 		try {
 			await app.z.mutate.removeWorkspaceMember({ workspaceId, targetUserId }).client
+			trackEvent('remove-workspace-member', { source: 'workspace-settings' })
 		} catch (error) {
 			console.error('Error removing member:', error)
 			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
@@ -309,6 +316,7 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 							const name = value.trim()
 							if (name && name !== workspace.name) {
 								app.z.mutate.updateWorkspace({ id: workspaceId, name })
+								trackEvent('rename-workspace', { source: 'workspace-settings' })
 							}
 						}}
 						placeholder={namePlaceholderMsg}
@@ -439,6 +447,10 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 																		targetUserId: member.userId,
 																		role: value,
 																	}).client
+																	trackEvent('set-workspace-member-role', {
+																		source: 'workspace-settings',
+																		role: value,
+																	})
 																} catch (err) {
 																	console.error('Failed to change member role', err)
 																	app.showMutationRejectionToast(

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -112,27 +112,29 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 	})
 
 	// The name input live-saves on each keystroke, but we only want one `rename-workspace`
-	// analytics event per edit session. Capture the name on open and the latest on each render,
-	// then fire a single event when the dialog unmounts (closes) if the name actually changed.
-	const initialWorkspaceNameRef = useRef<string | null>(null)
-	const latestWorkspaceNameRef = useRef<string | null>(null)
+	// analytics event per edit session. Capture the name on open in the effect closure and
+	// compare it against the latest name when the dialog unmounts.
 	const workspaceName = workspaceMembership?.group?.name ?? null
-	if (initialWorkspaceNameRef.current === null && workspaceName !== null) {
-		initialWorkspaceNameRef.current = workspaceName
-	}
+	const latestWorkspaceNameRef = useRef(workspaceName)
 	if (workspaceName !== null) {
 		latestWorkspaceNameRef.current = workspaceName
 	}
 	const trackEventRef = useRef(trackEvent)
 	trackEventRef.current = trackEvent
 	useEffect(() => {
+		const initialWorkspaceName = workspaceName
 		return () => {
-			const initial = initialWorkspaceNameRef.current
-			const latest = latestWorkspaceNameRef.current
-			if (initial !== null && latest !== null && latest !== initial) {
+			const latestWorkspaceName = latestWorkspaceNameRef.current
+			if (
+				initialWorkspaceName !== null &&
+				latestWorkspaceName !== null &&
+				latestWorkspaceName !== initialWorkspaceName
+			) {
 				trackEventRef.current('rename-workspace', { source: 'workspace-settings' })
 			}
 		}
+		// We intentionally capture the workspace name from the dialog's initial render.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [])
 
 	if (!workspaceMembership) return null

--- a/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/WorkspaceSettingsDialog.tsx
@@ -1,6 +1,6 @@
 import { MAX_WORKSPACE_NAME_LENGTH, Role, ZErrorCode, can } from '@tldraw/dotcom-shared'
 import { Tooltip as _Tooltip } from 'radix-ui'
-import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
 	TldrawUiDialogBody,
@@ -111,6 +111,30 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 		content.style.maxHeight = '70vh'
 	})
 
+	// The name input live-saves on each keystroke, but we only want one `rename-workspace`
+	// analytics event per edit session. Capture the name on open and the latest on each render,
+	// then fire a single event when the dialog unmounts (closes) if the name actually changed.
+	const initialWorkspaceNameRef = useRef<string | null>(null)
+	const latestWorkspaceNameRef = useRef<string | null>(null)
+	const workspaceName = workspaceMembership?.group?.name ?? null
+	if (initialWorkspaceNameRef.current === null && workspaceName !== null) {
+		initialWorkspaceNameRef.current = workspaceName
+	}
+	if (workspaceName !== null) {
+		latestWorkspaceNameRef.current = workspaceName
+	}
+	const trackEventRef = useRef(trackEvent)
+	trackEventRef.current = trackEvent
+	useEffect(() => {
+		return () => {
+			const initial = initialWorkspaceNameRef.current
+			const latest = latestWorkspaceNameRef.current
+			if (initial !== null && latest !== null && latest !== initial) {
+				trackEventRef.current('rename-workspace', { source: 'workspace-settings' })
+			}
+		}
+	}, [])
+
 	if (!workspaceMembership) return null
 	const workspace = workspaceMembership.group
 	if (!workspace) return null
@@ -146,9 +170,14 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 		setTimeout(() => setCopiedInviteLink(false), 1000)
 	}
 
-	const handleToggleInviteLink = (enabled: boolean) => {
-		app.z.mutate.setWorkspaceInviteLinkEnabled({ id: workspaceId, enabled })
-		trackEvent('set-workspace-invite-link-enabled', { source: 'workspace-settings', enabled })
+	const handleToggleInviteLink = async (enabled: boolean) => {
+		try {
+			await app.z.mutate.setWorkspaceInviteLinkEnabled({ id: workspaceId, enabled }).client
+			trackEvent('set-workspace-invite-link-enabled', { source: 'workspace-settings', enabled })
+		} catch (error) {
+			console.error('Error toggling invite link:', error)
+			app.showMutationRejectionToast((error as Error).message as ZErrorCode)
+		}
 	}
 
 	const handleRegenerateInviteLink = async () => {
@@ -316,7 +345,6 @@ export function WorkspaceSettingsDialog({ workspaceId, onClose }: WorkspaceSetti
 							const name = value.trim()
 							if (name && name !== workspace.name) {
 								app.z.mutate.updateWorkspace({ id: workspaceId, name })
-								trackEvent('rename-workspace', { source: 'workspace-settings' })
 							}
 						}}
 						placeholder={namePlaceholderMsg}

--- a/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
+++ b/apps/dotcom/client/src/tla/utils/app-ui-events.tsx
@@ -1,4 +1,4 @@
-import { TlaFile, TlaUser } from '@tldraw/dotcom-shared'
+import { Role, TlaFile, TlaUser } from '@tldraw/dotcom-shared'
 import { createContext, useContext } from 'react'
 import { trackEvent } from '../../utils/analytics'
 import { TldrawAppSessionState } from './local-session-state'
@@ -21,10 +21,19 @@ export type TLAppUiEventSource =
 	| 'app'
 	| 'cookie-settings'
 	| 'dialog'
+	| 'workspace-settings'
 
 /** @public */
 export interface TLAppUiEventMap {
 	'create-file': null
+	'create-workspace': null
+	'rename-workspace': null
+	'delete-workspace': null
+	'leave-workspace': null
+	'remove-workspace-member': null
+	'set-workspace-member-role': { role: Role }
+	'set-workspace-invite-link-enabled': { enabled: boolean }
+	'regenerate-workspace-invite-secret': null
 	'delete-file': null
 	'rename-file': { name: string }
 	'duplicate-file': null


### PR DESCRIPTION
In order to understand how people use shared workspaces on tldraw.com, this PR adds PostHog analytics events for the workspace lifecycle and membership actions, which were previously untracked. Before this change, the only workspace-related event was `accept-workspace-invite`, so we had no visibility into workspace creation, deletion, renaming, the invite funnel, or member management.

Events are dispatched through the existing `trackEvent` / `useTldrawAppUiEvents` handler and are fired on the success path of each mutation (after it resolves, before any error toast), so failed mutations don't generate events. A new `workspace-settings` event source is added for events originating in the manage-workspace dialog.

### New events

| Event | Payload | Fires when |
| --- | --- | --- |
| `create-workspace` | — | A workspace is created (sidebar switcher or file menu) |
| `rename-workspace` | — | The workspace name is changed |
| `delete-workspace` | — | A workspace is deleted |
| `leave-workspace` | — | A member leaves a workspace |
| `remove-workspace-member` | — | A member is removed |
| `set-workspace-member-role` | `{ role }` | A member's role changes |
| `set-workspace-invite-link-enabled` | `{ enabled }` | The invite link is toggled on/off |
| `regenerate-workspace-invite-secret` | — | The invite link is regenerated |

Together with the existing `accept-workspace-invite`, these complete the invite/membership funnel and the workspace lifecycle. High-volume, low-signal actions (`move-file-to-workspace`, pin/unpin) are intentionally left untracked.

### Change type

- [x] `improvement`

### Test plan

1. Create a workspace from the sidebar switcher and from the file menu's "Move to" submenu; confirm `create-workspace` is captured.
2. In the manage-workspace dialog: rename the workspace, toggle and regenerate the invite link, change a member's role, remove a member, and leave/delete the workspace; confirm each fires its event with the expected payload.
3. Confirm no event fires when a mutation fails (e.g. an action rejected by the server shows the rejection toast and no event).

### Release notes

- Add analytics events for workspace lifecycle and membership actions on tldraw.com.

### Code changes

| Section | LOC change |
| --- | --- |
| Apps | +27 / -2 |