### PR TITLE
feat(dotcom): redesign error screens

### DIFF
--- a/apps/dotcom/client/e2e/tests/sharing-live.scenario.spec.ts
+++ b/apps/dotcom/client/e2e/tests/sharing-live.scenario.spec.ts
@@ -130,11 +130,11 @@ test.describe('live sharing scenarios', () => {
 
 		await visitor.goto(sharedUrl)
 		await expect(visitor.shareMenu.shareButton).toBeVisible()
-		await expect(visitor.page.getByTestId('tla-error-icon')).not.toBeVisible()
+		await expect(visitor.page.getByTestId('tla-error')).not.toBeVisible()
 
 		await scenario.setSharedLinkType(owner, 'no-access')
 		await expect(visitor.shareMenu.shareButton).not.toBeVisible({ timeout: 10000 })
-		await expect(visitor.page.getByTestId('tla-error-icon')).toBeVisible({ timeout: 10000 })
+		await expect(visitor.page.getByTestId('tla-error')).toBeVisible({ timeout: 10000 })
 	})
 
 	test('published snapshots update only after publishing changes', async ({

--- a/apps/dotcom/client/e2e/tests/smoke/sharing.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/sharing.spec.ts
@@ -83,7 +83,7 @@ test.describe('signed in user on own file', () => {
 
 		// The second page should have the share button and not the error
 		await expect(newShareMenu.shareButton).toBeVisible()
-		await expect(newPage.getByTestId('tla-error-icon')).not.toBeVisible()
+		await expect(newPage.getByTestId('tla-error')).not.toBeVisible()
 
 		// Now unshare it it...
 		await page.getByTestId('shared-link-shared-switch').click()
@@ -94,7 +94,7 @@ test.describe('signed in user on own file', () => {
 
 		// The second page should have an error and not the share button
 		await expect(newShareMenu.shareButton).not.toBeVisible()
-		await expect(newPage.getByTestId('tla-error-icon')).toBeVisible()
+		await expect(newPage.getByTestId('tla-error')).toBeVisible()
 
 		// Now reshare it...
 		await page.getByTestId('shared-link-shared-switch').click()
@@ -105,7 +105,7 @@ test.describe('signed in user on own file', () => {
 
 		// The second page should have the share button and not the error again
 		await expect(newShareMenu.shareButton).toBeVisible()
-		await expect(newPage.getByTestId('tla-error-icon')).not.toBeVisible()
+		await expect(newPage.getByTestId('tla-error')).not.toBeVisible()
 
 		await newContext.close()
 	})

--- a/apps/dotcom/client/e2e/tests/ui.scenario.spec.ts
+++ b/apps/dotcom/client/e2e/tests/ui.scenario.spec.ts
@@ -178,7 +178,7 @@ test.describe('UI scenarios', () => {
 		await owner.waitForMutationResolution()
 
 		await visitor.page.goto(publishedUrl, { waitUntil: 'load' })
-		await expect(visitor.page.getByTestId('tla-error-icon')).toBeVisible()
+		await expect(visitor.page.getByTestId('tla-error')).toBeVisible()
 	})
 
 	test('missing files show not-found UI to signed-in and signed-out users', async ({
@@ -191,13 +191,13 @@ test.describe('UI scenarios', () => {
 		await expect(async () => {
 			await owner.errorPage.expectNotFoundVisible()
 		}).toPass()
-		await expect(owner.page.getByTestId('tla-error-icon')).toBeVisible()
+		await expect(owner.page.getByTestId('tla-error')).toBeVisible()
 
 		await visitor.page.goto(missingFileUrl, { waitUntil: 'load' })
 		await expect(async () => {
 			await visitor.errorPage.expectNotFoundVisible()
 		}).toPass()
-		await expect(visitor.page.getByTestId('tla-error-icon')).toBeVisible()
+		await expect(visitor.page.getByTestId('tla-error')).toBeVisible()
 	})
 
 	test('anonymous export downloads an image file', async ({ visitor }) => {

--- a/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
+++ b/apps/dotcom/client/src/components/ErrorPage/ErrorPage.tsx
@@ -1,7 +1,6 @@
 import { Component, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import translationsEnJson from '../../../public/tla/locales-compiled/en.json'
-import { TlaButton } from '../../tla/components/TlaButton/TlaButton'
 import { F, IntlProvider } from '../../tla/utils/i18n'
 import { isInIframe } from '../../utils/iFrame'
 
@@ -41,19 +40,16 @@ export const sadFaceIcon = (
 
 export function ErrorPage({
 	messages,
-	icon = sadFaceIcon,
 	cta = <GoBackLink />,
 }: {
-	icon?: ReactNode
 	messages: { header: string; para1: string; para2?: string; cta?: string }
 	cta?: ReactNode
 }) {
 	return (
 		// This sits outside the regular providers, it needs to be able to have the intl object in the app context.
 		<IntlProvider defaultLocale="en" locale="en" messages={translationsEnJson}>
-			<div className="error-page">
+			<div className="error-page" data-testid="tla-error">
 				<div className="error-page__container">
-					{icon}
 					<div className="error-page__content">
 						<h1>{messages.header}</h1>
 						<p>{messages.para1}</p>
@@ -83,9 +79,9 @@ export class RefreshErrorBoundary extends Component<
 				<ErrorPage
 					messages={this.props.messages}
 					cta={
-						<TlaButton variant="primary" onClick={() => window.location.reload()}>
+						<button type="button" onClick={() => window.location.reload()}>
 							{this.props.messages.cta}
-						</TlaButton>
+						</button>
 					}
 				/>
 			)

--- a/apps/dotcom/client/src/components/StoreErrorScreen.tsx
+++ b/apps/dotcom/client/src/components/StoreErrorScreen.tsx
@@ -1,5 +1,4 @@
 import { TLRemoteSyncError, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
-import { TlaButton } from '../tla/components/TlaButton/TlaButton'
 import { ErrorPage } from './ErrorPage/ErrorPage'
 import LoginRedirectPage from './LoginRedirectPage/LoginRedirectPage'
 
@@ -12,23 +11,14 @@ export function StoreErrorScreen({ error }: { error: Error }) {
 			case TLSyncErrorCloseEventReason.CLIENT_TOO_OLD: {
 				return (
 					<ErrorPage
-						icon={
-							<img
-								width={36}
-								height={36}
-								src="/tldraw-white-on-black.svg"
-								loading="lazy"
-								role="presentation"
-							/>
-						}
 						messages={{
 							header: 'Refresh the page',
 							para1: 'You need to update to the latest version of tldraw to continue.',
 						}}
 						cta={
-							<TlaButton variant="primary" onClick={() => window.location.reload()}>
+							<button type="button" onClick={() => window.location.reload()}>
 								Refresh
-							</TlaButton>
+							</button>
 						}
 					/>
 				)

--- a/apps/dotcom/client/src/tla/components/TlaFileError/TlaFileError.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaFileError/TlaFileError.module.css
@@ -6,11 +6,41 @@
 	justify-content: center;
 	height: 100%;
 	text-align: center;
-	gap: var(--tl-space-6);
+	gap: 12px;
+	text-wrap: balance;
 }
 
 .content {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	max-width: 400px;
+}
+
+.content h1 {
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1.6;
+	margin: 0 0 12px;
+	color: var(--tl-color-text-0);
+}
+
+.content p {
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.6;
+	margin: 0;
+	color: var(--tl-color-text-1);
+}
+
+.link {
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.6;
+	color: var(--tl-color-text-0);
+	text-decoration: underline;
+	background: none;
+	border: none;
+	padding: 0;
+	cursor: pointer;
 }

--- a/apps/dotcom/client/src/tla/components/TlaFileError/TlaFileError.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileError/TlaFileError.tsx
@@ -1,12 +1,10 @@
 import { TLRemoteSyncError, TLSyncErrorCloseEventReason } from '@tldraw/sync-core'
 import { ReactElement, useEffect } from 'react'
 import { TldrawUiButton, useDialogs } from 'tldraw'
-import { sadFaceIcon } from '../../../components/ErrorPage/ErrorPage'
 import { useSetIsReady } from '../../hooks/useIsReady'
 import { F } from '../../utils/i18n'
 import { SubmitFeedbackDialog } from '../dialogs/SubmitFeedbackDialog'
 import { TlaSignInDialog } from '../dialogs/TlaSignInDialog'
-import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
 import styles from './TlaFileError.module.css'
 
 function DefaultError() {
@@ -104,12 +102,14 @@ function NotAuthenticatedError() {
 			header={<F defaultMessage="Sign in" />}
 			para1={<F defaultMessage="You need to sign in to view this file." />}
 			cta={
-				<TlaCtaButton
+				<button
+					type="button"
+					className={styles.link}
 					data-testid="tla-sign-in-button"
 					onClick={() => dialogs.addDialog({ component: TlaSignInDialog })}
 				>
 					<F defaultMessage="Sign in" />
-				</TlaCtaButton>
+				</button>
 			}
 		/>
 	)
@@ -127,8 +127,7 @@ function TlaFileErrorContent({
 	cta?: ReactElement
 }) {
 	return (
-		<div className={styles.container}>
-			{sadFaceIcon}
+		<div className={styles.container} data-testid="tla-error">
 			<div className={styles.content}>
 				<h1>{header}</h1>
 				<p>{para1}</p>

--- a/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
+++ b/apps/dotcom/client/src/tla/providers/TlaRootProviders.tsx
@@ -30,7 +30,6 @@ import { globalEditor } from '../../utils/globalEditor'
 import { TlaCookieConsent } from '../components/dialogs/TlaCookieConsent'
 import { TlaLegalAcceptance } from '../components/dialogs/TlaLegalAcceptance'
 import { MaybeForceUserRefresh } from '../components/MaybeForceUserRefresh/MaybeForceUserRefresh'
-import { TlaButton } from '../components/TlaButton/TlaButton'
 import { components } from '../components/TlaEditor/TlaEditor'
 import { WorkspaceInviteHandler } from '../components/WorkspaceInviteHandler'
 import { AppStateProvider, useMaybeApp } from '../hooks/useAppState'
@@ -283,9 +282,9 @@ function SignedInProvider({
 						para1: intl.formatMessage(appMessages.clerkUnavailablePara),
 					}}
 					cta={
-						<TlaButton variant="primary" onClick={() => window.location.reload()}>
+						<button type="button" onClick={() => window.location.reload()}>
 							{intl.formatMessage(appMessages.refresh)}
-						</TlaButton>
+						</button>
 					}
 				/>
 			)

--- a/apps/dotcom/client/styles/globals.css
+++ b/apps/dotcom/client/styles/globals.css
@@ -150,7 +150,7 @@ a {
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	gap: 30px;
+	gap: 12px;
 }
 
 .error-page__content {
@@ -159,30 +159,32 @@ a {
 	align-items: center;
 	justify-content: center;
 	text-align: center;
-	max-width: 500px;
+	max-width: 400px;
 	text-wrap: balance;
 }
 
-/* text-header mb-sm */
 .error-page__content h1 {
-	font-size: 18px;
-	font-weight: 800;
-	margin-bottom: 0.5rem;
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1.6;
+	margin: 0 0 12px;
 }
 
-/* text-primary-bold text-grey */
 .error-page__content p {
-	font-size: 14px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.6;
+	margin: 0;
 	color: var(--text-color-2);
 }
 
-/* text-primary-bold text-grey */
 .error-page__container a,
 .error-page__container button {
-	font-size: 14px;
+	font-size: 12px;
 	font-weight: 500;
-	color: var(--text-color-2);
-	padding: 12px 4px;
+	line-height: 1.6;
+	color: inherit;
+	padding: 0;
 	text-decoration: underline;
 	background: none;
 	border: none;


### PR DESCRIPTION
In order to bring the tldraw.com error screens in line with the new design, this PR restyles every dotcom error surface to a minimal centered block: a semibold title, medium body text, and an underlined text-link action, with the large sad-face icon removed. Placement of each error is unchanged — some render inside the app shell, others full-page.

- `ErrorPage` and `TlaFileError`: remove the icon, add a `tla-error` container test marker, and convert primary-button CTAs to underlined text links.
- `StoreErrorScreen` and `TlaRootProviders`: convert the refresh CTAs to text links.
- `globals.css` and `TlaFileError.module.css`: new compact type scale (12px semibold title, 12px medium body, 19.2px line-height), 12px gap, underlined link styling.
- e2e: re-anchor the "error is showing" assertions from the removed `tla-error-icon` to the new `tla-error` container marker.

`sadFaceIcon` is still exported since `TlaInviteExpiredDialog` (not an error screen) continues to use it.

### Change type

- [x] `improvement`

### Test plan

1. Trigger a 404 (visit a non-existent page) and confirm the redesigned error block.
2. Open a file you don't have access to and confirm the "invite only" / "sign in" states render with underlined link CTAs.
3. Force a client-too-old / update state and confirm the "refresh" link works.

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Redesign the tldraw.com error screens with a cleaner, more compact layout.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +8 / -8    |
| Apps    | +57 / -41  |
