### PR TITLE
security(deps): bump undici, silence socket false positives

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,11 @@
+version: 2
+
+# Socket.dev configuration. See https://docs.socket.dev/docs/socket-yml
+#
+# issueRules turns specific alert types on or off repo-wide. Keys are the alert
+# type slugs shown on Socket's issues page. Anything omitted falls back to the
+# org dashboard settings.
+issueRules:
+  # posthog-js is an intentional, first-party analytics dependency. The telemetry
+  # alert is informational and not actionable here.
+  telemetry: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -32252,25 +32252,25 @@ __metadata:
   linkType: hard
 
 "undici@npm:^5.25.4":
-  version: 5.28.5
-  resolution: "undici@npm:5.28.5"
+  version: 5.29.0
+  resolution: "undici@npm:5.29.0"
   dependencies:
     "@fastify/busboy": "npm:^2.0.0"
-  checksum: 10/459cd84ab75fe90d696fa2634a8b5b23f9e1080b27236c6809bd74e51862be85df6d95b4a8fed3ee42554495008cb3c05f1bc9d4a1807478f433cca567003d70
+  checksum: 10/0ceca8924a32acdcc0cfb8dd2d368c217840970aa3f5e314fc169608474be6341c5b8e50cad7bd257dbe3b4e432bc5d0a0d000f83644b54fa11a48735ec52b93
   languageName: node
   linkType: hard
 
 "undici@npm:^6.21.3, undici@npm:^6.23.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10/a1715ee4304f58fecd61e0a8c3bd7064435cfbc98b3ec1414dba5e89de97d436b7e88dd094b06ff8440428bf36b56163fc88972118890826039865edf58bdfcf
+  version: 6.27.0
+  resolution: "undici@npm:6.27.0"
+  checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
   languageName: node
   linkType: hard
 
 "undici@npm:^7.16.0, undici@npm:^7.19.0, undici@npm:^7.25.0":
-  version: 7.27.0
-  resolution: "undici@npm:7.27.0"
-  checksum: 10/7b6a56a03983f6421b1c61dffcd69cbd3e7708a75c4bafdd2a5156536f95979f4b95dcd9508ea1a6af6fce2c3398a7c86606542cc9d1c8c11c06ec76cabbcf7a
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to #9366, addressing the latest socket.dev scan of `main`.

## Context

The re-scan confirms #9366 landed cleanly — `vite` and `lodash.pick` alerts are gone. The only genuinely new actionable item is a batch of undici advisories, plus a small config change.

## Change type

- [x] `other`

## Changes

### Bump undici to 7.28.0
Five advisories were published against the `undici@7.27.0` already in the tree since the prior scan:

- CVE-2026-12151 (**7.5**), CVE-2026-6734 (**7.5**) — high
- CVE-2026-9679 (5.9), CVE-2026-6733 (3.7), CVE-2026-11525 (3.7)

on top of the existing CVE-2026-9697 (7.4) and CVE-2026-9678 (5.9). undici is a production transitive dep (via `@vercel/sandbox`, `cheerio`, `jsdom`), all of which allow `^7.x`, so `7.28.0` resolves with no override. `yarn up -R` also moved the dev-scope copies up (`5.28.5 → 5.29.0`, `6.26.0 → 6.27.0`), clearing those advisories too. Lockfile-only, 9 lines.

### Add `socket.yml`
Disables the `telemetry` alert category repo-wide — it flags `posthog-js`, a deliberate first-party analytics dependency, and is informational rather than actionable.

## Not included

- **`obfuscatedFile` suppression** — intentionally left enabled. Those alerts are noisy false positives on minified bundles, but keeping the category on preserves the signal for a genuinely malicious obfuscated payload in a future dependency.
- **`tar@6.2.1`** — still deferred; the consumers (`cacache`, `node-gyp`, `sqlite3`) need the tar v6 API and the fix is v7.
- The lower-severity `monitor`-level transitive tail (lodash-es, ws, js-cookie, path-to-regexp, @remix-run/router, qs, react-router) and dev-only CVEs — can batch separately if wanted.

## Test plan

- `yarn typecheck` passes.
- Pre-commit hooks pass.