### PR TITLE
fix(dotcom): delete local db after a fully-successful slurp

### DIFF
--- a/apps/dotcom/client/src/tla/utils/slurping.tsx
+++ b/apps/dotcom/client/src/tla/utils/slurping.tsx
@@ -1,4 +1,4 @@
-// import { deleteDB } from 'idb'
+import { deleteDB } from 'idb'
 import {
 	Editor,
 	ExecutionQueue,
@@ -19,6 +19,8 @@ import { SlurpFailure } from '../components/TlaEditor/SlurpFailure'
 
 const UPLOAD_CONCURRENCY = 3
 const SHOULD_SLURP_FILE = 'SHOULD_SLURP_FILE'
+// Must match STORE_PREFIX in packages/editor LocalIndexedDb.ts
+const STORE_PREFIX = 'TLDRAW_DOCUMENT_v2'
 
 export function getShouldSlurpFile() {
 	return getFromLocalStorage(SHOULD_SLURP_FILE)
@@ -223,15 +225,22 @@ export class Slurper {
 			// .every returns true if the array is empty, so this will run if there
 			// were no assets to upload!
 
-			// all uploads succeeded, clear the local db
-			// (temporarily do not delete the db in case something goes wrong and people lose their stuffs)
-			// deleteDB('TLDRAW_DOCUMENT_v2' + this.opts.slurpPersistenceKey)
+			// the document data has been loaded into the (now cloud-synced) editor and
+			// every asset has been uploaded to the cloud, so the local db is fully
+			// redundant. Mark the slurp as finished first so we never re-slurp, then
+			// delete the local db to reclaim the storage.
 			this.opts.editor.updateDocumentSettings({
 				meta: {
 					...this.opts.editor.getDocumentSettings().meta,
 					slurpFinished: true,
 				},
 			})
+			try {
+				await deleteDB(STORE_PREFIX + this.opts.slurpPersistenceKey)
+			} catch (e) {
+				// non-fatal: the slurp is already finished, this just leaves stale local data behind
+				console.error('Failed to delete local db after slurp', e)
+			}
 			return
 		}
 


### PR DESCRIPTION
In order to stop redundant local data piling up in IndexedDB, this PR deletes the local file's IndexedDB database once a signed-out user's file has been fully slurped into the cloud.

When a signed-out user signs in, their local file is slurped: document records are loaded into the now cloud-synced editor and every local asset is uploaded, with each asset's `src` rewritten from `asset:` to its cloud URL. Previously the local IndexedDB database was intentionally left behind (a temporary safety measure), so the `records` and `assets` stores kept accumulating data that was already migrated to the cloud.

Once the slurp fully succeeds the local database is redundant, so we now delete it. `slurpFinished` is set first so we never re-slurp, and the deletion is best-effort: on failure we fall back to the previous behavior of leaving the local data in place. Failed slurps still preserve the local database via the existing `onSlurpFail` path, so nothing is removed unless every asset upload succeeded.

### Change type

- [x] `bugfix`

### Test plan

1. While signed out, create a local file with some image/asset content (assets are stored in IndexedDB under `TLDRAW_DOCUMENT_v2<key>` → `assets` store).
2. Sign in and let the file slurp into the cloud.
3. Once the slurp finishes, confirm the `TLDRAW_DOCUMENT_v2<key>` database is gone from IndexedDB and assets still render (now served from the cloud).
4. Force an asset upload failure mid-slurp and confirm the local database is preserved and the failure dialog appears.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Delete a signed-out user's local IndexedDB file after it has been fully migrated to the cloud on sign-in, instead of leaving the migrated data behind.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +13 / -4   |