### PR TITLE
fix(sync): handle invalid R2 asset keys

### DIFF
--- a/apps/dotcom/client/src/utils/multiplayerAssetStore.ts
+++ b/apps/dotcom/client/src/utils/multiplayerAssetStore.ts
@@ -3,13 +3,17 @@ import { loadLocalFile } from '../tla/utils/slurping'
 import { USER_CONTENT_URL } from './config'
 import { isDevelopmentEnv, isPreviewEnv } from './env'
 
+const MAX_R2_OBJECT_NAME_BYTES = 1024
+
 // Assets are uploaded to and served from a separate tldrawusercontent worker (USER_CONTENT_URL).
 // Same R2 bucket as before — the worker just adds auth gating and Cloudflare Image Transformations.
 // For app files, a fileId query param triggers server-side write-access validation and DB association.
 async function getUrl(file: File, fileId: string | undefined) {
 	const id = uniqueId()
 
-	const objectName = `${id}-${file.name}`.replace(/\W/g, '-')
+	const namePrefix = `${id}-`
+	const maxFileNameLength = MAX_R2_OBJECT_NAME_BYTES - namePrefix.length
+	const objectName = namePrefix + file.name.replace(/\W/g, '-').slice(0, maxFileNameLength)
 	const url = `${USER_CONTENT_URL}/${objectName}`
 	if (fileId) {
 		return {

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -49,7 +49,7 @@ import {
 	retry,
 	uniqueId,
 } from '@tldraw/utils'
-import { createSentry } from '@tldraw/worker-shared'
+import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
@@ -807,7 +807,11 @@ export class TLFileDurableObject extends DurableObject {
 							!assetSrc.startsWith('data:')
 						) {
 							const objectName = new URL(assetSrc).pathname.split('/').pop()
-							if (objectName && assetObjectNames.has(objectName)) {
+							if (
+								objectName &&
+								assetObjectNames.has(objectName) &&
+								isValidR2ObjectName(objectName)
+							) {
 								const blob = await env.UPLOADS.get(objectName)
 								if (blob) {
 									const ab = await blob.arrayBuffer()
@@ -1156,6 +1160,8 @@ export class TLFileDurableObject extends DurableObject {
 		await Promise.allSettled(
 			assetsToReplace.map(async (asset) => {
 				try {
+					if (!isValidR2ObjectName(asset.objectName)) return
+
 					const currentAsset = await this.env.UPLOADS.get(asset.objectName)
 					if (!currentAsset) return
 					await this.env.UPLOADS.put(asset.newObjectName, currentAsset.body, {

--- a/packages/worker-shared/src/index.ts
+++ b/packages/worker-shared/src/index.ts
@@ -17,5 +17,6 @@ export {
 	TRANSIENT_RETRY_OPTIONS,
 	handleUserAssetGet,
 	handleUserAssetUpload,
+	isValidR2ObjectName,
 	type R2BucketLike,
 } from './userAssetUploads'

--- a/packages/worker-shared/src/userAssetUploads.test.ts
+++ b/packages/worker-shared/src/userAssetUploads.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	MAX_R2_OBJECT_NAME_BYTES,
+	handleUserAssetGet,
+	handleUserAssetUpload,
+} from './userAssetUploads'
+
+describe('userAssetUploads', () => {
+	const match = vi.fn()
+	const putCache = vi.fn()
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		match.mockResolvedValue(undefined)
+		putCache.mockResolvedValue(undefined)
+		vi.stubGlobal('caches', {
+			default: {
+				match,
+				put: putCache,
+			},
+		})
+	})
+
+	describe('handleUserAssetGet', () => {
+		it('returns 400 without calling R2 when the object name is too long', async () => {
+			const bucket = {
+				head: vi.fn(),
+				get: vi.fn(),
+				put: vi.fn(),
+			}
+			const response = await handleUserAssetGet({
+				request: new Request('https://example.com/assets/too-long') as any,
+				bucket,
+				objectName: 'a'.repeat(MAX_R2_OBJECT_NAME_BYTES + 1),
+				context: { waitUntil: vi.fn() } as any,
+			})
+
+			expect(response.status).toBe(400)
+			expect(await response.json()).toEqual({ error: 'Invalid object name' })
+			expect(bucket.get).not.toHaveBeenCalled()
+			expect(match).not.toHaveBeenCalled()
+		})
+
+		it('returns 400 when R2 rejects a valid-looking object name as invalid', async () => {
+			const bucket = {
+				head: vi.fn(),
+				get: vi
+					.fn()
+					.mockRejectedValue(new Error('get: The specified object name is not valid. (10020)')),
+				put: vi.fn(),
+			}
+			const response = await handleUserAssetGet({
+				request: new Request('https://example.com/assets/test') as any,
+				bucket,
+				objectName: 'test',
+				context: { waitUntil: vi.fn() } as any,
+			})
+
+			expect(response.status).toBe(400)
+			expect(await response.json()).toEqual({ error: 'Invalid object name' })
+			expect(bucket.get).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('handleUserAssetUpload', () => {
+		it('returns 400 without calling R2 when the object name is too long', async () => {
+			const bucket = {
+				head: vi.fn(),
+				get: vi.fn(),
+				put: vi.fn(),
+			}
+			const response = await handleUserAssetUpload({
+				body: null,
+				headers: new Headers(),
+				bucket,
+				objectName: 'a'.repeat(MAX_R2_OBJECT_NAME_BYTES + 1),
+			})
+
+			expect(response.status).toBe(400)
+			expect(await response.json()).toEqual({ error: 'Invalid object name' })
+			expect(bucket.head).not.toHaveBeenCalled()
+			expect(bucket.put).not.toHaveBeenCalled()
+		})
+
+		it('returns 400 when R2 rejects a valid-looking object name as invalid', async () => {
+			const bucket = {
+				head: vi
+					.fn()
+					.mockRejectedValue(new Error('get: The specified object name is not valid. (10020)')),
+				get: vi.fn(),
+				put: vi.fn(),
+			}
+			const response = await handleUserAssetUpload({
+				body: null,
+				headers: new Headers(),
+				bucket,
+				objectName: 'test',
+			})
+
+			expect(response.status).toBe(400)
+			expect(await response.json()).toEqual({ error: 'Invalid object name' })
+			expect(bucket.head).toHaveBeenCalledTimes(1)
+			expect(bucket.put).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/packages/worker-shared/src/userAssetUploads.ts
+++ b/packages/worker-shared/src/userAssetUploads.ts
@@ -2,11 +2,28 @@ import { retry } from '@tldraw/utils'
 import { IRequest } from 'itty-router'
 import { notFound } from './errors'
 
+export const MAX_R2_OBJECT_NAME_BYTES = 1024
+
 function isTransientWorkerError(error: unknown): boolean {
 	const msg = String(error)
 	return /internal error|connectivity|network connection lost|service temporarily unavailable|proxy request failed|unspecified error|connection (refused|reset|timed?\s?out)/i.test(
 		msg
 	)
+}
+
+function isInvalidObjectNameError(error: unknown): boolean {
+	const msg = String(error)
+	return msg.includes('The specified object name is not valid') || msg.includes('(10020)')
+}
+
+export function isValidR2ObjectName(objectName: string): boolean {
+	return (
+		objectName.length > 0 && new TextEncoder().encode(objectName).length <= MAX_R2_OBJECT_NAME_BYTES
+	)
+}
+
+function invalidObjectNameResponse() {
+	return Response.json({ error: 'Invalid object name' }, { status: 400 })
 }
 
 export const TRANSIENT_RETRY_OPTIONS = {
@@ -71,20 +88,27 @@ export async function handleUserAssetUpload({
 	body: ReadableStream | null
 	headers: Headers
 }): Promise<Response> {
-	const existing = await retry(() => bucket.head(objectName), TRANSIENT_RETRY_OPTIONS)
-	if (existing) {
-		return Response.json({ error: 'Asset already exists' }, { status: 409 })
+	if (!isValidR2ObjectName(objectName)) return invalidObjectNameResponse()
+
+	try {
+		const existing = await retry(() => bucket.head(objectName), TRANSIENT_RETRY_OPTIONS)
+		if (existing) {
+			return Response.json({ error: 'Asset already exists' }, { status: 409 })
+		}
+
+		// Buffer body so retries can re-send (ReadableStream is single-use)
+		const buffer = body ? await new Response(body).arrayBuffer() : null
+
+		const object = await retry(
+			() => bucket.put(objectName, buffer, { httpMetadata: headers }),
+			TRANSIENT_RETRY_OPTIONS
+		)
+
+		return Response.json({ object: objectName }, { headers: { etag: object.httpEtag } })
+	} catch (error) {
+		if (isInvalidObjectNameError(error)) return invalidObjectNameResponse()
+		throw error
 	}
-
-	// Buffer body so retries can re-send (ReadableStream is single-use)
-	const buffer = body ? await new Response(body).arrayBuffer() : null
-
-	const object = await retry(
-		() => bucket.put(objectName, buffer, { httpMetadata: headers }),
-		TRANSIENT_RETRY_OPTIONS
-	)
-
-	return Response.json({ object: objectName }, { headers: { etag: object.httpEtag } })
 }
 
 /**
@@ -127,6 +151,8 @@ export async function handleUserAssetGet({
 	objectName: string
 	context: ExecutionContext
 }): Promise<Response> {
+	if (!isValidR2ObjectName(objectName)) return invalidObjectNameResponse()
+
 	// this cache automatically handles range responses etc.
 	const cacheKey = new Request(request.url, { headers: request.headers })
 	const cachedResponse = await caches.default.match(cacheKey)
@@ -134,10 +160,16 @@ export async function handleUserAssetGet({
 		return cachedResponse
 	}
 
-	const object = await retry(
-		() => bucket.get(objectName, { range: request.headers, onlyIf: request.headers }),
-		TRANSIENT_RETRY_OPTIONS
-	)
+	let object
+	try {
+		object = await retry(
+			() => bucket.get(objectName, { range: request.headers, onlyIf: request.headers }),
+			TRANSIENT_RETRY_OPTIONS
+		)
+	} catch (error) {
+		if (isInvalidObjectNameError(error)) return invalidObjectNameResponse()
+		throw error
+	}
 
 	if (!object) {
 		return notFound()


### PR DESCRIPTION
In order to prevent malformed asset object names from surfacing as sync-worker Sentry errors, this PR validates R2 asset keys before calling R2 and converts Cloudflare invalid object-name errors into 400 responses. This likely happens when an uploaded asset has an extremely long original filename; before this change, the client included that filename in the R2 object name, so a 10,000-character filename could exceed R2 object key limits and trigger `10020`. This PR also caps generated upload object names so long filenames do not exceed R2 limits.

### Change type

- [x] `bugfix`

### Test plan

1. Upload or request an asset with an object name longer than R2 allows and confirm the worker returns 400 instead of reporting an internal error.
2. Open or download a file containing a stale malformed asset URL and confirm invalid asset object names are skipped instead of reported to Sentry.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix uploaded asset handling for invalid R2 object names.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +48 / -15  |
| Tests     | +106 / -0  |
| Apps      | +13 / -3   |