### PR TITLE
fix(tldraw): fix toast title and content for unbreakable text

### DIFF
--- a/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -26,7 +26,17 @@ function MyDialog({ onClose }: { onClose(): void }) {
 				<TldrawUiDialogTitle>Title</TldrawUiDialogTitle>
 				<TldrawUiDialogCloseButton />
 			</TldrawUiDialogHeader>
-			<TldrawUiDialogBody style={{ maxWidth: 350 }}>Description...</TldrawUiDialogBody>
+			<TldrawUiDialogBody style={{ maxWidth: 350 }}>
+				<p>
+					This dialog body holds a few sentences of text so you can see how longer content behaves.
+					Regular prose wraps onto multiple lines within the dialog width.
+				</p>
+				<p>
+					Long unbroken strings, like
+					https://example.com/a/really/long/url/that/cannot/wrap/onto/the/next/line, also break
+					instead of overflowing or being clipped.
+				</p>
+			</TldrawUiDialogBody>
 			<TldrawUiDialogFooter className="tlui-dialog__footer__actions">
 				<TldrawUiButton type="normal" onClick={onClose}>
 					<TldrawUiButtonLabel>Cancel</TldrawUiButtonLabel>

--- a/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
+++ b/apps/examples/src/examples/ui/toasts-and-dialogs/ToastsDialogsExample.tsx
@@ -152,6 +152,18 @@ const CustomSharePanel = () => {
 				Show toast
 			</button>
 			<button
+				onClick={() => {
+					addToast({
+						title: 'This is a very long toast title that keeps going and going',
+						description:
+							'Long descriptions and unbroken strings like https://example.com/a/really/long/url/that/cannot/wrap/onto/the/next/line wrap within the toast instead of overflowing.',
+						severity: 'info',
+					})
+				}}
+			>
+				Show long toast
+			</button>
+			<button
 				data-testid="show-dialog"
 				onClick={() => {
 					addDialog({

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1604,6 +1604,7 @@ tldraw? probably.
 .tlui-toast__main {
 	flex-grow: 2;
 	max-width: 280px;
+	min-width: 0;
 }
 
 .tlui-toast__content {
@@ -1612,6 +1613,7 @@ tldraw? probably.
 	line-height: 1.4;
 	flex-direction: column;
 	gap: var(--tl-space-3);
+	min-width: 0;
 }
 
 .tlui-toast__main[data-actions='true'] .tlui-toast__content {
@@ -1623,6 +1625,7 @@ tldraw? probably.
 	color: var(--tl-color-text-1);
 	/* this makes the default toast look better */
 	line-height: 16px;
+	overflow-wrap: anywhere;
 }
 
 .tlui-toast__description {
@@ -1630,6 +1633,7 @@ tldraw? probably.
 	padding: var(--tl-space-3);
 	margin: 0px;
 	padding: 0px;
+	overflow-wrap: anywhere;
 }
 
 .tlui-toast__icon + .tlui-toast__main > .tlui-toast__actions {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1760,6 +1760,7 @@ tldraw? probably.
 	color: var(--tl-color-text-1);
 	user-select: all;
 	-webkit-user-select: text;
+	overflow-wrap: anywhere;
 }
 .tlui-dialog__body a {
 	color: var(--tl-color-selected);


### PR DESCRIPTION
Fixes https://github.com/tldraw/tldraw/issues/9536

Unbreakable text does not display well, we need the css to account for potential long urls / text and/or filepath to be correctly broken

<img width="445" height="212" alt="Screenshot 2026-07-09 at 10 38 33" src="https://github.com/user-attachments/assets/cfcf7a4f-5fa1-4a92-b0f5-88bf710cb8c7" />
<img width="413" height="290" alt="image" src="https://github.com/user-attachments/assets/8145bf27-349d-4b9d-89fb-c9a43b4bc8f2" />

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Open a toast with some url into it and see if it display nicely

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed long toast and dialog content overflowing instead of wrapping. Long text and unbroken strings like URLs now wrap within the toast or dialog.