### PR TITLE
fix(sync): add close() to sync storage classes to cancel pending tombstone prune

### DIFF
--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -98,6 +98,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **SS16** `getSnapshot()` returns `{ documentClock, tombstoneHistoryStartsAtClock, documents, tombstones, schema }` reflecting all committed transactions.
 - **SS17** Snapshot fallbacks at construction: `documentClock ?? clock ?? 0`; `tombstoneHistoryStartsAtClock ?? documentClock`.
 - **SS18** Deleting a record schedules a throttled (1s, trailing-only) tombstone prune; nothing else schedules one, so a storage constructed with an oversized tombstone set stays unpruned until the next delete. When the prune runs and the tombstone count exceeds `MAX_TOMBSTONES` (5000), it deletes the oldest tombstones — the overflow plus `TOMBSTONE_PRUNE_BUFFER_SIZE` (1000) more, never splitting a clock value — and advances `tombstoneHistoryStartsAtClock` to the oldest surviving tombstone's clock.
+- **SS19** `close()` cancels any pending throttled tombstone prune and marks the storage closed (`isClosed()` returns true): calling `close()` again is a no-op, and further `transaction()` calls throw. This lets a consumer release the storage's underlying resources without a stray prune timer firing afterwards.
 
 ## 11. `InMemorySyncStorage` specifics (IM)
 
@@ -116,6 +117,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **SQ4** `SQLiteSyncStorage.hasBeenInitialized(wrapper)` is true exactly when the metadata table exists and holds a non-empty schema string; it respects the table prefix and returns false (rather than throwing) on a missing table.
 - **SQ5** `SQLiteSyncStorage.getDocumentClock(wrapper)` returns the persisted clock, or `null` when storage is uninitialized.
 - **SQ6** Document state is stored as JSON-encoded BLOBs. Databases created by the v1 schema (TEXT column) are migrated to BLOB preserving data; fresh databases start at migration version 2.
+- **SQ7** After `close()`, closing the underlying database is safe: a prune scheduled by an earlier delete never runs against the finalized prepared statements.
 
 ## 13. `computeTombstonePruning` (TP) — internal
 

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -109,6 +109,7 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
         onChange?(arg: TLSyncStorageOnChangeCallbackProps): unknown;
         snapshot?: RoomSnapshot;
     });
+    close(): void;
     // @internal (undocumented)
     documentClock: Atom<number>;
     // @internal (undocumented)
@@ -120,6 +121,7 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
     getClock(): number;
     // (undocumented)
     getSnapshot(): RoomSnapshot;
+    isClosed(): boolean;
     // (undocumented)
     onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => unknown): () => void;
     // @internal (undocumented)
@@ -324,6 +326,7 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
         snapshot?: RoomSnapshot | StoreSnapshot<R>;
         sql: TLSyncSqliteWrapper;
     });
+    close(): void;
     // (undocumented)
     getClock(): number;
     static getDocumentClock(storage: TLSyncSqliteWrapper): null | number;
@@ -334,6 +337,7 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
     // @internal (undocumented)
     _getTombstoneHistoryStartsAtClock(): number;
     static hasBeenInitialized(storage: TLSyncSqliteWrapper): boolean;
+    isClosed(): boolean;
     // (undocumented)
     onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => void): () => void;
     // @internal (undocumented)
@@ -733,10 +737,12 @@ export interface TLSyncSqliteWrapperConfig {
 
 // @public
 export interface TLSyncStorage<R extends UnknownRecord> {
+    close?(): void;
     // (undocumented)
     getClock(): number;
     // (undocumented)
     getSnapshot?(): RoomSnapshot;
+    isClosed?(): boolean;
     // (undocumented)
     onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => unknown): () => void;
     // (undocumented)

--- a/packages/sync-core/src/lib/InMemorySyncStorage.ts
+++ b/packages/sync-core/src/lib/InMemorySyncStorage.ts
@@ -177,10 +177,36 @@ export class InMemorySyncStorage<R extends UnknownRecord> implements TLSyncStora
 		}
 	}
 
+	private _isClosed = false
+
+	/**
+	 * Check whether the storage has been closed.
+	 *
+	 * @returns True if {@link InMemorySyncStorage.close} has been called
+	 */
+	isClosed(): boolean {
+		return this._isClosed
+	}
+
+	/**
+	 * Close the storage and cancel any pending background work.
+	 *
+	 * Deleting records schedules a throttled tombstone prune on a timer. Call
+	 * this when you are done with the storage so the pending prune does not
+	 * fire afterwards. Closing more than once is a no-op; transactions throw
+	 * after the storage has been closed.
+	 */
+	close(): void {
+		if (this._isClosed) return
+		this._isClosed = true
+		this.pruneTombstones.cancel()
+	}
+
 	transaction<T>(
 		callback: TLSyncStorageTransactionCallback<R, T>,
 		opts?: TLSyncStorageTransactionOptions
 	): TLSyncStorageTransactionResult<T, R> {
+		assert(!this._isClosed, 'Storage has been closed')
 		const clockBefore = this.documentClock.get()
 		const trackChanges = opts?.emitChanges === 'always'
 		const txn = new InMemorySyncStorageTransaction<R>(this)

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.test.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.test.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync } from 'node:sqlite'
 import { DocumentRecordType, PageRecordType, TLDOCUMENT_ID, TLRecord } from '@tldraw/tlschema'
 import { ZERO_INDEX_KEY } from '@tldraw/utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
 	contractRecords,
 	contractSchema,
@@ -234,6 +234,30 @@ describe('SQLiteSyncStorage', () => {
 				.prepare<{ migrationVersion: number }>('SELECT migrationVersion FROM metadata')
 				.all()[0]
 			expect(row?.migrationVersion).toBe(2)
+		})
+	})
+
+	describe('close', () => {
+		it('[SQ7] a pending tombstone prune does not run against a closed database', () => {
+			vi.useFakeTimers()
+			try {
+				const db = new DatabaseSync(':memory:')
+				const storage = new SQLiteSyncStorage<TLRecord>({ sql: new NodeSqliteWrapper(db) })
+				const page = makePage('doomed')
+				storage.transaction((txn) => txn.set(page.id, page))
+				// deleting a record schedules the throttled prune on a timer
+				storage.transaction((txn) => txn.delete(page.id))
+
+				storage.close()
+				db.close()
+
+				// without close(), the pending prune would run its prepared statements
+				// against the closed database and throw 'statement has been finalized'
+				expect(() => vi.advanceTimersByTime(2000)).not.toThrow()
+				expect(() => storage.pruneTombstones.flush()).not.toThrow()
+			} finally {
+				vi.useRealTimers()
+			}
 		})
 	})
 })

--- a/packages/sync-core/src/lib/SQLiteSyncStorage.ts
+++ b/packages/sync-core/src/lib/SQLiteSyncStorage.ts
@@ -386,10 +386,37 @@ export class SQLiteSyncStorage<R extends UnknownRecord> implements TLSyncStorage
 		return this.notifier.register(callback)
 	}
 
+	private _isClosed = false
+
+	/**
+	 * Check whether the storage has been closed.
+	 *
+	 * @returns True if {@link SQLiteSyncStorage.close} has been called
+	 */
+	isClosed(): boolean {
+		return this._isClosed
+	}
+
+	/**
+	 * Close the storage and cancel any pending background work.
+	 *
+	 * Deleting records schedules a throttled tombstone prune on a timer that
+	 * runs the storage's prepared statements. Call this before closing the
+	 * underlying SQLite database so the pending prune does not run against
+	 * finalized statements. Closing more than once is a no-op; transactions
+	 * throw after the storage has been closed.
+	 */
+	close(): void {
+		if (this._isClosed) return
+		this._isClosed = true
+		this.pruneTombstones.cancel()
+	}
+
 	transaction<T>(
 		callback: TLSyncStorageTransactionCallback<R, T>,
 		opts?: TLSyncStorageTransactionOptions
 	): TLSyncStorageTransactionResult<T, R> {
+		assert(!this._isClosed, 'Storage has been closed')
 		const clockBefore = this.getClock()
 		const trackChanges = opts?.emitChanges === 'always'
 		return this.sql.transaction(() => {

--- a/packages/sync-core/src/lib/TLSyncStorage.ts
+++ b/packages/sync-core/src/lib/TLSyncStorage.ts
@@ -84,6 +84,20 @@ export interface TLSyncStorage<R extends UnknownRecord> {
 	onChange(callback: (arg: TLSyncStorageOnChangeCallbackProps) => unknown): () => void
 
 	getSnapshot?(): RoomSnapshot
+
+	/**
+	 * Close the storage and cancel any pending background work, like the
+	 * throttled tombstone pruning that record deletion schedules. Call this
+	 * before releasing the storage's underlying resources (e.g. closing a
+	 * SQLite database). Closing more than once is a no-op; the storage must
+	 * not be used after it has been closed.
+	 */
+	close?(): void
+
+	/**
+	 * Check whether the storage has been closed via {@link TLSyncStorage.close}.
+	 */
+	isClosed?(): boolean
 }
 
 /**

--- a/packages/sync-core/src/test/storageContractSuite.ts
+++ b/packages/sync-core/src/test/storageContractSuite.ts
@@ -540,15 +540,15 @@ export function registerStorageContractTests(factory: StorageContractFactory) {
 			})
 		})
 
-		describe('tombstone pruning', () => {
-			const makeTombstones = (count: number) => {
-				const tombstones: Record<string, number> = {}
-				for (let i = 0; i < count; i++) {
-					tombstones[`shape:doc${i}`] = i + 1
-				}
-				return tombstones
+		const makeTombstones = (count: number) => {
+			const tombstones: Record<string, number> = {}
+			for (let i = 0; i < count; i++) {
+				tombstones[`shape:doc${i}`] = i + 1
 			}
+			return tombstones
+		}
 
+		describe('tombstone pruning', () => {
 			const flushPrune = (storage: TLSyncStorage<TLRecord>) => {
 				const prune = (storage as any).pruneTombstones
 				prune()
@@ -612,6 +612,49 @@ export function registerStorageContractTests(factory: StorageContractFactory) {
 				const remaining = Object.values(storage.getSnapshot!().tombstones!)
 				expect(remaining.length).toBe(MAX_TOMBSTONES - TOMBSTONE_PRUNE_BUFFER_SIZE - overflow)
 				expect(remaining.every((clock) => clock === 2)).toBe(true)
+			})
+		})
+
+		describe('close', () => {
+			it('[SS19] close cancels a pending tombstone prune', () => {
+				vi.useFakeTimers()
+				try {
+					const total = MAX_TOMBSTONES + 500
+					const storage = create(
+						makeContractSnapshot(contractRecords, {
+							tombstones: makeTombstones(total),
+							documentClock: total + 1,
+							tombstoneHistoryStartsAtClock: 0,
+						})
+					)
+					// deleting a record schedules the throttled prune
+					storage.transaction((txn) => txn.delete(contractRecords[1].id))
+					storage.close!()
+					vi.advanceTimersByTime(2000)
+					// the prune never ran: the oversized tombstone set is untouched
+					// (the delete above added one more tombstone)
+					expect(Object.keys(storage.getSnapshot!().tombstones!).length).toBe(total + 1)
+					// flushing the throttle after close is a no-op too
+					;(storage as any).pruneTombstones.flush()
+					expect(Object.keys(storage.getSnapshot!().tombstones!).length).toBe(total + 1)
+				} finally {
+					vi.useRealTimers()
+				}
+			})
+
+			it('[SS19] close is idempotent and marks the storage closed', () => {
+				const storage = factory.create()
+				expect(storage.isClosed!()).toBe(false)
+				storage.close!()
+				expect(storage.isClosed!()).toBe(true)
+				expect(() => storage.close!()).not.toThrow()
+				expect(storage.isClosed!()).toBe(true)
+			})
+
+			it('[SS19] transactions throw after close', () => {
+				const storage = factory.create()
+				storage.close!()
+				expect(() => storage.transaction(() => {})).toThrow('Storage has been closed')
 			})
 		})
 	})


### PR DESCRIPTION
In order to let consumers safely shut down a sync storage, this PR adds a public `close()` method to `SQLiteSyncStorage` and `InMemorySyncStorage` (and an optional `close?()` to the `TLSyncStorage` interface) that cancels the pending throttled tombstone prune.

Deleting a record schedules `pruneTombstones`, a trailing-only throttle (1s) that runs the storage's cached prepared statements from a bare `setTimeout`. Until now the storage classes exposed no way to cancel it, so a consumer that closed the underlying SQLite database with the timer still pending got an uncaught "Error: statement has been finalized" up to a second later. The tldraw desktop app hit this in practice (flaky CI plus a real runtime uncaughtException after closing a window whose save deleted records) and currently works around it by casting to the internal `pruneTombstones` throttle and calling `.cancel()` before closing the database — that workaround can be deleted once this ships.

`close()` cancels the pending prune and marks the storage closed: closing again is a no-op, and further transactions throw. `isClosed()` reports the state, matching the `close()`/`isClosed()` lifecycle pair on `TLSyncRoom`. `InMemorySyncStorage` gets the same treatment for symmetry — its pending timer can't throw, but it's still a leak after the storage is logically done.

The new SQLite regression test reproduces the original crash when the `close()` call is removed.

### Change type

- [x] `api`

### Test plan

- [x] Unit tests

New spec rules SS19 (contract: close cancels the pending prune, is idempotent, transactions throw after close) and SQ7 (a pending prune never runs against a closed database), covered in the shared storage contract suite and the SQLite-specific tests.

### Release notes

- Added `close()` and `isClosed()` to `SQLiteSyncStorage` and `InMemorySyncStorage`. Call `close()` before closing the underlying database to cancel the pending throttled tombstone prune; previously the timer could fire after the database was closed and throw an uncaught "statement has been finalized" error.

### API changes

- Added `SQLiteSyncStorage.close()` and `SQLiteSyncStorage.isClosed()`
- Added `InMemorySyncStorage.close()` and `InMemorySyncStorage.isClosed()`
- Added optional `close?()` and `isClosed?()` to the `TLSyncStorage` interface

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +69 / -0   |
| Tests           | +75 / -8   |
| Automated files | +6 / -0    |
