### PR TITLE
feat(dotcom): land on most recent file on root and workspace switch

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -628,6 +628,46 @@ export class TldrawApp {
 		return sortedFiles
 	}
 
+	/**
+	 * The id of the user's most recently visited file, or null if they have none.
+	 *
+	 * Used to land the user on the file they last had open: across all workspaces when returning to
+	 * the root URL, or within a single workspace when switching to it. Recency comes from
+	 * `file_state`, which is synced per user, so the result follows the user across devices and
+	 * sessions. Files the user can no longer access (deleted, moved away, or revoked) drop out of
+	 * `file_state` sync or come back without a `file` relation, so they're skipped and the next most
+	 * recent available file wins.
+	 *
+	 * When the user has no visited files in scope, fall back to the most recent file in their home
+	 * workspace (root URL) or the top of the workspace's file list (workspace scope) — this covers
+	 * files the user has but has never opened on this account.
+	 *
+	 * @param workspaceId - When provided, only files visible in that workspace are considered.
+	 */
+	getMostRecentFileId(workspaceId?: string): string | null {
+		// Files in scope, ordered pinned-first then by recency. Used both to scope the recency
+		// search and as the fallback when the user has visited none of these files.
+		const scopedFiles = workspaceId ? this.getWorkspaceFilesSorted(workspaceId) : this.getMyFiles()
+		const fileIdsInScope = workspaceId ? new Set(scopedFiles.map((f) => f.fileId)) : null
+
+		let bestFileId: string | null = null
+		let bestDate = -Infinity
+		for (const state of this.getUserFileStates()) {
+			if (fileIdsInScope && !fileIdsInScope.has(state.fileId)) continue
+			const file = state.file
+			if (!file || file.isDeleted) continue
+			const date =
+				state.lastVisitAt ?? state.lastEditAt ?? state.firstVisitAt ?? file.createdAt ?? 0
+			if (date > bestDate) {
+				bestDate = date
+				bestFileId = state.fileId
+			}
+		}
+		if (bestFileId) return bestFileId
+
+		return scopedFiles[0]?.fileId ?? null
+	}
+
 	private canCreateNewFile(workspaceId: string) {
 		if (this.isWorkspacesMigrated()) {
 			// Count only files the workspace actually owns — not guest files (shared files the

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -109,12 +109,7 @@ window.zero = () => {
 	location.reload()
 }
 
-/**
- * The timestamp used to rank a file by recency. Prefers the user's most recent activity on the
- * file — last visit, then last edit, then first visit — and falls back to when the file was
- * created. This is the single source of truth for "how recent is this file" across recent-file
- * lists and most-recent-file navigation, so the ordering stays consistent everywhere.
- */
+/** Ranks a file by recency: last visit, else last edit, else first visit, else when it was created. */
 export function getFileRecencyDate(
 	state: TlaFileState | undefined,
 	file: TlaFile | undefined
@@ -643,24 +638,15 @@ export class TldrawApp {
 	}
 
 	/**
-	 * The id of the user's most recently visited file, or null if they have none.
-	 *
-	 * Used to land the user on the file they last had open: across all workspaces when returning to
-	 * the root URL, or within a single workspace when switching to it. Recency comes from
-	 * `file_state`, which is synced per user, so the result follows the user across devices and
-	 * sessions. Files the user can no longer access (deleted, moved away, or revoked) drop out of
-	 * `file_state` sync or come back without a `file` relation, so they're skipped and the next most
-	 * recent available file wins.
-	 *
-	 * When the user has no visited files in scope, fall back to the most recent file in their home
-	 * workspace (root URL) or the top of the workspace's file list (workspace scope) — this covers
-	 * files the user has but has never opened on this account.
+	 * The id of the user's most recently visited file, or null if they have none. Skips files the
+	 * user can no longer access (they drop out of `file_state` sync), so the next available file
+	 * wins; falls back to the top of the in-scope list when none have been visited. Recency comes
+	 * from per-user `file_state`, so it follows the user across devices.
 	 *
 	 * @param workspaceId - When provided, only files visible in that workspace are considered.
 	 */
 	getMostRecentFileId(workspaceId?: string): string | null {
-		// Files in scope, ordered pinned-first then by recency. Used both to scope the recency
-		// search and as the fallback when the user has visited none of these files.
+		// In-scope files, also used as the fallback when none have been visited.
 		const scopedFiles = workspaceId ? this.getWorkspaceFilesSorted(workspaceId) : this.getMyFiles()
 		const fileIdsInScope = workspaceId ? new Set(scopedFiles.map((f) => f.fileId)) : null
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -10,6 +10,7 @@ import {
 	ROOM_PREFIX,
 	TlaFile,
 	WELCOME_CREATE_SOURCE,
+	TlaFileState,
 	TlaFileStatePartial,
 	TlaFlags,
 	TlaGroupFile,
@@ -114,12 +115,9 @@ window.zero = () => {
  * created. This is the single source of truth for "how recent is this file" across recent-file
  * lists and most-recent-file navigation, so the ordering stays consistent everywhere.
  */
-function getFileRecencyDate(
-	state:
-		| { lastVisitAt?: number | null; lastEditAt?: number | null; firstVisitAt?: number | null }
-		| undefined
-		| null,
-	file: { createdAt?: number | null } | undefined | null
+export function getFileRecencyDate(
+	state: TlaFileState | undefined,
+	file: TlaFile | undefined
 ): number {
 	return state?.lastVisitAt ?? state?.lastEditAt ?? state?.firstVisitAt ?? file?.createdAt ?? 0
 }

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -639,9 +639,10 @@ export class TldrawApp {
 
 	/**
 	 * The id of the user's most recently visited file, or null if they have none. Skips files the
-	 * user can no longer access (they drop out of `file_state` sync), so the next available file
-	 * wins; falls back to the top of the in-scope list when none have been visited. Recency comes
-	 * from per-user `file_state`, so it follows the user across devices.
+	 * user can no longer access — their `file` relation comes back null (moved/revoked) or flagged
+	 * deleted — so the next available file wins; falls back to the top of the in-scope list when
+	 * none have been visited. Recency comes from per-user `file_state`, so it follows the user
+	 * across devices.
 	 *
 	 * @param workspaceId - When provided, only files visible in that workspace are considered.
 	 */

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -108,6 +108,22 @@ window.zero = () => {
 	location.reload()
 }
 
+/**
+ * The timestamp used to rank a file by recency. Prefers the user's most recent activity on the
+ * file — last visit, then last edit, then first visit — and falls back to when the file was
+ * created. This is the single source of truth for "how recent is this file" across recent-file
+ * lists and most-recent-file navigation, so the ordering stays consistent everywhere.
+ */
+function getFileRecencyDate(
+	state:
+		| { lastVisitAt?: number | null; lastEditAt?: number | null; firstVisitAt?: number | null }
+		| undefined
+		| null,
+	file: { createdAt?: number | null } | undefined | null
+): number {
+	return state?.lastVisitAt ?? state?.lastEditAt ?? state?.firstVisitAt ?? file?.createdAt ?? 0
+}
+
 export class TldrawApp {
 	config = {
 		maxNumberOfFiles: MAX_NUMBER_OF_FILES,
@@ -470,7 +486,7 @@ export class TldrawApp {
 			const state = this.getFileState(file.fileId)
 			newOrdering.push({
 				fileId: file.fileId,
-				date: Math.max(state?.lastEditAt ?? state?.firstVisitAt ?? file.file.createdAt),
+				date: getFileRecencyDate(state, file.file),
 			})
 		}
 
@@ -593,7 +609,7 @@ export class TldrawApp {
 			const newEntry = {
 				fileId,
 				isPinned,
-				date: state.lastEditAt ?? state.firstVisitAt ?? file.createdAt ?? 0,
+				date: getFileRecencyDate(state, file),
 			}
 
 			// If this was previously unpinned and we have existing ordering,
@@ -656,8 +672,7 @@ export class TldrawApp {
 			if (fileIdsInScope && !fileIdsInScope.has(state.fileId)) continue
 			const file = state.file
 			if (!file || file.isDeleted) continue
-			const date =
-				state.lastVisitAt ?? state.lastEditAt ?? state.firstVisitAt ?? file.createdAt ?? 0
+			const date = getFileRecencyDate(state, file)
 			if (date > bestDate) {
 				bestDate = date
 				bestFileId = state.fileId

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -664,21 +664,15 @@ export class TldrawApp {
 		const scopedFiles = workspaceId ? this.getWorkspaceFilesSorted(workspaceId) : this.getMyFiles()
 		const fileIdsInScope = workspaceId ? new Set(scopedFiles.map((f) => f.fileId)) : null
 
-		let bestFileId: string | null = null
-		let bestDate = -Infinity
+		let mostRecent: { fileId: string; date: number } | null = null
 		for (const state of this.getUserFileStates()) {
 			if (fileIdsInScope && !fileIdsInScope.has(state.fileId)) continue
-			const file = state.file
-			if (!file || file.isDeleted) continue
-			const date = getFileRecencyDate(state, file)
-			if (date > bestDate) {
-				bestDate = date
-				bestFileId = state.fileId
-			}
+			if (!state.file || state.file.isDeleted) continue
+			const date = getFileRecencyDate(state, state.file)
+			if (!mostRecent || date > mostRecent.date) mostRecent = { fileId: state.fileId, date }
 		}
-		if (bestFileId) return bestFileId
 
-		return scopedFiles[0]?.fileId ?? null
+		return mostRecent?.fileId ?? scopedFiles[0]?.fileId ?? null
 	}
 
 	private canCreateNewFile(workspaceId: string) {

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -109,12 +109,17 @@ window.zero = () => {
 	location.reload()
 }
 
-/** Ranks a file by recency: last visit, else last edit, else first visit, else when it was created. */
+/** When the user last opened the file (visit, else edit, else first visit), or undefined if never. */
+export function getFileVisitDate(state: TlaFileState | undefined): number | undefined {
+	return state?.lastVisitAt ?? state?.lastEditAt ?? state?.firstVisitAt ?? undefined
+}
+
+/** Ranks a file for display: when it was last opened, else when it was created. */
 export function getFileRecencyDate(
 	state: TlaFileState | undefined,
 	file: TlaFile | undefined
 ): number {
-	return state?.lastVisitAt ?? state?.lastEditAt ?? state?.firstVisitAt ?? file?.createdAt ?? 0
+	return getFileVisitDate(state) ?? file?.createdAt ?? 0
 }
 
 export class TldrawApp {
@@ -655,7 +660,11 @@ export class TldrawApp {
 		for (const state of this.getUserFileStates()) {
 			if (fileIdsInScope && !fileIdsInScope.has(state.fileId)) continue
 			if (!state.file || state.file.isDeleted) continue
-			const date = getFileRecencyDate(state, state.file)
+			// Rank by actual visits only. A created-but-never-opened file has null visit timestamps
+			// (its `createdAt` must not let it outrank a genuinely visited file); it defers to the
+			// `scopedFiles` fallback below.
+			const date = getFileVisitDate(state)
+			if (date === undefined) continue
 			if (!mostRecent || date > mostRecent.date) mostRecent = { fileId: state.fileId, date }
 		}
 

--- a/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
+++ b/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { getFileRecencyDate, TldrawApp } from './TldrawApp'
+
+// `getMostRecentFileId` reads only `getUserFileStates()` (via `fileStates$`) plus, for the
+// in-scope/fallback list, `getMyFiles()` or `getWorkspaceFilesSorted()`. We stub those three on a
+// bare prototype instance instead of constructing a full TldrawApp, which needs Zero, Clerk, and a
+// router (same approach as getWorkspaceFilesSorted.test.ts).
+function createAppStub({
+	fileStates = [] as any[],
+	myFiles = [] as any[],
+	workspaceFiles = {} as Record<string, any[]>,
+	userId = 'user:home',
+} = {}) {
+	const app = Object.create(TldrawApp.prototype)
+	Object.assign(app, {
+		userId,
+		fileStates$: { get: () => fileStates },
+		getMyFiles: () => myFiles,
+		getWorkspaceFilesSorted: (id: string) => workspaceFiles[id] ?? [],
+	})
+	return app as TldrawApp
+}
+
+function makeState(fileId: string, overrides: Partial<any> = {}) {
+	const { file: fileOverride, ...rest } = overrides
+	// `file: undefined` must stay undefined to model an inaccessible file; only merge defaults when
+	// a partial file is given, and use the default when the key is omitted entirely.
+	const file =
+		'file' in overrides
+			? fileOverride && { id: fileId, isDeleted: false, createdAt: 1000, ...fileOverride }
+			: { id: fileId, isDeleted: false, createdAt: 1000 }
+	return {
+		fileId,
+		userId: 'user:home',
+		firstVisitAt: null,
+		lastEditAt: null,
+		lastVisitAt: null,
+		file,
+		...rest,
+	}
+}
+
+describe('getFileRecencyDate', () => {
+	it('prefers lastVisitAt over lastEditAt, firstVisitAt, and createdAt', () => {
+		const state = { lastVisitAt: 4, lastEditAt: 3, firstVisitAt: 2 } as any
+		expect(getFileRecencyDate(state, { createdAt: 1 } as any)).toBe(4)
+	})
+
+	it('falls through lastEditAt, then firstVisitAt, then createdAt, then 0', () => {
+		expect(
+			getFileRecencyDate({ lastEditAt: 3, firstVisitAt: 2 } as any, { createdAt: 1 } as any)
+		).toBe(3)
+		expect(getFileRecencyDate({ firstVisitAt: 2 } as any, { createdAt: 1 } as any)).toBe(2)
+		expect(getFileRecencyDate({} as any, { createdAt: 1 } as any)).toBe(1)
+		expect(getFileRecencyDate(undefined, undefined)).toBe(0)
+	})
+})
+
+describe('getMostRecentFileId', () => {
+	it('returns the globally most recent file across all workspaces', () => {
+		const app = createAppStub({
+			fileStates: [
+				makeState('file:a', { lastVisitAt: 100 }),
+				makeState('file:b', { lastVisitAt: 300 }),
+				makeState('file:c', { lastVisitAt: 200 }),
+			],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:b')
+	})
+
+	it('skips deleted and inaccessible files and picks the next most recent available one', () => {
+		const app = createAppStub({
+			fileStates: [
+				// Most recent, but the file is no longer accessible (relation resolved to undefined).
+				makeState('file:gone', { lastVisitAt: 300, file: undefined }),
+				// Next most recent, but deleted.
+				makeState('file:deleted', { lastVisitAt: 200, file: { isDeleted: true } }),
+				makeState('file:ok', { lastVisitAt: 100 }),
+			],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:ok')
+	})
+
+	it('falls back to the most recent home file when the user has no visited files', () => {
+		const app = createAppStub({
+			fileStates: [],
+			myFiles: [{ fileId: 'file:home-top' }, { fileId: 'file:home-2' }],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:home-top')
+	})
+
+	it('returns null when the user has no files at all', () => {
+		expect(createAppStub().getMostRecentFileId()).toBe(null)
+	})
+
+	it('only considers files in the given workspace when scoped', () => {
+		const app = createAppStub({
+			workspaceFiles: { 'group:x': [{ fileId: 'file:1' }, { fileId: 'file:2' }] },
+			fileStates: [
+				makeState('file:1', { lastVisitAt: 100 }),
+				makeState('file:2', { lastVisitAt: 500 }),
+				// Most recent overall, but not in group:x — must be ignored.
+				makeState('file:other', { lastVisitAt: 999 }),
+			],
+		})
+		expect(app.getMostRecentFileId('group:x')).toBe('file:2')
+	})
+
+	it('falls back to the top of the workspace list when none of its files were visited', () => {
+		const app = createAppStub({
+			workspaceFiles: { 'group:x': [{ fileId: 'file:top' }, { fileId: 'file:2' }] },
+			fileStates: [makeState('file:other', { lastVisitAt: 999 })],
+		})
+		expect(app.getMostRecentFileId('group:x')).toBe('file:top')
+	})
+})

--- a/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
+++ b/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getFileRecencyDate, TldrawApp } from './TldrawApp'
+import { getFileRecencyDate, getFileVisitDate, TldrawApp } from './TldrawApp'
 
 // Stub the three members `getMostRecentFileId` reads on a bare prototype instance, avoiding a full
 // TldrawApp (Zero/Clerk/router). Same approach as getWorkspaceFilesSorted.test.ts.
@@ -53,6 +53,17 @@ describe('getFileRecencyDate', () => {
 	})
 })
 
+describe('getFileVisitDate', () => {
+	it('returns the most recent visit/edit, or undefined when never opened', () => {
+		expect(getFileVisitDate({ lastVisitAt: 4, lastEditAt: 3, firstVisitAt: 2 } as any)).toBe(4)
+		expect(getFileVisitDate({ lastEditAt: 3, firstVisitAt: 2 } as any)).toBe(3)
+		expect(getFileVisitDate({ firstVisitAt: 2 } as any)).toBe(2)
+		// Never opened: createdAt is not a visit and must not appear here.
+		expect(getFileVisitDate({} as any)).toBeUndefined()
+		expect(getFileVisitDate(undefined)).toBeUndefined()
+	})
+})
+
 describe('getMostRecentFileId', () => {
 	it('returns the globally most recent file across all workspaces', () => {
 		const app = createAppStub({
@@ -75,6 +86,25 @@ describe('getMostRecentFileId', () => {
 			],
 		})
 		expect(app.getMostRecentFileId()).toBe('file:edited')
+	})
+
+	it('does not let a never-opened file outrank a genuinely visited one via createdAt', () => {
+		const app = createAppStub({
+			fileStates: [
+				makeState('file:visited', { lastVisitAt: 50 }),
+				// Just created, never opened (null visit timestamps, recent createdAt).
+				makeState('file:new', { file: { createdAt: 9999 } }),
+			],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:visited')
+	})
+
+	it('falls back to the in-scope top file when the user has only never-opened files', () => {
+		const app = createAppStub({
+			fileStates: [makeState('file:new', { file: { createdAt: 9999 } })],
+			myFiles: [{ fileId: 'file:home-top' }, { fileId: 'file:new' }],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:home-top')
 	})
 
 	it('keeps the first file on a recency tie', () => {

--- a/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
+++ b/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
@@ -65,6 +65,28 @@ describe('getMostRecentFileId', () => {
 		expect(app.getMostRecentFileId()).toBe('file:b')
 	})
 
+	it('ranks across recency fields, not just lastVisitAt', () => {
+		const app = createAppStub({
+			fileStates: [
+				makeState('file:visited', { lastVisitAt: 100 }),
+				// No visit, but edited more recently than file:visited was visited.
+				makeState('file:edited', { lastEditAt: 300 }),
+				makeState('file:created', { file: { createdAt: 200 } }),
+			],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:edited')
+	})
+
+	it('keeps the first file on a recency tie', () => {
+		const app = createAppStub({
+			fileStates: [
+				makeState('file:first', { lastVisitAt: 500 }),
+				makeState('file:second', { lastVisitAt: 500 }),
+			],
+		})
+		expect(app.getMostRecentFileId()).toBe('file:first')
+	})
+
 	it('skips deleted and inaccessible files and picks the next most recent available one', () => {
 		const app = createAppStub({
 			fileStates: [

--- a/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
+++ b/apps/dotcom/client/src/tla/app/getMostRecentFileId.test.ts
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { getFileRecencyDate, TldrawApp } from './TldrawApp'
 
-// `getMostRecentFileId` reads only `getUserFileStates()` (via `fileStates$`) plus, for the
-// in-scope/fallback list, `getMyFiles()` or `getWorkspaceFilesSorted()`. We stub those three on a
-// bare prototype instance instead of constructing a full TldrawApp, which needs Zero, Clerk, and a
-// router (same approach as getWorkspaceFilesSorted.test.ts).
+// Stub the three members `getMostRecentFileId` reads on a bare prototype instance, avoiding a full
+// TldrawApp (Zero/Clerk/router). Same approach as getWorkspaceFilesSorted.test.ts.
 function createAppStub({
 	fileStates = [] as any[],
 	myFiles = [] as any[],
@@ -23,8 +21,7 @@ function createAppStub({
 
 function makeState(fileId: string, overrides: Partial<any> = {}) {
 	const { file: fileOverride, ...rest } = overrides
-	// `file: undefined` must stay undefined to model an inaccessible file; only merge defaults when
-	// a partial file is given, and use the default when the key is omitted entirely.
+	// `file: undefined` stays undefined to model an inaccessible file; a partial merges onto defaults.
 	const file =
 		'file' in overrides
 			? fileOverride && { id: fileId, isDeleted: false, createdAt: 1000, ...fileOverride }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -30,9 +30,9 @@ const messages = defineMessages({
 /**
  * The fixed top region of the sidebar: a dropdown for switching between the
  * home workspace and the user's other workspaces, followed by action rows for
- * the active workspace. Selecting a workspace opens its top file (first pinned
- * file, otherwise the most recent one), which makes it active (the active
- * workspace is derived from the open file).
+ * the active workspace. Selecting a workspace opens the file the user most
+ * recently had open in it (or its top file if they've visited none), which makes
+ * it active (the active workspace is derived from the open file).
  */
 export function TlaSidebarWorkspaceSwitcher() {
 	const app = useApp()
@@ -198,9 +198,11 @@ function useSwitchToWorkspace() {
 
 	return useCallback(
 		async (workspaceId: string) => {
-			const files = app.getWorkspaceFilesSorted(workspaceId)
-			if (files.length) {
-				navigate(routes.tlaFile(files[0]!.fileId))
+			// Open the file the user most recently had open in this workspace, not just the top of
+			// the pinned-first list, so switching picks up where they left off.
+			const mostRecentFileId = app.getMostRecentFileId(workspaceId)
+			if (mostRecentFileId) {
+				navigate(routes.tlaFile(mostRecentFileId))
 				return
 			}
 			// A workspace created moments ago may still be seeding its welcome file: the

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarWorkspaceSwitcher.tsx
@@ -198,8 +198,7 @@ function useSwitchToWorkspace() {
 
 	return useCallback(
 		async (workspaceId: string) => {
-			// Open the file the user most recently had open in this workspace, not just the top of
-			// the pinned-first list, so switching picks up where they left off.
+			// Open the file the user last had open here, not just the top of the pinned-first list.
 			const mostRecentFileId = app.getMostRecentFileId(workspaceId)
 			if (mostRecentFileId) {
 				navigate(routes.tlaFile(mostRecentFileId))

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -77,9 +77,7 @@ export function Component() {
 				}
 			}
 
-			// Land on the file the user most recently had open, across all of their workspaces, so
-			// returning to the root URL picks up where they left off rather than dropping them on
-			// their home workspace.
+			// Land on the file the user last had open, across all workspaces, not just home.
 			const mostRecentFileId = app.getMostRecentFileId()
 			if (!mostRecentFileId) {
 				const result = await app.createFile()

--- a/apps/dotcom/client/src/tla/pages/local.tsx
+++ b/apps/dotcom/client/src/tla/pages/local.tsx
@@ -77,8 +77,11 @@ export function Component() {
 				}
 			}
 
-			const recentFiles = app.getMyFiles()
-			if (recentFiles.length === 0) {
+			// Land on the file the user most recently had open, across all of their workspaces, so
+			// returning to the root URL picks up where they left off rather than dropping them on
+			// their home workspace.
+			const mostRecentFileId = app.getMostRecentFileId()
+			if (!mostRecentFileId) {
 				const result = await app.createFile()
 
 				assert(result.ok, 'Failed to create file')
@@ -93,7 +96,7 @@ export function Component() {
 				return
 			}
 
-			navigate(routes.tlaFile(recentFiles[0].fileId), { replace: true, state: location.state })
+			navigate(routes.tlaFile(mostRecentFileId), { replace: true, state: location.state })
 		}
 
 		handleFileOperations()


### PR DESCRIPTION
In order to let users pick up where they left off, this PR makes tldraw.com restore your most recently opened file instead of always dropping you on your home workspace. Closes #9364.

Visiting the bare `tldraw.com` URL now navigates to the file you most recently had open across **all** of your workspaces, opening into whatever workspace that file belongs to. Recency comes from `file_state`, which is synced per user, so the "most recent" file follows you across devices and sessions. Files you can no longer access (deleted, moved away, or revoked) are skipped, so the next most recent available file wins; if you have no visited files at all, it falls back to the most recent file in your home workspace.

The same logic now applies when switching workspaces from the sidebar switcher: it opens the file you most recently had open in that workspace, rather than the top of the pinned-first list. If you've never visited a file in that workspace, it falls back to that workspace's top file (and the empty-workspace seed/create behavior is unchanged).

Recency lives in two small helpers so it's computed consistently: `getFileVisitDate(state)` returns when the user last opened a file (`lastVisitAt → lastEditAt → firstVisitAt`, or `undefined` if never opened), and `getFileRecencyDate(state, file)` adds a `createdAt` fallback for ordering files in lists. Most-recent navigation ranks by `getFileVisitDate` only — a created-but-never-opened file (its `file_state` row has null visit timestamps) must not hijack the landing on its `createdAt`; it defers to the fallback. The recent-files list and workspace sorting use `getFileRecencyDate`. Note: this brings `lastVisitAt` into the sidebar recent-file ordering, which previously only considered `lastEditAt`/`firstVisitAt`.

### Change type

- [x] `feature`

### Test plan

Note: `lastVisitAt` is written on a 10s throttle (and flushed on file exit), so after opening a file either navigate away or wait ~10s before testing, so the visit timestamp has synced.

1. Sign in and open a file in a non-home workspace, then navigate to the bare `tldraw.com` URL — you should land back on that file, in its workspace.
2. Open files across multiple workspaces, then return to `tldraw.com` — you should land on the single most recently opened one.
3. Switch to another workspace via the sidebar switcher — you should land on the file you most recently had open there, not necessarily its top pinned file.
4. Delete/lose access to your most recent file, then return to `tldraw.com` — you should land on the next most recent available file (home workspace's most recent as the final fallback).
5. New user with no files visiting `tldraw.com` — a file is created and opened as before.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +56 / -11  |
| Tests   | +165 / -0  |

### Release notes

- tldraw.com now reopens your most recently opened file when you visit the site, and switching workspaces opens the file you most recently had open there.