### PR TITLE
fix(template): fix workflow template node update

### DIFF
--- a/templates/workflow/src/nodes/types/SliderNode.tsx
+++ b/templates/workflow/src/nodes/types/SliderNode.tsx
@@ -76,7 +76,7 @@ export function SliderNodeComponent({ shape, node }: NodeComponentProps<SliderNo
 				title={node.value.toString()}
 				onValueChange={(value) => {
 					editor.setSelectedShapes([shape.id])
-					updateNode<SliderNode>(editor, shape, (node) => ({ ...node, value }), false)
+					updateNode<SliderNode>(editor, shape, (node) => ({ ...node, value }))
 				}}
 				onHistoryMark={() => {}}
 			/>


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/7692

updateNode `isOutOfDate` param defaults to true (shared.tsx:92), but SliderNode passes false, so the slider marks itself not dirty and downstream nodes never recompute.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Run the workflow template
2. Create a slider
3. Create an "add" block
4. Connect slider to "add"
5. Run the workflow,
6. Update the slider

The slider out node is grey-ed as well as its connection on the "add" block

### Release notes

- Fixed the workflow template so dirty nodes are now shown correctly when updating sliders