### PR TITLE
fix(editor): clear meta key reactive state on keyup (macOS)

### DIFF
--- a/apps/examples/src/examples/editor-api/reactive-inputs/ReactiveInputsExample.tsx
+++ b/apps/examples/src/examples/editor-api/reactive-inputs/ReactiveInputsExample.tsx
@@ -67,7 +67,7 @@ function ReactiveInputsPanel() {
 	const accelKey = useValue('accel key', () => editor.inputs.getAccelKey(), [editor])
 
 	return (
-		<div className="reactive-inputs-panel">
+		<div className="tlui-menu reactive-inputs-panel">
 			<div className="reactive-inputs-content">
 				{/* [5] */}
 				<div className="input-group">

--- a/apps/examples/src/examples/editor-api/reactive-inputs/reactive-inputs.css
+++ b/apps/examples/src/examples/editor-api/reactive-inputs/reactive-inputs.css
@@ -1,35 +1,35 @@
+/* tlui-menu provides the native panel background, radius, and shadow. */
 .reactive-inputs-panel {
-	padding: 6px;
-	border: 1px solid #ccc;
-	box-shadow: none;
+	margin: 8px;
+	padding: var(--tl-space-2);
 	pointer-events: all;
 }
 
 .reactive-inputs-content {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 6px;
+	gap: var(--tl-space-2);
 	align-items: center;
 }
 
 .input-group {
 	display: flex;
 	align-items: baseline;
-	gap: 4px;
-	padding: 2px 8px;
-	background: #fff;
-	border: 1px solid #ccc;
+	gap: var(--tl-space-1);
+	padding: var(--tl-space-1) var(--tl-space-3);
+	background: var(--tl-color-muted-2);
+	border-radius: var(--tl-radius-2);
 }
 
 .input-label {
 	font-size: 12px;
-	color: #333;
+	color: var(--tl-color-text);
 	white-space: nowrap;
 }
 
 .input-value {
 	font-size: 10px;
-	color: #111;
+	color: var(--tl-color-text);
 	white-space: nowrap;
 	font-variant-numeric: tabular-nums;
 	min-width: 80px;
@@ -37,26 +37,25 @@
 
 .input-hint {
 	font-size: 11px;
-	color: #666;
+	color: var(--tl-color-text-3);
 }
 
 .modifier-keys {
 	display: flex;
 	flex-wrap: wrap;
-	gap: 4px;
+	gap: var(--tl-space-1);
 }
 
 .modifier-key {
 	display: inline-block;
-	padding: 2px 6px;
+	padding: var(--tl-space-1) var(--tl-space-2);
 	font-size: 11px;
-	background: #e0e0e0;
-	color: #666;
-	border: 1px solid #ccc;
+	background: var(--tl-color-muted-1);
+	color: var(--tl-color-text-3);
+	border-radius: var(--tl-radius-1);
 }
 
 .modifier-key[data-active='true'] {
-	background: #333;
-	color: #fff;
-	border-color: #333;
+	background: var(--tl-color-selected);
+	color: var(--tl-color-selected-contrast);
 }

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10983,7 +10983,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._ctrlKeyTimeout = this.timers.setTimeout(this._setCtrlKeyTimeout, 150)
 		}
 
-		if (info.metaKey) {
+		if (info.metaKey && info.name !== 'key_up') {
+			// Unlike the other modifiers, the native metaKey property is still true on keyup.
+			// If we don't have this guard, then the metakey will be left true without the timeout.
 			clearTimeout(this._metaKeyTimeout)
 			this._metaKeyTimeout = -1
 			inputs.setMetaKey(true)


### PR DESCRIPTION
🗣️ Fixes a bug where we were assuming that metaKey would be false on meta key keyups, but to my surprise it was not, leading to sticky meta state.

---

Fixes the reactive Meta (Cmd) key input state not clearing on keyup until a pointer event fired.

On macOS, the native `KeyboardEvent` for the Meta key's own `keyup` event still reports `e.metaKey === true` (a browser/OS quirk). The modifier update logic in `Editor.dispatch()` checks `info.metaKey` first and re-sets the atom to `true`, so the branch that schedules the clearing timeout was never reached. The result: `editor.inputs.getMetaKey()` (and `getAccelKey()` on macOS) stayed `true` after release until a pointer event dispatched with `metaKey: false`. Shift, Alt, and Ctrl were unaffected because their native flags clear correctly on keyup.

The fix guards the re-set so it ignores `key_up` events, letting the existing clear-timeout branch run as it does for the other modifiers.

### Change type

- [x] `bugfix`

### Test plan

1. Open the reactive inputs example and subscribe to `editor.inputs.getMetaKey()`.
2. Press the Meta (Cmd) key — value reactively changes to `true`.
3. Release the Meta key — value now changes to `false` immediately, without moving the pointer.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where the reactive Meta (Cmd) key state was not cleared on keyup until a pointer event, affecting `getMetaKey()` and `getAccelKey()` on macOS.

Closes #7981
