### PR TITLE
feat(tldraw): hold cmd/ctrl to select the exact shape under the pointer

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -1490,6 +1490,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this._flushEventsForTick(0)
 		this.complete()
 		this.history.undo()
+		this._clearIsChangingStyleIfPointerIsOutsideSelection()
 		this.performance._notifyUndoRedo('undo', this.history.getNumUndos(), this.history.getNumRedos())
 		return this
 	}
@@ -1521,6 +1522,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this._flushEventsForTick(0)
 		this.complete()
 		this.history.redo()
+		this._clearIsChangingStyleIfPointerIsOutsideSelection()
 		this.performance._notifyUndoRedo('redo', this.history.getNumUndos(), this.history.getNumRedos())
 		return this
 	}
@@ -1973,6 +1975,27 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _isChangingStyleTimeout = -1 as any
 
+	private _clearIsChangingStyleIfPointerIsOutsideSelection() {
+		if (!this.getInstanceState().isChangingStyle) return
+
+		if (!this._isPointInRotatedSelectionBounds(this.inputs.getCurrentPagePoint())) {
+			this.updateInstanceState({ isChangingStyle: false })
+		}
+	}
+
+	private _isPointInRotatedSelectionBounds(point: VecLike) {
+		const selectionBounds = this.getSelectionRotatedPageBounds()
+		if (!selectionBounds) return false
+
+		const selectionRotation = this.getSelectionRotation()
+		if (!selectionRotation) return selectionBounds.containsPoint(point)
+
+		return pointInPolygon(
+			point,
+			selectionBounds.corners.map((c) => Vec.RotWith(c, selectionBounds.point, selectionRotation))
+		)
+	}
+
 	// Menus
 
 	menus = tlmenus.forContext(this.contextId)
@@ -2092,14 +2115,18 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	setSelectedShapes(shapes: TLShapeId[] | TLShape[]): this {
+		const ids = shapes.map((shape) => (typeof shape === 'string' ? shape : shape.id))
+		const { selectedShapeIds: prevSelectedShapeIds } = this.getCurrentPageState()
+		const prevSet = new Set(prevSelectedShapeIds)
+
+		if (ids.length === prevSet.size && ids.every((id) => prevSet.has(id))) return this
+
+		if (this.getInstanceState().isChangingStyle) {
+			this.updateInstanceState({ isChangingStyle: false })
+		}
+
 		return this.run(
 			() => {
-				const ids = shapes.map((shape) => (typeof shape === 'string' ? shape : shape.id))
-				const { selectedShapeIds: prevSelectedShapeIds } = this.getCurrentPageState()
-				const prevSet = new Set(prevSelectedShapeIds)
-
-				if (ids.length === prevSet.size && ids.every((id) => prevSet.has(id))) return null
-
 				this.store.put([{ ...this.getCurrentPageState(), selectedShapeIds: ids }])
 			},
 			{ history: 'record-preserveRedoStack' }
@@ -2178,6 +2205,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 	 * @public
 	 */
 	selectAll(): this {
+		if (this.getInstanceState().isChangingStyle) {
+			this.updateInstanceState({ isChangingStyle: false })
+		}
+
 		let parentToSelectWithinId: TLParentId | null = null
 
 		const selectedShapeIds = this.getSelectedShapeIds()

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Idle.ts
@@ -60,7 +60,10 @@ export class Idle extends StateNode {
 		if (!updateHoveredOverlayId(this.editor)) {
 			updateHoveredShapeId(this.editor)
 		}
-		if (unsafe__withoutCapture(() => this.editor.getInstanceState()).isChangingStyle) {
+		if (
+			unsafe__withoutCapture(() => this.editor.getInstanceState()).isChangingStyle &&
+			!isPointInRotatedSelectionBounds(this.editor, this.editor.inputs.getCurrentPagePoint())
+		) {
 			this.editor.updateInstanceState({ isChangingStyle: false })
 		}
 	}
@@ -99,9 +102,12 @@ export class Idle extends StateNode {
 				const onlySelectedShape = this.editor.getOnlySelectedShape()
 
 				if (
-					selectedShapeIds.length > 1 ||
-					(onlySelectedShape &&
-						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
+					!info.accelKey &&
+					(selectedShapeIds.length > 1 ||
+						(onlySelectedShape &&
+							!this.editor
+								.getShapeUtil(onlySelectedShape)
+								.hideSelectionBoundsBg(onlySelectedShape)))
 				) {
 					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
 						this.onPointerDown({
@@ -419,7 +425,10 @@ export class Idle extends StateNode {
 				// when the focus layer changes.
 				const selectedShapeIds = this.editor.getSelectedShapeIds()
 				const isGroup = this.editor.isShapeOfType(shape, 'group')
-				if (isGroup || this.editor.getOutermostSelectableShape(shape).id !== shape.id) {
+				if (
+					!info.accelKey &&
+					(isGroup || this.editor.getOutermostSelectableShape(shape).id !== shape.id)
+				) {
 					const shapeToSelect = this.editor.getOutermostSelectableShape(
 						shape,
 						(parent) => !selectedShapeIds.includes(parent.id)
@@ -494,9 +503,12 @@ export class Idle extends StateNode {
 				// Check selection bounds first so that right-clicking inside the
 				// selection preserves it, even when a filled shape sits behind it.
 				if (
-					selectedShapeIds.length > 1 ||
-					(onlySelectedShape &&
-						!this.editor.getShapeUtil(onlySelectedShape).hideSelectionBoundsBg(onlySelectedShape))
+					!info.accelKey &&
+					(selectedShapeIds.length > 1 ||
+						(onlySelectedShape &&
+							!this.editor
+								.getShapeUtil(onlySelectedShape)
+								.hideSelectionBoundsBg(onlySelectedShape)))
 				) {
 					if (isPointInRotatedSelectionBounds(this.editor, currentPagePoint)) {
 						this.onRightClick({
@@ -536,10 +548,12 @@ export class Idle extends StateNode {
 				const { selectedShapeIds } = this.editor.getCurrentPageState()
 				const { shape } = info
 
-				const targetShape = this.editor.getOutermostSelectableShape(
-					shape,
-					(parent) => !selectedShapeIds.includes(parent.id)
-				)
+				const targetShape = info.accelKey
+					? shape
+					: this.editor.getOutermostSelectableShape(
+							shape,
+							(parent) => !selectedShapeIds.includes(parent.id)
+						)
 
 				if (
 					!selectedShapeIds.includes(targetShape.id) &&
@@ -569,6 +583,14 @@ export class Idle extends StateNode {
 
 	override onKeyDown(info: TLKeyboardEventInfo) {
 		this.selectedShapesOnKeyDown = this.editor.getSelectedShapes()
+
+		if (info.key === 'Shift' || info.code === 'ShiftLeft') {
+			this.editor.updateInstanceState({ isChangingStyle: false })
+		}
+
+		if (info.accelKey) {
+			updateHoveredShapeId(this.editor)
+		}
 
 		switch (info.code) {
 			case 'ArrowLeft':
@@ -649,6 +671,10 @@ export class Idle extends StateNode {
 	}
 
 	override onKeyUp(info: TLKeyboardEventInfo) {
+		if ((info.key === 'Meta' || info.key === 'Control') && this.editor.inputs.getAccelKey()) {
+			this.editor.timers.setTimeout(() => updateHoveredShapeId(this.editor), 150)
+		}
+
 		switch (info.key) {
 			case 'Enter': {
 				// Because Enter onKeyDown can happen outside the canvas (but then focus the canvas potentially),

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingArrowLabel.ts
@@ -62,7 +62,7 @@ export class PointingArrowLabel extends StateNode {
 
 		this.markId = this.editor.markHistoryStoppingPoint('label-drag start')
 
-		const additiveSelectionKey = info.shiftKey || info.accelKey
+		const additiveSelectionKey = info.shiftKey
 		if (additiveSelectionKey) {
 			const selectedShapeIds = this.editor.getSelectedShapeIds()
 			this.editor.setSelectedShapes([...selectedShapeIds, this.shapeId])

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingCanvas.ts
@@ -5,7 +5,7 @@ export class PointingCanvas extends StateNode {
 	static override id = 'pointing_canvas'
 
 	override onEnter(info: TLPointerEventInfo & { target: 'canvas' }) {
-		const additiveSelectionKey = info.shiftKey || info.accelKey
+		const additiveSelectionKey = info.shiftKey
 
 		if (!additiveSelectionKey) {
 			if (this.editor.getSelectedShapeIds().length > 0) {

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingShape.ts
@@ -22,7 +22,9 @@ export class PointingShape extends StateNode {
 		this.hitShape = info.shape
 		this.isDoubleClick = false
 		this.didCtrlOnEnter = accelKey
-		const outermostSelectingShape = this.editor.getOutermostSelectableShape(info.shape)
+		const outermostSelectingShape = accelKey
+			? info.shape
+			: this.editor.getOutermostSelectableShape(info.shape)
 		const selectedAncestor = this.editor.findShapeAncestor(outermostSelectingShape, (parent) =>
 			selectedShapeIds.includes(parent.id)
 		)
@@ -66,7 +68,7 @@ export class PointingShape extends StateNode {
 		const zoomLevel = this.editor.getZoomLevel()
 		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
 
-		const additiveSelectionKey = info.shiftKey || info.accelKey
+		const additiveSelectionKey = info.shiftKey
 
 		const hitShape =
 			this.editor.getShapeAtPoint(currentPagePoint, {
@@ -84,7 +86,9 @@ export class PointingShape extends StateNode {
 		}
 
 		const selectingShape = hitShape
-			? this.editor.getOutermostSelectableShape(hitShape)
+			? info.accelKey
+				? hitShape
+				: this.editor.getOutermostSelectableShape(hitShape)
 			: this.hitShapeForPointerUp
 
 		if (selectingShape) {
@@ -116,12 +120,14 @@ export class PointingShape extends StateNode {
 			// if the shape has an ancestor which is a focusable layer and it is not focused but it is selected
 			// then we should focus the layer and select the shape
 
-			const outermostSelectableShape = this.editor.getOutermostSelectableShape(
-				hitShape,
-				// if a group is selected, we want to stop before reaching that group
-				// so we can drill down into the group
-				(parent) => !selectedShapeIds.includes(parent.id)
-			)
+			const outermostSelectableShape = info.accelKey
+				? hitShape
+				: this.editor.getOutermostSelectableShape(
+						hitShape,
+						// if a group is selected, we want to stop before reaching that group
+						// so we can drill down into the group
+						(parent) => !selectedShapeIds.includes(parent.id)
+					)
 
 			// If the outermost shape is selected, then either select or deselect the SELECTING shape
 			if (selectedShapeIds.includes(outermostSelectableShape.id)) {
@@ -137,7 +143,7 @@ export class PointingShape extends StateNode {
 						// handler to do this logic, and prevent the regular pointer up event, so we won't be here in that case.
 
 						// if the shape has a text label, and we're inside of the label, then we want to begin editing the label.
-						if (selectedShapeIds.length === 1) {
+						if (!info.accelKey && selectedShapeIds.length === 1) {
 							const geometry = this.editor.getShapeUtil(selectingShape).getGeometry(selectingShape)
 							const textLabels = getTextLabels(geometry)
 							const textLabel = textLabels.length === 1 ? textLabels[0] : undefined

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/Translating.ts
@@ -194,6 +194,9 @@ export class Translating extends StateNode {
 			this.editor,
 			this.snapshot.movingShapes.map((s) => s.id)
 		)
+		if (!this.isCreating && this.editor.getSelectedShapeIds().length > 1) {
+			this.editor.updateInstanceState({ isChangingStyle: true })
+		}
 
 		const { onInteractionEnd } = this.info
 		if (onInteractionEnd) {

--- a/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/getHitShapeOnCanvasPointerDown.ts
@@ -8,15 +8,18 @@ export function getHitShapeOnCanvasPointerDown(
 	const zoomLevel = editor.getZoomLevel()
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
+	const hitShape = editor.getShapeAtPoint(currentPagePoint, {
+		hitInside: false,
+		hitLabels,
+		hitLocked: editor.options.selectLockedShapes,
+		margin: editor.options.hitTestMargin / zoomLevel,
+		renderingOnly: true,
+	})
+
+	if (editor.inputs.getAccelKey()) return hitShape
+
 	return (
-		// hovered shape at point
-		editor.getShapeAtPoint(currentPagePoint, {
-			hitInside: false,
-			hitLabels,
-			hitLocked: editor.options.selectLockedShapes,
-			margin: editor.options.hitTestMargin / zoomLevel,
-			renderingOnly: true,
-		}) ??
+		hitShape ??
 		// selected shape at point
 		editor.getSelectedShapeAtPoint(currentPagePoint)
 	)

--- a/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/selectOnCanvasPointerUp.ts
@@ -7,7 +7,7 @@ export function selectOnCanvasPointerUp(
 	const selectedShapeIds = editor.getSelectedShapeIds()
 	const currentPagePoint = editor.inputs.getCurrentPagePoint()
 	const { shiftKey, altKey, accelKey } = info
-	const additiveSelectionKey = shiftKey || accelKey
+	const additiveSelectionKey = shiftKey
 
 	const selectLockedShapes = editor.options.selectLockedShapes
 	const hitShape = editor.getShapeAtPoint(currentPagePoint, {
@@ -28,7 +28,9 @@ export function selectOnCanvasPointerUp(
 	// we want to select the outermost selected shape instead of the shape
 
 	if (hitShape) {
-		const outermostSelectableShape = editor.getOutermostSelectableShape(hitShape)
+		const outermostSelectableShape = accelKey
+			? hitShape
+			: editor.getOutermostSelectableShape(hitShape)
 		// If the user is holding shift, they're either adding to or removing from
 		// their selection.
 		if (additiveSelectionKey && !altKey) {
@@ -41,12 +43,16 @@ export function selectOnCanvasPointerUp(
 			} else {
 				// Add it to selected shapes
 				editor.markHistoryStoppingPoint('shift selecting shape')
-				editor.setSelectedShapes([...selectedShapeIds, outermostSelectableShape.id])
+				const ancestors = editor.getShapeAncestors(outermostSelectableShape)
+				editor.setSelectedShapes([
+					...selectedShapeIds.filter((id) => !ancestors.find((ancestor) => ancestor.id === id)),
+					outermostSelectableShape.id,
+				])
 			}
 		} else {
 			let shapeToSelect: TLShape | undefined = undefined
 
-			if (outermostSelectableShape === hitShape) {
+			if (accelKey || outermostSelectableShape === hitShape) {
 				// There's no group around the shape, so we can select it.
 				shapeToSelect = hitShape
 			} else {

--- a/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
+++ b/packages/tldraw/src/lib/tools/selection-logic/updateHoveredShapeId.ts
@@ -32,6 +32,10 @@ function getShapeToHover(editor: Editor): TLShapeId | null {
 
 	if (!hitShape) return null
 
+	if (editor.inputs.getAccelKey()) {
+		return hitShape.id
+	}
+
 	let shapeToHover: TLShape | undefined = undefined
 
 	const outermostShape = editor.getOutermostSelectableShape(hitShape)

--- a/packages/tldraw/src/test/commands/nudge.test.ts
+++ b/packages/tldraw/src/test/commands/nudge.test.ts
@@ -308,7 +308,7 @@ describe('When nudging, the selection overlay is hidden...', () => {
 		editor.keyUp('ArrowUp')
 	})
 
-	it('Clears isChangingStyle when the pointer moves over the canvas', () => {
+	it('Keeps isChangingStyle true when the pointer moves inside the selection bounds', () => {
 		editor.setSelectedShapes([ids.boxA])
 
 		editor.keyDown('ArrowUp')
@@ -316,6 +316,80 @@ describe('When nudging, the selection overlay is hidden...', () => {
 		editor.keyUp('ArrowUp')
 
 		editor.pointerMove(50, 50)
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+	})
+
+	it('Clears isChangingStyle when the pointer moves outside the selection bounds', () => {
+		editor.setSelectedShapes([ids.boxA])
+
+		editor.keyDown('ArrowUp')
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+		editor.keyUp('ArrowUp')
+
+		editor.pointerMove(200, 200)
+		expect(editor.getInstanceState().isChangingStyle).toBe(false)
+	})
+
+	it('Clears isChangingStyle when shift is pressed', () => {
+		editor.setSelectedShapes([ids.boxA])
+
+		editor.keyDown('ArrowUp')
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+		editor.keyUp('ArrowUp')
+
+		editor.keyDown('Shift')
+		expect(editor.getInstanceState().isChangingStyle).toBe(false)
+		editor.keyUp('Shift')
+	})
+
+	it('Clears isChangingStyle when the selection changes', () => {
+		editor.setSelectedShapes([ids.boxA])
+
+		editor.keyDown('ArrowUp')
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+		editor.keyUp('ArrowUp')
+
+		editor.setSelectedShapes([ids.boxA, ids.boxB])
+		expect(editor.getInstanceState().isChangingStyle).toBe(false)
+	})
+
+	it('Clears isChangingStyle when select all is performed, even if the selection does not change', () => {
+		editor.selectAll()
+		expect(editor.getSelectedShapeIds()).toHaveLength(2)
+
+		editor.updateInstanceState({ isChangingStyle: true })
+		editor.selectAll()
+
+		expect(editor.getSelectedShapeIds()).toHaveLength(2)
+		expect(editor.getInstanceState().isChangingStyle).toBe(false)
+	})
+
+	it('Keeps isChangingStyle on undo and redo when the selection remains under the pointer', () => {
+		editor.setSelectedShapes([ids.boxA])
+		editor.pointerMove(50, 50)
+		editor.markHistoryStoppingPoint('move shape')
+		editor.updateShapes([{ id: ids.boxA, type: 'geo', x: 20, y: 20 }])
+		editor.updateInstanceState({ isChangingStyle: true })
+
+		editor.undo()
+		expect(editor.getShape(ids.boxA)).toMatchObject({ x: 10, y: 10 })
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+
+		editor.redo()
+		expect(editor.getShape(ids.boxA)).toMatchObject({ x: 20, y: 20 })
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+	})
+
+	it('Clears isChangingStyle on undo when the selection is no longer under the pointer', () => {
+		editor.setSelectedShapes([ids.boxA])
+		editor.updateShapes([{ id: ids.boxA, type: 'geo', x: 200, y: 200 }])
+		editor.pointerMove(50, 50)
+		editor.markHistoryStoppingPoint('move shape')
+		editor.updateShapes([{ id: ids.boxA, type: 'geo', x: 10, y: 10 }])
+		editor.updateInstanceState({ isChangingStyle: true })
+
+		editor.undo()
+		expect(editor.getShape(ids.boxA)).toMatchObject({ x: 200, y: 200 })
 		expect(editor.getInstanceState().isChangingStyle).toBe(false)
 	})
 

--- a/packages/tldraw/src/test/selection-omnibus.test.ts
+++ b/packages/tldraw/src/test/selection-omnibus.test.ts
@@ -34,6 +34,14 @@ beforeEach(() => {
 	editor.setScreenBounds({ w: 3000, h: 3000, x: 0, y: 0 })
 })
 
+function keyDownAccel() {
+	editor.keyDown(tlenv.isDarwin ? 'Meta' : 'Control')
+}
+
+function keyUpAccel() {
+	editor.keyUp(tlenv.isDarwin ? 'Meta' : 'Control')
+}
+
 it('lists a sorted shapes array correctly', () => {
 	editor.createShapes([
 		{ id: ids.box1, type: 'geo' },
@@ -1029,6 +1037,28 @@ describe('Selects inside of groups', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.group1])
 	})
 
+	it('hovers and selects the exact child in a group when accel is held', () => {
+		keyDownAccel()
+		editor.pointerMove(250, 50)
+		expect(editor.getHoveredShapeId()).toBe(ids.box2)
+
+		editor.click()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+		expect(editor.getFocusedGroupId()).toBe(ids.group1)
+	})
+
+	it('updates the hovered shape when accel is pressed or released', () => {
+		editor.pointerMove(250, 50)
+		expect(editor.getHoveredShapeId()).toBe(ids.group1)
+
+		keyDownAccel()
+		expect(editor.getHoveredShapeId()).toBe(ids.box2)
+
+		keyUpAccel()
+		vi.advanceTimersByTime(150)
+		expect(editor.getHoveredShapeId()).toBe(ids.group1)
+	})
+
 	it('drops selection when pointing up on the space between shapes in a group', () => {
 		editor.pointerMove(0, 0)
 		expect(editor.getHoveredShapeId()).toBe(ids.group1)
@@ -1169,6 +1199,18 @@ describe('Selects inside of groups', () => {
 		expect(editor.getFocusedGroupId()).toBe(ids.group1)
 	})
 
+	it('selects the exact child in a nested group when accel is held', () => {
+		nestGroup1()
+		keyDownAccel()
+		editor.pointerMove(250, 50)
+
+		expect(editor.getHoveredShapeId()).toBe(ids.box2)
+
+		editor.click()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box2])
+		expect(editor.getFocusedGroupId()).toBe(ids.group1)
+	})
+
 	it('treats a double click as two clicks through nested groups', () => {
 		nestGroup1()
 		editor.pointerMove(250, 50)
@@ -1248,136 +1290,178 @@ describe('when selecting behind selection', () => {
 	})
 })
 
-for (const key of ['Shift', 'Control']) {
-	describe('when additive+selecting', () => {
-		beforeEach(() => {
-			editor
-				.createShapes([
-					{ id: ids.box1, type: 'geo', x: 0, y: 0 },
-					{ id: ids.box2, type: 'geo', x: 200, y: 0 },
-					{ id: ids.box3, type: 'geo', x: 400, y: 0, props: { fill: 'solid' } },
-				])
-				.select(ids.box1)
-		})
+describe('when shift+selecting', () => {
+	const key = 'Shift'
 
-		it('adds solid shape to selection on pointer down / pointer up', () => {
-			editor.keyDown(key)
-			editor.pointerMove(450, 50) // inside of box 3
-			expect(editor.getHoveredShapeId()).toBe(ids.box3)
-			editor.pointerDown()
-
-			if (key === 'Shift') {
-				expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
-			} else {
-				expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			}
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
-		})
-
-		it('adds and removes solid shape from selection on pointer up (without causing a double click)', () => {
-			editor.keyDown(key)
-			editor.pointerMove(450, 50) // above box 3
-			expect(editor.getHoveredShapeId()).toBe(ids.box3)
-			editor.pointerDown()
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
-			editor.pointerDown()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		})
-
-		it('adds and removes solid shape from selection on double clicks (without causing an edit by double clicks)', () => {
-			editor.keyDown(key)
-			editor.pointerMove(450, 50) // above box 3
-			expect(editor.getHoveredShapeId()).toBe(ids.box3)
-			editor.doubleClick()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
-			editor.doubleClick()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		})
-
-		it('adds how shape to selection on pointer down when pointing margin', () => {
-			editor.keyDown(key)
-			editor.pointerMove(204, 50) // inside of box 2 margin
-			expect(editor.getHoveredShapeId()).toBe(ids.box2)
-			editor.pointerDown()
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
-		})
-
-		it('adds and removes hollow shape from selection on pointer up (without causing a double click) when pointing margin', () => {
-			editor.keyDown(key)
-			editor.pointerMove(204, 50) // inside of box 2 margin
-			expect(editor.getHoveredShapeId()).toBe(ids.box2)
-			editor.pointerDown()
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
-			editor.pointerDown()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		})
-
-		it('does not add hollow shape to selection on pointer up when in empty space', () => {
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.keyDown(key)
-			editor.pointerMove(215, 75) // above box 2
-			expect(editor.getHoveredShapeId()).toBe(null)
-			editor.pointerDown()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		})
-
-		it('does not add hollow shape to selection on pointer up when over the edge/label, but select on pointer up', () => {
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.keyDown(key)
-			editor.pointerMove(250, 50) // above box 2's label
-			expect(editor.getHoveredShapeId()).toBe(null)
-			editor.pointerDown()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
-		})
-
-		it('does not add and remove hollow shape from selection on pointer up (without causing an edit by double clicks)', () => {
-			editor.keyDown(key)
-			editor.pointerMove(215, 75) // above box 2, empty space
-			expect(editor.getHoveredShapeId()).toBe(null)
-			editor.pointerDown()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.pointerDown()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.pointerUp()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		})
-
-		it('does not add and remove hollow shape from selection on double clicks (without causing an edit by double clicks)', () => {
-			editor.keyDown(key)
-			editor.pointerMove(215, 75) // above box 2, empty space
-			expect(editor.getHoveredShapeId()).toBe(null)
-			editor.doubleClick()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-			editor.doubleClick()
-			expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
-		})
-
-		it('but holding shift prevents double clicking into label', () => {
-			// while selecting box 1...
-			editor.keyDown(key)
-			editor.pointerMove(450, 50) // inside of box 3
-			editor.pointerDown()
-			editor.pointerUp()
-			editor.pointerDown()
-			editor.pointerUp()
-			editor.expectToBeIn('select.idle')
-		})
+	beforeEach(() => {
+		editor
+			.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 200, y: 0 },
+				{ id: ids.box3, type: 'geo', x: 400, y: 0, props: { fill: 'solid' } },
+			])
+			.select(ids.box1)
 	})
-}
+
+	it('adds solid shape to selection on pointer down / pointer up', () => {
+		editor.keyDown(key)
+		editor.pointerMove(450, 50) // inside of box 3
+		expect(editor.getHoveredShapeId()).toBe(ids.box3)
+		editor.pointerDown()
+
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+	})
+
+	it('adds and removes solid shape from selection on pointer up (without causing a double click)', () => {
+		editor.keyDown(key)
+		editor.pointerMove(450, 50) // above box 3
+		expect(editor.getHoveredShapeId()).toBe(ids.box3)
+		editor.pointerDown()
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('adds and removes solid shape from selection on double clicks (without causing an edit by double clicks)', () => {
+		editor.keyDown(key)
+		editor.pointerMove(450, 50) // above box 3
+		expect(editor.getHoveredShapeId()).toBe(ids.box3)
+		editor.doubleClick()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		editor.doubleClick()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('adds how shape to selection on pointer down when pointing margin', () => {
+		editor.keyDown(key)
+		editor.pointerMove(204, 50) // inside of box 2 margin
+		expect(editor.getHoveredShapeId()).toBe(ids.box2)
+		editor.pointerDown()
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
+	})
+
+	it('adds and removes hollow shape from selection on pointer up (without causing a double click) when pointing margin', () => {
+		editor.keyDown(key)
+		editor.pointerMove(204, 50) // inside of box 2 margin
+		expect(editor.getHoveredShapeId()).toBe(ids.box2)
+		editor.pointerDown()
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('does not add hollow shape to selection on pointer up when in empty space', () => {
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.keyDown(key)
+		editor.pointerMove(215, 75) // above box 2
+		expect(editor.getHoveredShapeId()).toBe(null)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('does not add hollow shape to selection on pointer up when over the edge/label, but select on pointer up', () => {
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.keyDown(key)
+		editor.pointerMove(250, 50) // above box 2's label
+		expect(editor.getHoveredShapeId()).toBe(null)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box2])
+	})
+
+	it('does not add and remove hollow shape from selection on pointer up (without causing an edit by double clicks)', () => {
+		editor.keyDown(key)
+		editor.pointerMove(215, 75) // above box 2, empty space
+		expect(editor.getHoveredShapeId()).toBe(null)
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('does not add and remove hollow shape from selection on double clicks (without causing an edit by double clicks)', () => {
+		editor.keyDown(key)
+		editor.pointerMove(215, 75) // above box 2, empty space
+		expect(editor.getHoveredShapeId()).toBe(null)
+		editor.doubleClick()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.doubleClick()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+	})
+
+	it('but holding shift prevents double clicking into label', () => {
+		// while selecting box 1...
+		editor.keyDown(key)
+		editor.pointerMove(450, 50) // inside of box 3
+		editor.pointerDown()
+		editor.pointerUp()
+		editor.pointerDown()
+		editor.pointerUp()
+		editor.expectToBeIn('select.idle')
+	})
+})
+
+describe('when accel+selecting', () => {
+	beforeEach(() => {
+		editor
+			.createShapes([
+				{ id: ids.box1, type: 'geo', x: 0, y: 0 },
+				{ id: ids.box2, type: 'geo', x: 200, y: 0 },
+				{ id: ids.box3, type: 'geo', x: 400, y: 0, props: { fill: 'solid' } },
+			])
+			.select(ids.box1)
+	})
+
+	it('selects the hit shape instead of adding it to the existing selection', () => {
+		keyDownAccel()
+		editor.pointerMove(450, 50)
+		expect(editor.getHoveredShapeId()).toBe(ids.box3)
+
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+	})
+
+	it('does not deselect the hit shape on a second click', () => {
+		keyDownAccel()
+		editor.pointerMove(450, 50)
+
+		editor.click()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+
+		editor.click()
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
+	})
+
+	it('does not use the selected-shape bounds fallback as a hit target', () => {
+		editor.select(ids.box2)
+		keyDownAccel()
+		editor.pointerMove(215, 75)
+		expect(editor.getHoveredShapeId()).toBe(null)
+
+		editor.pointerDown()
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		editor.pointerUp()
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+})
 
 describe('when shift+selecting a group', () => {
 	beforeEach(() => {
@@ -2169,7 +2253,7 @@ describe('control pointing', () => {
 			.select(ids.box1)
 	})
 
-	it('selects on pointer up', () => {
+	it('selects the hit shape on pointer up', () => {
 		editor.keyDown('Control')
 		editor.pointerMove(450, 50) // inside of box 3
 		expect(editor.getHoveredShapeId()).toBe(ids.box3)
@@ -2180,7 +2264,7 @@ describe('control pointing', () => {
 
 		editor.pointerUp()
 		// now
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
 	})
 
 	it('brushes on pointer move', () => {
@@ -2225,17 +2309,17 @@ describe('control pointing', () => {
 		editor.expectToBeIn('select.editing_shape')
 	})
 
-	it('but holding ctrl double clicks without double clicking into label', () => {
+	it('but holding ctrl clicks without double clicking into label', () => {
 		// while selecting box 1...
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
 		editor.keyDown('Control')
 		editor.pointerMove(450, 50) // inside of box 3
 		editor.pointerDown()
 		editor.pointerUp()
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
 		editor.pointerDown()
 		editor.pointerUp()
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
 		editor.expectToBeIn('select.idle')
 	})
 
@@ -2264,7 +2348,7 @@ describe('control pointing', () => {
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box4])
 	})
 
-	it('selects on ctrl click when on a pc or other device', () => {
+	it('selects the hit shape on ctrl click when on a pc or other device', () => {
 		tlenv.isDarwin = false
 
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
@@ -2272,10 +2356,10 @@ describe('control pointing', () => {
 		editor.pointerMove(450, 50) // inside of box 3
 		editor.pointerDown()
 		editor.pointerUp()
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
 	})
 
-	it('selects on meta click when on a mac', () => {
+	it('selects the hit shape on meta click when on a mac', () => {
 		tlenv.isDarwin = true
 
 		expect(editor.getSelectedShapeIds()).toEqual([ids.box1])
@@ -2283,7 +2367,7 @@ describe('control pointing', () => {
 		editor.pointerMove(450, 50) // inside of box 3
 		editor.pointerDown()
 		editor.pointerUp()
-		expect(editor.getSelectedShapeIds()).toEqual([ids.box1, ids.box3])
+		expect(editor.getSelectedShapeIds()).toEqual([ids.box3])
 	})
 })
 

--- a/packages/tldraw/src/test/translating.test.ts
+++ b/packages/tldraw/src/test/translating.test.ts
@@ -198,6 +198,22 @@ describe('When translating...', () => {
 			.pointerUp()
 			.expectShapeToMatch({ id: ids.box1, x: 60, y: 60 }, { id: ids.box2, x: 250, y: 250 })
 	})
+
+	it('hides the selection overlay after translating multiple shapes until the pointer leaves the selection bounds', () => {
+		editor
+			.select(ids.box1, ids.box2)
+			.pointerDown(50, 50, ids.box1)
+			.pointerMove(100, 100)
+			.pointerUp()
+
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+
+		editor.pointerMove(100, 100)
+		expect(editor.getInstanceState().isChangingStyle).toBe(true)
+
+		editor.pointerMove(500, 500)
+		expect(editor.getInstanceState().isChangingStyle).toBe(false)
+	})
 })
 
 describe('When cloning...', () => {


### PR DESCRIPTION
In order to let people reach into groups and stacked shapes without changing focus, this PR repurposes the accel key (cmd on mac, ctrl elsewhere) in the select tool. Previously accel acted as a second additive-selection key alongside shift. Now holding accel drills straight to the exact shape under the pointer — bypassing groups and focus layers — and replaces the current selection instead of adding to it. Hover updates live as accel is pressed and released so you can preview what you're about to select. Shift keeps its existing additive-selection behavior.

This PR also refines the selection overlay's `isChangingStyle` flag (which hides the overlay while you nudge or restyle a shape) so it only clears when the pointer actually leaves the selection bounds, rather than on any pointer move. It now also clears when you press shift, change the selection, select all, or undo/redo to a state where the selection is no longer under the pointer, and is set while translating multiple shapes.

### Change type

- [x] `improvement`

### Test plan

1. Create a group of shapes, or stack a small shape on top of a larger filled one.
2. Hold cmd/ctrl and hover a child shape — the exact shape under the pointer highlights.
3. Click while holding cmd/ctrl — only that shape is selected, and the group stays focused.
4. Release cmd/ctrl — hover returns to the outermost selectable shape.
5. Nudge a shape with the arrow keys, then move the pointer inside the selection (overlay stays hidden) and then outside it (overlay reappears).

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section   | LOC change  |
| --------- | ----------- |
| Core code | +122 / -46  |
| Tests     | +303 / -129 |

### Release notes

- Hold cmd (or ctrl) in the select tool to select the exact shape under the pointer, drilling into groups and past overlapping shapes without changing focus.
