### PR TITLE
perf(dotcom): spike — authenticate file socket via cookie

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -44,6 +44,7 @@ import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
+import { logElapsed } from '../../utils/spikeAuthPerf'
 import { TlaAnonDotDevLink } from '../TlaAnonDotDevLink/TlaAnonDotDevLink'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
@@ -196,7 +197,6 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const getUserToken = useEvent(async () => {
 		return (await user?.getToken()) ?? 'not-logged-in'
 	})
-	const hasUser = !!user
 	const assets = useMemo(() => {
 		return multiplayerAssetStore({ getFileId: () => fileId, getToken: getUserToken })
 	}, [fileId, getUserToken])
@@ -218,19 +218,31 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	}, [app?.tlUser.userPreferences])
 
 	const store = useSync({
-		uri: useCallback(async () => {
-			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileSlug}`)
-			if (hasUser) {
-				url.searchParams.set('accessToken', await getUserToken())
-			}
-			return url.toString()
-		}, [fileSlug, hasUser, getUserToken]),
+		// SPIKE (cookie-auth decouple): the document-room WebSocket is same-origin
+		// with the app in staging/production (MULTIPLAYER_SERVER === `${origin}/api`),
+		// so the browser already sends the Clerk `__session` cookie on the handshake
+		// and the worker's getAuth authenticates from it. We therefore drop the
+		// awaited `accessToken` from the URL entirely, removing the ~150ms Clerk
+		// token fetch from the navigation critical path. The callback is synchronous.
+		//
+		// Caveat: local dev is cross-origin (ws://localhost:8787), so the cookie is
+		// NOT sent and this will fail to authenticate locally — validate on a
+		// preview/staging deploy (dotcom-preview-please).
+		uri: useCallback(() => `${MULTIPLAYER_SERVER}/app/file/${fileSlug}`, [fileSlug]),
 		assets,
 		users,
 		onCustomMessageReceived: useCallback((message: TLCustomServerEvent) => {
 			trackEvent(message.type)
 		}, []),
 	})
+
+	// SPIKE INSTRUMENTATION — measure time from editor mount to first remote sync.
+	const mountedAtRef = useRef(performance.now())
+	useEffect(() => {
+		if (store.status === 'synced-remote') {
+			logElapsed('time to synced-remote (cookie-auth)', mountedAtRef.current)
+		}
+	}, [store.status])
 
 	// we need to prevent calling onFileExit if the store is in an error state
 	const storeError = useRef(false)

--- a/apps/dotcom/client/src/tla/utils/spikeAuthPerf.ts
+++ b/apps/dotcom/client/src/tla/utils/spikeAuthPerf.ts
@@ -1,0 +1,19 @@
+// SPIKE INSTRUMENTATION — not for merge.
+// Measures the auth cost on the file-navigation critical path so the three
+// spike branches can be compared. Logs to the console under the [spike-auth] tag.
+/* eslint-disable no-console */
+
+/** Time an async step (e.g. fetching the auth token) and log how long it took. */
+export async function timeAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+	const start = performance.now()
+	try {
+		return await fn()
+	} finally {
+		console.log(`[spike-auth] ${label}: ${(performance.now() - start).toFixed(1)}ms`)
+	}
+}
+
+/** Log elapsed time since a captured `performance.now()` mark. */
+export function logElapsed(label: string, sinceMs: number) {
+	console.log(`[spike-auth] ${label}: ${(performance.now() - sinceMs).toFixed(1)}ms`)
+}


### PR DESCRIPTION
**Spike — not for merge.** One of three drafts exploring how to remove the ~150ms Clerk token fetch from signed-in file navigation. See also the warm-cache and persistent-socket spikes.

## Problem

On every file navigation, `TlaEditor` force-remounts (`key={fileSlug}`), tearing down and recreating the document-room WebSocket. `useSync`'s `uri` callback then `await`s a Clerk token (`getUserToken()` → `getToken()`, ~150ms) **before** the socket can open. That await sits on the navigation critical path.

The app-level Zero connection is a session singleton and is *not* the cost — this is specifically the per-file document socket.

## Technique: authenticate via the same-origin cookie

In staging/production, `MULTIPLAYER_SERVER` resolves to `` `${window.location.origin}/api` `` (see `apps/dotcom/client/src/utils/config.ts`), so the document-room WebSocket is **same-origin** with the app. The browser already sends the Clerk `__session` cookie on that handshake, and the worker's `getAuth` already authenticates from cookies. The token in the URL is therefore redundant.

This PR makes the `uri` callback **synchronous** and drops `accessToken` entirely:

```ts
uri: useCallback(() => `${MULTIPLAYER_SERVER}/app/file/${fileSlug}`, [fileSlug]),
```

No worker change required. This is the smallest of the three approaches and also removes the session JWT from the URL/query-string logs.

## Tradeoffs

- ✅ Removes the ~150ms await from the critical path completely.
- ✅ No JWT in the WebSocket URL.
- ⚠️ **Local dev is cross-origin** (`ws://localhost:8787`) so the cookie is not sent — this must be validated on a preview/staging deploy (`dotcom-preview-please`), not `yarn dev-app`.
- ⚠️ Relies on third-party-cookie behavior holding for the same-site WS; worth checking Safari/ITP and cold-incognito first-connect.

## Measuring

Added `[spike-auth]` console instrumentation logging time from editor mount to `synced-remote`. Compare against `main` and the warm-cache spike across ~10 A↔B navigations.

## Out of scope

Moving the asset-upload token path to cookies; production hardening.
