### PR TITLE
fix(editor): don't update font states after FontManager is disposed

### DIFF
--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.test.ts
@@ -144,6 +144,49 @@ describe('FontManager', () => {
 		})
 	})
 
+	describe('dispose during font loading', () => {
+		it('does not throw when a font finishes loading after dispose', async () => {
+			const font = createMockFont()
+			let resolveLoad: () => void
+			;(global.FontFace as Mock).mockImplementationOnce(function (family: any) {
+				return {
+					family,
+					load: vi.fn(() => new Promise<void>((resolve) => (resolveLoad = resolve))),
+				}
+			})
+
+			const loadingPromise = fontManager.ensureFontIsLoaded(font)
+			fontManager.dispose()
+			resolveLoad!()
+
+			await expect(loadingPromise).resolves.toBeUndefined()
+			// only the creation-time add from findOrCreateFontFace, not a second
+			// post-load add after dispose
+			expect(document.fonts.add).toHaveBeenCalledTimes(1)
+		})
+
+		it('does not throw when a font fails to load after dispose', async () => {
+			const font = createMockFont()
+			const error = new Error('Font load failed')
+			let rejectLoad: (err: Error) => void
+			;(global.FontFace as Mock).mockImplementationOnce(function (family: any) {
+				return {
+					family,
+					load: vi.fn(() => new Promise<void>((_resolve, reject) => (rejectLoad = reject))),
+				}
+			})
+			const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+			const loadingPromise = fontManager.ensureFontIsLoaded(font)
+			fontManager.dispose()
+			rejectLoad!(error)
+
+			await expect(loadingPromise).resolves.toBeUndefined()
+			expect(consoleSpy).toHaveBeenCalledWith(error)
+			consoleSpy.mockRestore()
+		})
+	})
+
 	describe('getShapeFontFaces', () => {
 		it('should return empty array when no fonts found', () => {
 			const shape = createMockShape()

--- a/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
+++ b/packages/editor/src/lib/editor/managers/FontManager/FontManager.ts
@@ -112,11 +112,16 @@ export class FontManager {
 			loadingPromise: instance
 				.load()
 				.then(() => {
+					// dispose() clears fontStates, so a font that finishes loading after
+					// disposal has no entry to update (and AtomMap.update throws on
+					// missing keys).
+					if (!this.fontStates.has(font)) return
 					this.editor.getContainerDocument().fonts.add(instance)
 					this.fontStates.update(font, (s) => ({ ...s, state: 'ready' }))
 				})
 				.catch((err) => {
 					console.error(err)
+					if (!this.fontStates.has(font)) return
 					this.fontStates.update(font, (s) => ({ ...s, state: 'error' }))
 				}),
 		}


### PR DESCRIPTION
In order to stop unhandled `AtomMap: key [object Object] not found` rejections when an editor is disposed while fonts are still loading, this PR guards the `FontFace.load()` callbacks in `FontManager.ensureFontIsLoaded` with a `fontStates.has(font)` check. `dispose()` clears the `fontStates` map, so any font that resolved or rejected after disposal tried to `update()` a missing key, and `AtomMap.update` throws on missing keys — the error-handling path itself became an unhandled rejection. Closes #9114.

The per-font `has` check (rather than a manager-wide disposed flag) keeps the existing dispose-then-reuse behavior working: `dispose()` acts as a reset, and fonts re-requested afterwards get a fresh state entry that late callbacks may still legitimately update. On the success path the guard also skips the post-load `document.fonts.add`, so a disposed manager no longer touches the document's font set; the failure path still logs the load error before bailing.

Root-caused in tldraw/tldraw-internal#674 while fixing the desktop app's reopen error storm; the desktop app worked around it, but the SDK race remained for anyone unmounting an editor during font loading.

### Change type

- [x] `bugfix`

### Test plan

1. Delay `FontFace.prototype.load` (e.g. via devtools override or a mock)
2. Mount an editor with text shapes, then unmount it before the font loads resolve
3. Verify no unhandled `AtomMap: key ... not found` rejection is thrown

- [x] Unit tests

### Release notes

- Fix an unhandled `AtomMap: key not found` error when a font finishes loading or fails to load after the editor has been disposed.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -0    |
| Tests     | +43 / -0   |
