### PR TITLE
fix(dotcom): keep shared files visible in the sidebar despite orphan group_file links

### DIFF
--- a/apps/dotcom/workspaces-feature.md
+++ b/apps/dotcom/workspaces-feature.md
@@ -45,12 +45,14 @@ A file has exactly one owner:
 - Legacy files have `ownerId`.
 - Workspace files have `owningGroupId`.
 
-A workspace file also has a `group_file` row for the workspace that owns it. A `group_file` row can also represent a link to a shared file in another workspace. In that case, the file is listed in the workspace, but its `owningGroupId` remains somewhere else.
+A workspace file also has a `group_file` row for the workspace that owns it. The only other kind of `group_file` row is a home guest link: when a user opens a shared file that none of their workspaces own, the server adds a `group_file` row into their home workspace so it shows up as a "guest file". That row's `groupId` is the user's id, and the file's `owningGroupId` stays with its real owner.
+
+There is no way to link a shared file into a non-home workspace it doesn't own. An earlier drag-to-link feature (#9107) allowed this, but it was removed in #9254, and the `validate_group_file_association` trigger now rejects such rows.
 
 This distinction matters:
 
 - Moving an owned file transfers `owningGroupId` and moves the owning `group_file` row.
-- Removing a linked file removes the link, not the underlying file.
+- Removing a home guest link removes that link, not the underlying file.
 - Deleting/removing an owned workspace file marks the file deleted for everyone.
 
 ### File state
@@ -187,7 +189,7 @@ The move:
 
 The move does not change `shared` or `sharedLinkType`.
 
-The file menu's "Move to" action moves the owned file. Drag operations have extra logic for linked files: if the file listed in a workspace is only a link, the drag move can move the link instead of transferring file ownership.
+The file menu's "Move to" action moves the owned file. A file listed in a non-home workspace is always owned by that workspace, so moving it always transfers ownership.
 
 If the "Move to new workspace" flow creates a new workspace and then the move fails, the workspace remains created.
 
@@ -197,7 +199,7 @@ The delete/forget dialog calls `removeFileFromWorkspace`.
 
 If the workspace owns the file, removal marks the file deleted. Database cleanup then removes file states and group file rows for that file. Connected canvas sessions are closed with not found.
 
-If the workspace only links to the file, removal deletes the link and the actor's file state, but does not delete the file.
+If the file is only a home guest link (the actor's home workspace does not own it), removal deletes that link and the actor's file state, but does not delete the file.
 
 Because members have `removeFiles`, any member can delete a file owned by their workspace. In the UI this appears as "Delete" because file admin rights resolve to workspace file access.
 
@@ -286,7 +288,7 @@ If the current viewer does not belong to the destination workspace, the sidebar 
 
 If the file is owned by the current workspace, removal is a delete for everyone. Other members lose it from their lists, and active sessions in that file close with not found.
 
-If the file is only linked into the current workspace, removal removes that workspace's link. The file continues to exist in its owning workspace and anywhere else it is linked or shared.
+If the file is only a home guest link, removal removes that home link. The file continues to exist in its owning workspace and anywhere else it is shared.
 
 ## Multiplayer scenarios
 
@@ -348,12 +350,6 @@ If the file is owned by that workspace, deletion marks the file deleted. Databas
 
 The deleting user's client navigates to another file or creates a new one. Other users rely on sync and the closed file session. The current implementation does not present a workspace-specific "this file was deleted by another member" recovery flow in the workspace UI.
 
-### Another member removes a linked file from a workspace
-
-The linked `group_file` row is deleted for that workspace. Members of that workspace stop seeing the linked file there.
-
-The underlying file is not deleted. Users who are also members of the owning workspace, or who have shared-link access, can continue to access it through those paths.
-
 ### An owner removes the current user from a workspace
 
 The current user's `group_user` row is deleted. Their user durable object loses the workspace subscription and refetches the graph. The workspace disappears from the sidebar.
@@ -377,8 +373,6 @@ If another tab or device is open in a file from that workspace, it receives the 
 ### An owner deletes a workspace
 
 All members lose the workspace. Files owned by the workspace are marked deleted and connected sessions close with not found.
-
-Files merely linked into the workspace are not owned by it, but the workspace's links are removed when the workspace is deleted.
 
 ### An owner changes the current user's role
 
@@ -432,7 +426,7 @@ If the product expectation is "member can collaborate but not administer files,"
 
 For workspace-owned files, any member is treated as having file admin rights and sees "Delete." That action deletes the file for everyone.
 
-For linked files, removal is closer to "remove from this workspace" or "forget," because the underlying file remains.
+For a home guest link, removal is closer to "remove from home" or "forget," because the underlying file remains.
 
 The UI text is based on the user's file admin rights, not directly on whether the current workspace owns the file.
 

--- a/apps/dotcom/zero-cache/migrations/038_cleanup_orphan_group_file_links.sql
+++ b/apps/dotcom/zero-cache/migrations/038_cleanup_orphan_group_file_links.sql
@@ -1,0 +1,65 @@
+-- Clean up orphan "link" group_file rows left by the removed drag-to-link feature.
+--
+-- #9107 shipped handleFileDragOperation with a "file link" concept: dragging a
+-- SHARED file you don't own onto a workspace inserted a group_file row into that
+-- workspace WITHOUT changing the file's owningGroupId (a "link", not a move). The
+-- validate_group_file_association trigger allowed it because the file is shared.
+-- #9254 removed that feature and moved to a single-ownership model, but never
+-- cleaned up the rows it had already written.
+--
+-- In the current model a non-home workspace lists a file only when it OWNS it
+-- (getWorkspaceFilesSorted: owningGroupId === workspaceId). So each leftover link
+-- row is invisible AND — worse — onEnterFile's old guard treated "a group_file row
+-- exists in one of my groups" as "the file is already visible to me", so it skipped
+-- creating the home guest-link. A member of the workspace the file was linked into
+-- therefore saw the file NOWHERE. (The onEnterFile guard is fixed separately to key
+-- off ownership; this migration removes the bad data.)
+--
+-- An orphan link row is a group_file row whose group neither owns the file nor is a
+-- user's home group (home group id === user id). We must NOT touch:
+--   * the owning row (groupId === owningGroupId), or
+--   * home guest rows (groupId is some user's id).
+
+-- 1) Re-link affected files into the home of users who could reach them ONLY through
+--    an orphan row: members of the orphan's workspace who visited the file as a guest
+--    and have no home link yet. Mirrors the fixed onEnterFile so the file reappears in
+--    their sidebar without needing to re-open it. Runs before the delete so the orphan
+--    rows are still present to derive the affected set. Idempotent via ON CONFLICT.
+INSERT INTO public."group_file" ("fileId", "groupId", "createdAt", "updatedAt", "index")
+SELECT DISTINCT
+  fs."fileId",
+  fs."userId",
+  (EXTRACT(EPOCH FROM NOW()) * 1000)::bigint,
+  (EXTRACT(EPOCH FROM NOW()) * 1000)::bigint,
+  NULL
+FROM public."group_file" orphan
+JOIN public."file" f ON f."id" = orphan."fileId"
+JOIN public."group_user" gu ON gu."groupId" = orphan."groupId"
+JOIN public."file_state" fs ON fs."fileId" = orphan."fileId" AND fs."userId" = gu."userId"
+WHERE
+  -- orphan condition: the row's group does not own the file...
+  orphan."groupId" IS DISTINCT FROM f."owningGroupId"
+  -- ...and is not a user's home group
+  AND NOT EXISTS (SELECT 1 FROM public."user" ou WHERE ou."id" = orphan."groupId")
+  -- only surface files the user can actually still access
+  AND f."shared" = true
+  AND f."isDeleted" = false
+  AND fs."isFileOwner" = false
+  -- skip users who own the file via a workspace they belong to (already visible there)
+  AND NOT EXISTS (
+    SELECT 1 FROM public."group_user" owns
+    WHERE owns."userId" = fs."userId" AND owns."groupId" = f."owningGroupId"
+  )
+  -- skip users who already have a home link for this file
+  AND NOT EXISTS (
+    SELECT 1 FROM public."group_file" home
+    WHERE home."fileId" = fs."fileId" AND home."groupId" = fs."userId"
+  )
+ON CONFLICT ("fileId", "groupId") DO NOTHING;
+
+-- 2) Delete the orphan link rows.
+DELETE FROM public."group_file" gf
+USING public."file" f
+WHERE gf."fileId" = f."id"
+  AND gf."groupId" IS DISTINCT FROM f."owningGroupId"
+  AND NOT EXISTS (SELECT 1 FROM public."user" u WHERE u."id" = gf."groupId");

--- a/apps/dotcom/zero-cache/migrations/039_tighten_group_file_association.sql
+++ b/apps/dotcom/zero-cache/migrations/039_tighten_group_file_association.sql
@@ -1,0 +1,37 @@
+-- Tighten validate_group_file_association to match the single-ownership model.
+--
+-- The original trigger (023_groups.sql) allowed a group_file row whenever the file
+-- was shared OR owned by the group. That "shared" allowance is what let the removed
+-- drag-to-link feature (#9107, removed in #9254) link a shared file into ANY
+-- workspace without changing owningGroupId — the orphan rows cleaned up in migration
+-- 038. Now that only two kinds of group_file rows are legitimate, tighten the check
+-- so the database rejects a re-appearance of those cross-workspace links:
+--
+--   1. The owning row: group_file.groupId === file.owningGroupId.
+--   2. A home guest link: group_file.groupId is a user's home group (a user exists
+--      with that id) and the file is shared, i.e. the guest can actually access it.
+--
+-- A shared file can no longer be linked into a non-home workspace that doesn't own
+-- it. All current insert paths (createFile, onEnterFile home link, moveFileToWorkspace)
+-- satisfy one of the two allowed cases.
+CREATE OR REPLACE FUNCTION validate_group_file_association() RETURNS TRIGGER AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM "file" f
+    WHERE f."id" = NEW."fileId"
+      AND (
+        -- the group owns the file
+        f."owningGroupId" = NEW."groupId"
+        -- ...or it's a home guest link for a shared file
+        OR (
+          f."shared" = true
+          AND EXISTS (SELECT 1 FROM "user" u WHERE u."id" = NEW."groupId")
+        )
+      )
+  ) THEN
+    RAISE EXCEPTION 'Cannot link file to group: group must own the file, or the file must be shared and linked into a user home group';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -670,6 +670,35 @@ describe('onEnterFile', () => {
 		expect((s.group_file as TlaGroupFile[]).some((gf) => gf.groupId === userId)).toBe(false)
 	})
 
+	it('mirrors a shared file into home even when a mislinked group_file row points at one of my workspaces', async () => {
+		// Regression: a leftover "link" group_file row (from the removed drag-to-link feature)
+		// puts the file in a workspace the user belongs to WITHOUT that workspace owning it.
+		// The sidebar only lists a non-home workspace's file when it owns it, so this row shows
+		// the file nowhere. Entering the file must still create the home link so it's visible.
+		const ownerHome = 'user_fileowner1234567'
+		const workspaceB = 'group_workspaceB12345'
+		const s = {
+			user: [makeUser({ id: userId })],
+			file: [makeFile({ id: fileId, owningGroupId: ownerHome, shared: true })],
+			file_state: [],
+			group: [
+				makeGroup({ id: userId }),
+				makeGroup({ id: workspaceB }),
+				makeGroup({ id: ownerHome }),
+			],
+			group_user: [
+				makeGroupUser({ userId, groupId: userId, role: 'owner' }),
+				makeGroupUser({ userId, groupId: workspaceB, role: 'member' }),
+			],
+			// mislinked row: workspaceB does not own the file (owningGroupId is ownerHome)
+			group_file: [makeGroupFile({ fileId, groupId: workspaceB })],
+		}
+		const { tx } = createMockTx(s, { location: 'server' })
+		const m = createMutators(userId)
+		await m.onEnterFile(tx, { fileId, time: Date.now() })
+		expect((s.group_file as TlaGroupFile[]).some((gf) => gf.groupId === userId)).toBe(true)
+	})
+
 	it('mirrors a group-less (legacy) file into home so it stays findable', async () => {
 		const s = {
 			user: [makeUser({ id: userId })],

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -19,7 +19,6 @@ import {
 	TlaFileStatePartial,
 	TlaFlags,
 	TlaGroupFile,
-	TlaGroupUser,
 	TlaSchema,
 	TlaUser,
 	TlaUserPartial,
@@ -419,8 +418,6 @@ export function createMutators(userId: string) {
 			// If we get here, the user has legitimate access to the file
 			await tx.mutate.file_state.upsert({ fileId, userId, firstVisitAt: time })
 
-			const workspaceFileRows = await tx.run(zql.group_file.where('fileId', '=', fileId))
-			const userWorkspaceMemberships = await tx.run(zql.group_user.where('userId', '=', userId))
 			// Add a visited file to the user's home group so it shows as a "guest file" in the
 			// sidebar — unless it's already visible to the user somewhere else. A file is listed
 			// in a workspace only when that workspace actually OWNS it (getWorkspaceFilesSorted
@@ -433,21 +430,23 @@ export function createMutators(userId: string) {
 			// #9107/#9254, or a create-workspace-race mirror) points at a workspace that does
 			// not own the file, so it shows the file nowhere. Counting it here would skip the
 			// home link and make the file invisible in the sidebar entirely.
-			const owningGroupId = file?.owningGroupId
-			const ownedByOneOfMyWorkspaces =
-				owningGroupId != null &&
-				userWorkspaceMemberships.some((g: TlaGroupUser) => g.groupId === owningGroupId)
-			const alreadyLinkedInHome = workspaceFileRows.some(
-				(gf: TlaGroupFile) => gf.groupId === userId
+			const alreadyLinkedInHome = await tx.run(
+				zql.group_file.where('fileId', '=', fileId).where('groupId', '=', userId).one()
 			)
-			if (!ownedByOneOfMyWorkspaces && !alreadyLinkedInHome) {
-				await tx.mutate.group_file.insert({
-					fileId,
-					groupId: userId,
-					createdAt: time,
-					updatedAt: time,
-					index: null,
-				})
+			if (!alreadyLinkedInHome) {
+				// getRole returns null when the user isn't a member of the file's owning
+				// workspace (and for a null owningGroupId), so this is true only when the file
+				// is genuinely owned by a workspace the user belongs to.
+				const ownedByOneOfMyWorkspaces = (await getRole(tx, userId, file?.owningGroupId)) !== null
+				if (!ownedByOneOfMyWorkspaces) {
+					await tx.mutate.group_file.insert({
+						fileId,
+						groupId: userId,
+						createdAt: time,
+						updatedAt: time,
+						index: null,
+					})
+				}
 			}
 		},
 		createWorkspace: async (tx: Tx, { id, name }: { id: string; name: string }) => {

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -409,9 +409,10 @@ export function createMutators(userId: string) {
 			assert(fileId, ZErrorCode.bad_request)
 			time = ensureSensibleTimestamp(time)
 
+			const file = await tx.run(zql.file.where('id', '=', fileId).one())
+
 			// Verify the user has permission to access this file
 			if (tx.location === 'server') {
-				const file = await tx.run(zql.file.where('id', '=', fileId).one())
 				await assertUserCanAccessFile(tx, userId, file!)
 			}
 
@@ -420,16 +421,26 @@ export function createMutators(userId: string) {
 
 			const workspaceFileRows = await tx.run(zql.group_file.where('fileId', '=', fileId))
 			const userWorkspaceMemberships = await tx.run(zql.group_user.where('userId', '=', userId))
-			// Add a visited file to the user's home group unless it already belongs to one of
-			// their groups. This is what surfaces a shared file the user opened as a "guest
-			// file" in their sidebar. (Files owned by a workspace the user is a member of are
-			// not mirrored here — and the sidebar read path also filters out any that slip
-			// through, see getWorkspaceFilesSorted — so a workspace file never shows in home.)
-			if (
-				!userWorkspaceMemberships.some((g: TlaGroupUser) =>
-					workspaceFileRows.some((gf: TlaGroupFile) => gf.groupId === g.groupId)
-				)
-			) {
+			// Add a visited file to the user's home group so it shows as a "guest file" in the
+			// sidebar — unless it's already visible to the user somewhere else. A file is listed
+			// in a workspace only when that workspace actually OWNS it (getWorkspaceFilesSorted
+			// lists a non-home workspace's file only when owningGroupId === workspaceId), so the
+			// only thing that should suppress the home link is the file being owned by a
+			// workspace the user belongs to.
+			//
+			// We deliberately do NOT key off "any group_file row in one of my groups": a
+			// stale/mislinked row (e.g. a leftover from the removed drag-to-link feature,
+			// #9107/#9254, or a create-workspace-race mirror) points at a workspace that does
+			// not own the file, so it shows the file nowhere. Counting it here would skip the
+			// home link and make the file invisible in the sidebar entirely.
+			const owningGroupId = file?.owningGroupId
+			const ownedByOneOfMyWorkspaces =
+				owningGroupId != null &&
+				userWorkspaceMemberships.some((g: TlaGroupUser) => g.groupId === owningGroupId)
+			const alreadyLinkedInHome = workspaceFileRows.some(
+				(gf: TlaGroupFile) => gf.groupId === userId
+			)
+			if (!ownedByOneOfMyWorkspaces && !alreadyLinkedInHome) {
 				await tx.mutate.group_file.insert({
 					fileId,
 					groupId: userId,


### PR DESCRIPTION
In order to fix shared files that are invisible in the tldraw.com sidebar, this PR makes `onEnterFile` create a user's home "guest file" link based on file *ownership*, and cleans up the stale `group_file` rows that caused the problem.

### The bug

A file owned by one workspace could have a leftover `group_file` row pointing at a *different* workspace that doesn't own it. These orphan rows were written by the old drag-to-link feature (`handleFileDragOperation`, #9107), which inserted a `group_file` link without changing `owningGroupId`. #9254 removed that feature but left the rows behind.

For any user who is a member of the workspace an orphan row points at, the file then became invisible everywhere:

- `getWorkspaceFilesSorted` only lists a non-home workspace's file when `owningGroupId === workspaceId`, so the orphan workspace never showed it.
- `onEnterFile`'s guard treated "a `group_file` row exists in any of my groups" as "the file is already visible to me", so it skipped adding the home guest-link — even though the orphan row showed the file nowhere.

The two code paths disagreed about whether that row counted, so the file fell through the gap.

### The fix

- `onEnterFile` now only skips the home guest-link when the file is owned by a workspace the user belongs to (or a home link already exists). A stale/mislinked row no longer suppresses the link. This also makes the mutator robust against any future orphan rows.
- Migration `038` re-links affected files into affected users' home groups (so the files reappear without needing to re-open them) and deletes the orphan `group_file` rows. It's scoped to genuine orphans (a `group_file` group that neither owns the file nor is a user's home group) and is idempotent.

### Change type

- [x] `bugfix`

### Test plan

1. As user A, create and share a file from your personal workspace.
2. As user B (a member of a shared workspace W), open A's file, then drag/link it into W under the old model — or seed a `group_file` row for `(file, W)` directly.
3. Re-open the file as user B and confirm it now appears in B's home "recent files".
4. Run migration `038` (dry-run first) and confirm orphan `group_file` rows are removed and affected users get home links.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix shared files that could be missing from the sidebar for members of a workspace the file had been linked into.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +22 / -11  |
| Tests          | +25 / -0   |
| Apps           | +65 / -0   |
