### PR TITLE
fix(editor): ignore pinch and secondary pointers during an active drag

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10930,6 +10930,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 	/** @internal */
 	capturedPointerId: number | null = null
 
+	/**
+	 * Pointer ids that were rejected because they touched down while another
+	 * pointer was already mid-drag (e.g. a second finger during a stroke). Their
+	 * events are ignored until they lift, so they can't corrupt or hijack the
+	 * active interaction.
+	 * @internal
+	 */
+	private _rejectedPointerIds = new Set<number>()
+
 	/** @internal */
 	private readonly performanceTracker: PerformanceTracker
 
@@ -11083,6 +11092,15 @@ export class Editor extends EventEmitter<TLEventMap> {
 		switch (type) {
 			case 'pinch': {
 				if (cameraOptions.isLocked) return
+
+				// Don't let a pinch hijack an interaction that's already underway (e.g.
+				// drawing a stroke, translating, resizing, brushing). Once a drag is
+				// active, a second finger should be ignored rather than interrupting the
+				// current action. Bail before updateFromEvent so the ignored pinch can't
+				// move the pointer to the two-finger midpoint and corrupt the stroke. A
+				// fresh pinch works again after the interaction ends and both fingers lift.
+				if (!inputs.getIsPinching() && inputs.getIsDragging()) return
+
 				clearTimeout(this._longPressTimeout)
 				this.inputs.updateFromEvent(info)
 
@@ -11268,6 +11286,24 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// Ignore pointer events while we're pinching
 				if (inputs.getIsPinching()) return
 
+				// A pointer that touches down while another pointer is already mid-drag
+				// (e.g. a second finger during a stroke) must not disturb that
+				// interaction. Reject it on the way in and ignore its later move/up
+				// events until it lifts, so the active drag continues uninterrupted.
+				if (
+					info.name === 'pointer_down' &&
+					inputs.getIsDragging() &&
+					this.capturedPointerId !== null &&
+					this.capturedPointerId !== info.pointerId
+				) {
+					this._rejectedPointerIds.add(info.pointerId)
+					return
+				}
+				if (this._rejectedPointerIds.has(info.pointerId)) {
+					if (info.name === 'pointer_up') this._rejectedPointerIds.delete(info.pointerId)
+					return
+				}
+
 				this.inputs.updateFromEvent(info)
 				const { isPen } = info
 				const { isPenMode } = instanceState
@@ -11440,6 +11476,9 @@ export class Editor extends EventEmitter<TLEventMap> {
 						if (this.capturedPointerId === info.pointerId) {
 							this.capturedPointerId = null
 							info.button = 0
+							// The primary pointer lifted; forget any pointers we rejected during
+							// its drag so a fresh interaction starts clean.
+							this._rejectedPointerIds.clear()
 						}
 
 						if (inputs.getIsPanning()) {

--- a/packages/tldraw/src/test/pinch.test.ts
+++ b/packages/tldraw/src/test/pinch.test.ts
@@ -137,3 +137,87 @@ describe('Pinch preserves the pre-gesture selection', () => {
 		expect(editor.getEditingShapeId()).toBe(ids.box1)
 	})
 })
+
+describe('Pinch is ignored while a tool interaction is active', () => {
+	it('does not start pinching or zoom when a second finger lands mid-stroke (drawing)', () => {
+		editor.setCurrentTool('draw')
+
+		// First finger draws a stroke and passes the drag threshold.
+		editor.pointerMove(100, 100)
+		editor.pointerDown(100, 100)
+		editor.pointerMove(160, 160)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+		expect(editor.getPath()).toBe('draw.drawing')
+
+		const zoomBefore = editor.getZoomLevel()
+
+		// Second finger lands and tries to pinch. It must be ignored: the stroke
+		// keeps going, we never start pinching, and the camera does not zoom.
+		editor.pinchStart(130, 130, editor.getZoomLevel(), 0, 0, 0)
+		editor.pinchTo(130, 130, 2, 0, 0, 0)
+
+		expect(editor.inputs.getIsPinching()).toBe(false)
+		expect(editor.getZoomLevel()).toBe(zoomBefore)
+		expect(editor.getPath()).toBe('draw.drawing')
+	})
+
+	it('ignores a second finger down while dragging without corrupting the pointer position', () => {
+		editor.setCurrentTool('draw')
+
+		editor.pointerMove(100, 100)
+		editor.pointerDown(100, 100)
+		editor.pointerMove(160, 160)
+		expect(editor.inputs.getIsDragging()).toBe(true)
+
+		const pageBefore = editor.inputs.getCurrentPagePoint().clone()
+
+		// A second finger touches down far away and moves. Because a drag is active,
+		// its events are rejected and must not move the current pointer point.
+		editor.pointerDown(500, 500, { pointerId: 2 })
+		editor.pointerMove(600, 600, { pointerId: 2 })
+		expect(editor.inputs.getCurrentPagePoint()).toMatchObject({
+			x: pageBefore.x,
+			y: pageBefore.y,
+		})
+
+		// The primary finger still controls the interaction.
+		editor.pointerMove(200, 200, { pointerId: 1 })
+		expect(editor.inputs.getCurrentPagePoint()).toMatchObject({ x: 200, y: 200 })
+	})
+
+	it('still allows a pinch that begins before the interaction becomes a drag', () => {
+		// First finger is down but has not passed the drag threshold, so no
+		// interaction is active yet — a pinch from here should zoom as usual.
+		editor.pointerMove(250, 50)
+		editor.pointerDown(250, 50)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+
+		editor.pinchStart(250, 50, editor.getZoomLevel(), 0, 0, 0)
+		editor.pinchTo(250, 50, 2, 0, 0, 0)
+		editor.forceTick()
+
+		expect(editor.inputs.getIsPinching()).toBe(true)
+		expect(editor.getZoomLevel()).toBeGreaterThan(1)
+	})
+
+	it('allows a fresh pinch after the active interaction ends', () => {
+		editor.setCurrentTool('draw')
+
+		editor.pointerMove(100, 100)
+		editor.pointerDown(100, 100)
+		editor.pointerMove(160, 160)
+		editor.pinchStart(130, 130, editor.getZoomLevel(), 0, 0, 0)
+		expect(editor.inputs.getIsPinching()).toBe(false)
+		editor.pointerUp(160, 160)
+		expect(editor.inputs.getIsDragging()).toBe(false)
+
+		// With the stroke finished, a new pinch works normally.
+		editor.setCurrentTool('select')
+		const zoomBefore = editor.getZoomLevel()
+		editor.pinchStart(250, 50, editor.getZoomLevel(), 0, 0, 0)
+		editor.pinchTo(250, 50, 2, 0, 0, 0)
+		editor.forceTick()
+		expect(editor.inputs.getIsPinching()).toBe(true)
+		expect(editor.getZoomLevel()).toBeGreaterThan(zoomBefore)
+	})
+})


### PR DESCRIPTION
In order to keep a touch interaction from being wrecked by an accidental second finger, this makes the editor ignore a pinch (and any concurrent pointer) once a drag is already underway. Previously, if you were mid-stroke on a touch device and a second finger landed — a stray palm, a partner grabbing the tablet, or just reaching to pan — the second finger started a pinch, which called `editor.interrupt()` and cancelled the in-progress action, leaving a broken stroke and an unexpected zoom. Closes #9534.

Now, once `inputs.getIsDragging()` is true (drawing, translating, resizing, brushing, etc.), a starting pinch is dropped and events from any other pointer are rejected until it lifts, so the active interaction continues uninterrupted. A pinch that begins *before* the interaction becomes a drag still zooms exactly as before, and a fresh pinch works again after both fingers lift.

Two places needed guarding, because the pinch and the second finger arrive through separate event streams on touch:

- **Pinch stream:** bail at the top of the `pinch` case, before `updateFromEvent`, when `!isPinching && isDragging`. Bailing before `updateFromEvent` matters — otherwise the ignored pinch would still move the pointer to the two-finger midpoint and corrupt the stroke.
- **Pointer stream:** a second finger also emits a `pointer_down`. While a drag owned by another pointer is active, its id is added to a rejected set and its `pointer_down`/`move`/`up` are ignored until it lifts (the set is also cleared when the primary pointer lifts). Without this, the second finger's `updateFromEvent` would reset the drag origin and current point.

### Change type

- [x] `bugfix`

### Test plan

On a touch device (or touch emulation): pick the draw tool, start a stroke with one finger, and while still drawing, tap/drag a second finger. The stroke should continue uninterrupted with no zoom. Lifting both fingers and pinching again should zoom normally.

- [x] Unit tests

### Release notes

- Fix pinch-to-zoom interrupting an in-progress touch interaction (drawing, dragging, resizing) when a second finger lands mid-gesture. Pinch now only begins when no interaction is already active.