### PR TITLE
fix(editor): paste shapes in place when pasting back into their container

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -9904,13 +9904,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			}
 
 			for (const shape of selectedShapes) {
-				// Find the nearest container: the shape itself if it can accept,
-				// an accepting ancestor, or fall back to the shape's parent
-				// (handles groups and other non-frame containers)
-				const candidate = canAcceptAll(shape)
-					? shape
-					: (this.findShapeAncestor(shape, canAcceptAll) ??
-						(isShapeId(shape.parentId) ? this.getShape(shape.parentId)! : null))
+				// Only an explicitly selected container counts as a paste target.
+				// A selected leaf shape does not pull in its container ancestor —
+				// that case falls through to a page-level paste, which then
+				// reparents by position if the shape lands inside a frame.
+				const candidate = canAcceptAll(shape) ? shape : null
 
 				if (!candidate) {
 					selectedParent = null
@@ -10074,36 +10072,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const rootBounds = Box.Common(compact(rootShapes.map((s) => this.getShapePageBounds(s.id))))
 
 			if (point === undefined) {
-				const viewportPageBounds = this.getViewportPageBounds()
-				const isOnScreen = rootShapes.some((s) => {
-					const b = this.getShapePageBounds(s.id)
-					return b && viewportPageBounds.collides(b)
-				})
-
 				if (!isPageId(pasteParentId)) {
-					const parent = this.getShape(pasteParentId)!
-					const parentPageBounds = this.getShapePageBounds(parent)
-					// If the copied shapes already sit inside the paste target (e.g. you
-					// copied a shape from this frame and pasted it back with that shape
-					// still selected), keep them where they are — unless that position is
-					// off screen, in which case paste at the viewport center. Only recenter
-					// in the container when pasting into a different container than the
-					// content came from.
-					if (parentPageBounds?.containsPoint(rootBounds.center)) {
-						point = isOnScreen ? rootBounds.center : viewportPageBounds.center
-					} else {
-						// Paste into selected parent → center in that shape
-						point = Mat.applyToPoint(
-							this.getShapePageTransform(parent),
-							this.getShapeGeometry(parent).bounds.center
-						)
-					}
+					// Paste into selected parent → center in that shape
+					const shape = this.getShape(pasteParentId)!
+					point = Mat.applyToPoint(
+						this.getShapePageTransform(shape),
+						this.getShapeGeometry(shape).bounds.center
+					)
 				} else if (preservePosition) {
 					// preservePosition (page duplication) → keep original coords
 					point = rootBounds.center
 				} else {
-					// Standard paste to page: paste in place if on screen, else at the viewport center
-					point = isOnScreen ? rootBounds.center : viewportPageBounds.center
+					// Standard paste to page: check viewport overlap
+					const viewportPageBounds = this.getViewportPageBounds()
+					const anyOverlap = rootShapes.some((s) => {
+						const b = this.getShapePageBounds(s.id)
+						return b && viewportPageBounds.collides(b)
+					})
+					point = anyOverlap ? rootBounds.center : viewportPageBounds.center
 				}
 			}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10074,15 +10074,23 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const rootBounds = Box.Common(compact(rootShapes.map((s) => this.getShapePageBounds(s.id))))
 
 			if (point === undefined) {
+				const viewportPageBounds = this.getViewportPageBounds()
+				const isOnScreen = rootShapes.some((s) => {
+					const b = this.getShapePageBounds(s.id)
+					return b && viewportPageBounds.collides(b)
+				})
+
 				if (!isPageId(pasteParentId)) {
 					const parent = this.getShape(pasteParentId)!
 					const parentPageBounds = this.getShapePageBounds(parent)
 					// If the copied shapes already sit inside the paste target (e.g. you
 					// copied a shape from this frame and pasted it back with that shape
-					// still selected), keep them where they are. Only recenter when
-					// pasting into a different container than the content came from.
+					// still selected), keep them where they are — unless that position is
+					// off screen, in which case paste at the viewport center. Only recenter
+					// in the container when pasting into a different container than the
+					// content came from.
 					if (parentPageBounds?.containsPoint(rootBounds.center)) {
-						point = rootBounds.center
+						point = isOnScreen ? rootBounds.center : viewportPageBounds.center
 					} else {
 						// Paste into selected parent → center in that shape
 						point = Mat.applyToPoint(
@@ -10094,13 +10102,8 @@ export class Editor extends EventEmitter<TLEventMap> {
 					// preservePosition (page duplication) → keep original coords
 					point = rootBounds.center
 				} else {
-					// Standard paste to page: check viewport overlap
-					const viewportPageBounds = this.getViewportPageBounds()
-					const anyOverlap = rootShapes.some((s) => {
-						const b = this.getShapePageBounds(s.id)
-						return b && viewportPageBounds.collides(b)
-					})
-					point = anyOverlap ? rootBounds.center : viewportPageBounds.center
+					// Standard paste to page: paste in place if on screen, else at the viewport center
+					point = isOnScreen ? rootBounds.center : viewportPageBounds.center
 				}
 			}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10075,12 +10075,21 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			if (point === undefined) {
 				if (!isPageId(pasteParentId)) {
-					// Paste into selected parent → center in that shape
-					const shape = this.getShape(pasteParentId)!
-					point = Mat.applyToPoint(
-						this.getShapePageTransform(shape),
-						this.getShapeGeometry(shape).bounds.center
-					)
+					const parent = this.getShape(pasteParentId)!
+					const parentPageBounds = this.getShapePageBounds(parent)
+					// If the copied shapes already sit inside the paste target (e.g. you
+					// copied a shape from this frame and pasted it back with that shape
+					// still selected), keep them where they are. Only recenter when
+					// pasting into a different container than the content came from.
+					if (parentPageBounds?.containsPoint(rootBounds.center)) {
+						point = rootBounds.center
+					} else {
+						// Paste into selected parent → center in that shape
+						point = Mat.applyToPoint(
+							this.getShapePageTransform(parent),
+							this.getShapeGeometry(parent).bounds.center
+						)
+					}
 				} else if (preservePosition) {
 					// preservePosition (page duplication) → keep original coords
 					point = rootBounds.center

--- a/packages/tldraw/src/test/commands/clipboard.test.ts
+++ b/packages/tldraw/src/test/commands/clipboard.test.ts
@@ -478,6 +478,6 @@ describe('When copying and pasting', () => {
 		const pastedShape = editor.getCurrentPageShapes()[editor.getCurrentPageShapes().length - 1]
 		const pastedPoint = { x: pastedShape.x, y: pastedShape.y }
 
-		expect(pastedPoint).toMatchObject({ x: 150, y: 150 }) // center of group
+		expect(pastedPoint).toMatchObject({ x: 0, y: 0 }) // pasted in place, same spot as the copied shape
 	})
 })

--- a/packages/tldraw/src/test/commands/clipboard.test.ts
+++ b/packages/tldraw/src/test/commands/clipboard.test.ts
@@ -478,6 +478,9 @@ describe('When copying and pasting', () => {
 		const pastedShape = editor.getCurrentPageShapes()[editor.getCurrentPageShapes().length - 1]
 		const pastedPoint = { x: pastedShape.x, y: pastedShape.y }
 
-		expect(pastedPoint).toMatchObject({ x: 0, y: 0 }) // pasted in place, same spot as the copied shape
+		// Selecting a child of the group does not paste back into the group; it
+		// pastes in place at the page level, at the copied shape's page position.
+		expect(pastedShape.parentId).toBe(editor.getCurrentPageId())
+		expect(pastedPoint).toMatchObject({ x: 400, y: 400 })
 	})
 })

--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -664,4 +664,49 @@ describe('When pasting into frames...', () => {
 		expect(left.parentId).toBe(editor.getCurrentPageId())
 		expect(right.parentId).toBe(editor.getCurrentPageId())
 	})
+
+	it('Pastes a copied child shape back in place when it is still selected and on screen', () => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+
+		// Frame at the origin with a small shape inside it
+		editor.createShapes([{ id: ids.frame1, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } }])
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', parentId: ids.frame1, x: 150, y: 150, props: { w: 10, h: 10 } },
+		])
+
+		// Copy the shape and paste it while it is still selected
+		editor.select(ids.box1).copy()
+		editor.paste()
+
+		const pasted = editor.getCurrentPageShapes().find((s) => s.type === 'geo' && s.id !== ids.box1)!
+		// It stays parented to the frame, in the same spot as the original
+		expect(pasted.parentId).toBe(ids.frame1)
+		expect({ x: pasted.x, y: pasted.y }).toMatchObject({ x: 150, y: 150 })
+	})
+
+	it('Pastes a copied child shape at the viewport center when its original position is off screen', () => {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+
+		// Frame at the origin with a small shape inside it
+		editor.createShapes([{ id: ids.frame1, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } }])
+		editor.createShapes([
+			{ id: ids.box1, type: 'geo', parentId: ids.frame1, x: 150, y: 150, props: { w: 10, h: 10 } },
+		])
+
+		editor.select(ids.box1).copy()
+
+		// Scroll far away so the shape's original position is off screen
+		editor.setCamera({ x: -3000, y: -3000, z: 1 })
+		const viewportCenter = editor.getViewportPageBounds().center
+
+		// The shape is still selected, so the frame is the paste parent, but
+		// because the original position is off screen the paste lands at the
+		// viewport center instead of in place.
+		editor.paste()
+
+		const pasted = editor.getCurrentPageShapes().find((s) => s.type === 'geo' && s.id !== ids.box1)!
+		const pastedCenter = editor.getShapePageBounds(pasted.id)!.center
+		expect(approximately(pastedCenter.x, viewportCenter.x)).toBe(true)
+		expect(approximately(pastedCenter.y, viewportCenter.y)).toBe(true)
+	})
 })

--- a/packages/tldraw/src/test/paste.test.ts
+++ b/packages/tldraw/src/test/paste.test.ts
@@ -277,7 +277,7 @@ describe('When pasting', () => {
 		)
 	})
 
-	it('pastes shapes as children of the most common ancestor', () => {
+	it('does not paste leaf shapes into their ancestor frame (pastes at page level instead)', () => {
 		editor.reparentShapes([ids.frame3], ids.frame1)
 		editor.reparentShapes([ids.frame4], ids.frame1)
 		editor.reparentShapes([ids.box1], ids.frame3)
@@ -285,26 +285,26 @@ describe('When pasting', () => {
 		/*
     Before:
     page
-      - frame1 
+      - frame1
         - frame3
           - box1 *
         - frame4
           - box2 *
-      - frame2 
+      - frame2
       - box3
 
-    After:
+    After (box1/box2 sit at 500,500 / 600,600 — outside every frame — so the
+    pasted copies stay at the page level, in place):
     page
-      - frame1 
+      - frame1
         - frame3
-          - box1  
+          - box1
         - frame4
-          - box2 
-        - box1copy *
-        - box2copy *
-      - frame2 
-      - box2
+          - box2
+      - frame2
       - box3
+      - box1copy *
+      - box2copy *
     */
 
 		editor.select(ids.box1, ids.box2)
@@ -313,13 +313,18 @@ describe('When pasting', () => {
 
 		const shapes = getShapes()
 
-		// Should make the pasted shapes the children of the frame
-		expect(shapes.new.box1?.parentId).toBe(shapes.old.frame1.id)
-		expect(shapes.new.box2?.parentId).toBe(shapes.old.frame1.id)
+		// Selecting leaf shapes does not paste into their common ancestor frame;
+		// the copies land at the page level.
+		expect(shapes.new.box1?.parentId).toBe(editor.getCurrentPageId())
+		expect(shapes.new.box2?.parentId).toBe(editor.getCurrentPageId())
 
-		// Should put the pasted shapes centered in the frame
-		editor.select(shapes.new.box1!.id, shapes.new.box1!.id)
-		expect(editor.getSelectionPageCenter()).toMatchObject(editor.getPageCenter(shapes.old.frame1)!)
+		// And they are pasted in place, at the originals' positions.
+		expect(editor.getShapePageBounds(shapes.new.box1)).toMatchObject(
+			editor.getShapePageBounds(shapes.old.box1)!
+		)
+		expect(editor.getShapePageBounds(shapes.new.box2)).toMatchObject(
+			editor.getShapePageBounds(shapes.old.box2)!
+		)
 	})
 })
 


### PR DESCRIPTION
In order to stop pasting from dragging a copied shape into a frame it no longer belongs to, this PR makes the selection resolve a frame (or other container) as the paste target only when that container is **explicitly selected**. Relates to #8516.

Previously, selecting a shape and pasting would walk up to the shape's nearest container ancestor and use that as the paste parent, centering the paste inside it. That produced surprising results: copying a shape inside a frame and pasting it (with the shape still selected) centered the copy in the frame instead of pasting in place — and if the frame had moved, the copy jumped to the frame's new center.

Now a selected **leaf** shape doesn't pull in its container ancestor. That case falls through to the standard page-level paste, which:

- pastes **in place** when the original position is on screen (parenting into a frame only if the copy lands inside one by position),
- falls back to the **viewport center** when the original position is off screen.

Explicitly selecting a frame still pastes into it, centered, as before.

### Change type

- [x] `bugfix`

### Test plan

1. Create a frame with a shape inside it.
2. Select the shape, copy it, and paste — the copy appears in place, parented to the frame.
3. Move the frame away, then copy the shape and paste — the copy appears in place on the canvas (not dragged into the moved frame).
4. Scroll so the original position is off screen, then paste — the copy appears at the viewport center.
5. Select the frame itself and paste — the copy is centered inside the frame.

- [x] Unit tests

### Release notes

- Fix paste so selecting a shape inside a frame and pasting keeps the copy in place instead of recentering it in the frame. Pasting into a frame now happens only when the frame itself is selected, or when the pasted shape lands inside the frame by position.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -7    |
| Tests     | +71 / -18  |
