### PR TITLE
feat(editor): add undo/redo history snapshots

### DIFF
--- a/apps/docs/content/sdk-features/persistence.mdx
+++ b/apps/docs/content/sdk-features/persistence.mdx
@@ -140,6 +140,20 @@ export default function App() {
 }
 ```
 
+### History snapshots
+
+Document and session snapshots don't include the editor's undo/redo history. If you rebuild the editor on the same document — for example, after changing which shape utils or tools are passed to it — you can carry the history across with [Editor#getHistorySnapshot](?) and [Editor#loadHistorySnapshot](?):
+
+```ts
+const history = editor.getHistorySnapshot()
+
+// ...rebuild the editor on the same document...
+
+newEditor.loadHistorySnapshot(history)
+```
+
+History entries contain full record values, so a history snapshot can only be loaded into an editor whose store schema matches the schema it was captured under. If the schemas differ — for example, a shape type was added, removed, or migrated — the snapshot is ignored with a warning. Unlike document snapshots, history snapshots are never migrated: discard them when your schema changes.
+
 ## Custom persistence with store
 
 For more control, create your own store and pass it to the editor. This lets you load data before mounting and implement custom sync logic.

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -1335,6 +1335,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     getHighestIndexForParent(parent: TLPage | TLParentId | TLShape): IndexKey;
     getHintingShape(): NonNullable<TLShape | undefined>[];
     getHintingShapeIds(): TLShapeId[];
+    getHistorySnapshot(): TLHistorySnapshot;
     getHitTestMargin(): number;
     getHoveredShape(): TLShape | undefined;
     getHoveredShapeId(): null | TLShapeId;
@@ -1491,6 +1492,7 @@ export class Editor extends EventEmitter<TLEventMap> {
     // (undocumented)
     isShapeOfType<T extends TLShape = TLShape>(shapeId: TLShapeId, type: T['type']): boolean;
     isShapeOrAncestorLocked(shape?: TLShape | TLShapeId): boolean;
+    loadHistorySnapshot(snapshot: TLHistorySnapshot): this;
     loadSnapshot(snapshot: Partial<TLEditorSnapshot> | TLStoreSnapshot, opts?: TLLoadSnapshotOptions): this;
     markEventAsHandled(e: {
         nativeEvent: Event;
@@ -2186,10 +2188,12 @@ export class HistoryManager<R extends UnknownRecord> {
     getNumRedos(): number;
     // (undocumented)
     getNumUndos(): number;
+    getSnapshot(): TLHistorySnapshot<R>;
     // @internal (undocumented)
     _isInBatch: boolean;
     // @internal (undocumented)
     isReplaying(): boolean;
+    loadSnapshot(snapshot: TLHistorySnapshot<R>): void;
     // @internal (undocumented)
     _mark(id: string): void;
     // (undocumented)
@@ -4259,6 +4263,14 @@ export interface TLHistoryMark {
     id: string;
     // (undocumented)
     type: 'stop';
+}
+
+// @public
+export interface TLHistorySnapshot<R extends UnknownRecord = TLRecord> {
+    redos: TLHistoryEntry<R>[];
+    schema: SerializedSchema;
+    undos: TLHistoryEntry<R>[];
+    version: number;
 }
 
 // @public (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -254,6 +254,7 @@ export {
 	type TLHistoryDiff,
 	type TLHistoryEntry,
 	type TLHistoryMark,
+	type TLHistorySnapshot,
 } from './lib/editor/types/history-types'
 export {
 	type OptionalKeys,

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -181,7 +181,7 @@ import { TLContent } from './types/clipboard-types'
 import { TLEventMap } from './types/emit-types'
 import { TLEventInfo, TLPointerEventInfo } from './types/event-types'
 import { TLExternalAsset, TLExternalContent } from './types/external-content'
-import { TLHistoryBatchOptions } from './types/history-types'
+import { TLHistoryBatchOptions, TLHistorySnapshot } from './types/history-types'
 import {
 	OptionalKeys,
 	RequiredKeys,
@@ -1563,6 +1563,56 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 	clearHistory() {
 		this.history.clear()
+		return this
+	}
+
+	/**
+	 * Get a serializable snapshot of the editor's undo/redo history, including any changes
+	 * that have not yet been committed to the undo stack. Capturing a snapshot does not
+	 * modify the history.
+	 *
+	 * Use this with {@link Editor.loadHistorySnapshot} to carry the undo/redo history across
+	 * editor instances, for example when rebuilding the editor on the same document.
+	 *
+	 * History entries contain full record values, so a snapshot can only be loaded into an
+	 * editor whose store schema matches the schema it was captured under (for example, the
+	 * same shape types with the same versions). If you change the schema, discard any
+	 * history snapshots captured under the old one.
+	 *
+	 * @example
+	 * ```ts
+	 * const history = editor.getHistorySnapshot()
+	 * // ...dispose the editor, then rebuild it on the same document...
+	 * newEditor.loadHistorySnapshot(history)
+	 * ```
+	 *
+	 * @public
+	 */
+	getHistorySnapshot(): TLHistorySnapshot {
+		return this.history.getSnapshot()
+	}
+
+	/**
+	 * Load a history snapshot captured with {@link Editor.getHistorySnapshot}, replacing the
+	 * editor's current undo/redo history. This does not change the document: it only
+	 * restores what undo and redo will do.
+	 *
+	 * If the snapshot was captured under a different store schema, or is invalid, it is
+	 * ignored with a warning.
+	 *
+	 * @example
+	 * ```ts
+	 * const history = editor.getHistorySnapshot()
+	 * // ...dispose the editor, then rebuild it on the same document...
+	 * newEditor.loadHistorySnapshot(history)
+	 * ```
+	 *
+	 * @param snapshot - The history snapshot to load.
+	 *
+	 * @public
+	 */
+	loadHistorySnapshot(snapshot: TLHistorySnapshot): this {
+		this.history.loadSnapshot(snapshot)
 		return this
 	}
 

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.test.ts
@@ -715,6 +715,215 @@ describe('HistoryManager getters and utilities', () => {
 	})
 })
 
+describe('history snapshots', () => {
+	let store: Store<TestRecord>
+	let manager: HistoryManager<TestRecord>
+
+	beforeEach(() => {
+		store = new Store({ schema: testSchema, props: null })
+		store.put([
+			testSchema.types.test.create({ id: ids.a, value: 0 }),
+			testSchema.types.test.create({ id: ids.b, value: 0 }),
+		])
+		manager = new HistoryManager<TestRecord>({ store })
+	})
+
+	function setA(n: number) {
+		store.update(ids.a, (r) => ({ ...r, value: n }))
+	}
+	function setB(n: number) {
+		store.update(ids.b, (r) => ({ ...r, value: n }))
+	}
+	function getState(s: Store<TestRecord>) {
+		return { a: s.get(ids.a)!.value, b: s.get(ids.b)!.value }
+	}
+
+	// mimics a host rebuilding the editor on the same document: a new store with the same
+	// records and a fresh manager, with the history restored from the snapshot
+	function restoreIntoNewManager(snapshot = manager.getSnapshot()) {
+		const newStore = new Store<TestRecord>({ schema: testSchema, props: null })
+		newStore.put(store.allRecords())
+		const newManager = new HistoryManager<TestRecord>({ store: newStore })
+		newManager.loadSnapshot(snapshot)
+		return { newStore, newManager }
+	}
+
+	it('produces a JSON-serializable snapshot', () => {
+		setA(1)
+		manager._mark('one')
+		setB(1)
+
+		const snapshot = manager.getSnapshot()
+
+		expect(JSON.parse(JSON.stringify(snapshot))).toEqual(snapshot)
+	})
+
+	it('restores undo/redo behavior in a new manager', () => {
+		setA(1)
+		manager._mark('one')
+		setA(2)
+		manager._mark('two')
+		setB(1)
+		manager.undo() // move the b change onto the redo stack
+
+		expect(getState(store)).toEqual({ a: 2, b: 0 })
+
+		const snapshot = JSON.parse(JSON.stringify(manager.getSnapshot()))
+		const { newStore, newManager } = restoreIntoNewManager(snapshot)
+
+		expect(newManager.getNumUndos()).toBe(manager.getNumUndos())
+		expect(newManager.getNumRedos()).toBe(manager.getNumRedos())
+
+		// from here on, both managers should behave identically
+		for (const method of ['redo', 'undo', 'undo', 'undo', 'redo'] as const) {
+			manager[method]()
+			newManager[method]()
+			expect(getState(newStore)).toEqual(getState(store))
+		}
+	})
+
+	it('includes uncommitted changes without modifying the live history', () => {
+		manager._mark('start')
+		setA(1) // not yet committed to the undo stack
+
+		const numUndosBefore = manager.getNumUndos()
+		const snapshot = manager.getSnapshot()
+		expect(manager.getNumUndos()).toBe(numUndosBefore)
+
+		const { newStore, newManager } = restoreIntoNewManager(snapshot)
+		expect(newManager.getNumUndos()).toBe(numUndosBefore)
+		newManager.undo()
+		expect(getState(newStore)).toEqual({ a: 0, b: 0 })
+
+		// the live manager still works as before
+		manager.undo()
+		expect(getState(store)).toEqual({ a: 0, b: 0 })
+	})
+
+	it('does not leak later changes into a captured snapshot', () => {
+		setA(1)
+		const recordsAtCapture = store.allRecords()
+		const snapshot = manager.getSnapshot()
+
+		// this squashes into the same uncommitted diff the snapshot captured
+		setA(2)
+
+		const newStore = new Store<TestRecord>({ schema: testSchema, props: null })
+		newStore.put(recordsAtCapture)
+		const newManager = new HistoryManager<TestRecord>({ store: newStore })
+		newManager.loadSnapshot(snapshot)
+
+		newManager.undo()
+		expect(newStore.get(ids.a)!.value).toBe(0)
+		newManager.redo()
+		expect(newStore.get(ids.a)!.value).toBe(1)
+	})
+
+	it('preserves marks so bailToMark keeps working', () => {
+		setA(1)
+		manager._mark('my-mark')
+		setB(1)
+		setB(2)
+
+		const { newStore, newManager } = restoreIntoNewManager()
+
+		newManager.bailToMark('my-mark')
+		expect(getState(newStore)).toEqual({ a: 1, b: 0 })
+	})
+
+	it('preserves marks so squashToMark keeps working', () => {
+		manager._mark('a')
+		setA(1)
+		manager._mark('b')
+		setB(1)
+		manager._mark('c')
+		setB(2)
+
+		const { newStore, newManager } = restoreIntoNewManager()
+
+		newManager.squashToMark('b')
+		newManager.undo()
+		expect(getState(newStore)).toEqual({ a: 1, b: 0 })
+	})
+
+	it('replaces existing history and discards uncommitted changes when loading', () => {
+		setA(1)
+		manager._mark('m')
+		const snapshot = manager.getSnapshot()
+
+		setB(1) // uncommitted change made after the capture
+		manager.loadSnapshot(snapshot)
+
+		expect(manager.getNumUndos()).toBe(2) // the a diff and the mark
+		expect(manager.getNumRedos()).toBe(0)
+
+		// the a change is undoable again, the b change is not
+		manager.undo()
+		expect(getState(store)).toEqual({ a: 0, b: 1 })
+	})
+
+	it('round-trips an empty history', () => {
+		const snapshot = manager.getSnapshot()
+		expect(snapshot.undos).toEqual([])
+		expect(snapshot.redos).toEqual([])
+
+		const { newManager } = restoreIntoNewManager(snapshot)
+		expect(newManager.getNumUndos()).toBe(0)
+		expect(newManager.getNumRedos()).toBe(0)
+	})
+
+	it('ignores snapshots captured under a different schema', () => {
+		setA(1)
+		const snapshot = manager.getSnapshot()
+		snapshot.schema = { schemaVersion: 2, sequences: { 'com.test.foo': 1 } }
+
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		try {
+			const newStore = new Store<TestRecord>({ schema: testSchema, props: null })
+			newStore.put(store.allRecords())
+			const newManager = new HistoryManager<TestRecord>({ store: newStore })
+			newManager.loadSnapshot(snapshot)
+
+			expect(warn).toHaveBeenCalled()
+			expect(newManager.getNumUndos()).toBe(0)
+			expect(newManager.getNumRedos()).toBe(0)
+		} finally {
+			warn.mockRestore()
+		}
+	})
+
+	it('ignores structurally invalid snapshots', () => {
+		setA(1)
+		manager._mark('m')
+		const numUndosBefore = manager.getNumUndos()
+
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+		try {
+			manager.loadSnapshot(null as any)
+			manager.loadSnapshot({} as any)
+			manager.loadSnapshot({
+				version: 0,
+				schema: testSchema.serialize(),
+				undos: [{ type: 'bogus' }],
+				redos: [],
+			} as any)
+			manager.loadSnapshot({
+				version: 0,
+				schema: testSchema.serialize(),
+				undos: [
+					{ type: 'diff', diff: { added: {}, updated: { 'test:a': [{}, {}, {}] }, removed: {} } },
+				],
+				redos: [],
+			} as any)
+
+			expect(warn).toHaveBeenCalledTimes(4)
+			expect(manager.getNumUndos()).toBe(numUndosBefore)
+		} finally {
+			warn.mockRestore()
+		}
+	})
+})
+
 describe('HistoryManager error scenarios and edge cases', () => {
 	let manager: HistoryManager<TestRecord>
 	let store: Store<TestRecord>

--- a/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
+++ b/packages/editor/src/lib/editor/managers/HistoryManager/HistoryManager.ts
@@ -4,12 +4,14 @@ import {
 	isRecordsDiffEmpty,
 	RecordsDiff,
 	reverseRecordsDiff,
+	squashRecordDiffs,
 	squashRecordDiffsMutable,
 	Store,
 	UnknownRecord,
 } from '@tldraw/store'
-import { exhaustiveSwitchError, noop } from '@tldraw/utils'
-import { TLHistoryBatchOptions, TLHistoryEntry } from '../../types/history-types'
+import { exhaustiveSwitchError, isEqual, noop, structuredClone } from '@tldraw/utils'
+import { T } from '@tldraw/validate'
+import { TLHistoryBatchOptions, TLHistoryEntry, TLHistorySnapshot } from '../../types/history-types'
 
 const HistoryRecorderState = {
 	Recording: 'recording',
@@ -313,6 +315,58 @@ export class HistoryManager<R extends UnknownRecord> {
 		this.pendingDiff.clear()
 	}
 
+	/**
+	 * Get a serializable snapshot of the current undo/redo history, including any changes
+	 * that have not yet been committed to the undo stack. Capturing a snapshot does not
+	 * modify the history.
+	 *
+	 * Restore it with {@link HistoryManager.loadSnapshot}.
+	 */
+	getSnapshot(): TLHistorySnapshot<R> {
+		const { undos, redos } = this.stacks.get()
+
+		const undosArray: TLHistoryEntry<R>[] = stackToArray(undos).slice().reverse()
+		if (!this.pendingDiff.isEmpty()) {
+			undosArray.push({ type: 'diff', diff: this.pendingDiff.snapshot() })
+		}
+
+		return {
+			version: CURRENT_HISTORY_SNAPSHOT_VERSION,
+			schema: this.store.schema.serialize(),
+			undos: undosArray,
+			redos: stackToArray(redos).slice().reverse(),
+		}
+	}
+
+	/**
+	 * Load a history snapshot captured with {@link HistoryManager.getSnapshot}, replacing
+	 * the current undo/redo history. Any changes that have not yet been committed to the
+	 * undo stack are discarded.
+	 *
+	 * History entries contain full record values, so a snapshot can only be loaded into a
+	 * store whose schema matches the schema it was captured under. If the schemas differ,
+	 * or the snapshot is invalid, the snapshot is ignored with a warning.
+	 */
+	loadSnapshot(snapshot: TLHistorySnapshot<R>) {
+		const res = migrateAndValidateHistorySnapshot(snapshot)
+		if (!res) return
+
+		if (!isEqual(this.store.schema.serialize(), res.schema)) {
+			console.warn(
+				'History snapshot schema does not match the store schema. Ignoring the snapshot.'
+			)
+			return
+		}
+
+		transact(() => {
+			this.pendingDiff.clear()
+			this.stacks.set({
+				undos: stackFromArray(res.undos as TLHistoryEntry<R>[]),
+				redos: stackFromArray(res.redos as TLHistoryEntry<R>[]),
+			})
+		})
+	}
+
 	/** @internal */
 	getMarkIdMatching(idSubstring: string) {
 		let top = this.stacks.get().undos
@@ -342,6 +396,75 @@ const modeToState = {
 	'record-preserveRedoStack': HistoryRecorderState.RecordingPreserveRedoStack,
 	ignore: HistoryRecorderState.Paused,
 } as const
+
+const Versions = {
+	Initial: 0,
+} as const
+
+const CURRENT_HISTORY_SNAPSHOT_VERSION = Math.max(...Object.values(Versions))
+
+function migrateHistorySnapshot(snapshot: any) {
+	if (snapshot.version < Versions.Initial) {
+		// initial version
+		// noop
+	}
+	// add further migrations down here. see TLUserPreferences.ts for an example.
+
+	// finally
+	snapshot.version = CURRENT_HISTORY_SNAPSHOT_VERSION
+}
+
+const updatedTupleValidator = T.arrayOf(T.unknownObject).check((tuple) => {
+	if (tuple.length !== 2) {
+		throw new T.ValidationError(
+			`Expected a [from, to] tuple, got an array of length ${tuple.length}`
+		)
+	}
+})
+
+// this checks the structure of the snapshot, but not the record values themselves: those
+// are covered by the schema comparison in loadSnapshot, plus the store's usual record
+// validation when a diff is applied by undo/redo.
+const historyEntryValidator = T.union('type', {
+	stop: T.object({ type: T.literal('stop'), id: T.string }),
+	diff: T.object({
+		type: T.literal('diff'),
+		diff: T.object({
+			added: T.dict(T.string, T.unknownObject),
+			updated: T.dict(T.string, updatedTupleValidator),
+			removed: T.dict(T.string, T.unknownObject),
+		}),
+	}),
+})
+
+const historySnapshotValidator = T.object({
+	version: T.number,
+	schema: T.unknownObject,
+	undos: T.arrayOf(historyEntryValidator),
+	redos: T.arrayOf(historyEntryValidator),
+})
+
+function migrateAndValidateHistorySnapshot(snapshot: unknown): TLHistorySnapshot<any> | null {
+	if (!snapshot || typeof snapshot !== 'object') {
+		console.warn('Invalid history snapshot')
+		return null
+	}
+	if (!('version' in snapshot) || typeof snapshot.version !== 'number') {
+		console.warn('No version in history snapshot')
+		return null
+	}
+	if (snapshot.version !== CURRENT_HISTORY_SNAPSHOT_VERSION) {
+		snapshot = structuredClone(snapshot)
+		migrateHistorySnapshot(snapshot)
+	}
+
+	try {
+		return historySnapshotValidator.validate(snapshot) as unknown as TLHistorySnapshot<any>
+	} catch (e) {
+		console.warn(e)
+		return null
+	}
+}
 
 class PendingDiff<R extends UnknownRecord> {
 	private diff = createEmptyRecordsDiff<R>()
@@ -375,6 +498,13 @@ class PendingDiff<R extends UnknownRecord> {
 		} else if (this.isEmptyAtom.__unsafe__getWithoutCapture()) {
 			this.isEmptyAtom.set(!hasAnyKey(diff.updated))
 		}
+	}
+
+	// returns a copy of the current diff that is safe to hold onto: `apply` mutates both
+	// the diff's collections and its updated tuples in place. squashing a single diff gives
+	// fresh collections and tuples while sharing the (never-mutated) record values.
+	snapshot(): RecordsDiff<R> {
+		return squashRecordDiffs([this.diff])
 	}
 
 	debug() {
@@ -429,4 +559,14 @@ function stackToArray<T>(stack: Stack<T>) {
 		stack = stack.tail
 	}
 	return arr
+}
+
+// builds a stack from an array ordered oldest to newest, so the last item in the array
+// becomes the head of the stack
+function stackFromArray<T>(items: T[]): Stack<T> {
+	let result = stack<T>()
+	for (const item of items) {
+		result = result.push(item)
+	}
+	return result
 }

--- a/packages/editor/src/lib/editor/types/history-types.ts
+++ b/packages/editor/src/lib/editor/types/history-types.ts
@@ -1,4 +1,5 @@
-import { RecordsDiff, UnknownRecord } from '@tldraw/store'
+import { RecordsDiff, SerializedSchema, UnknownRecord } from '@tldraw/store'
+import { TLRecord } from '@tldraw/tlschema'
 
 /** @public */
 export interface TLHistoryMark {
@@ -14,6 +15,27 @@ export interface TLHistoryDiff<R extends UnknownRecord> {
 
 /** @public */
 export type TLHistoryEntry<R extends UnknownRecord> = TLHistoryMark | TLHistoryDiff<R>
+
+/**
+ * A serializable snapshot of the editor's undo/redo history. Capture one with
+ * {@link Editor.getHistorySnapshot} and restore it with {@link Editor.loadHistorySnapshot}.
+ *
+ * The history entries contain full record values, so a snapshot can only be loaded into a
+ * store whose schema matches the schema it was captured under. The `schema` property is
+ * used to enforce this on load.
+ *
+ * @public
+ */
+export interface TLHistorySnapshot<R extends UnknownRecord = TLRecord> {
+	/** The version of the history snapshot format. */
+	version: number
+	/** The serialized schema of the store the snapshot was captured from. */
+	schema: SerializedSchema
+	/** The undo stack, ordered from oldest to most recent entry. */
+	undos: TLHistoryEntry<R>[]
+	/** The redo stack, ordered from oldest to most recent entry. */
+	redos: TLHistoryEntry<R>[]
+}
 
 /** @public */
 export interface TLHistoryBatchOptions {

--- a/packages/tldraw/src/test/Editor.test.tsx
+++ b/packages/tldraw/src/test/Editor.test.tsx
@@ -668,6 +668,44 @@ describe('snapshots', () => {
 	})
 })
 
+describe('history snapshots', () => {
+	it('carries the undo/redo history across editor instances', () => {
+		editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0 }])
+		editor.markHistoryStoppingPoint()
+		editor.updateShape({ id: ids.box1, type: 'geo', x: 100 })
+		expect(editor.getShape(ids.box1)!.x).toBe(100)
+
+		const snapshot = getSnapshot(editor.store)
+		const history = JSON.parse(JSON.stringify(editor.getHistorySnapshot()))
+
+		const newEditor = new TestEditor()
+		loadSnapshot(newEditor.store, snapshot)
+		newEditor.loadHistorySnapshot(history)
+
+		expect(newEditor.getCanUndo()).toBe(true)
+		newEditor.undo()
+		expect(newEditor.getShape(ids.box1)!.x).toBe(0)
+		newEditor.redo()
+		expect(newEditor.getShape(ids.box1)!.x).toBe(100)
+	})
+
+	it('preserves mark ids so bailToMark works across editor instances', () => {
+		editor.createShapes([{ id: ids.box1, type: 'geo', x: 0, y: 0 }])
+		const mark = editor.markHistoryStoppingPoint('before-move')
+		editor.updateShape({ id: ids.box1, type: 'geo', x: 100 })
+
+		const snapshot = getSnapshot(editor.store)
+		const history = editor.getHistorySnapshot()
+
+		const newEditor = new TestEditor()
+		loadSnapshot(newEditor.store, snapshot)
+		newEditor.loadHistorySnapshot(history)
+
+		newEditor.bailToMark(mark)
+		expect(newEditor.getShape(ids.box1)!.x).toBe(0)
+	})
+})
+
 describe('when the user prefers dark UI', () => {
 	beforeEach(() => {
 		window.matchMedia = vi.fn().mockImplementation((query) => {


### PR DESCRIPTION
**The motivation.** We want to be able to reload the editor without losing the user's place — the same way hot-module reload swaps out component code without resetting your app state. A host sometimes has to rebuild the `Editor` on the same document: the shape utils, tools, bindings, and UI components an editor is built with are fixed when it's constructed, so the only way to change any of them at runtime is to construct a new editor. When that happens, the document is carried across with `getSnapshot`/`loadSnapshot` and the camera, selection, and current page with the session snapshot — but the undo/redo history isn't. It lives in memory inside the per-editor `HistoryManager` with no capture/restore path, so today rebuilding the editor silently wipes everything the user could have undone. That's the one piece of state that turns an otherwise-seamless reload back into a hard reset.

**What this adds.** `editor.getHistorySnapshot()` and `editor.loadHistorySnapshot(snapshot)` — the history counterpart to the existing document and session snapshots. Capture the history off the old editor, load it into the new one, and undo/redo continue as if nothing happened. The concrete case driving this is a document that carries its own custom shape and tool definitions as code: editing that code has to reconstruct the editor to pick up the new definitions, and this keeps the undo stack intact across that reload. The same applies to toggling a plugin, switching editor modes, or #1714's request to carry history between tabs and editor contexts (people were reaching into `editor.history._undos` by hand to fake it).

**How it works.** A `TLHistorySnapshot` is plain JSON: a format `version`, the store's serialized `schema`, and the `undos`/`redos` stacks as arrays ordered oldest to newest. Capturing is side-effect free — changes not yet committed to the undo stack are included as a final undo entry without flushing them in the live editor. Loading replaces both stacks atomically and discards any uncommitted changes. Mark ids are preserved, so `squashToMark` and `bailToMark` keep working with ids taken before the rebuild.

**When history is dropped.** History entries hold full record values and are never migrated, so a snapshot is only valid against a store with the schema it was captured under. Loading validates the snapshot's structure and requires its schema to match the current store's schema exactly; on any mismatch it warns and leaves the history untouched. This is deliberate: if the editor is rebuilt with a genuinely different set of shapes or tools — a different schema — replaying old diffs against records it no longer understands would be unsound, so the old history is dropped rather than restored. Behavior-only reloads keep history; schema changes drop it.

### Change type

- [x] `feature`

### Test plan

1. Create and move some shapes, then undo a step or two so both stacks are non-empty.
2. Capture with `editor.getHistorySnapshot()`, rebuild the editor on the same document (`getSnapshot`/`loadSnapshot`), then call `editor.loadHistorySnapshot(history)` on the new editor.
3. Undo and redo continue seamlessly across the rebuild; a mark captured before the rebuild still works with `bailToMark`.

- [x] Unit tests

### Release notes

- Add `editor.getHistorySnapshot()` and `editor.loadHistorySnapshot()` for carrying the undo/redo history across editor instances working on the same document.

### API changes

- Added `Editor.getHistorySnapshot()` and `Editor.loadHistorySnapshot(snapshot)`
- Added `HistoryManager.getSnapshot()` and `HistoryManager.loadSnapshot(snapshot)`
- Added the `TLHistorySnapshot` type

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +217 / -4  |
| Tests           | +247 / -0  |
| Automated files | +12 / -0   |
| Documentation   | +14 / -0   |
