### PR TITLE
fix(editor): treat license expiry as end of named day in UTC

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -594,38 +594,54 @@ describe('LicenseManager', () => {
 		})
 
 		it('Handles grace period correctly - 20 days expired should still be within grace period', async () => {
-			const expiredLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
-			const expiredDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 20) // 20 days ago
-			expiredLicenseInfo[PROPERTIES.EXPIRY_DATE] = expiredDate.toISOString()
+			// Pin the clock and use a date-only UTC expiry so the calculation is timezone
+			// independent. The named day is fully usable, so an expiry 20 calendar days before
+			// "now" has been past its usable window for 19 full days.
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-06-26T12:00:00.000Z'))
+			try {
+				const expiredLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+				expiredLicenseInfo[PROPERTIES.EXPIRY_DATE] = '2026-06-06' // 20 days before now
 
-			const expiredLicenseKey = await generateLicenseKey(
-				JSON.stringify(expiredLicenseInfo),
-				keyPair
-			)
+				const expiredLicenseKey = await generateLicenseKey(
+					JSON.stringify(expiredLicenseInfo),
+					keyPair
+				)
 
-			// Test the getLicenseFromKey method to verify grace period calculation
-			const result = (await licenseManager.getLicenseFromKey(
-				expiredLicenseKey
-			)) as ValidLicenseKeyResult
-			expect(result.isAnnualLicense).toBe(true)
-			expect(result.isAnnualLicenseExpired).toBe(false) // Within 30-day grace period
-			expect(result.daysSinceExpiry).toBe(20)
+				// Test the getLicenseFromKey method to verify grace period calculation
+				const result = (await licenseManager.getLicenseFromKey(
+					expiredLicenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isAnnualLicense).toBe(true)
+				expect(result.isAnnualLicenseExpired).toBe(false) // Within 30-day grace period
+				expect(result.daysSinceExpiry).toBe(19)
+			} finally {
+				vi.useRealTimers()
+			}
 		})
 
 		it('Calculates days since expiry correctly', async () => {
-			const expiredLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
-			const expiredDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 15) // 15 days ago
-			expiredLicenseInfo[PROPERTIES.EXPIRY_DATE] = expiredDate.toISOString()
+			// Pin the clock and use a date-only UTC expiry so the calculation is timezone
+			// independent. The named day is fully usable, so an expiry 15 calendar days before
+			// "now" has been past its usable window for 14 full days.
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-06-26T12:00:00.000Z'))
+			try {
+				const expiredLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+				expiredLicenseInfo[PROPERTIES.EXPIRY_DATE] = '2026-06-11' // 15 days before now
 
-			const expiredLicenseKey = await generateLicenseKey(
-				JSON.stringify(expiredLicenseInfo),
-				keyPair
-			)
+				const expiredLicenseKey = await generateLicenseKey(
+					JSON.stringify(expiredLicenseInfo),
+					keyPair
+				)
 
-			const result = (await licenseManager.getLicenseFromKey(
-				expiredLicenseKey
-			)) as ValidLicenseKeyResult
-			expect(result.daysSinceExpiry).toBe(15)
+				const result = (await licenseManager.getLicenseFromKey(
+					expiredLicenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.daysSinceExpiry).toBe(14)
+			} finally {
+				vi.useRealTimers()
+			}
 		})
 	})
 

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -510,6 +510,60 @@ describe('LicenseManager', () => {
 		})
 	})
 
+	describe('Expiry date timezone handling', () => {
+		afterEach(() => {
+			vi.useRealTimers()
+		})
+
+		// The named expiry date is minted as a date-only string and should mean "the license
+		// is fully usable through the end of that day in UTC", giving every user the same
+		// cutoff regardless of their local timezone.
+		async function makeEvaluationLicenseWithExpiry(expiry: string) {
+			const licenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			licenseInfo[PROPERTIES.FLAGS] = FLAGS.EVALUATION_LICENSE
+			licenseInfo[PROPERTIES.EXPIRY_DATE] = expiry
+			return generateLicenseKey(JSON.stringify(licenseInfo), keyPair)
+		}
+
+		it('Keeps the license valid through the end of the named expiry day (UTC)', async () => {
+			const key = await makeEvaluationLicenseWithExpiry('2026-06-26')
+
+			// The final moment of the named day is still valid.
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-06-26T23:59:59.000Z'))
+			expect(
+				((await licenseManager.getLicenseFromKey(key)) as ValidLicenseKeyResult)
+					.isEvaluationLicenseExpired
+			).toBe(false)
+		})
+
+		it('Expires the license at the start of the day after the named expiry day (UTC)', async () => {
+			const key = await makeEvaluationLicenseWithExpiry('2026-06-26')
+
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-06-27T00:00:01.000Z'))
+			expect(
+				((await licenseManager.getLicenseFromKey(key)) as ValidLicenseKeyResult)
+					.isEvaluationLicenseExpired
+			).toBe(true)
+		})
+
+		it('Does not expire early for users west of UTC who are still on the named day locally', async () => {
+			const key = await makeEvaluationLicenseWithExpiry('2026-06-26')
+
+			// Under the old logic a user west of UTC parsed the date one calendar day early and
+			// expired at the *start* of that day, losing most of a day. With the uniform UTC
+			// cutoff the license stays valid all through June 26 for everyone, no matter their
+			// local offset. 1pm UTC on June 26 is well before the cutoff, so it is still valid.
+			vi.useFakeTimers()
+			vi.setSystemTime(new Date('2026-06-26T13:00:00.000Z'))
+			expect(
+				((await licenseManager.getLicenseFromKey(key)) as ValidLicenseKeyResult)
+					.isEvaluationLicenseExpired
+			).toBe(false)
+		})
+	})
+
 	describe('License expiry and grace period', () => {
 		it('Fails if the license key has expired beyond grace period', async () => {
 			const expiredLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -372,14 +372,26 @@ export class LicenseManager {
 	}
 
 	private getExpirationDateWithoutGracePeriod(expiryDate: Date) {
-		return new Date(expiryDate.getFullYear(), expiryDate.getMonth(), expiryDate.getDate())
+		// The named expiry date is the last day the license is fully usable, so the license
+		// expires at the end of that day, i.e. the start of the following day. We work in UTC
+		// (the expiry date is minted and parsed as a UTC date-only string) so the cutoff is a
+		// single predictable instant for every user regardless of their local timezone.
+		return new Date(
+			Date.UTC(
+				expiryDate.getUTCFullYear(),
+				expiryDate.getUTCMonth(),
+				expiryDate.getUTCDate() + 1 // Add 1 day so the named date is fully usable
+			)
+		)
 	}
 
 	private getExpirationDateWithGracePeriod(expiryDate: Date) {
 		return new Date(
-			expiryDate.getFullYear(),
-			expiryDate.getMonth(),
-			expiryDate.getDate() + GRACE_PERIOD_DAYS + 1 // Add 1 day to include the expiration day
+			Date.UTC(
+				expiryDate.getUTCFullYear(),
+				expiryDate.getUTCMonth(),
+				expiryDate.getUTCDate() + GRACE_PERIOD_DAYS + 1 // Add 1 day to include the expiration day
+			)
 		)
 	}
 


### PR DESCRIPTION
Closes #9431

## Problem

License `expiryDate` values are stored as date-only strings (e.g. `2026-06-26`), which `new Date(...)` parses as UTC midnight. The expiry checks then rebuilt that date with **local-time** getters (`getFullYear`/`getMonth`/`getDate`) and compared `now >= expiration`, so:

- The license expired at the **start** of the named day rather than being usable through the end of it.
- Because the date was read back in a different timezone frame than it was parsed in, users **west of UTC** lost an additional calendar day — a license dated June 26 stopped working while they were still on June 25 locally.

The shift is fully exposed on evaluation licenses (no grace period); on annual/perpetual licenses it was normally masked by the 30-day grace period.

## Fix

Compute the expiration boundary in **UTC** and treat the named date as the **last fully-usable day**. `getExpirationDateWithoutGracePeriod` and `getExpirationDateWithGracePeriod` now use `Date.UTC` with `getUTC*` getters, and the no-grace variant adds one day so the license is valid through the end of the named day.

A license dated `2026-06-26` is now valid until `2026-06-27T00:00:00Z` — a single predictable cutoff, identical for every user regardless of timezone.

Scope is limited to client-side expiry validation; key minting is unchanged. Because validation runs in the customer's installed bundle, minted keys should keep padding the expiry date by a day or two until customers upgrade to a fixed version.

## Change type

- [x] `other`

## Test plan

- Added regression tests in `LicenseManager.test.ts` using a date-only expiry string and a pinned clock (`vi.setSystemTime`):
  - valid at `2026-06-26T23:59:59Z` (end of the named day)
  - expired at `2026-06-27T00:00:01Z` (start of the next day)
  - not expired mid-day on June 26 (guards against the west-of-UTC early expiry)
- `yarn test run LicenseManager` — 58 passed
- `yarn typecheck`, `yarn lint`, `yarn api-check` — pass
