### PR TITLE
fix(editor): wait for fonts before measuring SVG exports

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10181,6 +10181,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		if (ids.length === 0) return undefined
 
+		// Text geometry is measured from the loaded font, so the export's bounds - and the
+		// layout of any text within it - depend on the right fonts having loaded. Wait for them
+		// before we measure; otherwise an export taken before fonts finish loading (e.g. right
+		// after the editor mounts) is sized and laid out with fallback-font metrics.
+		await this.fonts.loadRequiredFontsForCurrentPage(this.options.maxFontsToLoadBeforeRender)
+
 		return exportToSvg(this, ids, opts)
 	}
 

--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -163,8 +163,8 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 		const shapeIds = editor.getCurrentPageShapeIds()
 
 		async function setSvg() {
-			// We have to wait for the fonts to load so that we can correctly measure text sizes
-			await editor.fonts.loadRequiredFontsForCurrentPage(editor.options.maxFontsToLoadBeforeRender)
+			// toImage waits for the required fonts to load (so text is measured correctly) before
+			// it renders, so we don't need to do it here.
 			const imageResult = await editor.toImage([...shapeIds], {
 				bounds,
 				scale,

--- a/packages/tldraw/src/test/commands/getSvgString.test.ts
+++ b/packages/tldraw/src/test/commands/getSvgString.test.ts
@@ -136,3 +136,33 @@ it('Accepts a background option', async () => {
 	)
 	expect(svg2.style.backgroundColor).toBe('transparent')
 })
+
+// Note: this test exports, which bumps a module-level id counter that the snapshot tests
+// above are sensitive to - so keep it after them.
+it('waits for required fonts to load before measuring the export', async () => {
+	// Text geometry is measured from the loaded font, so the export must not be measured
+	// until the fonts it uses have loaded.
+	let resolveFonts!: () => void
+	const fontsLoaded = new Promise<void>((resolve) => {
+		resolveFonts = resolve
+	})
+	const loadFonts = vi
+		.spyOn(editor.fonts, 'loadRequiredFontsForCurrentPage')
+		.mockReturnValue(fontsLoaded)
+
+	let resolved = false
+	const exportPromise = editor.getSvgString(editor.getSelectedShapeIds()).then((result) => {
+		resolved = true
+		return result
+	})
+
+	// let the export run up to the font-loading await
+	await new Promise((resolve) => setTimeout(resolve, 0))
+	expect(loadFonts).toHaveBeenCalled()
+	expect(resolved).toBe(false)
+
+	resolveFonts()
+	const svg = await exportPromise
+	expect(resolved).toBe(true)
+	expect(svg!.svg).toMatch(/^<svg/)
+})


### PR DESCRIPTION
In order to stop SVG/PNG exports from being sized with fallback-font metrics, this PR makes the export pipeline wait for the required fonts to load before it measures anything.

### Problem

`editor.toImage()` / `getSvgString()` / `getSvgElement()` compute the export's bounding box from shape geometry, and a text shape's geometry is measured from its **loaded** font. Nothing in the export path waited for fonts, so an export taken before the required fonts had finished loading - for example a headless `editor.toImage()` right after creating an editor, or an export triggered immediately on mount - was sized, and had its text laid out, with fallback-font metrics instead of the real font.

In a normal mounted editor this is usually masked: `TldrawEditor` already awaits `loadRequiredFontsForCurrentPage` on mount before it paints, so by the time a user clicks "export" the fonts are loaded. But callers that export without that guarantee had to remember to load fonts themselves (`TldrawImage` did; the export-as / copy-as / print paths did not).

This is the SDK-side counterpart to [#9370](https://github.com/tldraw/tldraw/pull/9370), which fixed the same fallback-metrics problem in the export-snapshot e2e test.

### Fix

Await `loadRequiredFontsForCurrentPage(maxFontsToLoadBeforeRender)` inside `getSvgElement`. It respects the existing `maxFontsToLoadBeforeRender` option, is a fast no-op once fonts are loaded, and lets `TldrawImage` drop its own pre-`toImage` font load.

**Why `getSvgElement` and not `toImage`?** `toImage` is only one of several export entry points - `getSvgString` is called directly (bypassing `toImage`) by print, copy-as, flatten, and overlay export. `getSvgElement` is the single point they all funnel through, right before the bounding box is measured, so one await there covers every path:

```
toImage ───────────────┐
toImageDataUrl → toImage ┘
                         ↓
   getSvgString ──→ getSvgElement ──→ exportToSvg   (bbox measured here)
                         ↑
   (direct getSvgString callers below)
```

| Caller | Method | What it is |
| --- | --- | --- |
| `usePrint.ts` | `getSvgString` | print |
| `copyAs.ts` | `getSvgString` | copy as SVG |
| `useFlatten.ts` | `getSvgString` | flatten shapes to image |
| `DefaultCanvas.tsx` | `getSvgString` | overlay export |
| `export.ts` | `getSvgString` + `toImage` | export util |
| `exportAs.ts`, `TldrawImage` | `toImage` | export-as / `<TldrawImage>` |

The only thing lower than `getSvgElement` is `exportToSvg` itself, but that's editor-package-internal; `getSvgElement` is the public boundary that owns `this.fonts` and `this.options`.

### Verifying

With the font response artificially delayed and no manual font loading, an immediate `getShapePageBounds` measures the text at the fallback width (323px) while `getSvgString` now returns the loaded-font width (374px + padding); `getSvgString`'s wall-clock time scales with the font delay, confirming it awaits the load.

### Change type

- [x] `bugfix`

### Test plan

- Added a unit test asserting the export blocks until `loadRequiredFontsForCurrentPage` resolves.
- Existing `getSvgString` snapshot tests are unchanged.

- [x] Unit tests
- [ ] End to end tests

### API changes

None - `getSvgElement` was already `async`; no signature changes (api-check passes clean).

### Release notes

- Fixed text in exported images sometimes being sized with a fallback font when the export ran before the document's fonts had finished loading.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -2    |
| Tests     | +30 / -0   |
