### PR TITLE
fix(utils): restore index key jitter to 30 bits

### DIFF
--- a/packages/utils/src/lib/fractionalIndexing.ts
+++ b/packages/utils/src/lib/fractionalIndexing.ts
@@ -22,9 +22,16 @@ const SMALLEST_INTEGER = 'A' + ZERO.repeat(26)
 // reducing the chance of collisions when multiple clients insert into the same
 // gap at once. Each bit costs one extra key generation and ~0.17 characters of
 // key length, so this trades collision resistance against compute and key size.
-// 16 keeps collisions below ~0.1% even for ~10 simultaneous same-position
-// inserts, which is ample headroom for real multiplayer use.
-const JITTER_BITS = 16
+//
+// This is the upstream `jittered-fractional-indexing` default. The collision
+// margin has to cover the worst case of many keys generated into the *same*
+// gap at once — e.g. an offline client that reordered a heavily-populated page
+// reconnecting and merging its keys in one batch. At our 4000-shape ceiling the
+// birthday-collision odds for that worst case are ~0.7% at 30 bits, versus
+// effectively certain at 16. Colliding index keys are what caused the duplicate
+// z-order bugs that motivated jitter in the first place (#3932, #4126, #4210,
+// #5864, #6141), so we keep the conservative margin.
+const JITTER_BITS = 30
 
 function getIntegerLength(head: string): number {
 	if (head >= 'a' && head <= 'z') {


### PR DESCRIPTION
## What's changed?

Restores the fractional-index jitter to **30 bits**. PR #9352 ("inline fractional indexing") lowered it from 30 to 16 while vendoring the library. 30 wasn't an arbitrary number — it's the upstream `jittered-fractional-indexing` default, chosen for a large collision margin.

## Why?

Jitter exists to stop two clients from generating the **same** index key for the same position, which surfaces as duplicate/unstable z-order — the exact class of bug that motivated jitter originally (#3932, #4126, #4210, #5864, #6141).

Collisions are **per-gap**: they only matter when many keys are generated into the same `(a, b)` gap concurrently. The realistic worst case is an offline client that reordered a heavily-populated page reconnecting and merging its keys in one batch. Against our 4000-shape ceiling, the birthday-collision odds for that worst case are:

| jitter bits | buckets | collision % at k=4000 (same gap) |
| --- | --- | --- |
| 16 (current `main`) | 65,536 | ~100% (effectively certain) |
| 24 | 16.7M | ~38% |
| **30 (this PR)** | 1.07B | **~0.7%** |

16 bits is fine for everyday concurrency (~0.1% at ~10 simultaneous inserts) but has no headroom against our own stated maximum. Since we know the ceiling is 4000, sizing the margin from that number rather than "~10 inserts" is the safer call.

## Trade-off

This gives back the ~3-character key-length reduction and the per-key generation savings from #9352. The much larger win in that PR — `validateIndexKey` no longer generating and discarding a fully jittered key on every validation — is on the validation path and is **unaffected** by this change.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

`packages/utils` `fractionalIndexing.test.ts` passes (31/31). The jittered invariants (ordered, valid, in-bounds, distinct) hold; no test asserts on jitter bit count or key length.

### Release notes

- Restored fractional index key jitter to its previous strength (30 bits) to keep the collision margin large for big offline/multiplayer reorders. Newly generated index keys are slightly longer again.