### PR TITLE
fix(dotcom): improve sidebar section header contrast in dark themes

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -470,6 +470,13 @@
 	color: var(--tl-color-text-3);
 }
 
+/* In dark mode, text-3 alone is too low-contrast on the darkest theme sidebars
+   (e.g. GitHub, One Dark, Flexoki); blend toward the primary text color to lift
+   the floor. Light themes keep plain text-3, where it reads fine and stays subtle. */
+:global(.tla-theme__dark) .sidebarFileSectionTitle {
+	color: color-mix(in srgb, var(--tl-color-text-3) 60%, var(--tl-color-text));
+}
+
 .sidebar[data-workspaces='true'] .sidebarFileSectionTitle {
 	padding: 0px 8px;
 	font-weight: 500;


### PR DESCRIPTION
## Problem

In dark themes, the sidebar section headers ("Pinned", "This month") render too dark to read. The labels use `--tl-color-text-3` — an intentionally muted token — directly on `--tla-color-sidebar`, and that pairing was never tuned for contrast. Auditing every theme, only High Contrast and GitHub light clear WCAG AA; the worst offenders are the darkest dark themes:

| Theme (dark) | header text vs sidebar | previous | with fix |
| --- | --- | --- | --- |
| GitHub | `#484f58` on `#010409` | 2.48 : 1 | 5.35 : 1 |
| One Dark | `#5c6370` on `#21252b` | 2.55 : 1 | 4.01 : 1 |
| Flexoki | `#575653` on `#0b0a0a` | 2.69 : 1 | 5.39 : 1 |

The previous values sit below ~2.7:1, where the muted text visually disappears; the fix lifts every dark theme above 3:1.

## Fix

In dark mode, blend the muted token toward the theme's primary text color. The base rule is unchanged; a dark-scoped override does the blend:

```css
:global(.tla-theme__dark) .sidebarFileSectionTitle {
	color: color-mix(in srgb, var(--tl-color-text-3) 60%, var(--tl-color-text));
}
```

Because the blend is relative to each theme's own primary text, it self-scales: dark themes (bright primary text) get a large lift. It keeps the headers quieter than the file rows while lifting every dark theme above 3:1 — GitHub and Flexoki land north of 5:1, One Dark at ~4:1.

The light/dark distinction comes from the `tla-theme__dark` / `tla-theme__light` class that `TlaRootProviders` puts on the root container; the named color theme (GitHub, Dracula, …) is applied separately as inline CSS variables, so light/dark class is the stable hook to scope against.

## Why not just retune `--tl-color-text-3`?

It's tempting, since `#484f58` is genuinely too dark across all of GitHub dark's surfaces. But `--tl-color-text-3` is a **shared SDK token** (`packages/tldraw`), not a sidebar-local one. The dotcom themes set its value, but the embedded editor reads the same variable for five surfaces: input placeholders, page-menu drag handles, page-menu submenu buttons, shortcut-dialog group titles, and people-menu labels. Lightening the token to fix the sidebar would simultaneously recolour all of those — across both the app and the SDK, in every theme — and some (like the drag handle) are deliberately faint affordances. Fixing the contrast at the sidebar's consumption site keeps the change scoped and leaves the editor surfaces untouched.

There is a related, real issue: in GitHub dark the same token is also low-contrast on the editor panels (page-menu drag handle ~2.1:1, ~1.8:1 on a hovered row). That's a separate, cross-package SDK decision and is intentionally **out of scope** here.

## Scope: dark mode only

The override is deliberately scoped to dark mode. The blend only modestly helps **light** themes anyway — there the primary text is dark and `--tl-color-text-3` is a mid-gray, so pulling toward primary against a near-white sidebar moves contrast little — and light themes already read acceptably, so they keep plain `text-3` untouched. If we later decide light themes also need work, that's a separate, light-specific treatment.

## Preview & how to test

Preview: https://pr-9386-preview-deploy.tldraw.com/

1. Open the preview and sign in.
2. Open user preferences and set the color theme to **GitHub** with **dark** appearance (also worth checking **One Dark** and **Flexoki** dark).
3. Look at the sidebar "Pinned" / "This month" section headers — before this change they're nearly invisible; after, they're legible while still clearly subordinate to the file names below them.


Before and after:

<img width="259" height="404" alt="Screenshot 2026-06-23 at 16 12 27" src="https://github.com/user-attachments/assets/9f28b4b5-6481-4b79-9465-ad55c3388983" />
<img width="259" height="404" alt="Screenshot 2026-06-23 at 16 12 29" src="https://github.com/user-attachments/assets/1aebb459-4ab8-4a31-9965-9b362736621b" />
