### PR TITLE
perf(dotcom): speed up file lookups in TldrawApp

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -458,16 +458,16 @@ export class TldrawApp {
 		const pinned = groupFiles.filter((f) => f.index !== null)
 		const unpinned = groupFiles.filter((f) => f.index === null)
 
+		const unpinnedFileIds = new Set(unpinned.map((f) => f.fileId))
 		const lastOrdering = this.lastWorkspaceFileOrderings.get(workspaceId)
-		const retainedOrdering =
-			lastOrdering?.filter((f) => unpinned.some((p) => p.fileId === f.fileId)) ?? []
+		const retainedOrdering = lastOrdering?.filter((f) => unpinnedFileIds.has(f.fileId)) ?? []
+		const retainedFileIds = new Set(retainedOrdering.map((f) => f.fileId))
 		const newOrdering: typeof retainedOrdering = []
 
 		pinned.sort(sortByMaybeIndex)
 
 		for (const file of unpinned) {
-			const existing = retainedOrdering?.find((f) => f.fileId === file.fileId)
-			if (existing) continue
+			if (retainedFileIds.has(file.fileId)) continue
 
 			// For new files, use current updatedAt
 			const state = this.getFileState(file.fileId)
@@ -599,7 +599,12 @@ export class TldrawApp {
 	}
 
 	isPinned(fileId: string, workspaceId: string) {
-		return this.getWorkspaceFilesSorted(workspaceId).some((f) => f.fileId === fileId && f.isPinned)
+		if (!workspaceId) return false
+		return (
+			this.getWorkspaceMembership(workspaceId)?.groupFiles.some(
+				(f) => f.fileId === fileId && f.index !== null && !!f.file
+			) ?? false
+		)
 	}
 
 	// A workspace's welcome file is seeded once, when the workspace is created. Its
@@ -795,11 +800,11 @@ export class TldrawApp {
 
 	getFile(fileId?: string): TlaFile | null {
 		if (!fileId) return null
-		return (
-			this.getWorkspaceMemberships()
-				.find((g) => g.groupFiles.some((gf) => gf.fileId === fileId))
-				?.groupFiles.find((gf) => gf.fileId === fileId)?.file ?? null
-		)
+		for (const membership of this.workspaceMemberships$.get()) {
+			const groupFile = membership.groupFiles.find((gf) => gf.fileId === fileId)
+			if (groupFile?.file) return groupFile.file
+		}
+		return null
 	}
 
 	canUpdateFile(fileId: string): boolean {

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -120,6 +120,22 @@ export function getFileRecencyDate(
 	return getFileVisitDate(state) ?? file?.createdAt ?? 0
 }
 
+/**
+ * A workspace membership and its group_file rows, as returned by the query — the `file` relation on
+ * each row is a nullable `.one()` join, so it may be absent even when the row exists.
+ */
+type TlaWorkspaceMembership = QueryResultType<typeof queries.workspaceMemberships>[number]
+type TlaWorkspaceGroupFile = TlaWorkspaceMembership['groupFiles'][number]
+
+/**
+ * A group_file row is pinned when it has a manual ordering `index` — and only counts if its `file`
+ * has resolved (a row can outlive or arrive before its file). The single definition of "pinned",
+ * shared by the workspace indexes and getWorkspaceFilesSorted.
+ */
+function isGroupFilePinned(groupFile: TlaWorkspaceGroupFile): boolean {
+	return !!groupFile.file && groupFile.index !== null
+}
+
 export class TldrawApp {
 	config = {
 		maxNumberOfFiles: MAX_NUMBER_OF_FILES,
@@ -425,8 +441,44 @@ export class TldrawApp {
 		return this.workspaceMemberships$.get().slice(0).sort(sortByIndex)
 	}
 
+	/**
+	 * Lookup indexes derived from the workspace memberships, rebuilt only when memberships change.
+	 * Turns the per-call linear scans in getWorkspaceMembership, getFile, and isPinned — each of
+	 * which runs once per file/component across a sidebar render — into O(1) map lookups.
+	 */
+	@computed
+	private getWorkspaceIndexes() {
+		const memberships = this.workspaceMemberships$.get()
+		const membershipByWorkspaceId = new Map<string, TlaWorkspaceMembership>()
+		const fileByFileId = new Map<string, TlaFile>()
+		const pinnedFileIdsByWorkspaceId = new Map<string, Set<string>>()
+
+		for (const membership of memberships) {
+			// Index every membership's files: a file can be reachable through a workspace the user is
+			// a member of even when it's owned elsewhere. First resolved row wins, matching the
+			// previous getFile scan order.
+			for (const groupFile of membership.groupFiles) {
+				if (groupFile.file && !fileByFileId.has(groupFile.fileId)) {
+					fileByFileId.set(groupFile.fileId, groupFile.file)
+				}
+			}
+
+			// First membership row wins for a given workspace id, matching the previous `.find()`.
+			if (membershipByWorkspaceId.has(membership.groupId)) continue
+			membershipByWorkspaceId.set(membership.groupId, membership)
+
+			const pinnedFileIds = new Set<string>()
+			for (const groupFile of membership.groupFiles) {
+				if (isGroupFilePinned(groupFile)) pinnedFileIds.add(groupFile.fileId)
+			}
+			pinnedFileIdsByWorkspaceId.set(membership.groupId, pinnedFileIds)
+		}
+
+		return { membershipByWorkspaceId, fileByFileId, pinnedFileIdsByWorkspaceId }
+	}
+
 	getWorkspaceMembership(workspaceId: string) {
-		return this.workspaceMemberships$.get().find((g) => g.groupId === workspaceId)
+		return this.getWorkspaceIndexes().membershipByWorkspaceId.get(workspaceId)
 	}
 
 	getWorkspaceFilesSorted(workspaceId: string) {
@@ -455,8 +507,8 @@ export class TldrawApp {
 			return owningGroupId == null || !this.getWorkspaceMembership(owningGroupId)
 		})
 
-		const pinned = groupFiles.filter((f) => f.index !== null)
-		const unpinned = groupFiles.filter((f) => f.index === null)
+		const pinned = groupFiles.filter(isGroupFilePinned)
+		const unpinned = groupFiles.filter((f) => !isGroupFilePinned(f))
 
 		const unpinnedFileIds = new Set(unpinned.map((f) => f.fileId))
 		const lastOrdering = this.lastWorkspaceFileOrderings.get(workspaceId)
@@ -601,9 +653,7 @@ export class TldrawApp {
 	isPinned(fileId: string, workspaceId: string) {
 		if (!workspaceId) return false
 		return (
-			this.getWorkspaceMembership(workspaceId)?.groupFiles.some(
-				(f) => f.fileId === fileId && f.index !== null && !!f.file
-			) ?? false
+			this.getWorkspaceIndexes().pinnedFileIdsByWorkspaceId.get(workspaceId)?.has(fileId) ?? false
 		)
 	}
 
@@ -800,11 +850,7 @@ export class TldrawApp {
 
 	getFile(fileId?: string): TlaFile | null {
 		if (!fileId) return null
-		for (const membership of this.workspaceMemberships$.get()) {
-			const groupFile = membership.groupFiles.find((gf) => gf.fileId === fileId)
-			if (groupFile?.file) return groupFile.file
-		}
-		return null
+		return this.getWorkspaceIndexes().fileByFileId.get(fileId) ?? null
 	}
 
 	canUpdateFile(fileId: string): boolean {

--- a/apps/dotcom/client/src/tla/app/getWorkspaceFilesSorted.test.ts
+++ b/apps/dotcom/client/src/tla/app/getWorkspaceFilesSorted.test.ts
@@ -59,3 +59,33 @@ describe('getWorkspaceFilesSorted', () => {
 		expect(app.getWorkspaceFilesSorted(homeId)).toEqual([])
 	})
 })
+
+describe('isPinned', () => {
+	it('checks the workspace group_file row directly', () => {
+		const workspaceId = 'group:workspace'
+		const pinnedFile = makeFile({ id: 'file:pinned', owningGroupId: workspaceId })
+		const unpinnedFile = makeFile({ id: 'file:unpinned', owningGroupId: workspaceId })
+		const app = createAppStub([
+			makeMembership(workspaceId, [
+				{ fileId: 'file:pinned', groupId: workspaceId, index: 'a1', file: pinnedFile },
+				{ fileId: 'file:unpinned', groupId: workspaceId, index: null, file: unpinnedFile },
+			]),
+		])
+
+		expect(app.isPinned('file:pinned', workspaceId)).toBe(true)
+		expect(app.isPinned('file:unpinned', workspaceId)).toBe(false)
+	})
+
+	it('ignores missing workspaces and orphaned group_file rows', () => {
+		const workspaceId = 'group:workspace'
+		const app = createAppStub([
+			makeMembership(workspaceId, [
+				{ fileId: 'file:orphan', groupId: workspaceId, index: 'a1', file: undefined },
+			]),
+		])
+
+		expect(app.isPinned('file:orphan', workspaceId)).toBe(false)
+		expect(app.isPinned('file:orphan', '')).toBe(false)
+		expect(app.isPinned('file:orphan', 'group:missing')).toBe(false)
+	})
+})


### PR DESCRIPTION
## The problem

`TldrawApp` exposes three lookups that the sidebar leans on constantly: `getWorkspaceMembership`, `getFile`, and `isPinned`. Each of them walked the full membership list (and, for `getFile`, every group_file row inside every membership) on every call.

The trouble is *where* they're called. `getFile` is read reactively from a dozen components — one per file link in the sidebar, plus the file menu, share menu, and drop handler. `isPinned` runs once per file link via `useIsFilePinned`. Each call site is wrapped in `useValue`, so the result is cached — but the cache key is the whole `workspaceMemberships$` signal, which is a Zero query that joins **every file** into the result:

```ts
workspaceMemberships: defineQuery(({ ctx }) =>
  zql.group_user.where('userId', '=', ctx.userId)
    .related('groupFiles', (gf) => gf.related('file', (file) => file.one()))
    ...
)
```

So the signal changes whenever any file changes — a rename, an edit that bumps `updatedAt`, a create, a delete. (Recency is the exception: it lives in the separate `fileStates$` signal, so opening a file doesn't invalidate this.) On each of those common events, all N file links' cached lookups invalidate at once and each re-scans all N files: an **O(N²)** burst per file change.

There was also a subtler issue. "Pinned" was defined in two places with two slightly different expressions — `f.index !== null` inline in `getWorkspaceFilesSorted`, and `f.index !== null && !!f.file` inside `isPinned`. The sidebar reads *both* paths (the sorted list's `isPinned` field for section ordering, and `app.isPinned()` for each file's pin indicator), so any drift between the two definitions would show up as a file ordered as pinned but rendered as unpinned, or vice versa.

## What this PR does

- Adds a single `@computed getWorkspaceIndexes()` that builds three lookup maps in one pass over the memberships — `membership by workspace id`, `file by file id`, and `pinned file ids by workspace id`. Because it's a computed, it rebuilds only when the memberships signal changes, and every dependent lookup tracks the computed rather than re-deriving from scratch.
- Rewrites `getWorkspaceMembership`, `getFile`, and `isPinned` to read from those maps, turning each from an O(files) scan into an O(1) `Map.get`. On a file change the recompute burst drops from O(N²) to O(N): the index rebuilds once and is shared across every call site, then each lookup is O(1).
- Extracts the definition of "pinned" into one helper, `isGroupFilePinned` (a group_file row with a non-null `index` and a resolved `file`), and uses it in both the index and `getWorkspaceFilesSorted`, so the two sidebar code paths can't disagree.
- Keeps the workspace ordering pass on `Set` membership checks instead of the nested `.some()`/`.find()` it used before.

The index preserves the previous scan semantics: first membership wins for a given workspace id, and the first resolved row wins for a given file id.

## Do we need this?

Honestly, it depends on how many files a workspace has, so here's the realistic case for and against.

**The perf win only matters at scale.** For a user with a handful of files, O(N²) vs O(N) is a few dozen operations either way — invisible. The change earns its keep for **large or shared workspaces** — power users and teams with hundreds of files in the sidebar — where the O(N²) re-scan fires on *every* file edit, rename, or create. That's a real, frequent path for those users (edit a file → `updatedAt` bumps → whole sidebar re-scans), so if we care about the sidebar staying smooth for big workspaces, this is the hot loop to fix. If we expect workspaces to stay small in practice, the perf argument is speculative and this is premature.

**What it does *not* fix:** the underlying reactivity is still coarse-grained. One file's rename invalidates the entire `workspaceMemberships$` signal and rebuilds the whole index (all workspaces, all files) — it's O(N) instead of O(N²), but it isn't "only recompute the changed file." Getting to genuinely incremental updates would need per-file/per-workspace signals, which is a much larger change. This PR is the cheap 80%, not that.

**The part that's worth having regardless of scale** is the single definition of "pinned." That's a correctness/maintainability fix, not a perf one: today the sidebar's ordering and its pin indicators derive "pinned" from two separate expressions that can silently drift. Collapsing them to one helper is a small, always-on improvement independent of how many files anyone has.

So: clearly worth it if large/shared workspaces are a case we want to support well; borderline-but-cheap if not, with the "pinned" unification standing on its own either way. If we'd rather not carry the index speculatively, the honest smaller version is the first commit alone (the `Set`-based ordering cleanup and the direct `isPinned`/`getFile` reads).

### Change type

- [x] `improvement`

### Test plan

1. Open a workspace with pinned and unpinned files.
2. Confirm pinned files appear in the pinned section and unpinned files retain their ordering.
3. Confirm the pin toggle in a file's menu matches its position in the sidebar.

- [x] Unit tests

### Code changes

| Section  | LOC change |
| -------- | ---------- |
| Tests    | +30 / -0   |
| Apps     | +64 / -13  |

### Release notes

- Improve performance of file lookups in the tldraw.com sidebar.
