### PR TITLE
fix(dotcom): stop sign-in dialog jumping for Clerk's invisible CAPTCHA

### DIFF
--- a/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
+++ b/apps/dotcom/client/src/tla/components/dialogs/auth.module.css
@@ -168,7 +168,15 @@
 	font-weight: 500;
 }
 
-.clerkCaptcha:not(:empty) {
+/*
+ * Pad the CAPTCHA only when there's a visible, interactive challenge. By
+ * default Clerk runs an invisible ("smart") Turnstile challenge that mounts an
+ * off-screen iframe and sets `max-height: 0` inline on the mount point; the
+ * `:not([style*='max-height: 0'])` guard skips padding for that case, which
+ * would otherwise briefly reserve 32px and make the dialog grow then shrink as
+ * the challenge resolves.
+ */
+.clerkCaptcha:not(:empty):not([style*='max-height: 0']) {
 	padding: var(--tl-space-8);
 	margin-top: calc(-1 * var(--tl-space-8));
 }


### PR DESCRIPTION
In order to stop the sign-in dialog from momentarily growing and shrinking when submitting an email, this PR stops reserving vertical space for Clerk's invisible CAPTCHA.

Clerk's default "smart" Turnstile runs an invisible challenge: it mounts an off-screen 1px iframe into the `#clerk-captcha` container and sets `max-height: 0` inline on that container. Our `.clerkCaptcha:not(:empty)` rule reserved `32px` of padding for *any* non-empty state, so the padding flashed in for the split second the invisible challenge was mounted, then disappeared when Clerk resolved it and emptied the node. This was most visible on new signups, where `signUp.create` triggers a fresh challenge.

The padding is still wanted when Turnstile escalates to a genuinely visible, interactive checkbox challenge. So rather than remove it, we guard the existing rule to skip the invisible case, keyed off Clerk's own `max-height: 0` inline marker:

```css
.clerkCaptcha:not(:empty):not([style*='max-height: 0']) {
	padding: var(--tl-space-8);
	margin-top: calc(-1 * var(--tl-space-8));
}
```

When the challenge escalates, `max-height` becomes non-zero, the selector matches again, and the padding returns.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw.com signed out and open the sign-in dialog.
2. Enter an email address (ideally a new one) and continue.
3. The dialog should not visibly grow then shrink as the request is sent.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the sign-in dialog briefly growing and shrinking when submitting an email address.
