### PR TITLE
feat(editor): spike - add way to find and delete unused assets that are lingering  after soft deletion

### DIFF
--- a/apps/examples/src/examples/editor-api/prune-unused-assets/PruneUnusedAssetsExample.tsx
+++ b/apps/examples/src/examples/editor-api/prune-unused-assets/PruneUnusedAssetsExample.tsx
@@ -1,0 +1,182 @@
+import { useRef } from 'react'
+import {
+	AssetRecordType,
+	Editor,
+	TLComponents,
+	TLImageShape,
+	Tldraw,
+	TldrawUiButton,
+	createShapeId,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './prune-unused-assets.css'
+
+// There's a guide at the bottom of this file!
+
+const IMAGE_SIZE = 180
+const GRID_GAP = 24
+const GRID_COLS = 4
+const GRID_MARGIN = 40
+
+// [1]
+function makeImageDataUrl(size = 320) {
+	const canvas = document.createElement('canvas')
+	canvas.width = size
+	canvas.height = size
+	const ctx = canvas.getContext('2d')!
+	const hue = Math.floor(Math.random() * 360)
+	ctx.fillStyle = `hsl(${hue}, 70%, 60%)`
+	ctx.fillRect(0, 0, size, size)
+	// Random noise keeps the PNG from compressing away, so the document size
+	// visibly grows with every image — the whole point of the demo.
+	const image = ctx.getImageData(0, 0, size, size)
+	for (let i = 0; i < image.data.length; i += 4) {
+		const n = Math.floor(Math.random() * 60)
+		image.data[i] = Math.min(255, image.data[i] + n)
+		image.data[i + 1] = Math.min(255, image.data[i + 1] + n)
+		image.data[i + 2] = Math.min(255, image.data[i + 2] + n)
+	}
+	ctx.putImageData(image, 0, 0)
+	return { src: canvas.toDataURL('image/png'), w: size, h: size }
+}
+
+// [2]
+function addImage(editor: Editor, slot: number) {
+	const { src, w, h } = makeImageDataUrl()
+	const assetId = AssetRecordType.createId()
+	editor.createAssets([
+		{
+			id: assetId,
+			type: 'image',
+			typeName: 'asset',
+			props: { w, h, name: 'noise.png', isAnimated: false, mimeType: 'image/png', src },
+			meta: {},
+		},
+	])
+	// `slot` is a monotonic counter, so images never share a grid cell even
+	// after some have been deleted.
+	const col = slot % GRID_COLS
+	const row = Math.floor(slot / GRID_COLS)
+	editor.createShape<TLImageShape>({
+		id: createShapeId(),
+		type: 'image',
+		x: GRID_MARGIN + col * (IMAGE_SIZE + GRID_GAP),
+		y: GRID_MARGIN + row * (IMAGE_SIZE + GRID_GAP),
+		props: { w: IMAGE_SIZE, h: IMAGE_SIZE, assetId },
+	})
+	editor.zoomToFit({ animation: { duration: 200 } })
+}
+
+function formatBytes(bytes: number) {
+	if (bytes < 1024) return `${bytes} B`
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`
+}
+
+// [3]
+function ControlPanel() {
+	const editor = useEditor()
+	// A monotonic grid slot so added images never share a cell, even after some
+	// are deleted. Seeded from the current shape count so a restored document
+	// starts past its existing shapes.
+	const nextSlot = useRef(editor.getCurrentPageShapeIds().size)
+
+	const stats = useValue(
+		'asset stats',
+		() => ({
+			shapes: editor.getCurrentPageShapeIds().size,
+			assets: editor.getAssets().length,
+			unused: editor.getUnusedAssetIds().length,
+			bytes: JSON.stringify(editor.getSnapshot().document).length,
+		}),
+		[editor]
+	)
+
+	return (
+		<div className="prune-panel" onPointerDown={(e) => e.stopPropagation()}>
+			<div className="prune-panel__stats">
+				<span>Visible shapes</span>
+				<b>{stats.shapes}</b>
+				<span>Asset records</span>
+				<b>{stats.assets}</b>
+				<span>Unused (orphaned)</span>
+				<b className={stats.unused ? 'prune-panel__warn' : undefined}>{stats.unused}</b>
+				<span>Document size</span>
+				<b>{formatBytes(stats.bytes)}</b>
+			</div>
+
+			<div className="prune-panel__actions">
+				<TldrawUiButton type="normal" onClick={() => addImage(editor, nextSlot.current++)}>
+					Add image
+				</TldrawUiButton>
+				<TldrawUiButton
+					type="normal"
+					onClick={() => editor.deleteShapes(editor.getSelectedShapeIds())}
+				>
+					Delete selected shapes
+				</TldrawUiButton>
+				<TldrawUiButton type="primary" onClick={() => editor.pruneUnusedAssets()}>
+					Prune unused assets
+				</TldrawUiButton>
+			</div>
+
+			<p className="prune-panel__note">
+				Only image, video, and bookmark shapes create asset records. Add a few images, delete their
+				shapes, and watch the document size stay high while the orphan count climbs. Pruning
+				reclaims that space.
+			</p>
+		</div>
+	)
+}
+
+// [4]
+const components: TLComponents = {
+	TopPanel: ControlPanel,
+	StylePanel: null,
+}
+
+export default function PruneUnusedAssetsExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="prune-unused-assets-example"
+				components={components}
+				onMount={(editor) => {
+					// [5]
+					editor.pruneUnusedAssets()
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+[1]
+Generates a noisy PNG as a base64 data URL. With the default asset store these
+data URLs are stored inline in the document, so every image meaningfully
+increases the document's serialized size.
+
+[2]
+Creates an image asset plus an image shape that references it, laid out in a
+grid so new images never overlap. Deleting the shape later does NOT delete this
+asset record — that is the leak this example demonstrates.
+
+[3]
+The side panel, rendered through a UI slot (see [4]) so it sits in the clickable
+UI layer. editor.getUnusedAssetIds() reports asset records that no shape
+references; editor.pruneUnusedAssets() deletes them (and, with an external asset
+store, calls its remove() to delete the underlying file), returning the removed
+ids. The readout uses useValue so it recomputes reactively as the store changes.
+
+[4]
+We render the panel through the TopPanel UI slot (empty by default) and hide the
+default StylePanel so it doesn't overlap our panel on the right.
+
+[5]
+The safest place to prune is at a persistence boundary. On load there is no undo
+history, so pruning can't strip an asset that a future undo would need. Pruning
+before you persist a snapshot keeps saved documents from carrying orphaned
+assets.
+*/

--- a/apps/examples/src/examples/editor-api/prune-unused-assets/README.md
+++ b/apps/examples/src/examples/editor-api/prune-unused-assets/README.md
@@ -1,0 +1,18 @@
+---
+title: Prune unused assets
+component: ./PruneUnusedAssetsExample.tsx
+priority: 6
+keywords: [assets, images, prune, cleanup, document size, orphaned, garbage collection, storage]
+---
+
+Reclaim document space by removing image, video, and bookmark assets that no shape references.
+
+---
+
+Deleting an image, video, or bookmark shape does not delete its asset record. With the default asset store, image data is stored inline as a base64 data URL, so orphaned assets keep inflating the document's size long after their shapes are gone.
+
+This example shows the live document size, the number of asset records, and how many of them are orphaned. Add a few images, delete their shapes, and watch the orphan count and document size stay high — then prune to reclaim the space.
+
+`editor.getUnusedAssetIds()` returns the asset ids that no shape on any page references. `editor.pruneUnusedAssets()` deletes those assets and returns the ids it removed; with an external asset store it also calls the store's `remove()` so the underlying files are deleted.
+
+Asset deletion is not tracked by the undo history, so pruning is not undoable. Prune at a point where a removed asset cannot be brought back by undo — most naturally right after loading a document (when there is no history) or before persisting a snapshot. This example prunes on mount for exactly that reason.

--- a/apps/examples/src/examples/editor-api/prune-unused-assets/prune-unused-assets.css
+++ b/apps/examples/src/examples/editor-api/prune-unused-assets/prune-unused-assets.css
@@ -1,0 +1,37 @@
+.prune-panel {
+	position: absolute;
+	top: 60px;
+	right: 12px;
+	width: 248px;
+	padding: 14px;
+	background: var(--tl-color-panel);
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 10px;
+	box-shadow: var(--tl-shadow-2);
+	font-size: 13px;
+	z-index: 300;
+	pointer-events: all;
+}
+
+.prune-panel__stats {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	row-gap: 6px;
+}
+
+.prune-panel__warn {
+	color: var(--tl-color-warning);
+}
+
+.prune-panel__actions {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-top: 14px;
+}
+
+.prune-panel__note {
+	margin-top: 14px;
+	margin-bottom: 0;
+	color: var(--tl-color-text-3);
+}

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1434,6 +1434,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getThemes(): TLThemes;
     // @internal (undocumented)
     getUnorderedRenderingShapes(useEditorState: boolean): TLRenderingShape[];
+    getUnusedAssetIds(): TLAssetId[];
     getViewportPageBounds(): Box;
     getViewportScreenBounds(): Box;
     getViewportScreenCenter(): Vec;
@@ -1518,6 +1519,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     pageToViewport(point: VecLike): Vec;
     readonly performance: PerformanceManager;
     popFocusedGroupId(): this;
+    pruneUnusedAssets(): TLAssetId[];
     putContentOntoCurrentPage(content: TLContent, opts?: {
         point?: VecLike;
         preserveIds?: boolean;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5120,6 +5120,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 		return this.store.query.records('asset')
 	}
 
+	/** @internal */
+	@computed private _getAllShapesQuery() {
+		return this.store.query.records('shape')
+	}
+
 	/**
 	 * Get all assets in the editor.
 	 *
@@ -5206,6 +5211,48 @@ export class Editor extends EventEmitter<TLEventMap> {
 			{ history: 'ignore' }
 		)
 		return this
+	}
+
+	/**
+	 * Get the ids of all assets (image, video, or bookmark) not referenced by any
+	 * shape on any page. Deleting a shape does not delete its asset, so these
+	 * orphans accumulate and inflate the document over time. Remove them with
+	 * {@link Editor.pruneUnusedAssets}.
+	 *
+	 * @public
+	 */
+	getUnusedAssetIds(): TLAssetId[] {
+		const usedAssetIds = new Set<TLAssetId>()
+		for (const shape of this._getAllShapesQuery().get()) {
+			if ('assetId' in shape.props && shape.props.assetId) {
+				usedAssetIds.add(shape.props.assetId)
+			}
+		}
+		return this.getAssets()
+			.filter((asset) => !usedAssetIds.has(asset.id))
+			.map((asset) => asset.id)
+	}
+
+	/**
+	 * Delete all assets not referenced by any shape on any page (see
+	 * {@link Editor.getUnusedAssetIds}), reclaiming the space they take in the
+	 * document. An external {@link @tldraw/tlschema#TLAssetStore | asset store}'s
+	 * `remove` is also called, but not awaited.
+	 *
+	 * This is not undoable, so only prune where a removed asset can't be needed
+	 * again — typically just after loading or before saving, and not while an
+	 * upload is in flight, a deletion is still undoable, or peers share the
+	 * document.
+	 *
+	 * @returns The ids of the removed assets.
+	 *
+	 * @public
+	 */
+	pruneUnusedAssets(): TLAssetId[] {
+		if (this.getIsReadonly()) return []
+		const unusedAssetIds = this.getUnusedAssetIds()
+		this.deleteAssets(unusedAssetIds)
+		return unusedAssetIds
 	}
 
 	/**

--- a/packages/tldraw/src/test/pruneUnusedAssets.test.ts
+++ b/packages/tldraw/src/test/pruneUnusedAssets.test.ts
@@ -1,0 +1,234 @@
+import { AssetRecordType, TLAssetId, createShapeId } from '@tldraw/editor'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+function createImage(index: number, assetId = AssetRecordType.createId(`asset-${index}`)) {
+	editor.createAssets([
+		{
+			type: 'image',
+			id: assetId,
+			typeName: 'asset',
+			props: {
+				w: 100,
+				h: 100,
+				name: `image-${index}.png`,
+				isAnimated: false,
+				mimeType: 'image/png',
+				src: `https://example.com/${index}.png`,
+			},
+			meta: {},
+		},
+	])
+	const shapeId = createShapeId(`shape-${index}`)
+	editor.createShapes([
+		{
+			id: shapeId,
+			type: 'image',
+			x: index * 120,
+			y: 0,
+			props: { w: 100, h: 100, assetId, crop: null, flipX: false, flipY: false },
+		},
+	])
+	return { shapeId, assetId }
+}
+
+function createVideo(index: number, assetId = AssetRecordType.createId(`video-${index}`)) {
+	editor.createAssets([
+		{
+			type: 'video',
+			id: assetId,
+			typeName: 'asset',
+			props: {
+				w: 100,
+				h: 100,
+				name: `video-${index}.mp4`,
+				isAnimated: true,
+				mimeType: 'video/mp4',
+				src: `https://example.com/${index}.mp4`,
+			},
+			meta: {},
+		},
+	])
+	const shapeId = createShapeId(`video-shape-${index}`)
+	editor.createShapes([
+		{ id: shapeId, type: 'video', x: 0, y: 0, props: { w: 100, h: 100, assetId } },
+	])
+	return { shapeId, assetId }
+}
+
+function createBookmark(index: number, assetId = AssetRecordType.createId(`bookmark-${index}`)) {
+	const url = `https://example.com/${index}`
+	editor.createAssets([
+		{
+			type: 'bookmark',
+			id: assetId,
+			typeName: 'asset',
+			props: { title: '', description: '', image: '', favicon: '', src: url },
+			meta: {},
+		},
+	])
+	const shapeId = createShapeId(`bookmark-shape-${index}`)
+	editor.createShapes([{ id: shapeId, type: 'bookmark', x: 0, y: 0, props: { assetId, url } }])
+	return { shapeId, assetId }
+}
+
+describe('getUnusedAssetIds', () => {
+	it('returns nothing for an empty store', () => {
+		expect(editor.getUnusedAssetIds()).toEqual([])
+	})
+
+	it('returns nothing when every asset is referenced', () => {
+		createImage(0)
+		createImage(1)
+		expect(editor.getUnusedAssetIds()).toEqual([])
+	})
+
+	it('returns assets whose shapes have been deleted', () => {
+		const a = createImage(0)
+		const b = createImage(1)
+		editor.deleteShapes([a.shapeId])
+
+		expect(editor.getUnusedAssetIds()).toEqual([a.assetId])
+		// The still-referenced asset is untouched.
+		expect(editor.getUnusedAssetIds()).not.toContain(b.assetId)
+	})
+
+	it('treats an asset shared by multiple shapes as used until all are gone', () => {
+		const shared = AssetRecordType.createId('shared')
+		const a = createImage(0, shared)
+		const b = createImage(1, shared)
+
+		editor.deleteShapes([a.shapeId])
+		expect(editor.getUnusedAssetIds()).toEqual([]) // still used by b
+
+		editor.deleteShapes([b.shapeId])
+		expect(editor.getUnusedAssetIds()).toEqual([shared])
+	})
+
+	it('detects orphaned video assets', () => {
+		const v = createVideo(0)
+		expect(editor.getUnusedAssetIds()).toEqual([])
+		editor.deleteShapes([v.shapeId])
+		expect(editor.getUnusedAssetIds()).toEqual([v.assetId])
+	})
+
+	it('detects orphaned bookmark assets', () => {
+		const b = createBookmark(0)
+		expect(editor.getUnusedAssetIds()).toEqual([])
+		editor.deleteShapes([b.shapeId])
+		expect(editor.getUnusedAssetIds()).toEqual([b.assetId])
+	})
+
+	it('counts shapes on other pages as references', () => {
+		createImage(0)
+		const page1 = editor.getCurrentPageId()
+		editor.createPage({ name: 'Page 2' })
+		const page2 = editor.getPages().find((p) => p.id !== page1)!.id
+		editor.setCurrentPage(page2)
+
+		// The shape that references the asset lives on page 1, not the current page.
+		expect(editor.getUnusedAssetIds()).toEqual([])
+		expect(editor.getCurrentPageShapeIds().size).toBe(0)
+	})
+})
+
+describe('pruneUnusedAssets', () => {
+	it('removes orphaned assets and returns their ids', () => {
+		const a = createImage(0)
+		const b = createImage(1)
+		editor.deleteShapes([a.shapeId, b.shapeId])
+
+		// getUnusedAssetIds/pruneUnusedAssets do not guarantee a return order, so
+		// compare as a set whenever more than one id is involved.
+		const removed = editor.pruneUnusedAssets()
+		expect(new Set(removed)).toEqual(new Set([a.assetId, b.assetId]))
+		expect(editor.getAssets()).toEqual([])
+	})
+
+	it('returns an empty array when nothing is unused', () => {
+		createImage(0)
+		createImage(1)
+
+		expect(editor.pruneUnusedAssets()).toEqual([])
+		expect(editor.getAssets()).toHaveLength(2)
+	})
+
+	it('keeps assets that are still referenced', () => {
+		const a = createImage(0)
+		const b = createImage(1)
+		editor.deleteShapes([a.shapeId])
+
+		editor.pruneUnusedAssets()
+		expect(editor.getAsset(a.assetId)).toBeUndefined()
+		expect(editor.getAsset(b.assetId)).toBeDefined()
+	})
+
+	it('calls the asset store remove() so external blobs are freed', () => {
+		const removed: TLAssetId[][] = []
+		const e = new TestEditor(
+			{},
+			{
+				assets: {
+					async upload() {
+						return { src: 'https://example.com/x.png' }
+					},
+					async remove(ids) {
+						removed.push(ids)
+					},
+				},
+			}
+		)
+		const assetId = AssetRecordType.createId('ext')
+		e.createAssets([
+			{
+				type: 'image',
+				id: assetId,
+				typeName: 'asset',
+				props: {
+					w: 1,
+					h: 1,
+					name: '',
+					isAnimated: false,
+					mimeType: 'image/png',
+					src: 'https://example.com/x.png',
+				},
+				meta: {},
+			},
+		])
+		// No shape references it, so it's an orphan.
+		expect(e.pruneUnusedAssets()).toEqual([assetId])
+		expect(removed).toEqual([[assetId]])
+		e.dispose()
+	})
+
+	it('is a no-op in readonly mode', () => {
+		const a = createImage(0)
+		editor.deleteShapes([a.shapeId])
+		editor.updateInstanceState({ isReadonly: true })
+
+		expect(editor.pruneUnusedAssets()).toEqual([])
+		expect(editor.getAsset(a.assetId)).toBeDefined()
+	})
+
+	it('does not record the prune in the undo stack', () => {
+		const a = createImage(0)
+		editor.markHistoryStoppingPoint()
+		editor.deleteShapes([a.shapeId])
+		editor.pruneUnusedAssets()
+
+		// Undo brings the shape back; its asset is gone (documented caveat) — the
+		// point here is that the prune itself produced no separate undo step.
+		editor.undo()
+		expect(editor.getShape(a.shapeId)).toBeDefined()
+		expect(editor.getAsset(a.assetId)).toBeUndefined()
+	})
+})


### PR DESCRIPTION
Had some recent customer feedback about the risk of boards where assets have been deleted growing very large and wanting a way to properly delete the lingering assets to keep board shape small. 

I tested and confirmed this by creating boards with dozens of images and then deleting them - this left boards with no visible images that were still 10+ mb.

This spike adds two public Editor methods:

- getUnusedAssetIds(): gets the asset ids not referenced by any shape on any page.
- pruneUnusedAssets(): delete those assets (also calling an external asset store's remove() to free the underlying file) and return the removed ids.

Also adds in a prune unused assets example to show how this would work in practice

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`
