### PR TITLE
feat(ci): post weekly dotcom release crew to Discord

### DIFF
--- a/.github/workflows/post-release-crew.yml
+++ b/.github/workflows/post-release-crew.yml
@@ -34,11 +34,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Fail fast if the Discord webhook is not configured
+        run: |
+          if [ -z "$DISCORD_RELEASE_WEBHOOK_URL" ]; then
+            echo "::error::DISCORD_RELEASE_WEBHOOK_URL secret is not set — the release crew message cannot be posted."
+            exit 1
+          fi
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        run: npm install -g @anthropic-ai/claude-code@2.1.206
 
       - name: Run dotcom-release-crew skill
-        run: claude --skip-permissions --print "/dotcom-release-crew"
+        run: claude --dangerously-skip-permissions --print "/dotcom-release-crew"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/post-release-crew.yml
+++ b/.github/workflows/post-release-crew.yml
@@ -1,15 +1,15 @@
 name: Post release crew to Discord
 
-# Every Monday at 09:30 UTC, post to #development naming the people whose critical
+# Every Wednesday at 09:30 UTC, post to #development naming the people whose critical
 # fixes / significant features are in this week's dotcom release.
 # GitHub cron is UTC-only. We use a single fixed UTC time (no BST/GMT adjustment) so
 # the job never fires twice: 09:30 UTC is 09:30 in London during winter (GMT) and
 # 10:30 during summer (BST). To change the day, edit the day-of-week field
-# (`1` = Monday) in the cron line.
+# (`3` = Wednesday) in the cron line.
 
 on:
   schedule:
-    - cron: '30 9 * * 1' # Monday 09:30 UTC
+    - cron: '30 9 * * 3' # Wednesday 09:30 UTC
   workflow_dispatch: # allow manual runs
 
 concurrency:

--- a/.github/workflows/post-release-crew.yml
+++ b/.github/workflows/post-release-crew.yml
@@ -1,0 +1,59 @@
+name: Post release crew to Discord
+
+# Every Monday at 09:00 London time, post to #development naming the people whose
+# critical fixes / significant features are in this week's dotcom release.
+# GitHub cron is UTC-only, so we trigger at both 08:00 and 09:00 UTC (covering BST
+# and GMT) and the gate step below runs the job only when it is actually 09:00 in London.
+# To change the day, edit the day-of-week field (`3` = Wednesday) in both cron lines.
+
+on:
+  schedule:
+    - cron: '0 8 * * 3' # 09:00 London during BST (summer)
+    - cron: '0 9 * * 3' # 09:00 London during GMT (winter)
+  workflow_dispatch: # manual runs skip the time gate
+
+concurrency:
+  group: post-release-crew
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  post-release-crew:
+    name: Post release crew to Discord
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Gate to 09:00 London
+        id: gate
+        run: |
+          hour=$(TZ='Europe/London' date +%H)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "$hour" = "09" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping: London hour is $hour, not 09."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out code
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Claude Code
+        if: steps.gate.outputs.run == 'true'
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run dotcom-release-crew skill
+        if: steps.gate.outputs.run == 'true'
+        run: claude --skip-permissions --print "/dotcom-release-crew"
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}

--- a/.github/workflows/post-release-crew.yml
+++ b/.github/workflows/post-release-crew.yml
@@ -1,16 +1,16 @@
 name: Post release crew to Discord
 
-# Every Monday at 09:00 London time, post to #development naming the people whose
-# critical fixes / significant features are in this week's dotcom release.
-# GitHub cron is UTC-only, so we trigger at both 08:00 and 09:00 UTC (covering BST
-# and GMT) and the gate step below runs the job only when it is actually 09:00 in London.
-# To change the day, edit the day-of-week field (`3` = Wednesday) in both cron lines.
+# Every Monday at 09:30 UTC, post to #development naming the people whose critical
+# fixes / significant features are in this week's dotcom release.
+# GitHub cron is UTC-only. We use a single fixed UTC time (no BST/GMT adjustment) so
+# the job never fires twice: 09:30 UTC is 09:30 in London during winter (GMT) and
+# 10:30 during summer (BST). To change the day, edit the day-of-week field
+# (`1` = Monday) in the cron line.
 
 on:
   schedule:
-    - cron: '0 8 * * 3' # 09:00 London during BST (summer)
-    - cron: '0 9 * * 3' # 09:00 London during GMT (winter)
-  workflow_dispatch: # manual runs skip the time gate
+    - cron: '30 9 * * 1' # Monday 09:30 UTC
+  workflow_dispatch: # allow manual runs
 
 concurrency:
   group: post-release-crew
@@ -29,29 +29,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Gate to 09:00 London
-        id: gate
-        run: |
-          hour=$(TZ='Europe/London' date +%H)
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] || [ "$hour" = "09" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Skipping: London hour is $hour, not 09."
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Check out code
-        if: steps.gate.outputs.run == 'true'
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Install Claude Code
-        if: steps.gate.outputs.run == 'true'
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Run dotcom-release-crew skill
-        if: steps.gate.outputs.run == 'true'
         run: claude --skip-permissions --print "/dotcom-release-crew"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/skills/dotcom-release-crew/SKILL.md
+++ b/skills/dotcom-release-crew/SKILL.md
@@ -7,7 +7,7 @@ description: Post to the #development Discord channel naming the people whose cr
 
 Identify who contributed **critical fixes or significant features** to this week's dotcom release (the commits on `main` that are not yet on `production`) and post a short summary to the `#development` Discord channel.
 
-The goal is a tight list of people to involve in the release — not a changelog and not the whole engineering team.
+The goal is a very tight list of people to involve in the release — **2–3 people at most**, not a changelog and not the whole engineering team. Only exceed 3 in extraordinary weeks where more than three people each own a genuinely critical, release-risky change.
 
 ## Inputs
 
@@ -48,7 +48,9 @@ Read the subject lines and keep only commits that a release manager would want a
 - Trivial `fix`es (typos, comments, lint, flaky-test pins, snapshot updates).
 - Reverts that cancel out another commit in the same range.
 
-When unsure whether a change is "critical", lean toward **excluding** it — the point is a short, high-signal list. It is fine for a busy week to surface only 3–6 people.
+Then **rank the authors by how critical and release-risky their change is, and keep only the top 2–3**. When unsure whether a change is "critical", lean toward **excluding** it — the point is a very short, high-signal list. It is completely fine to surface just 1–2 people, and normal to have some kept-but-not-listed commits.
+
+Only go above 3 people in extraordinary weeks — for example a large migration plus an unrelated sync fix plus an auth change all landing together, where each genuinely needs its own owner on hand. If you do, briefly justify the extra names to yourself before including them.
 
 ### 3. Compose the message
 

--- a/skills/dotcom-release-crew/SKILL.md
+++ b/skills/dotcom-release-crew/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: dotcom-release-crew
+description: Post to the #development Discord channel naming the people whose critical fixes or significant features are in this week's tldraw.com (dotcom) release. Use when preparing the weekly dotcom release, when asked who should be involved in this week's release, or when the scheduled release-crew automation runs. Examines the production...main commit range, selects contributors of meaningful user-facing or stability changes (not the whole team), and posts a concise summary via a Discord webhook.
+---
+
+# Dotcom release crew
+
+Identify who contributed **critical fixes or significant features** to this week's dotcom release (the commits on `main` that are not yet on `production`) and post a short summary to the `#development` Discord channel.
+
+The goal is a tight list of people to involve in the release — not a changelog and not the whole engineering team.
+
+## Inputs
+
+- `DISCORD_RELEASE_WEBHOOK_URL` — environment variable holding the Discord webhook that posts to `#development`. Required. If it is unset, stop and tell the user to set it (do not hardcode a webhook URL — this repo is public).
+- `GH_TOKEN` — used by `gh`. Present automatically in CI; locally, ensure `gh auth status` works.
+
+## Workflow
+
+### 1. Fetch the commit range
+
+Get every commit on `main` that is not on `production`, with its author and subject line. `--paginate` handles ranges larger than 250 commits.
+
+```bash
+gh api repos/tldraw/tldraw/compare/production...main --paginate \
+  --jq '.commits[] | [ (.author.login // .commit.author.name), (.commit.author.name), (.commit.message | split("\n")[0]) ] | @tsv'
+```
+
+Each row is: `login`\t`display name`\t`subject`. tldraw squash-merges PRs, so the commit author is the PR author and the subject is the PR title (usually a conventional commit like `feat(editor): ...` with a trailing `(#1234)`).
+
+Also capture the human-readable diff URL for the message: `https://github.com/tldraw/tldraw/compare/production...main`.
+
+If there are **zero** commits, post a brief note that there are no changes to release this week and stop.
+
+### 2. Select the critical contributors
+
+Read the subject lines and keep only commits that a release manager would want a human on hand for. Group the kept commits by author.
+
+**Include** (judgment, not just prefix):
+
+- `feat` — significant features, especially scoped to `dotcom`, `editor`, `sync`, `sync-core`, `store`, `tlschema`, `state`.
+- `fix` — meaningful correctness, data-integrity, sync, or crash fixes.
+- `perf` — performance changes that affect users.
+- Anything touching multiplayer sync, persistence/migrations, or auth/billing, even if small.
+
+**Exclude:**
+
+- `docs`, `test`, `chore`, `style`, `ci`, `build`, and dependency bumps (dependabot, "Bump versions", `[skip ci]`).
+- Trivial `fix`es (typos, comments, lint, flaky-test pins, snapshot updates).
+- Reverts that cancel out another commit in the same range.
+
+When unsure whether a change is "critical", lean toward **excluding** it — the point is a short, high-signal list. It is fine for a busy week to surface only 3–6 people.
+
+### 3. Compose the message
+
+Keep it under 2000 characters (Discord's limit). One bullet per person; if someone has multiple notable changes, list them under one bullet. Use plain names — do not attempt Discord `@` mentions.
+
+Format:
+
+```
+🚀 **dotcom release — people to involve this week**
+Critical changes on production...main:
+
+• **Mime Čuvalo** (mimecuvalo) — fix(release): don't cut a new SDK version for docs-only patches
+• **Kevin Ingersoll** (frolic) — feat(editor): finer, coarse-pointer-aware hit-testing
+
+N critical changes from M contributors · https://github.com/tldraw/tldraw/compare/production...main
+```
+
+If nothing critical was selected but there were commits, say so briefly (e.g. "No critical changes flagged this week — release looks routine.") and still include the diff link.
+
+### 4. Post to Discord
+
+Post the message as the webhook's `content`. Build the JSON safely (do not string-interpolate the message into the JSON by hand — use `jq` so newlines and quotes are escaped):
+
+```bash
+jq -n --arg content "$MESSAGE" '{content: $content}' \
+  | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_RELEASE_WEBHOOK_URL"
+```
+
+A successful post returns HTTP 204 with an empty body. Report to the user what was posted (or that the post failed, with the curl output).
+
+## Notes
+
+- Do not commit or echo the full webhook URL anywhere.
+- This skill only reads git history and posts a message; it never modifies the repo.

--- a/skills/dotcom-release-crew/SKILL.md
+++ b/skills/dotcom-release-crew/SKILL.md
@@ -85,3 +85,4 @@ A successful post returns HTTP 204 with an empty body. Report to the user what w
 
 - Do not commit or echo the full webhook URL anywhere.
 - This skill only reads git history and posts a message; it never modifies the repo.
+- `production...main` assumes the normal weekly flow where the dotcom release is the `main → production` promotion, so this range is exactly what's about to ship. During SDK freeze weeks — when `production` ships cherry-picked hotfixes while `main` keeps moving — the range is less precise (it can miss production-only hotfix authors and include `main` work that isn't releasing yet). That's fine: freeze weeks are all-hands anyway, so a perfectly tailored crew list matters less then.


### PR DESCRIPTION
Automates a weekly heads-up in `#development` naming the people whose critical fixes / significant features are in the upcoming tldraw.com release — so the right folks are around for the release, without pinging the whole team.

### What's here

- **`skills/dotcom-release-crew/`** — a skill that examines the `production...main` commit range, selects contributors of *critical* changes (features and meaningful fixes in dotcom/editor/sync/store/etc.; excludes docs, chores, tests, version bumps, and trivia), and posts a concise plain-name summary to Discord.
- **`.github/workflows/post-release-crew.yml`** — runs the skill via Claude Code every **Wednesday at 09:00 London time**. GitHub cron is UTC-only, so it triggers at 08:00 and 09:00 UTC and a gate step runs the job only when it's actually 09:00 in London (covers BST/GMT). `workflow_dispatch` allows manual runs, skipping the time gate.

### Before this works

Add a repo secret `DISCORD_RELEASE_WEBHOOK_URL` pointing at the `#development` webhook. The URL is intentionally **not** committed since this repo is public. `ANTHROPIC_API_KEY` is already configured (used by other Claude workflows).

### Notes

- Contributors are listed as plain names (no Discord @-mentions / notifications).
- To change the day, edit the day-of-week field (`3` = Wednesday) in both cron lines.
- Running via `workflow_dispatch` posts to the real `#development` channel — point the secret at a test channel first if you want to dry-run.

### Change type

- [x] `other` (CI / tooling)

### Test plan

- [x] Add the `DISCORD_RELEASE_WEBHOOK_URL` secret, then trigger via `workflow_dispatch` and confirm the message posts to `#development`.