### PR TITLE
feat(tldraw): replace a cropping image by pasting a new image

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/clipboard/pasteFiles.ts
+++ b/packages/tldraw/src/lib/ui/hooks/clipboard/pasteFiles.ts
@@ -20,6 +20,24 @@ export async function pasteFiles(
 		blob instanceof File ? blob : new File([blob], 'tldrawFile', { type: blob.type })
 	)
 
+	// When a single image is pasted while an image is being cropped, replace the
+	// cropped image in place instead of creating a new shape. This matches the
+	// "replace image" action, preserving the crop transform across the swap.
+	const croppingShapeId = editor.getCroppingShapeId()
+	if (croppingShapeId && files.length === 1 && files[0].type.startsWith('image/')) {
+		const croppingShape = editor.getShape(croppingShapeId)
+		if (croppingShape?.type === 'image') {
+			editor.markHistoryStoppingPoint('paste')
+			await editor.replaceExternalContent({
+				type: 'file-replace',
+				file: files[0],
+				shapeId: croppingShapeId,
+				isImage: true,
+			})
+			return
+		}
+	}
+
 	editor.markHistoryStoppingPoint('paste')
 
 	await putPastedExternalContent(

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -138,10 +138,10 @@ const isSvgText = (text: string) => {
  *
  * @internal
  */
-function areShortcutsDisabled(editor: Editor) {
+function areShortcutsDisabled(editor: Editor, { ignoreFocusedElement = false } = {}) {
 	return (
 		editor.menus.hasAnyOpenMenus() ||
-		activeElementShouldCaptureKeys(false, editor.getContainerDocument())
+		(!ignoreFocusedElement && activeElementShouldCaptureKeys(false, editor.getContainerDocument()))
 	)
 }
 
@@ -927,8 +927,15 @@ export function useNativeClipboardEvents() {
 
 			// If we're editing a shape, or we are focusing an editable input, then
 			// we would want the user's paste interaction to go to that element or
-			// input instead; e.g. when pasting text into a text shape's content
-			if (editor.getEditingShapeId() !== null || areShortcutsDisabled(editor)) return
+			// input instead; e.g. when pasting text into a text shape's content.
+			// While cropping, the crop zoom slider holds keyboard focus; don't let
+			// that suppress paste, so pasting an image can replace the cropped image.
+			const isCroppingImage = editor.getCroppingShapeId() !== null
+			if (
+				editor.getEditingShapeId() !== null ||
+				areShortcutsDisabled(editor, { ignoreFocusedElement: isCroppingImage })
+			)
+				return
 
 			// Cmd+Shift+V / Ctrl+Shift+V = paste as plain text (no formatting).
 			// If there's no plain text on the clipboard (e.g., a copied PNG), fall

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1,6 +1,7 @@
 import { createShapeId, TLImageShape } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { MIN_CROP_SIZE } from '../lib/shapes/shared/crop'
+import { pasteFiles } from '../lib/ui/hooks/clipboard/pasteFiles'
 import { defaultHandleOverlays, TestEditor } from './TestEditor'
 
 vi.useFakeTimers()
@@ -1238,5 +1239,69 @@ describe('When cropping with modifiers and snapping...', () => {
 
 		editor.pointerUp()
 		expect(editor.snaps.getIndicators().length).toBe(0)
+	})
+})
+
+describe('Pasting an image while cropping', () => {
+	function makeImageFile() {
+		return new File(['fake'], 'pasted.png', { type: 'image/png' })
+	}
+
+	it('replaces the cropping image in place without creating a new shape', async () => {
+		const replaceSpy = vi.spyOn(editor, 'replaceExternalContent').mockResolvedValue()
+		const putSpy = vi.spyOn(editor, 'putExternalContent').mockResolvedValue()
+
+		editor.select(ids.imageA)
+		editor.setCroppingShape(ids.imageA)
+		expect(editor.getCroppingShapeId()).toBe(ids.imageA)
+
+		const shapeCountBefore = editor.getCurrentPageShapes().length
+		await pasteFiles(editor, [makeImageFile()])
+
+		expect(replaceSpy).toHaveBeenCalledTimes(1)
+		expect(replaceSpy.mock.calls[0][0]).toMatchObject({
+			type: 'file-replace',
+			shapeId: ids.imageA,
+		})
+		expect(putSpy).not.toHaveBeenCalled()
+		// No new shape is created and we stay in crop mode on the same shape.
+		expect(editor.getCurrentPageShapes().length).toBe(shapeCountBefore)
+		expect(editor.getCroppingShapeId()).toBe(ids.imageA)
+	})
+
+	it('does a normal paste when not cropping', async () => {
+		const replaceSpy = vi.spyOn(editor, 'replaceExternalContent').mockResolvedValue()
+		const putSpy = vi.spyOn(editor, 'putExternalContent').mockResolvedValue()
+
+		expect(editor.getCroppingShapeId()).toBe(null)
+		await pasteFiles(editor, [makeImageFile()])
+
+		expect(replaceSpy).not.toHaveBeenCalled()
+		expect(putSpy).toHaveBeenCalledTimes(1)
+		expect(putSpy.mock.calls[0][0]).toMatchObject({ type: 'files' })
+	})
+
+	it('does a normal paste when multiple images are pasted while cropping', async () => {
+		const replaceSpy = vi.spyOn(editor, 'replaceExternalContent').mockResolvedValue()
+		const putSpy = vi.spyOn(editor, 'putExternalContent').mockResolvedValue()
+
+		editor.setCroppingShape(ids.imageA)
+		await pasteFiles(editor, [makeImageFile(), makeImageFile()])
+
+		expect(replaceSpy).not.toHaveBeenCalled()
+		expect(putSpy).toHaveBeenCalledTimes(1)
+		expect(putSpy.mock.calls[0][0]).toMatchObject({ type: 'files' })
+	})
+
+	it('does a normal paste when a non-image file is pasted while cropping', async () => {
+		const replaceSpy = vi.spyOn(editor, 'replaceExternalContent').mockResolvedValue()
+		const putSpy = vi.spyOn(editor, 'putExternalContent').mockResolvedValue()
+
+		editor.setCroppingShape(ids.imageA)
+		await pasteFiles(editor, [new File(['fake'], 'clip.mp4', { type: 'video/mp4' })])
+
+		expect(replaceSpy).not.toHaveBeenCalled()
+		expect(putSpy).toHaveBeenCalledTimes(1)
+		expect(putSpy.mock.calls[0][0]).toMatchObject({ type: 'files' })
 	})
 })


### PR DESCRIPTION
In order to let people swap a cropped image without leaving crop mode (closes #9334), this PR makes pasting a single image while an image is in crop mode replace that image in place, matching the existing **"replace image"** menu action — the crop transform is preserved across the swap. The editor stays in crop mode. This applies to **paste only**: drag-and-drop and the file picker still create a new shape.

It also fixes a focus issue that made the paste unreliable: the image crop zoom slider holds keyboard focus while cropping (and re-grabs it whenever the crop toolbar remounts after a drag/resize), which previously suppressed clipboard paste until the user clicked the image again. Paste is now allowed to proceed while cropping; open menus and text editing still take precedence.

### Change type

- [x] `feature`

### Test plan

1. Add an image to the canvas and double-click it to enter crop mode.
2. Copy a different image to the clipboard.
3. Paste (Cmd/Ctrl+V) — the cropped image is replaced in place, the crop transform is preserved, and you stay in crop mode.
4. Repeat the paste immediately after each of: dragging the image within the crop, dragging a crop border handle, and dragging the zoom slider — paste works without a preceding click.
5. Confirm drag-and-drop and file-picker insert still create a new shape, and that an open aspect-ratio dropdown still blocks paste.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- When cropping an image, paste an image to replace it in place, matching the replace image action.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +29 / -4   |
| Tests     | +65 / -0   |
