### PR TITLE
fix(editor): fix firing of onChildrenChange on shape creation

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -563,6 +563,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let deletedBindings = new Map<TLBindingId, BindingOnDeleteOptions<any>>()
 		const deletedShapeIds = new Set<TLShapeId>()
 		const invalidParents = new Set<TLShapeId>()
+		const createdShapes = new Set<TLShapeId>()
 		let invalidBindingTypes = new Set<TLBinding['type']>()
 
 		this.disposables.add(
@@ -571,8 +572,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// and we want the next invocation of this handler to handle those separately
 				deletedShapeIds.clear()
 
+				const justCreatedShapeIds = new Set(createdShapes)
+				createdShapes.clear()
+
 				for (const parentId of invalidParents) {
 					invalidParents.delete(parentId)
+					if (justCreatedShapeIds.has(parentId)) continue
 					const parent = this.getShape(parentId)
 					if (!parent) continue
 
@@ -608,6 +613,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.disposables.add(
 			this.sideEffects.register({
 				shape: {
+					afterCreate: (shape) => {
+						createdShapes.add(shape.id)
+						if (shape.parentId && isShapeId(shape.parentId)) {
+							invalidParents.add(shape.parentId)
+						}
+					},
 					afterChange: (shapeBefore, shapeAfter) => {
 						for (const binding of this.getBindingsInvolvingShape(shapeAfter)) {
 							invalidBindingTypes.add(binding.type)

--- a/packages/tldraw/src/test/shapeutils.test.ts
+++ b/packages/tldraw/src/test/shapeutils.test.ts
@@ -611,3 +611,73 @@ describe('When interacting with a shape...', () => {
 		expect(calls).toEqual(['start', 'change', 'change', 'cancel'])
 	})
 })
+
+describe('onChildrenChange', () => {
+	it('fires when a shape is created with a parentId pointing at an existing shape', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const fn = vi.fn()
+		util.onChildrenChange = fn
+
+		editor.createShape({
+			id: createShapeId('newchild'),
+			type: 'geo',
+			parentId: ids.frame1,
+			x: 0,
+			y: 0,
+		})
+
+		expect(fn).toHaveBeenCalledTimes(1)
+		expect(fn).toHaveBeenCalledWith(editor.getShape(ids.frame1))
+	})
+
+	it('fires when a shape is reparented into an existing shape', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const fn = vi.fn()
+		util.onChildrenChange = fn
+
+		editor.reparentShapes([ids.box1], ids.frame1)
+
+		expect(fn).toHaveBeenCalled()
+		expect(fn).toHaveBeenCalledWith(editor.getShape(ids.frame1))
+	})
+
+	it('fires when a child shape is deleted', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const fn = vi.fn()
+		util.onChildrenChange = fn
+
+		editor.deleteShape(ids.box2)
+
+		expect(fn).toHaveBeenCalledTimes(1)
+		expect(fn).toHaveBeenCalledWith(editor.getShape(ids.frame1))
+	})
+
+	it('fires when a child shape is duplicated into the same parent', () => {
+		const util = editor.getShapeUtil<TLFrameShape>('frame')
+		const fn = vi.fn()
+		util.onChildrenChange = fn
+
+		editor.duplicateShapes([ids.box2])
+
+		expect(fn).toHaveBeenCalled()
+		expect(fn).toHaveBeenCalledWith(editor.getShape(ids.frame1))
+	})
+
+	it('does not dissolve a group created together with its children in the same operation', () => {
+		const groupId = createShapeId('group1')
+		const childA = createShapeId('childA')
+		const childB = createShapeId('childB')
+
+		// A group dissolves itself via onChildrenChange when it has fewer than two
+		// children. Creating the group and its children in one operation must not
+		// trigger that, since the group is still being assembled.
+		editor.createShapes([
+			{ id: groupId, type: 'group', x: 0, y: 0 },
+			{ id: childA, type: 'geo', parentId: groupId, x: 0, y: 0 },
+			{ id: childB, type: 'geo', parentId: groupId, x: 50, y: 0 },
+		])
+
+		expect(editor.getShape(groupId)).toBeDefined()
+		expect(editor.getSortedChildIdsForParent(groupId)).toEqual([childA, childB])
+	})
+})


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8078

We're missing the firing of `onChildrenChange` when creating a shape passing the parent id.
After a shape is created, it was not gathered for side effects at all and this is why it was not firing the callback.

This fix was already proposed in https://github.com/tldraw/tldraw/pull/8172 but @max-drake figured it was now firing twice… but in reality it was because we were firing once for creating the shape and a second time by resizing the shape, this is a different issue and in some ways I believe this is correct behaviour. Should we batch the changes in order to fire once is a follow-up question to this PR

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Reproduction case in issue

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed missing `onChildrenChange` call when directly creating a shape within a parent shape.