### PR TITLE
docs(skills): add overlap check and pre-review pass to pr skill

### DIFF
--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -30,6 +30,7 @@ Use `../write-pr/SKILL.md` as the standards reference for PR titles, description
    - Does it leave the codebase better than we found it — clearer names, no dead or duplicated code, no drive-by regressions?
    - Any weird abstractions, premature generality, or unnecessary code that a reviewer would flag? Prefer the smaller, more direct version.
    - Fix what's clearly worth fixing so the human review starts from a strong diff. If a finding needs a product or design call, raise it with the user instead of guessing.
+   - Commit and push any fixes from this pass so the remote branch matches before the PR is created, updated, or shared. Never force push.
 5. If no PR exists, create one with `gh pr create`.
 6. If a PR exists, read it with `gh pr view --json title,body,labels,number` and inspect the changed-file summary with `gh pr diff --stat`.
 7. Update the title or body with `gh pr edit` if the existing PR does not match the current diff or the `write-pr` standards.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -16,15 +16,25 @@ Use `../write-pr/SKILL.md` as the standards reference for PR titles, description
    - Working tree: `git status --short`
    - Existing PR: `gh pr view --json number,title,url 2>/dev/null`
    - Recent branch commits: `git log main..HEAD --oneline 2>/dev/null || git log -3 --oneline`
-2. Prepare the branch:
+2. Check for overlapping work so we don't step on a teammate's toes:
+   - List open PRs touching the same area: `gh pr list --state open --json number,title,url,author,headRefName,updatedAt`, and search for related work: `gh pr list --search "<keywords>" --state open`.
+   - Compare their changed files against ours (`gh pr diff <number> --stat`) to judge real overlap, not just a shared filename.
+   - If someone already has a PR open for this: prefer building on their work over racing it. Offer to base our branch on theirs, contribute a review or a follow-up commit, or hand our changes over. Only open a competing PR when the approaches genuinely diverge, and when we do, link to theirs and explain how ours differs so the choice is easy for reviewers.
+   - Surface what you found to the user before proceeding when there's meaningful overlap.
+3. Prepare the branch:
    - If on `main`, create a new branch with a descriptive name.
    - Commit relevant changes, excluding secrets and explicitly private content.
    - Push the branch to the remote. Never force push.
-3. If no PR exists, create one with `gh pr create`.
-4. If a PR exists, read it with `gh pr view --json title,body,labels,number` and inspect the changed-file summary with `gh pr diff --stat`.
-5. Update the title or body with `gh pr edit` if the existing PR does not match the current diff or the `write-pr` standards.
-6. Search for related issues and link them in the PR description with `Closes #123` or `Relates to #123` where appropriate.
-7. Share the PR URL with the user.
+4. Run an initial review pass before asking a human to look. Spin out a few subagents in parallel over the diff (`git diff main...HEAD`), each with a focused lens, then fold their findings into concrete fixes:
+   - Does the change actually solve the stated problem, end to end, rather than papering over a symptom?
+   - Does it leave the codebase better than we found it — clearer names, no dead or duplicated code, no drive-by regressions?
+   - Any weird abstractions, premature generality, or unnecessary code that a reviewer would flag? Prefer the smaller, more direct version.
+   - Fix what's clearly worth fixing so the human review starts from a strong diff. If a finding needs a product or design call, raise it with the user instead of guessing.
+5. If no PR exists, create one with `gh pr create`.
+6. If a PR exists, read it with `gh pr view --json title,body,labels,number` and inspect the changed-file summary with `gh pr diff --stat`.
+7. Update the title or body with `gh pr edit` if the existing PR does not match the current diff or the `write-pr` standards.
+8. Search for related issues and link them in the PR description with `Closes #123` or `Relates to #123` where appropriate.
+9. Share the PR URL with the user.
 
 ## Handling problems
 

--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -68,6 +68,19 @@ Start with: "In order to X, this PR does Y."
 - Link related issues in the first paragraph
 - Don't expect readers to also read the linked issue
 
+### Write for the reviewer
+
+Write the description for a reviewer who knows the codebase architecture but has **not** read your code or most of the diff. Their time is the scarce resource: the description's job is to get them to understand the important bits and to give them what they need to push back on a decision. Assume they'll read your description, skim a few key files, and trust the rest.
+
+Cover, in whatever depth the change warrants:
+
+- **The higher-level change.** What actually changes, described at the level of behavior and structure, not a line-by-line restatement of the diff. Reviewers can read code; they can't read your intent.
+- **Motivation.** Why this change, and why now. What was wrong or missing before.
+- **Trade-offs and decisions.** The choices you made that a reviewer might have made differently — the approach you picked, what you ruled out and why, anything you're unsure about. Name these explicitly so the reviewer can steer if a call is the wrong one. A decision you don't surface is a decision the reviewer can't catch.
+- **Short example snippets.** For anything touching an API, data shape, or usage pattern, a few lines of before/after or a small "here's how it's used now" snippet explains more than a paragraph. Keep them minimal and illustrative, not exhaustive.
+
+Match the depth to the change: a one-line fix needs a sentence, a new system needs the fuller treatment below. Don't pad a small PR with ceremony, and don't under-describe a large one. When in doubt about what a reviewer needs, err toward explaining the *why* and the *trade-offs* — those are the parts they can't reconstruct from the diff.
+
 ### Change type
 
 - Tick exactly one type with `[x]`


### PR DESCRIPTION
Improves the `/pr` workflow and the PR-writing standards so the SDK's automated PR flow moves faster, keeps the codebase healthy, and respects both teammates and reviewers.

### `/pr` skill — two new workflow steps

- **Check for overlapping work** (before touching the branch): list open PRs in the same area, compare actual changed files (not just filenames) to gauge real overlap, and lean toward *building on* a teammate's existing PR — base on theirs, review it, add a follow-up commit, or hand the changes over — rather than racing it. A competing PR is the last resort, and when it happens the skill links the other PR and explains how ours differs so reviewers aren't stuck untangling two.
- **Run an initial review pass** (after pushing, before opening the PR): spin out a few parallel subagents over the diff, each with a focused lens — does this concretely solve the problem end to end, does it leave the codebase better (no dead/duplicated code, no drive-by regressions), any weird abstractions or unnecessary code. Clear wins get folded into fixes, then **committed and pushed** so the remote matches before the PR is created or shared; anything needing a product/design call goes back to the user.

### `write-pr` skill — write the description for the reviewer

Adds a "Write for the reviewer" section to the PR-content standards. The guiding assumption: the reviewer knows the architecture but hasn't read your code or most of the diff, and their time is the scarce resource. Descriptions should walk through the higher-level change, the motivation, the trade-offs and decisions (named explicitly, so a reviewer can steer if a call is wrong), and short example snippets for anything touching an API or usage pattern. Depth scales with the change — a one-liner gets a sentence, a new system gets the fuller treatment.

### Why

Three goals, one theme — remove friction without lowering the bar:

- **Velocity:** catch overlap and obvious diff issues before a human round-trip.
- **Codebase health:** the review lenses keep abstractions honest and cruft out.
- **Good social practice:** don't step on teammates' toes; respect reviewers' time.

### Change type

- [x] `other` (agent tooling / skills)

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +30 / -6   |

Both files are agent skills under `skills/`; there is no runtime or product-code impact.
