### PR TITLE
fix(tldraw): refresh minimap screen bounds on pointer down

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
+++ b/packages/tldraw/src/lib/ui/components/Minimap/DefaultMinimap.tsx
@@ -76,6 +76,8 @@ export function DefaultMinimap() {
 			if (!minimap) return
 			if (e.button !== 0) return
 
+			minimap.updateCanvasScreenBounds()
+
 			const elm = e.currentTarget
 			setPointerCapture(elm, e)
 			if (!editor.getCurrentPageShapeIds().size) return

--- a/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
+++ b/packages/tldraw/src/lib/ui/components/Minimap/MinimapManager.ts
@@ -83,16 +83,21 @@ export class MinimapManager {
 		return new Box(x, y, width, height)
 	}
 
-	private readonly canvasBoundingClientRect = atom('canvasBoundingClientRect', new Box())
+	private readonly canvasBoundingClientRect = atom('canvasBoundingClientRect', new Box(), {
+		isEqual: (a, b) => a.equals(b),
+	})
 
 	getCanvasScreenBounds() {
 		return this.canvasBoundingClientRect.get()
 	}
 
+	updateCanvasScreenBounds() {
+		this.canvasBoundingClientRect.set(this._getCanvasBoundingRect())
+	}
+
 	private _listenForCanvasResize() {
 		const observer = new ResizeObserver(() => {
-			const rect = this._getCanvasBoundingRect()
-			this.canvasBoundingClientRect.set(rect)
+			this.updateCanvasScreenBounds()
 		})
 		observer.observe(this.elem)
 		observer.observe(this.container)


### PR DESCRIPTION
## What

Fixes #8383

Fixes the minimap click offset where clicking to navigate jumps to a point offset from the cursor.

## Why

The minimap converts a click to a page point using its cached on-screen rect (`canvasBoundingClientRect`). That cache was only refreshed by a `ResizeObserver`, which fires on size changes but **not** when the element moves on screen without resizing — page scroll, toggling panels, layout reflow, or an embedded page shifting around. When that happened, the cached position went stale and every click was offset by however much the minimap had moved.

## How

- Refresh the cached rect on **pointer down**, before mapping the click to a page point. This covers every navigation path (click, drag, double-click), since a drag always starts with a pointer down and a double-click is always preceded by one.
- The `canvasBoundingClientRect` atom now uses `Box` value-equality (`isEqual`), so re-measuring to the same rect is a no-op and never triggers a re-render.
- `render()` keeps reading the cached value, so the per-frame render path stays free of layout reads.

## Performance

The fix needs a fresh `getBoundingClientRect()` measurement at the right moment. The table shows how many measurements each approach makes (a forced layout read), per scenario:

| Scenario | Cache only (before, buggy) | `getBoundingClientRect` in `render()` | Refresh in `getMinimapPagePoint` | Refresh on pointer down (this PR) |
|---|---|---|---|---|
| Idle | 0 | 0 | 0 | 0 |
| Main-canvas pan/zoom (not on minimap) | 0 | **1 per frame** | 0 | 0 |
| Hover over minimap | 0 | 0 | 2 per `pointermove` | 0 |
| Click to navigate | 0 | 1 per frame while easing | 1 | **1** |
| Drag on minimap | 0 | 1 per frame | 2 per `pointermove` | **1 (at drag start)** |
| Correct after the minimap moves without resizing | ❌ | ✅ | ✅ | ✅ |

Pointer-down refresh fixes the bug with a single measurement per interaction, while keeping the render loop and normal canvas panning free of layout reads. The only path that still uses the last-known rect is plain hover, which drives hover feedback only — never navigation.

## Test plan

- [ ] Open tldraw with shapes, click around the minimap — viewport centers on the click point.
- [ ] Scroll the page (or toggle panels) so the minimap moves without resizing, then click the minimap — still centers correctly.
- [ ] Drag on the minimap — viewport follows smoothly.
- [ ] Double-click the minimap — centers and zooms to the point.