### PR TITLE
feat(examples): use @tldraw/ui components in examples app

### DIFF
--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -55,6 +55,7 @@
 		"@tldraw/mermaid": "workspace:*",
 		"@tldraw/state": "workspace:*",
 		"@tldraw/sync": "workspace:*",
+		"@tldraw/ui": "workspace:*",
 		"ag-grid-community": "^32.3.3",
 		"ag-grid-react": "^32.3.3",
 		"axe-core": "^4.10.3",

--- a/apps/examples/src/examples/configuration/environment-detection/EnvironmentDetectionExample.tsx
+++ b/apps/examples/src/examples/configuration/environment-detection/EnvironmentDetectionExample.tsx
@@ -1,5 +1,7 @@
-import { Tldraw, TldrawUiButton, TldrawUiIcon, tlenv, tlenvReactive, useValue } from 'tldraw'
+import { TlButton, TlIcon } from '@tldraw/ui'
+import { Tldraw, tlenv, tlenvReactive, useValue } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './environment-detection.css'
 
 // [1]
@@ -13,42 +15,44 @@ function EnvironmentInfo() {
 	const buttonSize = isCoarsePointer ? '48px' : '32px'
 
 	return (
-		<div className="tlui-menu environment-info">
-			{/* [4] Static detection with tlenv */}
-			<div>
-				<strong>Platform (tlenv):</strong> {tlenv.isIos && 'iOS'}
-				{tlenv.isDarwin && !tlenv.isIos && 'macOS'}
-				{tlenv.isAndroid && 'Android'}
-				{!tlenv.isDarwin && !tlenv.isIos && !tlenv.isAndroid && 'Other'}
-			</div>
-			<div>
-				<strong>Browser:</strong> {tlenv.isSafari && 'Safari'}
-				{tlenv.isFirefox && 'Firefox'}
-				{tlenv.isChromeForIos && 'Chrome for iOS'}
-				{!tlenv.isSafari && !tlenv.isFirefox && !tlenv.isChromeForIos && 'Other'}
-			</div>
-			<div>
-				<strong>Modifier key:</strong> {tlenv.isDarwin ? '⌘ Cmd' : 'Ctrl'}
-			</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu environment-info">
+				{/* [4] Static detection with tlenv */}
+				<div>
+					<strong>Platform (tlenv):</strong> {tlenv.isIos && 'iOS'}
+					{tlenv.isDarwin && !tlenv.isIos && 'macOS'}
+					{tlenv.isAndroid && 'Android'}
+					{!tlenv.isDarwin && !tlenv.isIos && !tlenv.isAndroid && 'Other'}
+				</div>
+				<div>
+					<strong>Browser:</strong> {tlenv.isSafari && 'Safari'}
+					{tlenv.isFirefox && 'Firefox'}
+					{tlenv.isChromeForIos && 'Chrome for iOS'}
+					{!tlenv.isSafari && !tlenv.isFirefox && !tlenv.isChromeForIos && 'Other'}
+				</div>
+				<div>
+					<strong>Modifier key:</strong> {tlenv.isDarwin ? '⌘ Cmd' : 'Ctrl'}
+				</div>
 
-			{/* [5] Reactive detection with tlenvReactive */}
-			<div>
-				<strong>Pointer type (reactive):</strong> {isCoarsePointer ? 'Touch' : 'Mouse'}
-			</div>
+				{/* [5] Reactive detection with tlenvReactive */}
+				<div>
+					<strong>Pointer type (reactive):</strong> {isCoarsePointer ? 'Touch' : 'Mouse'}
+				</div>
 
-			{/* [6] Adaptive button based on pointer type */}
-			<TldrawUiButton
-				type="normal"
-				style={{
-					width: buttonSize,
-					height: buttonSize,
-					border: '1px solid var(--tl-color-text-3)',
-				}}
-				onClick={() => alert(`Button size: ${buttonSize}`)}
-			>
-				<TldrawUiIcon icon="dot" label="Dot" />
-			</TldrawUiButton>
-		</div>
+				{/* [6] Adaptive button based on pointer type */}
+				<TlButton
+					type="normal"
+					style={{
+						width: buttonSize,
+						height: buttonSize,
+						border: '1px solid var(--tl-color-text-3)',
+					}}
+					onClick={() => alert(`Button size: ${buttonSize}`)}
+				>
+					<TlIcon icon="dot" label="Dot" />
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
+++ b/apps/examples/src/examples/configuration/reduced-motion/ReducedMotionExample.tsx
@@ -1,3 +1,4 @@
+import { TlButton } from '@tldraw/ui'
 import {
 	Geometry2d,
 	HTMLContainer,
@@ -8,11 +9,11 @@ import {
 	TLComponents,
 	TLShape,
 	Tldraw,
-	TldrawUiButton,
 	track,
 	useEditor,
 	usePrefersReducedMotion,
 } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 import './reduced-motion.css'
 
@@ -92,14 +93,16 @@ const MotionToggle = track(function MotionToggle() {
 	}
 
 	return (
-		<div className="motion-toggle">
-			<span className="motion-toggle__label">
-				Motion: {prefersReducedMotion ? 'Reduced' : 'Normal'}
-			</span>
-			<TldrawUiButton type="primary" onClick={toggleMotion}>
-				Toggle
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div className="motion-toggle">
+				<span className="motion-toggle__label">
+					Motion: {prefersReducedMotion ? 'Reduced' : 'Normal'}
+				</span>
+				<TlButton type="primary" onClick={toggleMotion}>
+					Toggle
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 })
 

--- a/apps/examples/src/examples/editor-api/align-and-distribute-shapes/AlignAndDistributeShapesExample.tsx
+++ b/apps/examples/src/examples/editor-api/align-and-distribute-shapes/AlignAndDistributeShapesExample.tsx
@@ -1,5 +1,7 @@
+import { TlButton } from '@tldraw/ui'
 import { useRef } from 'react'
-import { createShapeId, Tldraw, TldrawUiButton, useEditor } from 'tldraw'
+import { createShapeId, Tldraw, useEditor } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 import './align-and-distribute-shapes.css'
 
@@ -21,58 +23,60 @@ function ControlPanel({
 	const editor = useEditor()
 
 	return (
-		<div className="tlui-menu control-panel">
-			{ALIGN_OPERATIONS.map(({ operation, label }) => (
-				<TldrawUiButton
-					type="normal"
-					key={operation}
-					onClick={() => {
-						// [2]
-						const selectedIds = editor.getSelectedShapeIds()
-						if (selectedIds.length > 1) {
-							editor.alignShapes(selectedIds, operation)
-						}
-					}}
-				>
-					{label}
-				</TldrawUiButton>
-			))}
-			{DISTRIBUTE_OPERATIONS.map(({ operation, label }) => (
-				<TldrawUiButton
-					type="normal"
-					key={operation}
-					onClick={() => {
-						// [4]
-						const selectedIds = editor.getSelectedShapeIds()
-						if (selectedIds.length > 2) {
-							editor.distributeShapes(selectedIds, operation)
-						}
-					}}
-				>
-					{label}
-				</TldrawUiButton>
-			))}
-			<TldrawUiButton
-				type="normal"
-				onClick={() => {
-					const shapes = editor.getCurrentPageShapes()
-					editor.run(() => {
-						for (const shape of shapes) {
-							const originalPos = originalPositions.current?.get(shape.id)
-							if (originalPos) {
-								editor.updateShape({
-									...shape,
-									x: originalPos.x,
-									y: originalPos.y,
-								})
+		<ExampleTlUiProvider>
+			<div className="tl-menu control-panel">
+				{ALIGN_OPERATIONS.map(({ operation, label }) => (
+					<TlButton
+						type="normal"
+						key={operation}
+						onClick={() => {
+							// [2]
+							const selectedIds = editor.getSelectedShapeIds()
+							if (selectedIds.length > 1) {
+								editor.alignShapes(selectedIds, operation)
 							}
-						}
-					})
-				}}
-			>
-				Reset positions
-			</TldrawUiButton>
-		</div>
+						}}
+					>
+						{label}
+					</TlButton>
+				))}
+				{DISTRIBUTE_OPERATIONS.map(({ operation, label }) => (
+					<TlButton
+						type="normal"
+						key={operation}
+						onClick={() => {
+							// [4]
+							const selectedIds = editor.getSelectedShapeIds()
+							if (selectedIds.length > 2) {
+								editor.distributeShapes(selectedIds, operation)
+							}
+						}}
+					>
+						{label}
+					</TlButton>
+				))}
+				<TlButton
+					type="normal"
+					onClick={() => {
+						const shapes = editor.getCurrentPageShapes()
+						editor.run(() => {
+							for (const shape of shapes) {
+								const originalPos = originalPositions.current?.get(shape.id)
+								if (originalPos) {
+									editor.updateShape({
+										...shape,
+										x: originalPos.x,
+										y: originalPos.y,
+									})
+								}
+							}
+						})
+					}}
+				>
+					Reset positions
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/editor-api/locked-shapes/LockedShapesExample.tsx
+++ b/apps/examples/src/examples/editor-api/locked-shapes/LockedShapesExample.tsx
@@ -1,5 +1,7 @@
+import { TlButton } from '@tldraw/ui'
 import { useState } from 'react'
-import { createShapeId, Tldraw, TldrawUiButton, TLShapeId, toRichText, useEditor } from 'tldraw'
+import { createShapeId, Tldraw, TLShapeId, toRichText, useEditor } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 
 // [1]
@@ -60,28 +62,30 @@ function ControlPanel() {
 	}
 
 	return (
-		<div className="tlui-menu" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-			<label
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					gap: 6,
-					fontSize: 13,
-					cursor: 'pointer',
-					userSelect: 'none',
-				}}
-				title="When on, left-click and brush selection include locked shapes."
-			>
-				<input type="checkbox" checked={selectLocked} onChange={toggleSelectLocked} />
-				Allow selecting locked shapes
-			</label>
-			<TldrawUiButton type="normal" onClick={handleScatter}>
-				Scatter
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={handleReset}>
-				Reset
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu" style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+				<label
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 6,
+						fontSize: 13,
+						cursor: 'pointer',
+						userSelect: 'none',
+					}}
+					title="When on, left-click and brush selection include locked shapes."
+				>
+					<input type="checkbox" checked={selectLocked} onChange={toggleSelectLocked} />
+					Allow selecting locked shapes
+				</label>
+				<TlButton type="normal" onClick={handleScatter}>
+					Scatter
+				</TlButton>
+				<TlButton type="normal" onClick={handleReset}>
+					Reset
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/editor-api/shape-animation/ShapeAnimationExample.tsx
+++ b/apps/examples/src/examples/editor-api/shape-animation/ShapeAnimationExample.tsx
@@ -1,12 +1,6 @@
-import {
-	createShapeId,
-	EASINGS,
-	TLComponents,
-	Tldraw,
-	TldrawUiButton,
-	useEditor,
-	useValue,
-} from 'tldraw'
+import { TlButton } from '@tldraw/ui'
+import { createShapeId, EASINGS, TLComponents, Tldraw, useEditor, useValue } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 import './shape-animation.css'
 
@@ -89,23 +83,25 @@ function AnimationControls() {
 	)
 
 	return (
-		<div className="tlui-menu animation-controls">
-			<TldrawUiButton type="normal" disabled={hasOneSelected} onClick={animatePosition}>
-				Animate position
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" disabled={hasOneSelected} onClick={animateRotation}>
-				Animate rotation
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" disabled={hasOneSelected} onClick={animateFade}>
-				Fade in/out
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" disabled={hasOneSelected} onClick={animateAll}>
-				Animate all
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={animateMultiple}>
-				Animate multiple shapes
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu animation-controls">
+				<TlButton type="normal" disabled={hasOneSelected} onClick={animatePosition}>
+					Animate position
+				</TlButton>
+				<TlButton type="normal" disabled={hasOneSelected} onClick={animateRotation}>
+					Animate rotation
+				</TlButton>
+				<TlButton type="normal" disabled={hasOneSelected} onClick={animateFade}>
+					Fade in/out
+				</TlButton>
+				<TlButton type="normal" disabled={hasOneSelected} onClick={animateAll}>
+					Animate all
+				</TlButton>
+				<TlButton type="normal" onClick={animateMultiple}>
+					Animate multiple shapes
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/editor-api/text-search/TextSearchPanel.tsx
+++ b/apps/examples/src/examples/editor-api/text-search/TextSearchPanel.tsx
@@ -1,5 +1,7 @@
+import { TlButton } from '@tldraw/ui'
 import { useEffect, useRef, useState } from 'react'
-import { EASINGS, Editor, TLShape, TldrawUiButton, track, useEditor } from 'tldraw'
+import { EASINGS, Editor, TLShape, track, useEditor } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import { showSearch } from './TextSearchExample'
 
 interface SearchResult {
@@ -53,28 +55,30 @@ export const TextSearchPanel = track(() => {
 
 	const results = getShapesWithText(editor, searchText)
 	return (
-		<div
-			className="text-search-panel scroll-light"
-			onPointerDown={editor.markEventAsHandled}
-			onKeyDown={keyDown}
-		>
-			<input
-				className="text-search-input"
-				ref={inputRef}
-				onChange={(e) => setSearchText(e.target.value)}
-			></input>
-			{results.map((result) => {
-				return (
-					<TldrawUiButton
-						key={'text-search-panel-button:' + result.shape.id}
-						type="normal"
-						className="text-search-panel-button"
-						onClick={() => moveToShape(editor, result.shape)}
-					>
-						{result.text}
-					</TldrawUiButton>
-				)
-			})}
-		</div>
+		<ExampleTlUiProvider>
+			<div
+				className="text-search-panel scroll-light"
+				onPointerDown={editor.markEventAsHandled}
+				onKeyDown={keyDown}
+			>
+				<input
+					className="text-search-input"
+					ref={inputRef}
+					onChange={(e) => setSearchText(e.target.value)}
+				></input>
+				{results.map((result) => {
+					return (
+						<TlButton
+							key={'text-search-panel-button:' + result.shape.id}
+							type="normal"
+							className="text-search-panel-button"
+							onClick={() => moveToShape(editor, result.shape)}
+						>
+							{result.text}
+						</TlButton>
+					)
+				})}
+			</div>
+		</ExampleTlUiProvider>
 	)
 })

--- a/apps/examples/src/examples/editor-api/z-order/ZOrderExample.tsx
+++ b/apps/examples/src/examples/editor-api/z-order/ZOrderExample.tsx
@@ -1,4 +1,6 @@
-import { createShapeId, Tldraw, TldrawUiButton, useEditor } from 'tldraw'
+import { TlButton } from '@tldraw/ui'
+import { createShapeId, Tldraw, useEditor } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 import './z-order.css'
 
@@ -34,33 +36,35 @@ export default function ZOrderExample() {
 					TopPanel: () => {
 						const editor = useEditor()
 						return (
-							<div className="tlui-menu z-order-controls">
-								{/* [1] */}
-								<TldrawUiButton
-									type="normal"
-									onClick={() => editor.sendToBack(editor.getSelectedShapeIds())}
-								>
-									Send to back
-								</TldrawUiButton>
-								<TldrawUiButton
-									type="normal"
-									onClick={() => editor.sendBackward(editor.getSelectedShapeIds())}
-								>
-									Send backward
-								</TldrawUiButton>
-								<TldrawUiButton
-									type="normal"
-									onClick={() => editor.bringForward(editor.getSelectedShapeIds())}
-								>
-									Bring forward
-								</TldrawUiButton>
-								<TldrawUiButton
-									type="normal"
-									onClick={() => editor.bringToFront(editor.getSelectedShapeIds())}
-								>
-									Bring to front
-								</TldrawUiButton>
-							</div>
+							<ExampleTlUiProvider>
+								<div className="tl-menu z-order-controls">
+									{/* [1] */}
+									<TlButton
+										type="normal"
+										onClick={() => editor.sendToBack(editor.getSelectedShapeIds())}
+									>
+										Send to back
+									</TlButton>
+									<TlButton
+										type="normal"
+										onClick={() => editor.sendBackward(editor.getSelectedShapeIds())}
+									>
+										Send backward
+									</TlButton>
+									<TlButton
+										type="normal"
+										onClick={() => editor.bringForward(editor.getSelectedShapeIds())}
+									>
+										Bring forward
+									</TlButton>
+									<TlButton
+										type="normal"
+										onClick={() => editor.bringToFront(editor.getSelectedShapeIds())}
+									>
+										Bring to front
+									</TlButton>
+								</div>
+							</ExampleTlUiProvider>
 						)
 					},
 				}}

--- a/apps/examples/src/examples/editor-api/zoom-to-bounds/ZoomToBoundsExample.tsx
+++ b/apps/examples/src/examples/editor-api/zoom-to-bounds/ZoomToBoundsExample.tsx
@@ -1,4 +1,6 @@
-import { Box, createShapeId, Tldraw, TldrawUiButton, useEditor } from 'tldraw'
+import { TlButton } from '@tldraw/ui'
+import { Box, createShapeId, Tldraw, useEditor } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './zoom-to-bounds.css'
 
 export default function ZoomToBoundsExample() {
@@ -40,36 +42,38 @@ export default function ZoomToBoundsExample() {
 					TopPanel: () => {
 						const editor = useEditor()
 						return (
-							<div className="tlui-menu control-panel">
-								<TldrawUiButton
-									type="normal"
-									// Zoom to bounds!
-									onClick={() => editor.zoomToBounds(zoomBox1, { inset: 72 })}
-								>
-									Zoom to violet box
-								</TldrawUiButton>
-								<TldrawUiButton
-									type="normal"
-									// Zoom to bounds!
-									onClick={() =>
-										editor.zoomToBounds(zoomBox2, { inset: 72, animation: { duration: 200 } })
-									}
-								>
-									Zoom to blue box
-								</TldrawUiButton>
-								<TldrawUiButton
-									type="normal"
-									// Zoom to bounds!
-									onClick={() =>
-										editor.zoomToBounds(Box.Common([zoomBox1, zoomBox2]), {
-											inset: 200,
-											animation: { duration: 200 },
-										})
-									}
-								>
-									Zoom to both boxes
-								</TldrawUiButton>
-							</div>
+							<ExampleTlUiProvider>
+								<div className="tl-menu control-panel">
+									<TlButton
+										type="normal"
+										// Zoom to bounds!
+										onClick={() => editor.zoomToBounds(zoomBox1, { inset: 72 })}
+									>
+										Zoom to violet box
+									</TlButton>
+									<TlButton
+										type="normal"
+										// Zoom to bounds!
+										onClick={() =>
+											editor.zoomToBounds(zoomBox2, { inset: 72, animation: { duration: 200 } })
+										}
+									>
+										Zoom to blue box
+									</TlButton>
+									<TlButton
+										type="normal"
+										// Zoom to bounds!
+										onClick={() =>
+											editor.zoomToBounds(Box.Common([zoomBox1, zoomBox2]), {
+												inset: 200,
+												animation: { duration: 200 },
+											})
+										}
+									>
+										Zoom to both boxes
+									</TlButton>
+								</div>
+							</ExampleTlUiProvider>
 						)
 					},
 				}}

--- a/apps/examples/src/examples/shapes/tools/outlined-text/OutlinedTextExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/outlined-text/OutlinedTextExample.tsx
@@ -1,15 +1,16 @@
 import { Mark, mergeAttributes } from '@tiptap/core'
 import { StarterKit } from '@tiptap/starter-kit'
+import { TlButton } from '@tldraw/ui'
 import {
 	DefaultRichTextToolbar,
 	TLComponents,
 	Tldraw,
-	TldrawUiButton,
 	preventDefault,
 	useEditor,
 	useValue,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../../misc/ExampleTlUiProvider'
 import './OutlinedTextExample.css'
 
 interface OutlineExtensionOptions {
@@ -80,17 +81,19 @@ const components: TLComponents = {
 
 		return (
 			<DefaultRichTextToolbar>
-				<TldrawUiButton
-					type="icon"
-					onClick={() => {
-						textEditor?.chain().focus().toggleOutline().run()
-					}}
-					isActive={textEditor?.isActive('outline')}
-					onPointerDown={preventDefault}
-					title="Toggle text outline"
-				>
-					⬜
-				</TldrawUiButton>
+				<ExampleTlUiProvider>
+					<TlButton
+						type="icon"
+						onClick={() => {
+							textEditor?.chain().focus().toggleOutline().run()
+						}}
+						isActive={textEditor?.isActive('outline')}
+						onPointerDown={preventDefault}
+						title="Toggle text outline"
+					>
+						⬜
+					</TlButton>
+				</ExampleTlUiProvider>
 			</DefaultRichTextToolbar>
 		)
 	},

--- a/apps/examples/src/examples/shapes/tools/rich-text-custom-extension/RichTextCustomExtension.tsx
+++ b/apps/examples/src/examples/shapes/tools/rich-text-custom-extension/RichTextCustomExtension.tsx
@@ -1,14 +1,15 @@
 import { Mark, mergeAttributes } from '@tiptap/core'
 import { StarterKit } from '@tiptap/starter-kit'
+import { TlButton } from '@tldraw/ui'
 import {
 	DefaultRichTextToolbar,
 	TLComponents,
 	Tldraw,
-	TldrawUiButton,
 	preventDefault,
 	useEditor,
 	useValue,
 } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 import './RichTextCustomExtension.css'
 
@@ -76,16 +77,18 @@ const components: TLComponents = {
 
 		return (
 			<DefaultRichTextToolbar>
-				<TldrawUiButton
-					type="icon"
-					onClick={() => {
-						textEditor?.chain().focus().toggleWavy().run()
-					}}
-					isActive={textEditor?.isActive('wavy')}
-					onPointerDown={preventDefault}
-				>
-					〰️
-				</TldrawUiButton>
+				<ExampleTlUiProvider>
+					<TlButton
+						type="icon"
+						onClick={() => {
+							textEditor?.chain().focus().toggleWavy().run()
+						}}
+						isActive={textEditor?.isActive('wavy')}
+						onPointerDown={preventDefault}
+					>
+						〰️
+					</TlButton>
+				</ExampleTlUiProvider>
 				{/* Add the DefaultRichTextToolbarContent if you want to add more items. */}
 				{/* <DefaultRichTextToolbarContent textEditor={textEditor} onEditLinkIntent={() => {}} /> */}
 			</DefaultRichTextToolbar>

--- a/apps/examples/src/examples/ui/custom-language-translations/CustomLanguageTranslationExample.tsx
+++ b/apps/examples/src/examples/ui/custom-language-translations/CustomLanguageTranslationExample.tsx
@@ -1,12 +1,7 @@
-import {
-	TLComponents,
-	TLUiOverrides,
-	Tldraw,
-	TldrawUiButton,
-	useEditor,
-	useTranslation,
-} from 'tldraw'
+import { TlButton } from '@tldraw/ui'
+import { TLComponents, TLUiOverrides, Tldraw, useEditor, useTranslation } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './custom-language-translations.css'
 
 // There's a guide at the bottom of this file!
@@ -17,21 +12,20 @@ function CustomToolbar() {
 	const msg = useTranslation()
 
 	return (
-		<div className="tlui-menu custom-language-toolbar">
-			<TldrawUiButton
-				type="normal"
-				onClick={() => editor.duplicateShapes(editor.getSelectedShapeIds())}
-			>
-				{/* [2] */}
-				{msg('action.duplicate')}
-			</TldrawUiButton>
-			<TldrawUiButton
-				type="normal"
-				onClick={() => editor.deleteShapes(editor.getSelectedShapeIds())}
-			>
-				{msg('action.delete')}
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu custom-language-toolbar">
+				<TlButton
+					type="normal"
+					onClick={() => editor.duplicateShapes(editor.getSelectedShapeIds())}
+				>
+					{/* [2] */}
+					{msg('action.duplicate')}
+				</TlButton>
+				<TlButton type="normal" onClick={() => editor.deleteShapes(editor.getSelectedShapeIds())}>
+					{msg('action.delete')}
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/ui/custom-theme/CustomThemeExample.tsx
+++ b/apps/examples/src/examples/ui/custom-theme/CustomThemeExample.tsx
@@ -1,3 +1,4 @@
+import { TlButton, TlButtonLabel } from '@tldraw/ui'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import {
 	DEFAULT_THEME,
@@ -8,11 +9,10 @@ import {
 	TLThemes,
 	TLUiOverrides,
 	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonLabel,
 	toRichText,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import silkscreenBoldUrl from './custom-font/Silkscreen-Bold.ttf'
 import silkscreenRegularUrl from './custom-font/Silkscreen-Regular.ttf'
 import './custom-theme.css'
@@ -276,46 +276,48 @@ function ThemeControls({
 	onStrokeWidthChange(v: number): void
 }) {
 	return (
-		<div className="tlui-menu custom-theme-toolbar" onPointerDown={(e) => e.stopPropagation()}>
-			<ThemeSlider
-				label="Font size"
-				value={fontSize}
-				onChange={onFontSizeChange}
-				min={8}
-				max={32}
-				step={1}
-				defaultValue={DEFAULTS.fontSize}
-			/>
-			<ThemeSlider
-				label="Line height"
-				value={lineHeight}
-				onChange={onLineHeightChange}
-				min={1}
-				max={2}
-				step={0.05}
-				defaultValue={DEFAULTS.lineHeight}
-			/>
-			<ThemeSlider
-				label="Stroke width"
-				value={strokeWidth}
-				onChange={onStrokeWidthChange}
-				min={0.5}
-				max={6}
-				step={0.25}
-				defaultValue={DEFAULTS.strokeWidth}
-			/>
+		<ExampleTlUiProvider>
+			<div className="tl-menu custom-theme-toolbar" onPointerDown={(e) => e.stopPropagation()}>
+				<ThemeSlider
+					label="Font size"
+					value={fontSize}
+					onChange={onFontSizeChange}
+					min={8}
+					max={32}
+					step={1}
+					defaultValue={DEFAULTS.fontSize}
+				/>
+				<ThemeSlider
+					label="Line height"
+					value={lineHeight}
+					onChange={onLineHeightChange}
+					min={1}
+					max={2}
+					step={0.05}
+					defaultValue={DEFAULTS.lineHeight}
+				/>
+				<ThemeSlider
+					label="Stroke width"
+					value={strokeWidth}
+					onChange={onStrokeWidthChange}
+					min={0.5}
+					max={6}
+					step={0.25}
+					defaultValue={DEFAULTS.strokeWidth}
+				/>
 
-			<TldrawUiButton
-				type="low"
-				onClick={() => {
-					onFontSizeChange(DEFAULTS.fontSize)
-					onLineHeightChange(DEFAULTS.lineHeight)
-					onStrokeWidthChange(DEFAULTS.strokeWidth)
-				}}
-			>
-				<TldrawUiButtonLabel>Reset to defaults</TldrawUiButtonLabel>
-			</TldrawUiButton>
-		</div>
+				<TlButton
+					type="low"
+					onClick={() => {
+						onFontSizeChange(DEFAULTS.fontSize)
+						onLineHeightChange(DEFAULTS.lineHeight)
+						onStrokeWidthChange(DEFAULTS.strokeWidth)
+					}}
+				>
+					<TlButtonLabel>Reset to defaults</TlButtonLabel>
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/ui/menu-system-hover/MenuSystemHoverExample.tsx
+++ b/apps/examples/src/examples/ui/menu-system-hover/MenuSystemHoverExample.tsx
@@ -1,65 +1,60 @@
 import {
-	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonLabel,
-	TldrawUiDropdownMenuContent,
-	TldrawUiDropdownMenuItem,
-	TldrawUiDropdownMenuRoot,
-	TldrawUiDropdownMenuTrigger,
-	useEditor,
-	useMenuIsOpen,
-} from 'tldraw'
+	TlButton,
+	TlButtonLabel,
+	TlDropdownMenuContent,
+	TlDropdownMenuItem,
+	TlDropdownMenuRoot,
+	TlDropdownMenuTrigger,
+	useTlMenuIsOpen,
+	useTlMenuState,
+} from '@tldraw/ui'
+import { Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './menu-system-hover.css'
 
 // [1]
 function HoverControlledMenu() {
-	const editor = useEditor()
-	const [isOpen] = useMenuIsOpen('hover-menu')
+	const { openMenu, closeMenu } = useTlMenuState()
+	const [isOpen] = useTlMenuIsOpen('hover-menu')
 
 	return (
 		<div className="hover-menu-container">
 			{/* [2] */}
-			<div
-				className="hover-zone hover-zone-open"
-				onMouseEnter={() => editor.menus.addOpenMenu('hover-menu')}
-			>
+			<div className="hover-zone hover-zone-open" onMouseEnter={() => openMenu('hover-menu')}>
 				Hover to open menu
 			</div>
 
 			{/* [3] */}
-			<div
-				className="hover-zone hover-zone-close"
-				onMouseEnter={() => editor.menus.deleteOpenMenu('hover-menu')}
-			>
+			<div className="hover-zone hover-zone-close" onMouseEnter={() => closeMenu('hover-menu')}>
 				Hover to close menu
 			</div>
 
 			{/* [4] */}
-			<TldrawUiDropdownMenuRoot id="hover-menu">
-				<TldrawUiDropdownMenuTrigger>
-					<TldrawUiButton type="normal">
-						<TldrawUiButtonLabel>Menu {isOpen ? '(open)' : '(closed)'}</TldrawUiButtonLabel>
-					</TldrawUiButton>
-				</TldrawUiDropdownMenuTrigger>
-				<TldrawUiDropdownMenuContent>
-					<TldrawUiDropdownMenuItem>
-						<TldrawUiButton type="menu">
-							<TldrawUiButtonLabel>Menu item 1</TldrawUiButtonLabel>
-						</TldrawUiButton>
-					</TldrawUiDropdownMenuItem>
-					<TldrawUiDropdownMenuItem>
-						<TldrawUiButton type="menu">
-							<TldrawUiButtonLabel>Menu item 2</TldrawUiButtonLabel>
-						</TldrawUiButton>
-					</TldrawUiDropdownMenuItem>
-					<TldrawUiDropdownMenuItem>
-						<TldrawUiButton type="menu">
-							<TldrawUiButtonLabel>Menu item 3</TldrawUiButtonLabel>
-						</TldrawUiButton>
-					</TldrawUiDropdownMenuItem>
-				</TldrawUiDropdownMenuContent>
-			</TldrawUiDropdownMenuRoot>
+			<TlDropdownMenuRoot id="hover-menu">
+				<TlDropdownMenuTrigger>
+					<TlButton type="normal">
+						<TlButtonLabel>Menu {isOpen ? '(open)' : '(closed)'}</TlButtonLabel>
+					</TlButton>
+				</TlDropdownMenuTrigger>
+				<TlDropdownMenuContent>
+					<TlDropdownMenuItem>
+						<TlButton type="menu">
+							<TlButtonLabel>Menu item 1</TlButtonLabel>
+						</TlButton>
+					</TlDropdownMenuItem>
+					<TlDropdownMenuItem>
+						<TlButton type="menu">
+							<TlButtonLabel>Menu item 2</TlButtonLabel>
+						</TlButton>
+					</TlDropdownMenuItem>
+					<TlDropdownMenuItem>
+						<TlButton type="menu">
+							<TlButtonLabel>Menu item 3</TlButtonLabel>
+						</TlButton>
+					</TlDropdownMenuItem>
+				</TlDropdownMenuContent>
+			</TlDropdownMenuRoot>
 		</div>
 	)
 }
@@ -68,7 +63,9 @@ export default function MenuSystemHoverExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw>
-				<HoverControlledMenu />
+				<ExampleTlUiProvider>
+					<HoverControlledMenu />
+				</ExampleTlUiProvider>
 			</Tldraw>
 		</div>
 	)

--- a/apps/examples/src/examples/ui/multiple-themes/MultipleThemesExample.tsx
+++ b/apps/examples/src/examples/ui/multiple-themes/MultipleThemesExample.tsx
@@ -1,3 +1,4 @@
+import { TlButton, TlButtonLabel } from '@tldraw/ui'
 import { useCallback, useMemo } from 'react'
 import {
 	DEFAULT_THEME,
@@ -6,14 +7,13 @@ import {
 	TLThemeId,
 	TLThemes,
 	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonLabel,
 	structuredClone,
 	toRichText,
 	useEditor,
 	useValue,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 
 // There's a guide at the bottom of this file!
 
@@ -106,17 +106,19 @@ function ThemeSwitcher() {
 	)
 
 	return (
-		<div style={useMemo(() => styles.container, [])}>
-			{(Object.keys(THEME_LABELS) as TLThemeId[]).map((id) => (
-				<TldrawUiButton
-					key={id}
-					type={currentThemeId === id ? 'primary' : 'normal'}
-					onClick={() => handleClick(id)}
-				>
-					<TldrawUiButtonLabel>{THEME_LABELS[id]}</TldrawUiButtonLabel>
-				</TldrawUiButton>
-			))}
-		</div>
+		<ExampleTlUiProvider>
+			<div style={useMemo(() => styles.container, [])}>
+				{(Object.keys(THEME_LABELS) as TLThemeId[]).map((id) => (
+					<TlButton
+						key={id}
+						type={currentThemeId === id ? 'primary' : 'normal'}
+						onClick={() => handleClick(id)}
+					>
+						<TlButtonLabel>{THEME_LABELS[id]}</TlButtonLabel>
+					</TlButton>
+				))}
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/ui/rich-text-on-multiple-shapes/RichTextFormatOnMultipleShapesExample.tsx
+++ b/apps/examples/src/examples/ui/rich-text-on-multiple-shapes/RichTextFormatOnMultipleShapesExample.tsx
@@ -1,3 +1,4 @@
+import { TlButton, TlButtonIcon, TlButtonLabel } from '@tldraw/ui'
 import {
 	DefaultStylePanel,
 	DefaultStylePanelContent,
@@ -7,13 +8,11 @@ import {
 	TLShape,
 	TLUiStylePanelProps,
 	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonIcon,
-	TldrawUiButtonLabel,
 	useEditor,
 	useValue,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 
 type ShapeWithRichText = ExtractShapeByProps<{ richText: TLRichText }>
 
@@ -167,18 +166,20 @@ function CustomStylePanel(props: TLUiStylePanelProps) {
 
 	return (
 		<DefaultStylePanel {...props}>
-			<div className="tlui-style-panel__section">
-				<TldrawUiButton
-					type="menu"
-					data-isactive={allBold}
-					onClick={handleToggleBold}
-					title="Bold all text in selected shapes"
-					disabled={!hasRichTextSelection}
-				>
-					<TldrawUiButtonIcon icon="bold" />
-					<TldrawUiButtonLabel>Bold All Text</TldrawUiButtonLabel>
-				</TldrawUiButton>
-			</div>
+			<ExampleTlUiProvider>
+				<div className="tlui-style-panel__section">
+					<TlButton
+						type="menu"
+						isActive={allBold}
+						onClick={handleToggleBold}
+						title="Bold all text in selected shapes"
+						disabled={!hasRichTextSelection}
+					>
+						<TlButtonIcon icon="bold" />
+						<TlButtonLabel>Bold All Text</TlButtonLabel>
+					</TlButton>
+				</div>
+			</ExampleTlUiProvider>
 			<DefaultStylePanelContent />
 		</DefaultStylePanel>
 	)

--- a/apps/examples/src/examples/ui/screen-reader-accessibility/ScreenReaderAccessibilityExample.tsx
+++ b/apps/examples/src/examples/ui/screen-reader-accessibility/ScreenReaderAccessibilityExample.tsx
@@ -1,3 +1,4 @@
+import { TlButton } from '@tldraw/ui'
 import { useState } from 'react'
 import {
 	BaseBoxShapeUtil,
@@ -5,12 +6,12 @@ import {
 	RecordProps,
 	T,
 	Tldraw,
-	TldrawUiButton,
 	TLShape,
 	useA11y,
 	useEditor,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './screen-reader-accessibility.css'
 
 const CARD_SHAPE_TYPE = 'note-card'
@@ -136,17 +137,19 @@ function CustomAnnouncementPanel() {
 	}
 
 	return (
-		<div className="tlui-menu announcement-panel">
-			<TldrawUiButton type="normal" onClick={handleActionConfirmation}>
-				Perform action
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={handleValidation}>
-				Validate selection
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={handleToggle}>
-				{isEnabled ? 'Disable' : 'Enable'} feature
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu announcement-panel">
+				<TlButton type="normal" onClick={handleActionConfirmation}>
+					Perform action
+				</TlButton>
+				<TlButton type="normal" onClick={handleValidation}>
+					Validate selection
+				</TlButton>
+				<TlButton type="normal" onClick={handleToggle}>
+					{isEnabled ? 'Disable' : 'Enable'} feature
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/ui/text-mass-style-updates/TextMassStyleUpdates.tsx
+++ b/apps/examples/src/examples/ui/text-mass-style-updates/TextMassStyleUpdates.tsx
@@ -1,5 +1,6 @@
 import { getSchema, JSONContent } from '@tiptap/core'
 import { Fragment, Node, Schema } from '@tiptap/pm/model'
+import { TlButton, TlButtonIcon, TlButtonLabel } from '@tldraw/ui'
 import {
 	DefaultStylePanel,
 	DefaultStylePanelContent,
@@ -7,9 +8,6 @@ import {
 	tipTapDefaultExtensions,
 	TLComponents,
 	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonIcon,
-	TldrawUiButtonLabel,
 	TLShape,
 	TLShapeId,
 	TLTextShape,
@@ -18,6 +16,7 @@ import {
 	useValue,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 
 // There's a guide at the bottom of this file!
 
@@ -127,17 +126,19 @@ function CustomStylePanel(props: TLUiStylePanelProps) {
 	return (
 		<DefaultStylePanel {...props}>
 			{hasTextShapes && (
-				<div className="tlui-style-panel__section">
-					{STYLES.map(({ style, icon, label }) => (
-						<StyleButton
-							key={style}
-							style={style}
-							icon={icon}
-							label={label}
-							textShapeIds={allTextShapeIds}
-						/>
-					))}
-				</div>
+				<ExampleTlUiProvider>
+					<div className="tlui-style-panel__section">
+						{STYLES.map(({ style, icon, label }) => (
+							<StyleButton
+								key={style}
+								style={style}
+								icon={icon}
+								label={label}
+								textShapeIds={allTextShapeIds}
+							/>
+						))}
+					</div>
+				</ExampleTlUiProvider>
 			)}
 			<DefaultStylePanelContent />
 		</DefaultStylePanel>
@@ -165,9 +166,9 @@ function StyleButton({
 	)
 
 	return (
-		<TldrawUiButton
+		<TlButton
 			type="menu"
-			data-isactive={isActive}
+			isActive={isActive}
 			onClick={() => {
 				const shouldRemove = textShapeIds.every((id) => isUniformlyStyled(editor, id, style))
 				editor.run(() => {
@@ -178,9 +179,9 @@ function StyleButton({
 			}}
 			title={`${label} all text in selected shapes`}
 		>
-			<TldrawUiButtonIcon icon={icon} />
-			<TldrawUiButtonLabel>{label} All</TldrawUiButtonLabel>
-		</TldrawUiButton>
+			<TlButtonIcon icon={icon} />
+			<TlButtonLabel>{label} All</TlButtonLabel>
+		</TlButton>
 	)
 }
 

--- a/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -1,40 +1,48 @@
+import {
+	TlButton,
+	TlButtonLabel,
+	TlDialogBody,
+	TlDialogCloseButton,
+	TlDialogFooter,
+	TlDialogHeader,
+	TlDialogTitle,
+	useTlContainer,
+	useTlDialogs,
+	useTlToasts,
+} from '@tldraw/ui'
 import { Select as _Select } from 'radix-ui'
 import { useState } from 'react'
-import {
-	TLComponents,
-	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonLabel,
-	TldrawUiDialogBody,
-	TldrawUiDialogCloseButton,
-	TldrawUiDialogFooter,
-	TldrawUiDialogHeader,
-	TldrawUiDialogTitle,
-	useContainer,
-	useDialogs,
-	useToasts,
-} from 'tldraw'
+import { TLComponents, Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 
 // There's a guide at the bottom of this file
+
+const dialogFooterActionsStyle = {
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'flex-end',
+} as const
 
 // [1]
 function MyDialog({ onClose }: { onClose(): void }) {
 	return (
 		<>
-			<TldrawUiDialogHeader>
-				<TldrawUiDialogTitle>Title</TldrawUiDialogTitle>
-				<TldrawUiDialogCloseButton />
-			</TldrawUiDialogHeader>
-			<TldrawUiDialogBody style={{ maxWidth: 350 }}>Description...</TldrawUiDialogBody>
-			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
-				<TldrawUiButton type="normal" onClick={onClose}>
-					<TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>
-				</TldrawUiButton>
-				<TldrawUiButton type="primary" onClick={onClose}>
-					<TldrawUiButtonLabel>Continue</TldrawUiButtonLabel>
-				</TldrawUiButton>
-			</TldrawUiDialogFooter>
+			<TlDialogHeader>
+				<TlDialogTitle>Title</TlDialogTitle>
+				<TlDialogCloseButton />
+			</TlDialogHeader>
+			<TlDialogBody style={{ maxWidth: 350 }}>Description...</TlDialogBody>
+			<TlDialogFooter>
+				<div style={dialogFooterActionsStyle}>
+					<TlButton type="normal" onClick={onClose}>
+						<TlButtonLabel>Cancel</TlButtonLabel>
+					</TlButton>
+					<TlButton type="primary" onClick={onClose}>
+						<TlButtonLabel>Continue</TlButtonLabel>
+					</TlButton>
+				</div>
+			</TlDialogFooter>
 		</>
 	)
 }
@@ -52,15 +60,15 @@ function MySimpleDialog({ onClose }: { onClose(): void }) {
 
 // [3]
 function MyDialogWithSelect({ onClose }: { onClose(): void }) {
-	const container = useContainer()
+	const container = useTlContainer()
 	const [value, setValue] = useState('a')
 	return (
 		<>
-			<TldrawUiDialogHeader>
-				<TldrawUiDialogTitle>Dialog with a select</TldrawUiDialogTitle>
-				<TldrawUiDialogCloseButton />
-			</TldrawUiDialogHeader>
-			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
+			<TlDialogHeader>
+				<TlDialogTitle>Dialog with a select</TlDialogTitle>
+				<TlDialogCloseButton />
+			</TlDialogHeader>
+			<TlDialogBody style={{ maxWidth: 350 }}>
 				<p>A select opened inside a modal is its own dismissable layer.</p>
 				<_Select.Root value={value} onValueChange={setValue}>
 					<_Select.Trigger
@@ -98,12 +106,14 @@ function MyDialogWithSelect({ onClose }: { onClose(): void }) {
 						</_Select.Content>
 					</_Select.Portal>
 				</_Select.Root>
-			</TldrawUiDialogBody>
-			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
-				<TldrawUiButton type="primary" onClick={onClose}>
-					<TldrawUiButtonLabel>Done</TldrawUiButtonLabel>
-				</TldrawUiButton>
-			</TldrawUiDialogFooter>
+			</TlDialogBody>
+			<TlDialogFooter>
+				<div style={dialogFooterActionsStyle}>
+					<TlButton type="primary" onClick={onClose}>
+						<TlButtonLabel>Done</TlButtonLabel>
+					</TlButton>
+				</div>
+			</TlDialogFooter>
 		</>
 	)
 }
@@ -111,7 +121,7 @@ function MyDialogWithSelect({ onClose }: { onClose(): void }) {
 // [4] A dialog that opens a second dialog, so the two stack. Stacked dialogs stay modal,
 // so each one — including the topmost — keeps its own controls interactive (taps included).
 function MyNestedDialog({ onClose }: { onClose(): void }) {
-	const { addDialog } = useDialogs()
+	const { addDialog } = useTlDialogs()
 	return (
 		<div data-testid="dialog-parent" style={{ padding: 16 }}>
 			<h2>Parent dialog</h2>
@@ -139,8 +149,16 @@ function MyConfirmDialog({ onClose }: { onClose(): void }) {
 }
 
 const CustomSharePanel = () => {
-	const { addToast } = useToasts()
-	const { addDialog } = useDialogs()
+	return (
+		<ExampleTlUiProvider>
+			<CustomSharePanelContent />
+		</ExampleTlUiProvider>
+	)
+}
+
+function CustomSharePanelContent() {
+	const { addToast } = useTlToasts()
+	const { addDialog } = useTlDialogs()
 
 	return (
 		<div style={{ padding: 16, gap: 16, display: 'flex', pointerEvents: 'all' }}>
@@ -199,7 +217,15 @@ const CustomSharePanel = () => {
 // Rendered in front of the canvas rather than in the SharePanel, which overflows
 // off-screen on mobile — so the stacked-dialog demo stays reachable on a touchscreen.
 function StackedDialogLauncher() {
-	const { addDialog } = useDialogs()
+	return (
+		<ExampleTlUiProvider>
+			<StackedDialogLauncherContent />
+		</ExampleTlUiProvider>
+	)
+}
+
+function StackedDialogLauncherContent() {
+	const { addDialog } = useTlDialogs()
 	return (
 		<button
 			data-testid="show-nested-dialog"

--- a/apps/examples/src/examples/ui/ui-primitives/UiPrimitivesExample.tsx
+++ b/apps/examples/src/examples/ui/ui-primitives/UiPrimitivesExample.tsx
@@ -1,36 +1,34 @@
-import { useState } from 'react'
 import {
-	iconTypes,
-	Tldraw,
-	TldrawUiButton,
-	TldrawUiButtonIcon,
-	TldrawUiButtonLabel,
-	TldrawUiDropdownMenuCheckboxItem,
-	TldrawUiDropdownMenuContent,
-	TldrawUiDropdownMenuGroup,
-	TldrawUiDropdownMenuItem,
-	TldrawUiDropdownMenuRoot,
-	TldrawUiDropdownMenuSub,
-	TldrawUiDropdownMenuSubContent,
-	TldrawUiDropdownMenuSubTrigger,
-	TldrawUiDropdownMenuTrigger,
-	TldrawUiIcon,
-	TldrawUiInput,
-	TldrawUiKbd,
-	TldrawUiPopover,
-	TldrawUiPopoverContent,
-	TldrawUiPopoverTrigger,
-	TldrawUiSelect,
-	TldrawUiSelectContent,
-	TldrawUiSelectItem,
-	TldrawUiSelectTrigger,
-	TldrawUiSelectValue,
-	TldrawUiSlider,
-	TldrawUiTooltip,
-	TLEditorComponents,
-	useEditor,
-} from 'tldraw'
+	TlButton,
+	TlButtonIcon,
+	TlButtonLabel,
+	TlDropdownMenuCheckboxItem,
+	TlDropdownMenuContent,
+	TlDropdownMenuGroup,
+	TlDropdownMenuItem,
+	TlDropdownMenuRoot,
+	TlDropdownMenuSub,
+	TlDropdownMenuSubContent,
+	TlDropdownMenuSubTrigger,
+	TlDropdownMenuTrigger,
+	TlIcon,
+	TlInput,
+	TlKbd,
+	TlPopover,
+	TlPopoverContent,
+	TlPopoverTrigger,
+	TlSelect,
+	TlSelectContent,
+	TlSelectItem,
+	TlSelectTrigger,
+	TlSelectValue,
+	TlSlider,
+	TlTooltip,
+} from '@tldraw/ui'
+import { useState } from 'react'
+import { iconTypes, Tldraw, TLEditorComponents, useEditor } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './ui-primitives.css'
 
 // [1]
@@ -42,239 +40,236 @@ function UiShowcase() {
 	const [selectValue, setSelectValue] = useState('medium')
 
 	return (
-		<div className="ui-showcase" onPointerDown={editor.markEventAsHandled}>
-			<h2>UI primitives</h2>
+		<ExampleTlUiProvider>
+			<div className="ui-showcase" onPointerDown={editor.markEventAsHandled}>
+				<h2>UI primitives</h2>
 
-			{/* Buttons */}
-			<section>
-				<h3>Buttons</h3>
-				<div className="ui-row">
-					<TldrawUiButton type="normal" onClick={() => {}}>
-						<TldrawUiButtonLabel>Normal</TldrawUiButtonLabel>
-					</TldrawUiButton>
-					<TldrawUiButton type="primary" onClick={() => {}}>
-						<TldrawUiButtonLabel>Primary</TldrawUiButtonLabel>
-					</TldrawUiButton>
-					<TldrawUiButton type="danger" onClick={() => {}}>
-						<TldrawUiButtonLabel>Danger</TldrawUiButtonLabel>
-					</TldrawUiButton>
-					<TldrawUiButton type="normal" disabled>
-						<TldrawUiButtonLabel>Disabled</TldrawUiButtonLabel>
-					</TldrawUiButton>
-				</div>
-				<div className="ui-row">
-					<TldrawUiButton type="icon" title="Draw tool">
-						<TldrawUiButtonIcon icon="tool-pencil" />
-					</TldrawUiButton>
-					<TldrawUiButton type="icon" title="Eraser tool">
-						<TldrawUiButtonIcon icon="tool-eraser" />
-					</TldrawUiButton>
-					<TldrawUiButton type="icon" title="Select tool">
-						<TldrawUiButtonIcon icon="tool-pointer" />
-					</TldrawUiButton>
-					<TldrawUiButton type="normal">
-						<TldrawUiButtonIcon icon="external-link" />
-						<TldrawUiButtonLabel>With icon</TldrawUiButtonLabel>
-					</TldrawUiButton>
-				</div>
-			</section>
+				{/* Buttons */}
+				<section>
+					<h3>Buttons</h3>
+					<div className="ui-row">
+						<TlButton type="normal" onClick={() => {}}>
+							<TlButtonLabel>Normal</TlButtonLabel>
+						</TlButton>
+						<TlButton type="primary" onClick={() => {}}>
+							<TlButtonLabel>Primary</TlButtonLabel>
+						</TlButton>
+						<TlButton type="danger" onClick={() => {}}>
+							<TlButtonLabel>Danger</TlButtonLabel>
+						</TlButton>
+						<TlButton type="normal" disabled>
+							<TlButtonLabel>Disabled</TlButtonLabel>
+						</TlButton>
+					</div>
+					<div className="ui-row">
+						<TlButton type="icon" title="Draw tool">
+							<TlButtonIcon icon="tool-pencil" />
+						</TlButton>
+						<TlButton type="icon" title="Eraser tool">
+							<TlButtonIcon icon="tool-eraser" />
+						</TlButton>
+						<TlButton type="icon" title="Select tool">
+							<TlButtonIcon icon="tool-pointer" />
+						</TlButton>
+						<TlButton type="normal">
+							<TlButtonIcon icon="external-link" />
+							<TlButtonLabel>With icon</TlButtonLabel>
+						</TlButton>
+					</div>
+				</section>
 
-			{/* Dropdown Menu */}
-			<section>
-				<h3>Dropdown menu</h3>
-				<div className="ui-row">
-					<TldrawUiDropdownMenuRoot id="example-dropdown">
-						<TldrawUiDropdownMenuTrigger>
-							<TldrawUiButton type="normal">
-								<TldrawUiButtonLabel>Open menu</TldrawUiButtonLabel>
-							</TldrawUiButton>
-						</TldrawUiDropdownMenuTrigger>
-						<TldrawUiDropdownMenuContent side="bottom" align="start">
-							<TldrawUiDropdownMenuGroup>
-								<TldrawUiDropdownMenuItem>
-									<TldrawUiButton type="menu">
-										<TldrawUiButtonLabel>Cut</TldrawUiButtonLabel>
-										<TldrawUiKbd>⌘X</TldrawUiKbd>
-									</TldrawUiButton>
-								</TldrawUiDropdownMenuItem>
-								<TldrawUiDropdownMenuItem>
-									<TldrawUiButton type="menu">
-										<TldrawUiButtonLabel>Copy</TldrawUiButtonLabel>
-										<TldrawUiKbd>⌘C</TldrawUiKbd>
-									</TldrawUiButton>
-								</TldrawUiDropdownMenuItem>
-								<TldrawUiDropdownMenuItem>
-									<TldrawUiButton type="menu">
-										<TldrawUiButtonLabel>Paste</TldrawUiButtonLabel>
-										<TldrawUiKbd>⌘V</TldrawUiKbd>
-									</TldrawUiButton>
-								</TldrawUiDropdownMenuItem>
-							</TldrawUiDropdownMenuGroup>
-							<TldrawUiDropdownMenuGroup>
-								<TldrawUiDropdownMenuCheckboxItem
-									checked={checkboxValue}
-									title="Toggle option"
-									onSelect={() => setCheckboxValue(!checkboxValue)}
-								>
-									<TldrawUiButtonLabel>Checkbox item</TldrawUiButtonLabel>
-								</TldrawUiDropdownMenuCheckboxItem>
-							</TldrawUiDropdownMenuGroup>
-							<TldrawUiDropdownMenuGroup>
-								<TldrawUiDropdownMenuSub id="example-submenu">
-									<TldrawUiDropdownMenuSubTrigger label="More options..." />
-									<TldrawUiDropdownMenuSubContent>
-										<TldrawUiDropdownMenuItem>
-											<TldrawUiButton type="menu">
-												<TldrawUiButtonLabel>Option A</TldrawUiButtonLabel>
-											</TldrawUiButton>
-										</TldrawUiDropdownMenuItem>
-										<TldrawUiDropdownMenuItem>
-											<TldrawUiButton type="menu">
-												<TldrawUiButtonLabel>Option B</TldrawUiButtonLabel>
-											</TldrawUiButton>
-										</TldrawUiDropdownMenuItem>
-									</TldrawUiDropdownMenuSubContent>
-								</TldrawUiDropdownMenuSub>
-							</TldrawUiDropdownMenuGroup>
-						</TldrawUiDropdownMenuContent>
-					</TldrawUiDropdownMenuRoot>
-				</div>
-			</section>
+				{/* Dropdown Menu */}
+				<section>
+					<h3>Dropdown menu</h3>
+					<div className="ui-row">
+						<TlDropdownMenuRoot id="example-dropdown">
+							<TlDropdownMenuTrigger>
+								<TlButton type="normal">
+									<TlButtonLabel>Open menu</TlButtonLabel>
+								</TlButton>
+							</TlDropdownMenuTrigger>
+							<TlDropdownMenuContent side="bottom" align="start">
+								<TlDropdownMenuGroup>
+									<TlDropdownMenuItem>
+										<TlButton type="menu">
+											<TlButtonLabel>Cut</TlButtonLabel>
+											<TlKbd>⌘X</TlKbd>
+										</TlButton>
+									</TlDropdownMenuItem>
+									<TlDropdownMenuItem>
+										<TlButton type="menu">
+											<TlButtonLabel>Copy</TlButtonLabel>
+											<TlKbd>⌘C</TlKbd>
+										</TlButton>
+									</TlDropdownMenuItem>
+									<TlDropdownMenuItem>
+										<TlButton type="menu">
+											<TlButtonLabel>Paste</TlButtonLabel>
+											<TlKbd>⌘V</TlKbd>
+										</TlButton>
+									</TlDropdownMenuItem>
+								</TlDropdownMenuGroup>
+								<TlDropdownMenuGroup>
+									<TlDropdownMenuCheckboxItem
+										checked={checkboxValue}
+										title="Toggle option"
+										onSelect={() => setCheckboxValue(!checkboxValue)}
+									>
+										<TlButtonLabel>Checkbox item</TlButtonLabel>
+									</TlDropdownMenuCheckboxItem>
+								</TlDropdownMenuGroup>
+								<TlDropdownMenuGroup>
+									<TlDropdownMenuSub id="example-submenu">
+										<TlDropdownMenuSubTrigger label="More options..." />
+										<TlDropdownMenuSubContent>
+											<TlDropdownMenuItem>
+												<TlButton type="menu">
+													<TlButtonLabel>Option A</TlButtonLabel>
+												</TlButton>
+											</TlDropdownMenuItem>
+											<TlDropdownMenuItem>
+												<TlButton type="menu">
+													<TlButtonLabel>Option B</TlButtonLabel>
+												</TlButton>
+											</TlDropdownMenuItem>
+										</TlDropdownMenuSubContent>
+									</TlDropdownMenuSub>
+								</TlDropdownMenuGroup>
+							</TlDropdownMenuContent>
+						</TlDropdownMenuRoot>
+					</div>
+				</section>
 
-			{/* Select */}
-			<section>
-				<h3>Select</h3>
-				<div className="ui-row">
-					<TldrawUiSelect id="size-select-icons" value={selectValue} onValueChange={setSelectValue}>
-						<TldrawUiSelectTrigger>
-							<TldrawUiSelectValue placeholder="Select size...">{selectValue}</TldrawUiSelectValue>
-						</TldrawUiSelectTrigger>
-						<TldrawUiSelectContent>
-							<TldrawUiSelectItem value="small" label="Small" icon="size-small" />
-							<TldrawUiSelectItem value="medium" label="Medium" icon="size-medium" />
-							<TldrawUiSelectItem value="large" label="Large" icon="size-large" />
-						</TldrawUiSelectContent>
-					</TldrawUiSelect>
-					<TldrawUiSelect id="size-select" value={selectValue} onValueChange={setSelectValue}>
-						<TldrawUiSelectTrigger>
-							<TldrawUiSelectValue placeholder="Select...">{selectValue}</TldrawUiSelectValue>
-						</TldrawUiSelectTrigger>
-						<TldrawUiSelectContent>
-							<TldrawUiSelectItem value="small" label="Small" />
-							<TldrawUiSelectItem value="medium" label="Medium" />
-							<TldrawUiSelectItem value="large" label="Large" />
-						</TldrawUiSelectContent>
-					</TldrawUiSelect>
-					<TldrawUiSelect
-						id="size-select-disabled"
-						value={selectValue}
-						onValueChange={setSelectValue}
-						disabled
-					>
-						<TldrawUiSelectTrigger>
-							<TldrawUiSelectValue placeholder="Select...">{selectValue}</TldrawUiSelectValue>
-						</TldrawUiSelectTrigger>
-						<TldrawUiSelectContent>
-							<TldrawUiSelectItem value="small" label="Small" />
-							<TldrawUiSelectItem value="medium" label="Medium" />
-							<TldrawUiSelectItem value="large" label="Large" />
-						</TldrawUiSelectContent>
-					</TldrawUiSelect>
-				</div>
-			</section>
+				{/* Select */}
+				<section>
+					<h3>Select</h3>
+					<div className="ui-row">
+						<TlSelect id="size-select-icons" value={selectValue} onValueChange={setSelectValue}>
+							<TlSelectTrigger>
+								<TlSelectValue placeholder="Select size...">{selectValue}</TlSelectValue>
+							</TlSelectTrigger>
+							<TlSelectContent>
+								<TlSelectItem value="small" label="Small" icon="size-small" />
+								<TlSelectItem value="medium" label="Medium" icon="size-medium" />
+								<TlSelectItem value="large" label="Large" icon="size-large" />
+							</TlSelectContent>
+						</TlSelect>
+						<TlSelect id="size-select" value={selectValue} onValueChange={setSelectValue}>
+							<TlSelectTrigger>
+								<TlSelectValue placeholder="Select...">{selectValue}</TlSelectValue>
+							</TlSelectTrigger>
+							<TlSelectContent>
+								<TlSelectItem value="small" label="Small" />
+								<TlSelectItem value="medium" label="Medium" />
+								<TlSelectItem value="large" label="Large" />
+							</TlSelectContent>
+						</TlSelect>
+						<TlSelect
+							id="size-select-disabled"
+							value={selectValue}
+							onValueChange={setSelectValue}
+							disabled
+						>
+							<TlSelectTrigger>
+								<TlSelectValue placeholder="Select...">{selectValue}</TlSelectValue>
+							</TlSelectTrigger>
+							<TlSelectContent>
+								<TlSelectItem value="small" label="Small" />
+								<TlSelectItem value="medium" label="Medium" />
+								<TlSelectItem value="large" label="Large" />
+							</TlSelectContent>
+						</TlSelect>
+					</div>
+				</section>
 
-			{/* Input */}
-			<section>
-				<h3>Input</h3>
-				<div className="ui-row">
-					<TldrawUiInput
-						placeholder="Enter text..."
-						value={inputValue}
-						onValueChange={setInputValue}
-					/>
-				</div>
-			</section>
+				{/* Input */}
+				<section>
+					<h3>Input</h3>
+					<div className="ui-row">
+						<TlInput placeholder="Enter text..." value={inputValue} onValueChange={setInputValue} />
+					</div>
+				</section>
 
-			{/* Slider */}
-			<section>
-				<h3>Slider</h3>
-				<div className="ui-row ui-row-wide">
-					<TldrawUiSlider
-						label="opacity"
-						title="Opacity"
-						value={sliderValue}
-						steps={100}
-						onValueChange={setSliderValue}
-					/>
-					<span className="ui-value">{sliderValue}%</span>
-				</div>
-			</section>
+				{/* Slider */}
+				<section>
+					<h3>Slider</h3>
+					<div className="ui-row ui-row-wide">
+						<TlSlider
+							label="opacity"
+							title="Opacity"
+							value={sliderValue}
+							steps={100}
+							onValueChange={setSliderValue}
+						/>
+						<span className="ui-value">{sliderValue}%</span>
+					</div>
+				</section>
 
-			{/* Popover */}
-			<section>
-				<h3>Popover</h3>
-				<div className="ui-row">
-					<TldrawUiPopover id="example-popover">
-						<TldrawUiPopoverTrigger>
-							<TldrawUiButton type="normal">
-								<TldrawUiButtonLabel>Open popover</TldrawUiButtonLabel>
-							</TldrawUiButton>
-						</TldrawUiPopoverTrigger>
-						<TldrawUiPopoverContent side="bottom" align="start">
-							<div className="ui-popover-content">
-								<p>This is popover content!</p>
-								<p>It can contain any elements.</p>
-							</div>
-						</TldrawUiPopoverContent>
-					</TldrawUiPopover>
-				</div>
-			</section>
+				{/* Popover */}
+				<section>
+					<h3>Popover</h3>
+					<div className="ui-row">
+						<TlPopover id="example-popover">
+							<TlPopoverTrigger>
+								<TlButton type="normal">
+									<TlButtonLabel>Open popover</TlButtonLabel>
+								</TlButton>
+							</TlPopoverTrigger>
+							<TlPopoverContent side="bottom" align="start">
+								<div className="ui-popover-content">
+									<p>This is popover content!</p>
+									<p>It can contain any elements.</p>
+								</div>
+							</TlPopoverContent>
+						</TlPopover>
+					</div>
+				</section>
 
-			{/* Icons */}
-			<section>
-				<h3>Icons ({iconTypes.length})</h3>
-				<div className="ui-icon-grid">
-					{iconTypes.map((icon: (typeof iconTypes)[number]) => (
-						<TldrawUiTooltip key={icon} content={icon}>
-							<div className="ui-icon-cell">
-								<TldrawUiIcon icon={icon} label={icon} />
-							</div>
-						</TldrawUiTooltip>
-					))}
-				</div>
-			</section>
+				{/* Icons */}
+				<section>
+					<h3>Icons ({iconTypes.length})</h3>
+					<div className="ui-icon-grid">
+						{iconTypes.map((icon: (typeof iconTypes)[number]) => (
+							<TlTooltip key={icon} content={icon}>
+								<div className="ui-icon-cell">
+									<TlIcon icon={icon} label={icon} />
+								</div>
+							</TlTooltip>
+						))}
+					</div>
+				</section>
 
-			{/* Tooltip */}
-			<section>
-				<h3>Tooltip</h3>
-				<div className="ui-row">
-					<TldrawUiTooltip content="This is a tooltip!">
-						<TldrawUiButton type="normal">
-							<TldrawUiButtonLabel>Hover me</TldrawUiButtonLabel>
-						</TldrawUiButton>
-					</TldrawUiTooltip>
-					{/* Note: TldrawUiKbd inside tooltips crashes outside TldrawUiContextProvider (see bug) */}
-					<TldrawUiTooltip content="Info tooltip">
-						<TldrawUiButton type="icon" title="Info">
-							<TldrawUiButtonIcon icon="question-mark" />
-						</TldrawUiButton>
-					</TldrawUiTooltip>
-				</div>
-			</section>
+				{/* Tooltip */}
+				<section>
+					<h3>Tooltip</h3>
+					<div className="ui-row">
+						<TlTooltip content="This is a tooltip!">
+							<TlButton type="normal">
+								<TlButtonLabel>Hover me</TlButtonLabel>
+							</TlButton>
+						</TlTooltip>
+						<TlTooltip content="Info tooltip">
+							<TlButton type="icon" title="Info">
+								<TlButtonIcon icon="question-mark" />
+							</TlButton>
+						</TlTooltip>
+					</div>
+				</section>
 
-			{/* Keyboard shortcuts */}
-			<section>
-				<h3>Keyboard shortcuts</h3>
-				<div className="ui-row">
-					<TldrawUiKbd>⌘</TldrawUiKbd>
-					<TldrawUiKbd>⇧</TldrawUiKbd>
-					<TldrawUiKbd>⌥</TldrawUiKbd>
-					<TldrawUiKbd>⌃</TldrawUiKbd>
-					<TldrawUiKbd>⌘S</TldrawUiKbd>
-					<TldrawUiKbd>⌘⇧Z</TldrawUiKbd>
-				</div>
-			</section>
-		</div>
+				{/* Keyboard shortcuts */}
+				<section>
+					<h3>Keyboard shortcuts</h3>
+					<div className="ui-row">
+						<TlKbd>⌘</TlKbd>
+						<TlKbd>⇧</TlKbd>
+						<TlKbd>⌥</TlKbd>
+						<TlKbd>⌃</TlKbd>
+						<TlKbd>⌘S</TlKbd>
+						<TlKbd>⌘⇧Z</TlKbd>
+					</div>
+				</section>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/use-cases/custom-shape-mermaids/CustomShapeMermaids.tsx
+++ b/apps/examples/src/examples/use-cases/custom-shape-mermaids/CustomShapeMermaids.tsx
@@ -4,8 +4,10 @@
  * - `blueprintRender.mapNodeToRenderSpec` maps each flowchart vertex to `flowchart-util` + `mermaidNodeId`.
  * - After import, graph and layer badges come from arrows + bindings (`extractFlowchartPipelineFromEditor`).
  */
+import { TlButton } from '@tldraw/ui'
 import { useCallback, useState } from 'react'
-import { TLComponents, Tldraw, TldrawUiButton, useEditor, useValue } from 'tldraw'
+import { TLComponents, Tldraw, useEditor, useValue } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import 'tldraw/tldraw.css'
 import { FlowchartShapeUtil } from './customMermaidShapeUtil'
 import './custom-shape-mermaid.css'
@@ -130,35 +132,37 @@ function TopPanel() {
 	}, [])
 
 	return (
-		<div className="custom-shape-mermaid">
-			<div>
-				Paste a Mermaid <strong>flowchart</strong> or <strong>graph</strong> (branching is ok; merge
-				nodes run after <strong>all</strong> incoming steps pass). Apply runs Mermaid import, then
-				builds the DAG from <strong>arrows on the canvas</strong>. Run simulates steps; failures can
-				be retried on the shape. Step badges are Kahn layers, not a global sequence. Status is only
-				in memory for this demo.
+		<ExampleTlUiProvider>
+			<div className="custom-shape-mermaid">
+				<div>
+					Paste a Mermaid <strong>flowchart</strong> or <strong>graph</strong> (branching is ok;
+					merge nodes run after <strong>all</strong> incoming steps pass). Apply runs Mermaid
+					import, then builds the DAG from <strong>arrows on the canvas</strong>. Run simulates
+					steps; failures can be retried on the shape. Step badges are Kahn layers, not a global
+					sequence. Status is only in memory for this demo.
+				</div>
+				<textarea
+					value={mermaidText}
+					onChange={(e) => setMermaidText(e.target.value)}
+					rows={7}
+					spellCheck={false}
+					className="custom-shape-mermaid__textarea"
+				/>
+				{pipeline.parseError && (
+					<div className="custom-shape-mermaid__error">{pipeline.parseError}</div>
+				)}
+				<div className="custom-shape-mermaid__controls">
+					<TlButton type="normal" onClick={applyWorkflow} disabled={isApplying}>
+						{isApplying ? 'Applying…' : 'Apply workflow'}
+					</TlButton>
+					<TlButton type="low" onClick={runPipeline} disabled={!canRun}>
+						Run pipeline
+					</TlButton>
+				</div>
+				{pipeline.isRunning && (
+					<div className="custom-shape-mermaid__notice">Running simulated steps…</div>
+				)}
 			</div>
-			<textarea
-				value={mermaidText}
-				onChange={(e) => setMermaidText(e.target.value)}
-				rows={7}
-				spellCheck={false}
-				className="custom-shape-mermaid__textarea"
-			/>
-			{pipeline.parseError && (
-				<div className="custom-shape-mermaid__error">{pipeline.parseError}</div>
-			)}
-			<div className="custom-shape-mermaid__controls">
-				<TldrawUiButton type="normal" onClick={applyWorkflow} disabled={isApplying}>
-					{isApplying ? 'Applying…' : 'Apply workflow'}
-				</TldrawUiButton>
-				<TldrawUiButton type="low" onClick={runPipeline} disabled={!canRun}>
-					Run pipeline
-				</TldrawUiButton>
-			</div>
-			{pipeline.isRunning && (
-				<div className="custom-shape-mermaid__notice">Running simulated steps…</div>
-			)}
-		</div>
+		</ExampleTlUiProvider>
 	)
 }

--- a/apps/examples/src/examples/use-cases/hundred-mermaids/MermaidDiagramsExample.tsx
+++ b/apps/examples/src/examples/use-cases/hundred-mermaids/MermaidDiagramsExample.tsx
@@ -1,15 +1,16 @@
+import { TlButton } from '@tldraw/ui'
 import { useCallback } from 'react'
 import {
 	Editor,
 	TLComponents,
 	TLShapeId,
 	Tldraw,
-	TldrawUiButton,
 	createShapeId,
 	useAtom,
 	useEditor,
 	useValue,
 } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import mermaidDefinitions from './mermaids'
 
 const GAP = 100
@@ -165,26 +166,28 @@ function TopPanel() {
 	}, [editor, isGeneratingAtom, countAtom])
 
 	return (
-		<div
-			style={{
-				position: 'fixed',
-				top: 0,
-				left: '50%',
-				transform: 'translateX(-50%)',
-				padding: '8px',
-				background: '#eee',
-				borderRadius: '0 0 8px 8px',
-				display: 'flex',
-				gap: '8px',
-				zIndex: 1000,
-				opacity: isGenerating ? 0 : 1,
-			}}
-		>
-			<TldrawUiButton type="low" onClick={handleClick}>
-				Click to see a thousand mermaids
-				{count > 0 && <>({count} actually…)</>}
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div
+				style={{
+					position: 'fixed',
+					top: 0,
+					left: '50%',
+					transform: 'translateX(-50%)',
+					padding: '8px',
+					background: '#eee',
+					borderRadius: '0 0 8px 8px',
+					display: 'flex',
+					gap: '8px',
+					zIndex: 1000,
+					opacity: isGenerating ? 0 : 1,
+				}}
+			>
+				<TlButton type="low" onClick={handleClick}>
+					Click to see a thousand mermaids
+					{count > 0 && <>({count} actually…)</>}
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/use-cases/many-shapes/ManyShapesExample.tsx
+++ b/apps/examples/src/examples/use-cases/many-shapes/ManyShapesExample.tsx
@@ -1,12 +1,7 @@
-import {
-	Editor,
-	TLCreateShapePartial,
-	Tldraw,
-	TldrawUiButton,
-	createShapeId,
-	useEditor,
-} from 'tldraw'
+import { TlButton } from '@tldraw/ui'
+import { Editor, TLCreateShapePartial, Tldraw, createShapeId, useEditor } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 
 // [1]
 const GEO_TYPES = [
@@ -117,20 +112,22 @@ function Controls() {
 	}
 
 	return (
-		<div style={{ display: 'flex', gap: 4, padding: 8, flexWrap: 'wrap' }}>
-			<TldrawUiButton type="normal" onClick={() => handleGenerate(200)}>
-				Add 200 shapes
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={() => handleGenerate(500)}>
-				Add 500 shapes
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={() => handleGenerate(1000)}>
-				Add 1000 shapes
-			</TldrawUiButton>
-			<TldrawUiButton type="normal" onClick={handleClear}>
-				Clear all
-			</TldrawUiButton>
-		</div>
+		<ExampleTlUiProvider>
+			<div style={{ display: 'flex', gap: 4, padding: 8, flexWrap: 'wrap' }}>
+				<TlButton type="normal" onClick={() => handleGenerate(200)}>
+					Add 200 shapes
+				</TlButton>
+				<TlButton type="normal" onClick={() => handleGenerate(500)}>
+					Add 500 shapes
+				</TlButton>
+				<TlButton type="normal" onClick={() => handleGenerate(1000)}>
+					Add 1000 shapes
+				</TlButton>
+				<TlButton type="normal" onClick={handleClear}>
+					Clear all
+				</TlButton>
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/use-cases/slides/SlidesPanel.tsx
+++ b/apps/examples/src/examples/use-cases/slides/SlidesPanel.tsx
@@ -1,4 +1,6 @@
-import { TldrawUiButton, track, useEditor, useValue } from 'tldraw'
+import { TlButton } from '@tldraw/ui'
+import { track, useEditor, useValue } from 'tldraw'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import { moveToSlide, useCurrentSlide, useSlides } from './useSlides'
 
 export const SlidesPanel = track(() => {
@@ -9,25 +11,27 @@ export const SlidesPanel = track(() => {
 
 	if (slides.length === 0) return null
 	return (
-		<div className="slides-panel scroll-light" onPointerDown={editor.markEventAsHandled}>
-			{slides.map((slide, i) => {
-				const isSelected = selectedShapes.includes(slide)
-				return (
-					<TldrawUiButton
-						key={'slides-panel-button:' + slide.id}
-						type="normal"
-						className="slides-panel-button"
-						onClick={() => moveToSlide(editor, slide)}
-						style={{
-							background:
-								currentSlide?.id === slide.id ? 'var(--tl-color-background)' : 'transparent',
-							outline: isSelected ? 'var(--tl-color-selection-stroke) solid 1.5px' : 'none',
-						}}
-					>
-						{`Slide ${i + 1}`}
-					</TldrawUiButton>
-				)
-			})}
-		</div>
+		<ExampleTlUiProvider>
+			<div className="slides-panel scroll-light" onPointerDown={editor.markEventAsHandled}>
+				{slides.map((slide, i) => {
+					const isSelected = selectedShapes.includes(slide)
+					return (
+						<TlButton
+							key={'slides-panel-button:' + slide.id}
+							type="normal"
+							className="slides-panel-button"
+							onClick={() => moveToSlide(editor, slide)}
+							style={{
+								background:
+									currentSlide?.id === slide.id ? 'var(--tl-color-background)' : 'transparent',
+								outline: isSelected ? 'var(--tl-color-selection-stroke) solid 1.5px' : 'none',
+							}}
+						>
+							{`Slide ${i + 1}`}
+						</TlButton>
+					)
+				})}
+			</div>
+		</ExampleTlUiProvider>
 	)
 })

--- a/apps/examples/src/examples/use-cases/timeline-scrubber/TimelineScrubberExample.tsx
+++ b/apps/examples/src/examples/use-cases/timeline-scrubber/TimelineScrubberExample.tsx
@@ -1,14 +1,15 @@
+import { TlSlider } from '@tldraw/ui'
 import { useCallback, useEffect, useState } from 'react'
 import {
 	RecordsDiff,
 	reverseRecordsDiff,
 	squashRecordDiffs,
 	Tldraw,
-	TldrawUiSlider,
 	track,
 	useEditor,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './timeline-scrubber.css'
 
 interface TimelineEntry {
@@ -125,26 +126,28 @@ const TimelineScrubber = track(() => {
 	const length = Math.max(3, String(timeline.entries.length).length)
 
 	return (
-		<div className="timeline-scrubber-controls">
-			<div className="timeline-scrubber-info">
-				{isEmpty
-					? '000 / 000'
-					: `${timeline.currentIndex.toString().padStart(length, '0')} / ${timeline.entries.length.toString().padStart(length, '0')}`}
+		<ExampleTlUiProvider>
+			<div className="timeline-scrubber-controls">
+				<div className="timeline-scrubber-info">
+					{isEmpty
+						? '000 / 000'
+						: `${timeline.currentIndex.toString().padStart(length, '0')} / ${timeline.entries.length.toString().padStart(length, '0')}`}
+				</div>
+				<TlSlider
+					steps={timeline.entries.length}
+					value={isEmpty ? 1 : timeline.currentIndex}
+					label="History"
+					title={
+						timeline.currentIndex === 0
+							? 'Empty canvas'
+							: new Date(
+									timeline.entries[timeline.currentIndex - 1]?.timestamp ?? Date.now()
+								).toLocaleString()
+					}
+					onValueChange={handleSliderChange}
+				/>
 			</div>
-			<TldrawUiSlider
-				steps={timeline.entries.length}
-				value={isEmpty ? 1 : timeline.currentIndex}
-				label="History"
-				title={
-					timeline.currentIndex === 0
-						? 'Empty canvas'
-						: new Date(
-								timeline.entries[timeline.currentIndex - 1]?.timestamp ?? Date.now()
-							).toLocaleString()
-				}
-				onValueChange={handleSliderChange}
-			/>
-		</div>
+		</ExampleTlUiProvider>
 	)
 })
 

--- a/apps/examples/src/examples/use-cases/timeline-scrubber/timeline-scrubber.css
+++ b/apps/examples/src/examples/use-cases/timeline-scrubber/timeline-scrubber.css
@@ -23,7 +23,7 @@
 	font-variant: tabular-nums;
 }
 
-.timeline-scrubber-controls .tlui-slider__container {
+.timeline-scrubber-controls .tl-slider__container {
 	flex: 1;
 }
 

--- a/apps/examples/src/examples/users/attribution-timeline/AttributionTimelineExample.tsx
+++ b/apps/examples/src/examples/users/attribution-timeline/AttributionTimelineExample.tsx
@@ -1,3 +1,4 @@
+import { TlButton, TlSlider } from '@tldraw/ui'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import {
 	atom,
@@ -8,8 +9,6 @@ import {
 	reverseRecordsDiff,
 	squashRecordDiffs,
 	Tldraw,
-	TldrawUiButton,
-	TldrawUiSlider,
 	TLUser,
 	TLUserStore,
 	track,
@@ -17,6 +16,7 @@ import {
 	UserRecordType,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './attribution-timeline.css'
 
 // There's a guide at the bottom of this file!
@@ -89,21 +89,23 @@ function UserSwitcher() {
 	const [activeUserId, setActiveUserId] = useState(currentUserIdAtom.get())
 
 	return (
-		<div className="tlui-menu attribution-timeline-user-switcher">
-			{Object.values(USERS).map((user) => (
-				<TldrawUiButton
-					key={user.id}
-					type={activeUserId === user.id ? 'primary' : 'normal'}
-					onClick={() => {
-						currentUserIdAtom.set(user.id)
-						setActiveUserId(user.id)
-					}}
-				>
-					<span className="attribution-timeline-dot" style={{ backgroundColor: user.color }} />
-					{user.name}
-				</TldrawUiButton>
-			))}
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu attribution-timeline-user-switcher">
+				{Object.values(USERS).map((user) => (
+					<TlButton
+						key={user.id}
+						type={activeUserId === user.id ? 'primary' : 'normal'}
+						onClick={() => {
+							currentUserIdAtom.set(user.id)
+							setActiveUserId(user.id)
+						}}
+					>
+						<span className="attribution-timeline-dot" style={{ backgroundColor: user.color }} />
+						{user.name}
+					</TlButton>
+				))}
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 
@@ -288,70 +290,75 @@ const AttributionTimeline = track(() => {
 	})()
 
 	return (
-		<div className="attribution-timeline-controls">
-			<div className="attribution-timeline-row attribution-timeline-row--all">
-				<div className="attribution-timeline-user">
-					<span className="attribution-timeline-name">All</span>
-				</div>
-				<TldrawUiSlider
-					steps={Math.max(totalEntries, 1)}
-					value={totalEntries === 0 ? null : totalApplied}
-					label="History"
-					title={allTitle}
-					onValueChange={handleAllSliderChange}
-				/>
-				<div className="attribution-timeline-info">
-					{`${totalApplied.toString().padStart(totalLength, '0')} / ${totalEntries.toString().padStart(totalLength, '0')}`}
-				</div>
-				<TldrawUiButton
-					type="normal"
-					disabled={totalEntries === 0}
-					onClick={handleReset}
-					tooltip="Clear the canvas and timeline history"
-					className="attribution-timeline-reset"
-				>
-					Reset
-				</TldrawUiButton>
-			</div>
-			{Object.values(USERS).map((user) => {
-				const indices = userIndices[user.id] ?? []
-				const total = indices.length
-				const applied = timeline.appliedCounts[user.id] ?? 0
-				const length = Math.max(2, String(total).length)
-				const isEmpty = total === 0
-
-				const sliderTitle = (() => {
-					if (isEmpty) return `${user.name} hasn't made any changes yet`
-					if (applied === 0) return `None of ${user.name}'s changes applied`
-					const entry = timeline.entries[indices[applied - 1]]
-					if (!entry) return ''
-					const time = new Date(entry.timestamp).toLocaleTimeString()
-					return `${user.name} — ${time}`
-				})()
-
-				return (
-					<div
-						key={user.id}
-						className={`attribution-timeline-row${user.id === activeUserId ? ' attribution-timeline-row--active' : ''}`}
-					>
-						<div className="attribution-timeline-user">
-							<span className="attribution-timeline-dot" style={{ backgroundColor: user.color }} />
-							<span className="attribution-timeline-name">{user.name}</span>
-						</div>
-						<TldrawUiSlider
-							steps={Math.max(total, 1)}
-							value={isEmpty ? null : applied}
-							label="History"
-							title={sliderTitle}
-							onValueChange={(value) => handleUserSliderChange(user.id, value)}
-						/>
-						<div className="attribution-timeline-info">
-							{`${applied.toString().padStart(length, '0')} / ${total.toString().padStart(length, '0')}`}
-						</div>
+		<ExampleTlUiProvider>
+			<div className="attribution-timeline-controls">
+				<div className="attribution-timeline-row attribution-timeline-row--all">
+					<div className="attribution-timeline-user">
+						<span className="attribution-timeline-name">All</span>
 					</div>
-				)
-			})}
-		</div>
+					<TlSlider
+						steps={Math.max(totalEntries, 1)}
+						value={totalEntries === 0 ? null : totalApplied}
+						label="History"
+						title={allTitle}
+						onValueChange={handleAllSliderChange}
+					/>
+					<div className="attribution-timeline-info">
+						{`${totalApplied.toString().padStart(totalLength, '0')} / ${totalEntries.toString().padStart(totalLength, '0')}`}
+					</div>
+					<TlButton
+						type="normal"
+						disabled={totalEntries === 0}
+						onClick={handleReset}
+						tooltip="Clear the canvas and timeline history"
+						className="attribution-timeline-reset"
+					>
+						Reset
+					</TlButton>
+				</div>
+				{Object.values(USERS).map((user) => {
+					const indices = userIndices[user.id] ?? []
+					const total = indices.length
+					const applied = timeline.appliedCounts[user.id] ?? 0
+					const length = Math.max(2, String(total).length)
+					const isEmpty = total === 0
+
+					const sliderTitle = (() => {
+						if (isEmpty) return `${user.name} hasn't made any changes yet`
+						if (applied === 0) return `None of ${user.name}'s changes applied`
+						const entry = timeline.entries[indices[applied - 1]]
+						if (!entry) return ''
+						const time = new Date(entry.timestamp).toLocaleTimeString()
+						return `${user.name} — ${time}`
+					})()
+
+					return (
+						<div
+							key={user.id}
+							className={`attribution-timeline-row${user.id === activeUserId ? ' attribution-timeline-row--active' : ''}`}
+						>
+							<div className="attribution-timeline-user">
+								<span
+									className="attribution-timeline-dot"
+									style={{ backgroundColor: user.color }}
+								/>
+								<span className="attribution-timeline-name">{user.name}</span>
+							</div>
+							<TlSlider
+								steps={Math.max(total, 1)}
+								value={isEmpty ? null : applied}
+								label="History"
+								title={sliderTitle}
+								onValueChange={(value) => handleUserSliderChange(user.id, value)}
+							/>
+							<div className="attribution-timeline-info">
+								{`${applied.toString().padStart(length, '0')} / ${total.toString().padStart(length, '0')}`}
+							</div>
+						</div>
+					)
+				})}
+			</div>
+		</ExampleTlUiProvider>
 	)
 })
 

--- a/apps/examples/src/examples/users/attribution-timeline/attribution-timeline.css
+++ b/apps/examples/src/examples/users/attribution-timeline/attribution-timeline.css
@@ -70,7 +70,7 @@
 	text-align: right;
 }
 
-.attribution-timeline-controls .tlui-slider__container {
+.attribution-timeline-controls .tl-slider__container {
 	flex: 1;
 }
 
@@ -96,6 +96,6 @@
 	border-radius: 50%;
 }
 
-.tlui-button .attribution-timeline-dot {
+.tl-button .attribution-timeline-dot {
 	margin-right: 4px;
 }

--- a/apps/examples/src/examples/users/attribution/AttributionExample.tsx
+++ b/apps/examples/src/examples/users/attribution/AttributionExample.tsx
@@ -1,10 +1,10 @@
+import { TlButton } from '@tldraw/ui'
 import {
 	atom,
 	computed,
 	createCachedUserResolve,
 	createUserId,
 	Tldraw,
-	TldrawUiButton,
 	TLNoteShape,
 	TLShape,
 	TLUser,
@@ -14,6 +14,7 @@ import {
 	useValue,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './attribution.css'
 
 // There's a guide at the bottom of this file!
@@ -56,32 +57,34 @@ function UserSwitcher() {
 	const activeUser = allUsers[activeUserId]
 
 	return (
-		<div className="tlui-menu attribution-controls">
-			{Object.values(allUsers).map((user) => (
-				<TldrawUiButton
-					key={user.id}
-					type={activeUserId === user.id ? 'primary' : 'normal'}
-					onClick={() => currentUserIdAtom.set(user.id)}
-				>
-					<span className="attribution-dot" style={{ backgroundColor: user.color }} />
-					{user.name}
-				</TldrawUiButton>
-			))}
-			{activeUser && (
-				<input
-					className="attribution-name-input"
-					value={activeUser.name}
-					onChange={(e) => {
-						usersAtom.update((prev) => ({
-							...prev,
-							[activeUserId]: { ...prev[activeUserId], name: e.target.value },
-						}))
-					}}
-					onPointerDown={(e) => e.stopPropagation()}
-					placeholder="Edit name…"
-				/>
-			)}
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu attribution-controls">
+				{Object.values(allUsers).map((user) => (
+					<TlButton
+						key={user.id}
+						type={activeUserId === user.id ? 'primary' : 'normal'}
+						onClick={() => currentUserIdAtom.set(user.id)}
+					>
+						<span className="attribution-dot" style={{ backgroundColor: user.color }} />
+						{user.name}
+					</TlButton>
+				))}
+				{activeUser && (
+					<input
+						className="attribution-name-input"
+						value={activeUser.name}
+						onChange={(e) => {
+							usersAtom.update((prev) => ({
+								...prev,
+								[activeUserId]: { ...prev[activeUserId], name: e.target.value },
+							}))
+						}}
+						onPointerDown={(e) => e.stopPropagation()}
+						placeholder="Edit name…"
+					/>
+				)}
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/examples/users/custom-user/CustomUserExample.tsx
+++ b/apps/examples/src/examples/users/custom-user/CustomUserExample.tsx
@@ -1,10 +1,10 @@
+import { TlButton } from '@tldraw/ui'
 import {
 	atom,
 	computed,
 	createCachedUserResolve,
 	createUserId,
 	Tldraw,
-	TldrawUiButton,
 	TLUser,
 	TLUserStore,
 	useEditor,
@@ -12,6 +12,7 @@ import {
 	useValue,
 } from 'tldraw'
 import 'tldraw/tldraw.css'
+import { ExampleTlUiProvider } from '../../../misc/ExampleTlUiProvider'
 import './custom-user.css'
 
 // There's a guide at the bottom of this file!
@@ -67,18 +68,20 @@ function UserSwitcher() {
 	const activeUserId = useValue(currentUserIdAtom)
 
 	return (
-		<div className="tlui-menu custom-user-controls">
-			{Object.values(allUsers).map((user) => (
-				<TldrawUiButton
-					key={user.id}
-					type={activeUserId === user.id ? 'primary' : 'normal'}
-					onClick={() => currentUserIdAtom.set(user.id)}
-				>
-					<span className="custom-user-dot" style={{ backgroundColor: user.color }} />
-					{user.name}
-				</TldrawUiButton>
-			))}
-		</div>
+		<ExampleTlUiProvider>
+			<div className="tl-menu custom-user-controls">
+				{Object.values(allUsers).map((user) => (
+					<TlButton
+						key={user.id}
+						type={activeUserId === user.id ? 'primary' : 'normal'}
+						onClick={() => currentUserIdAtom.set(user.id)}
+					>
+						<span className="custom-user-dot" style={{ backgroundColor: user.color }} />
+						{user.name}
+					</TlButton>
+				))}
+			</div>
+		</ExampleTlUiProvider>
 	)
 }
 

--- a/apps/examples/src/misc/ExampleTlUiProvider.tsx
+++ b/apps/examples/src/misc/ExampleTlUiProvider.tsx
@@ -1,0 +1,25 @@
+import { getAssetUrlsByMetaUrl } from '@tldraw/assets/urls'
+import { TlUiProvider } from '@tldraw/ui'
+import '@tldraw/ui/ui.css'
+import { ReactNode } from 'react'
+import { useMaybeEditor, useValue } from 'tldraw'
+
+const assetUrls = getAssetUrlsByMetaUrl()
+
+/**
+ * Wraps example UI built with `@tldraw/ui` components. Provides the SDK icon
+ * set and keeps the theme in sync with the editor's dark mode when rendered
+ * inside a `Tldraw` component. Portals (menus, dialogs, toasts) mount inside
+ * the provider's own `.tl-ui` element, so place this outside any container
+ * with `overflow: hidden` when using popovers or dropdowns.
+ */
+export function ExampleTlUiProvider({ children }: { children: ReactNode }) {
+	const editor = useMaybeEditor()
+	const isDarkMode = useValue('isDarkMode', () => editor?.user.getIsDarkMode() ?? false, [editor])
+
+	return (
+		<TlUiProvider theme={isDarkMode ? 'dark' : 'light'} iconAssetUrls={assetUrls.icons}>
+			{children}
+		</TlUiProvider>
+	)
+}

--- a/apps/examples/tsconfig.json
+++ b/apps/examples/tsconfig.json
@@ -9,6 +9,7 @@
 		{ "path": "../../packages/sync" },
 		{ "path": "../../packages/state" },
 		{ "path": "../../packages/tldraw" },
+		{ "path": "../../packages/ui" },
 		{ "path": "../../packages/dotcom-shared" },
 		{ "path": "../../packages/driver" }
 	]

--- a/packages/ui/api-report.api.md
+++ b/packages/ui/api-report.api.md
@@ -4,6 +4,8 @@
 
 ```ts
 
+import { Atom } from '@tldraw/state';
+import { ComponentType } from 'react';
 import { CSSProperties } from 'react';
 import { ForwardRefExoticComponent } from 'react';
 import { HTMLAttributes } from 'react';
@@ -180,6 +182,18 @@ export interface TlCopyButtonProps {
 }
 
 // @public (undocumented)
+export interface TlDialog {
+    // (undocumented)
+    component: ComponentType<TlDialogProps>;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    onClose?(): void;
+    // (undocumented)
+    preventBackgroundClose?: boolean;
+}
+
+// @public (undocumented)
 export function TlDialogBody({ className, children, style }: TlDialogBodyProps): JSX.Element;
 
 // @public (undocumented)
@@ -199,6 +213,9 @@ export function TlDialogCloseButton({ closeLabel }: TlDialogCloseButtonProps): J
 export interface TlDialogCloseButtonProps {
     closeLabel?: string;
 }
+
+// @public (undocumented)
+export type TlDialogEvent = 'close' | 'open';
 
 // @public (undocumented)
 export function TlDialogFooter({ className, children }: TlDialogFooterProps): JSX.Element;
@@ -223,6 +240,12 @@ export interface TlDialogHeaderProps {
 }
 
 // @public (undocumented)
+export interface TlDialogProps {
+    // (undocumented)
+    onClose(): void;
+}
+
+// @public (undocumented)
 export function TlDialogRoot({ children, open, defaultOpen, onOpenChange, preventBackgroundClose }: TlDialogRootProps): JSX.Element;
 
 // @public (undocumented)
@@ -236,6 +259,33 @@ export interface TlDialogRootProps {
     // (undocumented)
     open?: boolean;
     preventBackgroundClose?: boolean;
+}
+
+// @public (undocumented)
+export interface TlDialogsContextValue {
+    // (undocumented)
+    addDialog(dialog: Omit<TlDialog, 'id'> & {
+        id?: string;
+    }): string;
+    // (undocumented)
+    clearDialogs(): void;
+    // (undocumented)
+    dialogs: Atom<TlDialog[]>;
+    // (undocumented)
+    removeDialog(id: string): void;
+}
+
+// @public (undocumented)
+export function TlDialogsProvider({ children, onEvent }: TlDialogsProviderProps): JSX.Element;
+
+// @public (undocumented)
+export interface TlDialogsProviderProps {
+    // (undocumented)
+    children: ReactNode;
+    // (undocumented)
+    onEvent?(event: TlDialogEvent, data: {
+        id: string;
+    }): void;
 }
 
 // @public (undocumented)
@@ -621,6 +671,16 @@ export function TlMenuSection({ children }: {
 }): JSX.Element;
 
 // @public (undocumented)
+export interface TlMenuStateContextValue {
+    // (undocumented)
+    closeMenu(id: string): void;
+    // (undocumented)
+    isMenuOpen(id: string): boolean;
+    // (undocumented)
+    openMenu(id: string): void;
+}
+
+// @public (undocumented)
 export function TlMenuStateProvider({ children, onMenuOpenChange }: TlMenuStateProviderProps): JSX.Element;
 
 // @public (undocumented)
@@ -951,6 +1011,26 @@ export interface TlToastAction {
 }
 
 // @public (undocumented)
+export interface TlToastData {
+    // (undocumented)
+    actions?: TlToastAction[];
+    // (undocumented)
+    description?: string;
+    // (undocumented)
+    icon?: string;
+    // (undocumented)
+    iconLabel?: string;
+    // (undocumented)
+    id?: string;
+    // (undocumented)
+    keepOpen?: boolean;
+    // (undocumented)
+    severity?: TlToastSeverity;
+    // (undocumented)
+    title?: string;
+}
+
+// @public (undocumented)
 export interface TlToastProps {
     // (undocumented)
     actions?: TlToastAction[];
@@ -994,7 +1074,25 @@ export interface TlToastProviderProps {
 }
 
 // @public (undocumented)
+export interface TlToastsContextValue {
+    // (undocumented)
+    addToast(toast: TlToastData): string;
+    // (undocumented)
+    clearToasts(): void;
+    // (undocumented)
+    removeToast(id: string): void;
+    // (undocumented)
+    toasts: Atom<TlToastData[]>;
+}
+
+// @public (undocumented)
 export type TlToastSeverity = 'error' | 'info' | 'success' | 'warning';
+
+// @public (undocumented)
+export function TlToastsProvider({ children, ...toastProviderProps }: TlToastsProviderProps): JSX.Element;
+
+// @public (undocumented)
+export type TlToastsProviderProps = TlToastProviderProps;
 
 // @public (undocumented)
 export function TlToastViewport(): JSX.Element;
@@ -1159,6 +1257,12 @@ export interface TlUiProviderProps {
 export function useTlBreakpoint(): number;
 
 // @public (undocumented)
+export function useTlContainer(): HTMLElement | undefined;
+
+// @public (undocumented)
+export function useTlDialogs(): TlDialogsContextValue;
+
+// @public (undocumented)
 export function useTlIconUrl(icon: string): string | undefined;
 
 // @public (undocumented)
@@ -1174,6 +1278,9 @@ export function useTlMenuContext(): {
 export function useTlMenuIsOpen(id: string): [isOpen: boolean, onOpenChange: (isOpen: boolean) => void];
 
 // @public (undocumented)
+export function useTlMenuState(): TlMenuStateContextValue;
+
+// @public (undocumented)
 export function useTlOrientation(): TlOrientationContext;
 
 // @public (undocumented)
@@ -1181,6 +1288,9 @@ export function useTlPlatform(): TlPlatformContextValue;
 
 // @public (undocumented)
 export function useTlPortalContainer(): HTMLElement | undefined;
+
+// @public (undocumented)
+export function useTlToasts(): TlToastsContextValue;
 
 // @public (undocumented)
 export function useTlTranslation(): TlTranslationContextValue;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -13,6 +13,8 @@ export {
 	TlMenuStateProvider,
 	useTlIsAnyMenuOpen,
 	useTlMenuIsOpen,
+	useTlMenuState,
+	type TlMenuStateContextValue,
 	type TlMenuStateProviderProps,
 } from './lib/context/menu-state'
 export {
@@ -23,6 +25,7 @@ export {
 } from './lib/context/platform'
 export {
 	TlPortalProvider,
+	useTlContainer,
 	useTlPortalContainer,
 	type TlPortalProviderProps,
 } from './lib/context/portal'
@@ -82,6 +85,15 @@ export {
 	type TlDialogTitleProps,
 } from './lib/components/TlDialog'
 export {
+	TlDialogsProvider,
+	useTlDialogs,
+	type TlDialog,
+	type TlDialogEvent,
+	type TlDialogProps,
+	type TlDialogsContextValue,
+	type TlDialogsProviderProps,
+} from './lib/components/TlDialogs'
+export {
 	TlDropdownMenuCheckboxItem,
 	TlDropdownMenuContent,
 	TlDropdownMenuGroup,
@@ -136,6 +148,13 @@ export {
 	type TlToastProviderProps,
 	type TlToastSeverity,
 } from './lib/components/TlToast'
+export {
+	TlToastsProvider,
+	useTlToasts,
+	type TlToastData,
+	type TlToastsContextValue,
+	type TlToastsProviderProps,
+} from './lib/components/TlToasts'
 export {
 	TlToolbar,
 	TlToolbarButton,

--- a/packages/ui/src/lib/components/TlDialogs.tsx
+++ b/packages/ui/src/lib/components/TlDialogs.tsx
@@ -1,0 +1,143 @@
+import { atom, Atom } from '@tldraw/state'
+import { useValue } from '@tldraw/state-react'
+import { uniqueId } from '@tldraw/utils'
+import {
+	ComponentType,
+	createContext,
+	memo,
+	ReactNode,
+	useCallback,
+	useContext,
+	useMemo,
+	useRef,
+} from 'react'
+import { TlDialogRoot } from './TlDialog'
+
+/** @public */
+export interface TlDialogProps {
+	onClose(): void
+}
+
+/** @public */
+export interface TlDialog {
+	id: string
+	component: ComponentType<TlDialogProps>
+	onClose?(): void
+	preventBackgroundClose?: boolean
+}
+
+/** @public */
+export type TlDialogEvent = 'open' | 'close'
+
+/** @public */
+export interface TlDialogsContextValue {
+	addDialog(dialog: Omit<TlDialog, 'id'> & { id?: string }): string
+	removeDialog(id: string): void
+	clearDialogs(): void
+	dialogs: Atom<TlDialog[]>
+}
+
+const TlDialogsContext = createContext<TlDialogsContextValue | null>(null)
+
+/** @public */
+export interface TlDialogsProviderProps {
+	children: ReactNode
+	onEvent?(event: TlDialogEvent, data: { id: string }): void
+}
+
+/** @public @react */
+export function TlDialogsProvider({ children, onEvent }: TlDialogsProviderProps) {
+	const parentCtx = useContext(TlDialogsContext)
+	const dialogsRef = useRef(atom<TlDialog[]>('tl-dialogs', []))
+
+	const content = useMemo((): TlDialogsContextValue => {
+		const dialogs = dialogsRef.current
+
+		return {
+			dialogs,
+			addDialog(dialog: Omit<TlDialog, 'id'> & { id?: string }) {
+				const id = dialog.id ?? uniqueId()
+				dialogs.update((d) => [...d.filter((m) => m.id !== id), { ...dialog, id }])
+				onEvent?.('open', { id })
+				return id
+			},
+			removeDialog(id: string) {
+				const dialog = dialogs.get().find((d) => d.id === id)
+				if (dialog) {
+					dialog.onClose?.()
+					onEvent?.('close', { id })
+					dialogs.update((d) => d.filter((m) => m !== dialog))
+				}
+			},
+			clearDialogs() {
+				const current = dialogs.get()
+				if (current.length === 0) return
+				current.forEach((d) => {
+					d.onClose?.()
+					onEvent?.('close', { id: d.id })
+				})
+				dialogs.set([])
+			},
+		}
+	}, [onEvent])
+
+	if (parentCtx) return <>{children}</>
+
+	return (
+		<TlDialogsContext.Provider value={content}>
+			{children}
+			<TlDialogsRenderer />
+		</TlDialogsContext.Provider>
+	)
+}
+
+/** @public */
+export function useTlDialogs(): TlDialogsContextValue {
+	const ctx = useContext(TlDialogsContext)
+
+	if (!ctx) {
+		throw new Error('useTlDialogs must be used within a TlDialogsProvider')
+	}
+
+	return ctx
+}
+
+const TlManagedDialog = memo(function TlManagedDialog({
+	id,
+	component: ModalContent,
+	preventBackgroundClose,
+}: TlDialog) {
+	const { removeDialog } = useTlDialogs()
+
+	const handleOpenChange = useCallback(
+		(isOpen: boolean) => {
+			if (!isOpen) {
+				removeDialog(id)
+			}
+		},
+		[id, removeDialog]
+	)
+
+	return (
+		<TlDialogRoot
+			defaultOpen
+			onOpenChange={handleOpenChange}
+			preventBackgroundClose={preventBackgroundClose}
+		>
+			<ModalContent onClose={() => handleOpenChange(false)} />
+		</TlDialogRoot>
+	)
+})
+
+const TlDialogsRenderer = memo(function TlDialogsRenderer() {
+	const { dialogs } = useTlDialogs()
+	const dialogsArray = useValue('tl-dialogs', () => dialogs.get(), [dialogs])
+
+	return (
+		<>
+			{dialogsArray.map((dialog) => (
+				<TlManagedDialog key={dialog.id} {...dialog} />
+			))}
+		</>
+	)
+})

--- a/packages/ui/src/lib/components/TlToasts.tsx
+++ b/packages/ui/src/lib/components/TlToasts.tsx
@@ -1,0 +1,128 @@
+import { atom, Atom } from '@tldraw/state'
+import { useValue } from '@tldraw/state-react'
+import { uniqueId } from '@tldraw/utils'
+import { createContext, memo, useCallback, useContext, useMemo, useRef } from 'react'
+import {
+	TlToast,
+	TlToastAction,
+	TlToastProvider,
+	TlToastProviderProps,
+	TlToastSeverity,
+	TlToastViewport,
+} from './TlToast'
+
+/** @public */
+export interface TlToastData {
+	id?: string
+	severity?: TlToastSeverity
+	title?: string
+	description?: string
+	icon?: string
+	iconLabel?: string
+	actions?: TlToastAction[]
+	keepOpen?: boolean
+}
+
+interface TlManagedToastData extends TlToastData {
+	id: string
+}
+
+/** @public */
+export interface TlToastsContextValue {
+	addToast(toast: TlToastData): string
+	removeToast(id: string): void
+	clearToasts(): void
+	toasts: Atom<TlToastData[]>
+}
+
+const TlToastsContext = createContext<TlToastsContextValue | null>(null)
+
+/** @public */
+export type TlToastsProviderProps = TlToastProviderProps
+
+/** @public @react */
+export function TlToastsProvider({ children, ...toastProviderProps }: TlToastsProviderProps) {
+	const parentCtx = useContext(TlToastsContext)
+	const toastsRef = useRef(atom<TlToastData[]>('tl-toasts', []))
+
+	const content = useMemo((): TlToastsContextValue => {
+		const toasts = toastsRef.current
+
+		return {
+			toasts,
+			addToast(toast: TlToastData) {
+				const id = toast.id ?? uniqueId()
+				toasts.update((d) => [...d.filter((m) => m.id !== id), { ...toast, id }])
+				return id
+			},
+			removeToast(id: string) {
+				toasts.update((d) => d.filter((m) => m.id !== id))
+			},
+			clearToasts() {
+				toasts.set([])
+			},
+		}
+	}, [])
+
+	if (parentCtx) return <>{children}</>
+
+	return (
+		<TlToastProvider {...toastProviderProps}>
+			<TlToastsContext.Provider value={content}>
+				{children}
+				<TlToastsRenderer />
+			</TlToastsContext.Provider>
+		</TlToastProvider>
+	)
+}
+
+/** @public */
+export function useTlToasts(): TlToastsContextValue {
+	const ctx = useContext(TlToastsContext)
+
+	if (!ctx) {
+		throw new Error('useTlToasts must be used within a TlToastsProvider')
+	}
+
+	return ctx
+}
+
+const TlManagedToast = memo(function TlManagedToast({ toast }: { toast: TlManagedToastData }) {
+	const { removeToast } = useTlToasts()
+
+	const onOpenChange = useCallback(
+		(isOpen: boolean) => {
+			if (!isOpen) {
+				removeToast(toast.id)
+			}
+		},
+		[removeToast, toast.id]
+	)
+
+	return (
+		<TlToast
+			onOpenChange={onOpenChange}
+			severity={toast.severity}
+			icon={toast.icon}
+			iconLabel={toast.iconLabel}
+			title={toast.title}
+			description={toast.description}
+			actions={toast.actions}
+			keepOpen={toast.keepOpen}
+		/>
+	)
+})
+
+const TlToastsRenderer = memo(function TlToastsRenderer() {
+	const { toasts } = useTlToasts()
+	const toastsArray = useValue('tl-toasts', () => toasts.get(), [toasts])
+
+	return (
+		<>
+			{toastsArray.map((toast) => (
+				<TlManagedToast key={toast.id ?? ''} toast={toast as TlManagedToastData} />
+			))}
+			<TlToastViewport />
+		</>
+	)
+})

--- a/packages/ui/src/lib/context/TlUiProvider.tsx
+++ b/packages/ui/src/lib/context/TlUiProvider.tsx
@@ -1,5 +1,7 @@
 import classNames from 'classnames'
 import { ReactNode, useCallback, useEffect, useState } from 'react'
+import { TlDialogsProvider } from '../components/TlDialogs'
+import { TlToastsProvider } from '../components/TlToasts'
 import { TlTooltipProvider } from '../components/TlTooltip'
 import { TlBreakpointProvider } from './breakpoint'
 import { TlIconProvider } from './icons'
@@ -99,7 +101,9 @@ function TlUiRoot({ rootRef, dir, theme, className, children }: TlUiRootProps) {
 					className
 				)}
 			>
-				{children}
+				<TlToastsProvider>
+					<TlDialogsProvider>{children}</TlDialogsProvider>
+				</TlToastsProvider>
 			</div>
 		</TlTooltipProvider>
 	)

--- a/packages/ui/src/lib/context/menu-state.tsx
+++ b/packages/ui/src/lib/context/menu-state.tsx
@@ -2,12 +2,12 @@ import { atom, Atom } from '@tldraw/state'
 import { useValue } from '@tldraw/state-react'
 import { createContext, ReactNode, useCallback, useContext, useMemo, useRef, useState } from 'react'
 
-interface TlMenuStateContextValue {
+interface TlMenuStateProviderContextValue {
 	openMenusAtom: Atom<Set<string>>
 	onMenuOpenChange?(id: string, isOpen: boolean): void
 }
 
-const TlMenuStateContext = createContext<TlMenuStateContextValue | null>(null)
+const TlMenuStateContext = createContext<TlMenuStateProviderContextValue | null>(null)
 
 /** @public */
 export interface TlMenuStateProviderProps {
@@ -77,4 +77,53 @@ export function useTlIsAnyMenuOpen(): boolean {
 		},
 		[ctx]
 	)
+}
+
+/** @public */
+export interface TlMenuStateContextValue {
+	openMenu(id: string): void
+	closeMenu(id: string): void
+	isMenuOpen(id: string): boolean
+}
+
+/** @public */
+export function useTlMenuState(): TlMenuStateContextValue {
+	const ctx = useContext(TlMenuStateContext)
+
+	if (!ctx) {
+		throw new Error('useTlMenuState must be used within a TlMenuStateProvider')
+	}
+
+	const openMenu = useCallback(
+		(id: string) => {
+			ctx.openMenusAtom.update((prev: Set<string>) => {
+				const next = new Set(prev)
+				next.add(id)
+				return next
+			})
+			ctx.onMenuOpenChange?.(id, true)
+		},
+		[ctx]
+	)
+
+	const closeMenu = useCallback(
+		(id: string) => {
+			ctx.openMenusAtom.update((prev: Set<string>) => {
+				const next = new Set(prev)
+				next.delete(id)
+				return next
+			})
+			ctx.onMenuOpenChange?.(id, false)
+		},
+		[ctx]
+	)
+
+	const isMenuOpen = useCallback(
+		(id: string) => {
+			return ctx.openMenusAtom.get().has(id)
+		},
+		[ctx]
+	)
+
+	return { openMenu, closeMenu, isMenuOpen }
 }

--- a/packages/ui/src/lib/context/portal.tsx
+++ b/packages/ui/src/lib/context/portal.tsx
@@ -19,3 +19,8 @@ export function TlPortalProvider({ container, children }: TlPortalProviderProps)
 export function useTlPortalContainer(): HTMLElement | undefined {
 	return useContext(TlPortalContext)
 }
+
+/** @public */
+export function useTlContainer(): HTMLElement | undefined {
+	return useTlPortalContainer()
+}

--- a/packages/ui/src/styles/dialog.css
+++ b/packages/ui/src/styles/dialog.css
@@ -9,23 +9,19 @@
 	}
 }
 
+/* Fixed positioning: the .tl-ui root can be any element, so dialogs cover the
+   viewport rather than the provider's own box. */
 .tl-ui .tl-dialog__overlay {
-	position: absolute;
-	top: 0px;
-	left: 0px;
-	width: 100%;
-	height: 100%;
+	position: fixed;
+	inset: 0px;
 	z-index: var(--tl-layer-overlays);
 	background-color: var(--tl-color-overlay);
 	animation: tl-fade-in 0.12s ease-out;
 }
 
 .tl-ui .tl-dialog__positioner {
-	position: absolute;
-	top: 0px;
-	left: 0px;
-	width: 100%;
-	height: 100%;
+	position: fixed;
+	inset: 0px;
 	z-index: var(--tl-layer-overlays);
 	pointer-events: all;
 	display: grid;

--- a/packages/ui/src/styles/toast.css
+++ b/packages/ui/src/styles/toast.css
@@ -45,8 +45,10 @@
 	}
 }
 
+/* Fixed positioning: the .tl-ui root can be any element, so toasts pin to the
+   viewport rather than the provider's own box. */
 .tl-ui .tl-toast__viewport {
-	position: absolute;
+	position: fixed;
 	inset: 0px;
 	margin: 0px;
 	display: flex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12234,7 +12234,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@tldraw/ui@workspace:packages/ui":
+"@tldraw/ui@workspace:*, @tldraw/ui@workspace:packages/ui":
   version: 0.0.0-use.local
   resolution: "@tldraw/ui@workspace:packages/ui"
   dependencies:
@@ -19994,6 +19994,7 @@ __metadata:
     "@tldraw/mermaid": "workspace:*"
     "@tldraw/state": "workspace:*"
     "@tldraw/sync": "workspace:*"
+    "@tldraw/ui": "workspace:*"
     "@types/d3-geo": "npm:^3.1.0"
     "@types/lodash": "npm:^4.17.14"
     "@types/react": "npm:^19.2.7"


### PR DESCRIPTION
In order to prove out the new standalone `@tldraw/ui` package (#9517) against a real consumer, this PR migrates the examples app to it: 27 example files now import `Tl*` components from `@tldraw/ui` instead of `TldrawUi*` primitives from `tldraw`. It also adds the manager APIs the gap analysis showed were missing from the package. Stacked on #9517.

### What was added to `@tldraw/ui`

| Item | API |
| --- | --- |
| Dialogs manager | `TlDialogsProvider` / `useTlDialogs` — `addDialog({ component, onClose?, id?, preventBackgroundClose? })`, `removeDialog`, `clearDialogs`; stack rendered through `TlDialogRoot` |
| Toasts manager | `TlToastsProvider` / `useTlToasts` — `addToast({ title, severity?, description?, icon?, actions?, keepOpen?, id? })`, `removeToast`, `clearToasts` |
| Imperative menu API | `useTlMenuState()` — `openMenu(id)`, `closeMenu(id)`, `isMenuOpen(id)` (for hover-driven menus) |
| Container hook | `useTlContainer()` — SDK-`useContainer()`-shaped alias for the portal container |

Both managers are provided automatically by `TlUiProvider`. Two CSS fixes came out of live testing: dialog overlay/positioner and toast viewport now use `position: fixed` instead of the SDK's container-relative `absolute`, since the `.tl-ui` root can be any element rather than a full-screen container.

### How the examples consume it

A shared `ExampleTlUiProvider` helper (`apps/examples/src/misc/ExampleTlUiProvider.tsx`) wraps each example's custom UI subtree: it feeds the SDK icon set via `getAssetUrlsByMetaUrl().icons`, syncs the theme with the editor's dark mode, and imports `@tldraw/ui/ui.css`.

- 20 files were rename-only conversions (`TldrawUiButton` → `TlButton`, etc).
- 7 files needed the new APIs: the ui-primitives showcase, toasts-and-dialogs (managers + `useTlContainer`), menu-system-hover (`useTlMenuState` replaces `editor.menus.*`), and four icon-dependent examples.
- 21 files intentionally stay on `tldraw`: they need the Editor (`useTools`/`useActions` menu items, `TldrawUiContextualToolbar`, `Default*` menu composition) — that's the SDK-adapter migration, not this PR.

Verified live in the dev server: ui-primitives renders all 162 icons plus working dropdown/select/popover/slider/tooltip; dialogs open centered with background-dismiss; toasts render bottom-right with severity styling; hover-controlled menus open and close.

### Change type

- [x] `improvement`

### Test plan

1. `yarn dev`, open `/ui-primitives/full` — buttons, icons, menus, select, slider, popover, tooltips all render and function.
2. Open `/toasts-and-dialogs/full` — toasts appear bottom-right; dialogs open centered, stack, and dismiss on background click.
3. Open `/menu-system-hover/full` — hovering the zones opens/closes the menu.
4. `yarn typecheck`, `yarn check-packages`, and lint all pass.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add dialog and toast managers (`useTlDialogs`, `useTlToasts`), an imperative menu-state API (`useTlMenuState`), and `useTlContainer` to `@tldraw/ui`; migrate 27 examples to the new package.

### API changes

- `@tldraw/ui`: added `TlDialogsProvider`, `useTlDialogs`, `TlDialog`/`TlDialogProps`/`TlDialogEvent` types, `TlToastsProvider`, `useTlToasts`, `TlToastData`, `useTlMenuState`, and `useTlContainer`. No changes to existing package APIs.

### Code changes

| Section         | LOC change   |
| --------------- | ------------ |
| Core code       | +360 / -14   |
| Automated files | +110 / -0    |
| Documentation   | +1049 / -950 |
| Config/tooling  | +4 / -1      |
