### PR TITLE
fix(arrows): defer handle double click toggle

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeTool.test.ts
@@ -22,6 +22,7 @@ const ids = {
 	box1: createShapeId('box1'),
 	box2: createShapeId('box2'),
 	box3: createShapeId('box3'),
+	arrow1: createShapeId('arrow1'),
 }
 
 function bindings(id: TLShapeId) {
@@ -133,6 +134,72 @@ describe('When dragging the arrow', () => {
 		const shapesAfter = editor.getCurrentPageShapes().length
 		expect(shapesAfter).toBe(shapesBefore)
 		editor.expectToBeIn('arrow.idle')
+	})
+})
+
+describe('When double-clicking an arrow handle', () => {
+	function createArrow() {
+		editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+		editor.createShapes([
+			{
+				id: ids.arrow1,
+				type: 'arrow',
+				x: 0,
+				y: 0,
+				props: {
+					start: { x: 0, y: 0 },
+					end: { x: 100, y: 100 },
+					arrowheadEnd: 'arrow',
+				},
+			},
+		])
+		editor.select(ids.arrow1)
+		return editor.getShape(ids.arrow1) as TLArrowShape
+	}
+
+	function getEndHandle() {
+		return { id: 'end', type: 'vertex' as const, index: 'a0' as IndexKey, x: 100, y: 100 }
+	}
+
+	function getEndHandleInfo() {
+		return {
+			target: 'handle' as const,
+			shape: editor.getShape(ids.arrow1) as TLArrowShape,
+			handle: getEndHandle(),
+		}
+	}
+
+	beforeEach(() => {
+		editor._transformPointerDownSpy.mockRestore()
+		editor._transformPointerUpSpy.mockRestore()
+	})
+
+	it('toggles the arrowhead on the second pointer up', () => {
+		createArrow()
+
+		editor.pointerDown(100, 100, getEndHandleInfo()).pointerUp(100, 100, getEndHandleInfo())
+		expect((editor.getShape(ids.arrow1) as TLArrowShape).props.arrowheadEnd).toBe('arrow')
+
+		editor.pointerDown(100, 100, getEndHandleInfo())
+		expect((editor.getShape(ids.arrow1) as TLArrowShape).props.arrowheadEnd).toBe('arrow')
+		editor.expectToBeIn('select.pointing_handle')
+
+		editor.pointerUp(100, 100, getEndHandleInfo())
+		expect((editor.getShape(ids.arrow1) as TLArrowShape).props.arrowheadEnd).toBe('none')
+	})
+
+	it('starts a drag instead of toggling when the second click moves', () => {
+		createArrow()
+
+		editor.pointerDown(100, 100, getEndHandleInfo()).pointerUp(100, 100, getEndHandleInfo())
+
+		editor.pointerDown(100, 100, getEndHandleInfo())
+		expect((editor.getShape(ids.arrow1) as TLArrowShape).props.arrowheadEnd).toBe('arrow')
+
+		editor.pointerMove(140, 140)
+
+		editor.expectToBeIn('select.dragging_handle')
+		expect((editor.getShape(ids.arrow1) as TLArrowShape).props.arrowheadEnd).toBe('arrow')
 	})
 })
 

--- a/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/childStates/PointingHandle.ts
@@ -23,9 +23,11 @@ export class PointingHandle extends StateNode {
 	didCtrlOnEnter = false
 
 	info = {} as TLPointerEventInfo & { target: 'handle' }
+	isDoubleClick = false
 
 	override onEnter(info: TLPointerEventInfo & { target: 'handle' }) {
 		this.info = info
+		this.isDoubleClick = false
 
 		this.didCtrlOnEnter = info.accelKey
 
@@ -59,6 +61,17 @@ export class PointingHandle extends StateNode {
 	override onPointerUp() {
 		const { shape, handle } = this.info
 
+		if (this.isDoubleClick) {
+			this.parent.transition('idle')
+			this.parent.getCurrent()?.handleEvent({
+				...this.info,
+				type: 'click',
+				name: 'double_click',
+				phase: 'down',
+			})
+			return
+		}
+
 		if (this.editor.isShapeOfType(shape, 'note')) {
 			const { editor } = this
 			const nextNote = getNoteForAdjacentPosition(editor, shape, handle, false)
@@ -81,8 +94,7 @@ export class PointingHandle extends StateNode {
 			return
 		}
 
-		this.parent.transition('idle')
-		this.parent.getCurrent()?.handleEvent(info)
+		this.isDoubleClick = true
 	}
 
 	override onPointerMove(info: TLPointerEventInfo) {


### PR DESCRIPTION
In order to prevent arrow handle double-clicks from stealing a second click that is becoming a drag, this PR defers handle double-click actions until pointer up.

### Change type

- [x] `bugfix`

### Test plan

1. Double-click an arrow endpoint handle and confirm the arrowhead toggles on release.
2. Click an arrow endpoint handle, then click again and drag before releasing; confirm the handle drags and the arrowhead does not toggle.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix arrow endpoint double-click toggles firing before a second click can become a drag.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +14 / -2   |
| Tests     | +67 / -0   |
