### PR TITLE
fix(editor): ignore stale font load callbacks

### DIFF
--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
@@ -160,15 +160,53 @@ describe('FontManager', () => {
 					),
 				}
 			})
-			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+			const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
 
 			const promise = fontManager.ensureFontIsLoaded(font)
 			fontManager.dispose()
 			rejectLoad(error)
 
 			await expect(promise).resolves.toBeUndefined()
-			expect(consoleSpy).not.toHaveBeenCalled()
-			consoleSpy.mockRestore()
+			expect(errorSpy).not.toHaveBeenCalled()
+			expect(debugSpy).toHaveBeenCalledWith(
+				`Font "${font.family}" load interrupted by editor dispose`,
+				error
+			)
+			errorSpy.mockRestore()
+			debugSpy.mockRestore()
+		})
+
+		it('ignores font loads that finish after disposal', async () => {
+			const font = createMockFont()
+			let resolveLoad: () => void = () => {}
+			;(global.FontFace as Mock).mockImplementationOnce(function (family, src, descriptors) {
+				return {
+					family,
+					src,
+					...descriptors,
+					load: vi.fn(
+						() =>
+							new Promise<void>((resolve) => {
+								resolveLoad = resolve
+							})
+					),
+				}
+			})
+			const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {})
+
+			const promise = fontManager.ensureFontIsLoaded(font)
+			fontManager.dispose()
+			resolveLoad()
+
+			await expect(promise).resolves.toBeUndefined()
+			// only the creation-time add from findOrCreateFontFace, not a second
+			// post-load add after dispose
+			expect(document.fonts.add).toHaveBeenCalledTimes(1)
+			expect(debugSpy).toHaveBeenCalledWith(
+				`Font "${font.family}" load interrupted by editor dispose`
+			)
+			debugSpy.mockRestore()
 		})
 	})
 

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
@@ -142,6 +142,34 @@ describe('FontManager', () => {
 
 			await secondPromise
 		})
+
+		it('ignores font load failures after disposal', async () => {
+			const font = createMockFont()
+			const error = new Error('Font load failed')
+			let rejectLoad: (err: Error) => void = () => {}
+			;(global.FontFace as Mock).mockImplementationOnce(function (family, src, descriptors) {
+				return {
+					family,
+					src,
+					...descriptors,
+					load: vi.fn(
+						() =>
+							new Promise<void>((_, reject) => {
+								rejectLoad = reject
+							})
+					),
+				}
+			})
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+			const promise = fontManager.ensureFontIsLoaded(font)
+			fontManager.dispose()
+			rejectLoad(error)
+
+			await expect(promise).resolves.toBeUndefined()
+			expect(consoleSpy).not.toHaveBeenCalled()
+			consoleSpy.mockRestore()
+		})
 	})
 
 	describe('getShapeFontFaces', () => {

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -106,25 +106,32 @@ export class FontManager {
 		if (existingState) return existingState.loadingPromise
 
 		const instance = this.findOrCreateFontFace(font)
-		const updateState = (updater: (state: FontState) => FontState) => {
-			if (this.fontStates.__unsafe__getWithoutCapture(font) !== state) return false
-			this.fontStates.update(font, updater)
-			return true
-		}
+		// dispose() clears fontStates while loads may still be in flight, so a late
+		// callback must only touch the exact entry it was created for - not a fresh
+		// entry from a later request. Check identity, not just presence.
+		const isStale = () => this.fontStates.__unsafe__getWithoutCapture(font) !== state
 		const state: FontState = {
 			state: 'loading',
 			instance,
 			loadingPromise: instance
 				.load()
 				.then(() => {
-					if (this.fontStates.__unsafe__getWithoutCapture(font) !== state) return
+					if (isStale()) {
+						// eslint-disable-next-line no-console
+						console.debug(`Font "${font.family}" load interrupted by editor dispose`)
+						return
+					}
 					this.editor.getContainerDocument().fonts.add(instance)
-					updateState((s) => ({ ...s, state: 'ready' }))
+					this.fontStates.update(font, (s) => ({ ...s, state: 'ready' }))
 				})
 				.catch((err) => {
-					if (this.fontStates.__unsafe__getWithoutCapture(font) !== state) return
+					if (isStale()) {
+						// eslint-disable-next-line no-console
+						console.debug(`Font "${font.family}" load interrupted by editor dispose`, err)
+						return
+					}
 					console.error(err)
-					updateState((s) => ({ ...s, state: 'error' }))
+					this.fontStates.update(font, (s) => ({ ...s, state: 'error' }))
 				}),
 		}
 

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -106,18 +106,25 @@ export class FontManager {
 		if (existingState) return existingState.loadingPromise
 
 		const instance = this.findOrCreateFontFace(font)
+		const updateState = (updater: (state: FontState) => FontState) => {
+			if (this.fontStates.__unsafe__getWithoutCapture(font) !== state) return false
+			this.fontStates.update(font, updater)
+			return true
+		}
 		const state: FontState = {
 			state: 'loading',
 			instance,
 			loadingPromise: instance
 				.load()
 				.then(() => {
+					if (this.fontStates.__unsafe__getWithoutCapture(font) !== state) return
 					this.editor.getContainerDocument().fonts.add(instance)
-					this.fontStates.update(font, (s) => ({ ...s, state: 'ready' }))
+					updateState((s) => ({ ...s, state: 'ready' }))
 				})
 				.catch((err) => {
+					if (this.fontStates.__unsafe__getWithoutCapture(font) !== state) return
 					console.error(err)
-					this.fontStates.update(font, (s) => ({ ...s, state: 'error' }))
+					updateState((s) => ({ ...s, state: 'error' }))
 				}),
 		}
 


### PR DESCRIPTION
In order to prevent failed font loads from crashing after an editor is disposed, this PR makes `FontManager` ignore stale font load callbacks when their tracked font state has already been cleared. Closes #9114.

Stale callbacks are detected by identity, not presence: a callback only updates the exact state entry it was created for, so a font re-requested after `dispose()` (which acts as a reset) can never be touched by a leftover callback from before the reset. Interrupted loads are logged at debug level instead of silently swallowed, so a genuine font failure in a short-lived editor is still visible in verbose console output without contributing error noise.

### Change type

- [x] `bugfix`

### Test plan

1. Navigate away from a file while a custom font load is pending, then let the load fail.
2. Confirm the stale callback does not throw `AtomMap: key [object Object] not found`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix a crash that could happen when a font failed to load after an editor was disposed.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +14 / -0   |
| Tests     | +66 / -0   |
