### PR TITLE
spike(dotcom): design-system gallery at /dev/components (lay of the land)

### DIFF
--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -79,6 +79,10 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/dev/components/typography/?$",
   },
   {
+    "reactRouterPattern": "/dev/components/z-index",
+    "vercelRouterPattern": "^/dev/components/z-index/?$",
+  },
+  {
     "reactRouterPattern": "/dev/reset-local-state",
     "vercelRouterPattern": "^/dev/reset-local-state/?$",
   },

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -63,6 +63,10 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/dev/components/presence/?$",
   },
   {
+    "reactRouterPattern": "/dev/components/shadows",
+    "vercelRouterPattern": "^/dev/components/shadows/?$",
+  },
+  {
     "reactRouterPattern": "/dev/components/sidebar",
     "vercelRouterPattern": "^/dev/components/sidebar/?$",
   },

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -15,6 +15,66 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/admin/?$",
   },
   {
+    "reactRouterPattern": "/dev/components/buttons",
+    "vercelRouterPattern": "^/dev/components/buttons/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/dialogs",
+    "vercelRouterPattern": "^/dev/components/dialogs/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/editor",
+    "vercelRouterPattern": "^/dev/components/editor/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/form-controls",
+    "vercelRouterPattern": "^/dev/components/form-controls/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/icons",
+    "vercelRouterPattern": "^/dev/components/icons/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/inputs",
+    "vercelRouterPattern": "^/dev/components/inputs/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/links",
+    "vercelRouterPattern": "^/dev/components/links/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/logo",
+    "vercelRouterPattern": "^/dev/components/logo/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/menus",
+    "vercelRouterPattern": "^/dev/components/menus/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/overlays",
+    "vercelRouterPattern": "^/dev/components/overlays/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/presence",
+    "vercelRouterPattern": "^/dev/components/presence/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/sidebar",
+    "vercelRouterPattern": "^/dev/components/sidebar/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/states",
+    "vercelRouterPattern": "^/dev/components/states/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/components/typography",
+    "vercelRouterPattern": "^/dev/components/typography/?$",
+  },
+  {
+    "reactRouterPattern": "/dev/reset-local-state",
+    "vercelRouterPattern": "^/dev/reset-local-state/?$",
+  },
+  {
     "reactRouterPattern": "/f/:fileSlug",
     "vercelRouterPattern": "^/f/[^/]*/?$",
   },

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -35,6 +35,10 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/dev/components/icons/?$",
   },
   {
+    "reactRouterPattern": "/dev/components/identity",
+    "vercelRouterPattern": "^/dev/components/identity/?$",
+  },
+  {
     "reactRouterPattern": "/dev/components/inputs",
     "vercelRouterPattern": "^/dev/components/inputs/?$",
   },

--- a/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
+++ b/apps/dotcom/client/src/__snapshots__/routes.test.tsx.snap
@@ -67,6 +67,10 @@ exports[`the_routes 1`] = `
     "vercelRouterPattern": "^/dev/components/states/?$",
   },
   {
+    "reactRouterPattern": "/dev/components/timestamps",
+    "vercelRouterPattern": "^/dev/components/timestamps/?$",
+  },
+  {
     "reactRouterPattern": "/dev/components/typography",
     "vercelRouterPattern": "^/dev/components/typography/?$",
   },

--- a/apps/dotcom/client/src/pages/dev-buttons.tsx
+++ b/apps/dotcom/client/src/pages/dev-buttons.tsx
@@ -4,12 +4,12 @@ import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 import { TlaCtaButton } from '../tla/components/TlaCtaButton/TlaCtaButton'
+import { DevComponentsNav } from './dev-components-nav'
 import dialogStyles from '../tla/components/dialogs/dialogs.module.css'
 import inviteStyles from '../tla/components/dialogs/TlaInviteDialog.module.css'
 import menuStyles from '../tla/components/tla-menu/menu.module.css'
-import sidebarStyles from '../tla/components/TlaSidebar/sidebar.module.css'
 import '../tla/styles/tla.css'
-import { DevComponentsNav } from './dev-components-nav'
+import sidebarStyles from '../tla/components/TlaSidebar/sidebar.module.css'
 
 /**
  * Dev-only inventory of every button in the dotcom app, rendered together so
@@ -320,7 +320,6 @@ export function Component() {
 						<button className="tla-button-text">Opt out</button>
 					</Specimen>
 				</Section>
-
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-buttons.tsx
+++ b/apps/dotcom/client/src/pages/dev-buttons.tsx
@@ -9,6 +9,7 @@ import inviteStyles from '../tla/components/dialogs/TlaInviteDialog.module.css'
 import menuStyles from '../tla/components/tla-menu/menu.module.css'
 import sidebarStyles from '../tla/components/TlaSidebar/sidebar.module.css'
 import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
 
 /**
  * Dev-only inventory of every button in the dotcom app, rendered together so
@@ -97,6 +98,7 @@ export function Component() {
 			<style>{PAGE_CSS}</style>
 
 			<div className="page">
+				<DevComponentsNav />
 				<header className="page__header">
 					<h1 className="page__title">Button inventory</h1>
 					<p className="page__lede">

--- a/apps/dotcom/client/src/pages/dev-buttons.tsx
+++ b/apps/dotcom/client/src/pages/dev-buttons.tsx
@@ -315,12 +315,6 @@ export function Component() {
 					</Specimen>
 				</Section>
 
-				<footer className="page__footer">
-					Source of the divergence: there is no single owner of &ldquo;a button.&rdquo; Accent-solid
-					is expressed three ways, hover has at least four treatments (primary-hover,
-					secondary-hover, muted halo, underline, cta-hover), and height takes four values. See
-					tldraw/tldraw#9194.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-buttons.tsx
+++ b/apps/dotcom/client/src/pages/dev-buttons.tsx
@@ -1,0 +1,399 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { TlaButton } from '../tla/components/TlaButton/TlaButton'
+import { TlaCtaButton } from '../tla/components/TlaCtaButton/TlaCtaButton'
+import dialogStyles from '../tla/components/dialogs/dialogs.module.css'
+import inviteStyles from '../tla/components/dialogs/TlaInviteDialog.module.css'
+import menuStyles from '../tla/components/tla-menu/menu.module.css'
+import sidebarStyles from '../tla/components/TlaSidebar/sidebar.module.css'
+import '../tla/styles/tla.css'
+
+/**
+ * Dev-only inventory of every button in the dotcom app, rendered together so
+ * the styling divergences are visible at a glance. Each specimen renders the
+ * real component / real CSS-module class (no reconstruction), inside the app's
+ * own theme container so all `--tl-*` / `--tla-*` tokens resolve as in prod.
+ *
+ * Serves the design-system button work: tldraw/tldraw#9194 (fold TlaCtaButton),
+ * #9193 (consolidate button CSS), #9190 (raw buttons). Route: /dev/buttons.
+ */
+
+/** One labelled button specimen with a mono caption of its divergent props. */
+const Specimen = ({
+	label,
+	code,
+	meta,
+	source,
+	children,
+}: {
+	label: string
+	/** The literal JSX / props used to render this specimen. */
+	code?: string
+	meta: string
+	/** Where this button's styling is defined and which component renders it. */
+	source?: string
+	children: ReactNode
+}): ReactNode => (
+	<div className="specimen">
+		<div className="specimen__stage">{children}</div>
+		<div className="specimen__label">{label}</div>
+		{code && <div className="specimen__code">{code}</div>}
+		<div className="specimen__meta">{meta}</div>
+		{source && <div className="specimen__source">{source}</div>}
+	</div>
+)
+
+const Section = ({
+	title,
+	note,
+	api,
+	source,
+	children,
+}: {
+	title: string
+	note: string
+	/** The props the component accepts (its public API). */
+	api?: string
+	/** Where the component is defined and which files render it. */
+	source?: string
+	children: ReactNode
+}) => (
+	<section className="section">
+		<h2 className="section__title">{title}</h2>
+		<p className="section__note">{note}</p>
+		{(api || source) && (
+			<div className="section__api">
+				{api && (
+					<div>
+						<span className="k">props</span>
+						{api}
+					</div>
+				)}
+				{source && (
+					<div>
+						<span className="k">source</span>
+						{source}
+					</div>
+				)}
+			</div>
+		)}
+		<div className="grid">{children}</div>
+	</section>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			// .tl-container is the editor's flex, full-height, overflow-hidden layout root.
+			// Override it so this dev page is a normal scrollable block.
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Button inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<header className="page__header">
+					<h1 className="page__title">Button inventory</h1>
+					<p className="page__lede">
+						Every button in the dotcom app, rendered together. The point is to see where the styling
+						diverges — height, radius, weight, fill mechanism, and hover token are annotated under
+						each. Real components and real CSS classes, so divergences are real.
+					</p>
+				</header>
+
+				{/* The punchline: the divergence matrix. */}
+				<section className="section">
+					<h2 className="section__title">Divergence matrix</h2>
+					<p className="section__note">
+						An &ldquo;accent solid button&rdquo; exists in three different geometries (rows 1–3).
+					</p>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>button</th>
+								<th>height</th>
+								<th>radius</th>
+								<th>weight</th>
+								<th>fill</th>
+								<th>hover</th>
+							</tr>
+						</thead>
+						<tbody>
+							{MATRIX.map((r) => (
+								<tr key={r[0]} data-accent={r[6] === 'accent' || undefined}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+									<td>{r[3]}</td>
+									<td>{r[4]}</td>
+									<td>{r[5]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<Section
+					title="TlaButton — the app primitive"
+					note="One component, prop axes: variant (primary / secondary / cta) × ghost × big. Note that variant='cta' here is the stub: identical to primary except font-weight 600."
+					api="variant?: 'primary' | 'secondary' | 'cta', ghost?, big?, isLoading?, icon? (UNUSED — no call site passes it), iconRight? (2 uses), iconRightClassName? (1 use) — plus all native <button> attributes (onClick, disabled, type, …)"
+					source="defined in tla/components/TlaButton/TlaButton.tsx · used in ~10 files: WorkspaceSettingsDialog, TlaInviteExpiredDialog, TlaFileShareMenu (export / publish tabs), ErrorPage, StoreErrorScreen, admin, MaybeForceUserRefresh, TlaRootProviders"
+				>
+					<Specimen
+						label="variant='primary'"
+						code={`<TlaButton variant="primary">`}
+						meta="h32 · r4 · w500 · fill primary · hover primary-hover"
+					>
+						<TlaButton variant="primary">Continue</TlaButton>
+					</Specimen>
+					<Specimen
+						label="variant='secondary'"
+						code={`<TlaButton variant="secondary">`}
+						meta="h32 · r4 · w500 · secondary bg + border · hover secondary-hover"
+					>
+						<TlaButton variant="secondary">Cancel</TlaButton>
+					</Specimen>
+					<Specimen
+						label="variant='cta' (stub)"
+						code={`<TlaButton variant="cta">`}
+						meta="h32 · r4 · w600 · fill primary · hover primary-hover ⚠ = primary + bold"
+					>
+						<TlaButton variant="cta">Get started</TlaButton>
+					</Specimen>
+					<Specimen
+						label="variant='primary' big"
+						code={`<TlaButton variant="primary" big>`}
+						meta="h36 · r6 · w500 — note radius jumps 4→6"
+					>
+						<TlaButton variant="primary" big>
+							Continue
+						</TlaButton>
+					</Specimen>
+					<Specimen
+						label="variant='primary' ghost"
+						code={`<TlaButton variant="primary" ghost>`}
+						meta="transparent · text primary · hover muted halo"
+					>
+						<TlaButton variant="primary" ghost>
+							Continue
+						</TlaButton>
+					</Specimen>
+					<Specimen
+						label="variant='secondary' ghost"
+						code={`<TlaButton variant="secondary" ghost>`}
+						meta="transparent · text secondary · no border"
+					>
+						<TlaButton variant="secondary" ghost>
+							Cancel
+						</TlaButton>
+					</Specimen>
+					<Specimen
+						label="isLoading"
+						code={`<TlaButton variant="primary" isLoading>`}
+						meta="spinner swaps in; onClick suppressed"
+					>
+						<TlaButton variant="primary" isLoading>
+							Saving
+						</TlaButton>
+					</Specimen>
+				</Section>
+
+				<Section
+					title="TlaCtaButton — the separate CTA component (#9194)"
+					note="A whole second component for the prominent call-to-action. Fills via a ::before pseudo-element (not background-color) so it can layer over the canvas. This is the real CTA — bigger and heavier than TlaButton's cta stub above."
+					api="canvas?, secondary? — plus all native <button> attributes. Note: no variant/size/icon props — a different, smaller API than TlaButton, for overlapping intent."
+					source="defined in tla/components/TlaCtaButton/TlaCtaButton.tsx · used in 5 files: TlaSignInDialog, TlaLegalAcceptance, TlaEditorTopRightPanel, TlaHistorySnapshotEditor, TlaFileError"
+				>
+					<Specimen
+						label="<TlaCtaButton>"
+						code={`<TlaCtaButton>`}
+						meta="h36 · r6 (::before) · w600 · pad 0 16 · hover primary-hover"
+					>
+						<TlaCtaButton>
+							<span>Get started</span>
+						</TlaCtaButton>
+					</Specimen>
+					<Specimen
+						label="canvas"
+						code={`<TlaCtaButton canvas>`}
+						meta="+ ::after background halo so it reads over the infinite canvas"
+					>
+						<TlaCtaButton canvas>
+							<span>Share</span>
+						</TlaCtaButton>
+					</Specimen>
+					<Specimen
+						label="secondary"
+						code={`<TlaCtaButton secondary>`}
+						meta="muted ::before + border · text-0 · hover muted-1"
+					>
+						<TlaCtaButton secondary>
+							<span>Maybe later</span>
+						</TlaCtaButton>
+					</Specimen>
+				</Section>
+
+				<Section
+					title="Bespoke raw <button>s (#9193 / #9190)"
+					note="Hand-styled buttons that never adopted a component, each with its own module CSS. Heights and hover treatments diverge from both TlaButton and each other."
+					api="none — these are raw <button> elements with a CSS-module class. No component, no variant/loading/icon props; only native <button> attributes. The styling lives in CSS, not a shared API."
+				>
+					<Specimen
+						label=".sidebarActionButton"
+						code={`<button className={styles.sidebarActionButton}>`}
+						meta="h36 · no border · gap6 · hover ::after muted-2"
+						source="sidebar.module.css · rendered by TlaSidebarSearch, TlaSidebarWorkspaceActions"
+					>
+						<button className={sidebarStyles.sidebarActionButton}>New file</button>
+					</Specimen>
+					<Specimen
+						label=".sidebarLinkButton"
+						code={`<button className={styles.sidebarLinkButton}>`}
+						meta="h36 · pad 0 8 · text-0"
+						source="sidebar.module.css · rendered by TlaSidebarFeedbackButton"
+					>
+						<button className={sidebarStyles.sidebarLinkButton}>Give feedback</button>
+					</Specimen>
+					<Specimen
+						label=".sidebarWorkspaceSwitcherTrigger"
+						code={`<button className={styles.sidebarWorkspaceSwitcherTrigger}>`}
+						meta="h36 · full width"
+						source="sidebar.module.css · rendered by TlaSidebarWorkspaceSwitcher"
+					>
+						<button className={sidebarStyles.sidebarWorkspaceSwitcherTrigger}>Workspace</button>
+					</Specimen>
+					<Specimen
+						label=".inlineButton"
+						code={`<button className={styles.inlineButton}>`}
+						meta="text · pad 4 0 · w500 · hover UNDERLINE (no fill/height)"
+						source="dialogs.module.css · rendered by WorkspaceSettingsDialog"
+					>
+						<button className={dialogStyles.inlineButton}>Regenerate link</button>
+					</Specimen>
+					<Specimen
+						label=".inlineButton .inlineButtonDanger"
+						code={`<button className={cn(styles.inlineButton, styles.inlineButtonDanger)}>`}
+						meta="text · color danger · hover underline"
+						source="dialogs.module.css · rendered by WorkspaceSettingsDialog"
+					>
+						<button className={`${dialogStyles.inlineButton} ${dialogStyles.inlineButtonDanger}`}>
+							Delete workspace
+						</button>
+					</Specimen>
+					<Specimen
+						label=".menuTabsTab"
+						code={`<button className={styles.menuTabsTab} data-active>`}
+						meta="h40 · tab style · active underline"
+						source="tla-menu/menu.module.css · rendered by tla-menu.tsx (TlaMenuTabs)"
+					>
+						<button className={menuStyles.menuTabsTab} data-active>
+							Export
+						</button>
+					</Specimen>
+					<Specimen
+						label=".acceptButton"
+						code={`<button className={styles.acceptButton}>`}
+						meta="width 100% · w500 · cta-hover token (a 4th hover treatment)"
+						source="dialogs/TlaInviteDialog.module.css · rendered by TlaInviteDialog"
+					>
+						<button className={inviteStyles.acceptButton}>Accept invite</button>
+					</Specimen>
+					<Specimen
+						label="global .tla-button-text"
+						code={`<button className="tla-button-text">`}
+						meta="shared text-button class (cookie consent, etc.)"
+						source="global class in tla/styles/tla.css · e.g. rendered by TlaCookieConsent"
+					>
+						<button className="tla-button-text">Opt out</button>
+					</Specimen>
+				</Section>
+
+				<footer className="page__footer">
+					Source of the divergence: there is no single owner of &ldquo;a button.&rdquo; Accent-solid
+					is expressed three ways, hover has at least four treatments (primary-hover,
+					secondary-hover, muted halo, underline, cta-hover), and height takes four values. See
+					tldraw/tldraw#9194.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const MATRIX: ReadonlyArray<readonly [string, string, string, string, string, string, string]> = [
+	['TlaButton primary', '32px', 'r1 / 4px', '500', 'background-color', 'primary-hover', 'accent'],
+	[
+		'TlaButton cta (stub)',
+		'32px',
+		'r1 / 4px',
+		'600',
+		'background-color',
+		'primary-hover',
+		'accent',
+	],
+	['TlaCtaButton', '36px', '6px (::before)', '600', '::before pseudo', 'primary-hover', 'accent'],
+	['TlaButton secondary', '32px', 'r1 / 4px', '500', 'background-color', 'secondary-hover', ''],
+	['TlaButton big', '36px', 'r2 / 6px', '500', 'background-color', 'primary-hover', 'accent'],
+	['TlaCtaButton secondary', '36px', '6px (::before)', '600', '::before pseudo', 'muted-1', ''],
+	['.sidebarActionButton', '36px', '—', '—', 'none (::after hover)', 'muted-2 halo', ''],
+	['.inlineButton', 'auto', '—', '500', 'none (text)', 'underline', ''],
+	['.menuTabsTab', '40px', '—', '—', 'none (text)', 'active underline', ''],
+	['.acceptButton', 'auto', '—', '500', 'background-color', 'cta-hover', ''],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 48px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 720px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.section { margin-bottom: 56px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 720px; }
+.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; margin: 0 0 24px; max-width: 820px; }
+.section__api > div { display: flex; gap: 8px; }
+.section__api > div + div { margin-top: 4px; }
+.section__api .k { color: var(--tl-color-text-3); flex: 0 0 48px; }
+.grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+	gap: 20px;
+}
+.specimen {
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 8px;
+	padding: 20px 16px 14px;
+	background: var(--tl-color-panel);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.specimen__stage {
+	min-height: 56px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--tl-color-low);
+	border-radius: 6px;
+	padding: 12px;
+}
+.specimen__label { font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace; }
+.specimen__code { font-size: 11px; line-height: 1.4; color: var(--tl-color-text-1); font-family: ui-monospace, monospace; background: var(--tl-color-low); border-radius: 4px; padding: 5px 7px; white-space: pre-wrap; word-break: break-word; }
+.specimen__meta { font-size: 11px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; }
+.specimen__source { font-size: 10px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; border-top: 1px dashed var(--tl-color-divider); padding-top: 8px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 14px 6px 0; border-bottom: 1px solid var(--tl-color-divider); }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix tr[data-accent] td:first-child { color: var(--tl-color-primary); font-weight: 600; }
+.page__footer { max-width: 720px; font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-buttons.tsx
+++ b/apps/dotcom/client/src/pages/dev-buttons.tsx
@@ -27,6 +27,7 @@ const Specimen = ({
 	code,
 	meta,
 	source,
+	mock,
 	children,
 }: {
 	label: string
@@ -35,9 +36,14 @@ const Specimen = ({
 	meta: string
 	/** Where this button's styling is defined and which component renders it. */
 	source?: string
+	/** True when the stage is a representation rather than a live render. */
+	mock?: boolean
 	children: ReactNode
 }): ReactNode => (
 	<div className="specimen">
+		<span className="specimen__badge" data-mock={mock || undefined}>
+			{mock ? 'mock' : 'live'}
+		</span>
 		<div className="specimen__stage">{children}</div>
 		<div className="specimen__label">{label}</div>
 		{code && <div className="specimen__code">{code}</div>}
@@ -366,6 +372,7 @@ const PAGE_CSS = `
 	gap: 20px;
 }
 .specimen {
+	position: relative;
 	border: 1px solid var(--tl-color-divider);
 	border-radius: 8px;
 	padding: 20px 16px 14px;
@@ -374,6 +381,8 @@ const PAGE_CSS = `
 	flex-direction: column;
 	gap: 12px;
 }
+.specimen__badge { position: absolute; top: 8px; right: 8px; font-size: 9px; font-family: ui-monospace, monospace; text-transform: uppercase; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 999px; background: color-mix(in srgb, var(--tl-color-success, #2a9d3c) 16%, transparent); color: var(--tl-color-success, #2a9d3c); }
+.specimen__badge[data-mock] { background: color-mix(in srgb, var(--tl-color-text-3) 18%, transparent); color: var(--tl-color-text-3); }
 .specimen__stage {
 	min-height: 56px;
 	display: flex;

--- a/apps/dotcom/client/src/pages/dev-components-kit.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-kit.tsx
@@ -6,7 +6,7 @@ import { ReactNode } from 'react'
  * family shows the same overview shape: a rendered instance, the literal props
  * that produced it, the divergence note, and where it lives.
  */
-export const Specimen = ({
+export function Specimen({
 	label,
 	code,
 	meta,
@@ -28,18 +28,20 @@ export const Specimen = ({
 	 */
 	mock?: boolean
 	children: ReactNode
-}): ReactNode => (
-	<div className="specimen">
-		<span className="specimen__badge" data-mock={mock || undefined}>
-			{mock ? 'mock' : 'live'}
-		</span>
-		<div className="specimen__stage">{children}</div>
-		<div className="specimen__label">{label}</div>
-		{code && <div className="specimen__code">{code}</div>}
-		{meta && <div className="specimen__meta">{meta}</div>}
-		{source && <div className="specimen__source">{source}</div>}
-	</div>
-)
+}): ReactNode {
+	return (
+		<div className="specimen">
+			<span className="specimen__badge" data-mock={mock || undefined}>
+				{mock ? 'mock' : 'live'}
+			</span>
+			<div className="specimen__stage">{children}</div>
+			<div className="specimen__label">{label}</div>
+			{code && <div className="specimen__code">{code}</div>}
+			{meta && <div className="specimen__meta">{meta}</div>}
+			{source && <div className="specimen__source">{source}</div>}
+		</div>
+	)
+}
 
 /** The shared card + grid styling. Append to each page's <style>. */
 export const SPECIMEN_CSS = `

--- a/apps/dotcom/client/src/pages/dev-components-kit.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-kit.tsx
@@ -1,0 +1,43 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+
+/**
+ * Shared specimen card for the /dev/components/* inventory pages, so every
+ * family shows the same overview shape: a rendered instance, the literal props
+ * that produced it, the divergence note, and where it lives.
+ */
+export const Specimen = ({
+	label,
+	code,
+	meta,
+	source,
+	children,
+}: {
+	label: string
+	/** The literal JSX / props used to render this specimen. */
+	code?: string
+	/** A short note — the divergent property, or what to look at. */
+	meta?: string
+	/** Where this instance is defined / which component renders it. */
+	source?: string
+	children: ReactNode
+}): ReactNode => (
+	<div className="specimen">
+		<div className="specimen__stage">{children}</div>
+		<div className="specimen__label">{label}</div>
+		{code && <div className="specimen__code">{code}</div>}
+		{meta && <div className="specimen__meta">{meta}</div>}
+		{source && <div className="specimen__source">{source}</div>}
+	</div>
+)
+
+/** The shared card + grid styling. Append to each page's <style>. */
+export const SPECIMEN_CSS = `
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 20px; }
+.specimen { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 20px 16px 14px; background: var(--tl-color-panel); display: flex; flex-direction: column; gap: 12px; }
+.specimen__stage { min-height: 56px; display: flex; align-items: center; justify-content: center; background: var(--tl-color-low); border-radius: 6px; padding: 12px; overflow: hidden; }
+.specimen__label { font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace; }
+.specimen__code { font-size: 11px; line-height: 1.4; color: var(--tl-color-text-1); font-family: ui-monospace, monospace; background: var(--tl-color-low); border-radius: 4px; padding: 5px 7px; white-space: pre-wrap; word-break: break-word; }
+.specimen__meta { font-size: 11px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; }
+.specimen__source { font-size: 10px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; border-top: 1px dashed var(--tl-color-divider); padding-top: 8px; }
+`

--- a/apps/dotcom/client/src/pages/dev-components-kit.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-kit.tsx
@@ -11,6 +11,7 @@ export const Specimen = ({
 	code,
 	meta,
 	source,
+	mock,
 	children,
 }: {
 	label: string
@@ -20,9 +21,18 @@ export const Specimen = ({
 	meta?: string
 	/** Where this instance is defined / which component renders it. */
 	source?: string
+	/**
+	 * True when the stage shows a hand-drawn representation rather than the real
+	 * component (because the real one needs editor / dialog / asset context to
+	 * mount). Defaults to false = a live render of the referenced code.
+	 */
+	mock?: boolean
 	children: ReactNode
 }): ReactNode => (
 	<div className="specimen">
+		<span className="specimen__badge" data-mock={mock || undefined}>
+			{mock ? 'mock' : 'live'}
+		</span>
 		<div className="specimen__stage">{children}</div>
 		<div className="specimen__label">{label}</div>
 		{code && <div className="specimen__code">{code}</div>}
@@ -34,7 +44,9 @@ export const Specimen = ({
 /** The shared card + grid styling. Append to each page's <style>. */
 export const SPECIMEN_CSS = `
 .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 20px; }
-.specimen { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 20px 16px 14px; background: var(--tl-color-panel); display: flex; flex-direction: column; gap: 12px; }
+.specimen { position: relative; border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 20px 16px 14px; background: var(--tl-color-panel); display: flex; flex-direction: column; gap: 12px; }
+.specimen__badge { position: absolute; top: 8px; right: 8px; font-size: 9px; font-family: ui-monospace, monospace; text-transform: uppercase; letter-spacing: 0.04em; padding: 1px 6px; border-radius: 999px; background: color-mix(in srgb, var(--tl-color-success, #2a9d3c) 16%, transparent); color: var(--tl-color-success, #2a9d3c); }
+.specimen__badge[data-mock] { background: color-mix(in srgb, var(--tl-color-text-3) 18%, transparent); color: var(--tl-color-text-3); }
 .specimen__stage { min-height: 56px; display: flex; align-items: center; justify-content: center; background: var(--tl-color-low); border-radius: 6px; padding: 12px; overflow: hidden; }
 .specimen__label { font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace; }
 .specimen__code { font-size: 11px; line-height: 1.4; color: var(--tl-color-text-1); font-family: ui-monospace, monospace; background: var(--tl-color-low); border-radius: 4px; padding: 5px 7px; white-space: pre-wrap; word-break: break-word; }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -21,6 +21,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/inputs" style={link}>
 				inputs
 			</a>
+			<a href="/dev/components/typography" style={link}>
+				typography
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -66,6 +66,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/z-index" style={link}>
 				z-index
 			</a>
+			<a href="/dev/components/shadows" style={link}>
+				shadows
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -33,6 +33,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/icons" style={link}>
 				icons
 			</a>
+			<a href="/dev/components/links" style={link}>
+				links
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+
+/** Shared header nav for the /dev/components/* inventory pages. */
+export function DevComponentsNav(): ReactNode {
+	const link = { color: 'var(--tl-color-primary)', textDecoration: 'none' } as const
+	return (
+		<nav
+			style={{
+				display: 'flex',
+				gap: 16,
+				marginBottom: 24,
+				fontFamily: 'var(--tla-font-ui)',
+				fontSize: 13,
+			}}
+		>
+			<span style={{ color: 'var(--tl-color-text-3)' }}>dev / components:</span>
+			<a href="/dev/components/buttons" style={link}>
+				buttons
+			</a>
+			<a href="/dev/components/inputs" style={link}>
+				inputs
+			</a>
+		</nav>
+	)
+}

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -60,6 +60,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/timestamps" style={link}>
 				dates
 			</a>
+			<a href="/dev/components/identity" style={link}>
+				identity
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -27,6 +27,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/dialogs" style={link}>
 				dialogs
 			</a>
+			<a href="/dev/components/menus" style={link}>
+				menus
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -51,6 +51,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/states" style={link}>
 				states
 			</a>
+			<a href="/dev/components/sidebar" style={link}>
+				sidebar map
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -30,6 +30,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/menus" style={link}>
 				menus
 			</a>
+			<a href="/dev/components/icons" style={link}>
+				icons
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -39,6 +39,15 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/overlays" style={link}>
 				overlays
 			</a>
+			<a href="/dev/components/form-controls" style={link}>
+				form controls
+			</a>
+			<a href="/dev/components/presence" style={link}>
+				presence
+			</a>
+			<a href="/dev/components/logo" style={link}>
+				logo
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -54,6 +54,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/sidebar" style={link}>
 				sidebar map
 			</a>
+			<a href="/dev/components/editor" style={link}>
+				editor map
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -63,6 +63,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/identity" style={link}>
 				identity
 			</a>
+			<a href="/dev/components/z-index" style={link}>
+				z-index
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -36,6 +36,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/links" style={link}>
 				links
 			</a>
+			<a href="/dev/components/overlays" style={link}>
+				overlays
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -24,6 +24,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/typography" style={link}>
 				typography
 			</a>
+			<a href="/dev/components/dialogs" style={link}>
+				dialogs
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -57,6 +57,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/editor" style={link}>
 				editor map
 			</a>
+			<a href="/dev/components/timestamps" style={link}>
+				dates
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-components-nav.tsx
+++ b/apps/dotcom/client/src/pages/dev-components-nav.tsx
@@ -48,6 +48,9 @@ export function DevComponentsNav(): ReactNode {
 			<a href="/dev/components/logo" style={link}>
 				logo
 			</a>
+			<a href="/dev/components/states" style={link}>
+				states
+			</a>
 		</nav>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -1,10 +1,52 @@
 /* eslint-disable tldraw/jsx-no-literals */
+import { Dialog as RadixDialog } from 'radix-ui'
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
+import {
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	TldrawUiDialogBody,
+	TldrawUiDialogCloseButton,
+	TldrawUiDialogFooter,
+	TldrawUiDialogHeader,
+	TldrawUiDialogTitle,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { DevComponentsNav } from './dev-components-nav'
-import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { IsolationProviders } from './dev-editor-harness'
+
+/** A real dialog, no modal machinery. The Title/CloseButton are Radix Dialog
+ * primitives so they need a Dialog.Root, but modal={false} + no Portal keeps it
+ * inline (no scroll-lock, no backdrop) — the real dialog UI, resolved open. */
+const LiveDialog = (): ReactNode => (
+	<div className="dialogStage">
+		<RadixDialog.Root open modal={false}>
+			<RadixDialog.Content
+				className="tlui-dialog__content"
+				onInteractOutside={(e) => e.preventDefault()}
+				onEscapeKeyDown={(e) => e.preventDefault()}
+				onOpenAutoFocus={(e) => e.preventDefault()}
+			>
+				<TldrawUiDialogHeader>
+					<TldrawUiDialogTitle>Rename file</TldrawUiDialogTitle>
+					<TldrawUiDialogCloseButton />
+				</TldrawUiDialogHeader>
+				<TldrawUiDialogBody style={{ maxWidth: 350 }}>
+					Give this file a new name. The body is the only part dialogs size differently.
+				</TldrawUiDialogBody>
+				<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+					<TldrawUiButton type="normal">
+						<TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>
+					</TldrawUiButton>
+					<TldrawUiButton type="primary">
+						<TldrawUiButtonLabel>Rename</TldrawUiButtonLabel>
+					</TldrawUiButton>
+				</TldrawUiDialogFooter>
+			</RadixDialog.Content>
+		</RadixDialog.Root>
+	</div>
+)
 
 /**
  * Dev-only inventory of the dotcom app's dialogs. The healthiest family: nearly
@@ -25,154 +67,160 @@ export function Component() {
 			<Helmet>
 				<title>Dialog inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+			<style>{PAGE_CSS}</style>
 
-			<div className="page">
-				<DevComponentsNav />
-				<header className="page__header">
-					<h1 className="page__title">Dialog inventory</h1>
-					<p className="page__lede">
-						Every dialog in the dotcom app. Unlike buttons / inputs / type, this family is well
-						consolidated: almost all use the SDK <code>TldrawUiDialog</code> primitive. The
-						divergence is configurational — inconsistent body widths — plus one justified bespoke
-						modal.
-					</p>
-				</header>
+			<IsolationProviders>
+				<div className="page">
+					<DevComponentsNav />
+					<header className="page__header">
+						<h1 className="page__title">Dialog inventory</h1>
+						<p className="page__lede">
+							Every dialog in the dotcom app. Unlike buttons / inputs / type, this family is well
+							consolidated: almost all use the SDK <code>TldrawUiDialog</code> primitive. The
+							divergence is configurational — inconsistent body widths — plus one justified bespoke
+							modal.
+						</p>
+					</header>
 
-				<section className="section">
-					<h2 className="section__title">Adoption</h2>
-					<p className="section__note">
-						12 of 13 dialogs compose the SDK <code>TldrawUiDialog*</code> parts. One is bespoke (and
-						documented).
-					</p>
-					<div className="stats">
-						<Stat n="12" label="use TldrawUiDialog primitive" good />
-						<Stat n="1" label="bespoke modal (justified)" />
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">Adoption</h2>
+						<p className="section__note">
+							12 of 13 dialogs compose the SDK <code>TldrawUiDialog*</code> parts. One is bespoke
+							(and documented).
+						</p>
+						<div className="stats">
+							<Stat n="12" label="use TldrawUiDialog primitive" good />
+							<Stat n="1" label="bespoke modal (justified)" />
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">The SDK primitive — anatomy</h2>
-					<p className="section__note">
-						<code>TldrawUiDialog</code> is a Radix-based compound:{' '}
-						<code>Header › Title + CloseButton</code>, <code>Body</code>, <code>Footer</code>. The
-						mock below uses the real <code>.tlui-dialog__*</code> classes.
-					</p>
-					<div className="dialogMock">
-						<div className="tlui-dialog__header dialogMock__header">
-							<span className="tlui-dialog__header__title">Dialog title</span>
-							<span className="dialogMock__x">✕</span>
+					<section className="section">
+						<h2 className="section__title">The SDK primitive — anatomy</h2>
+						<p className="section__note">
+							<code>TldrawUiDialog</code> is a Radix-based compound:{' '}
+							<code>Header › Title + CloseButton</code>, <code>Body</code>, <code>Footer</code>.
+							Below is the real thing — actual <code>TldrawUiDialog*</code> primitives, rendered
+							open (non-modal so it sits in the page instead of taking it over).
+						</p>
+						<LiveDialog />
+						<div className="section__api" style={{ marginTop: 20 }}>
+							<div>
+								<span className="k">parts</span>
+								TldrawUiDialogHeader, TldrawUiDialogTitle, TldrawUiDialogCloseButton,
+								TldrawUiDialogBody, TldrawUiDialogFooter
+							</div>
+							<div>
+								<span className="k">opened</span>
+								via the editor's dialogs manager (addDialog / useDialogs) — portalled by Radix
+							</div>
 						</div>
-						<div className="tlui-dialog__body dialogMock__body">
-							Body content — the only part dialogs size differently.
-						</div>
-						<div className="tlui-dialog__footer dialogMock__footer">Footer · actions</div>
-					</div>
-					<div className="section__api" style={{ marginTop: 20 }}>
-						<div>
-							<span className="k">parts</span>
-							TldrawUiDialogHeader, TldrawUiDialogTitle, TldrawUiDialogCloseButton,
-							TldrawUiDialogBody, TldrawUiDialogFooter
-						</div>
-						<div>
-							<span className="k">opened</span>
-							via the editor's dialogs manager (addDialog / useDialogs) — portalled by Radix
-						</div>
-					</div>
-				</section>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">Props in use</h2>
-					<p className="section__note">
-						The parts have a tiny API; the only behavioural prop lives in the open call.
-					</p>
-					<div className="section__api">
-						<div>
-							<span className="k">parts</span>
-							className + children + style (Body / Title) — that's the whole surface. Footer
-							consistently uses className="tlui-dialog__footer__actions".
+					<section className="section">
+						<h2 className="section__title">Props in use</h2>
+						<p className="section__note">
+							The parts have a tiny API; the only behavioural prop lives in the open call.
+						</p>
+						<div className="section__api">
+							<div>
+								<span className="k">parts</span>
+								className + children + style (Body / Title) — that's the whole surface. Footer
+								consistently uses className="tlui-dialog__footer__actions".
+							</div>
+							<div>
+								<span className="k">width</span>
+								body width set two ways — style={'{{'} maxWidth {'}}'} (6) vs className (8); see
+								below
+							</div>
 						</div>
-						<div>
-							<span className="k">width</span>
-							body width set two ways — style={'{{'} maxWidth {'}}'} (6) vs className (8); see below
+						<div className="section__api" style={{ marginTop: 12 }}>
+							<div>
+								<span className="k">open</span>
+								addDialog({'{'} id, component, onClose?, preventBackgroundClose? {'}'}) — id +
+								component always; onClose common
+							</div>
+							<div>
+								<span className="k">prevent</span>
+								preventBackgroundClose: true — only 2 dialogs (WorkspaceInviteHandler sign-in +
+								invite-join, SneakyLegacyModal). Opts out of backdrop dismiss for required-state
+								dialogs.
+							</div>
 						</div>
-					</div>
-					<div className="section__api" style={{ marginTop: 12 }}>
-						<div>
-							<span className="k">open</span>
-							addDialog({'{'} id, component, onClose?, preventBackgroundClose? {'}'}) — id +
-							component always; onClose common
-						</div>
-						<div>
-							<span className="k">prevent</span>
-							preventBackgroundClose: true — only 2 dialogs (WorkspaceInviteHandler sign-in +
-							invite-join, SneakyLegacyModal). Opts out of backdrop dismiss for required-state
-							dialogs.
-						</div>
-					</div>
-				</section>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">The dialogs</h2>
-					<p className="section__note">
-						Every dialog component, its mechanism, and the width it sets on the body.
-					</p>
-					<div className="grid">
-						{DIALOGS.map((r) => (
-							<Specimen key={r[0]} label={r[0]} code={r[1]} meta={`maxWidth ${r[2]} · ${r[3]}`} mock>
-								<div className="miniDialog" data-bespoke={r[1] === 'bespoke' || undefined}>
-									<div className="miniDialog__h" />
-									<div className="miniDialog__b" />
-								</div>
-							</Specimen>
-						))}
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Width divergence (the real cleanup)</h2>
-					<p className="section__note">
-						Two inconsistencies at once. <strong>Mechanism</strong>: 6 bodies set width via inline{' '}
-						<code>
-							style={'{{'} maxWidth {'}}'}
-						</code>
-						, 8 via a <code>className</code> — same goal, two idioms in sibling files.{' '}
-						<strong>Value</strong>: <code>maxWidth: 350</code> is hand-typed inline 5 times, with no
-						shared rung. A single <code>size</code> prop (or one width class) collapses both.
-					</p>
-					<table className="matrix">
-						<thead>
-							<tr>
-								<th>width</th>
-								<th>count</th>
-								<th>note</th>
-							</tr>
-						</thead>
-						<tbody>
-							{WIDTHS.map((r) => (
-								<tr key={r[0]} data-off={r[2].startsWith('drift') || undefined}>
-									<td>{r[0]}</td>
-									<td>{r[1]}</td>
-									<td>{r[2]}</td>
+					<section className="section">
+						<h2 className="section__title">The dialogs</h2>
+						<p className="section__note">
+							Every dialog component, its mechanism, and the width it sets on the body — the
+							catalogue (data) behind the one real dialog rendered above.
+						</p>
+						<table className="matrix">
+							<thead>
+								<tr>
+									<th>dialog</th>
+									<th>mechanism</th>
+									<th>maxWidth</th>
+									<th>purpose</th>
 								</tr>
-							))}
-						</tbody>
-					</table>
-				</section>
+							</thead>
+							<tbody>
+								{DIALOGS.map((r) => (
+									<tr key={r[0]} data-off={r[1] === 'bespoke' || undefined}>
+										<td>{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+										<td>{r[3]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">The one bespoke modal — justified</h2>
-					<div className="callout">
-						<code>MaybeForceUserRefresh</code> is <strong>not</strong> a <code>TldrawUiDialog</code>
-						: it renders at the app-provider root to dim the whole app when the client is outdated —
-						a context where the Radix dialog primitives and their UI-context hooks (
-						<code>useTranslation</code>, <code>useDirection</code>) are not available. It&rsquo;s a
-						custom overlay by necessity, and it&rsquo;s documented in-code. This is a{' '}
-						<strong>justified</strong> divergence, not drift — the kind an audit should leave alone.
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">Width divergence (the real cleanup)</h2>
+						<p className="section__note">
+							Two inconsistencies at once. <strong>Mechanism</strong>: 6 bodies set width via inline{' '}
+							<code>
+								style={'{{'} maxWidth {'}}'}
+							</code>
+							, 8 via a <code>className</code> — same goal, two idioms in sibling files.{' '}
+							<strong>Value</strong>: <code>maxWidth: 350</code> is hand-typed inline 5 times, with
+							no shared rung. A single <code>size</code> prop (or one width class) collapses both.
+						</p>
+						<table className="matrix">
+							<thead>
+								<tr>
+									<th>width</th>
+									<th>count</th>
+									<th>note</th>
+								</tr>
+							</thead>
+							<tbody>
+								{WIDTHS.map((r) => (
+									<tr key={r[0]} data-off={r[2].startsWith('drift') || undefined}>
+										<td>{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
 
-			</div>
+					<section className="section">
+						<h2 className="section__title">The one bespoke modal — justified</h2>
+						<div className="callout">
+							<code>MaybeForceUserRefresh</code> is <strong>not</strong> a{' '}
+							<code>TldrawUiDialog</code>: it renders at the app-provider root to dim the whole app
+							when the client is outdated — a context where the Radix dialog primitives and their
+							UI-context hooks (<code>useTranslation</code>, <code>useDirection</code>) are not
+							available. It&rsquo;s a custom overlay by necessity, and it&rsquo;s documented
+							in-code. This is a <strong>justified</strong> divergence, not drift — the kind an
+							audit should leave alone.
+						</div>
+					</section>
+				</div>
+			</IsolationProviders>
 		</div>
 	)
 }
@@ -230,6 +278,7 @@ const PAGE_CSS = `
 .stat__n { font-size: 28px; font-weight: 700; font-family: ui-monospace, monospace; }
 .stat[data-good] .stat__n { color: var(--tl-color-success, #2a9d3c); }
 .stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.dialogStage { position: relative; transform: translateZ(0); min-height: 260px; display: flex; align-items: center; justify-content: center; padding: 24px; border: 1px solid var(--tl-color-divider); border-radius: 8px; background: var(--tl-color-low); }
 .dialogMock { max-width: 360px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-3); overflow: hidden; box-shadow: 0 6px 24px rgba(0,0,0,0.12); background: var(--tl-color-panel); }
 .dialogMock__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 14px; border-bottom: 1px solid var(--tl-color-divider); font-weight: 600; font-size: 13px; }
 .dialogMock__x { color: var(--tl-color-text-3); }

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -1,0 +1,265 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's dialogs. The healthiest family: nearly
+ * every dialog uses the SDK TldrawUiDialog primitive, so the divergence is not
+ * structural but CONFIGURATIONAL — the body maxWidth is hand-set per dialog with
+ * no shared size convention — plus one justified bespoke exception.
+ *
+ * Serves tldraw/tldraw#9199 (misc design-system cleanups). Route:
+ * /dev/components/dialogs.
+ */
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Dialog inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Dialog inventory</h1>
+					<p className="page__lede">
+						Every dialog in the dotcom app. Unlike buttons / inputs / type, this family is well
+						consolidated: almost all use the SDK <code>TldrawUiDialog</code> primitive. The
+						divergence is configurational — inconsistent body widths — plus one justified bespoke
+						modal.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">Adoption</h2>
+					<p className="section__note">
+						12 of 13 dialogs compose the SDK <code>TldrawUiDialog*</code> parts. One is bespoke (and
+						documented).
+					</p>
+					<div className="stats">
+						<Stat n="12" label="use TldrawUiDialog primitive" good />
+						<Stat n="1" label="bespoke modal (justified)" />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The SDK primitive — anatomy</h2>
+					<p className="section__note">
+						<code>TldrawUiDialog</code> is a Radix-based compound:{' '}
+						<code>Header › Title + CloseButton</code>, <code>Body</code>, <code>Footer</code>. The
+						mock below uses the real <code>.tlui-dialog__*</code> classes.
+					</p>
+					<div className="dialogMock">
+						<div className="tlui-dialog__header dialogMock__header">
+							<span className="tlui-dialog__header__title">Dialog title</span>
+							<span className="dialogMock__x">✕</span>
+						</div>
+						<div className="tlui-dialog__body dialogMock__body">
+							Body content — the only part dialogs size differently.
+						</div>
+						<div className="tlui-dialog__footer dialogMock__footer">Footer · actions</div>
+					</div>
+					<div className="section__api" style={{ marginTop: 20 }}>
+						<div>
+							<span className="k">parts</span>
+							TldrawUiDialogHeader, TldrawUiDialogTitle, TldrawUiDialogCloseButton,
+							TldrawUiDialogBody, TldrawUiDialogFooter
+						</div>
+						<div>
+							<span className="k">opened</span>
+							via the editor's dialogs manager (addDialog / useDialogs) — portalled by Radix
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Props in use</h2>
+					<p className="section__note">
+						The parts have a tiny API; the only behavioural prop lives in the open call.
+					</p>
+					<div className="section__api">
+						<div>
+							<span className="k">parts</span>
+							className + children + style (Body / Title) — that's the whole surface. Footer
+							consistently uses className="tlui-dialog__footer__actions".
+						</div>
+						<div>
+							<span className="k">width</span>
+							body width set two ways — style={'{{'} maxWidth {'}}'} (6) vs className (8); see below
+						</div>
+					</div>
+					<div className="section__api" style={{ marginTop: 12 }}>
+						<div>
+							<span className="k">open</span>
+							addDialog({'{'} id, component, onClose?, preventBackgroundClose? {'}'}) — id +
+							component always; onClose common
+						</div>
+						<div>
+							<span className="k">prevent</span>
+							preventBackgroundClose: true — only 2 dialogs (WorkspaceInviteHandler sign-in +
+							invite-join, SneakyLegacyModal). Opts out of backdrop dismiss for required-state
+							dialogs.
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The dialogs</h2>
+					<p className="section__note">
+						Every dialog component, its mechanism, and the width it sets on the body.
+					</p>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>dialog</th>
+								<th>mechanism</th>
+								<th>body width</th>
+								<th>purpose</th>
+							</tr>
+						</thead>
+						<tbody>
+							{DIALOGS.map((r) => (
+								<tr key={r[0]} data-off={r[1] === 'bespoke' || undefined}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+									<td>{r[3]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Width divergence (the real cleanup)</h2>
+					<p className="section__note">
+						Two inconsistencies at once. <strong>Mechanism</strong>: 6 bodies set width via inline{' '}
+						<code>
+							style={'{{'} maxWidth {'}}'}
+						</code>
+						, 8 via a <code>className</code> — same goal, two idioms in sibling files.{' '}
+						<strong>Value</strong>: <code>maxWidth: 350</code> is hand-typed inline 5 times, with no
+						shared rung. A single <code>size</code> prop (or one width class) collapses both.
+					</p>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>width</th>
+								<th>count</th>
+								<th>note</th>
+							</tr>
+						</thead>
+						<tbody>
+							{WIDTHS.map((r) => (
+								<tr key={r[0]} data-off={r[2].startsWith('drift') || undefined}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The one bespoke modal — justified</h2>
+					<div className="callout">
+						<code>MaybeForceUserRefresh</code> is <strong>not</strong> a <code>TldrawUiDialog</code>
+						: it renders at the app-provider root to dim the whole app when the client is outdated —
+						a context where the Radix dialog primitives and their UI-context hooks (
+						<code>useTranslation</code>, <code>useDirection</code>) are not available. It&rsquo;s a
+						custom overlay by necessity, and it&rsquo;s documented in-code. This is a{' '}
+						<strong>justified</strong> divergence, not drift — the kind an audit should leave alone.
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					Takeaway for #9199: dialogs are the model the other families should reach — near-total
+					adoption of one primitive. The only worthwhile cleanup is a shared body-size convention (a{' '}
+					<code>size</code> prop or a small set of width classes) to retire the repeated{' '}
+					<code>maxWidth: 350</code>; the bespoke modal is a documented exception to keep. See
+					tldraw/tldraw#9199.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const Stat = ({ n, label, good }: { n: string; label: string; good?: boolean }): ReactNode => (
+	<div className="stat" data-good={good || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+const DIALOGS: ReadonlyArray<readonly [string, string, string, string]> = [
+	['ConfirmDialog', 'TldrawUiDialog', '300', 'generic confirm'],
+	['CreateWorkspaceDialog', 'TldrawUiDialog', '350', 'create a workspace'],
+	['TlaDeleteFileDialog', 'TldrawUiDialog', '350', 'delete-file confirm'],
+	['SneakyLargeFileHandler', 'TldrawUiDialog', '350', 'large-file warning'],
+	['shouldOverrideDocument', 'TldrawUiDialog', '350', 'override-document prompt'],
+	['TlaSignInDialog', 'TldrawUiDialog', '450 (auth)', 'sign in (Clerk)'],
+	['SubmitFeedbackDialog', 'TldrawUiDialog', '— (500)', 'feedback form (textarea)'],
+	['TlaInviteDialog', 'TldrawUiDialog', '— (500)', 'accept workspace invite'],
+	['TlaInviteExpiredDialog', 'TldrawUiDialog', '— (500)', 'invite expired'],
+	['TlaManageCookiesDialog', 'TldrawUiDialog', '— (500)', 'cookie settings'],
+	['WorkspaceSettingsDialog', 'TldrawUiDialog', '— (500)', 'workspace settings (large)'],
+	['SneakyLegacyModal', 'TldrawUiDialog', '— (500)', 'legacy editor modal'],
+	['MaybeForceUserRefresh', 'bespoke', 'full-screen', 'force-refresh outdated client'],
+]
+
+const WIDTHS: ReadonlyArray<readonly [string, string, string]> = [
+	['350px', '5', 'drift — hand-typed inline, no shared class'],
+	['300px', '1', 'ConfirmDialog'],
+	['450px', '1', 'auth (sign-in)'],
+	['500px', 'default', '.dialogBody base'],
+	['360 / 240px', '2', 'other dialog elements'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.section code, .callout code, .page__footer code, .section__note code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 220px; background: var(--tl-color-panel); }
+.stat[data-good] { border-color: var(--tl-color-success, #2a9d3c); }
+.stat__n { font-size: 28px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-good] .stat__n { color: var(--tl-color-success, #2a9d3c); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.dialogMock { max-width: 360px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-3); overflow: hidden; box-shadow: 0 6px 24px rgba(0,0,0,0.12); background: var(--tl-color-panel); }
+.dialogMock__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 14px; border-bottom: 1px solid var(--tl-color-divider); font-weight: 600; font-size: 13px; }
+.dialogMock__x { color: var(--tl-color-text-3); }
+.dialogMock__body { padding: 16px 14px; font-size: 13px; color: var(--tl-color-text-1); }
+.dialogMock__footer { padding: 12px 14px; border-top: 1px solid var(--tl-color-divider); font-size: 12px; color: var(--tl-color-text-3); text-align: right; }
+.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; max-width: 860px; }
+.section__api > div { display: flex; gap: 8px; }
+.section__api > div + div { margin-top: 4px; }
+.section__api .k { color: var(--tl-color-text-3); flex: 0 0 56px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix tr[data-off] td:first-child { font-weight: 700; color: var(--tl-color-warning, #cb4b16); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -205,16 +205,12 @@ export function Component() {
 						<h2 className="section__title">The dialogs — all {DIALOGS.length}, each live</h2>
 						<p className="section__note">
 							Every dialog, rendered as a real non-modal <code>TldrawUiDialog</code> titled with its
-							component name. <code>maxWidth</code> in the meta. One is bespoke (not a TldrawUiDialog).
+							component name. <code>maxWidth</code> in the meta. One is bespoke (not a
+							TldrawUiDialog).
 						</p>
 						<div className="grid grid--dialogs">
 							{DIALOGS.map((r) => (
-								<Specimen
-									key={r[0]}
-									label={r[0]}
-									code={r[1]}
-									meta={`maxWidth ${r[2]} · ${r[3]}`}
-								>
+								<Specimen key={r[0]} label={r[0]} code={r[1]} meta={`maxWidth ${r[2]} · ${r[3]}`}>
 									<DialogCard name={r[0]} mechanism={r[1]} purpose={r[3]} />
 								</Specimen>
 							))}

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -13,8 +13,61 @@ import {
 } from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
 import { IsolationProviders } from './dev-editor-harness'
+
+const preventDefault = (e: Event) => e.preventDefault()
+
+/** One real dialog per card: a non-modal Dialog.Root + the real TldrawUiDialog
+ * primitives, titled per dialog. The bespoke one isn't a TldrawUiDialog, so it's
+ * shown as a note. */
+const DialogCard = ({
+	name,
+	mechanism,
+	purpose,
+}: {
+	name: string
+	mechanism: string
+	purpose: string
+}): ReactNode => {
+	if (mechanism === 'bespoke') {
+		return (
+			<div className="dialogCardStage dialogCardStage--bespoke">
+				<div className="bespokeNote">
+					<strong>{name}</strong>
+					<span>bespoke full-screen overlay — not a TldrawUiDialog</span>
+				</div>
+			</div>
+		)
+	}
+	return (
+		<div className="dialogCardStage">
+			<RadixDialog.Root open modal={false}>
+				<RadixDialog.Content
+					className="tlui-dialog__content"
+					onInteractOutside={preventDefault}
+					onEscapeKeyDown={preventDefault}
+					onOpenAutoFocus={preventDefault}
+				>
+					<TldrawUiDialogHeader>
+						<TldrawUiDialogTitle>{name}</TldrawUiDialogTitle>
+						<TldrawUiDialogCloseButton />
+					</TldrawUiDialogHeader>
+					<TldrawUiDialogBody>{purpose}</TldrawUiDialogBody>
+					<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
+						<TldrawUiButton type="normal">
+							<TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>
+						</TldrawUiButton>
+						<TldrawUiButton type="primary">
+							<TldrawUiButtonLabel>OK</TldrawUiButtonLabel>
+						</TldrawUiButton>
+					</TldrawUiDialogFooter>
+				</RadixDialog.Content>
+			</RadixDialog.Root>
+		</div>
+	)
+}
 
 /** A real dialog, no modal machinery. The Title/CloseButton are Radix Dialog
  * primitives so they need a Dialog.Root, but modal={false} + no Portal keeps it
@@ -67,7 +120,7 @@ export function Component() {
 			<Helmet>
 				<title>Dialog inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<IsolationProviders>
 				<div className="page">
@@ -149,31 +202,23 @@ export function Component() {
 					</section>
 
 					<section className="section">
-						<h2 className="section__title">The dialogs</h2>
+						<h2 className="section__title">The dialogs — all {DIALOGS.length}, each live</h2>
 						<p className="section__note">
-							Every dialog component, its mechanism, and the width it sets on the body — the
-							catalogue (data) behind the one real dialog rendered above.
+							Every dialog, rendered as a real non-modal <code>TldrawUiDialog</code> titled with its
+							component name. <code>maxWidth</code> in the meta. One is bespoke (not a TldrawUiDialog).
 						</p>
-						<table className="matrix">
-							<thead>
-								<tr>
-									<th>dialog</th>
-									<th>mechanism</th>
-									<th>maxWidth</th>
-									<th>purpose</th>
-								</tr>
-							</thead>
-							<tbody>
-								{DIALOGS.map((r) => (
-									<tr key={r[0]} data-off={r[1] === 'bespoke' || undefined}>
-										<td>{r[0]}</td>
-										<td>{r[1]}</td>
-										<td>{r[2]}</td>
-										<td>{r[3]}</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
+						<div className="grid grid--dialogs">
+							{DIALOGS.map((r) => (
+								<Specimen
+									key={r[0]}
+									label={r[0]}
+									code={r[1]}
+									meta={`maxWidth ${r[2]} · ${r[3]}`}
+								>
+									<DialogCard name={r[0]} mechanism={r[1]} purpose={r[3]} />
+								</Specimen>
+							))}
+						</div>
 					</section>
 
 					<section className="section">
@@ -279,6 +324,12 @@ const PAGE_CSS = `
 .stat[data-good] .stat__n { color: var(--tl-color-success, #2a9d3c); }
 .stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
 .dialogStage { position: relative; transform: translateZ(0); min-height: 260px; display: flex; align-items: center; justify-content: center; padding: 24px; border: 1px solid var(--tl-color-divider); border-radius: 8px; background: var(--tl-color-low); }
+.grid--dialogs { grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); }
+.dialogCardStage { position: relative; transform: translateZ(0); width: 100%; min-height: 210px; display: flex; align-items: center; justify-content: center; padding: 16px; border-radius: 8px; background: var(--tl-color-low); overflow: hidden; }
+.dialogCardStage .tlui-dialog__content { position: static; width: 100%; min-width: 0; max-width: 340px; box-shadow: 0 4px 16px rgba(0,0,0,0.1); }
+.dialogCardStage--bespoke { min-height: 120px; border: 1px dashed var(--tl-color-warning, #cb4b16); }
+.bespokeNote { display: flex; flex-direction: column; gap: 6px; text-align: center; font-size: 12px; color: var(--tl-color-warning, #cb4b16); }
+.bespokeNote strong { font-family: ui-monospace, monospace; }
 .dialogMock { max-width: 360px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-3); overflow: hidden; box-shadow: 0 6px 24px rgba(0,0,0,0.12); background: var(--tl-color-panel); }
 .dialogMock__header { display: flex; align-items: center; justify-content: space-between; padding: 12px 14px; border-bottom: 1px solid var(--tl-color-divider); font-weight: 600; font-size: 13px; }
 .dialogMock__x { color: var(--tl-color-text-3); }

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { DevComponentsNav } from './dev-components-nav'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 
 /**
  * Dev-only inventory of the dotcom app's dialogs. The healthiest family: nearly
@@ -24,7 +25,7 @@ export function Component() {
 			<Helmet>
 				<title>Dialog inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
@@ -116,26 +117,16 @@ export function Component() {
 					<p className="section__note">
 						Every dialog component, its mechanism, and the width it sets on the body.
 					</p>
-					<table className="matrix">
-						<thead>
-							<tr>
-								<th>dialog</th>
-								<th>mechanism</th>
-								<th>body width</th>
-								<th>purpose</th>
-							</tr>
-						</thead>
-						<tbody>
-							{DIALOGS.map((r) => (
-								<tr key={r[0]} data-off={r[1] === 'bespoke' || undefined}>
-									<td>{r[0]}</td>
-									<td>{r[1]}</td>
-									<td>{r[2]}</td>
-									<td>{r[3]}</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
+					<div className="grid">
+						{DIALOGS.map((r) => (
+							<Specimen key={r[0]} label={r[0]} code={r[1]} meta={`maxWidth ${r[2]} · ${r[3]}`}>
+								<div className="miniDialog" data-bespoke={r[1] === 'bespoke' || undefined}>
+									<div className="miniDialog__h" />
+									<div className="miniDialog__b" />
+								</div>
+							</Specimen>
+						))}
+					</div>
 				</section>
 
 				<section className="section">
@@ -251,6 +242,11 @@ const PAGE_CSS = `
 .dialogMock__x { color: var(--tl-color-text-3); }
 .dialogMock__body { padding: 16px 14px; font-size: 13px; color: var(--tl-color-text-1); }
 .dialogMock__footer { padding: 12px 14px; border-top: 1px solid var(--tl-color-divider); font-size: 12px; color: var(--tl-color-text-3); text-align: right; }
+.miniDialog { width: 96px; border: 1px solid var(--tl-color-divider); border-radius: 5px; overflow: hidden; background: var(--tl-color-panel); box-shadow: 0 3px 10px rgba(0,0,0,0.1); }
+.miniDialog__h { height: 14px; border-bottom: 1px solid var(--tl-color-divider); background: var(--tl-color-low); }
+.miniDialog__b { height: 30px; }
+.miniDialog[data-bespoke] { border-color: var(--tl-color-warning, #cb4b16); }
+.miniDialog[data-bespoke] .miniDialog__h { background: var(--tl-color-warning, #cb4b16); opacity: 0.25; }
 .section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; max-width: 860px; }
 .section__api > div { display: flex; gap: 8px; }
 .section__api > div + div { margin-top: 4px; }

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -172,13 +172,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					Takeaway for #9199: dialogs are the model the other families should reach — near-total
-					adoption of one primitive. The only worthwhile cleanup is a shared body-size convention (a{' '}
-					<code>size</code> prop or a small set of width classes) to retire the repeated{' '}
-					<code>maxWidth: 350</code>; the bespoke modal is a documented exception to keep. See
-					tldraw/tldraw#9199.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -119,7 +119,7 @@ export function Component() {
 					</p>
 					<div className="grid">
 						{DIALOGS.map((r) => (
-							<Specimen key={r[0]} label={r[0]} code={r[1]} meta={`maxWidth ${r[2]} · ${r[3]}`}>
+							<Specimen key={r[0]} label={r[0]} code={r[1]} meta={`maxWidth ${r[2]} · ${r[3]}`} mock>
 								<div className="miniDialog" data-bespoke={r[1] === 'bespoke' || undefined}>
 									<div className="miniDialog__h" />
 									<div className="miniDialog__b" />

--- a/apps/dotcom/client/src/pages/dev-dialogs.tsx
+++ b/apps/dotcom/client/src/pages/dev-dialogs.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable tldraw/jsx-no-literals */
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
 import { Dialog as RadixDialog } from 'radix-ui'
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'

--- a/apps/dotcom/client/src/pages/dev-editor-harness.tsx
+++ b/apps/dotcom/client/src/pages/dev-editor-harness.tsx
@@ -52,17 +52,21 @@ export const IsolationProviders = ({ children }: { children: ReactNode }): React
 export const MinimalEditorHarness = ({
 	children,
 	height = 360,
+	bare,
 }: {
 	children: ReactNode
 	height?: number
+	/** Fill the parent with no frame — for embedding inside a card's own stage. */
+	bare?: boolean
 }): ReactNode => (
 	<div
 		style={{
 			position: 'relative',
 			height,
-			maxWidth: 640,
-			border: '1px solid var(--tl-color-divider)',
-			borderRadius: 8,
+			width: bare ? '100%' : undefined,
+			maxWidth: bare ? undefined : 640,
+			border: bare ? undefined : '1px solid var(--tl-color-divider)',
+			borderRadius: bare ? undefined : 8,
 			overflow: 'hidden',
 		}}
 	>

--- a/apps/dotcom/client/src/pages/dev-editor-harness.tsx
+++ b/apps/dotcom/client/src/pages/dev-editor-harness.tsx
@@ -37,11 +37,13 @@ const Providers = ({
  * e.g. TlaMenuSelect). No editor. Use to wrap a whole page so its components
  * render live. document.body is a fine portal container for a dev page.
  */
-export const IsolationProviders = ({ children }: { children: ReactNode }): ReactNode => (
-	<Providers container={typeof document !== 'undefined' ? document.body : undefined}>
-		{children}
-	</Providers>
-)
+export function IsolationProviders({ children }: { children: ReactNode }): ReactNode {
+	return (
+		<Providers container={typeof document !== 'undefined' ? document.body : undefined}>
+			{children}
+		</Providers>
+	)
+}
 
 /**
  * Full: a minimal, empty, in-memory <Tldraw hideUi> supplying editor + container
@@ -49,7 +51,7 @@ export const IsolationProviders = ({ children }: { children: ReactNode }): React
  * TldrawUiMenu* action-dropdown system). Heavier — mounts a real editor — so use
  * only when a component needs one. Fake content, real function.
  */
-export const MinimalEditorHarness = ({
+export function MinimalEditorHarness({
 	children,
 	height = 360,
 	bare,
@@ -58,20 +60,22 @@ export const MinimalEditorHarness = ({
 	height?: number
 	/** Fill the parent with no frame — for embedding inside a card's own stage. */
 	bare?: boolean
-}): ReactNode => (
-	<div
-		style={{
-			position: 'relative',
-			height,
-			width: bare ? '100%' : undefined,
-			maxWidth: bare ? undefined : 640,
-			border: bare ? undefined : '1px solid var(--tl-color-divider)',
-			borderRadius: bare ? undefined : 8,
-			overflow: 'hidden',
-		}}
-	>
-		<Tldraw hideUi>
-			<Providers>{children}</Providers>
-		</Tldraw>
-	</div>
-)
+}): ReactNode {
+	return (
+		<div
+			style={{
+				position: 'relative',
+				height,
+				width: bare ? '100%' : undefined,
+				maxWidth: bare ? undefined : 640,
+				border: bare ? undefined : '1px solid var(--tl-color-divider)',
+				borderRadius: bare ? undefined : 8,
+				overflow: 'hidden',
+			}}
+		>
+			<Tldraw hideUi>
+				<Providers>{children}</Providers>
+			</Tldraw>
+		</div>
+	)
+}

--- a/apps/dotcom/client/src/pages/dev-editor-harness.tsx
+++ b/apps/dotcom/client/src/pages/dev-editor-harness.tsx
@@ -1,0 +1,73 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { ContainerProvider, Tldraw, TldrawUiContextProvider } from 'tldraw'
+import 'tldraw/tldraw.css'
+import translationsEnJson from '../../public/tla/locales-compiled/en.json'
+import { IntlProvider } from '../tla/utils/i18n'
+
+/**
+ * Shared harnesses for rendering otherwise-mocked dotcom components live in the
+ * /dev/components gallery. A component is "mockable" because it needs host
+ * context; these supply that context cheaply so the real component can render.
+ *
+ * The split mirrors the coupling itself: most components need only React
+ * context (intl + the SDK UI providers + a container element for portals), which
+ * IsolationProviders gives without an editor; a few are bound to the editor
+ * runtime (useEditor / the menu schema) and need MinimalEditorHarness.
+ */
+
+const Providers = ({
+	children,
+	container,
+}: {
+	children: ReactNode
+	container?: HTMLElement
+}): ReactNode => {
+	const ui = <TldrawUiContextProvider forceMobile={false}>{children}</TldrawUiContextProvider>
+	return (
+		<IntlProvider defaultLocale="en" locale="en" messages={translationsEnJson}>
+			{container ? <ContainerProvider container={container}>{ui}</ContainerProvider> : ui}
+		</IntlProvider>
+	)
+}
+
+/**
+ * Lightweight: dotcom react-intl (so useMsg works) + the SDK UI context (assets,
+ * tooltips, SDK translations) + a container element (so useContainer resolves,
+ * e.g. TlaMenuSelect). No editor. Use to wrap a whole page so its components
+ * render live. document.body is a fine portal container for a dev page.
+ */
+export const IsolationProviders = ({ children }: { children: ReactNode }): ReactNode => (
+	<Providers container={typeof document !== 'undefined' ? document.body : undefined}>
+		{children}
+	</Providers>
+)
+
+/**
+ * Full: a minimal, empty, in-memory <Tldraw hideUi> supplying editor + container
+ * context, for components truly bound to the editor runtime (the SDK
+ * TldrawUiMenu* action-dropdown system). Heavier — mounts a real editor — so use
+ * only when a component needs one. Fake content, real function.
+ */
+export const MinimalEditorHarness = ({
+	children,
+	height = 360,
+}: {
+	children: ReactNode
+	height?: number
+}): ReactNode => (
+	<div
+		style={{
+			position: 'relative',
+			height,
+			maxWidth: 640,
+			border: '1px solid var(--tl-color-divider)',
+			borderRadius: 8,
+			overflow: 'hidden',
+		}}
+	>
+		<Tldraw hideUi>
+			<Providers>{children}</Providers>
+		</Tldraw>
+	</div>
+)

--- a/apps/dotcom/client/src/pages/dev-editor.tsx
+++ b/apps/dotcom/client/src/pages/dev-editor.tsx
@@ -1,0 +1,273 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only CONSUMPTION MAP for the dotcom editor — companion to the sidebar map,
+ * but the inverse shape. The sidebar builds its own chrome; the editor is the SDK
+ * <Tldraw> with only a few slots overridden (MenuPanel / TopPanel / SharePanel)
+ * plus behavioral injections. Mostly delegated, small bespoke surface.
+ *
+ * Route: /dev/components/editor.
+ */
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Editor consumption map — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Editor — consumption map</h1>
+					<p className="page__lede">
+						The inverse of the <a href="/dev/components/sidebar">sidebar</a>. The editor isn&rsquo;t
+						built by dotcom — it&rsquo;s the SDK <code>&lt;Tldraw&gt;</code> with a handful of slots
+						swapped via its <code>components=&#123;&#125;</code> prop. Canvas, toolbar, style panel,
+						context menu — all SDK defaults, untouched. dotcom overrides three slots and injects some
+						behavior.
+					</p>
+				</header>
+
+				<section className="section">
+					<div className="stats">
+						<Stat n="3" label="SDK slots overridden" />
+						<Stat n="5" label="editor variants (<Tldraw> wrappers)" />
+						<Stat n="3" label="bespoke chrome classes" accent />
+						<Stat n="8" label="Sneaky* behavior injections" />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The override model</h2>
+					<p className="section__note">
+						What dotcom swaps in via <code>&lt;Tldraw components=&#123;…&#125;&gt;</code>. Everything
+						not listed is the SDK default.
+					</p>
+					<table className="cmap">
+						<thead>
+							<tr>
+								<th>SDK slot</th>
+								<th>dotcom override</th>
+								<th>what it is</th>
+							</tr>
+						</thead>
+						<tbody>
+							{SLOTS.map((s) => (
+								<tr key={s.slot}>
+									<td className="cmap__name">{s.slot}</td>
+									<td>
+										<span className="chip chip--ds">{s.override}</span>
+									</td>
+									<td>{s.note}</td>
+								</tr>
+							))}
+							<tr data-default>
+								<td className="cmap__name">everything else</td>
+								<td>
+									<span className="chip chip--ok">SDK default ✓</span>
+								</td>
+								<td>canvas, Toolbar, StylePanel, ContextMenu, HelpMenu… — untouched</td>
+							</tr>
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Override-panel consumption</h2>
+					<p className="section__note">
+						The two slots that hold real chrome. Green = design-system primitive; orange = bespoke
+						class / raw element. This is the editor&rsquo;s entire bespoke surface — three classes.
+					</p>
+					<table className="cmap">
+						<thead>
+							<tr>
+								<th>panel</th>
+								<th>design-system primitives</th>
+								<th>bespoke</th>
+							</tr>
+						</thead>
+						<tbody>
+							{PANELS.map((p) => (
+								<tr key={p.name}>
+									<td className="cmap__name">{p.name}</td>
+									<td>
+										{p.ds.map((d) => (
+											<span key={d} className="chip chip--ds">
+												{d}
+											</span>
+										))}
+									</td>
+									<td>
+										{p.bespoke.map((b) => (
+											<span key={b} className="chip chip--bespoke">
+												{b}
+											</span>
+										))}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Editor variants</h2>
+					<p className="section__note">
+						Five <code>&lt;Tldraw&gt;</code> wrappers, each overriding a slightly different slot set.
+					</p>
+					<table className="cmap">
+						<thead>
+							<tr>
+								<th>wrapper</th>
+								<th>slots overridden</th>
+								<th>for</th>
+							</tr>
+						</thead>
+						<tbody>
+							{VARIANTS.map((v) => (
+								<tr key={v.name}>
+									<td className="cmap__name">{v.name}</td>
+									<td>{v.slots}</td>
+									<td>{v.note}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Behavioral injections (Sneaky*)</h2>
+					<p className="section__note">
+						Side-effect components mounted inside the editor — mostly no UI, just behavior (a couple
+						open SDK dialogs). The &ldquo;sneaky&rdquo; prefix is the codebase&rsquo;s name for
+						editor-injected behavior.
+					</p>
+					<table className="cmap">
+						<thead>
+							<tr>
+								<th>component</th>
+								<th>does</th>
+								<th>UI?</th>
+							</tr>
+						</thead>
+						<tbody>
+							{SNEAKY.map((s) => (
+								<tr key={s.name}>
+									<td className="cmap__name">{s.name}</td>
+									<td>{s.does}</td>
+									<td>{s.ui ? <span className="chip chip--ds">{s.ui}</span> : <span className="chip chip--none">none</span>}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">vs the sidebar</h2>
+					<div className="callout">
+						The two maps are opposite poles of the ownership axis. The{' '}
+						<a href="/dev/components/sidebar">sidebar</a> <strong>builds its own chrome</strong> — 17
+						components, 9 bespoke button classes. The editor <strong>borrows the SDK&rsquo;s</strong>{' '}
+						— it overrides 3 slots and adds 3 bespoke classes, total. Same app, two strategies: where
+						the SDK offers a slot (the editor), dotcom delegates and diverges little; where it
+						doesn&rsquo;t (the sidebar is pure dotcom), dotcom builds and diverges a lot. The
+						editor&rsquo;s small bespoke surface is the strongest evidence that{' '}
+						<strong>good SDK extension points prevent drift</strong>.
+					</div>
+				</section>
+			</div>
+		</div>
+	)
+}
+
+const SLOTS: ReadonlyArray<{ slot: string; override: string; note: string }> = [
+	{ slot: 'MenuPanel', override: 'TlaEditorMenuPanel → TlaEditorTopLeftPanel', note: 'file name, main menu, logo' },
+	{ slot: 'TopPanel', override: 'TlaEditorTopPanel', note: 'top-centre strip' },
+	{ slot: 'SharePanel', override: 'TlaEditorSharePanel (+ Legacy / Published) → TlaEditorTopRightPanel', note: 'share / sign-in CTA' },
+]
+
+const PANELS: ReadonlyArray<{ name: string; ds: string[]; bespoke: string[] }> = [
+	{
+		name: 'TlaEditorTopLeftPanel (466)',
+		ds: ['TlaIcon', 'TlaLogo', 'TldrawUiButton', 'TldrawUiInput', 'TldrawUiDropdownMenu', 'ExternalLink'],
+		bespoke: ['<button>', '.topLeftMainMenuTrigger', '.topLeftPanelButton'],
+	},
+	{
+		name: 'TlaEditorTopRightPanel (183)',
+		ds: ['TlaCtaButton', 'TlaIcon', 'TldrawUiButton'],
+		bespoke: ['.topRightAnonShareButton'],
+	},
+]
+
+const VARIANTS: ReadonlyArray<{ name: string; slots: string; note: string }> = [
+	{ name: 'TlaEditor', slots: 'MenuPanel · TopPanel · SharePanel', note: 'the main editor' },
+	{ name: 'TlaLegacyFileEditor', slots: 'MenuPanel · TopPanel · SharePanel (legacy)', note: 'legacy files' },
+	{ name: 'TlaPublishEditor', slots: 'MenuPanel (anon) · SharePanel (published)', note: 'published read-only view' },
+	{ name: 'TlaHistorySnapshotEditor', slots: '<Tldraw> + TlaCtaButton restore bar', note: 'file history snapshot' },
+	{ name: 'TlaLegacySnapshotEditor', slots: '<Tldraw> (defaults)', note: 'legacy snapshot' },
+]
+
+const SNEAKY: ReadonlyArray<{ name: string; does: string; ui?: string }> = [
+	{ name: 'SneakyDarkModeSync', does: 'syncs app theme → editor color scheme' },
+	{ name: 'SneakyFileDropHandler', does: 'handles .tldr / image file drops' },
+	{ name: 'SneakyToolSwitcher', does: 'tool-switching behavior' },
+	{ name: 'SneakySetDocumentTitle', does: 'sets document.title from file name' },
+	{ name: 'SneakyLegacytSetDocumentTitle', does: 'document.title for legacy files' },
+	{ name: 'SneakyDebugModeToast', does: 'shows a debug-mode toast', ui: 'addToast' },
+	{ name: 'SneakyLargeFileHandler', does: 'warns on too-large files', ui: 'TldrawUiDialog' },
+	{ name: 'SneakyLegacyModal', does: 'legacy-changes acknowledgement', ui: 'TldrawUiDialog' },
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 800px; margin-bottom: 32px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede a, .callout a { color: var(--tl-color-primary); }
+.page__lede code, .section__note code, .callout code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 40px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 780px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 150px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.cmap { border-collapse: collapse; width: 100%; max-width: 1000px; font-size: 12px; }
+.cmap th, .cmap td { text-align: left; padding: 8px 14px 8px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.cmap th { color: var(--tl-color-text-3); font-weight: 500; font-family: ui-monospace, monospace; }
+.cmap__name { font-family: ui-monospace, monospace; font-weight: 600; white-space: nowrap; }
+.cmap tr[data-default] .cmap__name { color: var(--tl-color-success, #2a9d3c); }
+.chip { display: inline-block; font-family: ui-monospace, monospace; font-size: 11px; padding: 2px 7px; border-radius: 4px; margin: 2px 4px 2px 0; }
+.chip--ds { background: color-mix(in srgb, var(--tl-color-success, #2a9d3c) 14%, transparent); color: var(--tl-color-success, #2a9d3c); }
+.chip--bespoke { background: color-mix(in srgb, var(--tl-color-warning, #cb4b16) 14%, transparent); color: var(--tl-color-warning, #cb4b16); }
+.chip--ok { color: var(--tl-color-success, #2a9d3c); }
+.chip--none { color: var(--tl-color-text-3); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 860px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+`

--- a/apps/dotcom/client/src/pages/dev-editor.tsx
+++ b/apps/dotcom/client/src/pages/dev-editor.tsx
@@ -40,8 +40,8 @@ export function Component() {
 						The inverse of the <a href="/dev/components/sidebar">sidebar</a>. The editor isn&rsquo;t
 						built by dotcom — it&rsquo;s the SDK <code>&lt;Tldraw&gt;</code> with a handful of slots
 						swapped via its <code>components=&#123;&#125;</code> prop. Canvas, toolbar, style panel,
-						context menu — all SDK defaults, untouched. dotcom overrides three slots and injects some
-						behavior.
+						context menu — all SDK defaults, untouched. dotcom overrides three slots and injects
+						some behavior.
 					</p>
 				</header>
 
@@ -57,8 +57,8 @@ export function Component() {
 				<section className="section">
 					<h2 className="section__title">The override model</h2>
 					<p className="section__note">
-						What dotcom swaps in via <code>&lt;Tldraw components=&#123;…&#125;&gt;</code>. Everything
-						not listed is the SDK default.
+						What dotcom swaps in via <code>&lt;Tldraw components=&#123;…&#125;&gt;</code>.
+						Everything not listed is the SDK default.
 					</p>
 					<table className="cmap">
 						<thead>
@@ -130,7 +130,8 @@ export function Component() {
 				<section className="section">
 					<h2 className="section__title">Editor variants</h2>
 					<p className="section__note">
-						Five <code>&lt;Tldraw&gt;</code> wrappers, each overriding a slightly different slot set.
+						Five <code>&lt;Tldraw&gt;</code> wrappers, each overriding a slightly different slot
+						set.
 					</p>
 					<table className="cmap">
 						<thead>
@@ -172,7 +173,13 @@ export function Component() {
 								<tr key={s.name}>
 									<td className="cmap__name">{s.name}</td>
 									<td>{s.does}</td>
-									<td>{s.ui ? <span className="chip chip--ds">{s.ui}</span> : <span className="chip chip--none">none</span>}</td>
+									<td>
+										{s.ui ? (
+											<span className="chip chip--ds">{s.ui}</span>
+										) : (
+											<span className="chip chip--none">none</span>
+										)}
+									</td>
 								</tr>
 							))}
 						</tbody>
@@ -183,13 +190,13 @@ export function Component() {
 					<h2 className="section__title">vs the sidebar</h2>
 					<div className="callout">
 						The two maps are opposite poles of the ownership axis. The{' '}
-						<a href="/dev/components/sidebar">sidebar</a> <strong>builds its own chrome</strong> — 17
-						components, 9 bespoke button classes. The editor <strong>borrows the SDK&rsquo;s</strong>{' '}
-						— it overrides 3 slots and adds 3 bespoke classes, total. Same app, two strategies: where
-						the SDK offers a slot (the editor), dotcom delegates and diverges little; where it
-						doesn&rsquo;t (the sidebar is pure dotcom), dotcom builds and diverges a lot. The
-						editor&rsquo;s small bespoke surface is the strongest evidence that{' '}
-						<strong>good SDK extension points prevent drift</strong>.
+						<a href="/dev/components/sidebar">sidebar</a> <strong>builds its own chrome</strong> —
+						17 components, 9 bespoke button classes. The editor{' '}
+						<strong>borrows the SDK&rsquo;s</strong> — it overrides 3 slots and adds 3 bespoke
+						classes, total. Same app, two strategies: where the SDK offers a slot (the editor),
+						dotcom delegates and diverges little; where it doesn&rsquo;t (the sidebar is pure
+						dotcom), dotcom builds and diverges a lot. The editor&rsquo;s small bespoke surface is
+						the strongest evidence that <strong>good SDK extension points prevent drift</strong>.
 					</div>
 				</section>
 			</div>
@@ -198,15 +205,30 @@ export function Component() {
 }
 
 const SLOTS: ReadonlyArray<{ slot: string; override: string; note: string }> = [
-	{ slot: 'MenuPanel', override: 'TlaEditorMenuPanel → TlaEditorTopLeftPanel', note: 'file name, main menu, logo' },
+	{
+		slot: 'MenuPanel',
+		override: 'TlaEditorMenuPanel → TlaEditorTopLeftPanel',
+		note: 'file name, main menu, logo',
+	},
 	{ slot: 'TopPanel', override: 'TlaEditorTopPanel', note: 'top-centre strip' },
-	{ slot: 'SharePanel', override: 'TlaEditorSharePanel (+ Legacy / Published) → TlaEditorTopRightPanel', note: 'share / sign-in CTA' },
+	{
+		slot: 'SharePanel',
+		override: 'TlaEditorSharePanel (+ Legacy / Published) → TlaEditorTopRightPanel',
+		note: 'share / sign-in CTA',
+	},
 ]
 
 const PANELS: ReadonlyArray<{ name: string; ds: string[]; bespoke: string[] }> = [
 	{
 		name: 'TlaEditorTopLeftPanel (466)',
-		ds: ['TlaIcon', 'TlaLogo', 'TldrawUiButton', 'TldrawUiInput', 'TldrawUiDropdownMenu', 'ExternalLink'],
+		ds: [
+			'TlaIcon',
+			'TlaLogo',
+			'TldrawUiButton',
+			'TldrawUiInput',
+			'TldrawUiDropdownMenu',
+			'ExternalLink',
+		],
 		bespoke: ['<button>', '.topLeftMainMenuTrigger', '.topLeftPanelButton'],
 	},
 	{
@@ -218,9 +240,21 @@ const PANELS: ReadonlyArray<{ name: string; ds: string[]; bespoke: string[] }> =
 
 const VARIANTS: ReadonlyArray<{ name: string; slots: string; note: string }> = [
 	{ name: 'TlaEditor', slots: 'MenuPanel · TopPanel · SharePanel', note: 'the main editor' },
-	{ name: 'TlaLegacyFileEditor', slots: 'MenuPanel · TopPanel · SharePanel (legacy)', note: 'legacy files' },
-	{ name: 'TlaPublishEditor', slots: 'MenuPanel (anon) · SharePanel (published)', note: 'published read-only view' },
-	{ name: 'TlaHistorySnapshotEditor', slots: '<Tldraw> + TlaCtaButton restore bar', note: 'file history snapshot' },
+	{
+		name: 'TlaLegacyFileEditor',
+		slots: 'MenuPanel · TopPanel · SharePanel (legacy)',
+		note: 'legacy files',
+	},
+	{
+		name: 'TlaPublishEditor',
+		slots: 'MenuPanel (anon) · SharePanel (published)',
+		note: 'published read-only view',
+	},
+	{
+		name: 'TlaHistorySnapshotEditor',
+		slots: '<Tldraw> + TlaCtaButton restore bar',
+		note: 'file history snapshot',
+	},
 	{ name: 'TlaLegacySnapshotEditor', slots: '<Tldraw> (defaults)', note: 'legacy snapshot' },
 ]
 

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable tldraw/jsx-no-literals */
-import { ReactNode } from 'react'
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
 import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import {

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -42,135 +42,173 @@ export function Component() {
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<IsolationProviders>
-			<div className="page">
-				<DevComponentsNav />
-				<header className="page__header">
-					<h1 className="page__title">Form controls</h1>
-					<p className="page__lede">
-						The settings-panel controls from <code>tla-menu</code> — Switch, Select, Tabs, and the
-						labeled Control row. These live inside the share menu and settings dialogs (the
-						&ldquo;panel&rdquo; half of the <a href="/dev/components/menus">menus</a> story), shown
-						here with their props and states.
-					</p>
-				</header>
+				<div className="page">
+					<DevComponentsNav />
+					<header className="page__header">
+						<h1 className="page__title">Form controls</h1>
+						<p className="page__lede">
+							The settings-panel controls from <code>tla-menu</code> — Switch, Select, Tabs, and the
+							labeled Control row. These live inside the share menu and settings dialogs (the
+							&ldquo;panel&rdquo; half of the <a href="/dev/components/menus">menus</a> story),
+							shown here with their props and states.
+						</p>
+					</header>
 
-				<section className="section">
-					<h2 className="section__title">TlaMenuSwitch — all states (live)</h2>
-					<p className="section__note">
-						Props: <code>id · checked · onChange · disabled</code>. A native{' '}
-						<code>checkbox</code> with <code>role="switch"</code>, styled.
-					</p>
-					<div className="grid">
-						<Specimen label="checked" code={`checked`} meta="role=switch" source="tla-menu.tsx:243">
-							<TlaMenuSwitch id="fc-on" checked onChange={() => {}} />
-						</Specimen>
-						<Specimen label="unchecked" code={`checked={false}`} meta="role=switch" source="tla-menu.tsx:243">
-							<TlaMenuSwitch id="fc-off" checked={false} onChange={() => {}} />
-						</Specimen>
-						<Specimen label="disabled" code={`disabled`} meta="non-interactive" source="tla-menu.tsx:243">
-							<TlaMenuSwitch id="fc-dis" checked disabled onChange={() => {}} />
-						</Specimen>
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">TlaMenuSwitch — all states (live)</h2>
+						<p className="section__note">
+							Props: <code>id · checked · onChange · disabled</code>. A native <code>checkbox</code>{' '}
+							with <code>role="switch"</code>, styled.
+						</p>
+						<div className="grid">
+							<Specimen
+								label="checked"
+								code={`checked`}
+								meta="role=switch"
+								source="tla-menu.tsx:243"
+							>
+								<TlaMenuSwitch id="fc-on" checked onChange={() => {}} />
+							</Specimen>
+							<Specimen
+								label="unchecked"
+								code={`checked={false}`}
+								meta="role=switch"
+								source="tla-menu.tsx:243"
+							>
+								<TlaMenuSwitch id="fc-off" checked={false} onChange={() => {}} />
+							</Specimen>
+							<Specimen
+								label="disabled"
+								code={`disabled`}
+								meta="non-interactive"
+								source="tla-menu.tsx:243"
+							>
+								<TlaMenuSwitch id="fc-dis" checked disabled onChange={() => {}} />
+							</Specimen>
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">TlaMenuSelect — live</h2>
-					<p className="section__note">
-						A generic <code>TlaMenuSelect&lt;T&gt;</code> over a Radix Select. Notable: an{' '}
-						<code>actions</code> slot for a destructive option below the choices. Rendered live — it
-						needs a container element for its portal, which the page&rsquo;s providers supply.
-					</p>
-					<div className="grid">
-						<Specimen
-							label="TlaMenuSelect"
-							code={`label · value · options[] · onChange`}
-							meta="generic <T> · Radix Select · ×4"
-							source="tla-menu.tsx:119"
-						>
-							<TlaMenuSelect
-								id="fc-select"
-								label="Access"
-								value="editor"
-								onChange={() => {}}
-								options={[
-									{ value: 'editor', label: 'Can edit' },
-									{ value: 'viewer', label: 'Can view' },
-								]}
-							/>
-						</Specimen>
-						<Specimen
-							label="with actions"
-							code={`actions={[{ label: 'Remove', onSelect }]}`}
-							meta="destructive action below options"
-							source="tla-menu.tsx:119"
-						>
-							<TlaMenuSelect
-								id="fc-select-actions"
-								label="Member"
-								value="editor"
-								onChange={() => {}}
-								options={[
-									{ value: 'editor', label: 'Can edit' },
-									{ value: 'viewer', label: 'Can view' },
-								]}
-								actions={[
-									{ id: 'remove', label: 'Remove member', onSelect: () => {}, destructive: true },
-								]}
-							/>
-						</Specimen>
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">TlaMenuSelect — live</h2>
+						<p className="section__note">
+							A generic <code>TlaMenuSelect&lt;T&gt;</code> over a Radix Select. Notable: an{' '}
+							<code>actions</code> slot for a destructive option below the choices. Rendered live —
+							it needs a container element for its portal, which the page&rsquo;s providers supply.
+						</p>
+						<div className="grid">
+							<Specimen
+								label="TlaMenuSelect"
+								code={`label · value · options[] · onChange`}
+								meta="generic <T> · Radix Select · ×4"
+								source="tla-menu.tsx:119"
+							>
+								<TlaMenuSelect
+									id="fc-select"
+									label="Access"
+									value="editor"
+									onChange={() => {}}
+									options={[
+										{ value: 'editor', label: 'Can edit' },
+										{ value: 'viewer', label: 'Can view' },
+									]}
+								/>
+							</Specimen>
+							<Specimen
+								label="with actions"
+								code={`actions={[{ label: 'Remove', onSelect }]}`}
+								meta="destructive action below options"
+								source="tla-menu.tsx:119"
+							>
+								<TlaMenuSelect
+									id="fc-select-actions"
+									label="Member"
+									value="editor"
+									onChange={() => {}}
+									options={[
+										{ value: 'editor', label: 'Can edit' },
+										{ value: 'viewer', label: 'Can view' },
+									]}
+									actions={[
+										{ id: 'remove', label: 'Remove member', onSelect: () => {}, destructive: true },
+									]}
+								/>
+							</Specimen>
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">TlaMenuTabs — Root / Tabs / Tab / Page (live)</h2>
-					<p className="section__note">
-						ARIA tabs (<code>role=tablist / tab / tabpanel</code>). The share menu&rsquo;s
-						Invite / Export / Publish tabs, rendered with the real components (Invite active).
-					</p>
-					<div className="grid">
-						<Specimen
-							label="TlaMenuTabs"
-							code={`<Root activeTab><Tabs><Tab id>`}
-							meta="role=tablist · Invite active"
-							source="tla-menu.tsx:296"
-						>
-							<TlaMenuTabsRoot activeTab="invite" onTabChange={() => {}}>
-								<TlaMenuTabsTabs>
-									<TlaMenuTabsTab id="invite">Invite</TlaMenuTabsTab>
-									<TlaMenuTabsTab id="export">Export</TlaMenuTabsTab>
-									<TlaMenuTabsTab id="publish">Publish</TlaMenuTabsTab>
-								</TlaMenuTabsTabs>
-							</TlaMenuTabsRoot>
-						</Specimen>
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">TlaMenuTabs — Root / Tabs / Tab / Page (live)</h2>
+						<p className="section__note">
+							ARIA tabs (<code>role=tablist / tab / tabpanel</code>). The share menu&rsquo;s Invite
+							/ Export / Publish tabs, rendered with the real components (Invite active).
+						</p>
+						<div className="grid">
+							<Specimen
+								label="TlaMenuTabs"
+								code={`<Root activeTab><Tabs><Tab id>`}
+								meta="role=tablist · Invite active"
+								source="tla-menu.tsx:296"
+							>
+								<TlaMenuTabsRoot activeTab="invite" onTabChange={() => {}}>
+									<TlaMenuTabsTabs>
+										<TlaMenuTabsTab id="invite">Invite</TlaMenuTabsTab>
+										<TlaMenuTabsTab id="export">Export</TlaMenuTabsTab>
+										<TlaMenuTabsTab id="publish">Publish</TlaMenuTabsTab>
+									</TlaMenuTabsTabs>
+								</TlaMenuTabsRoot>
+							</Specimen>
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">Control rows — Control / Label / InfoTooltip / Detail</h2>
-					<p className="section__note">
-						The layout pieces that hold a control: a label, an optional info tooltip, and detail
-						text.
-					</p>
-					<div className="grid">
-						<Specimen label="TlaMenuControl" code={`<TlaMenuControl>`} meta="labeled row · ×10" source="tla-menu.tsx:43">
-							<TlaMenuControl className="fcWide">
-								<TlaMenuControlLabel htmlFor="fc-ctrl">Share this file</TlaMenuControlLabel>
-								<TlaMenuSwitch id="fc-ctrl" checked onChange={() => {}} />
-							</TlaMenuControl>
-						</Specimen>
-						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96">
-							<TlaMenuControlLabel htmlFor="fc-lbl">Label text</TlaMenuControlLabel>
-						</Specimen>
-						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="info icon · tooltip on hover" source="tla-menu.tsx:60">
-							<TlaMenuControlInfoTooltip>More information about this setting</TlaMenuControlInfoTooltip>
-						</Specimen>
-						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111">
-							<TlaMenuDetail>Supporting detail copy</TlaMenuDetail>
-						</Specimen>
-					</div>
-				</section>
-
-			</div>
+					<section className="section">
+						<h2 className="section__title">
+							Control rows — Control / Label / InfoTooltip / Detail
+						</h2>
+						<p className="section__note">
+							The layout pieces that hold a control: a label, an optional info tooltip, and detail
+							text.
+						</p>
+						<div className="grid">
+							<Specimen
+								label="TlaMenuControl"
+								code={`<TlaMenuControl>`}
+								meta="labeled row · ×10"
+								source="tla-menu.tsx:43"
+							>
+								<TlaMenuControl className="fcWide">
+									<TlaMenuControlLabel htmlFor="fc-ctrl">Share this file</TlaMenuControlLabel>
+									<TlaMenuSwitch id="fc-ctrl" checked onChange={() => {}} />
+								</TlaMenuControl>
+							</Specimen>
+							<Specimen
+								label="TlaMenuControlLabel"
+								code={`<TlaMenuControlLabel>`}
+								meta="control label · ×10"
+								source="tla-menu.tsx:96"
+							>
+								<TlaMenuControlLabel htmlFor="fc-lbl">Label text</TlaMenuControlLabel>
+							</Specimen>
+							<Specimen
+								label="TlaMenuControlInfoTooltip"
+								code={`<TlaMenuControlInfoTooltip>`}
+								meta="info icon · tooltip on hover"
+								source="tla-menu.tsx:60"
+							>
+								<TlaMenuControlInfoTooltip>
+									More information about this setting
+								</TlaMenuControlInfoTooltip>
+							</Specimen>
+							<Specimen
+								label="TlaMenuDetail"
+								code={`<TlaMenuDetail>`}
+								meta="detail text · ×1"
+								source="tla-menu.tsx:111"
+							>
+								<TlaMenuDetail>Supporting detail copy</TlaMenuDetail>
+							</Specimen>
+						</div>
+					</section>
+				</div>
 			</IsolationProviders>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -1,0 +1,166 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom form controls — the tla-menu settings-control
+ * set (Switch / Select / Tabs / Control rows). These are the inputs of the
+ * "settings panel" half of the menus story, shown here with their full props
+ * and states. Switch is live; the rest are mocked (Select needs editor context).
+ *
+ * Route: /dev/components/form-controls. Companion to the menus page.
+ */
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Form controls — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Form controls</h1>
+					<p className="page__lede">
+						The settings-panel controls from <code>tla-menu</code> — Switch, Select, Tabs, and the
+						labeled Control row. These live inside the share menu and settings dialogs (the
+						&ldquo;panel&rdquo; half of the <a href="/dev/components/menus">menus</a> story), shown
+						here with their props and states.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">TlaMenuSwitch — all states (live)</h2>
+					<p className="section__note">
+						Props: <code>id · checked · onChange · disabled</code>. A native{' '}
+						<code>checkbox</code> with <code>role="switch"</code>, styled.
+					</p>
+					<div className="grid">
+						<Specimen label="checked" code={`checked`} meta="role=switch" source="tla-menu.tsx:243">
+							<TlaMenuSwitch id="fc-on" checked onChange={() => {}} />
+						</Specimen>
+						<Specimen label="unchecked" code={`checked={false}`} meta="role=switch" source="tla-menu.tsx:243">
+							<TlaMenuSwitch id="fc-off" checked={false} onChange={() => {}} />
+						</Specimen>
+						<Specimen label="disabled" code={`disabled`} meta="non-interactive" source="tla-menu.tsx:243">
+							<TlaMenuSwitch id="fc-dis" checked disabled onChange={() => {}} />
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">TlaMenuSelect — API (mocked)</h2>
+					<p className="section__note">
+						A generic <code>TlaMenuSelect&lt;T&gt;</code> over a Radix Select. Notable: an{' '}
+						<code>actions</code> slot for a destructive option below the choices. Needs editor
+						context to render, so mocked.
+					</p>
+					<div className="grid">
+						<Specimen
+							label="TlaMenuSelect"
+							code={`label · value · options[] · onChange`}
+							meta="generic <T> · Radix Select · ×4"
+							source="tla-menu.tsx:119"
+						>
+							<div className="ctrlMock">Everyone ▾</div>
+						</Specimen>
+						<Specimen
+							label="with actions"
+							code={`actions={[{ label: 'Remove', onSelect }]}`}
+							meta="destructive action below options"
+							source="tla-menu.tsx:119"
+						>
+							<div className="ctrlMock">Members ▾</div>
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">TlaMenuTabs — Root / Tabs / Tab / Page (mocked)</h2>
+					<p className="section__note">
+						ARIA tabs (<code>role=tablist / tab / tabpanel</code>). The share menu&rsquo;s
+						Invite / Export / Publish tabs.
+					</p>
+					<div className="grid">
+						<Specimen label="TlaMenuTabsTab" code={`active`} meta="role=tab" source="tla-menu.tsx:313">
+							<div className="tabMock">
+								<span data-active>Invite</span>
+								<span>Export</span>
+								<span>Publish</span>
+							</div>
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Control rows — Control / Label / InfoTooltip / Detail</h2>
+					<p className="section__note">
+						The layout pieces that hold a control: a label, an optional info tooltip, and detail
+						text.
+					</p>
+					<div className="grid">
+						<Specimen label="TlaMenuControl" code={`<TlaMenuControl>`} meta="labeled row · ×10" source="tla-menu.tsx:43">
+							<div className="rowMock rowMock--wide">
+								<span>Share this file</span>
+								<TlaMenuSwitch id="fc-row" checked onChange={() => {}} />
+							</div>
+						</Specimen>
+						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96">
+							<div className="rowMock">Label text</div>
+						</Specimen>
+						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="info tooltip · ×4" source="tla-menu.tsx:60">
+							<div className="rowMock">ⓘ more info</div>
+						</Specimen>
+						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111">
+							<div className="rowMock">supporting detail copy</div>
+						</Specimen>
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					These are the same parts the <a href="/dev/components/menus">menus</a> page lists under
+					&ldquo;tla-menu&rdquo; — this page is the control-level view (props + states) rather than
+					the two-systems view. Together they argue the same point: the settings-panel system is
+					deliberately its own thing, distinct from action dropdowns. See tldraw/tldraw#9191 /
+					#9199.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede code, .section__note code, .page__footer code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.page__lede a, .page__footer a { color: var(--tl-color-primary); }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
+.tabMock { display: inline-flex; gap: 4px; }
+.tabMock span { padding: 4px 10px; border-radius: var(--tl-radius-2); font-size: 12px; color: var(--tl-color-text-3); }
+.tabMock span[data-active] { background: var(--tl-color-muted-2); color: var(--tl-color-text); }
+.rowMock { padding: 6px 10px; border-radius: var(--tl-radius-2); font-size: 13px; background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); min-width: 130px; text-align: left; }
+.rowMock--wide { display: flex; align-items: center; justify-content: space-between; gap: 12px; width: 100%; box-sizing: border-box; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { TldrawUiContextProvider } from 'tldraw'
 import 'tldraw/tldraw.css'
 import {
 	TlaMenuControl,
+	TlaMenuControlInfoTooltip,
 	TlaMenuControlLabel,
 	TlaMenuDetail,
+	TlaMenuSelect,
 	TlaMenuSwitch,
 	TlaMenuTabsRoot,
 	TlaMenuTabsTab,
@@ -15,15 +16,16 @@ import {
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
+import { IsolationProviders } from './dev-editor-harness'
 
 /**
  * Dev-only inventory of the dotcom form controls — the tla-menu settings-control
  * set (Switch / Select / Tabs / Control rows). These are the inputs of the
  * "settings panel" half of the menus story, shown here with their full props
- * and states. Switch, Tabs, Control, ControlLabel and Detail render live under a
- * TldrawUiContextProvider (editor-less). Two stay mocked: Select (calls
- * useContainer(), needs a real <Tldraw>) and ControlInfoTooltip (calls useMsg,
- * needs the dotcom react-intl IntlProvider, a separate i18n system).
+ * and states. All render live under IsolationProviders (dotcom react-intl + a
+ * container element + the SDK UI context), no editor needed: Select needs the
+ * container for its portal, ControlInfoTooltip needs react-intl for useMsg, the
+ * rest need only the SDK UI context.
  *
  * Route: /dev/components/form-controls. Companion to the menus page.
  */
@@ -39,7 +41,7 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
-			<TldrawUiContextProvider forceMobile={false}>
+			<IsolationProviders>
 			<div className="page">
 				<DevComponentsNav />
 				<header className="page__header">
@@ -72,11 +74,11 @@ export function Component() {
 				</section>
 
 				<section className="section">
-					<h2 className="section__title">TlaMenuSelect — API (mocked)</h2>
+					<h2 className="section__title">TlaMenuSelect — live</h2>
 					<p className="section__note">
 						A generic <code>TlaMenuSelect&lt;T&gt;</code> over a Radix Select. Notable: an{' '}
-						<code>actions</code> slot for a destructive option below the choices. Needs editor
-						context to render, so mocked.
+						<code>actions</code> slot for a destructive option below the choices. Rendered live — it
+						needs a container element for its portal, which the page&rsquo;s providers supply.
 					</p>
 					<div className="grid">
 						<Specimen
@@ -84,18 +86,37 @@ export function Component() {
 							code={`label · value · options[] · onChange`}
 							meta="generic <T> · Radix Select · ×4"
 							source="tla-menu.tsx:119"
-							mock
 						>
-							<div className="ctrlMock">Everyone ▾</div>
+							<TlaMenuSelect
+								id="fc-select"
+								label="Access"
+								value="editor"
+								onChange={() => {}}
+								options={[
+									{ value: 'editor', label: 'Can edit' },
+									{ value: 'viewer', label: 'Can view' },
+								]}
+							/>
 						</Specimen>
 						<Specimen
 							label="with actions"
 							code={`actions={[{ label: 'Remove', onSelect }]}`}
 							meta="destructive action below options"
 							source="tla-menu.tsx:119"
-							mock
 						>
-							<div className="ctrlMock">Members ▾</div>
+							<TlaMenuSelect
+								id="fc-select-actions"
+								label="Member"
+								value="editor"
+								onChange={() => {}}
+								options={[
+									{ value: 'editor', label: 'Can edit' },
+									{ value: 'viewer', label: 'Can view' },
+								]}
+								actions={[
+									{ id: 'remove', label: 'Remove member', onSelect: () => {}, destructive: true },
+								]}
+							/>
 						</Specimen>
 					</div>
 				</section>
@@ -140,8 +161,8 @@ export function Component() {
 						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96">
 							<TlaMenuControlLabel htmlFor="fc-lbl">Label text</TlaMenuControlLabel>
 						</Specimen>
-						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="needs dotcom IntlProvider (useMsg)" source="tla-menu.tsx:60" mock>
-							<div className="rowMock">ⓘ more info</div>
+						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="info icon · tooltip on hover" source="tla-menu.tsx:60">
+							<TlaMenuControlInfoTooltip>More information about this setting</TlaMenuControlInfoTooltip>
 						</Specimen>
 						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111">
 							<TlaMenuDetail>Supporting detail copy</TlaMenuDetail>
@@ -150,7 +171,7 @@ export function Component() {
 				</section>
 
 			</div>
-			</TldrawUiContextProvider>
+			</IsolationProviders>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -1,8 +1,17 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
+import { TldrawUiContextProvider } from 'tldraw'
 import 'tldraw/tldraw.css'
-import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
+import {
+	TlaMenuControl,
+	TlaMenuControlLabel,
+	TlaMenuDetail,
+	TlaMenuSwitch,
+	TlaMenuTabsRoot,
+	TlaMenuTabsTab,
+	TlaMenuTabsTabs,
+} from '../tla/components/tla-menu/tla-menu'
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
@@ -11,7 +20,10 @@ import { DevComponentsNav } from './dev-components-nav'
  * Dev-only inventory of the dotcom form controls — the tla-menu settings-control
  * set (Switch / Select / Tabs / Control rows). These are the inputs of the
  * "settings panel" half of the menus story, shown here with their full props
- * and states. Switch is live; the rest are mocked (Select needs editor context).
+ * and states. Switch, Tabs, Control, ControlLabel and Detail render live under a
+ * TldrawUiContextProvider (editor-less). Two stay mocked: Select (calls
+ * useContainer(), needs a real <Tldraw>) and ControlInfoTooltip (calls useMsg,
+ * needs the dotcom react-intl IntlProvider, a separate i18n system).
  *
  * Route: /dev/components/form-controls. Companion to the menus page.
  */
@@ -27,6 +39,7 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
+			<TldrawUiContextProvider forceMobile={false}>
 			<div className="page">
 				<DevComponentsNav />
 				<header className="page__header">
@@ -88,18 +101,25 @@ export function Component() {
 				</section>
 
 				<section className="section">
-					<h2 className="section__title">TlaMenuTabs — Root / Tabs / Tab / Page (mocked)</h2>
+					<h2 className="section__title">TlaMenuTabs — Root / Tabs / Tab / Page (live)</h2>
 					<p className="section__note">
 						ARIA tabs (<code>role=tablist / tab / tabpanel</code>). The share menu&rsquo;s
-						Invite / Export / Publish tabs.
+						Invite / Export / Publish tabs, rendered with the real components (Invite active).
 					</p>
 					<div className="grid">
-						<Specimen label="TlaMenuTabsTab" code={`active`} meta="role=tab" source="tla-menu.tsx:313" mock>
-							<div className="tabMock">
-								<span data-active>Invite</span>
-								<span>Export</span>
-								<span>Publish</span>
-							</div>
+						<Specimen
+							label="TlaMenuTabs"
+							code={`<Root activeTab><Tabs><Tab id>`}
+							meta="role=tablist · Invite active"
+							source="tla-menu.tsx:296"
+						>
+							<TlaMenuTabsRoot activeTab="invite" onTabChange={() => {}}>
+								<TlaMenuTabsTabs>
+									<TlaMenuTabsTab id="invite">Invite</TlaMenuTabsTab>
+									<TlaMenuTabsTab id="export">Export</TlaMenuTabsTab>
+									<TlaMenuTabsTab id="publish">Publish</TlaMenuTabsTab>
+								</TlaMenuTabsTabs>
+							</TlaMenuTabsRoot>
 						</Specimen>
 					</div>
 				</section>
@@ -111,25 +131,26 @@ export function Component() {
 						text.
 					</p>
 					<div className="grid">
-						<Specimen label="TlaMenuControl" code={`<TlaMenuControl>`} meta="labeled row · ×10" source="tla-menu.tsx:43" mock>
-							<div className="rowMock rowMock--wide">
-								<span>Share this file</span>
-								<TlaMenuSwitch id="fc-row" checked onChange={() => {}} />
-							</div>
+						<Specimen label="TlaMenuControl" code={`<TlaMenuControl>`} meta="labeled row · ×10" source="tla-menu.tsx:43">
+							<TlaMenuControl className="fcWide">
+								<TlaMenuControlLabel htmlFor="fc-ctrl">Share this file</TlaMenuControlLabel>
+								<TlaMenuSwitch id="fc-ctrl" checked onChange={() => {}} />
+							</TlaMenuControl>
 						</Specimen>
-						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96" mock>
-							<div className="rowMock">Label text</div>
+						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96">
+							<TlaMenuControlLabel htmlFor="fc-lbl">Label text</TlaMenuControlLabel>
 						</Specimen>
-						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="info tooltip · ×4" source="tla-menu.tsx:60" mock>
+						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="needs dotcom IntlProvider (useMsg)" source="tla-menu.tsx:60" mock>
 							<div className="rowMock">ⓘ more info</div>
 						</Specimen>
-						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111" mock>
-							<div className="rowMock">supporting detail copy</div>
+						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111">
+							<TlaMenuDetail>Supporting detail copy</TlaMenuDetail>
 						</Specimen>
 					</div>
 				</section>
 
 			</div>
+			</TldrawUiContextProvider>
 		</div>
 	)
 }
@@ -151,6 +172,7 @@ const PAGE_CSS = `
 .section { margin-bottom: 48px; }
 .section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
 .section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.fcWide { width: 100%; }
 .ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
 .tabMock { display: inline-flex; gap: 4px; }
 .tabMock span { padding: 4px 10px; border-radius: var(--tl-radius-2); font-size: 12px; color: var(--tl-color-text-3); }

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -71,6 +71,7 @@ export function Component() {
 							code={`label · value · options[] · onChange`}
 							meta="generic <T> · Radix Select · ×4"
 							source="tla-menu.tsx:119"
+							mock
 						>
 							<div className="ctrlMock">Everyone ▾</div>
 						</Specimen>
@@ -79,6 +80,7 @@ export function Component() {
 							code={`actions={[{ label: 'Remove', onSelect }]}`}
 							meta="destructive action below options"
 							source="tla-menu.tsx:119"
+							mock
 						>
 							<div className="ctrlMock">Members ▾</div>
 						</Specimen>
@@ -92,7 +94,7 @@ export function Component() {
 						Invite / Export / Publish tabs.
 					</p>
 					<div className="grid">
-						<Specimen label="TlaMenuTabsTab" code={`active`} meta="role=tab" source="tla-menu.tsx:313">
+						<Specimen label="TlaMenuTabsTab" code={`active`} meta="role=tab" source="tla-menu.tsx:313" mock>
 							<div className="tabMock">
 								<span data-active>Invite</span>
 								<span>Export</span>
@@ -109,19 +111,19 @@ export function Component() {
 						text.
 					</p>
 					<div className="grid">
-						<Specimen label="TlaMenuControl" code={`<TlaMenuControl>`} meta="labeled row · ×10" source="tla-menu.tsx:43">
+						<Specimen label="TlaMenuControl" code={`<TlaMenuControl>`} meta="labeled row · ×10" source="tla-menu.tsx:43" mock>
 							<div className="rowMock rowMock--wide">
 								<span>Share this file</span>
 								<TlaMenuSwitch id="fc-row" checked onChange={() => {}} />
 							</div>
 						</Specimen>
-						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96">
+						<Specimen label="TlaMenuControlLabel" code={`<TlaMenuControlLabel>`} meta="control label · ×10" source="tla-menu.tsx:96" mock>
 							<div className="rowMock">Label text</div>
 						</Specimen>
-						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="info tooltip · ×4" source="tla-menu.tsx:60">
+						<Specimen label="TlaMenuControlInfoTooltip" code={`<TlaMenuControlInfoTooltip>`} meta="info tooltip · ×4" source="tla-menu.tsx:60" mock>
 							<div className="rowMock">ⓘ more info</div>
 						</Specimen>
-						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111">
+						<Specimen label="TlaMenuDetail" code={`<TlaMenuDetail>`} meta="detail text · ×1" source="tla-menu.tsx:111" mock>
 							<div className="rowMock">supporting detail copy</div>
 						</Specimen>
 					</div>

--- a/apps/dotcom/client/src/pages/dev-form-controls.tsx
+++ b/apps/dotcom/client/src/pages/dev-form-controls.tsx
@@ -127,13 +127,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					These are the same parts the <a href="/dev/components/menus">menus</a> page lists under
-					&ldquo;tla-menu&rdquo; — this page is the control-level view (props + states) rather than
-					the two-systems view. Together they argue the same point: the settings-panel system is
-					deliberately its own thing, distinct from action dropdowns. See tldraw/tldraw#9191 /
-					#9199.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-icons.tsx
+++ b/apps/dotcom/client/src/pages/dev-icons.tsx
@@ -144,6 +144,7 @@ export function Component() {
 							code={`<TldrawUiIcon icon="…" label="…" small />`}
 							meta="per-icon asset · small/tiny sizing · needs AssetUrlsProvider"
 							source="tldraw (packages/tldraw)"
+							mock
 						>
 							<span className="iconStage iconStage--mock">asset ctx</span>
 						</Specimen>

--- a/apps/dotcom/client/src/pages/dev-icons.tsx
+++ b/apps/dotcom/client/src/pages/dev-icons.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable tldraw/jsx-no-literals */
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { TldrawUiContextProvider, TldrawUiIcon } from 'tldraw'

--- a/apps/dotcom/client/src/pages/dev-icons.tsx
+++ b/apps/dotcom/client/src/pages/dev-icons.tsx
@@ -37,177 +37,176 @@ export function Component() {
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<TldrawUiContextProvider forceMobile={false}>
-			<div className="page">
-				<DevComponentsNav />
-				<header className="page__header">
-					<h1 className="page__title">Icon inventory</h1>
-					<p className="page__lede">
-						Three ways to render an icon — competing implementations, the same divergence mode as
-						buttons. <code>TlaIcon</code> and <code>TldrawUiIcon</code> are both CSS-mask icons, yet
-						they can&rsquo;t share icons: different sprite sources, different contexts.
-					</p>
-				</header>
+				<div className="page">
+					<DevComponentsNav />
+					<header className="page__header">
+						<h1 className="page__title">Icon inventory</h1>
+						<p className="page__lede">
+							Three ways to render an icon — competing implementations, the same divergence mode as
+							buttons. <code>TlaIcon</code> and <code>TldrawUiIcon</code> are both CSS-mask icons,
+							yet they can&rsquo;t share icons: different sprite sources, different contexts.
+						</p>
+					</header>
 
-				<section className="section">
-					<h2 className="section__title">Usage</h2>
-					<div className="stats">
-						<Stat n="28" label="TlaIcon (dotcom sprite)" />
-						<Stat n="6" label="TldrawUiIcon (SDK)" />
-						<Stat n="1" label="inline <svg>" />
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">Usage</h2>
+						<div className="stats">
+							<Stat n="28" label="TlaIcon (dotcom sprite)" />
+							<Stat n="6" label="TldrawUiIcon (SDK)" />
+							<Stat n="1" label="inline <svg>" />
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">
-						Sprite coverage — {USED.size} of {ALL_ICONS.length} used
-					</h2>
-					<p className="section__note">
-						The merged sprite ships all {ALL_ICONS.length} icons; only {USED.size} are referenced.
-						The rest still download (the {`:target`} stack can't tree-shake). Every icon below is
-						rendered live from the sprite; unused ones are dimmed. (Static snapshot — names flowing
-						through data may bump the used count a little.)
-					</p>
-					<div className="stats" style={{ marginBottom: 20 }}>
-						<Stat n={String(ALL_ICONS.length)} label="icons in 0_merged_tla.svg" />
-						<Stat n={String(USED.size)} label="referenced in code" />
-						<Stat n={String(ALL_ICONS.length - USED.size)} label="apparently unused" />
-					</div>
-					<div className="spriteGrid">
-						{ALL_ICONS.map((name) => (
-							<div key={name} className="spriteCell" data-unused={!USED.has(name) || undefined}>
-								<span className="spriteCell__icon">
-									<TlaIcon icon={name} />
-								</span>
-								<span className="spriteCell__name">{name}</span>
-							</div>
-						))}
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Overview</h2>
-					<p className="section__note">
-						<code>TlaIcon</code> shown live (its sprite is bundled). The SDK icon needs the editor
-						asset context, so it&rsquo;s a mock.
-					</p>
-					<div className="grid">
-						<Specimen
-							label="TlaIcon"
-							code={`<TlaIcon icon="search" />`}
-							meta="15px · currentColor mask · 0_merged_tla.svg"
-							source="tla/components/TlaIcon"
-						>
-							<span className="iconStage">
-								<TlaIcon icon="search" />
-							</span>
-						</Specimen>
-						<Specimen
-							label="TlaIcon"
-							code={`<TlaIcon icon="close" />`}
-							meta="same sprite, by name"
-							source="tla/components/TlaIcon"
-						>
-							<span className="iconStage">
-								<TlaIcon icon="close" />
-							</span>
-						</Specimen>
-						<Specimen
-							label="TlaIcon"
-							code={`<TlaIcon icon="avatar" />`}
-							meta="masked currentColor shape"
-							source="tla/components/TlaIcon"
-						>
-							<span className="iconStage">
-								<TlaIcon icon="avatar" />
-							</span>
-						</Specimen>
-						<Specimen
-							label="TlaIcon invertIcon"
-							code={`<TlaIcon icon="chevron-right" invertIcon />`}
-							meta="transform: scale(-1, 1)"
-							source="tla/components/TlaIcon"
-						>
-							<span className="iconStage">
-								<TlaIcon icon="chevron-right" invertIcon />
-							</span>
-						</Specimen>
-						<Specimen
-							label="TlaIcon icon='none'"
-							code={`<TlaIcon icon="none" />`}
-							meta="empty spacer — keeps the 15px box, paints nothing"
-							source="tla/components/TlaIcon"
-						>
-							<span className="iconStage iconStage--ghost">
-								<TlaIcon icon="none" />
-							</span>
-						</Specimen>
-						<Specimen
-							label="TldrawUiIcon (SDK)"
-							code={`<TldrawUiIcon icon="chevron-right" />`}
-							meta="per-icon asset · resolves via AssetUrlsProvider"
-							source="tldraw (packages/tldraw)"
-						>
-							<span className="iconStage">
-								<TldrawUiIcon icon="chevron-right" label="chevron-right" />
-							</span>
-						</Specimen>
-						<Specimen
-							label="inline <svg>"
-							code={`<svg viewBox="0 0 16 16">…</svg>`}
-							meta="two-colour, can't be a monochrome mask; offline-safe"
-							source="components/ErrorPage"
-						>
-							<svg viewBox="0 0 16 16" width="22" height="22" aria-hidden>
-								<circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.4" />
-								<circle cx="5.5" cy="6.5" r="1" fill="currentColor" />
-								<circle cx="10.5" cy="6.5" r="1" fill="currentColor" />
-								<path d="M5 11 q3 -2 6 0" fill="none" stroke="currentColor" strokeWidth="1.4" />
-							</svg>
-						</Specimen>
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Three mechanisms, compared</h2>
-					<table className="matrix matrix--wide">
-						<thead>
-							<tr>
-								<th></th>
-								<th>TlaIcon</th>
-								<th>TldrawUiIcon (SDK)</th>
-								<th>inline &lt;svg&gt;</th>
-							</tr>
-						</thead>
-						<tbody>
-							{ROWS.map((r) => (
-								<tr key={r[0]}>
-									<td className="rowhead">{r[0]}</td>
-									<td>{r[1]}</td>
-									<td>{r[2]}</td>
-									<td>{r[3]}</td>
-								</tr>
+					<section className="section">
+						<h2 className="section__title">
+							Sprite coverage — {USED.size} of {ALL_ICONS.length} used
+						</h2>
+						<p className="section__note">
+							The merged sprite ships all {ALL_ICONS.length} icons; only {USED.size} are referenced.
+							The rest still download (the {`:target`} stack can't tree-shake). Every icon below is
+							rendered live from the sprite; unused ones are dimmed. (Static snapshot — names
+							flowing through data may bump the used count a little.)
+						</p>
+						<div className="stats" style={{ marginBottom: 20 }}>
+							<Stat n={String(ALL_ICONS.length)} label="icons in 0_merged_tla.svg" />
+							<Stat n={String(USED.size)} label="referenced in code" />
+							<Stat n={String(ALL_ICONS.length - USED.size)} label="apparently unused" />
+						</div>
+						<div className="spriteGrid">
+							{ALL_ICONS.map((name) => (
+								<div key={name} className="spriteCell" data-unused={!USED.has(name) || undefined}>
+									<span className="spriteCell__icon">
+										<TlaIcon icon={name} />
+									</span>
+									<span className="spriteCell__name">{name}</span>
+								</div>
 							))}
-						</tbody>
-					</table>
-				</section>
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">Why two mask-icon components</h2>
-					<div className="callout">
-						<code>TlaIcon</code> and <code>TldrawUiIcon</code> both paint an icon by{' '}
-						<code>mask</code>-ing a coloured box — but <code>TlaIcon</code> reads one bundled merged
-						sprite (<code>0_merged_tla.svg</code>) with no context, while <code>TldrawUiIcon</code>{' '}
-						resolves <em>per-icon</em> asset URLs through the editor&rsquo;s{' '}
-						<code>AssetUrlsProvider</code>. So the dotcom app, which renders chrome <em>outside</em>{' '}
-						the editor, needs its own icon component and its own sprite —{' '}
-						<strong>partly justified</strong>. But the two can&rsquo;t share an icon set, and a
-						design-system icon would have to bridge both. The lone inline <code>&lt;svg&gt;</code>{' '}
-						(ErrorPage&rsquo;s two-colour face) is a genuine exception: a monochrome mask
-						can&rsquo;t render it, and it must work offline.
-					</div>
-				</section>
+					<section className="section">
+						<h2 className="section__title">Overview</h2>
+						<p className="section__note">
+							<code>TlaIcon</code> shown live (its sprite is bundled). The SDK icon needs the editor
+							asset context, so it&rsquo;s a mock.
+						</p>
+						<div className="grid">
+							<Specimen
+								label="TlaIcon"
+								code={`<TlaIcon icon="search" />`}
+								meta="15px · currentColor mask · 0_merged_tla.svg"
+								source="tla/components/TlaIcon"
+							>
+								<span className="iconStage">
+									<TlaIcon icon="search" />
+								</span>
+							</Specimen>
+							<Specimen
+								label="TlaIcon"
+								code={`<TlaIcon icon="close" />`}
+								meta="same sprite, by name"
+								source="tla/components/TlaIcon"
+							>
+								<span className="iconStage">
+									<TlaIcon icon="close" />
+								</span>
+							</Specimen>
+							<Specimen
+								label="TlaIcon"
+								code={`<TlaIcon icon="avatar" />`}
+								meta="masked currentColor shape"
+								source="tla/components/TlaIcon"
+							>
+								<span className="iconStage">
+									<TlaIcon icon="avatar" />
+								</span>
+							</Specimen>
+							<Specimen
+								label="TlaIcon invertIcon"
+								code={`<TlaIcon icon="chevron-right" invertIcon />`}
+								meta="transform: scale(-1, 1)"
+								source="tla/components/TlaIcon"
+							>
+								<span className="iconStage">
+									<TlaIcon icon="chevron-right" invertIcon />
+								</span>
+							</Specimen>
+							<Specimen
+								label="TlaIcon icon='none'"
+								code={`<TlaIcon icon="none" />`}
+								meta="empty spacer — keeps the 15px box, paints nothing"
+								source="tla/components/TlaIcon"
+							>
+								<span className="iconStage iconStage--ghost">
+									<TlaIcon icon="none" />
+								</span>
+							</Specimen>
+							<Specimen
+								label="TldrawUiIcon (SDK)"
+								code={`<TldrawUiIcon icon="chevron-right" />`}
+								meta="per-icon asset · resolves via AssetUrlsProvider"
+								source="tldraw (packages/tldraw)"
+							>
+								<span className="iconStage">
+									<TldrawUiIcon icon="chevron-right" label="chevron-right" />
+								</span>
+							</Specimen>
+							<Specimen
+								label="inline <svg>"
+								code={`<svg viewBox="0 0 16 16">…</svg>`}
+								meta="two-colour, can't be a monochrome mask; offline-safe"
+								source="components/ErrorPage"
+							>
+								<svg viewBox="0 0 16 16" width="22" height="22" aria-hidden>
+									<circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.4" />
+									<circle cx="5.5" cy="6.5" r="1" fill="currentColor" />
+									<circle cx="10.5" cy="6.5" r="1" fill="currentColor" />
+									<path d="M5 11 q3 -2 6 0" fill="none" stroke="currentColor" strokeWidth="1.4" />
+								</svg>
+							</Specimen>
+						</div>
+					</section>
 
-			</div>
+					<section className="section">
+						<h2 className="section__title">Three mechanisms, compared</h2>
+						<table className="matrix matrix--wide">
+							<thead>
+								<tr>
+									<th></th>
+									<th>TlaIcon</th>
+									<th>TldrawUiIcon (SDK)</th>
+									<th>inline &lt;svg&gt;</th>
+								</tr>
+							</thead>
+							<tbody>
+								{ROWS.map((r) => (
+									<tr key={r[0]}>
+										<td className="rowhead">{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+										<td>{r[3]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Why two mask-icon components</h2>
+						<div className="callout">
+							<code>TlaIcon</code> and <code>TldrawUiIcon</code> both paint an icon by{' '}
+							<code>mask</code>-ing a coloured box — but <code>TlaIcon</code> reads one bundled
+							merged sprite (<code>0_merged_tla.svg</code>) with no context, while{' '}
+							<code>TldrawUiIcon</code> resolves <em>per-icon</em> asset URLs through the
+							editor&rsquo;s <code>AssetUrlsProvider</code>. So the dotcom app, which renders chrome{' '}
+							<em>outside</em> the editor, needs its own icon component and its own sprite —{' '}
+							<strong>partly justified</strong>. But the two can&rsquo;t share an icon set, and a
+							design-system icon would have to bridge both. The lone inline <code>&lt;svg&gt;</code>{' '}
+							(ErrorPage&rsquo;s two-colour face) is a genuine exception: a monochrome mask
+							can&rsquo;t render it, and it must work offline.
+						</div>
+					</section>
+				</div>
 			</TldrawUiContextProvider>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-icons.tsx
+++ b/apps/dotcom/client/src/pages/dev-icons.tsx
@@ -203,14 +203,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					Notable quirk: <code>TlaIcon</code> sets <code>webkitMask</code> imperatively in a{' '}
-					<code>useLayoutEffect</code> — a documented fix (TLD-1700) for React re-rendering and
-					re-requesting the sprite on every hand-tool drag. A small reminder that even a 60-line
-					icon component carries hard-won performance scars. For #9199 / #9190: the inline svg is a
-					keeper; the real question is whether dotcom and the SDK should ever converge on one icon
-					pipeline.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-icons.tsx
+++ b/apps/dotcom/client/src/pages/dev-icons.tsx
@@ -1,0 +1,378 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { TlaIcon } from '../tla/components/TlaIcon/TlaIcon'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's icon mechanisms. Three ways to render
+ * an icon — TlaIcon (sprite-mask), the SDK TldrawUiIcon (per-icon assets), and
+ * inline <svg> — i.e. competing implementations, the same divergence mode as
+ * buttons but smaller. TlaIcon and TldrawUiIcon are both CSS-mask icons yet
+ * can't share icons: different sprite sources and different contexts.
+ *
+ * Serves tldraw/tldraw#9199 / #9190 (icon items). Route: /dev/components/icons.
+ */
+
+const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
+	<div className="stat">
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Icon inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Icon inventory</h1>
+					<p className="page__lede">
+						Three ways to render an icon — competing implementations, the same divergence mode as
+						buttons. <code>TlaIcon</code> and <code>TldrawUiIcon</code> are both CSS-mask icons, yet
+						they can&rsquo;t share icons: different sprite sources, different contexts.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">Usage</h2>
+					<div className="stats">
+						<Stat n="28" label="TlaIcon (dotcom sprite)" />
+						<Stat n="6" label="TldrawUiIcon (SDK)" />
+						<Stat n="1" label="inline <svg>" />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">
+						Sprite coverage — {USED.size} of {ALL_ICONS.length} used
+					</h2>
+					<p className="section__note">
+						The merged sprite ships all {ALL_ICONS.length} icons; only {USED.size} are referenced.
+						The rest still download (the {`:target`} stack can't tree-shake). Every icon below is
+						rendered live from the sprite; unused ones are dimmed. (Static snapshot — names flowing
+						through data may bump the used count a little.)
+					</p>
+					<div className="stats" style={{ marginBottom: 20 }}>
+						<Stat n={String(ALL_ICONS.length)} label="icons in 0_merged_tla.svg" />
+						<Stat n={String(USED.size)} label="referenced in code" />
+						<Stat n={String(ALL_ICONS.length - USED.size)} label="apparently unused" />
+					</div>
+					<div className="spriteGrid">
+						{ALL_ICONS.map((name) => (
+							<div key={name} className="spriteCell" data-unused={!USED.has(name) || undefined}>
+								<span className="spriteCell__icon">
+									<TlaIcon icon={name} />
+								</span>
+								<span className="spriteCell__name">{name}</span>
+							</div>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Overview</h2>
+					<p className="section__note">
+						<code>TlaIcon</code> shown live (its sprite is bundled). The SDK icon needs the editor
+						asset context, so it&rsquo;s a mock.
+					</p>
+					<div className="grid">
+						<Specimen
+							label="TlaIcon"
+							code={`<TlaIcon icon="search" />`}
+							meta="15px · currentColor mask · 0_merged_tla.svg"
+							source="tla/components/TlaIcon"
+						>
+							<span className="iconStage">
+								<TlaIcon icon="search" />
+							</span>
+						</Specimen>
+						<Specimen
+							label="TlaIcon"
+							code={`<TlaIcon icon="close" />`}
+							meta="same sprite, by name"
+							source="tla/components/TlaIcon"
+						>
+							<span className="iconStage">
+								<TlaIcon icon="close" />
+							</span>
+						</Specimen>
+						<Specimen
+							label="TlaIcon"
+							code={`<TlaIcon icon="avatar" />`}
+							meta="masked currentColor shape"
+							source="tla/components/TlaIcon"
+						>
+							<span className="iconStage">
+								<TlaIcon icon="avatar" />
+							</span>
+						</Specimen>
+						<Specimen
+							label="TlaIcon invertIcon"
+							code={`<TlaIcon icon="chevron-right" invertIcon />`}
+							meta="transform: scale(-1, 1)"
+							source="tla/components/TlaIcon"
+						>
+							<span className="iconStage">
+								<TlaIcon icon="chevron-right" invertIcon />
+							</span>
+						</Specimen>
+						<Specimen
+							label="TlaIcon icon='none'"
+							code={`<TlaIcon icon="none" />`}
+							meta="empty spacer — keeps the 15px box, paints nothing"
+							source="tla/components/TlaIcon"
+						>
+							<span className="iconStage iconStage--ghost">
+								<TlaIcon icon="none" />
+							</span>
+						</Specimen>
+						<Specimen
+							label="TldrawUiIcon (SDK)"
+							code={`<TldrawUiIcon icon="…" label="…" small />`}
+							meta="per-icon asset · small/tiny sizing · needs AssetUrlsProvider"
+							source="tldraw (packages/tldraw)"
+						>
+							<span className="iconStage iconStage--mock">asset ctx</span>
+						</Specimen>
+						<Specimen
+							label="inline <svg>"
+							code={`<svg viewBox="0 0 16 16">…</svg>`}
+							meta="two-colour, can't be a monochrome mask; offline-safe"
+							source="components/ErrorPage"
+						>
+							<svg viewBox="0 0 16 16" width="22" height="22" aria-hidden>
+								<circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.4" />
+								<circle cx="5.5" cy="6.5" r="1" fill="currentColor" />
+								<circle cx="10.5" cy="6.5" r="1" fill="currentColor" />
+								<path d="M5 11 q3 -2 6 0" fill="none" stroke="currentColor" strokeWidth="1.4" />
+							</svg>
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Three mechanisms, compared</h2>
+					<table className="matrix matrix--wide">
+						<thead>
+							<tr>
+								<th></th>
+								<th>TlaIcon</th>
+								<th>TldrawUiIcon (SDK)</th>
+								<th>inline &lt;svg&gt;</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ROWS.map((r) => (
+								<tr key={r[0]}>
+									<td className="rowhead">{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+									<td>{r[3]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Why two mask-icon components</h2>
+					<div className="callout">
+						<code>TlaIcon</code> and <code>TldrawUiIcon</code> both paint an icon by{' '}
+						<code>mask</code>-ing a coloured box — but <code>TlaIcon</code> reads one bundled merged
+						sprite (<code>0_merged_tla.svg</code>) with no context, while <code>TldrawUiIcon</code>{' '}
+						resolves <em>per-icon</em> asset URLs through the editor&rsquo;s{' '}
+						<code>AssetUrlsProvider</code>. So the dotcom app, which renders chrome <em>outside</em>{' '}
+						the editor, needs its own icon component and its own sprite —{' '}
+						<strong>partly justified</strong>. But the two can&rsquo;t share an icon set, and a
+						design-system icon would have to bridge both. The lone inline <code>&lt;svg&gt;</code>{' '}
+						(ErrorPage&rsquo;s two-colour face) is a genuine exception: a monochrome mask
+						can&rsquo;t render it, and it must work offline.
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					Notable quirk: <code>TlaIcon</code> sets <code>webkitMask</code> imperatively in a{' '}
+					<code>useLayoutEffect</code> — a documented fix (TLD-1700) for React re-rendering and
+					re-requesting the sprite on every hand-tool drag. A small reminder that even a 60-line
+					icon component carries hard-won performance scars. For #9199 / #9190: the inline svg is a
+					keeper; the real question is whether dotcom and the SDK should ever converge on one icon
+					pipeline.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+// Every icon id in 0_merged_tla.svg (the merged sprite).
+const ALL_ICONS = [
+	'avatar',
+	'bookmark',
+	'check',
+	'chevron-down',
+	'chevron-down-strong',
+	'chevron-right',
+	'chevron-right-strong',
+	'chevron-up',
+	'chevron-up-down',
+	'chevron-up-strong',
+	'close',
+	'close-strong',
+	'comment',
+	'copy',
+	'copy-strong',
+	'doc',
+	'doc-strong',
+	'dots-horizontal',
+	'dots-horizontal-strong',
+	'dots-vertical',
+	'dots-vertical-strong',
+	'draw',
+	'edit',
+	'edit-strong',
+	'export',
+	'external',
+	'feedback',
+	'folder',
+	'folder-new',
+	'folder-open',
+	'group',
+	'group-strong',
+	'help-circle',
+	'home',
+	'home-strong',
+	'import',
+	'info',
+	'invite',
+	'link',
+	'link-strong',
+	'manual',
+	'more',
+	'pin',
+	'pin-strong',
+	'plus',
+	'plus-strong',
+	'qr',
+	'question',
+	'question-circle',
+	'refresh',
+	'search',
+	'settings',
+	'share',
+	'shared',
+	'sidebar',
+	'sidebar-strong',
+	'sign-in',
+	'spinner',
+	'star',
+	'star-fill',
+	'star-strong',
+	'star-strong-fill',
+	'tick',
+	'tldraw',
+	'untick',
+	'update',
+] as const
+
+// Icons referenced in code — static snapshot from icon= / iconLeft= / iconRight= literals
+// intersected with the sprite. Regenerate by grepping those attributes; a few data-driven
+// names may not be captured, so treat this as a floor.
+const USED = new Set<string>([
+	'avatar',
+	'check',
+	'chevron-down',
+	'chevron-up-down',
+	'close',
+	'comment',
+	'copy',
+	'dots-vertical-strong',
+	'edit',
+	'edit-strong',
+	'export',
+	'external',
+	'feedback',
+	'group',
+	'help-circle',
+	'pin',
+	'plus',
+	'search',
+	'settings',
+	'share',
+	'sidebar-strong',
+	'sign-in',
+	'spinner',
+])
+
+const ROWS: ReadonlyArray<readonly [string, string, string, string]> = [
+	[
+		'mechanism',
+		'CSS mask of a merged sprite',
+		'CSS mask of a per-icon asset',
+		'the SVG markup itself',
+	],
+	[
+		'source',
+		'0_merged_tla.svg (bundled)',
+		'AssetUrlsProvider (per icon)',
+		'inline in the component',
+	],
+	['sizing', '15px default · free via CSS/style', 'small / tiny booleans', 'whatever the svg sets'],
+	['colour', 'currentColor', 'color prop / currentColor', 'fill in the markup'],
+	['a11y', 'aria-hidden + optional ariaLabel', 'label required', 'manual'],
+	['context', 'none — sprite imported', 'needs the editor asset context', 'none'],
+	['where', 'dotcom UI (28)', 'SDK-derived UI (6)', 'ErrorPage two-colour (1)'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede code, .section code, .callout code, .page__footer code, .section__note code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 200px; background: var(--tl-color-panel); }
+.stat__n { font-size: 28px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.iconStage { display: inline-flex; align-items: center; justify-content: center; color: var(--tl-color-text); }
+.iconStage > span { width: 22px; height: 22px; }
+.spriteGrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(92px, 1fr)); gap: 8px; }
+.spriteCell { display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 14px 6px 10px; border: 1px solid var(--tl-color-divider); border-radius: 6px; background: var(--tl-color-panel); font-size: 10px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); }
+.spriteCell__icon { color: var(--tl-color-text); display: inline-flex; }
+.spriteCell__icon > span { width: 20px; height: 20px; }
+.spriteCell__name { max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.spriteCell[data-unused] { opacity: 0.5; background: transparent; border-style: dashed; }
+.spriteCell[data-unused] .spriteCell__icon { color: var(--tl-color-text-3); }
+.spriteCell[data-unused] .spriteCell__name { text-decoration: line-through; }
+.iconStage--ghost { outline: 1px dashed var(--tl-color-divider); border-radius: 4px; }
+.iconStage--mock { font-family: ui-monospace, monospace; font-size: 10px; color: var(--tl-color-text-3); border: 1px dashed var(--tl-color-divider); border-radius: 4px; padding: 6px 8px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix--wide td, .matrix--wide th { padding-right: 24px; max-width: 280px; }
+.matrix .rowhead { color: var(--tl-color-text-3); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-icons.tsx
+++ b/apps/dotcom/client/src/pages/dev-icons.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
+import { TldrawUiContextProvider, TldrawUiIcon } from 'tldraw'
 import 'tldraw/tldraw.css'
 import { TlaIcon } from '../tla/components/TlaIcon/TlaIcon'
 import '../tla/styles/tla.css'
@@ -35,6 +36,7 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
+			<TldrawUiContextProvider forceMobile={false}>
 			<div className="page">
 				<DevComponentsNav />
 				<header className="page__header">
@@ -141,12 +143,13 @@ export function Component() {
 						</Specimen>
 						<Specimen
 							label="TldrawUiIcon (SDK)"
-							code={`<TldrawUiIcon icon="…" label="…" small />`}
-							meta="per-icon asset · small/tiny sizing · needs AssetUrlsProvider"
+							code={`<TldrawUiIcon icon="chevron-right" />`}
+							meta="per-icon asset · resolves via AssetUrlsProvider"
 							source="tldraw (packages/tldraw)"
-							mock
 						>
-							<span className="iconStage iconStage--mock">asset ctx</span>
+							<span className="iconStage">
+								<TldrawUiIcon icon="chevron-right" label="chevron-right" />
+							</span>
 						</Specimen>
 						<Specimen
 							label="inline <svg>"
@@ -205,6 +208,7 @@ export function Component() {
 				</section>
 
 			</div>
+			</TldrawUiContextProvider>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-identity.tsx
+++ b/apps/dotcom/client/src/pages/dev-identity.tsx
@@ -1,0 +1,377 @@
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
+import { ReactNode, useEffect } from 'react'
+import { Helmet } from 'react-helmet-async'
+import {
+	DefaultPeopleMenuAvatar,
+	InstancePresenceRecordType,
+	PeopleMenu,
+	TLUserId,
+	useEditor,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { TlaIcon } from '../tla/components/TlaIcon/TlaIcon'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+import { MinimalEditorHarness } from './dev-editor-harness'
+
+/**
+ * Dev-only inventory of how a user's DISPLAY NAME is sourced and rendered. There
+ * is no single source of truth and no shared accessor: Clerk seeds the name once,
+ * then the app keeps three independent copies (user.name, member.userName, the
+ * SDK presence name) that each drift. Each surface reads a different raw field,
+ * with a different empty-name fallback and a different avatar treatment.
+ *
+ * Two "seed once, never resync" bugs are catalogued here:
+ *   1. Clerk fullName -> user.name is create-once (TLUserDurableObject.ts:114,
+ *      `if (!user)`); renaming in Clerk never propagates.
+ *   2. user.name -> member.userName is write-once (mutators.ts:260/:482); the
+ *      workspace members list tracks neither Clerk nor user.name.
+ *
+ * The presence surfaces render live (fake instance_presence); the app-coupled
+ * surfaces (user menu, members list) are faithful representations. Candidate for
+ * a shared useUserName / <UserAvatar> primitive. Route: /dev/components/identity.
+ */
+
+const USER = { id: 'user:casey' as TLUserId, name: 'Casey Jordan', color: '#268bd2' }
+
+/** Fake presence so the real SDK name UI has data (lastActivityTimestamp: null =
+ * always active). `name` overrides so we can demo empty-name fallbacks. */
+const InjectPresence = ({ name = USER.name }: { name?: string }): ReactNode => {
+	const editor = useEditor()
+	useEffect(() => {
+		editor.store.put([
+			InstancePresenceRecordType.create({
+				id: InstancePresenceRecordType.createId(USER.id),
+				userId: USER.id,
+				userName: name,
+				currentPageId: editor.getCurrentPageId(),
+				color: USER.color,
+				cursor: { x: 60, y: 45, type: 'default', rotation: 0 },
+				lastActivityTimestamp: null,
+			}),
+		])
+	}, [editor, name])
+	return null
+}
+
+const PresenceStage = ({ name, overlay }: { name?: string; overlay?: ReactNode }): ReactNode => (
+	<MinimalEditorHarness height={140} bare>
+		<InjectPresence name={name} />
+		{overlay && <div className="idOverlay">{overlay}</div>}
+	</MinimalEditorHarness>
+)
+
+/** Faithful representation of the sidebar user-settings trigger, which reads
+ * app.getUser().name and falls back to the literal text "Account". Marked mock:
+ * the real TlaSidebarUserSettingsMenu needs the app/Zero context. */
+const UserMenuTrigger = ({ name }: { name: string }): ReactNode => (
+	<span className="menuTrigger">
+		<TlaIcon icon="avatar" className="menuTrigger__avatar" />
+		<span className="menuTrigger__name">{name || 'Account'}</span>
+		<TlaIcon icon="dots-vertical-strong" className="menuTrigger__dots" />
+	</span>
+)
+
+/** The members-list treatment: an initials chip from userName.charAt(0) + the name. */
+const MemberRow = ({ name }: { name: string }): ReactNode => (
+	<span className="memberRow">
+		<span className="memberRow__initial" style={{ background: USER.color }}>
+			{name.charAt(0).toUpperCase()}
+		</span>
+		<span className="memberRow__name">{name}</span>
+	</span>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Identity & names — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Identity &amp; names</h1>
+					<p className="page__lede">
+						How a user's <strong>display name</strong> is sourced and shown. There is{' '}
+						<strong>no single source of truth and no shared accessor</strong> — Clerk seeds the name
+						once, then three independent copies drift, and every surface reads a different raw field
+						with a different empty-name fallback and a different avatar. Same shape as the{' '}
+						<a href="/dev/components/timestamps">dates</a> finding, but with a live staleness bug.
+					</p>
+				</header>
+
+				<section className="section">
+					<div className="stats">
+						<Stat n="3" label="stored copies of the name" accent />
+						<Stat n="0" label="shared accessor (useUserName)" />
+						<Stat n="2" label='"seed once, never resync" bugs' accent />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The flow</h2>
+					<p className="section__note">
+						One name, seeded from Clerk, denormalised into three stores at different lifecycle
+						moments. Bold arrows are the two one-way seed steps that never resync.
+					</p>
+					<div className="flow">
+						<div className="flow__node flow__node--root">
+							Clerk<span className="flow__sub">clerkUser.fullName</span>
+						</div>
+						<div className="flow__arrow flow__arrow--bug">
+							↓ create-once
+							<span className="flow__sub">TLUserDurableObject.ts:114 · if (!user)</span>
+						</div>
+						<div className="flow__node">
+							user record<span className="flow__sub">user.name</span>
+						</div>
+						<div className="flow__split">
+							<div className="flow__branch">
+								<div className="flow__arrow">↓ derived (live)</div>
+								<div className="flow__node flow__node--sdk">
+									SDK presence<span className="flow__sub">instance_presence.userName</span>
+								</div>
+								<div className="flow__arrow">↓</div>
+								<div className="flow__leaf">user cursor · people menu</div>
+							</div>
+							<div className="flow__branch">
+								<div className="flow__arrow">↓ read (live)</div>
+								<div className="flow__leaf">user menu</div>
+							</div>
+							<div className="flow__branch">
+								<div className="flow__arrow flow__arrow--bug">
+									↓ write-once<span className="flow__sub">mutators.ts:260</span>
+								</div>
+								<div className="flow__node flow__node--snap">
+									member record<span className="flow__sub">member.userName (snapshot)</span>
+								</div>
+								<div className="flow__arrow">↓</div>
+								<div className="flow__leaf">workspace members list</div>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The same name, four surfaces</h2>
+					<p className="section__note">
+						Presence surfaces render live (a fake <code>instance_presence</code> record); the
+						app-coupled surfaces are faithful representations (they need the app/Zero context).
+					</p>
+					<div className="grid">
+						<Specimen
+							label="user cursor"
+							code={`instance_presence.userName`}
+							meta="name label in the user's colour"
+							source="SDK editor · TlaEditor.tsx"
+						>
+							<PresenceStage />
+						</Specimen>
+						<Specimen
+							label="people menu"
+							code={`<PeopleMenu />`}
+							meta="collaborator names"
+							source="TlaInviteTab.tsx"
+						>
+							<PresenceStage overlay={<PeopleMenu />} />
+						</Specimen>
+						<Specimen
+							label="people-menu avatar"
+							code={`<DefaultPeopleMenuAvatar userId />`}
+							meta="colour swatch, no initials"
+							source="SharePanel"
+						>
+							<PresenceStage overlay={<DefaultPeopleMenuAvatar userId={USER.id} />} />
+						</Specimen>
+						<Specimen
+							label="user menu (sidebar)"
+							code={`app.getUser().name || 'Account'`}
+							meta="generic avatar icon · fallback text 'Account'"
+							source="TlaSidebarUserSettingsMenu.tsx:67"
+							mock
+						>
+							<UserMenuTrigger name={USER.name} />
+						</Specimen>
+						<Specimen
+							label="workspace members"
+							code={`member.userName · userName.charAt(0)`}
+							meta="initials chip from the snapshot name"
+							source="WorkspaceSettingsDialog.tsx:440"
+							mock
+						>
+							<MemberRow name={USER.name} />
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Where each store comes from</h2>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>store</th>
+								<th>seeded from</th>
+								<th>updates when</th>
+								<th>feeds</th>
+							</tr>
+						</thead>
+						<tbody>
+							{STORES.map((r) => (
+								<tr key={r[0]} data-bug={r[4] || undefined}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+									<td>{r[3]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The bug: seed once, never resync</h2>
+					<div className="callout callout--bug">
+						Two copies are written once and never updated.{' '}
+						<strong>
+							<code>user.name</code> is create-once
+						</strong>{' '}
+						(<code>TLUserDurableObject.ts:114</code> guards the whole bootstrap with{' '}
+						<code>if (!user)</code>, seeding <code>clerkUser.fullName</code>), and there's no Clerk
+						webhook — so renaming yourself in Clerk never reaches dotcom.{' '}
+						<strong>
+							<code>member.userName</code> is write-once
+						</strong>{' '}
+						(<code>mutators.ts:260</code>, no update path). Editing your name in the editor updates{' '}
+						<code>user.name</code> (cursor + menu) but not <code>member.userName</code> — so the
+						workspace members list is <strong>doubly stale</strong>: it tracks neither Clerk nor{' '}
+						<code>user.name</code>.
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Empty-name: three different fallbacks (live)</h2>
+					<p className="section__note">
+						The same user with <code>name = ''</code>. Each surface degrades differently — no shared
+						"anonymous" treatment.
+					</p>
+					<div className="grid">
+						<Specimen label="cursor" meta="blank label (?? '')" source="SDK">
+							<PresenceStage name="" />
+						</Specimen>
+						<Specimen label="user menu" meta={`text 'Account'`} source="menu" mock>
+							<UserMenuTrigger name="" />
+						</Specimen>
+						<Specimen label="members list" meta="empty initial + blank" source="members" mock>
+							<MemberRow name="" />
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The gap</h2>
+					<div className="callout">
+						Timestamps needed a <code>&lt;Timestamp&gt;</code>; names need a shared{' '}
+						<strong>
+							<code>useUserName(userId)</code> / <code>&lt;UserName&gt;</code> +{' '}
+							<code>&lt;UserAvatar&gt;</code>
+						</strong>{' '}
+						resolver. The denormalised copies can stay for sync/perf, but every read should go
+						through one accessor that resolves a single source, decides the snapshot-vs-live
+						question once, and owns the fallback + avatar treatment — instead of four raw
+						field-reads with four different empty-states.
+					</div>
+				</section>
+			</div>
+		</div>
+	)
+}
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+const STORES: ReadonlyArray<readonly [string, string, string, string, boolean]> = [
+	[
+		'clerkUser.fullName',
+		'the user (Clerk account)',
+		'user edits Clerk profile',
+		'seed only',
+		false,
+	],
+	[
+		'user.name',
+		'Clerk fullName, once',
+		'editor preferences only — NOT Clerk',
+		'cursor · people menu · user menu',
+		true,
+	],
+	[
+		'member.userName',
+		'user.name / Clerk, at join',
+		'never (write-once)',
+		'workspace members list',
+		true,
+	],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 820px; margin-bottom: 32px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede a { color: var(--tl-color-primary); }
+.page__lede code, .section__note code, .callout code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 44px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 820px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 180px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.idOverlay { position: absolute; top: 12px; right: 12px; z-index: 100; }
+.menuTrigger { display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px; border-radius: var(--tl-radius-2); background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); font-size: 13px; }
+.menuTrigger__avatar { width: 20px; height: 20px; color: var(--tl-color-text-3); }
+.menuTrigger__name { font-weight: 500; color: var(--tl-color-text-0); }
+.menuTrigger__dots { width: 16px; height: 16px; color: var(--tl-color-text-3); margin-left: 8px; }
+.memberRow { display: inline-flex; align-items: center; gap: 10px; font-size: 13px; }
+.memberRow__initial { width: 26px; height: 26px; border-radius: 50%; color: #fff; font-size: 12px; font-weight: 600; display: inline-flex; align-items: center; justify-content: center; }
+.memberRow__name { color: var(--tl-color-text-0); }
+.flow { display: flex; flex-direction: column; align-items: center; gap: 4px; font-size: 12px; font-family: ui-monospace, monospace; padding: 8px 0; }
+.flow__node { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 8px 14px; background: var(--tl-color-panel); text-align: center; }
+.flow__node--root { border-color: var(--tl-color-primary); }
+.flow__node--sdk { border-color: var(--tl-color-selected, #3b82f6); }
+.flow__node--snap { border-color: var(--tl-color-warning, #cb4b16); }
+.flow__sub { display: block; font-size: 10px; color: var(--tl-color-text-3); margin-top: 2px; }
+.flow__arrow { color: var(--tl-color-text-3); text-align: center; padding: 2px 0; }
+.flow__arrow--bug { color: var(--tl-color-warning, #cb4b16); font-weight: 600; }
+.flow__split { display: flex; gap: 24px; align-items: flex-start; margin-top: 6px; flex-wrap: wrap; justify-content: center; }
+.flow__branch { display: flex; flex-direction: column; align-items: center; gap: 2px; }
+.flow__leaf { border: 1px dashed var(--tl-color-divider); border-radius: 6px; padding: 6px 12px; color: var(--tl-color-text-1); }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; width: 100%; max-width: 900px; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix tr[data-bug] td:nth-child(3) { color: var(--tl-color-warning, #cb4b16); font-weight: 600; }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 900px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.callout--bug { border-color: var(--tl-color-warning, #cb4b16); }
+`

--- a/apps/dotcom/client/src/pages/dev-inputs.tsx
+++ b/apps/dotcom/client/src/pages/dev-inputs.tsx
@@ -3,81 +3,43 @@ import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { TldrawUiInput } from 'tldraw'
 import 'tldraw/tldraw.css'
-import dialogStyles from '../tla/components/dialogs/dialogs.module.css'
 import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
 
 /**
- * Dev-only inventory of every text-input surface in the dotcom app. Unlike
- * buttons (which diverge by redundancy — many ways to do one thing), inputs
- * diverge by SCARCITY: TldrawUiInput is a single narrow editable-text field, so
- * raw <input>/<textarea> appear wherever a native capability it lacks is needed.
- * Each raw card flags the exact attribute the component can't express.
+ * Dev-only inventory of every text-input surface in the dotcom app. Inputs
+ * diverge by SCARCITY: TldrawUiInput is one narrow editable-text field, so raw
+ * <input>/<textarea> appear wherever a native capability it lacks is needed.
+ * Every call site is shown — nothing filtered.
  *
- * Serves tldraw/tldraw#9191 (replace raw inputs with shared input components).
- * Route: /dev/components/inputs.
+ * Serves tldraw/tldraw#9191. Route: /dev/components/inputs.
  */
 
-const Specimen = ({
-	label,
-	code,
-	meta,
-	source,
-	children,
-}: {
-	label: string
-	/** The literal JSX / props used to render this specimen. */
-	code?: string
-	/** For raw inputs: the native capability TldrawUiInput cannot express. */
-	meta: string
-	/** Where this input lives and which component renders it. */
-	source?: string
-	children: ReactNode
-}): ReactNode => (
-	<div className="specimen">
-		<div className="specimen__stage">{children}</div>
-		<div className="specimen__label">{label}</div>
-		{code && <div className="specimen__code">{code}</div>}
-		<div className="specimen__meta">{meta}</div>
-		{source && <div className="specimen__source">{source}</div>}
-	</div>
-)
-
-const Section = ({
-	title,
-	note,
-	api,
-	source,
-	children,
-}: {
-	title: string
-	note: string
-	api?: string
-	source?: string
-	children: ReactNode
-}) => (
+const Section = ({ title, note, children }: { title: string; note: string; children: ReactNode }) => (
 	<section className="section">
 		<h2 className="section__title">{title}</h2>
 		<p className="section__note">{note}</p>
-		{(api || source) && (
-			<div className="section__api">
-				{api && (
-					<div>
-						<span className="k">props</span>
-						{api}
-					</div>
-				)}
-				{source && (
-					<div>
-						<span className="k">source</span>
-						{source}
-					</div>
-				)}
-			</div>
-		)}
 		<div className="grid">{children}</div>
 	</section>
 )
+
+/** Renders a raw input element faithfully by kind. */
+const RawInput = ({ el, placeholder }: { el: RawKind; placeholder?: string }): ReactNode => {
+	if (el === 'checkbox') return <input type="checkbox" role="switch" defaultChecked className="rawSwitch" />
+	if (el === 'textarea')
+		return (
+			<textarea placeholder={placeholder} className="rawInput" style={{ minHeight: 44, resize: 'vertical' }} />
+		)
+	return (
+		<input
+			type={el === 'email' ? 'email' : 'text'}
+			inputMode={el === 'numeric' ? 'numeric' : undefined}
+			placeholder={placeholder}
+			className="rawInput"
+		/>
+	)
+}
 
 export function Component() {
 	return (
@@ -88,7 +50,7 @@ export function Component() {
 			<Helmet>
 				<title>Input inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
@@ -97,11 +59,10 @@ export function Component() {
 					<p className="page__lede">
 						Every text-input surface in the dotcom app. Inputs diverge by capability, not pixels:
 						TldrawUiInput is one narrow editable-text field, so raw inputs appear wherever a native
-						attribute it can't express is needed. Each raw card flags that missing capability.
+						attribute it can&rsquo;t express is needed. Each raw card flags that missing capability.
 					</p>
 				</header>
 
-				{/* The punchline: a coverage table, not a styling one. */}
 				<section className="section">
 					<h2 className="section__title">Coverage matrix</h2>
 					<p className="section__note">
@@ -128,102 +89,81 @@ export function Component() {
 				</section>
 
 				<Section
-					title="TldrawUiInput — the SDK primitive (well adopted)"
-					note="An editable single-line text field with a custom Enter=onComplete / Escape=onCancel model (not native onChange). Adopted across the app for inline rename and search."
-					api="value/defaultValue, placeholder, label, icon/iconLeft, autoFocus, autoSelect, maxLength, disabled, onComplete(value), onValueChange(value), onCancel(value), onBlur, onFocus, className. NO type / name / required / readOnly / inputMode / pattern; no <textarea>; no native onChange."
-					source="from 'tldraw' (packages/tldraw) · used in TlaSidebarSearch, TlaSidebarInlineInput, WorkspaceSettingsDialog, CreateWorkspaceDialog, TlaEditorTopLeftPanel"
+					title={`TldrawUiInput — all ${SDK_INPUTS.length} call sites`}
+					note="The SDK's editable single-line text field (custom Enter=onComplete / Escape=onCancel, not native onChange). Rendered live."
 				>
-					<Specimen
-						label="text"
-						code={`<TldrawUiInput placeholder="Rename" />`}
-						meta="editable text · Enter → onComplete, Esc → onCancel"
-					>
-						<TldrawUiInput placeholder="Rename file" className="demoInput" />
-					</Specimen>
-					<Specimen
-						label="label"
-						code={`<TldrawUiInput label="Name" />`}
-						meta="label resolves via translation (passthrough for non-keys)"
-					>
-						<TldrawUiInput label="Workspace name" placeholder="Acme" className="demoInput" />
-					</Specimen>
-					<Specimen
-						label="defaultValue + maxLength"
-						code={`<TldrawUiInput defaultValue="Untitled" maxLength={32} />`}
-						meta="seeded value, capped length"
-					>
-						<TldrawUiInput defaultValue="Untitled" maxLength={32} className="demoInput" />
-					</Specimen>
-					<Specimen
-						label="disabled"
-						code={`<TldrawUiInput disabled />`}
-						meta="non-interactive"
-					>
-						<TldrawUiInput placeholder="Disabled" disabled className="demoInput" />
-					</Specimen>
+					{SDK_INPUTS.map((i) => (
+						<Specimen key={i.source} label={i.label} code={i.code} meta={i.meta} source={i.source}>
+							<TldrawUiInput
+								defaultValue={i.defaultValue}
+								placeholder={i.placeholder}
+								className="demoInput"
+							/>
+						</Specimen>
+					))}
 				</Section>
 
 				<Section
-					title="Raw inputs — the escapes (#9191)"
-					note="Each of these is raw because it needs exactly what TldrawUiInput lacks. Rendered with their real native attributes (the divergence axis), styled minimally — the gap is capability, not appearance."
-					api="native <input> / <textarea> attributes only — no shared component"
+					title={`Raw <input> / <textarea> — all ${RAW_INPUTS.length}`}
+					note="Each is raw because it needs exactly what TldrawUiInput lacks. Rendered with real native attributes; meta names the missing capability."
 				>
-					<Specimen
-						label="email (sign-in)"
-						code={`<input type="email" name="identifier" required>`}
-						meta="needs type + name + required → TldrawUiInput has none (it's a Clerk form field)"
-						source="TlaSignInDialog.tsx"
-					>
-						<input type="email" name="identifier" required placeholder="you@example.com" className="rawInput" />
-					</Specimen>
-					<Specimen
-						label="verification code"
-						code={`<input type="text" inputMode="numeric" autoFocus>`}
-						meta="needs inputMode='numeric' to get the numeric keypad → not exposed"
-						source="TlaSignInDialog.tsx (hidden OTP input behind digit boxes)"
-					>
-						<input type="text" inputMode="numeric" placeholder="123456" className="rawInput" />
-					</Specimen>
-					<Specimen
-						label="feedback (multi-line)"
-						code={`<textarea defaultValue=… onInput=…>`}
-						meta="needs a <textarea> → TldrawUiInput is single-line <input> only"
-						source="SubmitFeedbackDialog.tsx · dialogs.module.css .feedbackDialogTextArea"
-					>
-						<textarea
-							placeholder="Tell us more…"
-							className={dialogStyles.feedbackDialogTextArea}
-							style={{ minHeight: 56 }}
-						/>
-					</Specimen>
-					<Specimen
-						label="sharing toggle"
-						code={`<input type="checkbox" role="switch">`}
-						meta="not a text field at all — a different control (TlaMenuSwitch)"
-						source="tla-menu.tsx (TlaMenuSwitch)"
-					>
-						<input type="checkbox" role="switch" defaultChecked className="rawSwitch" />
-					</Specimen>
-					<Specimen
-						label="admin file lookup"
-						code={`<input type="text" ref={inputRef} /> + Enter`}
-						meta="internal tool: imperative ref reads + Enter-to-search; raw by choice"
-						source="admin.tsx (×9 inputs) · admin.module.css .searchInput"
-					>
-						<input type="text" placeholder="File ID" className="rawInput" />
-					</Specimen>
+					{RAW_INPUTS.map((i) => (
+						<Specimen key={i.source} label={i.label} code={i.code} meta={i.meta} source={i.source}>
+							<RawInput el={i.el} placeholder={i.placeholder} />
+						</Specimen>
+					))}
 				</Section>
 
 				<footer className="page__footer">
-					The shape of the gap: TldrawUiInput is a great <em>editable-text</em> field but not a
-					general input — it can't be a typed/native form field, a numeric input, a textarea, or a
-					toggle. So #9191 isn't a mechanical swap; it's blocked on richer shared form components
-					(a typed/controlled input, a textarea, a toggle). See tldraw/tldraw#9191.
+					TldrawUiInput is a great <em>editable-text</em> field but not a general input — it
+					can&rsquo;t be a typed/native form field, a numeric input, a textarea, or a toggle. So
+					#9191 isn&rsquo;t a mechanical swap; it&rsquo;s blocked on richer shared form components.
+					The 8 admin inputs are an internal tool (imperative refs + Enter-to-search), lower priority
+					but shown for completeness. See tldraw/tldraw#9191.
 				</footer>
 			</div>
 		</div>
 	)
 }
+
+type RawKind = 'text' | 'email' | 'numeric' | 'checkbox' | 'textarea'
+
+const SDK_INPUTS: ReadonlyArray<{
+	label: string
+	code: string
+	meta: string
+	source: string
+	placeholder?: string
+	defaultValue?: string
+}> = [
+	{ label: 'sidebar search', code: 'placeholder · onValueChange · autoFocus · autoSelect', meta: 'search box', source: 'TlaSidebarSearch:87', placeholder: 'Search files…' },
+	{ label: 'inline file rename', code: 'defaultValue · onComplete · onCancel', meta: 'inline rename', source: 'TlaSidebarInlineInput:53', defaultValue: 'My file' },
+	{ label: 'create workspace', code: 'value · onValueChange · onComplete · placeholder', meta: 'workspace name', source: 'CreateWorkspaceDialog:65', placeholder: 'Workspace name' },
+	{ label: 'rename workspace', code: 'defaultValue · onValueChange', meta: 'settings rename', source: 'WorkspaceSettingsDialog:342', defaultValue: 'Acme Inc' },
+	{ label: 'rename current file', code: 'value · onValueChange · autoFocus · autoSelect', meta: 'editor file name', source: 'TlaEditorTopLeftPanel:407', defaultValue: 'Untitled' },
+]
+
+const RAW_INPUTS: ReadonlyArray<{
+	label: string
+	el: RawKind
+	code: string
+	meta: string
+	source: string
+	placeholder?: string
+}> = [
+	{ label: 'sharing toggle', el: 'checkbox', code: 'type="checkbox" role="switch" name="shared"', meta: 'TlaMenuSwitch — not a text field', source: 'tla-menu.tsx:260' },
+	{ label: 'sign-in email', el: 'email', code: 'type="email" name="identifier"', meta: 'needs type + name (Clerk form)', source: 'TlaSignInDialog:244', placeholder: 'you@example.com' },
+	{ label: 'verification code', el: 'numeric', code: 'type="text" inputMode="numeric"', meta: 'needs inputMode', source: 'TlaSignInDialog:449', placeholder: '123456' },
+	{ label: 'admin: user lookup', el: 'text', code: 'type="text" ref placeholder="Email or ID"', meta: 'imperative ref + Enter', source: 'admin.tsx:175', placeholder: 'Email or ID' },
+	{ label: 'admin: published file', el: 'text', code: 'type="text" ref placeholder="Published file ID"', meta: 'ref read', source: 'admin.tsx:367', placeholder: 'Published file ID' },
+	{ label: 'admin: toggle', el: 'checkbox', code: 'type="checkbox"', meta: 'admin toggle', source: 'admin.tsx:509' },
+	{ label: 'admin: toggle', el: 'checkbox', code: 'type="checkbox"', meta: 'admin toggle', source: 'admin.tsx:574' },
+	{ label: 'admin: text field', el: 'text', code: 'type="text"', meta: 'admin field', source: 'admin.tsx:586', placeholder: '…' },
+	{ label: 'admin: file ID', el: 'text', code: 'type="text" ref .searchInput', meta: 'Enter-to-search', source: 'admin.tsx:666', placeholder: 'File ID' },
+	{ label: 'admin: file ID', el: 'text', code: 'type="text" ref .searchInput', meta: 'Enter-to-search', source: 'admin.tsx:766', placeholder: 'File ID' },
+	{ label: 'admin: user lookup', el: 'text', code: 'type="text" ref placeholder="User ID or Email"', meta: 'ref read', source: 'admin.tsx:844', placeholder: 'User ID or Email' },
+	{ label: 'feedback', el: 'textarea', code: '<textarea defaultValue · onInput · ref>', meta: 'multi-line — TldrawUiInput is input-only', source: 'SubmitFeedbackDialog:159', placeholder: 'Tell us more…' },
+]
 
 const MATRIX: ReadonlyArray<readonly [string, string, string]> = [
 	['inline rename / file name', 'editable text + Enter/Esc', '✓ TldrawUiInput'],
@@ -249,38 +189,7 @@ const PAGE_CSS = `
 .page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
 .section { margin-bottom: 56px; }
 .section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
-.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 720px; }
-.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; margin: 0 0 24px; max-width: 880px; }
-.section__api > div { display: flex; gap: 8px; }
-.section__api > div + div { margin-top: 4px; }
-.section__api .k { color: var(--tl-color-text-3); flex: 0 0 48px; }
-.grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-	gap: 20px;
-}
-.specimen {
-	border: 1px solid var(--tl-color-divider);
-	border-radius: 8px;
-	padding: 20px 16px 14px;
-	background: var(--tl-color-panel);
-	display: flex;
-	flex-direction: column;
-	gap: 12px;
-}
-.specimen__stage {
-	min-height: 56px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: var(--tl-color-low);
-	border-radius: 6px;
-	padding: 12px;
-}
-.specimen__label { font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace; }
-.specimen__code { font-size: 11px; line-height: 1.4; color: var(--tl-color-text-1); font-family: ui-monospace, monospace; background: var(--tl-color-low); border-radius: 4px; padding: 5px 7px; white-space: pre-wrap; word-break: break-word; }
-.specimen__meta { font-size: 11px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; }
-.specimen__source { font-size: 10px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; border-top: 1px dashed var(--tl-color-divider); padding-top: 8px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 24px; max-width: 720px; }
 .matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
 .matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); }
 .matrix th { color: var(--tl-color-text-3); font-weight: 500; }

--- a/apps/dotcom/client/src/pages/dev-inputs.tsx
+++ b/apps/dotcom/client/src/pages/dev-inputs.tsx
@@ -1,0 +1,291 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { TldrawUiInput } from 'tldraw'
+import 'tldraw/tldraw.css'
+import dialogStyles from '../tla/components/dialogs/dialogs.module.css'
+import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of every text-input surface in the dotcom app. Unlike
+ * buttons (which diverge by redundancy — many ways to do one thing), inputs
+ * diverge by SCARCITY: TldrawUiInput is a single narrow editable-text field, so
+ * raw <input>/<textarea> appear wherever a native capability it lacks is needed.
+ * Each raw card flags the exact attribute the component can't express.
+ *
+ * Serves tldraw/tldraw#9191 (replace raw inputs with shared input components).
+ * Route: /dev/components/inputs.
+ */
+
+const Specimen = ({
+	label,
+	code,
+	meta,
+	source,
+	children,
+}: {
+	label: string
+	/** The literal JSX / props used to render this specimen. */
+	code?: string
+	/** For raw inputs: the native capability TldrawUiInput cannot express. */
+	meta: string
+	/** Where this input lives and which component renders it. */
+	source?: string
+	children: ReactNode
+}): ReactNode => (
+	<div className="specimen">
+		<div className="specimen__stage">{children}</div>
+		<div className="specimen__label">{label}</div>
+		{code && <div className="specimen__code">{code}</div>}
+		<div className="specimen__meta">{meta}</div>
+		{source && <div className="specimen__source">{source}</div>}
+	</div>
+)
+
+const Section = ({
+	title,
+	note,
+	api,
+	source,
+	children,
+}: {
+	title: string
+	note: string
+	api?: string
+	source?: string
+	children: ReactNode
+}) => (
+	<section className="section">
+		<h2 className="section__title">{title}</h2>
+		<p className="section__note">{note}</p>
+		{(api || source) && (
+			<div className="section__api">
+				{api && (
+					<div>
+						<span className="k">props</span>
+						{api}
+					</div>
+				)}
+				{source && (
+					<div>
+						<span className="k">source</span>
+						{source}
+					</div>
+				)}
+			</div>
+		)}
+		<div className="grid">{children}</div>
+	</section>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Input inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Input inventory</h1>
+					<p className="page__lede">
+						Every text-input surface in the dotcom app. Inputs diverge by capability, not pixels:
+						TldrawUiInput is one narrow editable-text field, so raw inputs appear wherever a native
+						attribute it can't express is needed. Each raw card flags that missing capability.
+					</p>
+				</header>
+
+				{/* The punchline: a coverage table, not a styling one. */}
+				<section className="section">
+					<h2 className="section__title">Coverage matrix</h2>
+					<p className="section__note">
+						Where TldrawUiInput suffices, and where the app drops to a raw element — and why.
+					</p>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>case</th>
+								<th>native need</th>
+								<th>TldrawUiInput?</th>
+							</tr>
+						</thead>
+						<tbody>
+							{MATRIX.map((r) => (
+								<tr key={r[0]} data-gap={r[2].startsWith('✗') || undefined}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<Section
+					title="TldrawUiInput — the SDK primitive (well adopted)"
+					note="An editable single-line text field with a custom Enter=onComplete / Escape=onCancel model (not native onChange). Adopted across the app for inline rename and search."
+					api="value/defaultValue, placeholder, label, icon/iconLeft, autoFocus, autoSelect, maxLength, disabled, onComplete(value), onValueChange(value), onCancel(value), onBlur, onFocus, className. NO type / name / required / readOnly / inputMode / pattern; no <textarea>; no native onChange."
+					source="from 'tldraw' (packages/tldraw) · used in TlaSidebarSearch, TlaSidebarInlineInput, WorkspaceSettingsDialog, CreateWorkspaceDialog, TlaEditorTopLeftPanel"
+				>
+					<Specimen
+						label="text"
+						code={`<TldrawUiInput placeholder="Rename" />`}
+						meta="editable text · Enter → onComplete, Esc → onCancel"
+					>
+						<TldrawUiInput placeholder="Rename file" className="demoInput" />
+					</Specimen>
+					<Specimen
+						label="label"
+						code={`<TldrawUiInput label="Name" />`}
+						meta="label resolves via translation (passthrough for non-keys)"
+					>
+						<TldrawUiInput label="Workspace name" placeholder="Acme" className="demoInput" />
+					</Specimen>
+					<Specimen
+						label="defaultValue + maxLength"
+						code={`<TldrawUiInput defaultValue="Untitled" maxLength={32} />`}
+						meta="seeded value, capped length"
+					>
+						<TldrawUiInput defaultValue="Untitled" maxLength={32} className="demoInput" />
+					</Specimen>
+					<Specimen
+						label="disabled"
+						code={`<TldrawUiInput disabled />`}
+						meta="non-interactive"
+					>
+						<TldrawUiInput placeholder="Disabled" disabled className="demoInput" />
+					</Specimen>
+				</Section>
+
+				<Section
+					title="Raw inputs — the escapes (#9191)"
+					note="Each of these is raw because it needs exactly what TldrawUiInput lacks. Rendered with their real native attributes (the divergence axis), styled minimally — the gap is capability, not appearance."
+					api="native <input> / <textarea> attributes only — no shared component"
+				>
+					<Specimen
+						label="email (sign-in)"
+						code={`<input type="email" name="identifier" required>`}
+						meta="needs type + name + required → TldrawUiInput has none (it's a Clerk form field)"
+						source="TlaSignInDialog.tsx"
+					>
+						<input type="email" name="identifier" required placeholder="you@example.com" className="rawInput" />
+					</Specimen>
+					<Specimen
+						label="verification code"
+						code={`<input type="text" inputMode="numeric" autoFocus>`}
+						meta="needs inputMode='numeric' to get the numeric keypad → not exposed"
+						source="TlaSignInDialog.tsx (hidden OTP input behind digit boxes)"
+					>
+						<input type="text" inputMode="numeric" placeholder="123456" className="rawInput" />
+					</Specimen>
+					<Specimen
+						label="feedback (multi-line)"
+						code={`<textarea defaultValue=… onInput=…>`}
+						meta="needs a <textarea> → TldrawUiInput is single-line <input> only"
+						source="SubmitFeedbackDialog.tsx · dialogs.module.css .feedbackDialogTextArea"
+					>
+						<textarea
+							placeholder="Tell us more…"
+							className={dialogStyles.feedbackDialogTextArea}
+							style={{ minHeight: 56 }}
+						/>
+					</Specimen>
+					<Specimen
+						label="sharing toggle"
+						code={`<input type="checkbox" role="switch">`}
+						meta="not a text field at all — a different control (TlaMenuSwitch)"
+						source="tla-menu.tsx (TlaMenuSwitch)"
+					>
+						<input type="checkbox" role="switch" defaultChecked className="rawSwitch" />
+					</Specimen>
+					<Specimen
+						label="admin file lookup"
+						code={`<input type="text" ref={inputRef} /> + Enter`}
+						meta="internal tool: imperative ref reads + Enter-to-search; raw by choice"
+						source="admin.tsx (×9 inputs) · admin.module.css .searchInput"
+					>
+						<input type="text" placeholder="File ID" className="rawInput" />
+					</Specimen>
+				</Section>
+
+				<footer className="page__footer">
+					The shape of the gap: TldrawUiInput is a great <em>editable-text</em> field but not a
+					general input — it can't be a typed/native form field, a numeric input, a textarea, or a
+					toggle. So #9191 isn't a mechanical swap; it's blocked on richer shared form components
+					(a typed/controlled input, a textarea, a toggle). See tldraw/tldraw#9191.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const MATRIX: ReadonlyArray<readonly [string, string, string]> = [
+	['inline rename / file name', 'editable text + Enter/Esc', '✓ TldrawUiInput'],
+	['search box', 'editable text', '✓ TldrawUiInput'],
+	['email (sign-in)', 'type=email · name · required', '✗ no type / name / required'],
+	['verification code', 'inputMode=numeric', '✗ no inputMode'],
+	['feedback', '<textarea> (multi-line)', '✗ single-line input only'],
+	['sharing toggle', 'type=checkbox · role=switch', '✗ not a text field'],
+	['admin file lookup', 'imperative ref + Enter', '— raw by choice (internal)'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 720px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.section { margin-bottom: 56px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 720px; }
+.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; margin: 0 0 24px; max-width: 880px; }
+.section__api > div { display: flex; gap: 8px; }
+.section__api > div + div { margin-top: 4px; }
+.section__api .k { color: var(--tl-color-text-3); flex: 0 0 48px; }
+.grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: 20px;
+}
+.specimen {
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 8px;
+	padding: 20px 16px 14px;
+	background: var(--tl-color-panel);
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+.specimen__stage {
+	min-height: 56px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--tl-color-low);
+	border-radius: 6px;
+	padding: 12px;
+}
+.specimen__label { font-size: 12px; font-weight: 600; font-family: ui-monospace, monospace; }
+.specimen__code { font-size: 11px; line-height: 1.4; color: var(--tl-color-text-1); font-family: ui-monospace, monospace; background: var(--tl-color-low); border-radius: 4px; padding: 5px 7px; white-space: pre-wrap; word-break: break-word; }
+.specimen__meta { font-size: 11px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; }
+.specimen__source { font-size: 10px; line-height: 1.5; color: var(--tl-color-text-3); font-family: ui-monospace, monospace; border-top: 1px dashed var(--tl-color-divider); padding-top: 8px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix tr[data-gap] td:last-child { color: var(--tl-color-warning, #cb4b16); }
+.page__footer { max-width: 720px; font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+.demoInput, .rawInput { font-family: var(--tla-font-ui); font-size: 13px; padding: 6px 8px; border: 1px solid var(--tl-color-muted-1); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); color: var(--tl-color-text); width: 100%; box-sizing: border-box; }
+.rawSwitch { width: 36px; height: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-inputs.tsx
+++ b/apps/dotcom/client/src/pages/dev-inputs.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
 import { TldrawUiInput } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
@@ -16,7 +17,15 @@ import { DevComponentsNav } from './dev-components-nav'
  * Serves tldraw/tldraw#9191. Route: /dev/components/inputs.
  */
 
-const Section = ({ title, note, children }: { title: string; note: string; children: ReactNode }) => (
+const Section = ({
+	title,
+	note,
+	children,
+}: {
+	title: string
+	note: string
+	children: ReactNode
+}) => (
 	<section className="section">
 		<h2 className="section__title">{title}</h2>
 		<p className="section__note">{note}</p>
@@ -26,10 +35,18 @@ const Section = ({ title, note, children }: { title: string; note: string; child
 
 /** Renders a raw input element faithfully by kind. */
 const RawInput = ({ el, placeholder }: { el: RawKind; placeholder?: string }): ReactNode => {
-	if (el === 'checkbox') return <input type="checkbox" role="switch" defaultChecked className="rawSwitch" />
+	// The sharing toggle is a real TlaMenuSwitch (a styled switch), not a bare
+	// checkbox — render the actual component so the preview matches the app.
+	if (el === 'switch') return <TlaMenuSwitch id="inp-sharing-switch" checked onChange={() => {}} />
+	// The admin toggles are genuinely plain, unstyled checkboxes.
+	if (el === 'checkbox') return <input type="checkbox" defaultChecked />
 	if (el === 'textarea')
 		return (
-			<textarea placeholder={placeholder} className="rawInput" style={{ minHeight: 44, resize: 'vertical' }} />
+			<textarea
+				placeholder={placeholder}
+				className="rawInput"
+				style={{ minHeight: 44, resize: 'vertical' }}
+			/>
 		)
 	return (
 		<input
@@ -113,13 +130,12 @@ export function Component() {
 						</Specimen>
 					))}
 				</Section>
-
 			</div>
 		</div>
 	)
 }
 
-type RawKind = 'text' | 'email' | 'numeric' | 'checkbox' | 'textarea'
+type RawKind = 'text' | 'email' | 'numeric' | 'checkbox' | 'switch' | 'textarea'
 
 const SDK_INPUTS: ReadonlyArray<{
 	label: string
@@ -129,11 +145,41 @@ const SDK_INPUTS: ReadonlyArray<{
 	placeholder?: string
 	defaultValue?: string
 }> = [
-	{ label: 'sidebar search', code: 'placeholder · onValueChange · autoFocus · autoSelect', meta: 'search box', source: 'TlaSidebarSearch:87', placeholder: 'Search files…' },
-	{ label: 'inline file rename', code: 'defaultValue · onComplete · onCancel', meta: 'inline rename', source: 'TlaSidebarInlineInput:53', defaultValue: 'My file' },
-	{ label: 'create workspace', code: 'value · onValueChange · onComplete · placeholder', meta: 'workspace name', source: 'CreateWorkspaceDialog:65', placeholder: 'Workspace name' },
-	{ label: 'rename workspace', code: 'defaultValue · onValueChange', meta: 'settings rename', source: 'WorkspaceSettingsDialog:342', defaultValue: 'Acme Inc' },
-	{ label: 'rename current file', code: 'value · onValueChange · autoFocus · autoSelect', meta: 'editor file name', source: 'TlaEditorTopLeftPanel:407', defaultValue: 'Untitled' },
+	{
+		label: 'sidebar search',
+		code: 'placeholder · onValueChange · autoFocus · autoSelect',
+		meta: 'search box',
+		source: 'TlaSidebarSearch:87',
+		placeholder: 'Search files…',
+	},
+	{
+		label: 'inline file rename',
+		code: 'defaultValue · onComplete · onCancel',
+		meta: 'inline rename',
+		source: 'TlaSidebarInlineInput:53',
+		defaultValue: 'My file',
+	},
+	{
+		label: 'create workspace',
+		code: 'value · onValueChange · onComplete · placeholder',
+		meta: 'workspace name',
+		source: 'CreateWorkspaceDialog:65',
+		placeholder: 'Workspace name',
+	},
+	{
+		label: 'rename workspace',
+		code: 'defaultValue · onValueChange',
+		meta: 'settings rename',
+		source: 'WorkspaceSettingsDialog:342',
+		defaultValue: 'Acme Inc',
+	},
+	{
+		label: 'rename current file',
+		code: 'value · onValueChange · autoFocus · autoSelect',
+		meta: 'editor file name',
+		source: 'TlaEditorTopLeftPanel:407',
+		defaultValue: 'Untitled',
+	},
 ]
 
 const RAW_INPUTS: ReadonlyArray<{
@@ -144,18 +190,99 @@ const RAW_INPUTS: ReadonlyArray<{
 	source: string
 	placeholder?: string
 }> = [
-	{ label: 'sharing toggle', el: 'checkbox', code: 'type="checkbox" role="switch" name="shared"', meta: 'TlaMenuSwitch — not a text field', source: 'tla-menu.tsx:260' },
-	{ label: 'sign-in email', el: 'email', code: 'type="email" name="identifier"', meta: 'needs type + name (Clerk form)', source: 'TlaSignInDialog:244', placeholder: 'you@example.com' },
-	{ label: 'verification code', el: 'numeric', code: 'type="text" inputMode="numeric"', meta: 'needs inputMode', source: 'TlaSignInDialog:449', placeholder: '123456' },
-	{ label: 'admin: user lookup', el: 'text', code: 'type="text" ref placeholder="Email or ID"', meta: 'imperative ref + Enter', source: 'admin.tsx:175', placeholder: 'Email or ID' },
-	{ label: 'admin: published file', el: 'text', code: 'type="text" ref placeholder="Published file ID"', meta: 'ref read', source: 'admin.tsx:367', placeholder: 'Published file ID' },
-	{ label: 'admin: toggle', el: 'checkbox', code: 'type="checkbox"', meta: 'admin toggle', source: 'admin.tsx:509' },
-	{ label: 'admin: toggle', el: 'checkbox', code: 'type="checkbox"', meta: 'admin toggle', source: 'admin.tsx:574' },
-	{ label: 'admin: text field', el: 'text', code: 'type="text"', meta: 'admin field', source: 'admin.tsx:586', placeholder: '…' },
-	{ label: 'admin: file ID', el: 'text', code: 'type="text" ref .searchInput', meta: 'Enter-to-search', source: 'admin.tsx:666', placeholder: 'File ID' },
-	{ label: 'admin: file ID', el: 'text', code: 'type="text" ref .searchInput', meta: 'Enter-to-search', source: 'admin.tsx:766', placeholder: 'File ID' },
-	{ label: 'admin: user lookup', el: 'text', code: 'type="text" ref placeholder="User ID or Email"', meta: 'ref read', source: 'admin.tsx:844', placeholder: 'User ID or Email' },
-	{ label: 'feedback', el: 'textarea', code: '<textarea defaultValue · onInput · ref>', meta: 'multi-line — TldrawUiInput is input-only', source: 'SubmitFeedbackDialog:159', placeholder: 'Tell us more…' },
+	{
+		label: 'sharing toggle',
+		el: 'switch',
+		code: '<TlaMenuSwitch> (wraps type="checkbox" role="switch")',
+		meta: 'real TlaMenuSwitch — not a text field',
+		source: 'tla-menu.tsx:260',
+	},
+	{
+		label: 'sign-in email',
+		el: 'email',
+		code: 'type="email" name="identifier"',
+		meta: 'needs type + name (Clerk form)',
+		source: 'TlaSignInDialog:244',
+		placeholder: 'you@example.com',
+	},
+	{
+		label: 'verification code',
+		el: 'numeric',
+		code: 'type="text" inputMode="numeric"',
+		meta: 'needs inputMode',
+		source: 'TlaSignInDialog:449',
+		placeholder: '123456',
+	},
+	{
+		label: 'admin: user lookup',
+		el: 'text',
+		code: 'type="text" ref placeholder="Email or ID"',
+		meta: 'imperative ref + Enter',
+		source: 'admin.tsx:175',
+		placeholder: 'Email or ID',
+	},
+	{
+		label: 'admin: published file',
+		el: 'text',
+		code: 'type="text" ref placeholder="Published file ID"',
+		meta: 'ref read',
+		source: 'admin.tsx:367',
+		placeholder: 'Published file ID',
+	},
+	{
+		label: 'admin: toggle',
+		el: 'checkbox',
+		code: 'type="checkbox"',
+		meta: 'admin toggle',
+		source: 'admin.tsx:509',
+	},
+	{
+		label: 'admin: toggle',
+		el: 'checkbox',
+		code: 'type="checkbox"',
+		meta: 'admin toggle',
+		source: 'admin.tsx:574',
+	},
+	{
+		label: 'admin: text field',
+		el: 'text',
+		code: 'type="text"',
+		meta: 'admin field',
+		source: 'admin.tsx:586',
+		placeholder: '…',
+	},
+	{
+		label: 'admin: file ID',
+		el: 'text',
+		code: 'type="text" ref .searchInput',
+		meta: 'Enter-to-search',
+		source: 'admin.tsx:666',
+		placeholder: 'File ID',
+	},
+	{
+		label: 'admin: file ID',
+		el: 'text',
+		code: 'type="text" ref .searchInput',
+		meta: 'Enter-to-search',
+		source: 'admin.tsx:766',
+		placeholder: 'File ID',
+	},
+	{
+		label: 'admin: user lookup',
+		el: 'text',
+		code: 'type="text" ref placeholder="User ID or Email"',
+		meta: 'ref read',
+		source: 'admin.tsx:844',
+		placeholder: 'User ID or Email',
+	},
+	{
+		label: 'feedback',
+		el: 'textarea',
+		code: '<textarea defaultValue · onInput · ref>',
+		meta: 'multi-line — TldrawUiInput is input-only',
+		source: 'SubmitFeedbackDialog:159',
+		placeholder: 'Tell us more…',
+	},
 ]
 
 const MATRIX: ReadonlyArray<readonly [string, string, string]> = [

--- a/apps/dotcom/client/src/pages/dev-inputs.tsx
+++ b/apps/dotcom/client/src/pages/dev-inputs.tsx
@@ -114,13 +114,6 @@ export function Component() {
 					))}
 				</Section>
 
-				<footer className="page__footer">
-					TldrawUiInput is a great <em>editable-text</em> field but not a general input — it
-					can&rsquo;t be a typed/native form field, a numeric input, a textarea, or a toggle. So
-					#9191 isn&rsquo;t a mechanical swap; it&rsquo;s blocked on richer shared form components.
-					The 8 admin inputs are an internal tool (imperative refs + Enter-to-search), lower priority
-					but shown for completeness. See tldraw/tldraw#9191.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-links.tsx
+++ b/apps/dotcom/client/src/pages/dev-links.tsx
@@ -115,7 +115,6 @@ export function Component() {
 						&ldquo;leave it alone&rdquo; verdict the menus and icons pages reached.
 					</div>
 				</section>
-
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-links.tsx
+++ b/apps/dotcom/client/src/pages/dev-links.tsx
@@ -1,0 +1,328 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { ExternalLink } from '../tla/components/ExternalLink/ExternalLink'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's links. The cleanest adoption story in
+ * the gallery: a #9198 sweep moved raw anchors to ExternalLink, leaving exactly
+ * one raw <a> — a justified exception (outside the router context). This is what
+ * "done" looks like: near-total adoption plus one documented holdout.
+ *
+ * Serves tldraw/tldraw#9198 (use ExternalLink consistently). Route:
+ * /dev/components/links.
+ */
+
+const Stat = ({ n, label, good }: { n: string; label: string; good?: boolean }): ReactNode => (
+	<div className="stat" data-good={good || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Link inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Link inventory</h1>
+					<p className="page__lede">
+						The healthiest adoption in the gallery. <code>ExternalLink</code> is used everywhere; a
+						#9198 sweep retired the raw anchors, leaving exactly one — and that one is a justified
+						exception. This page is what &ldquo;done&rdquo; looks like.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">Adoption</h2>
+					<div className="stats">
+						<Stat n="17" label="ExternalLink" good />
+						<Stat n="1" label="raw <a> (justified)" />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">All {LINKS.length} links</h2>
+					<p className="section__note">
+						Every <code>ExternalLink</code> call site in the app, plus the one raw{' '}
+						<code>&lt;a&gt;</code> — nothing filtered. Each rendered live; <code>code</code> is the
+						literal <code>to</code>, <code>source</code> the file:line.
+					</p>
+					<div className="grid">
+						{LINKS.map((l) => (
+							<Specimen key={l.source} label={l.kind} code={l.code} meta={l.meta} source={l.source}>
+								<span className="linkStage">
+									{l.raw ? (
+										// eslint-disable-next-line react/jsx-no-target-blank
+										<a href={l.render} target="_blank" rel="noopener noreferrer">
+											{l.text}
+										</a>
+									) : (
+										<ExternalLink to={l.render} eventName={l.event}>
+											{l.text}
+										</ExternalLink>
+									)}
+								</span>
+							</Specimen>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Props in use</h2>
+					<div className="section__api">
+						<div>
+							<span className="k">api</span>
+							to (a react-router target, not href), eventName? (analytics), + all <code>
+								Link
+							</code>{' '}
+							props (children, onClick, className…)
+						</div>
+						<div>
+							<span className="k">baked</span>
+							always target="_blank" + rel="noopener noreferrer"; eventName fires trackEvent on
+							click
+						</div>
+						<div>
+							<span className="k">handles</span>
+							root-relative static files (/tos.html), absolute external URLs, and in-app routes —
+							all open in a new tab
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The one raw &lt;a&gt; — justified</h2>
+					<div className="callout">
+						<code>IFrameProtector</code> renders a raw <code>&lt;a href&gt;</code> because it sits{' '}
+						<strong>outside the tla subsystem and the router context</strong> — a low-dependency
+						guard shown when the app is framed, where react-router&rsquo;s <code>Link</code> (and
+						its context) may not be available. It keeps the same <code>target</code>/
+						<code>rel</code> hardening by hand. A justified exception, not drift — the same
+						&ldquo;leave it alone&rdquo; verdict the menus and icons pages reached.
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					A latent design question worth noting: <code>ExternalLink</code> wraps react-router{' '}
+					<code>Link</code> even for <em>absolute external</em> URLs, where a plain{' '}
+					<code>&lt;a href&gt;</code> would be the more natural primitive — and the lone exception (
+					<code>IFrameProtector</code>) is, ironically, the &ldquo;more correct&rdquo; form for an
+					external link. So the adoption is excellent, but the abstraction itself slightly conflates
+					in-app navigation with external links. See tldraw/tldraw#9198.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+// Every ExternalLink call site in the app, plus the one raw <a>. `render` is a
+// real URL used for the live link; `code` is the literal `to` as written.
+const LINKS: ReadonlyArray<{
+	kind: string
+	code: string
+	render: string
+	text: string
+	meta?: string
+	source: string
+	event?: string
+	raw?: boolean
+}> = [
+	{
+		kind: 'sidebar dotdev',
+		code: 'to="https://tldraw.dev?…sidebar-link"',
+		render: 'https://tldraw.dev',
+		text: 'tldraw.dev',
+		meta: 'external · utm sidebar-link',
+		source: 'TlaSidebarDotDevLink:14',
+	},
+	{
+		kind: 'slurp file link',
+		code: 'to={routes.tlaLocalFile(key)}',
+		render: '/f/abc123',
+		text: 'Go here to see the content',
+		meta: 'in-app route → new tab',
+		source: 'SlurpFailure:49',
+	},
+	{
+		kind: 'slurp discord',
+		code: 'to="https://discord.tldraw.com/?…slurp-failure"',
+		render: 'https://discord.tldraw.com/',
+		text: 'Get help on Discord',
+		meta: 'external',
+		source: 'SlurpFailure:65',
+	},
+	{
+		kind: 'anon dotdev',
+		code: 'to="https://tldraw.dev?…anon-overlay-link"',
+		render: 'https://tldraw.dev',
+		text: 'tldraw.dev',
+		meta: 'eventName',
+		source: 'TlaAnonDotDevLink:37',
+		event: 'anon-dotdev-link-clicked',
+	},
+	{
+		kind: 'feedback discord',
+		code: 'to="https://discord.tldraw.com/?…dotcom-feedback"',
+		render: 'https://discord.tldraw.com/',
+		text: 'Discord',
+		meta: 'eventName',
+		source: 'SubmitFeedbackDialog:54',
+		event: 'menu-feedback-discord-link-clicked',
+	},
+	{
+		kind: 'feedback github',
+		code: 'to="https://github.com/tldraw/tldraw/issues"',
+		render: 'https://github.com/tldraw/tldraw/issues',
+		text: 'GitHub issues',
+		meta: 'eventName',
+		source: 'SubmitFeedbackDialog:62',
+		event: 'menu-feedback-github-link-clicked',
+	},
+	{
+		kind: 'feedback discord (2)',
+		code: 'to="https://discord.tldraw.com/?…dotcom-feedback"',
+		render: 'https://discord.tldraw.com/',
+		text: 'Discord',
+		meta: 'eventName · 2nd render path',
+		source: 'SubmitFeedbackDialog:138',
+		event: 'menu-feedback-discord-link-clicked',
+	},
+	{
+		kind: 'feedback github (2)',
+		code: 'to="https://github.com/tldraw/tldraw/issues"',
+		render: 'https://github.com/tldraw/tldraw/issues',
+		text: 'GitHub issues',
+		meta: 'eventName · 2nd render path',
+		source: 'SubmitFeedbackDialog:148',
+		event: 'menu-feedback-github-link-clicked',
+	},
+	{
+		kind: 'sign-in tos',
+		code: 'to="/tos.html"',
+		render: '/tos.html',
+		text: 'Terms of Use',
+		meta: 'static file',
+		source: 'TlaSignInDialog:270',
+	},
+	{
+		kind: 'sign-in privacy',
+		code: 'to="/privacy.html"',
+		render: '/privacy.html',
+		text: 'Privacy Policy',
+		meta: 'static file',
+		source: 'TlaSignInDialog:275',
+	},
+	{
+		kind: 'legal tos',
+		code: 'to="/tos.html"',
+		render: '/tos.html',
+		text: 'Terms',
+		meta: 'static file · i18n <F> chunk',
+		source: 'TlaLegalAcceptance:78',
+	},
+	{
+		kind: 'legal privacy',
+		code: 'to="/privacy.html"',
+		render: '/privacy.html',
+		text: 'Privacy',
+		meta: 'static file · i18n <F> chunk',
+		source: 'TlaLegalAcceptance:79',
+	},
+	{
+		kind: 'legal cookies',
+		code: 'to="/cookies.html"',
+		render: '/cookies.html',
+		text: 'Cookies',
+		meta: 'static file · i18n <F> chunk',
+		source: 'TlaLegalAcceptance:90',
+	},
+	{
+		kind: 'cookies dialog',
+		code: 'to={COOKIE_POLICY_URL}',
+		render: '/cookies.html',
+		text: 'Cookie policy',
+		meta: 'COOKIE_POLICY_URL = /cookies.html',
+		source: 'TlaManageCookiesDialog:39',
+	},
+	{
+		kind: 'cookies dialog (2)',
+		code: 'to={COOKIE_POLICY_URL}',
+		render: '/cookies.html',
+		text: 'Cookie policy',
+		meta: '2nd render path',
+		source: 'TlaManageCookiesDialog:71',
+	},
+	{
+		kind: 'editor logo',
+		code: 'to="https://tldraw.dev?…top-left-logo"',
+		render: 'https://tldraw.dev',
+		text: 'tldraw.dev (logo)',
+		meta: 'eventName · aria-label',
+		source: 'TlaEditorTopLeftPanel:110',
+		event: 'top-left-logo-clicked',
+	},
+	{
+		kind: 'debug help',
+		code: 'to={issue.helpUrl}',
+		render: 'https://tldraw.dev',
+		text: 'More info',
+		meta: 'dynamic · issue.helpUrl',
+		source: 'TlaDebug:78',
+	},
+	{
+		kind: 'raw <a> (exception)',
+		code: '<a href={url} target="_blank" rel="…">',
+		render: 'https://tldraw.com',
+		text: 'Visit this page on tldraw.com',
+		meta: 'outside router ctx · uses href, not to',
+		source: 'IFrameProtector:66',
+		raw: true,
+	},
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede code, .section code, .callout code, .page__footer code, .section__note code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 200px; background: var(--tl-color-panel); }
+.stat[data-good] { border-color: var(--tl-color-success, #2a9d3c); }
+.stat__n { font-size: 28px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-good] .stat__n { color: var(--tl-color-success, #2a9d3c); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.linkStage a { color: var(--tl-color-primary); text-decoration: underline; font-size: 13px; }
+.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; max-width: 860px; }
+.section__api > div { display: flex; gap: 8px; }
+.section__api > div + div { margin-top: 4px; }
+.section__api .k { color: var(--tl-color-text-3); flex: 0 0 64px; }
+.section__api code { background: none; padding: 0; }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-links.tsx
+++ b/apps/dotcom/client/src/pages/dev-links.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable tldraw/jsx-no-literals */
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'

--- a/apps/dotcom/client/src/pages/dev-links.tsx
+++ b/apps/dotcom/client/src/pages/dev-links.tsx
@@ -116,14 +116,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					A latent design question worth noting: <code>ExternalLink</code> wraps react-router{' '}
-					<code>Link</code> even for <em>absolute external</em> URLs, where a plain{' '}
-					<code>&lt;a href&gt;</code> would be the more natural primitive — and the lone exception (
-					<code>IFrameProtector</code>) is, ironically, the &ldquo;more correct&rdquo; form for an
-					external link. So the adoption is excellent, but the abstraction itself slightly conflates
-					in-app navigation with external links. See tldraw/tldraw#9198.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-logo.tsx
+++ b/apps/dotcom/client/src/pages/dev-logo.tsx
@@ -68,11 +68,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					The single cleanest component in the gallery: one file, one asset, five call sites, no
-					variants. Branding is the one place where having exactly one implementation is obviously
-					correct — there is only one logo.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-logo.tsx
+++ b/apps/dotcom/client/src/pages/dev-logo.tsx
@@ -31,9 +31,9 @@ export function Component() {
 					<h1 className="page__title">Logo inventory</h1>
 					<p className="page__lede">
 						One component — <code>TlaLogo</code> — a <code>&lt;span&gt;</code> that masks{' '}
-						<code>/tldraw_sidebar_logo.svg</code> with <code>currentColor</code>. The same
-						mask-tint trick as <code>TlaIcon</code>, so the wordmark inherits text colour and
-						adapts to light/dark for free.
+						<code>/tldraw_sidebar_logo.svg</code> with <code>currentColor</code>. The same mask-tint
+						trick as <code>TlaIcon</code>, so the wordmark inherits text colour and adapts to
+						light/dark for free.
 					</p>
 				</header>
 
@@ -45,7 +45,13 @@ export function Component() {
 					</p>
 					<div className="grid">
 						{USES.map((u) => (
-							<Specimen key={u.source} label={u.label} code={u.code} meta={u.meta} source={u.source}>
+							<Specimen
+								key={u.source}
+								label={u.label}
+								code={u.code}
+								meta={u.meta}
+								source={u.source}
+							>
 								<span className="logoStage" style={{ color: u.color }}>
 									<TlaLogo style={{ width: u.w, height: u.h }} />
 								</span>
@@ -67,7 +73,6 @@ export function Component() {
 						the call site.
 					</div>
 				</section>
-
 			</div>
 		</div>
 	)
@@ -82,11 +87,47 @@ const USES: ReadonlyArray<{
 	h: number
 	color?: string
 }> = [
-	{ label: 'sidebar workspace', code: '<TlaLogo />', meta: 'default · inherits text colour', source: 'TlaSidebarWorkspaceLink.tsx', w: 76, h: 16 },
-	{ label: 'editor top-left', code: '<TlaLogo /> (in ExternalLink)', meta: 'links to tldraw.dev', source: 'TlaEditorTopLeftPanel.tsx', w: 76, h: 16 },
-	{ label: 'sign-in dialog', code: '<TlaLogo />', meta: 'auth header', source: 'TlaSignInDialog.tsx', w: 100, h: 21 },
-	{ label: 'legal acceptance', code: '<TlaLogo />', meta: 'legal dialog', source: 'TlaLegalAcceptance.tsx', w: 100, h: 21 },
-	{ label: 'tinted (primary)', code: '<TlaLogo style={{ color }} />', meta: 'mask tints with currentColor', source: 'any call site', w: 100, h: 21, color: 'var(--tl-color-primary)' },
+	{
+		label: 'sidebar workspace',
+		code: '<TlaLogo />',
+		meta: 'default · inherits text colour',
+		source: 'TlaSidebarWorkspaceLink.tsx',
+		w: 76,
+		h: 16,
+	},
+	{
+		label: 'editor top-left',
+		code: '<TlaLogo /> (in ExternalLink)',
+		meta: 'links to tldraw.dev',
+		source: 'TlaEditorTopLeftPanel.tsx',
+		w: 76,
+		h: 16,
+	},
+	{
+		label: 'sign-in dialog',
+		code: '<TlaLogo />',
+		meta: 'auth header',
+		source: 'TlaSignInDialog.tsx',
+		w: 100,
+		h: 21,
+	},
+	{
+		label: 'legal acceptance',
+		code: '<TlaLogo />',
+		meta: 'legal dialog',
+		source: 'TlaLegalAcceptance.tsx',
+		w: 100,
+		h: 21,
+	},
+	{
+		label: 'tinted (primary)',
+		code: '<TlaLogo style={{ color }} />',
+		meta: 'mask tints with currentColor',
+		source: 'any call site',
+		w: 100,
+		h: 21,
+		color: 'var(--tl-color-primary)',
+	},
 ]
 
 const PAGE_CSS = `

--- a/apps/dotcom/client/src/pages/dev-logo.tsx
+++ b/apps/dotcom/client/src/pages/dev-logo.tsx
@@ -1,0 +1,117 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { TlaLogo } from '../tla/components/TlaLogo/TlaLogo'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom logo. One component, TlaLogo — a <span>
+ * masking /tldraw_sidebar_logo.svg with currentColor (the same mask-tint
+ * technique as TlaIcon, but for the wordmark). Used in 5 places. Shown live.
+ *
+ * Route: /dev/components/logo.
+ */
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Logo inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Logo inventory</h1>
+					<p className="page__lede">
+						One component — <code>TlaLogo</code> — a <code>&lt;span&gt;</code> that masks{' '}
+						<code>/tldraw_sidebar_logo.svg</code> with <code>currentColor</code>. The same
+						mask-tint trick as <code>TlaIcon</code>, so the wordmark inherits text colour and
+						adapts to light/dark for free.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">All {USES.length} call sites</h2>
+					<p className="section__note">
+						Rendered live at its natural and a few scaled sizes (the mask is{' '}
+						<code>100% / 100%</code>, so size comes from the element box).
+					</p>
+					<div className="grid">
+						{USES.map((u) => (
+							<Specimen key={u.source} label={u.label} code={u.code} meta={u.meta} source={u.source}>
+								<span className="logoStage" style={{ color: u.color }}>
+									<TlaLogo style={{ width: u.w, height: u.h }} />
+								</span>
+							</Specimen>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">How it works</h2>
+					<div className="callout">
+						<code>TlaLogo</code> sets <code>mask: url(/tldraw_sidebar_logo.svg) center / 100%</code>{' '}
+						on a <code>&lt;span&gt;</code> whose <code>background-color</code> is{' '}
+						<code>currentColor</code> — so the wordmark is a stencil painted in the inherited text
+						colour. Identical in spirit to <code>TlaIcon</code> (single asset, masked, tinted), and
+						it carries the same <code>webkitMask</code>-in-<code>useLayoutEffect</code> hack to
+						avoid React re-requesting the asset. Because it&rsquo;s a mask it is{' '}
+						<strong>monochrome</strong>; the colour is whatever <code>color</code> resolves to at
+						the call site.
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					The single cleanest component in the gallery: one file, one asset, five call sites, no
+					variants. Branding is the one place where having exactly one implementation is obviously
+					correct — there is only one logo.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const USES: ReadonlyArray<{
+	label: string
+	code: string
+	meta: string
+	source: string
+	w: number
+	h: number
+	color?: string
+}> = [
+	{ label: 'sidebar workspace', code: '<TlaLogo />', meta: 'default · inherits text colour', source: 'TlaSidebarWorkspaceLink.tsx', w: 76, h: 16 },
+	{ label: 'editor top-left', code: '<TlaLogo /> (in ExternalLink)', meta: 'links to tldraw.dev', source: 'TlaEditorTopLeftPanel.tsx', w: 76, h: 16 },
+	{ label: 'sign-in dialog', code: '<TlaLogo />', meta: 'auth header', source: 'TlaSignInDialog.tsx', w: 100, h: 21 },
+	{ label: 'legal acceptance', code: '<TlaLogo />', meta: 'legal dialog', source: 'TlaLegalAcceptance.tsx', w: 100, h: 21 },
+	{ label: 'tinted (primary)', code: '<TlaLogo style={{ color }} />', meta: 'mask tints with currentColor', source: 'any call site', w: 100, h: 21, color: 'var(--tl-color-primary)' },
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede code, .section__note code, .callout code, .page__footer code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.logoStage { display: inline-flex; align-items: center; justify-content: center; color: var(--tl-color-text); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -50,9 +50,7 @@ const noop = () => {}
 /**
  * Every tla-menu part rendered live under the page's IsolationProviders
  * (react-intl + a container element + the SDK UI context). Select needs the
- * container, ControlInfoTooltip needs react-intl, the rest only the UI context —
- * all covered, so none fall back to PartStage. (PartStage still renders the SDK
- * TldrawUiMenu* mock cards, which are shown composed-live above instead.)
+ * container, ControlInfoTooltip needs react-intl, the rest only the UI context.
  */
 const renderLive = (name: string): ReactNode => {
 	switch (name) {

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -4,19 +4,39 @@ import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
 import '../tla/styles/tla.css'
-import { DevComponentsNav } from './dev-components-nav'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
 
 /**
  * Dev-only inventory of the dotcom app's two menu systems. This family shows a
- * divergence mode the others don't: INTENTIONAL COEXISTENCE. The word "menu" is
- * overloaded — `tla-menu` is a settings-panel system (labeled Select/Switch/Tabs
- * controls), the SDK `TldrawUiMenu*` is an action-dropdown system (command
- * menus). They are different UI patterns, so two systems is correct, not drift.
+ * divergence mode the others don't: INTENTIONAL COEXISTENCE. tla-menu is a
+ * settings-panel system; the SDK TldrawUiMenu* is an action-dropdown system.
+ * Different UI patterns sharing the word "menu", deliberately separate. Every
+ * part of both systems (that the app uses) is shown.
  *
- * Relevant to tldraw/tldraw#9199, which explicitly excluded "consolidate the
- * menus" from the sweep. Route: /dev/components/menus.
+ * Relevant to tldraw/tldraw#9199. Route: /dev/components/menus.
  */
+
+type PartKind = 'switch' | 'select' | 'tab' | 'row' | 'wrap'
+
+const PartStage = ({ kind, sample }: { kind: PartKind; sample?: string }): ReactNode => {
+	switch (kind) {
+		case 'switch':
+			return <TlaMenuSwitch id="ov-switch" checked onChange={() => {}} />
+		case 'select':
+			return <div className="ctrlMock">Everyone ▾</div>
+		case 'tab':
+			return (
+				<div className="tabMock">
+					<span data-active>{sample ?? 'Tab'}</span>
+				</div>
+			)
+		case 'row':
+			return <div className="rowMock">{sample}</div>
+		case 'wrap':
+			return <div className="wrapMock">{sample}</div>
+	}
+}
 
 export function Component() {
 	return (
@@ -34,18 +54,18 @@ export function Component() {
 				<header className="page__header">
 					<h1 className="page__title">Menu inventory</h1>
 					<p className="page__lede">
-						Two systems share the word &ldquo;menu&rdquo; — and that&rsquo;s the point. Unlike the
-						other families, this divergence is <strong>intentional</strong>:{' '}
-						<code>tla-menu</code> is a settings-panel system, the SDK <code>TldrawUiMenu*</code> is an
-						action-dropdown system. Different patterns, deliberately separate.
+						Two systems share the word &ldquo;menu&rdquo; — and that&rsquo;s the point. This
+						divergence is <strong>intentional</strong>: <code>tla-menu</code> is a settings-panel
+						system, the SDK <code>TldrawUiMenu*</code> is an action-dropdown system. Different
+						patterns, deliberately separate.
 					</p>
 				</header>
 
 				<section className="section">
 					<h2 className="section__title">Two systems, one word</h2>
 					<p className="section__note">
-						The names collide on &ldquo;menu&rdquo;, but a <em>share menu</em> (a panel of settings)
-						and a <em>file menu</em> (a dropdown of actions) are different UI patterns.
+						A <em>share menu</em> (a panel of settings) and a <em>file menu</em> (a dropdown of
+						actions) are different UI patterns that happen to share a noun.
 					</p>
 					<table className="matrix matrix--wide">
 						<thead>
@@ -68,138 +88,33 @@ export function Component() {
 				</section>
 
 				<section className="section">
-					<h2 className="section__title">Overview</h2>
+					<h2 className="section__title">tla-menu — all {TLA_PARTS.length} parts</h2>
 					<p className="section__note">
-						Each system's controls and items, with their props — tla-menu controls live, SDK items as
-						mocks (they need the editor's menu context to render).
+						The settings-panel system (in <code>tla/components/tla-menu/tla-menu.tsx</code>). Switch
+						is live; the rest are mocked. <code>meta</code> shows the role and dotcom usage count.
 					</p>
 					<div className="grid">
-						<Specimen
-							label="TlaMenuSwitch"
-							code={`<TlaMenuSwitch checked>`}
-							meta="tla-menu · role=switch"
-							source="tla-menu.tsx"
-						>
-							<TlaMenuSwitch id="ov-on" checked onChange={() => {}} />
-						</Specimen>
-						<Specimen
-							label="TlaMenuSwitch"
-							code={`<TlaMenuSwitch checked={false}>`}
-							meta="tla-menu · role=switch"
-							source="tla-menu.tsx"
-						>
-							<TlaMenuSwitch id="ov-off" checked={false} onChange={() => {}} />
-						</Specimen>
-						<Specimen
-							label="TlaMenuSelect"
-							code={`<TlaMenuSelect options={…} />`}
-							meta="tla-menu · Radix Select"
-							source="tla-menu.tsx"
-						>
-							<div className="ctrlMock">Everyone ▾</div>
-						</Specimen>
-						<Specimen
-							label="TlaMenuTabs"
-							code={`<TlaMenuTabsRoot>…`}
-							meta="tla-menu · role=tablist"
-							source="tla-menu.tsx"
-						>
-							<div className="tabMock">
-								<span data-active>Export</span>
-								<span>Publish</span>
-							</div>
-						</Specimen>
-						<Specimen
-							label="TldrawUiMenuItem"
-							code={`<TldrawUiMenuItem>`}
-							meta="SDK · action item"
-							source="tldraw"
-						>
-							<div className="rowMock">Rename</div>
-						</Specimen>
-						<Specimen
-							label="TldrawUiMenuCheckboxItem"
-							code={`<TldrawUiMenuCheckboxItem>`}
-							meta="SDK · toggle item"
-							source="tldraw"
-						>
-							<div className="rowMock">✓ Show grid</div>
-						</Specimen>
-						<Specimen
-							label="TldrawUiMenuSubmenu"
-							code={`<TldrawUiMenuSubmenu>`}
-							meta="SDK · nested"
-							source="tldraw"
-						>
-							<div className="rowMock">Export as ›</div>
-						</Specimen>
+						{TLA_PARTS.map((p) => (
+							<Specimen key={p.name} label={p.name} code={`<${p.name}>`} meta={p.meta} source="tla-menu.tsx">
+								<PartStage kind={p.kind} sample={p.sample} />
+							</Specimen>
+						))}
 					</div>
 				</section>
 
 				<section className="section">
-					<h2 className="section__title">tla-menu — settings panel system</h2>
+					<h2 className="section__title">SDK TldrawUiMenu* — {SDK_PARTS.length} parts used in dotcom</h2>
 					<p className="section__note">
-						Declarative labeled controls inside a panel. Parts in{' '}
-						<code>tla/components/tla-menu/tla-menu.tsx</code>. Switch shown live:
+						The action-dropdown system (a declarative menu schema → Radix dropdown). Mocked — these
+						need the editor&rsquo;s menu context to render. The SDK exports more parts; these are
+						the ones dotcom uses.
 					</p>
-					<div className="demoRow">
-						<div className="demoRow__control">
-							<TlaMenuSwitch id="demo-on" checked onChange={() => {}} />
-							<span>checked</span>
-						</div>
-						<div className="demoRow__control">
-							<TlaMenuSwitch id="demo-off" checked={false} onChange={() => {}} />
-							<span>unchecked</span>
-						</div>
-					</div>
-					<div className="section__api">
-						<div>
-							<span className="k">layout</span>
-							TlaMenuSection, TlaMenuControlGroup, TlaMenuControl, TlaMenuControlLabel,
-							TlaMenuDetail, TlaMenuControlInfoTooltip
-						</div>
-						<div>
-							<span className="k">controls</span>
-							TlaMenuSelect (Radix Select), TlaMenuSwitch (role=switch), TlaMenuTabs Root / Tabs /
-							Tab / Page (role=tablist / tab / tabpanel)
-						</div>
-						<div>
-							<span className="k">used in</span>
-							TlaFileShareMenu (+ Publish / Invite / Export / AnonCopyLink tabs),
-							WorkspaceSettingsDialog, TlaManageCookiesDialog, TlaLegalAcceptance
-						</div>
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">SDK TldrawUiMenu* — action dropdown system</h2>
-					<p className="section__note">
-						A declarative menu schema (groups + items) rendered into a Radix dropdown. Mock below
-						(it needs the editor&rsquo;s menu context to render live).
-					</p>
-					<div className="menuMock">
-						<div className="menuMock__item">Rename</div>
-						<div className="menuMock__item">Duplicate</div>
-						<div className="menuMock__item">Copy link</div>
-						<div className="menuMock__sep" />
-						<div className="menuMock__item menuMock__danger">Delete</div>
-					</div>
-					<div className="section__api">
-						<div>
-							<span className="k">schema</span>
-							TldrawUiMenuContextProvider, TldrawUiMenuGroup, TldrawUiMenuItem,
-							TldrawUiMenuSubmenu, TldrawUiMenuCheckboxItem, TldrawUiMenuActionItem
-						</div>
-						<div>
-							<span className="k">shell</span>
-							TldrawUiDropdownMenuRoot / Trigger / Content / Item / Sub / SubTrigger / SubContent
-							(Radix)
-						</div>
-						<div>
-							<span className="k">used in</span>
-							TlaFileMenu, TlaSidebarUserSettingsMenu, menu-items.tsx, TlaEditor context menus,
-							local-file
-						</div>
+					<div className="grid">
+						{SDK_PARTS.map((p) => (
+							<Specimen key={p.name} label={p.name} code={`<${p.name}>`} meta={p.meta} source="tldraw">
+								<PartStage kind={p.kind} sample={p.sample} />
+							</Specimen>
+						))}
 					</div>
 				</section>
 
@@ -217,10 +132,10 @@ export function Component() {
 				</section>
 
 				<footer className="page__footer">
-					The lesson this page adds to the gallery: not all divergence is drift. Buttons, inputs, and
-					type each hide a problem to fix; the two menu systems are a boundary to <em>respect</em>.
-					Telling the two apart — accidental inconsistency vs deliberate design — is the whole skill
-					of a design-system audit. See tldraw/tldraw#9199.
+					Not all divergence is drift. Buttons, inputs, and type each hide a problem to fix; the two
+					menu systems are a boundary to <em>respect</em>. Telling the two apart — accidental
+					inconsistency vs deliberate design — is the whole skill of a design-system audit. See
+					tldraw/tldraw#9199.
 				</footer>
 			</div>
 		</div>
@@ -233,6 +148,33 @@ const SYSTEMS: ReadonlyArray<readonly [string, string, string]> = [
 	['controls', 'Select · Switch · Tabs', 'Item · CheckboxItem · Submenu · ActionItem'],
 	['ARIA', 'role=switch / tab / tablist / tabpanel', 'role=menu / menuitem (Radix)'],
 	['where', 'share menu, settings & cookies dialogs', 'file menu, user menu, context menus'],
+]
+
+const TLA_PARTS: ReadonlyArray<{ name: string; kind: PartKind; meta: string; sample?: string }> = [
+	{ name: 'TlaMenuSwitch', kind: 'switch', meta: 'control · role=switch · ×8' },
+	{ name: 'TlaMenuSelect', kind: 'select', meta: 'control · Radix Select · ×4' },
+	{ name: 'TlaMenuTabsTab', kind: 'tab', meta: 'control · role=tab · ×6', sample: 'Export' },
+	{ name: 'TlaMenuControl', kind: 'row', meta: 'labeled control row · ×10', sample: 'Setting       ◉' },
+	{ name: 'TlaMenuControlLabel', kind: 'row', meta: 'control label · ×10', sample: 'Label' },
+	{ name: 'TlaMenuControlInfoTooltip', kind: 'row', meta: 'info tooltip · ×4', sample: 'ⓘ  more info' },
+	{ name: 'TlaMenuDetail', kind: 'row', meta: 'detail text · ×1', sample: 'detail copy' },
+	{ name: 'TlaMenuSection', kind: 'wrap', meta: 'layout wrapper · ×4', sample: 'section' },
+	{ name: 'TlaMenuControlGroup', kind: 'wrap', meta: 'layout wrapper · ×4', sample: 'control group' },
+	{ name: 'TlaMenuTabsRoot', kind: 'wrap', meta: 'tabs root · ×2', sample: 'tabs root' },
+	{ name: 'TlaMenuTabsTabs', kind: 'wrap', meta: 'role=tablist · ×2', sample: 'tablist' },
+	{ name: 'TlaMenuTabsPage', kind: 'wrap', meta: 'role=tabpanel · ×7', sample: 'tabpanel' },
+]
+
+const SDK_PARTS: ReadonlyArray<{ name: string; kind: PartKind; meta: string; sample?: string }> = [
+	{ name: 'TldrawUiMenuItem', kind: 'row', meta: 'action item · ×16', sample: 'Rename' },
+	{ name: 'TldrawUiMenuCheckboxItem', kind: 'row', meta: 'toggle item · ×4', sample: '✓ Show grid' },
+	{ name: 'TldrawUiMenuSubmenu', kind: 'row', meta: 'nested menu · ×6', sample: 'Export as ›' },
+	{ name: 'TldrawUiMenuActionItem', kind: 'row', meta: 'bound to an action · ×3', sample: 'Undo   ⌘Z' },
+	{ name: 'TldrawUiMenuGroup', kind: 'wrap', meta: 'item group · ×20', sample: 'group' },
+	{ name: 'TldrawUiMenuContextProvider', kind: 'wrap', meta: 'menu schema root · ×4', sample: 'context provider' },
+	{ name: 'TldrawUiDropdownMenuRoot', kind: 'wrap', meta: 'Radix shell · ×3', sample: 'dropdown root' },
+	{ name: 'TldrawUiDropdownMenuTrigger', kind: 'wrap', meta: 'Radix shell · ×3', sample: 'trigger' },
+	{ name: 'TldrawUiDropdownMenuContent', kind: 'wrap', meta: 'Radix shell · ×3', sample: 'content' },
 ]
 
 const PAGE_CSS = `
@@ -252,22 +194,12 @@ const PAGE_CSS = `
 .section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
 .section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
 .section code, .callout code, .page__footer code, .section__note code, .page__lede code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
-.demoRow { display: flex; gap: 32px; margin-bottom: 20px; padding: 18px; background: var(--tl-color-low); border-radius: 8px; }
-.demoRow__control { display: flex; align-items: center; gap: 10px; font-size: 12px; color: var(--tl-color-text-1); }
-.menuMock { display: inline-block; min-width: 180px; padding: 6px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-3); background: var(--tl-color-panel); box-shadow: 0 6px 24px rgba(0,0,0,0.12); margin-bottom: 20px; }
-.menuMock__item { padding: 7px 10px; border-radius: var(--tl-radius-2); font-size: 13px; cursor: default; }
-.menuMock__item:hover { background: var(--tl-color-muted-2); }
-.menuMock__danger { color: var(--tl-color-warning, #cb4b16); }
-.menuMock__sep { height: 1px; background: var(--tl-color-divider); margin: 6px 4px; }
 .ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
 .tabMock { display: inline-flex; gap: 4px; }
 .tabMock span { padding: 4px 10px; border-radius: var(--tl-radius-2); font-size: 12px; color: var(--tl-color-text-3); }
 .tabMock span[data-active] { background: var(--tl-color-muted-2); color: var(--tl-color-text); }
 .rowMock { padding: 6px 10px; border-radius: var(--tl-radius-2); font-size: 13px; background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); min-width: 130px; text-align: left; }
-.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; max-width: 880px; }
-.section__api > div { display: flex; gap: 8px; }
-.section__api > div + div { margin-top: 4px; }
-.section__api .k { color: var(--tl-color-text-3); flex: 0 0 70px; }
+.wrapMock { font-size: 11px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); border: 1px dashed var(--tl-color-divider); border-radius: 5px; padding: 8px 12px; }
 .matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
 .matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
 .matrix th { color: var(--tl-color-text-3); font-weight: 500; }

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -1,8 +1,20 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
+import { TldrawUiContextProvider } from 'tldraw'
 import 'tldraw/tldraw.css'
-import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
+import {
+	TlaMenuControl,
+	TlaMenuControlGroup,
+	TlaMenuControlLabel,
+	TlaMenuDetail,
+	TlaMenuSection,
+	TlaMenuSwitch,
+	TlaMenuTabsPage,
+	TlaMenuTabsRoot,
+	TlaMenuTabsTab,
+	TlaMenuTabsTabs,
+} from '../tla/components/tla-menu/tla-menu'
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
@@ -38,6 +50,66 @@ const PartStage = ({ kind, sample }: { kind: PartKind; sample?: string }): React
 	}
 }
 
+const noop = () => {}
+
+/**
+ * Real, editor-less-safe tla-menu parts rendered live under the page's
+ * TldrawUiContextProvider. Returns null for the two that need a heavier provider
+ * (Select → useContainer/editor, ControlInfoTooltip → useMsg/dotcom intl), which
+ * fall back to PartStage and keep their mock badge.
+ */
+const renderLive = (name: string): ReactNode => {
+	switch (name) {
+		case 'TlaMenuSwitch':
+			return <TlaMenuSwitch id="m-switch" checked onChange={noop} />
+		case 'TlaMenuControl':
+			return (
+				<TlaMenuControl className="mWide">
+					<TlaMenuControlLabel htmlFor="m-ctrl">Setting</TlaMenuControlLabel>
+					<TlaMenuSwitch id="m-ctrl" checked onChange={noop} />
+				</TlaMenuControl>
+			)
+		case 'TlaMenuControlLabel':
+			return <TlaMenuControlLabel htmlFor="m-lbl">Label</TlaMenuControlLabel>
+		case 'TlaMenuDetail':
+			return <TlaMenuDetail>detail copy</TlaMenuDetail>
+		case 'TlaMenuControlGroup':
+			return (
+				<TlaMenuControlGroup>
+					<TlaMenuControl className="mWide">
+						<TlaMenuControlLabel htmlFor="m-grp">Grouped</TlaMenuControlLabel>
+						<TlaMenuSwitch id="m-grp" checked onChange={noop} />
+					</TlaMenuControl>
+				</TlaMenuControlGroup>
+			)
+		case 'TlaMenuSection':
+			return (
+				<TlaMenuSection>
+					<TlaMenuControlLabel htmlFor="m-sec">section contents</TlaMenuControlLabel>
+				</TlaMenuSection>
+			)
+		case 'TlaMenuTabsTab':
+		case 'TlaMenuTabsTabs':
+		case 'TlaMenuTabsRoot':
+			return (
+				<TlaMenuTabsRoot activeTab="export" onTabChange={noop}>
+					<TlaMenuTabsTabs>
+						<TlaMenuTabsTab id="export">Export</TlaMenuTabsTab>
+						<TlaMenuTabsTab id="publish">Publish</TlaMenuTabsTab>
+					</TlaMenuTabsTabs>
+				</TlaMenuTabsRoot>
+			)
+		case 'TlaMenuTabsPage':
+			return (
+				<TlaMenuTabsRoot activeTab="p" onTabChange={noop}>
+					<TlaMenuTabsPage id="p">tab page content</TlaMenuTabsPage>
+				</TlaMenuTabsRoot>
+			)
+		default:
+			return null
+	}
+}
+
 export function Component() {
 	return (
 		<div
@@ -49,96 +121,112 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
-			<div className="page">
-				<DevComponentsNav />
-				<header className="page__header">
-					<h1 className="page__title">Menu inventory</h1>
-					<p className="page__lede">
-						Two systems share the word &ldquo;menu&rdquo; — and that&rsquo;s the point. This
-						divergence is <strong>intentional</strong>: <code>tla-menu</code> is a settings-panel
-						system, the SDK <code>TldrawUiMenu*</code> is an action-dropdown system. Different
-						patterns, deliberately separate.
-					</p>
-				</header>
+			<TldrawUiContextProvider forceMobile={false}>
+				<div className="page">
+					<DevComponentsNav />
+					<header className="page__header">
+						<h1 className="page__title">Menu inventory</h1>
+						<p className="page__lede">
+							Two systems share the word &ldquo;menu&rdquo; — and that&rsquo;s the point. This
+							divergence is <strong>intentional</strong>: <code>tla-menu</code> is a settings-panel
+							system, the SDK <code>TldrawUiMenu*</code> is an action-dropdown system. Different
+							patterns, deliberately separate.
+						</p>
+					</header>
 
-				<section className="section">
-					<h2 className="section__title">Two systems, one word</h2>
-					<p className="section__note">
-						A <em>share menu</em> (a panel of settings) and a <em>file menu</em> (a dropdown of
-						actions) are different UI patterns that happen to share a noun.
-					</p>
-					<table className="matrix matrix--wide">
-						<thead>
-							<tr>
-								<th></th>
-								<th>tla-menu (settings panels)</th>
-								<th>SDK TldrawUiMenu* (action dropdowns)</th>
-							</tr>
-						</thead>
-						<tbody>
-							{SYSTEMS.map((r) => (
-								<tr key={r[0]}>
-									<td className="rowhead">{r[0]}</td>
-									<td>{r[1]}</td>
-									<td>{r[2]}</td>
+					<section className="section">
+						<h2 className="section__title">Two systems, one word</h2>
+						<p className="section__note">
+							A <em>share menu</em> (a panel of settings) and a <em>file menu</em> (a dropdown of
+							actions) are different UI patterns that happen to share a noun.
+						</p>
+						<table className="matrix matrix--wide">
+							<thead>
+								<tr>
+									<th></th>
+									<th>tla-menu (settings panels)</th>
+									<th>SDK TldrawUiMenu* (action dropdowns)</th>
 								</tr>
+							</thead>
+							<tbody>
+								{SYSTEMS.map((r) => (
+									<tr key={r[0]}>
+										<td className="rowhead">{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">tla-menu — all {TLA_PARTS.length} parts</h2>
+						<p className="section__note">
+							The settings-panel system (in <code>tla/components/tla-menu/tla-menu.tsx</code>). Most
+							parts render live under a <code>TldrawUiContextProvider</code>; only{' '}
+							<code>TlaMenuSelect</code> (needs the editor via <code>useContainer</code>) and{' '}
+							<code>TlaMenuControlInfoTooltip</code> (needs the dotcom <code>IntlProvider</code>)
+							stay mocked. <code>meta</code> shows the role and dotcom usage count.
+						</p>
+						<div className="grid">
+							{TLA_PARTS.map((p) => {
+								const live = renderLive(p.name)
+								return (
+									<Specimen
+										key={p.name}
+										label={p.name}
+										code={`<${p.name}>`}
+										meta={p.meta}
+										source="tla-menu.tsx"
+										mock={!live}
+									>
+										{live ?? <PartStage kind={p.kind} sample={p.sample} />}
+									</Specimen>
+								)
+							})}
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">
+							SDK TldrawUiMenu* — {SDK_PARTS.length} parts used in dotcom
+						</h2>
+						<p className="section__note">
+							The action-dropdown system (a declarative menu schema → Radix dropdown). Mocked —
+							these need the editor&rsquo;s menu context to render. The SDK exports more parts;
+							these are the ones dotcom uses.
+						</p>
+						<div className="grid">
+							{SDK_PARTS.map((p) => (
+								<Specimen
+									key={p.name}
+									label={p.name}
+									code={`<${p.name}>`}
+									meta={p.meta}
+									source="tldraw"
+									mock
+								>
+									<PartStage kind={p.kind} sample={p.sample} />
+								</Specimen>
 							))}
-						</tbody>
-					</table>
-				</section>
+						</div>
+					</section>
 
-				<section className="section">
-					<h2 className="section__title">tla-menu — all {TLA_PARTS.length} parts</h2>
-					<p className="section__note">
-						The settings-panel system (in <code>tla/components/tla-menu/tla-menu.tsx</code>). Switch
-						is live; the rest are mocked. <code>meta</code> shows the role and dotcom usage count.
-					</p>
-					<div className="grid">
-						{TLA_PARTS.map((p) => (
-							<Specimen
-								key={p.name}
-								label={p.name}
-								code={`<${p.name}>`}
-								meta={p.meta}
-								source="tla-menu.tsx"
-								mock={p.kind !== 'switch'}
-							>
-								<PartStage kind={p.kind} sample={p.sample} />
-							</Specimen>
-						))}
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">SDK TldrawUiMenu* — {SDK_PARTS.length} parts used in dotcom</h2>
-					<p className="section__note">
-						The action-dropdown system (a declarative menu schema → Radix dropdown). Mocked — these
-						need the editor&rsquo;s menu context to render. The SDK exports more parts; these are
-						the ones dotcom uses.
-					</p>
-					<div className="grid">
-						{SDK_PARTS.map((p) => (
-							<Specimen key={p.name} label={p.name} code={`<${p.name}>`} meta={p.meta} source="tldraw" mock>
-								<PartStage kind={p.kind} sample={p.sample} />
-							</Specimen>
-						))}
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Why the split is deliberate</h2>
-					<div className="callout">
-						These are not two implementations of one thing — they are two different things. A{' '}
-						<strong>settings panel</strong> is persistent, inline, and made of labeled controls you
-						read and adjust; an <strong>action dropdown</strong> is transient, floating, and made of
-						commands you click once. They share the noun &ldquo;menu&rdquo; and nothing else.
-						Consolidating them would force a settings form and a command list into one abstraction —
-						strictly worse. #9199 was right to exclude this from the sweep:{' '}
-						<strong>this is the divergence an audit must learn to leave alone.</strong>
-					</div>
-				</section>
-
-			</div>
+					<section className="section">
+						<h2 className="section__title">Why the split is deliberate</h2>
+						<div className="callout">
+							These are not two implementations of one thing — they are two different things. A{' '}
+							<strong>settings panel</strong> is persistent, inline, and made of labeled controls
+							you read and adjust; an <strong>action dropdown</strong> is transient, floating, and
+							made of commands you click once. They share the noun &ldquo;menu&rdquo; and nothing
+							else. Consolidating them would force a settings form and a command list into one
+							abstraction — strictly worse. #9199 was right to exclude this from the sweep:{' '}
+							<strong>this is the divergence an audit must learn to leave alone.</strong>
+						</div>
+					</section>
+				</div>
+			</TldrawUiContextProvider>
 		</div>
 	)
 }
@@ -155,12 +243,27 @@ const TLA_PARTS: ReadonlyArray<{ name: string; kind: PartKind; meta: string; sam
 	{ name: 'TlaMenuSwitch', kind: 'switch', meta: 'control · role=switch · ×8' },
 	{ name: 'TlaMenuSelect', kind: 'select', meta: 'control · Radix Select · ×4' },
 	{ name: 'TlaMenuTabsTab', kind: 'tab', meta: 'control · role=tab · ×6', sample: 'Export' },
-	{ name: 'TlaMenuControl', kind: 'row', meta: 'labeled control row · ×10', sample: 'Setting       ◉' },
+	{
+		name: 'TlaMenuControl',
+		kind: 'row',
+		meta: 'labeled control row · ×10',
+		sample: 'Setting       ◉',
+	},
 	{ name: 'TlaMenuControlLabel', kind: 'row', meta: 'control label · ×10', sample: 'Label' },
-	{ name: 'TlaMenuControlInfoTooltip', kind: 'row', meta: 'info tooltip · ×4', sample: 'ⓘ  more info' },
+	{
+		name: 'TlaMenuControlInfoTooltip',
+		kind: 'row',
+		meta: 'info tooltip · ×4',
+		sample: 'ⓘ  more info',
+	},
 	{ name: 'TlaMenuDetail', kind: 'row', meta: 'detail text · ×1', sample: 'detail copy' },
 	{ name: 'TlaMenuSection', kind: 'wrap', meta: 'layout wrapper · ×4', sample: 'section' },
-	{ name: 'TlaMenuControlGroup', kind: 'wrap', meta: 'layout wrapper · ×4', sample: 'control group' },
+	{
+		name: 'TlaMenuControlGroup',
+		kind: 'wrap',
+		meta: 'layout wrapper · ×4',
+		sample: 'control group',
+	},
 	{ name: 'TlaMenuTabsRoot', kind: 'wrap', meta: 'tabs root · ×2', sample: 'tabs root' },
 	{ name: 'TlaMenuTabsTabs', kind: 'wrap', meta: 'role=tablist · ×2', sample: 'tablist' },
 	{ name: 'TlaMenuTabsPage', kind: 'wrap', meta: 'role=tabpanel · ×7', sample: 'tabpanel' },
@@ -168,14 +271,44 @@ const TLA_PARTS: ReadonlyArray<{ name: string; kind: PartKind; meta: string; sam
 
 const SDK_PARTS: ReadonlyArray<{ name: string; kind: PartKind; meta: string; sample?: string }> = [
 	{ name: 'TldrawUiMenuItem', kind: 'row', meta: 'action item · ×16', sample: 'Rename' },
-	{ name: 'TldrawUiMenuCheckboxItem', kind: 'row', meta: 'toggle item · ×4', sample: '✓ Show grid' },
+	{
+		name: 'TldrawUiMenuCheckboxItem',
+		kind: 'row',
+		meta: 'toggle item · ×4',
+		sample: '✓ Show grid',
+	},
 	{ name: 'TldrawUiMenuSubmenu', kind: 'row', meta: 'nested menu · ×6', sample: 'Export as ›' },
-	{ name: 'TldrawUiMenuActionItem', kind: 'row', meta: 'bound to an action · ×3', sample: 'Undo   ⌘Z' },
+	{
+		name: 'TldrawUiMenuActionItem',
+		kind: 'row',
+		meta: 'bound to an action · ×3',
+		sample: 'Undo   ⌘Z',
+	},
 	{ name: 'TldrawUiMenuGroup', kind: 'wrap', meta: 'item group · ×20', sample: 'group' },
-	{ name: 'TldrawUiMenuContextProvider', kind: 'wrap', meta: 'menu schema root · ×4', sample: 'context provider' },
-	{ name: 'TldrawUiDropdownMenuRoot', kind: 'wrap', meta: 'Radix shell · ×3', sample: 'dropdown root' },
-	{ name: 'TldrawUiDropdownMenuTrigger', kind: 'wrap', meta: 'Radix shell · ×3', sample: 'trigger' },
-	{ name: 'TldrawUiDropdownMenuContent', kind: 'wrap', meta: 'Radix shell · ×3', sample: 'content' },
+	{
+		name: 'TldrawUiMenuContextProvider',
+		kind: 'wrap',
+		meta: 'menu schema root · ×4',
+		sample: 'context provider',
+	},
+	{
+		name: 'TldrawUiDropdownMenuRoot',
+		kind: 'wrap',
+		meta: 'Radix shell · ×3',
+		sample: 'dropdown root',
+	},
+	{
+		name: 'TldrawUiDropdownMenuTrigger',
+		kind: 'wrap',
+		meta: 'Radix shell · ×3',
+		sample: 'trigger',
+	},
+	{
+		name: 'TldrawUiDropdownMenuContent',
+		kind: 'wrap',
+		meta: 'Radix shell · ×3',
+		sample: 'content',
+	},
 ]
 
 const PAGE_CSS = `
@@ -195,6 +328,7 @@ const PAGE_CSS = `
 .section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
 .section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
 .section code, .callout code, .page__footer code, .section__note code, .page__lede code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.mWide { width: 100%; }
 .ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
 .tabMock { display: inline-flex; gap: 4px; }
 .tabMock span { padding: 4px 10px; border-radius: var(--tl-radius-2); font-size: 12px; color: var(--tl-color-text-3); }

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -131,12 +131,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					Not all divergence is drift. Buttons, inputs, and type each hide a problem to fix; the two
-					menu systems are a boundary to <em>respect</em>. Telling the two apart — accidental
-					inconsistency vs deliberate design — is the whole skill of a design-system audit. See
-					tldraw/tldraw#9199.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -95,7 +95,14 @@ export function Component() {
 					</p>
 					<div className="grid">
 						{TLA_PARTS.map((p) => (
-							<Specimen key={p.name} label={p.name} code={`<${p.name}>`} meta={p.meta} source="tla-menu.tsx">
+							<Specimen
+								key={p.name}
+								label={p.name}
+								code={`<${p.name}>`}
+								meta={p.meta}
+								source="tla-menu.tsx"
+								mock={p.kind !== 'switch'}
+							>
 								<PartStage kind={p.kind} sample={p.sample} />
 							</Specimen>
 						))}
@@ -111,7 +118,7 @@ export function Component() {
 					</p>
 					<div className="grid">
 						{SDK_PARTS.map((p) => (
-							<Specimen key={p.name} label={p.name} code={`<${p.name}>`} meta={p.meta} source="tldraw">
+							<Specimen key={p.name} label={p.name} code={`<${p.name}>`} meta={p.meta} source="tldraw" mock>
 								<PartStage kind={p.kind} sample={p.sample} />
 							</Specimen>
 						))}

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -1,0 +1,203 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
+import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's two menu systems. This family shows a
+ * divergence mode the others don't: INTENTIONAL COEXISTENCE. The word "menu" is
+ * overloaded — `tla-menu` is a settings-panel system (labeled Select/Switch/Tabs
+ * controls), the SDK `TldrawUiMenu*` is an action-dropdown system (command
+ * menus). They are different UI patterns, so two systems is correct, not drift.
+ *
+ * Relevant to tldraw/tldraw#9199, which explicitly excluded "consolidate the
+ * menus" from the sweep. Route: /dev/components/menus.
+ */
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Menu inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Menu inventory</h1>
+					<p className="page__lede">
+						Two systems share the word &ldquo;menu&rdquo; — and that&rsquo;s the point. Unlike the
+						other families, this divergence is <strong>intentional</strong>:{' '}
+						<code>tla-menu</code> is a settings-panel system, the SDK <code>TldrawUiMenu*</code> is an
+						action-dropdown system. Different patterns, deliberately separate.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">Two systems, one word</h2>
+					<p className="section__note">
+						The names collide on &ldquo;menu&rdquo;, but a <em>share menu</em> (a panel of settings)
+						and a <em>file menu</em> (a dropdown of actions) are different UI patterns.
+					</p>
+					<table className="matrix matrix--wide">
+						<thead>
+							<tr>
+								<th></th>
+								<th>tla-menu (settings panels)</th>
+								<th>SDK TldrawUiMenu* (action dropdowns)</th>
+							</tr>
+						</thead>
+						<tbody>
+							{SYSTEMS.map((r) => (
+								<tr key={r[0]}>
+									<td className="rowhead">{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">tla-menu — settings panel system</h2>
+					<p className="section__note">
+						Declarative labeled controls inside a panel. Parts in{' '}
+						<code>tla/components/tla-menu/tla-menu.tsx</code>. Switch shown live:
+					</p>
+					<div className="demoRow">
+						<div className="demoRow__control">
+							<TlaMenuSwitch id="demo-on" checked onChange={() => {}} />
+							<span>checked</span>
+						</div>
+						<div className="demoRow__control">
+							<TlaMenuSwitch id="demo-off" checked={false} onChange={() => {}} />
+							<span>unchecked</span>
+						</div>
+					</div>
+					<div className="section__api">
+						<div>
+							<span className="k">layout</span>
+							TlaMenuSection, TlaMenuControlGroup, TlaMenuControl, TlaMenuControlLabel,
+							TlaMenuDetail, TlaMenuControlInfoTooltip
+						</div>
+						<div>
+							<span className="k">controls</span>
+							TlaMenuSelect (Radix Select), TlaMenuSwitch (role=switch), TlaMenuTabs Root / Tabs /
+							Tab / Page (role=tablist / tab / tabpanel)
+						</div>
+						<div>
+							<span className="k">used in</span>
+							TlaFileShareMenu (+ Publish / Invite / Export / AnonCopyLink tabs),
+							WorkspaceSettingsDialog, TlaManageCookiesDialog, TlaLegalAcceptance
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">SDK TldrawUiMenu* — action dropdown system</h2>
+					<p className="section__note">
+						A declarative menu schema (groups + items) rendered into a Radix dropdown. Mock below
+						(it needs the editor&rsquo;s menu context to render live).
+					</p>
+					<div className="menuMock">
+						<div className="menuMock__item">Rename</div>
+						<div className="menuMock__item">Duplicate</div>
+						<div className="menuMock__item">Copy link</div>
+						<div className="menuMock__sep" />
+						<div className="menuMock__item menuMock__danger">Delete</div>
+					</div>
+					<div className="section__api">
+						<div>
+							<span className="k">schema</span>
+							TldrawUiMenuContextProvider, TldrawUiMenuGroup, TldrawUiMenuItem,
+							TldrawUiMenuSubmenu, TldrawUiMenuCheckboxItem, TldrawUiMenuActionItem
+						</div>
+						<div>
+							<span className="k">shell</span>
+							TldrawUiDropdownMenuRoot / Trigger / Content / Item / Sub / SubTrigger / SubContent
+							(Radix)
+						</div>
+						<div>
+							<span className="k">used in</span>
+							TlaFileMenu, TlaSidebarUserSettingsMenu, menu-items.tsx, TlaEditor context menus,
+							local-file
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Why the split is deliberate</h2>
+					<div className="callout">
+						These are not two implementations of one thing — they are two different things. A{' '}
+						<strong>settings panel</strong> is persistent, inline, and made of labeled controls you
+						read and adjust; an <strong>action dropdown</strong> is transient, floating, and made of
+						commands you click once. They share the noun &ldquo;menu&rdquo; and nothing else.
+						Consolidating them would force a settings form and a command list into one abstraction —
+						strictly worse. #9199 was right to exclude this from the sweep:{' '}
+						<strong>this is the divergence an audit must learn to leave alone.</strong>
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					The lesson this page adds to the gallery: not all divergence is drift. Buttons, inputs, and
+					type each hide a problem to fix; the two menu systems are a boundary to <em>respect</em>.
+					Telling the two apart — accidental inconsistency vs deliberate design — is the whole skill
+					of a design-system audit. See tldraw/tldraw#9199.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const SYSTEMS: ReadonlyArray<readonly [string, string, string]> = [
+	['purpose', 'persistent labeled controls in a panel', 'transient dropdown of one-shot commands'],
+	['pattern', 'a form inside a panel', 'a declarative menu schema → Radix dropdown'],
+	['controls', 'Select · Switch · Tabs', 'Item · CheckboxItem · Submenu · ActionItem'],
+	['ARIA', 'role=switch / tab / tablist / tabpanel', 'role=menu / menuitem (Radix)'],
+	['where', 'share menu, settings & cookies dialogs', 'file menu, user menu, context menus'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong, .callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.section code, .callout code, .page__footer code, .section__note code, .page__lede code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.demoRow { display: flex; gap: 32px; margin-bottom: 20px; padding: 18px; background: var(--tl-color-low); border-radius: 8px; }
+.demoRow__control { display: flex; align-items: center; gap: 10px; font-size: 12px; color: var(--tl-color-text-1); }
+.menuMock { display: inline-block; min-width: 180px; padding: 6px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-3); background: var(--tl-color-panel); box-shadow: 0 6px 24px rgba(0,0,0,0.12); margin-bottom: 20px; }
+.menuMock__item { padding: 7px 10px; border-radius: var(--tl-radius-2); font-size: 13px; cursor: default; }
+.menuMock__item:hover { background: var(--tl-color-muted-2); }
+.menuMock__danger { color: var(--tl-color-warning, #cb4b16); }
+.menuMock__sep { height: 1px; background: var(--tl-color-divider); margin: 6px 4px; }
+.section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; max-width: 880px; }
+.section__api > div { display: flex; gap: 8px; }
+.section__api > div + div { margin-top: 4px; }
+.section__api .k { color: var(--tl-color-text-3); flex: 0 0 70px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix--wide td, .matrix--wide th { padding-right: 28px; max-width: 340px; }
+.matrix .rowhead { color: var(--tl-color-text-3); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -2,10 +2,8 @@
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
 import {
-	Tldraw,
 	TldrawUiButton,
 	TldrawUiButtonLabel,
-	TldrawUiContextProvider,
 	TldrawUiDropdownMenuContent,
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
@@ -19,9 +17,11 @@ import 'tldraw/tldraw.css'
 import {
 	TlaMenuControl,
 	TlaMenuControlGroup,
+	TlaMenuControlInfoTooltip,
 	TlaMenuControlLabel,
 	TlaMenuDetail,
 	TlaMenuSection,
+	TlaMenuSelect,
 	TlaMenuSwitch,
 	TlaMenuTabsPage,
 	TlaMenuTabsRoot,
@@ -31,6 +31,7 @@ import {
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
+import { IsolationProviders, MinimalEditorHarness } from './dev-editor-harness'
 
 /**
  * Dev-only inventory of the dotcom app's two menu systems. This family shows a
@@ -66,10 +67,11 @@ const PartStage = ({ kind, sample }: { kind: PartKind; sample?: string }): React
 const noop = () => {}
 
 /**
- * Real, editor-less-safe tla-menu parts rendered live under the page's
- * TldrawUiContextProvider. Returns null for the two that need a heavier provider
- * (Select → useContainer/editor, ControlInfoTooltip → useMsg/dotcom intl), which
- * fall back to PartStage and keep their mock badge.
+ * Every tla-menu part rendered live under the page's IsolationProviders
+ * (react-intl + a container element + the SDK UI context). Select needs the
+ * container, ControlInfoTooltip needs react-intl, the rest only the UI context —
+ * all covered, so none fall back to PartStage. (PartStage still renders the SDK
+ * TldrawUiMenu* mock cards, which are shown composed-live above instead.)
  */
 const renderLive = (name: string): ReactNode => {
 	switch (name) {
@@ -118,6 +120,21 @@ const renderLive = (name: string): ReactNode => {
 					<TlaMenuTabsPage id="p">tab page content</TlaMenuTabsPage>
 				</TlaMenuTabsRoot>
 			)
+		case 'TlaMenuSelect':
+			return (
+				<TlaMenuSelect
+					id="m-select"
+					label="Access"
+					value="editor"
+					onChange={noop}
+					options={[
+						{ value: 'editor', label: 'Can edit' },
+						{ value: 'viewer', label: 'Can view' },
+					]}
+				/>
+			)
+		case 'TlaMenuControlInfoTooltip':
+			return <TlaMenuControlInfoTooltip>More info about this setting</TlaMenuControlInfoTooltip>
 		default:
 			return null
 	}
@@ -131,10 +148,8 @@ const renderLive = (name: string): ReactNode => {
  * the resolved menu shows with no click. Fake content, real function.
  */
 const RealActionMenu = (): ReactNode => (
-	<div className="realMenuStage">
-		<Tldraw hideUi>
-			<TldrawUiContextProvider>
-				<div className="realMenuAnchor">
+	<MinimalEditorHarness>
+		<div className="realMenuAnchor">
 					<TldrawUiDropdownMenuRoot id="dev-real-menu" debugOpen>
 						<TldrawUiDropdownMenuTrigger>
 							<TldrawUiButton type="normal">
@@ -162,10 +177,8 @@ const RealActionMenu = (): ReactNode => (
 							</TldrawUiMenuContextProvider>
 						</TldrawUiDropdownMenuContent>
 					</TldrawUiDropdownMenuRoot>
-				</div>
-			</TldrawUiContextProvider>
-		</Tldraw>
-	</div>
+		</div>
+	</MinimalEditorHarness>
 )
 
 export function Component() {
@@ -179,7 +192,7 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
-			<TldrawUiContextProvider forceMobile={false}>
+			<IsolationProviders>
 				<div className="page">
 					<DevComponentsNav />
 					<header className="page__header">
@@ -221,11 +234,10 @@ export function Component() {
 					<section className="section">
 						<h2 className="section__title">tla-menu — all {TLA_PARTS.length} parts</h2>
 						<p className="section__note">
-							The settings-panel system (in <code>tla/components/tla-menu/tla-menu.tsx</code>). Most
-							parts render live under a <code>TldrawUiContextProvider</code>; only{' '}
-							<code>TlaMenuSelect</code> (needs the editor via <code>useContainer</code>) and{' '}
-							<code>TlaMenuControlInfoTooltip</code> (needs the dotcom <code>IntlProvider</code>)
-							stay mocked. <code>meta</code> shows the role and dotcom usage count.
+							The settings-panel system (in <code>tla/components/tla-menu/tla-menu.tsx</code>). All
+							parts render live under <code>IsolationProviders</code> (react-intl for{' '}
+							<code>useMsg</code>, a container element for <code>useContainer</code>, and the SDK UI
+							context) — no editor needed. <code>meta</code> shows the role and dotcom usage count.
 						</p>
 						<div className="grid">
 							{TLA_PARTS.map((p) => {
@@ -296,7 +308,7 @@ export function Component() {
 						</div>
 					</section>
 				</div>
-			</TldrawUiContextProvider>
+			</IsolationProviders>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -5,6 +5,7 @@ import 'tldraw/tldraw.css'
 import { TlaMenuSwitch } from '../tla/components/tla-menu/tla-menu'
 import '../tla/styles/tla.css'
 import { DevComponentsNav } from './dev-components-nav'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 
 /**
  * Dev-only inventory of the dotcom app's two menu systems. This family shows a
@@ -26,7 +27,7 @@ export function Component() {
 			<Helmet>
 				<title>Menu inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
@@ -64,6 +65,75 @@ export function Component() {
 							))}
 						</tbody>
 					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Overview</h2>
+					<p className="section__note">
+						Each system's controls and items, with their props — tla-menu controls live, SDK items as
+						mocks (they need the editor's menu context to render).
+					</p>
+					<div className="grid">
+						<Specimen
+							label="TlaMenuSwitch"
+							code={`<TlaMenuSwitch checked>`}
+							meta="tla-menu · role=switch"
+							source="tla-menu.tsx"
+						>
+							<TlaMenuSwitch id="ov-on" checked onChange={() => {}} />
+						</Specimen>
+						<Specimen
+							label="TlaMenuSwitch"
+							code={`<TlaMenuSwitch checked={false}>`}
+							meta="tla-menu · role=switch"
+							source="tla-menu.tsx"
+						>
+							<TlaMenuSwitch id="ov-off" checked={false} onChange={() => {}} />
+						</Specimen>
+						<Specimen
+							label="TlaMenuSelect"
+							code={`<TlaMenuSelect options={…} />`}
+							meta="tla-menu · Radix Select"
+							source="tla-menu.tsx"
+						>
+							<div className="ctrlMock">Everyone ▾</div>
+						</Specimen>
+						<Specimen
+							label="TlaMenuTabs"
+							code={`<TlaMenuTabsRoot>…`}
+							meta="tla-menu · role=tablist"
+							source="tla-menu.tsx"
+						>
+							<div className="tabMock">
+								<span data-active>Export</span>
+								<span>Publish</span>
+							</div>
+						</Specimen>
+						<Specimen
+							label="TldrawUiMenuItem"
+							code={`<TldrawUiMenuItem>`}
+							meta="SDK · action item"
+							source="tldraw"
+						>
+							<div className="rowMock">Rename</div>
+						</Specimen>
+						<Specimen
+							label="TldrawUiMenuCheckboxItem"
+							code={`<TldrawUiMenuCheckboxItem>`}
+							meta="SDK · toggle item"
+							source="tldraw"
+						>
+							<div className="rowMock">✓ Show grid</div>
+						</Specimen>
+						<Specimen
+							label="TldrawUiMenuSubmenu"
+							code={`<TldrawUiMenuSubmenu>`}
+							meta="SDK · nested"
+							source="tldraw"
+						>
+							<div className="rowMock">Export as ›</div>
+						</Specimen>
+					</div>
 				</section>
 
 				<section className="section">
@@ -189,6 +259,11 @@ const PAGE_CSS = `
 .menuMock__item:hover { background: var(--tl-color-muted-2); }
 .menuMock__danger { color: var(--tl-color-warning, #cb4b16); }
 .menuMock__sep { height: 1px; background: var(--tl-color-divider); margin: 6px 4px; }
+.ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
+.tabMock { display: inline-flex; gap: 4px; }
+.tabMock span { padding: 4px 10px; border-radius: var(--tl-radius-2); font-size: 12px; color: var(--tl-color-text-3); }
+.tabMock span[data-active] { background: var(--tl-color-muted-2); color: var(--tl-color-text); }
+.rowMock { padding: 6px 10px; border-radius: var(--tl-radius-2); font-size: 13px; background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); min-width: 130px; text-align: left; }
 .section__api { font-size: 11px; font-family: ui-monospace, monospace; line-height: 1.6; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 6px; padding: 10px 12px; max-width: 880px; }
 .section__api > div { display: flex; gap: 8px; }
 .section__api > div + div { margin-top: 4px; }

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -1,7 +1,20 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { TldrawUiContextProvider } from 'tldraw'
+import {
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	TldrawUiContextProvider,
+	TldrawUiDropdownMenuContent,
+	TldrawUiDropdownMenuRoot,
+	TldrawUiDropdownMenuTrigger,
+	TldrawUiMenuCheckboxItem,
+	TldrawUiMenuContextProvider,
+	TldrawUiMenuGroup,
+	TldrawUiMenuItem,
+	TldrawUiMenuSubmenu,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 import {
 	TlaMenuControl,
@@ -110,6 +123,51 @@ const renderLive = (name: string): ReactNode => {
 	}
 }
 
+/**
+ * A genuinely real SDK action menu. The TldrawUiMenu* parts can't render
+ * individually (each calls useEditor and the 'menu' type emits a Radix
+ * DropdownMenu.Item), but composed inside a minimal in-memory <Tldraw> they
+ * work. hideUi drops the default chrome; debugOpen forces the dropdown open so
+ * the resolved menu shows with no click. Fake content, real function.
+ */
+const RealActionMenu = (): ReactNode => (
+	<div className="realMenuStage">
+		<Tldraw hideUi>
+			<TldrawUiContextProvider>
+				<div className="realMenuAnchor">
+					<TldrawUiDropdownMenuRoot id="dev-real-menu" debugOpen>
+						<TldrawUiDropdownMenuTrigger>
+							<TldrawUiButton type="normal">
+								<TldrawUiButtonLabel>Actions</TldrawUiButtonLabel>
+							</TldrawUiButton>
+						</TldrawUiDropdownMenuTrigger>
+						<TldrawUiDropdownMenuContent side="bottom" align="start">
+							<TldrawUiMenuContextProvider type="menu" sourceId="dialog">
+								<TldrawUiMenuGroup id="dev-edit">
+									<TldrawUiMenuItem id="rename" label="Rename" icon="edit" onSelect={noop} />
+									<TldrawUiMenuItem
+										id="duplicate"
+										label="Duplicate"
+										icon="duplicate"
+										onSelect={noop}
+									/>
+								</TldrawUiMenuGroup>
+								<TldrawUiMenuGroup id="dev-view">
+									<TldrawUiMenuCheckboxItem id="grid" label="Show grid" checked onSelect={noop} />
+									<TldrawUiMenuSubmenu id="export" label="Export as">
+										<TldrawUiMenuItem id="png" label="PNG" onSelect={noop} />
+										<TldrawUiMenuItem id="svg" label="SVG" onSelect={noop} />
+									</TldrawUiMenuSubmenu>
+								</TldrawUiMenuGroup>
+							</TldrawUiMenuContextProvider>
+						</TldrawUiDropdownMenuContent>
+					</TldrawUiDropdownMenuRoot>
+				</div>
+			</TldrawUiContextProvider>
+		</Tldraw>
+	</div>
+)
+
 export function Component() {
 	return (
 		<div
@@ -189,13 +247,25 @@ export function Component() {
 					</section>
 
 					<section className="section">
+						<h2 className="section__title">A real action menu (live)</h2>
+						<p className="section__note">
+							The parts below can&rsquo;t render on their own — each calls <code>useEditor</code>{' '}
+							and the <code>menu</code> type emits a Radix dropdown item. But composed inside a
+							minimal, in-memory <code>&lt;Tldraw&gt;</code> (fake content, real function) they
+							work. This is a genuine <code>TldrawUiDropdownMenu</code> forced open with{' '}
+							<code>debugOpen</code> — real <code>MenuItem</code> / <code>CheckboxItem</code> /{' '}
+							<code>Submenu</code>.
+						</p>
+						<RealActionMenu />
+					</section>
+
+					<section className="section">
 						<h2 className="section__title">
 							SDK TldrawUiMenu* — {SDK_PARTS.length} parts used in dotcom
 						</h2>
 						<p className="section__note">
-							The action-dropdown system (a declarative menu schema → Radix dropdown). Mocked —
-							these need the editor&rsquo;s menu context to render. The SDK exports more parts;
-							these are the ones dotcom uses.
+							The same system broken into parts. Each is mocked here because, alone, it needs the
+							editor&rsquo;s menu context — the live menu above shows them composed for real.
 						</p>
 						<div className="grid">
 							{SDK_PARTS.map((p) => (
@@ -329,6 +399,8 @@ const PAGE_CSS = `
 .section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
 .section code, .callout code, .page__footer code, .section__note code, .page__lede code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
 .mWide { width: 100%; }
+.realMenuStage { position: relative; height: 380px; max-width: 640px; border: 1px solid var(--tl-color-divider); border-radius: 8px; overflow: hidden; }
+.realMenuAnchor { position: absolute; top: 20px; left: 20px; z-index: 100; }
 .ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
 .tabMock { display: inline-flex; gap: 4px; }
 .tabMock span { padding: 4px 10px; border-radius: var(--tl-radius-2); font-size: 12px; color: var(--tl-color-text-3); }

--- a/apps/dotcom/client/src/pages/dev-menus.tsx
+++ b/apps/dotcom/client/src/pages/dev-menus.tsx
@@ -45,25 +45,6 @@ import { IsolationProviders, MinimalEditorHarness } from './dev-editor-harness'
 
 type PartKind = 'switch' | 'select' | 'tab' | 'row' | 'wrap'
 
-const PartStage = ({ kind, sample }: { kind: PartKind; sample?: string }): ReactNode => {
-	switch (kind) {
-		case 'switch':
-			return <TlaMenuSwitch id="ov-switch" checked onChange={() => {}} />
-		case 'select':
-			return <div className="ctrlMock">Everyone ▾</div>
-		case 'tab':
-			return (
-				<div className="tabMock">
-					<span data-active>{sample ?? 'Tab'}</span>
-				</div>
-			)
-		case 'row':
-			return <div className="rowMock">{sample}</div>
-		case 'wrap':
-			return <div className="wrapMock">{sample}</div>
-	}
-}
-
 const noop = () => {}
 
 /**
@@ -150,33 +131,28 @@ const renderLive = (name: string): ReactNode => {
 const RealActionMenu = (): ReactNode => (
 	<MinimalEditorHarness>
 		<div className="realMenuAnchor">
-					<TldrawUiDropdownMenuRoot id="dev-real-menu" debugOpen>
-						<TldrawUiDropdownMenuTrigger>
-							<TldrawUiButton type="normal">
-								<TldrawUiButtonLabel>Actions</TldrawUiButtonLabel>
-							</TldrawUiButton>
-						</TldrawUiDropdownMenuTrigger>
-						<TldrawUiDropdownMenuContent side="bottom" align="start">
-							<TldrawUiMenuContextProvider type="menu" sourceId="dialog">
-								<TldrawUiMenuGroup id="dev-edit">
-									<TldrawUiMenuItem id="rename" label="Rename" icon="edit" onSelect={noop} />
-									<TldrawUiMenuItem
-										id="duplicate"
-										label="Duplicate"
-										icon="duplicate"
-										onSelect={noop}
-									/>
-								</TldrawUiMenuGroup>
-								<TldrawUiMenuGroup id="dev-view">
-									<TldrawUiMenuCheckboxItem id="grid" label="Show grid" checked onSelect={noop} />
-									<TldrawUiMenuSubmenu id="export" label="Export as">
-										<TldrawUiMenuItem id="png" label="PNG" onSelect={noop} />
-										<TldrawUiMenuItem id="svg" label="SVG" onSelect={noop} />
-									</TldrawUiMenuSubmenu>
-								</TldrawUiMenuGroup>
-							</TldrawUiMenuContextProvider>
-						</TldrawUiDropdownMenuContent>
-					</TldrawUiDropdownMenuRoot>
+			<TldrawUiDropdownMenuRoot id="dev-real-menu" debugOpen>
+				<TldrawUiDropdownMenuTrigger>
+					<TldrawUiButton type="normal">
+						<TldrawUiButtonLabel>Actions</TldrawUiButtonLabel>
+					</TldrawUiButton>
+				</TldrawUiDropdownMenuTrigger>
+				<TldrawUiDropdownMenuContent side="bottom" align="start">
+					<TldrawUiMenuContextProvider type="menu" sourceId="dialog">
+						<TldrawUiMenuGroup id="dev-edit">
+							<TldrawUiMenuItem id="rename" label="Rename" icon="edit" onSelect={noop} />
+							<TldrawUiMenuItem id="duplicate" label="Duplicate" icon="duplicate" onSelect={noop} />
+						</TldrawUiMenuGroup>
+						<TldrawUiMenuGroup id="dev-view">
+							<TldrawUiMenuCheckboxItem id="grid" label="Show grid" checked onSelect={noop} />
+							<TldrawUiMenuSubmenu id="export" label="Export as">
+								<TldrawUiMenuItem id="png" label="PNG" onSelect={noop} />
+								<TldrawUiMenuItem id="svg" label="SVG" onSelect={noop} />
+							</TldrawUiMenuSubmenu>
+						</TldrawUiMenuGroup>
+					</TldrawUiMenuContextProvider>
+				</TldrawUiDropdownMenuContent>
+			</TldrawUiDropdownMenuRoot>
 		</div>
 	</MinimalEditorHarness>
 )
@@ -251,7 +227,7 @@ export function Component() {
 										source="tla-menu.tsx"
 										mock={!live}
 									>
-										{live ?? <PartStage kind={p.kind} sample={p.sample} />}
+										{live}
 									</Specimen>
 								)
 							})}
@@ -276,23 +252,26 @@ export function Component() {
 							SDK TldrawUiMenu* — {SDK_PARTS.length} parts used in dotcom
 						</h2>
 						<p className="section__note">
-							The same system broken into parts. Each is mocked here because, alone, it needs the
-							editor&rsquo;s menu context — the live menu above shows them composed for real.
+							The same system broken into parts — catalogued as data here, because each only has a
+							resolved state <em>composed</em> (a lone menu item must live inside a dropdown). The
+							live menu above is these parts, real.
 						</p>
-						<div className="grid">
-							{SDK_PARTS.map((p) => (
-								<Specimen
-									key={p.name}
-									label={p.name}
-									code={`<${p.name}>`}
-									meta={p.meta}
-									source="tldraw"
-									mock
-								>
-									<PartStage kind={p.kind} sample={p.sample} />
-								</Specimen>
-							))}
-						</div>
+						<table className="matrix matrix--wide">
+							<thead>
+								<tr>
+									<th>part</th>
+									<th>role · usage</th>
+								</tr>
+							</thead>
+							<tbody>
+								{SDK_PARTS.map((p) => (
+									<tr key={p.name}>
+										<td>{p.name}</td>
+										<td>{p.meta}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
 					</section>
 
 					<section className="section">

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -11,6 +11,7 @@ import {
 	TldrawUiPopoverTrigger,
 	useToasts,
 } from 'tldraw'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { DevComponentsNav } from './dev-components-nav'
@@ -26,50 +27,44 @@ import { IsolationProviders } from './dev-editor-harness'
  * Route: /dev/components/overlays.
  */
 
-const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
-	<div className="stat">
-		<div className="stat__n">{n}</div>
-		<div className="stat__label">{label}</div>
-	</div>
-)
-
-/**
- * Real toasts, no trigger. The SDK owns the toast UI (DefaultToasts is the real
- * viewport); we fake the state by firing one keepOpen toast per severity on
- * mount. So the UI is genuine — only the content is fake. The .toastStage's
- * transform makes it a containing block so the viewport's fixed positioning
- * stays inside the card instead of floating to the window corner.
- */
-const LIVE_TOASTS: ReadonlyArray<{
-	id: string
-	severity?: 'error' | 'warning' | 'info' | 'success'
-	title: string
-	description?: string
-}> = [
-	{
-		id: 'lt-error',
-		severity: 'error',
-		title: 'Could not load file',
-		description: 'Something went wrong. Please try again.',
-	},
-	{ id: 'lt-warning', severity: 'warning', title: 'Unsupported mermaid diagram' },
-	{ id: 'lt-info', severity: 'info', title: 'Uploading .tldr files…' },
-	{ id: 'lt-success', severity: 'success', title: 'Feedback submitted' },
-	{ id: 'lt-neutral', title: 'Copied invite link' },
-]
-
-const LiveToasts = (): ReactNode => {
+const FireToast = ({
+	toast,
+}: {
+	toast: { title: string; sev: Sev; keepOpen?: boolean; source: string }
+}): ReactNode => {
 	const { addToast, toasts } = useToasts()
 	useEffect(() => {
 		if (toasts.get().length > 0) return
-		for (const t of LIVE_TOASTS) addToast({ ...t, keepOpen: true })
-	}, [addToast, toasts])
-	return (
-		<div className="toastStage">
+		addToast({
+			id: toast.source,
+			title: toast.title,
+			severity: toast.sev === 'default' ? undefined : toast.sev,
+			keepOpen: true,
+		})
+	}, [addToast, toasts, toast])
+	return null
+}
+
+/**
+ * One real toast per card. The SDK owns the toast UI (DefaultToasts is the real
+ * viewport). Each card gets its OWN TldrawUiContextProvider so its toast state is
+ * isolated — TldrawUiToastsProvider reuses a parent context if one exists, so the
+ * card must not sit under a page-level provider (hence the toast section is
+ * outside the page IsolationProviders). The stage's transform is a containing
+ * block so the viewport's fixed positioning stays in the card.
+ */
+const ToastCard = ({
+	toast,
+}: {
+	toast: { title: string; sev: Sev; keepOpen?: boolean; source: string }
+}): ReactNode => (
+	<IsolationProviders>
+		<div className="toastCardStage">
+			<FireToast toast={toast} />
 			<DefaultToasts />
 		</div>
-	)
-}
+	</IsolationProviders>
+)
 
 /**
  * TldrawUiTooltip has no `open` prop (its open state is internal hover), so we
@@ -99,9 +94,8 @@ export function Component() {
 			<Helmet>
 				<title>Feedback & overlays — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
-			<IsolationProviders>
 				<div className="page">
 					<DevComponentsNav />
 					<header className="page__header">
@@ -115,52 +109,28 @@ export function Component() {
 					</header>
 
 					<section className="section">
-						<h2 className="section__title">Toasts — live (no trigger)</h2>
+						<h2 className="section__title">Toasts — all {TOASTS.length}, each live</h2>
 						<p className="section__note">
-							The real SDK toast UI (<code>DefaultToasts</code>), one per severity. We don&rsquo;t
-							trigger them — we fake the <em>state</em> by firing a <code>keepOpen</code> toast of
-							each severity on mount. Real UI, fake content.
+							Every <code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> call site,
+							rendered as a real toast. Each card has its own <code>TldrawUiToastsProvider</code> and
+							fires its one toast <code>keepOpen</code> on mount — real SDK toast UI, no trigger.
 						</p>
-						<LiveToasts />
-					</section>
-
-					<section className="section">
-						<h2 className="section__title">Toasts — all {TOASTS.length} call sites</h2>
-						<p className="section__note">
-							Where the app actually fires them: every{' '}
-							<code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> call. dotcom renders
-							no toast component — it owns the call sites (the data), the SDK owns the UI (shown
-							live above). Cards below catalogue the call sites.
-						</p>
-						<div className="stats" style={{ marginBottom: 20 }}>
-							<Stat n="6" label="severity: error" />
-							<Stat n="6" label="no severity (neutral)" />
-							<Stat n="2" label="success" />
-							<Stat n="1" label="info" />
-							<Stat n="1" label="warning" />
+						<div className="grid grid--toasts">
+							{TOASTS.map((t) => (
+								<Specimen
+									key={t.source}
+									label={t.title}
+									code={`severity: ${t.sev}${t.keepOpen ? ' · keepOpen' : ''}`}
+									meta={t.keepOpen ? 'manual dismiss' : 'auto-dismiss'}
+									source={t.source}
+								>
+									<ToastCard toast={t} />
+								</Specimen>
+							))}
 						</div>
-						<table className="matrix">
-							<thead>
-								<tr>
-									<th>toast</th>
-									<th>severity</th>
-									<th>dismiss</th>
-									<th>source</th>
-								</tr>
-							</thead>
-							<tbody>
-								{TOASTS.map((t) => (
-									<tr key={t.source}>
-										<td>{t.title}</td>
-										<td>{t.sev}</td>
-										<td>{t.keepOpen ? 'keepOpen' : 'auto'}</td>
-										<td>{t.source}</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
 					</section>
 
+					<IsolationProviders>
 					<section className="section">
 						<h2 className="section__title">Tooltips — live (forced open)</h2>
 						<p className="section__note">
@@ -194,8 +164,8 @@ export function Component() {
 							</TldrawUiPopover>
 						</div>
 					</section>
+					</IsolationProviders>
 				</div>
-			</IsolationProviders>
 		</div>
 	)
 }
@@ -247,6 +217,8 @@ const PAGE_CSS = `
 .stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 14px 18px; min-width: 130px; background: var(--tl-color-panel); }
 .stat__n { font-size: 24px; font-weight: 700; font-family: ui-monospace, monospace; }
 .stat__label { font-size: 11px; color: var(--tl-color-text-1); margin-top: 4px; }
+.grid--toasts { grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); }
+.toastCardStage { position: relative; transform: translateZ(0); width: 100%; min-height: 150px; overflow: hidden; }
 .toastStage { position: relative; transform: translateZ(0); min-height: 320px; border: 1px solid var(--tl-color-divider); border-radius: 8px; background: var(--tl-color-low); overflow: hidden; }
 .toastMock { padding: 9px 11px; border-radius: 6px; font-size: 12px; background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); border-left: 3px solid var(--tl-color-text-3); width: 100%; box-sizing: border-box; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
 .toastMock[data-sev=error] { border-left-color: var(--tl-color-danger, #dc322f); }

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -68,6 +68,7 @@ export function Component() {
 								code={`addToast({ severity: '${t.sev}'${t.keepOpen ? ', keepOpen: true' : ''} })`}
 								meta={t.keepOpen ? 'keepOpen — manual dismiss' : 'auto-dismiss'}
 								source={t.source}
+								mock
 							>
 								<div className="toastMock" data-sev={t.sev}>
 									{t.title}
@@ -85,7 +86,7 @@ export function Component() {
 					</p>
 					<div className="grid">
 						{TOOLTIPS.map((t) => (
-							<Specimen key={t.name + t.source} label={t.name} code={t.code} meta={t.meta} source={t.source}>
+							<Specimen key={t.name + t.source} label={t.name} code={t.code} meta={t.meta} source={t.source} mock>
 								<div className="tipMock">{t.sample}</div>
 							</Specimen>
 						))}
@@ -104,6 +105,7 @@ export function Component() {
 							code={`<TldrawUiPopoverRoot><Trigger/><Content/>`}
 							meta="Radix popover · ×1 consumer"
 							source="TlaFileShareMenu.tsx"
+							mock
 						>
 							<div className="popMock">
 								<div className="popMock__trigger">Share ▾</div>

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable tldraw/jsx-no-literals */
-import { ReactNode } from 'react'
+import { ReactNode, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
+import { DefaultToasts, useToasts } from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
+import { IsolationProviders } from './dev-editor-harness'
 
 /**
  * Dev-only inventory of the dotcom app's transient feedback & overlay UI:
@@ -23,6 +25,44 @@ const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
 	</div>
 )
 
+/**
+ * Real toasts, no trigger. The SDK owns the toast UI (DefaultToasts is the real
+ * viewport); we fake the state by firing one keepOpen toast per severity on
+ * mount. So the UI is genuine — only the content is fake. The .toastStage's
+ * transform makes it a containing block so the viewport's fixed positioning
+ * stays inside the card instead of floating to the window corner.
+ */
+const LIVE_TOASTS: ReadonlyArray<{
+	id: string
+	severity?: 'error' | 'warning' | 'info' | 'success'
+	title: string
+	description?: string
+}> = [
+	{
+		id: 'lt-error',
+		severity: 'error',
+		title: 'Could not load file',
+		description: 'Something went wrong. Please try again.',
+	},
+	{ id: 'lt-warning', severity: 'warning', title: 'Unsupported mermaid diagram' },
+	{ id: 'lt-info', severity: 'info', title: 'Uploading .tldr files…' },
+	{ id: 'lt-success', severity: 'success', title: 'Feedback submitted' },
+	{ id: 'lt-neutral', title: 'Copied invite link' },
+]
+
+const LiveToasts = (): ReactNode => {
+	const { addToast, toasts } = useToasts()
+	useEffect(() => {
+		if (toasts.get().length > 0) return
+		for (const t of LIVE_TOASTS) addToast({ ...t, keepOpen: true })
+	}, [addToast, toasts])
+	return (
+		<div className="toastStage">
+			<DefaultToasts />
+		</div>
+	)
+}
+
 export function Component() {
 	return (
 		<div
@@ -34,87 +74,106 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
-			<div className="page">
-				<DevComponentsNav />
-				<header className="page__header">
-					<h1 className="page__title">Feedback &amp; overlays</h1>
-					<p className="page__lede">
-						Toasts, tooltips, popovers — transient UI the app <strong>delegates</strong> to the SDK.
-						A new mode: not "own and diverge" (buttons) but "call and render nothing." For toasts the
-						app owns <em>no</em> component at all — it calls <code>addToast()</code> and the SDK draws
-						it.
-					</p>
-				</header>
+			<IsolationProviders>
+				<div className="page">
+					<DevComponentsNav />
+					<header className="page__header">
+						<h1 className="page__title">Feedback &amp; overlays</h1>
+						<p className="page__lede">
+							Toasts, tooltips, popovers — transient UI the app <strong>delegates</strong> to the
+							SDK. A new mode: not "own and diverge" (buttons) but "call and render nothing." For
+							toasts the app owns <em>no</em> component at all — it calls <code>addToast()</code>{' '}
+							and the SDK draws it.
+						</p>
+					</header>
 
-				<section className="section">
-					<h2 className="section__title">Toasts — all {TOASTS.length} call sites</h2>
-					<p className="section__note">
-						Every <code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> in the app. No toast
-						component is rendered by dotcom; the SDK&rsquo;s toast manager owns the UI. Mocks below
-						are coloured by severity.
-					</p>
-					<div className="stats" style={{ marginBottom: 20 }}>
-						<Stat n="6" label="severity: error" />
-						<Stat n="6" label="no severity (neutral)" />
-						<Stat n="2" label="success" />
-						<Stat n="1" label="info" />
-						<Stat n="1" label="warning" />
-					</div>
-					<div className="grid">
-						{TOASTS.map((t) => (
+					<section className="section">
+						<h2 className="section__title">Toasts — live (no trigger)</h2>
+						<p className="section__note">
+							The real SDK toast UI (<code>DefaultToasts</code>), one per severity. We don&rsquo;t
+							trigger them — we fake the <em>state</em> by firing a <code>keepOpen</code> toast of
+							each severity on mount. Real UI, fake content.
+						</p>
+						<LiveToasts />
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Toasts — all {TOASTS.length} call sites</h2>
+						<p className="section__note">
+							Where the app actually fires them: every{' '}
+							<code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> call. dotcom renders
+							no toast component — it owns the call sites (the data), the SDK owns the UI (shown
+							live above). Cards below catalogue the call sites.
+						</p>
+						<div className="stats" style={{ marginBottom: 20 }}>
+							<Stat n="6" label="severity: error" />
+							<Stat n="6" label="no severity (neutral)" />
+							<Stat n="2" label="success" />
+							<Stat n="1" label="info" />
+							<Stat n="1" label="warning" />
+						</div>
+						<div className="grid">
+							{TOASTS.map((t) => (
+								<Specimen
+									key={t.source}
+									label={t.title}
+									code={`addToast({ severity: '${t.sev}'${t.keepOpen ? ', keepOpen: true' : ''} })`}
+									meta={t.keepOpen ? 'keepOpen — manual dismiss' : 'auto-dismiss'}
+									source={t.source}
+									mock
+								>
+									<div className="toastMock" data-sev={t.sev}>
+										{t.title}
+									</div>
+								</Specimen>
+							))}
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Tooltips</h2>
+						<p className="section__note">
+							<code>TldrawUiTooltip</code> (SDK) used directly in 3 files, plus the{' '}
+							<code>TlaMenuControlInfoTooltip</code> app wrapper. Mocked.
+						</p>
+						<div className="grid">
+							{TOOLTIPS.map((t) => (
+								<Specimen
+									key={t.name + t.source}
+									label={t.name}
+									code={t.code}
+									meta={t.meta}
+									source={t.source}
+									mock
+								>
+									<div className="tipMock">{t.sample}</div>
+								</Specimen>
+							))}
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Popovers</h2>
+						<p className="section__note">
+							<code>TldrawUiPopover</code> (SDK: Root / Trigger / Content) — one consumer, the share
+							menu. Mocked.
+						</p>
+						<div className="grid">
 							<Specimen
-								key={t.source}
-								label={t.title}
-								code={`addToast({ severity: '${t.sev}'${t.keepOpen ? ', keepOpen: true' : ''} })`}
-								meta={t.keepOpen ? 'keepOpen — manual dismiss' : 'auto-dismiss'}
-								source={t.source}
+								label="TldrawUiPopover"
+								code={`<TldrawUiPopoverRoot><Trigger/><Content/>`}
+								meta="Radix popover · ×1 consumer"
+								source="TlaFileShareMenu.tsx"
 								mock
 							>
-								<div className="toastMock" data-sev={t.sev}>
-									{t.title}
+								<div className="popMock">
+									<div className="popMock__trigger">Share ▾</div>
 								</div>
 							</Specimen>
-						))}
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Tooltips</h2>
-					<p className="section__note">
-						<code>TldrawUiTooltip</code> (SDK) used directly in 3 files, plus the{' '}
-						<code>TlaMenuControlInfoTooltip</code> app wrapper. Mocked.
-					</p>
-					<div className="grid">
-						{TOOLTIPS.map((t) => (
-							<Specimen key={t.name + t.source} label={t.name} code={t.code} meta={t.meta} source={t.source} mock>
-								<div className="tipMock">{t.sample}</div>
-							</Specimen>
-						))}
-					</div>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Popovers</h2>
-					<p className="section__note">
-						<code>TldrawUiPopover</code> (SDK: Root / Trigger / Content) — one consumer, the share
-						menu. Mocked.
-					</p>
-					<div className="grid">
-						<Specimen
-							label="TldrawUiPopover"
-							code={`<TldrawUiPopoverRoot><Trigger/><Content/>`}
-							meta="Radix popover · ×1 consumer"
-							source="TlaFileShareMenu.tsx"
-							mock
-						>
-							<div className="popMock">
-								<div className="popMock__trigger">Share ▾</div>
-							</div>
-						</Specimen>
-					</div>
-				</section>
-
-			</div>
+						</div>
+					</section>
+				</div>
+			</IsolationProviders>
 		</div>
 	)
 }
@@ -133,18 +192,53 @@ const TOASTS: ReadonlyArray<{ title: string; sev: Sev; keepOpen?: boolean; sourc
 	{ title: 'Error accepting invite', sev: 'error', source: 'TldrawApp:1298' },
 	{ title: 'Error accepting invite', sev: 'error', source: 'TldrawApp:1313' },
 	{ title: 'Copied link', sev: 'default', source: 'TlaFileMenu:147' },
-	{ title: 'Workspace invite error', sev: 'error', keepOpen: true, source: 'WorkspaceInviteHandler:122' },
+	{
+		title: 'Workspace invite error',
+		sev: 'error',
+		keepOpen: true,
+		source: 'WorkspaceInviteHandler:122',
+	},
 	{ title: 'Already a member', sev: 'default', source: 'WorkspaceInviteHandler:155' },
 	{ title: 'Feedback submitted', sev: 'success', source: 'SubmitFeedbackDialog:107' },
 	{ title: 'Debug mode', sev: 'default', keepOpen: true, source: 'SneakyDebugModeToast:26' },
 	{ title: 'Import failed', sev: 'error', keepOpen: true, source: 'local.tsx:54' },
 ]
 
-const TOOLTIPS: ReadonlyArray<{ name: string; code: string; meta: string; sample: string; source: string }> = [
-	{ name: 'TldrawUiTooltip', code: '<TldrawUiTooltip content>', meta: 'SDK · sidebar file link', sample: 'Rename', source: 'TlaSidebarFileLink.tsx' },
-	{ name: 'TldrawUiTooltip', code: '<TldrawUiTooltip content>', meta: 'SDK · menu control', sample: 'Info', source: 'tla-menu.tsx' },
-	{ name: 'TldrawUiTooltip', code: '<TldrawUiTooltip content>', meta: 'SDK · workspace settings', sample: 'Copy', source: 'WorkspaceSettingsDialog.tsx' },
-	{ name: 'TlaMenuControlInfoTooltip', code: '<TlaMenuControlInfoTooltip>', meta: 'app wrapper · ×4', sample: 'ⓘ', source: 'tla-menu.tsx' },
+const TOOLTIPS: ReadonlyArray<{
+	name: string
+	code: string
+	meta: string
+	sample: string
+	source: string
+}> = [
+	{
+		name: 'TldrawUiTooltip',
+		code: '<TldrawUiTooltip content>',
+		meta: 'SDK · sidebar file link',
+		sample: 'Rename',
+		source: 'TlaSidebarFileLink.tsx',
+	},
+	{
+		name: 'TldrawUiTooltip',
+		code: '<TldrawUiTooltip content>',
+		meta: 'SDK · menu control',
+		sample: 'Info',
+		source: 'tla-menu.tsx',
+	},
+	{
+		name: 'TldrawUiTooltip',
+		code: '<TldrawUiTooltip content>',
+		meta: 'SDK · workspace settings',
+		sample: 'Copy',
+		source: 'WorkspaceSettingsDialog.tsx',
+	},
+	{
+		name: 'TlaMenuControlInfoTooltip',
+		code: '<TlaMenuControlInfoTooltip>',
+		meta: 'app wrapper · ×4',
+		sample: 'ⓘ',
+		source: 'tla-menu.tsx',
+	},
 ]
 
 const PAGE_CSS = `
@@ -168,6 +262,7 @@ const PAGE_CSS = `
 .stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 14px 18px; min-width: 130px; background: var(--tl-color-panel); }
 .stat__n { font-size: 24px; font-weight: 700; font-family: ui-monospace, monospace; }
 .stat__label { font-size: 11px; color: var(--tl-color-text-1); margin-top: 4px; }
+.toastStage { position: relative; transform: translateZ(0); min-height: 320px; border: 1px solid var(--tl-color-divider); border-radius: 8px; background: var(--tl-color-low); overflow: hidden; }
 .toastMock { padding: 9px 11px; border-radius: 6px; font-size: 12px; background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); border-left: 3px solid var(--tl-color-text-3); width: 100%; box-sizing: border-box; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
 .toastMock[data-sev=error] { border-left-color: var(--tl-color-danger, #dc322f); }
 .toastMock[data-sev=warning] { border-left-color: var(--tl-color-warning, #cb4b16); }

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -112,13 +112,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					The delegation pattern is why these families don&rsquo;t drift: the app holds no
-					implementation to diverge. Toasts are the purest case — 16 call sites, zero app-owned UI.
-					Set against the buttons page (three implementations of one button), it shows the gallery&rsquo;s
-					deepest pattern: <strong>divergence is a function of ownership</strong>. What the app owns,
-					it diverges on; what it delegates, it doesn&rsquo;t.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable tldraw/jsx-no-literals */
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
 import { Tooltip as RadixTooltip } from 'radix-ui'
 import { ReactNode, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -1,0 +1,185 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's transient feedback & overlay UI:
+ * toasts, tooltips, popovers. These show the DELEGATION mode — the app owns no
+ * implementation, it calls the SDK. Toasts especially: the app renders nothing,
+ * it just calls addToast(); the SDK owns the toast UI entirely. The opposite
+ * pole from TlaButton (own + diverge). Every toast call site is shown.
+ *
+ * Route: /dev/components/overlays.
+ */
+
+const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
+	<div className="stat">
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Feedback & overlays — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Feedback &amp; overlays</h1>
+					<p className="page__lede">
+						Toasts, tooltips, popovers — transient UI the app <strong>delegates</strong> to the SDK.
+						A new mode: not "own and diverge" (buttons) but "call and render nothing." For toasts the
+						app owns <em>no</em> component at all — it calls <code>addToast()</code> and the SDK draws
+						it.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">Toasts — all {TOASTS.length} call sites</h2>
+					<p className="section__note">
+						Every <code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> in the app. No toast
+						component is rendered by dotcom; the SDK&rsquo;s toast manager owns the UI. Mocks below
+						are coloured by severity.
+					</p>
+					<div className="stats" style={{ marginBottom: 20 }}>
+						<Stat n="6" label="severity: error" />
+						<Stat n="6" label="no severity (neutral)" />
+						<Stat n="2" label="success" />
+						<Stat n="1" label="info" />
+						<Stat n="1" label="warning" />
+					</div>
+					<div className="grid">
+						{TOASTS.map((t) => (
+							<Specimen
+								key={t.source}
+								label={t.title}
+								code={`addToast({ severity: '${t.sev}'${t.keepOpen ? ', keepOpen: true' : ''} })`}
+								meta={t.keepOpen ? 'keepOpen — manual dismiss' : 'auto-dismiss'}
+								source={t.source}
+							>
+								<div className="toastMock" data-sev={t.sev}>
+									{t.title}
+								</div>
+							</Specimen>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Tooltips</h2>
+					<p className="section__note">
+						<code>TldrawUiTooltip</code> (SDK) used directly in 3 files, plus the{' '}
+						<code>TlaMenuControlInfoTooltip</code> app wrapper. Mocked.
+					</p>
+					<div className="grid">
+						{TOOLTIPS.map((t) => (
+							<Specimen key={t.name + t.source} label={t.name} code={t.code} meta={t.meta} source={t.source}>
+								<div className="tipMock">{t.sample}</div>
+							</Specimen>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Popovers</h2>
+					<p className="section__note">
+						<code>TldrawUiPopover</code> (SDK: Root / Trigger / Content) — one consumer, the share
+						menu. Mocked.
+					</p>
+					<div className="grid">
+						<Specimen
+							label="TldrawUiPopover"
+							code={`<TldrawUiPopoverRoot><Trigger/><Content/>`}
+							meta="Radix popover · ×1 consumer"
+							source="TlaFileShareMenu.tsx"
+						>
+							<div className="popMock">
+								<div className="popMock__trigger">Share ▾</div>
+							</div>
+						</Specimen>
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					The delegation pattern is why these families don&rsquo;t drift: the app holds no
+					implementation to diverge. Toasts are the purest case — 16 call sites, zero app-owned UI.
+					Set against the buttons page (three implementations of one button), it shows the gallery&rsquo;s
+					deepest pattern: <strong>divergence is a function of ownership</strong>. What the app owns,
+					it diverges on; what it delegates, it doesn&rsquo;t.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+type Sev = 'error' | 'warning' | 'info' | 'success' | 'default'
+
+const TOASTS: ReadonlyArray<{ title: string; sev: Sev; keepOpen?: boolean; source: string }> = [
+	{ title: 'Shared document open error', sev: 'error', source: 'SneakyOnDropOverride:28' },
+	{ title: 'Unsupported mermaid diagram', sev: 'warning', source: 'SneakyMermaidHandler:55' },
+	{ title: 'Mutation error', sev: 'default', source: 'TldrawApp:391' },
+	{ title: 'Max files reached', sev: 'default', keepOpen: true, source: 'TldrawApp:696' },
+	{ title: 'Uploading .tldr files…', sev: 'info', source: 'TldrawApp:1111' },
+	{ title: 'Unknown error', sev: 'error', keepOpen: true, source: 'TldrawApp:1149' },
+	{ title: 'Adding .tldr files', sev: 'success', source: 'TldrawApp:1176' },
+	{ title: 'Copied invite link', sev: 'default', source: 'TldrawApp:1280' },
+	{ title: 'Error accepting invite', sev: 'error', source: 'TldrawApp:1298' },
+	{ title: 'Error accepting invite', sev: 'error', source: 'TldrawApp:1313' },
+	{ title: 'Copied link', sev: 'default', source: 'TlaFileMenu:147' },
+	{ title: 'Workspace invite error', sev: 'error', keepOpen: true, source: 'WorkspaceInviteHandler:122' },
+	{ title: 'Already a member', sev: 'default', source: 'WorkspaceInviteHandler:155' },
+	{ title: 'Feedback submitted', sev: 'success', source: 'SubmitFeedbackDialog:107' },
+	{ title: 'Debug mode', sev: 'default', keepOpen: true, source: 'SneakyDebugModeToast:26' },
+	{ title: 'Import failed', sev: 'error', keepOpen: true, source: 'local.tsx:54' },
+]
+
+const TOOLTIPS: ReadonlyArray<{ name: string; code: string; meta: string; sample: string; source: string }> = [
+	{ name: 'TldrawUiTooltip', code: '<TldrawUiTooltip content>', meta: 'SDK · sidebar file link', sample: 'Rename', source: 'TlaSidebarFileLink.tsx' },
+	{ name: 'TldrawUiTooltip', code: '<TldrawUiTooltip content>', meta: 'SDK · menu control', sample: 'Info', source: 'tla-menu.tsx' },
+	{ name: 'TldrawUiTooltip', code: '<TldrawUiTooltip content>', meta: 'SDK · workspace settings', sample: 'Copy', source: 'WorkspaceSettingsDialog.tsx' },
+	{ name: 'TlaMenuControlInfoTooltip', code: '<TlaMenuControlInfoTooltip>', meta: 'app wrapper · ×4', sample: 'ⓘ', source: 'tla-menu.tsx' },
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong, .page__footer strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede code, .section__note code, .page__footer code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.stats { display: flex; gap: 12px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 14px 18px; min-width: 130px; background: var(--tl-color-panel); }
+.stat__n { font-size: 24px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat__label { font-size: 11px; color: var(--tl-color-text-1); margin-top: 4px; }
+.toastMock { padding: 9px 11px; border-radius: 6px; font-size: 12px; background: var(--tl-color-panel); border: 1px solid var(--tl-color-divider); border-left: 3px solid var(--tl-color-text-3); width: 100%; box-sizing: border-box; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+.toastMock[data-sev=error] { border-left-color: var(--tl-color-danger, #dc322f); }
+.toastMock[data-sev=warning] { border-left-color: var(--tl-color-warning, #cb4b16); }
+.toastMock[data-sev=info] { border-left-color: var(--tl-color-primary); }
+.toastMock[data-sev=success] { border-left-color: var(--tl-color-success, #2a9d3c); }
+.tipMock { font-size: 12px; color: var(--tl-color-panel-contrast, #fff); background: var(--tl-color-tooltip, #1d1d1d); padding: 5px 9px; border-radius: 5px; }
+.popMock { display: inline-block; }
+.popMock__trigger { font-size: 13px; padding: 6px 12px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -96,41 +96,41 @@ export function Component() {
 			</Helmet>
 			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
-				<div className="page">
-					<DevComponentsNav />
-					<header className="page__header">
-						<h1 className="page__title">Feedback &amp; overlays</h1>
-						<p className="page__lede">
-							Toasts, tooltips, popovers — transient UI the app <strong>delegates</strong> to the
-							SDK. A new mode: not "own and diverge" (buttons) but "call and render nothing." For
-							toasts the app owns <em>no</em> component at all — it calls <code>addToast()</code>{' '}
-							and the SDK draws it.
-						</p>
-					</header>
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Feedback &amp; overlays</h1>
+					<p className="page__lede">
+						Toasts, tooltips, popovers — transient UI the app <strong>delegates</strong> to the SDK.
+						A new mode: not "own and diverge" (buttons) but "call and render nothing." For toasts
+						the app owns <em>no</em> component at all — it calls <code>addToast()</code> and the SDK
+						draws it.
+					</p>
+				</header>
 
-					<section className="section">
-						<h2 className="section__title">Toasts — all {TOASTS.length}, each live</h2>
-						<p className="section__note">
-							Every <code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> call site,
-							rendered as a real toast. Each card has its own <code>TldrawUiToastsProvider</code> and
-							fires its one toast <code>keepOpen</code> on mount — real SDK toast UI, no trigger.
-						</p>
-						<div className="grid grid--toasts">
-							{TOASTS.map((t) => (
-								<Specimen
-									key={t.source}
-									label={t.title}
-									code={`severity: ${t.sev}${t.keepOpen ? ' · keepOpen' : ''}`}
-									meta={t.keepOpen ? 'manual dismiss' : 'auto-dismiss'}
-									source={t.source}
-								>
-									<ToastCard toast={t} />
-								</Specimen>
-							))}
-						</div>
-					</section>
+				<section className="section">
+					<h2 className="section__title">Toasts — all {TOASTS.length}, each live</h2>
+					<p className="section__note">
+						Every <code>addToast(&#123; title, severity?, keepOpen? &#125;)</code> call site,
+						rendered as a real toast. Each card has its own <code>TldrawUiToastsProvider</code> and
+						fires its one toast <code>keepOpen</code> on mount — real SDK toast UI, no trigger.
+					</p>
+					<div className="grid grid--toasts">
+						{TOASTS.map((t) => (
+							<Specimen
+								key={t.source}
+								label={t.title}
+								code={`severity: ${t.sev}${t.keepOpen ? ' · keepOpen' : ''}`}
+								meta={t.keepOpen ? 'manual dismiss' : 'auto-dismiss'}
+								source={t.source}
+							>
+								<ToastCard toast={t} />
+							</Specimen>
+						))}
+					</div>
+				</section>
 
-					<IsolationProviders>
+				<IsolationProviders>
 					<section className="section">
 						<h2 className="section__title">Tooltips — live (forced open)</h2>
 						<p className="section__note">
@@ -164,8 +164,8 @@ export function Component() {
 							</TldrawUiPopover>
 						</div>
 					</section>
-					</IsolationProviders>
-				</div>
+				</IsolationProviders>
+			</div>
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/pages/dev-overlays.tsx
+++ b/apps/dotcom/client/src/pages/dev-overlays.tsx
@@ -1,10 +1,18 @@
 /* eslint-disable tldraw/jsx-no-literals */
+import { Tooltip as RadixTooltip } from 'radix-ui'
 import { ReactNode, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { DefaultToasts, useToasts } from 'tldraw'
+import {
+	DefaultToasts,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	TldrawUiPopover,
+	TldrawUiPopoverContent,
+	TldrawUiPopoverTrigger,
+	useToasts,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
-import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
 import { IsolationProviders } from './dev-editor-harness'
 
@@ -63,6 +71,25 @@ const LiveToasts = (): ReactNode => {
 	)
 }
 
+/**
+ * TldrawUiTooltip has no `open` prop (its open state is internal hover), so we
+ * compose the same Radix Tooltip primitives it uses, with the SDK .tlui-tooltip
+ * styling, forced open. Real tooltip UI, no hover.
+ */
+const LiveTooltip = ({ label, content }: { label: string; content: string }): ReactNode => (
+	<RadixTooltip.Root open delayDuration={0}>
+		<RadixTooltip.Trigger asChild>
+			<button className="tipTrigger" type="button">
+				{label}
+			</button>
+		</RadixTooltip.Trigger>
+		<RadixTooltip.Content className="tlui-tooltip" side="top" sideOffset={6}>
+			{content}
+			<RadixTooltip.Arrow className="tlui-tooltip__arrow" />
+		</RadixTooltip.Content>
+	</RadixTooltip.Root>
+)
+
 export function Component() {
 	return (
 		<div
@@ -72,7 +99,7 @@ export function Component() {
 			<Helmet>
 				<title>Feedback & overlays — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+			<style>{PAGE_CSS}</style>
 
 			<IsolationProviders>
 				<div className="page">
@@ -112,64 +139,59 @@ export function Component() {
 							<Stat n="1" label="info" />
 							<Stat n="1" label="warning" />
 						</div>
-						<div className="grid">
-							{TOASTS.map((t) => (
-								<Specimen
-									key={t.source}
-									label={t.title}
-									code={`addToast({ severity: '${t.sev}'${t.keepOpen ? ', keepOpen: true' : ''} })`}
-									meta={t.keepOpen ? 'keepOpen — manual dismiss' : 'auto-dismiss'}
-									source={t.source}
-									mock
-								>
-									<div className="toastMock" data-sev={t.sev}>
-										{t.title}
-									</div>
-								</Specimen>
-							))}
+						<table className="matrix">
+							<thead>
+								<tr>
+									<th>toast</th>
+									<th>severity</th>
+									<th>dismiss</th>
+									<th>source</th>
+								</tr>
+							</thead>
+							<tbody>
+								{TOASTS.map((t) => (
+									<tr key={t.source}>
+										<td>{t.title}</td>
+										<td>{t.sev}</td>
+										<td>{t.keepOpen ? 'keepOpen' : 'auto'}</td>
+										<td>{t.source}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Tooltips — live (forced open)</h2>
+						<p className="section__note">
+							<code>TldrawUiTooltip</code> exposes no <code>open</code> prop (its state is internal
+							hover), so these compose the same Radix <code>Tooltip</code> primitives it uses with
+							the SDK <code>.tlui-tooltip</code> styling, forced open. Real tooltip UI, no hover.
+						</p>
+						<div className="tipStage">
+							<LiveTooltip label="Rename" content="Rename this file" />
+							<LiveTooltip label="ⓘ" content="More information about this setting" />
+							<LiveTooltip label="Copy" content="Copy link" />
 						</div>
 					</section>
 
 					<section className="section">
-						<h2 className="section__title">Tooltips</h2>
+						<h2 className="section__title">Popover — live (forced open)</h2>
 						<p className="section__note">
-							<code>TldrawUiTooltip</code> (SDK) used directly in 3 files, plus the{' '}
-							<code>TlaMenuControlInfoTooltip</code> app wrapper. Mocked.
+							The real <code>TldrawUiPopover</code> (Root / Trigger / Content), forced open via its{' '}
+							<code>open</code> prop — the share menu&rsquo;s one popover consumer.
 						</p>
-						<div className="grid">
-							{TOOLTIPS.map((t) => (
-								<Specimen
-									key={t.name + t.source}
-									label={t.name}
-									code={t.code}
-									meta={t.meta}
-									source={t.source}
-									mock
-								>
-									<div className="tipMock">{t.sample}</div>
-								</Specimen>
-							))}
-						</div>
-					</section>
-
-					<section className="section">
-						<h2 className="section__title">Popovers</h2>
-						<p className="section__note">
-							<code>TldrawUiPopover</code> (SDK: Root / Trigger / Content) — one consumer, the share
-							menu. Mocked.
-						</p>
-						<div className="grid">
-							<Specimen
-								label="TldrawUiPopover"
-								code={`<TldrawUiPopoverRoot><Trigger/><Content/>`}
-								meta="Radix popover · ×1 consumer"
-								source="TlaFileShareMenu.tsx"
-								mock
-							>
-								<div className="popMock">
-									<div className="popMock__trigger">Share ▾</div>
-								</div>
-							</Specimen>
+						<div className="popStage">
+							<TldrawUiPopover id="dev-popover" open>
+								<TldrawUiPopoverTrigger>
+									<TldrawUiButton type="normal">
+										<TldrawUiButtonLabel>Share</TldrawUiButtonLabel>
+									</TldrawUiButton>
+								</TldrawUiPopoverTrigger>
+								<TldrawUiPopoverContent side="bottom" align="start">
+									<div className="popoverDemo">Anyone with the link can view this file.</div>
+								</TldrawUiPopoverContent>
+							</TldrawUiPopover>
 						</div>
 					</section>
 				</div>
@@ -204,43 +226,6 @@ const TOASTS: ReadonlyArray<{ title: string; sev: Sev; keepOpen?: boolean; sourc
 	{ title: 'Import failed', sev: 'error', keepOpen: true, source: 'local.tsx:54' },
 ]
 
-const TOOLTIPS: ReadonlyArray<{
-	name: string
-	code: string
-	meta: string
-	sample: string
-	source: string
-}> = [
-	{
-		name: 'TldrawUiTooltip',
-		code: '<TldrawUiTooltip content>',
-		meta: 'SDK · sidebar file link',
-		sample: 'Rename',
-		source: 'TlaSidebarFileLink.tsx',
-	},
-	{
-		name: 'TldrawUiTooltip',
-		code: '<TldrawUiTooltip content>',
-		meta: 'SDK · menu control',
-		sample: 'Info',
-		source: 'tla-menu.tsx',
-	},
-	{
-		name: 'TldrawUiTooltip',
-		code: '<TldrawUiTooltip content>',
-		meta: 'SDK · workspace settings',
-		sample: 'Copy',
-		source: 'WorkspaceSettingsDialog.tsx',
-	},
-	{
-		name: 'TlaMenuControlInfoTooltip',
-		code: '<TlaMenuControlInfoTooltip>',
-		meta: 'app wrapper · ×4',
-		sample: 'ⓘ',
-		source: 'tla-menu.tsx',
-	},
-]
-
 const PAGE_CSS = `
 .page {
 	min-height: 100vh;
@@ -268,6 +253,13 @@ const PAGE_CSS = `
 .toastMock[data-sev=warning] { border-left-color: var(--tl-color-warning, #cb4b16); }
 .toastMock[data-sev=info] { border-left-color: var(--tl-color-primary); }
 .toastMock[data-sev=success] { border-left-color: var(--tl-color-success, #2a9d3c); }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; width: 100%; max-width: 760px; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.tipStage { display: flex; gap: 64px; align-items: center; padding: 56px 32px 28px; border: 1px solid var(--tl-color-divider); border-radius: 8px; background: var(--tl-color-low); }
+.tipTrigger { font-size: 13px; padding: 6px 12px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); color: var(--tl-color-text); cursor: default; }
+.popStage { position: relative; min-height: 180px; padding: 20px; border: 1px solid var(--tl-color-divider); border-radius: 8px; background: var(--tl-color-low); }
+.popoverDemo { padding: 12px 14px; font-size: 13px; max-width: 240px; line-height: 1.5; }
 .tipMock { font-size: 12px; color: var(--tl-color-panel-contrast, #fff); background: var(--tl-color-tooltip, #1d1d1d); padding: 5px 9px; border-radius: 5px; }
 .popMock { display: inline-block; }
 .popMock__trigger { font-size: 13px; padding: 6px 12px; border: 1px solid var(--tl-color-divider); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); }

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { InstancePresenceRecordType, TLUserId, useEditor } from 'tldraw'
+import { InstancePresenceRecordType, PeopleMenu, TLUserId, useEditor } from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
-import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
 import { MinimalEditorHarness } from './dev-editor-harness'
 
@@ -59,9 +58,12 @@ const InjectPresence = (): ReactNode => {
 	return null
 }
 
-const LiveCursors = (): ReactNode => (
-	<MinimalEditorHarness height={300}>
+const LivePresence = (): ReactNode => (
+	<MinimalEditorHarness height={320}>
 		<InjectPresence />
+		<div className="presenceOverlay">
+			<PeopleMenu />
+		</div>
 	</MinimalEditorHarness>
 )
 
@@ -74,7 +76,7 @@ export function Component() {
 			<Helmet>
 				<title>Presence inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+			<style>{PAGE_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
@@ -99,80 +101,15 @@ export function Component() {
 				</section>
 
 				<section className="section">
-					<h2 className="section__title">Live cursors — fake collaborators, real UI</h2>
+					<h2 className="section__title">Live presence — fake collaborators, real UI</h2>
 					<p className="section__note">
-						No multiplayer session. The editor draws a cursor for every record in{' '}
-						<code>editor.getCollaborators()</code> — so we put three fake{' '}
-						<code>instance_presence</code> records into the store (
-						<code>lastActivityTimestamp: null</code> = always active). The cursors below are the
-						real SDK presence UI; only the collaborators are fake.
+						No multiplayer session. We put three fake <code>instance_presence</code> records into
+						the store (<code>lastActivityTimestamp: null</code> = always active); the editor then
+						draws the real collaborator cursors, and the real <code>PeopleMenu</code> (facepile +
+						current user, top-right) reads the same peers via <code>usePeerIds()</code>. All real UI
+						— only the collaborators are fake.
 					</p>
-					<LiveCursors />
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Share-panel presence (SDK-owned, mocked)</h2>
-					<p className="section__note">
-						These render inside the live editor / share panel; mocked here. dotcom supplies the
-						user&rsquo;s colour and identity, the SDK renders the rest.
-					</p>
-					<div className="grid">
-						<Specimen
-							label="live cursor"
-							code={`(SDK, from collaborator presence)`}
-							meta="name label in the user's colour"
-							source="editor — TlaEditor.tsx"
-							mock
-						>
-							<div className="cursorMock">
-								<svg width="16" height="16" viewBox="0 0 16 16">
-									<path d="M2 2 L2 13 L5.5 9.5 L8 14 L10 13 L7.5 8.5 L12 8 Z" fill="#268bd2" />
-								</svg>
-								<span className="cursorMock__name">Casey</span>
-							</div>
-						</Specimen>
-						<Specimen
-							label="facepile / avatars"
-							code={`<PeopleMenu> (SDK share panel)`}
-							meta="collaborators' avatars, by colour"
-							source="TldrawUiSharePanel"
-							mock
-						>
-							<div className="facepile">
-								<span className="avatar" style={{ background: '#268bd2' }}>
-									C
-								</span>
-								<span className="avatar" style={{ background: '#859900' }}>
-									J
-								</span>
-								<span className="avatar" style={{ background: '#cb4b16' }}>
-									M
-								</span>
-							</div>
-						</Specimen>
-						<Specimen
-							label="PeopleMenu trigger"
-							code={`<PeopleMenu>`}
-							meta="opens the collaborators list · ×3"
-							source="TlaInviteTab.tsx"
-							mock
-						>
-							<div className="ctrlMock">People ▾</div>
-						</Specimen>
-						<Specimen
-							label="TldrawCurrentUser"
-							code={`<TldrawCurrentUser />`}
-							meta="the local user's presence record · ×9"
-							source="TlaEditorTopRightPanel.tsx"
-							mock
-						>
-							<div className="facepile">
-								<span className="avatar" style={{ background: '#6c71c4' }}>
-									You
-								</span>
-							</div>
-						</Specimen>
-					</div>
+					<LivePresence />
 				</section>
 
 				<section className="section">
@@ -230,6 +167,7 @@ const PAGE_CSS = `
 .stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 180px; background: var(--tl-color-panel); }
 .stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
 .stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; font-family: ui-monospace, monospace; }
+.presenceOverlay { position: absolute; top: 12px; right: 12px; z-index: 100; }
 .cursorMock { display: inline-flex; align-items: center; gap: 4px; }
 .cursorMock__name { background: #268bd2; color: #fff; font-size: 11px; padding: 1px 6px; border-radius: 4px; }
 .facepile { display: inline-flex; }

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -127,9 +127,9 @@ export function Component() {
 					<h2 className="section__title">Live presence — fake collaborators, real UI</h2>
 					<p className="section__note">
 						No multiplayer session. Each card is a minimal editor with three fake{' '}
-						<code>instance_presence</code> records (<code>lastActivityTimestamp: null</code> = always
-						active); the real SDK presence components then render from that data. Real UI — only the
-						collaborators are fake.
+						<code>instance_presence</code> records (<code>lastActivityTimestamp: null</code> =
+						always active); the real SDK presence components then render from that data. Real UI —
+						only the collaborators are fake.
 					</p>
 					<div className="grid">
 						<Specimen
@@ -157,7 +157,11 @@ export function Component() {
 							source="TldrawUiSharePanel"
 						>
 							<PresenceCard>
-								<DefaultPeopleMenuFacePile userIds={COLLAB_IDS} userName="You" userColor="#6c71c4" />
+								<DefaultPeopleMenuFacePile
+									userIds={COLLAB_IDS}
+									userName="You"
+									userColor="#6c71c4"
+								/>
 							</PresenceCard>
 						</Specimen>
 						<Specimen

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -1,9 +1,17 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { ReactNode, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { InstancePresenceRecordType, PeopleMenu, TLUserId, useEditor } from 'tldraw'
+import {
+	DefaultPeopleMenuAvatar,
+	DefaultPeopleMenuFacePile,
+	InstancePresenceRecordType,
+	PeopleMenu,
+	TLUserId,
+	useEditor,
+} from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
 import { MinimalEditorHarness } from './dev-editor-harness'
 
@@ -32,12 +40,19 @@ const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
  * they never time out). Real UI, fake collaborators — no multiplayer needed.
  */
 const COLLABORATORS = [
-	{ id: 'user:casey', name: 'Casey', color: '#268bd2', x: 130, y: 90 },
-	{ id: 'user:jordan', name: 'Jordan', color: '#859900', x: 320, y: 150 },
-	{ id: 'user:morgan', name: 'Morgan', color: '#cb4b16', x: 210, y: 220 },
+	{ id: 'user:casey', name: 'Casey', color: '#268bd2', x: 70, y: 50 },
+	{ id: 'user:jordan', name: 'Jordan', color: '#859900', x: 180, y: 95 },
+	{ id: 'user:morgan', name: 'Morgan', color: '#cb4b16', x: 120, y: 140 },
 ]
+const COLLAB_IDS = COLLABORATORS.map((c) => c.id as TLUserId)
 
-const InjectPresence = (): ReactNode => {
+/**
+ * Puts fake collaborators into the editor store so the real presence UI has data
+ * to render (lastActivityTimestamp: null = always active). cursors=false parks
+ * them off-screen so cards that show a DOM component (facepile / menu) aren't
+ * cluttered by cursors on the canvas behind.
+ */
+const InjectPresence = ({ cursors }: { cursors?: boolean }): ReactNode => {
 	const editor = useEditor()
 	useEffect(() => {
 		const currentPageId = editor.getCurrentPageId()
@@ -49,21 +64,29 @@ const InjectPresence = (): ReactNode => {
 					userName: c.name,
 					currentPageId,
 					color: c.color,
-					cursor: { x: c.x, y: c.y, type: 'default', rotation: 0 },
+					cursor: cursors
+						? { x: c.x, y: c.y, type: 'default', rotation: 0 }
+						: { x: -1000, y: -1000, type: 'default', rotation: 0 },
 					lastActivityTimestamp: null,
 				})
 			)
 		)
-	}, [editor])
+	}, [editor, cursors])
 	return null
 }
 
-const LivePresence = (): ReactNode => (
-	<MinimalEditorHarness height={320}>
-		<InjectPresence />
-		<div className="presenceOverlay">
-			<PeopleMenu />
-		</div>
+/** One presence card: a minimal editor (fake collaborators) with an optional
+ * DOM component overlaid. cursors shows the collaborator cursors on the canvas. */
+const PresenceCard = ({
+	cursors,
+	children,
+}: {
+	cursors?: boolean
+	children?: ReactNode
+}): ReactNode => (
+	<MinimalEditorHarness height={150} bare>
+		<InjectPresence cursors={cursors} />
+		{children && <div className="presenceOverlay">{children}</div>}
 	</MinimalEditorHarness>
 )
 
@@ -76,7 +99,7 @@ export function Component() {
 			<Helmet>
 				<title>Presence inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
@@ -103,13 +126,51 @@ export function Component() {
 				<section className="section">
 					<h2 className="section__title">Live presence — fake collaborators, real UI</h2>
 					<p className="section__note">
-						No multiplayer session. We put three fake <code>instance_presence</code> records into
-						the store (<code>lastActivityTimestamp: null</code> = always active); the editor then
-						draws the real collaborator cursors, and the real <code>PeopleMenu</code> (facepile +
-						current user, top-right) reads the same peers via <code>usePeerIds()</code>. All real UI
-						— only the collaborators are fake.
+						No multiplayer session. Each card is a minimal editor with three fake{' '}
+						<code>instance_presence</code> records (<code>lastActivityTimestamp: null</code> = always
+						active); the real SDK presence components then render from that data. Real UI — only the
+						collaborators are fake.
 					</p>
-					<LivePresence />
+					<div className="grid">
+						<Specimen
+							label="live cursor"
+							code={`(editor canvas · from presence)`}
+							meta="name label in the user's colour"
+							source="editor — TlaEditor.tsx"
+						>
+							<PresenceCard cursors />
+						</Specimen>
+						<Specimen
+							label="DefaultPeopleMenuAvatar"
+							code={`<DefaultPeopleMenuAvatar userId />`}
+							meta="one collaborator's avatar"
+							source="SharePanel"
+						>
+							<PresenceCard>
+								<DefaultPeopleMenuAvatar userId={COLLAB_IDS[0]} />
+							</PresenceCard>
+						</Specimen>
+						<Specimen
+							label="DefaultPeopleMenuFacePile"
+							code={`<DefaultPeopleMenuFacePile userIds />`}
+							meta="all collaborators' avatars"
+							source="TldrawUiSharePanel"
+						>
+							<PresenceCard>
+								<DefaultPeopleMenuFacePile userIds={COLLAB_IDS} />
+							</PresenceCard>
+						</Specimen>
+						<Specimen
+							label="PeopleMenu"
+							code={`<PeopleMenu />`}
+							meta="facepile + collaborators dropdown · ×3"
+							source="TlaInviteTab.tsx"
+						>
+							<PresenceCard>
+								<PeopleMenu />
+							</PresenceCard>
+						</Specimen>
+					</div>
 				</section>
 
 				<section className="section">

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -1,0 +1,192 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom collaboration / presence UI: cursors, avatars,
+ * the people menu, the current user. This family is almost entirely DELEGATED to
+ * the SDK — dotcom wires up TldrawCurrentUser / PeopleMenu / TldrawUser and the
+ * editor renders the live cursors and presence. The app owns colour and wiring,
+ * not the UI. Mocked (the real components need a live editor / sync session).
+ *
+ * Route: /dev/components/presence.
+ */
+
+const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
+	<div className="stat">
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Presence inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Presence &amp; collaboration</h1>
+					<p className="page__lede">
+						Cursors, avatars, the people menu, the current user — multiplayer UI the app{' '}
+						<strong>delegates</strong> to the SDK (the same mode as{' '}
+						<a href="/dev/components/overlays">overlays</a>). dotcom wires up the SDK presence
+						components and supplies the user colour; the editor draws the live cursors. The app owns
+						almost no collaboration UI of its own.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">What dotcom uses</h2>
+					<div className="stats">
+						<Stat n="9" label="TldrawCurrentUser" />
+						<Stat n="3" label="PeopleMenu" />
+						<Stat n="2" label="TldrawUser" />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The presence UI (SDK-owned, mocked)</h2>
+					<p className="section__note">
+						These render inside the live editor / share panel; mocked here. dotcom supplies the
+						user&rsquo;s colour and identity, the SDK renders the rest.
+					</p>
+					<div className="grid">
+						<Specimen
+							label="live cursor"
+							code={`(SDK, from collaborator presence)`}
+							meta="name label in the user's colour"
+							source="editor — TlaEditor.tsx"
+						>
+							<div className="cursorMock">
+								<svg width="16" height="16" viewBox="0 0 16 16">
+									<path d="M2 2 L2 13 L5.5 9.5 L8 14 L10 13 L7.5 8.5 L12 8 Z" fill="#268bd2" />
+								</svg>
+								<span className="cursorMock__name">Casey</span>
+							</div>
+						</Specimen>
+						<Specimen
+							label="facepile / avatars"
+							code={`<PeopleMenu> (SDK share panel)`}
+							meta="collaborators' avatars, by colour"
+							source="TldrawUiSharePanel"
+						>
+							<div className="facepile">
+								<span className="avatar" style={{ background: '#268bd2' }}>
+									C
+								</span>
+								<span className="avatar" style={{ background: '#859900' }}>
+									J
+								</span>
+								<span className="avatar" style={{ background: '#cb4b16' }}>
+									M
+								</span>
+							</div>
+						</Specimen>
+						<Specimen
+							label="PeopleMenu trigger"
+							code={`<PeopleMenu>`}
+							meta="opens the collaborators list · ×3"
+							source="TlaInviteTab.tsx"
+						>
+							<div className="ctrlMock">People ▾</div>
+						</Specimen>
+						<Specimen
+							label="TldrawCurrentUser"
+							code={`<TldrawCurrentUser />`}
+							meta="the local user's presence record · ×9"
+							source="TlaEditorTopRightPanel.tsx"
+						>
+							<div className="facepile">
+								<span className="avatar" style={{ background: '#6c71c4' }}>
+									You
+								</span>
+							</div>
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Where dotcom touches presence</h2>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>what</th>
+								<th>who owns it</th>
+								<th>dotcom&rsquo;s part</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ROWS.map((r) => (
+								<tr key={r[0]}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<footer className="page__footer">
+					Presence is the deepest delegation in the app: live collaboration is hard and
+					stateful, so dotcom hands it entirely to the editor and contributes only identity and
+					colour. Like toasts, there&rsquo;s nothing to diverge on because there&rsquo;s no app-owned
+					implementation — the ownership-vs-divergence pattern again.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const ROWS: ReadonlyArray<readonly [string, string, string]> = [
+	['live cursors', 'SDK editor', 'nothing — rendered from sync presence'],
+	['collaborator avatars', 'SDK share panel / PeopleMenu', 'wires PeopleMenu into the invite tab'],
+	['current user', 'SDK (TldrawCurrentUser)', 'supplies identity + colour via useUser'],
+	['user colour', 'dotcom + SDK', 'member.userColor seeds the presence colour'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede code, .page__footer code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.page__lede a { color: var(--tl-color-primary); }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 180px; background: var(--tl-color-panel); }
+.stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; font-family: ui-monospace, monospace; }
+.cursorMock { display: inline-flex; align-items: center; gap: 4px; }
+.cursorMock__name { background: #268bd2; color: #fff; font-size: 11px; padding: 1px 6px; border-radius: 4px; }
+.facepile { display: inline-flex; }
+.avatar { display: inline-flex; align-items: center; justify-content: center; width: 26px; height: 26px; border-radius: 50%; color: #fff; font-size: 10px; font-weight: 600; border: 2px solid var(--tl-color-panel); margin-left: -6px; }
+.avatar:first-child { margin-left: 0; }
+.ctrlMock { display: inline-flex; align-items: center; gap: 6px; padding: 5px 10px; border: 1px solid var(--tla-color-secondary-border, var(--tl-color-divider)); border-radius: var(--tl-radius-2); background: var(--tl-color-panel); font-size: 12px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -1,10 +1,12 @@
 /* eslint-disable tldraw/jsx-no-literals */
-import { ReactNode } from 'react'
+import { ReactNode, useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
+import { InstancePresenceRecordType, TLUserId, useEditor } from 'tldraw'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 import { DevComponentsNav } from './dev-components-nav'
+import { MinimalEditorHarness } from './dev-editor-harness'
 
 /**
  * Dev-only inventory of the dotcom collaboration / presence UI: cursors, avatars,
@@ -21,6 +23,46 @@ const Stat = ({ n, label }: { n: string; label: string }): ReactNode => (
 		<div className="stat__n">{n}</div>
 		<div className="stat__label">{label}</div>
 	</div>
+)
+
+/**
+ * Live presence with no sync session. The cursor UI is real — the editor renders
+ * a cursor for every collaborator in editor.getCollaborators(), which just reads
+ * instance_presence records from the store. We fake the data by putting three
+ * fake presence records in (lastActivityTimestamp: null = "active right now", so
+ * they never time out). Real UI, fake collaborators — no multiplayer needed.
+ */
+const COLLABORATORS = [
+	{ id: 'user:casey', name: 'Casey', color: '#268bd2', x: 130, y: 90 },
+	{ id: 'user:jordan', name: 'Jordan', color: '#859900', x: 320, y: 150 },
+	{ id: 'user:morgan', name: 'Morgan', color: '#cb4b16', x: 210, y: 220 },
+]
+
+const InjectPresence = (): ReactNode => {
+	const editor = useEditor()
+	useEffect(() => {
+		const currentPageId = editor.getCurrentPageId()
+		editor.store.put(
+			COLLABORATORS.map((c) =>
+				InstancePresenceRecordType.create({
+					id: InstancePresenceRecordType.createId(c.id),
+					userId: c.id as TLUserId,
+					userName: c.name,
+					currentPageId,
+					color: c.color,
+					cursor: { x: c.x, y: c.y, type: 'default', rotation: 0 },
+					lastActivityTimestamp: null,
+				})
+			)
+		)
+	}, [editor])
+	return null
+}
+
+const LiveCursors = (): ReactNode => (
+	<MinimalEditorHarness height={300}>
+		<InjectPresence />
+	</MinimalEditorHarness>
 )
 
 export function Component() {
@@ -57,7 +99,19 @@ export function Component() {
 				</section>
 
 				<section className="section">
-					<h2 className="section__title">The presence UI (SDK-owned, mocked)</h2>
+					<h2 className="section__title">Live cursors — fake collaborators, real UI</h2>
+					<p className="section__note">
+						No multiplayer session. The editor draws a cursor for every record in{' '}
+						<code>editor.getCollaborators()</code> — so we put three fake{' '}
+						<code>instance_presence</code> records into the store (
+						<code>lastActivityTimestamp: null</code> = always active). The cursors below are the
+						real SDK presence UI; only the collaborators are fake.
+					</p>
+					<LiveCursors />
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Share-panel presence (SDK-owned, mocked)</h2>
 					<p className="section__note">
 						These render inside the live editor / share panel; mocked here. dotcom supplies the
 						user&rsquo;s colour and identity, the SDK renders the rest.
@@ -142,7 +196,6 @@ export function Component() {
 						</tbody>
 					</table>
 				</section>
-
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -68,6 +68,7 @@ export function Component() {
 							code={`(SDK, from collaborator presence)`}
 							meta="name label in the user's colour"
 							source="editor — TlaEditor.tsx"
+							mock
 						>
 							<div className="cursorMock">
 								<svg width="16" height="16" viewBox="0 0 16 16">
@@ -81,6 +82,7 @@ export function Component() {
 							code={`<PeopleMenu> (SDK share panel)`}
 							meta="collaborators' avatars, by colour"
 							source="TldrawUiSharePanel"
+							mock
 						>
 							<div className="facepile">
 								<span className="avatar" style={{ background: '#268bd2' }}>
@@ -99,6 +101,7 @@ export function Component() {
 							code={`<PeopleMenu>`}
 							meta="opens the collaborators list · ×3"
 							source="TlaInviteTab.tsx"
+							mock
 						>
 							<div className="ctrlMock">People ▾</div>
 						</Specimen>
@@ -107,6 +110,7 @@ export function Component() {
 							code={`<TldrawCurrentUser />`}
 							meta="the local user's presence record · ×9"
 							source="TlaEditorTopRightPanel.tsx"
+							mock
 						>
 							<div className="facepile">
 								<span className="avatar" style={{ background: '#6c71c4' }}>

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -139,12 +139,6 @@ export function Component() {
 					</table>
 				</section>
 
-				<footer className="page__footer">
-					Presence is the deepest delegation in the app: live collaboration is hard and
-					stateful, so dotcom hands it entirely to the editor and contributes only identity and
-					colour. Like toasts, there&rsquo;s nothing to diverge on because there&rsquo;s no app-owned
-					implementation — the ownership-vs-divergence pattern again.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-presence.tsx
+++ b/apps/dotcom/client/src/pages/dev-presence.tsx
@@ -157,7 +157,7 @@ export function Component() {
 							source="TldrawUiSharePanel"
 						>
 							<PresenceCard>
-								<DefaultPeopleMenuFacePile userIds={COLLAB_IDS} />
+								<DefaultPeopleMenuFacePile userIds={COLLAB_IDS} userName="You" userColor="#6c71c4" />
 							</PresenceCard>
 						</Specimen>
 						<Specimen

--- a/apps/dotcom/client/src/pages/dev-shadows.tsx
+++ b/apps/dotcom/client/src/pages/dev-shadows.tsx
@@ -1,0 +1,238 @@
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only audit of box-shadow / elevation. A fourth divergence flavour: the
+ * DUPLICATED primitive. Shadows are properly tokenised (--tl-shadow-1..4 in the
+ * SDK) AND used — but the app maintains a near-verbatim copy (--tla-shadow-1..4)
+ * with the same drop-shadow geometry, because the token bundles geometry + an
+ * inset border colour, so overriding the colour forces copying the geometry. The
+ * copy has already drifted: --tla-shadow-2 in dark mode is maroon-tinted. Both
+ * scales are rendered live so the duplication (and the red) are visible.
+ * Route: /dev/components/shadows.
+ */
+
+const LEVELS = [1, 2, 3, 4] as const
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Box-shadow audit — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Box-shadow &amp; elevation</h1>
+					<p className="page__lede">
+						A fourth divergence flavour: the <strong>duplicated</strong> primitive. Unlike{' '}
+						<a href="/dev/components/z-index">z-index</a> (an ignored scale), shadows are properly
+						tokenised <em>and</em> used — but the app keeps a <strong>near-verbatim copy</strong> of
+						the SDK scale (<code>--tla-shadow-1..4</code> mirrors <code>--tl-shadow-1..4</code>),
+						because the token bundles drop-shadow geometry with an inset border colour. Both scales
+						are rendered live below — they look identical, because they are.
+					</p>
+				</header>
+
+				<section className="section">
+					<div className="stats">
+						<Stat n="2" label="parallel shadow scales" accent />
+						<Stat n="4" label="rungs each (1–4)" />
+						<Stat n="1" label="hidden dark-mode divergence" accent />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The two scales, side by side (live)</h2>
+					<p className="section__note">
+						The SDK scale (<code>--tl-shadow-N</code>) and the app scale (
+						<code>--tla-shadow-N</code>), same rung, same page. Same geometry — the app copy just
+						swaps the inset border colour var and rewrites the alphas in <code>hsl</code> instead of
+						hex.
+					</p>
+					<div className="shadowGrid">
+						<div className="shadowGrid__label">--tl-shadow-N (SDK)</div>
+						{LEVELS.map((n) => (
+							<div
+								key={`tl${n}`}
+								className="chip-box"
+								style={{ boxShadow: `var(--tl-shadow-${n})` }}
+							>
+								{n}
+							</div>
+						))}
+						<div className="shadowGrid__label">--tla-shadow-N (app)</div>
+						{LEVELS.map((n) => (
+							<div
+								key={`tla${n}`}
+								className="chip-box"
+								style={{ boxShadow: `var(--tla-shadow-${n})` }}
+							>
+								{n}
+							</div>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The bundling problem</h2>
+					<div className="callout">
+						Why does the app copy exist at all? The token isn't just a drop shadow — each rung ends
+						with <code>inset 0px 0px 0px 1px var(--tl-color-…-contrast)</code>, a 1px inner border.
+						The app wanted a <em>different</em> inset colour (
+						<code>--tl-color-selected-contrast</code> instead of{' '}
+						<code>--tl-color-panel-contrast</code>), and because geometry and border live in one
+						value, changing the colour meant <strong>re-typing all four rungs of geometry</strong>.
+						A token that does two jobs forces duplication to override one.
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The copy already drifted (live)</h2>
+					<p className="section__note">
+						In <strong>dark mode</strong>, <code>--tla-shadow-2</code> is{' '}
+						<code>hsla(0, 44%, 27%, 0.666)</code> — a <strong>maroon-tinted</strong> shadow — while
+						the SDK's <code>--tl-shadow-2</code> is neutral black. Rendered on dark panels below:
+						the app shadow has a red cast. Almost certainly an accident a review of a copied token
+						wouldn't catch.
+					</p>
+					<div className="darkRow tla-theme__dark tl-theme__dark">
+						<div className="dark-box" style={{ boxShadow: 'var(--tl-shadow-2)' }}>
+							--tl-shadow-2<span className="dark-box__sub">SDK · neutral</span>
+						</div>
+						<div className="dark-box" style={{ boxShadow: 'var(--tla-shadow-2)' }}>
+							--tla-shadow-2<span className="dark-box__sub">app · maroon-tinted</span>
+						</div>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Rung-by-rung</h2>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>rung</th>
+								<th>drop-shadow geometry</th>
+								<th>inset border colour</th>
+								<th>notation</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ROWS.map((r) => (
+								<tr key={r[0]}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+									<td>{r[3]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Loose ends</h2>
+					<div className="callout">
+						<ul className="clist">
+							<li>
+								<strong>Scale mixing.</strong> dotcom's own CSS uses both:{' '}
+								<code>menu.module.css:137</code> reaches for <code>--tl-shadow-3</code> (SDK) while{' '}
+								<code>dialogs.module.css:50</code> and <code>MaybeForceUserRefresh:20</code> use{' '}
+								<code>--tla-shadow-3</code> (app) — for the same "elevation 3" intent.
+							</li>
+							<li>
+								<strong>One magic shadow.</strong> <code>dev-reset-local-state.tsx:136</code>{' '}
+								hardcodes <code>0 8px 28px rgb(0 0 0 / 8%)</code> — an off-scale shadow matching no
+								token.
+							</li>
+							<li>
+								<strong>Canvas-shape shadows are fine.</strong> <code>NoteShapeUtil</code>,{' '}
+								<code>EmbedShapeUtil</code>, <code>BookmarkShapeUtil</code> compute rotation-aware
+								shadows (<code>getRotatedBoxShadow</code>) — functional, not chrome, correctly not
+								tokenised.
+							</li>
+						</ul>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The gap</h2>
+					<div className="callout">
+						Split the token's two jobs: a shared <strong>drop-shadow geometry</strong> token the app
+						references (never copies), plus a separate <strong>inset-border</strong> token the app
+						can re-colour on its own. Then there's one elevation scale, the app themes only the
+						border, and a maroon shadow can't sneak in through a hand-retyped copy.
+					</div>
+				</section>
+			</div>
+		</div>
+	)
+}
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }) => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+const ROWS: ReadonlyArray<readonly [string, string, string, string]> = [
+	['1', 'identical (2 layers, 25% / 9%)', '— (no inset)', 'hsl == hsl'],
+	[
+		'2',
+		'identical geometry',
+		'panel-contrast → selected-contrast',
+		'hex vs hsl · dark drifts to maroon',
+	],
+	['3', 'identical (28% / 14%)', 'panel-contrast → selected-contrast', 'hex (#…47/#…24) vs hsl'],
+	['4', 'identical (3 layers)', 'panel-contrast → selected-contrast', 'hex vs hsl'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 820px; margin-bottom: 32px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede a { color: var(--tl-color-primary); }
+.page__lede code, .section__note code, .callout code { font-family: ui-monospace, monospace; font-size: 0.9em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 44px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 820px; }
+.section__note strong { color: var(--tl-color-text-0); }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 170px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 24px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.shadowGrid { display: grid; grid-template-columns: 180px repeat(4, 1fr); gap: 20px 24px; align-items: center; max-width: 760px; }
+.shadowGrid__label { font-family: ui-monospace, monospace; font-size: 12px; color: var(--tl-color-text-1); }
+.chip-box { height: 64px; border-radius: 8px; background: var(--tl-color-panel); display: flex; align-items: center; justify-content: center; font-family: ui-monospace, monospace; font-size: 13px; color: var(--tl-color-text-3); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 900px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.clist { margin: 0; padding-left: 20px; }
+.clist li { margin-bottom: 8px; }
+.darkRow { display: flex; gap: 40px; background: #1a1a1a; border-radius: 12px; padding: 40px; max-width: 620px; }
+.dark-box { flex: 1; height: 84px; border-radius: 8px; background: #2a2a2a; display: flex; flex-direction: column; align-items: center; justify-content: center; font-family: ui-monospace, monospace; font-size: 12px; color: #ddd; gap: 3px; }
+.dark-box__sub { font-size: 10px; color: #888; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; width: 100%; max-width: 900px; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+`

--- a/apps/dotcom/client/src/pages/dev-sidebar.tsx
+++ b/apps/dotcom/client/src/pages/dev-sidebar.tsx
@@ -1,0 +1,210 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only CONSUMPTION MAP for the dotcom file-navigation sidebar — a different
+ * kind of page from the rest of the gallery. Not "what is this component?" but
+ * "what does this feature consume?": per sidebar component, which design-system
+ * primitives it uses vs. where it reaches for a bespoke class. The sidebar is
+ * the densest concentration of the buttons-page (#9193) bespoke-button debt.
+ *
+ * Route: /dev/components/sidebar.
+ */
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Sidebar consumption map — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Sidebar — consumption map</h1>
+					<p className="page__lede">
+						A different lens: the file-navigation sidebar isn&rsquo;t a component to inventory,
+						it&rsquo;s a feature that <em>consumes</em> the design system. Per component below: the DS
+						primitives it uses (green) and where it rolls a bespoke class (orange). The pattern is
+						stark — icons are fully adopted, but almost every clickable element is bespoke.
+					</p>
+				</header>
+
+				<section className="section">
+					<div className="stats">
+						<Stat n="17" label="sidebar components" />
+						<Stat n="5" label="DS-only (no bespoke)" />
+						<Stat n="9" label="distinct bespoke button/trigger classes" accent />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Per-component consumption</h2>
+					<p className="section__note">
+						Green = design-system primitive used as-is. Orange = bespoke class / raw element.
+					</p>
+					<table className="cmap">
+						<thead>
+							<tr>
+								<th>component</th>
+								<th>design-system primitives</th>
+								<th>bespoke</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ROWS.map((r) => (
+								<tr key={r.name} data-clean={r.bespoke.length === 0 || undefined}>
+									<td className="cmap__name">{r.name}</td>
+									<td>
+										{r.ds.length ? (
+											r.ds.map((d) => (
+												<span key={d} className="chip chip--ds">
+													{d}
+												</span>
+											))
+										) : (
+											<span className="chip chip--none">—</span>
+										)}
+									</td>
+									<td>
+										{r.bespoke.length ? (
+											r.bespoke.map((b) => (
+												<span key={b} className="chip chip--bespoke">
+													{b}
+												</span>
+											))
+										) : (
+											<span className="chip chip--ok">none ✓</span>
+										)}
+									</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The bespoke button vocabulary</h2>
+					<p className="section__note">
+						The sidebar has invented its own set of clickable-element classes instead of using
+						TldrawUiButton / TlaButton. This is where the #9193 debt concentrates — nine of them:
+					</p>
+					<div className="vocab">
+						{VOCAB.map((v) => (
+							<span key={v} className="chip chip--bespoke">
+								.{v}
+							</span>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">What it tells a redesign</h2>
+					<div className="callout">
+						The sidebar consumes <strong>icons cleanly</strong> (TlaIcon everywhere) and{' '}
+						<strong>inputs cleanly</strong> (TldrawUiInput, wrapped once as TlaSidebarInlineInput) —
+						but its <strong>interactive elements are almost all bespoke</strong>. Where it does pull
+						in TldrawUiButton, it&rsquo;s for secondary icon-buttons inside menus; the primary rows,
+						triggers, and links each have their own <code>.sidebar*</code> class. So a redesign that
+						adds a complete TlaButton (the #9194 / orthogonal-variant work) would have its biggest
+						single payoff <em>here</em> — nine bespoke classes collapsing into button variants. The
+                        sidebar is the test case for whether the button rework actually lands.
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					This is the feature-organized companion to the type-organized gallery: the buttons page says
+					&ldquo;these bespoke button classes exist&rdquo;; this page says &ldquo;they all live in one
+					feature, and here&rsquo;s the shape of it.&rdquo; The same debt, seen from the consumer
+					instead of the catalog. See tldraw/tldraw#9193 / #9194.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const ROWS: ReadonlyArray<{ name: string; ds: string[]; bespoke: string[] }> = [
+	{ name: 'TlaSidebar (parent)', ds: [], bespoke: ['<button> overlay (all:unset, keep-raw)'] },
+	{ name: 'TlaSidebarWorkspaceLink', ds: ['TlaLogo'], bespoke: ['.sidebarWorkspaceButton'] },
+	{ name: 'TlaSidebarWorkspaceSwitcher', ds: ['TlaIcon'], bespoke: ['<button> .sidebarWorkspaceSwitcherTrigger'] },
+	{ name: 'TlaSidebarWorkspaceActions', ds: ['TlaIcon'], bespoke: ['<button> .sidebarActionButton'] },
+	{ name: 'TlaSidebarCreateFileButton', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: ['.sidebarCreateFileButton'] },
+	{ name: 'TlaSidebarRecentFiles', ds: [], bespoke: [] },
+	{ name: 'TlaSidebarFileSection', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: ['.sidebarCreateFileButton'] },
+	{ name: 'TlaSidebarFileLink', ds: ['TlaIcon', 'TldrawUiTooltip'], bespoke: ['.sidebarFileListItemButton', '.sidebarFileListItemGuestBadgeTrigger'] },
+	{ name: 'TlaSidebarFileLinkMenu', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: ['.sidebarFileListItemMenuTrigger'] },
+	{ name: 'TlaSidebarSearch', ds: ['TlaIcon', 'TldrawUiButton', 'TldrawUiInput'], bespoke: ['<button> .sidebarActionButton'] },
+	{ name: 'TlaSidebarInlineInput', ds: ['TldrawUiInput'], bespoke: [] },
+	{ name: 'TlaSidebarRenameInline', ds: ['TlaSidebarInlineInput'], bespoke: [] },
+	{ name: 'TlaSidebarDotDevLink', ds: ['ExternalLink'], bespoke: ['.sidebarLinkButton'] },
+	{ name: 'TlaSidebarFeedbackButton', ds: ['TlaIcon'], bespoke: ['<button> .sidebarLinkButton'] },
+	{ name: 'TlaSidebarUserSettingsMenu', ds: ['TlaIcon', 'TldrawUiButton', 'TldrawUiDropdownMenu'], bespoke: ['.sidebarUserSettingsTrigger'] },
+	{ name: 'TlaSidebarToggle', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: [] },
+	{ name: 'TlaSidebarToggleMobile', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: [] },
+]
+
+const VOCAB = [
+	'sidebarWorkspaceButton',
+	'sidebarWorkspaceSwitcherTrigger',
+	'sidebarActionButton',
+	'sidebarCreateFileButton',
+	'sidebarFileListItemButton',
+	'sidebarFileListItemMenuTrigger',
+	'sidebarFileListItemGuestBadgeTrigger',
+	'sidebarLinkButton',
+	'sidebarUserSettingsTrigger',
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 800px; margin-bottom: 32px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede em, .callout em { font-style: italic; }
+.section { margin-bottom: 40px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.callout code, .page__footer code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 160px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.cmap { border-collapse: collapse; width: 100%; max-width: 1000px; font-size: 12px; }
+.cmap th, .cmap td { text-align: left; padding: 8px 14px 8px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.cmap th { color: var(--tl-color-text-3); font-weight: 500; font-family: ui-monospace, monospace; }
+.cmap__name { font-family: ui-monospace, monospace; font-weight: 600; white-space: nowrap; }
+.cmap tr[data-clean] .cmap__name { color: var(--tl-color-success, #2a9d3c); }
+.chip { display: inline-block; font-family: ui-monospace, monospace; font-size: 11px; padding: 2px 7px; border-radius: 4px; margin: 2px 4px 2px 0; }
+.chip--ds { background: color-mix(in srgb, var(--tl-color-success, #2a9d3c) 14%, transparent); color: var(--tl-color-success, #2a9d3c); }
+.chip--bespoke { background: color-mix(in srgb, var(--tl-color-warning, #cb4b16) 14%, transparent); color: var(--tl-color-warning, #cb4b16); }
+.chip--ok { color: var(--tl-color-success, #2a9d3c); }
+.chip--none { color: var(--tl-color-text-3); }
+.vocab { display: flex; flex-wrap: wrap; gap: 2px; max-width: 900px; }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 860px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__footer { max-width: 800px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-sidebar.tsx
+++ b/apps/dotcom/client/src/pages/dev-sidebar.tsx
@@ -39,9 +39,9 @@ export function Component() {
 					<h1 className="page__title">Sidebar — consumption map</h1>
 					<p className="page__lede">
 						A different lens: the file-navigation sidebar isn&rsquo;t a component to inventory,
-						it&rsquo;s a feature that <em>consumes</em> the design system. Per component below: the DS
-						primitives it uses (green) and where it rolls a bespoke class (orange). The pattern is
-						stark — icons are fully adopted, but almost every clickable element is bespoke.
+						it&rsquo;s a feature that <em>consumes</em> the design system. Per component below: the
+						DS primitives it uses (green) and where it rolls a bespoke class (orange). The pattern
+						is stark — icons are fully adopted, but almost every clickable element is bespoke.
 					</p>
 				</header>
 
@@ -123,10 +123,9 @@ export function Component() {
 						triggers, and links each have their own <code>.sidebar*</code> class. So a redesign that
 						adds a complete TlaButton (the #9194 / orthogonal-variant work) would have its biggest
 						single payoff <em>here</em> — nine bespoke classes collapsing into button variants. The
-                        sidebar is the test case for whether the button rework actually lands.
+						sidebar is the test case for whether the button rework actually lands.
 					</div>
 				</section>
-
 			</div>
 		</div>
 	)
@@ -135,19 +134,51 @@ export function Component() {
 const ROWS: ReadonlyArray<{ name: string; ds: string[]; bespoke: string[] }> = [
 	{ name: 'TlaSidebar (parent)', ds: [], bespoke: ['<button> overlay (all:unset, keep-raw)'] },
 	{ name: 'TlaSidebarWorkspaceLink', ds: ['TlaLogo'], bespoke: ['.sidebarWorkspaceButton'] },
-	{ name: 'TlaSidebarWorkspaceSwitcher', ds: ['TlaIcon'], bespoke: ['<button> .sidebarWorkspaceSwitcherTrigger'] },
-	{ name: 'TlaSidebarWorkspaceActions', ds: ['TlaIcon'], bespoke: ['<button> .sidebarActionButton'] },
-	{ name: 'TlaSidebarCreateFileButton', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: ['.sidebarCreateFileButton'] },
+	{
+		name: 'TlaSidebarWorkspaceSwitcher',
+		ds: ['TlaIcon'],
+		bespoke: ['<button> .sidebarWorkspaceSwitcherTrigger'],
+	},
+	{
+		name: 'TlaSidebarWorkspaceActions',
+		ds: ['TlaIcon'],
+		bespoke: ['<button> .sidebarActionButton'],
+	},
+	{
+		name: 'TlaSidebarCreateFileButton',
+		ds: ['TlaIcon', 'TldrawUiButton'],
+		bespoke: ['.sidebarCreateFileButton'],
+	},
 	{ name: 'TlaSidebarRecentFiles', ds: [], bespoke: [] },
-	{ name: 'TlaSidebarFileSection', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: ['.sidebarCreateFileButton'] },
-	{ name: 'TlaSidebarFileLink', ds: ['TlaIcon', 'TldrawUiTooltip'], bespoke: ['.sidebarFileListItemButton', '.sidebarFileListItemGuestBadgeTrigger'] },
-	{ name: 'TlaSidebarFileLinkMenu', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: ['.sidebarFileListItemMenuTrigger'] },
-	{ name: 'TlaSidebarSearch', ds: ['TlaIcon', 'TldrawUiButton', 'TldrawUiInput'], bespoke: ['<button> .sidebarActionButton'] },
+	{
+		name: 'TlaSidebarFileSection',
+		ds: ['TlaIcon', 'TldrawUiButton'],
+		bespoke: ['.sidebarCreateFileButton'],
+	},
+	{
+		name: 'TlaSidebarFileLink',
+		ds: ['TlaIcon', 'TldrawUiTooltip'],
+		bespoke: ['.sidebarFileListItemButton', '.sidebarFileListItemGuestBadgeTrigger'],
+	},
+	{
+		name: 'TlaSidebarFileLinkMenu',
+		ds: ['TlaIcon', 'TldrawUiButton'],
+		bespoke: ['.sidebarFileListItemMenuTrigger'],
+	},
+	{
+		name: 'TlaSidebarSearch',
+		ds: ['TlaIcon', 'TldrawUiButton', 'TldrawUiInput'],
+		bespoke: ['<button> .sidebarActionButton'],
+	},
 	{ name: 'TlaSidebarInlineInput', ds: ['TldrawUiInput'], bespoke: [] },
 	{ name: 'TlaSidebarRenameInline', ds: ['TlaSidebarInlineInput'], bespoke: [] },
 	{ name: 'TlaSidebarDotDevLink', ds: ['ExternalLink'], bespoke: ['.sidebarLinkButton'] },
 	{ name: 'TlaSidebarFeedbackButton', ds: ['TlaIcon'], bespoke: ['<button> .sidebarLinkButton'] },
-	{ name: 'TlaSidebarUserSettingsMenu', ds: ['TlaIcon', 'TldrawUiButton', 'TldrawUiDropdownMenu'], bespoke: ['.sidebarUserSettingsTrigger'] },
+	{
+		name: 'TlaSidebarUserSettingsMenu',
+		ds: ['TlaIcon', 'TldrawUiButton', 'TldrawUiDropdownMenu'],
+		bespoke: ['.sidebarUserSettingsTrigger'],
+	},
 	{ name: 'TlaSidebarToggle', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: [] },
 	{ name: 'TlaSidebarToggleMobile', ds: ['TlaIcon', 'TldrawUiButton'], bespoke: [] },
 ]

--- a/apps/dotcom/client/src/pages/dev-sidebar.tsx
+++ b/apps/dotcom/client/src/pages/dev-sidebar.tsx
@@ -127,12 +127,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					This is the feature-organized companion to the type-organized gallery: the buttons page says
-					&ldquo;these bespoke button classes exist&rdquo;; this page says &ldquo;they all live in one
-					feature, and here&rsquo;s the shape of it.&rdquo; The same debt, seen from the consumer
-					instead of the catalog. See tldraw/tldraw#9193 / #9194.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-states.tsx
+++ b/apps/dotcom/client/src/pages/dev-states.tsx
@@ -1,0 +1,202 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import { TlaButton } from '../tla/components/TlaButton/TlaButton'
+import { TlaIcon } from '../tla/components/TlaIcon/TlaIcon'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's non-happy-path states: error UIs,
+ * loading states, and the spinner. Not a reusable-component family, but exactly
+ * the kind of cross-cutting concern that should be understood when redesigning
+ * the design system — it's where consistency quietly breaks.
+ *
+ * Route: /dev/components/states.
+ */
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Error & loading states — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Error &amp; loading states</h1>
+					<p className="page__lede">
+						The non-happy-path UI — error screens, loading, the spinner. Not a single component, but
+						a cross-cutting concern worth understanding for a redesign: there&rsquo;s no shared
+						error-state primitive, loading is inline-only, and the spin animation is duplicated.
+					</p>
+				</header>
+
+				<section className="section">
+					<h2 className="section__title">Error UIs — {ERRORS.length} bespoke screens</h2>
+					<p className="section__note">
+						Four error screens, no shared error-state component, split across two styling systems
+						(<code>ErrorPage</code> is BEM; <code>TlaFileError</code> is CSS-modules). Mocked.
+					</p>
+					<div className="grid">
+						{ERRORS.map((e) => (
+							<Specimen key={e.source} label={e.label} code={e.styling} meta={e.trigger} source={e.source}>
+								<div className="errMock">
+									<div className="errMock__face">{e.face}</div>
+									<div className="errMock__msg">{e.msg}</div>
+								</div>
+							</Specimen>
+						))}
+					</div>
+					<div className="callout">
+						The gap for a redesign: there is <strong>no shared <code>&lt;ErrorState&gt;</code></strong>.{' '}
+						<code>StoreErrorScreen</code> reuses <code>ErrorPage</code>, but{' '}
+						<code>TlaFileError</code> and <code>TlaEditorErrorFallback</code> each roll their own
+						layout — and <code>ErrorPage</code> is deliberately on BEM CSS with its own{' '}
+						<code>IntlProvider</code> and an inline SVG (so it works offline / outside providers).
+						That low-dependency constraint is real, but it means &ldquo;an error screen&rdquo; has no
+						single owner.
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Loading states — inline only</h2>
+					<p className="section__note">
+						No skeletons, no loading screens — loading is shown inline, mostly via{' '}
+						<code>TlaButton isLoading</code> (live below). <code>isLoading</code> appears in{' '}
+						{LOADERS.length} files, each ad-hoc; there&rsquo;s no shared &ldquo;loading view.&rdquo;
+					</p>
+					<div className="grid">
+						<Specimen
+							label="TlaButton isLoading"
+							code={`<TlaButton isLoading>`}
+							meta="spinner swaps in; onClick suppressed"
+							source="TlaButton.tsx:52"
+						>
+							<TlaButton variant="primary" isLoading>
+								Saving
+							</TlaButton>
+						</Specimen>
+						<Specimen
+							label="isLoading consumers"
+							code={`isLoading={…}`}
+							meta={`${LOADERS.length} files, ad-hoc flags`}
+							source="(distributed)"
+						>
+							<div className="listMock">
+								{LOADERS.map((l) => (
+									<div key={l}>{l}</div>
+								))}
+							</div>
+						</Specimen>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Spinner</h2>
+					<p className="section__note">
+						The spinner is the <code>spinner</code> sprite icon spun by a CSS keyframe. Live below.
+					</p>
+					<div className="grid">
+						<Specimen
+							label="spinner (live)"
+							code={`<TlaIcon icon="spinner" /> + tla-spin`}
+							meta="sprite icon + CSS rotation"
+							source="TlaButton.tsx:54"
+						>
+							<span className="spinStage">
+								<TlaIcon icon="spinner" />
+							</span>
+						</Specimen>
+						<Specimen
+							label="⚠ duplicated keyframe"
+							code={`@keyframes tla-spin (×2)`}
+							meta="defined twice, used at 1.5s AND 1.2s"
+							source="button.module.css:55, :98"
+						>
+							<div className="errMock errMock--warn">
+								<div className="errMock__msg">tla-spin lives in button CSS, defined 2×</div>
+							</div>
+						</Specimen>
+					</div>
+					<div className="callout">
+						The redesign finding: the spin animation (<code>@keyframes tla-spin</code>) is{' '}
+						<strong>defined twice in one file</strong> (<code>button.module.css</code>) and applied at
+						two different speeds (1.5s and 1.2s). The spinner isn&rsquo;t a component at all — it&rsquo;s
+						a sprite icon plus an animation that happens to live in the button&rsquo;s stylesheet. A
+						design system would want one <code>&lt;Spinner&gt;</code> (or one shared keyframe + token
+						for speed), not an animation coupled to a button.
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					Three redesign takeaways: (1) a shared <code>&lt;ErrorState&gt;</code> so the four error
+					screens stop diverging (respecting ErrorPage&rsquo;s offline constraint); (2) a loading
+					convention (even if it stays inline-only — that&rsquo;s a deliberate choice worth stating);
+					(3) a single spinner + one keyframe. None are reusable-component gaps in the usual sense —
+					they&rsquo;re the cross-cutting state UX that a design system has to own too.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const ERRORS: ReadonlyArray<{
+	label: string
+	styling: string
+	trigger: string
+	source: string
+	face: string
+	msg: string
+}> = [
+	{ label: 'ErrorPage', styling: 'BEM (.error-page__*)', trigger: 'top-level error boundary · offline-safe', source: 'components/ErrorPage', face: ':(', msg: 'Something went wrong' },
+	{ label: 'StoreErrorScreen', styling: 'reuses ErrorPage', trigger: 'store / sync failure', source: 'components/StoreErrorScreen.tsx', face: ':(', msg: 'Could not load · Reload' },
+	{ label: 'TlaFileError', styling: 'CSS modules', trigger: 'file not-found / forbidden (TLRemoteSyncError)', source: 'tla/components/TlaFileError', face: '∅', msg: 'File not available' },
+	{ label: 'TlaEditorErrorFallback', styling: 'own layout', trigger: 'editor render crash', source: 'TlaEditor/editor-components', face: '!', msg: 'The editor crashed' },
+]
+
+const LOADERS = [
+	'TlaButton.tsx',
+	'BoardHistoryLog.tsx',
+	'file-share-menu-primitives.tsx',
+	'TlaPublishTab.tsx',
+	'admin.tsx',
+	'file-history.tsx',
+	'file-pierre-history.tsx',
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede code, .section__note code, .callout code, .page__footer code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.errMock { display: flex; flex-direction: column; align-items: center; gap: 6px; text-align: center; }
+.errMock__face { font-size: 22px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); }
+.errMock__msg { font-size: 12px; color: var(--tl-color-text-1); }
+.errMock--warn .errMock__msg { color: var(--tl-color-warning, #cb4b16); font-family: ui-monospace, monospace; font-size: 11px; }
+.listMock { font-size: 10px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); line-height: 1.6; text-align: left; }
+.spinStage { display: inline-flex; color: var(--tl-color-primary); animation: devspin 1.2s linear infinite; }
+.spinStage > span { width: 22px; height: 22px; }
+@keyframes devspin { to { transform: rotate(360deg); } }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; margin-top: 4px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-states.tsx
+++ b/apps/dotcom/client/src/pages/dev-states.tsx
@@ -47,7 +47,7 @@ export function Component() {
 					</p>
 					<div className="grid">
 						{ERRORS.map((e) => (
-							<Specimen key={e.source} label={e.label} code={e.styling} meta={e.trigger} source={e.source}>
+							<Specimen key={e.source} label={e.label} code={e.styling} meta={e.trigger} source={e.source} mock>
 								<div className="errMock">
 									<div className="errMock__face">{e.face}</div>
 									<div className="errMock__msg">{e.msg}</div>
@@ -89,6 +89,7 @@ export function Component() {
 							code={`isLoading={…}`}
 							meta={`${LOADERS.length} files, ad-hoc flags`}
 							source="(distributed)"
+							mock
 						>
 							<div className="listMock">
 								{LOADERS.map((l) => (
@@ -120,6 +121,7 @@ export function Component() {
 							code={`@keyframes tla-spin (×2)`}
 							meta="defined twice, used at 1.5s AND 1.2s"
 							source="button.module.css:55, :98"
+							mock
 						>
 							<div className="errMock errMock--warn">
 								<div className="errMock__msg">tla-spin lives in button CSS, defined 2×</div>

--- a/apps/dotcom/client/src/pages/dev-states.tsx
+++ b/apps/dotcom/client/src/pages/dev-states.tsx
@@ -42,19 +42,30 @@ export function Component() {
 				<section className="section">
 					<h2 className="section__title">Error UIs — {ERRORS.length} bespoke screens</h2>
 					<p className="section__note">
-						Four error screens, no shared error-state component, split across two styling systems
-						(<code>ErrorPage</code> is BEM; <code>TlaFileError</code> is CSS-modules). Mocked.
+						Four full-page error screens, no shared error-state component, split across two styling
+						systems (<code>ErrorPage</code> is BEM; <code>TlaFileError</code> is CSS-modules). They
+						take over the viewport, so they&rsquo;re catalogued as data here.
 					</p>
-					<div className="grid">
-						{ERRORS.map((e) => (
-							<Specimen key={e.source} label={e.label} code={e.styling} meta={e.trigger} source={e.source} mock>
-								<div className="errMock">
-									<div className="errMock__face">{e.face}</div>
-									<div className="errMock__msg">{e.msg}</div>
-								</div>
-							</Specimen>
-						))}
-					</div>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>screen</th>
+								<th>styling</th>
+								<th>trigger</th>
+								<th>source</th>
+							</tr>
+						</thead>
+						<tbody>
+							{ERRORS.map((e) => (
+								<tr key={e.source}>
+									<td>{e.label}</td>
+									<td>{e.styling}</td>
+									<td>{e.trigger}</td>
+									<td>{e.source}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
 					<div className="callout">
 						The gap for a redesign: there is <strong>no shared <code>&lt;ErrorState&gt;</code></strong>.{' '}
 						<code>StoreErrorScreen</code> reuses <code>ErrorPage</code>, but{' '}
@@ -84,20 +95,11 @@ export function Component() {
 								Saving
 							</TlaButton>
 						</Specimen>
-						<Specimen
-							label="isLoading consumers"
-							code={`isLoading={…}`}
-							meta={`${LOADERS.length} files, ad-hoc flags`}
-							source="(distributed)"
-							mock
-						>
-							<div className="listMock">
-								{LOADERS.map((l) => (
-									<div key={l}>{l}</div>
-								))}
-							</div>
-						</Specimen>
 					</div>
+					<p className="section__note" style={{ marginTop: 14 }}>
+						<code>isLoading</code> consumers — {LOADERS.length} files, each ad-hoc:{' '}
+						{LOADERS.join(' · ')}.
+					</p>
 				</section>
 
 				<section className="section">
@@ -115,17 +117,6 @@ export function Component() {
 							<span className="spinStage">
 								<TlaIcon icon="spinner" />
 							</span>
-						</Specimen>
-						<Specimen
-							label="⚠ duplicated keyframe"
-							code={`@keyframes tla-spin (×2)`}
-							meta="defined twice, used at 1.5s AND 1.2s"
-							source="button.module.css:55, :98"
-							mock
-						>
-							<div className="errMock errMock--warn">
-								<div className="errMock__msg">tla-spin lives in button CSS, defined 2×</div>
-							</div>
 						</Specimen>
 					</div>
 					<div className="callout">
@@ -183,6 +174,9 @@ const PAGE_CSS = `
 .section { margin-bottom: 48px; }
 .section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
 .section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; width: 100%; max-width: 820px; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
 .errMock { display: flex; flex-direction: column; align-items: center; gap: 6px; text-align: center; }
 .errMock__face { font-size: 22px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); }
 .errMock__msg { font-size: 12px; color: var(--tl-color-text-1); }

--- a/apps/dotcom/client/src/pages/dev-states.tsx
+++ b/apps/dotcom/client/src/pages/dev-states.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable tldraw/jsx-no-literals */
-import { ReactNode } from 'react'
 import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import { TlaButton } from '../tla/components/TlaButton/TlaButton'

--- a/apps/dotcom/client/src/pages/dev-states.tsx
+++ b/apps/dotcom/client/src/pages/dev-states.tsx
@@ -136,13 +136,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					Three redesign takeaways: (1) a shared <code>&lt;ErrorState&gt;</code> so the four error
-					screens stop diverging (respecting ErrorPage&rsquo;s offline constraint); (2) a loading
-					convention (even if it stays inline-only — that&rsquo;s a deliberate choice worth stating);
-					(3) a single spinner + one keyframe. None are reusable-component gaps in the usual sense —
-					they&rsquo;re the cross-cutting state UX that a design system has to own too.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-states.tsx
+++ b/apps/dotcom/client/src/pages/dev-states.tsx
@@ -67,13 +67,16 @@ export function Component() {
 						</tbody>
 					</table>
 					<div className="callout">
-						The gap for a redesign: there is <strong>no shared <code>&lt;ErrorState&gt;</code></strong>.{' '}
-						<code>StoreErrorScreen</code> reuses <code>ErrorPage</code>, but{' '}
+						The gap for a redesign: there is{' '}
+						<strong>
+							no shared <code>&lt;ErrorState&gt;</code>
+						</strong>
+						. <code>StoreErrorScreen</code> reuses <code>ErrorPage</code>, but{' '}
 						<code>TlaFileError</code> and <code>TlaEditorErrorFallback</code> each roll their own
 						layout — and <code>ErrorPage</code> is deliberately on BEM CSS with its own{' '}
 						<code>IntlProvider</code> and an inline SVG (so it works offline / outside providers).
-						That low-dependency constraint is real, but it means &ldquo;an error screen&rdquo; has no
-						single owner.
+						That low-dependency constraint is real, but it means &ldquo;an error screen&rdquo; has
+						no single owner.
 					</div>
 				</section>
 
@@ -121,14 +124,13 @@ export function Component() {
 					</div>
 					<div className="callout">
 						The redesign finding: the spin animation (<code>@keyframes tla-spin</code>) is{' '}
-						<strong>defined twice in one file</strong> (<code>button.module.css</code>) and applied at
-						two different speeds (1.5s and 1.2s). The spinner isn&rsquo;t a component at all — it&rsquo;s
-						a sprite icon plus an animation that happens to live in the button&rsquo;s stylesheet. A
-						design system would want one <code>&lt;Spinner&gt;</code> (or one shared keyframe + token
-						for speed), not an animation coupled to a button.
+						<strong>defined twice in one file</strong> (<code>button.module.css</code>) and applied
+						at two different speeds (1.5s and 1.2s). The spinner isn&rsquo;t a component at all —
+						it&rsquo;s a sprite icon plus an animation that happens to live in the button&rsquo;s
+						stylesheet. A design system would want one <code>&lt;Spinner&gt;</code> (or one shared
+						keyframe + token for speed), not an animation coupled to a button.
 					</div>
 				</section>
-
 			</div>
 		</div>
 	)
@@ -142,10 +144,38 @@ const ERRORS: ReadonlyArray<{
 	face: string
 	msg: string
 }> = [
-	{ label: 'ErrorPage', styling: 'BEM (.error-page__*)', trigger: 'top-level error boundary · offline-safe', source: 'components/ErrorPage', face: ':(', msg: 'Something went wrong' },
-	{ label: 'StoreErrorScreen', styling: 'reuses ErrorPage', trigger: 'store / sync failure', source: 'components/StoreErrorScreen.tsx', face: ':(', msg: 'Could not load · Reload' },
-	{ label: 'TlaFileError', styling: 'CSS modules', trigger: 'file not-found / forbidden (TLRemoteSyncError)', source: 'tla/components/TlaFileError', face: '∅', msg: 'File not available' },
-	{ label: 'TlaEditorErrorFallback', styling: 'own layout', trigger: 'editor render crash', source: 'TlaEditor/editor-components', face: '!', msg: 'The editor crashed' },
+	{
+		label: 'ErrorPage',
+		styling: 'BEM (.error-page__*)',
+		trigger: 'top-level error boundary · offline-safe',
+		source: 'components/ErrorPage',
+		face: ':(',
+		msg: 'Something went wrong',
+	},
+	{
+		label: 'StoreErrorScreen',
+		styling: 'reuses ErrorPage',
+		trigger: 'store / sync failure',
+		source: 'components/StoreErrorScreen.tsx',
+		face: ':(',
+		msg: 'Could not load · Reload',
+	},
+	{
+		label: 'TlaFileError',
+		styling: 'CSS modules',
+		trigger: 'file not-found / forbidden (TLRemoteSyncError)',
+		source: 'tla/components/TlaFileError',
+		face: '∅',
+		msg: 'File not available',
+	},
+	{
+		label: 'TlaEditorErrorFallback',
+		styling: 'own layout',
+		trigger: 'editor render crash',
+		source: 'TlaEditor/editor-components',
+		face: '!',
+		msg: 'The editor crashed',
+	},
 ]
 
 const LOADERS = [

--- a/apps/dotcom/client/src/pages/dev-timestamps.tsx
+++ b/apps/dotcom/client/src/pages/dev-timestamps.tsx
@@ -119,12 +119,16 @@ export function Component() {
 							</Specimen>
 							<Specimen
 								label="react-intl FormattedRelativeTime"
-								code={`<FormattedRelativeTime value={secondsSince} numeric="auto" />`}
-								meta="locale-aware · auto-updates every 15s"
+								code={`<FormattedRelativeTime value={s} numeric="auto" updateIntervalInSeconds={15} />`}
+								meta="locale-aware · auto-updates · picks the human unit"
 								source="TlaPublishTab.tsx:122"
 							>
 								<span className="ts">
-									<FormattedRelativeTime value={SECONDS_AGO} numeric="auto" />
+									<FormattedRelativeTime
+										value={SECONDS_AGO}
+										numeric="auto"
+										updateIntervalInSeconds={15}
+									/>
 								</span>
 							</Specimen>
 							<Specimen

--- a/apps/dotcom/client/src/pages/dev-timestamps.tsx
+++ b/apps/dotcom/client/src/pages/dev-timestamps.tsx
@@ -1,0 +1,267 @@
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import { FormattedRelativeTime, useIntl } from 'react-intl'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+import { IsolationProviders } from './dev-editor-harness'
+
+/**
+ * Dev-only inventory of how the dotcom app renders dates & times. There is NO
+ * shared Timestamp component — each call site formats its own way, via five
+ * different mechanisms, and they disagree on locale (two hardcode en-GB, two
+ * follow the user locale via react-intl, one uses the browser default). The SDK
+ * renders no user-facing dates at all (only internal new Date() for logic), so a
+ * Timestamp primitive belongs in the app layer. All five are rendered live off
+ * one reference instant so the divergence is real.
+ *
+ * Candidate primitive for a design system. Route: /dev/components/timestamps.
+ */
+
+const REF = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000) // ~3 days ago
+const SECONDS_AGO = -3 * 24 * 60 * 60
+
+const enGBMonthYear = new Intl.DateTimeFormat('en-GB', { year: 'numeric', month: 'long' }).format(
+	REF
+)
+const enGBFull = new Intl.DateTimeFormat('en-GB', {
+	year: 'numeric',
+	month: 'short',
+	day: 'numeric',
+	hour: 'numeric',
+	minute: 'numeric',
+	second: 'numeric',
+}).format(REF)
+const browserTime = REF.toLocaleTimeString()
+
+/** The react-intl absolute path (locale-aware), as TldrawApp uses it. */
+const IntlAbsolute = (): ReactNode => {
+	const intl = useIntl()
+	return (
+		<>
+			{intl.formatDate(REF, {
+				year: 'numeric',
+				month: 'short',
+				day: 'numeric',
+				hour: 'numeric',
+				minute: 'numeric',
+			})}
+		</>
+	)
+}
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Dates & timestamps — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<IsolationProviders>
+				<div className="page">
+					<DevComponentsNav />
+					<header className="page__header">
+						<h1 className="page__title">Dates &amp; timestamps</h1>
+						<p className="page__lede">
+							There is <strong>no shared Timestamp component</strong>. Every date/time is formatted
+							ad-hoc at the call site — <strong>five different mechanisms</strong> that disagree on
+							locale. All five below render the <em>same</em> reference instant (~3 days ago), live,
+							so the divergence is real, not drawn.
+						</p>
+					</header>
+
+					<section className="section">
+						<div className="stats">
+							<Stat n="5" label="formatting mechanisms" accent />
+							<Stat n="0" label="shared components / utils" />
+							<Stat n="2" label="hardcode en-GB (locale bug)" accent />
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Same instant, five renderings (live)</h2>
+						<p className="section__note">
+							One <code>Date</code> ({REF.toISOString()}), formatted by each mechanism the app
+							actually uses.
+						</p>
+						<div className="grid">
+							<Specimen
+								label="Intl.DateTimeFormat — month/year"
+								code={`Intl.DateTimeFormat('en-GB', { year, month: 'long' })`}
+								meta="hardcoded en-GB · ignores user locale"
+								source="BoardHistoryLog.tsx:14"
+							>
+								<span className="ts">{enGBMonthYear}</span>
+							</Specimen>
+							<Specimen
+								label="Intl.DateTimeFormat — full"
+								code={`Intl.DateTimeFormat('en-GB', { …y m d h m s })`}
+								meta="hardcoded en-GB · ignores user locale"
+								source="BoardHistoryLog.tsx:87"
+							>
+								<span className="ts">{enGBFull}</span>
+							</Specimen>
+							<Specimen
+								label="react-intl formatDate"
+								code={`intl.formatDate(date, format)`}
+								meta="locale-aware (follows the app language)"
+								source="TldrawApp.ts:727"
+							>
+								<span className="ts">
+									<IntlAbsolute />
+								</span>
+							</Specimen>
+							<Specimen
+								label="react-intl FormattedRelativeTime"
+								code={`<FormattedRelativeTime value={secondsSince} numeric="auto" />`}
+								meta="locale-aware · auto-updates every 15s"
+								source="TlaPublishTab.tsx:122"
+							>
+								<span className="ts">
+									<FormattedRelativeTime value={SECONDS_AGO} numeric="auto" />
+								</span>
+							</Specimen>
+							<Specimen
+								label="toLocaleTimeString"
+								code={`new Date(t).toLocaleTimeString()`}
+								meta="browser default locale · time only"
+								source="admin.tsx:810"
+							>
+								<span className="ts">{browserTime}</span>
+							</Specimen>
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">The locale drift</h2>
+						<div className="callout">
+							This isn&rsquo;t just style — the mechanisms <strong>disagree on behaviour</strong>.
+							Two call sites{' '}
+							<strong>
+								hardcode <code>en-GB</code>
+							</strong>{' '}
+							(British format regardless of the user&rsquo;s language); two go through{' '}
+							<strong>react-intl</strong> and follow the app locale; one uses the{' '}
+							<strong>browser default</strong>. So the same product shows dates differently
+							depending on which screen you&rsquo;re on. A single <code>&lt;Timestamp&gt;</code>{' '}
+							that reads locale from context fixes the drift as a side effect.
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">Where the app renders dates</h2>
+						<table className="matrix">
+							<thead>
+								<tr>
+									<th>call site</th>
+									<th>mechanism</th>
+									<th>locale</th>
+									<th>shape</th>
+								</tr>
+							</thead>
+							<tbody>
+								{SITES.map((r) => (
+									<tr key={r[0]} data-off={r[2] === 'hardcoded en-GB' || undefined}>
+										<td>{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+										<td>{r[3]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">The SDK renders no dates</h2>
+						<div className="callout">
+							<code>packages/tldraw</code> / <code>packages/editor</code> render{' '}
+							<strong>no user-facing dates at all</strong> — the only date usage is internal (
+							<code>new Date()</code> ×27, <code>.toISOString</code> ×5, e.g. presence{' '}
+							<code>lastActivityTimestamp</code>). The canvas engine has no chrome that shows a
+							date, so unlike buttons or dialogs (SDK-owned), a <code>&lt;Timestamp&gt;</code> is
+							squarely an <strong>app-layer</strong> primitive — a <code>--tla-*</code>-world
+							component, where all the divergence above lives.
+						</div>
+					</section>
+
+					<section className="section">
+						<h2 className="section__title">The gap</h2>
+						<div className="callout">
+							A <code>&lt;Timestamp&gt;</code> — absolute vs relative mode, locale from context, one
+							set of format presets — would collapse all five mechanisms into one and remove the
+							en-GB drift. The same shape as the missing <code>&lt;ErrorState&gt;</code> the{' '}
+							<a href="/dev/components/states">states</a> page flagged: a primitive that
+							doesn&rsquo;t exist yet, reinvented per site.
+						</div>
+					</section>
+				</div>
+			</IsolationProviders>
+		</div>
+	)
+}
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+const SITES: ReadonlyArray<readonly [string, string, string, string]> = [
+	[
+		'BoardHistoryLog (month header)',
+		"Intl.DateTimeFormat('en-GB')",
+		'hardcoded en-GB',
+		'June 2026',
+	],
+	[
+		'BoardHistoryLog (row)',
+		"Intl.DateTimeFormat('en-GB')",
+		'hardcoded en-GB',
+		'29 Jun 2026, 14:30:00',
+	],
+	['TldrawApp.formatFileDate', 'intl.formatDate', 'user locale', 'dynamic (getDateFormat)'],
+	['TlaPublishTab', 'FormattedRelativeTime', 'user locale', 'relative — "3 days ago"'],
+	['admin (log)', 'toLocaleTimeString', 'browser default', 'time only'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 800px; margin-bottom: 32px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede em { font-style: italic; }
+.page__lede code, .section__note code, .callout code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 40px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 800px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 170px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.ts { font-size: 14px; font-family: ui-monospace, monospace; color: var(--tl-color-text-0); text-align: center; }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 860px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.callout a { color: var(--tl-color-primary); }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; width: 100%; max-width: 820px; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix tr[data-off] td:nth-child(3) { color: var(--tl-color-warning, #cb4b16); font-weight: 600; }
+`

--- a/apps/dotcom/client/src/pages/dev-typography.tsx
+++ b/apps/dotcom/client/src/pages/dev-typography.tsx
@@ -4,28 +4,48 @@ import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { DevComponentsNav } from './dev-components-nav'
-import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 
 /**
- * Dev-only inventory of the dotcom app's type scale, and how it sits next to the
- * SDK's separate text system. Typography diverges by a MISSING, UNREACHABLE
- * scale: the dotcom ramp exists only as global CSS utility classes
- * (.tla-text_ui__*) with no token and no component, so CSS Modules can't use it
- * and hardcode font-size/weight — most text bypasses the scale entirely. The SDK
- * (tl layer) is a wholly separate system that doesn't use tla-text_ui at all.
+ * Dev-only inventory of the dotcom app's type sizes. Typography diverges by a
+ * MISSING, UNREACHABLE scale: the only ramp is five global CSS utility classes
+ * (.tla-text_ui__*) — and three of them are the same 12px — with no token and no
+ * component, so CSS Modules can't reach it and hardcode font-size instead. Every
+ * hardcoded and inline size is rendered below at its real value; nothing
+ * filtered. The hardcoded 11/12px aren't even new sizes — they retype what the
+ * classes already define.
  *
  * Serves tldraw/tldraw#9196 (establish a typography system). Route:
  * /dev/components/typography.
  */
 
-const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
-	<div className="stat" data-accent={accent || undefined}>
-		<div className="stat__n">{n}</div>
-		<div className="stat__label">{label}</div>
+const SAMPLE = 'The quick brown fox'
+
+const TypeSample = ({
+	px,
+	selector,
+	source,
+	inline,
+}: {
+	px: number
+	selector: string
+	source: string
+	inline?: boolean
+}): ReactNode => (
+	<div className="ts">
+		<div className="ts__render" style={{ fontSize: px }}>
+			{SAMPLE}
+		</div>
+		<div className="ts__meta">
+			<span className="ts__px">{px}px</span>
+			<span className="ts__sel">{selector}</span>
+			{inline && <span className="ts__tag">inline style</span>}
+		</div>
+		<div className="ts__src">{source}</div>
 	</div>
 )
 
 export function Component() {
+	const total = HARDCODED.length + CLASSES.length
 	return (
 		<div
 			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
@@ -34,243 +54,161 @@ export function Component() {
 			<Helmet>
 				<title>Typography inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+			<style>{PAGE_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
 				<header className="page__header">
 					<h1 className="page__title">Typography inventory</h1>
 					<p className="page__lede">
-						Every text-styling mechanism in the dotcom app, and the boundary with the SDK. The short
-						answer to &ldquo;does everything use <code>.tla-text_ui__*</code>?&rdquo; is no: the
-						scale is the minority, most text hardcodes its size, and the SDK is a separate system
-						entirely.
+						Every type size in the dotcom app, rendered at its real value. There is no type scale:{' '}
+						{total} size declarations collapse to just {ALL_SIZES.length} distinct sizes, and{' '}
+						<strong>12px is hardcoded {COUNT_12}× outside the classes</strong>. The five{' '}
+						<code>.tla-text_ui__*</code> classes are the only ramp — but three of them are the same
+						12px, so they offer no reason to be reached for, and CSS Modules can&rsquo;t reach them
+						anyway.
 					</p>
 				</header>
 
-				{/* Punchline 1: the scale is the minority. */}
 				<section className="section">
-					<h2 className="section__title">Coverage reality (dotcom text styling)</h2>
-					<p className="section__note">
-						How dotcom elements get their text size. More text hardcodes a font-size than reaches
-						the scale.
-					</p>
 					<div className="stats">
-						<Stat n="34" label="use a .tla-text_ui__* class" />
-						<Stat n="39" label="hardcode font-size in *.module.css" accent />
-						<Stat n="2" label="inline style fontSize" accent />
+						<Stat n={String(total)} label="size declarations" />
+						<Stat n={String(ALL_SIZES.length)} label="distinct sizes" />
+						<Stat n={`${COUNT_12}×`} label="12px hardcoded (non-class)" accent />
+						<Stat n="5→3" label=".tla-text_ui__ names → sizes" accent />
 					</div>
 				</section>
 
-				{/* Punchline 2: two separate systems. */}
 				<section className="section">
-					<h2 className="section__title">Two separate text systems</h2>
+					<h2 className="section__title">The class scale — .tla-text_ui__* (the intended ramp)</h2>
 					<p className="section__note">
-						<code>.tla-text_ui__*</code> is dotcom-only — zero uses in <code>packages/</code>. The
-						SDK has its own font system that the app layer doesn&rsquo;t touch. Neither has a
-						font-size token.
-					</p>
-					<table className="matrix matrix--wide">
-						<thead>
-							<tr>
-								<th></th>
-								<th>dotcom (tla layer)</th>
-								<th>SDK (tl layer)</th>
-							</tr>
-						</thead>
-						<tbody>
-							{SYSTEMS.map((r) => (
-								<tr key={r[0]}>
-									<td className="rowhead">{r[0]}</td>
-									<td>{r[1]}</td>
-									<td>{r[2]}</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">The dotcom scale, as it exists</h2>
-					<p className="section__note">
-						Five global classes in <code>tla/styles/tla.css</code> — only three distinct sizes (11 /
-						12 / 24px), a 12→24 gap, and a byte-identical pair.
+						Rendered with the real classes. Note <code>medium</code>, <code>regular</code> and{' '}
+						<code>title</code> are all 12px — five names, three sizes.
 					</p>
 					<div className="grid">
-						<Specimen
-							label="big"
-							code={`className="tla-text_ui__big"`}
-							meta="24px · 400 · text-0 · 1 use"
-							source="tla.css"
-						>
-							<span className="tla-text_ui__big">Heading</span>
-						</Specimen>
-						<Specimen
-							label="title"
-							code={`className="tla-text_ui__title"`}
-							meta="12px · 700 · +0.2px letter-spacing · 7 uses"
-							source="tla.css"
-						>
-							<span className="tla-text_ui__title">Section title</span>
-						</Specimen>
-						<Specimen
-							label="medium ⚠ ≡ regular"
-							code={`className="tla-text_ui__medium"`}
-							meta="12px · 500 · 4 uses — identical to regular"
-							source="tla.css"
-						>
-							<span className="tla-text_ui__medium">Medium body</span>
-						</Specimen>
-						<Specimen
-							label="regular ⚠ ≡ medium"
-							code={`className="tla-text_ui__regular"`}
-							meta="12px · 500 · 12 uses — identical to medium"
-							source="tla.css"
-						>
-							<span className="tla-text_ui__regular">Regular body</span>
-						</Specimen>
-						<Specimen
-							label="small"
-							code={`className="tla-text_ui__small"`}
-							meta="11px · 500 · text-3 · 10 uses"
-							source="tla.css"
-						>
-							<span className="tla-text_ui__small">Small caption</span>
-						</Specimen>
+						{CLASSES.map((c) => (
+							<div className="ts" key={c.cls}>
+								<div className={`ts__render ${c.cls}`}>{SAMPLE}</div>
+								<div className="ts__meta">
+									<span className="ts__px">{c.px}px</span>
+									<span className="ts__sel">.{c.cls}</span>
+								</div>
+								<div className="ts__src">tla.css:{c.line}</div>
+							</div>
+						))}
 					</div>
 				</section>
 
+				{DISTINCT.map((px) => {
+					const group = HARDCODED.filter((h) => h.px === px)
+					return (
+						<section className="section" key={px}>
+							<h2 className="section__title">
+								{px}px — hardcoded {group.length}× {px === 12 && '(the same size as three classes)'}
+							</h2>
+							<div className="grid">
+								{group.map((h) => (
+									<TypeSample
+										key={h.source}
+										px={h.px}
+										selector={h.selector}
+										source={h.source}
+										inline={h.inline}
+									/>
+								))}
+							</div>
+						</section>
+					)
+				})}
+
 				<section className="section">
-					<h2 className="section__title">The structural gap</h2>
+					<h2 className="section__title">What it tells a redesign</h2>
 					<div className="callout">
-						The scale exists <strong>only as global CSS utility classes</strong> (
-						<code>.tla-text_ui__*</code>). There is <strong>no token layer</strong> (no{' '}
-						<code>--tla-font-size-*</code> / <code>--tla-font-weight-*</code>) and{' '}
-						<strong>
-							no <code>&lt;TlaText&gt;</code> component
-						</strong>
-						. CSS Modules are locally scoped and can&rsquo;t reference the global classes, so every
-						module that wants &ldquo;12px / 500 text&rdquo; re-types it by hand — which is why the
-						39 hardcoded font-sizes above outnumber the 34 that reach the scale. The scale is
-						unreachable from where text is actually styled.
+						The hardcoded sizes aren&rsquo;t a wild spread — they cluster on{' '}
+						<strong>11px and 12px</strong>, the exact sizes <code>.tla-text_ui__small</code> and{' '}
+						<code>.tla-text_ui__regular</code> already define. So this isn&rsquo;t a scale that
+						doesn&rsquo;t exist; it&rsquo;s a scale that&rsquo;s{' '}
+						<strong>retyped by hand 40+ times</strong> because it has no token (a{' '}
+						<code>--tla-font-size-*</code> a CSS Module could reference) and no semantic names worth
+						reaching for. A real scale needs both: tokens CSS Modules can consume, and names that{' '}
+						<em>mean</em> something (<code>body</code>, <code>caption</code>, <code>heading</code>)
+						rather than three aliases for 12px.
 					</div>
 				</section>
-
-				<section className="section">
-					<h2 className="section__title">Where the hardcoding lives (*.module.css)</h2>
-					<p className="section__note">
-						Per-file count of hardcoded <code>font-size</code> declarations — the auth and admin
-						forms dominate.
-					</p>
-					<table className="matrix">
-						<thead>
-							<tr>
-								<th>file</th>
-								<th>font-size decls</th>
-							</tr>
-						</thead>
-						<tbody>
-							{BY_FILE.map((r) => (
-								<tr key={r[0]}>
-									<td>{r[0]}</td>
-									<td>{r[1]}</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</section>
-
-				<section className="section">
-					<h2 className="section__title">Drift & off-scale (the hardcoded values)</h2>
-					<p className="section__note">
-						Matches-a-rung values are drift (should reference the scale); the rest reveal missing
-						rungs.
-					</p>
-					<div className="tables">
-						<table className="matrix">
-							<thead>
-								<tr>
-									<th>font-size</th>
-									<th>count</th>
-									<th>status</th>
-								</tr>
-							</thead>
-							<tbody>
-								{SIZES.map((r) => (
-									<tr key={r[0]} data-off={r[2].startsWith('off') || undefined}>
-										<td>{r[0]}</td>
-										<td>{r[1]}</td>
-										<td>{r[2]}</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-						<table className="matrix">
-							<thead>
-								<tr>
-									<th>font-weight</th>
-									<th>count</th>
-									<th>status</th>
-								</tr>
-							</thead>
-							<tbody>
-								{WEIGHTS.map((r) => (
-									<tr key={r[0]} data-off={r[2].startsWith('off') || undefined}>
-										<td>{r[0]}</td>
-										<td>{r[1]}</td>
-										<td>{r[2]}</td>
-									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
-				</section>
-
 			</div>
 		</div>
 	)
 }
 
-const SYSTEMS: ReadonlyArray<readonly [string, string, string]> = [
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+const CLASSES: ReadonlyArray<{ cls: string; px: number; line: number }> = [
+	{ cls: 'tla-text_ui__small', px: 11, line: 106 },
+	{ cls: 'tla-text_ui__medium', px: 12, line: 114 },
+	{ cls: 'tla-text_ui__regular', px: 12, line: 121 },
+	{ cls: 'tla-text_ui__title', px: 12, line: 95 },
+	{ cls: 'tla-text_ui__big', px: 24, line: 128 },
+]
+
+const HARDCODED: ReadonlyArray<{ px: number; selector: string; source: string; inline?: boolean }> =
 	[
-		'font family',
-		'--tla-font-ui (Inter + system)',
-		'--tl-font-draw / sans / serif / mono (custom) + system for UI',
-	],
-	[
-		'size scale',
-		'.tla-text_ui__* — 5 global classes',
-		'none — base .tl-container 12px, ad-hoc per rule',
-	],
-	['size token', 'none', 'none'],
-	['uses .tla-text_ui__*?', 'partially — 34 sites', 'no — dotcom-only'],
-	['hardcoded sizes', '39 in *.module.css + 2 inline', '~18 font-size decls in ui.css'],
-]
+		{ px: 11, selector: '.adminReleaseValue', source: 'admin.module.css:32' },
+		{ px: 11, selector: '.dataDisplay', source: 'admin.module.css:121' },
+		{ px: 11, selector: '.fieldLabel', source: 'admin.module.css:249' },
+		{ px: 11, selector: '.logContainer', source: 'admin.module.css:193' },
+		{ px: 11, selector: '.statLabel', source: 'admin.module.css:290' },
+		{ px: 12, selector: '.adminReleaseMeta', source: 'admin.module.css:20' },
+		{ px: 12, selector: '.anonDotDevLink > div', source: 'TlaAnonDotDevLink.module.css:11' },
+		{ px: 12, selector: '.authCheckboxLabel', source: 'auth.module.css:160' },
+		{ px: 12, selector: '.authCtaButton', source: 'auth.module.css:53' },
+		{ px: 12, selector: '.authDescription', source: 'auth.module.css:42' },
+		{ px: 12, selector: '.authDivider', source: 'auth.module.css:73' },
+		{ px: 12, selector: '.authError', source: 'auth.module.css:125' },
+		{ px: 12, selector: '.authInput', source: 'auth.module.css:108' },
+		{ px: 12, selector: '.authInput::placeholder', source: 'auth.module.css:294' },
+		{ px: 12, selector: '.authLabel', source: 'auth.module.css:97' },
+		{ px: 12, selector: '.authResendButton', source: 'auth.module.css:256' },
+		{ px: 12, selector: '.authResendWrapper', source: 'auth.module.css:242' },
+		{ px: 12, selector: '.authTermsOfUse a', source: 'auth.module.css:144' },
+		{ px: 12, selector: '.cookieButton', source: 'dialogs.module.css:104' },
+		{ px: 12, selector: '.cookieText', source: 'dialogs.module.css:75' },
+		{ px: 12, selector: '.countDisplay', source: 'admin.module.css:310' },
+		{ px: 12, selector: '.ctaButton', source: 'cta-button.module.css:15' },
+		{ px: 12, selector: '.errorMessage', source: 'admin.module.css:83' },
+		{ px: 12, selector: '.fieldValue', source: 'admin.module.css:257' },
+		{ px: 12, selector: '.inlineButton', source: 'dialogs.module.css:320' },
+		{ px: 12, selector: '.memberRole', source: 'dialogs.module.css:266' },
+		{ px: 12, selector: '.message', source: 'TlaInviteDialog.module.css:21' },
+		{ px: 12, selector: '.message', source: 'TlaInviteExpiredDialog.module.css:27' },
+		{ px: 12, selector: '.progressLog h5', source: 'admin.module.css:182' },
+		{ px: 12, selector: '.searchInput', source: 'admin.module.css:67' },
+		{ px: 12, selector: '.successMessage', source: 'admin.module.css:93' },
+		{ px: 12, selector: '.tla .tl-container', source: 'tla.css:88' },
+		{ px: 12, selector: '.tlaButton', source: 'button.module.css:19' },
+		{ px: 14, selector: '.modalContent', source: 'MaybeForceUserRefresh.module.css:18' },
+		{
+			px: 14,
+			selector: '<div style={{ fontSize: 14 }}>',
+			source: 'SlurpFailure.tsx:27',
+			inline: true,
+		},
+		{ px: 16, selector: '.authInput', source: 'auth.module.css:290' },
+		{ px: 16, selector: '.dialogBody .header', source: 'TlaInviteExpiredDialog.module.css:20' },
+		{ px: 16, selector: '.feedbackDialogTextArea', source: 'dialogs.module.css:31' },
+		{ px: 16, selector: '.modalTitle', source: 'MaybeForceUserRefresh.module.css:29' },
+		{ px: 16, selector: '.statValue', source: 'admin.module.css:297' },
+		{ px: 16, selector: '.tla select', source: 'tla.css:16' },
+		{ px: 20, selector: '.authOtpBox', source: 'auth.module.css:201' },
+	]
 
-const BY_FILE: ReadonlyArray<readonly [string, string]> = [
-	['dialogs/auth.module.css', '13'],
-	['pages/admin.module.css', '13'],
-	['dialogs/dialogs.module.css', '5'],
-	['MaybeForceUserRefresh.module.css', '2'],
-	['dialogs/TlaInviteExpiredDialog.module.css', '2'],
-	['+ 4 files (button / cta / invite / anon-link)', '1 each'],
-]
-
-const SIZES: ReadonlyArray<readonly [string, string, string]> = [
-	['12px', '27', 'drift → matches medium / regular'],
-	['11px', '5', 'drift → matches small'],
-	['16px', '5', 'off-scale — no rung (12→24 gap)'],
-	['20px', '1', 'off-scale'],
-	['14px', '1', 'off-scale'],
-]
-
-const WEIGHTS: ReadonlyArray<readonly [string, string, string]> = [
-	['500', '16', 'on scale (small / medium / regular)'],
-	['700', '2', 'on scale (title)'],
-	['bold', '1', 'on scale — keyword spelling of 700'],
-	['600', '9', 'off-scale — not in {400, 500, 700}'],
-	['800', '3', 'off-scale'],
-]
+const DISTINCT = [11, 12, 14, 16, 20]
+const ALL_SIZES = [11, 12, 14, 16, 20, 24]
+const COUNT_12 = HARDCODED.filter((h) => h.px === 12).length
 
 const PAGE_CSS = `
 .page {
@@ -281,35 +219,29 @@ const PAGE_CSS = `
 	padding: 24px 40px 80px;
 	box-sizing: border-box;
 }
-.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__header { max-width: 800px; margin-bottom: 32px; }
 .page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
 .page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
-.section { margin-bottom: 48px; }
+.page__lede strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede code, .section__note code, .callout code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 40px; }
 .section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
-.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
-.section code, .callout code, .page__footer code, .section__note code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 800px; }
 .stats { display: flex; gap: 16px; flex-wrap: wrap; }
-.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 200px; background: var(--tl-color-panel); }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 150px; background: var(--tl-color-panel); }
 .stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
-.stat__n { font-size: 28px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat__n { font-size: 26px; font-weight: 700; font-family: ui-monospace, monospace; }
 .stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
 .stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
-.ladder { border: 1px solid var(--tl-color-divider); border-radius: 8px; overflow: hidden; max-width: 880px; }
-.rung { display: flex; align-items: baseline; justify-content: space-between; gap: 32px; padding: 16px 18px; border-bottom: 1px solid var(--tl-color-divider); }
-.rung:last-child { border-bottom: none; }
-.rung__sample { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.rung__meta { flex: 0 0 auto; display: flex; align-items: baseline; gap: 12px; font-size: 11px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); }
-.rung__meta code { color: var(--tl-color-text-1); }
-.rung__flag { color: var(--tl-color-warning, #cb4b16); }
-.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 16px; }
+.ts { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 14px 16px; background: var(--tl-color-panel); display: flex; flex-direction: column; gap: 8px; overflow: hidden; }
+.ts__render { color: var(--tl-color-text); line-height: 1.3; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ts__meta { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.ts__px { font-size: 12px; font-weight: 700; font-family: ui-monospace, monospace; color: var(--tl-color-text-0); }
+.ts__sel { font-size: 11px; font-family: ui-monospace, monospace; color: var(--tl-color-text-1); }
+.ts__tag { font-size: 9px; text-transform: uppercase; letter-spacing: 0.04em; font-family: ui-monospace, monospace; padding: 1px 6px; border-radius: 999px; background: color-mix(in srgb, var(--tl-color-warning, #cb4b16) 16%, transparent); color: var(--tl-color-warning, #cb4b16); }
+.ts__src { font-size: 10px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); border-top: 1px dashed var(--tl-color-divider); padding-top: 6px; }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 860px; }
 .callout strong { color: var(--tl-color-text-0); font-weight: 600; }
-.tables { display: flex; gap: 48px; flex-wrap: wrap; }
-.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
-.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
-.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
-.matrix--wide td, .matrix--wide th { padding-right: 28px; max-width: 360px; }
-.matrix .rowhead { color: var(--tl-color-text-3); }
-.matrix tr[data-off] td:last-child { color: var(--tl-color-warning, #cb4b16); }
-.matrix tr[data-off] td:first-child { font-weight: 700; }
-.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+.callout em { font-style: italic; }
 `

--- a/apps/dotcom/client/src/pages/dev-typography.tsx
+++ b/apps/dotcom/client/src/pages/dev-typography.tsx
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet-async'
 import 'tldraw/tldraw.css'
 import '../tla/styles/tla.css'
 import { DevComponentsNav } from './dev-components-nav'
+import { Specimen, SPECIMEN_CSS } from './dev-components-kit'
 
 /**
  * Dev-only inventory of the dotcom app's type scale, and how it sits next to the
@@ -16,27 +17,6 @@ import { DevComponentsNav } from './dev-components-nav'
  * Serves tldraw/tldraw#9196 (establish a typography system). Route:
  * /dev/components/typography.
  */
-
-const Rung = ({
-	cls,
-	sample,
-	meta,
-	dupe,
-}: {
-	cls: string
-	sample: string
-	meta: string
-	dupe?: boolean
-}): ReactNode => (
-	<div className="rung">
-		<div className={`rung__sample ${cls}`}>{sample}</div>
-		<div className="rung__meta">
-			<code>.{cls}</code>
-			<span>{meta}</span>
-			{dupe && <span className="rung__flag">⚠ identical to its pair</span>}
-		</div>
-	</div>
-)
 
 const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
 	<div className="stat" data-accent={accent || undefined}>
@@ -54,7 +34,7 @@ export function Component() {
 			<Helmet>
 				<title>Typography inventory — dev</title>
 			</Helmet>
-			<style>{PAGE_CSS}</style>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
 
 			<div className="page">
 				<DevComponentsNav />
@@ -116,34 +96,47 @@ export function Component() {
 						Five global classes in <code>tla/styles/tla.css</code> — only three distinct sizes (11 /
 						12 / 24px), a 12→24 gap, and a byte-identical pair.
 					</p>
-					<div className="ladder">
-						<Rung
-							cls="tla-text_ui__big"
-							sample="Big — page heading"
+					<div className="grid">
+						<Specimen
+							label="big"
+							code={`className="tla-text_ui__big"`}
 							meta="24px · 400 · text-0 · 1 use"
-						/>
-						<Rung
-							cls="tla-text_ui__title"
-							sample="Title — section header"
-							meta="12px · 700 · +0.2px letter-spacing · text-0 · 7 uses"
-						/>
-						<Rung
-							cls="tla-text_ui__medium"
-							sample="Medium — body text"
-							meta="12px · 500 · 4 uses"
-							dupe
-						/>
-						<Rung
-							cls="tla-text_ui__regular"
-							sample="Regular — body text"
-							meta="12px · 500 · 12 uses"
-							dupe
-						/>
-						<Rung
-							cls="tla-text_ui__small"
-							sample="Small — muted caption"
+							source="tla.css"
+						>
+							<span className="tla-text_ui__big">Heading</span>
+						</Specimen>
+						<Specimen
+							label="title"
+							code={`className="tla-text_ui__title"`}
+							meta="12px · 700 · +0.2px letter-spacing · 7 uses"
+							source="tla.css"
+						>
+							<span className="tla-text_ui__title">Section title</span>
+						</Specimen>
+						<Specimen
+							label="medium ⚠ ≡ regular"
+							code={`className="tla-text_ui__medium"`}
+							meta="12px · 500 · 4 uses — identical to regular"
+							source="tla.css"
+						>
+							<span className="tla-text_ui__medium">Medium body</span>
+						</Specimen>
+						<Specimen
+							label="regular ⚠ ≡ medium"
+							code={`className="tla-text_ui__regular"`}
+							meta="12px · 500 · 12 uses — identical to medium"
+							source="tla.css"
+						>
+							<span className="tla-text_ui__regular">Regular body</span>
+						</Specimen>
+						<Specimen
+							label="small"
+							code={`className="tla-text_ui__small"`}
 							meta="11px · 500 · text-3 · 10 uses"
-						/>
+							source="tla.css"
+						>
+							<span className="tla-text_ui__small">Small caption</span>
+						</Specimen>
 					</div>
 				</section>
 

--- a/apps/dotcom/client/src/pages/dev-typography.tsx
+++ b/apps/dotcom/client/src/pages/dev-typography.tsx
@@ -226,14 +226,6 @@ export function Component() {
 					</div>
 				</section>
 
-				<footer className="page__footer">
-					Three decisions for #9196, none of them a sweep: (1) the canonical rungs — keep 11 / 12 /
-					24, or add the off-scale 14 / 16 / 20 and a 600 weight the app keeps reaching for? (2) how
-					to expose them — design tokens, a <code>&lt;TlaText&gt;</code> component, or both — so CSS
-					Modules and JSX can reference the scale instead of hardcoding it; (3) collapse the medium
-					≡ regular duplicate. (Whether to unify with the SDK&rsquo;s <code>tl</code> text layer at
-					all is a separate, larger question.) See tldraw/tldraw#9196.
-				</footer>
 			</div>
 		</div>
 	)

--- a/apps/dotcom/client/src/pages/dev-typography.tsx
+++ b/apps/dotcom/client/src/pages/dev-typography.tsx
@@ -1,0 +1,330 @@
+/* eslint-disable tldraw/jsx-no-literals */
+import { ReactNode } from 'react'
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only inventory of the dotcom app's type scale, and how it sits next to the
+ * SDK's separate text system. Typography diverges by a MISSING, UNREACHABLE
+ * scale: the dotcom ramp exists only as global CSS utility classes
+ * (.tla-text_ui__*) with no token and no component, so CSS Modules can't use it
+ * and hardcode font-size/weight — most text bypasses the scale entirely. The SDK
+ * (tl layer) is a wholly separate system that doesn't use tla-text_ui at all.
+ *
+ * Serves tldraw/tldraw#9196 (establish a typography system). Route:
+ * /dev/components/typography.
+ */
+
+const Rung = ({
+	cls,
+	sample,
+	meta,
+	dupe,
+}: {
+	cls: string
+	sample: string
+	meta: string
+	dupe?: boolean
+}): ReactNode => (
+	<div className="rung">
+		<div className={`rung__sample ${cls}`}>{sample}</div>
+		<div className="rung__meta">
+			<code>.{cls}</code>
+			<span>{meta}</span>
+			{dupe && <span className="rung__flag">⚠ identical to its pair</span>}
+		</div>
+	</div>
+)
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }): ReactNode => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Typography inventory — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Typography inventory</h1>
+					<p className="page__lede">
+						Every text-styling mechanism in the dotcom app, and the boundary with the SDK. The short
+						answer to &ldquo;does everything use <code>.tla-text_ui__*</code>?&rdquo; is no: the
+						scale is the minority, most text hardcodes its size, and the SDK is a separate system
+						entirely.
+					</p>
+				</header>
+
+				{/* Punchline 1: the scale is the minority. */}
+				<section className="section">
+					<h2 className="section__title">Coverage reality (dotcom text styling)</h2>
+					<p className="section__note">
+						How dotcom elements get their text size. More text hardcodes a font-size than reaches
+						the scale.
+					</p>
+					<div className="stats">
+						<Stat n="34" label="use a .tla-text_ui__* class" />
+						<Stat n="39" label="hardcode font-size in *.module.css" accent />
+						<Stat n="2" label="inline style fontSize" accent />
+					</div>
+				</section>
+
+				{/* Punchline 2: two separate systems. */}
+				<section className="section">
+					<h2 className="section__title">Two separate text systems</h2>
+					<p className="section__note">
+						<code>.tla-text_ui__*</code> is dotcom-only — zero uses in <code>packages/</code>. The
+						SDK has its own font system that the app layer doesn&rsquo;t touch. Neither has a
+						font-size token.
+					</p>
+					<table className="matrix matrix--wide">
+						<thead>
+							<tr>
+								<th></th>
+								<th>dotcom (tla layer)</th>
+								<th>SDK (tl layer)</th>
+							</tr>
+						</thead>
+						<tbody>
+							{SYSTEMS.map((r) => (
+								<tr key={r[0]}>
+									<td className="rowhead">{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The dotcom scale, as it exists</h2>
+					<p className="section__note">
+						Five global classes in <code>tla/styles/tla.css</code> — only three distinct sizes (11 /
+						12 / 24px), a 12→24 gap, and a byte-identical pair.
+					</p>
+					<div className="ladder">
+						<Rung
+							cls="tla-text_ui__big"
+							sample="Big — page heading"
+							meta="24px · 400 · text-0 · 1 use"
+						/>
+						<Rung
+							cls="tla-text_ui__title"
+							sample="Title — section header"
+							meta="12px · 700 · +0.2px letter-spacing · text-0 · 7 uses"
+						/>
+						<Rung
+							cls="tla-text_ui__medium"
+							sample="Medium — body text"
+							meta="12px · 500 · 4 uses"
+							dupe
+						/>
+						<Rung
+							cls="tla-text_ui__regular"
+							sample="Regular — body text"
+							meta="12px · 500 · 12 uses"
+							dupe
+						/>
+						<Rung
+							cls="tla-text_ui__small"
+							sample="Small — muted caption"
+							meta="11px · 500 · text-3 · 10 uses"
+						/>
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The structural gap</h2>
+					<div className="callout">
+						The scale exists <strong>only as global CSS utility classes</strong> (
+						<code>.tla-text_ui__*</code>). There is <strong>no token layer</strong> (no{' '}
+						<code>--tla-font-size-*</code> / <code>--tla-font-weight-*</code>) and{' '}
+						<strong>
+							no <code>&lt;TlaText&gt;</code> component
+						</strong>
+						. CSS Modules are locally scoped and can&rsquo;t reference the global classes, so every
+						module that wants &ldquo;12px / 500 text&rdquo; re-types it by hand — which is why the
+						39 hardcoded font-sizes above outnumber the 34 that reach the scale. The scale is
+						unreachable from where text is actually styled.
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Where the hardcoding lives (*.module.css)</h2>
+					<p className="section__note">
+						Per-file count of hardcoded <code>font-size</code> declarations — the auth and admin
+						forms dominate.
+					</p>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>file</th>
+								<th>font-size decls</th>
+							</tr>
+						</thead>
+						<tbody>
+							{BY_FILE.map((r) => (
+								<tr key={r[0]}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Drift & off-scale (the hardcoded values)</h2>
+					<p className="section__note">
+						Matches-a-rung values are drift (should reference the scale); the rest reveal missing
+						rungs.
+					</p>
+					<div className="tables">
+						<table className="matrix">
+							<thead>
+								<tr>
+									<th>font-size</th>
+									<th>count</th>
+									<th>status</th>
+								</tr>
+							</thead>
+							<tbody>
+								{SIZES.map((r) => (
+									<tr key={r[0]} data-off={r[2].startsWith('off') || undefined}>
+										<td>{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+						<table className="matrix">
+							<thead>
+								<tr>
+									<th>font-weight</th>
+									<th>count</th>
+									<th>status</th>
+								</tr>
+							</thead>
+							<tbody>
+								{WEIGHTS.map((r) => (
+									<tr key={r[0]} data-off={r[2].startsWith('off') || undefined}>
+										<td>{r[0]}</td>
+										<td>{r[1]}</td>
+										<td>{r[2]}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				</section>
+
+				<footer className="page__footer">
+					Three decisions for #9196, none of them a sweep: (1) the canonical rungs — keep 11 / 12 /
+					24, or add the off-scale 14 / 16 / 20 and a 600 weight the app keeps reaching for? (2) how
+					to expose them — design tokens, a <code>&lt;TlaText&gt;</code> component, or both — so CSS
+					Modules and JSX can reference the scale instead of hardcoding it; (3) collapse the medium
+					≡ regular duplicate. (Whether to unify with the SDK&rsquo;s <code>tl</code> text layer at
+					all is a separate, larger question.) See tldraw/tldraw#9196.
+				</footer>
+			</div>
+		</div>
+	)
+}
+
+const SYSTEMS: ReadonlyArray<readonly [string, string, string]> = [
+	[
+		'font family',
+		'--tla-font-ui (Inter + system)',
+		'--tl-font-draw / sans / serif / mono (custom) + system for UI',
+	],
+	[
+		'size scale',
+		'.tla-text_ui__* — 5 global classes',
+		'none — base .tl-container 12px, ad-hoc per rule',
+	],
+	['size token', 'none', 'none'],
+	['uses .tla-text_ui__*?', 'partially — 34 sites', 'no — dotcom-only'],
+	['hardcoded sizes', '39 in *.module.css + 2 inline', '~18 font-size decls in ui.css'],
+]
+
+const BY_FILE: ReadonlyArray<readonly [string, string]> = [
+	['dialogs/auth.module.css', '13'],
+	['pages/admin.module.css', '13'],
+	['dialogs/dialogs.module.css', '5'],
+	['MaybeForceUserRefresh.module.css', '2'],
+	['dialogs/TlaInviteExpiredDialog.module.css', '2'],
+	['+ 4 files (button / cta / invite / anon-link)', '1 each'],
+]
+
+const SIZES: ReadonlyArray<readonly [string, string, string]> = [
+	['12px', '27', 'drift → matches medium / regular'],
+	['11px', '5', 'drift → matches small'],
+	['16px', '5', 'off-scale — no rung (12→24 gap)'],
+	['20px', '1', 'off-scale'],
+	['14px', '1', 'off-scale'],
+]
+
+const WEIGHTS: ReadonlyArray<readonly [string, string, string]> = [
+	['500', '16', 'on scale (small / medium / regular)'],
+	['700', '2', 'on scale (title)'],
+	['bold', '1', 'on scale — keyword spelling of 700'],
+	['600', '9', 'off-scale — not in {400, 500, 700}'],
+	['800', '3', 'off-scale'],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 760px; margin-bottom: 40px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.section { margin-bottom: 48px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 760px; }
+.section code, .callout code, .page__footer code, .section__note code { font-family: ui-monospace, monospace; font-size: 0.92em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 200px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 28px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.ladder { border: 1px solid var(--tl-color-divider); border-radius: 8px; overflow: hidden; max-width: 880px; }
+.rung { display: flex; align-items: baseline; justify-content: space-between; gap: 32px; padding: 16px 18px; border-bottom: 1px solid var(--tl-color-divider); }
+.rung:last-child { border-bottom: none; }
+.rung__sample { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rung__meta { flex: 0 0 auto; display: flex; align-items: baseline; gap: 12px; font-size: 11px; font-family: ui-monospace, monospace; color: var(--tl-color-text-3); }
+.rung__meta code { color: var(--tl-color-text-1); }
+.rung__flag { color: var(--tl-color-warning, #cb4b16); }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 840px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.tables { display: flex; gap: 48px; flex-wrap: wrap; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix--wide td, .matrix--wide th { padding-right: 28px; max-width: 360px; }
+.matrix .rowhead { color: var(--tl-color-text-3); }
+.matrix tr[data-off] td:last-child { color: var(--tl-color-warning, #cb4b16); }
+.matrix tr[data-off] td:first-child { font-weight: 700; }
+.page__footer { max-width: 760px; font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); border-top: 1px solid var(--tl-color-divider); padding-top: 20px; }
+`

--- a/apps/dotcom/client/src/pages/dev-zindex.tsx
+++ b/apps/dotcom/client/src/pages/dev-zindex.tsx
@@ -1,0 +1,270 @@
+/* eslint-disable tldraw/jsx-no-literals, react/no-unescaped-entities */
+import { Helmet } from 'react-helmet-async'
+import 'tldraw/tldraw.css'
+import '../tla/styles/tla.css'
+import { SPECIMEN_CSS } from './dev-components-kit'
+import { DevComponentsNav } from './dev-components-nav'
+
+/**
+ * Dev-only audit of z-index / stacking order. Unlike the dates and identity
+ * findings (a missing primitive), here the primitive EXISTS and is ignored: the
+ * SDK ships a full --tl-layer-* token scale (~30 named layers across two ladders,
+ * canvas + UI), but dotcom mostly uses magic numbers — 51 literal z-index
+ * declarations, only 4 referencing the tokens. The magic numbers land on named
+ * rungs (250 = menu-click-capture = canvas-in-front; 10000 = canvas-blocker), so
+ * a bare integer can't express intent and any SDK renumber silently reorders the
+ * app. Route: /dev/components/z-index.
+ */
+
+/** One rung of the stacking order: a z-index value and who sits there. */
+interface Rung {
+	z: number
+	sdk?: string[] // SDK --tl-layer-* names at this value
+	dotcom?: string[] // dotcom magic-number sites at this value
+}
+
+// Sorted high → low (top of the stack first), curated to the rungs dotcom competes with.
+const LADDER: Rung[] = [
+	{ z: 10000, sdk: ['canvas-blocker'], dotcom: ['MaybeForceUserRefresh'] },
+	{ z: 999, sdk: ['header-footer'] },
+	{ z: 700, sdk: ['cursor'] },
+	{ z: 650, sdk: ['toasts'] },
+	{ z: 500, sdk: ['canvas-overlays'] },
+	{ z: 400, sdk: ['menus'] },
+	{ z: 300, sdk: ['panels', 'canvas-shapes'] },
+	{ z: 250, sdk: ['menu-click-capture', 'canvas-in-front'], dotcom: ['TlaSidebarLayout'] },
+	{ z: 200, sdk: ['watermark'] },
+	{ z: 150, sdk: ['canvas-grid'] },
+	{ z: 100, sdk: ['canvas-background', 'overlays-selection-fg'], dotcom: ['TlaSidebar ×2'] },
+	{ z: 99, dotcom: ['TlaSidebar'] },
+	{ z: 10, sdk: ['focused-input', 'overlays-collaborator-scribble'] },
+	{ z: 1, sdk: ['above', 'text-container', 'error-overlay'] },
+]
+
+const isCollision = (r: Rung) => !!r.dotcom && !!r.sdk
+
+export function Component() {
+	return (
+		<div
+			className="tla tl-container tla-theme-container tla-theme__light tl-theme__light"
+			style={{ position: 'absolute', inset: 0, display: 'block', overflow: 'auto' }}
+		>
+			<Helmet>
+				<title>Z-index audit — dev</title>
+			</Helmet>
+			<style>{PAGE_CSS + SPECIMEN_CSS}</style>
+
+			<div className="page">
+				<DevComponentsNav />
+				<header className="page__header">
+					<h1 className="page__title">Z-index &amp; stacking order</h1>
+					<p className="page__lede">
+						The opposite of the <a href="/dev/components/timestamps">dates</a> /{' '}
+						<a href="/dev/components/identity">identity</a> findings: here the primitive{' '}
+						<strong>exists and is ignored</strong>. The SDK ships a full <code>--tl-layer-*</code>{' '}
+						token scale (~30 named layers), but dotcom mostly uses <strong>magic numbers</strong> —
+						51 literal <code>z-index</code> declarations, only <strong>4</strong> reference the
+						tokens. And the magic numbers land on named rungs, so a bare integer can't say what it
+						means.
+					</p>
+				</header>
+
+				<section className="section">
+					<div className="stats">
+						<Stat n="~30" label="SDK --tl-layer-* tokens" />
+						<Stat n="51" label="dotcom literal z-index" accent />
+						<Stat n="4" label="dotcom uses the tokens" />
+						<Stat n="10000" label="highest magic number" accent />
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The stacking order</h2>
+					<p className="section__note">
+						The SDK ladder (green) with dotcom's magic numbers (orange) placed on the same number
+						line. Rows where an <strong>orange lands on a green</strong> are collisions — a bare
+						number that happens to equal a named layer, with no way to tell if that was intended.
+					</p>
+					<div className="ladder">
+						{LADDER.map((r) => (
+							<div key={r.z} className="rung" data-collision={isCollision(r) || undefined}>
+								<div className="rung__z">{r.z}</div>
+								<div className="rung__bars">
+									{r.sdk?.map((n) => (
+										<span key={n} className="chip chip--sdk">
+											--tl-layer-{n}
+										</span>
+									))}
+									{r.dotcom?.map((n) => (
+										<span key={n} className="chip chip--dotcom">
+											{n}
+										</span>
+									))}
+								</div>
+								{isCollision(r) && <div className="rung__flag">collision</div>}
+							</div>
+						))}
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The collisions</h2>
+					<div className="callout callout--bug">
+						A magic number can't express intent, and it silently hitches to whatever the SDK numbers
+						happen to be:
+						<ul className="clist">
+							<li>
+								<code>250</code> (<code>TlaSidebarLayout</code>) equals <strong>three</strong>{' '}
+								things: <code>--tl-layer-menu-click-capture</code>,{' '}
+								<code>--tl-layer-canvas-in-front</code>, and itself. Is the sidebar meant to sit at
+								the menu-capture layer, or did it just pick 250? Unknowable.
+							</li>
+							<li>
+								<code>10000</code> (<code>MaybeForceUserRefresh</code>) equals{' '}
+								<code>--tl-layer-canvas-blocker</code> — plausibly intentional (both are
+								block-everything overlays), but written as a bare number it doesn't say so.
+							</li>
+							<li>
+								<code>100</code> (<code>TlaSidebar</code>) equals{' '}
+								<code>--tl-layer-canvas-background</code> /{' '}
+								<code>--tl-layer-overlays-selection-fg</code>.
+							</li>
+						</ul>
+						If the SDK ever renumbers the scale, these app surfaces reorder with no code change and
+						no warning.
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">Two ladders share one number line</h2>
+					<div className="callout">
+						Even within the SDK the scale is doubled: a <strong>canvas</strong> ladder (
+						<code>
+							canvas-background 100 → watermark 200 → canvas-in-front 250 → canvas-shapes 300 →
+							canvas-overlays 500 → canvas-blocker 10000
+						</code>
+						) and a <strong>UI</strong> ladder (
+						<code>
+							above 1 → menu-click-capture 250 → panels 300 → menus 400 → toasts 650 → cursor 700 →
+							header-footer 999
+						</code>
+						) reuse the same integers for different jobs (<code>250</code>, <code>300</code> each
+						mean two things). That's fine <em>because</em> the canvas and UI stacking contexts don't
+						overlap — but it means "just pick a bigger number" is never safe reasoning, since 250
+						isn't one layer, it's two.
+					</div>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">dotcom's literal z-indexes</h2>
+					<table className="matrix">
+						<thead>
+							<tr>
+								<th>site</th>
+								<th>z-index</th>
+								<th>lands on</th>
+							</tr>
+						</thead>
+						<tbody>
+							{OFFENDERS.map((r) => (
+								<tr key={r[0]} data-bug={r[3] || undefined}>
+									<td>{r[0]}</td>
+									<td>{r[1]}</td>
+									<td>{r[2]}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
+					<p className="section__note" style={{ marginTop: 14 }}>
+						Plus a swarm of local <code>z-index: 0/1/2/3</code> across ~10 files — mostly benign
+						within-component stacking, but each still a literal rather than a token.
+					</p>
+				</section>
+
+				<section className="section">
+					<h2 className="section__title">The gap</h2>
+					<div className="callout">
+						The fix here is nearly free: the scale already exists. Every app <code>z-index</code>{' '}
+						should reference <code>var(--tl-layer-*)</code> — or, where the app needs its own rungs,
+						define <code>--tla-layer-*</code> tokens that <em>slot into</em> the SDK scale in one
+						place — so intent is explicit and a renumber is a one-file change. A bare{' '}
+						<code>250</code> should never be how the sidebar says where it lives.
+					</div>
+				</section>
+			</div>
+		</div>
+	)
+}
+
+const Stat = ({ n, label, accent }: { n: string; label: string; accent?: boolean }) => (
+	<div className="stat" data-accent={accent || undefined}>
+		<div className="stat__n">{n}</div>
+		<div className="stat__label">{label}</div>
+	</div>
+)
+
+const OFFENDERS: ReadonlyArray<readonly [string, string, string, boolean]> = [
+	['MaybeForceUserRefresh.module.css:12', '10000', '--tl-layer-canvas-blocker', true],
+	[
+		'TlaSidebarLayout/sidebar-layout.module.css:44',
+		'250',
+		'menu-click-capture / canvas-in-front',
+		true,
+	],
+	['TlaSidebar/sidebar.module.css:8,173', '100', 'canvas-background / selection-fg', true],
+	['TlaSidebar/sidebar.module.css:32', '99', '(just below 100)', false],
+	['sidebar.module.css:548', 'var(--tl-layer-menus)', '✓ uses the token', false],
+	['tla-menu/menu.module.css:134', 'var(--tl-layer-canvas-overlays)', '✓ uses the token', false],
+	['dialogs.module.css:166', 'var(--tl-layer-toasts)', '✓ uses the token', false],
+	[
+		'TlaAnonDotDevLink.module.css:5',
+		'calc(var(--tl-layer-watermark) + 1)',
+		'✓ uses the token',
+		false,
+	],
+]
+
+const PAGE_CSS = `
+.page {
+	min-height: 100vh;
+	background: var(--tl-color-background);
+	color: var(--tl-color-text);
+	font-family: var(--tla-font-ui);
+	padding: 24px 40px 80px;
+	box-sizing: border-box;
+}
+.page__header { max-width: 820px; margin-bottom: 32px; }
+.page__title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+.page__lede { font-size: 14px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0; }
+.page__lede strong { color: var(--tl-color-text-0); font-weight: 600; }
+.page__lede a { color: var(--tl-color-primary); }
+.page__lede code, .section__note code, .callout code { font-family: ui-monospace, monospace; font-size: 0.9em; background: var(--tl-color-low); padding: 1px 4px; border-radius: 3px; }
+.section { margin-bottom: 44px; }
+.section__title { font-size: 18px; font-weight: 600; margin: 0 0 6px; }
+.section__note { font-size: 13px; line-height: 1.6; color: var(--tl-color-text-1); margin: 0 0 16px; max-width: 820px; }
+.section__note strong { color: var(--tl-color-text-0); }
+.stats { display: flex; gap: 16px; flex-wrap: wrap; }
+.stat { border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 20px; min-width: 160px; background: var(--tl-color-panel); }
+.stat[data-accent] { border-color: var(--tl-color-warning, #cb4b16); }
+.stat__n { font-size: 24px; font-weight: 700; font-family: ui-monospace, monospace; }
+.stat[data-accent] .stat__n { color: var(--tl-color-warning, #cb4b16); }
+.stat__label { font-size: 12px; color: var(--tl-color-text-1); margin-top: 4px; }
+.ladder { display: flex; flex-direction: column; gap: 2px; max-width: 860px; border-left: 2px solid var(--tl-color-divider); padding-left: 4px; }
+.rung { display: flex; align-items: center; gap: 12px; padding: 5px 8px; border-radius: 6px; }
+.rung[data-collision] { background: color-mix(in srgb, var(--tl-color-warning, #cb4b16) 10%, transparent); }
+.rung__z { width: 54px; text-align: right; font-family: ui-monospace, monospace; font-size: 13px; font-weight: 600; color: var(--tl-color-text-3); }
+.rung__bars { display: flex; gap: 6px; flex-wrap: wrap; flex: 1; }
+.chip { font-family: ui-monospace, monospace; font-size: 11px; padding: 2px 8px; border-radius: 999px; white-space: nowrap; }
+.chip--sdk { background: color-mix(in srgb, var(--tl-color-success, #2a9d3c) 16%, transparent); color: var(--tl-color-success, #2a9d3c); }
+.chip--dotcom { background: color-mix(in srgb, var(--tl-color-warning, #cb4b16) 18%, transparent); color: var(--tl-color-warning, #cb4b16); font-weight: 600; }
+.rung__flag { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--tl-color-warning, #cb4b16); font-weight: 600; }
+.callout { font-size: 13px; line-height: 1.7; color: var(--tl-color-text-1); background: var(--tl-color-low); border: 1px solid var(--tl-color-divider); border-radius: 8px; padding: 16px 18px; max-width: 900px; }
+.callout strong { color: var(--tl-color-text-0); font-weight: 600; }
+.callout--bug { border-color: var(--tl-color-warning, #cb4b16); }
+.clist { margin: 10px 0 0; padding-left: 20px; }
+.clist li { margin-bottom: 8px; }
+.matrix { border-collapse: collapse; font-size: 12px; font-family: ui-monospace, monospace; width: 100%; max-width: 900px; }
+.matrix th, .matrix td { text-align: left; padding: 6px 18px 6px 0; border-bottom: 1px solid var(--tl-color-divider); vertical-align: top; }
+.matrix th { color: var(--tl-color-text-3); font-weight: 500; }
+.matrix tr[data-bug] td:nth-child(3) { color: var(--tl-color-warning, #cb4b16); font-weight: 600; }
+`

--- a/apps/dotcom/client/src/routes.test.tsx
+++ b/apps/dotcom/client/src/routes.test.tsx
@@ -108,7 +108,11 @@ function getSpaRoutes(routeObjects: RouteObject[]) {
 	)
 }
 
-const spaRoutes = getSpaRoutes(createAppRouter({ includeDevRoutes: false }))
+// Spike: include dev routes in the SPA manifest so the /dev/components gallery is
+// reachable on the PR preview deploy. The client still gates rendering on a
+// dev/preview hostname (getDefaultIncludeDevRoutes), so prod just serves the
+// not-found page for these paths.
+const spaRoutes = getSpaRoutes(createAppRouter({ includeDevRoutes: true }))
 const devSpaRoutes = getSpaRoutes(createAppRouter({ includeDevRoutes: true }))
 
 const allVercelRouterPatterns = spaRoutes.map((route) => route.vercelRouterPattern)
@@ -117,9 +121,9 @@ test('the_routes', () => {
 	expect(spaRoutes).toMatchSnapshot()
 })
 
-test('dev reset route exists only in development routing', () => {
+test('dev routes are included in the SPA routing (spike preview)', () => {
 	expect(devSpaRoutes.map((route) => route.reactRouterPattern)).toContain('/dev/reset-local-state')
-	expect(spaRoutes.map((route) => route.reactRouterPattern)).not.toContain('/dev/reset-local-state')
+	expect(spaRoutes.map((route) => route.reactRouterPattern)).toContain('/dev/components/buttons')
 })
 
 test('all React routes match', () => {

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -81,6 +81,7 @@ export function createAppRouter({
 					<Route path="/dev/components/typography" lazy={() => import('./pages/dev-typography')} />
 					<Route path="/dev/components/dialogs" lazy={() => import('./pages/dev-dialogs')} />
 					<Route path="/dev/components/menus" lazy={() => import('./pages/dev-menus')} />
+					<Route path="/dev/components/icons" lazy={() => import('./pages/dev-icons')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -102,6 +102,7 @@ export function createAppRouter({
 					<Route path="/dev/components/timestamps" lazy={() => import('./pages/dev-timestamps')} />
 					<Route path="/dev/components/identity" lazy={() => import('./pages/dev-identity')} />
 					<Route path="/dev/components/z-index" lazy={() => import('./pages/dev-zindex')} />
+					<Route path="/dev/components/shadows" lazy={() => import('./pages/dev-shadows')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -100,6 +100,7 @@ export function createAppRouter({
 					<Route path="/dev/components/sidebar" lazy={() => import('./pages/dev-sidebar')} />
 					<Route path="/dev/components/editor" lazy={() => import('./pages/dev-editor')} />
 					<Route path="/dev/components/timestamps" lazy={() => import('./pages/dev-timestamps')} />
+					<Route path="/dev/components/identity" lazy={() => import('./pages/dev-identity')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -74,7 +74,10 @@ export function createAppRouter({
 			}}
 		>
 			{includeDevRoutes && (
-				<Route path="/dev/reset-local-state" lazy={() => import('./pages/dev-reset-local-state')} />
+				<>
+					<Route path="/dev/reset-local-state" lazy={() => import('./pages/dev-reset-local-state')} />
+					<Route path="/dev/buttons" lazy={() => import('./pages/dev-buttons')} />
+				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>
 				<Route path={ROUTES.tlaRoot} lazy={() => import('./tla/pages/local')} />

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -82,6 +82,7 @@ export function createAppRouter({
 					<Route path="/dev/components/dialogs" lazy={() => import('./pages/dev-dialogs')} />
 					<Route path="/dev/components/menus" lazy={() => import('./pages/dev-menus')} />
 					<Route path="/dev/components/icons" lazy={() => import('./pages/dev-icons')} />
+					<Route path="/dev/components/links" lazy={() => import('./pages/dev-links')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -101,6 +101,7 @@ export function createAppRouter({
 					<Route path="/dev/components/editor" lazy={() => import('./pages/dev-editor')} />
 					<Route path="/dev/components/timestamps" lazy={() => import('./pages/dev-timestamps')} />
 					<Route path="/dev/components/identity" lazy={() => import('./pages/dev-identity')} />
+					<Route path="/dev/components/z-index" lazy={() => import('./pages/dev-zindex')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -87,6 +87,7 @@ export function createAppRouter({
 					<Route path="/dev/components/form-controls" lazy={() => import('./pages/dev-form-controls')} />
 					<Route path="/dev/components/presence" lazy={() => import('./pages/dev-presence')} />
 					<Route path="/dev/components/logo" lazy={() => import('./pages/dev-logo')} />
+					<Route path="/dev/components/states" lazy={() => import('./pages/dev-states')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -78,7 +78,10 @@ export function createAppRouter({
 		>
 			{includeDevRoutes && (
 				<>
-					<Route path="/dev/reset-local-state" lazy={() => import('./pages/dev-reset-local-state')} />
+					<Route
+						path="/dev/reset-local-state"
+						lazy={() => import('./pages/dev-reset-local-state')}
+					/>
 					<Route path="/dev/components/buttons" lazy={() => import('./pages/dev-buttons')} />
 					<Route path="/dev/components/inputs" lazy={() => import('./pages/dev-inputs')} />
 					<Route path="/dev/components/typography" lazy={() => import('./pages/dev-typography')} />
@@ -87,7 +90,10 @@ export function createAppRouter({
 					<Route path="/dev/components/icons" lazy={() => import('./pages/dev-icons')} />
 					<Route path="/dev/components/links" lazy={() => import('./pages/dev-links')} />
 					<Route path="/dev/components/overlays" lazy={() => import('./pages/dev-overlays')} />
-					<Route path="/dev/components/form-controls" lazy={() => import('./pages/dev-form-controls')} />
+					<Route
+						path="/dev/components/form-controls"
+						lazy={() => import('./pages/dev-form-controls')}
+					/>
 					<Route path="/dev/components/presence" lazy={() => import('./pages/dev-presence')} />
 					<Route path="/dev/components/logo" lazy={() => import('./pages/dev-logo')} />
 					<Route path="/dev/components/states" lazy={() => import('./pages/dev-states')} />

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -88,6 +88,7 @@ export function createAppRouter({
 					<Route path="/dev/components/presence" lazy={() => import('./pages/dev-presence')} />
 					<Route path="/dev/components/logo" lazy={() => import('./pages/dev-logo')} />
 					<Route path="/dev/components/states" lazy={() => import('./pages/dev-states')} />
+					<Route path="/dev/components/sidebar" lazy={() => import('./pages/dev-sidebar')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -89,6 +89,7 @@ export function createAppRouter({
 					<Route path="/dev/components/logo" lazy={() => import('./pages/dev-logo')} />
 					<Route path="/dev/components/states" lazy={() => import('./pages/dev-states')} />
 					<Route path="/dev/components/sidebar" lazy={() => import('./pages/dev-sidebar')} />
+					<Route path="/dev/components/editor" lazy={() => import('./pages/dev-editor')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -79,6 +79,7 @@ export function createAppRouter({
 					<Route path="/dev/components/buttons" lazy={() => import('./pages/dev-buttons')} />
 					<Route path="/dev/components/inputs" lazy={() => import('./pages/dev-inputs')} />
 					<Route path="/dev/components/typography" lazy={() => import('./pages/dev-typography')} />
+					<Route path="/dev/components/dialogs" lazy={() => import('./pages/dev-dialogs')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -83,6 +83,7 @@ export function createAppRouter({
 					<Route path="/dev/components/menus" lazy={() => import('./pages/dev-menus')} />
 					<Route path="/dev/components/icons" lazy={() => import('./pages/dev-icons')} />
 					<Route path="/dev/components/links" lazy={() => import('./pages/dev-links')} />
+					<Route path="/dev/components/overlays" lazy={() => import('./pages/dev-overlays')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -99,6 +99,7 @@ export function createAppRouter({
 					<Route path="/dev/components/states" lazy={() => import('./pages/dev-states')} />
 					<Route path="/dev/components/sidebar" lazy={() => import('./pages/dev-sidebar')} />
 					<Route path="/dev/components/editor" lazy={() => import('./pages/dev-editor')} />
+					<Route path="/dev/components/timestamps" lazy={() => import('./pages/dev-timestamps')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -80,6 +80,7 @@ export function createAppRouter({
 					<Route path="/dev/components/inputs" lazy={() => import('./pages/dev-inputs')} />
 					<Route path="/dev/components/typography" lazy={() => import('./pages/dev-typography')} />
 					<Route path="/dev/components/dialogs" lazy={() => import('./pages/dev-dialogs')} />
+					<Route path="/dev/components/menus" lazy={() => import('./pages/dev-menus')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -16,7 +16,10 @@ interface CreateAppRouterOptions {
 
 function getDefaultIncludeDevRoutes() {
 	// @ts-ignore this is provided by Vite
-	return import.meta.env.DEV
+	if (import.meta.env.DEV) return true
+	// Also include them on PR preview deploys (pr-<N>-preview-deploy.tldraw.com) so
+	// the /dev/components gallery is shareable, without exposing it in production.
+	return typeof window !== 'undefined' && window.location.hostname.includes('preview-deploy')
 }
 
 export function createAppRouter({

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -78,6 +78,7 @@ export function createAppRouter({
 					<Route path="/dev/reset-local-state" lazy={() => import('./pages/dev-reset-local-state')} />
 					<Route path="/dev/components/buttons" lazy={() => import('./pages/dev-buttons')} />
 					<Route path="/dev/components/inputs" lazy={() => import('./pages/dev-inputs')} />
+					<Route path="/dev/components/typography" lazy={() => import('./pages/dev-typography')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -84,6 +84,9 @@ export function createAppRouter({
 					<Route path="/dev/components/icons" lazy={() => import('./pages/dev-icons')} />
 					<Route path="/dev/components/links" lazy={() => import('./pages/dev-links')} />
 					<Route path="/dev/components/overlays" lazy={() => import('./pages/dev-overlays')} />
+					<Route path="/dev/components/form-controls" lazy={() => import('./pages/dev-form-controls')} />
+					<Route path="/dev/components/presence" lazy={() => import('./pages/dev-presence')} />
+					<Route path="/dev/components/logo" lazy={() => import('./pages/dev-logo')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -76,7 +76,8 @@ export function createAppRouter({
 			{includeDevRoutes && (
 				<>
 					<Route path="/dev/reset-local-state" lazy={() => import('./pages/dev-reset-local-state')} />
-					<Route path="/dev/buttons" lazy={() => import('./pages/dev-buttons')} />
+					<Route path="/dev/components/buttons" lazy={() => import('./pages/dev-buttons')} />
+					<Route path="/dev/components/inputs" lazy={() => import('./pages/dev-inputs')} />
 				</>
 			)}
 			<Route lazy={() => import('./tla/providers/TlaRootProviders')}>


### PR DESCRIPTION
## What this is

A spike to get a **lay of the land** of the dotcom design system — *not* for merge. It adds a dev-only gallery at `/dev/components` that renders (almost) every shared UI component the app uses, **live**, so we can see what exists and where it diverges before deciding what a real design system should be. Exploratory groundwork for #9189 — happy to keep it, fold it into something durable, or close it.

## How to view

Preview: <https://pr-9449-preview-deploy.tldraw.com/dev/components/buttons> — use the nav at the top of each page to walk the families. (Gated to dev + preview deploys; it does **not** appear in production.)

## What's in it

16 live pages — **families** (buttons, inputs, typography, dialogs, menus, icons, links, overlays, form controls, presence, logo, states) and two **consumption maps** (sidebar, editor: which design-system primitives a feature reuses vs. where it goes bespoke). Every specimen renders the **real** component — editor/context-coupled ones (menus, dialogs, toasts, presence) run in a minimal in-memory `<Tldraw>` or with faked state (fake presence records, forced-open dropdowns), so you see the resolved UI with no live session.

## What it surfaced

- The sidebar alone reaches for **9 bespoke button/trigger classes** instead of the SDK button (#9193 / #9194)
- Typography: **47 size declarations collapse to 6 sizes**; `12px` is hardcoded **28×** outside the classes (#9196)
- Icons: only **23 of 66** sprite icons are used (~65% dead)
- A duplicate `@keyframes tla-spin`, no shared `<ErrorState>`, and two parallel i18n systems (SDK vs dotcom react-intl)

## Testing

Open the preview, visit `/dev/components/buttons`, and walk the nav. Nothing ships to production — routes are gated on `import.meta.env.DEV` or a `*-preview-deploy` hostname.
