### PR TITLE
fix(release): don't cut a new SDK version for docs-only patches

### DIFF
--- a/internal/scripts/lib/didAnyPackageChange.ts
+++ b/internal/scripts/lib/didAnyPackageChange.ts
@@ -62,13 +62,26 @@ type Diff =
 			diff: string
 	  }
 
+// These files are bundled into the `tldraw` package tarball but are generated
+// during publishing from the docs content in `apps/docs/content` (see
+// `generate-tldraw-package-docs.ts`), not from SDK source. A docs-only change
+// therefore alters them, which would otherwise make this diff check report a
+// package change and cut a spurious SDK patch release. Ignore them so that
+// docs-only patches don't trigger a new SDK version.
+const GENERATED_DOCS_FILES = new Set(['DOCS.md', 'RELEASE_NOTES.md'])
+
+function isGeneratedDocsFile(filePath: string) {
+	// Tarball entry paths are prefixed with `package/`, e.g. `package/DOCS.md`.
+	return GENERATED_DOCS_FILES.has(filePath.split('/').pop()!)
+}
+
 function getManifestFirstDiff(
 	packageName: string,
 	a: Record<string, Buffer>,
 	b: Record<string, Buffer>
 ): Diff | null {
-	const aKeys = Object.keys(a)
-	const bKeys = Object.keys(b)
+	const aKeys = Object.keys(a).filter((key) => !isGeneratedDocsFile(key))
+	const bKeys = Object.keys(b).filter((key) => !isGeneratedDocsFile(key))
 	for (const key of aKeys) {
 		if (!bKeys.includes(key)) {
 			return { type: 'removed', packageName, filePath: key }

--- a/internal/scripts/lib/didAnyPackageChange.ts
+++ b/internal/scripts/lib/didAnyPackageChange.ts
@@ -69,13 +69,17 @@ type Diff =
 // patch release. Ignore them for the `tldraw` package so that docs-only patches
 // don't trigger a new SDK version. Other packages ship a hand-authored DOCS.md
 // as real source, so we only skip these for `tldraw`.
-const GENERATED_DOCS_FILES = new Set(['DOCS.md', 'RELEASE_NOTES.md'])
+//
+// `generate-tldraw-package-docs.ts` writes these files to the package root, so
+// in the tarball they live at exactly `package/<name>` (tarball entry paths are
+// prefixed with `package/`). Match the full path rather than the basename so a
+// same-named file in some other folder still counts as a real change.
+const GENERATED_DOCS_FILES = new Set(['package/DOCS.md', 'package/RELEASE_NOTES.md'])
 const GENERATED_DOCS_PACKAGE = 'tldraw'
 
 function isGeneratedDocsFile(packageName: string, filePath: string) {
 	if (packageName !== GENERATED_DOCS_PACKAGE) return false
-	// Tarball entry paths are prefixed with `package/`, e.g. `package/DOCS.md`.
-	return GENERATED_DOCS_FILES.has(filePath.split('/').pop()!)
+	return GENERATED_DOCS_FILES.has(filePath)
 }
 
 function getManifestFirstDiff(

--- a/internal/scripts/lib/didAnyPackageChange.ts
+++ b/internal/scripts/lib/didAnyPackageChange.ts
@@ -62,15 +62,18 @@ type Diff =
 			diff: string
 	  }
 
-// These files are bundled into the `tldraw` package tarball but are generated
-// during publishing from the docs content in `apps/docs/content` (see
-// `generate-tldraw-package-docs.ts`), not from SDK source. A docs-only change
-// therefore alters them, which would otherwise make this diff check report a
-// package change and cut a spurious SDK patch release. Ignore them so that
-// docs-only patches don't trigger a new SDK version.
+// In the `tldraw` package these files are generated during publishing from the
+// docs content in `apps/docs/content` (see `generate-tldraw-package-docs.ts`),
+// not from SDK source. A docs-only change therefore alters them, which would
+// otherwise make this diff check report a package change and cut a spurious SDK
+// patch release. Ignore them for the `tldraw` package so that docs-only patches
+// don't trigger a new SDK version. Other packages ship a hand-authored DOCS.md
+// as real source, so we only skip these for `tldraw`.
 const GENERATED_DOCS_FILES = new Set(['DOCS.md', 'RELEASE_NOTES.md'])
+const GENERATED_DOCS_PACKAGE = 'tldraw'
 
-function isGeneratedDocsFile(filePath: string) {
+function isGeneratedDocsFile(packageName: string, filePath: string) {
+	if (packageName !== GENERATED_DOCS_PACKAGE) return false
 	// Tarball entry paths are prefixed with `package/`, e.g. `package/DOCS.md`.
 	return GENERATED_DOCS_FILES.has(filePath.split('/').pop()!)
 }
@@ -80,8 +83,8 @@ function getManifestFirstDiff(
 	a: Record<string, Buffer>,
 	b: Record<string, Buffer>
 ): Diff | null {
-	const aKeys = Object.keys(a).filter((key) => !isGeneratedDocsFile(key))
-	const bKeys = Object.keys(b).filter((key) => !isGeneratedDocsFile(key))
+	const aKeys = Object.keys(a).filter((key) => !isGeneratedDocsFile(packageName, key))
+	const bKeys = Object.keys(b).filter((key) => !isGeneratedDocsFile(packageName, key))
 	for (const key of aKeys) {
 		if (!bKeys.includes(key)) {
 			return { type: 'removed', packageName, filePath: key }


### PR DESCRIPTION
In order to stop docs-only patches from cutting a spurious SDK version (#9459), this PR makes the package-diff release guard ignore the generated `DOCS.md` and `RELEASE_NOTES.md` files.

The `tldraw` package tarball bundles `DOCS.md` and `RELEASE_NOTES.md`, which `prepack` generates from `apps/docs/content` at publish time (`generate-tldraw-package-docs.ts`). Because these files are part of the published tarball, a docs-only change alters them, so `getAnyPackageDiff` reported the `tldraw` package as "changed" and the docs-only guard in `publish-patch.ts` and `trigger-sdk-hotfix.ts` no longer skipped the release. This is what cut a spurious `v5.2.1` right after the v5.2.0 release-notes PR (#9433) landed on `v5.2.x`.

The fix filters these generated docs files out of the tarball manifest comparison in `getManifestFirstDiff`, so a change confined to them no longer counts as a package change. Real SDK source changes are still detected as before.

### Change type

- [x] `bugfix`

### Test plan

Release-pipeline scripts, not runtime code — verified by reasoning through the diff logic:

1. A docs-only cherry-pick onto a `vX.Y.x` branch changes only `DOCS.md` / `RELEASE_NOTES.md` in the `tldraw` tarball, so `getAnyPackageDiff` now returns `null` and `publish-patch.ts` logs `No packages have changed, skipping release`.
2. A change that touches real SDK source still produces a diff and releases normally.
3. `trigger-sdk-hotfix.ts` no longer falsely rejects a `docs-hotfix-please` PR whose only tarball impact is these generated files.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +14 / -2   |
