### PR TITLE
refactor(dotcom): simplify the terms of use acceptance dialog

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/SignInDialog.ts
+++ b/apps/dotcom/client/e2e/fixtures/SignInDialog.ts
@@ -8,7 +8,6 @@ export class SignInDialog {
 	public readonly continueWithEmailButton: Locator
 	public readonly codeInput: Locator
 	public readonly resendButton: Locator
-	public readonly analyticsCheckbox: Locator
 	public readonly acceptAndContinueButton: Locator
 
 	constructor(private readonly page: Page) {
@@ -17,9 +16,6 @@ export class SignInDialog {
 		this.continueWithEmailButton = this.page.getByTestId('tla-continue-with-email-button')
 		this.codeInput = this.page.locator('#tla-verification-code')
 		this.resendButton = this.page.getByTestId('tla-resend-code-button')
-		this.analyticsCheckbox = this.page.getByRole('checkbox', {
-			name: /Allow analytics to help improve tldraw/i,
-		})
 		this.acceptAndContinueButton = this.page.getByTestId('tla-accept-and-continue-button')
 	}
 
@@ -59,28 +55,8 @@ export class SignInDialog {
 	}
 
 	@step
-	async expectAnalyticsToggleVisible() {
-		await expect(this.analyticsCheckbox).toBeVisible()
-	}
-
-	@step
-	async expectAnalyticsToggleHidden() {
-		await expect(this.analyticsCheckbox).toHaveCount(0)
-	}
-
-	@step
 	async expectAcceptAndContinueDisabled() {
 		await expect(this.acceptAndContinueButton).toBeDisabled()
-	}
-
-	@step
-	async setAnalyticsOptIn(optIn: boolean) {
-		if ((await this.analyticsCheckbox.count()) === 0) return
-		if (optIn) {
-			await this.analyticsCheckbox.check()
-		} else {
-			await this.analyticsCheckbox.uncheck()
-		}
 	}
 
 	@step

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -331,6 +331,12 @@
       "value": "Thanks for helping us improve tldraw!"
     }
   ],
+  "46de2de6bb": [
+    {
+      "type": 0,
+      "value": "Accept terms of use"
+    }
+  ],
   "477df802ca": [
     {
       "type": 0,
@@ -1167,26 +1173,6 @@
     {
       "type": 0,
       "value": "Learn more about sharing."
-    }
-  ],
-  "c28aed8348": [
-    {
-      "type": 0,
-      "value": "Allow "
-    },
-    {
-      "children": [
-        {
-          "type": 0,
-          "value": "analytics"
-        }
-      ],
-      "type": 8,
-      "value": "cookies"
-    },
-    {
-      "type": 0,
-      "value": " to help us improve tldraw."
     }
   ],
   "c303bd1095": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -149,6 +149,9 @@
   "46137245cd": {
     "translation": "Thanks for helping us improve tldraw!"
   },
+  "46de2de6bb": {
+    "translation": "Accept terms of use"
+  },
   "477df802ca": {
     "translation": "To continue editing please copy the file to your files."
   },
@@ -494,9 +497,6 @@
   },
   "c2276c9127": {
     "translation": "Learn more about sharing."
-  },
-  "c28aed8348": {
-    "translation": "Allow <cookies>analytics</cookies> to help us improve tldraw."
   },
   "c303bd1095": {
     "translation": "Unable to publish the file."

--- a/apps/dotcom/client/src/tla/components/dialogs/TlaLegalAcceptance.tsx
+++ b/apps/dotcom/client/src/tla/components/dialogs/TlaLegalAcceptance.tsx
@@ -1,21 +1,14 @@
 import { useUser } from '@clerk/clerk-react'
 import classNames from 'classnames'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { TldrawUiDialogBody, TldrawUiDialogHeader, TldrawUiDialogTitle } from 'tldraw'
-import { useAnalyticsConsent } from '../../hooks/useAnalyticsConsent'
 import { F } from '../../utils/i18n'
 import { ExternalLink } from '../ExternalLink/ExternalLink'
-import { TlaMenuSwitch } from '../tla-menu/tla-menu'
 import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
-import { TlaLogo } from '../TlaLogo/TlaLogo'
 import styles from './auth.module.css'
 
 export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 	const { user } = useUser()
-	const [currentConsent, updateAnalyticsConsent] = useAnalyticsConsent()
-	const [analyticsOptIn, setAnalyticsOptIn] = useState(currentConsent)
-	const initialAnalyticsOptIn = useRef(analyticsOptIn)
-	const showAnalyticsToggle = initialAnalyticsOptIn.current !== true
 
 	const [isSubmitting, setIsSubmitting] = useState(false)
 	const [error, setError] = useState<string | null>(null)
@@ -28,11 +21,6 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 
 		try {
 			if (!user) return
-
-			// Persist analytics choice before redirecting
-			if (analyticsOptIn !== null) {
-				updateAnalyticsConsent(analyticsOptIn)
-			}
 
 			// Store acceptance in user metadata
 			await user.update({
@@ -55,23 +43,17 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 		} finally {
 			setIsSubmitting(false)
 		}
-	}, [isSubmitting, onClose, analyticsOptIn, updateAnalyticsConsent, user])
+	}, [isSubmitting, onClose, user])
 
 	return (
-		<div className={styles.authContainer}>
-			<TldrawUiDialogHeader>
+		<div className={styles.legalContainer}>
+			<TldrawUiDialogHeader className={styles.legalDialogHeader}>
 				<TldrawUiDialogTitle>
-					<span />
+					<F defaultMessage="Accept terms of use" />
 				</TldrawUiDialogTitle>
 			</TldrawUiDialogHeader>
-			<TldrawUiDialogBody className={styles.authBody}>
-				<div className={styles.authLogoWrapper}>
-					<div className={styles.authLogo}>
-						<TlaLogo />
-					</div>
-				</div>
-
-				<p className={styles.authDescription}>
+			<TldrawUiDialogBody className={styles.legalBody}>
+				<p className={styles.legalDescription}>
 					<F
 						defaultMessage="Before you start, please accept our <tos>terms of use</tos> and <privacy>privacy policy</privacy>."
 						values={{
@@ -81,30 +63,12 @@ export function TlaLegalAcceptance({ onClose }: { onClose(): void }) {
 					/>
 				</p>
 
-				{showAnalyticsToggle && (
-					<label className={styles.authCheckboxLabel}>
-						<span>
-							<F
-								defaultMessage="Allow <cookies>analytics</cookies> to help us improve tldraw."
-								values={{
-									cookies: (chunks) => <ExternalLink to="/cookies.html">{chunks}</ExternalLink>,
-								}}
-							/>
-						</span>
-						<TlaMenuSwitch
-							id="tla-analytics-switch"
-							checked={!!analyticsOptIn}
-							onChange={(checked) => setAnalyticsOptIn(checked)}
-						/>
-					</label>
-				)}
-
 				{error && <div className={styles.authError}>{error}</div>}
 				<TlaCtaButton
 					data-testid="tla-accept-and-continue-button"
 					onClick={handleContinue}
 					disabled={isSubmitting}
-					className={classNames(styles.authCtaButton, styles.authTermsAcceptAndContinueButton)}
+					className={classNames(styles.authCtaButton, styles.legalCtaButton)}
 				>
 					<F defaultMessage="Accept and continue" />
 				</TlaCtaButton>

--- a/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
@@ -9,11 +9,30 @@
 	padding: 0;
 }
 
+.legalContainer {
+	width: 360px;
+	max-width: calc(100vw - 32px);
+}
+
+.legalDialogHeader {
+	height: 0;
+	padding: 0;
+	overflow: hidden;
+}
+
 .authBody {
 	display: flex;
 	flex-direction: column;
 	padding: 8px 20px 24px 20px;
 	gap: 24px;
+}
+
+.legalBody {
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	gap: 24px;
+	padding: 32px 28px 28px 28px;
 }
 
 /* Logo */
@@ -46,12 +65,31 @@
 	margin-bottom: 12px;
 }
 
+.legalDescription {
+	max-width: 260px;
+	margin: 0 auto;
+	color: var(--tl-color-text-0);
+	font-size: 12px;
+	font-weight: 600;
+	line-height: 1.5;
+	text-align: center;
+	text-wrap: balance;
+}
+
+.legalDescription a {
+	color: var(--tl-color-selected);
+}
+
 /* Cta button */
 .authCtaButton {
 	height: 36px;
 	width: 100%;
 	font-size: 12px;
 	font-weight: 500;
+}
+
+.legalCtaButton {
+	margin-left: 0;
 }
 
 /* The google logo in the cta button on the sign in dialog */


### PR DESCRIPTION
In order to simplify the sign-in flow, this PR removes the analytics opt-in toggle from the terms of use acceptance dialog and restyles that dialog. It adds an accessible "Accept terms of use" dialog title (kept in the DOM for the dialog's accessible label but visually hidden), drops the tldraw logo, and uses a dedicated compact layout. Analytics consent is unaffected elsewhere (the cookie consent banner still handles it).

- `TlaLegalAcceptance`: remove the analytics consent toggle and its persistence on accept; switch to the new `legal*` dialog styles and add an accessible (visually hidden) dialog title.
- `auth.module.css`: add the legal dialog layout styles (`legalContainer`, `legalBody`, `legalDescription`, `legalCtaButton`); `legalDialogHeader` collapses the header so the title labels the dialog without being shown.
- e2e: drop the now-unused analytics-toggle fixtures from `SignInDialog`.

### Change type

- [x] `improvement`

### Test plan

1. Sign in as a user who has not accepted the legal terms.
2. Confirm the acceptance dialog shows the centered terms of use / privacy policy description and the "Accept and continue" button, with no analytics toggle and no visible title heading.
3. Accept and continue; confirm acceptance is stored and the dialog closes.

- [ ] Unit tests
- [x] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Apps            | +46 / -44  |
| Tests           | +0 / -24   |
| Automated files | +9 / -23   |
