### PR TITLE
fix(arrows): allow selected clipped arrows to be dragged

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5805,10 +5805,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 */
 	getSelectedShapeAtPoint(point: VecLike): TLShape | undefined {
 		const selectedShapeIds = this.getSelectedShapeIds()
+		const margin = this.options.hitTestMargin / this.getZoomLevel()
 		return this.getCurrentPageShapesSorted()
 			.filter((shape) => shape.type !== 'group' && selectedShapeIds.includes(shape.id))
 			.reverse() // find last
-			.find((shape) => this.isPointInShape(shape, point, { hitInside: true, margin: 0 }))
+			.find((shape) =>
+				this.getShapeGeometry(shape).hitTestPoint(
+					this.getPointInShapeSpace(shape, point),
+					margin,
+					true
+				)
+			)
 	}
 
 	/**

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5806,16 +5806,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 	getSelectedShapeAtPoint(point: VecLike): TLShape | undefined {
 		const selectedShapeIds = this.getSelectedShapeIds()
 		const margin = this.options.hitTestMargin / this.getZoomLevel()
-		return this.getCurrentPageShapesSorted()
-			.filter((shape) => shape.type !== 'group' && selectedShapeIds.includes(shape.id))
-			.reverse() // find last
-			.find((shape) =>
+		const sortedShapes = this.getCurrentPageShapesSorted()
+
+		for (let i = sortedShapes.length - 1; i >= 0; i--) {
+			const shape = sortedShapes[i]
+			if (shape.type === 'group') continue
+			if (!selectedShapeIds.includes(shape.id)) continue
+			if (
 				this.getShapeGeometry(shape).hitTestPoint(
 					this.getPointInShapeSpace(shape, point),
 					margin,
 					true
 				)
-			)
+			) {
+				return shape
+			}
+		}
+
+		return undefined
 	}
 
 	/**

--- a/packages/tldraw/src/test/custom-clipping.test.ts
+++ b/packages/tldraw/src/test/custom-clipping.test.ts
@@ -8,6 +8,7 @@ import {
 	resizeBox,
 	StateNode,
 	T,
+	TLArrowShape,
 	TLEventHandlers,
 	TLGeoShape,
 	TLResizeInfo,
@@ -140,6 +141,7 @@ afterEach(() => {
 const ids = {
 	circleClip1: createShapeId('circleClip1'),
 	circleClip2: createShapeId('circleClip2'),
+	arrow1: createShapeId('arrow1'),
 	text1: createShapeId('text1'),
 	geo1: createShapeId('geo1'),
 	geo2: createShapeId('geo2'),
@@ -318,6 +320,53 @@ describe('CircleClipShapeUtil', () => {
 })
 
 describe('Integration tests', () => {
+	it('can grab a selected clipped arrow where it extends outside its clipping parent', () => {
+		editor.createShape({
+			id: ids.circleClip1,
+			type: CIRCLE_CLIP_TYPE,
+			x: 100,
+			y: 100,
+			props: {
+				w: 200,
+				h: 200,
+			},
+		})
+
+		editor.createShape({
+			id: ids.arrow1,
+			type: 'arrow',
+			x: 50,
+			y: 190,
+			parentId: ids.circleClip1,
+			props: {
+				start: { x: 0, y: 0 },
+				end: { x: 100, y: 0 },
+				bend: 60,
+			},
+		})
+
+		expect(editor.getShapeClipPath(ids.arrow1)).toBeDefined()
+
+		const transform = editor.getShapePageTransform(ids.arrow1)
+		const clippedPoint = transform
+			.applyToPoints(editor.getShapeGeometry(ids.arrow1).vertices)
+			.reduce((lowest, point) => (point.y > lowest.y ? point : lowest))
+
+		expect(editor.getShapeAtPoint(clippedPoint, { hitInside: true, margin: 0 })).toBeUndefined()
+
+		editor.setCurrentTool('select')
+		editor.select(ids.arrow1)
+		expect(editor.getSelectedShapeAtPoint(clippedPoint)?.id).toBe(ids.arrow1)
+
+		editor.pointerDown(clippedPoint.x, clippedPoint.y)
+		editor.pointerMove(clippedPoint.x, clippedPoint.y + 40)
+		editor.expectToBeIn('select.translating')
+		editor.pointerUp()
+
+		const arrow = editor.getShape<TLArrowShape>(ids.arrow1)!
+		expect(arrow.y).not.toBe(190)
+	})
+
 	it('should create and manage circle clip shapes with children', () => {
 		// Create circle clip shape
 		editor.createShape({


### PR DESCRIPTION
In order to preserve the clipped-arrow selection fix from #9429 after #9470 moved frame-bound arrows out of clipping, this PR lets already-selected shapes be hit-tested against their geometry using the standard hit-test margin when deciding whether a drag should start. This keeps selected arrows grabbable at the same places as their selection indicator, including for custom clipping containers that still clip arrow children.

### Why this change is needed

Normal shape picking still goes through `getShapeAtPoint`, which uses the editor's standard hit-test margin and respects clipping masks. That is the right behavior for finding the top-most visible shape under the pointer.

The selected-shape path is different. `getSelectedShapeAtPoint` runs after a shape is already selected, and it decides whether a pointer down should start dragging that selected shape. Before this PR, it used `isPointInShape` with `margin: 0`. That worked for many selected clipped shapes because closed shapes have an inside area and this path passed `hitInside: true`.

Arrows are different: they are open, thin geometry, so `margin: 0` required an exact hit on the arrow body. For a curved arrow that is already selected and visually represented by its selection indicator, pointer down near the selected arrow could miss the selected shape and start another canvas interaction instead.

This PR keeps `isPointInShape` as the clipped/visible-shape test used by normal picking, and makes `getSelectedShapeAtPoint` use the selected shape's own geometry with the standard hit-test margin. The result matches the interaction model: normal picking still uses clipped shape hit-testing, while already-selected arrows remain draggable with the same forgiving margin as regular arrow hits.

### Change type

- [x] `bugfix`

### Test plan

1. Use a custom clipping parent with a curved arrow child that extends outside the clip path.
2. Confirm a normal shape hit-test misses the clipped point, but the selected arrow can be dragged from that point.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix selected clipped arrows so they can be dragged where their geometry extends outside a clipping parent.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +19 / -4   |
| Tests     | +49 / -0   |