### PR TITLE
feat(editor): add Editor.isMounted

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1342,6 +1342,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getInstanceState(): TLInstance;
     // (undocumented)
     getIsFocused(): boolean;
+    getIsMounted(): boolean;
     // (undocumented)
     getIsReadonly(): boolean;
     // @internal

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1342,7 +1342,6 @@ export class Editor extends EventEmitter<TLEventMap> {
     getInstanceState(): TLInstance;
     // (undocumented)
     getIsFocused(): boolean;
-    getIsMounted(): boolean;
     // (undocumented)
     getIsReadonly(): boolean;
     // @internal
@@ -1470,6 +1469,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     isDisposed: boolean;
     isIn(path: string): boolean;
     isInAny(...paths: string[]): boolean;
+    isMounted: boolean;
     isPointInShape(shape: TLShape | TLShapeId, point: VecLike, opts?: {
         hitInside?: boolean | undefined;
         margin?: number | undefined;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -899,6 +899,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 		this.on('tick', this._flushEventsForTick)
 
+		this.once('mount', () => {
+			this._isMounted.set(true)
+		})
+
 		this.timers.requestAnimationFrame(() => {
 			this._tickManager.start()
 		})
@@ -1010,6 +1014,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	isDisposed = false
+
+	private readonly _isMounted = atom('isMounted', false)
+
+	/**
+	 * Whether the editor has mounted. This becomes `true` after the editor's `mount` event fires,
+	 * once the editor's component has mounted into the DOM.
+	 *
+	 * @public
+	 */
+	@computed getIsMounted(): boolean {
+		return this._isMounted.get()
+	}
 
 	/**
 	 * A manager for the editor's tick events.

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -900,7 +900,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.on('tick', this._flushEventsForTick)
 
 		this.once('mount', () => {
-			this._isMounted.set(true)
+			this.isMounted = true
 		})
 
 		this.timers.requestAnimationFrame(() => {
@@ -1015,17 +1015,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	isDisposed = false
 
-	private readonly _isMounted = atom('isMounted', false)
-
 	/**
-	 * Whether the editor has mounted. This becomes `true` after the editor's `mount` event fires,
-	 * once the editor's component has mounted into the DOM.
+	 * Whether the editor is mounted.
 	 *
 	 * @public
 	 */
-	@computed getIsMounted(): boolean {
-		return this._isMounted.get()
-	}
+	isMounted = false
 
 	/**
 	 * A manager for the editor's tick events.


### PR DESCRIPTION
In order to let code that only holds the `editor` object check whether the editor has mounted, this PR adds an `Editor.isMounted` flag — mirroring the existing `Editor.isDisposed`.

The editor already exposes both a `dispose` event and an `isDisposed` flag, but for mount there was only the `mount` event and no flag. Because `mount` is fire-once, code that obtained the editor after it had already mounted (the common case) had no way to check whether mount had happened. `isMounted` closes that gap:

```ts
if (editor.isMounted) runNow()
else editor.once('mount', runNow)
```

This is aimed at making it easier to script against a live editor from outside (e.g. posting scripts to an exec endpoint), where you need a synchronous "has it mounted yet?" check rather than racing the fire-once event. Reacting to the transitions is still done via the `mount` / `dispose` events, matching how `isDisposed` works.

### API changes

- Added `Editor.isMounted`, set to `true` once the editor's `mount` event has fired. Mirrors `Editor.isDisposed`.

### Change type

- [x] `api`

### Test plan

1. Mount a `<Tldraw>` / `TldrawEditor` and confirm `editor.isMounted` is `true` in `onMount` and after.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add `Editor.isMounted` to check whether the editor has mounted, mirroring `Editor.isDisposed`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +7 / -0    |
| Automated files | +1 / -0    |
