### PR TITLE
docs(skills): sharpen write-pr guidance on the motivation paragraph

### DIFF
--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -64,6 +64,9 @@ Use this template:
 
 Start with: "In order to X, this PR does Y."
 
+- X is the **concrete situation that made this work necessary** — the real thing someone was trying to do — not a restatement of what Y does. "In order to let apps carry undo history across editor rebuilds, this adds an API to carry undo history across editor rebuilds" is circular: X just renames Y. Push X up a level to the actual goal, e.g. "so desktop can reload the editor without losing the user's place, the way HMR preserves component state across a code edit."
+- Name the real driving case, not a hypothetical. If you're inventing example scenarios to illustrate the why ("e.g. if someone toggled a plugin…"), you're reverse-engineering a justification from the finished code — you haven't written down the case that actually prompted it. Work forward from that case instead.
+- Beware abstract mechanism as a stand-in for motivation. A true technical fact about the SDK ("editor config is fixed at construction time") explains a constraint, not why anyone cares. Keep going until a reader can picture the specific thing that stopped working or became possible.
 - Keep it specific - avoid vague phrases like "improve user experience"
 - Link related issues in the first paragraph
 - Don't expect readers to also read the linked issue


### PR DESCRIPTION
In order to stop PR descriptions from opening with a motivation that only restates the feature, this PR sharpens the "Description paragraph" guidance in the `write-pr` skill. The `In order to X, this PR does Y` template is easy to satisfy with an X that just renames Y ("in order to let apps carry undo history across editor rebuilds, add an API to carry undo history across editor rebuilds"), and the existing "keep it specific" bullet doesn't catch it — a description can be specific and still circular. The three added bullets name the three ways the why goes wrong and how to fix each:

- **Circular** — X restates what Y does. Push X up to the actual goal.
- **Hypothetical** — inventing example scenarios to illustrate the why is the tell that the real driving case hasn't been written down. Work forward from that case.
- **Abstract mechanism** — a true technical constraint explains a limitation, not why anyone cares. Keep going until a reader can picture the specific thing that broke or became possible.

Each bullet uses a real worked example from a recent PR so the guidance is concrete rather than more advice-about-advice.

### Change type

- [x] `other`

### Test plan

Documentation-only change to a skill file; no code affected.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Documentation   | +3 / -0    |
