### PR TITLE
fix(dotcom): gate app debug flags behind dev mode and let i18n flags toggle off

### DIFF
--- a/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
+++ b/apps/dotcom/client/src/tla/components/menu-items/menu-items.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from '@clerk/clerk-react'
 import { fileOpen } from 'browser-fs-access'
 import { DropdownMenu as _DropdownMenu } from 'radix-ui'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
 	TLDRAW_FILE_EXTENSION,
@@ -20,11 +20,12 @@ import {
 import { useOpenUrlAndTrack } from '../../../hooks/useOpenUrlAndTrack'
 import { routes } from '../../../routeDefs'
 import { signoutAnalytics } from '../../../utils/analytics'
+import { isDevelopmentEnv } from '../../../utils/env'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { UI_THEMES } from '../../themes/ui-themes'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { getCurrentEditor } from '../../utils/getCurrentEditor'
-import { defineMessages, useMsg } from '../../utils/i18n'
+import { defineMessages, isInternalLocale, useMsg } from '../../utils/i18n'
 import {
 	getLocalSessionState,
 	resetLocalSessionStateButKeepTheme,
@@ -371,7 +372,9 @@ export function DebugMenuGroup() {
 	const isDebugMode = useValue('debug', () => maybeEditor?.getInstanceState().isDebugMode, [
 		maybeEditor,
 	])
-	if (!isDebugMode) return null
+	// These are internal developer tools, so only surface them in local development —
+	// not on staging/preview deploys or to production users who enable debug mode.
+	if (!isDevelopmentEnv || !isDebugMode) return null
 
 	return <DebugSubmenu />
 }
@@ -388,6 +391,14 @@ export function DebugSubmenu() {
 		{ name: useMsg(messages.langLongString), locale: 'xx-LS' },
 		{ name: useMsg(messages.langHighlightMissing), locale: 'xx-MS' },
 	]
+
+	// Remember the user's real locale so an internal debug locale can be toggled back off.
+	// Falls back to 'en' if we load already stuck in a debug locale.
+	const previousLocale = useRef('en')
+	const currentLocale = editor?.user.getLocale() ?? 'en'
+	if (!isInternalLocale(currentLocale)) {
+		previousLocale.current = currentLocale
+	}
 
 	useEffect(() => {
 		document.body.classList.toggle('tla-lang-highlight-missing', shouldHighlightMissing)
@@ -413,7 +424,11 @@ export function DebugSubmenu() {
 							if (flag.locale === 'xx-MS') {
 								setShouldHighlightMissing(!shouldHighlightMissing)
 							} else {
-								editor?.user.updateUserPreferences({ locale: flag.locale })
+								// Selecting the active locale again restores the user's real language.
+								const isActive = editor?.user.getLocale() === flag.locale
+								editor?.user.updateUserPreferences({
+									locale: isActive ? previousLocale.current : flag.locale,
+								})
 							}
 						}}
 					/>


### PR DESCRIPTION
In order to keep tldraw.com's internal i18n debug tools from confusing production users, this PR makes two related fixes to the "App debug flags" submenu in the user settings menu. Closes #9511 and closes #9507.

- **Gate the submenu behind dev mode (#9511):** the submenu previously appeared for anyone who enabled the editor's debug mode, including on staging, PR previews, and production. It now only renders in local development, reusing the existing `isDevelopmentEnv` check the app already uses elsewhere. The editor's own debug menu is unaffected.
- **Let the i18n locale flags toggle off (#9507):** selecting "i18n: Accented" or "i18n: Long String" applied an internal test locale with no way to turn it back off, so users got stuck in the debug locale. Selecting an already-active flag now restores the user's real language, matching how the neighboring "Highlight Missing" flag already toggles. The real locale is remembered before switching, falling back to `en` if the page loads already in a debug locale.

### Change type

- [x] `bugfix`

### Test plan

1. Run the app locally (`yarn dev-app`) and enable debug mode.
2. Open the user settings menu → "App debug flags".
3. Select "i18n: Accented" — the app text changes; the item shows as checked.
4. Select "i18n: Accented" again — your normal language is restored and the item is unchecked.
5. Repeat for "i18n: Long String".
6. Confirm "App debug flags" does not appear when `TLDRAW_ENV` is not `development` (staging/preview/production builds), even with debug mode on.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the tldraw.com i18n debug locale flags so selecting an active flag restores your normal language, and only show the app debug flags menu in local development.
