### PR TITLE
spike(editor): modifier timer free latch

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10905,33 +10905,37 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 	}
 
+	/** @internal EXPERIMENT: pending-release flags for the timer-free latch model. */
+	private _shiftKeyPendingRelease = false
+	/** @internal */
+	private _altKeyPendingRelease = false
+	/** @internal */
+	private _ctrlKeyPendingRelease = false
+	/** @internal */
+	private _metaKeyPendingRelease = false
+
 	/**
-	 * Flush any modifier still sitting in its 150ms release-debounce window, so a new
-	 * interaction (a pointer down) starts with correct modifier state instead of a
-	 * just-released key still being counted as held. A pending timer is exactly
-	 * "released but still counted as held"; a genuinely-held modifier has no timer
-	 * (-1) and is left alone.
+	 * Resolve any modifier that was latched (kept on) during the previous gesture, so a
+	 * new interaction (a pointer down) starts with correct modifier state instead of a
+	 * just-released key still being counted as held. A genuinely-held modifier is not
+	 * pending, so it is left alone.
 	 * @internal
 	 */
 	private _releaseDebouncedModifiers() {
-		if (this._shiftKeyTimeout !== -1) {
-			clearTimeout(this._shiftKeyTimeout)
-			this._shiftKeyTimeout = -1
+		if (this._shiftKeyPendingRelease) {
+			this._shiftKeyPendingRelease = false
 			this.inputs.setShiftKey(false)
 		}
-		if (this._altKeyTimeout !== -1) {
-			clearTimeout(this._altKeyTimeout)
-			this._altKeyTimeout = -1
+		if (this._altKeyPendingRelease) {
+			this._altKeyPendingRelease = false
 			this.inputs.setAltKey(false)
 		}
-		if (this._ctrlKeyTimeout !== -1) {
-			clearTimeout(this._ctrlKeyTimeout)
-			this._ctrlKeyTimeout = -1
+		if (this._ctrlKeyPendingRelease) {
+			this._ctrlKeyPendingRelease = false
 			this.inputs.setCtrlKey(false)
 		}
-		if (this._metaKeyTimeout !== -1) {
-			clearTimeout(this._metaKeyTimeout)
-			this._metaKeyTimeout = -1
+		if (this._metaKeyPendingRelease) {
+			this._metaKeyPendingRelease = false
 			this.inputs.setMetaKey(false)
 		}
 	}
@@ -11069,38 +11073,62 @@ export class Editor extends EventEmitter<TLEventMap> {
 			return
 		}
 
+		// EXPERIMENT: timer-free "latch during gesture" model.
+		// - flag true -> modifier on immediately.
+		// - flag false while pointing (a gesture is active) -> latch it (keep on, mark
+		//   pending). This runs before the event reaches the state chart, so a modifier
+		//   released a hair before pointer_up still applies to the finishing gesture.
+		// - flag false while idle (between gestures) -> release immediately, so a stale
+		//   modifier can't linger into the next interaction.
+		const isPointing = inputs.getIsPointing()
+
 		if (info.shiftKey) {
-			clearTimeout(this._shiftKeyTimeout)
-			this._shiftKeyTimeout = -1
 			inputs.setShiftKey(true)
-		} else if (!info.shiftKey && inputs.getShiftKey() && this._shiftKeyTimeout === -1) {
-			this._shiftKeyTimeout = this.timers.setTimeout(this._setShiftKeyTimeout, 150)
+			this._shiftKeyPendingRelease = false
+		} else if (inputs.getShiftKey()) {
+			if (isPointing) {
+				this._shiftKeyPendingRelease = true
+			} else {
+				inputs.setShiftKey(false)
+				this._shiftKeyPendingRelease = false
+			}
 		}
 
 		if (info.altKey) {
-			clearTimeout(this._altKeyTimeout)
-			this._altKeyTimeout = -1
 			inputs.setAltKey(true)
-		} else if (!info.altKey && inputs.getAltKey() && this._altKeyTimeout === -1) {
-			this._altKeyTimeout = this.timers.setTimeout(this._setAltKeyTimeout, 150)
+			this._altKeyPendingRelease = false
+		} else if (inputs.getAltKey()) {
+			if (isPointing) {
+				this._altKeyPendingRelease = true
+			} else {
+				inputs.setAltKey(false)
+				this._altKeyPendingRelease = false
+			}
 		}
 
 		if (info.ctrlKey) {
-			clearTimeout(this._ctrlKeyTimeout)
-			this._ctrlKeyTimeout = -1
 			inputs.setCtrlKey(true)
-		} else if (!info.ctrlKey && inputs.getCtrlKey() && this._ctrlKeyTimeout === -1) {
-			this._ctrlKeyTimeout = this.timers.setTimeout(this._setCtrlKeyTimeout, 150)
+			this._ctrlKeyPendingRelease = false
+		} else if (inputs.getCtrlKey()) {
+			if (isPointing) {
+				this._ctrlKeyPendingRelease = true
+			} else {
+				inputs.setCtrlKey(false)
+				this._ctrlKeyPendingRelease = false
+			}
 		}
 
 		if (info.metaKey && info.name !== 'key_up') {
 			// Unlike the other modifiers, the native metaKey property is still true on keyup.
-			// If we don't have this guard, then the metakey will be left true without the timeout.
-			clearTimeout(this._metaKeyTimeout)
-			this._metaKeyTimeout = -1
 			inputs.setMetaKey(true)
-		} else if (!info.metaKey && inputs.getMetaKey() && this._metaKeyTimeout === -1) {
-			this._metaKeyTimeout = this.timers.setTimeout(this._setMetaKeyTimeout, 150)
+			this._metaKeyPendingRelease = false
+		} else if (inputs.getMetaKey()) {
+			if (isPointing) {
+				this._metaKeyPendingRelease = true
+			} else {
+				inputs.setMetaKey(false)
+				this._metaKeyPendingRelease = false
+			}
 		}
 
 		if (!inputs.getIsPointing()) {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10905,6 +10905,37 @@ export class Editor extends EventEmitter<TLEventMap> {
 		})
 	}
 
+	/**
+	 * Flush any modifier still sitting in its 150ms release-debounce window, so a new
+	 * interaction (a pointer down) starts with correct modifier state instead of a
+	 * just-released key still being counted as held. A pending timer is exactly
+	 * "released but still counted as held"; a genuinely-held modifier has no timer
+	 * (-1) and is left alone.
+	 * @internal
+	 */
+	private _releaseDebouncedModifiers() {
+		if (this._shiftKeyTimeout !== -1) {
+			clearTimeout(this._shiftKeyTimeout)
+			this._shiftKeyTimeout = -1
+			this.inputs.setShiftKey(false)
+		}
+		if (this._altKeyTimeout !== -1) {
+			clearTimeout(this._altKeyTimeout)
+			this._altKeyTimeout = -1
+			this.inputs.setAltKey(false)
+		}
+		if (this._ctrlKeyTimeout !== -1) {
+			clearTimeout(this._ctrlKeyTimeout)
+			this._ctrlKeyTimeout = -1
+			this.inputs.setCtrlKey(false)
+		}
+		if (this._metaKeyTimeout !== -1) {
+			clearTimeout(this._metaKeyTimeout)
+			this._metaKeyTimeout = -1
+			this.inputs.setMetaKey(false)
+		}
+	}
+
 	/** @internal */
 	private _restoreToolId = 'select'
 
@@ -11276,6 +11307,10 @@ export class Editor extends EventEmitter<TLEventMap> {
 					case 'pointer_down': {
 						// If we're in pen mode and the input is not a pen type, then stop here
 						if (isPenMode && !isPen) return
+
+						// A pointer down starts a new interaction, so flush any modifier that's
+						// still lingering in its release-debounce window: treat it as released now.
+						this._releaseDebouncedModifiers()
 
 						if (!this.inputs.getIsPanning()) {
 							// Start a long press timeout

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11703,6 +11703,14 @@ export class Editor extends EventEmitter<TLEventMap> {
 		this.root.handleEvent(info)
 		this.emit('event', info)
 
+		// A gesture just ended. Now that the finishing pointer_up has been handled with any
+		// mid-gesture-released modifier still applied (so the gesture isn't robbed of it),
+		// release those latched modifiers so they don't linger past the gesture. Genuinely
+		// held modifiers aren't pending, so they're left alone.
+		if (info.type === 'pointer' && info.name === 'pointer_up') {
+			this._releaseDebouncedModifiers()
+		}
+
 		// close open menus at the very end on pointer down! after everything else! συντελείας τοῦ κώδικα!!
 		if (info.type === 'pointer' && info.name === 'pointer_down') {
 			this.menus.clearOpenMenus()

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -98,6 +98,34 @@ it('pointer down keeps a genuinely held modifier', () => {
 	expect(editor.inputs.getShiftKey()).toBe(true)
 })
 
+it('release race — a modifier released just before pointer up still applies to the gesture', () => {
+	// Observe what shift is when the gesture-completing pointer_up is handled.
+	let shiftAtPointerUp: boolean | undefined
+	editor.on('event', (info) => {
+		if (info.type === 'pointer' && info.name === 'pointer_up') {
+			shiftAtPointerUp = editor.inputs.getShiftKey()
+		}
+	})
+
+	// Shift is held through a pointer interaction.
+	editor.pointerMove(100, 100, { shiftKey: true })
+	editor.pointerDown(100, 100, { shiftKey: true })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+
+	// The user lets go of shift a hair before the mouse button: key_up arrives first.
+	editor.keyUp('Shift')
+	expect(editor.inputs.getShiftKey()).toBe(true) // debounced, still "held"
+
+	// pointer_up arrives during the debounce window, so the finishing gesture still sees
+	// shift as held. Without the debounce this would race to false and drop the modifier.
+	editor.pointerUp(100, 100, { shiftKey: false })
+	expect(shiftAtPointerUp).toBe(true)
+
+	// Once the debounce expires with no further interaction, shift finally clears.
+	vi.advanceTimersByTime(200)
+	expect(editor.inputs.getShiftKey()).toBe(false)
+})
+
 it('keyboard events carry currently-held modifiers', () => {
 	const keyboardEvents: TLKeyboardEventInfo[] = []
 	editor.on('event', (info) => {

--- a/packages/tldraw/src/test/modifiers.test.ts
+++ b/packages/tldraw/src/test/modifiers.test.ts
@@ -37,6 +37,67 @@ it('Ctrl Key', () => {
 	expect(editor.inputs.getCtrlKey()).toBe(false)
 })
 
+it('pointer down releases a modifier still in its debounce window', () => {
+	// Collect any synthetic key_up events fired by the release-debounce timers.
+	const keyUps: string[] = []
+	editor.on('event', (info) => {
+		if (info.type === 'keyboard' && info.name === 'key_up') keyUps.push(info.key)
+	})
+
+	// Hold then release meta via pointer events; the release is debounced for 150ms.
+	editor.pointerMove(100, 100, { metaKey: true })
+	editor.pointerMove(100, 100, { metaKey: false })
+	expect(editor.inputs.getMetaKey()).toBe(true) // still held during the debounce window
+
+	// A new interaction starts with the key physically up: the lingering modifier
+	// should be treated as released immediately, without waiting for the timeout.
+	editor.pointerDown(100, 100, { metaKey: false })
+	expect(editor.inputs.getMetaKey()).toBe(false)
+
+	// The pending timer must have been cancelled: advancing past it should not flip
+	// state back nor fire the timer's synthetic key_up.
+	vi.advanceTimersByTime(200)
+	expect(editor.inputs.getMetaKey()).toBe(false)
+	expect(keyUps).not.toContain('Meta')
+})
+
+it('pointer down releases every modifier still in its debounce window', () => {
+	const keyUps: string[] = []
+	editor.on('event', (info) => {
+		if (info.type === 'keyboard' && info.name === 'key_up') keyUps.push(info.key)
+	})
+
+	editor.pointerMove(100, 100, { shiftKey: true, altKey: true, ctrlKey: true, metaKey: true })
+	editor.pointerMove(100, 100, { shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+	expect(editor.inputs.getAltKey()).toBe(true)
+	expect(editor.inputs.getCtrlKey()).toBe(true)
+	expect(editor.inputs.getMetaKey()).toBe(true)
+
+	editor.pointerDown(100, 100, { shiftKey: false, altKey: false, ctrlKey: false, metaKey: false })
+	expect(editor.inputs.getShiftKey()).toBe(false)
+	expect(editor.inputs.getAltKey()).toBe(false)
+	expect(editor.inputs.getCtrlKey()).toBe(false)
+	expect(editor.inputs.getMetaKey()).toBe(false)
+
+	// All four timers were cancelled, so nothing flips back or fires a synthetic key_up.
+	vi.advanceTimersByTime(200)
+	expect(editor.inputs.getShiftKey()).toBe(false)
+	expect(editor.inputs.getAltKey()).toBe(false)
+	expect(editor.inputs.getCtrlKey()).toBe(false)
+	expect(editor.inputs.getMetaKey()).toBe(false)
+	expect(keyUps).toEqual([])
+})
+
+it('pointer down keeps a genuinely held modifier', () => {
+	// Shift is actually held during the pointer down (flag stays true), so it must
+	// not be cleared by the debounce-flush.
+	editor.pointerMove(100, 100, { shiftKey: true })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+	editor.pointerDown(100, 100, { shiftKey: true })
+	expect(editor.inputs.getShiftKey()).toBe(true)
+})
+
 it('keyboard events carry currently-held modifiers', () => {
 	const keyboardEvents: TLKeyboardEventInfo[] = []
 	editor.on('event', (info) => {


### PR DESCRIPTION
Spike (not for merge): explore removing the 150ms modifier-release debounce timers in favour of a timer-free "latch during gesture" model.

Idea I got while working on https://github.com/tldraw/tldraw/pull/9523 

Would be amazing to consider this and also put all this behaviour into an editor manager.

- flag on → modifier on immediately
- flag off while pointing → latch (defer release to gesture end), so a modifier released just before pointer up still applies to the finishing gesture — the release race is protected without a timer
- flag off while idle → release immediately, so nothing lingers into the next interaction (covers the cmd-release-then-drag snap from #9444)

Race safety is proven by the new release-race test. This is a spike to inform a potental future `ModifierManager`; it intentionally leaves some tests red because they encode the old timer behaviour (`advanceTimersByTime` as the resolution trigger) and one genuine behaviour change (mid-gesture release now latches until the gesture ends instead of clearing after 150ms).

### Change type

- [x] `other` (spike / exploration)

### Test plan

- [x] Unit tests (expected red — see below)

Intentionally failing, documenting the fork:
- `modifiers` Shift/Alt/Ctrl + pointer-down tests — encoded the old timer grace; would move to an event-driven contract.
- `selection-omnibus` mid-gesture tests — mid-gesture release now latches until gesture end.

### Release notes

- Internal spike, no user-facing change.