### PR TITLE
fix(tldraw): don't close the stroke on unfilled closed draw shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -364,11 +364,11 @@ function DrawShapeSvg({
 
 	const strokePoints = getStrokePoints(allPointsFromSegments, options)
 	const isDot = strokePoints.length < 2
+	const fill = isDot || shape.props.isClosed ? shape.props.fill : 'none'
+
 	const solidStrokePath = isDot
 		? getDot(allPointsFromSegments[0], 0)
-		: getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed)
-
-	const fill = isDot || shape.props.isClosed ? shape.props.fill : 'none'
+		: getSvgPathFromStrokePoints(strokePoints, shape.props.isClosed && fill !== 'none')
 
 	return (
 		<>


### PR DESCRIPTION
In order to keep filled and unfilled closed draw shapes visually consistent across dash styles, this PR stops the solid/dashed/dotted stroke path from drawing an artificial closing segment when a closed draw shape has no fill.

A draw shape that auto-closes (`isClosed: true`) but has `fill: 'none'` was rendering a straight/curved segment bridging the stroke's end back to its start in the `solid`, `dashed`, and `dotted` dash styles. The default `draw` dash style never did this — it renders the raw ink path from the drawn points — so the two paths disagreed. Now the closing segment is only drawn when there's actually a fill to enclose (`shape.props.isClosed && fill !== 'none'`), matching the `draw` style.

The logical geometry is unchanged: the shape is still closed for hit-testing and its selection indicator, only the painted stroke no longer bridges the gap when there's nothing to fill.

### Change type

- [x] `bugfix`

### Test plan

1. Draw a closed loop with the draw tool (draw back near the start so it snaps closed).
2. Set its fill to `none` and its dash style to `solid` (also check `dashed` and `dotted`).
3. Confirm the stroke follows the drawn line and no longer paints a closing segment across the opening.
4. Set a fill and confirm the shape still closes and fills correctly.

- [x] Unit tests

### Release notes

- Fix unfilled closed draw shapes drawing a spurious closing segment in the solid, dashed, and dotted dash styles.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -3    |
