### PR TITLE
chore(repo): spike — disable dependency build scripts by default with allowlist

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,11 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+# Don't run third-party dependency build/install scripts by default. Packages that
+# genuinely need to build are allowlisted via dependenciesMeta.<pkg>.built in package.json.
+# This closes the postinstall code-execution vector; see the note in AGENTS.md.
+enableScripts: false
+
 enableInlineBuilds: true
 
 nodeLinker: node-modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,7 @@ Dependencies:
 
 - Keep dependencies workspace-appropriate.
 - If changing dependency manifests or lockfiles, make sure the lockfile update is intentional and included.
+- Dependency install/build scripts are off by default (`enableScripts: false` in `.yarnrc.yml`), which closes the main supply-chain `postinstall` code-execution path. Packages that genuinely need to build (native/napi modules, binary downloaders) are allowlisted with `built: true` under `dependenciesMeta` in the root `package.json`. When adding a dependency that ships a native addon or downloads a platform binary, add an allowlist entry — Yarn silently skips unlisted scripts, so a missing entry shows up as a runtime or build failure, not an install error.
 
 ## Writing style
 

--- a/package.json
+++ b/package.json
@@ -138,13 +138,54 @@
 		"our examples app depenends on pdf.js which pulls in canvas as an optional dependency.",
 		"it slows down installs quite a bit though, so we replace it with an empty package."
 	],
-	"// dependenciesMeta.workerd": [
-		"workerd's postinstall script runs the native binary to self-check it, which fails on",
-		"CI images without GLIBC 2.35+ (e.g. Vercel, which builds the docs site). Skipping the",
-		"build script doesn't affect wrangler at dev time — wrangler still invokes the platform",
+	"// dependenciesMeta": [
+		"enableScripts is false in .yarnrc.yml, so dependency build/install scripts don't run",
+		"unless allowlisted here with built: true. Add an entry when introducing a native or",
+		"binary-downloading dependency — Yarn silently skips unlisted scripts, so a missing entry",
+		"surfaces as a runtime/build failure, not an install error. See AGENTS.md.",
+		"",
+		"workerd stays built: false: its postinstall runs the native binary to self-check it, which",
+		"fails on CI images without GLIBC 2.35+ (e.g. Vercel, which builds the docs site). Skipping",
+		"the build script doesn't affect wrangler at dev time — wrangler still invokes the platform",
 		"binary normally on developer machines."
 	],
 	"dependenciesMeta": {
+		"@rocicorp/zero-sqlite3": {
+			"built": true
+		},
+		"@sentry/cli": {
+			"built": true
+		},
+		"@swc/core": {
+			"built": true
+		},
+		"@typescript/native-preview": {
+			"built": true
+		},
+		"@vscode/vsce-sign": {
+			"built": true
+		},
+		"better-sqlite3": {
+			"built": true
+		},
+		"edgedriver": {
+			"built": true
+		},
+		"esbuild": {
+			"built": true
+		},
+		"geckodriver": {
+			"built": true
+		},
+		"keytar": {
+			"built": true
+		},
+		"sharp": {
+			"built": true
+		},
+		"sqlite3": {
+			"built": true
+		},
 		"workerd": {
 			"built": false
 		}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11977,6 +11977,30 @@ __metadata:
     vitest: "npm:^4.1.7"
     vitest-canvas-mock: "npm:^1.1.3"
   dependenciesMeta:
+    "@rocicorp/zero-sqlite3":
+      built: true
+    "@sentry/cli":
+      built: true
+    "@swc/core":
+      built: true
+    "@typescript/native-preview":
+      built: true
+    "@vscode/vsce-sign":
+      built: true
+    better-sqlite3:
+      built: true
+    edgedriver:
+      built: true
+    esbuild:
+      built: true
+    geckodriver:
+      built: true
+    keytar:
+      built: true
+    sharp:
+      built: true
+    sqlite3:
+      built: true
     workerd:
       built: false
   languageName: unknown


### PR DESCRIPTION
## Spike: harden dependency installs with `enableScripts: false`

A spike exploring whether to flip dependency build/install scripts **off by default** and explicitly allowlist the packages that genuinely need to build. This closes the main npm supply-chain code-execution path (a compromised dependency's `postinstall`), and complements the `npmMinimalAgeGate: '7d'` install cooldown the repo already runs. It brings us to roughly pnpm `onlyBuiltDependencies` / npm v12 parity, ahead of npm forcing this default.

### Changes
- **`.yarnrc.yml`** — `enableScripts: false`. Third-party dependency install/postinstall scripts no longer run by default.
- **`package.json`** — `dependenciesMeta.<pkg>.built: true` allowlist for the native/binary deps that must build; `workerd` stays `built: false` as before.
- **`AGENTS.md`** — documents the convention for contributors adding new native deps.

## Change type

- [x] `other`

### Allowlisted (build on install)
`@swc/core`, `better-sqlite3`, `sqlite3`, `@rocicorp/zero-sqlite3`, `keytar`, `sharp`, `esbuild`, `@sentry/cli`, `@vscode/vsce-sign`, `@typescript/native-preview`, `edgedriver`, `geckodriver`.

Deliberately **not** allowlisted (benign banner/no-op scripts now skipped): `core-js`, `core-js-pure`, `protobufjs`, `postinstall-postinstall`, `@clerk/shared`, `@modelcontextprotocol/ext-apps`.

### Verification (local)
- Clean reinstall: every allowlisted native built (`YN0007`); only the benign scripts were skipped (`YN0004`).
- Root `postinstall` still runs — `husky` hooks install and `refresh-assets` runs (confirmed `enableScripts` only gates *dependency* scripts, not the project's own).
- `yarn install --immutable` passes (matches CI's install command).
- All native modules load (`better-sqlite3`, `sharp`, `@rocicorp/zero-sqlite3`, `@swc/core`, `keytar`, `esbuild`).
- `yarn typecheck` exits 0.

### Known limitation
Unlike pnpm's `strictDepBuilds`, Yarn **silently skips** unlisted scripts — it does not error when a *new* native dep appears. The failure mode is a runtime/build error, not an install error. Mitigation is process: the `YN0004` install warnings flag skipped scripts, and the `AGENTS.md` note reminds contributors to allowlist new native deps.

### Open questions for review
- Is the allowlist the right boundary, or should any of the "benign" scripts also run?
- Do we want CI to surface `YN0004` skips more loudly (e.g. fail on unexpected new build scripts) to compensate for Yarn not erroring?
