### PR TITLE
fix: add bottom margin to sidebar file sections

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -451,6 +451,7 @@
 
 .sidebarFileSectionWrapper {
 	margin-top: 8px;
+	margin-bottom: 28px;
 }
 
 .sidebarFileSection {

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -314,6 +314,7 @@ li.example__sidebar__category {
 	position: relative;
 	padding: 0;
 	margin-top: 8px;
+	margin-bottom: 28px;
 }
 
 .example__sidebar__category:has(> ul > li) {


### PR DESCRIPTION
In order to give the last file in the sidebar room to breathe, this PR adds `margin-bottom: 28px` to the sidebar file section wrappers in the tldraw.com client and the examples app. Previously the last item sat flush against the bottom of the list with no spacing.

### Change type

- [x] `improvement`

### Test plan

1. Open the tldraw.com sidebar and scroll to the bottom of the file list; confirm there is spacing below the last item.
2. Open the examples app sidebar and confirm the same spacing below the last category.

### Release notes

- Add bottom spacing below the last item in the sidebar file list.
