### PR TITLE
security(deps): clear newly-disclosed socket alerts (dompurify, undici, ip-address)

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,9 @@
 		"postcss": "8.5.10",
 		"react-router": "6.30.4",
 		"@remix-run/router": "1.23.2",
-		"@octokit/plugin-paginate-rest@11.3.1": "11.4.1"
+		"@octokit/plugin-paginate-rest@11.3.1": "11.4.1",
+		"undici@7.24.4": "7.28.0",
+		"ip-address@10.1.0": "10.2.0"
 	},
 	"dependencies": {
 		"@sentry/cli": "^2.41.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18561,14 +18561,14 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^3.3.1":
-  version: 3.4.10
-  resolution: "dompurify@npm:3.4.10"
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10/e051c70e7a0729d8cc04d40d7863dc8977495140857e81dc668fb548b7a43c7f80cfc973e3c9c0a6cd18b8eaa94ea7de9603daa02d38c8b15a9b32cc25a6f440
+  checksum: 10/d0473e1a22ed9cc23d86ef426717bce866913d1a725512a9478985bd917b272e0faba5f1d6ad8b2e37f3f4219206c4385162d7c984cfedcd23396e1e6ae0bc5e
   languageName: node
   linkType: hard
 
@@ -22312,14 +22312,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.1.0":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 10/a6979629d1ad9c1fb424bc25182203fad739b40225aebc55ec6243bbff5035faf7b9ed6efab3a097de6e713acbbfde944baacfa73e11852bb43989c45a68d79e
-  languageName: node
-  linkType: hard
-
-"ip-address@npm:^10.1.1":
+"ip-address@npm:10.2.0, ip-address@npm:^10.1.1":
   version: 10.2.0
   resolution: "ip-address@npm:10.2.0"
   checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
@@ -32342,10 +32335,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:7.24.4":
-  version: 7.24.4
-  resolution: "undici@npm:7.24.4"
-  checksum: 10/747e76e0fd685ae1bb6fc1a2ebce0caca4ee8bd5599a77da36a3f94eac146987a9547bdbec7a74d18c0776df8ad348dccb4209901ca83fc4076f560de0d5dc7a
+"undici@npm:7.28.0, undici@npm:^7.16.0, undici@npm:^7.19.0, undici@npm:^7.25.0":
+  version: 7.28.0
+  resolution: "undici@npm:7.28.0"
+  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 
@@ -32362,13 +32355,6 @@ __metadata:
   version: 6.27.0
   resolution: "undici@npm:6.27.0"
   checksum: 10/30c18cdb235edf4dd36f8aa3ace1ffaf44060289a7d62ad44c33180d2d74a224015d25574812f62ce9c625b5beb1b0b766495b650fedf356aca11eed7ce2c816
-  languageName: node
-  linkType: hard
-
-"undici@npm:^7.16.0, undici@npm:^7.19.0, undici@npm:^7.25.0":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10/154423b280d623278a61decb437f8a7e581fb18b8c95556ef956b32a58cd668eadbb812d28e20678cb2dc545a566f35a3afc0962307ca801da30f4741117986d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In order to clear the CVEs that socket.dev disclosed after the tier 1–3 dependency cleanup (#9366, #9381, #9389, #9390) landed, this PR bumps three production transitive deps to versions already reachable in the tree. Follows the same risk logic as #9390: only in-range bumps and same-major `resolutions` overrides, no forced majors.

### Cleared CVEs

**In-range bump (`yarn up -R`)**

| Package | From → To | Advisory |
|---|---|---|
| dompurify | 3.4.10 → 3.4.11 | permanent `ALLOWED_ATTR` pollution via `setConfig()` |

**`resolutions` overrides (retire stale exact pins; same-major, API-compatible)**

| Package | From → To | Advisory |
|---|---|---|
| undici | 7.24.4 → 7.28.0 | CVE-2026-9697, CVE-2026-12151, CVE-2026-6734, CVE-2026-9678/9679, CVE-2026-11525, CVE-2026-6733 |
| ip-address | 10.1.0 → 10.2.0 | CVE-2026-42338 |

Both overrides just collapse a stale exact pin onto a version the rest of the tree already resolves (`undici@^7` → 7.28.0, `ip-address@^10.1.1` → 10.2.0), so there is no net API change.

### Knowingly left open (unchanged from #9390's reasoning)

- **tar@6.2.1** — consumers (`cacache`, `node-gyp`, `sqlite3`) need the v6 API.
- **jws@4.0.0** — Socket's suggested "fix" is a downgrade to 3.2.3; no valid forward fix.
- **@opentelemetry/core 2.7.1** — pinned by the `0.218.0` suite; forcing only `core` to 2.8.0 risks a runtime version mismatch. Wants a deliberate, tested suite bump.
- **uuid@8** (fix is major v11), **qs@`<6.10`** (fix is 6.14, out of the consumer's range) — need forced majors / out-of-range overrides.
- **Dev-only pins** (fast-xml-parser, lodash, serialize-javascript, minimatch, ajv, tmp, xml2js, nanoid) and Socket's **obfuscated-code** warnings — better suppressed via the Socket dashboard than via forced major overrides on the toolchain.

### Change type

- [x] `other`

### Test plan

- `yarn typecheck` passes.
- ⚠️ Forced/transitive bumps aren't fully exercised by typecheck alone — worth a CI run (and a smoke of anything using `dompurify` sanitization) before merge.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +11 / -23  |