### PR TITLE
fix(tldraw): prevent crash when a pointed-at shape is deleted mid-click

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -75,6 +75,14 @@ export class PointingShape extends StateNode {
 				renderingOnly: true,
 			}) ?? this.hitShape
 
+		// The hit shape may have been deleted between pointer down and pointer up
+		// (e.g. by a remote user or an undo), in which case the fallback hitShape
+		// is stale. Bail to idle so we don't dereference a missing shape.
+		if (!this.editor.getShape(hitShape.id)) {
+			this.parent.transition('idle', info)
+			return
+		}
+
 		const selectingShape = hitShape
 			? this.editor.getOutermostSelectableShape(hitShape)
 			: this.hitShapeForPointerUp

--- a/packages/tldraw/src/test/SelectTool.test.ts
+++ b/packages/tldraw/src/test/SelectTool.test.ts
@@ -122,6 +122,44 @@ describe.skip('Edit on type', () => {
 	})
 })
 
+describe('TLSelectTool.PointingShape when the shape is deleted mid-click', () => {
+	// Reproduces https://github.com/tldraw/tldraw/issues/8558: a remote user,
+	// undo, or other actor can delete the pointed-at shape between pointer down
+	// and pointer up. The tool should bail to idle instead of crashing.
+
+	it('does not crash on pointer up when an already-selected shape is deleted', () => {
+		// pre-selecting the shape means didSelectOnEnter is false, so pointer up
+		// runs the selection logic that dereferences the (now deleted) shape
+		editor.select(ids.box1)
+		const shape = editor.getShape(ids.box1)!
+
+		editor.pointerDown(shape.x + 10, shape.y + 10, { target: 'shape', shape })
+		editor.expectToBeIn('select.pointing_shape')
+
+		editor.deleteShapes([ids.box1])
+
+		expect(() => editor.pointerUp(shape.x + 10, shape.y + 10)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+
+	it('does not crash on pointer up when a ctrl-clicked shape is deleted', () => {
+		// ctrl/accel on enter also leaves didSelectOnEnter false
+		const shape = editor.getShape(ids.box1)!
+
+		editor.pointerDown(shape.x + 10, shape.y + 10, {
+			target: 'shape',
+			shape,
+			accelKey: true,
+		})
+		editor.expectToBeIn('select.pointing_shape')
+
+		editor.deleteShapes([ids.box1])
+
+		expect(() => editor.pointerUp(shape.x + 10, shape.y + 10)).not.toThrow()
+		editor.expectToBeIn('select.idle')
+	})
+})
+
 describe('TLSelectTool.Translating', () => {
 	it('Enters from pointing and exits to idle', () => {
 		const shape = editor.getShape(ids.box1)


### PR DESCRIPTION
When a shape is deleted between pointer down and pointer up (e.g. by a remote user or an undo), the select tool dereferenced the now-missing shape and threw "Cannot read properties of undefined (reading 'id')" in PointingShape.onPointerUp.

getOutermostSelectableShape used getShape(id)! and could return undefined despite its TLShape return type. It now returns TLShape | undefined, and PointingShape bails to idle when the shape no longer exists. Updated the remaining callers and the API report to match.

Fixes #8558

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

This one requires a friend. 

- Click on a shape (enters PointingShape state)
- Shape gets deleted before pointer up (e.g., remote collaborator deletes it, or undo)
- Release mouse — crash

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix a crash when a shape is deleted mid-click (e.g. by a remote user or an undo) while clicking on it.

### API changes

- `Editor.getOutermostSelectableShape()` now returns `TLShape | undefined`; it could already return `undefined` for a missing shape despite its old `TLShape` type.