### PR TITLE
fix(editor): treat all loopback hosts as development environment

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -62,26 +62,29 @@ describe('LicenseManager', () => {
 
 		it('Signals that it is development mode for loopback hosts', async () => {
 			process.env.NODE_ENV = 'production'
-			const schemes = ['http', 'https']
-			const hosts = ['localhost', '127.0.0.1', '127.0.0.2', '[::1]']
-			for (const scheme of schemes) {
-				for (const host of hosts) {
-					// @ts-ignore
-					delete window.location
-					// @ts-ignore
-					window.location = new URL(`${scheme}://${host}:3000`)
+			try {
+				const schemes = ['http', 'https']
+				const hosts = ['localhost', '127.0.0.1', '127.0.0.2', '[::1]']
+				for (const scheme of schemes) {
+					for (const host of hosts) {
+						// @ts-ignore
+						delete window.location
+						// @ts-ignore
+						window.location = new URL(`${scheme}://${host}:3000`)
 
-					const testEnvLicenseManager = new LicenseManager('', keyPair.publicKey)
-					const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
-					const result = await testEnvLicenseManager.getLicenseFromKey(licenseKey)
-					expect(result).toMatchObject({
-						isLicenseParseable: true,
-						isDomainValid: false,
-						isDevelopment: true,
-					})
+						const testEnvLicenseManager = new LicenseManager('', keyPair.publicKey)
+						const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+						const result = await testEnvLicenseManager.getLicenseFromKey(licenseKey)
+						expect(result).toMatchObject({
+							isLicenseParseable: true,
+							isDomainValid: false,
+							isDevelopment: true,
+						})
+					}
 				}
+			} finally {
+				process.env.NODE_ENV = 'test'
 			}
-			process.env.NODE_ENV = 'test'
 		})
 
 		it('Signals that it is development mode when NODE_ENV is not production', async () => {

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -60,23 +60,28 @@ describe('LicenseManager', () => {
 			expect(result).toMatchObject({ isLicenseParseable: false, reason: 'no-key-provided' })
 		})
 
-		it('Signals that it is development mode when localhost', async () => {
+		it('Signals that it is development mode for loopback hosts', async () => {
+			process.env.NODE_ENV = 'production'
 			const schemes = ['http', 'https']
+			const hosts = ['localhost', '127.0.0.1', '127.0.0.2', '[::1]']
 			for (const scheme of schemes) {
-				// @ts-ignore
-				delete window.location
-				// @ts-ignore
-				window.location = new URL(`${scheme}://localhost:3000`)
+				for (const host of hosts) {
+					// @ts-ignore
+					delete window.location
+					// @ts-ignore
+					window.location = new URL(`${scheme}://${host}:3000`)
 
-				const testEnvLicenseManager = new LicenseManager('', keyPair.publicKey)
-				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
-				const result = await testEnvLicenseManager.getLicenseFromKey(licenseKey)
-				expect(result).toMatchObject({
-					isLicenseParseable: true,
-					isDomainValid: false,
-					isDevelopment: true,
-				})
+					const testEnvLicenseManager = new LicenseManager('', keyPair.publicKey)
+					const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+					const result = await testEnvLicenseManager.getLicenseFromKey(licenseKey)
+					expect(result).toMatchObject({
+						isLicenseParseable: true,
+						isDomainValid: false,
+						isDevelopment: true,
+					})
+				}
 			}
+			process.env.NODE_ENV = 'test'
 		})
 
 		it('Signals that it is development mode when NODE_ENV is not production', async () => {

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -125,12 +125,18 @@ export class LicenseManager {
 	}
 
 	private getIsDevelopment() {
-		// If we are using https on a non-localhost domain we assume it's a production env and a development one otherwise
+		// If we are using https on a non-loopback domain we assume it's a production env and a development one otherwise
 		return (
 			!['https:', 'vscode-webview:'].includes(window.location.protocol) ||
-			window.location.hostname === 'localhost' ||
+			this.isLoopbackHost(window.location.hostname) ||
 			process.env.NODE_ENV !== 'production'
 		)
+	}
+
+	private isLoopbackHost(hostname: string) {
+		// localhost, IPv4 loopback (127.0.0.0/8) and IPv6 loopback (::1) are all local development hosts
+		const host = hostname.toLowerCase().replace(/^\[|\]$/g, '')
+		return host === 'localhost' || host === '::1' || /^127(?:\.\d{1,3}){3}$/.test(host)
 	}
 
 	private getTrackType(result: LicenseFromKeyResult, licenseState: LicenseState): TrackType {


### PR DESCRIPTION
In order to support local development served over loopback addresses other than `localhost`, this PR makes the license manager treat all loopback hosts as a development environment.

Previously `LicenseManager.getIsDevelopment()` only recognized `localhost`. When an app was served over `https://127.0.0.1` or `https://[::1]` (for example, SiYuan's plugin host opens pages on `https://127.0.0.1`), tldraw treated it as a production deployment and validated the license against the domain, surfacing license errors in what is really a local dev environment.

This change recognizes the full IPv4 loopback range (`127.0.0.0/8`), the IPv6 loopback (`::1`, with or without brackets), and `localhost` as development hosts.

### Change type

- [x] `bugfix`

### Test plan

1. Serve a tldraw app with a non-`localhost` loopback host (e.g. `https://127.0.0.1` or `https://[::1]`) in a production build.
2. Confirm it is treated as a development environment (no production license validation/error).

- [x] Unit tests

### Release notes

- Fix the license manager treating loopback hosts other than `localhost` (such as `127.0.0.1` and `::1`) as production environments.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Core code | +8 / -2 |
| Tests   | +19 / -14 |
