### PR TITLE
fix(tldraw): don't set prevDraggingOverShape to the initial one 

### DIFF
--- a/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/DragAndDropManager.ts
@@ -82,7 +82,11 @@ export class DragAndDropManager {
 			.sort((a, b) => allShapes.indexOf(a) - allShapes.indexOf(b))
 
 		this.initialDraggingOverShape = editor.getDraggingOverShape(point, this.shapesToActuallyMove)
-		this.prevDraggingOverShape = this.initialDraggingOverShape
+
+		// The drag hasn't visited any target yet, so start with no previous target (as if over the
+		// page). This makes the first update fire onDragShapesIn for whatever we're already over,
+		// instead of treating the origin's target as already-entered and skipping it.
+		this.prevDraggingOverShape = undefined
 
 		// run once on first frame
 		this.updateDraggingShapes(point, cb)

--- a/packages/tldraw/src/test/dragAndDrop.test.ts
+++ b/packages/tldraw/src/test/dragAndDrop.test.ts
@@ -158,6 +158,28 @@ describe('canRemoveChildrenOfType for non-frame containers', () => {
 	})
 })
 
+describe('reparenting when a drag starts already over the target', () => {
+	it('reparents immediately, without needing to leave the target and re-enter it', () => {
+		// Grid at (100, 100) covers (100, 100) to (600, 300)
+		editor.createShape({ id: ids.grid, type: GRID_TYPE, x: 100, y: 100 })
+
+		// Counter created on the page outside the grid, then moved over the grid without
+		// re-evaluating its parent. It's positioned inside the grid but still parented to the page.
+		editor.createShape({ id: ids.counter, type: COUNTER_TYPE, x: 700, y: 100 })
+		editor.updateShape({ id: ids.counter, type: COUNTER_TYPE, x: 200, y: 150 })
+		expect(editor.getShape(ids.counter)!.parentId).toBe(editor.getCurrentPageId())
+
+		// Start dragging from a point already over the grid and keep it over the grid the whole
+		// time, never passing over the empty page. It should still reparent into the grid.
+		editor.setCurrentTool('select')
+		editor.pointerDown(225, 175, ids.counter).pointerMove(275, 225)
+		vi.advanceTimersByTime(300)
+		editor.pointerUp(275, 225)
+
+		expect(editor.getShape(ids.counter)!.parentId).toBe(ids.grid)
+	})
+})
+
 describe('kickoutOccludedShapes respects canRemoveChildrenOfType', () => {
 	it('keeps a pinned child parented when it no longer overlaps its parent', () => {
 		// Grid covers (100, 100) to (600, 300)

--- a/packages/tldraw/src/test/dragAndDrop.test.ts
+++ b/packages/tldraw/src/test/dragAndDrop.test.ts
@@ -158,8 +158,8 @@ describe('canRemoveChildrenOfType for non-frame containers', () => {
 	})
 })
 
-describe('reparenting when a drag starts already over the target', () => {
-	it('reparents immediately, without needing to leave the target and re-enter it', () => {
+describe('dragging starts over a frame', () => {
+	it('reparents the shape', () => {
 		// Grid at (100, 100) covers (100, 100) to (600, 300)
 		editor.createShape({ id: ids.grid, type: GRID_TYPE, x: 100, y: 100 })
 

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -486,8 +486,9 @@ describe('frame shapes', () => {
 		// box A should still be beneath box B
 		expect(editor.getShape(box1)!.index.localeCompare(editor.getShape(box2)!.index)).toBe(-1)
 
-		// We don't highlight the frame until dragged out and back in
-		expect(editor.getHintingShapeIds()).toHaveLength(0)
+		// The frame is highlighted as a drop target from the first update, even though the shape
+		// started over it (it's still the shape's parent, so nothing is reparented)
+		expect(editor.getHintingShapeIds()).toHaveLength(1)
 
 		expect(editor.getOnlySelectedShape()!.parentId).toBe(frame.id)
 


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/9457

This happens because we're initialising the dragging with a previous drag set to the same initial drag, which means there no change in location and so we end up not parenting the shape.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a frame and move it under the toolbox
2. Drag a new shape from the toolbox to the frame
3. The frame should indicates the new shape will be parented to it

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed the dragging of a shape from the toolbox to a frame when the frame is under the toolbox, the shape is now properly parented to the frame