### PR TITLE
perf(state): cache parent change checks

### DIFF
--- a/packages/state/api-report.api.md
+++ b/packages/state/api-report.api.md
@@ -39,6 +39,8 @@ export interface AtomOptions<Value, Diff> {
 export interface Child {
     __debug_ancestor_epochs__: Map<Signal<any, any>, number> | null;
     isActivelyListening: boolean;
+    lastParentCheckEpoch?: number;
+    lastParentCheckResult?: boolean;
     lastTraversedEpoch: number;
     readonly name: string;
     readonly parentEpochs: number[];

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -275,7 +275,7 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 				(this.isActivelyListening &&
 					getIsReacting() &&
 					this.lastTraversedEpoch < getReactionEpoch()) ||
-				!haveParentsChanged(this))
+				!haveParentsChanged(this, globalEpoch))
 		) {
 			this.lastCheckedEpoch = globalEpoch
 			if (this.error) {

--- a/packages/state/src/lib/EffectScheduler.ts
+++ b/packages/state/src/lib/EffectScheduler.ts
@@ -92,12 +92,13 @@ class __EffectScheduler__<Result> implements EffectScheduler<Result> {
 	maybeScheduleEffect() {
 		// bail out if we have been cancelled by another effect
 		if (!this._isActivelyListening) return
+		const globalEpoch = getGlobalEpoch()
 		// bail out if no atoms have changed since the last time we ran this effect
-		if (this.lastReactedEpoch === getGlobalEpoch()) return
+		if (this.lastReactedEpoch === globalEpoch) return
 
 		// bail out if we have parents and they have not changed since last time
-		if (this.parents.length && !haveParentsChanged(this)) {
-			this.lastReactedEpoch = getGlobalEpoch()
+		if (this.parents.length && !haveParentsChanged(this, globalEpoch)) {
+			this.lastReactedEpoch = globalEpoch
 			return
 		}
 		// if we don't have parents it's probably the first time this is running.

--- a/packages/state/src/lib/__tests__/helpers.test.ts
+++ b/packages/state/src/lib/__tests__/helpers.test.ts
@@ -3,6 +3,7 @@ import { ArraySet } from '../ArraySet'
 import { atom } from '../Atom'
 import { reactor } from '../EffectScheduler'
 import { attach, detach, equals, hasReactors, haveParentsChanged, singleton } from '../helpers'
+import { getGlobalEpoch } from '../transactions'
 import { Child } from '../types'
 
 // Unit tests for the internal helpers behind SPEC.md rules EQ1/EQ2 (equals),
@@ -38,6 +39,21 @@ describe('helpers', () => {
 			expect(haveParentsChanged(child)).toBe(true)
 		})
 
+		it('does not read a parent whose changed epoch is already known', () => {
+			const parentAtom = atom('parent', 1)
+			const oldEpoch = parentAtom.lastChangedEpoch
+
+			const child = makeChild()
+			child.parents.push(parentAtom)
+			child.parentEpochs.push(oldEpoch)
+
+			parentAtom.set(2)
+			const getWithoutCapture = vi.spyOn(parentAtom, '__unsafe__getWithoutCapture')
+
+			expect(haveParentsChanged(child, getGlobalEpoch())).toBe(true)
+			expect(getWithoutCapture).not.toHaveBeenCalled()
+		})
+
 		it('returns true when any parent has changed among multiple parents', () => {
 			const parent1 = atom('parent1', 1)
 			const parent2 = atom('parent2', 2)
@@ -50,6 +66,21 @@ describe('helpers', () => {
 			parent2.set(3)
 
 			expect(haveParentsChanged(child)).toBe(true)
+		})
+
+		it('reuses the parent check result for a child within the same global epoch', () => {
+			const parent = atom('parent', 1)
+			const getWithoutCapture = vi.spyOn(parent, '__unsafe__getWithoutCapture')
+
+			const child = makeChild()
+			child.parents.push(parent)
+			child.parentEpochs.push(parent.lastChangedEpoch)
+
+			const epoch = getGlobalEpoch()
+			expect(haveParentsChanged(child, epoch)).toBe(false)
+			expect(haveParentsChanged(child, epoch)).toBe(false)
+
+			expect(getWithoutCapture).toHaveBeenCalledTimes(1)
 		})
 	})
 

--- a/packages/state/src/lib/capture.ts
+++ b/packages/state/src/lib/capture.ts
@@ -69,6 +69,8 @@ export function unsafe__withoutCapture<T>(fn: () => T): T {
  */
 export function startCapturingParents(child: Child) {
 	inst.stack = new CaptureStackFrame(inst.stack, child)
+	child.lastParentCheckEpoch = undefined
+	child.lastParentCheckResult = undefined
 	if (child.__debug_ancestor_epochs__) {
 		const previousAncestorEpochs = child.__debug_ancestor_epochs__
 		child.__debug_ancestor_epochs__ = null
@@ -100,6 +102,8 @@ export function startCapturingParents(child: Child) {
 export function stopCapturingParents() {
 	const frame = inst.stack!
 	inst.stack = frame.below
+	frame.child.lastParentCheckEpoch = undefined
+	frame.child.lastParentCheckResult = undefined
 
 	if (frame.offset < frame.child.parents.length) {
 		for (let i = frame.offset; i < frame.child.parents.length; i++) {

--- a/packages/state/src/lib/helpers.ts
+++ b/packages/state/src/lib/helpers.ts
@@ -30,18 +30,42 @@ function isChild(x: any): x is Child {
  * ```
  * @internal
  */
-export function haveParentsChanged(child: Child): boolean {
+export function haveParentsChanged(child: Child, globalEpoch?: number): boolean {
+	if (
+		globalEpoch !== undefined &&
+		child.lastParentCheckEpoch === globalEpoch &&
+		child.lastParentCheckResult !== undefined
+	) {
+		return child.lastParentCheckResult
+	}
+
+	let parentsChanged = false
+
 	for (let i = 0, n = child.parents.length; i < n; i++) {
+		const parent = child.parents[i]
+
+		// If the parent's epoch already differs from the child's view, it has definitely changed.
+		if (parent.lastChangedEpoch !== child.parentEpochs[i]) {
+			parentsChanged = true
+			break
+		}
+
 		// Get the parent's value without capturing it.
-		child.parents[i].__unsafe__getWithoutCapture(true)
+		parent.__unsafe__getWithoutCapture(true)
 
 		// If the parent's epoch does not match the child's view of the parent's epoch, then the parent has changed.
-		if (child.parents[i].lastChangedEpoch !== child.parentEpochs[i]) {
-			return true
+		if (parent.lastChangedEpoch !== child.parentEpochs[i]) {
+			parentsChanged = true
+			break
 		}
 	}
 
-	return false
+	if (globalEpoch !== undefined) {
+		child.lastParentCheckEpoch = globalEpoch
+		child.lastParentCheckResult = parentsChanged
+	}
+
+	return parentsChanged
 }
 
 /**

--- a/packages/state/src/lib/types.ts
+++ b/packages/state/src/lib/types.ts
@@ -162,6 +162,18 @@ export interface Child {
 	readonly parentEpochs: number[]
 
 	/**
+	 * The global epoch when this child's parents were last checked for changes.
+	 * Used internally to avoid repeating the same parent validation during a
+	 * single propagation pass.
+	 */
+	lastParentCheckEpoch?: number
+
+	/**
+	 * The result of the parent check at lastParentCheckEpoch.
+	 */
+	lastParentCheckResult?: boolean
+
+	/**
 	 * Human-readable name for this child, used in debugging output.
 	 */
 	readonly name: string


### PR DESCRIPTION
In order to reduce repeated reactive graph validation during large-board interactions, this PR caches parent-change checks inside `@tldraw/state` for the current global epoch.

### What we found

Moving a large selection on a large board was spending a meaningful amount of time re-validating the same reactive parent relationships. In the traces we looked at, `haveParentsChanged` repeatedly walked parent lists and called `__unsafe__getWithoutCapture(true)` even when another check in the same global epoch had already established the answer for that child.

On the seeded 960-shape board, the scripted browser comparison showed the same pattern. The branch reduced move sync work from 200.7 ms total on main to 65.4 ms total, and reduced total sync work across select, move, create, and delete from 240.0 ms to 76.3 ms. In the windowed DevTools trace, `haveParentsChanged` dropped from 127.2 ms to 30.7 ms, and `__unsafe__getWithoutCapture` dropped from 135.5 ms to 33.8 ms.

### What we changed

`haveParentsChanged` now accepts the current global epoch. When a child has already checked its parents during that epoch, it reuses the cached boolean result instead of walking the same parents again.

The helper also checks each parent's `lastChangedEpoch` before forcing an uncaptured parent read. If the epoch already differs from the child's recorded parent epoch, the parent is definitely changed, so we can return without forcing `__unsafe__getWithoutCapture(true)`.

`Computed` and `EffectScheduler` now pass a stable `globalEpoch` into `haveParentsChanged` for their current pass. The capture lifecycle clears the cached parent-check state whenever a child starts or stops recapturing dependencies, so dependency changes do not inherit stale parent-check results.

The state helper tests cover both new correctness paths: early exit when a parent's epoch already proves it changed, and same-epoch memoization for repeated parent checks.

### What you need to know

This is intended to be an internal performance change. It should not change public state semantics: parent checks are cached only per child, only for the current global epoch, and are cleared when dependencies are recaptured.

The main tradeoff is two optional bookkeeping fields on `Child`: `lastParentCheckEpoch` and `lastParentCheckResult`. They show up in the API report because `Child` is part of the package surface, but they are internal implementation details for parent-check memoization.

The browser comparison restored both seeded tabs afterward: 960 shapes, 160 selected shapes, no temporary test shapes left behind, and no console errors.

### Change type

- [x] `improvement`

### Test plan

1. `cd packages/state && yarn test run`
2. `cd packages/state && yarn lint`
3. `cd packages/state && yarn build && yarn build-api`
4. Select and move shapes on a large board, then compare trace hot paths for `haveParentsChanged` and `__unsafe__getWithoutCapture`.

- [x] Unit tests
- [ ] End to end tests

### API changes

- Added internal `Child.lastParentCheckEpoch` and `Child.lastParentCheckResult` fields for parent-check memoization.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +50 / -9   |
| Tests           | +31 / -0   |
| Automated files | +2 / -0    |

### Release notes

- Improve large-board interaction performance by reducing repeated reactive parent validation.
