### PR TITLE
ci: notify tldraw-internal on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,6 +245,32 @@ jobs:
             https://api.github.com/repos/tldraw/tldraw-desktop/dispatches \
             -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","tag":"next"}}'
 
+      # Tell tldraw-internal to update its pinned SDK version. Fires for every
+      # real release channel — next prereleases, hotfix patches, and manual/new
+      # releases (workflow_dispatch) — but NOT canary (every push to main) or
+      # internal (PR preview publishes), which would be far too noisy. The
+      # tldraw-internal "Update tldraw" workflow listens for the `tldraw-release`
+      # repository_dispatch and resolves the newest published version itself, so
+      # the payload version is informational.
+      - name: Generate tldraw-internal token
+        if: contains(fromJSON('["next","patch","manual","new"]'), steps.publish_mode.outputs.mode)
+        id: generate_internal_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.HUPPY_APP_ID }}
+          private-key: ${{ secrets.HUPPY_PRIVATE_KEY }}
+          owner: tldraw
+          repositories: tldraw-internal
+
+      - name: Notify tldraw-internal
+        if: contains(fromJSON('["next","patch","manual","new"]'), steps.publish_mode.outputs.mode)
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.generate_internal_token.outputs.token }}" \
+            https://api.github.com/repos/tldraw/tldraw-internal/dispatches \
+            -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","mode":"${{ steps.publish_mode.outputs.mode }}"}}'
+
       # Earlier steps run before checkout, so re-fetch the local action on failure.
       - name: Check out Discord notify action
         if: failure()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -245,15 +245,13 @@ jobs:
             https://api.github.com/repos/tldraw/tldraw-desktop/dispatches \
             -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","tag":"next"}}'
 
-      # Tell tldraw-internal to update its pinned SDK version. Fires for every
-      # real release channel — next prereleases, hotfix patches, and manual/new
-      # releases (workflow_dispatch) — but NOT canary (every push to main) or
-      # internal (PR preview publishes), which would be far too noisy. The
-      # tldraw-internal "Update tldraw" workflow listens for the `tldraw-release`
-      # repository_dispatch and resolves the newest published version itself, so
-      # the payload version is informational.
+      # Tell tldraw-internal to update its pinned SDK version. Fires only on a
+      # `next` publish — the prerelease channel the internal monorepo tracks.
+      # The tldraw-internal "Update tldraw" workflow listens for the
+      # `tldraw-release` repository_dispatch and resolves the latest `next`
+      # version itself, so the payload version is informational.
       - name: Generate tldraw-internal token
-        if: contains(fromJSON('["next","patch","manual","new"]'), steps.publish_mode.outputs.mode)
+        if: steps.publish_mode.outputs.mode == 'next'
         id: generate_internal_token
         uses: actions/create-github-app-token@v2
         with:
@@ -263,13 +261,13 @@ jobs:
           repositories: tldraw-internal
 
       - name: Notify tldraw-internal
-        if: contains(fromJSON('["next","patch","manual","new"]'), steps.publish_mode.outputs.mode)
+        if: steps.publish_mode.outputs.mode == 'next'
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ steps.generate_internal_token.outputs.token }}" \
             https://api.github.com/repos/tldraw/tldraw-internal/dispatches \
-            -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","mode":"${{ steps.publish_mode.outputs.mode }}"}}'
+            -d '{"event_type":"tldraw-release","client_payload":{"version":"${{ steps.version.outputs.value }}","tag":"next"}}'
 
       # Earlier steps run before checkout, so re-fetch the local action on failure.
       - name: Check out Discord notify action


### PR DESCRIPTION
Adds a `repository_dispatch` from `publish.yml` to **`tldraw/tldraw-internal`** so the internal monorepo keeps its pinned tldraw SDK version up to date automatically — the event-driven replacement for an hourly poll it runs today.

## API changes

- [x] `other`

## What this does

Right after publishing, `publish.yml` already notifies `tldraw-desktop`. This mirrors that for `tldraw-internal`, adding two steps gated on **`mode == 'next'`** (the prerelease channel the internal monorepo tracks):

- `Generate tldraw-internal token` — a huppy app token scoped to `tldraw-internal`.
- `Notify tldraw-internal` — `POST /repos/tldraw/tldraw-internal/dispatches` with `event_type: tldraw-release`.

## ⚠️ Prerequisite: app access

Reuses the existing `HUPPY_APP_ID` / `HUPPY_PRIVATE_KEY`, but the huppy GitHub App must be **granted access to the `tldraw-internal` repo** (it currently only lists `tldraw-desktop`). Without that grant, the token step fails.

## Companion PR

The receiving workflow: **tldraw/tldraw-internal#637** (listens for `repository_dispatch: types: [tldraw-release]`). The `event_type` string matches exactly on both ends.

> Side note: the existing `Notify tldraw-desktop` step appears to be dispatching into the void — it sends `event_type: tldraw-release`, but `tldraw-desktop`'s only workflow now listens for `types: [release]`. Worth a separate fix if desktop auto-update is still expected to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)