### PR TITLE
fix(sync): restart connection on malformed websocket message

### DIFF
--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -410,23 +410,29 @@ describe('ClientWebSocketAdapter', () => {
 			expect(onMessage).toHaveBeenCalledWith({ type: 'message', data: 'hello' })
 		})
 
-		it('[CW7] drops malformed JSON messages without closing the socket', async () => {
+		it('[CW7] restarts the connection on a malformed JSON message instead of forwarding it', async () => {
 			const warnOnceMock = vi.mocked(warnOnce)
 			const onMessage = vi.fn()
+			const onStatusChange = vi.fn()
 			adapter.onReceiveMessage(onMessage)
+			adapter.onStatusChange(onStatusChange)
 
 			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			const prevWs = adapter._ws
 			warnOnceMock.mockClear()
 
 			connectedServerSocket.send('{ "type": "message",')
-			connectedServerSocket.send('{ "type": "message", "data": "hello" }')
 
-			await waitFor(() => onMessage.mock.calls.length === 1)
-			expect(onMessage).toHaveBeenCalledWith({ type: 'message', data: 'hello' })
-			expect(adapter.connectionStatus).toBe('online')
+			// the malformed message is never forwarded to listeners, and the connection restarts so
+			// the client re-hydrates from the last known server clock rather than silently desyncing
+			await waitFor(() => adapter._ws !== prevWs && adapter._ws?.readyState === WebSocket.OPEN)
+			expect(onMessage).not.toHaveBeenCalled()
 			expect(warnOnceMock).toHaveBeenCalledWith(
-				'Received malformed WebSocket message. Dropping message.'
+				'Received malformed WebSocket message. Restarting the connection.'
 			)
+			expect(onStatusChange).toHaveBeenCalledWith({ status: 'offline' })
+			expect(onStatusChange).toHaveBeenCalledWith({ status: 'online' })
+			expect(adapter.connectionStatus).toBe('online')
 		})
 
 		it('[CW7] stops delivering messages after unsubscribe', async () => {

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -433,6 +433,12 @@ describe('ClientWebSocketAdapter', () => {
 			expect(onStatusChange).toHaveBeenCalledWith({ status: 'offline' })
 			expect(onStatusChange).toHaveBeenCalledWith({ status: 'online' })
 			expect(adapter.connectionStatus).toBe('online')
+
+			// the restarted connection is fully functional: a well-formed message on the new socket
+			// is delivered to listeners as usual
+			connectedServerSocket.send('{ "type": "message", "data": "hello" }')
+			await waitFor(() => onMessage.mock.calls.length === 1)
+			expect(onMessage).toHaveBeenCalledWith({ type: 'message', data: 'hello' })
 		})
 
 		it('[CW7] stops delivering messages after unsubscribe', async () => {

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -216,7 +216,13 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 			try {
 				parsed = JSON.parse(ev.data.toString())
 			} catch {
-				warnOnce('Received malformed WebSocket message. Dropping message.')
+				// A malformed message means the connection delivered corrupt data, so we can't trust
+				// that we're still in sync. Dropping the message can silently desync the client (e.g. a
+				// missed 'patch' is applied as if it never happened), so instead we restart the
+				// connection. Reconnecting re-hydrates the store from the last known server clock and
+				// brings us fully back in sync.
+				warnOnce('Received malformed WebSocket message. Restarting the connection.')
+				this.restart()
 				return
 			}
 			this.messageListeners.forEach((cb) => cb(parsed))


### PR DESCRIPTION
Follow-up to #9356. That PR fixed the crash from malformed WebSocket frames (#9119) by catching the `JSON.parse` failure and dropping the message. This tightens the recovery so a dropped message can't silently desync the client.

### The problem with dropping

Server→client messages are not chunked (`ServerSocketAdapter.sendMessage` sends whole JSON), so a malformed frame is genuinely corrupt data, not a chunk fragment. Most message types recover on their own if dropped:

- `push_result` — the next one fails the `clientClock` ordering check in `rebase`, which resets the connection.
- `connect` response — `isConnectedToRoom` never becomes true, so the client stays offline and never applies server data. It can't silently desync; at worst it's visibly stuck offline until the next connection attempt.

But a dropped `patch` does not. The patch path applies network diffs incrementally and does not check `serverClock` for gaps, so a missed partial patch is applied as if it never happened. The result is a silently stale field that only heals on the next reconnect.

### The fix

On a malformed message, restart the connection instead of dropping it. Reconnecting sends a `connect` with the last known `serverClock`, and the server responds with a re-hydration diff that brings the client fully back in sync. The crash is still gone, and these frames are rare and indicate a flaky connection anyway (the original Sentry issue was mostly mobile Safari), so the cost of a reconnect round-trip is negligible.

### Change type

- [x] `bugfix`

### Test plan

1. Send a malformed JSON frame to a `ClientWebSocketAdapter` socket.
2. Confirm the message is not forwarded to listeners.
3. Confirm the adapter restarts: it goes offline then back online with a new socket.
4. Confirm the restarted connection still delivers well-formed messages.

- [x] Unit tests

### Release notes

- Sync clients now restart the connection when they receive a malformed WebSocket message, so a corrupt frame can no longer silently leave the client out of sync.
