### PR TITLE
perf(dotcom): spike — warm auth-token cache for file socket

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -44,6 +44,7 @@ import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
+import { logElapsed, timeAsync } from '../../utils/spikeAuthPerf'
 import { TlaAnonDotDevLink } from '../TlaAnonDotDevLink/TlaAnonDotDevLink'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
@@ -218,10 +219,14 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	}, [app?.tlUser.userPreferences])
 
 	const store = useSync({
+		// SPIKE (warm cache): the URL still carries the token, but getUserToken now
+		// resolves from a warm cache (see UserProvider), so this await is ~0ms after
+		// the first navigation instead of the ~150ms Clerk refresh.
 		uri: useCallback(async () => {
 			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileSlug}`)
 			if (hasUser) {
-				url.searchParams.set('accessToken', await getUserToken())
+				const token = await timeAsync('token fetch (warm cache)', getUserToken)
+				url.searchParams.set('accessToken', token)
 			}
 			return url.toString()
 		}, [fileSlug, hasUser, getUserToken]),
@@ -231,6 +236,14 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			trackEvent(message.type)
 		}, []),
 	})
+
+	// SPIKE INSTRUMENTATION — measure time from editor mount to first remote sync.
+	const mountedAtRef = useRef(performance.now())
+	useEffect(() => {
+		if (store.status === 'synced-remote') {
+			logElapsed('time to synced-remote (warm cache)', mountedAtRef.current)
+		}
+	}, [store.status])
 
 	// we need to prevent calling onFileExit if the store is in an error state
 	const storeError = useRef(false)

--- a/apps/dotcom/client/src/tla/hooks/useUser.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useUser.tsx
@@ -1,7 +1,8 @@
 import { useAuth, useUser as useClerkUser } from '@clerk/clerk-react'
 import type { UserResource } from '@clerk/types'
-import { ReactNode, createContext, useContext, useMemo } from 'react'
+import { ReactNode, createContext, useContext, useEffect, useMemo } from 'react'
 import { assert, useShallowObjectIdentity } from 'tldraw'
+import { createWarmTokenGetter } from '../utils/warmTokenCache'
 import { useMaybeApp } from './useAppState'
 
 interface TldrawUser {
@@ -24,6 +25,19 @@ export function UserProvider({ children }: { children: ReactNode }) {
 	// app can be null during hot reloading sometimes?
 	const app = useMaybeApp()
 
+	// SPIKE (warm cache): wrap Clerk's getToken in a cache that stays warm across
+	// file navigations. Because UserProvider lives above the per-file routes, this
+	// cache survives the per-file editor remount (unlike a cache inside TlaEditor),
+	// so the per-file sync connection gets a token in ~0ms instead of waiting ~150ms
+	// on a Clerk refresh.
+	const tokenCache = useMemo(() => createWarmTokenGetter(() => getToken()), [getToken])
+	useEffect(() => {
+		// Prime immediately and keep the token hot ahead of expiry.
+		void tokenCache.keepWarm().catch(() => {})
+		const interval = setInterval(() => void tokenCache.keepWarm().catch(() => {}), 50_000)
+		return () => clearInterval(interval)
+	}, [tokenCache])
+
 	const value = useMemo(() => {
 		if (!user || !isSignedIn || !app) return null
 
@@ -37,12 +51,12 @@ export function UserProvider({ children }: { children: ReactNode }) {
 				user?.primaryEmailAddress?.verification.status === 'verified' &&
 				user.primaryEmailAddress.emailAddress.endsWith('@tldraw.com'),
 			getToken: async () => {
-				const token = await getToken()
+				const token = await tokenCache.get()
 				assert(token)
 				return token
 			},
 		}
-	}, [getToken, isSignedIn, user, app])
+	}, [tokenCache, isSignedIn, user, app])
 
 	if (!isLoaded || !isAuthLoaded || !app) {
 		// Render a blank editor surface while auth loads, with no spinner or fade.

--- a/apps/dotcom/client/src/tla/utils/spikeAuthPerf.ts
+++ b/apps/dotcom/client/src/tla/utils/spikeAuthPerf.ts
@@ -1,0 +1,19 @@
+// SPIKE INSTRUMENTATION — not for merge.
+// Measures the auth cost on the file-navigation critical path so the three
+// spike branches can be compared. Logs to the console under the [spike-auth] tag.
+/* eslint-disable no-console */
+
+/** Time an async step (e.g. fetching the auth token) and log how long it took. */
+export async function timeAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+	const start = performance.now()
+	try {
+		return await fn()
+	} finally {
+		console.log(`[spike-auth] ${label}: ${(performance.now() - start).toFixed(1)}ms`)
+	}
+}
+
+/** Log elapsed time since a captured `performance.now()` mark. */
+export function logElapsed(label: string, sinceMs: number) {
+	console.log(`[spike-auth] ${label}: ${(performance.now() - sinceMs).toFixed(1)}ms`)
+}

--- a/apps/dotcom/client/src/tla/utils/warmTokenCache.ts
+++ b/apps/dotcom/client/src/tla/utils/warmTokenCache.ts
@@ -1,0 +1,76 @@
+// SPIKE — warm auth-token cache. Not for merge.
+//
+// Keeps a recently-minted Clerk token in memory so callers on the navigation
+// critical path (the per-file sync connection) get it synchronously-fast instead
+// of paying ~150ms for a Clerk token refresh. A `keepWarm()` tick refreshes the
+// token ahead of expiry so `get()` almost always hits the cache.
+//
+// This is a distilled, dotcom-scoped variant of the app-wide cache in #9343. To
+// survive the per-file editor remount it must be instantiated ABOVE the file
+// routes (see UserProvider), not inside TlaEditor.
+
+const MIN_TIME_TO_EXPIRY_MS = 10_000
+const FALLBACK_TTL_MS = 30_000
+
+interface CachedToken {
+	token: string
+	expiresAt: number
+}
+
+export interface WarmTokenGetter {
+	/** Return a cached token if it has enough life left, otherwise refresh. */
+	get(): Promise<string | undefined>
+	/** Force a refresh (used by the keep-warm interval). */
+	keepWarm(): Promise<string | undefined>
+}
+
+export function createWarmTokenGetter(
+	getToken: () => Promise<string | null | undefined>
+): WarmTokenGetter {
+	let cached: CachedToken | null = null
+	let pending: Promise<string | undefined> | null = null
+
+	function refresh() {
+		if (!pending) {
+			pending = Promise.resolve()
+				.then(getToken)
+				.then((token) => {
+					cached = token ? { token, expiresAt: getJwtExpiry(token) } : null
+					return token ?? undefined
+				})
+				.finally(() => {
+					pending = null
+				})
+		}
+		return pending
+	}
+
+	return {
+		get() {
+			if (cached && cached.expiresAt - Date.now() > MIN_TIME_TO_EXPIRY_MS) {
+				return Promise.resolve(cached.token)
+			}
+			return refresh()
+		},
+		keepWarm() {
+			return refresh()
+		},
+	}
+}
+
+function getJwtExpiry(token: string): number {
+	const fallback = Date.now() + FALLBACK_TTL_MS
+	try {
+		const payload = token.split('.')[1]
+		if (!payload) return fallback
+		const normalized = payload.replace(/-/g, '+').replace(/_/g, '/')
+		const padded = normalized + '='.repeat((4 - (normalized.length % 4)) % 4)
+		const parsed = JSON.parse(globalThis.atob(padded)) as { exp?: unknown }
+		if (typeof parsed.exp === 'number' && Number.isFinite(parsed.exp)) {
+			return parsed.exp * 1000
+		}
+	} catch {
+		// Clerk token shape changed — fall back to a short TTL.
+	}
+	return fallback
+}


### PR DESCRIPTION
**Spike — not for merge.** One of three drafts exploring how to remove the ~150ms Clerk token fetch from signed-in file navigation. See also the cookie-decouple and persistent-socket spikes. This one is a distilled, dotcom-scoped variant of #9343 built independently off `main` so the three approaches compare cleanly.

## Problem

On every file navigation, `TlaEditor` force-remounts (`key={fileSlug}`), recreating the document-room WebSocket. `useSync`'s `uri` callback `await`s a Clerk token (`getUserToken()` → `getToken()`, ~150ms) before the socket can open — on the navigation critical path.

## Technique: keep the token warm

Keep the token in the URL, but serve it from an in-memory cache that stays warm:

- `createWarmTokenGetter` (`warmTokenCache.ts`) caches the token, decodes its `exp` to know when to refresh, and de-dups concurrent refreshes.
- It's instantiated in **`UserProvider`**, which lives *above* the per-file routes — so the cache survives the per-file editor remount. (A cache inside `TlaEditor` would be rebuilt cold on every navigation; this was the key design point.)
- A 50s `keepWarm()` interval refreshes ahead of expiry, and it primes on mount.

The `uri` callback is unchanged in shape; the `await` now resolves from cache in ~0ms after the first navigation.

## Tradeoffs

- ✅ Works in **local dev** too (no same-origin requirement) — easiest to measure.
- ✅ Minimal surface; no worker change.
- ⚠️ First navigation in a session still pays the cold fetch (cache not yet primed at that instant; the prime races the first connect).
- ⚠️ Overlaps #9343 by design — #9343 caches app-wide; this is scoped to the user-token path feeding the doc socket. JWT decode is unverified (refresh-timing only; server still verifies).

## Measuring

`[spike-auth]` console logs report token-fetch time and time-to-`synced-remote`. `yarn dev-app`, sign in, navigate A↔B ~10×; expect the first to be ~150ms and subsequent ones ~0ms.

## Out of scope

Asset-upload token path; production hardening; reconciling with #9343.
