### PR TITLE
feat(examples): add example for previewing generated shapes

### DIFF
--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/AgentGhostShapesExample.tsx
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/AgentGhostShapesExample.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useRef, useState } from 'react'
+import { TLComponents, Tldraw, TldrawUiButton, useEditor, useValue } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './agent-ghost-shapes.css'
+import { describeAction } from './actions'
+import { AgentActionStream, mockStream } from './agentStream'
+import { GhostLayer } from './ghostRenderers'
+import { acceptAll, applyActionToStage, clearProposals, proposals$, rejectAll } from './proposals'
+import { UIComponentShapeUtil } from './UIComponentShape'
+
+// Render proposed agent changes as ghost shapes on the canvas.
+//
+// This fuses two ideas:
+//   - An ephemeral on-canvas overlay: suggestions live in a local atom (never in
+//     the document store), are rendered through the `OnTheCanvas` slot, and become
+//     real shapes only when accepted.
+//   - The tldraw agent starter kit: the agent streams structured *actions*
+//     (create / update / delete) which are applied through an action registry.
+//
+// Here, the agent's actions are applied to a STAGING layer instead of the
+// editor. Each proposal is a ghost until you accept it — at which point it (and
+// only it) becomes a real, synced, persisted shape.
+
+// Swap this for `realStream` (see agentStream.ts) to drive ghosts from a real
+// model via your own backend.
+const driver: AgentActionStream = mockStream
+
+const components: TLComponents = {
+	OnTheCanvas: GhostLayer,
+	TopPanel: PromptBar,
+}
+
+// The agent can propose these custom UI-component shapes; register the util so
+// accepted proposals render as real, interactive React components on the canvas.
+const shapeUtils = [UIComponentShapeUtil]
+
+export default function AgentGhostShapesExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="agent-ghost-shapes"
+				shapeUtils={shapeUtils}
+				components={components}
+				// Ghosts are ephemeral; never restore them when the document loads.
+				onMount={() => clearProposals()}
+			/>
+		</div>
+	)
+}
+
+function PromptBar() {
+	const editor = useEditor()
+	const [input, setInput] = useState('')
+	const [status, setStatus] = useState<string | null>(null)
+	const [running, setRunning] = useState(false)
+	const runId = useRef(0)
+	const count = useValue('count', () => proposals$.get().length, [])
+
+	const run = useCallback(
+		async (message: string) => {
+			const id = ++runId.current
+			setRunning(true)
+			setStatus('Thinking…')
+			try {
+				for await (const action of driver.stream(message, editor)) {
+					if (runId.current !== id) return // a newer run superseded this one
+					setStatus(describeAction(action))
+					applyActionToStage(action)
+				}
+				setStatus(null)
+			} catch (error) {
+				setStatus(error instanceof Error ? error.message : 'Something went wrong')
+			} finally {
+				if (runId.current === id) setRunning(false)
+			}
+		},
+		[editor]
+	)
+
+	return (
+		<div className="aga-panel">
+			<div className="aga-row">
+				<input
+					className="aga-input"
+					value={input}
+					placeholder="Ask the agent… (try “login screen”, “flowchart”, “tidy up”)"
+					onChange={(e) => setInput(e.target.value)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' && input.trim()) run(input.trim())
+					}}
+				/>
+				<TldrawUiButton
+					type="normal"
+					disabled={!input.trim() || running}
+					onClick={() => run(input.trim())}
+				>
+					Send
+				</TldrawUiButton>
+			</div>
+
+			<div className="aga-row">
+				<TldrawUiButton type="low" disabled={running} onClick={() => run('login screen')}>
+					▶ Run demo
+				</TldrawUiButton>
+				<span className="aga-status">
+					{status
+						? status
+						: `${count} proposed change${count === 1 ? '' : 's'} (staged, not in the document)`}
+				</span>
+				<TldrawUiButton type="normal" disabled={count === 0} onClick={() => acceptAll(editor)}>
+					Accept all
+				</TldrawUiButton>
+				<TldrawUiButton type="low" disabled={count === 0} onClick={() => rejectAll()}>
+					Reject all
+				</TldrawUiButton>
+			</div>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/README.md
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/README.md
@@ -1,0 +1,60 @@
+---
+title: Agent ghost shapes
+component: ./AgentGhostShapesExample.tsx
+priority: 2
+keywords:
+  [
+    agent,
+    ai,
+    ghost shapes,
+    suggestions,
+    proposed changes,
+    staging,
+    accept,
+    reject,
+    OnTheCanvas,
+    streaming,
+    not synced,
+  ]
+---
+
+Render proposed agent changes as ghost shapes on the canvas, then accept or reject them.
+
+---
+
+This example combines two patterns. The first is an **ephemeral on-canvas overlay**: proposals live in
+a plain `atom` (`proposals$`), never in `editor.store`, and are rendered through the `OnTheCanvas` slot
+so they sit in page space and scale and pan with the camera. The second comes from the **tldraw agent
+starter kit**: a streaming, structured action vocabulary, where the agent emits a stream of `create`,
+`update`, and `delete` actions, each folded into the canvas through a small action registry.
+
+The key move is that actions are applied to a **staging layer**, not to the document. A proposed
+change is a ghost until you accept it:
+
+- **Create** proposals render a preview of the new shape. For built-in kinds (ellipse, arrow, …) that
+  is a dashed approximation; for `ui` kinds it is the **real React UI component** — the agent proposes
+  a custom `ui-component` shape (a button, an input, a card, a checkbox, an avatar, …), and the ghost
+  renders the exact same `UIComponent` it will become on accept, just dimmed and framed.
+- **Update** and **delete** proposals draw a halo (or a struck-through halo) over an existing real
+  shape, tracking it live.
+- **Accept** materializes the proposal into a real shape via `editor.createShape` / `updateShape` /
+  `deleteShapes` (a normal document record that syncs and persists), then drops the ghost. **Reject**
+  just drops the ghost; nothing was ever written to the store.
+
+Type a prompt (try "login screen", "flowchart", or "tidy up"), press **Run demo**, or use **Accept
+all** / **Reject all**. Open a second tab on the same `persistenceKey` to confirm: accepted shapes are
+there, ghosts are not.
+
+Two things to know about the trade-offs:
+
+- **Custom shapes preview exactly; built-in shapes are approximated.** A custom `ui-component` shape
+  (in `UIComponentShape.tsx`) shares one presentational `UIComponent` between its `ShapeUtil.component`
+  and the ghost preview, so what you preview is what you get. Built-in kinds are drawn with bespoke SVG
+  in the overlay, since the real `ShapeUtil` render only exists once a shape is in the store — that is
+  the cost of keeping proposals truly not-yet-real. If you would rather preview built-ins
+  pixel-accurately, apply them to the store immediately and reverse the change on reject with
+  `reverseRecordsDiff` — which is how the agent starter kit's chat-panel diff viewer works.
+- **The driver is pluggable.** `mockStream` (in `agentStream.ts`) ships scripted scenarios so the
+  example runs with no API key. Swap in `realStream` and point it at your own backend — or the agent
+  starter kit's worker — to drive the ghosts from a real model. The example never handles API keys
+  itself; the key stays on your server.

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/UIComponentShape.tsx
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/UIComponentShape.tsx
@@ -1,0 +1,257 @@
+import {
+	Geometry2d,
+	HTMLContainer,
+	RecordProps,
+	Rectangle2d,
+	resizeBox,
+	ShapeUtil,
+	T,
+	TLResizeInfo,
+	TLShape,
+} from 'tldraw'
+
+// A single, parameterized custom shape that renders a real React UI component
+// (a button, an input, a card, …). The agent proposes these as ghosts, and on
+// accept they become real `ui-component` shapes on the canvas. The same
+// `UIComponent` is used for both the ghost preview and the accepted shape, so
+// what you preview is exactly what you get.
+
+export const UI_COMPONENT_TYPE = 'ui-component'
+
+export type UIVariant =
+	| 'card'
+	| 'heading'
+	| 'text'
+	| 'input'
+	| 'button'
+	| 'checkbox'
+	| 'toggle'
+	| 'badge'
+	| 'avatar'
+
+export const UI_VARIANTS: UIVariant[] = [
+	'card',
+	'heading',
+	'text',
+	'input',
+	'button',
+	'checkbox',
+	'toggle',
+	'badge',
+	'avatar',
+]
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[UI_COMPONENT_TYPE]: { w: number; h: number; variant: UIVariant; label: string; accent: string }
+	}
+}
+
+type UIComponentShape = TLShape<typeof UI_COMPONENT_TYPE>
+
+export class UIComponentShapeUtil extends ShapeUtil<UIComponentShape> {
+	static override type = UI_COMPONENT_TYPE
+	static override props: RecordProps<UIComponentShape> = {
+		w: T.number,
+		h: T.number,
+		variant: T.literalEnum(...UI_VARIANTS),
+		label: T.string,
+		accent: T.string,
+	}
+
+	getDefaultProps(): UIComponentShape['props'] {
+		return { w: 240, h: 48, variant: 'button', label: 'Button', accent: '#8b5cf6' }
+	}
+
+	override canResize() {
+		return true
+	}
+
+	getGeometry(shape: UIComponentShape): Geometry2d {
+		return new Rectangle2d({ width: shape.props.w, height: shape.props.h, isFilled: true })
+	}
+
+	override onResize(shape: UIComponentShape, info: TLResizeInfo<UIComponentShape>) {
+		return resizeBox(shape, info)
+	}
+
+	component(shape: UIComponentShape) {
+		// `pointerEvents: 'none'` lets tldraw hit-test the shape from its geometry,
+		// so it selects and drags like any other shape. Switch to `'all'` only if
+		// the rendered UI needs to handle its own clicks.
+		return (
+			<HTMLContainer style={{ pointerEvents: 'none' }}>
+				<UIComponent {...shape.props} />
+			</HTMLContainer>
+		)
+	}
+
+	getIndicatorPath(shape: UIComponentShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+// ============================================================================
+// The presentational component, shared by the shape and the ghost preview.
+// ============================================================================
+
+export interface UIComponentProps {
+	w: number
+	h: number
+	variant: UIVariant
+	label: string
+	accent: string
+}
+
+export function UIComponent({ w, h, variant, label, accent }: UIComponentProps) {
+	const base: React.CSSProperties = {
+		width: w,
+		height: h,
+		boxSizing: 'border-box',
+		fontFamily: 'Inter, system-ui, sans-serif',
+		display: 'flex',
+		alignItems: 'center',
+	}
+
+	switch (variant) {
+		case 'card':
+			return (
+				<div
+					style={{
+						...base,
+						borderRadius: 16,
+						background: 'white',
+						border: '1px solid #e6e6e6',
+						boxShadow: '0 6px 24px rgba(0,0,0,0.06)',
+					}}
+				/>
+			)
+		case 'heading':
+			return (
+				<div style={{ ...base, fontSize: Math.min(h * 0.7, 28), fontWeight: 700, color: '#111' }}>
+					{label}
+				</div>
+			)
+		case 'text':
+			return (
+				<div style={{ ...base, fontSize: Math.min(h * 0.7, 14), color: '#667085' }}>{label}</div>
+			)
+		case 'input':
+			return (
+				<div
+					style={{
+						...base,
+						padding: '0 14px',
+						borderRadius: 10,
+						background: 'white',
+						border: '1px solid #d0d5dd',
+						color: '#98a2b3',
+						fontSize: 15,
+					}}
+				>
+					{label}
+				</div>
+			)
+		case 'button':
+			return (
+				<div
+					style={{
+						...base,
+						justifyContent: 'center',
+						borderRadius: 10,
+						background: accent,
+						color: 'white',
+						fontSize: 15,
+						fontWeight: 600,
+					}}
+				>
+					{label}
+				</div>
+			)
+		case 'checkbox':
+			return (
+				<div style={{ ...base, gap: 10, fontSize: 14, color: '#344054' }}>
+					<div
+						style={{
+							width: 20,
+							height: 20,
+							borderRadius: 5,
+							border: `2px solid ${accent}`,
+							flexShrink: 0,
+						}}
+					/>
+					{label}
+				</div>
+			)
+		case 'toggle':
+			return (
+				<div style={{ ...base, gap: 10, fontSize: 14, color: '#344054' }}>
+					<div
+						style={{
+							width: 38,
+							height: 22,
+							borderRadius: 999,
+							background: accent,
+							position: 'relative',
+							flexShrink: 0,
+						}}
+					>
+						<div
+							style={{
+								position: 'absolute',
+								top: 2,
+								right: 2,
+								width: 18,
+								height: 18,
+								borderRadius: 999,
+								background: 'white',
+							}}
+						/>
+					</div>
+					{label}
+				</div>
+			)
+		case 'badge':
+			return (
+				<div
+					style={{
+						...base,
+						width: 'fit-content',
+						justifyContent: 'center',
+						padding: '0 12px',
+						borderRadius: 999,
+						background: `${accent}1f`,
+						color: accent,
+						fontSize: 13,
+						fontWeight: 600,
+					}}
+				>
+					{label}
+				</div>
+			)
+		case 'avatar':
+			return (
+				<div
+					style={{
+						...base,
+						width: h,
+						justifyContent: 'center',
+						borderRadius: 999,
+						background: accent,
+						color: 'white',
+						fontSize: h * 0.4,
+						fontWeight: 600,
+					}}
+				>
+					{initials(label)}
+				</div>
+			)
+	}
+}
+
+function initials(label: string): string {
+	const parts = label.trim().split(/\s+/).slice(0, 2)
+	return parts.map((p) => p[0]?.toUpperCase() ?? '').join('') || '?'
+}

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/actions.ts
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/actions.ts
@@ -1,0 +1,172 @@
+import { TLShapeId } from 'tldraw'
+import type { UIVariant } from './UIComponentShape'
+
+// The vocabulary and streaming model here are borrowed from the tldraw agent
+// starter kit (templates/agent). The agent emits a stream of structured
+// *actions*; each action is applied through a small registry of "action utils".
+// The difference in this example: instead of applying actions to the editor's
+// document store, we apply them to a local *staging* layer (see proposals.ts),
+// so a proposed change is a ghost until the user accepts it.
+
+/**
+ * A streamed object that may not be complete yet. Mirrors the agent kit's
+ * `Streaming<T>`: while streaming, you get a partial with `complete: false`;
+ * once finished, the full object with `complete: true`.
+ */
+export type Streaming<T> = (Partial<T> & { complete: false }) | (T & { complete: true })
+
+// `ui` proposes a custom UI-component shape (see UIComponentShape.tsx); the rest
+// map to tldraw's built-in shapes. The example handles both as ghosts.
+export type GhostKind = 'ui' | 'rectangle' | 'ellipse' | 'text' | 'note' | 'arrow'
+
+/** A tldraw color name. A small, friendly subset of the full palette. */
+export type GhostColor = 'black' | 'blue' | 'green' | 'orange' | 'red' | 'violet' | 'yellow'
+
+/** Hex equivalents, used for the ghost preview and the custom shape's accent. */
+export const GHOST_HEX: Record<GhostColor, string> = {
+	black: '#1d1d1d',
+	blue: '#4263eb',
+	green: '#099268',
+	orange: '#e8590c',
+	red: '#e03131',
+	violet: '#8b5cf6',
+	yellow: '#f08c00',
+}
+
+export function hexOf(color?: GhostColor): string {
+	return GHOST_HEX[color ?? 'violet']
+}
+
+/**
+ * A normalized, store-independent description of a shape the agent wants to
+ * create. All geometry is in *page* coordinates so it can be rendered directly
+ * in the `OnTheCanvas` layer and converted to a real shape on accept.
+ */
+export interface GhostShape {
+	/** Staging id (a plain string). Becomes a real shape id when accepted. */
+	id: string
+	kind: GhostKind
+	/** Top-left for box-like shapes; the start point for arrows and draws. */
+	x: number
+	y: number
+	/** Box size (rectangle, ellipse, text, note). */
+	w?: number
+	h?: number
+	/** Label / body text (text, note, and as a label on geo shapes). */
+	text?: string
+	color?: GhostColor
+	/** Which UI component to render (only for kind `ui`). */
+	variant?: UIVariant
+	/** Arrow end point, in page coordinates. */
+	end?: { x: number; y: number }
+}
+
+/**
+ * An action streamed from the agent. `update` and `delete` target a *real*
+ * shape already on the canvas (by its `TLShapeId`); `create` introduces a new
+ * ghost. `think` is narration and produces no proposal.
+ */
+export type AgentAction =
+	| { _type: 'create'; shape: GhostShape; intent?: string }
+	| { _type: 'update'; shapeId: TLShapeId; changes: Partial<GhostShape>; intent?: string }
+	| { _type: 'delete'; shapeId: TLShapeId; intent?: string }
+	| { _type: 'think'; text: string }
+
+export type AgentActionType = AgentAction['_type']
+
+/**
+ * A staged proposal: the agent's intent held outside the document store. Accept
+ * materializes it into a real shape; reject drops it and nothing was ever
+ * written to the store.
+ */
+export type Proposal =
+	| { id: string; kind: 'create'; ghost: GhostShape; intent: string }
+	| {
+			id: string
+			kind: 'update'
+			targetId: TLShapeId
+			changes: Partial<GhostShape>
+			intent: string
+	  }
+	| { id: string; kind: 'delete'; targetId: TLShapeId; intent: string }
+
+/**
+ * The action registry, mirroring the agent kit's `AgentActionUtil`: each action
+ * type knows how to (a) describe itself for the chat/status line and (b) fold
+ * itself into the staging layer. `reduce` is a pure transform over the current
+ * proposals, which makes streaming upserts easy to reason about.
+ */
+interface ActionUtil<T extends AgentAction = AgentAction> {
+	describe(action: Streaming<T>): string
+	/** Returns the next proposals list. `think` returns it unchanged. */
+	reduce(proposals: Proposal[], action: Streaming<T>): Proposal[]
+}
+
+function upsert(proposals: Proposal[], next: Proposal): Proposal[] {
+	const index = proposals.findIndex((p) => p.id === next.id)
+	if (index === -1) return [...proposals, next]
+	const copy = [...proposals]
+	copy[index] = next
+	return copy
+}
+
+export const ACTION_UTILS: {
+	[K in AgentActionType]: ActionUtil<Extract<AgentAction, { _type: K }>>
+} = {
+	create: {
+		describe: (a) => a.intent ?? (a.shape ? `Add ${a.shape.kind}` : 'Add a shape'),
+		reduce: (proposals, a) => {
+			// Need at least a kind and an id before we can stage anything.
+			if (!a.shape || !a.shape.id || !a.shape.kind) return proposals
+			return upsert(proposals, {
+				id: a.shape.id,
+				kind: 'create',
+				ghost: a.shape as GhostShape,
+				intent: a.intent ?? `Add ${a.shape.kind}`,
+			})
+		},
+	},
+	update: {
+		describe: (a) => a.intent ?? 'Update a shape',
+		reduce: (proposals, a) => {
+			if (!a.shapeId) return proposals
+			return upsert(proposals, {
+				id: `update:${a.shapeId}`,
+				kind: 'update',
+				targetId: a.shapeId,
+				changes: a.changes ?? {},
+				intent: a.intent ?? 'Update a shape',
+			})
+		},
+	},
+	delete: {
+		describe: (a) => a.intent ?? 'Delete a shape',
+		reduce: (proposals, a) => {
+			if (!a.shapeId) return proposals
+			return upsert(proposals, {
+				id: `delete:${a.shapeId}`,
+				kind: 'delete',
+				targetId: a.shapeId,
+				intent: a.intent ?? 'Delete a shape',
+			})
+		},
+	},
+	think: {
+		describe: (a) => a.text ?? '',
+		reduce: (proposals) => proposals,
+	},
+}
+
+/** Describe any action for the status line / chat strip. */
+export function describeAction(action: Streaming<AgentAction>): string {
+	if (!action._type) return ''
+	const util = ACTION_UTILS[action._type] as ActionUtil
+	return util.describe(action)
+}
+
+/** Fold a streamed action into the proposals list (pure). */
+export function reduceAction(proposals: Proposal[], action: Streaming<AgentAction>): Proposal[] {
+	if (!action._type) return proposals
+	const util = ACTION_UTILS[action._type] as ActionUtil
+	return util.reduce(proposals, action)
+}

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/agent-ghost-shapes.css
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/agent-ghost-shapes.css
@@ -1,0 +1,82 @@
+/* The agent prompt bar, injected through the TopPanel component slot. */
+.aga-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: min(560px, 80vw);
+	padding: 10px;
+	border-radius: 12px;
+	background: white;
+	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+	pointer-events: all;
+}
+
+.aga-row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.aga-input {
+	flex: 1;
+	min-width: 180px;
+	border: 1px solid #d0d5dd;
+	border-radius: 8px;
+	padding: 8px 10px;
+	font-size: 14px;
+}
+
+.aga-status {
+	font-size: 12px;
+	color: #667085;
+	margin-right: auto;
+}
+
+/* Per-ghost accept/reject controls, rendered on the canvas above each ghost.
+   Position, scale and accent colour are set inline since they depend on the
+   ghost's bounds, the camera zoom and the proposal's colour. */
+.aga-controls {
+	position: absolute;
+	left: 0;
+	bottom: 100%;
+	transform-origin: bottom left;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding-bottom: 6px;
+	white-space: nowrap;
+}
+
+.aga-pill {
+	font-size: 12px;
+	font-weight: 600;
+	color: white;
+	padding: 4px 8px;
+	border-radius: 6px;
+}
+
+.aga-ghost-btn {
+	border-radius: 6px;
+	border: 1px solid #d0d5dd;
+	padding: 5px 12px;
+	font-size: 12px;
+	font-weight: 600;
+	cursor: pointer;
+	background: white;
+	color: #444;
+}
+
+.aga-ghost-btn.aga-ghost-btn--accept {
+	border: none;
+	color: white;
+}
+
+/* The dashed frame drawn around a ghost preview; border colour is set inline. */
+.aga-frame {
+	position: absolute;
+	border-style: dashed;
+	border-width: 2px;
+	border-radius: 12px;
+	pointer-events: none;
+}

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/agentStream.ts
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/agentStream.ts
@@ -1,0 +1,290 @@
+import { Editor, TLShapeId } from 'tldraw'
+import { AgentAction, GhostShape, Streaming } from './actions'
+
+// The driver seam. The ghost/staging layer doesn't care where actions come
+// from — it just consumes an async stream of `Streaming<AgentAction>`. This file
+// ships two drivers:
+//
+//   - `mockStream`: scripted scenarios that run with no API key and no network,
+//     so the example works out of the box.
+//   - `realStream`: an adapter that POSTs the prompt to a backend and yields the
+//     actions it streams back. Wire it to your own endpoint or the agent starter
+//     kit's worker (templates/agent). It is OFF by default.
+
+export interface AgentActionStream {
+	stream(input: string, editor: Editor): AsyncIterable<Streaming<AgentAction>>
+}
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+// ============================================================================
+// Mock driver
+// ============================================================================
+
+/** Emit a create as a partial (grows in) then a complete action. */
+async function* streamCreate(
+	shape: GhostShape,
+	intent: string
+): AsyncGenerator<Streaming<AgentAction>> {
+	const partial: GhostShape = { ...shape, h: shape.h ? Math.max(10, shape.h / 3) : shape.h }
+	yield { _type: 'create', complete: false, intent, shape: partial }
+	await delay(110)
+	yield { _type: 'create', complete: true, intent, shape }
+	await delay(160)
+}
+
+function think(text: string): Streaming<AgentAction> {
+	return { _type: 'think', complete: true, text }
+}
+
+async function* loginScenario(editor: Editor): AsyncGenerator<Streaming<AgentAction>> {
+	const vb = editor.getViewportPageBounds()
+	const x = vb.midX - 130
+	const top = vb.midY - 230
+
+	yield think('Designing a login screen…')
+	await delay(250)
+
+	yield* streamCreate(
+		{ id: 'g-card', kind: 'ui', variant: 'card', x: x - 28, y: top - 28, w: 316, h: 472 },
+		'Add card'
+	)
+	yield* streamCreate(
+		{
+			id: 'g-title',
+			kind: 'ui',
+			variant: 'heading',
+			x,
+			y: top,
+			w: 260,
+			h: 40,
+			text: 'Welcome back',
+		},
+		'Add heading'
+	)
+	yield* streamCreate(
+		{ id: 'g-email', kind: 'ui', variant: 'input', x, y: top + 72, w: 260, h: 48, text: 'Email' },
+		'Add email field'
+	)
+	yield* streamCreate(
+		{
+			id: 'g-pass',
+			kind: 'ui',
+			variant: 'input',
+			x,
+			y: top + 136,
+			w: 260,
+			h: 48,
+			text: 'Password',
+		},
+		'Add password field'
+	)
+	yield* streamCreate(
+		{
+			id: 'g-remember',
+			kind: 'ui',
+			variant: 'checkbox',
+			x,
+			y: top + 196,
+			w: 260,
+			h: 28,
+			text: 'Remember me',
+		},
+		'Add remember-me'
+	)
+	yield* streamCreate(
+		{
+			id: 'g-btn',
+			kind: 'ui',
+			variant: 'button',
+			x,
+			y: top + 240,
+			w: 260,
+			h: 50,
+			text: 'Sign in',
+			color: 'violet',
+		},
+		'Add sign-in button'
+	)
+	yield* streamCreate(
+		{
+			id: 'g-help',
+			kind: 'ui',
+			variant: 'text',
+			x,
+			y: top + 308,
+			w: 260,
+			h: 24,
+			text: 'Forgot password?',
+		},
+		'Add helper link'
+	)
+}
+
+async function* flowchartScenario(editor: Editor): AsyncGenerator<Streaming<AgentAction>> {
+	const vb = editor.getViewportPageBounds()
+	const cx = vb.midX
+	const top = vb.midY - 200
+
+	yield think('Sketching a flowchart…')
+	await delay(250)
+
+	yield* streamCreate(
+		{
+			id: 'f-start',
+			kind: 'ellipse',
+			x: cx - 80,
+			y: top,
+			w: 160,
+			h: 80,
+			text: 'Start',
+			color: 'green',
+		},
+		'Add start node'
+	)
+	yield* streamCreate(
+		{
+			id: 'f-step',
+			kind: 'rectangle',
+			x: cx - 90,
+			y: top + 150,
+			w: 180,
+			h: 90,
+			text: 'Do the thing',
+			color: 'blue',
+		},
+		'Add step'
+	)
+	yield* streamCreate(
+		{
+			id: 'f-end',
+			kind: 'ellipse',
+			x: cx - 80,
+			y: top + 300,
+			w: 160,
+			h: 80,
+			text: 'Done',
+			color: 'red',
+		},
+		'Add end node'
+	)
+	yield {
+		_type: 'create',
+		complete: true,
+		intent: 'Connect start to step',
+		shape: {
+			id: 'f-a1',
+			kind: 'arrow',
+			x: cx,
+			y: top + 80,
+			end: { x: cx, y: top + 150 },
+			color: 'black',
+		},
+	}
+	await delay(160)
+	yield {
+		_type: 'create',
+		complete: true,
+		intent: 'Connect step to end',
+		shape: {
+			id: 'f-a2',
+			kind: 'arrow',
+			x: cx,
+			y: top + 240,
+			end: { x: cx, y: top + 300 },
+			color: 'black',
+		},
+	}
+	await delay(160)
+}
+
+async function* tidyScenario(editor: Editor): AsyncGenerator<Streaming<AgentAction>> {
+	const shapes = editor.getCurrentPageShapes()
+	if (shapes.length === 0) {
+		yield think('Nothing on the canvas yet — accept a layout first, then ask me to tidy it.')
+		return
+	}
+
+	yield think('Reviewing the canvas…')
+	await delay(250)
+
+	// Propose recoloring the first few shapes, and deleting the last one.
+	for (const shape of shapes.slice(0, 3)) {
+		yield {
+			_type: 'update',
+			complete: true,
+			shapeId: shape.id as TLShapeId,
+			changes: { color: 'violet' },
+			intent: 'Recolor to violet',
+		}
+		await delay(180)
+	}
+	if (shapes.length > 3) {
+		yield {
+			_type: 'delete',
+			complete: true,
+			shapeId: shapes[shapes.length - 1].id as TLShapeId,
+			intent: 'Remove stray shape',
+		}
+	}
+}
+
+function pickScenario(input: string) {
+	const text = input.toLowerCase()
+	if (/(flow|chart|diagram|graph|process)/.test(text)) return flowchartScenario
+	if (/(tidy|clean|recolor|review|fix|organi[sz]e)/.test(text)) return tidyScenario
+	return loginScenario
+}
+
+export const mockStream: AgentActionStream = {
+	async *stream(input, editor) {
+		yield* pickScenario(input)(editor)
+	},
+}
+
+// ============================================================================
+// Real driver (off by default)
+// ============================================================================
+//
+// Point this at a backend that turns a prompt into a stream of AgentActions.
+// The agent starter kit's worker (templates/agent) is a good reference for the
+// server side. We expect newline-delimited JSON, one AgentAction per line.
+//
+// To use it: set the endpoint below and pass `realStream` instead of
+// `mockStream` in AgentGhostShapesExample.tsx. This example never handles API
+// keys directly — the key lives on your server.
+
+const REAL_STREAM_ENDPOINT = '' // e.g. 'http://localhost:5173/stream'
+
+export const realStream: AgentActionStream = {
+	async *stream(input) {
+		if (!REAL_STREAM_ENDPOINT) {
+			throw new Error(
+				'realStream is not configured. Set REAL_STREAM_ENDPOINT in agentStream.ts to your backend, then swap mockStream -> realStream in the example.'
+			)
+		}
+
+		const res = await fetch(REAL_STREAM_ENDPOINT, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({ message: input }),
+		})
+		if (!res.body) throw new Error('No response body from agent endpoint')
+
+		const reader = res.body.getReader()
+		const decoder = new TextDecoder()
+		let buffer = ''
+		while (true) {
+			const { done, value } = await reader.read()
+			if (done) break
+			buffer += decoder.decode(value, { stream: true })
+			const lines = buffer.split('\n')
+			buffer = lines.pop() ?? ''
+			for (const line of lines) {
+				const trimmed = line.trim()
+				if (trimmed) yield JSON.parse(trimmed) as Streaming<AgentAction>
+			}
+		}
+		if (buffer.trim()) yield JSON.parse(buffer.trim()) as Streaming<AgentAction>
+	},
+}

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/ghostRenderers.tsx
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/ghostRenderers.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react'
+import { Box, TLShapeId, useEditor, useValue } from 'tldraw'
+import { GHOST_HEX, GhostShape, hexOf, Proposal } from './actions'
+import { acceptProposal, proposals$, rejectProposal } from './proposals'
+import { UIComponent } from './UIComponentShape'
+
+// Ghosts are rendered through the `OnTheCanvas` slot, so everything here is in
+// page coordinates and scales / pans with the camera, just like a real shape.
+// Because the proposals never enter the store, we draw an approximation of each
+// shape: built-in kinds get a dashed box or line; `ui` kinds render the *same*
+// React component as the accepted shape, so the preview matches the result exactly.
+
+/** Page-space bounding box of a ghost shape. */
+function ghostBounds(g: GhostShape): Box {
+	if (g.kind === 'arrow') {
+		const end = g.end ?? { x: g.x + 120, y: g.y }
+		const x = Math.min(g.x, end.x)
+		const y = Math.min(g.y, end.y)
+		return new Box(x, y, Math.abs(end.x - g.x) || 1, Math.abs(end.y - g.y) || 1)
+	}
+	return new Box(g.x, g.y, g.w ?? 160, g.h ?? 100)
+}
+
+// `OnTheCanvas` renders *behind* the shapes layer (see DefaultCanvas), so without
+// this a freshly accepted shape would paint on top of the still-pending ghosts and
+// hide them. We lift the whole ghost layer above any real shape with a large
+// z-index base, and offset each ghost by its creation order so earlier proposals
+// (e.g. a background card) stay behind later ones.
+const GHOST_Z_BASE = 100_000
+
+/** The `OnTheCanvas` layer: one ghost per proposal. */
+export function GhostLayer() {
+	const proposals = useValue('proposals', () => proposals$.get(), [])
+	return (
+		<>
+			{proposals.map((proposal, i) => (
+				<GhostProposal key={proposal.id} proposal={proposal} z={GHOST_Z_BASE + i} />
+			))}
+		</>
+	)
+}
+
+function GhostProposal({ proposal, z }: { proposal: Proposal; z: number }) {
+	const editor = useEditor()
+	const [hovered, setHovered] = useState(false)
+	// The camera zoom, so we can counter-scale the controls to a constant
+	// on-screen size — otherwise they shrink to an un-clickable speck when zoomed
+	// out and balloon when zoomed in.
+	const zoom = useValue('zoom', () => editor.getZoomLevel(), [editor])
+
+	// For create, bounds come from the ghost. For update/delete, bounds come from
+	// the targeted real shape (reactive, so the ghost tracks the shape live).
+	const bounds = useValue(
+		'bounds',
+		() => {
+			if (proposal.kind === 'create') return ghostBounds(proposal.ghost)
+			return editor.getShapePageBounds(proposal.targetId as TLShapeId) ?? null
+		},
+		[proposal, editor]
+	)
+	if (!bounds) return null
+
+	const tint =
+		proposal.kind === 'delete'
+			? GHOST_HEX.red
+			: proposal.kind === 'update'
+				? GHOST_HEX.blue
+				: hexOf(proposal.kind === 'create' ? proposal.ghost.color : undefined)
+
+	// Dim the *visual* on hover (not the whole container) so the controls stay
+	// crisp and fully opaque.
+	const visualOpacity = hovered ? 1 : 0.55
+
+	return (
+		<div
+			onPointerEnter={() => setHovered(true)}
+			onPointerLeave={() => setHovered(false)}
+			onPointerDown={editor.markEventAsHandled}
+			style={{
+				position: 'absolute',
+				left: bounds.x,
+				top: bounds.y,
+				width: bounds.w,
+				height: bounds.h,
+				zIndex: z,
+				pointerEvents: 'all',
+			}}
+		>
+			{proposal.kind === 'create' && (
+				<GhostVisual ghost={proposal.ghost} bounds={bounds} opacity={visualOpacity} />
+			)}
+			{proposal.kind === 'update' && <Halo color={tint} opacity={visualOpacity} />}
+			{proposal.kind === 'delete' && <Halo color={tint} opacity={visualOpacity} struck />}
+
+			{/* Always visible, and counter-scaled to a constant on-screen size, so
+			    they're easy to hit regardless of zoom or pointer position. */}
+			<Controls
+				intent={proposal.intent}
+				tint={tint}
+				zoom={zoom}
+				onAccept={() => acceptProposal(editor, proposal.id)}
+				onReject={() => rejectProposal(proposal.id)}
+			/>
+		</div>
+	)
+}
+
+/** The dashed approximation of a created shape, filling the proposal box. */
+function GhostVisual({
+	ghost,
+	bounds,
+	opacity,
+}: {
+	ghost: GhostShape
+	bounds: Box
+	opacity: number
+}) {
+	const color = hexOf(ghost.color)
+
+	// `ui` ghosts render the real component, dimmed, with a dashed proposal frame
+	// around it — so the preview is pixel-identical to what accepting produces.
+	if (ghost.kind === 'ui') {
+		return (
+			<div
+				style={{
+					position: 'relative',
+					width: '100%',
+					height: '100%',
+					opacity,
+					transition: 'opacity 0.12s ease',
+				}}
+			>
+				<UIComponent
+					w={bounds.w}
+					h={bounds.h}
+					variant={ghost.variant ?? 'button'}
+					label={ghost.text ?? ''}
+					accent={color}
+				/>
+				<div className="aga-frame" style={{ inset: -4, borderColor: color }} />
+			</div>
+		)
+	}
+
+	if (ghost.kind === 'arrow') {
+		const pts = [{ x: ghost.x, y: ghost.y }, ghost.end ?? { x: ghost.x + 120, y: ghost.y }]
+		const rel = pts.map((p) => `${p.x - bounds.x},${p.y - bounds.y}`).join(' ')
+		return (
+			<svg
+				width={bounds.w}
+				height={bounds.h}
+				style={{ overflow: 'visible', display: 'block', opacity, transition: 'opacity 0.12s ease' }}
+				viewBox={`0 0 ${bounds.w} ${bounds.h}`}
+			>
+				<polyline
+					points={rel}
+					fill="none"
+					stroke={color}
+					strokeWidth={3}
+					strokeDasharray="6 5"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+				<ArrowHead pts={pts} bounds={bounds} color={color} />
+			</svg>
+		)
+	}
+
+	// Box-like shapes: rectangle, ellipse, text, note.
+	return (
+		<div
+			style={{
+				width: '100%',
+				height: '100%',
+				boxSizing: 'border-box',
+				border: `2px dashed ${color}`,
+				borderRadius: ghost.kind === 'ellipse' ? '50%' : ghost.kind === 'note' ? 4 : 8,
+				background: ghost.kind === 'text' ? 'transparent' : `${color}14`,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				padding: 8,
+				color,
+				fontSize: 14,
+				fontWeight: 500,
+				textAlign: 'center',
+				overflow: 'hidden',
+				opacity,
+				transition: 'opacity 0.12s ease',
+			}}
+		>
+			{ghost.text ?? ''}
+		</div>
+	)
+}
+
+function ArrowHead({
+	pts,
+	bounds,
+	color,
+}: {
+	pts: { x: number; y: number }[]
+	bounds: Box
+	color: string
+}) {
+	const a = pts[0]
+	const b = pts[pts.length - 1]
+	const angle = Math.atan2(b.y - a.y, b.x - a.x)
+	const size = 12
+	const tip = { x: b.x - bounds.x, y: b.y - bounds.y }
+	const left = {
+		x: tip.x - size * Math.cos(angle - Math.PI / 6),
+		y: tip.y - size * Math.sin(angle - Math.PI / 6),
+	}
+	const right = {
+		x: tip.x - size * Math.cos(angle + Math.PI / 6),
+		y: tip.y - size * Math.sin(angle + Math.PI / 6),
+	}
+	return (
+		<polyline
+			points={`${left.x},${left.y} ${tip.x},${tip.y} ${right.x},${right.y}`}
+			fill="none"
+			stroke={color}
+			strokeWidth={3}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+	)
+}
+
+/** A dashed halo drawn over an existing shape (for update / delete proposals). */
+function Halo({ color, opacity, struck }: { color: string; opacity: number; struck?: boolean }) {
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				inset: -6,
+				border: `2px dashed ${color}`,
+				borderRadius: 8,
+				background: `${color}12`,
+				opacity,
+				transition: 'opacity 0.12s ease',
+			}}
+		>
+			{struck && (
+				<svg width="100%" height="100%" style={{ display: 'block' }} preserveAspectRatio="none">
+					<line x1="0" y1="0" x2="100%" y2="100%" stroke={color} strokeWidth={2} />
+					<line x1="100%" y1="0" x2="0" y2="100%" stroke={color} strokeWidth={2} />
+				</svg>
+			)}
+		</div>
+	)
+}
+
+function Controls({
+	intent,
+	tint,
+	zoom,
+	onAccept,
+	onReject,
+}: {
+	intent: string
+	tint: string
+	zoom: number
+	onAccept(): void
+	onReject(): void
+}) {
+	return (
+		// Anchored to the ghost's top-left corner and scaled by 1/zoom around that
+		// corner, so the bar keeps a constant on-screen size and stays pinned just
+		// above the ghost at any zoom level.
+		<div className="aga-controls" style={{ transform: `scale(${1 / zoom})` }}>
+			<span className="aga-pill" style={{ background: tint }}>
+				✨ {intent}
+			</span>
+			<button
+				className="aga-ghost-btn aga-ghost-btn--accept"
+				style={{ background: tint }}
+				onClick={onAccept}
+			>
+				Accept
+			</button>
+			<button className="aga-ghost-btn" onClick={onReject}>
+				Reject
+			</button>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/use-cases/agent-ghost-shapes/proposals.ts
+++ b/apps/examples/src/examples/use-cases/agent-ghost-shapes/proposals.ts
@@ -1,0 +1,176 @@
+import { atom, createShapeId, Editor, TLShapeId, TLShapePartial, toRichText } from 'tldraw'
+import {
+	GhostColor,
+	GhostShape,
+	hexOf,
+	Proposal,
+	reduceAction,
+	Streaming,
+	type AgentAction,
+} from './actions'
+import { UI_COMPONENT_TYPE } from './UIComponentShape'
+
+// The staging layer. Proposals live in a plain local atom and are NEVER written
+// to `editor.store` — so they don't sync, don't persist, and are invisible to
+// other tabs. Accepting a proposal is the hand-off: it creates / updates /
+// deletes a real document record, which DOES sync and persist. Rejecting simply
+// drops the proposal.
+export const proposals$ = atom<Proposal[]>('agent-ghost-proposals', [])
+
+/** Fold a streamed agent action into the staging layer. */
+export function applyActionToStage(action: Streaming<AgentAction>) {
+	proposals$.update((proposals) => reduceAction(proposals, action))
+}
+
+export function clearProposals() {
+	proposals$.set([])
+}
+
+export function rejectProposal(id: string) {
+	proposals$.update((proposals) => proposals.filter((p) => p.id !== id))
+}
+
+export function rejectAll() {
+	clearProposals()
+}
+
+/** Materialize a single proposal into the real document, then drop the ghost. */
+export function acceptProposal(editor: Editor, id: string) {
+	const proposal = proposals$.get().find((p) => p.id === id)
+	if (!proposal) return
+	editor.run(() => materialize(editor, proposal))
+	rejectProposal(id)
+}
+
+/** Materialize every pending proposal in one batch. */
+export function acceptAll(editor: Editor) {
+	const all = proposals$.get()
+	if (all.length === 0) return
+	editor.run(() => {
+		for (const proposal of all) materialize(editor, proposal)
+	})
+	clearProposals()
+}
+
+function materialize(editor: Editor, proposal: Proposal) {
+	switch (proposal.kind) {
+		case 'create': {
+			editor.createShape(ghostToShapePartial(proposal.ghost))
+			break
+		}
+		case 'update': {
+			const partial = changesToShapePartial(editor, proposal.targetId, proposal.changes)
+			if (partial) editor.updateShape(partial)
+			break
+		}
+		case 'delete': {
+			editor.deleteShapes([proposal.targetId])
+			break
+		}
+	}
+}
+
+// ============================================================================
+// Ghost -> real tldraw shape conversion
+// ============================================================================
+//
+// The default prop shapes here mirror the agent kit's `SHAPE_DEFAULTS` in
+// templates/agent/client/actions/CreateActionUtil.ts. `createShape` fills in any
+// props we omit, so we only set what the ghost actually carries.
+
+/** Convert a staged ghost into a real shape partial for `editor.createShape`. */
+export function ghostToShapePartial(ghost: GhostShape): TLShapePartial {
+	const id = createShapeId()
+	const color = ghost.color ?? 'violet'
+
+	switch (ghost.kind) {
+		case 'ui':
+			return {
+				id,
+				type: UI_COMPONENT_TYPE,
+				x: ghost.x,
+				y: ghost.y,
+				props: {
+					w: ghost.w ?? 240,
+					h: ghost.h ?? 48,
+					variant: ghost.variant ?? 'button',
+					label: ghost.text ?? '',
+					accent: hexOf(ghost.color),
+				},
+			}
+		case 'rectangle':
+		case 'ellipse':
+			return {
+				id,
+				type: 'geo',
+				x: ghost.x,
+				y: ghost.y,
+				props: {
+					geo: ghost.kind,
+					w: ghost.w ?? 160,
+					h: ghost.h ?? 100,
+					color,
+					...(ghost.text ? { richText: toRichText(ghost.text) } : {}),
+				},
+			}
+		case 'text':
+			return {
+				id,
+				type: 'text',
+				x: ghost.x,
+				y: ghost.y,
+				props: { color, richText: toRichText(ghost.text ?? '') },
+			}
+		case 'note':
+			return {
+				id,
+				type: 'note',
+				x: ghost.x,
+				y: ghost.y,
+				props: { color, richText: toRichText(ghost.text ?? '') },
+			}
+		case 'arrow': {
+			const end = ghost.end ?? { x: ghost.x + 120, y: ghost.y }
+			return {
+				id,
+				type: 'arrow',
+				x: ghost.x,
+				y: ghost.y,
+				// Arrow start/end are relative to the shape's x/y.
+				props: { color, start: { x: 0, y: 0 }, end: { x: end.x - ghost.x, y: end.y - ghost.y } },
+			}
+		}
+	}
+}
+
+/** Build an update partial for an existing shape from a ghost change set. */
+function changesToShapePartial(
+	editor: Editor,
+	targetId: TLShapeId,
+	changes: Partial<GhostShape>
+): TLShapePartial | null {
+	const shape = editor.getShape(targetId)
+	if (!shape) return null
+
+	const isUI = shape.type === UI_COMPONENT_TYPE
+	const props: Record<string, unknown> = {}
+	if (changes.color) {
+		// Built-in shapes take a color-name style; the custom shape takes a hex accent.
+		if (isUI) props.accent = hexOf(changes.color)
+		else props.color = changes.color as GhostColor
+	}
+	if (changes.text !== undefined) {
+		if (isUI) props.label = changes.text
+		else if ('richText' in (shape.props as object)) props.richText = toRichText(changes.text)
+	}
+	if (changes.w !== undefined && 'w' in (shape.props as object)) props.w = changes.w
+	if (changes.h !== undefined && 'h' in (shape.props as object)) props.h = changes.h
+
+	return {
+		id: targetId,
+		type: shape.type,
+		...(changes.x !== undefined ? { x: changes.x } : {}),
+		...(changes.y !== undefined ? { y: changes.y } : {}),
+		...(Object.keys(props).length > 0 ? { props } : {}),
+	} as TLShapePartial
+}


### PR DESCRIPTION
Simple example for how you could have an agent render suggested shapes onto the canvas and then let a user accept or reject the changes