### PR TITLE
feat(commenting): shape-anchor modes, drag-to-move, and comment UI polish

### DIFF
--- a/apps/component-studio/src/comment-model.tsx
+++ b/apps/component-studio/src/comment-model.tsx
@@ -60,7 +60,7 @@ const PAGE_ID = 'page:studio' as TLPageId
 /** A sample thread, anchored to a shape. */
 export const sampleThread: TLCommentThread = createCommentThread({
 	pageId: PAGE_ID,
-	anchor: { type: 'shape', shapeId: createShapeId('box') },
+	anchor: { type: 'shape', shapeId: createShapeId('box'), x: 1, y: 0, isPrecise: false },
 	createdBy: 'ada',
 	now: NOW - 2 * HOUR,
 })

--- a/apps/component-studio/src/sketchbooks/anchoring/anchor-scene.tsx
+++ b/apps/component-studio/src/sketchbooks/anchoring/anchor-scene.tsx
@@ -154,7 +154,13 @@ function measureAnchor(
 			const b = editor.getShapePageBounds(shapeId)
 			if (!b) return null
 			const f = pageBoxToFrac(editor, c, b.x, b.y, b.w, b.h)
-			return { pin: { left: f.left + f.width, top: f.top }, textHighlights: [], region: null }
+			// precise pins sit at the stored normalized x/y; imprecise ones at the top-right badge
+			const { x, y } = anchor.isPrecise ? anchor : { x: 1, y: 0 }
+			return {
+				pin: { left: f.left + x * f.width, top: f.top + y * f.height },
+				textHighlights: [],
+				region: null,
+			}
 		}
 		case 'point': {
 			const f = pageBoxToFrac(editor, c, anchor.x, anchor.y, 0, 0)

--- a/apps/component-studio/src/sketchbooks/anchoring/comment-anchor.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/anchoring/comment-anchor.sketchbook.tsx
@@ -11,7 +11,7 @@ const sketchbook: Sketchbook<CommentAnchorProps> = {
 			control: 'union',
 			discriminant: 'type',
 			variants: {
-				shape: { type: 'shape', shapeId: createShapeId('box') },
+				shape: { type: 'shape', shapeId: createShapeId('box'), x: 1, y: 0, isPrecise: false },
 				point: { type: 'point', x: 120, y: 90 },
 				region: { type: 'region', x: 60, y: 60, w: 180, h: 120 },
 				page: { type: 'page' },
@@ -22,8 +22,20 @@ const sketchbook: Sketchbook<CommentAnchorProps> = {
 }
 export default sketchbook
 
-export const Shape: Sketch<CommentAnchorProps> = {
-	args: { anchor: { type: 'shape', shapeId: createShapeId('box') }, open: true },
+// Shape anchors have two modes, like arrow bindings: imprecise sits at a default badge spot
+// (top-right out of the box), precise sits exactly where it was placed. Both track the shape as it
+// moves and resizes, since x/y are normalized.
+export const ShapeImprecise: Sketch<CommentAnchorProps> = {
+	args: {
+		anchor: { type: 'shape', shapeId: createShapeId('box'), x: 1, y: 0, isPrecise: false },
+		open: true,
+	},
+}
+export const ShapePrecise: Sketch<CommentAnchorProps> = {
+	args: {
+		anchor: { type: 'shape', shapeId: createShapeId('box'), x: 0.5, y: 0.62, isPrecise: true },
+		open: true,
+	},
 }
 export const Point: Sketch<CommentAnchorProps> = {
 	args: { anchor: { type: 'point', x: 110, y: 110 }, open: true },

--- a/packages/commenting/src/canvas.ts
+++ b/packages/commenting/src/canvas.ts
@@ -20,4 +20,10 @@ export {
 	useThreadComments,
 } from './canvas/hooks'
 export { richTextToPlaintext } from './canvas/rich-text'
-export { anchorPagePoint, focusThread, openThreadId } from './canvas/thread-state'
+export {
+	anchorPagePoint,
+	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
+	focusThread,
+	openThreadId,
+	shapeAnchorAt,
+} from './canvas/thread-state'

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -1,12 +1,11 @@
-/* The comments layer is portaled into the editor container as a sibling of the UI panels.
-   It sits above their stacking context (`.tlui-layout` is z-index 300) so pins and popovers
-   read as UI chrome rather than being clipped by the canvas. It's click-through except on its
-   own children, so the canvas and panels underneath stay reachable. */
+/* The comments layer is portaled into the editor container. Pins live in the canvas-in-front layer
+   (beneath the UI panels at z-index 300), so the toolbar and style panel draw over them; the open
+   thread's popover portals up to the menus layer separately (`.cmt-canvas-popover`) so it isn't
+   clipped. Click-through except on its own children. */
 .cmt-canvas-layer {
 	position: absolute;
 	inset: 0;
-	/* popover-like, above the panels — the same layer menus/popovers use */
-	z-index: var(--tl-layer-menus);
+	z-index: var(--tl-layer-canvas-in-front);
 	pointer-events: none;
 }
 
@@ -26,19 +25,34 @@
 .cmt-canvas-pin__marker {
 	width: max-content;
 	transform: translate(-50%, -50%);
-	cursor: pointer;
+	cursor: grab;
+	touch-action: none;
+}
+.cmt-canvas-pin__marker:active {
+	cursor: grabbing;
 }
 
-/* The thread popover opens just to the right of the pin. */
-.cmt-canvas-pin__popover {
+/* The open thread's popover — portaled to the menus layer (above the UI), positioned at the pin. */
+.cmt-canvas-popover {
 	position: absolute;
-	top: 0;
-	left: 20px;
+	z-index: var(--tl-layer-menus);
+	pointer-events: auto;
 }
 
-/* The placement composer sits just below the click point. */
+/* The placement composer — a distinct floating view (portaled to the menus layer, below the click
+   point): a pencil "draft" avatar beside a pill field that is itself the surface (no wrapping
+   panel). Scoped here so the in-thread reply composer keeps its own squarer look. */
 .cmt-canvas-composer {
+	position: absolute;
+	z-index: var(--tl-layer-menus);
+	pointer-events: auto;
 	transform: translateY(8px);
+}
+.cmt-canvas-composer .cmt-composer__field {
+	background: var(--tl-color-panel);
+	border-color: transparent;
+	border-radius: var(--tl-radius-4);
+	box-shadow: var(--tl-shadow-2);
 }
 
 /* The comments list panel — a right-side surface shown while the comment tool is active. Below

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -11,6 +11,7 @@ import {
 	useTools,
 	VecLike,
 } from 'tldraw'
+import { shapeAnchorAt } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
  *  to. Shared between the tool (which sets it on click) and the overlay (which renders the
@@ -37,12 +38,17 @@ export class CommentTool extends StateNode {
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
 	}
 
+	// Escape leaves the tool, like the built-in tools (the editor dispatches `cancel` on Escape).
+	override onCancel() {
+		this.editor.setCurrentTool('select')
+	}
+
 	override onPointerDown() {
 		const { editor } = this
 		const point = editor.inputs.getCurrentPagePoint()
 		const hit = editor.getShapeAtPoint(point, { hitInside: true })
 		const anchor: TLCommentAnchor = hit
-			? { type: 'shape', shapeId: hit.id }
+			? shapeAnchorAt(editor, hit.id, point, editor.inputs.getAltKey())
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set({ anchor, point: { x: point.x, y: point.y } })
 		// Hand back to select; the open composer is now the focus.

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable tldraw/jsx-no-literals */
-import { ReactNode, useEffect, useRef, useState } from 'react'
+import {
+	type PointerEvent as ReactPointerEvent,
+	ReactNode,
+	useEffect,
+	useRef,
+	useState,
+} from 'react'
 import { createPortal } from 'react-dom'
 import {
 	createComment,
@@ -21,7 +27,7 @@ import { CommentBody } from './comment-body'
 import { pendingComment, PendingComment } from './comment-tool'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
 import { richTextToPlaintext } from './rich-text'
-import { anchorPagePoint, openThreadId } from './thread-state'
+import { anchorPagePoint, openThreadId, shapeAnchorAt } from './thread-state'
 import './canvas.css'
 
 /**
@@ -44,11 +50,34 @@ export interface CanvasCommentsProps {
 	renderPinContent?(thread: TLCommentThread, comments: TLComment[]): ReactNode
 	/** Called after any comment (a new thread's first comment, or a reply) is posted. */
 	onPostComment?(comment: TLComment): void
+	/** Where imprecise shape pins sit — a normalized (0–1) spot within the shape. Default top-right. */
+	impreciseShapeAnchor?: { x: number; y: number }
 }
 
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
 
 const initialOf = (name: string): string => (name.trim()[0] ?? '?').toUpperCase()
+
+/** The leading element for the placement composer — the comment pin's shape, but a pencil
+ *  instead of an initial, marking an unsent draft. */
+const draftAvatar = (
+	<CommentPin>
+		<svg
+			viewBox="0 0 24 24"
+			width="15"
+			height="15"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M12 20h9" />
+			<path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+		</svg>
+	</CommentPin>
+)
 
 function toCardProps(comment: TLComment, props: CanvasCommentsProps): CommentCardProps {
 	return {
@@ -81,6 +110,22 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		}
 	}, [editor])
 
+	// Escape collapses the open thread. Capture-phase + stopPropagation so it runs ahead of the
+	// editor (which would otherwise cancel the current tool or clear the selection). If a comment is
+	// being edited, let its own Escape handler exit edit mode first, keeping the thread open.
+	useEffect(() => {
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape' || openThreadId.get() === null) return
+			const target = e.target as HTMLElement | null
+			if (target && target.closest('.cmt-editing')) return
+			openThreadId.set(null)
+			e.preventDefault()
+			e.stopPropagation()
+		}
+		document.addEventListener('keydown', onKeyDown, true)
+		return () => document.removeEventListener('keydown', onKeyDown, true)
+	}, [])
+
 	// Render into the container (above the panels' stacking context) so the pins and popovers
 	// live in the UI layer rather than being clipped by the canvas layer.
 	return createPortal(
@@ -101,22 +146,27 @@ function ThreadPin({
 	thread,
 	...props
 }: CanvasCommentsProps & { editor: Editor; thread: TLCommentThread }) {
-	const { currentUserId, resolveName, renderPinContent, onPostComment } = props
+	const { currentUserId, resolveName, renderPinContent, onPostComment, impreciseShapeAnchor } =
+		props
+	const container = useContainer()
 	const comments = useThreadComments(editor, thread.id)
 	// Only one thread's popover is open at a time — shared across pins via the atom.
 	const open = useValue('thread open', () => openThreadId.get() === thread.id, [thread.id])
 	const [reply, setReply] = useState('')
 	const [editingId, setEditingId] = useState<string | null>(null)
 	const [editText, setEditText] = useState('')
+	// While dragging the marker, its page point overrides the anchor's; committed on drop.
+	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
+	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
 
 	const point = useValue(
 		'pin point',
 		() => {
 			if (thread.pageId !== editor.getCurrentPageId()) return null
-			const pagePoint = anchorPagePoint(editor, thread.anchor)
+			const pagePoint = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
 			return pagePoint ? editor.pageToViewport(pagePoint) : null
 		},
-		[editor, thread.anchor, thread.pageId]
+		[editor, thread.anchor, thread.pageId, impreciseShapeAnchor]
 	)
 
 	if (!point) return null
@@ -187,8 +237,12 @@ function ThreadPin({
 		if (editingId === comment.id) {
 			return (
 				<div
+					className="cmt-editing"
 					onKeyDown={(e) => {
-						if (e.key === 'Escape') setEditingId(null)
+						if (e.key === 'Escape') {
+							setEditingId(null)
+							e.stopPropagation()
+						}
 					}}
 				>
 					<CommentComposer
@@ -244,43 +298,89 @@ function ThreadPin({
 		? renderPinContent(thread, comments)
 		: initialOf(resolveName(thread.createdBy))
 
+	// Drag the marker to move the thread: its position is overridden locally while dragging, then
+	// re-anchored on drop (to a shape if dropped on one, else a point). A pointer that barely moves
+	// is a click — toggle the popover.
+	const startDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
+		e.stopPropagation()
+		dragRef.current = { startX: e.clientX, startY: e.clientY, moved: false }
+		e.currentTarget.setPointerCapture(e.pointerId)
+	}
+	const onDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
+		const drag = dragRef.current
+		if (!drag) return
+		if (!drag.moved && Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < 4) return
+		drag.moved = true
+		setDragPagePoint(editor.screenToPage({ x: e.clientX, y: e.clientY }))
+	}
+	const endDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
+		const drag = dragRef.current
+		dragRef.current = null
+		if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+			e.currentTarget.releasePointerCapture(e.pointerId)
+		}
+		if (!drag) return
+		if (!drag.moved) {
+			openThreadId.set(openThreadId.get() === thread.id ? null : thread.id)
+			return
+		}
+		const pagePoint = editor.screenToPage({ x: e.clientX, y: e.clientY })
+		setDragPagePoint(null)
+		const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
+		const anchor = hit
+			? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
+			: { type: 'point', x: pagePoint.x, y: pagePoint.y }
+		editor.run(() => editor.store.put([{ ...thread, anchor } as any]), { history: 'ignore' })
+	}
+
+	const renderPoint = dragPagePoint ? editor.pageToViewport(dragPagePoint) : point
+
 	return (
 		<div
 			className={open ? 'cmt-canvas-pin cmt-canvas-pin--open' : 'cmt-canvas-pin'}
-			style={{ left: point.x, top: point.y }}
+			style={{ left: renderPoint.x, top: renderPoint.y }}
 		>
 			<div
 				className="cmt-canvas-pin__marker"
-				onPointerDown={stop}
-				onClick={() => openThreadId.set(openThreadId.get() === thread.id ? null : thread.id)}
+				onPointerDown={startDrag}
+				onPointerMove={onDrag}
+				onPointerUp={endDrag}
 			>
 				<CommentPin resolved={thread.resolved != null} open={open}>
 					{pinContent}
 				</CommentPin>
 			</div>
-			{open && (
-				<div className="cmt-canvas-pin__popover" onPointerDown={stop}>
-					<CommentThread
-						header="Thread"
-						headerActions={headerActions}
-						renderComment={renderComment}
-						comments={comments.map((c) => toCardProps(c, props))}
-						resolvedBy={thread.resolved ? resolveName(thread.resolved.by) : undefined}
-						composer={
-							currentUserId && !thread.resolved
-								? {
-										author: resolveName(currentUserId),
-										placeholder: 'Reply…',
-										value: reply,
-										onChange: setReply,
-										onSubmit: postReply,
-										disabled: !reply.trim(),
-									}
-								: undefined
-						}
-					/>
-				</div>
-			)}
+			{/* The popover portals up to the menus layer (above the UI panels) so it isn't clipped;
+			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
+			{open &&
+				createPortal(
+					<div
+						className="cmt-canvas-popover"
+						style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
+						onPointerDown={stop}
+					>
+						<CommentThread
+							header="Comment"
+							headerActions={headerActions}
+							renderComment={renderComment}
+							comments={comments.map((c) => toCardProps(c, props))}
+							resolvedBy={thread.resolved ? resolveName(thread.resolved.by) : undefined}
+							composer={
+								currentUserId && !thread.resolved
+									? {
+											author: resolveName(currentUserId),
+											placeholder: 'Reply…',
+											value: reply,
+											onChange: setReply,
+											onSubmit: postReply,
+											disabled: !reply.trim(),
+										}
+									: undefined
+							}
+						/>
+					</div>,
+					container
+				)}
 		</div>
 	)
 }
@@ -294,6 +394,7 @@ function PendingComposer({
 }: CanvasCommentsProps & { editor: Editor; pending: PendingComment }) {
 	const [text, setText] = useState('')
 	const ref = useRef<HTMLDivElement>(null)
+	const container = useContainer()
 
 	const point = useValue('composer point', () => editor.pageToViewport(pending.point), [
 		editor,
@@ -336,7 +437,7 @@ function PendingComposer({
 		pendingComment.set(null)
 	}
 
-	return (
+	return createPortal(
 		<div
 			ref={ref}
 			className="cmt-canvas-composer"
@@ -354,7 +455,9 @@ function PendingComposer({
 				onSubmit={submit}
 				disabled={!text.trim()}
 				autoFocus
+				leading={draftAvatar}
 			/>
-		</div>
+		</div>,
+		container
 	)
 }

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -19,6 +19,8 @@ export interface CanvasCommentsSidebarProps {
 	header?: ReactNode
 	/** Shown when the page has no threads. */
 	empty?: ReactNode
+	/** Where imprecise shape pins sit, so navigation centres on the same spot. Default top-right. */
+	impreciseShapeAnchor?: { x: number; y: number }
 }
 
 /**
@@ -32,6 +34,7 @@ export function CanvasCommentsSidebar({
 	tools = ['comment'],
 	header = 'Comments',
 	empty = 'No comments on this page yet.',
+	impreciseShapeAnchor,
 }: CanvasCommentsSidebarProps) {
 	const editor = useEditor()
 	const container = useContainer()
@@ -76,7 +79,7 @@ export function CanvasCommentsSidebar({
 
 	const focus = (id: string) => {
 		const thread = threads.find((t) => t.id === id)
-		if (thread) focusThread(editor, thread)
+		if (thread) focusThread(editor, thread, impreciseShapeAnchor)
 	}
 
 	return createPortal(

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -3,13 +3,27 @@ import { atom, Editor, TLCommentAnchor, TLCommentThread, TLShapeId } from 'tldra
 /** The id of the one open thread (only one popover is open at a time), or null when all closed. */
 export const openThreadId = atom<string | null>('openThreadId', null)
 
-/** Where a thread's pin sits on the page, for each anchor kind. Null hides the pin. */
+/** Where an imprecise shape comment sits by default: the shape's top-right corner. Overridable. */
+export const DEFAULT_IMPRECISE_SHAPE_ANCHOR = { x: 1, y: 0 }
+
+/**
+ * Where a thread's pin sits on the page, for each anchor kind. Null hides the pin. For imprecise
+ * shape anchors the pin uses `impreciseShapeAnchor` (a normalized 0–1 spot, top-right by default)
+ * rather than the stored `x`/`y`.
+ */
 export function anchorPagePoint(
 	editor: Editor,
-	anchor: TLCommentAnchor
+	anchor: TLCommentAnchor,
+	impreciseShapeAnchor: { x: number; y: number } = DEFAULT_IMPRECISE_SHAPE_ANCHOR
 ): { x: number; y: number } | null {
 	switch (anchor.type) {
-		case 'shape':
+		case 'shape': {
+			const bounds = editor.getShapePageBounds(anchor.shapeId as TLShapeId)
+			if (!bounds) return null
+			// Precise pins sit at their stored x/y; imprecise ones at the consumer's default spot.
+			const { x, y } = anchor.isPrecise ? anchor : impreciseShapeAnchor
+			return { x: bounds.minX + x * bounds.w, y: bounds.minY + y * bounds.h }
+		}
 		case 'text-range': {
 			const bounds = editor.getShapePageBounds(anchor.shapeId as TLShapeId)
 			if (!bounds) return null
@@ -24,12 +38,40 @@ export function anchorPagePoint(
 	}
 }
 
+/**
+ * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
+ * shape's page bounds, remembered either way. When `precise` (Alt held) the pin sits at exactly
+ * `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the box).
+ */
+export function shapeAnchorAt(
+	editor: Editor,
+	shapeId: TLShapeId,
+	page: { x: number; y: number },
+	precise: boolean
+): TLCommentAnchor {
+	const bounds = editor.getShapePageBounds(shapeId)
+	if (!bounds || bounds.w === 0 || bounds.h === 0) {
+		return { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: precise }
+	}
+	return {
+		type: 'shape',
+		shapeId,
+		x: (page.x - bounds.minX) / bounds.w,
+		y: (page.y - bounds.minY) / bounds.h,
+		isPrecise: precise,
+	}
+}
+
 /** Open a thread and bring it into view — switch to its page if needed, then center its pin. */
-export function focusThread(editor: Editor, thread: TLCommentThread): void {
+export function focusThread(
+	editor: Editor,
+	thread: TLCommentThread,
+	impreciseShapeAnchor?: { x: number; y: number }
+): void {
 	if (thread.pageId !== editor.getCurrentPageId()) {
 		editor.setCurrentPage(thread.pageId as any)
 	}
 	openThreadId.set(thread.id)
-	const point = anchorPagePoint(editor, thread.anchor)
+	const point = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
 	if (point) editor.centerOnPoint(point, { animation: { duration: 200 } })
 }

--- a/packages/commenting/src/ui/avatar.tsx
+++ b/packages/commenting/src/ui/avatar.tsx
@@ -4,20 +4,15 @@ export interface AvatarProps {
 	name: string
 }
 
-function initials(name: string) {
-	return name
-		.split(' ')
-		.map((word) => word[0] ?? '')
-		.join('')
-		.slice(0, 2)
-		.toUpperCase()
+function initial(name: string) {
+	return (name.trim()[0] ?? '?').toUpperCase()
 }
 
-/** An initials avatar for a commenter. */
+/** A single-initial avatar for a commenter. */
 export function Avatar({ name }: AvatarProps) {
 	return (
 		<div className="cmt-avatar" aria-hidden="true">
-			{initials(name)}
+			{initial(name)}
 		</div>
 	)
 }

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { ReactNode, useEffect, useRef } from 'react'
 import { Avatar } from './avatar'
 import './comments.css'
 import { SendButton } from './send-button'
@@ -14,6 +14,8 @@ export interface CommentComposerProps {
 	sendLabel?: string
 	disabled?: boolean
 	autoFocus?: boolean
+	/** The leading element before the field. Defaults to the author's avatar. */
+	leading?: ReactNode
 }
 
 /** The input for writing a new comment, composed from Avatar and SendButton. Presentational
@@ -27,6 +29,7 @@ export function CommentComposer({
 	sendLabel = 'Send',
 	disabled,
 	autoFocus,
+	leading,
 }: CommentComposerProps) {
 	const inputRef = useRef<HTMLInputElement>(null)
 
@@ -43,22 +46,24 @@ export function CommentComposer({
 
 	return (
 		<div className="cmt-composer">
-			<Avatar name={author} />
-			<input
-				ref={inputRef}
-				className="cmt-input"
-				placeholder={placeholder}
-				value={value}
-				onChange={onChange ? (e) => onChange(e.target.value) : undefined}
-				onKeyDown={
-					onSubmit
-						? (e) => {
-								if (e.key === 'Enter') onSubmit()
-							}
-						: undefined
-				}
-			/>
-			<SendButton label={sendLabel} onClick={onSubmit} disabled={disabled} />
+			{leading ?? <Avatar name={author} />}
+			<div className="cmt-composer__field">
+				<input
+					ref={inputRef}
+					className="cmt-input"
+					placeholder={placeholder}
+					value={value}
+					onChange={onChange ? (e) => onChange(e.target.value) : undefined}
+					onKeyDown={
+						onSubmit
+							? (e) => {
+									if (e.key === 'Enter') onSubmit()
+								}
+							: undefined
+					}
+				/>
+				<SendButton label={sendLabel} onClick={onSubmit} disabled={disabled} />
+			</div>
 		</div>
 	)
 }

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -101,19 +101,28 @@
 	flex-shrink: 0;
 }
 
-/* composer */
+/* composer — an avatar beside a rounded-rect field (input + send). The avatar matches the comment
+   row's, so the two line up; the field is squarer than a pill, like tldraw's own buttons. */
 .cmt-composer {
 	display: flex;
 	align-items: center;
-	gap: 8px;
-	padding: 6px 6px 6px 8px;
-	width: 280px;
-	background: var(--tl-color-panel);
-	border: 1px solid var(--tl-color-divider);
-	border-radius: 999px;
+	gap: 10px;
+	padding: 4px 0 8px 4px;
 }
 
-.cmt-composer:focus-within {
+.cmt-composer__field {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	padding: 3px 3px 3px 12px;
+	background: var(--tl-color-muted-2);
+	border: 1px solid var(--tl-color-divider);
+	border-radius: var(--tl-radius-3);
+}
+
+.cmt-composer__field:focus-within {
 	border-color: var(--tl-color-selected);
 }
 
@@ -130,7 +139,7 @@
 
 .cmt-send {
 	border: 0;
-	border-radius: 999px;
+	border-radius: var(--tl-radius-2);
 	background: var(--tl-color-selected);
 	color: #fff;
 	font: inherit;
@@ -324,11 +333,9 @@
 	padding: 2px 2px 2px 4px;
 }
 .cmt-thread__title {
-	font-size: 11px;
+	font-size: 12px;
 	font-weight: 600;
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	color: var(--tl-color-text-3);
+	color: var(--tl-color-text-1);
 }
 .cmt-thread__actions {
 	display: flex;
@@ -365,16 +372,13 @@
 	flex-direction: column;
 	gap: 6px;
 }
-/* inside the panel, comments are plain content — no surrounding box; the composer reads as a field */
+/* inside the panel, comments are plain content — no surrounding box; the composer's field carries
+   its own surface. */
 .cmt-thread .cmt-card {
 	width: 100%;
+	padding: 6px 0 6px 4px;
 	background: transparent;
 	border: none;
-}
-.cmt-thread .cmt-composer {
-	width: 100%;
-	background: var(--tl-color-muted-2);
-	border-color: transparent;
 }
 
 /* comments list — thread summaries, one per row (used by the canvas sidebar) */

--- a/packages/commenting/src/ui/send-button.tsx
+++ b/packages/commenting/src/ui/send-button.tsx
@@ -6,7 +6,7 @@ export interface SendButtonProps {
 	onClick?(): void
 }
 
-/** The pill button that posts a comment. */
+/** The button that posts a comment. */
 export function SendButton({ label, disabled, onClick }: SendButtonProps) {
 	return (
 		<button className="cmt-send" type="button" disabled={disabled} onClick={onClick}>

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -1102,8 +1102,11 @@ export type TLCommentAnchor = {
     x: number;
     y: number;
 } | {
+    isPrecise: boolean;
     shapeId: TLShapeId;
     type: 'shape';
+    x: number;
+    y: number;
 } | {
     type: 'page';
 } | {

--- a/packages/tlschema/src/records/TLComment.test.ts
+++ b/packages/tlschema/src/records/TLComment.test.ts
@@ -17,7 +17,7 @@ const pageId = 'page:page1' as TLPageId
 const shapeId = 'shape:box1' as TLShapeId
 
 const anchors: TLCommentAnchor[] = [
-	{ type: 'shape', shapeId },
+	{ type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
 	{ type: 'point', x: 100, y: 200 },
 	{ type: 'region', x: 0, y: 0, w: 300, h: 150 },
 	{ type: 'page' },
@@ -55,7 +55,7 @@ describe('TLCommentThread', () => {
 	it('rejects unknown anchor kinds and malformed anchors', () => {
 		const thread = createCommentThread({
 			pageId,
-			anchor: { type: 'shape', shapeId },
+			anchor: { type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
 			createdBy: 'user1',
 			now: 1000,
 		})
@@ -69,7 +69,7 @@ describe('TLCommentThread', () => {
 			commentThreadRecordConfig.validator.validate({
 				...thread,
 				// shape anchors must reference a shape id
-				anchor: { type: 'shape', shapeId: 'page:nope' },
+				anchor: { type: 'shape', shapeId: 'page:nope', x: 1, y: 0, isPrecise: false },
 			})
 		).toThrow()
 	})
@@ -129,5 +129,35 @@ describe('schema registration', () => {
 		const types = schema.types as Record<string, { scope: string } | undefined>
 		expect(types['comment-thread']?.scope).toBe('document')
 		expect(types['comment']?.scope).toBe('document')
+	})
+})
+
+describe('comment-thread migrations', () => {
+	const migration = (commentThreadRecordConfig.migrations as any).sequence.find(
+		(m: any) => m.id === 'com.tldraw.comment-thread/2'
+	) as { up(r: any): any; down(r: any): any }
+
+	it('stamps existing shape anchors with the top-right position (x:1, y:0)', () => {
+		expect(migration.up({ anchor: { type: 'shape', shapeId } })).toEqual({
+			anchor: { type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
+		})
+	})
+
+	it('leaves shape anchors that already have x/y unchanged', () => {
+		const anchor = { type: 'shape', shapeId, x: 0.25, y: 0.75, isPrecise: true }
+		expect(migration.up({ anchor })).toEqual({ anchor })
+	})
+
+	it('leaves non-shape anchors untouched', () => {
+		const anchor = { type: 'point', x: 5, y: 6 }
+		expect(migration.up({ anchor })).toEqual({ anchor })
+	})
+
+	it('down-migrates by dropping x/y', () => {
+		expect(
+			migration.down({ anchor: { type: 'shape', shapeId, x: 0.3, y: 0.4, isPrecise: true } })
+		).toEqual({
+			anchor: { type: 'shape', shapeId },
+		})
 	})
 })

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -11,7 +11,10 @@ import { TLShapeId } from './TLShape'
  * Where a comment thread is anchored on the canvas. Modeled as a discriminated union so new
  * anchor kinds can be added without breaking existing threads:
  *
- * - `shape` — pinned to a shape; follows the shape as it moves, removed (or orphaned) with it
+ * - `shape` — pinned to a shape. `x`/`y` are normalized (0–1) within the shape's page bounds, so
+ *   the pin keeps its spot as the shape moves and resizes. `isPrecise` mirrors arrow bindings: when
+ *   true the pin sits at exactly `x`/`y`; when false (the default) it sits at a consumer-defined
+ *   spot (top-right out of the box), and `x`/`y` are the remembered precise position
  * - `point` — pinned to a fixed point on the page, in page coordinates
  * - `region` — pinned to a rectangular area of the page, in page coordinates
  * - `page` — a page-level thread with no spatial anchor
@@ -20,7 +23,7 @@ import { TLShapeId } from './TLShape'
  * @public
  */
 export type TLCommentAnchor =
-	| { type: 'shape'; shapeId: TLShapeId }
+	| { type: 'shape'; shapeId: TLShapeId; x: number; y: number; isPrecise: boolean }
 	| { type: 'point'; x: number; y: number }
 	| { type: 'region'; x: number; y: number; w: number; h: number }
 	| { type: 'page' }
@@ -94,6 +97,9 @@ const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
 	shape: T.object({
 		type: T.literal('shape'),
 		shapeId: idValidator<TLShapeId>('shape'),
+		x: T.number,
+		y: T.number,
+		isPrecise: T.boolean,
 	}),
 	point: T.object({
 		type: T.literal('point'),
@@ -125,7 +131,10 @@ const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
  * rejected with CLIENT_TOO_OLD (prompting a refresh) instead of being sent record types their
  * store cannot represent.
  */
-function createCommentGuardMigrations(typeName: 'comment' | 'comment-thread') {
+function createCommentGuardMigrations(
+	typeName: 'comment' | 'comment-thread',
+	extra: Parameters<typeof createRecordMigrationSequence>[0]['sequence'] = []
+) {
 	return createRecordMigrationSequence({
 		sequenceId: `com.tldraw.${typeName}`,
 		recordType: typeName,
@@ -135,6 +144,7 @@ function createCommentGuardMigrations(typeName: 'comment' | 'comment-thread') {
 				id: `com.tldraw.${typeName}/1`,
 				up: (record) => record,
 			},
+			...extra,
 		],
 	})
 }
@@ -147,7 +157,26 @@ function createCommentGuardMigrations(typeName: 'comment' | 'comment-thread') {
  */
 export const commentThreadRecordConfig: CustomRecordInfo = {
 	scope: 'document',
-	migrations: createCommentGuardMigrations('comment-thread'),
+	migrations: createCommentGuardMigrations('comment-thread', [
+		{
+			// Shape anchors gained normalized x/y + isPrecise; existing ones were imprecise (top-right).
+			id: 'com.tldraw.comment-thread/2',
+			up: (record) => {
+				const anchor = (record as any).anchor
+				if (anchor?.type === 'shape' && anchor.x === undefined) {
+					;(record as any).anchor = { ...anchor, x: 1, y: 0, isPrecise: false }
+				}
+				return record
+			},
+			down: (record) => {
+				const anchor = (record as any).anchor
+				if (anchor?.type === 'shape') {
+					;(record as any).anchor = { type: 'shape', shapeId: anchor.shapeId }
+				}
+				return record
+			},
+		},
+	]),
 	validator: T.object({
 		id: idValidator<TLCommentThreadId>('comment-thread'),
 		typeName: T.literal('comment-thread'),


### PR DESCRIPTION
## What

A polish pass on the canvas commenting UI, plus a schema upgrade so shape-anchored comments carry a real position.

## Shape anchoring (schema)

- The `shape` anchor now stores a **normalized `x/y`** (0–1 within the shape's page bounds), so a pin holds its relative spot as the shape moves *and* resizes.
- An **`isPrecise`** flag mirrors arrow bindings: precise pins sit at `x/y`; imprecise ones sit at a **consumer-configurable default** (`impreciseShapeAnchor`, top-right out of the box). Migration `/2` stamps existing shape anchors as imprecise/top-right.
- Placement + drag capture the exact `x/y`; hold **Alt** for precise.

## Interactions

- **Drag** a pin to move a thread; on drop it re-anchors (to a shape — precise with Alt — else a point).
- **Escape** exits the comment tool, or collapses an open thread (or backs out of a comment edit) first.

## Layering fix

- Pins now render in the **canvas-in-front layer**, beneath the UI (toolbar, style panel), instead of floating over it; the open popover and placement composer portal up to the **menus layer** so they're never clipped.

## UI polish

- Single-initial avatars, a "Comment" header, tighter comment cards, the popover offset from its anchor.
- A distinct **floating composer** for placing a new comment: the comment-pin shape with a pencil (marking a draft) beside a rounded-rect field.

## How to test

1. Comment tool (or drag a pin): place a comment on a shape → sits top-right; **Alt**-place → exactly where clicked. Resize the shape → the pin holds its spot.
2. Drag a pin around; drop on/off a shape.
3. Open a thread near the toolbar/style panel → pins tuck under the UI, popover draws over it.
4. Escape closes an open thread; Escape (no thread) exits the tool.
5. Studio: the `Anchoring` sketchbook has `ShapeImprecise` / `ShapePrecise`.

### API changes

**`@tldraw/tlschema` — `TLCommentAnchor`**
- The `shape` anchor variant gains `x: number`, `y: number` (normalized 0–1 position within the shape's page bounds) and `isPrecise: boolean`.
- **Breaking** for code constructing a `shape` anchor directly — it must now supply `x`, `y`, and `isPrecise`. Stored records migrate automatically (migration `/2` → imprecise/top-right). No fields removed; other anchor variants unchanged.

**`@tldraw/commenting`** (additive, non-breaking)
- `CanvasComments` / `CanvasCommentsSidebar` gain an optional `impreciseShapeAnchor` prop.
- New exports: `DEFAULT_IMPRECISE_SHAPE_ANCHOR`, `shapeAnchorAt`.
- `CommentComposer` gains an optional `leading` prop.
