### PR TITLE
feat(dotcom): fire GA4 sign_up conversion event on new account

### DIFF
--- a/apps/dotcom/client/src/tla/hooks/useSignUpTracking.test.ts
+++ b/apps/dotcom/client/src/tla/hooks/useSignUpTracking.test.ts
@@ -12,6 +12,13 @@ describe('isNewSignUp', () => {
 		expect(isNewSignUp({ createdAt: new Date(now - NEW_ACCOUNT_WINDOW_MS + 1) }, now)).toBe(true)
 	})
 
+	it('covers a multi-minute email verification delay', () => {
+		// The in-app email flow can leave several minutes between account creation
+		// and analytics mounting while the user fetches their code.
+		const fiveMinutesAgo = now - 5 * 60 * 1000
+		expect(isNewSignUp({ createdAt: new Date(fiveMinutesAgo) }, now)).toBe(true)
+	})
+
 	it('returns false once the account is older than the window (a returning login)', () => {
 		expect(isNewSignUp({ createdAt: new Date(now - NEW_ACCOUNT_WINDOW_MS - 1) }, now)).toBe(false)
 	})

--- a/apps/dotcom/client/src/tla/hooks/useSignUpTracking.test.ts
+++ b/apps/dotcom/client/src/tla/hooks/useSignUpTracking.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { NEW_ACCOUNT_WINDOW_MS, getSignUpMethod, isNewSignUp } from './useSignUpTracking'
+
+describe('isNewSignUp', () => {
+	const now = 1_700_000_000_000
+
+	it('returns true for an account created just now', () => {
+		expect(isNewSignUp({ createdAt: new Date(now) }, now)).toBe(true)
+	})
+
+	it('returns true within the new-account window', () => {
+		expect(isNewSignUp({ createdAt: new Date(now - NEW_ACCOUNT_WINDOW_MS + 1) }, now)).toBe(true)
+	})
+
+	it('returns false once the account is older than the window (a returning login)', () => {
+		expect(isNewSignUp({ createdAt: new Date(now - NEW_ACCOUNT_WINDOW_MS - 1) }, now)).toBe(false)
+	})
+
+	it('returns false for accounts created days ago', () => {
+		const twoDaysAgo = now - 2 * 24 * 60 * 60 * 1000
+		expect(isNewSignUp({ createdAt: new Date(twoDaysAgo) }, now)).toBe(false)
+	})
+
+	it('returns false when createdAt is missing', () => {
+		expect(isNewSignUp({ createdAt: null }, now)).toBe(false)
+	})
+})
+
+describe('getSignUpMethod', () => {
+	it('returns the OAuth provider when the account has an external account', () => {
+		expect(getSignUpMethod({ externalAccounts: [{ provider: 'google' }] })).toBe('google')
+	})
+
+	it('returns "email" when there are no external accounts', () => {
+		expect(getSignUpMethod({ externalAccounts: [] })).toBe('email')
+	})
+})

--- a/apps/dotcom/client/src/tla/hooks/useSignUpTracking.ts
+++ b/apps/dotcom/client/src/tla/hooks/useSignUpTracking.ts
@@ -6,19 +6,27 @@ import { trackEvent } from '../../utils/analytics'
 /**
  * Consider a Clerk account "newly created" if it was created within this window.
  * A returning sign-in has a `createdAt` from hours, days, or weeks ago, so it
- * never matches; the window only needs to comfortably span the post-sign-up
- * redirect back to the app and the legal-acceptance step before analytics mounts.
+ * never matches.
+ *
+ * The window must comfortably span the gap between the account being created and
+ * analytics mounting. tldraw.com has an in-app email flow (TlaSignInDialog) where
+ * the user requests a code, leaves to check their email, and returns to enter it,
+ * which can take several minutes. Clerk's verification codes expire after ~10
+ * minutes, which bounds how long a *completable* sign-up can take, so 30 minutes
+ * leaves comfortable margin above that ceiling while still excluding any returning
+ * login.
  */
-export const NEW_ACCOUNT_WINDOW_MS = 10 * 60 * 1000
+export const NEW_ACCOUNT_WINDOW_MS = 30 * 60 * 1000
 
 const SIGNUP_TRACKED_KEY_PREFIX = 'tldraw_signup_tracked_'
 
 /**
  * Whether `user` represents a genuine first-time sign-up rather than a returning
- * login, based on how recently the Clerk account was created. tldraw.com uses
- * Clerk's hosted sign-up flow, which completes on Clerk's pages and redirects
- * back, so there is no in-app sign-up callback to hook into — the freshly created
- * account's `createdAt` is the reliable client-side signal.
+ * login, based on how recently the Clerk account was created. Sign-up completes
+ * either via an OAuth redirect or the in-app email flow, both of which land the
+ * user in the signed-in app shortly after the account is created, so the freshly
+ * created account's `createdAt` is a reliable client-side signal. See
+ * {@link NEW_ACCOUNT_WINDOW_MS} for how the window accommodates the email flow.
  */
 export function isNewSignUp(user: { createdAt: Date | null }, now: number): boolean {
 	const createdAt = user.createdAt?.getTime()

--- a/apps/dotcom/client/src/tla/hooks/useSignUpTracking.ts
+++ b/apps/dotcom/client/src/tla/hooks/useSignUpTracking.ts
@@ -1,0 +1,63 @@
+import { useUser as useClerkUser } from '@clerk/clerk-react'
+import { useEffect } from 'react'
+import { getFromLocalStorage, setInLocalStorage } from 'tldraw'
+import { trackEvent } from '../../utils/analytics'
+
+/**
+ * Consider a Clerk account "newly created" if it was created within this window.
+ * A returning sign-in has a `createdAt` from hours, days, or weeks ago, so it
+ * never matches; the window only needs to comfortably span the post-sign-up
+ * redirect back to the app and the legal-acceptance step before analytics mounts.
+ */
+export const NEW_ACCOUNT_WINDOW_MS = 10 * 60 * 1000
+
+const SIGNUP_TRACKED_KEY_PREFIX = 'tldraw_signup_tracked_'
+
+/**
+ * Whether `user` represents a genuine first-time sign-up rather than a returning
+ * login, based on how recently the Clerk account was created. tldraw.com uses
+ * Clerk's hosted sign-up flow, which completes on Clerk's pages and redirects
+ * back, so there is no in-app sign-up callback to hook into — the freshly created
+ * account's `createdAt` is the reliable client-side signal.
+ */
+export function isNewSignUp(user: { createdAt: Date | null }, now: number): boolean {
+	const createdAt = user.createdAt?.getTime()
+	if (!createdAt) return false
+	return now - createdAt <= NEW_ACCOUNT_WINDOW_MS
+}
+
+/**
+ * The sign-up method to report to analytics: the OAuth provider used to create
+ * the account (e.g. `google`), or `email` for email-based sign-ups.
+ */
+export function getSignUpMethod(user: {
+	externalAccounts: ReadonlyArray<{ provider: string }>
+}): string {
+	return user.externalAccounts[0]?.provider ?? 'email'
+}
+
+/**
+ * Fires a `sign_up` analytics event once when a user first creates an account
+ * through Clerk. It distinguishes a genuine sign-up from a returning login using
+ * the Clerk account's `createdAt` (see {@link isNewSignUp}), and dedupes per
+ * account via localStorage so it fires at most once per new account on a given
+ * device — even if the user reloads or revisits while the account is still new.
+ *
+ * The event flows through {@link trackEvent}, which forwards `sign_up` to GA4
+ * (for Google Ads conversion measurement) as well as PostHog.
+ */
+export function useSignUpTracking() {
+	const { user, isLoaded } = useClerkUser()
+
+	useEffect(() => {
+		if (!isLoaded || !user) return
+		if (!isNewSignUp(user, Date.now())) return
+
+		// Fire once per account on this device.
+		const key = SIGNUP_TRACKED_KEY_PREFIX + user.id
+		if (getFromLocalStorage(key)) return
+		setInLocalStorage(key, '1')
+
+		trackEvent('sign_up', { method: getSignUpMethod(user) })
+	}, [isLoaded, user])
+}

--- a/apps/dotcom/client/src/utils/analytics.tsx
+++ b/apps/dotcom/client/src/utils/analytics.tsx
@@ -6,6 +6,7 @@ import ReactGA from 'react-ga4'
 import { useLocation } from 'react-router-dom'
 import { atom, getFromLocalStorage, react, setInLocalStorage, useValue, warnOnce } from 'tldraw'
 import { useApp } from '../tla/hooks/useAppState'
+import { useSignUpTracking } from '../tla/hooks/useSignUpTracking'
 import { getCurrentFlags, hasResolvedFlagsOnce } from '../tla/utils/FeatureFlagPoller'
 
 // Local storage key for cookie consent
@@ -311,6 +312,13 @@ export function trackEvent(name: string, data?: { [key: string]: any }) {
 		getGA4()?.event('page_view', data)
 	}
 
+	// Track new-account sign-ups in GA4 as well as PostHog. This is the conversion
+	// used to measure paid traffic (e.g. Google Ads) landing on tldraw.com. It is
+	// fired once per new account by useSignUpTracking, not on every login.
+	if (name === 'sign_up') {
+		getGA4()?.event('sign_up', data)
+	}
+
 	// Track watermark clicks in GA4
 	if (name === 'click-watermark' && data?.url) {
 		if (getGA4()) {
@@ -396,6 +404,7 @@ export function SignedInAnalytics() {
 	}, [user.allowAnalyticsCookie, user.email, user.id, user.name, app, storedConsent])
 
 	useTrackPageViews()
+	useSignUpTracking()
 
 	return null
 }


### PR DESCRIPTION
In order to measure whether paid traffic (notably the "dotcom youtube" Demand Gen campaign) results in account signups, this PR fires a GA4 `sign_up` conversion event when a user first creates an account on tldraw.com. Previously there was no sign-up event in GA4 at all, so campaign performance could not be judged on real conversions.

tldraw.com uses Clerk's hosted sign-up flow, which completes on Clerk's pages and redirects back to the app — so there is no in-app sign-up callback to hook into. Instead, `useSignUpTracking` (called from `SignedInAnalytics`) treats a signed-in user as a new sign-up when their Clerk account `createdAt` is within a short recency window, and dedupes per account in `localStorage` so the event fires once per new account rather than on every login or reload. The event flows through the existing `trackEvent` path, which now forwards `sign_up` to GA4 (with a `method` param of the OAuth provider, e.g. `google`, or `email`) as well as PostHog. Consent handling and buffering match the existing `page_view` event.

Note: GA4 only runs where `VITE_GA4_MEASUREMENT_ID` is set (deployed environments), so this needs verifying against a live GA4 stream. Marking `sign_up` as a key event in GA4 and importing it as a Google Ads conversion are console-only follow-ups.

### Change type

- [x] `feature`

### Test plan

1. In a staging environment, complete a fresh account sign-up (Google and email).
2. Confirm a single `sign_up` event appears in GA4 Realtime with a `method` param set.
3. Confirm the event carries the correct source/medium (not `(direct)`), so ad attribution survives the Clerk redirect.
4. Reload the page and sign out/in again as the same user; confirm no further `sign_up` events fire.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Internal analytics only; no user-facing changes.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +37 / -0   |
| Apps    | +72 / -0   |
