### PR TITLE
refactor(dotcom): remove the groups_backend flag from production

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Database.ts
+++ b/apps/dotcom/client/e2e/fixtures/Database.ts
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import { Page } from '@playwright/test'
-import { DB, userHasFlag } from '@tldraw/dotcom-shared'
+import { DB } from '@tldraw/dotcom-shared'
 import { Kysely, PostgresDialect, sql } from 'kysely'
 import pg from 'pg'
 import { OTHER_USERS, USERS } from '../consts'
@@ -43,46 +43,6 @@ export class Database {
 		}>`SELECT id FROM public.user WHERE email = ${email ?? ''}`.execute(db)
 		if (!dbUser.rows[0]) return
 		return dbUser.rows[0].id
-	}
-
-	/**
-	 * Check if a user is migrated to the groups model
-	 */
-	async isUserMigrated(isOther: boolean = false): Promise<boolean> {
-		return await this.isUserMigratedByEmail(this.getEmail(isOther))
-	}
-
-	async isUserMigratedByEmail(email: string): Promise<boolean> {
-		const id = await this.getUserIdByEmail(email)
-		if (!id) return false
-
-		const result = await sql<{
-			flags: string | null
-		}>`SELECT flags FROM public.user WHERE id = ${id}`.execute(db)
-
-		return userHasFlag(result.rows[0]?.flags, 'groups_backend')
-	}
-
-	/**
-	 * Migrate a user to the groups model
-	 */
-	async migrateUser(isOther: boolean = false): Promise<void> {
-		await this.migrateUserByEmail(this.getEmail(isOther))
-	}
-
-	async migrateUserByEmail(email: string): Promise<void> {
-		const id = await this.getUserIdByEmail(email)
-		if (!id) throw new Error(`User not found: ${email}`)
-		if (await this.isUserMigratedByEmail(email)) return
-
-		const inviteSecret = 'test' + Math.random().toString(36).substring(2, 15)
-
-		// Call the migration function
-		await sql`SELECT * FROM migrate_user_to_groups(${id}, ${inviteSecret})`.execute(db)
-	}
-
-	async ensureGroupsReadyByEmail(email: string): Promise<void> {
-		await this.migrateUserByEmail(email)
 	}
 
 	private async cleanUpUser(isOther: boolean) {

--- a/apps/dotcom/client/e2e/fixtures/scenario-test.ts
+++ b/apps/dotcom/client/e2e/fixtures/scenario-test.ts
@@ -508,8 +508,8 @@ class DotcomScenario {
 			.slice(0, MAX_WORKSPACE_NAME_LENGTH)
 		const fileName = opts.fileName ?? this.name('workspace file')
 
-		await this.ensureGroupsReady(opts.owner)
-		await this.ensureGroupsReady(opts.member)
+		await this.goToAndOpenSidebar(opts.owner)
+		await this.goToAndOpenSidebar(opts.member)
 
 		if (!opts.member.email) throw new Error('Workspace member actor is not signed in')
 		const memberUserId = await this.database.getUserIdByEmail(opts.member.email)
@@ -596,7 +596,7 @@ class DotcomScenario {
 		)
 	}
 
-	async ensureGroupsReady(actor: DotcomActor) {
+	async goToAndOpenSidebar(actor: DotcomActor) {
 		if (!actor.email) throw new Error(`Actor ${actor.name} is not signed in`)
 
 		await actor.goto()

--- a/apps/dotcom/client/e2e/fixtures/scenario-test.ts
+++ b/apps/dotcom/client/e2e/fixtures/scenario-test.ts
@@ -599,7 +599,6 @@ class DotcomScenario {
 	async ensureGroupsReady(actor: DotcomActor) {
 		if (!actor.email) throw new Error(`Actor ${actor.name} is not signed in`)
 
-		await this.database.ensureGroupsReadyByEmail(actor.email)
 		await actor.goto()
 		await actor.editor.ensureSidebarOpen()
 	}

--- a/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/workspaces.spec.ts
@@ -10,8 +10,7 @@ import { expect, test } from '../../fixtures/tla-test'
 // otherwise most recent (creating one if it's empty) — and creating a
 // workspace switches to it.
 test.describe('workspaces', () => {
-	test.beforeEach(async ({ database, editor }) => {
-		await database.migrateUser()
+	test.beforeEach(async ({ editor }) => {
 		await editor.isLoaded()
 		await editor.ensureSidebarOpen()
 	})
@@ -423,7 +422,7 @@ test.describe('workspaces', () => {
 			await context.grantPermissions(['clipboard-read', 'clipboard-write'])
 		})
 
-		test('invite already member user to workspace', async ({ sidebar, browser, database }) => {
+		test('invite already member user to workspace', async ({ sidebar, browser }) => {
 			const workspaceName = getRandomName()
 			const fileName = getRandomName()
 			const homeFileName = getRandomName()
@@ -435,9 +434,6 @@ test.describe('workspaces', () => {
 			await sidebar.moveFileToWorkspace(fileName, workspaceName)
 
 			const inviteUrl = await sidebar.copyWorkspaceInviteLink(workspaceName)
-
-			// Migrate invitee to groups backend but not frontend (tests auto-enable)
-			await database.migrateUser(true)
 
 			const parallelIndex = test.info().parallelIndex
 			const { newSidebar, newEditor, newWorkspaceInviteDialog, newContext } = await openNewTab(
@@ -475,7 +471,6 @@ test.describe('workspaces', () => {
 		test('signing in through the invite dialog completes the workspace join', async ({
 			sidebar,
 			browser,
-			database,
 		}) => {
 			const workspaceName = getRandomName()
 			const fileName = getRandomName()
@@ -488,9 +483,6 @@ test.describe('workspaces', () => {
 			await sidebar.moveFileToWorkspace(fileName, workspaceName)
 
 			const inviteUrl = await sidebar.copyWorkspaceInviteLink(workspaceName)
-
-			// Migrate invitee to groups backend but not frontend (tests auto-enable)
-			await database.migrateUser(true)
 
 			const parallelIndex = test.info().parallelIndex
 			const { newPage, newSidebar, newEditor, newWorkspaceInviteDialog, newContext } =

--- a/apps/dotcom/client/e2e/tests/ui.scenario.spec.ts
+++ b/apps/dotcom/client/e2e/tests/ui.scenario.spec.ts
@@ -128,7 +128,7 @@ test.describe('UI scenarios', () => {
 		const workspaceName = scenario.name('workspace nav')
 		const fileName = scenario.name('workspace movable file')
 
-		await scenario.ensureGroupsReady(owner)
+		await scenario.goToAndOpenSidebar(owner)
 		await scenario.createPersonalFile(owner, fileName)
 
 		await owner.sidebar.createWorkspace(workspaceName)
@@ -304,7 +304,7 @@ test.describe('UI scenarios', () => {
 		// Regression: the home workspace ("My workspace") used to render an empty dialog — the
 		// component returned null for it while the sidebar still opened the dialog, so the page
 		// just dimmed with no content. It's private: it can be renamed, but not shared or managed.
-		await scenario.ensureGroupsReady(owner)
+		await scenario.goToAndOpenSidebar(owner)
 		await owner.sidebar.switchToHomeWorkspace()
 		await owner.page.getByTestId('tla-sidebar-workspace-settings').click()
 
@@ -332,7 +332,7 @@ test.describe('UI scenarios', () => {
 		// Regression: the home workspace is renameable (the reason its settings dialog exists at
 		// all), so the rename must apply. Restore the name afterwards so later serial tests still
 		// see the original.
-		await scenario.ensureGroupsReady(owner)
+		await scenario.goToAndOpenSidebar(owner)
 		await owner.sidebar.switchToHomeWorkspace()
 		const originalName = await owner.page.getByTestId('tla-active-workspace-name').innerText()
 		const newName = scenario.name('home renamed')
@@ -356,7 +356,7 @@ test.describe('UI scenarios', () => {
 		const workspaceName = scenario.name('settings rename old')
 		const newWorkspaceName = scenario.name('settings rename new')
 
-		await scenario.ensureGroupsReady(owner)
+		await scenario.goToAndOpenSidebar(owner)
 		await owner.sidebar.createWorkspace(workspaceName)
 		await owner.sidebar.renameWorkspace(workspaceName, newWorkspaceName)
 

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -413,7 +413,7 @@ export class TldrawApp {
 
 	/**
 	 * Get the user's home workspace ID.
-	 * For migrated users, this is used to store shared files and pinned files.
+	 * Used to store shared files and pinned files.
 	 * The home workspace ID is the same as the user ID.
 	 */
 	getHomeWorkspaceId() {

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -58,8 +58,6 @@ import {
 	dataUrlToFile,
 	defaultUserPreferences,
 	getUserPreferences,
-	objectMapFromEntries,
-	objectMapKeys,
 	parseTldrawJsonFile,
 	react,
 	transact,
@@ -414,15 +412,6 @@ export class TldrawApp {
 	}
 
 	/**
-	 * Check if the user has been migrated to the new workspaces-based data model.
-	 * Users with the 'groups_backend' flag use group_file for access control and pinning.
-	 * Users without the flag use the legacy file_state-based approach.
-	 */
-	isWorkspacesMigrated() {
-		return this.hasFlag('groups_backend')
-	}
-
-	/**
 	 * Get the user's home workspace ID.
 	 * For migrated users, this is used to store shared files and pinned files.
 	 * The home workspace ID is the same as the user ID.
@@ -543,12 +532,6 @@ export class TldrawApp {
 		return this.fileStates$.get()
 	}
 
-	lastRecentFileOrdering = null as null | Array<{
-		fileId: TlaFile['id']
-		isPinned: boolean
-		date: number
-	}>
-
 	// Store stable workspace file ordering for each workspace to prevent jumping when files are edited
 	lastWorkspaceFileOrderings = new Map<
 		string,
@@ -560,86 +543,7 @@ export class TldrawApp {
 
 	@computed({ isEqual })
 	getMyFiles() {
-		if (this.isWorkspacesMigrated()) {
-			return this.getWorkspaceFilesSorted(this.getHomeWorkspaceId())
-		}
-		const myFiles = objectMapFromEntries(this.getUserOwnFiles().map((f) => [f.id, f]))
-		const myStates = objectMapFromEntries(this.getUserFileStates().map((f) => [f.fileId, f]))
-
-		const myFileIds = new Set<string>([...objectMapKeys(myFiles), ...objectMapKeys(myStates)])
-		const myWorkspaceMemberships = this.getWorkspaceMemberships()
-
-		const nextRecentFileOrdering: {
-			fileId: TlaFile['id']
-			isPinned: boolean
-			date: number
-		}[] = []
-
-		for (const fileId of myFileIds) {
-			const file = myFiles[fileId]
-			let state: (typeof myStates)[string] | undefined = myStates[fileId]
-			if (!file) continue
-			if (file.isDeleted) continue
-
-			if (!state && !file.isDeleted && file.ownerId === this.userId) {
-				state = this.fileStates$.get().find((fs) => fs.fileId === fileId)
-			}
-			if (!state) {
-				// if the file is deleted, we don't want to show it in the recent files
-				continue
-			}
-
-			// if the file is in a workspace we have access to, we don't want to show it in my workspace
-			if (myWorkspaceMemberships.some((g) => g.groupFiles.some((gf) => gf.fileId === fileId))) {
-				continue
-			}
-
-			const existing = this.lastRecentFileOrdering?.find((f) => f.fileId === fileId)
-			const isPinned = state.isPinned ?? false
-
-			if (existing && existing.isPinned === isPinned) {
-				// Preserve existing entry to maintain ordering
-				nextRecentFileOrdering.push(existing)
-				continue
-			}
-
-			// For new entries or pinned status changes
-			const newEntry = {
-				fileId,
-				isPinned,
-				date: getFileRecencyDate(state, file),
-			}
-
-			// If this was previously unpinned and we have existing ordering,
-			// preserve its position in the unpinned section to avoid real-time reordering
-			if (!isPinned && existing && !existing.isPinned) {
-				// Keep the old date to preserve ordering in "My workspace"
-				newEntry.date = existing.date
-			}
-
-			nextRecentFileOrdering.push(newEntry)
-		}
-
-		// separate pinned and unpinned files
-		const pinnedFiles = nextRecentFileOrdering.filter((f) => f.isPinned)
-		const unpinnedFiles = nextRecentFileOrdering.filter((f) => !f.isPinned)
-
-		// sort pinned files by their pinnedIndex
-		pinnedFiles.sort((a, b) => {
-			// If neither has an index, sort by date (fallback)
-			return b.date - a.date
-		})
-
-		// sort unpinned files by date with most recent first
-		unpinnedFiles.sort((a, b) => b.date - a.date)
-
-		// combine: pinned files first, then unpinned
-		const sortedFiles = [...pinnedFiles, ...unpinnedFiles]
-
-		// stash the ordering for next time
-		this.lastRecentFileOrdering = sortedFiles
-
-		return sortedFiles
+		return this.getWorkspaceFilesSorted(this.getHomeWorkspaceId())
 	}
 
 	/**
@@ -672,23 +576,17 @@ export class TldrawApp {
 	}
 
 	private canCreateNewFile(workspaceId: string) {
-		if (this.isWorkspacesMigrated()) {
-			// Count only files the workspace actually owns — not guest files (shared files the
-			// user opened) or mislinked rows that getWorkspaceFilesSorted hides. Counting those
-			// would let the limit fire on files the user can neither see nor remove. For migrated
-			// users createFile runs no server-side file-limit check, so this is the only gate;
-			// scoping it to owned files keeps it to what the user can actually manage.
-			const membership = this.getWorkspaceMembership(workspaceId)
-			if (!membership) return true
-			const nonDeletedCount = membership.groupFiles.filter(
-				(gf) => gf.file && !gf.file.isDeleted && gf.file.owningGroupId === workspaceId
-			).length
-			return nonDeletedCount < this.config.maxNumberOfFiles
-		} else {
-			// For unmigrated users, count non-deleted files owned by the user
-			const nonDeletedCount = this.getUserOwnFiles().filter((f) => !f.isDeleted).length
-			return nonDeletedCount < this.config.maxNumberOfFiles
-		}
+		// Count only files the workspace actually owns — not guest files (shared files the
+		// user opened) or mislinked rows that getWorkspaceFilesSorted hides. Counting those
+		// would let the limit fire on files the user can neither see nor remove. createFile
+		// runs no server-side file-limit check, so this is the only gate; scoping it to owned
+		// files keeps it to what the user can actually manage.
+		const membership = this.getWorkspaceMembership(workspaceId)
+		if (!membership) return true
+		const nonDeletedCount = membership.groupFiles.filter(
+			(gf) => gf.file && !gf.file.isDeleted && gf.file.owningGroupId === workspaceId
+		).length
+		return nonDeletedCount < this.config.maxNumberOfFiles
 	}
 
 	private showMaxFilesToast() {
@@ -701,12 +599,7 @@ export class TldrawApp {
 	}
 
 	isPinned(fileId: string, workspaceId: string) {
-		if (this.isWorkspacesMigrated()) {
-			return this.getWorkspaceFilesSorted(workspaceId).some(
-				(f) => f.fileId === fileId && f.isPinned
-			)
-		}
-		return this.getFileState(fileId)?.isPinned ?? false
+		return this.getWorkspaceFilesSorted(workspaceId).some((f) => f.fileId === fileId && f.isPinned)
 	}
 
 	// A workspace's welcome file is seeded once, when the workspace is created. Its
@@ -902,14 +795,11 @@ export class TldrawApp {
 
 	getFile(fileId?: string): TlaFile | null {
 		if (!fileId) return null
-		if (this.isWorkspacesMigrated()) {
-			return (
-				this.getWorkspaceMemberships()
-					.find((g) => g.groupFiles.some((gf) => gf.fileId === fileId))
-					?.groupFiles.find((gf) => gf.fileId === fileId)?.file ?? null
-			)
-		}
-		return this.getUserOwnFiles().find((f) => f.id === fileId) ?? null
+		return (
+			this.getWorkspaceMemberships()
+				.find((g) => g.groupFiles.some((gf) => gf.fileId === fileId))
+				?.groupFiles.find((gf) => gf.fileId === fileId)?.file ?? null
+		)
 	}
 
 	canUpdateFile(fileId: string): boolean {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -138,6 +138,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								exportPadding: true,
 								createdAt: now,
 								updatedAt: now,
+								// Vestigial migration done-marker that migrate_user_to_groups (an applied,
+								// immutable migration) keys off; no longer read as a feature flag.
 								flags: 'groups_backend',
 							})
 							.execute()
@@ -723,6 +725,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			await tx
 				.updateTable('user')
 				.set({
+					// Vestigial migration done-marker (see the insert above); not a feature flag.
 					flags: 'groups_backend',
 					allowAnalyticsCookie: null,
 					enhancedA11yMode: null,
@@ -782,29 +785,6 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 		// instead of resurrecting deleted files and groups.
 		await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
 		await this.cache?.reboot({ delay: false, source: 'admin', hard: true })
-	}
-
-	async admin_migrateToGroups(userId: string, inviteSecret: string | null = null) {
-		console.error('admin_migrateToGroups', userId, inviteSecret)
-		this.userId ??= userId
-
-		this.log.debug('migrating to groups', userId, inviteSecret)
-		// Call the Postgres migration function
-		const result = await sql<{
-			files_migrated: number
-			pinned_files_migrated: number
-			flag_added: boolean
-		}>`SELECT * FROM migrate_user_to_groups(${userId}, ${inviteSecret})`.execute(this.db)
-		console.error('admin_migrateToGroups result', result.rows)
-
-		this.log.debug('migration result', result.rows[0])
-
-		await this.env.USER_DO_SNAPSHOTS.delete(getUserDoSnapshotKey(this.env, userId))
-		await this.cache?.reboot({ delay: false, source: 'admin', hard: true })
-
-		this.log.debug('migration complete, user rebooted')
-
-		return result.rows[0]
 	}
 
 	async admin_forceHardReboot(userId: string) {

--- a/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLUserDurableObject.ts
@@ -138,9 +138,8 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 								exportPadding: true,
 								createdAt: now,
 								updatedAt: now,
-								// Vestigial migration done-marker that migrate_user_to_groups (an applied,
-								// immutable migration) keys off; no longer read as a feature flag.
-								flags: 'groups_backend',
+								// No feature flags on new users; the column is retained for future flags.
+								flags: '',
 							})
 							.execute()
 						await tx
@@ -725,8 +724,7 @@ export class TLUserDurableObject extends DurableObject<Environment> {
 			await tx
 				.updateTable('user')
 				.set({
-					// Vestigial migration done-marker (see the insert above); not a feature flag.
-					flags: 'groups_backend',
+					flags: '',
 					allowAnalyticsCookie: null,
 					enhancedA11yMode: null,
 					colorScheme: null,

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -53,16 +53,6 @@ export const adminRoutes = createRouter<Environment>()
 		await user.admin_forceHardReboot(userRow.id)
 		return new Response('Rebooted', { status: 200 })
 	})
-	.post('/app/admin/user/migrate', async (res, env) => {
-		const q = res.query['q']
-		if (typeof q !== 'string') {
-			return new Response('Missing query param', { status: 400 })
-		}
-		const userRow = await requireUser(env, q)
-		const user = getUserDurableObject(env, userRow.id)
-		const result = await user.admin_migrateToGroups(userRow.id, uniqueId())
-		return json(result)
-	})
 	.get('/app/admin/feature-flags', getFeatureFlagsAdmin)
 	.post('/app/admin/feature-flags', async (req, env) => {
 		const body: any = await req.json()

--- a/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/acceptInvite.ts
@@ -1,4 +1,4 @@
-import { AcceptInviteResponseBody, userHasFlag } from '@tldraw/dotcom-shared'
+import { AcceptInviteResponseBody } from '@tldraw/dotcom-shared'
 import { getIndexBelow, IndexKey } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
 import { sql } from 'kysely'
@@ -68,16 +68,6 @@ export async function acceptInvite(request: IRequest, env: Environment): Promise
 					{ status: 404 }
 				)
 			}
-			if (!userHasFlag(user.flags, 'groups_backend')) {
-				return Response.json(
-					{
-						error: true,
-						message: 'User is not migrated to the groups model',
-					} satisfies AcceptInviteResponseBody,
-					{ status: 400 }
-				)
-			}
-
 			// Get the lowest index to place new group at the top
 			const lowestIndexGroup = await sql<{
 				index: string

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -1512,9 +1512,9 @@ describe('createFile from source (duplicate) access control', () => {
 		await expectBadRequest(() => duplicate(m, tx, `${FILE_PREFIX}/${sourceId}`))
 	})
 
-	it('non-migrated user cannot duplicate an inaccessible legacy file', async () => {
+	it('cannot duplicate an inaccessible legacy (ownerId-owned) file', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: '' })],
+			user: [makeUser({ id: userId, flags: 'groups_backend' })],
 			file: [makeFile({ id: sourceId, ownerId: 'user_someoneElse1234', shared: false })],
 			file_state: [],
 			group: [],
@@ -1543,7 +1543,7 @@ describe('createFile from source (duplicate) access control', () => {
 	})
 })
 
-describe('legacy file creation (insertWithFileState removed as a mutator)', () => {
+describe('file creation security', () => {
 	const userId = 'user_aaaa11112222bbbb'
 
 	it('file.insertWithFileState is not exposed as a callable mutator', () => {
@@ -1551,31 +1551,5 @@ describe('legacy file creation (insertWithFileState removed as a mutator)', () =
 		// arbitrary file row (with an attacker-controlled createSource) directly.
 		const m = createMutators(userId)
 		expect((m.file as Record<string, unknown>).insertWithFileState).toBeUndefined()
-	})
-
-	it('non-migrated user can still create a blank file', async () => {
-		const s = {
-			user: [makeUser({ id: userId, flags: '' })],
-			file: [] as TlaFile[],
-			file_state: [] as TlaFileState[],
-			group: [],
-			group_user: [],
-			group_file: [],
-		}
-		const { tx } = createMockTx(s, { location: 'server' })
-		const m = createMutators(userId)
-		await expectValid(() =>
-			m.createFile(tx, {
-				fileId: 'file_legacy123456789',
-				workspaceId: userId,
-				name: 'Legacy file',
-				time: Date.now(),
-				createSource: null,
-			})
-		)
-		// the file and its file_state were created with legacy ownerId ownership
-		const created = s.file.find((f) => f.id === 'file_legacy123456789')
-		expect(created?.ownerId).toBe(userId)
-		expect(s.file_state.find((fs) => fs.fileId === 'file_legacy123456789')).toBeDefined()
 	})
 })

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -27,7 +27,7 @@ function makeUser(overrides: Partial<TlaUser> & { id: string }): TlaUser {
 		exportPadding: true,
 		createdAt: 1,
 		updatedAt: 1,
-		flags: 'groups_backend',
+		flags: '',
 		locale: null,
 		animationSpeed: null,
 		areKeyboardShortcutsEnabled: null,
@@ -296,18 +296,18 @@ function expectBadRequest(fn: () => Promise<any>) {
 
 describe('parseFlags / userHasFlag', () => {
 	it('parses comma-separated', () => {
-		expect(parseFlags('groups_backend,other_flag')).toEqual(['groups_backend', 'other_flag'])
+		expect(parseFlags('flag_a,flag_b')).toEqual(['flag_a', 'flag_b'])
 	})
 	it('parses space-separated', () => {
-		expect(parseFlags('groups_backend other_flag')).toEqual(['groups_backend', 'other_flag'])
+		expect(parseFlags('flag_a flag_b')).toEqual(['flag_a', 'flag_b'])
 	})
 	it('handles null/undefined', () => {
 		expect(parseFlags(null)).toEqual([])
 		expect(parseFlags(undefined)).toEqual([])
 	})
 	it('userHasFlag checks presence', () => {
-		expect(userHasFlag('groups_backend', 'groups_backend')).toBe(true)
-		expect(userHasFlag('other_flag', 'groups_backend')).toBe(false)
+		expect(userHasFlag('flag_a', 'flag_a')).toBe(true)
+		expect(userHasFlag('flag_b', 'flag_a')).toBe(false)
 	})
 })
 
@@ -365,7 +365,7 @@ describe('user mutations', () => {
 		})
 		const m = createMutators(userId)
 		// flags is NOT in immutableColumns.user, so this should succeed
-		await expectValid(() => m.user.update(tx, { id: userId, flags: 'groups_backend' }))
+		await expectValid(() => m.user.update(tx, { id: userId, flags: 'example_flag' }))
 	})
 })
 
@@ -454,7 +454,7 @@ describe('file creation', () => {
 
 	it('migrated user can create file in own workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -477,7 +477,7 @@ describe('file creation', () => {
 	it('migrated user cannot create file in another workspace', async () => {
 		const otherGroup = 'group_other123456789'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId }), makeGroup({ id: otherGroup })],
@@ -503,7 +503,7 @@ describe('file creation', () => {
 		// un-switchable, since selecting it creates-then-opens a file. Regression test:
 		// authorize via getRole (home => owner), not a raw group_user lookup.
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: userId })],
@@ -638,7 +638,7 @@ describe('onEnterFile', () => {
 		// their home group, which is what surfaces it as a "guest file" in the sidebar.
 		const otherGroup = 'group_other123456789'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: otherGroup, shared: true })],
 			file_state: [],
 			group: [makeGroup({ id: userId }), makeGroup({ id: otherGroup })],
@@ -654,7 +654,7 @@ describe('onEnterFile', () => {
 	it('does not mirror a file the user already has via a group they belong to', async () => {
 		const workspaceId = 'group_workspace1234ab'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: workspaceId, shared: true })],
 			file_state: [],
 			group: [makeGroup({ id: userId }), makeGroup({ id: workspaceId })],
@@ -672,7 +672,7 @@ describe('onEnterFile', () => {
 
 	it('mirrors a group-less (legacy) file into home so it stays findable', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: null, ownerId: userId, shared: true })],
 			file_state: [],
 			group: [makeGroup({ id: userId })],
@@ -691,7 +691,7 @@ describe('workspace mutations', () => {
 
 	it('migrated user can create workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [],
@@ -709,7 +709,7 @@ describe('workspace mutations', () => {
 
 	it('cannot create workspace with an empty name', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [],
@@ -726,7 +726,7 @@ describe('workspace mutations', () => {
 	it('owner can update workspace name', async () => {
 		const groupId = 'group_aaa11112222bbb'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -741,7 +741,7 @@ describe('workspace mutations', () => {
 	it('member cannot update workspace name', async () => {
 		const groupId = 'group_aaa11112222bbb'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -757,7 +757,7 @@ describe('workspace mutations', () => {
 		const groupId = 'group_aaa11112222bbb'
 		const fileId = 'file_aaaa11112222bbbb'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupId })],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -775,7 +775,7 @@ describe('workspace mutations', () => {
 	it('non-owner cannot delete workspace', async () => {
 		const groupId = 'group_aaa11112222bbb'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -795,7 +795,7 @@ describe('membership', () => {
 
 	it('owner can set member roles', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -817,7 +817,7 @@ describe('membership', () => {
 
 	it('member cannot set member roles', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -836,7 +836,7 @@ describe('membership', () => {
 
 	it('cannot demote last owner to member', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -855,7 +855,7 @@ describe('membership', () => {
 
 	it('last owner cannot leave workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -869,7 +869,7 @@ describe('membership', () => {
 
 	it('non-owner member can leave workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -887,7 +887,7 @@ describe('membership', () => {
 
 	it('owner can remove a member', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -905,7 +905,7 @@ describe('membership', () => {
 
 	it('member cannot remove members', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -924,7 +924,7 @@ describe('membership', () => {
 
 	it('cannot remove the last owner', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -950,7 +950,7 @@ describe('file operations across workspaces', () => {
 
 	it('member of both workspaces can move file between them', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupA })],
 			file_state: [],
 			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
@@ -968,7 +968,7 @@ describe('file operations across workspaces', () => {
 
 	it('member of source workspace only cannot move file to other workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupA })],
 			file_state: [],
 			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
@@ -982,7 +982,7 @@ describe('file operations across workspaces', () => {
 
 	it('member of target workspace only cannot move file from other workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupA })],
 			file_state: [],
 			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
@@ -996,7 +996,7 @@ describe('file operations across workspaces', () => {
 
 	it('member can remove file from workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupA })],
 			file_state: [makeFileState({ userId, fileId })],
 			group: [makeGroup({ id: groupA })],
@@ -1011,7 +1011,7 @@ describe('file operations across workspaces', () => {
 
 	it('non-member cannot remove file from workspace', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupA })],
 			file_state: [makeFileState({ userId, fileId })],
 			group: [makeGroup({ id: groupA })],
@@ -1027,7 +1027,7 @@ describe('file operations across workspaces', () => {
 	it('removing a linked file deletes only the link, not the file', async () => {
 		// the file is owned by workspace B but linked into workspace A
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: fileId, owningGroupId: groupB })],
 			file_state: [makeFileState({ userId, fileId })],
 			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
@@ -1049,7 +1049,7 @@ describe('file operations across workspaces', () => {
 		const otherFileId = 'file_bbbb11112222cccc'
 		const homePinnedId = 'file_cccc11112222dddd'
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [
 				makeFile({ id: fileId, owningGroupId: groupA }),
 				makeFile({ id: otherFileId, owningGroupId: groupA }),
@@ -1089,7 +1089,7 @@ describe('home workspace special case', () => {
 		// createFile with groupId === userId should pass the membership check
 		// even without a group_user row, because of the userId === groupId shortcut
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: userId })],
@@ -1114,12 +1114,12 @@ describe('home workspace special case', () => {
 	// or have its members managed. (It can be renamed.)
 	function homeState(extra?: { secondOwnerId?: string }) {
 		const group_user: TlaGroupUser[] = [makeGroupUser({ userId, groupId: userId, role: 'owner' })]
-		const user = [makeUser({ id: userId, flags: 'groups_backend' })]
+		const user = [makeUser({ id: userId })]
 		if (extra?.secondOwnerId) {
 			group_user.push(
 				makeGroupUser({ userId: extra.secondOwnerId, groupId: userId, role: 'owner' })
 			)
-			user.push(makeUser({ id: extra.secondOwnerId, flags: 'groups_backend' }))
+			user.push(makeUser({ id: extra.secondOwnerId }))
 		}
 		return {
 			user,
@@ -1159,7 +1159,7 @@ describe('home workspace special case', () => {
 	it('cannot change member roles in home workspace', async () => {
 		const targetId = 'user_target123456789'
 		const s = homeState()
-		s.user.push(makeUser({ id: targetId, flags: 'groups_backend' }))
+		s.user.push(makeUser({ id: targetId }))
 		s.group_user.push(makeGroupUser({ userId: targetId, groupId: userId, role: 'member' }))
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1175,7 +1175,7 @@ describe('regenerateWorkspaceInviteSecret', () => {
 
 	it('owner can regenerate invite secret', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId, inviteSecret: 'old_secret_1234567' })],
@@ -1191,7 +1191,7 @@ describe('regenerateWorkspaceInviteSecret', () => {
 
 	it('member cannot regenerate invite secret', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId, inviteSecret: 'old_secret_1234567' })],
@@ -1206,7 +1206,7 @@ describe('regenerateWorkspaceInviteSecret', () => {
 	it('non-member cannot regenerate invite secret', async () => {
 		const nonMemberId = 'user_nonmember123456'
 		const s = {
-			user: [makeUser({ id: nonMemberId, flags: 'groups_backend' })],
+			user: [makeUser({ id: nonMemberId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId })],
@@ -1226,7 +1226,7 @@ describe('setWorkspaceInviteLinkEnabled', () => {
 
 	it('owner can toggle the invite link', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId, inviteLinkEnabled: true })],
@@ -1243,7 +1243,7 @@ describe('setWorkspaceInviteLinkEnabled', () => {
 
 	it('member cannot toggle the invite link', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [],
 			file_state: [],
 			group: [makeGroup({ id: groupId, inviteLinkEnabled: true })],
@@ -1453,7 +1453,7 @@ describe('createFile from source (duplicate) access control', () => {
 	// migrated user whose target group is their home group (groupId === userId)
 	function baseStore(sourceFile: TlaFile) {
 		return {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [sourceFile],
 			file_state: [],
 			group: [makeGroup({ id: userId }), makeGroup({ id: otherGroup })],
@@ -1500,7 +1500,7 @@ describe('createFile from source (duplicate) access control', () => {
 
 	it('cannot duplicate a file you only know the id of (source not present)', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [] as TlaFile[],
 			file_state: [],
 			group: [makeGroup({ id: userId })],
@@ -1514,7 +1514,7 @@ describe('createFile from source (duplicate) access control', () => {
 
 	it('cannot duplicate an inaccessible legacy (ownerId-owned) file', async () => {
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [makeFile({ id: sourceId, ownerId: 'user_someoneElse1234', shared: false })],
 			file_state: [],
 			group: [],
@@ -1530,7 +1530,7 @@ describe('createFile from source (duplicate) access control', () => {
 		// a published-doc copy uses a different prefix and must still work even
 		// when there is no readable `file` row for the source id
 		const s = {
-			user: [makeUser({ id: userId, flags: 'groups_backend' })],
+			user: [makeUser({ id: userId })],
 			file: [] as TlaFile[],
 			file_state: [],
 			group: [makeGroup({ id: userId })],

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -239,7 +239,7 @@ export function createMutators(userId: string) {
 		init: async (tx: Tx, { user, time }: { user: TlaUser; time: number }) => {
 			assert(user.id === userId, ZErrorCode.forbidden)
 			time = ensureSensibleTimestamp(time)
-			await tx.mutate.user.insert({ ...user, flags: 'groups_backend' })
+			await tx.mutate.user.insert({ ...user, flags: '' })
 			await tx.mutate.group.insert({
 				id: userId,
 				name: user.name,

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -7,11 +7,7 @@ import {
 	sortByMaybeIndex,
 	uniqueId,
 } from '@tldraw/utils'
-import {
-	MAX_NUMBER_OF_FILES,
-	MAX_NUMBER_OF_WORKSPACES,
-	MAX_WORKSPACE_NAME_LENGTH,
-} from './constants'
+import { MAX_NUMBER_OF_WORKSPACES, MAX_WORKSPACE_NAME_LENGTH } from './constants'
 import { Role, can, isRole } from './roles'
 import { FILE_PREFIX } from './routes'
 import {
@@ -55,13 +51,6 @@ export function userHasFlag(flags: string | null | undefined, flag: TlaFlags): b
 	return parseFlags(flags).includes(flag)
 }
 
-async function assertUserHasFlag(tx: Transaction<TlaSchema>, userId: string, flag: TlaFlags) {
-	const user = await tx.run(zql.user.where('id', '=', userId).one())
-	assert(user, ZErrorCode.bad_request)
-	const flags = parseFlags(user.flags)
-	assert(flags.includes(flag), ZErrorCode.forbidden)
-}
-
 function disallowImmutableMutations<
 	S extends TlaFilePartial | TlaFileStatePartial | TlaUserPartial,
 >(data: S, immutableColumns: Set<keyof S>) {
@@ -72,14 +61,6 @@ function disallowImmutableMutations<
 
 export type TlaMutators = ReturnType<typeof createMutators>
 
-async function isMigratedToWorkspaces(
-	tx: Transaction<TlaSchema>,
-	userId: string
-): Promise<boolean> {
-	const user = await tx.run(zql.user.where('id', '=', userId).one())
-	return userHasFlag(user?.flags, 'groups_backend')
-}
-
 function ensureSensibleTimestamp(time: number) {
 	// if a mutation took more than 5 seconds to reach the server, or is in the future, let's use the server's time
 	const now = Date.now()
@@ -87,35 +68,6 @@ function ensureSensibleTimestamp(time: number) {
 		return now
 	}
 	return time
-}
-
-async function assertNotMaxFiles(tx: Transaction<TlaSchema>, userId: string) {
-	const migrated = await isMigratedToWorkspaces(tx, userId)
-
-	if (tx.location === 'client') {
-		const files = await tx.run(zql.file)
-		const count = files.filter((f: TlaFile) => {
-			if (f.isDeleted) return false
-			// For migrated users, count files owned by their home group
-			// For unmigrated users, count files owned directly by userId
-			if (migrated) {
-				return f.owningGroupId === userId
-			} else {
-				return f.ownerId === userId
-			}
-		}).length
-		assert(count < MAX_NUMBER_OF_FILES, ZErrorCode.max_files_reached)
-	} else {
-		// On the server, don't fetch all files because we don't need them
-		// Check both ownerId and owningGroupId to handle both migration states
-		const rows = Array.from(
-			await tx.dbTransaction.query(
-				`select count(*) from "file" where "isDeleted" = false and ("ownerId" = $1 OR "owningGroupId" = $1)`,
-				[userId]
-			)
-		) as { count: string }[]
-		assert(Number(rows[0].count) < MAX_NUMBER_OF_FILES, ZErrorCode.max_files_reached)
-	}
 }
 
 /**
@@ -346,46 +298,6 @@ export function createMutators(userId: string) {
 				}
 			}
 
-			const migrated = await isMigratedToWorkspaces(tx, userId)
-			if (!migrated) {
-				// Legacy (user-owned) file creation. ownerId, id and the file_state
-				// keys are constructed here to match userId/fileId, so the only checks
-				// that can fail are the file limit and id validity (createSource was
-				// gated above).
-				await assertNotMaxFiles(tx, userId)
-				assertValidId(fileId)
-				await tx.mutate.file.insert({
-					id: fileId,
-					name,
-					ownerId: userId,
-					owningGroupId: null,
-					ownerName: '',
-					ownerAvatar: '',
-					thumbnail: '',
-					shared: true,
-					sharedLinkType: 'edit',
-					published: false,
-					lastPublished: 0,
-					publishedSlug: uniqueId(),
-					createdAt: time,
-					updatedAt: time,
-					isEmpty: true,
-					isDeleted: false,
-					createSource,
-				})
-				await tx.mutate.file_state.upsert({
-					userId,
-					fileId,
-					firstVisitAt: null,
-					lastEditAt: null,
-					lastSessionState: null,
-					lastVisitAt: null,
-					isFileOwner: true,
-					isPinned: false,
-				})
-				return
-			}
-
 			const file = await tx.run(zql.file.where('id', '=', fileId).one())
 			assert(!file, ZErrorCode.bad_request)
 			assertValidId(fileId)
@@ -448,53 +360,32 @@ export function createMutators(userId: string) {
 			assert(typeof index === 'string' || index == null, ZErrorCode.bad_request)
 			assert(workspaceId, ZErrorCode.bad_request)
 
-			const migrated = await isMigratedToWorkspaces(tx, userId)
+			// Pinned files are group_file rows with a non-null index.
+			// New pins go above the workspace's current top pinned file.
+			let indexToUse = index
+			if (indexToUse == null) {
+				const allWorkspaceFiles = await tx.run(zql.group_file.where('groupId', '=', workspaceId))
+				const otherPinnedFiles = allWorkspaceFiles.filter((gf: TlaGroupFile) => gf.index !== null)
 
-			if (migrated) {
-				// Migrated users: pinned files are group_file rows with a non-null index.
-				// New pins go above the workspace's current top pinned file.
-				let indexToUse = index
-				if (indexToUse == null) {
-					const allWorkspaceFiles = await tx.run(zql.group_file.where('groupId', '=', workspaceId))
-					const otherPinnedFiles = allWorkspaceFiles.filter((gf: TlaGroupFile) => gf.index !== null)
-
-					otherPinnedFiles.sort(sortByMaybeIndex)
-					indexToUse = getIndexBelow(otherPinnedFiles[0]?.index) ?? ('a1' as IndexKey)
-				}
-
-				await tx.mutate.group_file.update({
-					fileId,
-					groupId: workspaceId,
-					index: indexToUse,
-				})
-			} else {
-				await tx.mutate.file_state.upsert({
-					fileId,
-					userId,
-					isPinned: true,
-					lastEditAt: Date.now(),
-				})
+				otherPinnedFiles.sort(sortByMaybeIndex)
+				indexToUse = getIndexBelow(otherPinnedFiles[0]?.index) ?? ('a1' as IndexKey)
 			}
+
+			await tx.mutate.group_file.update({
+				fileId,
+				groupId: workspaceId,
+				index: indexToUse,
+			})
 		},
 
 		unpinFile: async (tx: Tx, { fileId, workspaceId }: { fileId: string; workspaceId: string }) => {
 			assert(fileId, ZErrorCode.bad_request)
 
-			const migrated = await isMigratedToWorkspaces(tx, userId)
-
-			if (migrated) {
-				await tx.mutate.group_file.update({
-					fileId,
-					groupId: workspaceId,
-					index: null,
-				})
-			} else {
-				await tx.mutate.file_state.update({
-					fileId,
-					userId,
-					isPinned: false,
-				})
-			}
+			await tx.mutate.group_file.update({
+				fileId,
+				groupId: workspaceId,
+				index: null,
+			})
 		},
 
 		removeFileFromWorkspace: async (
@@ -503,13 +394,6 @@ export function createMutators(userId: string) {
 		) => {
 			assert(fileId, ZErrorCode.bad_request)
 			assert(workspaceId, ZErrorCode.bad_request)
-			const migrated = await isMigratedToWorkspaces(tx, userId)
-			if (!migrated) {
-				// eslint-disable-next-line @typescript-eslint/no-deprecated
-				await mutators.file.deleteOrForget(tx, { id: fileId })
-				return
-			}
-
 			const role = await getRole(tx, userId, workspaceId)
 			assert(can(role, 'removeFiles'), ZErrorCode.forbidden)
 			const file = await tx.run(zql.file.where('id', '=', fileId).one())
@@ -534,32 +418,28 @@ export function createMutators(userId: string) {
 			// If we get here, the user has legitimate access to the file
 			await tx.mutate.file_state.upsert({ fileId, userId, firstVisitAt: time })
 
-			const migrated = await isMigratedToWorkspaces(tx, userId)
-			if (migrated) {
-				const workspaceFileRows = await tx.run(zql.group_file.where('fileId', '=', fileId))
-				const userWorkspaceMemberships = await tx.run(zql.group_user.where('userId', '=', userId))
-				// Add a visited file to the user's home group unless it already belongs to one of
-				// their groups. This is what surfaces a shared file the user opened as a "guest
-				// file" in their sidebar. (Files owned by a workspace the user is a member of are
-				// not mirrored here — and the sidebar read path also filters out any that slip
-				// through, see getWorkspaceFilesSorted — so a workspace file never shows in home.)
-				if (
-					!userWorkspaceMemberships.some((g: TlaGroupUser) =>
-						workspaceFileRows.some((gf: TlaGroupFile) => gf.groupId === g.groupId)
-					)
-				) {
-					await tx.mutate.group_file.insert({
-						fileId,
-						groupId: userId,
-						createdAt: time,
-						updatedAt: time,
-						index: null,
-					})
-				}
+			const workspaceFileRows = await tx.run(zql.group_file.where('fileId', '=', fileId))
+			const userWorkspaceMemberships = await tx.run(zql.group_user.where('userId', '=', userId))
+			// Add a visited file to the user's home group unless it already belongs to one of
+			// their groups. This is what surfaces a shared file the user opened as a "guest
+			// file" in their sidebar. (Files owned by a workspace the user is a member of are
+			// not mirrored here — and the sidebar read path also filters out any that slip
+			// through, see getWorkspaceFilesSorted — so a workspace file never shows in home.)
+			if (
+				!userWorkspaceMemberships.some((g: TlaGroupUser) =>
+					workspaceFileRows.some((gf: TlaGroupFile) => gf.groupId === g.groupId)
+				)
+			) {
+				await tx.mutate.group_file.insert({
+					fileId,
+					groupId: userId,
+					createdAt: time,
+					updatedAt: time,
+					index: null,
+				})
 			}
 		},
 		createWorkspace: async (tx: Tx, { id, name }: { id: string; name: string }) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assertValidId(id)
 
 			const clampedName = name.trim().slice(0, MAX_WORKSPACE_NAME_LENGTH)
@@ -608,7 +488,6 @@ export function createMutators(userId: string) {
 			})
 		},
 		updateWorkspace: async (tx: Tx, { id, name }: { id: string; name: string }) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
 			assert(name && name.trim(), ZErrorCode.bad_request)
 			// The home workspace can be renamed (unlike other home-workspace actions),
@@ -622,7 +501,6 @@ export function createMutators(userId: string) {
 			})
 		},
 		regenerateWorkspaceInviteSecret: async (tx: Tx, { id }: { id: string }) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
 			await assertNotHomeWorkspace(tx, id)
 
@@ -637,7 +515,6 @@ export function createMutators(userId: string) {
 			tx: Tx,
 			{ id, enabled }: { id: string; enabled: boolean }
 		) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
 			await assertNotHomeWorkspace(tx, id)
 
@@ -656,7 +533,6 @@ export function createMutators(userId: string) {
 				role: targetRole,
 			}: { workspaceId: string; targetUserId: string; role: Role }
 		) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(workspaceId, ZErrorCode.bad_request)
 			assert(targetUserId, ZErrorCode.bad_request)
 			assert(isRole(targetRole), ZErrorCode.bad_request)
@@ -692,7 +568,6 @@ export function createMutators(userId: string) {
 			tx: Tx,
 			{ workspaceId, targetUserId }: { workspaceId: string; targetUserId: string }
 		) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(workspaceId, ZErrorCode.bad_request)
 			assert(targetUserId, ZErrorCode.bad_request)
 
@@ -717,7 +592,6 @@ export function createMutators(userId: string) {
 			await tx.mutate.group_user.delete({ userId: targetUserId, groupId: workspaceId })
 		},
 		leaveWorkspace: async (tx: Tx, { workspaceId }: { workspaceId: string }) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(workspaceId, ZErrorCode.bad_request)
 			await assertNotHomeWorkspace(tx, workspaceId)
 			const owners = await tx.run(
@@ -730,7 +604,6 @@ export function createMutators(userId: string) {
 			await tx.mutate.group_user.delete({ userId, groupId: workspaceId })
 		},
 		deleteWorkspace: async (tx: Tx, { id }: { id: string }) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(id, ZErrorCode.bad_request)
 			await assertNotHomeWorkspace(tx, id)
 			const role = await getRole(tx, userId, id)
@@ -760,7 +633,6 @@ export function createMutators(userId: string) {
 			tx: Tx,
 			{ fileId, workspaceId }: { fileId: string; workspaceId: string }
 		) => {
-			await assertUserHasFlag(tx, userId, 'groups_backend')
 			assert(fileId, ZErrorCode.bad_request)
 			assert(workspaceId, ZErrorCode.bad_request)
 

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -8,7 +8,7 @@ import {
 	string,
 	table,
 } from '@rocicorp/zero'
-import { IndexKey, stringEnum } from '@tldraw/utils'
+import { IndexKey } from '@tldraw/utils'
 import { Role } from './roles'
 
 export interface ZColumn {
@@ -315,5 +315,7 @@ export type TlaGroupFile = Row<typeof schema.tables.group_file>
 
 // Permissions are now handled via Synced Queries in queries.ts
 
-export const TlaFlags = stringEnum('groups_backend')
-export type TlaFlags = keyof typeof TlaFlags
+// No feature flags are currently defined. The user's `flags` column is kept as a
+// free-form, comma/space-separated string (see parseFlags/userHasFlag); to add a flag,
+// switch this back to a `stringEnum('flag_a', 'flag_b')` union.
+export type TlaFlags = string


### PR DESCRIPTION
This is the next step in retiring the workspaces feature flags. It removes `groups_backend` from production entirely — the logic that read it, the value written to new users, and the now-dead migration tooling. `groups_backend` is fully rolled out (every user is migrated and born with a home workspace), so the legacy (`file_state`/`ownerId`-based) branches it gated are dead, and new users no longer need it. Follows #9405 and #9411 (the `groups_frontend` removal), both merged. Relates to #8859.

**Preview deploy:** https://pr-9418-preview-deploy.tldraw.com/ — sign in and exercise file/workspace flows (create, pin, open, remove, move, accept invite) and the admin page. No flag setup needed; every account is migrated.

### What changed

- Removed `isWorkspacesMigrated()` and collapsed every branch on it to the migrated path: `mutators.ts` (`createFile`, `pinFile`/`unpinFile`, `removeFileFromWorkspace`, `onEnterFile`) and `TldrawApp.ts` (`getMyFiles`, `canCreateNewFile`, `isPinned`, `getFile`).
- Dropped the `assertUserHasFlag('groups_backend')` gates on the workspace mutators.
- Removed the admin migrate-to-groups tooling (`/app/admin/user/migrate` route + the `admin_migrateToGroups` durable-object method) and the `acceptInvite` migration check.
- Stopped writing `groups_backend` at the three user-creation sites; new users get `flags: ''`.
- Removed the redundant e2e groups-migration helpers (`migrateUser*`, `isUserMigrated*`, `ensureGroupsReadyByEmail`) and their call sites. Test users are born migrated via signup, so these were no-ops; the `ensureGroupsReady` scenario helper keeps its navigation/sidebar setup, only its migration call was dropped.
- Demoted `TlaFlags` to a `string` stub, keeping `parseFlags`/`userHasFlag`/`hasFlag` so the next feature flag has scaffolding.

### What's kept (deliberately)

- The `flags` column, the `TlaFlags` string stub, and `parseFlags`/`userHasFlag`/`hasFlag` — retained so the next feature flag has scaffolding (no schema migration needed).
- The `migrate_user_to_groups` SQL function. It lives in an applied (immutable) migration and is now uncalled, so it stays as frozen history.
- Dropping the `flags` column itself (a Postgres + Zero schema change) is intentionally out of scope — we're keeping the column for future flags.

### Decisions worth a reviewer's eye

- **Access control is intentionally untouched.** `assertUserCanAccessFile` / `canUpdateFile` branch on the *file's* shape (`ownerId` vs `owningGroupId`), not on the flag, so they're kept as defensive fallbacks for any legacy `ownerId` files. We stop *producing* legacy files but keep *tolerating* them.
- **New users get `flags: ''`.** Existing users' stored `groups_backend` value is harmless — nothing reads it after this PR.
- **`assertNotMaxFiles` removed.** This server-side `createFile` limit only ran on the legacy path and was already inert for migrated users; the client-side limit in `canCreateNewFile` remains. If a server-enforced per-workspace cap is wanted, that's a separate feature.

### Change type

- [x] `other` (internal refactor, no user-facing change)

### Test plan

1. On the preview deploy, sign in and confirm normal file/workspace flows work: create, pin/unpin, open, remove, move between workspaces, accept an invite.
2. Confirm the admin page loads with the "migrate user" action gone (other sections intact).

- [x] Unit tests
- [x] End to end tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +45 / -171 |
| Tests     | +6 / -81   |
| Apps      | +22 / -174 |
