### PR TITLE
feat(sync): per-type record authorizers (stamp/veto writes)

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -20,6 +20,7 @@ import {
 	can,
 	type RoomOpenMode,
 } from '@tldraw/dotcom-shared'
+import { UnknownRecord } from '@tldraw/store'
 import {
 	DEFAULT_INITIAL_SNAPSHOT,
 	DurableObjectSqliteSyncWrapper,
@@ -34,6 +35,8 @@ import {
 	type PersistedRoomSnapshotForSupabase,
 	type SessionStateSnapshot,
 	type TLObjectStoreAccess,
+	type TLRecordAuthorizer,
+	type TLRecordAuthorizers,
 } from '@tldraw/sync-core'
 import {
 	TLAsset,
@@ -155,30 +158,56 @@ const fileSyncSchema = createTLSchema({ records: commentSchemaRecords })
 // rather than the R2 document blob.
 const OBJECT_TYPES = ['comment-thread', 'comment'] as const
 
+// The room's record union, widened to include the object-lane records so the per-type authorizers
+// below are typed to their record (e.g. `comment`'s `next` is a `TLComment`). Renaming an attribution
+// field on one of these records makes the authorizer that stamps/guards it fail to compile.
+type FileRecord = TLRecord | TLComment | TLCommentThread
+
 /**
- * Authorize a create/update/delete of an "authored" record (comment or thread) from the session's
- * identity: stamp the attribution field (`authorId`/`createdBy`) on create, keep it immutable on
- * update, and allow deletes. Deletes are allowed because cascade cleanup (deleting a shape removes
- * its comments) is performed by whoever deletes the shape, not the comment's author — restricting
- * deletes to the author would break that.
+ * Build an authorizer for a record whose attribution lives in a single `field`: stamp it from the
+ * session's identity on create, keep it immutable on update, and allow deletes. Deletes are allowed
+ * because cascade cleanup (deleting a shape removes its comments) is performed by whoever deletes the
+ * shape, not the comment's author — restricting deletes to the author would break that.
+ *
+ * `field` is `keyof Rec`, so a rename of the record's attribution field is a compile error here.
  */
-function authorizeAuthoredRecord(
-	field: 'authorId' | 'createdBy',
-	userId: string | null,
-	type: 'create' | 'update' | 'delete',
-	prev: TLRecord | null,
-	next: TLRecord | null
-): TLRecord | null {
-	if (type === 'create') {
-		// No authenticated identity → can't attribute → reject; the client self-corrects.
-		if (!userId) return null
-		return { ...(next as any), [field]: userId }
+function authorizeAuthored<Rec extends UnknownRecord>(
+	field: keyof Rec & string
+): TLRecordAuthorizer<Rec, SessionMeta> {
+	return ({ session, type, prev, next }) => {
+		if (type === 'create') {
+			// No authenticated identity → can't attribute → reject; the client self-corrects.
+			if (!session.meta.userId) return null
+			return { ...next!, [field]: session.meta.userId } as Rec
+		}
+		// Attribution is immutable: veto any change to it. (Deletes fall through — allowed.)
+		if (type === 'update') return next![field] === prev![field] ? next : null
+		return prev
 	}
-	if (type === 'update') {
-		// Attribution is immutable: veto any change to it.
-		return (next as any)[field] === (prev as any)[field] ? next : null
-	}
-	return prev
+}
+
+/**
+ * Per-type authorizers: force comment/thread authorship and note-shape attribution from the session's
+ * authenticated identity, so nobody can post or draw in someone else's name.
+ */
+const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
+	comment: authorizeAuthored<TLComment>('authorId'),
+	'comment-thread': authorizeAuthored<TLCommentThread>('createdBy'),
+	// All shapes share typeName 'shape'; we only attribute note shapes (via meta.createdBy).
+	shape: ({ session, type, prev, next }) => {
+		const shape = (next ?? prev)!
+		if (shape.type !== 'note') return next ?? prev
+		const userId = session.meta.userId
+		if (type === 'create') {
+			if (!userId) return next // anonymous can still draw, just unattributed
+			return { ...next!, meta: { ...next!.meta, createdBy: userId } }
+		}
+		if (type === 'update') {
+			// creator attribution is immutable once set
+			return prev!.meta.createdBy === next!.meta.createdBy ? next : null
+		}
+		return prev // delete: anyone who can edit the doc may delete a shape
+	},
 }
 
 export class TLFileDurableObject extends DurableObject {
@@ -326,27 +355,7 @@ export class TLFileDurableObject extends DurableObject {
 					},
 					// Stamp attribution from the session's authenticated identity so a client can't post
 					// (or draw) in someone else's name, and keep that attribution immutable afterwards.
-					authorizeRecord: {
-						comment: ({ session, type, prev, next }) =>
-							authorizeAuthoredRecord('authorId', session.meta.userId, type, prev, next),
-						'comment-thread': ({ session, type, prev, next }) =>
-							authorizeAuthoredRecord('createdBy', session.meta.userId, type, prev, next),
-						// All shapes share typeName 'shape'; we only attribute note shapes (via meta.createdBy).
-						shape: ({ session, type, prev, next }) => {
-							const shape = (next ?? prev) as any
-							if (shape?.type !== 'note') return next ?? prev
-							const userId = session.meta.userId
-							if (type === 'create') {
-								if (!userId) return next // anonymous can still draw, just unattributed
-								return { ...(next as any), meta: { ...(next as any).meta, createdBy: userId } }
-							}
-							if (type === 'update') {
-								// creator attribution is immutable once set
-								return (prev as any).meta?.createdBy === (next as any).meta?.createdBy ? next : null
-							}
-							return prev // delete: anyone who can edit the doc may delete a shape
-						},
-					},
+					authorizeRecord: authorizeFileRecord,
 				})
 
 				this.logEvent({ type: 'room', roomId: slug, name: 'room_start' })

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -155,6 +155,32 @@ const fileSyncSchema = createTLSchema({ records: commentSchemaRecords })
 // rather than the R2 document blob.
 const OBJECT_TYPES = ['comment-thread', 'comment'] as const
 
+/**
+ * Authorize a create/update/delete of an "authored" record (comment or thread) from the session's
+ * identity: stamp the attribution field (`authorId`/`createdBy`) on create, keep it immutable on
+ * update, and allow deletes. Deletes are allowed because cascade cleanup (deleting a shape removes
+ * its comments) is performed by whoever deletes the shape, not the comment's author — restricting
+ * deletes to the author would break that.
+ */
+function authorizeAuthoredRecord(
+	field: 'authorId' | 'createdBy',
+	userId: string | null,
+	type: 'create' | 'update' | 'delete',
+	prev: TLRecord | null,
+	next: TLRecord | null
+): TLRecord | null {
+	if (type === 'create') {
+		// No authenticated identity → can't attribute → reject; the client self-corrects.
+		if (!userId) return null
+		return { ...(next as any), [field]: userId }
+	}
+	if (type === 'update') {
+		// Attribution is immutable: veto any change to it.
+		return (next as any)[field] === (prev as any)[field] ? next : null
+	}
+	return prev
+}
+
 export class TLFileDurableObject extends DurableObject {
 	// A unique identifier for this instance of the Durable Object
 	id: DurableObjectId
@@ -297,6 +323,29 @@ export class TLFileDurableObject extends DurableObject {
 					// replicates them to the app-level view quickly.
 					onCommittedChanges: ({ diff }) => {
 						this.enqueueCommentChanges(diff)
+					},
+					// Stamp attribution from the session's authenticated identity so a client can't post
+					// (or draw) in someone else's name, and keep that attribution immutable afterwards.
+					authorizeRecord: {
+						comment: ({ session, type, prev, next }) =>
+							authorizeAuthoredRecord('authorId', session.meta.userId, type, prev, next),
+						'comment-thread': ({ session, type, prev, next }) =>
+							authorizeAuthoredRecord('createdBy', session.meta.userId, type, prev, next),
+						// All shapes share typeName 'shape'; we only attribute note shapes (via meta.createdBy).
+						shape: ({ session, type, prev, next }) => {
+							const shape = (next ?? prev) as any
+							if (shape?.type !== 'note') return next ?? prev
+							const userId = session.meta.userId
+							if (type === 'create') {
+								if (!userId) return next // anonymous can still draw, just unattributed
+								return { ...(next as any), meta: { ...(next as any).meta, createdBy: userId } }
+							}
+							if (type === 'update') {
+								// creator attribution is immutable once set
+								return (prev as any).meta?.createdBy === (next as any).meta?.createdBy ? next : null
+							}
+							return prev // delete: anyone who can edit the doc may delete a shape
+						},
 					},
 				})
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -20,7 +20,6 @@ import {
 	can,
 	type RoomOpenMode,
 } from '@tldraw/dotcom-shared'
-import { UnknownRecord } from '@tldraw/store'
 import {
 	DEFAULT_INITIAL_SNAPSHOT,
 	DurableObjectSqliteSyncWrapper,
@@ -35,15 +34,12 @@ import {
 	type PersistedRoomSnapshotForSupabase,
 	type SessionStateSnapshot,
 	type TLObjectStoreAccess,
-	type TLRecordAuthorizer,
-	type TLRecordAuthorizers,
 } from '@tldraw/sync-core'
 import {
 	TLAsset,
 	TLAssetId,
 	TLDOCUMENT_ID,
 	TLDocument,
-	TLNoteShape,
 	TLRecord,
 	commentSchemaRecords,
 	createTLSchema,
@@ -62,6 +58,7 @@ import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
+import { SessionMeta, authorizeFileRecord } from './authorizeFileRecord'
 import {
 	findEmptiedCommentThreads,
 	isCommentAuthorFkViolation,
@@ -103,11 +100,6 @@ interface DocumentInfo {
 }
 
 export const ROOM_NOT_FOUND = Symbol('room_not_found')
-
-interface SessionMeta {
-	storeId: string
-	userId: string | null
-}
 
 interface SocketAttachment {
 	sessionId: string
@@ -158,62 +150,6 @@ const fileSyncSchema = createTLSchema({ records: commentSchemaRecords })
 // (instead of `isReadonly`), are excluded from `.tldr` downloads, and are persisted in Postgres
 // rather than the R2 document blob.
 const OBJECT_TYPES = ['comment-thread', 'comment'] as const
-
-// The room's record union, widened to include the object-lane records so the per-type authorizers
-// below are typed to their record (e.g. `comment`'s `next` is a `TLComment`). Renaming an attribution
-// field on one of these records makes the authorizer that stamps/guards it fail to compile.
-type FileRecord = TLRecord | TLComment | TLCommentThread
-
-/**
- * Build an authorizer for a record whose attribution lives in a single `field`: stamp it from the
- * session's identity on create, keep it immutable on update, and allow deletes. Deletes are allowed
- * because cascade cleanup (deleting a shape removes its comments) is performed by whoever deletes the
- * shape, not the comment's author — restricting deletes to the author would break that.
- *
- * `field` is `keyof Rec`, so a rename of the record's attribution field is a compile error here.
- */
-function authorizeAuthored<Rec extends UnknownRecord>(
-	field: keyof Rec & string
-): TLRecordAuthorizer<Rec, SessionMeta> {
-	return ({ session, type, prev, next }) => {
-		if (type === 'create') {
-			// No authenticated identity → can't attribute → reject; the client self-corrects.
-			if (!session.meta.userId) return null
-			return { ...next!, [field]: session.meta.userId } as Rec
-		}
-		// Attribution is immutable: veto any change to it. (Deletes fall through — allowed.)
-		if (type === 'update') return next![field] === prev![field] ? next : null
-		return prev
-	}
-}
-
-/**
- * Per-type authorizers: force comment/thread authorship and note-shape attribution from the session's
- * authenticated identity, so nobody can post or draw in someone else's name.
- */
-const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
-	comment: authorizeAuthored<TLComment>('authorId'),
-	'comment-thread': authorizeAuthored<TLCommentThread>('createdBy'),
-	// All shapes share typeName 'shape'; we only secure note-shape attribution. tldraw sets
-	// `props.textLastEditedBy` on the client (NoteShapeUtil.onBeforeUpdate) and renders it, so it's
-	// forgeable — here we enforce that it can only ever be null or the session's own user id.
-	shape: ({ session, type, prev, next }) => {
-		if ((next ?? prev)!.type !== 'note') return next ?? prev // not a note → write through
-		if (type === 'delete') return prev // anyone who can edit the doc may delete a shape
-		const userId = session.meta.userId
-		const nextBy = (next as TLNoteShape).props.textLastEditedBy
-		if (type === 'create') {
-			// A fresh note has textLastEditedBy: null; a non-null value is a duplicate or a forge.
-			// Strip anything that isn't the creator so a note can't be created as someone else.
-			if (nextBy == null || nextBy === userId) return next
-			const note = next as TLNoteShape
-			return { ...note, props: { ...note.props, textLastEditedBy: null } }
-		}
-		// update: allow null / unchanged / your own id; veto attributing an edit to anyone else.
-		const prevBy = (prev as TLNoteShape).props.textLastEditedBy
-		return nextBy !== prevBy && nextBy != null && nextBy !== userId ? null : next
-	},
-}
 
 export class TLFileDurableObject extends DurableObject {
 	// A unique identifier for this instance of the Durable Object

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -295,7 +295,7 @@ export class TLFileDurableObject extends DurableObject {
 						this.enqueueCommentChanges(diff)
 					},
 					// Stamp attribution from the session's authenticated identity so a client can't post
-					// (or draw) in someone else's name, and keep that attribution immutable afterwards.
+					// in someone else's name, and keep that attribution immutable afterwards.
 					authorizeRecord: authorizeFileRecord,
 				})
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -294,8 +294,8 @@ export class TLFileDurableObject extends DurableObject {
 					onCommittedChanges: ({ diff }) => {
 						this.enqueueCommentChanges(diff)
 					},
-					// Stamp attribution from the session's authenticated identity so a client can't post
-					// in someone else's name, and keep that attribution immutable afterwards.
+					// Guard attribution with the session's authenticated identity so a client can't
+					// post or edit in someone else's name.
 					authorizeRecord: authorizeFileRecord,
 				})
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -43,6 +43,7 @@ import {
 	TLAssetId,
 	TLDOCUMENT_ID,
 	TLDocument,
+	TLNoteShape,
 	TLRecord,
 	commentSchemaRecords,
 	createTLSchema,
@@ -193,20 +194,24 @@ function authorizeAuthored<Rec extends UnknownRecord>(
 const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
 	comment: authorizeAuthored<TLComment>('authorId'),
 	'comment-thread': authorizeAuthored<TLCommentThread>('createdBy'),
-	// All shapes share typeName 'shape'; we only attribute note shapes (via meta.createdBy).
+	// All shapes share typeName 'shape'; we only secure note-shape attribution. tldraw sets
+	// `props.textLastEditedBy` on the client (NoteShapeUtil.onBeforeUpdate) and renders it, so it's
+	// forgeable — here we enforce that it can only ever be null or the session's own user id.
 	shape: ({ session, type, prev, next }) => {
-		const shape = (next ?? prev)!
-		if (shape.type !== 'note') return next ?? prev
+		if ((next ?? prev)!.type !== 'note') return next ?? prev // not a note → write through
+		if (type === 'delete') return prev // anyone who can edit the doc may delete a shape
 		const userId = session.meta.userId
+		const nextBy = (next as TLNoteShape).props.textLastEditedBy
 		if (type === 'create') {
-			if (!userId) return next // anonymous can still draw, just unattributed
-			return { ...next!, meta: { ...next!.meta, createdBy: userId } }
+			// A fresh note has textLastEditedBy: null; a non-null value is a duplicate or a forge.
+			// Strip anything that isn't the creator so a note can't be created as someone else.
+			if (nextBy == null || nextBy === userId) return next
+			const note = next as TLNoteShape
+			return { ...note, props: { ...note.props, textLastEditedBy: null } }
 		}
-		if (type === 'update') {
-			// creator attribution is immutable once set
-			return prev!.meta.createdBy === next!.meta.createdBy ? next : null
-		}
-		return prev // delete: anyone who can edit the doc may delete a shape
+		// update: allow null / unchanged / your own id; veto attributing an edit to anyone else.
+		const prevBy = (prev as TLNoteShape).props.textLastEditedBy
+		return nextBy !== prevBy && nextBy != null && nextBy !== userId ? null : next
 	},
 }
 

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
@@ -89,9 +89,28 @@ describe('authorizeFileRecord', () => {
 			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBeNull()
 		})
 
-		it('lets a non-creator update the thread (e.g. resolve it)', () => {
+		it('lets a non-creator resolve the thread as themselves', () => {
 			const prev = makeThread('real-bob')
-			const next = { ...prev, resolvedBy: 'real-mallory', resolvedAt: 1 }
+			const next = { ...prev, resolved: { at: 1, by: 'real-mallory' } }
+			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('lets a non-creator reopen a resolved thread', () => {
+			const prev = { ...makeThread('real-bob'), resolved: { at: 1, by: 'real-alice' } }
+			const next = { ...prev, resolved: null }
+			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('vetoes a resolution attributed to someone else', () => {
+			const prev = makeThread('real-bob')
+			const next = { ...prev, resolved: { at: 1, by: 'real-alice' } }
+			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('allows an update that leaves an existing resolution untouched', () => {
+			const prev = { ...makeThread('real-bob'), resolved: { at: 1, by: 'real-alice' } }
+			// new object reference, same value — must not be treated as a change
+			const next = { ...prev, resolved: { ...prev.resolved } }
 			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBe(next)
 		})
 	})

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
@@ -1,9 +1,12 @@
 import {
 	TLComment,
 	TLCommentThread,
+	TLNoteShape,
 	TLPageId,
+	TLShape,
 	createComment,
 	createCommentThread,
+	createShapeId,
 	toRichText,
 } from '@tldraw/tlschema'
 import { describe, expect, it } from 'vitest'
@@ -130,6 +133,109 @@ describe('authorizeFileRecord', () => {
 				next,
 			}) as TLCommentThread
 			expect(result.resolved).toEqual({ at: 1, by: 'real-bob' })
+		})
+	})
+
+	describe('shape', () => {
+		const authorize = authorizeFileRecord.shape!
+
+		function makeNote(textLastEditedBy: string | null): TLNoteShape {
+			return {
+				id: createShapeId('note1'),
+				typeName: 'shape',
+				type: 'note',
+				x: 0,
+				y: 0,
+				rotation: 0,
+				index: 'a1' as TLNoteShape['index'],
+				parentId: 'page:test' as TLNoteShape['parentId'],
+				isLocked: false,
+				opacity: 1,
+				meta: {},
+				props: {
+					color: 'black',
+					richText: toRichText('hello'),
+					size: 'm',
+					font: 'draw',
+					align: 'middle',
+					verticalAlign: 'middle',
+					labelColor: 'black',
+					growY: 0,
+					fontSizeAdjustment: 1,
+					url: '',
+					scale: 1,
+					textLastEditedBy,
+				},
+			}
+		}
+
+		function makeGeo(): TLShape {
+			const note = makeNote(null)
+			const { textLastEditedBy: _, ...props } = note.props
+			return { ...note, id: createShapeId('geo1'), type: 'geo', props } as unknown as TLShape
+		}
+
+		it('passes creates through untouched, even with foreign attribution (duplication)', () => {
+			const next = makeNote('real-alice')
+			expect(authorize({ session: session('real-bob'), type: 'create', prev: null, next })).toBe(
+				next
+			)
+		})
+
+		it('passes creates through for anonymous sessions', () => {
+			const next = makeNote('real-alice')
+			expect(authorize({ session: session(null), type: 'create', prev: null, next })).toBe(next)
+		})
+
+		it('allows updates that do not touch attribution, from any user', () => {
+			const prev = makeNote('real-alice')
+			const next = { ...prev, x: 100 }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBe(next)
+			expect(authorize({ session: session(null), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('allows changing attribution to the session user', () => {
+			const prev = makeNote('real-alice')
+			const next = { ...prev, props: { ...prev.props, textLastEditedBy: 'real-bob' } }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('allows clearing attribution to null (text emptied, or anonymous edit)', () => {
+			const prev = makeNote('real-alice')
+			const next = { ...prev, props: { ...prev.props, textLastEditedBy: null } }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBe(next)
+			expect(authorize({ session: session(null), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('vetoes changing attribution to someone else', () => {
+			const prev = makeNote('real-bob')
+			const next = { ...prev, props: { ...prev.props, textLastEditedBy: 'real-alice' } }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('vetoes an anonymous session setting any non-null attribution', () => {
+			const prev = makeNote(null)
+			const next = { ...prev, props: { ...prev.props, textLastEditedBy: 'real-alice' } }
+			expect(authorize({ session: session(null), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('vetoes smuggling attribution in via a shape-type change', () => {
+			const prev = makeGeo()
+			const next = { ...makeNote('real-alice'), id: prev.id }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('ignores non-note shapes', () => {
+			const prev = makeGeo()
+			const next = { ...prev, x: 50 }
+			expect(authorize({ session: session(null), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('allows deletes', () => {
+			const prev = makeNote('real-alice')
+			expect(authorize({ session: session('real-bob'), type: 'delete', prev, next: null })).toBe(
+				prev
+			)
 		})
 	})
 })

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
@@ -1,0 +1,98 @@
+import {
+	TLComment,
+	TLCommentThread,
+	TLPageId,
+	createComment,
+	createCommentThread,
+	toRichText,
+} from '@tldraw/tlschema'
+import { describe, expect, it } from 'vitest'
+import { SessionMeta, authorizeFileRecord } from './authorizeFileRecord'
+
+const pageId = 'page:test' as TLPageId
+const thread = createCommentThread({
+	pageId,
+	anchor: { type: 'page' },
+	createdBy: 'client-claims-alice',
+})
+
+function session(userId: string | null): { sessionId: string; meta: SessionMeta } {
+	return { sessionId: 's1', meta: { storeId: 'store', userId } }
+}
+
+describe('authorizeFileRecord', () => {
+	describe('comment', () => {
+		const authorize = authorizeFileRecord.comment!
+		const comment = (authorId: string) =>
+			createComment({ threadId: thread.id, pageId, authorId, body: toRichText('hi') })
+
+		it('stamps authorId from the session on create, overriding the client value', () => {
+			const result = authorize({
+				session: session('real-bob'),
+				type: 'create',
+				prev: null,
+				next: comment('client-claims-alice'),
+			}) as TLComment
+			expect(result.authorId).toBe('real-bob')
+		})
+
+		it('rejects a create with no authenticated user', () => {
+			expect(
+				authorize({ session: session(null), type: 'create', prev: null, next: comment('anon') })
+			).toBeNull()
+		})
+
+		it('allows the author to edit their own comment', () => {
+			const prev = comment('real-bob')
+			const next = { ...prev, body: toRichText('edited') }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBe(next)
+		})
+
+		it('vetoes an edit from someone who is not the author', () => {
+			const prev = comment('real-bob')
+			const next = { ...prev, body: toRichText('sneakily rewritten') }
+			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('vetoes an update that changes the author', () => {
+			const prev = comment('real-bob')
+			const next = { ...prev, authorId: 'someone-else' }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('allows deletes', () => {
+			const prev = comment('real-bob')
+			expect(authorize({ session: session('real-bob'), type: 'delete', prev, next: null })).toBe(
+				prev
+			)
+		})
+	})
+
+	describe('comment-thread', () => {
+		const authorize = authorizeFileRecord['comment-thread']!
+		const makeThread = (createdBy: string) =>
+			createCommentThread({ pageId, anchor: { type: 'page' }, createdBy })
+
+		it('stamps createdBy from the session on create, overriding the client value', () => {
+			const result = authorize({
+				session: session('real-bob'),
+				type: 'create',
+				prev: null,
+				next: makeThread('client-claims-alice'),
+			}) as TLCommentThread
+			expect(result.createdBy).toBe('real-bob')
+		})
+
+		it('vetoes an update that changes the creator', () => {
+			const prev = makeThread('real-bob')
+			const next = { ...prev, createdBy: 'someone-else' }
+			expect(authorize({ session: session('real-bob'), type: 'update', prev, next })).toBeNull()
+		})
+
+		it('lets a non-creator update the thread (e.g. resolve it)', () => {
+			const prev = makeThread('real-bob')
+			const next = { ...prev, resolvedBy: 'real-mallory', resolvedAt: 1 }
+			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBe(next)
+		})
+	})
+})

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
@@ -113,5 +113,23 @@ describe('authorizeFileRecord', () => {
 			const next = { ...prev, resolved: { ...prev.resolved } }
 			expect(authorize({ session: session('real-mallory'), type: 'update', prev, next })).toBe(next)
 		})
+
+		it('vetoes a create with a resolution attributed to someone else', () => {
+			const next = { ...makeThread('real-mallory'), resolved: { at: 1, by: 'real-alice' } }
+			expect(
+				authorize({ session: session('real-mallory'), type: 'create', prev: null, next })
+			).toBeNull()
+		})
+
+		it('allows a create resolved by the creator themselves', () => {
+			const next = { ...makeThread('real-bob'), resolved: { at: 1, by: 'real-bob' } }
+			const result = authorize({
+				session: session('real-bob'),
+				type: 'create',
+				prev: null,
+				next,
+			}) as TLCommentThread
+			expect(result.resolved).toEqual({ at: 1, by: 'real-bob' })
+		})
 	})
 })

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -34,8 +34,8 @@ function authorizeAuthored<Rec extends UnknownRecord>(
 			return { ...next!, [field]: session.meta.userId } as Rec
 		}
 		if (type === 'update') {
-			if (next![field] !== prev![field]) return null // attribution is immutable
-			if (ownerOnlyUpdate && session.meta.userId !== prev![field]) return null // only the author edits
+			if (next[field] !== prev[field]) return null // attribution is immutable
+			if (ownerOnlyUpdate && session.meta.userId !== prev[field]) return null // only the author edits
 			return next
 		}
 		return prev

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -46,12 +46,18 @@ const authorizeThreadBase = authorizeAuthored<TLCommentThread>('createdBy')
 
 /**
  * Threads stay editable by anyone with access so they can be resolved and reopened, but resolution
- * is itself an attribution — `resolved.by` renders as "Resolved by X". When an update changes the
- * resolution, it must be a reopen (`null`) or a resolve attributed to the session's own user.
+ * is itself an attribution — `resolved.by` renders as "Resolved by X". Whether set at create or
+ * changed by an update, a non-null resolution must be attributed to the session's own user.
  */
 const authorizeThread: TLRecordAuthorizer<TLCommentThread, SessionMeta> = (args) => {
 	const result = authorizeThreadBase(args)
 	if (!result) return null
+	if (args.type === 'create') {
+		// A fresh thread must not arrive pre-resolved in someone else's name (deletes are allowed
+		// for cascade cleanup, so delete + re-put with a forged resolution is otherwise possible).
+		const { session, next } = args
+		if (next.resolved && next.resolved.by !== session.meta.userId) return null
+	}
 	if (args.type === 'update') {
 		const { session, prev, next } = args
 		const changed =

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -8,20 +8,14 @@ export interface SessionMeta {
 	userId: string | null
 }
 
-// The file room's record union, widened to include the object-lane comment records so the per-type
-// authorizers are typed to their record (e.g. `comment`'s `next` is a `TLComment`). Renaming an
-// attribution field makes the authorizer that stamps/guards it fail to compile.
+// The file room's record union, widened to include the object-lane comment records so each
+// authorizer is typed to its record — renaming an attribution field fails to compile here.
 type FileRecord = TLRecord | TLComment | TLCommentThread
 
 /**
- * Build an authorizer for a record whose attribution lives in a single `field`: stamp it from the
- * session's identity on create, keep it immutable on update, and allow deletes (cascade cleanup
- * relies on non-authors being able to remove a shape's comments). `field` is `keyof Rec`, so
- * renaming the record's attribution field is a compile error here.
- *
- * With `ownerOnlyUpdate`, only the record's own author may update it — so nobody can edit someone
- * else's comment (which would render under the original author). Leave it off for records anyone
- * with access may update, e.g. resolving a thread.
+ * Authorize a record whose attribution lives in `field`: stamped from the session on create,
+ * immutable on update, deletes allowed (cascade cleanup needs non-authors to remove a shape's
+ * comments). With `ownerOnlyUpdate`, only the author may update it at all.
  */
 function authorizeAuthored<Rec extends UnknownRecord>(
 	field: keyof Rec & string,
@@ -29,8 +23,7 @@ function authorizeAuthored<Rec extends UnknownRecord>(
 ): TLRecordAuthorizer<Rec, SessionMeta> {
 	return ({ session, type, prev, next }) => {
 		if (type === 'create') {
-			// No authenticated identity → can't attribute → reject; the client self-corrects.
-			if (!session.meta.userId) return null
+			if (!session.meta.userId) return null // no identity to attribute → reject
 			return { ...next, [field]: session.meta.userId } as Rec
 		}
 		if (type === 'update') {
@@ -45,16 +38,15 @@ function authorizeAuthored<Rec extends UnknownRecord>(
 const authorizeThreadBase = authorizeAuthored<TLCommentThread>('createdBy')
 
 /**
- * Threads stay editable by anyone with access so they can be resolved and reopened, but resolution
- * is itself an attribution — `resolved.by` renders as "Resolved by X". Whether set at create or
- * changed by an update, a non-null resolution must be attributed to the session's own user.
+ * Threads stay editable by anyone with access (resolve/reopen), but resolution is itself an
+ * attribution: a non-null `resolved.by`, set at create or changed by update, must be the
+ * session's own user.
  */
 const authorizeThread: TLRecordAuthorizer<TLCommentThread, SessionMeta> = (args) => {
 	const result = authorizeThreadBase(args)
 	if (!result) return null
 	if (args.type === 'create') {
-		// A fresh thread must not arrive pre-resolved in someone else's name (deletes are allowed
-		// for cascade cleanup, so delete + re-put with a forged resolution is otherwise possible).
+		// Delete + re-put could otherwise smuggle in a resolution forged in someone else's name.
 		const { session, next } = args
 		if (next.resolved && next.resolved.by !== session.meta.userId) return null
 	}
@@ -77,13 +69,11 @@ function getNoteAttribution(shape: TLShape): string | null | undefined {
 }
 
 /**
- * Notes stamp `textLastEditedBy` client-side: the current user on text edit, `null` when the text
- * is emptied or the editor is anonymous. Enforce that here: when an update changes the attribution,
- * the new value must be `null` or the session's own user.
- *
- * Creates pass through untouched — duplication and copy/paste legitimately carry another user's
- * attribution, so a forged create is indistinguishable from a duplication and strictness on create
- * would only break duplication. The delete + re-create loophole this leaves is accepted by design.
+ * Notes stamp `textLastEditedBy` client-side (the editor on text edit, `null` when emptied or
+ * anonymous); enforce it here: an update may only change the attribution to `null` or the
+ * session's own user. Creates pass through — duplication legitimately carries another user's
+ * attribution, so a forged create is indistinguishable from a duplicate (the delete + re-create
+ * loophole this leaves is accepted).
  */
 const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({
 	session,
@@ -100,9 +90,8 @@ const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({
 }
 
 /**
- * Force comment and thread authorship from the session's authenticated identity, so nobody can post
- * in — or edit a comment into — someone else's name, and guard note text attribution so edits
- * can't be pinned on another user.
+ * Force comment and thread authorship from the session's identity, and guard note text
+ * attribution, so nothing can be posted or pinned in someone else's name.
  */
 export const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
 	comment: authorizeAuthored<TLComment>('authorId', { ownerOnlyUpdate: true }),

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -1,0 +1,54 @@
+import { UnknownRecord } from '@tldraw/store'
+import { TLRecordAuthorizer, TLRecordAuthorizers } from '@tldraw/sync-core'
+import { TLComment, TLCommentThread, TLRecord } from '@tldraw/tlschema'
+
+/** Per-session metadata attached to each socket: the local store id and the authenticated user (if any). */
+export interface SessionMeta {
+	storeId: string
+	userId: string | null
+}
+
+// The file room's record union, widened to include the object-lane comment records so the per-type
+// authorizers are typed to their record (e.g. `comment`'s `next` is a `TLComment`). Renaming an
+// attribution field makes the authorizer that stamps/guards it fail to compile.
+type FileRecord = TLRecord | TLComment | TLCommentThread
+
+/**
+ * Build an authorizer for a record whose attribution lives in a single `field`: stamp it from the
+ * session's identity on create, keep it immutable on update, and allow deletes (cascade cleanup
+ * relies on non-authors being able to remove a shape's comments). `field` is `keyof Rec`, so
+ * renaming the record's attribution field is a compile error here.
+ *
+ * With `ownerOnlyUpdate`, only the record's own author may update it — so nobody can edit someone
+ * else's comment (which would render under the original author). Leave it off for records anyone
+ * with access may update, e.g. resolving a thread.
+ */
+function authorizeAuthored<Rec extends UnknownRecord>(
+	field: keyof Rec & string,
+	{ ownerOnlyUpdate = false } = {}
+): TLRecordAuthorizer<Rec, SessionMeta> {
+	return ({ session, type, prev, next }) => {
+		if (type === 'create') {
+			// No authenticated identity → can't attribute → reject; the client self-corrects.
+			if (!session.meta.userId) return null
+			return { ...next!, [field]: session.meta.userId } as Rec
+		}
+		if (type === 'update') {
+			if (next![field] !== prev![field]) return null // attribution is immutable
+			if (ownerOnlyUpdate && session.meta.userId !== prev![field]) return null // only the author edits
+			return next
+		}
+		return prev
+	}
+}
+
+/**
+ * Force comment and thread authorship from the session's authenticated identity, so nobody can post
+ * in — or edit a comment into — someone else's name.
+ */
+export const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
+	comment: authorizeAuthored<TLComment>('authorId', { ownerOnlyUpdate: true }),
+	// Threads stay editable by anyone with access so they can be resolved/reopened; only `createdBy`
+	// is pinned.
+	'comment-thread': authorizeAuthored<TLCommentThread>('createdBy'),
+}

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -1,6 +1,6 @@
 import { UnknownRecord } from '@tldraw/store'
 import { TLRecordAuthorizer, TLRecordAuthorizers } from '@tldraw/sync-core'
-import { TLComment, TLCommentThread, TLRecord } from '@tldraw/tlschema'
+import { TLComment, TLCommentThread, TLNoteShape, TLRecord, TLShape } from '@tldraw/tlschema'
 
 /** Per-session metadata attached to each socket: the local store id and the authenticated user (if any). */
 export interface SessionMeta {
@@ -68,10 +68,44 @@ const authorizeThread: TLRecordAuthorizer<TLCommentThread, SessionMeta> = (args)
 }
 
 /**
+ * A note's text attribution, or `undefined` when the shape isn't carrying one (non-note shapes).
+ * Authorizers see records at the server's schema version, so only the current field name exists.
+ */
+function getNoteAttribution(shape: TLShape): string | null | undefined {
+	if (shape.type !== 'note') return undefined
+	return (shape as TLNoteShape).props.textLastEditedBy
+}
+
+/**
+ * Notes stamp `textLastEditedBy` client-side: the current user on text edit, `null` when the text
+ * is emptied or the editor is anonymous. Enforce that here: when an update changes the attribution,
+ * the new value must be `null` or the session's own user.
+ *
+ * Creates pass through untouched — duplication and copy/paste legitimately carry another user's
+ * attribution, so a forged create is indistinguishable from a duplication and strictness on create
+ * would only break duplication. The delete + re-create loophole this leaves is accepted by design.
+ */
+const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({
+	session,
+	type,
+	prev,
+	next,
+}) => {
+	if (type === 'create') return next
+	if (type === 'delete') return prev
+	const before = getNoteAttribution(prev)
+	const after = getNoteAttribution(next)
+	if (after !== before && after != null && after !== session.meta.userId) return null
+	return next
+}
+
+/**
  * Force comment and thread authorship from the session's authenticated identity, so nobody can post
- * in — or edit a comment into — someone else's name.
+ * in — or edit a comment into — someone else's name, and guard note text attribution so edits
+ * can't be pinned on another user.
  */
 export const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
 	comment: authorizeAuthored<TLComment>('authorId', { ownerOnlyUpdate: true }),
 	'comment-thread': authorizeThread,
+	shape: authorizeShape,
 }

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -31,7 +31,7 @@ function authorizeAuthored<Rec extends UnknownRecord>(
 		if (type === 'create') {
 			// No authenticated identity → can't attribute → reject; the client self-corrects.
 			if (!session.meta.userId) return null
-			return { ...next!, [field]: session.meta.userId } as Rec
+			return { ...next, [field]: session.meta.userId } as Rec
 		}
 		if (type === 'update') {
 			if (next[field] !== prev[field]) return null // attribution is immutable
@@ -42,13 +42,30 @@ function authorizeAuthored<Rec extends UnknownRecord>(
 	}
 }
 
+const authorizeThreadBase = authorizeAuthored<TLCommentThread>('createdBy')
+
+/**
+ * Threads stay editable by anyone with access so they can be resolved and reopened, but resolution
+ * is itself an attribution — `resolved.by` renders as "Resolved by X". When an update changes the
+ * resolution, it must be a reopen (`null`) or a resolve attributed to the session's own user.
+ */
+const authorizeThread: TLRecordAuthorizer<TLCommentThread, SessionMeta> = (args) => {
+	const result = authorizeThreadBase(args)
+	if (!result) return null
+	if (args.type === 'update') {
+		const { session, prev, next } = args
+		const changed =
+			prev.resolved?.at !== next.resolved?.at || prev.resolved?.by !== next.resolved?.by
+		if (changed && next.resolved && next.resolved.by !== session.meta.userId) return null
+	}
+	return result
+}
+
 /**
  * Force comment and thread authorship from the session's authenticated identity, so nobody can post
  * in — or edit a comment into — someone else's name.
  */
 export const authorizeFileRecord: TLRecordAuthorizers<FileRecord, SessionMeta> = {
 	comment: authorizeAuthored<TLComment>('authorId', { ownerOnlyUpdate: true }),
-	// Threads stay editable by anyone with access so they can be resolved/reopened; only `createdBy`
-	// is pinned.
-	'comment-thread': authorizeAuthored<TLCommentThread>('createdBy'),
+	'comment-thread': authorizeThread,
 }

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -444,21 +444,22 @@ export interface TLPushRequest<R extends UnknownRecord> {
 }
 
 // @public
-export type TLRecordAuthorizer<R extends UnknownRecord, SessionMeta> = (args: {
-    prev: null | R;
-    next: null | R;
+export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: {
+    prev: null | Rec;
+    next: null | Rec;
     session: {
         meta: SessionMeta;
         sessionId: string;
     };
     type: 'create' | 'delete' | 'update';
-}) => null | R;
+}) => null | Rec;
 
 // @public
-export interface TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> {
-    // (undocumented)
-    [typeName: string]: TLRecordAuthorizer<R, SessionMeta>;
-}
+export type TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> = {
+    [K in R['typeName']]?: TLRecordAuthorizer<Extract<R, {
+        typeName: K;
+    }>, SessionMeta>;
+};
 
 // @public
 export class TLRemoteSyncError extends Error {

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -445,14 +445,23 @@ export interface TLPushRequest<R extends UnknownRecord> {
 
 // @public
 export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: {
-    prev: null | Rec;
-    next: null | Rec;
     session: {
         meta: SessionMeta;
         sessionId: string;
     };
-    type: 'create' | 'delete' | 'update';
-}) => null | Rec;
+} & ({
+    next: null;
+    prev: Rec;
+    type: 'delete';
+} | {
+    next: Rec;
+    prev: null;
+    type: 'create';
+} | {
+    next: Rec;
+    prev: Rec;
+    type: 'update';
+})) => null | Rec;
 
 // @public
 export type TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> = {

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -444,6 +444,23 @@ export interface TLPushRequest<R extends UnknownRecord> {
 }
 
 // @public
+export type TLRecordAuthorizer<R extends UnknownRecord, SessionMeta> = (args: {
+    prev: null | R;
+    next: null | R;
+    session: {
+        meta: SessionMeta;
+        sessionId: string;
+    };
+    type: 'create' | 'delete' | 'update';
+}) => null | R;
+
+// @public
+export interface TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> {
+    // (undocumented)
+    [typeName: string]: TLRecordAuthorizer<R, SessionMeta>;
+}
+
+// @public
 export class TLRemoteSyncError extends Error {
     constructor(reason: string | TLSyncErrorCloseEventReason);
     // (undocumented)
@@ -516,6 +533,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 
 // @public
 export interface TLSocketRoomOptions<R extends UnknownRecord, SessionMeta> {
+    authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>;
     // (undocumented)
     clientTimeout?: number;
     // @deprecated (undocumented)
@@ -687,6 +705,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
             diff: TLSyncForwardDiff<R>;
             documentClock: number;
         }): void;
+        authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>;
         objectTypes?: readonly string[];
         clientTimeout?: number;
         log?: TLSyncLog;

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -70,6 +70,8 @@ export {
 	type MinimalDocStore,
 	type PresenceStore,
 	type RoomSnapshot,
+	type TLRecordAuthorizer,
+	type TLRecordAuthorizers,
 	type TLRoomSocket,
 } from './lib/TLSyncRoom'
 export {

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -145,9 +145,9 @@ export interface TLSocketRoomOptions<R extends UnknownRecord, SessionMeta> {
 	 */
 	objectTypes?: readonly string[]
 	/**
-	 * Per-type authorizers that stamp/veto client record writes (create, update, delete) from the
-	 * session's authenticated identity — e.g. force a comment's `authorId` to the signed-in user, or
-	 * stamp who created a shape. See {@link TLRecordAuthorizers}.
+	 * Per-type authorizers for client record writes (create, update, delete): veto writes the
+	 * session isn't allowed to make, or rewrite the record on create — e.g. force a comment's
+	 * `authorId` to the signed-in user. See {@link TLRecordAuthorizers}.
 	 */
 	authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>
 	/**

--- a/packages/sync-core/src/lib/TLSocketRoom.ts
+++ b/packages/sync-core/src/lib/TLSocketRoom.ts
@@ -7,7 +7,7 @@ import { TLObjectStoreAccess, TLSocketServerSentEvent } from './protocol'
 import { RoomSessionState } from './RoomSession'
 import { ServerSocketAdapter, WebSocketMinimal } from './ServerSocketAdapter'
 import { TLSyncErrorCloseEventReason } from './TLSyncClient'
-import { RoomSnapshot, TLSyncRoom } from './TLSyncRoom'
+import { RoomSnapshot, TLRecordAuthorizers, TLSyncRoom } from './TLSyncRoom'
 import {
 	convertStoreSnapshotToRoomSnapshot,
 	loadSnapshotIntoStorage,
@@ -145,6 +145,12 @@ export interface TLSocketRoomOptions<R extends UnknownRecord, SessionMeta> {
 	 */
 	objectTypes?: readonly string[]
 	/**
+	 * Per-type authorizers that stamp/veto client record writes (create, update, delete) from the
+	 * session's authenticated identity — e.g. force a comment's `authorId` to the signed-in user, or
+	 * stamp who created a shape. See {@link TLRecordAuthorizers}.
+	 */
+	authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>
+	/**
 	 * When set, the room will call {@link TLSocketRoom.getSessionSnapshot} after
 	 * no message activity for a session for 5s and pass the result to this callback.
 	 * Use for persisting snapshots to WebSocket attachments (e.g. Cloudflare hibernation).
@@ -271,6 +277,7 @@ export class TLSocketRoom<R extends UnknownRecord = UnknownRecord, SessionMeta =
 			onPresenceChange: opts.onPresenceChange,
 			onCommittedChanges: opts.onCommittedChanges,
 			objectTypes: opts.objectTypes,
+			authorizeRecord: opts.authorizeRecord,
 			schema: opts.schema ?? (createTLSchema() as any),
 			log: opts.log,
 			storage,

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -147,16 +147,16 @@ export interface RoomSnapshot {
  *
  * @public
  */
-export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: {
-	/** The session performing the write, including its host-provided `meta` (e.g. the authenticated user id). */
-	session: { sessionId: string; meta: SessionMeta }
-	/** Whether the write creates, updates (put-over-existing or patch), or deletes the record. */
-	type: 'create' | 'update' | 'delete'
-	/** The existing record with this id, or `null` on `create`. */
-	prev: Rec | null
-	/** The record the write would produce (`null` on `delete`). */
-	next: Rec | null
-}) => Rec | null
+export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (
+	args: {
+		/** The session performing the write, including its host-provided `meta` (e.g. the authenticated user id). */
+		session: { sessionId: string; meta: SessionMeta }
+	} & (
+		| { type: 'create'; prev: null; next: Rec }
+		| { type: 'update'; prev: Rec; next: Rec }
+		| { type: 'delete'; prev: Rec; next: null }
+	)
+) => Rec | null
 
 /**
  * A map from record `typeName` to a {@link TLRecordAuthorizer} for that record type. Only listed
@@ -1317,12 +1317,21 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								const authorizePut = session && this.authorizerFor(record.typeName)
 								if (authorizePut) {
 									const prev = (txn.get(id) as R | undefined) ?? null
-									const result = authorizePut({
-										session: { sessionId: session.sessionId, meta: session.meta },
-										type: prev ? 'update' : 'create',
-										prev,
-										next: record,
-									})
+									const result = authorizePut(
+										prev
+											? {
+													session: { sessionId: session.sessionId, meta: session.meta },
+													type: 'update',
+													prev,
+													next: record,
+												}
+											: {
+													session: { sessionId: session.sessionId, meta: session.meta },
+													type: 'create',
+													prev: null,
+													next: record,
+												}
+									)
 									// Rejected: skip the op; the client self-corrects via discard/rebase.
 									if (!result) continue
 									// On create the returned (stamped) record is stored; on update it's an

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -1320,7 +1320,16 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 									// off the incoming typeName while the replace path validates against the
 									// stored one, so a swap would consult the wrong authorizer (or none).
 									// Skip it like a veto; the client self-corrects.
-									if (prev && prev.typeName !== record.typeName) continue
+									if (prev && prev.typeName !== record.typeName) {
+										this.log?.warn?.(
+											'skipping put that changes typeName',
+											`${prev.typeName} -> ${record.typeName}`,
+											id,
+											'session:',
+											session.sessionId
+										)
+										continue
+									}
 									const authorizePut = this.authorizerFor(record.typeName)
 									if (authorizePut) {
 										const result = authorizePut(
@@ -1339,7 +1348,16 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 													}
 										)
 										// Rejected: skip the op; the client self-corrects via discard/rebase.
-										if (!result) continue
+										if (!result) {
+											this.log?.warn?.(
+												'authorizer vetoed put',
+												record.typeName,
+												id,
+												'session:',
+												session.sessionId
+											)
+											continue
+										}
 										// On create the returned (stamped) record is stored; on update it's an
 										// allow/veto only, so the client's record is stored as-is.
 										if (!prev) record = result
@@ -1365,6 +1383,13 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 										next: applyObjectDiff(doc, op[1]),
 									})
 								) {
+									this.log?.warn?.(
+										'authorizer vetoed patch',
+										doc.typeName,
+										id,
+										'session:',
+										session.sessionId
+									)
 									continue
 								}
 								// Try to patch the document. If it fails, stop here.
@@ -1390,6 +1415,13 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 										next: null,
 									})
 								) {
+									this.log?.warn?.(
+										'authorizer vetoed delete',
+										doc.typeName,
+										id,
+										'session:',
+										session.sessionId
+									)
 									continue
 								}
 

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -150,8 +150,9 @@ export interface RoomSnapshot {
  * up-migration can overwrite stamped fields. On update, when the client's schema is older than the
  * server's, the committed record is produced by a downgrade→patch→upgrade pipeline and can differ
  * from the `next` preview the authorizer saw. Only guard record types whose live cross-version
- * migrations don't touch the fields you stamp or veto — or, like tldraw.com's comment records,
- * types whose guard migrations reject old-schema sessions outright.
+ * migrations don't touch the fields you stamp or veto (tldraw.com's comment threads: the anchor
+ * migration reshapes `anchor` but never `createdBy` or `resolved`), or types whose migrations
+ * reject old-schema sessions outright by having no `down`.
  *
  * @public
  */

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -122,9 +122,10 @@ export interface RoomSnapshot {
 }
 
 /**
- * Authorizes and/or stamps a single record write from a client, using the session's authenticated
- * identity — for example, forcing a comment's `authorId` to the signed-in user so nobody can post in
- * someone else's name, or stamping who created a shape.
+ * Authorizes a single record write from a client: any per-record, per-session rule the host wants
+ * to enforce server-side — veto writes the session isn't allowed to make, or rewrite the record on
+ * create. The session's `meta` carries whatever the rule needs (identity, roles, …); for example,
+ * force a comment's `authorId` to the signed-in user so nobody can post in someone else's name.
  *
  * Called on **create**, **update**, and **delete** of records whose `typeName` it's registered for
  * (see {@link TLRecordAuthorizers}), and only for client pushes — never for server-initiated writes.
@@ -353,8 +354,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		 */
 		objectTypes?: readonly string[]
 		/**
-		 * Per-type authorizers that stamp/veto client record writes (create, update, delete) from the
-		 * session's authenticated identity. See {@link TLRecordAuthorizers}.
+		 * Per-type authorizers for client record writes (create, update, delete): veto or, on
+		 * create, rewrite. See {@link TLRecordAuthorizers}.
 		 */
 		authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>
 		storage: TLSyncStorage<R>

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -1314,29 +1314,36 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								// Per-type authorizer: lets the host stamp/veto a write from the session's
 								// authenticated identity (e.g. a comment's authorId). Only for registered
 								// types, only for client pushes (session present).
-								const authorizePut = session && this.authorizerFor(record.typeName)
-								if (authorizePut) {
+								if (session && this.authorizeRecord) {
 									const prev = (txn.get(id) as R | undefined) ?? null
-									const result = authorizePut(
-										prev
-											? {
-													session: { sessionId: session.sessionId, meta: session.meta },
-													type: 'update',
-													prev,
-													next: record,
-												}
-											: {
-													session: { sessionId: session.sessionId, meta: session.meta },
-													type: 'create',
-													prev: null,
-													next: record,
-												}
-									)
-									// Rejected: skip the op; the client self-corrects via discard/rebase.
-									if (!result) continue
-									// On create the returned (stamped) record is stored; on update it's an
-									// allow/veto only, so the client's record is stored as-is.
-									if (!prev) record = result
+									// A put must not change the record's typeName: the authorizer lookup keys
+									// off the incoming typeName while the replace path validates against the
+									// stored one, so a swap would consult the wrong authorizer (or none).
+									// Skip it like a veto; the client self-corrects.
+									if (prev && prev.typeName !== record.typeName) continue
+									const authorizePut = this.authorizerFor(record.typeName)
+									if (authorizePut) {
+										const result = authorizePut(
+											prev
+												? {
+														session: { sessionId: session.sessionId, meta: session.meta },
+														type: 'update',
+														prev,
+														next: record,
+													}
+												: {
+														session: { sessionId: session.sessionId, meta: session.meta },
+														type: 'create',
+														prev: null,
+														next: record,
+													}
+										)
+										// Rejected: skip the op; the client self-corrects via discard/rebase.
+										if (!result) continue
+										// On create the returned (stamped) record is stored; on update it's an
+										// allow/veto only, so the client's record is stored as-is.
+										if (!prev) record = result
+									}
 								}
 								addDocument(txn, docChanges, id, record)
 								break

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -167,6 +167,9 @@ export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (
  * renaming a field on the record makes the authorizer that reads it fail to compile, rather than
  * silently stamp or guard the wrong field.
  *
+ * Presence records are never authorized (presence is per-session and ephemeral); registering the
+ * presence typeName is a construction-time error.
+ *
  * @public
  */
 export type TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> = {
@@ -397,6 +400,15 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		}
 
 		this.presenceType = presenceTypes.values().next()?.value ?? null
+
+		// The presence lane never consults authorizers, so a presence key in `authorizeRecord`
+		// would be a silent no-op — fail loudly at construction instead.
+		if (this.presenceType && this.authorizeRecord) {
+			assert(
+				!getOwnProperty(this.authorizeRecord, this.presenceType.typeName),
+				`TLSyncRoom: authorizeRecord['${this.presenceType.typeName}'] is a presence type; presence records are not authorized`
+			)
+		}
 
 		const { documentClock } = this.storage.transaction((txn) => {
 			this.schema.migrateStorage(txn)

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -122,6 +122,51 @@ export interface RoomSnapshot {
 }
 
 /**
+ * Authorizes and/or stamps a single record write from a client, using the session's authenticated
+ * identity — for example, forcing a comment's `authorId` to the signed-in user so nobody can post in
+ * someone else's name, or stamping who created a shape.
+ *
+ * Called on **create**, **update**, and **delete** of records whose `typeName` it's registered for
+ * (see {@link TLRecordAuthorizers}), and only for client pushes — never for server-initiated writes.
+ *
+ * Return `null` to reject the write — it's skipped and the client self-corrects, exactly like the
+ * `objectAccess` gate. Otherwise the write is allowed, and:
+ *
+ * - on **create**, the record you return is what gets stored, so stamp identity fields here (e.g.
+ *   set `authorId` from `session.meta`);
+ * - on **update** and **delete**, only allow-vs-reject is used (the returned record's contents are
+ *   ignored), so use them to veto changes to immutable fields or unauthorized deletes — return
+ *   `next`/`prev` to allow, `null` to reject.
+ *
+ * ⚠︎ Runs synchronously inside the commit transaction, on the same path as every document edit — it
+ * must be fast and do **no** I/O. For expensive, async checks (e.g. resolving mentions against who
+ * can access a file), react after the fact via `onCommittedChanges` instead.
+ *
+ * @public
+ */
+export type TLRecordAuthorizer<R extends UnknownRecord, SessionMeta> = (args: {
+	/** The session performing the write, including its host-provided `meta` (e.g. the authenticated user id). */
+	session: { sessionId: string; meta: SessionMeta }
+	/** Whether the write creates, updates (put-over-existing or patch), or deletes the record. */
+	type: 'create' | 'update' | 'delete'
+	/** The existing record with this id, or `null` on `create`. */
+	prev: R | null
+	/** The record the write would produce (`null` on `delete`). */
+	next: R | null
+}) => R | null
+
+/**
+ * A map from record `typeName` to a {@link TLRecordAuthorizer}. Only listed types are authorized;
+ * every other record writes through untouched, so this stays off the hot path for the vast majority
+ * of writes (shape drags etc.).
+ *
+ * @public
+ */
+export interface TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> {
+	[typeName: string]: TLRecordAuthorizer<R, SessionMeta>
+}
+
+/**
  * A collaborative workspace that manages multiple client sessions and synchronizes
  * document changes between them. The room serves as the authoritative source for
  * all document state and handles conflict resolution, schema migrations, and
@@ -248,6 +293,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	public readonly schema: StoreSchema<R, any>
 	private onPresenceChange?(): void
 	private onCommittedChanges?(args: { diff: TLSyncForwardDiff<R>; documentClock: number }): void
+	private readonly authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>
 	private readonly sessionIdleTimeout: number
 
 	constructor(opts: {
@@ -267,6 +313,11 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		 * gated per session by `objectAccess` rather than `isReadonly`.
 		 */
 		objectTypes?: readonly string[]
+		/**
+		 * Per-type authorizers that stamp/veto client record writes (create, update, delete) from the
+		 * session's authenticated identity. See {@link TLRecordAuthorizers}.
+		 */
+		authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>
 		storage: TLSyncStorage<R>
 		clientTimeout?: number
 	}) {
@@ -274,6 +325,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		this.log = opts.log
 		this.onPresenceChange = opts.onPresenceChange
 		this.onCommittedChanges = opts.onCommittedChanges
+		this.authorizeRecord = opts.authorizeRecord
 		this.storage = opts.storage
 		this.sessionIdleTimeout = opts.clientTimeout ?? SESSION_IDLE_TIMEOUT
 
@@ -1227,7 +1279,26 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 										TLSyncErrorCloseEventReason.INVALID_RECORD
 									)
 								}
-								addDocument(txn, docChanges, id, op[1])
+								let record = op[1]
+								// Per-type authorizer: lets the host stamp/veto a write from the session's
+								// authenticated identity (e.g. a comment's authorId). Only for registered
+								// types, only for client pushes (session present).
+								const authorizePut = session && this.authorizeRecord?.[record.typeName]
+								if (authorizePut) {
+									const prev = (txn.get(id) as R | undefined) ?? null
+									const result = authorizePut({
+										session: { sessionId: session.sessionId, meta: session.meta },
+										type: prev ? 'update' : 'create',
+										prev,
+										next: record,
+									})
+									// Rejected: skip the op; the client self-corrects via discard/rebase.
+									if (!result) continue
+									// On create the returned (stamped) record is stored; on update it's an
+									// allow/veto only, so the client's record is stored as-is.
+									if (!prev) record = result
+								}
+								addDocument(txn, docChanges, id, record)
 								break
 							}
 							case RecordOpType.Patch: {
@@ -1235,17 +1306,45 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								// if it was already deleted, there's no need to apply the patch
 								if (!doc) continue
 								if (!canWrite(doc.typeName)) continue
+								// Per-type authorizer (update): veto edits the session isn't allowed to make,
+								// e.g. changing a comment's authorId. Allow/veto only — the patch applies as-is.
+								const authorizePatch = session && this.authorizeRecord?.[doc.typeName]
+								if (
+									authorizePatch &&
+									!authorizePatch({
+										session: { sessionId: session.sessionId, meta: session.meta },
+										type: 'update',
+										prev: doc,
+										next: applyObjectDiff(doc, op[1]),
+									})
+								) {
+									continue
+								}
 								// Try to patch the document. If it fails, stop here.
 								patchDocument(txn, docChanges, id, op[1])
 								break
 							}
 							case RecordOpType.Remove: {
-								const doc = txn.get(id)
+								const doc = txn.get(id) as R | undefined
 								if (!doc) {
 									// If the doc was already deleted, don't do anything, no need to propagate a delete op
 									continue
 								}
 								if (!canWrite(doc.typeName)) continue
+								// Per-type authorizer (delete): veto deletes the session isn't allowed to make,
+								// e.g. deleting someone else's comment. Allow/veto only.
+								const authorizeRemove = session && this.authorizeRecord?.[doc.typeName]
+								if (
+									authorizeRemove &&
+									!authorizeRemove({
+										session: { sessionId: session.sessionId, meta: session.meta },
+										type: 'delete',
+										prev: doc,
+										next: null,
+									})
+								) {
+									continue
+								}
 
 								// Delete the document and propagate the delete op
 								// delete automatically creates tombstones

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -144,26 +144,30 @@ export interface RoomSnapshot {
  *
  * @public
  */
-export type TLRecordAuthorizer<R extends UnknownRecord, SessionMeta> = (args: {
+export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: {
 	/** The session performing the write, including its host-provided `meta` (e.g. the authenticated user id). */
 	session: { sessionId: string; meta: SessionMeta }
 	/** Whether the write creates, updates (put-over-existing or patch), or deletes the record. */
 	type: 'create' | 'update' | 'delete'
 	/** The existing record with this id, or `null` on `create`. */
-	prev: R | null
+	prev: Rec | null
 	/** The record the write would produce (`null` on `delete`). */
-	next: R | null
-}) => R | null
+	next: Rec | null
+}) => Rec | null
 
 /**
- * A map from record `typeName` to a {@link TLRecordAuthorizer}. Only listed types are authorized;
- * every other record writes through untouched, so this stays off the hot path for the vast majority
- * of writes (shape drags etc.).
+ * A map from record `typeName` to a {@link TLRecordAuthorizer} for that record type. Only listed
+ * types are authorized; every other record writes through untouched, so this stays off the hot path
+ * for the vast majority of writes (shape drags etc.).
+ *
+ * Each authorizer is typed to its record — e.g. `next` in the `comment` entry is a `TLComment` — so
+ * renaming a field on the record makes the authorizer that reads it fail to compile, rather than
+ * silently stamp or guard the wrong field.
  *
  * @public
  */
-export interface TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> {
-	[typeName: string]: TLRecordAuthorizer<R, SessionMeta>
+export type TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> = {
+	[K in R['typeName']]?: TLRecordAuthorizer<Extract<R, { typeName: K }>, SessionMeta>
 }
 
 /**
@@ -295,6 +299,16 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	private onCommittedChanges?(args: { diff: TLSyncForwardDiff<R>; documentClock: number }): void
 	private readonly authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>
 	private readonly sessionIdleTimeout: number
+
+	/**
+	 * The authorizer registered for a record type, widened to the room's record union. Each entry in
+	 * `authorizeRecord` is typed to its specific record; the cast here is the one place we can't
+	 * statically correlate a runtime `typeName` with its record type, so it lives in the library
+	 * rather than in every consumer.
+	 */
+	private authorizerFor(typeName: R['typeName']): TLRecordAuthorizer<R, SessionMeta> | undefined {
+		return this.authorizeRecord?.[typeName] as TLRecordAuthorizer<R, SessionMeta> | undefined
+	}
 
 	constructor(opts: {
 		log?: TLSyncLog
@@ -1283,7 +1297,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								// Per-type authorizer: lets the host stamp/veto a write from the session's
 								// authenticated identity (e.g. a comment's authorId). Only for registered
 								// types, only for client pushes (session present).
-								const authorizePut = session && this.authorizeRecord?.[record.typeName]
+								const authorizePut = session && this.authorizerFor(record.typeName)
 								if (authorizePut) {
 									const prev = (txn.get(id) as R | undefined) ?? null
 									const result = authorizePut({
@@ -1308,7 +1322,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								if (!canWrite(doc.typeName)) continue
 								// Per-type authorizer (update): veto edits the session isn't allowed to make,
 								// e.g. changing a comment's authorId. Allow/veto only — the patch applies as-is.
-								const authorizePatch = session && this.authorizeRecord?.[doc.typeName]
+								const authorizePatch = session && this.authorizerFor(doc.typeName)
 								if (
 									authorizePatch &&
 									!authorizePatch({
@@ -1333,7 +1347,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								if (!canWrite(doc.typeName)) continue
 								// Per-type authorizer (delete): veto deletes the session isn't allowed to make,
 								// e.g. deleting someone else's comment. Allow/veto only.
-								const authorizeRemove = session && this.authorizeRecord?.[doc.typeName]
+								const authorizeRemove = session && this.authorizerFor(doc.typeName)
 								if (
 									authorizeRemove &&
 									!authorizeRemove({

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -129,6 +129,11 @@ export interface RoomSnapshot {
  * Called on **create**, **update**, and **delete** of records whose `typeName` it's registered for
  * (see {@link TLRecordAuthorizers}), and only for client pushes — never for server-initiated writes.
  *
+ * `prev` and `next` are always at the **server's** schema version: client writes are migrated
+ * before the authorizer runs, so guarding or stamping a field never requires knowing what older
+ * clients call it. On create, the record you return is what gets stored (after validation) — no
+ * migration runs afterwards, so stamped fields can't be clobbered.
+ *
  * Return `null` to reject the write — it's skipped and the client self-corrects, exactly like the
  * `objectAccess` gate. Otherwise the write is allowed, and:
  *
@@ -139,20 +144,11 @@ export interface RoomSnapshot {
  *   `next`/`prev` to allow, `null` to reject.
  *
  * ⚠︎ Runs synchronously inside the commit transaction, on the same path as every document edit — it
- * must be fast and do **no** I/O. `next`/`prev` are the incoming client-controlled records, so treat
- * their contents as untrusted; prefer returning `null` to reject over throwing, though a throw is
+ * must be fast and do **no** I/O. `next`/`prev` are client-controlled records, so treat their
+ * contents as untrusted; prefer returning `null` to reject over throwing, though a throw is
  * caught, logged, and treated as a rejection (fail closed) rather than crashing the push. For
  * expensive, async checks (e.g. resolving mentions against who can access a file), react after the
  * fact via `onCommittedChanges`.
- *
- * ⚠︎ Migration caveat: the authorizer sees records at the **client's** schema version, before any
- * up-migration. On create, the record you return is up-migrated before being stored, so an
- * up-migration can overwrite stamped fields. On update, when the client's schema is older than the
- * server's, the committed record is produced by a downgrade→patch→upgrade pipeline and can differ
- * from the `next` preview the authorizer saw. Only guard record types whose live cross-version
- * migrations don't touch the fields you stamp or veto (tldraw.com's comment threads: the anchor
- * migration reshapes `anchor` but never `createdBy` or `resolved`), or types whose migrations
- * reject old-schema sessions outright by having no `down`.
  *
  * @public
  */
@@ -1183,7 +1179,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			storage: MinimalDocStore<R>,
 			changes: ActualChanges,
 			id: string,
-			_state: R
+			_state: R,
+			authorize?: (prev: R | null, next: R) => R | null
 		): Result<void, void> => {
 			const res = session
 				? this.schema.migratePersistedRecord(_state, session.serializedSchema, 'up')
@@ -1191,10 +1188,19 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			if (res.type === 'error') {
 				throw new TLSyncError(res.reason, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 			}
-			const { value: state } = res
+			let { value: state } = res
 
 			// Get the existing document, if any
 			const doc = storage.get(id) as R | undefined
+
+			// Authorize on the server-schema record: `state` is fully up-migrated, so the authorizer
+			// never sees old field names, and on create the (possibly stamped) record it returns is
+			// stored as-is — no later migration can clobber stamped fields.
+			if (authorize) {
+				const result = authorize(doc ?? null, state)
+				if (!result) return Result.ok(undefined) // vetoed: skip the op, the client self-corrects
+				if (!doc) state = result // create: store the authorizer's (stamped) record
+			}
 
 			if (doc) {
 				// If there's an existing document, replace it with the new state
@@ -1222,7 +1228,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			storage: MinimalDocStore<R>,
 			changes: ActualChanges,
 			id: string,
-			patch: ObjectDiff
+			patch: ObjectDiff,
+			authorize?: (prev: R, next: R) => R | null
 		) => {
 			// if it was already deleted, there's no need to apply the patch
 			const doc = storage.get(id) as R | undefined
@@ -1242,6 +1249,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				// If the versions are compatible, apply the patch and propagate the patch op
 				const diff = applyAndDiffRecord(doc, patch, recordType, legacyAppendMode)
 				if (diff) {
+					// Authorize on the committed candidate — the exact record that will be stored.
+					if (authorize && !authorize(doc, diff[1])) return
 					storage.set(id, diff[1])
 					propagateOp(changes, id, [RecordOpType.Patch, diff[0]], doc, diff[1])
 				}
@@ -1261,6 +1270,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				// replace the state with the upgraded version and propagate the patch op
 				const diff = diffAndValidateRecord(doc, upgraded.value, recordType, legacyAppendMode)
 				if (diff) {
+					// Authorize on the committed candidate — the upgraded record, not a raw preview.
+					if (authorize && !authorize(doc, upgraded.value)) return
 					storage.set(id, upgraded.value)
 					propagateOp(changes, id, [RecordOpType.Patch, diff], doc, upgraded.value)
 				}
@@ -1331,10 +1342,12 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 										TLSyncErrorCloseEventReason.INVALID_RECORD
 									)
 								}
-								let record = op[1]
+								const record = op[1]
 								// Per-type authorizer: lets the host stamp/veto a write from the session's
 								// authenticated identity (e.g. a comment's authorId). Only for registered
-								// types, only for client pushes (session present).
+								// types, only for client pushes (session present). The check itself runs
+								// inside `addDocument`, after the record is migrated to the server's schema.
+								let authorize: ((prev: R | null, next: R) => R | null) | undefined
 								if (session && this.authorizeRecord) {
 									const prev = (txn.get(id) as R | undefined) ?? null
 									// A put must not change the record's typeName: the authorizer lookup keys
@@ -1353,38 +1366,39 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 									}
 									const authorizePut = this.authorizerFor(record.typeName)
 									if (authorizePut) {
-										const result = authorizePut(
-											prev
-												? {
-														session: { sessionId: session.sessionId, meta: session.meta },
-														type: 'update',
-														prev,
-														next: record,
-													}
-												: {
-														session: { sessionId: session.sessionId, meta: session.meta },
-														type: 'create',
-														prev: null,
-														next: record,
-													}
-										)
-										// Rejected: skip the op; the client self-corrects via discard/rebase.
-										if (!result) {
-											this.log?.warn?.(
-												'authorizer vetoed put',
-												record.typeName,
-												id,
-												'session:',
-												session.sessionId
+										authorize = (prevRec, next) => {
+											const result = authorizePut(
+												prevRec
+													? {
+															session: { sessionId: session.sessionId, meta: session.meta },
+															type: 'update',
+															prev: prevRec,
+															next,
+														}
+													: {
+															session: { sessionId: session.sessionId, meta: session.meta },
+															type: 'create',
+															prev: null,
+															next,
+														}
 											)
-											continue
+											if (!result) {
+												this.log?.warn?.(
+													'authorizer vetoed put',
+													record.typeName,
+													id,
+													'session:',
+													session.sessionId
+												)
+												return null
+											}
+											// On create the returned (stamped) record is stored; on update it's
+											// allow/veto only, so the migrated client record is stored as-is.
+											return prevRec ? next : result
 										}
-										// On create the returned (stamped) record is stored; on update it's an
-										// allow/veto only, so the client's record is stored as-is.
-										if (!prev) record = result
 									}
 								}
-								addDocument(txn, docChanges, id, record)
+								addDocument(txn, docChanges, id, record, authorize)
 								break
 							}
 							case RecordOpType.Patch: {
@@ -1393,28 +1407,32 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								if (!doc) continue
 								if (!canWrite(doc.typeName)) continue
 								// Per-type authorizer (update): veto edits the session isn't allowed to make,
-								// e.g. changing a comment's authorId. Allow/veto only — the patch applies as-is.
+								// e.g. changing a comment's authorId. Runs inside `patchDocument` on the
+								// committed candidate — the server-schema record that will actually be
+								// stored — never on a raw client-version preview. Allow/veto only.
 								const authorizePatch = session && this.authorizerFor(doc.typeName)
-								if (
-									authorizePatch &&
-									!authorizePatch({
-										session: { sessionId: session.sessionId, meta: session.meta },
-										type: 'update',
-										prev: doc,
-										next: applyObjectDiff(doc, op[1]),
-									})
-								) {
-									this.log?.warn?.(
-										'authorizer vetoed patch',
-										doc.typeName,
-										id,
-										'session:',
-										session.sessionId
-									)
-									continue
-								}
+								const authorize = authorizePatch
+									? (prev: R, next: R) => {
+											const result = authorizePatch({
+												session: { sessionId: session.sessionId, meta: session.meta },
+												type: 'update',
+												prev,
+												next,
+											})
+											if (!result) {
+												this.log?.warn?.(
+													'authorizer vetoed patch',
+													doc.typeName,
+													id,
+													'session:',
+													session.sessionId
+												)
+											}
+											return result
+										}
+									: undefined
 								// Try to patch the document. If it fails, stop here.
-								patchDocument(txn, docChanges, id, op[1])
+								patchDocument(txn, docChanges, id, op[1], authorize)
 								break
 							}
 							case RecordOpType.Remove: {

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -139,8 +139,11 @@ export interface RoomSnapshot {
  *   `next`/`prev` to allow, `null` to reject.
  *
  * ⚠︎ Runs synchronously inside the commit transaction, on the same path as every document edit — it
- * must be fast and do **no** I/O. For expensive, async checks (e.g. resolving mentions against who
- * can access a file), react after the fact via `onCommittedChanges` instead.
+ * must be fast and do **no** I/O. `next`/`prev` are the incoming client-controlled records, so treat
+ * their contents as untrusted; prefer returning `null` to reject over throwing, though a throw is
+ * caught, logged, and treated as a rejection (fail closed) rather than crashing the push. For
+ * expensive, async checks (e.g. resolving mentions against who can access a file), react after the
+ * fact via `onCommittedChanges`.
  *
  * @public
  */
@@ -307,7 +310,21 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 	 * rather than in every consumer.
 	 */
 	private authorizerFor(typeName: R['typeName']): TLRecordAuthorizer<R, SessionMeta> | undefined {
-		return this.authorizeRecord?.[typeName] as TLRecordAuthorizer<R, SessionMeta> | undefined
+		const authorize = this.authorizeRecord?.[typeName] as
+			| TLRecordAuthorizer<R, SessionMeta>
+			| undefined
+		if (!authorize) return undefined
+		// Fail closed: an authorizer that throws rejects the write (and is logged) rather than
+		// aborting the whole push. Authorizers are security-sensitive, so a bug must never let a
+		// write through.
+		return (args) => {
+			try {
+				return authorize(args)
+			} catch (e) {
+				this.log?.error?.('record authorizer threw; rejecting the write', e)
+				return null
+			}
+		}
 	}
 
 	constructor(opts: {

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -1193,9 +1193,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 			// Get the existing document, if any
 			const doc = storage.get(id) as R | undefined
 
-			// Authorize on the server-schema record: `state` is fully up-migrated, so the authorizer
-			// never sees old field names, and on create the (possibly stamped) record it returns is
-			// stored as-is — no later migration can clobber stamped fields.
+			// Authorize on the up-migrated record; on create the authorizer's return is stored as-is,
+			// so no later migration can clobber stamped fields.
 			if (authorize) {
 				const result = authorize(doc ?? null, state)
 				if (!result) return Result.ok(undefined) // vetoed: skip the op, the client self-corrects
@@ -1249,7 +1248,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 				// If the versions are compatible, apply the patch and propagate the patch op
 				const diff = applyAndDiffRecord(doc, patch, recordType, legacyAppendMode)
 				if (diff) {
-					// Authorize on the committed candidate — the exact record that will be stored.
+					// Authorize on the committed candidate — the record that will actually be stored.
 					if (authorize && !authorize(doc, diff[1])) return
 					storage.set(id, diff[1])
 					propagateOp(changes, id, [RecordOpType.Patch, diff[0]], doc, diff[1])
@@ -1343,10 +1342,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 									)
 								}
 								const record = op[1]
-								// Per-type authorizer: lets the host stamp/veto a write from the session's
-								// authenticated identity (e.g. a comment's authorId). Only for registered
-								// types, only for client pushes (session present). The check itself runs
-								// inside `addDocument`, after the record is migrated to the server's schema.
+								// Per-type authorizer: stamp/veto the write from the session's identity.
+								// Client pushes only; runs inside `addDocument`, on the up-migrated record.
 								let authorize: ((prev: R | null, next: R) => R | null) | undefined
 								if (session && this.authorizeRecord) {
 									const prev = (txn.get(id) as R | undefined) ?? null
@@ -1392,8 +1389,7 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 												)
 												return null
 											}
-											// On create the returned (stamped) record is stored; on update it's
-											// allow/veto only, so the migrated client record is stored as-is.
+											// create: store the stamped record; update: allow/veto only
 											return prevRec ? next : result
 										}
 									}
@@ -1406,10 +1402,8 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								// if it was already deleted, there's no need to apply the patch
 								if (!doc) continue
 								if (!canWrite(doc.typeName)) continue
-								// Per-type authorizer (update): veto edits the session isn't allowed to make,
-								// e.g. changing a comment's authorId. Runs inside `patchDocument` on the
-								// committed candidate — the server-schema record that will actually be
-								// stored — never on a raw client-version preview. Allow/veto only.
+								// Per-type authorizer (update, allow/veto only): runs inside `patchDocument`
+								// on the committed candidate, never on a raw client-version preview.
 								const authorizePatch = session && this.authorizerFor(doc.typeName)
 								const authorize = authorizePatch
 									? (prev: R, next: R) => {

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -145,6 +145,14 @@ export interface RoomSnapshot {
  * expensive, async checks (e.g. resolving mentions against who can access a file), react after the
  * fact via `onCommittedChanges`.
  *
+ * ⚠︎ Migration caveat: the authorizer sees records at the **client's** schema version, before any
+ * up-migration. On create, the record you return is up-migrated before being stored, so an
+ * up-migration can overwrite stamped fields. On update, when the client's schema is older than the
+ * server's, the committed record is produced by a downgrade→patch→upgrade pipeline and can differ
+ * from the `next` preview the authorizer saw. Only guard record types whose live cross-version
+ * migrations don't touch the fields you stamp or veto — or, like tldraw.com's comment records,
+ * types whose guard migrations reject old-schema sessions outright.
+ *
  * @public
  */
 export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -526,6 +526,18 @@ describe('object store lane', () => {
 			expect(storedIds(storage)).toEqual([note.id])
 		})
 
+		it('rejects the write (fail closed) when the authorizer throws, without crashing the push', () => {
+			const { room, storage } = withNote(() => {
+				throw new Error('boom')
+			})
+			const socket = connectSession(room, 'alice', { meta: { userId: 'u' } })
+			const note = Note.create({ text: 'x' })
+
+			expect(() => push(room, 'alice', { [note.id]: [RecordOpType.Put, note] })).not.toThrow()
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedIds(storage)).toEqual([])
+		})
+
 		it('passes the change type for create, update, and delete', () => {
 			const types: string[] = []
 			const note = Note.create({ text: 'x' })

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -522,6 +522,19 @@ describe('object store lane', () => {
 			expect(storedNote(storage, note.id)?.text).toBe('edited')
 		})
 
+		it('does not consult the authorizer for a no-op patch', () => {
+			const authorize = vi.fn(({ type, prev, next }: any) => (type === 'delete' ? prev : next))
+			const { room, note } = seededWithNote(authorize)
+			connectSession(room, 'alice', { meta: { userId: 'u' } })
+			authorize.mockClear()
+
+			push(room, 'alice', {
+				[note.id]: [RecordOpType.Patch, { text: [ValueOpType.Put, note.text] }],
+			})
+
+			expect(authorize).not.toHaveBeenCalled()
+		})
+
 		it('vetoes a delete the authorizer rejects', () => {
 			const { room, storage, note } = seededWithNote(({ type, next }: any) =>
 				type === 'delete' ? null : next

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -91,6 +91,7 @@ function makeRoom(
 				next: any
 			}) => any
 		}
+		log?: any
 	} = {}
 ) {
 	const storage = new InMemorySyncStorage<R>({
@@ -109,6 +110,7 @@ function makeRoom(
 		objectTypes: opts.objectTypes,
 		onCommittedChanges: opts.onCommittedChanges,
 		authorizeRecord: opts.authorizeRecord,
+		log: opts.log,
 	})
 	disposables.push(() => room.close())
 	return { storage, room }
@@ -588,6 +590,22 @@ describe('object store lane', () => {
 			push(room, 'alice', { [note.id]: [RecordOpType.Remove] }, 3)
 
 			expect(types).toEqual(['create', 'update', 'delete'])
+		})
+
+		it('logs a warning when a write is vetoed', () => {
+			const warn = vi.fn()
+			const note = Note.create({ text: 'by:user-alice' })
+			const { room } = makeRoom({
+				objectTypes: ['note'],
+				authorizeRecord: { note: () => null },
+				log: { warn },
+			})
+			connectSession(room, 'mallory', { meta: { userId: 'user-mallory' } })
+
+			push(room, 'mallory', { [note.id]: [RecordOpType.Put, note] })
+
+			expect(warn).toHaveBeenCalledTimes(1)
+			expect(warn.mock.calls[0].join(' ')).toContain(note.id)
 		})
 	})
 })

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -398,6 +398,12 @@ describe('object store lane', () => {
 	})
 
 	describe('authorizeRecord', () => {
+		it('rejects a presence typeName key at construction', () => {
+			expect(() => makeRoom({ authorizeRecord: { presence: ({ next }: any) => next } })).toThrow(
+				/presence/
+			)
+		})
+
 		// A per-type authorizer like dotcom's: stamp the note's text from the session's user id on
 		// create, keep it immutable on update, allow deletes.
 		const authorizeNote = ({ session, type, prev, next }: any) => {

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -83,6 +83,14 @@ function makeRoom(
 		snapshot?: RoomSnapshot
 		objectTypes?: readonly string[]
 		onCommittedChanges?(args: { diff: any; documentClock: number }): void
+		authorizeRecord?: {
+			[typeName: string]: (args: {
+				session: { sessionId: string; meta: any }
+				type: 'create' | 'update' | 'delete'
+				prev: any
+				next: any
+			}) => any
+		}
 	} = {}
 ) {
 	const storage = new InMemorySyncStorage<R>({
@@ -100,6 +108,7 @@ function makeRoom(
 		storage,
 		objectTypes: opts.objectTypes,
 		onCommittedChanges: opts.onCommittedChanges,
+		authorizeRecord: opts.authorizeRecord,
 	})
 	disposables.push(() => room.close())
 	return { storage, room }
@@ -112,13 +121,14 @@ function connectSession(
 		isReadonly?: boolean
 		objectAccess?: 'read' | 'write'
 		clear?: boolean
+		meta?: any
 	} = {}
 ): MockSocket {
 	const socket = makeSocket()
 	room.handleNewSession({
 		sessionId,
 		socket,
-		meta: undefined,
+		meta: opts.meta,
 		isReadonly: opts.isReadonly ?? false,
 		objectAccess: opts.objectAccess,
 	})
@@ -382,6 +392,154 @@ describe('object store lane', () => {
 			await Promise.resolve()
 
 			expect(onCommittedChanges).not.toHaveBeenCalled()
+		})
+	})
+
+	describe('authorizeRecord', () => {
+		// A per-type authorizer like dotcom's: stamp the note's text from the session's user id on
+		// create, keep it immutable on update, allow deletes.
+		const authorizeNote = ({ session, type, prev, next }: any) => {
+			if (type === 'create') {
+				const userId = session.meta?.userId
+				if (!userId) return null
+				return { ...next, text: `by:${userId}` }
+			}
+			if (type === 'update') return next.text === prev.text ? next : null
+			return prev // delete allowed
+		}
+
+		function withNote(authorize: any, extra: any = {}) {
+			return makeRoom({ objectTypes: ['note'], authorizeRecord: { note: authorize }, ...extra })
+		}
+
+		function seededWithNote(authorize: any) {
+			const note = Note.create({ text: 'by:user-alice' })
+			const { room, storage } = withNote(authorize, {
+				snapshot: {
+					documents: [{ state: note, lastChangedClock: 0 }],
+					clock: 0,
+					documentClock: 0,
+					schema: schema.serialize(),
+				},
+			})
+			return { room, storage, note }
+		}
+
+		const storedNote = (storage: InMemorySyncStorage<R>, id: string) =>
+			storage.getObjectsSnapshot().find((d) => d.state.id === id)?.state as any
+
+		it('stamps a created record from the session, overriding the client value', () => {
+			const { room, storage } = withNote(authorizeNote)
+			const socket = connectSession(room, 'alice', { meta: { userId: 'user-alice' } })
+
+			const note = Note.create({ text: 'forged' })
+			push(room, 'alice', { [note.id]: [RecordOpType.Put, note] })
+
+			// the server rewrote the record, so it rebases the client onto the stamped value
+			expect(lastPushResult(socket)).toMatchObject({
+				action: {
+					rebaseWithDiff: { [note.id]: [RecordOpType.Put, { ...note, text: 'by:user-alice' }] },
+				},
+			})
+			expect(storedNote(storage, note.id)?.text).toBe('by:user-alice')
+		})
+
+		it('rejects a create the authorizer denies (returns null)', () => {
+			const { room, storage } = withNote(authorizeNote)
+			const socket = connectSession(room, 'anon', { meta: { userId: null } })
+
+			const note = Note.create({ text: 'nope' })
+			push(room, 'anon', { [note.id]: [RecordOpType.Put, note] })
+
+			expect(socket.close).not.toHaveBeenCalled()
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedIds(storage)).toEqual([])
+		})
+
+		it('only runs for registered types — other records write through untouched', () => {
+			const seen: string[] = []
+			const { room, storage } = withNote(({ next }: any) => {
+				seen.push('note')
+				return next
+			})
+			connectSession(room, 'writer', { meta: { userId: 'u' } })
+
+			const doc = Doc.create({ title: 'hi' })
+			push(room, 'writer', { [doc.id]: [RecordOpType.Put, doc] })
+
+			expect(seen).toEqual([])
+			expect(storedIds(storage)).toEqual([doc.id])
+		})
+
+		it('authorizes document-lane record types', () => {
+			// authorize `doc`, a document-lane record
+			const { room, storage } = makeRoom({
+				objectTypes: ['note'],
+				authorizeRecord: {
+					doc: ({ type, next }: any) => (type === 'create' ? { ...next, title: 'stamped' } : next),
+				},
+			})
+			connectSession(room, 'writer', { meta: { userId: 'u' } })
+
+			const doc = Doc.create({ title: 'client' })
+			push(room, 'writer', { [doc.id]: [RecordOpType.Put, doc] })
+
+			const stored = storage.getSnapshot().documents.find((d) => d.state.id === doc.id)
+				?.state as any
+			expect(stored?.title).toBe('stamped')
+		})
+
+		it('vetoes an update that changes an immutable field (patch)', () => {
+			const { room, storage, note } = seededWithNote(authorizeNote)
+			const socket = connectSession(room, 'mallory', { meta: { userId: 'user-mallory' } })
+
+			push(room, 'mallory', {
+				[note.id]: [RecordOpType.Patch, { text: [ValueOpType.Put, 'tampered'] }],
+			})
+
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedNote(storage, note.id)?.text).toBe('by:user-alice')
+		})
+
+		it('allows an update the authorizer permits (patch)', () => {
+			const { room, storage, note } = seededWithNote(({ type, prev, next }: any) =>
+				type === 'delete' ? prev : next
+			)
+			connectSession(room, 'alice', { meta: { userId: 'u' } })
+
+			push(room, 'alice', {
+				[note.id]: [RecordOpType.Patch, { text: [ValueOpType.Put, 'edited'] }],
+			})
+
+			expect(storedNote(storage, note.id)?.text).toBe('edited')
+		})
+
+		it('vetoes a delete the authorizer rejects', () => {
+			const { room, storage, note } = seededWithNote(({ type, next }: any) =>
+				type === 'delete' ? null : next
+			)
+			const socket = connectSession(room, 'mallory', { meta: { userId: 'm' } })
+
+			push(room, 'mallory', { [note.id]: [RecordOpType.Remove] })
+
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedIds(storage)).toEqual([note.id])
+		})
+
+		it('passes the change type for create, update, and delete', () => {
+			const types: string[] = []
+			const note = Note.create({ text: 'x' })
+			const { room } = withNote(({ type, prev, next }: any) => {
+				types.push(type)
+				return type === 'delete' ? prev : next
+			})
+			connectSession(room, 'alice', { meta: { userId: 'u' } })
+
+			push(room, 'alice', { [note.id]: [RecordOpType.Put, note] }, 1)
+			push(room, 'alice', { [note.id]: [RecordOpType.Patch, { text: [ValueOpType.Put, 'y'] }] }, 2)
+			push(room, 'alice', { [note.id]: [RecordOpType.Remove] }, 3)
+
+			expect(types).toEqual(['create', 'update', 'delete'])
 		})
 	})
 })

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -526,6 +526,42 @@ describe('object store lane', () => {
 			expect(storedIds(storage)).toEqual([note.id])
 		})
 
+		it('vetoes a put that changes the typeName of an existing record', () => {
+			const { room, storage, note } = seededWithNote(authorizeNote)
+			const socket = connectSession(room, 'mallory', { meta: { userId: 'user-mallory' } })
+
+			// a `doc`-shaped record reusing the note's id: the authorizer lookup keys off the incoming
+			// typeName, so the swap would consult the doc authorizer (here: none) instead of note's
+			push(room, 'mallory', {
+				[note.id]: [RecordOpType.Put, { id: note.id, typeName: 'doc', title: 'swapped' } as any],
+			})
+
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedNote(storage, note.id)?.typeName).toBe('note')
+		})
+
+		it('vetoes a put over an existing record that changes an immutable field', () => {
+			const { room, storage, note } = seededWithNote(authorizeNote)
+			const socket = connectSession(room, 'mallory', { meta: { userId: 'user-mallory' } })
+
+			push(room, 'mallory', { [note.id]: [RecordOpType.Put, { ...note, text: 'tampered' }] })
+
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedNote(storage, note.id)?.text).toBe('by:user-alice')
+		})
+
+		it('ignores the record returned by an update authorizer (allow/veto only)', () => {
+			const { room, storage, note } = seededWithNote(({ type, prev, next }: any) => {
+				if (type === 'update') return { ...next, text: 'stamped-on-update' }
+				return type === 'delete' ? prev : next
+			})
+			connectSession(room, 'alice', { meta: { userId: 'u' } })
+
+			push(room, 'alice', { [note.id]: [RecordOpType.Put, { ...note, text: 'edited' }] })
+
+			expect(storedNote(storage, note.id)?.text).toBe('edited')
+		})
+
 		it('rejects the write (fail closed) when the authorizer throws, without crashing the push', () => {
 			const { room, storage } = withNote(() => {
 				throw new Error('boom')

--- a/packages/sync-core/src/test/upgradeDowngrade.test.ts
+++ b/packages/sync-core/src/test/upgradeDowngrade.test.ts
@@ -173,8 +173,13 @@ class TestInstance {
 
 	hasLoaded = false
 
-	constructor(snapshot?: RoomSnapshot, oldSchema = schemaV1, newSchema = schemaV2) {
-		this.server = new TestServer(newSchema, snapshot)
+	constructor(
+		snapshot?: RoomSnapshot,
+		oldSchema = schemaV1,
+		newSchema = schemaV2,
+		roomOpts?: ConstructorParameters<typeof TestServer<RV2>>[2]
+	) {
+		this.server = new TestServer(newSchema, snapshot, roomOpts)
 		this.oldSocketPair = new TestSocketPair('test_upgrade_old', this.server)
 		this.newSocketPair = new TestSocketPair('test_upgrade_new', this.server)
 
@@ -1230,5 +1235,95 @@ describe('when the client is the same version', () => {
 				},
 			],
 		} satisfies TLSocketServerSentEvent<RV2>)
+	})
+})
+
+describe('record authorizers see server-schema records', () => {
+	function makeInstance(authorizeUser: (args: any) => any) {
+		return new TestInstance(undefined, schemaV1, schemaV2, {
+			authorizeRecord: { user: authorizeUser },
+		})
+	}
+
+	it('a put from an old client reaches the authorizer up-migrated', () => {
+		const seen: any[] = []
+		const t = makeInstance((args: any) => {
+			seen.push(structuredClone({ type: args.type, prev: args.prev, next: args.next }))
+			return args.next
+		})
+		t.oldSocketPair.connect()
+		t.flush()
+
+		const user = UserV1.create({ name: 'bob', age: 10 })
+		t.oldClient.store.put([user])
+		t.flush()
+
+		expect(seen).toHaveLength(1)
+		expect(seen[0].type).toBe('create')
+		expect(seen[0].next).toMatchObject({ name: 'bob', birthdate: null })
+		expect(seen[0].next).not.toHaveProperty('age')
+	})
+
+	it('a stamp applied on create survives — no migration runs after the authorizer', () => {
+		const t = makeInstance((args: any) =>
+			args.type === 'create' ? { ...args.next, birthdate: '2001-02-03' } : args.next
+		)
+		t.oldSocketPair.connect()
+		t.flush()
+
+		const user = UserV1.create({ name: 'bob', age: 10 })
+		t.oldClient.store.put([user])
+		t.flush()
+
+		expect(t.server.storage.documents.get(user.id)?.state).toMatchObject({
+			name: 'bob',
+			birthdate: '2001-02-03',
+		})
+	})
+
+	it('a patch from an old client reaches the authorizer as the upgraded committed candidate', () => {
+		const seen: any[] = []
+		const t = makeInstance((args: any) => {
+			seen.push(structuredClone({ type: args.type, prev: args.prev, next: args.next }))
+			return args.next
+		})
+		t.oldSocketPair.connect()
+		t.newSocketPair.connect()
+		t.flush()
+
+		const user = UserV2.create({ name: 'bob', birthdate: '2022-01-09' })
+		t.newClient.store.put([user])
+		t.flush()
+		seen.length = 0
+
+		t.oldClient.store.update(user.id as any, (u: any) => ({ ...u, name: 'bobby' }))
+		t.flush()
+
+		expect(seen).toHaveLength(1)
+		expect(seen[0].type).toBe('update')
+		expect(seen[0].prev).toMatchObject({ name: 'bob', birthdate: '2022-01-09' })
+		// The down→patch→up round-trip through the lossy v1 schema resets birthdate to null.
+		// The authorizer must see exactly what will be committed — not a preview mixing the
+		// server record with the raw v1 diff (which would still show the old birthdate).
+		expect(seen[0].next).toMatchObject({ name: 'bobby', birthdate: null })
+		expect(seen[0].next).not.toHaveProperty('age')
+	})
+
+	it('vetoes based on the server-schema record', () => {
+		const t = makeInstance((args: any) =>
+			args.type === 'update' && args.next.name === 'forged' ? null : args.next
+		)
+		t.oldSocketPair.connect()
+		t.newSocketPair.connect()
+		t.flush()
+
+		const user = UserV2.create({ name: 'bob', birthdate: '2022-01-09' })
+		t.newClient.store.put([user])
+		t.flush()
+
+		t.oldClient.store.update(user.id as any, (u: any) => ({ ...u, name: 'forged' }))
+		t.flush()
+
+		expect(t.server.storage.documents.get(user.id)?.state).toMatchObject({ name: 'bob' })
 	})
 })


### PR DESCRIPTION
In order to enforce write-level rules on synced records — starting with "you can only post a comment in your own name" — this PR adds `authorizeRecord` to `TLSocketRoom` / `TLSyncRoom`: a map from a record's `typeName` to a synchronous authorizer the room calls on **create**, **update**, and **delete** of that type, using the session's authenticated identity.

Stacked on #9478 (comments via tldraw sync); targets `commenting`.

### How it works

- Only listed types are authorized — every other record writes through untouched, so this stays off the hot path (shape drags etc.).
- Authorizers always see records at the **server's schema version**: client writes are migrated before the authorizer runs (the authorize step happens inside the commit helpers, on the exact record that will be stored). Guarding or stamping a field never requires knowing what older clients call it, and a stamped field can't be clobbered by a later up-migration.
- On **create** the record you return is what gets stored, so you stamp identity fields there. On **update** and **delete** only allow-vs-reject is used, so you veto changes to immutable fields or unauthorized deletes. Return `null` to reject — the write is skipped and the client self-corrects, exactly like the `objectAccess` gate.
- The return type is `R | null` (not a `Promise`) by design: the authorizer runs synchronously inside the commit transaction, on the same path as every document edit, so it must be fast and do **no** I/O. Expensive/async checks (e.g. resolving mentions against who can access a file) belong in `onCommittedChanges`, off the commit path.

### What dotcom does with it

- Forces `comment.authorId` / `comment-thread.createdBy` from the signed-in user on create, and keeps them immutable on update — so nobody can post in someone else's name. A thread's `resolved.by` must likewise be the session's own user, whether set on create or by an update.
- Guards **note-shape text attribution** (`props.textLastEditedBy`), branching on the shape's `type` (all shapes share `typeName: 'shape'`). Creates pass through untouched — duplication and copy/paste legitimately carry another user's attribution, so a forged create is indistinguishable from a duplication. Updates that change the attribution must set it to `null` (text emptied, or an anonymous editor) or the session's own user; anything else is vetoed. Notes stay fully usable anonymously — anonymous sessions just can't pin an edit on someone.
- Leaves deletes open — cascade cleanup (deleting a shape removes its comments) is performed by whoever deletes the shape, not the comment's author, so author-only deletes would break it.

### Follow-ups

- **Anonymous comments.** Today an unauthenticated session's comment create is rejected (there's no identity to attribute it to). We expect to allow anonymous comments in the future — at which point this becomes "stamp a server-assigned guest identity" rather than a reject.

### API changes

- Added `authorizeRecord?: TLRecordAuthorizers<R, SessionMeta>` to `TLSocketRoom` / `TLSyncRoom` options.
- Added `TLRecordAuthorizer` and `TLRecordAuthorizers` to `@tldraw/sync-core`.

### Change type

- [x] `feature`

### Test plan

Unit (`packages/sync-core/src/test/objectStore.test.ts`): create stamps and overrides the client value; a denied create is rejected and not stored; the authorizer only runs for registered types; it authorizes document-lane record types too; an immutable-field patch is vetoed while a permitted patch applies; a rejected delete is vetoed; a no-op patch never consults the authorizer; and the change type (create/update/delete) is passed correctly.

Cross-version (`packages/sync-core/src/test/upgradeDowngrade.test.ts`): a put from an old-schema client reaches the authorizer up-migrated; a patch from an old-schema client reaches it as the upgraded committed candidate; a stamp applied on create survives (no migration runs after the authorizer); vetoes apply to the server-schema record.

dotcom (`apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts`): the comment/thread authorship matrix, plus the note attribution matrix — create passthrough (including foreign attribution), unchanged-attribution updates from any user, self/null changes allowed, forged changes vetoed, the anonymous-session matrix, subtype-change smuggling vetoed, non-note shapes untouched, deletes allowed.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +228 / -7   |
| Tests           | +582 / -3   |
| Automated files | +29 / -0    |
| Apps            | +104 / -5   |

### Release notes

- Internal: sync rooms can register per-type record authorizers that stamp or veto client writes from the session's authenticated identity, always operating on server-schema records (used to enforce comment authorship and note text attribution). Not user-facing.
