### PR TITLE
fix(editor): cancel debounced modifiers on pointer down

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1541,6 +1541,14 @@ export class Editor extends EventEmitter<TLEventMap> {
     registerExternalContentHandler<T extends TLExternalContent<E>['type'], E>(type: T, handler: ((info: T extends TLExternalContent<E>['type'] ? Extract<TLExternalContent<E>, {
         type: T;
     }> : TLExternalContent<E>) => void) | null): this;
+    // @internal
+    _releaseAltKey(): void;
+    // @internal
+    _releaseCtrlKey(): void;
+    // @internal
+    _releaseMetaKey(): void;
+    // @internal
+    _releaseShiftKey(): void;
     removeTool(Tool: TLStateNodeConstructor, parent?: StateNode): void;
     renamePage(page: TLPage | TLPageId, name: string): this;
     reparentShapes(shapes: TLShape[] | TLShapeId[], parentId: TLParentId, insertIndex?: IndexKey): this;
@@ -1577,14 +1585,10 @@ export class Editor extends EventEmitter<TLEventMap> {
         considerAllShapes?: boolean;
     }): this;
     sendToBack(shapes: TLShape[] | TLShapeId[]): this;
-    // @internal (undocumented)
-    _setAltKeyTimeout(): void;
     setCamera(point: VecLike, opts?: TLCameraMoveOptions): this;
     setCameraOptions(opts: Partial<TLCameraOptions>): this;
     setColorMode(mode: 'dark' | 'light'): this;
     setCroppingShape(shape: null | TLShape | TLShapeId): this;
-    // @internal (undocumented)
-    _setCtrlKeyTimeout(): void;
     setCurrentPage(page: TLPage | TLPageId): this;
     setCurrentTheme(id: TLThemeId): this;
     setCurrentTool(id: string, info?: {}): this;
@@ -1594,14 +1598,10 @@ export class Editor extends EventEmitter<TLEventMap> {
     setFocusedGroup(shape: null | TLGroupShape | TLShapeId): this;
     setHintingShapes(shapes: TLShape[] | TLShapeId[]): this;
     setHoveredShape(shape: null | TLShape | TLShapeId): this;
-    // @internal (undocumented)
-    _setMetaKeyTimeout(): void;
     setOpacityForNextShapes(opacity: number, historyOptions?: TLHistoryBatchOptions): this;
     setOpacityForSelectedShapes(opacity: number): this;
     setRichTextEditor(textEditor: null | TiptapEditor): this;
     setSelectedShapes(shapes: TLShape[] | TLShapeId[]): this;
-    // @internal (undocumented)
-    _setShiftKeyTimeout(): void;
     setStyleForNextShapes<T>(style: StyleProp<T>, value: T, historyOptions?: TLHistoryBatchOptions): this;
     setStyleForSelectedShapes<S extends StyleProp<any>>(style: S, value: StylePropValue<S>): this;
     setTool(Tool: TLStateNodeConstructor, parent?: StateNode): void;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10840,9 +10840,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _shiftKeyTimeout = -1 as any
 
-	/** @internal */
+	/**
+	 * Release the shift modifier: clear its debounce timer id, drop the atom, and
+	 * dispatch a synthetic `key_up` so `inputs.keys` and tool `onKeyUp` handlers update.
+	 * Runs both as the 150ms debounce timer callback and when a pointer down flushes it.
+	 * @internal
+	 */
 	@bind
-	_setShiftKeyTimeout() {
+	_releaseShiftKey() {
+		this._shiftKeyTimeout = -1
 		this.inputs.setShiftKey(false)
 		this.dispatch({
 			type: 'keyboard',
@@ -10860,9 +10866,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _altKeyTimeout = -1 as any
 
-	/** @internal */
+	/**
+	 * Release the alt modifier. See {@link Editor._releaseShiftKey}.
+	 * @internal
+	 */
 	@bind
-	_setAltKeyTimeout() {
+	_releaseAltKey() {
+		this._altKeyTimeout = -1
 		this.inputs.setAltKey(false)
 		this.dispatch({
 			type: 'keyboard',
@@ -10880,9 +10890,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _ctrlKeyTimeout = -1 as any
 
-	/** @internal */
+	/**
+	 * Release the ctrl modifier. See {@link Editor._releaseShiftKey}.
+	 * @internal
+	 */
 	@bind
-	_setCtrlKeyTimeout() {
+	_releaseCtrlKey() {
+		this._ctrlKeyTimeout = -1
 		this.inputs.setCtrlKey(false)
 		this.dispatch({
 			type: 'keyboard',
@@ -10900,9 +10914,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	private _metaKeyTimeout = -1 as any
 
-	/** @internal */
+	/**
+	 * Release the meta modifier. See {@link Editor._releaseShiftKey}.
+	 * @internal
+	 */
 	@bind
-	_setMetaKeyTimeout() {
+	_releaseMetaKey() {
+		this._metaKeyTimeout = -1
 		this.inputs.setMetaKey(false)
 		this.dispatch({
 			type: 'keyboard',
@@ -10915,6 +10933,56 @@ export class Editor extends EventEmitter<TLEventMap> {
 			accelKey: this.inputs.getAccelKey(),
 			code: 'MetaLeft',
 		})
+	}
+
+	/**
+	 * Flush any modifier still sitting in its 150ms release-debounce window, so a new
+	 * interaction (a pointer down) starts with correct modifier state instead of a
+	 * just-released key still being counted as held. A pending timer is exactly
+	 * "released but still counted as held"; a genuinely-held modifier has no timer
+	 * (-1) and is left alone.
+	 *
+	 * Each modifier is released through the same path its timer would have taken
+	 * (`_releaseShiftKey` and friends), which dispatches the synthetic `key_up` so
+	 * stale codes (e.g. `ShiftLeft`) leave `inputs.keys` and tool `onKeyUp` handlers run.
+	 * We clear every pending modifier atom and timer *first*, then dispatch: a synthetic
+	 * `key_up` reports all currently-held modifiers, so releasing them one at a time
+	 * would make each event re-confirm the not-yet-released ones and cancel their flush.
+	 * @internal
+	 */
+	private _releaseDebouncedModifiers() {
+		const releaseShift = this._shiftKeyTimeout !== -1
+		const releaseAlt = this._altKeyTimeout !== -1
+		const releaseCtrl = this._ctrlKeyTimeout !== -1
+		const releaseMeta = this._metaKeyTimeout !== -1
+
+		if (releaseShift) {
+			clearTimeout(this._shiftKeyTimeout)
+			this._shiftKeyTimeout = -1
+			this.inputs.setShiftKey(false)
+		}
+		if (releaseAlt) {
+			clearTimeout(this._altKeyTimeout)
+			this._altKeyTimeout = -1
+			this.inputs.setAltKey(false)
+		}
+		if (releaseCtrl) {
+			clearTimeout(this._ctrlKeyTimeout)
+			this._ctrlKeyTimeout = -1
+			this.inputs.setCtrlKey(false)
+		}
+		if (releaseMeta) {
+			clearTimeout(this._metaKeyTimeout)
+			this._metaKeyTimeout = -1
+			this.inputs.setMetaKey(false)
+		}
+
+		// Dispatch the synthetic key_up for each flushed modifier (same path its 150ms
+		// timer would run): clears stale codes from inputs.keys and fires tool onKeyUp.
+		if (releaseShift) this._releaseShiftKey()
+		if (releaseAlt) this._releaseAltKey()
+		if (releaseCtrl) this._releaseCtrlKey()
+		if (releaseMeta) this._releaseMetaKey()
 	}
 
 	/** @internal */
@@ -11055,7 +11123,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._shiftKeyTimeout = -1
 			inputs.setShiftKey(true)
 		} else if (!info.shiftKey && inputs.getShiftKey() && this._shiftKeyTimeout === -1) {
-			this._shiftKeyTimeout = this.timers.setTimeout(this._setShiftKeyTimeout, 150)
+			this._shiftKeyTimeout = this.timers.setTimeout(this._releaseShiftKey, 150)
 		}
 
 		if (info.altKey) {
@@ -11063,7 +11131,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._altKeyTimeout = -1
 			inputs.setAltKey(true)
 		} else if (!info.altKey && inputs.getAltKey() && this._altKeyTimeout === -1) {
-			this._altKeyTimeout = this.timers.setTimeout(this._setAltKeyTimeout, 150)
+			this._altKeyTimeout = this.timers.setTimeout(this._releaseAltKey, 150)
 		}
 
 		if (info.ctrlKey) {
@@ -11071,7 +11139,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._ctrlKeyTimeout = -1
 			inputs.setCtrlKey(true)
 		} else if (!info.ctrlKey && inputs.getCtrlKey() && this._ctrlKeyTimeout === -1) {
-			this._ctrlKeyTimeout = this.timers.setTimeout(this._setCtrlKeyTimeout, 150)
+			this._ctrlKeyTimeout = this.timers.setTimeout(this._releaseCtrlKey, 150)
 		}
 
 		if (info.metaKey && info.name !== 'key_up') {
@@ -11081,7 +11149,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			this._metaKeyTimeout = -1
 			inputs.setMetaKey(true)
 		} else if (!info.metaKey && inputs.getMetaKey() && this._metaKeyTimeout === -1) {
-			this._metaKeyTimeout = this.timers.setTimeout(this._setMetaKeyTimeout, 150)
+			this._metaKeyTimeout = this.timers.setTimeout(this._releaseMetaKey, 150)
 		}
 
 		if (!inputs.getIsPointing()) {
@@ -11288,6 +11356,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 					case 'pointer_down': {
 						// If we're in pen mode and the input is not a pen type, then stop here
 						if (isPenMode && !isPen) return
+
+						// A pointer down starts a new interaction, so flush any modifier that's
+						// still lingering in its release-debounce window: treat it as released now.
+						this._releaseDebouncedModifiers()
 
 						if (!this.inputs.getIsPanning()) {
 							// Start a long press timeout

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -37,6 +37,110 @@ it('Ctrl Key', () => {
 	expect(editor.inputs.getCtrlKey()).toBe(false)
 })
 
+it('pointer down releases a modifier still in its debounce window', () => {
+	// Collect any synthetic key_up events fired when the release is flushed.
+	const keyUps: string[] = []
+	editor.on('event', (info) => {
+		if (info.type === 'keyboard' && info.name === 'key_up') keyUps.push(info.key)
+	})
+
+	// Hold then release meta via pointer events; the release is debounced for 150ms.
+	editor.pointerMove(100, 100, { metaKey: true })
+	editor.pointerMove(100, 100, { metaKey: false })
+	expect(editor.inputs.getMetaKey()).toBe(true) // still held during the debounce window
+
+	// A new interaction starts with the key physically up: the lingering modifier
+	// should be released immediately (same path as the timer), including its
+	// synthetic key_up, without waiting for the timeout.
+	editor.pointerDown(100, 100, { metaKey: false })
+	expect(editor.inputs.getMetaKey()).toBe(false)
+	expect(keyUps).toEqual(['Meta'])
+
+	// The pending timer must have been cancelled, so advancing past it does nothing
+	// and doesn't fire the synthetic key_up a second time.
+	vi.advanceTimersByTime(200)
+	expect(editor.inputs.getMetaKey()).toBe(false)
+	expect(keyUps).toEqual(['Meta'])
+})
+
+it('pointer down releases every modifier still in its debounce window', () => {
+	const keyUps: string[] = []
+	editor.on('event', (info) => {
+		if (info.type === 'keyboard' && info.name === 'key_up') keyUps.push(info.key)
+	})
+
+	editor.pointerMove(100, 100, { shiftKey: true, altKey: true, ctrlKey: true, metaKey: true })
+	editor.pointerMove(100, 100, { shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+	expect(editor.inputs.getAltKey()).toBe(true)
+	expect(editor.inputs.getCtrlKey()).toBe(true)
+	expect(editor.inputs.getMetaKey()).toBe(true)
+
+	editor.pointerDown(100, 100, { shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })
+	expect(editor.inputs.getShiftKey()).toBe(false)
+	expect(editor.inputs.getAltKey()).toBe(false)
+	expect(editor.inputs.getCtrlKey()).toBe(false)
+	expect(editor.inputs.getMetaKey()).toBe(false)
+
+	// Each flushed modifier fires its synthetic key_up so tools can react.
+	expect(keyUps).toEqual(expect.arrayContaining(['Shift', 'Alt', 'Ctrl', 'Meta']))
+	expect(keyUps).toHaveLength(4)
+
+	// All four timers were cancelled, so nothing flips back or fires again.
+	vi.advanceTimersByTime(200)
+	expect(editor.inputs.getShiftKey()).toBe(false)
+	expect(editor.inputs.getAltKey()).toBe(false)
+	expect(editor.inputs.getCtrlKey()).toBe(false)
+	expect(editor.inputs.getMetaKey()).toBe(false)
+	expect(keyUps).toHaveLength(4)
+})
+
+it('pointer down clears stale key codes when flushing a debounced modifier', () => {
+	// A real key_down records the code, then the release is only seen via pointer
+	// flags (no keyboard key_up), so the code lingers in inputs.keys until flushed.
+	editor.keyDown('Shift')
+	expect(editor.inputs.keys.has('ShiftLeft')).toBe(true)
+
+	editor.pointerMove(100, 100, { shiftKey: false })
+	expect(editor.inputs.getShiftKey()).toBe(true) // debounced, still counted as held
+	expect(editor.inputs.keys.has('ShiftLeft')).toBe(true) // code not yet cleared
+
+	// The pointer down flushes the debounce through the timer's path, which clears
+	// both the modifier atom and the stale code.
+	editor.pointerDown(100, 100, { shiftKey: false })
+	expect(editor.inputs.getShiftKey()).toBe(false)
+	expect(editor.inputs.keys.has('ShiftLeft')).toBe(false)
+})
+
+it('does not re-release a modifier after its natural debounce timer fired', () => {
+	const keyUps: string[] = []
+	editor.on('event', (info) => {
+		if (info.type === 'keyboard' && info.name === 'key_up') keyUps.push(info.key)
+	})
+
+	// Hold then release shift via pointer events and let the 150ms timer fire on its
+	// own, which releases shift with a single synthetic key_up.
+	editor.pointerMove(100, 100, { shiftKey: true })
+	editor.pointerMove(100, 100, { shiftKey: false })
+	vi.advanceTimersByTime(200)
+	expect(editor.inputs.getShiftKey()).toBe(false)
+	expect(keyUps).toEqual(['Shift'])
+
+	// A later pointer down must not treat the already-fired timer as an active
+	// debounce and emit another synthetic key_up.
+	editor.pointerDown(100, 100, { shiftKey: false })
+	expect(keyUps).toEqual(['Shift'])
+})
+
+it('pointer down keeps a genuinely held modifier', () => {
+	// Shift is actually held during the pointer down (flag stays true), so it must
+	// not be cleared by the debounce-flush.
+	editor.pointerMove(100, 100, { shiftKey: true })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+	editor.pointerDown(100, 100, { shiftKey: true })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+})
+
 it('keyboard events carry currently-held modifiers', () => {
 	const keyboardEvents: TLKeyboardEventInfo[] = []
 	editor.on('event', (info) => {


### PR DESCRIPTION
Closes #9444.

In order to fix a brief window where a just-released modifier key was still treated as held, this PR cancels any pending modifier-release timeouts on pointer down and clears the affected modifiers immediately. The editor debounces modifier-key releases (shift, alt, ctrl, meta) by 150ms to smooth over OS-level key flicker and key repeat. That grace window meant a just-released modifier stayed "active" for a moment — e.g. cmd-select a shape, release cmd, then start dragging, and the drag snaps briefly because meta is still considered held. On any pointer down we now flush those lingering releases so the interaction starts with the correct modifier state. The debounce itself is unchanged, and modifiers that are genuinely still held during the pointer down are left untouched.

Note: I am just wondering if this calls for yet another Editor Manager

### Change type

- [x] `bugfix`

### Test plan

1. On macOS, select a shape with cmd held, then release cmd and immediately drag another shape.
2. The drag should not snap/behave as if cmd is held.
3. Repeat with shift, alt, and ctrl.

- [x] Unit tests

### API changes

- Renamed the `@internal` `Editor` methods `_setShiftKeyTimeout`, `_setAltKeyTimeout`, `_setCtrlKeyTimeout`, and `_setMetaKeyTimeout` to `_releaseShiftKey`, `_releaseAltKey`, `_releaseCtrlKey`, and `_releaseMetaKey`. The new names reflect that each method releases the modifier and dispatches the synthetic `key_up`, rather than merely scheduling a timeout.
- These members are `@internal` and not part of the public SDK API. No public, breaking, or signature changes (same `(): void` signatures, no new or removed parameters).

### Release notes

- Fix modifier keys (shift, alt, ctrl, cmd) briefly being treated as held at the start of a new click or drag right after being released, which could momentarily affect snapping and other modifier-dependent behavior.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +36 / -0   |
| Tests     | +61 / -0   |
