### PR TITLE
fix(commenting): append the comment tool after the default toolbar tools

### DIFF
--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -66,7 +66,7 @@ export const commentToolOverrides: TLUiOverrides = {
 	},
 }
 
-/** A Toolbar with the comment tool added ahead of the default tools. Use as-is, or build your
+/** A Toolbar with the comment tool added after the default tools. Use as-is, or build your
  *  own toolbar with `tools.comment`. */
 export const commentToolComponents: TLComponents = {
 	Toolbar: (props) => {
@@ -74,8 +74,8 @@ export const commentToolComponents: TLComponents = {
 		const isSelected = useIsToolSelected(tools.comment)
 		return (
 			<DefaultToolbar {...props}>
-				<TldrawUiMenuItem {...tools.comment} isSelected={isSelected} />
 				<DefaultToolbarContent />
+				<TldrawUiMenuItem {...tools.comment} isSelected={isSelected} />
 			</DefaultToolbar>
 		)
 	},


### PR DESCRIPTION
## What

The comment tool was prepended to the dotcom toolbar, shifting the default tools right by one and pushing `rectangle` into the toolbar's overflow menu on narrower viewports. That broke the dotcom e2e tests that click `tools.rectangle` (`sharing-live.scenario`, `ui.scenario`).

Appending the comment tool after `DefaultToolbarContent` keeps the default tools in their original positions — `rectangle` stays visible, and the comment tool joins the existing "…" overflow instead.

## Notes

A proper home for the comment tool (a dedicated affordance rather than the shape toolbar) is being considered as part of the commenting UI polish pass; this is the minimal unblock to get `commenting`'s e2e green.
