### PR TITLE
fix(tldraw): don't highlight a fill dropdown item when the current fi…

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -3670,6 +3670,7 @@ export const StylePanelDropdownPickerInline: <T extends string>(props: StylePane
 export interface StylePanelDropdownPickerProps<T extends string> {
     // (undocumented)
     id: string;
+    isOverflow?: boolean;
     // (undocumented)
     items: StyleValuesForUi<T>;
     // (undocumented)

--- a/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/DefaultStylePanelContent.tsx
@@ -173,6 +173,7 @@ export function StylePanelFillPicker() {
 					items={STYLES.fillExtra}
 					value={fill}
 					sideOffset={116}
+					isOverflow
 				/>
 			</TldrawUiToolbar>
 		</>

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -33,6 +33,8 @@ export interface StylePanelDropdownPickerProps<T extends string> {
 	 * Defaults to the standard popover gap so standalone dropdowns don't sit flush against the panel.
 	 */
 	sideOffset?: number
+	/** Is the dropdown an overflow of a different radio group? If so, show active when the group's active item is inside of the dropdown.*/
+	isOverflow?: boolean
 }
 
 function StylePanelDropdownPickerInner<T extends string>(props: StylePanelDropdownPickerProps<T>) {
@@ -56,6 +58,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 		label,
 		uiType,
 		stylePanelType,
+		isOverflow,
 		style,
 		items,
 		type,
@@ -102,6 +105,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 					type={type}
 					data-testid={`style.${testIdType}`}
 					data-direction="left"
+					isActive={isOverflow && valueInItems}
 					title={titleStr}
 				>
 					{labelStr && <TldrawUiButtonLabel>{labelStr}</TldrawUiButtonLabel>}

--- a/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
+++ b/packages/tldraw/src/lib/ui/components/StylePanel/StylePanelDropdownPicker.tsx
@@ -122,7 +122,7 @@ function StylePanelDropdownPickerInlineInner<T extends string>(
 										' — ' +
 										msg(`${uiType}-style.${item.value}` as TLUiTranslationKey)
 									}
-									isActive={icon === item.icon}
+									isActive={valueInItems && icon === item.icon}
 									onClick={() => {
 										ctx.onHistoryMark('select style dropdown item')
 										onValueChange(style, item.value)


### PR DESCRIPTION
Fixes how the style panel highlights the active fill when the current fill lives in the overflow dropdown.

Two related changes:

- **Don't highlight a dropdown item when the current value isn't in the dropdown.** Previously, hovering the rightmost fill could pre-select a fill option before one was chosen. Items now only show as active when the current value actually belongs to that dropdown (`valueInItems`).
- **Highlight the overflow dropdown trigger when its active item is selected.** The overflow dropdown's trigger button now shows as active when the current value is one of the items inside it, via a new `isOverflow` prop on `StylePanelDropdownPicker`.

Closes #9339

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Create a shape and select a light fill (2nd or 3rd in the list).
2. Click the 4th fill icon.
3. None of the previous 3 fills should stay selected — all should be blank.
4. Select a fill that lives in the overflow dropdown and confirm the overflow trigger shows as active.

### API changes

- Added optional `isOverflow` prop to `StylePanelDropdownPickerProps` — marks a dropdown as the overflow of another radio group so its trigger shows active when the group's active item is inside it.
