### PR TITLE
fix(arrows): keep frame-bound arrows in the frame and grabbable when clipped

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3103,7 +3103,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     static props?: RecordProps<TLUnknownShape>;
     // @internal
     providesBackgroundForChildren(shape: Shape): boolean;
-    shouldClipChild?(child: TLShape): boolean;
+    shouldClipChild?(child: TLShape, self?: Shape): boolean;
     toBackgroundSvg?(shape: Shape, ctx: SvgExportContext): null | Promise<null | ReactElement> | ReactElement;
     toSvg?(shape: Shape, ctx: SvgExportContext): null | Promise<null | ReactElement> | ReactElement;
     static type: string;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5505,7 +5505,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				const util = this.getShapeUtil(ancestor)
 				const clipPath = util.getClipPath?.(ancestor)
 				if (!clipPath) continue
-				if (util.shouldClipChild?.(shape) === false) continue
+				if (util.shouldClipChild?.(shape, ancestor) === false) continue
 				const pageTransform = this.getShapePageTransform(ancestor.id)
 				clipPaths.push(pageTransform.applyToPoints(clipPath))
 			}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5805,10 +5805,23 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getSelectedShapeAtPoint(point: VecLike): TLShape | undefined {
 		const selectedShapeIds = this.getSelectedShapeIds()
+		// A selected shape can be grabbed anywhere on its geometry, even where an
+		// ancestor frame clips it (for example a curved arrow whose body bows outside
+		// the frame). This matches the selection indicator, which is drawn unclipped,
+		// so we hit test the geometry directly rather than going through isPointInShape,
+		// which would reject points outside the clip mask. We use the standard hit-test
+		// margin so thin shapes (like arrows) remain easy to grab.
+		const margin = this.options.hitTestMargin / this.getZoomLevel()
 		return this.getCurrentPageShapesSorted()
 			.filter((shape) => shape.type !== 'group' && selectedShapeIds.includes(shape.id))
 			.reverse() // find last
-			.find((shape) => this.isPointInShape(shape, point, { hitInside: true, margin: 0 }))
+			.find((shape) =>
+				this.getShapeGeometry(shape).hitTestPoint(
+					this.getPointInShapeSpace(shape, point),
+					margin,
+					true
+				)
+			)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -422,10 +422,14 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	 * If not defined, the default behavior is to clip all children.
 	 *
 	 * @param child - The child shape to check
+	 * @param self - This shape (the clipping ancestor being asked). Provided by the editor when
+	 *   computing clip masks. Useful when the decision depends on the relationship between the
+	 *   child and this specific shape, for example an arrow that is bound to this shape and so
+	 *   should not be clipped by it.
 	 * @returns boolean indicating if this child should be clipped
 	 * @public
 	 */
-	shouldClipChild?(child: TLShape): boolean
+	shouldClipChild?(child: TLShape, self?: Shape): boolean
 
 	/**
 	 * Whether a specific shape should hide in the minimap.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2028,6 +2028,8 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
     // (undocumented)
     static props: RecordProps<TLFrameShape>;
     // (undocumented)
+    shouldClipChild(child: TLShape, self?: TLFrameShape): boolean;
+    // (undocumented)
     toSvg(shape: TLFrameShape, ctx: SvgExportContext): JSX.Element;
     // (undocumented)
     static type: "frame";

--- a/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
+++ b/packages/tldraw/src/lib/bindings/arrow/ArrowBindingUtil.ts
@@ -123,8 +123,17 @@ function reparentArrow(editor: Editor, arrowId: TLShapeId) {
 
 	let nextParentId: TLParentId
 	if (startShape && endShape) {
-		// if arrow has two bindings, always parent arrow to closest common ancestor of the bindings
-		nextParentId = editor.findCommonAncestor([startShape, endShape]) ?? parentPageId
+		// If arrow has two bindings, parent it to the closest common ancestor of the
+		// bound shapes. When one bound shape is an ancestor-or-self of the other (for
+		// example an arrow drawn across a frame's interior binds to the frame itself,
+		// or binds to the frame on one end and a child inside it on the other),
+		// findCommonAncestor can't return that shape because it only walks strict
+		// ancestors. In that case parent the arrow into the container so it lives
+		// inside the frame and cascade-deletes along with it.
+		nextParentId =
+			getCommonBindingContainer(editor, arrow, startShape, endShape) ??
+			editor.findCommonAncestor([startShape, endShape]) ??
+			parentPageId
 	} else if (startShape || endShape) {
 		const bindingParentId = (startShape || endShape)?.parentId
 		// If the arrow and the shape that it is bound to have the same parent, then keep that parent
@@ -198,6 +207,39 @@ function reparentArrow(editor: Editor, arrowId: TLShapeId) {
 	if (finalIndex !== reparentedArrow.index) {
 		editor.updateShapes([{ id: arrowId, type: 'arrow', index: finalIndex }])
 	}
+}
+
+/**
+ * When an arrow's two bound shapes are in an ancestor-or-self relationship (the same
+ * shape on both ends, or a container and one of its descendants), return that container
+ * if it can contain the arrow. This lets arrows bound to a frame itself live inside the
+ * frame instead of falling through to the page. Returns undefined when there's no such
+ * relationship, or when the would-be container can't receive the arrow (for example a
+ * self-bound arrow on a plain shape), so the caller falls back to the common-ancestor walk.
+ */
+function getCommonBindingContainer(
+	editor: Editor,
+	arrow: TLArrowShape,
+	startShape: TLShape,
+	endShape: TLShape
+): TLShapeId | undefined {
+	let container: TLShape | undefined
+	if (startShape.id === endShape.id) {
+		container = startShape
+	} else if (editor.hasAncestor(startShape, endShape.id)) {
+		container = endShape
+	} else if (editor.hasAncestor(endShape, startShape.id)) {
+		container = startShape
+	}
+
+	if (
+		container &&
+		editor.getShapeUtil(container).canReceiveNewChildrenOfType(container, arrow.type)
+	) {
+		return container.id
+	}
+
+	return undefined
 }
 
 function arrowDidUpdate(editor: Editor, arrow: TLArrowShape) {

--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.test.ts
@@ -512,7 +512,9 @@ describe("an arrow's parents", () => {
 		editor.pointerDown(15, 15).pointerMove(50, 50)
 		const arrowId = editor.getOnlySelectedShape()!.id
 
-		expect(arrow(arrowId).parentId).toBe(editor.getCurrentPageId())
+		// start binds to box A (inside the frame) and end binds to the frame itself,
+		// so the arrow is parented into the frame
+		expect(arrow(arrowId).parentId).toBe(frameId)
 
 		// move arrow to b
 		editor.pointerMove(15, 85)
@@ -522,9 +524,9 @@ describe("an arrow's parents", () => {
 			end: { toId: boxBid },
 		})
 
-		// move back to empty space
+		// move back to empty space within the frame: still parented to the frame
 		editor.pointerMove(50, 50)
-		expect(arrow(arrowId).parentId).toBe(editor.getCurrentPageId())
+		expect(arrow(arrowId).parentId).toBe(frameId)
 		expect(bindings(arrowId)).toMatchObject({
 			start: { toId: boxAid },
 			end: { toId: frameId },

--- a/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/frame/FrameShapeUtil.tsx
@@ -6,10 +6,12 @@ import {
 	Rectangle2d,
 	SVGContainer,
 	SvgExportContext,
+	TLArrowBinding,
 	TLClickEventInfo,
 	TLEditStartInfo,
 	TLFrameShape,
 	TLFrameShapeProps,
+	TLShape,
 	TLShapePartial,
 	TLShapeUtilConstructor,
 	clamp,
@@ -230,6 +232,24 @@ export class FrameShapeUtil extends BaseFrameLikeShapeUtil<TLFrameShape> {
 				}),
 			],
 		})
+	}
+
+	override shouldClipChild(child: TLShape, self?: TLFrameShape): boolean {
+		// A frame should not clip an arrow that is bound to the frame itself on both ends. Such an
+		// arrow is "about" the frame, and its (curved) body is expected to bow outside the frame's
+		// edge, so clipping it would cut the arrow in half. Arrows bound to shapes *inside* the
+		// frame are still clipped like any other child.
+		if (self && child.type === 'arrow') {
+			let boundStart = false
+			let boundEnd = false
+			for (const binding of this.editor.getBindingsFromShape<TLArrowBinding>(child, 'arrow')) {
+				if (binding.toId !== self.id) continue
+				if (binding.props.terminal === 'start') boundStart = true
+				else if (binding.props.terminal === 'end') boundEnd = true
+			}
+			if (boundStart && boundEnd) return false
+		}
+		return true
 	}
 
 	override getText(shape: TLFrameShape): string | undefined {

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -788,6 +788,71 @@ describe('frame shapes', () => {
 		expect(editor.getShape(arrow.id)).toBeUndefined()
 	})
 
+	it('does not clip an arrow that is bound to the frame on both ends', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(300, 300).pointerUp(300, 300)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		// arrow with both ends bound to the frame itself
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(150, 150).pointerMove(250, 250).pointerUp(250, 250)
+		const arrowId = editor.getOnlySelectedShape()!.id
+		const bindings = getArrowBindings(editor, editor.getShape<TLArrowShape>(arrowId)!)
+		expect(bindings.start).toMatchObject({ toId: frameId })
+		expect(bindings.end).toMatchObject({ toId: frameId })
+
+		// it lives inside the frame but is NOT clipped by it
+		expect(editor.getShape(arrowId)!.parentId).toBe(frameId)
+		expect(editor.getShapeClipPath(arrowId)).toBeUndefined()
+		expect(editor.getShapeMask(arrowId)).toBeUndefined()
+
+		// a plain box child of the frame is still clipped as usual
+		const boxId = createShapeId()
+		editor.createShape({ id: boxId, type: 'geo', parentId: frameId, x: 150, y: 150 })
+		expect(editor.getShapeClipPath(boxId)).toBeDefined()
+	})
+
+	it('still clips an arrow that is bound only to shapes inside the frame', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(400, 400).pointerUp(400, 400)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		// two boxes inside the frame, and an arrow bound to those boxes (not the frame)
+		const a = createShapeId()
+		const b = createShapeId()
+		const arrowId = createShapeId()
+		editor.createShape({ id: a, type: 'geo', parentId: frameId, x: 150, y: 150 })
+		editor.createShape({ id: b, type: 'geo', parentId: frameId, x: 250, y: 250 })
+		editor.createShape({ id: arrowId, type: 'arrow', parentId: frameId })
+		editor.createBindings([
+			{
+				type: 'arrow',
+				fromId: arrowId,
+				toId: a,
+				props: {
+					terminal: 'start',
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					isExact: false,
+					isPrecise: true,
+				},
+			},
+			{
+				type: 'arrow',
+				fromId: arrowId,
+				toId: b,
+				props: {
+					terminal: 'end',
+					normalizedAnchor: { x: 0.5, y: 0.5 },
+					isExact: false,
+					isPrecise: true,
+				},
+			},
+		])
+
+		// bound to children, not the frame → still clipped by the frame
+		expect(editor.getShapeClipPath(arrowId)).toBeDefined()
+	})
+
 	it('lets you grab and move a selected frame-bound arrow where it bows outside the frame', () => {
 		editor.setCurrentTool('frame')
 		editor.pointerDown(100, 100).pointerMove(300, 300).pointerUp(300, 300)

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -761,7 +761,70 @@ describe('frame shapes', () => {
 		expect(bindings.start).toMatchObject({ toId: boxId })
 		expect(bindings.end).toMatchObject({ toId: frameId })
 
-		expect(arrow.parentId).toBe(editor.getCurrentPageId())
+		// both ends depend on the frame (a child inside it and the frame itself), so
+		// the arrow is parented into the frame
+		expect(arrow.parentId).toBe(frameId)
+	})
+
+	it('parents an arrow into a frame when both ends bind to the frame itself', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(300, 300).pointerUp(300, 300)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		// draw an arrow across two empty areas of the frame so both ends bind to the frame
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(150, 150).pointerMove(250, 250).pointerUp(250, 250)
+
+		const arrow = editor.getOnlySelectedShape()! as TLArrowShape
+		const bindings = getArrowBindings(editor, arrow)
+		expect(bindings.start).toMatchObject({ toId: frameId })
+		expect(bindings.end).toMatchObject({ toId: frameId })
+
+		// the arrow is parented to the frame, not the page
+		expect(arrow.parentId).toBe(frameId)
+
+		// so deleting the frame deletes the arrow with it
+		editor.deleteShapes([frameId])
+		expect(editor.getShape(arrow.id)).toBeUndefined()
+	})
+
+	it('lets you grab and move a selected frame-bound arrow where it bows outside the frame', () => {
+		editor.setCurrentTool('frame')
+		editor.pointerDown(100, 100).pointerMove(300, 300).pointerUp(300, 300)
+		const frameId = editor.getOnlySelectedShape()!.id
+
+		// draw an arrow along the bottom edge of the frame, both ends bound to the frame
+		editor.setCurrentTool('arrow')
+		editor.pointerDown(150, 290).pointerMove(250, 290).pointerUp(250, 290)
+		const arrowId = editor.getOnlySelectedShape()!.id
+		expect(editor.getShape(arrowId)!.parentId).toBe(frameId)
+
+		// bend it downward so the middle of the arrow bows below the frame (y > 300)
+		editor.updateShape({ id: arrowId, type: 'arrow', props: { bend: 60 } })
+
+		// the lowest point on the arrow's geometry sits below the frame, where the
+		// frame clips the arrow
+		const transform = editor.getShapePageTransform(arrowId)
+		const lowestPoint = transform
+			.applyToPoints(editor.getShapeGeometry(arrowId).vertices)
+			.reduce((lowest, p) => (p.y > lowest.y ? p : lowest))
+		expect(lowestPoint.y).toBeGreaterThan(300)
+
+		// a normal hit test misses the arrow there because it's clipped by the frame
+		expect(editor.getShapeAtPoint(lowestPoint, { hitInside: true, margin: 0 })).toBeUndefined()
+
+		// but once the arrow is selected it can be grabbed across its whole geometry,
+		// matching its (unclipped) selection indicator
+		editor.setCurrentTool('select')
+		editor.select(arrowId)
+		expect(editor.getSelectedShapeAtPoint(lowestPoint)?.id).toBe(arrowId)
+
+		// so pointing down outside the frame and dragging starts moving the arrow
+		// rather than starting a selection brush
+		editor.pointerDown(lowestPoint.x, lowestPoint.y)
+		editor.pointerMove(lowestPoint.x, lowestPoint.y + 40)
+		editor.expectToBeIn('select.translating')
+		editor.pointerUp()
 	})
 
 	it('can be edited', () => {


### PR DESCRIPTION
In order to stop arrows being orphaned when their frame is deleted (#8978) and to let you move an arrow where it bows outside its frame, this PR fixes how arrows bound to a frame are parented and hit-tested.

Two issues:

1. When an arrow's endpoints both resolve to a frame (both ends on the frame itself, or one end on the frame and the other on a child inside it), the arrow was parented to the page instead of the frame, so deleting the frame left the arrow behind. `reparentArrow` now parents the arrow into the bound shape when one binding target is an ancestor-or-self of the other (and can contain the arrow), via a new `getCommonBindingContainer` helper. The existing `findCommonAncestor` path (distinct children, groups) is unchanged.

2. A curved arrow that's a child of a frame is clipped at the frame's edge, but its selection indicator is drawn unclipped — so you could see the part sticking out but not grab it. `getSelectedShapeAtPoint` now hit-tests geometry directly (ignoring the clip mask) using the standard hit-test margin, so a selected shape is grabbable across its whole geometry. Pointing down outside the frame on a selected arrow now starts a move instead of a brush.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a frame, then draw an arrow between two empty areas inside it (both ends bind to the frame).
2. Delete the frame — the arrow is deleted with it.
3. Draw another such arrow and bend it so it bows outside the frame. Select it, then drag from the part outside the frame — it moves.

- [x] Unit tests

### API changes

- ShapeUtil.shouldClipChild now receives a second, optional self argument — the clipping ancestor being asked.

### Release notes

- Fix arrows bound to a frame being left behind when the frame is deleted.
- Fix being unable to select and move an arrow where it extends outside its frame.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +58 / -3   |
| Tests     | +69 / -4   |**