### PR TITLE
ci: drop postgres client install from dotcom deploy

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -140,12 +140,6 @@ jobs:
         if: env.DEPLOY_ZERO == 'flyio' || env.DEPLOY_ZERO == 'flyio-multinode'
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Install PostgreSQL client
-        if: env.DEPLOY_ZERO == 'flyio' || env.DEPLOY_ZERO == 'flyio-multinode'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y postgresql-client
-
       - name: Deploy
         run: yarn tsx internal/scripts/deploy-dotcom.ts
         env:


### PR DESCRIPTION
In order to stop installing an unused dependency on every dotcom deploy, this PR removes the `Install PostgreSQL client` step from the deploy workflow. `psql` was only used by the old `deployPermissionsToFlyIo()` step (running `permissions.sql` from `definePermissions`), which was removed in #7731 when Zero moved authorization to Synced Queries. No `psql` usage remains anywhere in the repo.

### Change type

- [x] `other`

### Test plan

- CI-only change; verified by confirming no `psql` references remain in the repo and that the deploy script no longer shells out to it.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +0 / -6    |