### PR TITLE
fix(agent): clarify setMyView bounds are top-left, not center

### DIFF
--- a/templates/agent/shared/schema/AgentActionSchemas.ts
+++ b/templates/agent/shared/schema/AgentActionSchemas.ts
@@ -310,7 +310,7 @@ export const SetMyViewAction = z
 	.meta({
 		title: 'Set My View',
 		description:
-			'The AI changes the bounds of its own viewport to navigate to other areas of the canvas if needed.',
+			'The AI changes the bounds of its own viewport to navigate to other areas of the canvas if needed. `x` and `y` are the top-left corner of the area you want to see, and `w` and `h` are its width and height. To center your view on a point, set `x` and `y` to that point minus half the width and height.',
 	})
 
 export type SetMyViewAction = z.infer<typeof SetMyViewAction>

--- a/templates/agent/shared/schema/PromptPartDefinitions.ts
+++ b/templates/agent/shared/schema/PromptPartDefinitions.ts
@@ -1,4 +1,4 @@
-import { Box, BoxModel, JsonValue } from 'tldraw'
+import { BoxModel, JsonValue } from 'tldraw'
 import { BlurryShape } from '../format/BlurryShape'
 import { FocusedShape } from '../format/FocusedShape'
 import { PeripheralShapeCluster } from '../format/PeripheralShapesCluster'
@@ -495,8 +495,9 @@ export const UserViewportBoundsPartDefinition: PromptPartDefinition<UserViewport
 		if (!userBounds) {
 			return []
 		}
-		const userViewCenter = Box.From(userBounds).center
-		return [`The user's view is centered at (${userViewCenter.x}, ${userViewCenter.y}).`]
+		return [
+			`The bounds of the part of the canvas that the user can currently see are: ${JSON.stringify(userBounds)}`,
+		]
 	},
 }
 

--- a/templates/agent/worker/prompt/sections/rules-section.ts
+++ b/templates/agent/worker/prompt/sections/rules-section.ts
@@ -185,7 +185,8 @@ ${flagged(flags.hasUserViewportBoundsPart, "- Don't go out of your way to work i
 ${flagged(flags.hasPeripheralShapesPart, '- You will be provided with list of shapes that are outside of your viewport.')}
 ${flagged(
 	flags.hasSetMyView,
-	`- You can use the \`setMyView\` action to change your viewport to navigate to other areas of the canvas if needed. This will provide you with an updated view of the canvas. You can also use this to functionally zoom in or out.`
+	`- You can use the \`setMyView\` action to change your viewport to navigate to other areas of the canvas if needed. This will provide you with an updated view of the canvas. You can also use this to functionally zoom in or out.
+- The \`setMyView\` \`x\` and \`y\` values are the top-left corner of the area you want to see, not its center. To center your view on a point, subtract half of \`w\` from \`x\` and half of \`h\` from \`y\`.`
 )}
 `
 )}


### PR DESCRIPTION
## Summary

The agent starter's `setMyView` action lets the AI move its own viewport, but the schema description and rules never said whether `x`/`y` are the top-left corner or the center of the target area. They're the top-left corner. On top of that, the user's viewport was reported to the model only as a single center point. Together this nudged the model to treat `x`/`y` as a center, so it mis-navigated when trying to focus on a point.

## Changes

- **`AgentActionSchemas.ts`** — Expand the `SetMyView` description to state that `x`/`y` are the top-left corner, `w`/`h` are width/height, and how to center the view on a point (subtract half the width/height).
- **`PromptPartDefinitions.ts`** — Report the user's full viewport bounds (`JSON.stringify(userBounds)`) instead of just the center point.
- **`rules-section.ts`** — Add a rule reiterating that `setMyView` `x`/`y` are the top-left corner, not the center, with the centering formula.

These are docs/prompt-only changes to the `templates/agent` starter; no runtime behavior in the SDK changes.