### PR TITLE
fix(tldraw): prevent frame heading crash when text spans can't be measured

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.test.ts
@@ -420,6 +420,48 @@ describe('TextManager', () => {
 			expect(Array.isArray(result)).toBe(true)
 		})
 
+		it('should not throw when the truncated remeasure yields no spans', () => {
+			// The text truncates on the first pass, but once we narrow the width
+			// to make room for the ellipsis, nothing measurable remains (e.g. the
+			// measurement element can't be laid out). This must not crash.
+			vi.spyOn(textManager, 'measureElementTextNodeSpans')
+				.mockReturnValueOnce({
+					spans: [{ text: 'Hello Wo', box: { x: 0, y: 0, w: 80, h: 16 } }],
+					didTruncate: true,
+				})
+				.mockReturnValueOnce({
+					spans: [{ text: '…', box: { x: 0, y: 0, w: 10, h: 16 } }],
+					didTruncate: false,
+				})
+				.mockReturnValueOnce({
+					spans: [],
+					didTruncate: false,
+				})
+
+			const opts = { ...defaultOpts, overflow: 'truncate-ellipsis' as const }
+			let result: ReturnType<typeof textManager.measureTextSpans> | undefined
+			expect(() => (result = textManager.measureTextSpans('Hello World', opts))).not.toThrow()
+			expect(result).toEqual([])
+		})
+
+		it('should not throw when the ellipsis itself cannot be measured', () => {
+			// If measuring the ellipsis returns no spans, fall back to a zero width
+			// rather than dereferencing a missing span.
+			vi.spyOn(textManager, 'measureElementTextNodeSpans')
+				.mockReturnValueOnce({
+					spans: [{ text: 'Hello Wo', box: { x: 0, y: 0, w: 80, h: 16 } }],
+					didTruncate: true,
+				})
+				.mockReturnValueOnce({ spans: [], didTruncate: false })
+				.mockReturnValueOnce({
+					spans: [{ text: 'Hello Wo', box: { x: 0, y: 0, w: 80, h: 16 } }],
+					didTruncate: false,
+				})
+
+			const opts = { ...defaultOpts, overflow: 'truncate-ellipsis' as const }
+			expect(() => textManager.measureTextSpans('Hello World', opts)).not.toThrow()
+		})
+
 		it('should handle truncate-clip overflow', () => {
 			vi.spyOn(textManager, 'measureElementTextNodeSpans').mockReturnValue({
 				spans: [

--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -435,7 +435,8 @@ export class TextManager extends EditorManager {
 			if (opts.overflow === 'truncate-ellipsis' && didTruncate) {
 				// we need to measure the ellipsis to know how much space it takes up
 				elm.textContent = '…'
-				const ellipsisWidth = Math.ceil(this.measureElementTextNodeSpans(elm).spans[0].box.w)
+				const ellipsisSpan = this.measureElementTextNodeSpans(elm).spans[0]
+				const ellipsisWidth = ellipsisSpan ? Math.ceil(ellipsisSpan.box.w) : 0
 
 				// then, we need to subtract that space from the width we have and measure again:
 				elm.style.setProperty('width', `${elementWidth - ellipsisWidth}px`)
@@ -448,7 +449,12 @@ export class TextManager extends EditorManager {
 				// have to do this after measuring, not before, because adding the
 				// ellipsis changes how whitespace might be getting collapsed by the
 				// browser.
-				const lastSpan = truncatedSpans[truncatedSpans.length - 1]!
+				const lastSpan = truncatedSpans[truncatedSpans.length - 1]
+				// If nothing measurable remained, return the (possibly empty)
+				// spans as-is rather than dereferencing a missing last span.
+				if (!lastSpan) {
+					return truncatedSpans
+				}
 				truncatedSpans.push({
 					text: '…',
 					box: {

--- a/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
+++ b/packages/tldraw/src/lib/shapes/frame/frameHelpers.ts
@@ -54,7 +54,16 @@ export function getFrameHeadingSize(
 		const frameTitle = defaultEmptyAs(shape.props.name, 'Frame') + String.fromCharCode(8203)
 		const spans = editor.textMeasure.measureTextSpans(frameTitle, opts)
 		const firstSpan = spans[0]
-		const lastSpan = last(spans)!
+		const lastSpan = last(spans)
+
+		if (!firstSpan || !lastSpan) {
+			// measureTextSpans can return no spans when the text can't be laid
+			// out yet — e.g. the measurement element isn't attached/visible
+			// during the initial editor mount, or every grapheme lacks a layout
+			// rect. Fall back to a zero-width heading and don't cache it, so the
+			// heading is remeasured once measurement is possible.
+			return new Box(0, -opts.height, 0, opts.height)
+		}
 
 		width = lastSpan.box.w + lastSpan.box.x - firstSpan.box.x
 		measurementWeakmap.set(shape.props, width)


### PR DESCRIPTION
In order to stop a `TypeError: Cannot read properties of undefined (reading 'box')` crash when computing frame geometry, this PR makes `getFrameHeadingSize` tolerate `measureTextSpans` returning an empty array. That happens when the text measurement element can't be laid out — for example during the initial editor mount, where the spatial index is built synchronously inside `new Editor()` before the measurement element is attached/visible, or when every grapheme lacks a layout rect (the case the #9112 fix started skipping). Previously the code did `last(spans)!` and immediately dereferenced `.box`, crashing whenever `spans` was empty.

The fix guards the empty-spans case in `getFrameHeadingSize` (returning a zero-width heading, uncached, so it's remeasured once layout is possible) and hardens the identical latent dereference in `TextManager`'s `truncate-ellipsis` path.

Relates to #9112.

### Change type

- [x] `bugfix`

### Test plan

Because `getFrameHeadingSize` short-circuits when `NODE_ENV === 'test'` and never calls `measureTextSpans`, this crash can't be reproduced through frame geometry in unit tests, so regression coverage lives at the `TextManager` level (the shared root cause).

1. Add a frame to a canvas and confirm the heading renders normally.
2. Confirm no crash occurs when an editor mounts with an existing frame present.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +18 / -3   |
| Tests     | +42 / -0   |

### Release notes

- Fix a crash when computing a frame's geometry if its heading text couldn't be measured yet.