### PR TITLE
fix(tldraw): align style panel dropdown popovers with panel gap

### DIFF
--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -28,7 +28,10 @@ export interface StylePanelDropdownPickerProps<T extends string> {
 	onValueChange?(style: StyleProp<T>, value: T): void
 	/** Override the test ID prefix. Defaults to uiType. */
 	testIdType?: string
-	/** Distance to push the popover left of the trigger so it lands flush with the style panel. */
+	/**
+	 * Distance to push the popover left of the trigger so it lands flush with the style panel.
+	 * Defaults to the standard popover gap so standalone dropdowns don't sit flush against the panel.
+	 */
 	sideOffset?: number
 }
 
@@ -59,7 +62,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 		value,
 		onValueChange = ctx.onValueChange,
 		testIdType = uiType,
-		sideOffset = 0,
+		sideOffset = 8,
 	} = props
 	const msg = useTranslation()
 	const editor = useEditor()


### PR DESCRIPTION
In order to keep the style panel's standalone dropdown popovers consistent with the rest of the panel, this PR gives the geo (Shape), arrow kind (Line), and spline dropdowns the standard popover gap instead of opening flush against the panel.

These standalone "menu" dropdowns relied on `StylePanelDropdownPicker`'s default `sideOffset` of `0`, which cancelled the standard 8px popover gap and jammed their popovers directly against the panel's left edge. The arrowhead and vertical-align popovers already open with the usual 8px gap, so the Shape/Line/spline dropdowns looked misaligned by comparison. Changing the default `sideOffset` from `0` to `8` brings them in line. The inline fill-extra and vertical-align pickers pass an explicit offset and are unaffected.

### Change type

- [x] `bugfix`

### Test plan

1. Open the examples app and select a geo shape, a line, and an arrow together so the Shape, Line, Arrows, and Spline dropdown rows all appear in the style panel.
2. Open each dropdown and verify every popover opens to the left of the panel with the same small gap (no popover should sit flush against the panel edge).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the style panel Shape, Line, and spline dropdown popovers so they open with the same gap as the other dropdowns instead of flush against the panel.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -2    |
