### PR TITLE
feat(editor): make hit-test margin finer and coarse-pointer aware

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -724,6 +724,7 @@ export const defaultTldrawOptions: {
     readonly cameraSlideFriction: 0.09;
     readonly coarseDragDistanceSquared: 36;
     readonly coarseHandleRadius: 20;
+    readonly coarseHitTestMargin: 4;
     readonly coarsePointerWidth: 12;
     readonly collaboratorCheckIntervalMs: 1200;
     readonly collaboratorIdleTimeoutMs: 3000;
@@ -763,7 +764,7 @@ export const defaultTldrawOptions: {
         readonly step: 1;
     }];
     readonly handleRadius: 12;
-    readonly hitTestMargin: 8;
+    readonly hitTestMargin: 3;
     readonly laserDelayMs: 1200;
     readonly laserFadeoutMs: 500;
     readonly longPressDurationMs: 500;
@@ -1334,6 +1335,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getHighestIndexForParent(parent: TLPage | TLParentId | TLShape): IndexKey;
     getHintingShape(): NonNullable<TLShape | undefined>[];
     getHintingShapeIds(): TLShapeId[];
+    getHitTestMargin(): number;
     getHoveredShape(): TLShape | undefined;
     getHoveredShapeId(): null | TLShapeId;
     getInitialMetaForShape(_shape: TLShape): JsonObject;
@@ -3780,6 +3782,8 @@ export interface TldrawOptions {
     readonly coarseDragDistanceSquared: number;
     // (undocumented)
     readonly coarseHandleRadius: number;
+    // (undocumented)
+    readonly coarseHitTestMargin: number;
     // (undocumented)
     readonly coarsePointerWidth: number;
     // (undocumented)

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5797,6 +5797,22 @@ export class Editor extends EventEmitter<TLEventMap> {
 	}
 
 	/**
+	 * Get the hit-test margin in page space—the distance in page units within which a pointer is
+	 * considered to be touching a shape. This resolves to {@link TldrawOptions.hitTestMargin} (or
+	 * {@link TldrawOptions.coarseHitTestMargin} when using a coarse pointer) divided by the current
+	 * (efficient) zoom level, so it stays a constant distance in screen space.
+	 *
+	 * @returns The hit-test margin in page space.
+	 *
+	 * @public
+	 */
+	@computed getHitTestMargin(): number {
+		const { hitTestMargin, coarseHitTestMargin } = this.options
+		const margin = this.getInstanceState().isCoarsePointer ? coarseHitTestMargin : hitTestMargin
+		return margin / this.getEfficientZoomLevel()
+	}
+
+	/**
 	 * Get the top-most selected shape at the given point, ignoring groups.
 	 *
 	 * @param point - The point to check.
@@ -5820,7 +5836,6 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @returns The shape at the given point, or undefined if there is no shape at the point.
 	 */
 	getShapeAtPoint(point: VecLike, opts: TLGetShapeAtPointOptions = {}): TLShape | undefined {
-		const zoomLevel = this.getZoomLevel()
 		const viewportPageBounds = this.getViewportPageBounds()
 		const {
 			filter,
@@ -5840,7 +5855,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		let inMarginClosestToEdgeHit: TLShape | null = null
 
 		// Use larger margin for spatial search to account for edge distance checks
-		const searchMargin = Math.max(innerMargin, outerMargin, this.options.hitTestMargin / zoomLevel)
+		const searchMargin = Math.max(innerMargin, outerMargin, this.getHitTestMargin())
 		const candidateIds = this._spatialIndex.getShapeIdsAtPoint(point, searchMargin)
 
 		const shapesToCheck = (
@@ -6009,7 +6024,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// For open shapes (e.g. lines or draw shapes) always use the margin.
 				// If the distance is less than the margin, return the shape as the hit.
 				// Use the editor's configurable hit test margin.
-				if (distance < this.options.hitTestMargin / zoomLevel) {
+				if (distance < this.getHitTestMargin()) {
 					return shape
 				}
 			}

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -5800,7 +5800,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * Get the hit-test margin in page space—the distance in page units within which a pointer is
 	 * considered to be touching a shape. This resolves to {@link TldrawOptions.hitTestMargin} (or
 	 * {@link TldrawOptions.coarseHitTestMargin} when using a coarse pointer) divided by the current
-	 * (efficient) zoom level, so it stays a constant distance in screen space.
+	 * zoom level, so it stays a constant distance in screen space.
 	 *
 	 * @returns The hit-test margin in page space.
 	 *
@@ -5809,7 +5809,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 	@computed getHitTestMargin(): number {
 		const { hitTestMargin, coarseHitTestMargin } = this.options
 		const margin = this.getInstanceState().isCoarsePointer ? coarseHitTestMargin : hitTestMargin
-		return margin / this.getEfficientZoomLevel()
+		return margin / this.getZoomLevel()
 	}
 
 	/**

--- a/packages/editor/src/lib/options.ts
+++ b/packages/editor/src/lib/options.ts
@@ -86,6 +86,7 @@ export interface TldrawOptions {
 	readonly collaboratorCheckIntervalMs: number
 	readonly cameraMovingTimeoutMs: number
 	readonly hitTestMargin: number
+	readonly coarseHitTestMargin: number
 	readonly edgeScrollDelay: number
 	readonly edgeScrollEaseDuration: number
 	readonly edgeScrollSpeed: number
@@ -312,7 +313,8 @@ export const defaultTldrawOptions = {
 	collaboratorIdleTimeoutMs: 3000,
 	collaboratorCheckIntervalMs: 1200,
 	cameraMovingTimeoutMs: 64,
-	hitTestMargin: 8,
+	hitTestMargin: 3,
+	coarseHitTestMargin: 4,
 	edgeScrollDelay: 200,
 	edgeScrollEaseDuration: 200,
 	edgeScrollSpeed: 25,

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Erasing.ts
@@ -81,7 +81,6 @@ export class Erasing extends StateNode {
 	update() {
 		const { editor, excludedShapeIds } = this
 		const erasingShapeIds = editor.getErasingShapeIds()
-		const zoomLevel = editor.getZoomLevel()
 		const currentPagePoint = editor.inputs.getCurrentPagePoint()
 		const previousPagePoint = editor.inputs.getPreviousPagePoint()
 
@@ -89,7 +88,7 @@ export class Erasing extends StateNode {
 
 		// Otherwise, erasing shapes are all the shapes that were hit before plus any new shapes that are hit
 		const erasing = new Set<TLShapeId>(erasingShapeIds)
-		const minDist = this.editor.options.hitTestMargin / zoomLevel
+		const minDist = this.editor.getHitTestMargin()
 
 		// Create bounds around line segment with margin
 		const lineBounds = Box.FromPoints([previousPagePoint, currentPagePoint]).expandBy(minDist)

--- a/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
+++ b/packages/tldraw/src/lib/tools/EraserTool/childStates/Pointing.ts
@@ -5,7 +5,6 @@ export class Pointing extends StateNode {
 
 	override onEnter(info: TLPointerEventInfo) {
 		const onlyEraseTopShape = info.accelKey
-		const zoomLevel = this.editor.getZoomLevel()
 		const currentPageShapesSorted = this.editor.getCurrentPageRenderingShapesSorted()
 		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 
@@ -22,7 +21,7 @@ export class Pointing extends StateNode {
 			if (
 				this.editor.isPointInShape(shape, currentPagePoint, {
 					hitInside: false,
-					margin: this.editor.options.hitTestMargin / zoomLevel,
+					margin: this.editor.getHitTestMargin(),
 				})
 			) {
 				const hitShape = this.editor.getOutermostSelectableShape(shape)

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Crop/children/Idle.ts
@@ -52,7 +52,7 @@ export class Idle extends StateNode {
 				const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 				const hitOverlay = this.editor.overlays.getOverlayAtPoint(
 					currentPagePoint,
-					this.editor.options.hitTestMargin / this.editor.getZoomLevel()
+					this.editor.getHitTestMargin()
 				)
 				if (hitOverlay) {
 					const overlayType = hitOverlay.props.overlayType as string | undefined
@@ -157,7 +157,7 @@ export class Idle extends StateNode {
 			const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 			const hitOverlay = this.editor.overlays.getOverlayAtPoint(
 				currentPagePoint,
-				this.editor.options.hitTestMargin / this.editor.getZoomLevel()
+				this.editor.getHitTestMargin()
 			)
 			if (hitOverlay) {
 				const overlayType = hitOverlay.props.overlayType as string | undefined

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -73,7 +73,7 @@ export class Idle extends StateNode {
 				const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 				const hitOverlay = this.editor.overlays.getOverlayAtPoint(
 					currentPagePoint,
-					this.editor.options.hitTestMargin / this.editor.getZoomLevel()
+					this.editor.getHitTestMargin()
 				)
 				if (hitOverlay) {
 					this.onPointerDown({
@@ -276,7 +276,7 @@ export class Idle extends StateNode {
 				// onDoubleClickCorner fire.
 				const hitOverlay = this.editor.overlays.getOverlayAtPoint(
 					currentPagePoint,
-					this.editor.options.hitTestMargin / this.editor.getZoomLevel()
+					this.editor.getHitTestMargin()
 				)
 				if (hitOverlay) {
 					if (hitOverlay.type === 'shape_handle') {
@@ -320,7 +320,7 @@ export class Idle extends StateNode {
 						? hoveredShape
 						: (this.editor.getSelectedShapeAtPoint(currentPagePoint) ??
 							this.editor.getShapeAtPoint(currentPagePoint, {
-								margin: this.editor.options.hitTestMargin / this.editor.getZoomLevel(),
+								margin: this.editor.getHitTestMargin(),
 								hitInside: false,
 							}))
 
@@ -513,7 +513,7 @@ export class Idle extends StateNode {
 					hoveredShape && !this.editor.isShapeOfType(hoveredShape, 'group')
 						? hoveredShape
 						: this.editor.getShapeAtPoint(currentPagePoint, {
-								margin: this.editor.options.hitTestMargin / this.editor.getZoomLevel(),
+								margin: this.editor.getHitTestMargin(),
 								hitInside: false,
 								hitLabels: true,
 								hitLocked: true,

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -63,14 +63,13 @@ export class PointingShape extends StateNode {
 	override onPointerUp(info: TLPointerEventInfo) {
 		const selectedShapeIds = this.editor.getSelectedShapeIds()
 		const focusedGroupId = this.editor.getFocusedGroupId()
-		const zoomLevel = this.editor.getZoomLevel()
 		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 
 		const additiveSelectionKey = info.shiftKey || info.accelKey
 
 		const hitShape =
 			this.editor.getShapeAtPoint(currentPagePoint, {
-				margin: this.editor.options.hitTestMargin / zoomLevel,
+				margin: this.editor.getHitTestMargin(),
 				hitInside: true,
 				renderingOnly: true,
 			}) ?? this.hitShape

--- a/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
@@ -5,7 +5,6 @@ export function getHitShapeOnCanvasPointerDown(
 	editor: Editor,
 	hitLabels = false
 ): TLShape | undefined {
-	const zoomLevel = editor.getZoomLevel()
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
 	return (
@@ -14,7 +13,7 @@ export function getHitShapeOnCanvasPointerDown(
 			hitInside: false,
 			hitLabels,
 			hitLocked: editor.options.selectLockedShapes,
-			margin: editor.options.hitTestMargin / zoomLevel,
+			margin: editor.getHitTestMargin(),
 			renderingOnly: true,
 		}) ??
 		// selected shape at point

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -12,7 +12,7 @@ export function selectOnCanvasPointerUp(
 	const selectLockedShapes = editor.options.selectLockedShapes
 	const hitShape = editor.getShapeAtPoint(currentPagePoint, {
 		hitInside: false,
-		margin: editor.options.hitTestMargin / editor.getZoomLevel(),
+		margin: editor.getHitTestMargin(),
 		hitLabels: true,
 		hitLocked: selectLockedShapes,
 		renderingOnly: true,

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredOverlayId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredOverlayId.ts
@@ -11,7 +11,7 @@ export function updateHoveredOverlayId(editor: Editor): boolean {
 	if (editor.isDisposed) return false
 
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
-	const margin = editor.options.hitTestMargin / editor.getZoomLevel()
+	const margin = editor.getHitTestMargin()
 	const overlay = editor.overlays.getOverlayAtPoint(currentPagePoint, margin)
 
 	const previousOverlayId = editor.overlays.getHoveredOverlayId()

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -26,7 +26,7 @@ function getShapeToHover(editor: Editor): TLShapeId | null {
 		hitInside: false,
 		hitLabels: false,
 		hitLocked: editor.options.selectLockedShapes,
-		margin: editor.options.hitTestMargin / editor.getZoomLevel(),
+		margin: editor.getHitTestMargin(),
 		renderingOnly: true,
 	})
 

--- a/packages/tldraw/src/lib/ui/context/actions.tsx
+++ b/packages/tldraw/src/lib/ui/context/actions.tsx
@@ -1916,7 +1916,7 @@ export function ActionsProvider({ overrides, children }: ActionsProviderProps) {
 						hitInside: false,
 						hitLabels: false,
 						hitLocked: editor.options.selectLockedShapes,
-						margin: editor.options.hitTestMargin / editor.getZoomLevel(),
+						margin: editor.getHitTestMargin(),
 					})
 
 					const path = editor.getPath()

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1291,8 +1291,8 @@ describe('When dragging a shape', () => {
 		const rectId: TLShapeId = createRect({ pos: [70, 10], size: [20, 20] })
 		// create frame next to shape
 		const frameId = dragCreateFrame({ down: [0, 0], move: [60, 100], up: [60, 100] })
-		// drag shape into frame
-		editor.pointerDown(80, 15)
+		// drag shape into frame (grab near the rect's edge so it hits with a tight hit-test margin)
+		editor.pointerDown(80, 12)
 		editor.pointerMove(30, 50)
 		editor.pointerUp(30, 50)
 		const parent = editor.getShape(rectId)?.parentId

--- a/packages/tldraw/src/test/groups.test.tsx
+++ b/packages/tldraw/src/test/groups.test.tsx
@@ -1584,7 +1584,8 @@ describe('erasing', () => {
 		expect(editor.getCurrentPageState().erasingShapeIds.length).toBe(1)
 		expect(editor.getCurrentPageState().erasingShapeIds[0]).toBe(ids.boxE)
 
-		// move to group B
+		// move across box B (inside the focus layer) and into group B (outside it)
+		editor.pointerMove(25, 5)
 		editor.pointerMove(65, 5)
 
 		expect(editor.getErasingShapeIds().length).toBe(3)

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -64,11 +64,11 @@ describe('Hovering shapes', () => {
 
 	it('hovers the margins of hollow shapes but not their insides', () => {
 		expect(editor.getHoveredShapeId()).toBe(null)
-		editor.pointerMove(-4, 50)
+		editor.pointerMove(-2, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.box1)
 		editor.pointerMove(-50, 50)
 		expect(editor.getHoveredShapeId()).toBe(null)
-		editor.pointerMove(4, 50)
+		editor.pointerMove(2, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.box1)
 		editor.pointerMove(75, 75)
 		expect(editor.getHoveredShapeId()).toBe(null)
@@ -116,11 +116,11 @@ describe('Hovering shapes', () => {
 	it('hovers the margins or inside of filled shapes', () => {
 		editor.updateShape({ id: ids.box1, type: 'geo', props: { fill: 'solid' } })
 		expect(editor.getHoveredShapeId()).toBe(null)
-		editor.pointerMove(-4, 50)
+		editor.pointerMove(-2, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.box1)
 		editor.pointerMove(-50, 50)
 		expect(editor.getHoveredShapeId()).toBe(null)
-		editor.pointerMove(4, 50)
+		editor.pointerMove(2, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.box1)
 		editor.pointerMove(50, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.box1)
@@ -238,7 +238,7 @@ describe('when shape is filled', () => {
 	})
 
 	it('hits on pointer down over shape margin (outside)', () => {
-		editor.pointerMove(104, 50)
+		editor.pointerMove(102, 50)
 		expect(editor.getHoveredShapeId()).toBe(box1.id)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([box1.id])
@@ -321,7 +321,7 @@ describe('when shape is hollow', () => {
 	})
 
 	it('hits on pointer down over shape margin (inside)', () => {
-		editor.pointerMove(96, 50)
+		editor.pointerMove(98, 50)
 		expect(editor.getHoveredShapeId()).toBe(box1.id)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([box1.id])
@@ -330,7 +330,7 @@ describe('when shape is hollow', () => {
 	})
 
 	it('hits on pointer down over shape margin (outside)', () => {
-		editor.pointerMove(104, 50)
+		editor.pointerMove(102, 50)
 		expect(editor.getHoveredShapeId()).toBe(box1.id)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([box1.id])
@@ -476,7 +476,7 @@ describe('when shape is a frame', () => {
 	})
 
 	it('hits on pointer down over shape margin (inside)', () => {
-		editor.pointerMove(96, 50)
+		editor.pointerMove(98, 50)
 		expect(editor.getHoveredShapeId()).toBe(frame1.id)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([frame1.id])
@@ -485,7 +485,7 @@ describe('when shape is a frame', () => {
 	})
 
 	it('hits on pointer down over shape margin (outside)', () => {
-		editor.pointerMove(104, 50)
+		editor.pointerMove(102, 50)
 		expect(editor.getHoveredShapeId()).toBe(frame1.id)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([frame1.id])
@@ -623,7 +623,7 @@ describe('when shape is inside of a frame', () => {
 	})
 
 	it('hits frame on pointer down over shape margin (inside)', () => {
-		editor.pointerMove(96, 50)
+		editor.pointerMove(98, 50)
 		expect(editor.getHoveredShapeId()).toBe(frame1.id)
 		editor.pointerDown() // inside of box1, in margin of frame1
 		expect(editor.getSelectedShapeIds()).toEqual([frame1.id])
@@ -641,7 +641,7 @@ describe('when shape is inside of a frame', () => {
 	})
 
 	it('hits frame on pointer down over shape margin (outside)', () => {
-		editor.pointerMove(104, 25)
+		editor.pointerMove(102, 25)
 		expect(editor.getHoveredShapeId()).toBe(frame1.id)
 		editor.pointerDown()
 		expect(editor.getSelectedShapeIds()).toEqual([frame1.id])
@@ -1237,7 +1237,7 @@ for (const key of ['Shift', 'Control']) {
 
 		it('adds how shape to selection on pointer down when pointing margin', () => {
 			editor.keyDown(key)
-			editor.pointerMove(204, 50) // inside of box 2 margin
+			editor.pointerMove(202, 50) // inside of box 2 margin
 			expect(editor.getHoveredShapeId()).toBe(ids.box2)
 			editor.pointerDown()
 			editor.pointerUp()
@@ -1246,7 +1246,7 @@ for (const key of ['Shift', 'Control']) {
 
 		it('adds and removes hollow shape from selection on pointer up (without causing a double click) when pointing margin', () => {
 			editor.keyDown(key)
-			editor.pointerMove(204, 50) // inside of box 2 margin
+			editor.pointerMove(202, 50) // inside of box 2 margin
 			expect(editor.getHoveredShapeId()).toBe(ids.box2)
 			editor.pointerDown()
 			editor.pointerUp()
@@ -1351,7 +1351,7 @@ describe('when shift+selecting a group', () => {
 
 	it('adds to selection on pointer down when clicking in margin', () => {
 		editor.keyDown('Shift')
-		editor.pointerMove(304, 50)
+		editor.pointerMove(302, 50)
 		expect(editor.getHoveredShapeId()).toBe(ids.group1)
 		editor.pointerDown() // inside of box 2, inside of group 1
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.group1])
@@ -1780,8 +1780,8 @@ describe('right clicking', () => {
 	it('selects on right click', () => {
 		editor.createShapes([{ id: ids.box1, type: 'geo' }])
 		expect(editor.getSelectedShapeIds()).toEqual([])
-		editor.pointerMove(4, 4)
-		editor.rightClick(4, 4)
+		editor.pointerMove(2, 2)
+		editor.rightClick(2, 2)
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 	})
 
@@ -1955,13 +1955,13 @@ describe('When a shape is locked', () => {
 		editor.createShape({ id: ids.box3, x: 200, y: 200, type: 'geo', props: { w: 50, h: 50 } })
 
 		// Select the first shape
-		editor.pointerMove(60, 60)
+		editor.pointerMove(52, 52)
 		editor.pointerDown()
 		editor.pointerUp()
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
 
 		// Shift select the second shape
-		editor.pointerMove(210, 210)
+		editor.pointerMove(202, 202)
 		editor.keyDown('Shift')
 		editor.pointerDown()
 		editor.pointerUp()


### PR DESCRIPTION
In order to make shape hover and hit-testing feel right across input types, this PR makes the hit-test margin coarse-pointer aware. Fine pointers (mouse/trackpad) now use a tighter default margin, and coarse pointers (touch/pen) use a slightly larger one so imprecise input still lands on shapes. The margin calculation is centralized behind a new `Editor.getHitTestMargin()` computed getter that every hit-testing call site (hover, select, erase, crop) now shares. It's derived from the efficient zoom level, so the margin stays a constant distance in screen space at any zoom.

Specifically:

- Adds a `coarseHitTestMargin` option (default `4`), used when the pointer is coarse.
- Retunes the default `hitTestMargin` from `8` to `3` for fine pointers.
- Adds `Editor.getHitTestMargin()` and routes all call sites through it, removing the duplicated `options.hitTestMargin / zoomLevel` expression.

### Change type

- [x] `improvement`

### Test plan

1. With a mouse/trackpad, hover just outside a shape — you now need to be within ~3px of its edge/fill.
2. On a touch device or with a pen (coarse pointer), the margin is ~4px.
3. Zoom in and out; the hover/hit distance stays constant in screen space.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Make the shape hit-test margin pointer-aware: fine pointers (mouse/trackpad) use a tighter default of 3px and coarse pointers (touch/pen) use 4px. Configurable via the `hitTestMargin` and new `coarseHitTestMargin` options.

### API changes

- Added `Editor.getHitTestMargin()`, returning the current hit-test margin in page space (coarse-pointer aware and zoom-adjusted).
- Added the `coarseHitTestMargin` option (default `4`).
- Changed the default `hitTestMargin` from `8` to `3`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +35 / -22  |
| Automated files | +5 / -1    |
