### PR TITLE
fix(tldraw): mirror crop when flipping a grouped image by drag resize

### DIFF
--- a/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/image/ImageShapeUtil.tsx
@@ -170,7 +170,7 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 	override onResize(shape: TLImageShape, info: TLResizeInfo<TLImageShape>) {
 		let resized: TLImageShape = resizeBox(shape, info)
 		const { flipX, flipY } = info.initialShape.props
-		const { scaleX, scaleY, mode } = info
+		const { scaleX, scaleY } = info
 
 		resized = {
 			...resized,
@@ -182,16 +182,12 @@ export class ImageShapeUtil extends BaseBoxShapeUtil<TLImageShape> {
 		}
 		if (!shape.props.crop) return resized
 
-		const flipCropHorizontally =
-			// We used the flip horizontally feature
-			(mode === 'scale_shape' && scaleX === -1) ||
-			// We resized the shape past it's bounds, so it flipped
-			(mode === 'resize_bounds' && flipX !== resized.props.flipX)
-		const flipCropVertically =
-			// We used the flip vertically feature
-			(mode === 'scale_shape' && scaleY === -1) ||
-			// We resized the shape past it's bounds, so it flipped
-			(mode === 'resize_bounds' && flipY !== resized.props.flipY)
+		// Mirror the crop whenever the shape is flipped along an axis. This happens both when
+		// using the flip command and when dragging a resize handle (including a group's handle)
+		// past the opposite edge. We can't check for an exact scale of -1 here because a group
+		// flip resizes its children by an arbitrary negative scale, not just -1.
+		const flipCropHorizontally = scaleX < 0
+		const flipCropVertically = scaleY < 0
 
 		const { topLeft, bottomRight } = shape.props.crop
 		resized.props.crop = {

--- a/packages/tldraw/src/test/ImageShapeUtil.test.ts
+++ b/packages/tldraw/src/test/ImageShapeUtil.test.ts
@@ -1,6 +1,44 @@
 import { createShapeId, Ellipse2d, Rectangle2d, TLImageShape } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
 
+const ids = {
+	image: createShapeId('image'),
+	box: createShapeId('box'),
+}
+
+function createCroppedImageWithSibling() {
+	editor.createShapes([
+		{
+			id: ids.image,
+			type: 'image',
+			x: 0,
+			y: 0,
+			props: {
+				w: 100,
+				h: 100,
+				assetId: null,
+				playing: true,
+				url: '',
+				// crop to the top-left quadrant of the source image
+				crop: {
+					topLeft: { x: 0, y: 0 },
+					bottomRight: { x: 0.5, y: 0.5 },
+				},
+				flipX: false,
+				flipY: false,
+				altText: '',
+			},
+		},
+		{
+			id: ids.box,
+			type: 'geo',
+			x: 300,
+			y: 0,
+			props: { w: 100, h: 100 },
+		},
+	])
+}
+
 let editor: TestEditor
 
 beforeEach(() => {
@@ -151,6 +189,56 @@ describe('ImageShapeUtil', () => {
 			expect(geometry.bounds.width).toBe(200)
 			expect(geometry.bounds.height).toBe(150)
 			expect(geometry.isFilled).toBe(true)
+		})
+	})
+
+	describe('flipping a cropped image when its group is resized', () => {
+		it('mirrors the crop when a grouped cropped image is flipped by drag resize', () => {
+			createCroppedImageWithSibling()
+			editor.select(ids.image, ids.box)
+			editor.groupShapes(editor.getSelectedShapeIds())
+
+			// Flip the group horizontally by dragging a corner handle past the
+			// opposite edge. The drag scale is not exactly -1, which is the case
+			// that previously left the crop un-mirrored.
+			editor.resizeSelection({ scaleX: -2, scaleY: 1 }, 'top_left')
+
+			const image = editor.getShape<TLImageShape>(ids.image)!
+			expect(image.props.flipX).toBe(true)
+			// The crop should be mirrored horizontally and unchanged vertically.
+			expect(image.props.crop).toMatchObject({
+				topLeft: { x: 0.5, y: 0 },
+				bottomRight: { x: 1, y: 0.5 },
+			})
+		})
+
+		it('mirrors the crop vertically when a grouped cropped image is flipped by drag resize', () => {
+			createCroppedImageWithSibling()
+			editor.select(ids.image, ids.box)
+			editor.groupShapes(editor.getSelectedShapeIds())
+
+			editor.resizeSelection({ scaleX: 1, scaleY: -2 }, 'top_left')
+
+			const image = editor.getShape<TLImageShape>(ids.image)!
+			expect(image.props.flipY).toBe(true)
+			expect(image.props.crop).toMatchObject({
+				topLeft: { x: 0, y: 0.5 },
+				bottomRight: { x: 0.5, y: 1 },
+			})
+		})
+
+		it('matches the flipShapes command result for a grouped cropped image', () => {
+			createCroppedImageWithSibling()
+			editor.select(ids.image, ids.box)
+			editor.groupShapes(editor.getSelectedShapeIds())
+			editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
+
+			const image = editor.getShape<TLImageShape>(ids.image)!
+			expect(image.props.flipX).toBe(true)
+			expect(image.props.crop).toMatchObject({
+				topLeft: { x: 0.5, y: 0 },
+				bottomRight: { x: 1, y: 0.5 },
+			})
 		})
 	})
 })


### PR DESCRIPTION
In order to fix flipping a group that contains a cropped image, this PR mirrors the crop whenever the resize scale becomes negative on an axis, regardless of resize mode. Closes #9392.

When you flip a group by dragging a corner handle, the group resizes its children with mode `scale_shape` and an arbitrary negative scale (rarely exactly `-1`, since the drag also resizes). `ImageShapeUtil.onResize` only mirrored the crop when the scale was exactly `-1` (the flip command) or in `resize_bounds` mode (a lone selected image). So a grouped cropped image had its `flipX`/`flipY` toggled but its crop left un-mirrored, and the visible window ended up showing the wrong part of the image — the "shifted" appearance in the report.

Both of the previous conditions reduce algebraically to "the scale sign flipped on that axis", so this replaces them with a direct `scaleX < 0` / `scaleY < 0` check. The `flipShapes` command (which passes exactly `-1`) and lone-image drag flips are unchanged; group drag flips now mirror the crop the same way.

### Change type

- [x] `bugfix`

### Test plan

1. Add an asymmetrical image to the canvas and crop it to a corner.
2. Add a second shape offset from the image and group the two.
3. Drag a corner handle of the group past the opposite edge to flip it.
4. The cropped image's visible region mirrors correctly and stays aligned, matching the result of the flip command.

- [x] Unit tests

### Release notes

- Fix the crop of a grouped, cropped image shifting when the group is flipped by dragging a resize handle.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -11   |
| Tests     | +88 / -0   |