### PR TITLE
feature(examples): midi sequencer

### DIFF
--- a/apps/examples/src/examples/use-cases/midi-sequencer/MidiSequencerExample.tsx
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/MidiSequencerExample.tsx
@@ -1,0 +1,205 @@
+import { ReactNode, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import {
+	DefaultToolbar,
+	DefaultToolbarContent,
+	TLComponents,
+	TLUiComponents,
+	TLUiOverrides,
+	Tldraw,
+	createShapeId,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { MidiEngine } from './engine/MidiEngine'
+import { ChainIcon, SequenceIcon } from './icons'
+import { ChainShapeTool, ChainShapeUtil } from './shapes/ChainShapeUtil'
+import { SequenceShapeTool, SequenceShapeUtil } from './shapes/SequenceShapeUtil'
+import { CHAIN_TYPE, SEQUENCE_TYPE } from './shapes/shared'
+import { registerEngineSync } from './syncEngine'
+import { TransportPanel } from './TransportPanel'
+import './midi-sequencer.css'
+
+// [1]
+const shapeUtils = [SequenceShapeUtil, ChainShapeUtil]
+const tools = [SequenceShapeTool, ChainShapeTool]
+
+// [2]
+const overrides: TLUiOverrides = {
+	tools(editor, schema) {
+		schema[SEQUENCE_TYPE] = {
+			id: SEQUENCE_TYPE,
+			label: 'Sequence',
+			icon: 'tool-note',
+			kbd: 'q',
+			onSelect: () => editor.setCurrentTool(SEQUENCE_TYPE),
+		}
+		schema[CHAIN_TYPE] = {
+			id: CHAIN_TYPE,
+			label: 'Chain',
+			icon: 'tool-frame',
+			kbd: 'w',
+			onSelect: () => editor.setCurrentTool(CHAIN_TYPE),
+		}
+		return schema
+	},
+}
+
+const DRAG_THRESHOLD = 8
+
+// A toolbar button you can either click (to select the tool and draw) or drag
+// onto the canvas to drop a shape where you release. Native HTML5 drag gets
+// swallowed inside the editor, so — like tldraw's drag-and-drop-tray example —
+// we drive this with pointer capture instead.
+function ToolButton({
+	type,
+	label,
+	children,
+}: {
+	type: typeof SEQUENCE_TYPE | typeof CHAIN_TYPE
+	label: string
+	children: ReactNode
+}) {
+	const editor = useEditor()
+	const selected = useValue('current tool', () => editor.getCurrentToolId() === type, [
+		editor,
+		type,
+	])
+	const start = useRef<{ x: number; y: number } | null>(null)
+	const dragging = useRef(false)
+	const [preview, setPreview] = useState<{ x: number; y: number } | null>(null)
+
+	const onPointerDown = (e: React.PointerEvent) => {
+		e.preventDefault()
+		e.stopPropagation()
+		try {
+			;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+		} catch {
+			// ignore environments without pointer capture
+		}
+		start.current = { x: e.clientX, y: e.clientY }
+		dragging.current = false
+	}
+
+	const onPointerMove = (e: React.PointerEvent) => {
+		const s = start.current
+		if (!s) return
+		if (!dragging.current && Math.hypot(e.clientX - s.x, e.clientY - s.y) > DRAG_THRESHOLD) {
+			dragging.current = true
+		}
+		if (dragging.current) setPreview({ x: e.clientX, y: e.clientY })
+	}
+
+	const onPointerUp = (e: React.PointerEvent) => {
+		;(e.currentTarget as HTMLElement).releasePointerCapture?.(e.pointerId)
+		if (dragging.current) {
+			const point = editor.screenToPage({ x: e.clientX, y: e.clientY })
+			const { w, h } = editor.getShapeUtil(type).getDefaultProps() as { w: number; h: number }
+			const id = createShapeId()
+			editor.markHistoryStoppingPoint('create from toolbar')
+			editor.createShape({ id, type, x: point.x - w / 2, y: point.y - h / 2 })
+			editor.select(id)
+			editor.setCurrentTool('select')
+		} else {
+			// A plain click selects the tool so you can draw.
+			editor.setCurrentTool(type)
+		}
+		start.current = null
+		dragging.current = false
+		setPreview(null)
+	}
+
+	return (
+		<>
+			<div
+				className={`midi-tool-button ${selected ? 'is-selected' : ''}`}
+				role="button"
+				tabIndex={0}
+				title={`${label} — drag onto the canvas, or click then draw`}
+				onPointerDown={onPointerDown}
+				onPointerMove={onPointerMove}
+				onPointerUp={onPointerUp}
+			>
+				{children}
+			</div>
+			{preview &&
+				createPortal(
+					<div className="midi-tool-drag-preview" style={{ left: preview.x, top: preview.y }}>
+						{children}
+					</div>,
+					document.body
+				)}
+		</>
+	)
+}
+
+// [3]
+const components: TLUiComponents & TLComponents = {
+	TopPanel: TransportPanel,
+	Toolbar: (props) => (
+		<DefaultToolbar {...props}>
+			<ToolButton type={SEQUENCE_TYPE} label="Sequence">
+				<SequenceIcon />
+			</ToolButton>
+			<ToolButton type={CHAIN_TYPE} label="Chain">
+				<ChainIcon />
+			</ToolButton>
+			<DefaultToolbarContent />
+		</DefaultToolbar>
+	),
+}
+
+export default function MidiSequencerExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				persistenceKey="midi-sequencer-2"
+				shapeUtils={shapeUtils}
+				tools={tools}
+				overrides={overrides}
+				components={components}
+				onMount={(editor) => {
+					const cleanup = registerEngineSync(editor)
+					editor.disposables.add(cleanup)
+					// Request Web MIDI up front so outputs (e.g. the IAC Driver) populate.
+					MidiEngine.get(editor).enableMidi()
+
+					// Space toggles the transport. Captured before tldraw's space-pan,
+					// but ignored while typing in a field.
+					const onKeyDown = (e: KeyboardEvent) => {
+						if (e.code !== 'Space' || e.repeat) return
+						const t = e.target as HTMLElement | null
+						const tag = t?.tagName
+						if (t?.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+							return
+						}
+						e.preventDefault()
+						e.stopPropagation()
+						MidiEngine.get(editor).togglePlay()
+					}
+					window.addEventListener('keydown', onKeyDown, { capture: true })
+					editor.disposables.add(() =>
+						window.removeEventListener('keydown', onKeyDown, { capture: true })
+					)
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+[1] Two custom shapes: a Sequence (a step pattern with a playhead, its own MIDI
+channel, clock source and chain-advance rules) and a Chain (a lane that plays the
+sequences inside it). The master clock lives in the engine (./engine), a
+TypeScript port of kaneel/midiseq; tempo is stored in the document's meta.
+
+[2] Register the tools in the UI schema so they appear in the toolbar.
+
+[3] TopPanel hosts global transport (play/stop, BPM) + MIDI output selection and
+song save/open. Each sequence picks its own clock source (the master tick, or
+another chain/sequence's note events) from selectors in its footer.
+
+[4] The toolbar items support pointer-drag-to-create (ToolButton): drag one onto
+the canvas to drop that shape where you release, or click it and draw as usual.
+*/

--- a/apps/examples/src/examples/use-cases/midi-sequencer/README.md
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/README.md
@@ -1,0 +1,43 @@
+---
+title: MIDI sequencer
+component: ./MidiSequencerExample.tsx
+category: use-cases
+priority: 5
+keywords: [midi, sequencer, music, audio, web midi, timeline, playhead]
+---
+
+A canvas-based MIDI sequencer built from custom shapes and a tick-driven engine.
+
+---
+
+This example turns tldraw into a node-based MIDI sequencer. It ports the
+event-bus engine from [kaneel/midiseq](https://github.com/kaneel/midiseq) to
+TypeScript and drives it from the canvas.
+
+There are two custom shapes:
+
+- **Sequence** – a step / piano-roll pattern with its own MIDI channel, trig
+  mode and a moving playhead along its timeline. Click cells to toggle notes.
+- **Chain** – a lane that plays the sequences placed inside it one at a time,
+  advancing to the next after a set number of loops. Drop sequence shapes inside
+  a chain to add them; their left-to-right order is the chain order.
+
+The engine mirrors kaneel's design: a central `EventBus`, a `Sequencer` that
+emits `Tick` events at a tempo (PPQ 480), `Sequence` objects whose playhead is
+advanced by those ticks, a `PlaybackManager` that schedules note-offs, and a
+`Chain` that forwards notes and switches active sequences on loop wrap. Shape
+props are the source of truth for configuration; the engine publishes transient
+runtime state (playheads, active sequence) through reactive atoms so the shapes
+re-render as the music plays.
+
+Use the top panel to start the transport and pick a Web MIDI output, and the
+Clock shape to set the tempo (BPM). Notes are sent out over Web MIDI only, so
+you need a Chromium-based browser and an output port.
+
+Because the whole song lives on the canvas (shapes and their props), "Save song"
+exports a `.tldr` file and "Open song" loads one back — the same format
+tldraw.com uses.
+
+To play into GarageBand on macOS: open Audio MIDI Setup, show the MIDI Studio,
+double-click the IAC Driver and tick "Device is online". The IAC Driver then
+appears as an output here, and GarageBand receives it on its track input.

--- a/apps/examples/src/examples/use-cases/midi-sequencer/TransportPanel.tsx
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/TransportPanel.tsx
@@ -1,0 +1,126 @@
+import { useRef } from 'react'
+import {
+	parseTldrawJsonFile,
+	serializeTldrawJsonBlob,
+	loadSnapshot,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import { MidiEngine } from './engine/MidiEngine'
+import { getSongBpm, setSongBpm, syncAllShapes } from './syncEngine'
+
+// Global transport + output selection + song save/open, shown in the top panel.
+export function TransportPanel() {
+	const editor = useEditor()
+	const engine = MidiEngine.get(editor)
+	const transport = useValue('transport', () => engine.transport.get(), [engine])
+	const midi = useValue('midi', () => engine.midi.get(), [engine])
+	const bpm = useValue('bpm', () => getSongBpm(editor), [editor])
+	const fileInput = useRef<HTMLInputElement>(null)
+
+	const saveSong = async () => {
+		const blob = await serializeTldrawJsonBlob(editor)
+		const url = URL.createObjectURL(blob)
+		const a = document.createElement('a')
+		a.href = url
+		a.download = 'song.tldr'
+		a.click()
+		URL.revokeObjectURL(url)
+	}
+
+	const openSong = async (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0]
+		e.target.value = '' // allow re-opening the same file
+		if (!file) return
+		const result = parseTldrawJsonFile({ schema: editor.store.schema, json: await file.text() })
+		if (!result.ok) {
+			// eslint-disable-next-line no-alert
+			window.alert('Could not open that file — it does not look like a tldraw song.')
+			return
+		}
+		loadSnapshot(editor.store, result.value.getStoreSnapshot())
+		// loadSnapshot replaces the store wholesale, so rebuild the engine from it.
+		syncAllShapes(editor)
+	}
+
+	return (
+		<div className="midi-transport tlui-menu">
+			<button
+				className={`midi-transport__play ${transport.playing ? 'is-playing' : ''}`}
+				onClick={() => engine.togglePlay()}
+			>
+				{transport.playing ? '■ Stop' : '▶ Play'}
+			</button>
+
+			<label className="midi-transport__bpm">
+				BPM
+				<input
+					type="number"
+					min={20}
+					max={300}
+					value={bpm}
+					onChange={(e) => setSongBpm(editor, Number(e.target.value) || 120)}
+				/>
+			</label>
+
+			<button
+				className="midi-transport__file"
+				onClick={saveSong}
+				title="Download this song as a .tldr file"
+			>
+				Save song
+			</button>
+			<button
+				className="midi-transport__file"
+				onClick={() => fileInput.current?.click()}
+				title="Open a .tldr song file"
+			>
+				Open song
+			</button>
+			<input
+				ref={fileInput}
+				type="file"
+				accept=".tldr,application/json"
+				style={{ display: 'none' }}
+				onChange={openSong}
+			/>
+
+			{!midi.supported ? (
+				<span className="midi-transport__warn">
+					Web MIDI not supported (use a Chromium browser)
+				</span>
+			) : !midi.enabled ? (
+				<button onClick={() => engine.enableMidi()}>Enable MIDI</button>
+			) : midi.outputs.length === 0 ? (
+				<span className="midi-transport__warn">
+					No MIDI outputs — enable the IAC Driver in Audio MIDI Setup, then turn on its input in
+					GarageBand
+				</span>
+			) : (
+				<label className="midi-transport__out">
+					Out
+					<select
+						value={midi.selectedId ?? ''}
+						onChange={(e) => engine.selectOutput(e.target.value)}
+					>
+						{midi.outputs.map((o) => (
+							<option key={o.id} value={o.id}>
+								{o.name}
+							</option>
+						))}
+					</select>
+				</label>
+			)}
+
+			{midi.enabled && (
+				<button
+					className="midi-transport__file"
+					onClick={() => engine.rescanMidi()}
+					title="Re-scan MIDI ports (e.g. after reopening GarageBand)"
+				>
+					Rescan
+				</button>
+			)}
+		</div>
+	)
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/Chain.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/Chain.ts
@@ -1,0 +1,174 @@
+import { EventBus } from './EventBus'
+import { NextAction, PlayAction, Sequence } from './Sequence'
+import { EventName } from './types'
+
+interface ForwardHandles {
+	noteOn: number
+	noteOff: number
+}
+
+/**
+ * Plays a list of sequences one at a time. Port of kaneel's Chain: it forwards
+ * each member's NoteOn/NoteOff under its own identity, and watches the active
+ * sequence's LoopWrap events to advance to the next sequence after a configured
+ * number of iterations.
+ */
+export class Chain {
+	private sequences: Sequence[] = []
+	private forwardHandles = new Map<Sequence, ForwardHandles>()
+
+	private activeSequence: Sequence | null = null
+	private activeIndex = 0
+	private playAction = PlayAction.None
+	private nextAction = NextAction.None
+	private targetIterations = 0
+	private wrapCount = 0
+	private advanceHandle = 0
+
+	constructor(
+		private eventBus: EventBus,
+		public readonly id: number
+	) {
+		this.eventBus.register(this)
+	}
+
+	get activeSequenceIndex() {
+		return this.activeSequence ? this.activeIndex : -1
+	}
+
+	get size() {
+		return this.sequences.length
+	}
+
+	addSequence(seq: Sequence) {
+		if (this.forwardHandles.has(seq)) return
+		this.sequences.push(seq)
+		this.subscribe(seq)
+	}
+
+	private subscribe(seq: Sequence) {
+		const noteOn = seq.addListener(EventName.NoteOn, (data) => {
+			this.eventBus.dispatchEvent(this, { name: EventName.NoteOn, data })
+		})
+		const noteOff = seq.addListener(EventName.NoteOff, (data) => {
+			this.eventBus.dispatchEvent(this, { name: EventName.NoteOff, data })
+		})
+		this.forwardHandles.set(seq, { noteOn, noteOff })
+	}
+
+	// Reconcile the chain's membership to `next` in order, keeping the chain's
+	// identity stable so anything listening to the chain's events stays bound,
+	// and without interrupting the active sequence when unrelated members change.
+	setMembers(next: Sequence[]) {
+		const nextSet = new Set(next)
+		for (const seq of [...this.sequences]) {
+			if (!nextSet.has(seq)) this.removeSequence(seq)
+		}
+		for (const seq of next) {
+			if (!this.forwardHandles.has(seq)) this.subscribe(seq)
+		}
+		this.sequences = [...next]
+		if (this.activeSequence) {
+			const idx = this.sequences.indexOf(this.activeSequence)
+			if (idx === -1) {
+				this.clearAdvanceSubscription()
+				this.activeSequence = null
+			} else {
+				this.activeIndex = idx
+			}
+		}
+	}
+
+	removeSequence(seq: Sequence) {
+		const handles = this.forwardHandles.get(seq)
+		if (handles) {
+			seq.removeListener(EventName.NoteOn, handles.noteOn)
+			seq.removeListener(EventName.NoteOff, handles.noteOff)
+			this.forwardHandles.delete(seq)
+		}
+
+		if (this.activeSequence === seq) {
+			this.clearAdvanceSubscription()
+			this.activeSequence = null
+		}
+
+		this.sequences = this.sequences.filter((s) => s !== seq)
+	}
+
+	private clearAdvanceSubscription() {
+		if (this.activeSequence && this.advanceHandle) {
+			this.activeSequence.removeListener(EventName.LoopWrap, this.advanceHandle)
+		}
+		this.advanceHandle = 0
+	}
+
+	setActiveSequence(index: number) {
+		if (index < 0 || index >= this.sequences.length) return
+		const seq = this.sequences[index]
+		if (!seq) return
+
+		this.clearAdvanceSubscription()
+
+		this.activeIndex = index
+		this.activeSequence = seq
+		this.activeSequence.restart()
+
+		this.playAction = seq.playActionValue
+		this.nextAction = seq.nextActionValue
+		this.targetIterations = seq.nextTimingValue
+		this.wrapCount = 0
+
+		if (this.playAction === PlayAction.LoopIteration && this.targetIterations > 0) {
+			this.advanceHandle = this.activeSequence.addListener(EventName.LoopWrap, () => {
+				if (++this.wrapCount >= this.targetIterations) {
+					this.setNextSequence()
+				}
+			})
+		}
+	}
+
+	setNextSequence() {
+		if (!this.activeSequence) return
+		this.activeSequence.stop()
+
+		let target = this.activeIndex
+		switch (this.nextAction) {
+			case NextAction.Next:
+				target = this.activeIndex + 1
+				break
+			case NextAction.Previous:
+				target = this.activeIndex - 1
+				break
+			case NextAction.First:
+				target = 0
+				break
+			case NextAction.Last:
+				target = this.sequences.length - 1
+				break
+			case NextAction.None:
+				target = this.activeIndex + 1
+				break
+		}
+
+		if (target < 0) target = this.sequences.length - 1
+		if (target >= this.sequences.length) target = 0
+
+		this.setActiveSequence(target)
+	}
+
+	stop() {
+		this.clearAdvanceSubscription()
+		this.activeSequence?.stop()
+		this.activeSequence = null
+	}
+
+	dispose() {
+		this.clearAdvanceSubscription()
+		for (const [seq, handles] of this.forwardHandles) {
+			seq.removeListener(EventName.NoteOn, handles.noteOn)
+			seq.removeListener(EventName.NoteOff, handles.noteOff)
+		}
+		this.forwardHandles.clear()
+		this.eventBus.unregister(this)
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/EventBus.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/EventBus.ts
@@ -1,0 +1,64 @@
+import { EventListener, EventName, MidiEvent } from './types'
+
+// Anything that emits or receives events is identified by its object identity,
+// just like the EventBusDelegate pointers in the C++ source.
+export type EventBusDelegate = object
+
+type ListenerMap = Map<number, EventListener>
+type Listeners = Map<EventName, ListenerMap>
+
+/**
+ * Central publish/subscribe hub. A direct port of kaneel/midiseq's EventBus:
+ * listeners are keyed by (delegate, eventName) and dispatch snapshots so that
+ * handlers can safely mutate subscriptions while an event is in flight.
+ */
+export class EventBus {
+	private delegates = new Map<EventBusDelegate, Listeners>()
+	private nextId = 1
+
+	register(delegate: EventBusDelegate) {
+		if (!this.delegates.has(delegate)) {
+			this.delegates.set(delegate, new Map())
+		}
+	}
+
+	addListener(delegate: EventBusDelegate, event: EventName, listener: EventListener): number {
+		let listeners = this.delegates.get(delegate)
+		if (!listeners) {
+			listeners = new Map()
+			this.delegates.set(delegate, listeners)
+		}
+		let slot = listeners.get(event)
+		if (!slot) {
+			slot = new Map()
+			listeners.set(event, slot)
+		}
+		const id = this.nextId++
+		slot.set(id, listener)
+		return id
+	}
+
+	removeListener(delegate: EventBusDelegate, event: EventName, id: number) {
+		const listeners = this.delegates.get(delegate)
+		if (!listeners) return
+		const slot = listeners.get(event)
+		if (!slot) return
+		slot.delete(id)
+	}
+
+	dispatchEvent(delegate: EventBusDelegate, event: MidiEvent) {
+		const listeners = this.delegates.get(delegate)
+		if (!listeners) return
+		const slot = listeners.get(event.name)
+		if (!slot) return
+		// Snapshot before calling so listeners can add/remove during dispatch.
+		const snapshot = Array.from(slot.values())
+		for (const listener of snapshot) {
+			listener(event.data)
+		}
+	}
+
+	unregister(delegate: EventBusDelegate) {
+		this.delegates.delete(delegate)
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/MidiEngine.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/MidiEngine.ts
@@ -1,0 +1,394 @@
+import { Atom, atom, Editor } from 'tldraw'
+import { Chain } from './Chain'
+import { EventBus } from './EventBus'
+import { MidiDelegate, MidiOutput } from './MidiOutput'
+import { PlaybackManager } from './PlaybackManager'
+import { NextAction, PlayAction, Sequence, TrigMode } from './Sequence'
+import { Sequencer } from './Sequencer'
+import { EventName, makeNote } from './types'
+
+export interface NoteCell {
+	step: number
+	pitch: number
+	velocity: number
+	length: number
+	probability?: number
+	ratchet?: number
+}
+
+export type ClockEvent = 'tick' | 'noteOn' | 'noteOff'
+
+export interface SequenceConfig {
+	channel: number
+	steps: number
+	stepper: number
+	trigMode: TrigMode
+	enabled: boolean
+	solo: boolean
+	notes: NoteCell[]
+	nextAction: NextAction
+	nextAfterLoops: number
+	// '' / the clock => sequencer tick; otherwise a chain shape id + its event.
+	clockSourceId: string
+	clockEvent: ClockEvent
+}
+
+export interface ChainConfig {
+	sequenceIds: string[]
+}
+
+interface TransportState {
+	playing: boolean
+	bpm: number
+}
+
+interface MidiState {
+	supported: boolean
+	enabled: boolean
+	outputs: { id: string; name: string }[]
+	selectedId: string | null
+}
+
+function nowMicros() {
+	return performance.now() * 1000
+}
+
+/**
+ * Orchestrates the ported engine and bridges it to tldraw's reactive store.
+ * Shape props are the source of truth for configuration; this class mirrors
+ * them into live Sequence/Chain objects and publishes transient runtime state
+ * (playheads, active sequence, transport) through @tldraw/state atoms so the
+ * shapes can render reactively. It also acts as the MidiDelegate, sending notes
+ * to the selected Web MIDI output (e.g. the macOS IAC Driver into GarageBand).
+ */
+export class MidiEngine implements MidiDelegate {
+	readonly eventBus = new EventBus()
+	readonly sequencer = new Sequencer(this.eventBus)
+	readonly playbackManager = new PlaybackManager()
+	readonly midiOutput = new MidiOutput(this.eventBus)
+
+	private sequences = new Map<string, Sequence>()
+	private sequenceConfigs = new Map<string, SequenceConfig>()
+	private chains = new Map<string, Chain>()
+	private chainConfigs = new Map<string, ChainConfig>()
+	private sequenceToChain = new Map<string, string>()
+	private nextId = 1
+
+	readonly playheads: Atom<Record<string, number>> = atom('midi:playheads', {})
+	readonly activeChainIndex: Atom<Record<string, number>> = atom('midi:activeChain', {})
+	readonly transport: Atom<TransportState> = atom('midi:transport', { playing: false, bpm: 120 })
+	readonly midi: Atom<MidiState> = atom('midi:state', {
+		supported: typeof navigator !== 'undefined' && 'requestMIDIAccess' in navigator,
+		enabled: false,
+		outputs: [],
+		selectedId: null,
+	})
+
+	private raf = 0
+	private disposed = false
+
+	constructor() {
+		this.eventBus.addListener(this.sequencer, EventName.Tick, () =>
+			this.playbackManager.pollPlaybacks()
+		)
+		const cut = () => {
+			this.playbackManager.cutAll()
+			this.midiOutput.allNotesOff()
+		}
+		this.eventBus.addListener(this.sequencer, EventName.TransportStop, cut)
+		this.eventBus.addListener(this.sequencer, EventName.TransportPause, cut)
+		this.loop()
+	}
+
+	private loop() {
+		if (this.disposed) return
+		// Never let an error (e.g. sending to a port that just disconnected) kill
+		// the clock — always reschedule the next frame.
+		try {
+			this.sequencer.run(nowMicros())
+			this.publishRuntimeState()
+		} catch (err) {
+			console.error('[midi] clock loop error', err)
+		}
+		this.raf = requestAnimationFrame(() => this.loop())
+	}
+
+	private publishRuntimeState() {
+		if (!this.sequencer.isPlaying) return
+		const next: Record<string, number> = {}
+		for (const [id, seq] of this.sequences) next[id] = seq.playheadPosition
+		this.playheads.set(next)
+
+		const activeNext: Record<string, number> = {}
+		for (const [id, chain] of this.chains) activeNext[id] = chain.activeSequenceIndex
+		this.activeChainIndex.set(activeNext)
+	}
+
+	// --- MidiDelegate (output routing) --------------------------------------
+
+	sendNoteOn(pitch: number, velocity: number, channel: number) {
+		this.midiOutput.sendNoteOn(pitch, velocity, channel)
+	}
+
+	sendNoteOff(pitch: number, velocity: number, channel: number) {
+		this.midiOutput.sendNoteOff(pitch, velocity, channel)
+	}
+
+	// --- transport -----------------------------------------------------------
+
+	setBpm(bpm: number) {
+		this.sequencer.setBPM(bpm)
+		this.transport.update((t) => ({ ...t, bpm }))
+	}
+
+	togglePlay() {
+		if (this.sequencer.isPlaying) this.stop()
+		else this.play()
+	}
+
+	play() {
+		this.recomputeMutes()
+		this.sequencer.play(nowMicros())
+		// Standalone sequences all start; mute/solo decides what's audible.
+		for (const [id, seq] of this.sequences) {
+			if (this.sequenceToChain.has(id)) continue
+			seq.restart()
+		}
+		for (const chain of this.chains.values()) {
+			if (chain.size > 0) chain.setActiveSequence(0)
+		}
+		this.transport.update((t) => ({ ...t, playing: true }))
+	}
+
+	// Mute = not enabled. Solo = if any sequence is soloed, only soloed ones sound.
+	private recomputeMutes() {
+		let anySolo = false
+		for (const cfg of this.sequenceConfigs.values()) {
+			if (cfg.solo) {
+				anySolo = true
+				break
+			}
+		}
+		for (const [id, seq] of this.sequences) {
+			const cfg = this.sequenceConfigs.get(id)
+			if (!cfg) continue
+			seq.setMuted(anySolo ? !cfg.solo : !cfg.enabled)
+		}
+	}
+
+	stop() {
+		this.sequencer.stop()
+		for (const seq of this.sequences.values()) {
+			seq.stop()
+			seq.resetPlayhead()
+		}
+		for (const chain of this.chains.values()) chain.stop()
+		this.playbackManager.cutAll()
+		this.midiOutput.allNotesOff()
+		const cleared: Record<string, number> = {}
+		for (const id of this.sequences.keys()) cleared[id] = 0
+		this.playheads.set(cleared)
+		this.activeChainIndex.set({})
+		this.transport.update((t) => ({ ...t, playing: false }))
+	}
+
+	// --- midi output ---------------------------------------------------------
+
+	async enableMidi() {
+		try {
+			await this.midiOutput.requestAccess()
+			this.midiOutput.onStateChange(() => this.refreshOutputs())
+			this.midi.update((m) => ({ ...m, enabled: true }))
+			this.refreshOutputs()
+		} catch {
+			this.midi.update((m) => ({ ...m, supported: this.midiOutput.isSupported, enabled: false }))
+		}
+	}
+
+	// Re-request MIDI access and re-read the available output ports. Useful after
+	// closing/reopening an app like GarageBand, whose virtual port disappears and
+	// comes back (possibly with a new id).
+	async rescanMidi() {
+		await this.enableMidi()
+	}
+
+	private refreshOutputs() {
+		const outputs = this.midiOutput.listOutputs().map((o) => ({ id: o.id, name: o.name ?? o.id }))
+		// Keep the current selection if still present, else fall back to the
+		// first available output (e.g. the IAC Driver into GarageBand).
+		let selectedId = this.midi.get().selectedId
+		if (!selectedId || !outputs.some((o) => o.id === selectedId)) {
+			selectedId = outputs[0]?.id ?? null
+		}
+		if (selectedId) this.midiOutput.selectOutput(selectedId)
+		this.midi.update((m) => ({ ...m, outputs, selectedId }))
+	}
+
+	selectOutput(id: string) {
+		this.midiOutput.selectOutput(id || null)
+		this.midi.update((m) => ({ ...m, selectedId: id || null }))
+	}
+
+	// --- sequence reconciliation --------------------------------------------
+
+	upsertSequence(id: string, config: SequenceConfig) {
+		let seq = this.sequences.get(id)
+		if (!seq) {
+			seq = new Sequence(this.eventBus, this, this.playbackManager, this.nextId++)
+			this.sequences.set(id, seq)
+		}
+		this.sequenceConfigs.set(id, config)
+		this.applySequenceConfig(seq, config)
+		this.refreshClockSources()
+		this.recomputeMutes()
+
+		if (this.sequencer.isPlaying && !this.sequenceToChain.has(id)) {
+			seq.play()
+		}
+	}
+
+	private applySequenceConfig(seq: Sequence, config: SequenceConfig) {
+		const totalTicks = config.steps * config.stepper
+		seq.setStepper(config.stepper)
+		seq.setLength(totalTicks)
+		seq.setLoopRange(0, totalTicks)
+		seq.loop(true)
+		seq.setChannel(config.channel)
+		seq.setTrigMode(config.trigMode)
+		seq.setNextAction(config.nextAction, PlayAction.LoopIteration, config.nextAfterLoops)
+
+		seq.clearNotes()
+		for (const cell of config.notes) {
+			seq.addNote(
+				cell.step * config.stepper,
+				makeNote(cell.pitch, cell.velocity, cell.length, cell.probability, cell.ratchet)
+			)
+		}
+	}
+
+	removeSequence(id: string) {
+		const seq = this.sequences.get(id)
+		if (!seq) return
+		for (const chain of this.chains.values()) chain.removeSequence(seq)
+		seq.dispose()
+		this.sequences.delete(id)
+		this.sequenceConfigs.delete(id)
+		this.sequenceToChain.delete(id)
+		this.refreshClockSources()
+		this.recomputeMutes()
+	}
+
+	// Bind every sequence's clock to its configured source: the master clock
+	// (tick), or the note events of another chain or sequence. Faithful to
+	// kaneel's SetClockSource.
+	private refreshClockSources() {
+		for (const [id, seq] of this.sequences) {
+			const cfg = this.sequenceConfigs.get(id)
+			if (!cfg) continue
+			if (cfg.clockEvent === 'tick') {
+				// Subdivide the master tick down to the step rate.
+				seq.setPulsesPerStep(cfg.stepper)
+				seq.setClockSource(this.sequencer, EventName.Tick)
+				continue
+			}
+			// The emitter can be a chain or another sequence. Each sparse event is
+			// a single step.
+			seq.setPulsesPerStep(1)
+			const emitter = this.chains.get(cfg.clockSourceId) ?? this.sequences.get(cfg.clockSourceId)
+			if (emitter && emitter !== seq) {
+				seq.setClockSource(
+					emitter,
+					cfg.clockEvent === 'noteOn' ? EventName.NoteOn : EventName.NoteOff
+				)
+			} else {
+				seq.clearClockSource()
+			}
+		}
+	}
+
+	getSequencePlayhead(id: string) {
+		return this.playheads.get()[id] ?? 0
+	}
+
+	// --- chain reconciliation -----------------------------------------------
+
+	upsertChain(id: string, config: ChainConfig) {
+		this.chainConfigs.set(id, config)
+		let chain = this.chains.get(id)
+		if (!chain) {
+			chain = new Chain(this.eventBus, this.nextId++)
+			this.chains.set(id, chain)
+		}
+		const members = config.sequenceIds
+			.map((sid) => this.sequences.get(sid))
+			.filter((s): s is Sequence => !!s)
+		chain.setMembers(members)
+		this.recomputeSequenceToChain()
+		this.refreshClockSources()
+
+		if (this.sequencer.isPlaying && chain.size > 0 && chain.activeSequenceIndex === -1) {
+			chain.setActiveSequence(0)
+		}
+	}
+
+	removeChain(id: string) {
+		const chain = this.chains.get(id)
+		if (chain) {
+			chain.dispose()
+			this.chains.delete(id)
+		}
+		this.chainConfigs.delete(id)
+		this.recomputeSequenceToChain()
+		this.refreshClockSources()
+	}
+
+	private recomputeSequenceToChain() {
+		this.sequenceToChain.clear()
+		for (const [chainId, config] of this.chainConfigs) {
+			for (const seqId of config.sequenceIds) {
+				this.sequenceToChain.set(seqId, chainId)
+			}
+		}
+	}
+
+	getActiveChainIndex(id: string) {
+		return this.activeChainIndex.get()[id] ?? -1
+	}
+
+	// Tear down all sequences/chains. Used before rebuilding from a loaded song.
+	clear() {
+		this.stop()
+		for (const chain of this.chains.values()) chain.dispose()
+		for (const seq of this.sequences.values()) seq.dispose()
+		this.chains.clear()
+		this.sequences.clear()
+		this.chainConfigs.clear()
+		this.sequenceConfigs.clear()
+		this.sequenceToChain.clear()
+		this.playheads.set({})
+		this.activeChainIndex.set({})
+	}
+
+	dispose(editor: Editor) {
+		this.disposed = true
+		cancelAnimationFrame(this.raf)
+		this.stop()
+		for (const chain of this.chains.values()) chain.dispose()
+		for (const seq of this.sequences.values()) seq.dispose()
+		this.chains.clear()
+		this.sequences.clear()
+		MidiEngine.instances.delete(editor)
+	}
+
+	private static instances = new WeakMap<Editor, MidiEngine>()
+
+	static get(editor: Editor): MidiEngine {
+		let engine = MidiEngine.instances.get(editor)
+		if (!engine) {
+			engine = new MidiEngine()
+			MidiEngine.instances.set(editor, engine)
+			editor.disposables.add(() => engine!.dispose(editor))
+		}
+		return engine
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/MidiOutput.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/MidiOutput.ts
@@ -1,0 +1,104 @@
+import { EventBus } from './EventBus'
+import { EventName } from './types'
+
+const STATUS_NOTE_ON = 0x90
+const STATUS_NOTE_OFF = 0x80
+
+/**
+ * The thing a sequence talks to when it wants to make sound. Mirrors kaneel's
+ * MIDIDelegate, but uses the Web MIDI API and carries a per-note channel so the
+ * canvas can route different sequences to different instruments.
+ */
+export interface MidiDelegate {
+	sendNoteOn(pitch: number, velocity: number, channel: number): void
+	sendNoteOff(pitch: number, velocity: number, channel: number): void
+}
+
+/**
+ * Web MIDI implementation of the delegate. Also re-dispatches NoteOn/NoteOff on
+ * the bus under its own identity, like MIDIManager does in the C++ source, so
+ * other parts of the graph can react to "real" output.
+ */
+export class MidiOutput implements MidiDelegate {
+	private access: MIDIAccess | null = null
+	private port: MIDIOutput | null = null
+
+	constructor(private eventBus: EventBus) {
+		this.eventBus.register(this)
+	}
+
+	get isSupported() {
+		return typeof navigator !== 'undefined' && 'requestMIDIAccess' in navigator
+	}
+
+	get hasAccess() {
+		return !!this.access
+	}
+
+	async requestAccess(): Promise<MIDIOutput[]> {
+		if (!this.isSupported) throw new Error('Web MIDI is not supported in this browser.')
+		this.access = await navigator.requestMIDIAccess({ sysex: false })
+		const outputs = this.listOutputs()
+		// Default to the first available output, matching the C++ behaviour of
+		// opening port 0.
+		if (!this.port && outputs.length > 0) this.port = outputs[0]
+		return outputs
+	}
+
+	// Notify when devices/ports are connected or disconnected.
+	onStateChange(cb: () => void) {
+		if (this.access) this.access.onstatechange = cb
+	}
+
+	listOutputs(): MIDIOutput[] {
+		if (!this.access) return []
+		return Array.from(this.access.outputs.values())
+	}
+
+	selectOutput(id: string | null) {
+		if (!this.access || id === null) {
+			this.port = null
+			return
+		}
+		this.port = this.access.outputs.get(id) ?? null
+	}
+
+	get selectedOutputId() {
+		return this.port?.id ?? null
+	}
+
+	private send(status: number, channel: number, data1: number, data2: number) {
+		if (!this.port) return
+		const clampedChannel = Math.max(0, Math.min(15, channel))
+		try {
+			this.port.send([status | clampedChannel, data1 & 0x7f, data2 & 0x7f])
+		} catch {
+			// The port may have just disconnected (e.g. an app closed). Ignore;
+			// a rescan / reselect will restore output.
+		}
+	}
+
+	sendNoteOn(pitch: number, velocity: number, channel: number) {
+		this.send(STATUS_NOTE_ON, channel, pitch, velocity)
+		this.eventBus.dispatchEvent(this, { name: EventName.NoteOn, data: pitch })
+	}
+
+	sendNoteOff(pitch: number, velocity: number, channel: number) {
+		this.send(STATUS_NOTE_OFF, channel, pitch, velocity)
+		this.eventBus.dispatchEvent(this, { name: EventName.NoteOff, data: pitch })
+	}
+
+	// Send a note-off on every channel/pitch. Used when the transport stops so
+	// we never leave a hanging note.
+	allNotesOff() {
+		if (!this.port) return
+		try {
+			for (let channel = 0; channel < 16; channel++) {
+				// CC 123 = All Notes Off.
+				this.port.send([0xb0 | channel, 123, 0])
+			}
+		} catch {
+			// Port may have disconnected; ignore.
+		}
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/PlaybackManager.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/PlaybackManager.ts
@@ -1,0 +1,100 @@
+import { Note } from './types'
+
+const MAX_PLAYBACKS = 64
+
+type ExpireCallback = (note: Note) => void
+
+interface Playback {
+	note: Note | null
+	channel: number
+	remaining: number
+	isAllocated: boolean
+	onExpire: ExpireCallback | null
+}
+
+/**
+ * Fixed pool of note "voices". Port of kaneel's PlaybackManager: every fired
+ * note grabs a slot whose `remaining` counter is decremented once per tick, and
+ * the expire callback (which sends the note-off) fires when it hits zero.
+ */
+export class PlaybackManager {
+	private playbacks: Playback[] = Array.from({ length: MAX_PLAYBACKS }, () => ({
+		note: null,
+		channel: 0,
+		remaining: 0,
+		isAllocated: false,
+		onExpire: null,
+	}))
+
+	// Tick-counted callbacks, used to schedule ratchet retriggers.
+	private scheduled: { remaining: number; fn(): void }[] = []
+
+	schedule(delayTicks: number, fn: () => void) {
+		this.scheduled.push({ remaining: Math.max(1, Math.round(delayTicks)), fn })
+	}
+
+	assignPlayback(note: Note, channel: number, onExpire: ExpireCallback) {
+		for (const playback of this.playbacks) {
+			if (!playback.isAllocated) {
+				playback.note = note
+				playback.channel = channel
+				playback.remaining = note.length
+				playback.isAllocated = true
+				playback.onExpire = onExpire
+				return
+			}
+		}
+	}
+
+	pollPlaybacks() {
+		for (const playback of this.playbacks) {
+			if (!playback.isAllocated) continue
+			if (--playback.remaining <= 0) {
+				playback.onExpire?.(playback.note!)
+				playback.isAllocated = false
+				playback.onExpire = null
+				playback.note = null
+			}
+		}
+
+		if (this.scheduled.length > 0) {
+			const due: (() => void)[] = []
+			this.scheduled = this.scheduled.filter((s) => {
+				s.remaining--
+				if (s.remaining <= 0) {
+					due.push(s.fn)
+					return false
+				}
+				return true
+			})
+			for (const fn of due) fn()
+		}
+	}
+
+	cutAll() {
+		this.scheduled = []
+		for (const playback of this.playbacks) {
+			if (playback.isAllocated) {
+				playback.onExpire?.(playback.note!)
+				playback.isAllocated = false
+				playback.onExpire = null
+				playback.note = null
+			}
+		}
+	}
+
+	// Cut any playing note that shares this note's pitch on the same channel.
+	// Gives the mono-per-pitch retrigger behaviour from the C++ source, but
+	// scoped per channel so sequences on different channels don't cut each other.
+	findAndCut(note: Note, channel: number) {
+		for (const playback of this.playbacks) {
+			if (!playback.isAllocated || !playback.note) continue
+			if (playback.note.pitch === note.pitch && playback.channel === channel) {
+				playback.onExpire?.(playback.note)
+				playback.isAllocated = false
+				playback.onExpire = null
+				playback.note = null
+			}
+		}
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/Sequence.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/Sequence.ts
@@ -1,0 +1,310 @@
+import { EventBus, EventBusDelegate } from './EventBus'
+import { MidiDelegate } from './MidiOutput'
+import { PlaybackManager } from './PlaybackManager'
+import { EventListener, EventName, Note } from './types'
+
+export enum PlayAction {
+	None,
+	LoopIteration,
+	Bar,
+}
+
+export enum NextAction {
+	None,
+	Next,
+	Previous,
+	First,
+	Last,
+}
+
+export enum TrigMode {
+	AdvanceByOne,
+	AdvanceByStep,
+	AdvanceToNextNote,
+	Restart,
+	FireCurrent,
+}
+
+/**
+ * A single playable pattern. Port of kaneel's Sequence: notes live in a map
+ * keyed by tick position, a playhead is advanced by an external clock pulse
+ * (`trig`) according to the trig mode, and notes are fired through the MIDI
+ * delegate with note-offs scheduled by the playback manager.
+ */
+export class Sequence {
+	private startTick = 0
+	private lengthTicks = 0
+	private playhead = 0
+	private notes = new Map<number, Note[]>()
+	private active = false
+	private muted = false
+	private looping = false
+	private loopRange: [number, number] = [0, 0]
+	private stepper = 480
+	private channel = 0
+
+	private playAction = PlayAction.None
+	private nextAction = NextAction.None
+	private nextTiming = 0
+
+	private clockEmitter: EventBusDelegate | null = null
+	private clockEvent: EventName = EventName.Tick
+	private clockHandle = 0
+	private trigMode: TrigMode = TrigMode.AdvanceByOne
+	// Guards against synchronous feedback loops, e.g. a sequence that is a chain
+	// member and is also clocked by that chain's note events.
+	private isTriggering = false
+	// Step-based trig modes act once every `pulsesPerStep` clock pulses, so a
+	// high-resolution clock (the master tick) is subdivided down to the step
+	// rate. For sparse event clocks this is 1 (each event is one step).
+	private pulsesPerStep = 1
+	private pulseCounter = 0
+
+	constructor(
+		private eventBus: EventBus,
+		private delegate: MidiDelegate,
+		private playbackManager: PlaybackManager,
+		public readonly id: number
+	) {
+		this.eventBus.register(this)
+	}
+
+	get length() {
+		return this.lengthTicks
+	}
+	get playheadPosition() {
+		return this.playhead
+	}
+	get isActive() {
+		return this.active
+	}
+	get currentChannel() {
+		return this.channel
+	}
+	get playActionValue() {
+		return this.playAction
+	}
+	get nextActionValue() {
+		return this.nextAction
+	}
+	get nextTimingValue() {
+		return this.nextTiming
+	}
+
+	setLength(length: number) {
+		this.lengthTicks = length
+	}
+	setStart(startTick: number) {
+		this.startTick = startTick
+	}
+	setLoopRange(start: number, end: number) {
+		this.loopRange = [start, end]
+	}
+	setStepper(ticks: number) {
+		this.stepper = ticks
+	}
+	setChannel(channel: number) {
+		this.channel = channel
+	}
+	// Muted sequences keep advancing (staying in sync) but produce no sound.
+	setMuted(muted: boolean) {
+		this.muted = muted
+	}
+	setTrigMode(mode: TrigMode) {
+		this.trigMode = mode
+	}
+	// How many clock pulses make up one step (e.g. `stepper` ticks for the
+	// master clock, or 1 for a per-event clock).
+	setPulsesPerStep(pulses: number) {
+		this.pulsesPerStep = Math.max(1, Math.floor(pulses))
+	}
+	loop(enabled: boolean) {
+		this.looping = enabled
+	}
+
+	setNextAction(action: NextAction, playAction: PlayAction, timing: number) {
+		this.nextAction = action
+		this.playAction = playAction
+		this.nextTiming = timing
+	}
+
+	play() {
+		this.active = true
+	}
+	stop() {
+		this.active = false
+	}
+	pause() {
+		this.active = false
+	}
+
+	resetPlayhead() {
+		this.playhead = this.loopRange[0]
+		this.pulseCounter = 0
+	}
+
+	// Start playing from the loop start and immediately fire whatever sits on
+	// the first step, so the downbeat sounds right away instead of only after
+	// the first loop wrap.
+	restart() {
+		this.playhead = this.loopRange[0]
+		this.pulseCounter = 0
+		this.active = true
+		this.fireNotesAtPlayhead()
+	}
+
+	clearNotes() {
+		this.notes.clear()
+	}
+
+	addNote(position: number, note: Note) {
+		const existing = this.notes.get(position)
+		if (existing) {
+			existing.push(note)
+			return
+		}
+		this.notes.set(position, [note])
+	}
+
+	setClockSource(emitter: EventBusDelegate, event: EventName) {
+		this.clearClockSource()
+		this.clockEmitter = emitter
+		this.clockEvent = event
+		this.clockHandle = this.eventBus.addListener(emitter, event, () => this.trig())
+	}
+
+	clearClockSource() {
+		if (this.clockEmitter && this.clockHandle) {
+			this.eventBus.removeListener(this.clockEmitter, this.clockEvent, this.clockHandle)
+		}
+		this.clockEmitter = null
+		this.clockHandle = 0
+	}
+
+	addListener(event: EventName, listener: EventListener) {
+		return this.eventBus.addListener(this, event, listener)
+	}
+	removeListener(event: EventName, id: number) {
+		this.eventBus.removeListener(this, event, id)
+	}
+
+	// One pulse from the bound clock source.
+	trig() {
+		if (!this.active) return
+		// If firing a note re-enters trig() (a feedback cycle through the event
+		// bus), ignore the nested call rather than recursing forever.
+		if (this.isTriggering) return
+		this.isTriggering = true
+		try {
+			// "Advance by one" glides per pulse; the other modes step, so they only
+			// act once per step-duration (subdividing a high-resolution clock).
+			if (this.trigMode !== TrigMode.AdvanceByOne) {
+				if (++this.pulseCounter < this.pulsesPerStep) return
+				this.pulseCounter = 0
+			}
+			this.trigInner()
+		} finally {
+			this.isTriggering = false
+		}
+	}
+
+	private trigInner() {
+		let target = this.playhead
+		switch (this.trigMode) {
+			case TrigMode.AdvanceByOne:
+				target = this.playhead + 1
+				break
+			case TrigMode.AdvanceByStep:
+				target = this.playhead + this.stepper
+				break
+			case TrigMode.AdvanceToNextNote: {
+				const next = this.firstNoteAfter(this.playhead)
+				if (next === null) {
+					if (!this.looping || this.notes.size === 0) return
+					target = this.firstNotePosition()!
+				} else {
+					target = next
+				}
+				break
+			}
+			case TrigMode.Restart:
+				target = this.loopRange[0]
+				break
+			case TrigMode.FireCurrent:
+				break
+		}
+
+		this.advanceTo(target)
+	}
+
+	private firstNoteAfter(position: number): number | null {
+		let best: number | null = null
+		for (const key of this.notes.keys()) {
+			if (key > position && (best === null || key < best)) best = key
+		}
+		return best
+	}
+
+	private firstNotePosition(): number | null {
+		let best: number | null = null
+		for (const key of this.notes.keys()) {
+			if (best === null || key < best) best = key
+		}
+		return best
+	}
+
+	private advanceTo(target: number) {
+		let wrapped = false
+		if (this.looping && target >= this.loopRange[1]) {
+			const span = this.loopRange[1] - this.loopRange[0]
+			target =
+				span > 0 ? this.loopRange[0] + ((target - this.loopRange[0]) % span) : this.loopRange[0]
+			wrapped = true
+		}
+
+		this.playhead = target
+		this.fireNotesAtPlayhead()
+
+		if (wrapped) {
+			this.eventBus.dispatchEvent(this, { name: EventName.LoopWrap, data: this.id })
+		}
+	}
+
+	private fireNotesAtPlayhead() {
+		if (this.muted) return
+		const notes = this.notes.get(this.playhead)
+		if (!notes) return
+
+		for (const note of notes) {
+			// Probability: skip the whole note (and its ratchets) on a failed roll.
+			const probability = note.probability ?? 1
+			if (probability < 1 && Math.random() >= probability) continue
+
+			const ratchet = Math.max(1, Math.min(8, note.ratchet ?? 1))
+			const sub = Math.max(1, Math.floor(note.length / ratchet))
+
+			// One ratchet hit: a short note of length `sub`, cutting any previous
+			// hit on the same pitch/channel so rolls retrigger cleanly.
+			const hit = () => {
+				const h: Note = { pitch: note.pitch, velocity: note.velocity, length: sub }
+				this.playbackManager.findAndCut(h, this.channel)
+				this.delegate.sendNoteOn(h.pitch, h.velocity, this.channel)
+				this.eventBus.dispatchEvent(this, { name: EventName.NoteOn, data: h.pitch })
+				this.playbackManager.assignPlayback(h, this.channel, (expired) => {
+					this.delegate.sendNoteOff(expired.pitch, expired.velocity, this.channel)
+					this.eventBus.dispatchEvent(this, { name: EventName.NoteOff, data: expired.pitch })
+				})
+			}
+
+			hit()
+			for (let i = 1; i < ratchet; i++) {
+				this.playbackManager.schedule(i * sub, hit)
+			}
+		}
+	}
+
+	dispose() {
+		this.clearClockSource()
+		this.eventBus.unregister(this)
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/Sequencer.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/Sequencer.ts
@@ -1,0 +1,98 @@
+import { EventBus } from './EventBus'
+import { EventName, PPQ } from './types'
+
+function microsPerTick(bpm: number) {
+	return 60_000_000 / bpm / PPQ
+}
+
+/**
+ * The master clock / transport. Port of kaneel's Sequencer: `run(now)` is
+ * called with a microsecond timestamp and emits as many Tick events as have
+ * elapsed since the last call, so the tempo is decoupled from the frame rate.
+ */
+export class Sequencer {
+	private bpm = 120
+	private lastTick = 0
+	private microsPerTick = microsPerTick(120)
+	private positionTick = 0
+	private playing = false
+	private loopRange: [number, number] = [0, 0]
+	private loopEnabled = false
+
+	constructor(private eventBus: EventBus) {
+		this.eventBus.register(this)
+	}
+
+	get isPlaying() {
+		return this.playing
+	}
+
+	get bpmValue() {
+		return this.bpm
+	}
+
+	get position() {
+		return this.positionTick
+	}
+
+	setBPM(bpm: number) {
+		if (bpm <= 0) return
+		this.bpm = bpm
+		this.microsPerTick = microsPerTick(bpm)
+	}
+
+	setLoop(start: number, end: number) {
+		this.loopRange = [start, end]
+	}
+
+	loop(enabled: boolean) {
+		this.loopEnabled = enabled
+	}
+
+	play(now: number) {
+		this.lastTick = now
+		this.playing = true
+		this.eventBus.dispatchEvent(this, { name: EventName.TransportPlay, data: 0 })
+	}
+
+	pause() {
+		this.playing = false
+		this.eventBus.dispatchEvent(this, { name: EventName.TransportPause, data: 0 })
+	}
+
+	stop() {
+		this.playing = false
+		this.positionTick = 0
+		this.eventBus.dispatchEvent(this, { name: EventName.TransportStop, data: 0 })
+	}
+
+	run(now: number) {
+		if (!this.playing) {
+			this.lastTick = now
+			return
+		}
+
+		let delta = now - this.lastTick
+		const step = this.microsPerTick
+		if (delta < step) return
+
+		// If we fell badly behind (tab inactive, GC, a breakpoint), don't fire a
+		// flood of catch-up ticks all at once — that bunches notes and desyncs
+		// everything. Just resync the clock and carry on.
+		if (delta > 200_000) {
+			this.lastTick = now
+			return
+		}
+
+		while (delta >= step) {
+			delta -= step
+			this.eventBus.dispatchEvent(this, { name: EventName.Tick, data: this.positionTick++ })
+
+			if (this.loopEnabled && this.positionTick >= this.loopRange[1]) {
+				this.positionTick = this.loopRange[0]
+			}
+		}
+
+		this.lastTick = now - delta
+	}
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/engine/types.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/engine/types.ts
@@ -1,0 +1,50 @@
+// A faithful port of the event model from kaneel/midiseq (C++).
+// The whole engine talks through a small event bus that dispatches numeric
+// payloads under a named event, scoped to the emitter's identity.
+
+export enum EventName {
+	NoteOn,
+	NoteOff,
+	MidiMessage,
+	Tick,
+	LoopWrap,
+	TransportPlay,
+	TransportPause,
+	TransportStop,
+}
+
+export interface MidiEvent {
+	name: EventName
+	data: number
+}
+
+// Listeners receive the single numeric payload, exactly like the C++ version.
+export type EventListener = (data: number) => void
+
+// Pulses per quarter note. Matches the C++ sequencer (PPQ = 480).
+export const PPQ = 480
+export const QUARTER = PPQ
+export const EIGHTH = QUARTER / 2
+export const SIXTEENTH = QUARTER / 4
+
+// A single note. Length is measured in ticks (decremented once per tick by the
+// playback manager), matching kaneel's note.h.
+export interface Note {
+	pitch: number
+	velocity: number
+	length: number
+	// Chance (0..1) the note fires on a given pass, and how many evenly-spaced
+	// retriggers (ratchets) to play across its length.
+	probability?: number
+	ratchet?: number
+}
+
+export function makeNote(
+	pitch = 63,
+	velocity = 100,
+	length = 90,
+	probability = 1,
+	ratchet = 1
+): Note {
+	return { pitch, velocity, length, probability, ratchet }
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/icons.tsx
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/icons.tsx
@@ -1,0 +1,46 @@
+// Small inline icons for the Clock, Sequence and Chain shapes. They use
+// currentColor so they inherit the surrounding text color.
+
+export function ClockIcon({ size = 18 }: { size?: number }) {
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+		>
+			<circle cx="12" cy="12" r="9" />
+			<path d="M12 7v5l3.5 2.5" strokeLinecap="round" strokeLinejoin="round" />
+		</svg>
+	)
+}
+
+export function SequenceIcon({ size = 18 }: { size?: number }) {
+	// A few "notes" scattered on a grid, reading as a step/piano-roll pattern.
+	return (
+		<svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+			<rect x="3" y="5" width="7" height="3" rx="1.5" />
+			<rect x="12" y="10.5" width="7" height="3" rx="1.5" />
+			<rect x="6" y="16" width="7" height="3" rx="1.5" />
+		</svg>
+	)
+}
+
+export function ChainIcon({ size = 18 }: { size?: number }) {
+	// Two interlocking links.
+	return (
+		<svg
+			width={size}
+			height={size}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+		>
+			<rect x="3" y="8" width="11" height="8" rx="4" />
+			<rect x="10" y="8" width="11" height="8" rx="4" />
+		</svg>
+	)
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/midi-sequencer.css
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/midi-sequencer.css
@@ -1,0 +1,514 @@
+/* ---- Sequence shape ---- */
+.midi-seq {
+	pointer-events: all;
+	background: #1e2026;
+	border: 1px solid #3a3f4b;
+	border-radius: 8px;
+	overflow: hidden;
+	font-family: var(--tl-font-sans, system-ui, sans-serif);
+	color: #d7dbe3;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+}
+
+.midi-seq__header {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 0 6px;
+	background: #262a32;
+	border-bottom: 1px solid #3a3f4b;
+	font-size: 11px;
+}
+/* The header (minus its interactive controls) drags the whole shape. */
+.midi-seq__drag-handle {
+	cursor: move;
+}
+
+.midi-seq__power {
+	border: none;
+	background: transparent;
+	color: #6b7280;
+	font-size: 13px;
+	cursor: pointer;
+	padding: 2px;
+}
+.midi-seq__power.is-on {
+	color: #4ade80;
+}
+
+.midi-seq__solo {
+	border: 1px solid #3a3f4b;
+	background: #1b1d22;
+	color: #6b7280;
+	font-size: 9px;
+	font-weight: 700;
+	border-radius: 4px;
+	width: 16px;
+	height: 16px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0;
+}
+.midi-seq__solo.is-on {
+	background: #fbbf24;
+	color: #2a1c02;
+	border-color: #fbbf24;
+}
+
+.midi-seq__icon {
+	display: inline-flex;
+	color: #818cf8;
+}
+.midi-seq__name {
+	flex: 1 1 auto;
+	min-width: 0;
+	background: transparent;
+	border: none;
+	color: #e7eaf0;
+	font-size: 11px;
+	font-weight: 600;
+	outline: none;
+}
+.midi-seq__name--display {
+	cursor: move;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	user-select: none;
+}
+
+.midi-seq__field,
+.midi-seq__trig {
+	font-size: 10px;
+	color: #9aa3b2;
+}
+.midi-seq__field select,
+.midi-seq__trig {
+	background: #1b1d22;
+	color: #d7dbe3;
+	border: 1px solid #3a3f4b;
+	border-radius: 4px;
+	font-size: 10px;
+	margin-left: 3px;
+}
+
+.midi-seq__clear {
+	background: #1b1d22;
+	color: #9aa3b2;
+	border: 1px solid #3a3f4b;
+	border-radius: 4px;
+	font-size: 10px;
+	cursor: pointer;
+	padding: 2px 6px;
+}
+
+.midi-seq__body {
+	position: absolute;
+	display: flex;
+}
+
+.midi-seq__labels {
+	position: relative;
+	background: #16181d;
+	border-right: 1px solid #3a3f4b;
+}
+.midi-seq__label {
+	position: absolute;
+	right: 3px;
+	font-size: 7px;
+	color: #5b6374;
+	line-height: 1;
+}
+
+.midi-seq__footer {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	display: flex;
+	flex-wrap: wrap;
+	align-content: flex-start;
+	align-items: center;
+	gap: 4px 8px;
+	padding: 4px 6px;
+	background: #1b1d22;
+	border-top: 1px solid #3a3f4b;
+	font-size: 9px;
+	color: #8a93a3;
+	overflow-y: auto;
+}
+.midi-seq__gen {
+	gap: 3px;
+}
+.midi-seq__gen button {
+	background: #2c313a;
+	color: #cbd3e1;
+	border: 1px solid #3a3f4b;
+	border-radius: 4px;
+	font-size: 9px;
+	padding: 1px 5px;
+	cursor: pointer;
+}
+.midi-seq__gen button:hover {
+	border-color: #6366f1;
+}
+.midi-seq__foot-field {
+	display: flex;
+	align-items: center;
+	gap: 3px;
+}
+.midi-seq__foot-field select,
+.midi-seq__foot-field input {
+	background: #262a32;
+	color: #d7dbe3;
+	border: 1px solid #3a3f4b;
+	border-radius: 4px;
+	font-size: 9px;
+}
+.midi-seq__foot-field input {
+	width: 32px;
+}
+
+.midi-seq__grid {
+	position: absolute;
+	display: block;
+	cursor: crosshair;
+}
+.midi-seq__grid .row--white {
+	fill: #20242c;
+}
+.midi-seq__grid .row--black {
+	fill: #191c22;
+}
+.midi-seq__grid .row--root {
+	fill: #2d2541;
+}
+.midi-seq__grid .row--in {
+	fill: #20242c;
+}
+.midi-seq__grid .row--out {
+	fill: #15171c;
+}
+.midi-seq__grid .divider {
+	stroke: #2c313a;
+	stroke-width: 1;
+}
+.midi-seq__grid .divider--beat {
+	stroke: #444b58;
+	stroke-width: 1;
+}
+.midi-seq__grid .active-step {
+	fill: rgba(99, 102, 241, 0.12);
+}
+.midi-seq__grid .note {
+	fill: #6366f1;
+	stroke: #a5b4fc;
+	stroke-width: 0.5;
+	cursor: move;
+}
+.midi-seq__grid .note-g:hover .note {
+	fill: #818cf8;
+}
+.midi-seq__grid .note-ratchet {
+	stroke: #1b1d22;
+	stroke-width: 1;
+	pointer-events: none;
+}
+.midi-seq__grid .note-handle {
+	fill: #c7d2fe;
+	cursor: ew-resize;
+	opacity: 0;
+}
+.midi-seq__grid .note-g:hover .note-handle {
+	opacity: 1;
+}
+.midi-seq__grid .playhead {
+	stroke: #f472b6;
+	stroke-width: 1.5;
+}
+
+/* ---- Chain shape ---- */
+.midi-chain {
+	pointer-events: all;
+	background: rgba(34, 38, 47, 0.55);
+	border: 1.5px dashed #4b5563;
+	border-radius: 10px;
+	font-family: var(--tl-font-sans, system-ui, sans-serif);
+	color: #cbd3e1;
+	overflow: hidden;
+}
+
+.midi-chain__header {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 0 10px;
+	background: rgba(38, 42, 50, 0.9);
+	border-bottom: 1px solid #3a3f4b;
+	font-size: 12px;
+}
+.midi-chain__title {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	font-weight: 700;
+}
+.midi-chain__field {
+	font-size: 11px;
+	color: #9aa3b2;
+	pointer-events: all;
+}
+.midi-chain__field input {
+	width: 44px;
+	margin-left: 4px;
+	background: #1b1d22;
+	color: #d7dbe3;
+	border: 1px solid #3a3f4b;
+	border-radius: 4px;
+	font-size: 11px;
+	pointer-events: all;
+}
+.midi-chain__hint {
+	margin-left: auto;
+	font-size: 10px;
+	color: #6b7280;
+	font-style: italic;
+}
+
+.midi-chain__track {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 10px;
+	height: 30px;
+}
+.midi-chain__empty {
+	font-size: 11px;
+	color: #6b7280;
+}
+.midi-chain__pill {
+	pointer-events: all;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	padding: 3px 8px;
+	background: #262a32;
+	border: 1px solid #3a3f4b;
+	border-radius: 999px;
+	font-size: 11px;
+	color: #aeb6c4;
+}
+.midi-chain__pill:hover {
+	border-color: #6366f1;
+}
+.midi-chain__pill.is-active {
+	background: #6366f1;
+	border-color: #a5b4fc;
+	color: white;
+}
+.midi-chain__index {
+	font-size: 9px;
+	opacity: 0.7;
+}
+
+/* ---- Clock shape ---- */
+.midi-clock {
+	pointer-events: all;
+	background: #1e2026;
+	border: 1px solid #3a3f4b;
+	border-radius: 8px;
+	padding: 8px 10px;
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	font-family: var(--tl-font-sans, system-ui, sans-serif);
+	color: #d7dbe3;
+	box-shadow: 0 2px 10px rgba(0, 0, 0, 0.25);
+}
+.midi-clock__title {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 12px;
+	font-weight: 700;
+	color: #e7eaf0;
+}
+.midi-clock__row {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+.midi-clock__play {
+	width: 30px;
+	height: 26px;
+	border-radius: 6px;
+	border: 1px solid #3a3f4b;
+	background: #4ade80;
+	color: #0b1f12;
+	font-weight: 700;
+	cursor: pointer;
+}
+.midi-clock__play.is-playing {
+	background: #f87171;
+	color: #2a0b0b;
+}
+.midi-clock__bpm {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	color: #9aa3b2;
+}
+.midi-clock__bpm input {
+	width: 52px;
+	background: #16181d;
+	color: #d7dbe3;
+	border: 1px solid #3a3f4b;
+	border-radius: 4px;
+}
+.midi-clock__emitter {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+	font-size: 10px;
+	color: #8a93a3;
+}
+.midi-clock__emitter code {
+	color: #f472b6;
+}
+.midi-clock__dot {
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: #555;
+	display: inline-block;
+}
+.midi-clock__emitter.is-pulsing .midi-clock__dot {
+	background: #f472b6;
+	animation: midi-pulse 0.5s ease-out infinite;
+}
+@keyframes midi-pulse {
+	0% {
+		box-shadow: 0 0 0 0 rgba(244, 114, 182, 0.6);
+	}
+	100% {
+		box-shadow: 0 0 0 6px rgba(244, 114, 182, 0);
+	}
+}
+
+/* ---- Event-flow wires ---- */
+.midi-wires {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	overflow: visible;
+}
+.midi-wire__line {
+	stroke-width: 2;
+	stroke-linecap: round;
+	opacity: 0.7;
+}
+.midi-wire--tick .midi-wire__line {
+	stroke: #f472b6;
+}
+.midi-wire--note .midi-wire__line {
+	stroke: #4ade80;
+}
+.midi-wire.is-flowing .midi-wire__line {
+	stroke-dasharray: 6 8;
+	animation: midi-flow 0.6s linear infinite;
+}
+@keyframes midi-flow {
+	to {
+		stroke-dashoffset: -14;
+	}
+}
+.midi-wire__label-bg {
+	fill: #11131a;
+	stroke: #3a3f4b;
+	stroke-width: 1;
+}
+.midi-wire__label {
+	fill: #cbd3e1;
+	font-size: 10px;
+	font-family: var(--tl-font-sans, system-ui, sans-serif);
+}
+
+/* ---- Draggable toolbar items ---- */
+.midi-tool-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 48px;
+	height: 48px;
+	border-radius: 9px;
+	cursor: grab;
+	color: var(--color-text, #1d1d1d);
+}
+.midi-tool-button svg {
+	display: block;
+}
+.midi-tool-button:hover {
+	background: var(--color-muted-2, rgba(0, 0, 0, 0.05));
+}
+.midi-tool-button.is-selected {
+	background: var(--color-selected, #4263eb);
+	color: var(--color-selected-contrast, #fff);
+}
+.midi-tool-button:active {
+	cursor: grabbing;
+}
+.midi-tool-drag-preview {
+	position: fixed;
+	z-index: 99999;
+	pointer-events: none;
+	transform: translate(-50%, -50%);
+	color: var(--color-selected, #4263eb);
+	opacity: 0.85;
+}
+
+/* ---- Transport panel ---- */
+.midi-transport {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin: 8px;
+	padding: 6px 10px;
+	font-size: 12px;
+}
+.midi-transport__play {
+	font-weight: 700;
+	padding: 5px 12px;
+	border-radius: 6px;
+	border: 1px solid #3a3f4b;
+	background: #4ade80;
+	color: #0b1f12;
+	cursor: pointer;
+}
+.midi-transport__play.is-playing {
+	background: #f87171;
+	color: #2a0b0b;
+}
+.midi-transport__bpm,
+.midi-transport__out {
+	display: flex;
+	align-items: center;
+	gap: 5px;
+}
+.midi-transport__bpm input {
+	width: 56px;
+}
+.midi-transport__file {
+	padding: 5px 10px;
+	border-radius: 6px;
+	border: 1px solid #3a3f4b;
+	background: #2c313a;
+	color: #cbd3e1;
+	cursor: pointer;
+}
+.midi-transport__warn {
+	color: #f59e0b;
+	max-width: 280px;
+	font-size: 11px;
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/shapes/ChainShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/shapes/ChainShapeUtil.tsx
@@ -1,0 +1,169 @@
+import {
+	BaseBoxShapeTool,
+	BaseFrameLikeShapeUtil,
+	Editor,
+	Group2d,
+	HTMLContainer,
+	Rectangle2d,
+	T,
+	TLResizeInfo,
+	TLShape,
+	TLShapeId,
+	resizeBox,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import { MidiEngine } from '../engine/MidiEngine'
+import { ChainIcon } from '../icons'
+import { SequenceShape } from './SequenceShapeUtil'
+import { CHAIN_TYPE, HEADER_HEIGHT, SEQUENCE_TYPE } from './shared'
+
+interface ChainProps {
+	w: number
+	h: number
+	name: string
+}
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[CHAIN_TYPE]: ChainProps
+	}
+}
+
+export type ChainShape = TLShape<typeof CHAIN_TYPE>
+
+/**
+ * A chain's members are the sequence shapes parented to it (dropping a sequence
+ * inside the chain reparents it). Members are ordered left to right, which gives
+ * the chain its "timeline" of sequences.
+ */
+export function getChainMemberIds(editor: Editor, chain: ChainShape): TLShapeId[] {
+	const members: { id: TLShapeId; x: number }[] = []
+	for (const id of editor.getSortedChildIdsForParent(chain.id)) {
+		const shape = editor.getShape(id)
+		if (shape?.type !== SEQUENCE_TYPE) continue
+		const bounds = editor.getShapePageBounds(id)
+		members.push({ id, x: bounds ? bounds.minX : 0 })
+	}
+	return members.sort((a, b) => a.x - b.x).map((m) => m.id)
+}
+
+// The chain is a real frame-like container: it clips and parents its children,
+// requires full-brush selection, and carries its sequences when moved. We only
+// accept sequences as children; everything else comes from BaseFrameLikeShapeUtil.
+export class ChainShapeUtil extends BaseFrameLikeShapeUtil<ChainShape> {
+	static override type = CHAIN_TYPE
+	static override props = {
+		w: T.positiveNumber,
+		h: T.positiveNumber,
+		name: T.string,
+	}
+
+	override getDefaultProps(): ChainProps {
+		return { w: 820, h: 460, name: 'Chain' }
+	}
+
+	// Frame-like shapes need a Group2d geometry with a label child — the
+	// hit-tester iterates geometry.children for them.
+	override getGeometry(shape: ChainShape) {
+		return new Group2d({
+			children: [
+				new Rectangle2d({ width: shape.props.w, height: shape.props.h, isFilled: false }),
+				new Rectangle2d({
+					x: 0,
+					y: 0,
+					width: Math.min(shape.props.w, 160),
+					height: HEADER_HEIGHT,
+					isFilled: true,
+					isLabel: true,
+					excludeFromShapeBounds: true,
+				}),
+			],
+		})
+	}
+
+	override canReceiveNewChildrenOfType(shape: ChainShape, type: TLShape['type']) {
+		return !shape.isLocked && type === SEQUENCE_TYPE
+	}
+
+	// Resizing the chain must NOT scale the sequences inside it (the base frame
+	// class leaves this at the default `true`; only FrameShapeUtil opts out).
+	override canResizeChildren() {
+		return false
+	}
+
+	override onResize(shape: ChainShape, info: TLResizeInfo<ChainShape>) {
+		return resizeBox(shape, info, { minWidth: 280, minHeight: 160 })
+	}
+
+	override component(shape: ChainShape) {
+		return <ChainComponent shape={shape} />
+	}
+
+	override getIndicatorPath(shape: ChainShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+function ChainComponent({ shape }: { shape: ChainShape }) {
+	const editor = useEditor()
+	const engine = MidiEngine.get(editor)
+	const { w, h, name } = shape.props
+
+	const memberNames = useValue(
+		'chain members',
+		() => {
+			const ids = getChainMemberIds(editor, shape)
+			return ids.map((id) => {
+				const seq = editor.getShape(id) as SequenceShape | undefined
+				return { id, name: seq?.props.name ?? 'Sequence' }
+			})
+		},
+		[editor, shape]
+	)
+	const activeIndex = useValue('chain active', () => engine.getActiveChainIndex(shape.id), [
+		engine,
+		shape.id,
+	])
+
+	return (
+		<HTMLContainer className="midi-chain" style={{ width: w, height: h }}>
+			<div className="midi-chain__header" style={{ height: HEADER_HEIGHT }}>
+				<span className="midi-chain__title">
+					<ChainIcon size={14} /> {name}
+				</span>
+				<span className="midi-chain__hint">
+					drop sequences inside · each advances after its own loop count
+				</span>
+			</div>
+			<div className="midi-chain__track">
+				{memberNames.length === 0 ? (
+					<span className="midi-chain__empty">no sequences yet</span>
+				) : (
+					memberNames.map((m, i) => (
+						<button
+							key={m.id}
+							className={`midi-chain__pill ${i === activeIndex ? 'is-active' : ''}`}
+							title="Select this sequence"
+							onPointerDown={(e) => e.stopPropagation()}
+							onClick={(e) => {
+								e.stopPropagation()
+								editor.select(m.id)
+							}}
+						>
+							<span className="midi-chain__index">{i + 1}</span>
+							{m.name}
+						</button>
+					))
+				)}
+			</div>
+		</HTMLContainer>
+	)
+}
+
+export class ChainShapeTool extends BaseBoxShapeTool {
+	static override id = CHAIN_TYPE
+	override shapeType = CHAIN_TYPE as typeof CHAIN_TYPE
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/shapes/SequenceShapeUtil.tsx
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/shapes/SequenceShapeUtil.tsx
@@ -1,0 +1,805 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+	BaseBoxShapeTool,
+	BaseBoxShapeUtil,
+	HTMLContainer,
+	T,
+	TLResizeInfo,
+	TLShape,
+	resizeBox,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import { ClockEvent, MidiEngine } from '../engine/MidiEngine'
+import { SequenceIcon } from '../icons'
+import {
+	CHAIN_TYPE,
+	CLOCK_EVENT_OPTIONS,
+	DEFAULT_SEQUENCE_HEIGHT,
+	DEFAULT_SEQUENCE_WIDTH,
+	DEFAULT_STEPPER,
+	DEFAULT_STEPS,
+	FOOTER_HEIGHT,
+	HEADER_HEIGHT,
+	isBlackKey,
+	euclid,
+	isInScale,
+	LABEL_WIDTH,
+	NEXT_ACTION_OPTIONS,
+	NextActionId,
+	PITCH_COUNT,
+	PITCH_LOW,
+	pitchName,
+	pitchToRow,
+	ROOT_OPTIONS,
+	rowToPitch,
+	SCALE_OPTIONS,
+	ScaleId,
+	SEQUENCE_TYPE,
+	snapToScale,
+	STEP_RESOLUTION_OPTIONS,
+	TRIG_MODE_OPTIONS,
+	TrigModeId,
+} from './shared'
+
+export interface NoteCellProps {
+	step: number
+	pitch: number
+	velocity: number
+	length: number
+	probability?: number
+	ratchet?: number
+}
+
+// A simple shared clipboard for copying a note pattern between sequences.
+let copiedPattern: NoteCellProps[] | null = null
+
+interface SequenceProps {
+	w: number
+	h: number
+	name: string
+	channel: number
+	steps: number
+	stepper: number
+	trigMode: TrigModeId
+	enabled: boolean
+	solo: boolean
+	notes: NoteCellProps[]
+	// Chain advance: which sequence to go to, and after how many loops.
+	chainNext: NextActionId
+	chainAfter: number
+	// Clock source: the shape id of the emitter ('' = master clock) + its event.
+	clockSourceId: string
+	clockEvent: ClockEvent
+	// Scale lock: notes snap to this key + scale ('chromatic' = no snapping).
+	scaleRoot: number
+	scaleType: ScaleId
+}
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[SEQUENCE_TYPE]: SequenceProps
+	}
+}
+
+export type SequenceShape = TLShape<typeof SEQUENCE_TYPE>
+
+const noteValidator = T.object({
+	step: T.number,
+	pitch: T.number,
+	velocity: T.number,
+	length: T.number,
+	probability: T.number.optional(),
+	ratchet: T.number.optional(),
+})
+
+export class SequenceShapeUtil extends BaseBoxShapeUtil<SequenceShape> {
+	static override type = SEQUENCE_TYPE
+	static override props = {
+		w: T.positiveNumber,
+		h: T.positiveNumber,
+		name: T.string,
+		channel: T.number,
+		steps: T.positiveNumber,
+		stepper: T.positiveNumber,
+		trigMode: T.literalEnum('one', 'step', 'nextNote', 'restart'),
+		enabled: T.boolean,
+		solo: T.boolean,
+		notes: T.arrayOf(noteValidator),
+		chainNext: T.literalEnum('next', 'previous', 'first', 'last'),
+		chainAfter: T.positiveNumber,
+		clockSourceId: T.string,
+		clockEvent: T.literalEnum('tick', 'noteOn', 'noteOff'),
+		scaleRoot: T.number,
+		scaleType: T.literalEnum(
+			'chromatic',
+			'major',
+			'minor',
+			'dorian',
+			'mixolydian',
+			'pentatonicMajor',
+			'pentatonicMinor',
+			'harmonicMinor'
+		),
+	}
+
+	override getDefaultProps(): SequenceProps {
+		return {
+			w: DEFAULT_SEQUENCE_WIDTH,
+			h: DEFAULT_SEQUENCE_HEIGHT,
+			name: 'Sequence',
+			channel: 0,
+			steps: DEFAULT_STEPS,
+			stepper: DEFAULT_STEPPER,
+			trigMode: 'one',
+			enabled: true,
+			solo: false,
+			notes: [],
+			chainNext: 'next',
+			chainAfter: 2,
+			clockSourceId: '',
+			clockEvent: 'tick',
+			scaleRoot: 0,
+			scaleType: 'chromatic',
+		}
+	}
+
+	override canResize() {
+		return true
+	}
+
+	override onResize(shape: SequenceShape, info: TLResizeInfo<SequenceShape>) {
+		// Keep cells legible: don't let the grid get smaller than usable.
+		return resizeBox(shape, info, {
+			minWidth: LABEL_WIDTH + 160,
+			minHeight: HEADER_HEIGHT + FOOTER_HEIGHT + 80,
+		})
+	}
+
+	override component(shape: SequenceShape) {
+		return <SequenceComponent shape={shape} />
+	}
+
+	override getIndicatorPath(shape: SequenceShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+function SequenceComponent({ shape }: { shape: SequenceShape }) {
+	const editor = useEditor()
+	const engine = MidiEngine.get(editor)
+	const { w, h, steps, stepper, channel, notes, enabled, solo, name, trigMode } = shape.props
+	const { chainNext, chainAfter, clockSourceId, clockEvent, scaleRoot, scaleType } = shape.props
+
+	const snap = (pitch: number) => snapToScale(pitch, scaleRoot, scaleType)
+
+	const totalTicks = steps * stepper
+	const gridWidth = w - LABEL_WIDTH
+	const gridHeight = h - HEADER_HEIGHT - FOOTER_HEIGHT
+	const cellW = gridWidth / steps
+	const cellH = gridHeight / PITCH_COUNT
+
+	// Possible note-event emitters: any chain or any other sequence.
+	const emitters = useValue(
+		'emitters',
+		() =>
+			editor
+				.getCurrentPageShapes()
+				.filter((s) => (s.type === CHAIN_TYPE || s.type === SEQUENCE_TYPE) && s.id !== shape.id)
+				.map((s) => ({
+					id: s.id,
+					name: (s.props as { name: string }).name,
+					kind: s.type === CHAIN_TYPE ? 'chain' : 'sequence',
+				})),
+		[editor, shape.id]
+	)
+
+	// Reactive playhead from the engine, in ticks.
+	const playhead = useValue('playhead', () => engine.getSequencePlayhead(shape.id), [
+		engine,
+		shape.id,
+	])
+	const isPlaying = useValue('playing', () => engine.transport.get().playing, [engine])
+	const playheadX = totalTicks > 0 ? (playhead / totalTicks) * gridWidth : 0
+	const activeStep = stepper > 0 ? Math.floor(playhead / stepper) % steps : -1
+
+	const update = (props: Partial<SequenceProps>) => {
+		editor.updateShape({ id: shape.id, type: SEQUENCE_TYPE, props })
+	}
+
+	// Changing key/scale re-snaps every existing note so the pattern stays in key.
+	const changeScale = (next: Partial<Pick<SequenceProps, 'scaleRoot' | 'scaleType'>>) => {
+		const root = next.scaleRoot ?? scaleRoot
+		const type = next.scaleType ?? scaleType
+		update({
+			...next,
+			notes: notes.map((n) => ({ ...n, pitch: snapToScale(n.pitch, root, type) })),
+		})
+	}
+
+	// --- generators ----------------------------------------------------------
+	const [pulses, setPulses] = useState(4)
+	const [everyN, setEveryN] = useState(4)
+
+	// A root pitch near the middle of the grid to generate single-pitch lines on.
+	const linePitch = () => {
+		const mid = PITCH_LOW + Math.floor(PITCH_COUNT / 2)
+		return snap(mid)
+	}
+	const noteAt = (step: number, pitch: number): NoteCellProps => ({
+		step,
+		pitch,
+		velocity: 100,
+		length: stepper,
+	})
+
+	const fillEuclid = () => {
+		const pitch = linePitch()
+		const pattern = euclid(pulses, steps)
+		update({ notes: pattern.flatMap((on, i) => (on ? [noteAt(i, pitch)] : [])) })
+	}
+	const fillEvery = () => {
+		const pitch = linePitch()
+		const n = Math.max(1, everyN)
+		const out: NoteCellProps[] = []
+		for (let i = 0; i < steps; i += n) out.push(noteAt(i, pitch))
+		update({ notes: out })
+	}
+	const fillRandom = () => {
+		const out: NoteCellProps[] = []
+		for (let i = 0; i < steps; i++) {
+			if (Math.random() < 0.35) {
+				const row = Math.floor(Math.random() * PITCH_COUNT)
+				out.push(noteAt(i, snap(rowToPitch(row))))
+			}
+		}
+		update({ notes: out })
+	}
+
+	// Scroll over a note to set its ratchet count; shift+scroll for probability.
+	// A non-passive native listener lets us stop tldraw from zooming.
+	const svgRef = useRef<SVGSVGElement | null>(null)
+	useEffect(() => {
+		const el = svgRef.current
+		if (!el) return
+		const onWheel = (e: WheelEvent) => {
+			const rect = el.getBoundingClientRect()
+			const zoom = editor.getZoomLevel()
+			const localX = (e.clientX - rect.left) / zoom
+			const localY = (e.clientY - rect.top) / zoom
+			const row = Math.floor(localY / cellH)
+			let index = -1
+			for (let i = notes.length - 1; i >= 0; i--) {
+				const n = notes[i]
+				if (pitchToRow(n.pitch) !== row) continue
+				const x0 = n.step * cellW
+				const x1 = (n.step + n.length / stepper) * cellW
+				if (localX >= x0 - 2 && localX <= x1 + 5) {
+					index = i
+					break
+				}
+			}
+			if (index < 0) return
+			e.preventDefault()
+			e.stopPropagation()
+			const dir = e.deltaY < 0 ? 1 : -1
+			const list = notes.map((n) => ({ ...n }))
+			const n = list[index]
+			if (e.shiftKey) {
+				const p = Math.round(((n.probability ?? 1) + dir * 0.1) * 10) / 10
+				n.probability = Math.max(0.1, Math.min(1, p))
+			} else {
+				n.ratchet = Math.max(1, Math.min(8, (n.ratchet ?? 1) + dir))
+			}
+			editor.updateShape({ id: shape.id, type: SEQUENCE_TYPE, props: { notes: list } })
+		}
+		el.addEventListener('wheel', onWheel, { passive: false })
+		return () => el.removeEventListener('wheel', onWheel)
+	}, [editor, shape.id, cellW, cellH, stepper, notes])
+
+	// While dragging we render from a local draft so the whole gesture commits
+	// as a single shape update.
+	const [draftNotes, setDraftNotes] = useState<NoteCellProps[] | null>(null)
+	const drag = useRef<{
+		mode: 'move' | 'resize'
+		index: number
+		downStep: number
+		downRow: number
+		orig: NoteCellProps
+		moved: boolean
+		created: boolean
+	} | null>(null)
+
+	const renderNotes = draftNotes ?? notes
+	const stepsOf = (n: NoteCellProps) => n.length / stepper
+
+	const coords = (e: React.PointerEvent) => {
+		const rect = e.currentTarget.getBoundingClientRect()
+		const zoom = editor.getZoomLevel()
+		const localX = (e.clientX - rect.left) / zoom
+		const localY = (e.clientY - rect.top) / zoom
+		return { stepFloat: localX / cellW, row: Math.floor(localY / cellH), localX }
+	}
+
+	// Find a note under the pointer, and whether the pointer is near its right
+	// edge (for resizing).
+	const hitTest = (localX: number, row: number) => {
+		for (let i = renderNotes.length - 1; i >= 0; i--) {
+			const n = renderNotes[i]
+			if (pitchToRow(n.pitch) !== row) continue
+			const x0 = n.step * cellW
+			const x1 = (n.step + stepsOf(n)) * cellW
+			if (localX >= x0 - 2 && localX <= x1 + 5) {
+				return { index: i, onEdge: Math.abs(localX - x1) <= 6 }
+			}
+		}
+		return null
+	}
+
+	const onGridPointerDown = (e: React.PointerEvent) => {
+		e.stopPropagation()
+		editor.markEventAsHandled(e)
+		const { stepFloat, row, localX } = coords(e)
+		if (stepFloat < 0 || stepFloat >= steps || row < 0 || row >= PITCH_COUNT) return
+		e.currentTarget.setPointerCapture(e.pointerId)
+
+		const hit = hitTest(localX, row)
+		let working = notes.map((n) => ({ ...n }))
+		if (hit) {
+			drag.current = {
+				mode: hit.onEdge ? 'resize' : 'move',
+				index: hit.index,
+				downStep: stepFloat,
+				downRow: row,
+				orig: { ...working[hit.index] },
+				moved: false,
+				created: false,
+			}
+		} else {
+			const note = {
+				step: Math.max(0, Math.min(steps - 1, Math.floor(stepFloat))),
+				pitch: snap(rowToPitch(row)),
+				velocity: 100,
+				length: stepper,
+			}
+			working = [...working, note]
+			drag.current = {
+				mode: 'resize',
+				index: working.length - 1,
+				downStep: stepFloat,
+				downRow: row,
+				orig: { ...note },
+				moved: false,
+				created: true,
+			}
+		}
+		setDraftNotes(working)
+	}
+
+	const onGridPointerMove = (e: React.PointerEvent) => {
+		const d = drag.current
+		if (!d) return
+		e.stopPropagation()
+		const { stepFloat, row } = coords(e)
+		const working = (draftNotes ?? notes).map((n) => ({ ...n }))
+		const n = working[d.index]
+		if (!n) return
+		if (Math.abs(stepFloat - d.downStep) > 0.1 || row !== d.downRow) d.moved = true
+
+		if (d.mode === 'move') {
+			const deltaSteps = Math.round(stepFloat - d.downStep)
+			const newStep = Math.max(0, Math.min(steps - 1, d.orig.step + deltaSteps))
+			const newRow = Math.max(
+				0,
+				Math.min(PITCH_COUNT - 1, pitchToRow(d.orig.pitch) + (row - d.downRow))
+			)
+			n.step = newStep
+			n.pitch = snap(rowToPitch(newRow))
+		} else {
+			const lenSteps = Math.max(1, Math.min(steps - n.step, Math.round(stepFloat - n.step)))
+			n.length = lenSteps * stepper
+		}
+		setDraftNotes(working)
+	}
+
+	const onGridPointerUp = (e: React.PointerEvent) => {
+		const d = drag.current
+		if (!d) return
+		e.stopPropagation()
+		try {
+			e.currentTarget.releasePointerCapture(e.pointerId)
+		} catch {
+			// capture may already be released
+		}
+		let final = (draftNotes ?? notes).map((n) => ({ ...n }))
+		// A click (no drag) on an existing note deletes it.
+		if (d.mode === 'move' && !d.moved && !d.created) {
+			final = final.filter((_, i) => i !== d.index)
+		}
+		drag.current = null
+		setDraftNotes(null)
+		update({ notes: final })
+	}
+
+	const stop = (e: React.SyntheticEvent) => e.stopPropagation()
+
+	// The name is a drag handle by default (so the header moves the shape) and
+	// becomes an input on double-click.
+	const [editingName, setEditingName] = useState(false)
+
+	return (
+		<HTMLContainer className="midi-seq" style={{ width: w, height: h }}>
+			<div className="midi-seq__header midi-seq__drag-handle" style={{ height: HEADER_HEIGHT }}>
+				<button
+					className={`midi-seq__power ${enabled ? 'is-on' : ''}`}
+					title={enabled ? 'Mute' : 'Unmute'}
+					onPointerDown={stop}
+					onClick={(e) => {
+						stop(e)
+						update({ enabled: !enabled })
+					}}
+				>
+					{enabled ? '●' : '○'}
+				</button>
+				<button
+					className={`midi-seq__solo ${solo ? 'is-on' : ''}`}
+					title="Solo"
+					onPointerDown={stop}
+					onClick={(e) => {
+						stop(e)
+						update({ solo: !solo })
+					}}
+				>
+					S
+				</button>
+				<span className="midi-seq__icon">
+					<SequenceIcon size={12} />
+				</span>
+				{editingName ? (
+					<input
+						className="midi-seq__name"
+						value={name}
+						autoFocus
+						onPointerDown={stop}
+						onChange={(e) => update({ name: e.target.value })}
+						onBlur={() => setEditingName(false)}
+						onKeyDown={(e) => {
+							if (e.key === 'Enter' || e.key === 'Escape') setEditingName(false)
+						}}
+					/>
+				) : (
+					<span
+						className="midi-seq__name midi-seq__name--display"
+						title="Drag to move · double-click to rename"
+						onDoubleClick={(e) => {
+							stop(e)
+							setEditingName(true)
+						}}
+					>
+						{name || 'Sequence'}
+					</span>
+				)}
+				<label className="midi-seq__field" onPointerDown={stop}>
+					ch
+					<select
+						value={channel}
+						onPointerDown={stop}
+						onChange={(e) => update({ channel: Number(e.target.value) })}
+					>
+						{Array.from({ length: 16 }, (_, i) => (
+							<option key={i} value={i}>
+								{i + 1}
+							</option>
+						))}
+					</select>
+				</label>
+				<button
+					className="midi-seq__clear"
+					onPointerDown={stop}
+					onClick={() => update({ notes: [] })}
+				>
+					clear
+				</button>
+			</div>
+
+			<div className="midi-seq__body" style={{ left: 0, top: HEADER_HEIGHT }}>
+				<div className="midi-seq__labels" style={{ width: LABEL_WIDTH, height: gridHeight }}>
+					{Array.from({ length: PITCH_COUNT }, (_, row) => {
+						const pitch = rowToPitch(row)
+						return pitch % 12 === 0 ? (
+							<div
+								key={row}
+								className="midi-seq__label"
+								style={{ top: row * cellH, height: cellH }}
+							>
+								{pitchName(pitch)}
+							</div>
+						) : null
+					})}
+				</div>
+
+				<svg
+					ref={svgRef}
+					className="midi-seq__grid"
+					width={gridWidth}
+					height={gridHeight}
+					style={{ left: LABEL_WIDTH }}
+					onPointerDown={onGridPointerDown}
+					onPointerMove={onGridPointerMove}
+					onPointerUp={onGridPointerUp}
+				>
+					{Array.from({ length: PITCH_COUNT }, (_, row) => {
+						const pitch = rowToPitch(row)
+						let cls: string
+						if (scaleType === 'chromatic') {
+							cls = isBlackKey(pitch) ? 'row row--black' : 'row row--white'
+						} else if (pitch % 12 === ((scaleRoot % 12) + 12) % 12) {
+							cls = 'row row--root'
+						} else if (isInScale(pitch, scaleRoot, scaleType)) {
+							cls = 'row row--in'
+						} else {
+							cls = 'row row--out'
+						}
+						return (
+							<rect
+								key={`row-${row}`}
+								x={0}
+								y={row * cellH}
+								width={gridWidth}
+								height={cellH}
+								className={cls}
+							/>
+						)
+					})}
+					{Array.from({ length: steps + 1 }, (_, step) => (
+						<line
+							key={`col-${step}`}
+							x1={step * cellW}
+							y1={0}
+							x2={step * cellW}
+							y2={gridHeight}
+							className={step % 4 === 0 ? 'divider divider--beat' : 'divider'}
+						/>
+					))}
+					{isPlaying && activeStep >= 0 && (
+						<rect
+							x={activeStep * cellW}
+							y={0}
+							width={cellW}
+							height={gridHeight}
+							className="active-step"
+						/>
+					)}
+					{renderNotes.map((note, i) => {
+						const y = pitchToRow(note.pitch) * cellH
+						const noteW = Math.max(3, stepsOf(note) * cellW)
+						const x = note.step * cellW
+						const prob = note.probability ?? 1
+						const ratchet = note.ratchet ?? 1
+						return (
+							<g key={`note-${i}`} className="note-g">
+								<rect
+									x={x + 1}
+									y={y + 1}
+									width={noteW - 2}
+									height={cellH - 2}
+									rx={2}
+									className="note"
+									fillOpacity={0.4 + 0.6 * prob}
+								/>
+								{ratchet > 1 &&
+									Array.from({ length: ratchet - 1 }, (_, k) => {
+										const lx = x + ((k + 1) * noteW) / ratchet
+										return (
+											<line
+												key={k}
+												className="note-ratchet"
+												x1={lx}
+												y1={y + 1}
+												x2={lx}
+												y2={y + cellH - 1}
+											/>
+										)
+									})}
+								<rect
+									x={x + noteW - 4}
+									y={y + 1}
+									width={3}
+									height={cellH - 2}
+									className="note-handle"
+								/>
+							</g>
+						)
+					})}
+					{isPlaying && (
+						<line className="playhead" x1={playheadX} y1={0} x2={playheadX} y2={gridHeight} />
+					)}
+				</svg>
+			</div>
+
+			<div className="midi-seq__footer" style={{ height: FOOTER_HEIGHT }}>
+				<label className="midi-seq__foot-field" onPointerDown={stop}>
+					steps
+					<input
+						type="number"
+						min={1}
+						max={64}
+						value={steps}
+						onPointerDown={stop}
+						onChange={(e) =>
+							update({ steps: Math.max(1, Math.min(64, Number(e.target.value) || 1)) })
+						}
+					/>
+				</label>
+				<label className="midi-seq__foot-field" onPointerDown={stop}>
+					of
+					<select
+						value={stepper}
+						onPointerDown={stop}
+						onChange={(e) => update({ stepper: Number(e.target.value) })}
+					>
+						{STEP_RESOLUTION_OPTIONS.map((opt) => (
+							<option key={opt.ticks} value={opt.ticks}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+				</label>
+				<label className="midi-seq__foot-field" onPointerDown={stop}>
+					key
+					<select
+						value={scaleRoot}
+						onPointerDown={stop}
+						onChange={(e) => changeScale({ scaleRoot: Number(e.target.value) })}
+					>
+						{ROOT_OPTIONS.map((opt) => (
+							<option key={opt.value} value={opt.value}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+					<select
+						value={scaleType}
+						onPointerDown={stop}
+						onChange={(e) => changeScale({ scaleType: e.target.value as ScaleId })}
+					>
+						{SCALE_OPTIONS.map((opt) => (
+							<option key={opt.id} value={opt.id}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+				</label>
+				<span className="midi-seq__foot-field midi-seq__gen" onPointerDown={stop}>
+					<button onClick={fillEuclid} title="Fill an even (Euclidean) rhythm">
+						euclid
+					</button>
+					<input
+						type="number"
+						min={0}
+						max={steps}
+						value={pulses}
+						onPointerDown={stop}
+						onChange={(e) => setPulses(Math.max(0, Math.min(steps, Number(e.target.value) || 0)))}
+					/>
+					<button onClick={fillRandom} title="Fill random notes (in scale)">
+						random
+					</button>
+					<button onClick={fillEvery} title="A note every N steps">
+						every
+					</button>
+					<input
+						type="number"
+						min={1}
+						max={steps}
+						value={everyN}
+						onPointerDown={stop}
+						onChange={(e) => setEveryN(Math.max(1, Math.min(steps, Number(e.target.value) || 1)))}
+					/>
+					<button
+						onClick={() => {
+							copiedPattern = notes.map((n) => ({ ...n }))
+						}}
+						title="Copy this pattern"
+					>
+						copy
+					</button>
+					<button
+						onClick={() => copiedPattern && update({ notes: copiedPattern.map((n) => ({ ...n })) })}
+						title="Paste the copied pattern"
+					>
+						paste
+					</button>
+				</span>
+				<label className="midi-seq__foot-field" onPointerDown={stop}>
+					clock
+					<select
+						value={clockEvent}
+						onPointerDown={stop}
+						onChange={(e) => {
+							const event = e.target.value as ClockEvent
+							if (event === 'tick') {
+								update({ clockEvent: 'tick', clockSourceId: '' })
+							} else {
+								// Make sure a source is chosen when switching to a note event.
+								const valid = emitters.some((em) => em.id === clockSourceId)
+								update({
+									clockEvent: event,
+									clockSourceId: valid ? clockSourceId : (emitters[0]?.id ?? ''),
+								})
+							}
+						}}
+					>
+						{CLOCK_EVENT_OPTIONS.map((opt) => (
+							<option key={opt.id} value={opt.id}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+				</label>
+				{clockEvent !== 'tick' && (
+					<label className="midi-seq__foot-field" onPointerDown={stop}>
+						from
+						<select
+							value={clockSourceId}
+							onPointerDown={stop}
+							onChange={(e) => update({ clockSourceId: e.target.value })}
+						>
+							{emitters.length === 0 && <option value="">(none)</option>}
+							{emitters.map((em) => (
+								<option key={em.id} value={em.id}>
+									{em.kind === 'chain' ? '⛓ ' : '♪ '}
+									{em.name}
+								</option>
+							))}
+						</select>
+					</label>
+				)}
+				<label className="midi-seq__foot-field" onPointerDown={stop}>
+					trig
+					<select
+						value={trigMode}
+						onPointerDown={stop}
+						onChange={(e) => update({ trigMode: e.target.value as TrigModeId })}
+					>
+						{TRIG_MODE_OPTIONS.map((opt) => (
+							<option key={opt.id} value={opt.id}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+				</label>
+				<label className="midi-seq__foot-field" onPointerDown={stop}>
+					after
+					<input
+						type="number"
+						min={1}
+						max={64}
+						value={chainAfter}
+						onPointerDown={stop}
+						onChange={(e) => update({ chainAfter: Math.max(1, Number(e.target.value) || 1) })}
+					/>
+					loops →
+					<select
+						value={chainNext}
+						onPointerDown={stop}
+						onChange={(e) => update({ chainNext: e.target.value as NextActionId })}
+					>
+						{NEXT_ACTION_OPTIONS.map((opt) => (
+							<option key={opt.id} value={opt.id}>
+								{opt.label}
+							</option>
+						))}
+					</select>
+				</label>
+			</div>
+		</HTMLContainer>
+	)
+}
+
+export class SequenceShapeTool extends BaseBoxShapeTool {
+	static override id = SEQUENCE_TYPE
+	override shapeType = SEQUENCE_TYPE as typeof SEQUENCE_TYPE
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/shapes/shared.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/shapes/shared.ts
@@ -1,0 +1,170 @@
+import { NextAction, TrigMode } from '../engine/Sequence'
+import { SIXTEENTH } from '../engine/types'
+
+export const SEQUENCE_TYPE = 'midi-sequence'
+export const CHAIN_TYPE = 'midi-chain'
+
+// Grid layout. Two octaves, rendered with the highest pitch at the top.
+export const PITCH_LOW = 48 // C3
+export const PITCH_COUNT = 24
+
+export const HEADER_HEIGHT = 30
+export const FOOTER_HEIGHT = 104
+export const LABEL_WIDTH = 30
+
+export const DEFAULT_STEPS = 16
+export const DEFAULT_STEPPER = SIXTEENTH
+
+export const CELL_WIDTH = 20
+export const CELL_HEIGHT = 9
+
+export const DEFAULT_SEQUENCE_WIDTH = LABEL_WIDTH + DEFAULT_STEPS * CELL_WIDTH
+export const DEFAULT_SEQUENCE_HEIGHT = HEADER_HEIGHT + PITCH_COUNT * CELL_HEIGHT + FOOTER_HEIGHT
+
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
+
+export const ROOT_OPTIONS = NOTE_NAMES.map((name, i) => ({ value: i, label: name }))
+
+// Scale lock: semitone offsets from the root. 'chromatic' means no snapping.
+export type ScaleId =
+	| 'chromatic'
+	| 'major'
+	| 'minor'
+	| 'dorian'
+	| 'mixolydian'
+	| 'pentatonicMajor'
+	| 'pentatonicMinor'
+	| 'harmonicMinor'
+
+export const SCALES: Record<ScaleId, number[]> = {
+	chromatic: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+	major: [0, 2, 4, 5, 7, 9, 11],
+	minor: [0, 2, 3, 5, 7, 8, 10],
+	dorian: [0, 2, 3, 5, 7, 9, 10],
+	mixolydian: [0, 2, 4, 5, 7, 9, 10],
+	pentatonicMajor: [0, 2, 4, 7, 9],
+	pentatonicMinor: [0, 3, 5, 7, 10],
+	harmonicMinor: [0, 2, 3, 5, 7, 8, 11],
+}
+
+export const SCALE_OPTIONS: { id: ScaleId; label: string }[] = [
+	{ id: 'chromatic', label: 'chromatic' },
+	{ id: 'major', label: 'major' },
+	{ id: 'minor', label: 'minor' },
+	{ id: 'dorian', label: 'dorian' },
+	{ id: 'mixolydian', label: 'mixolydian' },
+	{ id: 'pentatonicMajor', label: 'major pentatonic' },
+	{ id: 'pentatonicMinor', label: 'minor pentatonic' },
+	{ id: 'harmonicMinor', label: 'harmonic minor' },
+]
+
+export function isInScale(pitch: number, root: number, scale: ScaleId) {
+	const degree = (((pitch - root) % 12) + 12) % 12
+	return SCALES[scale].includes(degree)
+}
+
+// Snap a pitch to the nearest pitch that belongs to the scale.
+export function snapToScale(pitch: number, root: number, scale: ScaleId) {
+	if (scale === 'chromatic' || isInScale(pitch, root, scale)) return pitch
+	for (let d = 1; d <= 6; d++) {
+		if (isInScale(pitch - d, root, scale)) return pitch - d
+		if (isInScale(pitch + d, root, scale)) return pitch + d
+	}
+	return pitch
+}
+
+// Evenly distribute `pulses` hits across `steps` (Euclidean rhythm).
+export function euclid(pulses: number, steps: number): boolean[] {
+	const out: boolean[] = []
+	const p = Math.max(0, Math.min(steps, Math.round(pulses)))
+	let bucket = 0
+	for (let i = 0; i < steps; i++) {
+		bucket += p
+		if (bucket >= steps) {
+			bucket -= steps
+			out.push(true)
+		} else {
+			out.push(false)
+		}
+	}
+	return out
+}
+
+export function pitchName(pitch: number) {
+	const name = NOTE_NAMES[pitch % 12]
+	const octave = Math.floor(pitch / 12) - 1
+	return `${name}${octave}`
+}
+
+export function isBlackKey(pitch: number) {
+	return NOTE_NAMES[pitch % 12].includes('#')
+}
+
+// Row 0 is the top (highest pitch). Convert between the visual row and the MIDI
+// pitch number.
+export function rowToPitch(row: number) {
+	return PITCH_LOW + (PITCH_COUNT - 1 - row)
+}
+export function pitchToRow(pitch: number) {
+	return PITCH_COUNT - 1 - (pitch - PITCH_LOW)
+}
+
+export type TrigModeId = 'one' | 'step' | 'nextNote' | 'restart'
+
+export const TRIG_MODE_OPTIONS: { id: TrigModeId; label: string }[] = [
+	{ id: 'one', label: 'Advance by one' },
+	{ id: 'step', label: 'Advance by step' },
+	{ id: 'nextNote', label: 'Advance to next note' },
+	{ id: 'restart', label: 'Restart' },
+]
+
+export function toTrigMode(id: TrigModeId): TrigMode {
+	switch (id) {
+		case 'step':
+			return TrigMode.AdvanceByStep
+		case 'nextNote':
+			return TrigMode.AdvanceToNextNote
+		case 'restart':
+			return TrigMode.Restart
+		case 'one':
+		default:
+			return TrigMode.AdvanceByOne
+	}
+}
+
+export type NextActionId = 'next' | 'previous' | 'first' | 'last'
+
+export const NEXT_ACTION_OPTIONS: { id: NextActionId; label: string }[] = [
+	{ id: 'next', label: 'next' },
+	{ id: 'previous', label: 'previous' },
+	{ id: 'first', label: 'first' },
+	{ id: 'last', label: 'last' },
+]
+
+export function toNextAction(id: NextActionId): NextAction {
+	switch (id) {
+		case 'previous':
+			return NextAction.Previous
+		case 'first':
+			return NextAction.First
+		case 'last':
+			return NextAction.Last
+		case 'next':
+		default:
+			return NextAction.Next
+	}
+}
+
+export const CLOCK_EVENT_OPTIONS: { id: 'tick' | 'noteOn' | 'noteOff'; label: string }[] = [
+	{ id: 'tick', label: 'Clock (tick)' },
+	{ id: 'noteOff', label: 'note off' },
+	{ id: 'noteOn', label: 'note on' },
+]
+
+// Step resolution: how many ticks one grid step (column) lasts.
+export const STEP_RESOLUTION_OPTIONS: { ticks: number; label: string }[] = [
+	{ ticks: 480, label: '1/4' },
+	{ ticks: 240, label: '1/8' },
+	{ ticks: 120, label: '1/16' },
+	{ ticks: 60, label: '1/32' },
+]

--- a/apps/examples/src/examples/use-cases/midi-sequencer/syncEngine.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/syncEngine.ts
@@ -1,0 +1,125 @@
+import { Editor, TLShape } from 'tldraw'
+import { MidiEngine, SequenceConfig } from './engine/MidiEngine'
+import { ChainShape, getChainMemberIds } from './shapes/ChainShapeUtil'
+import { SequenceShape } from './shapes/SequenceShapeUtil'
+import { CHAIN_TYPE, SEQUENCE_TYPE, toNextAction, toTrigMode } from './shapes/shared'
+
+const DEFAULT_BPM = 120
+
+// Tempo lives in the document's meta so it saves into the .tldr song and
+// persists, without needing a dedicated shape.
+export function getSongBpm(editor: Editor): number {
+	const bpm = (editor.getDocumentSettings().meta as { bpm?: number }).bpm
+	return typeof bpm === 'number' ? bpm : DEFAULT_BPM
+}
+
+export function setSongBpm(editor: Editor, bpm: number) {
+	const clamped = Math.max(20, Math.min(300, Math.round(bpm) || DEFAULT_BPM))
+	editor.updateDocumentSettings({ meta: { ...editor.getDocumentSettings().meta, bpm: clamped } })
+	MidiEngine.get(editor).setBpm(clamped)
+}
+
+function sequenceConfig(shape: SequenceShape): SequenceConfig {
+	const {
+		channel,
+		steps,
+		stepper,
+		trigMode,
+		enabled,
+		solo,
+		notes,
+		chainNext,
+		chainAfter,
+		clockSourceId,
+		clockEvent,
+	} = shape.props
+	return {
+		channel,
+		steps,
+		stepper,
+		trigMode: toTrigMode(trigMode),
+		enabled,
+		solo,
+		notes: notes.map((n) => ({
+			step: n.step,
+			pitch: n.pitch,
+			velocity: n.velocity,
+			length: n.length,
+			probability: n.probability,
+			ratchet: n.ratchet,
+		})),
+		nextAction: toNextAction(chainNext),
+		nextAfterLoops: chainAfter,
+		clockSourceId,
+		clockEvent,
+	}
+}
+
+// Rebuild the whole engine from the shapes currently on the page. Used for the
+// initial sync and after loading a song (loadSnapshot replaces the store).
+export function syncAllShapes(editor: Editor) {
+	const engine = MidiEngine.get(editor)
+	engine.clear()
+	engine.setBpm(getSongBpm(editor))
+	const shapes = editor.getCurrentPageShapes()
+	// Sequences first, then chains so they find their members.
+	for (const shape of shapes) {
+		if (shape.type === SEQUENCE_TYPE) {
+			engine.upsertSequence(shape.id, sequenceConfig(shape as SequenceShape))
+		}
+	}
+	for (const shape of shapes) {
+		if (shape.type === CHAIN_TYPE) {
+			engine.upsertChain(shape.id, { sequenceIds: getChainMemberIds(editor, shape as ChainShape) })
+		}
+	}
+}
+
+/**
+ * Keeps the engine in sync with the shapes on the canvas. Sequence shapes map
+ * to Sequence engine objects; chain shapes map to Chain objects whose members
+ * are the sequences parented to them. The Clock shape carries the tempo.
+ */
+export function registerEngineSync(editor: Editor): () => void {
+	const engine = MidiEngine.get(editor)
+
+	const resyncChains = () => {
+		for (const shape of editor.getCurrentPageShapes()) {
+			if (shape.type !== CHAIN_TYPE) continue
+			const chain = shape as ChainShape
+			engine.upsertChain(chain.id, { sequenceIds: getChainMemberIds(editor, chain) })
+		}
+	}
+
+	const syncShape = (shape: TLShape) => {
+		if (shape.type === SEQUENCE_TYPE) {
+			engine.upsertSequence(shape.id, sequenceConfig(shape as SequenceShape))
+			resyncChains()
+		} else if (shape.type === CHAIN_TYPE) {
+			const chain = shape as ChainShape
+			engine.upsertChain(chain.id, { sequenceIds: getChainMemberIds(editor, chain) })
+		}
+	}
+
+	syncAllShapes(editor)
+
+	const disposers = [
+		editor.sideEffects.registerAfterCreateHandler('shape', (shape) => syncShape(shape)),
+		editor.sideEffects.registerAfterChangeHandler('shape', (_prev, next) => syncShape(next)),
+		editor.sideEffects.registerAfterDeleteHandler('shape', (shape) => {
+			if (shape.type === SEQUENCE_TYPE) {
+				engine.removeSequence(shape.id)
+				resyncChains()
+			} else if (shape.type === CHAIN_TYPE) {
+				engine.removeChain(shape.id)
+			}
+		}),
+		// Keep tempo in sync when the document's bpm changes (e.g. undo/redo).
+		editor.sideEffects.registerAfterChangeHandler('document', (_prev, next) => {
+			const bpm = (next.meta as { bpm?: number }).bpm
+			if (typeof bpm === 'number') engine.setBpm(bpm)
+		}),
+	]
+
+	return () => disposers.forEach((d) => d())
+}

--- a/apps/examples/src/examples/use-cases/midi-sequencer/useMidiEngine.ts
+++ b/apps/examples/src/examples/use-cases/midi-sequencer/useMidiEngine.ts
@@ -1,0 +1,8 @@
+import { useEditor } from 'tldraw'
+import { MidiEngine } from './engine/MidiEngine'
+
+// Convenience hook: one MidiEngine instance per editor.
+export function useMidiEngine() {
+	const editor = useEditor()
+	return MidiEngine.get(editor)
+}


### PR DESCRIPTION
Some fun, don't take seriously, it's missing "few stuff" in order to be perfect

1. fire garageband, or any virtual synth
2. find the midi port for it (you can rescan if it did not pop up)
3. create a sequence (toolbar has it)
4. draw note
5. press spacebar

BUT ALSO

chains! chains are frame-like groups for sequences that can have basic follow up actions

AND

you can send to different midi channels! FIRE MORE SYNTHS

ALSO

scroll over a note to set the "rachet"
shift+scroll to change the probability for the note

LAST BUT NOT LEAST

STEPPER MODE
Listen to note on/off from a chain -> step your sequence

https://github.com/user-attachments/assets/29d923c9-4d08-4dc7-834c-d734ff7707e0

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape...
7.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug with…