### PR TITLE
feat(tldraw): support snapping and option-resize while cropping

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3607,6 +3607,8 @@ export interface TLCropInfo<T extends TLShape> {
     // (undocumented)
     initialShape: T;
     // (undocumented)
+    isResizingFromCenter?: boolean;
+    // (undocumented)
     uncroppedSize: {
         h: number;
         w: number;

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -998,6 +998,7 @@ export interface TLCropInfo<T extends TLShape> {
 	uncroppedSize: { w: number; h: number }
 	initialShape: T
 	aspectRatioLocked?: boolean
+	isResizingFromCenter?: boolean
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/shapes/shared/crop.ts
+++ b/packages/tldraw/src/lib/shapes/shared/crop.ts
@@ -120,7 +120,7 @@ export function getCropBox<T extends ShapeWithCrop>(
 			props: ShapeWithCrop['props']
 	  }
 	| undefined {
-	const { handle, change, crop, aspectRatioLocked } = info
+	const { handle, change, crop, aspectRatioLocked, isResizingFromCenter } = info
 	const { w, h } = info.uncroppedSize
 	const { minWidth = MIN_CROP_SIZE, minHeight = MIN_CROP_SIZE } = opts
 
@@ -140,27 +140,86 @@ export function getCropBox<T extends ShapeWithCrop>(
 	const targetRatio = prevCropBox.aspectRatio
 	const tempBox = prevCropBox.clone()
 
-	// Basic resizing logic based on the handles
+	// Which axes does the dragged handle move?
+	const movesLeft = handle === 'top_left' || handle === 'bottom_left' || handle === 'left'
+	const movesRight = handle === 'top_right' || handle === 'bottom_right' || handle === 'right'
+	const movesTop = handle === 'top_left' || handle === 'top_right' || handle === 'top'
+	const movesBottom = handle === 'bottom_left' || handle === 'bottom_right' || handle === 'bottom'
 
-	if (handle === 'top_left' || handle === 'bottom_left' || handle === 'left') {
-		tempBox.x = clamp(tempBox.x + change.x, 0, prevCropBox.maxX - minWidth)
-		tempBox.w = prevCropBox.maxX - tempBox.x
-	} else if (handle === 'top_right' || handle === 'bottom_right' || handle === 'right') {
-		const tempRight = clamp(tempBox.maxX + change.x, prevCropBox.x + minWidth, w)
-		tempBox.w = tempRight - tempBox.x
-	}
+	if (isResizingFromCenter) {
+		// Resizing from the center (alt/option): the crop center stays fixed and the
+		// opposite edge mirrors the dragged edge, so the crop grows/shrinks symmetrically.
+		const cx = prevCropBox.midX
+		const cy = prevCropBox.midY
 
-	if (handle === 'top_left' || handle === 'top_right' || handle === 'top') {
-		tempBox.y = clamp(tempBox.y + change.y, 0, prevCropBox.maxY - minHeight)
-		tempBox.h = prevCropBox.maxY - tempBox.y
-	} else if (handle === 'bottom_left' || handle === 'bottom_right' || handle === 'bottom') {
-		const tempBottom = clamp(tempBox.maxY + change.y, prevCropBox.y + minHeight, h)
-		tempBox.h = tempBottom - tempBox.y
+		// Desired half-extents from the dragged edge. Undragged axes keep their size.
+		let halfW = prevCropBox.w / 2
+		let halfH = prevCropBox.h / 2
+		if (movesLeft) halfW = cx - (prevCropBox.x + change.x)
+		else if (movesRight) halfW = prevCropBox.maxX + change.x - cx
+		if (movesTop) halfH = cy - (prevCropBox.y + change.y)
+		else if (movesBottom) halfH = prevCropBox.maxY + change.y - cy
+
+		if (aspectRatioLocked) {
+			// Keep the aspect ratio while staying centered. Pick the driving dimension,
+			// derive the other from the ratio, then clamp both at once so the ratio holds.
+			const isCorner = (movesLeft || movesRight) && (movesTop || movesBottom)
+			let drivingHalfW: number
+			if (isCorner) {
+				drivingHalfW = halfW / halfH > targetRatio ? halfW : halfH * targetRatio
+			} else if (movesLeft || movesRight) {
+				drivingHalfW = halfW
+			} else {
+				drivingHalfW = halfH * targetRatio
+			}
+
+			const minHalfW = Math.max(minWidth / 2, (minHeight / 2) * targetRatio)
+			const maxHalfW = Math.min(cx, w - cx, cy * targetRatio, (h - cy) * targetRatio)
+			if (maxHalfW < minHalfW) return
+
+			halfW = clamp(drivingHalfW, minHalfW, maxHalfW)
+			halfH = halfW / targetRatio
+		} else {
+			// Clamp each dragged axis independently against the image bounds and min size.
+			if (movesLeft || movesRight) {
+				const maxHalfW = Math.min(cx, w - cx)
+				if (maxHalfW < minWidth / 2) return
+				halfW = clamp(halfW, minWidth / 2, maxHalfW)
+			}
+			if (movesTop || movesBottom) {
+				const maxHalfH = Math.min(cy, h - cy)
+				if (maxHalfH < minHeight / 2) return
+				halfH = clamp(halfH, minHeight / 2, maxHalfH)
+			}
+		}
+
+		tempBox.x = cx - halfW
+		tempBox.y = cy - halfH
+		tempBox.w = halfW * 2
+		tempBox.h = halfH * 2
+	} else {
+		// Basic resizing logic based on the handles
+
+		if (movesLeft) {
+			tempBox.x = clamp(tempBox.x + change.x, 0, prevCropBox.maxX - minWidth)
+			tempBox.w = prevCropBox.maxX - tempBox.x
+		} else if (movesRight) {
+			const tempRight = clamp(tempBox.maxX + change.x, prevCropBox.x + minWidth, w)
+			tempBox.w = tempRight - tempBox.x
+		}
+
+		if (movesTop) {
+			tempBox.y = clamp(tempBox.y + change.y, 0, prevCropBox.maxY - minHeight)
+			tempBox.h = prevCropBox.maxY - tempBox.y
+		} else if (movesBottom) {
+			const tempBottom = clamp(tempBox.maxY + change.y, prevCropBox.y + minHeight, h)
+			tempBox.h = tempBottom - tempBox.y
+		}
 	}
 
 	// Aspect ratio locked resizing logic
 
-	if (aspectRatioLocked) {
+	if (aspectRatioLocked && !isResizingFromCenter) {
 		const isXLimiting = tempBox.aspectRatio > targetRatio
 
 		if (isXLimiting) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Cropping.ts
@@ -1,10 +1,14 @@
 import {
+	Box,
+	HALF_PI,
 	SelectionHandle,
 	ShapeWithCrop,
 	StateNode,
 	TLPointerEventInfo,
 	Vec,
+	isAccelKey,
 	kickoutOccludedShapes,
+	rotateSelectionHandle,
 } from '@tldraw/editor'
 import { getCropBox, getDefaultCrop, getUncroppedSize } from '../../../../../shapes/shared/crop'
 import { CursorTypeMap } from '../../PointingResizeHandle'
@@ -67,6 +71,7 @@ export class Cropping extends StateNode {
 
 	override onExit() {
 		this.parent.setCurrentToolIdMask(undefined)
+		this.editor.snaps.clearIndicators()
 	}
 
 	private updateCursor() {
@@ -78,18 +83,45 @@ export class Cropping extends StateNode {
 	}
 
 	private updateShapes() {
-		const { shape, cursorHandleOffset } = this.snapshot
+		const { editor } = this
+		const { shape, cursorHandleOffset, initialSelectionPageBounds, selectionRotation } =
+			this.snapshot
 
 		if (!shape) return
-		const util = this.editor.getShapeUtil<ShapeWithCrop>(shape.type)
+		const util = editor.getShapeUtil<ShapeWithCrop>(shape.type)
 		if (!util) return
 
-		const shiftKey = this.editor.inputs.getShiftKey()
-		const currentPagePoint = this.editor.inputs
-			.getCurrentPagePoint()
-			.clone()
-			.sub(cursorHandleOffset)
-		const originPagePoint = this.editor.inputs.getOriginPagePoint().clone().sub(cursorHandleOffset)
+		const shiftKey = editor.inputs.getShiftKey()
+		const altKey = editor.inputs.getAltKey()
+		const isHoldingAccel = isAccelKey(editor.inputs)
+
+		const currentPagePoint = editor.inputs.getCurrentPagePoint().clone().sub(cursorHandleOffset)
+		const originPagePoint = editor.inputs.getOriginPagePoint().clone().sub(cursorHandleOffset)
+
+		// Grid snapping (matches resize): snap the cropped frame to the grid.
+		if (editor.getInstanceState().isGridMode && !isHoldingAccel) {
+			const { gridSize } = editor.getDocumentSettings()
+			currentPagePoint.snapToGrid(gridSize)
+		}
+
+		// Shape-bounds snapping: the visible crop frame is the shape's page bounds and its
+		// dragged edge moves 1:1 with the unrotated drag delta, so we can reuse the same
+		// snapping the resize uses. Gate it exactly like resize, and skip when rotated.
+		editor.snaps.clearIndicators()
+		const shouldSnap = editor.user.getIsSnapMode() ? !isHoldingAccel : isHoldingAccel
+		let didSnap = false
+		if (shouldSnap && initialSelectionPageBounds && selectionRotation % HALF_PI === 0) {
+			const { nudge } = editor.snaps.shapeBounds.snapResizeShapes({
+				dragDelta: Vec.Sub(currentPagePoint, originPagePoint),
+				initialSelectionPageBounds,
+				handle: rotateSelectionHandle(this.info.handle, selectionRotation),
+				isAspectRatioLocked: shiftKey,
+				isResizingFromCenter: altKey,
+			})
+			currentPagePoint.add(nudge)
+			didSnap = true
+		}
+
 		const change = currentPagePoint.clone().sub(originPagePoint).rot(-shape.rotation)
 
 		const crop = shape.props.crop ?? getDefaultCrop()
@@ -103,17 +135,64 @@ export class Cropping extends StateNode {
 			uncroppedSize,
 			initialShape: this.snapshot.shape,
 			aspectRatioLocked: shiftKey,
+			isResizingFromCenter: altKey,
 		})
-		if (!partial) return
+		if (partial) {
+			editor.updateShapes([
+				{
+					id: shape.id,
+					type: shape.type,
+					...partial,
+				},
+			])
+		}
 
-		this.editor.updateShapes([
-			{
-				id: shape.id,
-				type: shape.type,
-				...partial,
-			},
-		])
-		this.updateCursor()
+		// If the crop's content limit stopped the frame edge short of the snap target,
+		// clear the now-misleading snap line so it doesn't float past the image content.
+		if (didSnap && initialSelectionPageBounds) {
+			this.reconcileSnapIndicators(
+				initialSelectionPageBounds,
+				Vec.Sub(currentPagePoint, originPagePoint),
+				rotateSelectionHandle(this.info.handle, selectionRotation),
+				shiftKey,
+				altKey
+			)
+		}
+
+		if (partial) this.updateCursor()
+	}
+
+	private reconcileSnapIndicators(
+		initialSelectionPageBounds: Box,
+		snappedDelta: Vec,
+		handle: SelectionHandle,
+		isAspectRatioLocked: boolean,
+		isResizingFromCenter: boolean
+	) {
+		const { editor } = this
+		if (!editor.snaps.getIndicators().length) return
+
+		const actual = editor.getShapePageBounds(this.snapshot.shape.id)
+		if (!actual) return
+
+		const { box } = Box.Resize(
+			initialSelectionPageBounds,
+			handle,
+			isResizingFromCenter ? snappedDelta.x * 2 : snappedDelta.x,
+			isResizingFromCenter ? snappedDelta.y * 2 : snappedDelta.y,
+			isAspectRatioLocked
+		)
+		if (isResizingFromCenter) box.center = initialSelectionPageBounds.center
+
+		const EPSILON = 1
+		if (
+			Math.abs(actual.minX - box.minX) > EPSILON ||
+			Math.abs(actual.maxX - box.maxX) > EPSILON ||
+			Math.abs(actual.minY - box.minY) > EPSILON ||
+			Math.abs(actual.maxY - box.maxY) > EPSILON
+		) {
+			editor.snaps.clearIndicators()
+		}
 	}
 
 	private complete() {
@@ -163,9 +242,15 @@ export class Cropping extends StateNode {
 
 		const cursorHandleOffset = Vec.Sub(originPagePoint, dragHandlePoint)
 
+		// Axis-aligned page bounds of the crop frame, used for shape-bounds snapping.
+		// (selectionBounds above is rotated and only used for the cursor handle offset.)
+		const initialSelectionPageBounds = this.editor.getSelectionPageBounds()
+
 		return {
 			shape,
 			cursorHandleOffset,
+			initialSelectionPageBounds,
+			selectionRotation,
 		}
 	}
 }

--- a/packages/tldraw/src/test/crop.test.ts
+++ b/packages/tldraw/src/test/crop.test.ts
@@ -4,6 +4,7 @@ import {
 	getCroppedImageDataForAspectRatio,
 	getCroppedImageDataForReplacedImage,
 	getCroppedImageDataWhenZooming,
+	MIN_CROP_SIZE,
 } from '../lib/shapes/shared/crop'
 import { TestEditor } from './TestEditor'
 
@@ -921,6 +922,146 @@ describe('Resizing crop box when not aspect-ratio locked', () => {
 			expect(results3.props.crop.bottomRight.x).toBeLessThanOrEqual(1)
 			expect(results3.props.crop.bottomRight.y).toBeLessThanOrEqual(1)
 		}
+	})
+})
+
+describe('Resizing crop box from the center', () => {
+	// With isResizingFromCenter (alt/option), the crop center stays fixed and the
+	// opposite edge mirrors the dragged edge so the crop resizes symmetrically.
+
+	it('Resizes a single axis symmetrically when dragging an edge', () => {
+		const results = getCropBox(shape, {
+			handle: 'left',
+			change: new Vec(10, 0),
+			crop: initialCrop,
+			uncroppedSize: initialSize,
+			initialShape: shape,
+			isResizingFromCenter: true,
+		})
+		// Both the left and right edges move in by 10, keeping the center fixed.
+		expect(results).toMatchObject({
+			x: 110,
+			y: 100,
+			props: {
+				w: 80,
+				h: 100,
+				crop: {
+					topLeft: { x: 0.1, y: 0 },
+					bottomRight: { x: 0.9, y: 1 },
+				},
+			},
+		})
+	})
+
+	it('Mirrors the dragged edge regardless of which side is dragged', () => {
+		const results = getCropBox(shape, {
+			handle: 'right',
+			change: new Vec(-10, 0),
+			crop: initialCrop,
+			uncroppedSize: initialSize,
+			initialShape: shape,
+			isResizingFromCenter: true,
+		})
+		// Dragging the right edge in by 10 gives the same symmetric result as the left.
+		expect(results).toMatchObject({
+			x: 110,
+			y: 100,
+			props: {
+				w: 80,
+				h: 100,
+				crop: {
+					topLeft: { x: 0.1, y: 0 },
+					bottomRight: { x: 0.9, y: 1 },
+				},
+			},
+		})
+	})
+
+	it('Resizes both axes symmetrically when dragging a corner', () => {
+		const results = getCropBox(shape, {
+			handle: 'top_left',
+			change: new Vec(10, 20),
+			crop: initialCrop,
+			uncroppedSize: initialSize,
+			initialShape: shape,
+			isResizingFromCenter: true,
+		})
+		expect(results).toMatchObject({
+			x: 110,
+			y: 120,
+			props: {
+				w: 80,
+				h: 60,
+				crop: {
+					topLeft: { x: 0.1, y: 0.2 },
+					bottomRight: { x: 0.9, y: 0.8 },
+				},
+			},
+		})
+	})
+
+	it('Keeps the aspect ratio while staying centered with aspectRatioLocked', () => {
+		const results = getCropBox(shape, {
+			handle: 'top_left',
+			change: new Vec(10, 20),
+			crop: initialCrop,
+			uncroppedSize: initialSize,
+			initialShape: shape,
+			aspectRatioLocked: true,
+			isResizingFromCenter: true,
+		})
+		// The crop is square (ratio 1) so both half-extents collapse to the larger drag.
+		expect(results).toMatchObject({
+			x: 110,
+			y: 110,
+			props: {
+				w: 80,
+				h: 80,
+				crop: {
+					topLeft: { x: 0.1, y: 0.1 },
+					bottomRight: { x: 0.9, y: 0.9 },
+				},
+			},
+		})
+	})
+
+	it('Clamps to the minimum crop size while centered', () => {
+		const results = getCropBox(shape, {
+			handle: 'left',
+			change: new Vec(48, 0),
+			crop: initialCrop,
+			uncroppedSize: initialSize,
+			initialShape: shape,
+			isResizingFromCenter: true,
+		})
+		expect(results).toMatchObject({
+			x: 146,
+			y: 100,
+			props: {
+				w: MIN_CROP_SIZE,
+				h: 100,
+				crop: {
+					topLeft: { x: 0.46, y: 0 },
+					bottomRight: { x: 0.54, y: 1 },
+				},
+			},
+		})
+	})
+
+	it('Preserves a circular crop while centered', () => {
+		const results = getCropBox(shape, {
+			handle: 'left',
+			change: new Vec(10, 0),
+			crop: { ...initialCrop, isCircle: true },
+			uncroppedSize: initialSize,
+			initialShape: shape,
+			isResizingFromCenter: true,
+		})
+		expect(results?.props.crop).toMatchObject({
+			topLeft: { x: 0.1, y: 0 },
+			bottomRight: { x: 0.9, y: 1 },
+			isCircle: true,
+		})
 	})
 })
 

--- a/packages/tldraw/src/test/cropping.test.ts
+++ b/packages/tldraw/src/test/cropping.test.ts
@@ -1138,3 +1138,105 @@ describe('When cropping...', () => {
 			})
 	})
 })
+
+describe('When cropping with modifiers and snapping...', () => {
+	const cropId = createShapeId('cropModifiersImage')
+	const snapTargetId = createShapeId('cropSnapTarget')
+
+	const fullCrop = { topLeft: { x: 0, y: 0 }, bottomRight: { x: 1, y: 1 } }
+
+	beforeEach(() => {
+		// User preferences are global, so reset snap mode for deterministic gating.
+		editor.user.updateUserPreferences({ isSnapMode: false })
+		editor.createShapes([
+			{
+				id: cropId,
+				type: 'image',
+				x: 0,
+				y: 0,
+				props: { ...imageProps, w: 400, h: 400, crop: fullCrop },
+			},
+			// A thin box whose left edge sits at x = 300, used as a snap target.
+			{
+				id: snapTargetId,
+				type: 'geo',
+				x: 300,
+				y: 0,
+				props: { w: 10, h: 400 },
+			},
+		])
+	})
+
+	function enterCropAndPointHandle(handle: 'left' | 'right', x: number, y: number) {
+		editor
+			.select(cropId)
+			.keyDown('Enter')
+			.keyUp('Enter')
+			.expectToBeIn('select.crop.idle')
+			.pointerDown(x, y, { target: 'selection', handle })
+			.expectToBeIn('select.crop.pointing_crop_handle')
+	}
+
+	it('resizes the crop symmetrically from the center when holding alt', () => {
+		enterCropAndPointHandle('left', 0, 200)
+		editor.pointerMove(40, 200, { altKey: true }).expectToBeIn('select.crop.cropping')
+
+		const shape = editor.getShape<TLImageShape>(cropId)!
+		// Both the left and right edges move in by 40, keeping the frame centered on x = 200.
+		expect(shape.props.w).toBeCloseTo(320)
+		expect(shape.x + shape.props.w / 2).toBeCloseTo(200)
+		expect(shape.props.crop).toMatchObject({
+			topLeft: { x: 0.1, y: 0 },
+			bottomRight: { x: 0.9, y: 1 },
+		})
+	})
+
+	it('snaps a crop edge to another shape when snapping is enabled', () => {
+		enterCropAndPointHandle('right', 400, 200)
+		// Holding the accel key enables snapping (snap mode is off by default).
+		editor.pointerMove(298, 200, { ctrlKey: true }).expectToBeIn('select.crop.cropping')
+
+		const shape = editor.getShape<TLImageShape>(cropId)!
+		// The right edge snaps from x≈298 to the target's left edge at x = 300.
+		expect(shape.props.w).toBeCloseTo(300)
+		expect(shape.props.crop!.bottomRight.x).toBeCloseTo(0.75)
+		expect(editor.snaps.getIndicators().length).toBeGreaterThan(0)
+	})
+
+	it('does not snap when snapping is disabled', () => {
+		enterCropAndPointHandle('right', 400, 200)
+		editor.pointerMove(298, 200).expectToBeIn('select.crop.cropping')
+
+		const shape = editor.getShape<TLImageShape>(cropId)!
+		expect(shape.props.w).toBeCloseTo(298)
+		expect(editor.snaps.getIndicators().length).toBe(0)
+	})
+
+	it('lets the accel key invert snapping (snap mode on + accel = no snap)', () => {
+		editor.user.updateUserPreferences({ isSnapMode: true })
+		enterCropAndPointHandle('right', 400, 200)
+		editor.pointerMove(298, 200, { ctrlKey: true }).expectToBeIn('select.crop.cropping')
+
+		const shape = editor.getShape<TLImageShape>(cropId)!
+		expect(shape.props.w).toBeCloseTo(298)
+		expect(editor.snaps.getIndicators().length).toBe(0)
+	})
+
+	it('skips snapping while the image is rotated', () => {
+		editor.updateShape({ id: cropId, type: 'image', rotation: 0.5 })
+		enterCropAndPointHandle('right', 400, 200)
+		editor.pointerMove(298, 200, { ctrlKey: true }).expectToBeIn('select.crop.cropping')
+
+		// Snapping is gated to axis-aligned selections, so no snap line appears.
+		expect(editor.snaps.getIndicators().length).toBe(0)
+	})
+
+	it('clears snap indicators when the crop ends', () => {
+		enterCropAndPointHandle('right', 400, 200)
+		editor.pointerMove(298, 200, { ctrlKey: true }).expectToBeIn('select.crop.cropping')
+		expect(editor.snaps.getIndicators().length).toBeGreaterThan(0)
+
+		editor.pointerUp()
+		expect(editor.snaps.getIndicators().length).toBe(0)
+	})
+})


### PR DESCRIPTION
In order to make cropping an image feel like resizing a shape, this PR adds two crop-handle behaviors that previously didn't exist (closes #9335 and closes #9336):

- **Snapping (#9335):** dragging a crop edge now participates in the editor's snapping system. The visible crop frame snaps to other shapes' bounds and to the grid, gated by the user's snap setting / accel key, and shows the same snap-line guidelines as resizing. This reuses the existing resize snapping (`snaps.shapeBounds.snapResizeShapes`), since the crop frame is the shape's page bounds and its dragged edge moves 1:1 with the unrotated pointer delta. Snapping is skipped while the image is rotated (axis-aligned only), and a snap line is suppressed if the image's content limit stops the edge short of the target.
- **Option/alt resize from center (#9336):** holding option while dragging a crop handle resizes the crop region symmetrically from its center — one axis for edge handles, both for corners — mirroring regular shape resize. It combines with snapping and with shift (aspect-locked about the center).

The two compose: the `isResizingFromCenter` / `isAspectRatioLocked` flags flow into both the snap call and the crop math, so option+shift+snapping all work together in a single drag.

### Change type

- [x] `feature`

### Test plan

1. Add two images to the canvas; double-click one to enter crop mode.
2. Drag a crop edge near the other image's bound (or enable grid mode) — the crop frame snaps and shows a snap guideline. Toggle the snap setting / hold the accel key to invert snapping.
3. Hold option and drag a crop handle — the crop region grows/shrinks symmetrically about its center (one axis for an edge handle, both for a corner).
4. Hold shift+option — the crop stays centered and aspect-ratio locked, matching regular resize.
5. Rotate the image, then crop — snapping is skipped (no snap lines) while centered resize still works.
6. Confirm a normal (no-modifier) crop drag is unchanged.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- When cropping an image, crop edges now snap to other shapes and the grid (with the usual snap guidelines), and holding option resizes the crop region symmetrically from its center.

### API changes

- Added optional `isResizingFromCenter` to `TLCropInfo` (consumed by `getCropBox`) so crop utilities can resize symmetrically from the center.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +179 / -34 |
| Tests           | +243 / -0  |
| Automated files | +2 / -0    |