### PR TITLE
feat(examples): add collapse sidebar button to header

### DIFF
--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -58,6 +58,14 @@ export function ExamplePage({
 								<TldrawLogo />
 							</Link>
 							<span className="example__sidebar__header-title">Examples</span>
+							<Link
+								to={`${example.path}/full`}
+								className="example__sidebar__item__button hoverable hoverable__small"
+								aria-label="Collapse sidebar"
+								title="Collapse sidebar"
+							>
+								<CollapseSidebarIcon />
+							</Link>
 						</div>
 						<div className="example__sidebar__section">
 							<label className="example__sidebar__search hoverable">
@@ -352,6 +360,18 @@ function Dialogs() {
 				</div>
 			</_AlertDialog.Content>
 		</_AlertDialog.Root>
+	)
+}
+
+function CollapseSidebarIcon() {
+	return (
+		<svg width="15" height="15" viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<path
+				d="M12.143 12.607V14H2.857v-1.393zm.464-.464V2.857a.464.464 0 0 0-.464-.464H2.857a.464.464 0 0 0-.464.464v9.286c0 .256.208.464.464.464V14l-.095-.002a1.857 1.857 0 0 1-1.76-1.76L1 12.143V2.857c0-.994.78-1.805 1.762-1.855L2.857 1h9.286l.095.002c.982.05 1.762.861 1.762 1.855v9.286l-.002.095a1.857 1.857 0 0 1-1.76 1.76l-.095.002v-1.393a.464.464 0 0 0 .464-.464"
+				fill="currentColor"
+			/>
+			<path d="M5 1h1.5v13H5z" fill="currentColor" />
+		</svg>
 	)
 }
 

--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -87,7 +87,7 @@ export function ExamplePage({
 						</div>
 						<div className="example__sidebar__divider" />
 					</div>
-					<ul className="example__sidebar__categories scroll-light">
+					<ul className="example__sidebar__categories">
 						{categories.map((currentCategory) => (
 							<li key={currentCategory} className="example__sidebar__category">
 								<h3 className="example__sidebar__category__header">{currentCategory}</h3>

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -124,7 +124,7 @@ html,
 	display: flex;
 	height: 44px;
 	align-items: center;
-	padding: 3px 8px 0 4px;
+	padding: 0px 8px 3px 4px;
 	gap: 12px;
 }
 

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -287,9 +287,15 @@ ul.example__sidebar__categories {
 	list-style: none;
 	padding: 0 12px 40px 12px;
 	margin: 0;
-	overflow: auto;
+	overflow-y: scroll;
+	overflow-x: visible;
 	flex: 1 1 auto;
 	min-height: 0;
+	-ms-overflow-style: none; /* IE and Edge */
+	scrollbar-width: none; /* Firefox */
+}
+ul.example__sidebar__categories::-webkit-scrollbar {
+	display: none;
 }
 
 .example__sidebar__category__header {


### PR DESCRIPTION
In order to let people jump from an example into its full-screen view without hunting for the per-item standalone button, this PR adds a collapse sidebar button to the right side of the examples app header. It links to the current example's `/full` route, which renders the example without the sidebar. The icon reuses the dotcom sidebar toggle artwork.

### Change type

- [x] `improvement`

### Test plan

1. Run `yarn dev` and open any example.
2. Click the sidebar toggle button at the right of the header.
3. Confirm it navigates to the example's full-screen (`/full`) view.

### Release notes

- Add a collapse sidebar button to the examples app header that opens the current example's full-screen view.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +21 / -1   |
