### PR TITLE
docs(skills): make write-pr lead with reviewer-first framing

### DIFF
--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -13,12 +13,14 @@ This is the governing rule; everything below serves it. Write the description fo
 
 **Default to short.** A few sentences of framing is the norm, not the exception. Match length to the change: a one-line fix needs a sentence; a new system needs the fuller treatment. A description that looks long and structured is not more valuable — often it's less, because it buries the framing under scaffolding. If a reviewer would need their own AI to interpret yours, it has failed.
 
-Cover only what the diff can't tell them:
+**Order it coarse to granular.** Structure the description as an inverted pyramid, most important first. A reader should be able to stop at any point and leave with a correct, coherent understanding: a skimmer gets the goal and motivation from the opening lines; someone weighing the approach reads into the design and decisions; a close reviewer continues to the specifics. Never make someone read to the end to find out what the PR is for.
 
-- **Motivation.** Why this change, and why now. What was wrong or missing before.
-- **The higher-level change.** What changes at the level of behavior and structure — the shape of the solution, not a line-by-line restatement.
-- **Trade-offs and decisions.** The choices a reviewer might have made differently: the approach you picked, what you ruled out and why, anything you're unsure about. A decision you don't surface is one the reviewer can't catch.
-- **Short example snippets.** For anything touching an API, data shape, or usage pattern, a few lines of before/after say more than a paragraph. Keep them minimal.
+Cover the following, roughly in this order — each layer more detailed than the last, and each optional once the change no longer warrants it:
+
+- **Goal, motivation, and use case.** Why this change, why now, what it's for. What was wrong or missing before. This comes first, always.
+- **The higher-level change.** The shape of the solution — behavior and structure, not a line-by-line restatement of the diff.
+- **API design and decisions.** New or changed public surface, the approach you picked, what you ruled out and why, and anything you're unsure about. A decision you don't surface is one the reviewer can't catch.
+- **Example snippets and fine detail.** For anything touching an API, data shape, or usage pattern, a few lines of before/after say more than a paragraph. Keep them minimal.
 
 **Do not:**
 

--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -7,6 +7,27 @@ description: Reference standards for writing pull request titles and description
 
 Standards for PR titles and descriptions in tldraw/tldraw.
 
+## Write for the reviewer (read this first)
+
+This is the governing rule; everything below serves it. Write the description for a reviewer who knows the codebase architecture but has **not** read your code or the diff. Their time is the scarce resource. The description's job is to give them the framing they can't get from the code, then get out of the way.
+
+**Default to short.** A few sentences of framing is the norm, not the exception. Match length to the change: a one-line fix needs a sentence; a new system needs the fuller treatment. A description that looks long and structured is not more valuable — often it's less, because it buries the framing under scaffolding. If a reviewer would need their own AI to interpret yours, it has failed.
+
+Cover only what the diff can't tell them:
+
+- **Motivation.** Why this change, and why now. What was wrong or missing before.
+- **The higher-level change.** What changes at the level of behavior and structure — the shape of the solution, not a line-by-line restatement.
+- **Trade-offs and decisions.** The choices a reviewer might have made differently: the approach you picked, what you ruled out and why, anything you're unsure about. A decision you don't surface is one the reviewer can't catch.
+- **Short example snippets.** For anything touching an API, data shape, or usage pattern, a few lines of before/after say more than a paragraph. Keep them minimal.
+
+**Do not:**
+
+- Restate the diff. No file-by-file walkthrough, no narrating what a function does, no describing *how* the code works step by step. Reviewers can read code.
+- Generate tables or lists that mirror the code — a `Method | Description` table that just re-says the signatures, an inventory of every changed file, a term glossary of self-explanatory names.
+- Pad with ceremony. Structure that exists to look thorough is noise.
+
+**Never invent the *why*.** The motivation and trade-offs must come from real intent — the commits, the linked issue, or the author. If you don't know why a change was made or what was considered, **ask the user; do not guess.** A confident but fabricated rationale is worse than useless: it's misleading, and it's the thing reviewers most need to trust.
+
 ## PR title
 
 Use semantic PR titles (Conventional Commits format):
@@ -62,24 +83,11 @@ Use this template:
 
 ### Description paragraph
 
-Start with: "In order to X, this PR does Y."
+Start with: "In order to X, this PR does Y." Follow the reviewer-first rules at the top of this skill.
 
 - Keep it specific - avoid vague phrases like "improve user experience"
 - Link related issues in the first paragraph
 - Don't expect readers to also read the linked issue
-
-### Write for the reviewer
-
-Write the description for a reviewer who knows the codebase architecture but has **not** read your code or most of the diff. Their time is the scarce resource: the description's job is to get them to understand the important bits and to give them what they need to push back on a decision. Assume they'll read your description, skim a few key files, and trust the rest.
-
-Cover, in whatever depth the change warrants:
-
-- **The higher-level change.** What actually changes, described at the level of behavior and structure, not a line-by-line restatement of the diff. Reviewers can read code; they can't read your intent.
-- **Motivation.** Why this change, and why now. What was wrong or missing before.
-- **Trade-offs and decisions.** The choices you made that a reviewer might have made differently — the approach you picked, what you ruled out and why, anything you're unsure about. Name these explicitly so the reviewer can steer if a call is the wrong one. A decision you don't surface is a decision the reviewer can't catch.
-- **Short example snippets.** For anything touching an API, data shape, or usage pattern, a few lines of before/after or a small "here's how it's used now" snippet explains more than a paragraph. Keep them minimal and illustrative, not exhaustive.
-
-Match the depth to the change: a one-line fix needs a sentence, a new system needs the fuller treatment below. Don't pad a small PR with ceremony, and don't under-describe a large one. When in doubt about what a reviewer needs, err toward explaining the *why* and the *trade-offs* — those are the parts they can't reconstruct from the diff.
 
 ### Change type
 
@@ -98,9 +106,11 @@ Match the depth to the change: a one-line fix needs a sentence, a new system nee
 - Use imperative mood: "Add...", "Fix...", "Remove..."
 - Omit this section entirely for internal work (CI, tooling, tests, etc.) that has no user-facing impact
 
-## Concepts, examples, and FAQ (for large or feature-intensive PRs)
+## Concepts, examples, and FAQ (only when a reviewer genuinely needs them)
 
-When a PR introduces a new system, several new types/APIs, or otherwise has enough surface area that a reviewer would benefit from a glossary, include extra explanatory sections **above** the standard `### Change type` / `### Test plan` / `### Release notes` block. Skip these for small or focused PRs — they're for features and large refactors.
+Gate these on reviewer *need*, not PR size. A large PR is not a reason to add tables — a reviewer who needs shared vocabulary or a usage example to follow the change is. Most large PRs don't clear that bar. When they do, include the relevant sections **above** the standard `### Change type` / `### Test plan` / `### Release notes` block.
+
+Guardrail: a row only earns its place if it says something the code doesn't. A `Method | Description` table that restates signatures, or a Concepts row for a self-explanatory name, is diff-duplication — cut it. If in doubt, leave it out.
 
 Pull from this menu, in roughly this order, using only what fits:
 
@@ -129,6 +139,8 @@ Include when changes affect `api-report.md`:
 ```
 
 ## Code changes table
+
+This table is a deliberate exception to "don't restate the diff": it's a high-level index, not prose pretending to be insight. It lets a reviewer gauge scope at a glance — how much is core code vs tests vs generated vs tooling — and decide where to look. Always include it.
 
 Create a table that includes net LOC changes for each of the following sections. The sum of all rows must match the total PR diff. Omit rows with no changes.
 


### PR DESCRIPTION
In order to stop AI-generated PR descriptions from restating the diff while omitting the framing a reviewer actually needs, this PR restructures the `write-pr` skill so reviewer-first, coarse-to-granular writing is the governing rule.

**Motivation.** A reviewer can read code; what they can't reconstruct is intent. The skill already said this, but the structure fought it — the philosophy sat in the middle, the template rewarded box-filling, and the optional detail sections were gated on PR *size*, so big PRs got more diff-duplication rather than more insight.

**The higher-level change.** Reviewer-first writing moves to the top as the rule everything else serves, and it now prescribes an inverted-pyramid order: goal/motivation → higher-level change → API design and decisions → fine detail, so a reader can stop at any layer with a coherent understanding.

**Decisions.**

- Added a **do-not** list (don't restate the diff, don't generate tables that mirror the code, don't pad with ceremony) — negative constraints, since those are what change behavior.
- Added **never invent the *why***: motivation must come from real intent, and the author is asked when it isn't known, rather than fabricating a rationale a reviewer would then wrongly trust.
- Retargeted the Concepts/FAQ menu to reviewer *need* instead of PR size, with a guardrail that a row must say something the code doesn't.
- **Kept** the code-changes LOC table as a deliberate exception: it's a high-level scope index (core vs tests vs generated vs tooling), not prose pretending to be insight.

### Change type

- [x] `other` (docs/tooling)

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +36 / -18  |
