### PR TITLE
feat: license-gate first-party plugins via license key feature flags

### DIFF
--- a/apps/docs/content/docs/plugins.mdx
+++ b/apps/docs/content/docs/plugins.mdx
@@ -169,6 +169,16 @@ Plugin records are still document records, so ordinary [migration](/docs/persist
 - **Evolve records by extending the migration sequence.** When a plugin's record shape needs to change, add a new step to that plugin's migration sequence rather than editing the identity guard migration or changing the record type's validator in place.
 - **Deploy the server first.** As with any sync schema change, roll out the updated server before the updated client so there's never a window where clients speak a schema the server doesn't recognize.
 
+## Licensing
+
+Some first-party plugins, including comments, require a tldraw license that has the plugin enabled. Pass your license key to the `Tldraw` component via the `licenseKey` prop as usual - there's no separate plugin key.
+
+Without the entitlement, the plugin's UI and behavior are disabled everywhere, including local development, and a console warning explains why. Evaluation licenses that include the plugin work until they expire.
+
+The plugin's record types stay registered even when the plugin is disabled, so documents containing plugin data - synced comments, for example - load safely.
+
+Contact sales@tldraw.com to add a plugin to your license or to get an evaluation key.
+
 ## Writing your own plugin
 
 A plugin for your own record types follows the same shape as `commentsPlugin`. On the client, bundle your `records`, any `shapeUtils` or `tools` that operate on them, and the components that render them:

--- a/apps/docs/content/docs/plugins.mdx
+++ b/apps/docs/content/docs/plugins.mdx
@@ -173,7 +173,7 @@ Plugin records are still document records, so ordinary [migration](/docs/persist
 
 Some first-party plugins, including comments, require a tldraw license that has the plugin enabled. Pass your license key to the `Tldraw` component via the `licenseKey` prop as usual - there's no separate plugin key.
 
-Without the entitlement, the plugin's UI and behavior are disabled everywhere, including local development, and a console warning explains why. Evaluation licenses that include the plugin work until they expire.
+Without the entitlement, the plugin's UI and behavior are disabled everywhere, including local development. When license validation resolves without the entitlement, a console warning explains why. Evaluation licenses that include the plugin work until they expire.
 
 The plugin's record types stay registered even when the plugin is disabled, so documents containing plugin data - synced comments, for example - load safely.
 

--- a/internal/scripts/generate-test-licenses.ts
+++ b/internal/scripts/generate-test-licenses.ts
@@ -108,6 +108,15 @@ async function main() {
 			),
 		},
 		{
+			name: 'Valid Annual License with comments plugin',
+			info: createLicenseInfo(
+				'test-annual-comments',
+				['localhost'],
+				FLAGS.ANNUAL_LICENSE | FLAGS.COMMENTS_PLUGIN,
+				getDateOffset(60) // 2 months future
+			),
+		},
+		{
 			name: 'Valid Perpetual License',
 			info: createLicenseInfo(
 				'test-perpetual-valid',

--- a/packages/comments/src/commentsPlugin.test.ts
+++ b/packages/comments/src/commentsPlugin.test.ts
@@ -1,0 +1,8 @@
+import { FLAGS } from 'tldraw'
+import { commentsPlugin } from './commentsPlugin'
+
+describe('commentsPlugin', () => {
+	it('requires the comments license flag', () => {
+		expect(commentsPlugin().requiredLicenseFlags).toBe(FLAGS.COMMENTS_PLUGIN)
+	})
+})

--- a/packages/comments/src/commentsPlugin.tsx
+++ b/packages/comments/src/commentsPlugin.tsx
@@ -1,4 +1,4 @@
-import { Editor, TldrawPlugin, useEditor } from 'tldraw'
+import { Editor, FLAGS, TldrawPlugin, useEditor } from 'tldraw'
 import { commentToolComponents, commentToolOverrides, commentTools } from './canvas/comment-tool'
 import { CanvasComments } from './canvas/comments-overlay'
 import { CanvasCommentsSidebar } from './canvas/comments-sidebar'
@@ -29,6 +29,7 @@ export function commentsPlugin(options: CommentsPluginOptions = {}): TldrawPlugi
 	return {
 		id: 'tldraw.comments',
 		records: commentSchemaRecords,
+		requiredLicenseFlags: FLAGS.COMMENTS_PLUGIN,
 		tools: commentTools,
 		overrides: commentToolOverrides,
 		components: {

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -10,6 +10,7 @@ import { Awaitable } from '@tldraw/utils';
 import { BoxModel } from '@tldraw/tlschema';
 import { ComponentType } from 'react';
 import { Computed } from '@tldraw/state';
+import { Context } from 'react';
 import { CustomRecordInfo } from '@tldraw/tlschema';
 import { Dispatch } from 'react';
 import { Editor as Editor_2 } from '@tiptap/core';
@@ -1795,6 +1796,17 @@ export function extractSessionStateFromLegacySnapshot(store: Record<string, Unkn
 // @internal (undocumented)
 export const featureFlags: Record<string, DebugFlag<boolean>>;
 
+// @internal (undocumented)
+export const FLAGS: {
+    ANNUAL_LICENSE: number;
+    COMMENTS_PLUGIN: number;
+    EVALUATION_LICENSE: number;
+    INTERNAL_LICENSE: number;
+    NATIVE_LICENSE: number;
+    PERPETUAL_LICENSE: number;
+    WITH_WATERMARK: number;
+};
+
 // @public (undocumented)
 export class FontManager {
     constructor(editor: Editor, assetUrls?: {
@@ -2398,6 +2410,9 @@ export function kickoutOccludedShapes(editor: Editor, shapeIds: TLShapeId[], opt
 export const LICENSE_TIMEOUT = 5000;
 
 // @internal (undocumented)
+export const LicenseContext: Context<LicenseManager>;
+
+// @internal (undocumented)
 export type LicenseFromKeyResult = InvalidLicenseKeyResult | ValidLicenseKeyResult;
 
 // @internal (undocumented)
@@ -2417,12 +2432,14 @@ export class LicenseManager {
     constructor(licenseKey: string | undefined, testPublicKey?: string);
     // (undocumented)
     static className: string;
+    features: Atom<number, unknown>;
     // (undocumented)
     getLicenseFromKey(licenseKey?: string): Promise<LicenseFromKeyResult>;
     // (undocumented)
     isCryptoAvailable: boolean;
     // (undocumented)
     isDevelopment: boolean;
+    isFeatureEnabled(flag: number): boolean;
     // (undocumented)
     isTest: boolean;
     // (undocumented)
@@ -2430,6 +2447,12 @@ export class LicenseManager {
     // (undocumented)
     verbose: boolean;
 }
+
+// @internal (undocumented)
+export function LicenseProvider({ licenseKey, children }: {
+    children: ReactNode;
+    licenseKey?: string;
+}): JSX.Element;
 
 // @internal (undocumented)
 export type LicenseState = 'expired' | 'licensed-with-watermark' | 'licensed' | 'pending' | 'unlicensed-production' | 'unlicensed';
@@ -5041,6 +5064,9 @@ export function useIsCropping(shapeId: TLShapeId): boolean;
 
 // @public (undocumented)
 export function useIsEditing(shapeId: TLShapeId): boolean;
+
+// @internal (undocumented)
+export function useLicenseContext(): LicenseManager;
 
 // @internal (undocumented)
 export function useLocalStore(options: {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -321,6 +321,7 @@ export {
 export { useTLSchemaFromUtils, useTLStore } from './lib/hooks/useTLStore'
 export { useViewportHeight } from './lib/hooks/useViewportHeight'
 export {
+	FLAGS,
 	LicenseManager,
 	type InvalidLicenseKeyResult,
 	type InvalidLicenseReason,
@@ -329,7 +330,12 @@ export {
 	type LicenseState,
 	type ValidLicenseKeyResult,
 } from './lib/license/LicenseManager'
-export { LICENSE_TIMEOUT } from './lib/license/LicenseProvider'
+export {
+	LICENSE_TIMEOUT,
+	LicenseContext,
+	LicenseProvider,
+	useLicenseContext,
+} from './lib/license/LicenseProvider'
 export {
 	defaultTldrawOptions,
 	type TLClipboardPasteRawInfo,

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -629,6 +629,96 @@ describe('LicenseManager', () => {
 			expect(result.daysSinceExpiry).toBe(0)
 		})
 	})
+
+	describe('License features', () => {
+		async function getManagerForLicense(info: string) {
+			process.env.NODE_ENV = 'production'
+			const licenseKey = await generateLicenseKey(info, keyPair)
+			const manager = new LicenseManager(licenseKey, keyPair.publicKey)
+			await vi.waitFor(() => expect(manager.state.get()).not.toBe('pending'))
+			process.env.NODE_ENV = 'test'
+			return manager
+		}
+
+		it('starts with no features while pending', () => {
+			const manager = new LicenseManager('', keyPair.publicKey)
+			expect(manager.features.get()).toBe(0)
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(false)
+		})
+
+		it('exposes the license flags once a valid license resolves', async () => {
+			const manager = await getManagerForLicense(
+				JSON.stringify([
+					'id',
+					['www.example.com'],
+					FLAGS.ANNUAL_LICENSE | FLAGS.COMMENTS_PLUGIN,
+					expiryDate,
+				])
+			)
+			expect(manager.state.get()).toBe('licensed')
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(true)
+		})
+
+		it('does not report features the license does not have', async () => {
+			const manager = await getManagerForLicense(STANDARD_LICENSE_INFO)
+			expect(manager.state.get()).toBe('licensed')
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(false)
+		})
+
+		it('keeps features for licensed-with-watermark licenses', async () => {
+			const manager = await getManagerForLicense(
+				JSON.stringify([
+					'id',
+					['www.example.com'],
+					FLAGS.ANNUAL_LICENSE | FLAGS.WITH_WATERMARK | FLAGS.COMMENTS_PLUGIN,
+					expiryDate,
+				])
+			)
+			expect(manager.state.get()).toBe('licensed-with-watermark')
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(true)
+		})
+
+		it('exposes no features for an expired license', async () => {
+			const expiredDate = new Date(
+				now.getFullYear() - 1,
+				now.getMonth(),
+				now.getDate()
+			).toISOString()
+			const manager = await getManagerForLicense(
+				JSON.stringify([
+					'id',
+					['www.example.com'],
+					FLAGS.ANNUAL_LICENSE | FLAGS.COMMENTS_PLUGIN,
+					expiredDate,
+				])
+			)
+			expect(manager.state.get()).toBe('expired')
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(false)
+		})
+
+		it('exposes no features for an invalid domain in production', async () => {
+			// @ts-ignore
+			delete window.location
+			// @ts-ignore
+			window.location = new URL('https://www.other-domain.com')
+			const manager = await getManagerForLicense(
+				JSON.stringify([
+					'id',
+					['www.example.com'],
+					FLAGS.ANNUAL_LICENSE | FLAGS.COMMENTS_PLUGIN,
+					expiryDate,
+				])
+			)
+			expect(manager.state.get()).toBe('unlicensed-production')
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(false)
+		})
+
+		it('exposes no features when no key is provided', async () => {
+			const manager = new LicenseManager(undefined, keyPair.publicKey)
+			await vi.waitFor(() => expect(manager.state.get()).not.toBe('pending'))
+			expect(manager.isFeatureEnabled(FLAGS.COMMENTS_PLUGIN)).toBe(false)
+		})
+	})
 })
 
 async function generateLicenseKey(

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -5,6 +5,7 @@ import { importPublicKey, str2ab } from '../utils/licensing'
 
 const GRACE_PERIOD_DAYS = 30
 
+/** @internal */
 export const FLAGS = {
 	// -- MUTUALLY EXCLUSIVE FLAGS
 	// Annual means the license expires after a time period, usually 1 year.
@@ -22,6 +23,8 @@ export const FLAGS = {
 	// Native means the license is for native apps which switches
 	// on special-case logic.
 	NATIVE_LICENSE: 1 << 5,
+	// Comments plugin: unlocks the @tldraw/comments plugin.
+	COMMENTS_PLUGIN: 1 << 6,
 }
 const HIGHEST_FLAG = Math.max(...Object.values(FLAGS))
 
@@ -98,6 +101,11 @@ export class LicenseManager {
 	public isTest: boolean
 	public isCryptoAvailable: boolean
 	state = atom<LicenseState>('license state', 'pending')
+	/**
+	 * Bitwise feature flags from the validated license key. Zero while validation is pending
+	 * and whenever the license is not in a good state (invalid, wrong domain, expired).
+	 */
+	features = atom<number>('license features', 0)
 	public verbose = true
 
 	constructor(licenseKey: string | undefined, testPublicKey?: string) {
@@ -117,6 +125,13 @@ export class LicenseManager {
 				this.maybeTrack(result, licenseState)
 
 				this.state.set(licenseState)
+
+				if (
+					result.isLicenseParseable &&
+					(licenseState === 'licensed' || licenseState === 'licensed-with-watermark')
+				) {
+					this.features.set(result.license.flags)
+				}
 			})
 			.catch((error) => {
 				console.error('License validation failed:', error)
@@ -415,6 +430,11 @@ export class LicenseManager {
 
 	private isFlagEnabled(flags: number, flag: number) {
 		return (flags & flag) === flag
+	}
+
+	/** Reactively check whether the validated license includes the given feature flag. */
+	isFeatureEnabled(flag: number): boolean {
+		return (this.features.get() & flag) === flag
 	}
 
 	private outputNoLicenseKeyProvided() {

--- a/packages/editor/src/lib/license/LicenseProvider.tsx
+++ b/packages/editor/src/lib/license/LicenseProvider.tsx
@@ -19,6 +19,22 @@ export const LICENSE_TIMEOUT = 5000
 
 /** @internal */
 export function LicenseProvider({
+	licenseKey,
+	children,
+}: {
+	licenseKey?: string
+	children: ReactNode
+}) {
+	const existing = useContext(LicenseContext)
+	if (existing instanceof LicenseManager) {
+		// An ancestor already provides a license manager (e.g. Tldraw wrapping TldrawEditor).
+		// Reuse it instead of validating and tracking the key a second time.
+		return <>{children}</>
+	}
+	return <StandaloneLicenseProvider licenseKey={licenseKey}>{children}</StandaloneLicenseProvider>
+}
+
+function StandaloneLicenseProvider({
 	licenseKey = getLicenseKeyFromEnv() ?? undefined,
 	children,
 }: {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -4181,6 +4181,7 @@ export interface TldrawPlugin extends TLSchemaPlugin {
     components?: TLComponents;
     onMount?(editor: Editor): (() => void) | void;
     overrides?: TLUiOverrides;
+    requiredLicenseFlags?: number;
     shapeUtils?: readonly TLAnyShapeUtilConstructor[];
     tools?: readonly TLStateNodeConstructor[];
 }

--- a/packages/tldraw/src/lib/Tldraw.tsx
+++ b/packages/tldraw/src/lib/Tldraw.tsx
@@ -7,18 +7,21 @@ import {
 	TldrawEditor,
 	TldrawEditorBaseProps,
 	TldrawEditorStoreProps,
+	LicenseProvider,
 	assertUniquePluginIds,
 	defaultUserPreferences,
 	mergeArraysAndReplaceDefaults,
 	mergeSchemaPluginRecords,
 	useEditor,
 	useEditorComponents,
+	useLicenseContext,
 	useOnMount,
 	useShallowArrayIdentity,
 	useShallowObjectIdentity,
+	useValue,
 } from '@tldraw/editor'
 import { TLAnyAssetUtilConstructor } from '@tldraw/editor'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { ImageAssetUtil } from './assets/ImageAssetUtil'
 import { VideoAssetUtil } from './assets/VideoAssetUtil'
 import { defaultAssetUtils } from './defaultAssetUtils'
@@ -35,7 +38,12 @@ import { registerDefaultSideEffects } from './defaultSideEffects'
 import { defaultTools } from './defaultTools'
 import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
 import { allDefaultFontFaces } from './shapes/shared/defaultFonts'
-import { TldrawPlugin, createPluginOnMount, mergePluginComponents } from './TldrawPlugin'
+import {
+	TldrawPlugin,
+	createLicenseGatedOnMount,
+	createPluginOnMount,
+	mergePluginComponents,
+} from './TldrawPlugin'
 import { TLUiAssetUrlOverrides, useDefaultUiAssetUrlsWithOverrides } from './ui/assetUrls'
 import { LoadingScreen } from './ui/components/LoadingScreen'
 import { Spinner } from './ui/components/Spinner'
@@ -161,6 +169,14 @@ function configureDefaultAssetUtils(
 
 /** @public @react */
 export function Tldraw(props: TldrawProps) {
+	return (
+		<LicenseProvider licenseKey={props.licenseKey}>
+			<TldrawInner {...props} />
+		</LicenseProvider>
+	)
+}
+
+function TldrawInner(props: TldrawProps) {
 	const {
 		children,
 		maxImageDimension,
@@ -189,10 +205,45 @@ export function Tldraw(props: TldrawProps) {
 	const _plugins = useShallowArrayIdentity(plugins)
 	useMemo(() => assertUniquePluginIds(_plugins), [_plugins])
 
+	const licenseManager = useLicenseContext()
+	const licensedPluginIds = useValue(
+		'licensed plugin ids',
+		() =>
+			new Set(
+				_plugins
+					.filter(
+						(plugin) =>
+							plugin.requiredLicenseFlags === undefined ||
+							licenseManager.isFeatureEnabled(plugin.requiredLicenseFlags)
+					)
+					.map((plugin) => plugin.id)
+			),
+		[_plugins, licenseManager]
+	)
+	const uiPlugins = useMemo(
+		() => _plugins.filter((plugin) => licensedPluginIds.has(plugin.id)),
+		[_plugins, licensedPluginIds]
+	)
+
+	const licenseState = useValue('license state', () => licenseManager.state.get(), [licenseManager])
+	const warnedPluginIds = useRef(new Set<string>())
+	useEffect(() => {
+		if (licenseState === 'pending') return
+		for (const plugin of _plugins) {
+			if (plugin.requiredLicenseFlags === undefined) continue
+			if (licensedPluginIds.has(plugin.id)) continue
+			if (warnedPluginIds.current.has(plugin.id)) continue
+			warnedPluginIds.current.add(plugin.id)
+			console.warn(
+				`tldraw: The "${plugin.id}" plugin is not included in your tldraw license, so it has been disabled. Contact sales@tldraw.com to add it to your license.`
+			)
+		}
+	}, [licenseState, _plugins, licensedPluginIds])
+
 	const _components = useShallowObjectIdentity(components)
 	const pluginComponents = useMemo(
-		() => mergePluginComponents(_plugins, _components),
-		[_plugins, _components]
+		() => mergePluginComponents(uiPlugins, _components),
+		[uiPlugins, _components]
 	)
 
 	const CustomInFrontOfTheCanvas = pluginComponents.InFrontOfTheCanvas
@@ -258,8 +309,8 @@ export function Tldraw(props: TldrawProps) {
 	)
 
 	const _pluginOverrides = useMemo(
-		() => _plugins.map((p) => p.overrides).filter((o): o is NonNullable<typeof o> => o != null),
-		[_plugins]
+		() => uiPlugins.map((p) => p.overrides).filter((o): o is NonNullable<typeof o> => o != null),
+		[uiPlugins]
 	)
 	const _userOverrides = useShallowArrayIdentity(
 		rest.overrides == null ? [] : Array.isArray(rest.overrides) ? rest.overrides : [rest.overrides]
@@ -275,9 +326,18 @@ export function Tldraw(props: TldrawProps) {
 		[_plugins, _userRecords]
 	)
 
+	const pluginsForOnMount = useMemo(
+		() =>
+			_plugins.map((plugin) =>
+				plugin.requiredLicenseFlags === undefined || !plugin.onMount
+					? plugin
+					: { ...plugin, onMount: createLicenseGatedOnMount(plugin, licenseManager) }
+			),
+		[_plugins, licenseManager]
+	)
 	const onMountWithPlugins = useMemo(
-		() => createPluginOnMount(_plugins, onMount),
-		[_plugins, onMount]
+		() => createPluginOnMount(pluginsForOnMount, onMount),
+		[pluginsForOnMount, onMount]
 	)
 
 	const _imageMimeTypes = useShallowArrayIdentity(

--- a/packages/tldraw/src/lib/TldrawPlugin.tsx
+++ b/packages/tldraw/src/lib/TldrawPlugin.tsx
@@ -1,9 +1,11 @@
 import {
 	Editor,
+	LicenseManager,
 	TLAnyShapeUtilConstructor,
 	TLOnMountHandler,
 	TLSchemaPlugin,
 	TLStateNodeConstructor,
+	react,
 } from '@tldraw/editor'
 import { TLComponents } from './Tldraw'
 import { TLUiOverrides } from './ui/overrides'
@@ -23,6 +25,14 @@ export interface TldrawPlugin extends TLSchemaPlugin {
 	components?: TLComponents
 	/** UI overrides contributed by the plugin. */
 	overrides?: TLUiOverrides
+	/**
+	 * License feature flags (bits from {@link @tldraw/editor#FLAGS}) that must be present in the
+	 * tldraw license key for this plugin to activate. When the license does not include the
+	 * flags, the plugin's `components`, `overrides`, and `onMount` are disabled, but its
+	 * `records`, `shapeUtils`, and `tools` are still registered so that existing documents keep
+	 * working. When undefined, the plugin is not license-gated.
+	 */
+	requiredLicenseFlags?: number
 	/** Called when the editor mounts. May return a cleanup function. */
 	onMount?(editor: Editor): void | (() => void)
 }
@@ -111,6 +121,35 @@ export function createPluginOnMount(
 		if (typeof userCleanup === 'function') cleanups.push(userCleanup)
 		return () => {
 			for (const cleanup of cleanups) cleanup()
+		}
+	}
+}
+
+/**
+ * Wraps a gated plugin's `onMount` so it only runs once the license confirms the plugin's
+ * required flags. License validation is async and the editor's mount handler only fires once,
+ * so we watch the license manager's `features` atom and run the plugin's `onMount` when (and
+ * if) entitlement arrives. `features` only ever transitions from 0 to the license's flags, so
+ * the handler runs at most once.
+ *
+ * @internal
+ */
+export function createLicenseGatedOnMount(
+	plugin: TldrawPlugin,
+	licenseManager: LicenseManager
+): (editor: Editor) => () => void {
+	return (editor) => {
+		let pluginCleanup: void | (() => void)
+		let hasRun = false
+		const stopReacting = react(`plugin ${plugin.id} license gate`, () => {
+			if (hasRun) return
+			if (!licenseManager.isFeatureEnabled(plugin.requiredLicenseFlags!)) return
+			hasRun = true
+			pluginCleanup = plugin.onMount!(editor)
+		})
+		return () => {
+			stopReacting()
+			if (typeof pluginCleanup === 'function') pluginCleanup()
 		}
 	}
 }

--- a/packages/tldraw/src/test/pluginLicensing.test.tsx
+++ b/packages/tldraw/src/test/pluginLicensing.test.tsx
@@ -1,0 +1,123 @@
+import { act } from '@testing-library/react'
+import {
+	Editor,
+	FLAGS,
+	LicenseContext,
+	LicenseManager,
+	StateNode,
+	promiseWithResolve,
+} from '@tldraw/editor'
+import { vi } from 'vitest'
+import { Tldraw } from '../lib/Tldraw'
+import { TldrawPlugin } from '../lib/TldrawPlugin'
+import { renderTldrawComponent } from './testutils/renderTldrawComponent'
+
+class GatedTool extends StateNode {
+	static override id = 'gated-tool'
+}
+
+function makeGatedPlugin({
+	onMount,
+}: {
+	onMount?(editor: Editor): void
+} = {}): TldrawPlugin {
+	return {
+		id: 'test.gated',
+		requiredLicenseFlags: FLAGS.COMMENTS_PLUGIN,
+		components: {
+			InFrontOfTheCanvas: function GatedOverlay() {
+				return <div data-testid="gated-overlay" />
+			},
+		},
+		tools: [GatedTool],
+		onMount,
+	}
+}
+
+function makeStubManager(features: number) {
+	const manager = new LicenseManager(undefined)
+	manager.features.set(features)
+	return manager
+}
+
+async function renderWithManager(manager: LicenseManager, plugin: TldrawPlugin) {
+	const editorPromise = promiseWithResolve<Editor>()
+	const rendered = await renderTldrawComponent(
+		<LicenseContext.Provider value={manager}>
+			<Tldraw plugins={[plugin]} onMount={(editor) => editorPromise.resolve(editor)} />
+		</LicenseContext.Provider>,
+		{ waitForPatterns: false }
+	)
+	const editor = await editorPromise
+	return { rendered, editor }
+}
+
+describe('plugin licensing', () => {
+	it('renders a gated plugin when the license includes its flag', async () => {
+		const onMount = vi.fn()
+		const manager = makeStubManager(FLAGS.COMMENTS_PLUGIN)
+		const { rendered } = await renderWithManager(manager, makeGatedPlugin({ onMount }))
+
+		expect(await rendered.findByTestId('gated-overlay')).toBeTruthy()
+		expect(onMount).toHaveBeenCalledTimes(1)
+	})
+
+	it('suppresses a gated plugin without the flag, but still registers its tools', async () => {
+		const onMount = vi.fn()
+		const manager = makeStubManager(0)
+		const { rendered, editor } = await renderWithManager(manager, makeGatedPlugin({ onMount }))
+
+		expect(rendered.queryByTestId('gated-overlay')).toBeNull()
+		expect(onMount).not.toHaveBeenCalled()
+		// registration is never gated: the tool is in the state chart even when unentitled
+		expect(editor.getStateDescendant('gated-tool')).toBeTruthy()
+	})
+
+	it('activates a gated plugin when entitlement resolves after mount', async () => {
+		const onMount = vi.fn()
+		const manager = makeStubManager(0)
+		const { rendered } = await renderWithManager(manager, makeGatedPlugin({ onMount }))
+
+		expect(rendered.queryByTestId('gated-overlay')).toBeNull()
+		expect(onMount).not.toHaveBeenCalled()
+
+		await act(async () => {
+			manager.features.set(FLAGS.COMMENTS_PLUGIN)
+		})
+
+		expect(await rendered.findByTestId('gated-overlay')).toBeTruthy()
+		expect(onMount).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not gate plugins without requiredLicenseFlags', async () => {
+		const manager = makeStubManager(0)
+		const plugin: TldrawPlugin = {
+			id: 'test.ungated',
+			components: {
+				InFrontOfTheCanvas: function UngatedOverlay() {
+					return <div data-testid="ungated-overlay" />
+				},
+			},
+		}
+		const { rendered } = await renderWithManager(manager, plugin)
+		expect(await rendered.findByTestId('ungated-overlay')).toBeTruthy()
+	})
+
+	it('warns once when the license resolves without a required flag', async () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => void 0)
+		try {
+			const manager = makeStubManager(0)
+			await act(async () => {
+				manager.state.set('unlicensed')
+			})
+			await renderWithManager(manager, makeGatedPlugin())
+
+			const pluginWarnings = warn.mock.calls.filter((args) =>
+				String(args[0]).includes('test.gated')
+			)
+			expect(pluginWarnings).toHaveLength(1)
+		} finally {
+			warn.mockRestore()
+		}
+	})
+})


### PR DESCRIPTION
In order to sell first-party plugins (starting with `@tldraw/comments`) as licensed features, this PR lets the existing tldraw license key gate plugins via its feature flags. A plugin declares the flag it needs; the `Tldraw` component enforces it centrally. There is no separate plugin key.

### How it works

- The license key's bitwise `flags` gains `COMMENTS_PLUGIN = 1 << 6`. `LicenseManager` exposes a reactive `features` atom plus `isFeatureEnabled(flag)`; features are only set when validation resolves in a good state (`licensed` / `licensed-with-watermark`).
- `TldrawPlugin` gains `requiredLicenseFlags?: number`. When the license lacks the flags, the plugin's `components` and `overrides` are excluded from the merge and its `onMount` never runs; a one-time console warning explains why.
- A plugin's `records`, `shapeUtils`, and `tools` are always registered, regardless of entitlement. License validation is async while the schema must exist at store creation, and documents containing plugin records (for example synced comments) must load safely.
- License validation resolving after mount is handled: gating is reactive, and gated `onMount` handlers are deferred via `react()` on the features atom (the editor's mount handler only fires once), running at most once with proper cleanup.
- `Tldraw` now wraps itself in `LicenseProvider`, and `LicenseProvider` reuses an ancestor-provided manager, so `TldrawEditor`'s nested provider no longer validates (or tracks) the key a second time.
- `commentsPlugin()` declares `requiredLicenseFlags: FLAGS.COMMENTS_PLUGIN`.

### Design decisions

- **First-party plugins only.** Gating rides the existing tldraw license key and `LicenseManager`; no third-party plugin licensing infrastructure (per-plugin keys or signing).
- **No flag means disabled everywhere**, including local development. Evaluation happens via time-limited evaluation keys that include the plugin flags.
- **Declarative and central enforcement.** Plugins stay licensing-unaware; the `Tldraw` component owns the gate. Rejected: plugin self-gating via a public flag-check hook (every plugin reimplements it) and passing the key to the plugin factory (duplicate validation, key in two places).
- **Client-only enforcement.** `commentsSyncPlugin` is not gated — there is no server-side `LicenseManager` today, and this is the same honesty-based tier as the watermark. Server gating is a possible follow-up.
- **Fail closed while pending.** Gated UI renders nothing until validation confirms the flag (validation takes milliseconds, so at most one flash).

### Not in this PR

- The backend key generator must start honoring the `1 << 6` bit for customers licensing the comments plugin.
- The examples app needs a comments-entitled key via `VITE_TLDRAW_LICENSE_KEY` (picked up by the existing env fallback) for the comments example to work; without it the example renders a plain canvas plus the console warning.
- A direct test for the `tl-license-expired` hide gate rendered via `Tldraw` (it had no direct coverage before this PR either; it needs a faked production environment plus timers).

### Change type

- [x] `feature`

### Test plan

1. Run the examples app with a comments-entitled license key in `VITE_TLDRAW_LICENSE_KEY` and open the comments example: comment UI renders.
2. Remove the key: the comments example renders a plain canvas and logs a one-time console warning naming the plugin.

- [x] Unit tests

### Release notes

- Add license gating for first-party plugins. Plugins can declare `requiredLicenseFlags`; without the entitlement in your tldraw license key, the plugin's UI and behavior are disabled while its record types stay registered so existing documents load safely. The comments plugin now requires the comments entitlement.

### API changes

- Added `TldrawPlugin.requiredLicenseFlags` for declaring the license flags a plugin needs
- Added `LicenseManager.features` (reactive atom of the validated license's flags) and `LicenseManager.isFeatureEnabled(flag)`
- Added `FLAGS` (including `COMMENTS_PLUGIN`), `LicenseContext`, `LicenseProvider`, and `useLicenseContext` to the `@tldraw/editor` exports (internal)

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +152 / -10 |
| Tests           | +221 / -0  |
| Automated files | +27 / -0   |
| Documentation   | +10 / -0   |
| Config/tooling  | +9 / -0    |
