### PR TITLE
feat(sync): store object-lane records in a separate storage partition

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -158,12 +158,17 @@ export class TLFileDurableObject extends DurableObject {
 
 		// If SQLite has been initialized, use it directly
 		if (SQLiteSyncStorage.hasBeenInitialized(sql)) {
-			return new SQLiteSyncStorage<TLRecord>({ sql })
+			return new SQLiteSyncStorage<TLRecord>({ sql, objectTypes: OBJECT_TYPES })
 		}
 
-		// SQLite not initialized yet, load from R2 and initialize
+		// SQLite not initialized yet, load from R2 and initialize. The loaded snapshot has the
+		// R2 object lane merged in; the storage routes those records into its objects partition.
 		const result = await this.loadFromDatabase(slug)
-		const storage = new SQLiteSyncStorage<TLRecord>({ sql, snapshot: result.snapshot })
+		const storage = new SQLiteSyncStorage<TLRecord>({
+			sql,
+			snapshot: result.snapshot,
+			objectTypes: OBJECT_TYPES,
+		})
 		// We should not await on setRoomStorageUsedPercentage because it calls
 		// getStorage under the hood which will only resolve once this function has returned.
 		this.setRoomStorageUsedPercentage(result.roomSizeMB)
@@ -801,8 +806,8 @@ export class TLFileDurableObject extends DurableObject {
 
 		const storage = await this.getStorage()
 		assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
-		// object-lane records (comments) are not document content and don't belong in .tldr files
-		const snapshot = storage.getSnapshot({ excludeTypes: OBJECT_TYPES })
+		// the document snapshot never contains object-lane records (comments), so .tldr is clean
+		const snapshot = storage.getSnapshot()
 		const records = pruneUnusedAssetsForTldr(snapshot.documents.map((d) => d.state) as TLRecord[])
 
 		const assetRows = await this.db
@@ -1284,22 +1289,13 @@ export class TLFileDurableObject extends DurableObject {
 						if (this._lastPersistedClock === storage.getClock()) return
 						if (this._isRestoring) return
 
-						const fullSnapshot = storage.getSnapshot()
-						assert(fullSnapshot.documentClock !== undefined, 'documentClock must be present')
+						// The storage partitions object-lane records (comments) into their own store, so
+						// the document snapshot is pure-document by construction — no splitting needed.
+						const snapshot = storage.getSnapshot()
+						assert(snapshot.documentClock !== undefined, 'documentClock must be present')
 						this.maybeAssociateFileAssets()
 
-						// Object-lane records (comments) are persisted in a separate R2 lane, not the main
-						// document blob. Split them out in a single pass so the main snapshot (and Pierre)
-						// never carry object-lane records.
-						const objectDocs: RoomSnapshot['documents'] = []
-						const mainDocs: RoomSnapshot['documents'] = []
-						for (const doc of fullSnapshot.documents) {
-							;((OBJECT_TYPES as readonly string[]).includes(doc.state.typeName)
-								? objectDocs
-								: mainDocs
-							).push(doc)
-						}
-						const snapshot: RoomSnapshot = { ...fullSnapshot, documents: mainDocs }
+						const objectDocs = storage.getObjectsSnapshot()
 
 						const key = getR2KeyForRoom({ slug: slug, isApp: this.documentInfo.isApp })
 						await this._uploadSnapshotToR2(snapshot, key)
@@ -1312,7 +1308,7 @@ export class TLFileDurableObject extends DurableObject {
 						await this.persistToPierre(storage, snapshot)
 
 						this.logEvent({ type: 'persist_success', attempts: attempt })
-						this._lastPersistedClock = fullSnapshot.documentClock
+						this._lastPersistedClock = snapshot.documentClock
 						// Store the clock in DO storage so we can compare against SQLite on next load.
 						if (this.persistenceBad) {
 							this.broadcastPersistenceEvent({ type: 'persistence_good' })

--- a/object-store-design.md
+++ b/object-store-design.md
@@ -1,0 +1,115 @@
+# The object store as a fourth kind of record
+
+This doc captures the design thinking behind the object store exploration (the stacked PRs #9478 → #9484 → #9486), and where it should go next. It argues that "the object store" is best understood not as a feature bolted onto sync, but as the server half of a **fourth record scope** — a peer of `document`, `session`, and `presence` — and lays out a staged path for making it one.
+
+It's written to be read on its own, alongside `comments-design.md` (which covers the product-level options for comments; this doc covers the sync/storage architecture underneath them).
+
+---
+
+## The taxonomy we already have
+
+tldraw already distinguishes kinds of state, and the distinctions run along a handful of dimensions: whether state syncs, whether it persists, who owns its lifecycle, how writes are gated, and which content surfaces (snapshots, exports, undo) include it.
+
+Fill in the matrix for the existing scopes and for object-lane records (comments today; threads, reactions, and attachment metadata tomorrow):
+
+|                       | `document` (shapes) | `presence`      | `session` (camera etc.) | objects (comments)               |
+| --------------------- | ------------------- | --------------- | ----------------------- | -------------------------------- |
+| Synced                | ✓                   | ✓               | ✗                       | ✓                                |
+| Persisted server-side | ✓ (snapshot)        | ✗               | ✗                       | ✓ (own lane)                     |
+| Lifecycle owner       | the document        | the session     | the client tab          | itself (attached, but separable) |
+| Permission gate       | `isReadonly`        | own-record only | n/a                     | `objectAccess`                   |
+| In exports / `.tldr`  | ✓                   | ✗               | ✗                       | ✗ (by requirement)               |
+| Undoable              | ✓                   | ✗               | ✗                       | ✗ (by convention)                |
+| Schema-migrated       | ✓                   | ✓               | ✓                       | ✓                                |
+
+The objects column is not a combination of the existing ones. It is a genuinely new point in the space: **synced + persisted + separable lifecycle + own permission axis + excluded from content surfaces**. This is why every attempt to express comments with an existing scope fails somewhere:
+
+- **`document` scope** (what the stack uses today) gets the transport right but the membership wrong. Object records leak into snapshots, exports, and undo unless every consumer remembers to filter. PR #9486 fixed this _server-side_ by construction (a separate storage partition), but the client half of the leak remains: `editor.getSnapshot()` still includes comments, and undo exclusion is a call-site convention (`history: 'ignore'`), not a guarantee.
+- **`session` scope** gets the exclusions right but everything else wrong: session records don't sync, and — decisively — they don't persist for local-only files. `comments-design.md`'s Approach 1 promises that comments in a local file work offline with no server. No existing scope offers _persisted locally but excluded from `.tldr`_. That combination only exists as a new scope.
+
+One clarification the taxonomy needs: **sessions are not a kind of state — they are the carrier of the permission axes.** Each synced lane pairs with one gate on the session:
+
+- `document` ↔ `isReadonly`
+- `object` ↔ `objectAccess`
+- `presence` ↔ structural self-ownership (a session can only write its own presence record)
+
+Seen this way, PR #9484 didn't add "a permission boolean"; it added the gate that the fourth lane was missing, completing the pairing.
+
+---
+
+## Presence is the precedent — twice over
+
+The strongest evidence that the fourth-scope framing is correct (rather than just tidy) is that presence already demonstrates the whole pattern:
+
+1. **Its own wire field.** `presence` sits next to `diff` on the push message — a lane multiplexed over one socket, exactly how object records travel.
+2. **Its own server-side store.** `PresenceStore` is a separate in-room store with no clock and no tombstones — storage shaped to its semantics, exactly what the `objects` table is for object records.
+3. **Record-level, ownership-based authorization.** A session can only write its own presence record; the server enforces this structurally by keying writes to `session.presenceId` and ignoring whatever id the client claims.
+
+Point 3 matters most for the roadmap. The features coming after comments — threads ("only participants may resolve"), reactions ("you may only delete your own"), attachments — all need per-record ownership rules, which the binary `objectAccess` gate cannot express. That follow-up (`canWriteObject` + server-stamped `authorId`) is not a new invention: it is presence's authorization model generalized from "exactly one record per session" to "records tagged with your identity, verified by the server."
+
+After #9486, the server has three stores matching three kinds of state:
+
+| Store             | Clock      | Tombstones | Persisted    |
+| ----------------- | ---------- | ---------- | ------------ |
+| document storage  | ✓          | ✓          | ✓            |
+| objects partition | ✓ (shared) | ✓ (shared) | ✓ (own lane) |
+| `PresenceStore`   | ✗          | ✗          | ✗            |
+
+We have been building the taxonomy without naming it.
+
+---
+
+## Where the stack is, in taxonomy terms
+
+- **#9478** — comments exist, expressed as ordinary `document` records with server-side special-casing. Stage 0: the new column in the matrix is simulated by filters and conventions.
+- **#9484** — the permission axis. `objectTypes` partitions record types at the room; object-lane writes are gated by `objectAccess` per session instead of `isReadonly`. Stage 1: the lane exists as _server configuration_.
+- **#9486** — the separate store. Object records live in their own storage partition (own SQLite table / in-memory map) under the shared transaction, clock, and tombstone feed. `getSnapshot()` is pure-document by construction; `getObjectsSnapshot()` exposes the lane for separate persistence. Stage 1.5: the server half of the fourth scope is real.
+
+Notably, all three stages required **zero wire-protocol and zero client changes**. The lane rides the existing push/patch/rebase/connect messages; the only additive field is `objectAccess` on the connect message.
+
+---
+
+## The staged path to a first-class scope
+
+### Stage 2 — schema-declared lane (next, cheap)
+
+Move the lane declaration from server config into the schema: `CustomRecordInfo` gains `lane: 'object'`, and the room and storage derive `objectTypes` from the schema instead of receiving it as options.
+
+What this buys:
+
+- **Single-sourcing.** Today `objectTypes` is configured in two places (room and storage) with no drift check — the one known failure mode with no compensating benefit. Schema declaration eliminates it.
+- **Handshake validation nearly free.** The serialized schema already crosses the wire at connect, so client and server can detect lane disagreement instead of silently diverging.
+
+Blast radius: tlschema and sync only. This should land as part of the stack's graduation from spike.
+
+### Stage 3 — `RecordScope: 'object'` in `@tldraw/store` (the endgame)
+
+Add the fourth scope for real. This is what fixes the _client_ surfaces the same way #9486 fixed the server ones — by construction instead of convention:
+
+- `store.scopedTypes` / `filterChangesByScope` learn about objects → `editor.getSnapshot()` and `.tldr` exports exclude them automatically.
+- Undo exclusion becomes structural (scope-based) instead of the `history: 'ignore'` call-site convention.
+- `TLLocalSyncClient` can give objects their own IndexedDB lane → comments in local-only files persist offline and stay out of exports. This is the offline story no config-level approach can deliver.
+
+The cost is a real audit: every scope-switch in store/editor/tldraw must be checked. Two known traps found already:
+
+- `StoreSchema.migrateStorage`'s final cleanup pass **deletes** records whose scope isn't `'document'` — it would eat object records.
+- `TLSyncClient`'s push listener filters on `{ scope: 'document' }` — object-scoped records would silently stop syncing.
+
+Each is a one-line fix; the audit is the work. Presence also carries a warning label: scopes with bespoke semantics accrete special cases (the exactly-one-presence-type constraint, presence branches throughout sync). The fourth scope should define its semantics in the matrix above and resist growing bespoke branches beyond it.
+
+### Forcing functions
+
+Stage 3 gets scheduled when either of these bites:
+
+1. The client-surface leaks matter in practice (comments appearing in `editor.getSnapshot()`, client-side exports, or the undo stack).
+2. Comments in local-only files become a requirement (the offline promise of Approach 1 in `comments-design.md`).
+
+Until then, Stages 1–2 carry the product work, including threads and reactions — whose real blocker is record-level authorization, not scope.
+
+---
+
+## What deliberately stays out of scope
+
+- **Per-lane clocks and object-only subscriptions.** The shared clock is what keeps reconnect deltas, hydration, and mixed-push atomicity working unchanged. A fully independent object store (own clock, own hydration) enables partial subscriptions ("comments without the document") but costs cross-lane atomicity and protocol additions. Nothing on the current roadmap forces it.
+- **Record-level authorization** (`canWriteObject`, server-stamped `authorId`, cascade hooks). Required by threads/reactions/attachments; deliberately its own follow-up so the storage and permission layers land separately. Presence's self-ownership model is the template.
+- **Per-lane persistence keys.** The R2 lane keeps its `${key}/comments` name so existing rooms keep their data; a multi-tenant object store wants `${key}/objects/<lane>`.

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -100,17 +100,13 @@ export class DurableObjectSqliteSyncWrapper implements TLSyncSqliteWrapper {
 // @internal
 export function getNetworkDiff<R extends UnknownRecord>(diff: RecordsDiff<R>): NetworkDiff<R> | null;
 
-// @public
-export interface GetSnapshotOptions {
-    excludeTypes?: readonly string[];
-}
-
 // @internal
 export function getTlsyncProtocolVersion(): number;
 
 // @public
 export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
-    constructor({ snapshot, onChange }?: {
+    constructor({ snapshot, objectTypes, onChange }?: {
+        objectTypes?: readonly string[];
         onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown;
         snapshot?: RoomSnapshot;
     });
@@ -124,7 +120,16 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
     // (undocumented)
     getClock(): number;
     // (undocumented)
-    getSnapshot(opts?: GetSnapshotOptions): RoomSnapshot;
+    getObjectsSnapshot(): RoomSnapshot['documents'];
+    // (undocumented)
+    getSnapshot(): RoomSnapshot;
+    // @internal
+    objects: AtomMap<string, {
+        lastChangedClock: number;
+        state: R;
+    }>;
+    // @internal (undocumented)
+    readonly objectTypes: ReadonlySet<string>;
     // (undocumented)
     onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => unknown): () => void;
     // @internal (undocumented)
@@ -326,7 +331,8 @@ export interface SessionStateSnapshot {
 
 // @public
 export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
-    constructor({ sql, snapshot, onChange }: {
+    constructor({ sql, snapshot, objectTypes, onChange }: {
+        objectTypes?: readonly string[];
         onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown;
         snapshot?: RoomSnapshot | StoreSnapshot<R>;
         sql: TLSyncSqliteWrapper;
@@ -334,13 +340,17 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
     // (undocumented)
     getClock(): number;
     static getDocumentClock(storage: TLSyncSqliteWrapper): null | number;
+    // (undocumented)
+    getObjectsSnapshot(): RoomSnapshot['documents'];
     // @internal (undocumented)
     _getSchema(): SerializedSchema;
     // (undocumented)
-    getSnapshot(opts?: GetSnapshotOptions): RoomSnapshot;
+    getSnapshot(): RoomSnapshot;
     // @internal (undocumented)
     _getTombstoneHistoryStartsAtClock(): number;
     static hasBeenInitialized(storage: TLSyncSqliteWrapper): boolean;
+    // @internal (undocumented)
+    readonly objectTypes: ReadonlySet<string>;
     // (undocumented)
     onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => void): () => void;
     // @internal (undocumented)
@@ -458,8 +468,9 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
     close(): void;
     closeSession(sessionId: string, fatalReason?: string | TLSyncErrorCloseEventReason): void;
     getCurrentDocumentClock(): number;
+    getCurrentObjectsSnapshot(): RoomSnapshot['documents'];
     // @deprecated
-    getCurrentSnapshot(opts?: GetSnapshotOptions): RoomSnapshot;
+    getCurrentSnapshot(): RoomSnapshot;
     getNumActiveSessions(): number;
     // @internal
     getPresenceRecords(): Record<string, UnknownRecord>;
@@ -762,8 +773,8 @@ export interface TLSyncSqliteWrapperConfig {
 export interface TLSyncStorage<R extends UnknownRecord> {
     // (undocumented)
     getClock(): number;
-    // (undocumented)
-    getSnapshot?(opts?: GetSnapshotOptions): RoomSnapshot;
+    getObjectsSnapshot?(): RoomSnapshot['documents'];
+    getSnapshot?(): RoomSnapshot;
     // (undocumented)
     onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => unknown): () => void;
     // (undocumented)

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -67,7 +67,6 @@ export {
 } from './lib/TLSyncClient'
 export {
 	TLSyncRoom,
-	type GetSnapshotOptions,
 	type MinimalDocStore,
 	type PresenceStore,
 	type RoomSnapshot,

--- a/packages/sync-core/src/lib/InMemorySyncStorage.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.ts
@@ -9,7 +9,7 @@ import {
 } from '@tldraw/tlschema'
 import { assert, IndexKey, objectMapEntries, throttle } from '@tldraw/utils'
 import { MicrotaskNotifier } from './MicrotaskNotifier'
-import { GetSnapshotOptions, RoomSnapshot } from './TLSyncRoom'
+import { RoomSnapshot } from './TLSyncRoom'
 import {
 	TLSyncForwardDiff,
 	TLSyncStorage,
@@ -117,6 +117,14 @@ export const DEFAULT_INITIAL_SNAPSHOT = {
 export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStorage<R> {
 	/** @internal */
 	documents: AtomMap<string, { state: R; lastChangedClock: number }>
+	/**
+	 * Object-store lane records, partitioned out of `documents` so they never appear in the
+	 * document snapshot. They share the same clock, tombstones, and transactions as documents.
+	 * @internal
+	 */
+	objects: AtomMap<string, { state: R; lastChangedClock: number }>
+	/** @internal */
+	readonly objectTypes: ReadonlySet<string>
 	/** @internal */
 	tombstones: AtomMap<string, number>
 	/** @internal */
@@ -133,22 +141,38 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
 
 	constructor({
 		snapshot = DEFAULT_INITIAL_SNAPSHOT,
+		objectTypes,
 		onChange,
 	}: {
 		snapshot?: RoomSnapshot
+		/**
+		 * Record type names stored in the object-store lane. Records of these types are routed to
+		 * a separate partition: excluded from `getSnapshot()`, returned by `getObjectsSnapshot()`.
+		 */
+		objectTypes?: readonly string[]
 		onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown
 	} = {}) {
+		this.objectTypes = new Set(objectTypes ?? [])
 		const maxClockValue = Math.max(
 			0,
 			...Object.values(snapshot.tombstones ?? {}),
 			...Object.values(snapshot.documents.map((d) => d.lastChangedClock))
 		)
+		// route snapshot entries into their partitions (a seed snapshot may carry object-lane
+		// records merged in, e.g. loaded from a separate persistence lane)
+		const toEntry = (
+			d: RoomSnapshot['documents'][number]
+		): [string, { state: R; lastChangedClock: number }] => [
+			d.state.id,
+			{ state: devFreeze(d.state) as R, lastChangedClock: d.lastChangedClock },
+		]
 		this.documents = new AtomMap(
 			'room documents',
-			snapshot.documents.map((d) => [
-				d.state.id,
-				{ state: devFreeze(d.state) as R, lastChangedClock: d.lastChangedClock },
-			])
+			snapshot.documents.filter((d) => !this.objectTypes.has(d.state.typeName)).map(toEntry)
+		)
+		this.objects = new AtomMap(
+			'room objects',
+			snapshot.documents.filter((d) => this.objectTypes.has(d.state.typeName)).map(toEntry)
 		)
 		const documentClock = Math.max(maxClockValue, snapshot.documentClock ?? snapshot.clock ?? 0)
 
@@ -248,19 +272,20 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
 		{ leading: false }
 	)
 
-	getSnapshot(opts?: GetSnapshotOptions): RoomSnapshot {
-		const excludeTypes = opts?.excludeTypes
-		let documents = Array.from(this.documents.values())
-		if (excludeTypes?.length) {
-			documents = documents.filter((d) => !excludeTypes.includes(d.state.typeName))
-		}
+	getSnapshot(): RoomSnapshot {
+		// object-lane records live in their own partition, so the document snapshot is
+		// pure-document by construction
 		return {
 			tombstoneHistoryStartsAtClock: this.tombstoneHistoryStartsAtClock.get(),
 			documentClock: this.documentClock.get(),
-			documents,
+			documents: Array.from(this.documents.values()),
 			tombstones: Object.fromEntries(this.tombstones.entries()),
 			schema: this.schema.get(),
 		}
+	}
+
+	getObjectsSnapshot(): RoomSnapshot['documents'] {
+		return Array.from(this.objects.values())
 	}
 }
 
@@ -302,9 +327,16 @@ class InMemorySyncStorageTransaction<
 		return this._clock
 	}
 
+	/** The partition a record with this id currently lives in, if any. */
+	private mapContaining(id: string) {
+		if (this.storage.documents.has(id)) return this.storage.documents
+		if (this.storage.objects.has(id)) return this.storage.objects
+		return undefined
+	}
+
 	get(id: string): R | undefined {
 		this.assertNotClosed()
-		return this.storage.documents.get(id)?.state
+		return (this.storage.documents.get(id) ?? this.storage.objects.get(id))?.state
 	}
 
 	set(id: string, record: R): void {
@@ -315,7 +347,11 @@ class InMemorySyncStorageTransaction<
 		if (this.storage.tombstones.has(id)) {
 			this.storage.tombstones.delete(id)
 		}
-		this.storage.documents.set(id, {
+		// route by type: object-lane records live in their own partition
+		const map = this.storage.objectTypes.has(record.typeName)
+			? this.storage.objects
+			: this.storage.documents
+		map.set(id, {
 			state: devFreeze(record) as R,
 			lastChangedClock: clock,
 		})
@@ -324,34 +360,43 @@ class InMemorySyncStorageTransaction<
 	delete(id: string): void {
 		this.assertNotClosed()
 		// Only create a tombstone if the record actually exists
-		if (!this.storage.documents.has(id)) return
+		const map = this.mapContaining(id)
+		if (!map) return
 		const clock = this.getNextClock()
-		this.storage.documents.delete(id)
+		map.delete(id)
 		this.storage.tombstones.set(id, clock)
 		this.storage.pruneTombstones()
 	}
 
+	// iteration spans both partitions so schema migrations cover object-lane records too
+
 	*entries(): IterableIterator<[string, R]> {
 		this.assertNotClosed()
-		for (const [id, record] of this.storage.documents.entries()) {
-			this.assertNotClosed()
-			yield [id, record.state]
+		for (const map of [this.storage.documents, this.storage.objects]) {
+			for (const [id, record] of map.entries()) {
+				this.assertNotClosed()
+				yield [id, record.state]
+			}
 		}
 	}
 
 	*keys(): IterableIterator<string> {
 		this.assertNotClosed()
-		for (const key of this.storage.documents.keys()) {
-			this.assertNotClosed()
-			yield key
+		for (const map of [this.storage.documents, this.storage.objects]) {
+			for (const key of map.keys()) {
+				this.assertNotClosed()
+				yield key
+			}
 		}
 	}
 
 	*values(): IterableIterator<R> {
 		this.assertNotClosed()
-		for (const record of this.storage.documents.values()) {
-			this.assertNotClosed()
-			yield record.state
+		for (const map of [this.storage.documents, this.storage.objects]) {
+			for (const record of map.values()) {
+				this.assertNotClosed()
+				yield record.state
+			}
 		}
 	}
 
@@ -375,10 +420,13 @@ class InMemorySyncStorageTransaction<
 		}
 		const diff: TLSyncForwardDiff<R> = { puts: {}, deletes: [] }
 		const wipeAll = sinceClock < this.storage.tombstoneHistoryStartsAtClock.get()
-		for (const doc of this.storage.documents.values()) {
-			if (wipeAll || doc.lastChangedClock > sinceClock) {
-				// For historical changes, we don't have "from" state, so use added
-				diff.puts[doc.state.id] = doc.state as R
+		// both partitions share the clock and tombstones, so the change feed spans both
+		for (const map of [this.storage.documents, this.storage.objects]) {
+			for (const doc of map.values()) {
+				if (wipeAll || doc.lastChangedClock > sinceClock) {
+					// For historical changes, we don't have "from" state, so use added
+					diff.puts[doc.state.id] = doc.state as R
+				}
 			}
 		}
 		if (!wipeAll) {

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.test.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.test.ts
@@ -38,6 +38,33 @@ describe('SQLiteSyncStorage', () => {
 			).toEqual(newPage)
 		})
 
+		it('[SQ1] sweeps pre-partition object-lane rows out of the documents table on reopen', () => {
+			// a database written before the objects table existed: object-lane records (here
+			// 'page' stands in) live in the documents table
+			const sql = createWrapper()
+			const storage = new SQLiteSyncStorage<TLRecord>({
+				sql,
+				snapshot: makeContractSnapshot(contractRecords),
+			})
+			const extraPage = makePage('legacy')
+			storage.transaction((txn) => txn.set(extraPage.id, extraPage))
+			expect(storage.getSnapshot().documents).toHaveLength(3)
+
+			// reopening with objectTypes moves the rows into the objects partition
+			const reopened = new SQLiteSyncStorage<TLRecord>({ sql, objectTypes: ['page'] })
+			expect(reopened.getSnapshot().documents.map((d) => d.state.typeName)).toEqual(['document'])
+			expect(
+				reopened
+					.getObjectsSnapshot()
+					.map((d) => d.state.id)
+					.sort()
+			).toEqual([contractRecords[1].id, extraPage.id].sort())
+			// lastChangedClock survives the move
+			expect(
+				reopened.getObjectsSnapshot().find((d) => d.state.id === extraPage.id)?.lastChangedClock
+			).toBe(1)
+		})
+
 		it('[SQ1] honors the table prefix', () => {
 			const sql = createWrapper({ tablePrefix: 'tldraw_' })
 			const storage = new SQLiteSyncStorage<TLRecord>({
@@ -227,13 +254,13 @@ describe('SQLiteSyncStorage', () => {
 			expect(storage.getSnapshot().documents.length).toBe(3)
 		})
 
-		it('[SQ6] fresh databases start at migration version 2', () => {
+		it('[SQ6] fresh databases start at migration version 3', () => {
 			const sql = createWrapper()
 			new SQLiteSyncStorage<TLRecord>({ sql, snapshot: makeContractSnapshot(contractRecords) })
 			const row = sql
 				.prepare<{ migrationVersion: number }>('SELECT migrationVersion FROM metadata')
 				.all()[0]
-			expect(row?.migrationVersion).toBe(2)
+			expect(row?.migrationVersion).toBe(3)
 		})
 	})
 })

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.ts
@@ -7,7 +7,7 @@ import {
 	MAX_TOMBSTONES,
 } from './InMemorySyncStorage'
 import { MicrotaskNotifier } from './MicrotaskNotifier'
-import { GetSnapshotOptions, RoomSnapshot } from './TLSyncRoom'
+import { RoomSnapshot } from './TLSyncRoom'
 import {
 	convertStoreSnapshotToRoomSnapshot,
 	TLSyncForwardDiff,
@@ -86,9 +86,15 @@ export function migrateSqliteSyncStorage(
 	storage: TLSyncSqliteWrapper,
 	{
 		documentsTable = 'documents',
+		objectsTable = 'objects',
 		tombstonesTable = 'tombstones',
 		metadataTable = 'metadata',
-	}: { documentsTable?: string; tombstonesTable?: string; metadataTable?: string } = {}
+	}: {
+		documentsTable?: string
+		objectsTable?: string
+		tombstonesTable?: string
+		metadataTable?: string
+	} = {}
 ): void {
 	let migrationVersion = 0
 	try {
@@ -144,15 +150,31 @@ export function migrateSqliteSyncStorage(
 				state BLOB NOT NULL,
 				lastChangedClock INTEGER NOT NULL
 			);
-			
+
 			INSERT INTO ${documentsTable}_new (id, state, lastChangedClock)
 			SELECT id, CAST(state AS BLOB), lastChangedClock FROM ${documentsTable};
-			
+
 			DROP TABLE ${documentsTable};
-			
+
 			ALTER TABLE ${documentsTable}_new RENAME TO ${documentsTable};
-			
+
 			CREATE INDEX idx_${documentsTable}_lastChangedClock ON ${documentsTable}(lastChangedClock);
+		`)
+	}
+
+	if (migrationVersion === 2) {
+		// Migration 3: Add the object-store lane table. Object-lane records (e.g. comments) are
+		// partitioned out of the documents table so the document snapshot never contains them.
+		// They share the documents' clock and tombstones.
+		migrationVersion++
+		storage.exec(`
+			CREATE TABLE ${objectsTable} (
+				id TEXT PRIMARY KEY,
+				state BLOB NOT NULL,
+				lastChangedClock INTEGER NOT NULL
+			);
+
+			CREATE INDEX idx_${objectsTable}_lastChangedClock ON ${objectsTable}(lastChangedClock);
 		`)
 	}
 
@@ -250,22 +272,64 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 
 	private readonly sql: TLSyncSqliteWrapper
 
+	/** @internal */
+	readonly objectTypes: ReadonlySet<string>
+
 	constructor({
 		sql,
 		snapshot,
+		objectTypes,
 		onChange,
 	}: {
 		sql: TLSyncSqliteWrapper
 		snapshot?: RoomSnapshot | StoreSnapshot<R>
+		/**
+		 * Record type names stored in the object-store lane. Records of these types are routed to
+		 * a separate table: excluded from `getSnapshot()`, returned by `getObjectsSnapshot()`.
+		 * They share the documents' clock, tombstones, and transactions.
+		 */
+		objectTypes?: readonly string[]
 		onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown
 	}) {
 		this.sql = sql
+		this.objectTypes = new Set(objectTypes ?? [])
 		const prefix = sql.config?.tablePrefix ?? ''
 		const documentsTable = `${prefix}documents`
+		const objectsTable = `${prefix}objects`
 		const tombstonesTable = `${prefix}tombstones`
 		const metadataTable = `${prefix}metadata`
 
-		migrateSqliteSyncStorage(this.sql, { documentsTable, tombstonesTable, metadataTable })
+		migrateSqliteSyncStorage(this.sql, {
+			documentsTable,
+			objectsTable,
+			tombstonesTable,
+			metadataTable,
+		})
+
+		// Both record tables have identical shape; prepare the same statements for each.
+		const makeRecordTableStmts = (table: string) => ({
+			get: this.sql.prepare<{ state: Uint8Array }, [id: string]>(
+				`SELECT state FROM ${table} WHERE id = ?`
+			),
+			insert: this.sql.prepare<void, [id: string, state: Uint8Array, lastChangedClock: number]>(
+				`INSERT OR REPLACE INTO ${table} (id, state, lastChangedClock) VALUES (?, ?, ?)`
+			),
+			delete: this.sql.prepare<void, [id: string]>(`DELETE FROM ${table} WHERE id = ?`),
+			exists: this.sql.prepare<{ id: string }, [id: string]>(
+				`SELECT id FROM ${table} WHERE id = ?`
+			),
+			iterate: this.sql.prepare<{ state: Uint8Array; lastChangedClock: number }>(
+				`SELECT state, lastChangedClock FROM ${table}`
+			),
+			iterateEntries: this.sql.prepare<{ id: string; state: Uint8Array }>(
+				`SELECT id, state FROM ${table}`
+			),
+			iterateKeys: this.sql.prepare<{ id: string }>(`SELECT id FROM ${table}`),
+			iterateValues: this.sql.prepare<{ state: Uint8Array }>(`SELECT state FROM ${table}`),
+			changedSince: this.sql.prepare<{ state: Uint8Array }, [sinceClock: number]>(
+				`SELECT state FROM ${table} WHERE lastChangedClock > ?`
+			),
+		})
 
 		// Prepare all statements once
 		this.stmts = {
@@ -285,33 +349,9 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 				`UPDATE ${metadataTable} SET documentClock = documentClock + 1`
 			),
 
-			// Documents
-			getDocument: this.sql.prepare<{ state: Uint8Array }, [id: string]>(
-				`SELECT state FROM ${documentsTable} WHERE id = ?`
-			),
-			insertDocument: this.sql.prepare<
-				void,
-				[id: string, state: Uint8Array, lastChangedClock: number]
-			>(`INSERT OR REPLACE INTO ${documentsTable} (id, state, lastChangedClock) VALUES (?, ?, ?)`),
-			deleteDocument: this.sql.prepare<void, [id: string]>(
-				`DELETE FROM ${documentsTable} WHERE id = ?`
-			),
-			documentExists: this.sql.prepare<{ id: string }, [id: string]>(
-				`SELECT id FROM ${documentsTable} WHERE id = ?`
-			),
-			iterateDocuments: this.sql.prepare<{ state: Uint8Array; lastChangedClock: number }>(
-				`SELECT state, lastChangedClock FROM ${documentsTable}`
-			),
-			iterateDocumentEntries: this.sql.prepare<{ id: string; state: Uint8Array }>(
-				`SELECT id, state FROM ${documentsTable}`
-			),
-			iterateDocumentKeys: this.sql.prepare<{ id: string }>(`SELECT id FROM ${documentsTable}`),
-			iterateDocumentValues: this.sql.prepare<{ state: Uint8Array }>(
-				`SELECT state FROM ${documentsTable}`
-			),
-			getDocumentsChangedSince: this.sql.prepare<{ state: Uint8Array }, [sinceClock: number]>(
-				`SELECT state FROM ${documentsTable} WHERE lastChangedClock > ?`
-			),
+			// Record tables (document lane + object-store lane)
+			documents: makeRecordTableStmts(documentsTable),
+			objects: makeRecordTableStmts(objectsTable),
 
 			// Tombstones
 			insertTombstone: this.sql.prepare<void, [id: string, clock: number]>(
@@ -354,12 +394,17 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 			// Clear existing data
 			this.sql.exec(`
 				DELETE FROM ${documentsTable};
+				DELETE FROM ${objectsTable};
 				DELETE FROM ${tombstonesTable};
 			`)
 
-			// Insert documents
+			// Insert records, routing object-lane types into their partition (a seed snapshot may
+			// carry object-lane records merged in, e.g. loaded from a separate persistence lane)
 			for (const doc of snapshot.documents) {
-				this.stmts.insertDocument.run(doc.state.id, encodeState(doc.state), doc.lastChangedClock)
+				const table = this.objectTypes.has(doc.state.typeName)
+					? this.stmts.objects
+					: this.stmts.documents
+				table.insert.run(doc.state.id, encodeState(doc.state), doc.lastChangedClock)
 			}
 
 			// Insert tombstones
@@ -375,6 +420,21 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 				tombstoneHistoryStartsAtClock,
 				JSON.stringify(snapshot.schema)
 			)
+		} else {
+			// One-time sweep: rooms written before the objects table existed may have object-lane
+			// records sitting in the documents table. Record ids are typeName-prefixed, so a PK
+			// range scan per object type moves them cheaply (no-op once clean).
+			for (const typeName of this.objectTypes) {
+				const lo = `${typeName}:`
+				// ';' is the next code point after ':' — [lo, hi) covers exactly the `type:` prefix
+				const hi = `${typeName};`
+				this.sql.exec(`
+					INSERT OR REPLACE INTO ${objectsTable} (id, state, lastChangedClock)
+					SELECT id, state, lastChangedClock FROM ${documentsTable}
+					WHERE id >= '${lo}' AND id < '${hi}';
+					DELETE FROM ${documentsTable} WHERE id >= '${lo}' AND id < '${hi}';
+				`)
+			}
 		}
 		if (onChange) {
 			this.onChange(onChange)
@@ -469,22 +529,26 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 		{ leading: false }
 	)
 
-	getSnapshot(opts?: GetSnapshotOptions): RoomSnapshot {
-		const excludeTypes = opts?.excludeTypes
-		let documents = Array.from(this._iterateDocuments())
-		if (excludeTypes?.length) {
-			documents = documents.filter((d) => !excludeTypes.includes(d.state.typeName))
-		}
+	getSnapshot(): RoomSnapshot {
+		// object-lane records live in their own table, so the document snapshot is
+		// pure-document by construction
 		return {
 			tombstoneHistoryStartsAtClock: this._getTombstoneHistoryStartsAtClock(),
 			documentClock: this.getClock(),
-			documents,
+			documents: Array.from(this._iterateRecords(this.stmts.documents)),
 			tombstones: Object.fromEntries(this._iterateTombstones()),
 			schema: this._getSchema(),
 		}
 	}
-	private *_iterateDocuments(): IterableIterator<{ state: R; lastChangedClock: number }> {
-		for (const row of this.stmts.iterateDocuments.iterate()) {
+
+	getObjectsSnapshot(): RoomSnapshot['documents'] {
+		return Array.from(this._iterateRecords(this.stmts.objects))
+	}
+
+	private *_iterateRecords(
+		table: SQLiteSyncStorage<R>['stmts']['documents']
+	): IterableIterator<{ state: R; lastChangedClock: number }> {
+		for (const row of table.iterate.iterate()) {
 			yield { state: decodeState<R>(row.state), lastChangedClock: row.lastChangedClock }
 		}
 	}
@@ -536,9 +600,21 @@ class SQLiteSyncStorageTransaction<R extends UnknownRecord> implements TLSyncSto
 		return this._clock
 	}
 
+	/**
+	 * Which record table an id belongs to. Record ids are typeName-prefixed (`comment:abc`),
+	 * so the partition is derivable from the id alone.
+	 */
+	private tableFor(id: string) {
+		const sep = id.indexOf(':')
+		if (sep === -1) return this.stmts.documents
+		return this.storage.objectTypes.has(id.slice(0, sep))
+			? this.stmts.objects
+			: this.stmts.documents
+	}
+
 	get(id: string): R | undefined {
 		this.assertNotClosed()
-		const row = this.stmts.getDocument.all(id)[0]
+		const row = this.tableFor(id).get.all(id)[0]
 		if (!row) return undefined
 		return decodeState<R>(row.state)
 	}
@@ -549,41 +625,54 @@ class SQLiteSyncStorageTransaction<R extends UnknownRecord> implements TLSyncSto
 		const clock = this.getNextClock()
 		// Automatically clear tombstone if it exists
 		this.stmts.deleteTombstone.run(id)
-		this.stmts.insertDocument.run(id, encodeState(record), clock)
+		// route by type: object-lane records live in their own table
+		const table = this.storage.objectTypes.has(record.typeName)
+			? this.stmts.objects
+			: this.stmts.documents
+		table.insert.run(id, encodeState(record), clock)
 	}
 
 	delete(id: string): void {
 		this.assertNotClosed()
+		const table = this.tableFor(id)
 		// Only create a tombstone if the record actually exists
-		const exists = this.stmts.documentExists.all(id)[0]
+		const exists = table.exists.all(id)[0]
 		if (!exists) return
 		const clock = this.getNextClock()
-		this.stmts.deleteDocument.run(id)
+		table.delete.run(id)
 		this.stmts.insertTombstone.run(id, clock)
 		this.storage.pruneTombstones()
 	}
 
+	// iteration spans both record tables so schema migrations cover object-lane records too
+
 	*entries(): IterableIterator<[string, R]> {
 		this.assertNotClosed()
-		for (const row of this.stmts.iterateDocumentEntries.iterate()) {
-			this.assertNotClosed()
-			yield [row.id, decodeState<R>(row.state)]
+		for (const table of [this.stmts.documents, this.stmts.objects]) {
+			for (const row of table.iterateEntries.iterate()) {
+				this.assertNotClosed()
+				yield [row.id, decodeState<R>(row.state)]
+			}
 		}
 	}
 
 	*keys(): IterableIterator<string> {
 		this.assertNotClosed()
-		for (const row of this.stmts.iterateDocumentKeys.iterate()) {
-			this.assertNotClosed()
-			yield row.id
+		for (const table of [this.stmts.documents, this.stmts.objects]) {
+			for (const row of table.iterateKeys.iterate()) {
+				this.assertNotClosed()
+				yield row.id
+			}
 		}
 	}
 
 	*values(): IterableIterator<R> {
 		this.assertNotClosed()
-		for (const row of this.stmts.iterateDocumentValues.iterate()) {
-			this.assertNotClosed()
-			yield decodeState<R>(row.state)
+		for (const table of [this.stmts.documents, this.stmts.objects]) {
+			for (const row of table.iterateValues.iterate()) {
+				this.assertNotClosed()
+				yield decodeState<R>(row.state)
+			}
 		}
 	}
 
@@ -608,17 +697,22 @@ class SQLiteSyncStorageTransaction<R extends UnknownRecord> implements TLSyncSto
 		const diff: TLSyncForwardDiff<R> = { puts: {}, deletes: [] }
 		const wipeAll = sinceClock < this.storage._getTombstoneHistoryStartsAtClock()
 
+		// both record tables share the clock and tombstones, so the change feed spans both
 		if (wipeAll) {
-			// If wipeAll, include all documents
-			for (const row of this.stmts.iterateDocumentValues.iterate()) {
-				const state = decodeState<R>(row.state)
-				diff.puts[state.id] = state
+			// If wipeAll, include all records
+			for (const table of [this.stmts.documents, this.stmts.objects]) {
+				for (const row of table.iterateValues.iterate()) {
+					const state = decodeState<R>(row.state)
+					diff.puts[state.id] = state
+				}
 			}
 		} else {
-			// Get documents changed since clock
-			for (const row of this.stmts.getDocumentsChangedSince.iterate(sinceClock)) {
-				const state = decodeState<R>(row.state)
-				diff.puts[state.id] = state
+			// Get records changed since clock
+			for (const table of [this.stmts.documents, this.stmts.objects]) {
+				for (const row of table.changedSince.iterate(sinceClock)) {
+					const state = decodeState<R>(row.state)
+					diff.puts[state.id] = state
+				}
 			}
 			// When wipeAll, deletes are redundant (full state is in puts). Only include tombstones otherwise.
 			for (const row of this.stmts.getTombstonesChangedSince.iterate(sinceClock)) {

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -7,7 +7,7 @@ import { TLObjectStoreAccess, TLSocketServerSentEvent } from './protocol'
 import { RoomSessionState } from './RoomSession'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
 import { TLSyncErrorCloseEventReason } from './TLSyncClient'
-import { GetSnapshotOptions, RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
+import { RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
 import {
 	convertStoreSnapshotToRoomSnapshot,
 	loadSnapshotIntoStorage,
@@ -251,6 +251,8 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 						// eslint-disable-next-line @typescript-eslint/no-deprecated
 						opts.initialSnapshot ?? DEFAULT_INITIAL_SNAPSHOT
 					),
+					// keep the storage partition in step with the room's object lane
+					objectTypes: opts.objectTypes,
 				})
 
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -734,11 +736,23 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 	 * const newRoom = new TLSocketRoom({ initialSnapshot: savedSnapshot })
 	 * ```
 	 */
-	getCurrentSnapshot(opts?: GetSnapshotOptions) {
+	getCurrentSnapshot() {
 		if (this.storage.getSnapshot) {
-			return this.storage.getSnapshot(opts)
+			return this.storage.getSnapshot()
 		}
 		throw new Error('getCurrentSnapshot is not supported for this storage type')
+	}
+
+	/**
+	 * Returns a snapshot of the object-store lane (see `objectTypes`), for persisting
+	 * object-lane records separately from the document. Same entry shape as
+	 * {@link RoomSnapshot.documents}.
+	 */
+	getCurrentObjectsSnapshot(): RoomSnapshot['documents'] {
+		if (this.storage.getObjectsSnapshot) {
+			return this.storage.getObjectsSnapshot()
+		}
+		throw new Error('getCurrentObjectsSnapshot is not supported for this storage type')
 	}
 
 	/**

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -122,21 +122,6 @@ export interface RoomSnapshot {
 }
 
 /**
- * Options for {@link TLSyncStorage.getSnapshot}.
- *
- * @public
- */
-export interface GetSnapshotOptions {
-	/**
-	 * Record type names to exclude from the snapshot's `documents`. Use this to persist
-	 * certain record types in a separate lane (e.g. comments) while keeping them out of
-	 * the main persisted document. Only affects the returned snapshot — records of these
-	 * types are still synced/broadcast to clients and hydrated on connect. Defaults to none.
-	 */
-	excludeTypes?: readonly string[]
-}
-
-/**
  * A collaborative workspace that manages multiple client sessions and synchronizes
  * document changes between them. The room serves as the authoritative source for
  * all document state and handles conflict resolution, schema migrations, and

--- a/packages/sync-core/src/lib/TLSyncStorage.ts
+++ b/packages/sync-core/src/lib/TLSyncStorage.ts
@@ -2,7 +2,7 @@ import { StoreSchema, SynchronousStorage, UnknownRecord } from '@tldraw/store'
 import { assert, isEqual, objectMapEntriesIterable, objectMapValues } from '@tldraw/utils'
 import { TLStoreSnapshot } from 'tldraw'
 import { diffRecord, NetworkDiff, RecordOpType } from './diff'
-import { GetSnapshotOptions, RoomSnapshot } from './TLSyncRoom'
+import { RoomSnapshot } from './TLSyncRoom'
 
 /**
  * Transaction interface for storage operations. Provides methods to read and modify
@@ -83,7 +83,15 @@ export interface TLSyncStorage<R extends UnknownRecord> {
 
 	onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => unknown): () => void
 
-	getSnapshot?(opts?: GetSnapshotOptions): RoomSnapshot
+	/** A snapshot of the document lane only — never contains object-store lane records. */
+	getSnapshot?(): RoomSnapshot
+
+	/**
+	 * A snapshot of the object-store lane (see `objectTypes` on the storage), for hosts that
+	 * persist object-lane records separately from the document. Same entry shape as
+	 * `RoomSnapshot['documents']` so a lane can be persisted and re-seeded via a merged snapshot.
+	 */
+	getObjectsSnapshot?(): RoomSnapshot['documents']
 }
 
 /**

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -92,6 +92,8 @@ function makeRoom(
 			documentClock: 0,
 			schema: schema.serialize(),
 		},
+		// keep the storage partition in step with the room's object lane
+		objectTypes: opts.objectTypes,
 	})
 	const room = new TLSyncRoom<R, undefined>({
 		schema,
@@ -149,9 +151,9 @@ function lastPushResult(socket: MockSocket) {
 }
 
 function storedIds(storage: InMemorySyncStorage<R>) {
-	return storage
-		.getSnapshot()
-		.documents.map((d) => d.state.id)
+	// span both partitions: the document snapshot no longer contains object-lane records
+	return [...storage.getSnapshot().documents, ...storage.getObjectsSnapshot()]
+		.map((d) => d.state.id)
 		.sort()
 }
 
@@ -315,6 +317,30 @@ describe('object store lane', () => {
 			connectSession(room, 'commenter', { isReadonly: true, objectAccess: 'write' })
 			push(room, 'commenter', { [note.id]: [RecordOpType.Remove] })
 			expect(storedIds(storage)).toEqual([])
+		})
+	})
+
+	describe('storage partition', () => {
+		it('keeps object records out of the document snapshot but in the objects snapshot', () => {
+			const { room, storage } = makeRoom({ objectTypes: ['note'] })
+			connectSession(room, 'writer')
+
+			const doc = Doc.create({ title: 'canvas' })
+			const note = Note.create({ text: 'annotation' })
+			push(room, 'writer', {
+				[doc.id]: [RecordOpType.Put, doc],
+				[note.id]: [RecordOpType.Put, note],
+			})
+
+			// the document snapshot is pure-document by construction
+			expect(storage.getSnapshot().documents.map((d) => d.state.id)).toEqual([doc.id])
+			// the object lane is persisted separately
+			expect(storage.getObjectsSnapshot().map((d) => d.state.id)).toEqual([note.id])
+
+			// but a fresh connect still hydrates both (shared clock + change feed)
+			const late = connectSession(room, 'late', { clear: false })
+			const connectMsg = late.__messages.find((m: any) => m.type === 'connect') as any
+			expect(Object.keys(connectMsg.diff).sort()).toEqual([doc.id, note.id].sort())
 		})
 	})
 

--- a/packages/sync-core/src/test/storageContractSuite.ts
+++ b/packages/sync-core/src/test/storageContractSuite.ts
@@ -41,6 +41,7 @@ export function makePage(id: string, name = id, index = 'a2') {
 export interface StorageContractFactory {
 	create(opts?: {
 		snapshot?: RoomSnapshot
+		objectTypes?: readonly string[]
 		onChange?(arg: TLSyncStorageOnChangeCallbackProps): void
 	}): TLSyncStorage<TLRecord>
 }
@@ -61,21 +62,82 @@ export function registerStorageContractTests(factory: StorageContractFactory) {
 			expect(snapshot.documents.map((d) => d.lastChangedClock)).toEqual([0, 0])
 		})
 
-		it('getSnapshot with excludeTypes omits those record types from the snapshot (used to persist some types separately) without affecting the clock or schema', () => {
-			const storage = create(makeContractSnapshot(contractRecords, { documentClock: 5 }))
-			const full = storage.getSnapshot!()
-			expect(full.documents.map((d) => d.state.typeName).sort()).toEqual(['document', 'page'])
+		describe('object-store lane partition', () => {
+			// the storage doesn't care about record semantics, so 'page' stands in as a
+			// generic object-lane type here
+			const createPartitioned = (snapshot?: RoomSnapshot) =>
+				factory.create({ snapshot, objectTypes: ['page'] })
 
-			const filtered = storage.getSnapshot!({ excludeTypes: ['page'] })
-			expect(filtered.documents.map((d) => d.state.typeName)).toEqual(['document'])
-			// clock + schema are unaffected by the persistence-only filter
-			expect(filtered.documentClock).toBe(full.documentClock)
-			expect(filtered.schema).toEqual(full.schema)
+			it('partitions object-lane records out of getSnapshot into getObjectsSnapshot', () => {
+				const storage = createPartitioned(
+					makeContractSnapshot(contractRecords, { documentClock: 5 })
+				)
+				const snapshot = storage.getSnapshot!()
+				expect(snapshot.documents.map((d) => d.state.typeName)).toEqual(['document'])
+				// clock + schema are unaffected by the partition
+				expect(snapshot.documentClock).toBe(5)
 
-			// empty / omitted excludeTypes includes everything (backwards compatible)
-			expect(storage.getSnapshot!({ excludeTypes: [] }).documents.length).toBe(
-				full.documents.length
-			)
+				expect(storage.getObjectsSnapshot!().map((d) => d.state.typeName)).toEqual(['page'])
+			})
+
+			it('returns an empty objects snapshot when no objectTypes are configured', () => {
+				const storage = create(makeContractSnapshot(contractRecords))
+				expect(storage.getSnapshot!().documents.length).toBe(2)
+				expect(storage.getObjectsSnapshot!()).toEqual([])
+			})
+
+			it('routes writes by type and shares the clock, tombstones, and change feed', () => {
+				const storage = createPartitioned(makeContractSnapshot(contractRecords))
+				const newPage = makePage('lane')
+				storage.transaction((txn) => txn.set(newPage.id, newPage))
+
+				// the write landed in the object partition, not the document snapshot
+				expect(storage.getSnapshot!().documents.map((d) => d.state.id)).toEqual([TLDOCUMENT_ID])
+				expect(storage.getObjectsSnapshot!().map((d) => d.state.id)).toContain(newPage.id)
+
+				// reads and the change feed span both partitions
+				storage.transaction((txn) => {
+					expect(txn.get(newPage.id)).toEqual(newPage)
+					expect(txn.getChangesSince(0)!.diff.puts[newPage.id]).toEqual(newPage)
+				})
+
+				// deleting an object-lane record writes a shared tombstone
+				const clockBeforeDelete = storage.getClock()
+				storage.transaction((txn) => txn.delete(newPage.id))
+				expect(storage.getObjectsSnapshot!().map((d) => d.state.id)).not.toContain(newPage.id)
+				storage.transaction((txn) => {
+					expect(txn.getChangesSince(clockBeforeDelete)!.diff.deletes).toContain(newPage.id)
+				})
+			})
+
+			it('iterates both partitions so schema migrations cover object-lane records', () => {
+				const storage = createPartitioned(makeContractSnapshot(contractRecords))
+				storage.transaction((txn) => {
+					const ids = Array.from(txn.keys()).sort()
+					expect(ids).toEqual(contractRecords.map((r) => r.id).sort())
+					expect(
+						Array.from(txn.values())
+							.map((r) => r.id)
+							.sort()
+					).toEqual(ids)
+					expect(
+						Array.from(txn.entries())
+							.map(([id]) => id)
+							.sort()
+					).toEqual(ids)
+				})
+			})
+
+			it('round-trips through a merged snapshot (persist lanes separately, re-seed together)', () => {
+				const storage = createPartitioned(makeContractSnapshot(contractRecords))
+				const merged = {
+					...storage.getSnapshot!(),
+					documents: [...storage.getSnapshot!().documents, ...storage.getObjectsSnapshot!()],
+				}
+				const reseeded = createPartitioned(merged)
+				expect(reseeded.getSnapshot!().documents.map((d) => d.state.typeName)).toEqual(['document'])
+				expect(reseeded.getObjectsSnapshot!().map((d) => d.state.typeName)).toEqual(['page'])
+			})
 		})
 
 		describe('transactions', () => {


### PR DESCRIPTION
In order to make the object store a real store rather than a snapshot-time filter, this PR moves object-lane records (comments) into their own storage partition inside `TLSyncStorage` — so `getSnapshot()` never contains them at all. Stacked on #9484, third in the series after #9478.

This PR also adds `object-store-design.md`, which frames the series architecturally: the object store as the server half of a fourth record scope (a peer of `document`, `session`, and `presence`), presence as the precedent for both the lane and the eventual ownership-based authorization, and a staged path from today's server config to a schema-declared lane to a first-class `RecordScope`.

In #9484 the object lane was a permission partition: object records still lived in the same documents table/map, and hosts kept them out of the persisted blob by filtering at snapshot time (`excludeTypes`) or hand-splitting (the DO). Now the storage itself partitions records at write time:

- **`set()` routes by `record.typeName`**; `get()`/`delete()` route by the id's typeName prefix (`comment:abc`)
- **Both partitions share one transaction, one clock, and one tombstone feed** — so mixed doc+comment pushes stay atomic, `getChangesSince` spans both lanes, and reconnect deltas, `broadcastChanges`, connect hydration, and the `onCommittedChanges` projection all work unchanged. Zero wire or client changes.
- **`getSnapshot()` is pure-document by construction**; a new `getObjectsSnapshot()` returns the object lane in the same `{state, lastChangedClock}[]` shape the DO's R2 lane already stores, so existing persisted lane data stays compatible
- **Iteration (`entries`/`keys`/`values`) spans both partitions**, so schema migrations cover object-lane records
- **`excludeTypes` is deleted** — its only caller (`.tldr` downloads) now gets a clean snapshot for free

### SQLite specifics

- Storage format migration v2 → v3 adds an `objects` table (same shape as `documents`)
- On reopening a pre-partition database, a one-time sweep moves object-lane rows from `documents` to `objects` via PK range scans on the typeName prefix (no-op once clean)

### dotcom changes

- The DO passes `objectTypes` to `SQLiteSyncStorage`; the manual persist-time split is deleted in favor of `getSnapshot()` + `getObjectsSnapshot()`
- The load path is unchanged: the R2 comment lane is still merged into the seed snapshot, and the storage routes those records into the objects partition at seed time

### Known limitations (spike scope)

- `objectTypes` is now configured in two places (room + storage) with no drift check — a real API would single-source it from the schema (Stage 2 in `object-store-design.md`)
- `TLSocketRoom.updateStore` reads from the document snapshot only, so server-initiated edits can't see object records
- Version restore (`loadSnapshotIntoStorage` of a main-blob snapshot) still wipes comments — pre-existing behavior since #9478, unchanged here

### Change type

- [x] `feature`

### Test plan

1. `yarn dev-app`, add a comment, reload — comment survives (R2 lane round-trip through the new partition)
2. Open a room created before this change — existing comments still appear (constructor sweep + seed routing)
3. Download `.tldr` — no comment records
4. `/comments` page still lists comments (projection unchanged)

- [x] Unit tests

### API changes

- Added optional `TLSyncStorage.getObjectsSnapshot()` and `TLSocketRoom.getCurrentObjectsSnapshot()`
- Added `objectTypes` option to `InMemorySyncStorage` and `SQLiteSyncStorage` constructors
- Breaking! Removed `GetSnapshotOptions` (`excludeTypes`) from `getSnapshot()` / `getCurrentSnapshot()` — only ever shipped in #9484, which is unmerged

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +252 / -118 |
| Tests           | +127 / -16  |
| Automated files | +23 / -12   |
| Apps            | +16 / -20   |

