### PR TITLE
test(driver): carry held modifiers on simulated keyboard events

### DIFF
--- a/packages/driver/src/lib/Driver.ts
+++ b/packages/driver/src/lib/Driver.ts
@@ -255,13 +255,20 @@ export class Driver {
 		name: TLKeyboardEventInfo['name'],
 		options = {} as Partial<Omit<TLKeyboardEventInfo, 'point'>>
 	): TLKeyboardEventInfo {
-		return {
-			shiftKey: key === 'Shift',
-			ctrlKey: key === 'Control' || key === 'Meta',
-			altKey: key === 'Alt',
-			metaKey: key === 'Meta',
-			accelKey: tlenv.isDarwin ? key === 'Meta' : key === 'Control' || key === 'Meta',
+		// Like a real DOM keyboard event, the flags reflect every modifier currently held — not
+		// just the key being pressed. We OR in the editor's current modifier state so that, e.g.,
+		// pressing Shift while Control is held still reports ctrlKey: true. (keyUp passes explicit
+		// flag overrides for its release semantics, so those win over these defaults.)
+		const flags = {
+			shiftKey: key === 'Shift' || this.editor.inputs.getShiftKey(),
+			ctrlKey: key === 'Control' || key === 'Meta' || this.editor.inputs.getCtrlKey(),
+			altKey: key === 'Alt' || this.editor.inputs.getAltKey(),
+			metaKey: key === 'Meta' || this.editor.inputs.getMetaKey(),
 			...options,
+		}
+		return {
+			...flags,
+			accelKey: flags.accelKey ?? (tlenv.isDarwin ? flags.metaKey : flags.ctrlKey || flags.metaKey),
 			name,
 			code:
 				key === 'Shift'

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -1,3 +1,4 @@
+import { TLKeyboardEventInfo } from '@tldraw/editor'
 import { vi } from 'vitest'
 import { TestEditor } from './TestEditor'
 
@@ -34,4 +35,19 @@ it('Ctrl Key', () => {
 	expect(editor.inputs.getCtrlKey()).toBe(true)
 	vi.advanceTimersByTime(200)
 	expect(editor.inputs.getCtrlKey()).toBe(false)
+})
+
+it('keyboard events carry currently-held modifiers', () => {
+	const keyboardEvents: TLKeyboardEventInfo[] = []
+	editor.on('event', (info) => {
+		if (info.type === 'keyboard') keyboardEvents.push(info)
+	})
+
+	editor.keyDown('Control')
+	editor.keyDown('Shift') // pressed while Control is still held
+
+	// like a real DOM keyboard event, the Shift keydown reports Control as held
+	const shiftDown = keyboardEvents.find((e) => e.key === 'Shift' && e.name === 'key_down')!
+	expect(shiftDown.shiftKey).toBe(true)
+	expect(shiftDown.ctrlKey).toBe(true)
 })


### PR DESCRIPTION
In order to make the test Driver behave like real DOM input, this PR makes simulated keyboard events carry every currently-held modifier instead of just the key being pressed.

Previously `getKeyboardEventInfo` built `keydown`/`keyrepeat` flags from only the pressed key, so pressing Shift while Control was held would report `ctrlKey: false`. That was inconsistent with two things:

- `keyUp`, which already derives its flags from the editor's held modifier state.
- Real DOM keyboard events, where every event reflects the full set of currently-held modifiers.

That gap meant a test holding two modifiers (e.g. `keyDown('Control')` then `keyDown('Shift')`) didn't actually model "both held", which is easy to trip over when reasoning about modifier behaviour.

We OR in the editor's current modifier state for the four modifier flags (and derive `accelKey` from the merged result). `keyUp` passes explicit flag overrides, so its release semantics are unchanged.

### Change type

- [x] `other` (test infrastructure)

### Test plan

- [x] Unit tests

Full editor (830) and tldraw (2648) suites pass unchanged.

Made with [Cursor](https://cursor.com)