### PR TITLE
improvement(tldraw): delay the appearance of the back to content button

### DIFF
--- a/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/HelperButtons/BackToContent.tsx
@@ -1,10 +1,18 @@
 import { Editor, EditorAtom, useEditor, useQuickReactor } from '@tldraw/editor'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useActions } from '../../context/actions'
 import { TldrawUiMenuActionItem } from '../primitives/menus/TldrawUiMenuActionItem'
 
 const backToContentSuppressed = new EditorAtom('backToContentSuppressed', () => false)
 const suppressTimeout = new EditorAtom<number | null>('backToContentSuppressTimeout', () => null)
+
+/**
+ * How long all content must stay off-screen before the "back to content" button
+ * appears. Delaying the appearance stops the button from flickering during brief
+ * off-screen moments while panning or zooming.
+ * @internal
+ */
+export const BACK_TO_CONTENT_APPEAR_DELAY_MS = 1000
 
 /**
  * Hide the "back to content" helper button right away, regardless of where the
@@ -36,11 +44,11 @@ export function BackToContent() {
 
 	const [showBackToContent, setShowBackToContent] = useState(false)
 	const rIsShowing = useRef(false)
+	const rAppearTimeout = useRef<number | null>(null)
 
 	useQuickReactor(
 		'toggle showback to content',
 		() => {
-			const showBackToContentPrev = rIsShowing.current
 			let showBackToContentNow = false
 			if (!backToContentSuppressed.get(editor)) {
 				const shapeIds = editor.getCurrentPageShapeIds()
@@ -49,13 +57,49 @@ export function BackToContent() {
 				}
 			}
 
-			if (showBackToContentPrev !== showBackToContentNow) {
-				setShowBackToContent(showBackToContentNow)
-				rIsShowing.current = showBackToContentNow
+			if (showBackToContentNow === rIsShowing.current) {
+				// Already in the desired state. Cancel any pending appearance timer
+				// that's no longer needed (e.g. content came back into view before
+				// the delay elapsed).
+				if (rAppearTimeout.current !== null) {
+					clearTimeout(rAppearTimeout.current)
+					rAppearTimeout.current = null
+				}
+				return
+			}
+
+			if (showBackToContentNow) {
+				// Delay the appearance so the button doesn't flicker during brief
+				// off-screen moments. The timer cancels above if content returns.
+				if (rAppearTimeout.current === null) {
+					rAppearTimeout.current = editor.timers.setTimeout(() => {
+						rAppearTimeout.current = null
+						rIsShowing.current = true
+						setShowBackToContent(true)
+					}, BACK_TO_CONTENT_APPEAR_DELAY_MS)
+				}
+			} else {
+				// Hiding stays immediate.
+				if (rAppearTimeout.current !== null) {
+					clearTimeout(rAppearTimeout.current)
+					rAppearTimeout.current = null
+				}
+				rIsShowing.current = false
+				setShowBackToContent(false)
 			}
 		},
 		[editor]
 	)
+
+	// Clear any pending appearance timer if we unmount before it fires.
+	useEffect(() => {
+		return () => {
+			if (rAppearTimeout.current !== null) {
+				clearTimeout(rAppearTimeout.current)
+				rAppearTimeout.current = null
+			}
+		}
+	}, [])
 
 	if (!showBackToContent) return null
 

--- a/packages/tldraw/src/test/ui/BackToContent.test.tsx
+++ b/packages/tldraw/src/test/ui/BackToContent.test.tsx
@@ -1,6 +1,11 @@
 import { act, screen, waitFor } from '@testing-library/react'
 import { Box, Editor, Vec } from '@tldraw/editor'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Tldraw } from '../../lib/Tldraw'
+import {
+	BACK_TO_CONTENT_APPEAR_DELAY_MS,
+	suppressBackToContent,
+} from '../../lib/ui/components/HelperButtons/BackToContent'
 import { renderTldrawComponentWithEditor } from '../testutils/renderTldrawComponent'
 
 let editor: Editor
@@ -15,6 +20,10 @@ beforeEach(async () => {
 	act(() => {
 		editor.updateViewportScreenBounds(new Box(0, 0, 1000, 800))
 	})
+})
+
+afterEach(() => {
+	vi.useRealTimers()
 })
 
 function createShapeInViewport() {
@@ -36,29 +45,49 @@ function panAllShapesOffScreen() {
 	})
 }
 
+// Bring content back into view by adding a shape inside the current viewport, so not all shapes
+// are off-screen anymore. (Panning the camera back is unreliable in jsdom.)
+function bringContentBackIntoView() {
+	act(() => {
+		const center = editor.getViewportPageBounds().center
+		editor.createShape({
+			type: 'geo',
+			x: center.x - 50,
+			y: center.y - 50,
+			props: { w: 100, h: 100 },
+		})
+	})
+}
+
+const button = () => screen.queryByTestId('helper-buttons.back-to-content')
+
 describe('BackToContent button', () => {
-	it('shows when all shapes are off-screen', async () => {
+	it('shows when all shapes are off-screen, only after the appearance delay', async () => {
+		vi.useFakeTimers()
 		createShapeInViewport()
 
 		// Initially, button should not be visible (shapes are on screen)
-		await waitFor(() => {
-			expect(screen.queryByTestId('helper-buttons.back-to-content')).toBeNull()
-		})
+		expect(button()).toBeNull()
 
 		panAllShapesOffScreen()
 
-		// Now the button should appear
-		await waitFor(() => {
-			expect(screen.queryByTestId('helper-buttons.back-to-content')).not.toBeNull()
+		// The button should not appear immediately, nor just before the delay elapses.
+		expect(button()).toBeNull()
+		act(() => {
+			vi.advanceTimersByTime(BACK_TO_CONTENT_APPEAR_DELAY_MS - 1)
 		})
+		expect(button()).toBeNull()
+
+		// Once the delay elapses, the button appears.
+		act(() => {
+			vi.advanceTimersByTime(2)
+		})
+		expect(button()).not.toBeNull()
 	})
 
 	it('shows when selected shapes are off-screen', async () => {
+		vi.useFakeTimers()
 		createShapeInViewport()
-
-		await waitFor(() => {
-			expect(editor.getCurrentPageShapeIds().size).toBe(1)
-		})
 
 		const shapeId = editor.getCurrentPageShapeIds().values().next().value!
 
@@ -67,17 +96,15 @@ describe('BackToContent button', () => {
 			editor.select(shapeId)
 		})
 
-		// Initially, button should not be visible
-		await waitFor(() => {
-			expect(screen.queryByTestId('helper-buttons.back-to-content')).toBeNull()
-		})
+		expect(button()).toBeNull()
 
 		panAllShapesOffScreen()
 
-		// Button should still appear even though selected shapes aren't culled
-		await waitFor(() => {
-			expect(screen.queryByTestId('helper-buttons.back-to-content')).not.toBeNull()
+		// Button should still appear (after the delay) even though selected shapes aren't culled
+		act(() => {
+			vi.advanceTimersByTime(BACK_TO_CONTENT_APPEAR_DELAY_MS + 1)
 		})
+		expect(button()).not.toBeNull()
 	})
 
 	it('does not show when some shapes are still on-screen', async () => {
@@ -105,7 +132,59 @@ describe('BackToContent button', () => {
 
 		// Button should not appear since one shape is still visible
 		await waitFor(() => {
-			expect(screen.queryByTestId('helper-buttons.back-to-content')).toBeNull()
+			expect(button()).toBeNull()
 		})
+	})
+
+	it('does not appear if content returns before the delay elapses', async () => {
+		vi.useFakeTimers()
+		createShapeInViewport()
+		panAllShapesOffScreen()
+
+		// Part-way through the delay, bring content back into view.
+		act(() => {
+			vi.advanceTimersByTime(BACK_TO_CONTENT_APPEAR_DELAY_MS - 1)
+		})
+		expect(button()).toBeNull()
+		bringContentBackIntoView()
+
+		// Past the original delay, the button should still never have appeared.
+		act(() => {
+			vi.advanceTimersByTime(BACK_TO_CONTENT_APPEAR_DELAY_MS + 1)
+		})
+		expect(button()).toBeNull()
+	})
+
+	it('hides immediately when content returns after the button is shown', async () => {
+		vi.useFakeTimers()
+		createShapeInViewport()
+		panAllShapesOffScreen()
+
+		act(() => {
+			vi.advanceTimersByTime(BACK_TO_CONTENT_APPEAR_DELAY_MS + 1)
+		})
+		expect(button()).not.toBeNull()
+
+		// Hiding is immediate, with no delay.
+		bringContentBackIntoView()
+		expect(button()).toBeNull()
+	})
+
+	it('cancels a pending appearance when back-to-content is suppressed', async () => {
+		vi.useFakeTimers()
+		createShapeInViewport()
+		panAllShapesOffScreen()
+
+		// While the appearance timer is pending, suppress the button (as happens when the user
+		// navigates back to content).
+		act(() => {
+			suppressBackToContent(editor, BACK_TO_CONTENT_APPEAR_DELAY_MS * 4)
+		})
+
+		// The button should not appear once the delay elapses.
+		act(() => {
+			vi.advanceTimersByTime(BACK_TO_CONTENT_APPEAR_DELAY_MS + 1)
+		})
+		expect(button()).toBeNull()
 	})
 })


### PR DESCRIPTION
In order to stop the "back to content" helper button from flickering during normal panning and zooming, this PR delays its appearance by ~1s. Previously the button appeared the instant all content left the viewport (regression from #3532, which replaced the original 1s polling interval with an instant reactive check). The appearance timer cancels if content returns before it elapses, so the button never appears during brief off-screen moments. Hiding stays immediate — only the appearance is delayed. The delay is exported as an internal constant and can be tuned. Closes #9439.

### Change type

- [x] `improvement`

### Test plan

1. Create some shapes, then pan the camera so all content leaves the viewport.
2. Confirm the "back to content" button appears after ~1s, not instantly.
3. Pan content off then quickly back within 1s; confirm the button never appears.
4. With the button showing, bring content back; confirm it hides immediately.

- [x] Unit tests

### Release notes

- Delay the appearance of the "back to content" button by ~1s so it no longer flickers during normal panning and zooming. Hiding stays immediate.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +49 / -5   |
| Tests     | +98 / -19  |
