### PR TITLE
feat(commenting): persist comments in Postgres instead of R2

### DIFF
--- a/apps/dotcom/client/src/tla/pages/comments.tsx
+++ b/apps/dotcom/client/src/tla/pages/comments.tsx
@@ -44,9 +44,8 @@ export function Component() {
 								marginBottom: 8,
 							}}
 						>
-							{/* bodies are rich text; flatten for this basic UI (rich rendering forthcoming).
-							    The zero schema types the json `body` column as opaque JSON; the value is
-							    schema-validated TLRichText end-to-end (see commentRows.ts in sync-worker). */}
+							{/* bodies are rich text; flatten for this basic UI (rich rendering forthcoming) */}
+							{/* zero types json columns as opaque JSON */}
 							<div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
 								{richTextToPlaintext(c.body as TLRichText)}
 							</div>

--- a/apps/dotcom/client/src/tla/pages/comments.tsx
+++ b/apps/dotcom/client/src/tla/pages/comments.tsx
@@ -53,7 +53,7 @@ export function Component() {
 								<span> · </span>
 								<Link
 									style={{ color: 'var(--tl-color-primary)' }}
-									to={commentLink(c.fileId, c.shapeId, c.id)}
+									to={commentLink(c.fileId, c.thread?.shapeId, c.id)}
 								>
 									{c.file?.name || c.fileId}
 								</Link>

--- a/apps/dotcom/client/src/tla/pages/comments.tsx
+++ b/apps/dotcom/client/src/tla/pages/comments.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import { Link } from 'react-router-dom'
-import { createDeepLinkString, useValue } from 'tldraw'
+import { createDeepLinkString, TLRichText, useValue } from 'tldraw'
 import { routes } from '../../routeDefs'
 import { useMaybeApp } from '../hooks/useAppState'
 import { richTextToPlaintext } from '../utils/richText'
@@ -22,7 +22,7 @@ export function Component() {
 	const app = useMaybeApp()
 	const comments = useValue(
 		'comments',
-		() => [...((app?.getComments() ?? []) as any[])].sort((a, b) => b.createdAt - a.createdAt),
+		() => [...(app?.getComments() ?? [])].sort((a, b) => b.createdAt - a.createdAt),
 		[app]
 	)
 
@@ -44,9 +44,11 @@ export function Component() {
 								marginBottom: 8,
 							}}
 						>
-							{/* bodies are rich text; flatten for this basic UI (rich rendering forthcoming) */}
+							{/* bodies are rich text; flatten for this basic UI (rich rendering forthcoming).
+							    The zero schema types the json `body` column as opaque JSON; the value is
+							    schema-validated TLRichText end-to-end (see commentRows.ts in sync-worker). */}
 							<div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-								{richTextToPlaintext(c.body)}
+								{richTextToPlaintext(c.body as TLRichText)}
 							</div>
 							<div style={{ fontSize: 12, opacity: 0.7, marginTop: 6 }}>
 								<span>{c.author?.name ?? c.authorId}</span>

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1065,6 +1065,14 @@ export class TLFileDurableObject extends DurableObject {
 		try {
 			const key = getR2KeyForRoom({ slug, isApp: this.documentInfo.isApp })
 
+			// Kick off the Postgres comments load now so it overlaps with the R2 fetch below;
+			// only the merge points further down actually await it.
+			const commentsPromise = this.documentInfo.isApp ? this.loadCommentsFromPostgres() : null
+			// Prevent an unhandled rejection if we exit via a path that never merges (e.g.
+			// ROOM_NOT_FOUND). Merge points still await commentsPromise itself, so a Postgres
+			// failure there still fails the room open.
+			commentsPromise?.catch(() => {})
+
 			// when loading, prefer to fetch documents from the bucket
 			const r2FetchTimer = this.timer()
 			const roomFromBucket = await this.r2.rooms.get(key)
@@ -1078,8 +1086,8 @@ export class TLFileDurableObject extends DurableObject {
 				// seed the room and hydrate to clients on connect. A Postgres failure here fails the
 				// room open (bubbling like an R2 failure) — silently opening without comments would
 				// let the next persist treat them as deleted.
-				if (this.documentInfo.isApp) {
-					mergeCommentDocumentsIntoSnapshot(snapshot, await this.loadCommentsFromPostgres())
+				if (commentsPromise) {
+					mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
 				}
 
 				loadTimer.report('db_load_total')
@@ -1114,7 +1122,7 @@ export class TLFileDurableObject extends DurableObject {
 				// here too. Clone the shared DEFAULT_INITIAL_SNAPSHOT constant — the merge reassigns
 				// `documents` and clamps clocks, and must not mutate the module-level object.
 				const snapshot: RoomSnapshot = { ...DEFAULT_INITIAL_SNAPSHOT }
-				mergeCommentDocumentsIntoSnapshot(snapshot, await this.loadCommentsFromPostgres())
+				mergeCommentDocumentsIntoSnapshot(snapshot, await assertExists(commentsPromise))
 
 				return {
 					snapshot,
@@ -1168,16 +1176,10 @@ export class TLFileDurableObject extends DurableObject {
 
 	private async loadCommentsFromPostgres(): Promise<RoomSnapshot['documents']> {
 		const fileId = this.documentInfo.slug
-		const threadRows = await this.db
-			.selectFrom('comment_thread')
-			.where('fileId', '=', fileId)
-			.selectAll()
-			.execute()
-		const commentRows = await this.db
-			.selectFrom('comment')
-			.where('fileId', '=', fileId)
-			.selectAll()
-			.execute()
+		const [threadRows, commentRows] = await Promise.all([
+			this.db.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
+			this.db.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
+		])
 		return rowsToSnapshotDocuments(threadRows, commentRows)
 	}
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -60,6 +60,7 @@ import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
 import {
 	commentRecordToRow,
+	isCommentAuthorFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
 	rowsToSnapshotDocuments,
 	threadRecordToRow,
@@ -1563,9 +1564,11 @@ export class TLFileDurableObject extends DurableObject {
 	 * the DO output gate flushes them together), and the drain pushes the records' current state
 	 * to Postgres. Delivery is at-least-once: an entry's outbox row is only removed once its push
 	 * to Postgres has actually succeeded, so a row that fails (including its row-by-row retry) stays
-	 * queued and is retried on the next commit, persist, or DO wake. A row that keeps failing (e.g.
-	 * a genuine FK violation from a since-deleted user) stays queued indefinitely and keeps reporting
-	 * via reportError on every drain — that's the visibility mechanism for a stuck row.
+	 * queued and is retried on the next commit, persist, or DO wake. A row that keeps failing stays
+	 * queued indefinitely and keeps reporting via reportError on every drain — that's the visibility
+	 * mechanism for a stuck row. The one exception is a comment whose author's account was deleted
+	 * (authorId FK violation): Postgres already cascaded the row away, so the drain prunes the
+	 * record from the room instead of retrying (see drainCommentOutbox).
 	 */
 	private ensureCommentOutbox() {
 		this.ctx.storage.sql.exec(
@@ -1683,25 +1686,36 @@ export class TLFileDurableObject extends DurableObject {
 
 				// Threads before comments (comment.threadId FK); comment deletes before thread
 				// deletes is not required (thread deletes cascade), but keep the batch → row-by-row
-				// fallback so one bad row (e.g. an FK violation from a since-deleted user) doesn't
-				// drop the whole batch. Rows that fail both the batch insert and their individual
-				// retry are reported back (by record id) so the caller can keep their outbox entries
-				// queued instead of deleting them.
+				// fallback so one bad row doesn't drop the whole batch. Rows that fail both the
+				// batch insert and their individual retry are reported back (by record id) so the
+				// caller can keep their outbox entries queued instead of deleting them. Rows whose
+				// error matches `shouldPrune` are returned separately instead: they are not
+				// reported as failures and their outbox entries clear normally.
 				const runBatchWithFallback = async <R extends { id: string }>(
 					rows: R[],
-					insert: (rows: R[]) => Promise<unknown>
-				): Promise<string[]> => {
-					if (rows.length === 0) return []
+					insert: (rows: R[]) => Promise<unknown>,
+					shouldPrune?: (error: unknown) => boolean
+				): Promise<{ failedIds: string[]; prunedIds: string[] }> => {
+					const failedIds: string[] = []
+					const prunedIds: string[] = []
+					if (rows.length === 0) return { failedIds, prunedIds }
 					try {
 						await insert(rows)
-						return []
+						return { failedIds, prunedIds }
 					} catch (batchError) {
-						this.reportError(batchError)
-						const failedIds: string[] = []
+						// A prunable batch error isn't a generic failure — the row-by-row pass below
+						// attributes it to the specific rows.
+						if (!shouldPrune?.(batchError)) {
+							this.reportError(batchError)
+						}
 						for (const row of rows) {
 							try {
 								await insert([row])
 							} catch (rowError) {
+								if (shouldPrune?.(rowError)) {
+									prunedIds.push(row.id)
+									continue
+								}
 								failedIds.push(row.id)
 								this.logEvent({
 									type: 'room',
@@ -1711,14 +1725,26 @@ export class TLFileDurableObject extends DurableObject {
 								this.reportError(rowError)
 							}
 						}
-						return failedIds
+						return { failedIds, prunedIds }
 					}
 				}
 				const failedIds = new Set<string>()
-				for (const id of await runBatchWithFallback(threadUpserts, insertThreadRows)) {
+				const threadResult = await runBatchWithFallback(threadUpserts, insertThreadRows)
+				for (const id of threadResult.failedIds) {
 					failedIds.add(id)
 				}
-				for (const id of await runBatchWithFallback(commentUpserts, insertCommentRows)) {
+				// A comment upsert failing the authorId FK means the author's user account was
+				// deleted: Postgres cascaded their comment rows away (ON DELETE CASCADE) while this
+				// warm room still holds the records. Retrying can never succeed, so mirror the
+				// cascade into the room instead: prune the records below and let their outbox
+				// entries clear normally (the Postgres row being absent is already the desired end
+				// state). Threads are untouched — comment_thread has no user FK by design.
+				const commentResult = await runBatchWithFallback(
+					commentUpserts,
+					insertCommentRows,
+					isCommentAuthorFkViolation
+				)
+				for (const id of commentResult.failedIds) {
 					failedIds.add(id)
 				}
 				if (commentDeletes.length > 0) {
@@ -1726,6 +1752,28 @@ export class TLFileDurableObject extends DurableObject {
 				}
 				if (threadDeletes.length > 0) {
 					await this.db.deleteFrom('comment_thread').where('id', 'in', threadDeletes).execute()
+				}
+
+				if (commentResult.prunedIds.length > 0) {
+					this.logEvent({ type: 'room', roomId: fileId, name: 'comment_author_deleted_prune' })
+					// Remove the pruned records from the live room so connected clients see them
+					// disappear. Deleting through the shared storage handle is the sanctioned
+					// server-side mutation path: the room subscribes to storage.onChange and
+					// broadcasts external transactions to its sessions. It does not re-enqueue
+					// outbox entries (onCommittedChanges only fires for client pushes), so this
+					// can't loop; a crash between here and the outbox clear below just replays the
+					// prune on the next drain (the ids are then lane-absent, taking the no-op
+					// Postgres delete path). If the room isn't open there's nothing to mirror into:
+					// the next cold load rehydrates comments from Postgres, where the rows are
+					// already gone.
+					const room = this._room ? await this._room.catch(() => null) : null
+					if (room && !room.isClosed()) {
+						storage.transaction((txn) => {
+							for (const id of commentResult.prunedIds) {
+								txn.delete(id as TLRecord['id'])
+							}
+						})
+					}
 				}
 
 				// Keep entries queued for any record that failed to push (they'll be retried on the

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -555,20 +555,23 @@ export class TLFileDurableObject extends DurableObject {
 
 			await this.r2.rooms.put(roomKey, dataText)
 
-			// Version snapshots only contain the drawing data, so we have to restore both the
-			// document and the current comments — loadSnapshotIntoStorage deletes anything not
-			// present in the snapshot, and deleting comments here would leave their projected
-			// Postgres rows behind (storage transactions don't fire onCommittedChanges).
+			// Version snapshots only contain the drawing data. Restoring drops the file's comments
+			// (product decision): loading the bare snapshot wipes the object lane, and the Postgres
+			// rows are deleted explicitly since storage transactions don't fire onCommittedChanges.
+			// The delete runs through _objectPushQueue so it serializes after any in-flight outbox
+			// drain, and the outbox is cleared so a pending drain can't resurrect deleted rows.
 			const snapshot = JSON.parse(dataText) as RoomSnapshot
-			const comments = await this.r2.rooms.get(`${roomKey}/comments`)
-			if (comments) {
-				const commentDocs = (await comments.json()) as RoomSnapshot['documents']
-				snapshot.documents = [...snapshot.documents, ...commentDocs]
-			}
 
 			const storage = await this.getStorage()
 			storage.transaction((txn) => {
 				loadSnapshotIntoStorage(txn, fileSyncSchema, snapshot)
+			})
+
+			await this._objectPushQueue.push(async () => {
+				this.ensureCommentOutbox()
+				this.ctx.storage.sql.exec('DELETE FROM comment_outbox')
+				await this.db.deleteFrom('comment').where('fileId', '=', roomId).execute()
+				await this.db.deleteFrom('comment_thread').where('fileId', '=', roomId).execute()
 			})
 
 			this.maybeAssociateFileAssets()

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1607,8 +1607,7 @@ export class TLFileDurableObject extends DurableObject {
 					} else {
 						if (doc) {
 							const comment = doc.state as TLComment
-							const thread = lane.get(comment.threadId)?.state as TLCommentThread | undefined
-							commentUpserts.push(commentRecordToRow(comment, thread, fileId, doc.lastChangedClock))
+							commentUpserts.push(commentRecordToRow(comment, fileId, doc.lastChangedClock))
 						} else {
 							commentDeletes.push(id)
 						}
@@ -1624,9 +1623,11 @@ export class TLFileDurableObject extends DurableObject {
 								.column('id')
 								.doUpdateSet((eb) => ({
 									pageId: eb.ref('excluded.pageId'),
+									anchor: eb.ref('excluded.anchor'),
 									shapeId: eb.ref('excluded.shapeId'),
-									resolved: eb.ref('excluded.resolved'),
-									record: eb.ref('excluded.record'),
+									resolvedAt: eb.ref('excluded.resolvedAt'),
+									resolvedBy: eb.ref('excluded.resolvedBy'),
+									meta: eb.ref('excluded.meta'),
 									lastChangedClock: eb.ref('excluded.lastChangedClock'),
 								}))
 								.whereRef('comment_thread.lastChangedClock', '<', 'excluded.lastChangedClock')
@@ -1641,9 +1642,9 @@ export class TLFileDurableObject extends DurableObject {
 								.column('id')
 								.doUpdateSet((eb) => ({
 									body: eb.ref('excluded.body'),
-									shapeId: eb.ref('excluded.shapeId'),
+									editedAt: eb.ref('excluded.editedAt'),
 									updatedAt: eb.ref('excluded.updatedAt'),
-									record: eb.ref('excluded.record'),
+									meta: eb.ref('excluded.meta'),
 									lastChangedClock: eb.ref('excluded.lastChangedClock'),
 								}))
 								.whereRef('comment.lastChangedClock', '<', 'excluded.lastChangedClock')

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1594,8 +1594,6 @@ export class TLFileDurableObject extends DurableObject {
 		for (const id of ids) {
 			this.ctx.storage.sql.exec('INSERT INTO comment_outbox (recordId) VALUES (?)', id)
 		}
-		// Fire-and-forget: drainCommentOutbox handles its own errors internally (failed rows stay
-		// queued in the outbox and are retried on the next drain), so we don't await it here.
 		this.drainCommentOutbox()
 	}
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -58,7 +58,12 @@ import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
-import { commentRecordToRow, rowsToSnapshotDocuments, threadRecordToRow } from './commentRows'
+import {
+	commentRecordToRow,
+	mergeCommentDocumentsIntoSnapshot,
+	rowsToSnapshotDocuments,
+	threadRecordToRow,
+} from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
@@ -558,21 +563,38 @@ export class TLFileDurableObject extends DurableObject {
 			// Version snapshots only contain the drawing data. Restoring drops the file's comments
 			// (product decision): loading the bare snapshot wipes the object lane, and the Postgres
 			// rows are deleted explicitly since storage transactions don't fire onCommittedChanges.
-			// The delete runs through _objectPushQueue so it serializes after any in-flight outbox
-			// drain, and the outbox is cleared so a pending drain can't resurrect deleted rows.
+			// The cleanup runs through _objectPushQueue so it serializes after any in-flight outbox
+			// drain, and pre-restore outbox entries are cleared so a pending drain can't resurrect
+			// deleted rows.
+			//
+			// Two invariants make this safe against comments committed concurrently with the
+			// restore:
+			// (a) The lane wipe, the outbox high-water-mark capture, and the queue push below run
+			//     in one synchronous block with NO awaits in between. Storage change notifications
+			//     fire on a microtask, so a comment committed after the wipe enqueues its outbox
+			//     entry (seq > maxSeq) and its drain task strictly after ours (queue is FIFO) —
+			//     the entry survives the scoped clear and the later drain pushes it to Postgres.
+			// (b) The fileId-wide Postgres deletes may remove rows a post-wipe comment already
+			//     drained, but that's safe only because of (a): the surviving outbox entry means
+			//     a subsequent drain re-upserts the row.
 			const snapshot = JSON.parse(dataText) as RoomSnapshot
 
 			const storage = await this.getStorage()
 			storage.transaction((txn) => {
 				loadSnapshotIntoStorage(txn, fileSyncSchema, snapshot)
 			})
-
-			await this._objectPushQueue.push(async () => {
-				this.ensureCommentOutbox()
-				this.ctx.storage.sql.exec('DELETE FROM comment_outbox')
+			this.ensureCommentOutbox()
+			const maxSeq = Number(
+				this.ctx.storage.sql
+					.exec('SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM comment_outbox')
+					.toArray()[0].maxSeq
+			)
+			const cleanup = this._objectPushQueue.push(async () => {
+				this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
 				await this.db.deleteFrom('comment').where('fileId', '=', roomId).execute()
 				await this.db.deleteFrom('comment_thread').where('fileId', '=', roomId).execute()
 			})
+			await cleanup
 
 			this.maybeAssociateFileAssets()
 
@@ -1056,7 +1078,7 @@ export class TLFileDurableObject extends DurableObject {
 				// room open (bubbling like an R2 failure) — silently opening without comments would
 				// let the next persist treat them as deleted.
 				if (this.documentInfo.isApp) {
-					snapshot.documents = [...snapshot.documents, ...(await this.loadCommentsFromPostgres())]
+					mergeCommentDocumentsIntoSnapshot(snapshot, await this.loadCommentsFromPostgres())
 				}
 
 				loadTimer.report('db_load_total')
@@ -1086,8 +1108,15 @@ export class TLFileDurableObject extends DurableObject {
 					throw ROOM_NOT_FOUND
 				}
 
+				// Comments can exist in Postgres before the first throttled R2 persist ever runs
+				// (e.g. DO SQLite lost right after commenting on a fresh file), so rehydrate them
+				// here too. Clone the shared DEFAULT_INITIAL_SNAPSHOT constant — the merge reassigns
+				// `documents` and clamps clocks, and must not mutate the module-level object.
+				const snapshot: RoomSnapshot = { ...DEFAULT_INITIAL_SNAPSHOT }
+				mergeCommentDocumentsIntoSnapshot(snapshot, await this.loadCommentsFromPostgres())
+
 				return {
-					snapshot: DEFAULT_INITIAL_SNAPSHOT,
+					snapshot,
 					roomSizeMB: 0,
 				}
 			}
@@ -1641,6 +1670,7 @@ export class TLFileDurableObject extends DurableObject {
 							oc
 								.column('id')
 								.doUpdateSet((eb) => ({
+									pageId: eb.ref('excluded.pageId'),
 									body: eb.ref('excluded.body'),
 									editedAt: eb.ref('excluded.editedAt'),
 									updatedAt: eb.ref('excluded.updatedAt'),

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -171,7 +171,8 @@ export class TLFileDurableObject extends DurableObject {
 		}
 
 		// SQLite not initialized yet, load from R2 and initialize. The loaded snapshot has the
-		// R2 object lane merged in; the storage routes those records into its objects partition.
+		// Postgres comment rows merged in; the storage routes those records into its objects
+		// partition.
 		const result = await this.loadFromDatabase(slug)
 		const storage = new SQLiteSyncStorage<TLRecord>({
 			sql,
@@ -575,11 +576,21 @@ export class TLFileDurableObject extends DurableObject {
 			// (a) The lane wipe, the outbox high-water-mark capture, and the queue push below run
 			//     in one synchronous block with NO awaits in between. Storage change notifications
 			//     fire on a microtask, so a comment committed after the wipe enqueues its outbox
-			//     entry (seq > maxSeq) and its drain task strictly after ours (queue is FIFO) —
-			//     the entry survives the scoped clear and the later drain pushes it to Postgres.
+			//     entry (seq > maxSeq) and its drain task strictly after ours (queue is FIFO).
+			//     Drains are bounded to the outbox high-water mark captured when they are
+			//     scheduled (see drainCommentOutbox), so no drain queued before ours can touch
+			//     that entry: it survives our scoped clear and its own later drain pushes it to
+			//     Postgres.
 			// (b) The fileId-wide Postgres deletes may remove rows a post-wipe comment already
 			//     drained, but that's safe only because of (a): the surviving outbox entry means
 			//     a subsequent drain re-upserts the row.
+			//
+			// Inside the task, the Postgres deletes run BEFORE the outbox clear: if a delete
+			// throws, the pre-restore outbox entries survive, so subsequent drains keep retrying
+			// the per-id deletes (the records are lane-absent after the wipe, taking the delete
+			// path) and this handler's 500 tells the caller to retry the whole restore. Clearing
+			// the outbox first would destroy the only retry vehicle and let the dropped comments
+			// resurrect on the next fresh-SQLite load.
 			const snapshot = JSON.parse(dataText) as RoomSnapshot
 
 			const storage = await this.getStorage()
@@ -593,9 +604,9 @@ export class TLFileDurableObject extends DurableObject {
 					.toArray()[0].maxSeq
 			)
 			const cleanup = this._objectPushQueue.push(async () => {
-				this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
 				await this.db.deleteFrom('comment').where('fileId', '=', roomId).execute()
 				await this.db.deleteFrom('comment_thread').where('fileId', '=', roomId).execute()
+				this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
 			})
 			await cleanup
 
@@ -1358,6 +1369,13 @@ export class TLFileDurableObject extends DurableObject {
 						const slug = this.documentInfo.slug
 						const storage = await this.getStorage()
 						assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
+						// Object-lane records (comments) persist to Postgres via the outbox; the
+						// throttled persist just nudges a drain so pushes that failed earlier get
+						// retried. This must run BEFORE the clock early-return below: a quiet room
+						// (no new commits) would otherwise never retry a failed drain. Fire-and-forget:
+						// a Postgres outage must not fail the R2 document persist — the outbox keeps
+						// the pending work.
+						this.drainCommentOutbox()
 						if (this._lastPersistedClock === storage.getClock()) return
 						if (this._isRestoring) return
 
@@ -1370,11 +1388,6 @@ export class TLFileDurableObject extends DurableObject {
 						const key = getR2KeyForRoom({ slug: slug, isApp: this.documentInfo.isApp })
 						await this._uploadSnapshotToR2(snapshot, key)
 
-						// Object-lane records (comments) persist to Postgres via the outbox; the
-						// throttled persist just nudges a drain so pushes that failed earlier get
-						// retried even in a quiet room. Fire-and-forget: a Postgres outage must
-						// not fail the R2 document persist — the outbox keeps the pending work.
-						this.drainCommentOutbox()
 						await this.persistToPierre(storage, snapshot)
 
 						this.logEvent({ type: 'persist_success', attempts: attempt })
@@ -1607,16 +1620,28 @@ export class TLFileDurableObject extends DurableObject {
 	 * so multiple edits coalesce and a create-then-delete nets out to a delete. Upserts are
 	 * clock-guarded: a replayed push (same lastChangedClock) updates nothing, producing no WAL
 	 * entry and therefore no Zero replication churn.
+	 *
+	 * Each drain is bounded to the outbox high-water mark captured synchronously at SCHEDULE time,
+	 * not at execution time: entries enqueued while the drain sat in the queue are left for their
+	 * own drain (scheduled at enqueue, so its bound covers them). This is what lets the restore
+	 * handler wipe the lane and delete the file's Postgres rows without a stale queued drain
+	 * upserting — and clearing the outbox entry of — a comment committed after the wipe, which
+	 * the restore's fileId-wide delete would then remove from Postgres with no retry left.
 	 */
 	private drainCommentOutbox(): Promise<void> {
+		this.ensureCommentOutbox()
+		// sql.exec is synchronous, so the bound is captured before anything else can enqueue.
+		const drainBound = Number(
+			this.ctx.storage.sql
+				.exec('SELECT COALESCE(MAX(seq), 0) AS maxSeq FROM comment_outbox')
+				.toArray()[0].maxSeq
+		)
 		return this._objectPushQueue
 			.push(async () => {
-				this.ensureCommentOutbox()
 				const entries = this.ctx.storage.sql
-					.exec('SELECT seq, recordId FROM comment_outbox ORDER BY seq')
+					.exec('SELECT seq, recordId FROM comment_outbox WHERE seq <= ? ORDER BY seq', drainBound)
 					.toArray() as { seq: number; recordId: string }[]
 				if (entries.length === 0) return
-				const maxSeq = entries[entries.length - 1].seq
 				const pendingIds = new Set(entries.map((e) => e.recordId))
 
 				const storage = await this.getStorage()
@@ -1638,13 +1663,18 @@ export class TLFileDurableObject extends DurableObject {
 						} else {
 							threadDeletes.push(id)
 						}
-					} else {
+					} else if (isCommentId(id)) {
 						if (doc) {
 							const comment = doc.state as TLComment
 							commentUpserts.push(commentRecordToRow(comment, fileId, doc.lastChangedClock))
 						} else {
 							commentDeletes.push(id)
 						}
+					} else {
+						// enqueueCommentChanges only writes comment/comment-thread ids, so an unknown
+						// id means a bug or a corrupted outbox row. Skip it — its entry still clears
+						// below (retrying can't help) — and report for visibility.
+						this.reportError(new Error(`comment outbox: unknown record id ${JSON.stringify(id)}`))
 					}
 				}
 
@@ -1758,31 +1788,30 @@ export class TLFileDurableObject extends DurableObject {
 
 				if (commentResult.prunedIds.length > 0) {
 					this.logEvent({ type: 'room', roomId: fileId, name: 'comment_author_deleted_prune' })
-					// Remove the pruned records from the live room so connected clients see them
-					// disappear. Deleting through the shared storage handle is the sanctioned
-					// server-side mutation path: the room subscribes to storage.onChange and
-					// broadcasts external transactions to its sessions. It does not re-enqueue
-					// outbox entries (onCommittedChanges only fires for client pushes), so this
-					// can't loop; a crash between here and the outbox clear below just replays the
-					// prune on the next drain (the ids are then lane-absent, taking the no-op
-					// Postgres delete path). If the room isn't open there's nothing to mirror into:
-					// the next cold load rehydrates comments from Postgres, where the rows are
-					// already gone.
-					const room = this._room ? await this._room.catch(() => null) : null
-					if (room && !room.isClosed()) {
-						storage.transaction((txn) => {
-							for (const id of commentResult.prunedIds) {
-								txn.delete(id as TLRecord['id'])
-							}
-						})
-					}
+					// Remove the pruned records from the room's storage so it stops carrying rows
+					// Postgres already cascaded away. Deleting through the shared storage handle is
+					// the sanctioned server-side mutation path: a live room subscribes to
+					// storage.onChange and broadcasts external transactions to its sessions, so
+					// connected clients see the records disappear; a closed room needs no broadcast,
+					// but the prune must still run — the warm DO SQLite outlives the room, and
+					// loadStorage short-circuits Postgres rehydration when SQLite is already
+					// initialized, so skipping it would keep the deleted author's comments alive
+					// forever. The delete does not re-enqueue outbox entries (onCommittedChanges
+					// only fires for client pushes), so this can't loop; a crash between here and
+					// the outbox clear below just replays the prune on the next drain (the ids are
+					// then lane-absent, taking the no-op Postgres delete path).
+					storage.transaction((txn) => {
+						for (const id of commentResult.prunedIds) {
+							txn.delete(id as TLRecord['id'])
+						}
+					})
 				}
 
 				// Keep entries queued for any record that failed to push (they'll be retried on the
-				// next drain); only the entries that made it to Postgres are removed. If nothing
-				// failed, this collapses to the same unconditional delete as before.
+				// next drain); only the entries that made it to Postgres are removed. Only entries
+				// within this drain's bound are touched — later entries belong to their own drain.
 				if (failedIds.size === 0) {
-					this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
+					this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', drainBound)
 				} else {
 					for (const entry of entries) {
 						if (failedIds.has(entry.recordId)) continue

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -15,7 +15,6 @@ import {
 	ROOM_SIZE_LIMIT_MB,
 	SNAPSHOT_PREFIX,
 	TLCustomServerEvent,
-	TlaComment,
 	TlaFile,
 	WELCOME_CREATE_SOURCE,
 	can,
@@ -59,6 +58,7 @@ import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
+import { commentRecordToRow, threadRecordToRow } from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
@@ -272,10 +272,11 @@ export class TLFileDurableObject extends DurableObject {
 							messageLength: stringified.length,
 						})
 					},
-					// Project object-lane (comment) changes to Postgres as soon as they commit (not on
-					// the throttled R2 persist) so Zero replicates them to the app-level view quickly.
+					// Record object-lane (comment) changes in the durable outbox as soon as they
+					// commit and push them to Postgres (not on the throttled R2 persist) so Zero
+					// replicates them to the app-level view quickly.
 					onCommittedChanges: ({ diff }) => {
-						this.pushCommentChangesToPostgres(diff)
+						this.enqueueCommentChanges(diff)
 					},
 				})
 
@@ -1152,8 +1153,9 @@ export class TLFileDurableObject extends DurableObject {
 	// resurrect deleted records).
 	private _objectLaneWritten = false
 
-	// Serializes object-lane → Postgres pushes so they land in order. Separate from executionQueue
-	// (the R2/main-persist queue) since these pushes fire immediately on commit, not on the throttle.
+	// Serializes comment outbox drains (and the restore-path deletes) so they land in order.
+	// Separate from executionQueue (the R2/main-persist queue) since these pushes fire immediately
+	// on commit, not on the throttle.
 	private _objectPushQueue = new ExecutionQueue()
 
 	executionQueue = new ExecutionQueue()
@@ -1517,74 +1519,143 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	/**
-	 * Projects comment changes from a committed diff into Postgres so Zero replicates them to the
-	 * app-level view. Fires immediately on commit (see onCommittedChanges), serialized and
-	 * best-effort — it must never block or fail the canvas commit. The authoritative comment content
-	 * still lives in the R2 comment lane; these rows are a derived copy.
+	 * Durable outbox for comment persistence. Postgres is the sole durable store for comment
+	 * records; the DO's SQLite is the room's working copy. Each committed diff synchronously
+	 * appends the touched comment/comment-thread record ids here (same-task with the commit, so
+	 * the DO output gate flushes them together), and the drain pushes the records' current state
+	 * to Postgres. Entries are only removed after Postgres acks, so failed pushes are retried on
+	 * the next commit, persist, or DO wake.
 	 */
-	private pushCommentChangesToPostgres(diff: TLSyncForwardDiff<TLRecord>) {
-		const slug = this.documentInfo.slug
-		const comments: TLComment[] = []
-		const threadsInDiff = new Map<string, TLCommentThread>()
+	private ensureCommentOutbox() {
+		this.ctx.storage.sql.exec(
+			'CREATE TABLE IF NOT EXISTS comment_outbox (seq INTEGER PRIMARY KEY AUTOINCREMENT, recordId TEXT NOT NULL)'
+		)
+	}
+
+	private enqueueCommentChanges(diff: TLSyncForwardDiff<TLRecord>) {
+		const ids: string[] = []
 		for (const put of Object.values(diff.puts)) {
-			const record = (Array.isArray(put) ? put[1] : put) as { typeName: string }
-			if (record.typeName === 'comment') {
-				comments.push(record as unknown as TLComment)
-			} else if (record.typeName === 'comment-thread') {
-				threadsInDiff.set(
-					(record as unknown as TLCommentThread).id,
-					record as unknown as TLCommentThread
-				)
+			const record = (Array.isArray(put) ? put[1] : put) as { typeName: string; id: string }
+			if (record.typeName === 'comment' || record.typeName === 'comment-thread') {
+				ids.push(record.id)
 			}
 		}
-		// Deletes are ids only; comment ids are prefixed with `comment:`. Thread deletions don't
-		// touch the table directly — the client cascades by deleting the thread's comment records,
-		// which arrive here as `comment:` deletes in the same diff.
-		const deletedIds = diff.deletes.filter((id) => id.startsWith('comment:'))
+		for (const id of diff.deletes) {
+			if (id.startsWith('comment:') || id.startsWith('comment-thread:')) {
+				ids.push(id)
+			}
+		}
+		if (ids.length === 0) return
+		this.ensureCommentOutbox()
+		for (const id of ids) {
+			this.ctx.storage.sql.exec('INSERT INTO comment_outbox (recordId) VALUES (?)', id)
+		}
+		this.drainCommentOutbox()
+	}
 
-		if (comments.length === 0 && deletedIds.length === 0) return
-
-		this._objectPushQueue
+	/**
+	 * Push every outboxed record's current state to Postgres. The outbox stores only ids; whether
+	 * an id is an upsert or a delete is decided by its presence in the object lane at drain time,
+	 * so multiple edits coalesce and a create-then-delete nets out to a delete. Upserts are
+	 * clock-guarded: a replayed push (same lastChangedClock) updates nothing, producing no WAL
+	 * entry and therefore no Zero replication churn.
+	 */
+	private drainCommentOutbox(): Promise<void> {
+		return this._objectPushQueue
 			.push(async () => {
-				if (comments.length > 0) {
-					// The Postgres row denormalizes the thread's shape anchor; resolve each comment's
-					// thread from the same diff or from room storage. (A thread anchor changing does
-					// not re-project its existing comments — acceptable for the spike.)
-					const storage = await this.getStorage()
-					const upserts: TlaComment[] = comments.map((comment) => {
-						const thread =
-							threadsInDiff.get(comment.threadId) ??
-							(storage.transaction((txn) => txn.get(comment.threadId)).result as
-								| TLCommentThread
-								| undefined)
-						return this.commentRecordToRow(comment, thread, slug)
-					})
-					const insertRows = (rows: TlaComment[]) =>
-						this.db
-							.insertInto('comment')
-							.values(rows)
-							.onConflict((oc) =>
-								oc.column('id').doUpdateSet((eb) => ({
+				this.ensureCommentOutbox()
+				const entries = this.ctx.storage.sql
+					.exec('SELECT seq, recordId FROM comment_outbox ORDER BY seq')
+					.toArray() as { seq: number; recordId: string }[]
+				if (entries.length === 0) return
+				const maxSeq = entries[entries.length - 1].seq
+				const pendingIds = new Set(entries.map((e) => e.recordId))
+
+				const storage = await this.getStorage()
+				assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
+				const lane = new Map(storage.getObjectsSnapshot().map((doc) => [doc.state.id, doc]))
+				const fileId = this.documentInfo.slug
+
+				const threadUpserts: DB['comment_thread'][] = []
+				const commentUpserts: DB['comment'][] = []
+				const threadDeletes: string[] = []
+				const commentDeletes: string[] = []
+				for (const id of pendingIds) {
+					const doc = lane.get(id as TLRecord['id'])
+					if (id.startsWith('comment-thread:')) {
+						if (doc) {
+							threadUpserts.push(
+								threadRecordToRow(doc.state as TLCommentThread, fileId, doc.lastChangedClock)
+							)
+						} else {
+							threadDeletes.push(id)
+						}
+					} else {
+						if (doc) {
+							const comment = doc.state as TLComment
+							const thread = lane.get(comment.threadId)?.state as TLCommentThread | undefined
+							commentUpserts.push(commentRecordToRow(comment, thread, fileId, doc.lastChangedClock))
+						} else {
+							commentDeletes.push(id)
+						}
+					}
+				}
+
+				const insertThreadRows = (rows: DB['comment_thread'][]) =>
+					this.db
+						.insertInto('comment_thread')
+						.values(rows)
+						.onConflict((oc) =>
+							oc
+								.column('id')
+								.doUpdateSet((eb) => ({
+									pageId: eb.ref('excluded.pageId'),
+									shapeId: eb.ref('excluded.shapeId'),
+									resolved: eb.ref('excluded.resolved'),
+									record: eb.ref('excluded.record'),
+									lastChangedClock: eb.ref('excluded.lastChangedClock'),
+								}))
+								.whereRef('comment_thread.lastChangedClock', '<', 'excluded.lastChangedClock')
+						)
+						.execute()
+				const insertCommentRows = (rows: DB['comment'][]) =>
+					this.db
+						.insertInto('comment')
+						.values(rows)
+						.onConflict((oc) =>
+							oc
+								.column('id')
+								.doUpdateSet((eb) => ({
 									body: eb.ref('excluded.body'),
 									shapeId: eb.ref('excluded.shapeId'),
 									updatedAt: eb.ref('excluded.updatedAt'),
+									record: eb.ref('excluded.record'),
+									lastChangedClock: eb.ref('excluded.lastChangedClock'),
 								}))
-							)
-							.execute()
+								.whereRef('comment.lastChangedClock', '<', 'excluded.lastChangedClock')
+						)
+						.execute()
+
+				// Threads before comments (comment.threadId FK); comment deletes before thread
+				// deletes is not required (thread deletes cascade), but keep the batch → row-by-row
+				// fallback so one bad row (e.g. an FK violation from a since-deleted user) doesn't
+				// drop the whole batch.
+				const runBatchWithFallback = async <R>(
+					rows: R[],
+					insert: (rows: R[]) => Promise<unknown>
+				) => {
+					if (rows.length === 0) return
 					try {
-						await insertRows(upserts)
+						await insert(rows)
 					} catch (batchError) {
-						// A single bad row (e.g. an FK violation from a since-deleted user) must not
-						// drop the whole batch from the projection — retry row by row so only the
-						// genuinely bad rows are lost, and report those.
 						this.reportError(batchError)
-						for (const row of upserts) {
+						for (const row of rows) {
 							try {
-								await insertRows([row])
+								await insert([row])
 							} catch (rowError) {
 								this.logEvent({
 									type: 'room',
-									roomId: slug,
+									roomId: fileId,
 									name: 'failed_persist_comments_to_db',
 								})
 								this.reportError(rowError)
@@ -1592,40 +1663,25 @@ export class TLFileDurableObject extends DurableObject {
 						}
 					}
 				}
-				if (deletedIds.length > 0) {
-					await this.db.deleteFrom('comment').where('id', 'in', deletedIds).execute()
+				await runBatchWithFallback(threadUpserts, insertThreadRows)
+				await runBatchWithFallback(commentUpserts, insertCommentRows)
+				if (commentDeletes.length > 0) {
+					await this.db.deleteFrom('comment').where('id', 'in', commentDeletes).execute()
 				}
+				if (threadDeletes.length > 0) {
+					await this.db.deleteFrom('comment_thread').where('id', 'in', threadDeletes).execute()
+				}
+
+				this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
 			})
 			.catch((e) => {
 				this.logEvent({
 					type: 'room',
-					roomId: slug,
+					roomId: this.documentInfo.slug,
 					name: 'failed_persist_comments_to_db',
 				})
 				this.reportError(e)
 			})
-	}
-
-	private commentRecordToRow(
-		record: TLComment,
-		thread: TLCommentThread | undefined,
-		fileId: string
-	): TlaComment {
-		return {
-			id: record.id,
-			fileId,
-			threadId: record.threadId,
-			pageId: record.pageId,
-			authorId: record.authorId,
-			shapeId: thread?.anchor.type === 'shape' ? thread.anchor.shapeId : null,
-			// rich text stored as-is (JSONB) — the projection preserves the authoritative
-			// representation rather than flattening to plaintext. TLRichText types its content as
-			// unknown[], which doesn't structurally satisfy zero's ReadonlyJSONValue, but the value
-			// is schema-validated JSON.
-			body: record.body as TlaComment['body'],
-			createdAt: record.createdAt,
-			updatedAt: record.editedAt ?? record.createdAt,
-		}
 	}
 
 	private async persistToPierre(storage: TLSyncStorage<TLRecord>, snapshot: RoomSnapshot) {

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -58,7 +58,7 @@ import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
-import { commentRecordToRow, threadRecordToRow } from './commentRows'
+import { commentRecordToRow, rowsToSnapshotDocuments, threadRecordToRow } from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
@@ -137,15 +137,15 @@ function arrayBufferToBase64(ab: ArrayBuffer): string {
 const MB = 1024 * 1024
 
 // The schema for a file room. Includes the opt-in `comment` record type so comment records sync
-// through the room; comments are persisted in a separate R2 lane rather than the main document
-// blob (see persistToDatabase / loadFromDatabase). The same records must be registered on the
+// through the room; comments are persisted to Postgres rather than the main document blob (see
+// drainCommentOutbox / loadCommentsFromPostgres). The same records must be registered on the
 // client (see useSync in the dotcom client) or the schemas won't match.
 const fileSyncSchema = createTLSchema({ records: commentSchemaRecords })
 
 // Record types served through the room's object-store lane rather than the document lane.
 // Object-lane records sync over the same socket but are gated per session by `objectAccess`
-// (instead of `isReadonly`), are excluded from `.tldr` downloads, and are persisted in a
-// separate R2 lane next to the main document blob.
+// (instead of `isReadonly`), are excluded from `.tldr` downloads, and are persisted in Postgres
+// rather than the R2 document blob.
 const OBJECT_TYPES = ['comment-thread', 'comment'] as const
 
 export class TLFileDurableObject extends DurableObject {
@@ -1047,14 +1047,13 @@ export class TLFileDurableObject extends DurableObject {
 			if (roomFromBucket) {
 				const snapshot = (await roomFromBucket.json()) as RoomSnapshot
 
-				// Object-lane records (comments) live in a separate R2 lane (see persistToDatabase).
-				// Load them and merge them back into the snapshot so they seed the room and hydrate
-				// to clients on connect.
-				const objectLaneFromBucket = await this.r2.rooms.get(`${key}/comments`)
-				if (objectLaneFromBucket) {
-					const objectDocs = (await objectLaneFromBucket.json()) as RoomSnapshot['documents']
-					snapshot.documents = [...snapshot.documents, ...objectDocs]
-					this._objectLaneWritten = true
+				// Object-lane records (comments) live in Postgres, the sole durable comment store
+				// (see drainCommentOutbox). Load them and merge them back into the snapshot so they
+				// seed the room and hydrate to clients on connect. A Postgres failure here fails the
+				// room open (bubbling like an R2 failure) — silently opening without comments would
+				// let the next persist treat them as deleted.
+				if (this.documentInfo.isApp) {
+					snapshot.documents = [...snapshot.documents, ...(await this.loadCommentsFromPostgres())]
 				}
 
 				loadTimer.report('db_load_total')
@@ -1134,6 +1133,21 @@ export class TLFileDurableObject extends DurableObject {
 		}
 	}
 
+	private async loadCommentsFromPostgres(): Promise<RoomSnapshot['documents']> {
+		const fileId = this.documentInfo.slug
+		const threadRows = await this.db
+			.selectFrom('comment_thread')
+			.where('fileId', '=', fileId)
+			.selectAll()
+			.execute()
+		const commentRows = await this.db
+			.selectFrom('comment')
+			.where('fileId', '=', fileId)
+			.selectAll()
+			.execute()
+		return rowsToSnapshotDocuments(threadRows, commentRows)
+	}
+
 	timer() {
 		const start = Date.now()
 		return {
@@ -1146,12 +1160,6 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	_lastPersistedClock: number | null = null
-
-	// Whether this room's separate object-lane R2 object has ever been written (or existed on
-	// load). Used so we only write the lane once a room actually has object records, but still
-	// write an empty lane on later deletions (rather than leaving a stale object that would
-	// resurrect deleted records).
-	private _objectLaneWritten = false
 
 	// Serializes comment outbox drains (and the restore-path deletes) so they land in order.
 	// Separate from executionQueue (the R2/main-persist queue) since these pushes fire immediately
@@ -1322,16 +1330,14 @@ export class TLFileDurableObject extends DurableObject {
 						assert(snapshot.documentClock !== undefined, 'documentClock must be present')
 						this.maybeAssociateFileAssets()
 
-						const objectDocs = storage.getObjectsSnapshot()
-
 						const key = getR2KeyForRoom({ slug: slug, isApp: this.documentInfo.isApp })
 						await this._uploadSnapshotToR2(snapshot, key)
-						if (objectDocs.length > 0 || this._objectLaneWritten) {
-							// the lane keeps its original `/comments` key so existing rooms keep their data;
-							// a real API would want per-lane keys (e.g. `${key}/objects/<lane>`)
-							await this.r2.rooms.put(`${key}/comments`, JSON.stringify(objectDocs))
-							this._objectLaneWritten = true
-						}
+
+						// Object-lane records (comments) persist to Postgres via the outbox; the
+						// throttled persist just nudges a drain so pushes that failed earlier get
+						// retried even in a quiet room. Fire-and-forget: a Postgres outage must
+						// not fail the R2 document persist — the outbox keeps the pending work.
+						this.drainCommentOutbox()
 						await this.persistToPierre(storage, snapshot)
 
 						this.logEvent({ type: 'persist_success', attempts: attempt })

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1523,8 +1523,11 @@ export class TLFileDurableObject extends DurableObject {
 	 * records; the DO's SQLite is the room's working copy. Each committed diff synchronously
 	 * appends the touched comment/comment-thread record ids here (same-task with the commit, so
 	 * the DO output gate flushes them together), and the drain pushes the records' current state
-	 * to Postgres. Entries are only removed after Postgres acks, so failed pushes are retried on
-	 * the next commit, persist, or DO wake.
+	 * to Postgres. Delivery is at-least-once: an entry's outbox row is only removed once its push
+	 * to Postgres has actually succeeded, so a row that fails (including its row-by-row retry) stays
+	 * queued and is retried on the next commit, persist, or DO wake. A row that keeps failing (e.g.
+	 * a genuine FK violation from a since-deleted user) stays queued indefinitely and keeps reporting
+	 * via reportError on every drain — that's the visibility mechanism for a stuck row.
 	 */
 	private ensureCommentOutbox() {
 		this.ctx.storage.sql.exec(
@@ -1550,6 +1553,8 @@ export class TLFileDurableObject extends DurableObject {
 		for (const id of ids) {
 			this.ctx.storage.sql.exec('INSERT INTO comment_outbox (recordId) VALUES (?)', id)
 		}
+		// Fire-and-forget: drainCommentOutbox handles its own errors internally (failed rows stay
+		// queued in the outbox and are retried on the next drain), so we don't await it here.
 		this.drainCommentOutbox()
 	}
 
@@ -1639,20 +1644,25 @@ export class TLFileDurableObject extends DurableObject {
 				// Threads before comments (comment.threadId FK); comment deletes before thread
 				// deletes is not required (thread deletes cascade), but keep the batch → row-by-row
 				// fallback so one bad row (e.g. an FK violation from a since-deleted user) doesn't
-				// drop the whole batch.
-				const runBatchWithFallback = async <R>(
+				// drop the whole batch. Rows that fail both the batch insert and their individual
+				// retry are reported back (by record id) so the caller can keep their outbox entries
+				// queued instead of deleting them.
+				const runBatchWithFallback = async <R extends { id: string }>(
 					rows: R[],
 					insert: (rows: R[]) => Promise<unknown>
-				) => {
-					if (rows.length === 0) return
+				): Promise<string[]> => {
+					if (rows.length === 0) return []
 					try {
 						await insert(rows)
+						return []
 					} catch (batchError) {
 						this.reportError(batchError)
+						const failedIds: string[] = []
 						for (const row of rows) {
 							try {
 								await insert([row])
 							} catch (rowError) {
+								failedIds.push(row.id)
 								this.logEvent({
 									type: 'room',
 									roomId: fileId,
@@ -1661,10 +1671,16 @@ export class TLFileDurableObject extends DurableObject {
 								this.reportError(rowError)
 							}
 						}
+						return failedIds
 					}
 				}
-				await runBatchWithFallback(threadUpserts, insertThreadRows)
-				await runBatchWithFallback(commentUpserts, insertCommentRows)
+				const failedIds = new Set<string>()
+				for (const id of await runBatchWithFallback(threadUpserts, insertThreadRows)) {
+					failedIds.add(id)
+				}
+				for (const id of await runBatchWithFallback(commentUpserts, insertCommentRows)) {
+					failedIds.add(id)
+				}
 				if (commentDeletes.length > 0) {
 					await this.db.deleteFrom('comment').where('id', 'in', commentDeletes).execute()
 				}
@@ -1672,7 +1688,17 @@ export class TLFileDurableObject extends DurableObject {
 					await this.db.deleteFrom('comment_thread').where('id', 'in', threadDeletes).execute()
 				}
 
-				this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
+				// Keep entries queued for any record that failed to push (they'll be retried on the
+				// next drain); only the entries that made it to Postgres are removed. If nothing
+				// failed, this collapses to the same unconditional delete as before.
+				if (failedIds.size === 0) {
+					this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
+				} else {
+					for (const entry of entries) {
+						if (failedIds.has(entry.recordId)) continue
+						this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq = ?', entry.seq)
+					}
+				}
 			})
 			.catch((e) => {
 				this.logEvent({

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -45,6 +45,8 @@ import {
 	TLRecord,
 	commentSchemaRecords,
 	createTLSchema,
+	isCommentId,
+	isCommentThreadId,
 } from '@tldraw/tlschema'
 import {
 	ExecutionQueue,
@@ -1587,7 +1589,7 @@ export class TLFileDurableObject extends DurableObject {
 			}
 		}
 		for (const id of diff.deletes) {
-			if (id.startsWith('comment:') || id.startsWith('comment-thread:')) {
+			if (isCommentId(id) || isCommentThreadId(id)) {
 				ids.push(id)
 			}
 		}
@@ -1628,7 +1630,7 @@ export class TLFileDurableObject extends DurableObject {
 				const commentDeletes: string[] = []
 				for (const id of pendingIds) {
 					const doc = lane.get(id as TLRecord['id'])
-					if (id.startsWith('comment-thread:')) {
+					if (isCommentThreadId(id)) {
 						if (doc) {
 							threadUpserts.push(
 								threadRecordToRow(doc.state as TLCommentThread, fileId, doc.lastChangedClock)

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -38,8 +38,6 @@ import {
 import {
 	TLAsset,
 	TLAssetId,
-	TLComment,
-	TLCommentThread,
 	TLDOCUMENT_ID,
 	TLDocument,
 	TLRecord,
@@ -61,11 +59,11 @@ import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
 import {
-	commentRecordToRow,
 	isCommentAuthorFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
+	outboxEntriesToClear,
+	planCommentDrain,
 	rowsToSnapshotDocuments,
-	threadRecordToRow,
 } from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
@@ -202,6 +200,16 @@ export class TLFileDurableObject extends DurableObject {
 					storage.transaction((txn) => {
 						fileSyncSchema.migrateStorage(txn)
 					})
+					// Drain any outbox entries stranded by a previous incarnation (e.g. a Postgres
+					// blip during the last-out drain). Retries are otherwise onChange-driven
+					// (triggerPersist), so a reopened room where users only view would never drain.
+					// Deferred to a microtask because drainCommentOutbox's queued task awaits
+					// getStorage() — i.e. the very promise this callback resolves. The drain queue
+					// runs its tasks asynchronously so even a synchronous call here wouldn't
+					// deadlock, but kicking after this callback returns (storage resolved,
+					// `_storage` fully wired) keeps the non-reentrancy obvious. An empty outbox
+					// no-ops after one synchronous SQL read, so the cost per room start is trivial.
+					queueMicrotask(() => void this.drainCommentOutbox())
 					return storage
 				})
 				.catch((error) => {
@@ -581,16 +589,21 @@ export class TLFileDurableObject extends DurableObject {
 			//     scheduled (see drainCommentOutbox), so no drain queued before ours can touch
 			//     that entry: it survives our scoped clear and its own later drain pushes it to
 			//     Postgres.
-			// (b) The fileId-wide Postgres deletes may remove rows a post-wipe comment already
-			//     drained, but that's safe only because of (a): the surviving outbox entry means
-			//     a subsequent drain re-upserts the row.
+			// (b) The queue's FIFO order means the cleanup task below runs BEFORE any post-wipe
+			//     comment's drain task, so the fileId-wide Postgres deletes can only remove
+			//     pre-restore rows — never rows a post-wipe drain already wrote. The post-wipe
+			//     entry (seq > maxSeq) survives the scoped outbox clear, and its own drain
+			//     re-upserts the row to Postgres AFTER the cleanup.
 			//
 			// Inside the task, the Postgres deletes run BEFORE the outbox clear: if a delete
-			// throws, the pre-restore outbox entries survive, so subsequent drains keep retrying
-			// the per-id deletes (the records are lane-absent after the wipe, taking the delete
-			// path) and this handler's 500 tells the caller to retry the whole restore. Clearing
-			// the outbox first would destroy the only retry vehicle and let the dropped comments
-			// resurrect on the next fresh-SQLite load.
+			// throws, any pre-restore outbox entries survive, so subsequent drains retry the
+			// per-id deletes (the records are lane-absent after the wipe, taking the delete
+			// path). But a quiescent room has an empty outbox — no per-id retries at all — so
+			// the only guaranteed retry vehicle is this handler's 500 telling the caller to
+			// retry the whole restore. Clearing the outbox first would destroy even the per-id
+			// retries and let the dropped comments resurrect on the next fresh-SQLite load.
+			// follow-up: a durable wipe-marker recorded alongside the outbox would let the DO
+			// itself retry the fileId-wide delete, closing the dependence on caller retries.
 			const snapshot = JSON.parse(dataText) as RoomSnapshot
 
 			const storage = await this.getStorage()
@@ -1117,6 +1130,21 @@ export class TLFileDurableObject extends DurableObject {
 				const res = await this.handleFileCreateFromSource()
 				createFromSourceTimer.report('db_load_create_from_source')
 
+				// `createSource` is never cleared from the file record, so this branch re-enters
+				// whenever the R2 blob is missing — including a from-source file that gained
+				// comments and then lost its DO SQLite before the first throttled R2 persist.
+				// Merge the Postgres comments back in like the other branches, or they'd be
+				// orphaned: visible in the app-level /comments view but absent from the room, and
+				// resurrected inconsistently later. For a genuinely fresh duplicate the query
+				// returns zero rows and the merge is a no-op. Clone the snapshot before merging:
+				// loadCreateSourceData can return the shared DEFAULT_INITIAL_SNAPSHOT module
+				// constant, and the merge mutates top-level snapshot fields.
+				if (commentsPromise) {
+					const snapshot: RoomSnapshot = { ...res.snapshot }
+					mergeCommentDocumentsIntoSnapshot(snapshot, await commentsPromise)
+					res.snapshot = snapshot
+				}
+
 				loadTimer.report('db_load_total')
 
 				return res
@@ -1577,13 +1605,14 @@ export class TLFileDurableObject extends DurableObject {
 
 	/**
 	 * Durable outbox for comment persistence. Postgres is the sole durable store for comment
-	 * records; the DO's SQLite is the room's working copy. Each committed diff synchronously
-	 * appends the touched comment/comment-thread record ids here (same-task with the commit, so
-	 * the DO output gate flushes them together), and the drain pushes the records' current state
-	 * to Postgres. Delivery is at-least-once: an entry's outbox row is only removed once its push
-	 * to Postgres has actually succeeded, so a row that fails (including its row-by-row retry) stays
-	 * queued and is retried on the next commit, persist, or DO wake. A row that keeps failing stays
-	 * queued indefinitely and keeps reporting via reportError on every drain — that's the visibility
+	 * records; the DO's SQLite is the room's working copy. Each committed diff appends the touched
+	 * comment/comment-thread record ids here (same-task with the commit, so the DO output gate
+	 * flushes them together), and the drain pushes the records' current state to Postgres.
+	 * Delivery is at-least-once: an entry's outbox row is only removed once its push to Postgres
+	 * has actually succeeded, so a row that fails (including its row-by-row retry) stays queued
+	 * and is retried on the next commit, the next throttled persist, or the drain kicked when
+	 * storage loads on DO wake (see getStorage). A row that keeps failing stays queued
+	 * indefinitely and keeps reporting via reportError on every drain — that's the visibility
 	 * mechanism for a stuck row. The one exception is a comment whose author's account was deleted
 	 * (authorId FK violation): Postgres already cascaded the row away, so the drain prunes the
 	 * record from the room instead of retrying (see drainCommentOutbox).
@@ -1617,10 +1646,10 @@ export class TLFileDurableObject extends DurableObject {
 
 	/**
 	 * Push every outboxed record's current state to Postgres. The outbox stores only ids; whether
-	 * an id is an upsert or a delete is decided by its presence in the object lane at drain time,
-	 * so multiple edits coalesce and a create-then-delete nets out to a delete. Upserts are
-	 * clock-guarded: a replayed push (same lastChangedClock) updates nothing, producing no WAL
-	 * entry and therefore no Zero replication churn.
+	 * an id is an upsert or a delete is decided by its presence in the object lane at drain time
+	 * (see planCommentDrain), so multiple edits coalesce and a create-then-delete nets out to a
+	 * delete. Upserts are clock-guarded: a replayed push (same lastChangedClock) updates nothing,
+	 * producing no WAL entry and therefore no Zero replication churn.
 	 *
 	 * Each drain is bounded to the outbox high-water mark captured synchronously at SCHEDULE time,
 	 * not at execution time: entries enqueued while the drain sat in the queue are left for their
@@ -1643,40 +1672,21 @@ export class TLFileDurableObject extends DurableObject {
 					.exec('SELECT seq, recordId FROM comment_outbox WHERE seq <= ? ORDER BY seq', drainBound)
 					.toArray() as { seq: number; recordId: string }[]
 				if (entries.length === 0) return
-				const pendingIds = new Set(entries.map((e) => e.recordId))
 
 				const storage = await this.getStorage()
 				assert(storage instanceof SQLiteSyncStorage, 'storage must be a SQLiteSyncStorage')
-				const lane = new Map(storage.getObjectsSnapshot().map((doc) => [doc.state.id, doc]))
+				const lane = new Map(
+					storage.getObjectsSnapshot().map((doc) => [doc.state.id as string, doc])
+				)
 				const fileId = this.documentInfo.slug
 
-				const threadUpserts: DB['comment_thread'][] = []
-				const commentUpserts: DB['comment'][] = []
-				const threadDeletes: string[] = []
-				const commentDeletes: string[] = []
-				for (const id of pendingIds) {
-					const doc = lane.get(id as TLRecord['id'])
-					if (isCommentThreadId(id)) {
-						if (doc) {
-							threadUpserts.push(
-								threadRecordToRow(doc.state as TLCommentThread, fileId, doc.lastChangedClock)
-							)
-						} else {
-							threadDeletes.push(id)
-						}
-					} else if (isCommentId(id)) {
-						if (doc) {
-							const comment = doc.state as TLComment
-							commentUpserts.push(commentRecordToRow(comment, fileId, doc.lastChangedClock))
-						} else {
-							commentDeletes.push(id)
-						}
-					} else {
-						// enqueueCommentChanges only writes comment/comment-thread ids, so an unknown
-						// id means a bug or a corrupted outbox row. Skip it — its entry still clears
-						// below (retrying can't help) — and report for visibility.
-						this.reportError(new Error(`comment outbox: unknown record id ${JSON.stringify(id)}`))
-					}
+				const { threadUpserts, commentUpserts, threadDeletes, commentDeletes, unknownIds } =
+					planCommentDrain(entries, lane, fileId)
+				for (const id of unknownIds) {
+					// enqueueCommentChanges only writes comment/comment-thread ids, so an unknown
+					// id means a bug or a corrupted outbox row. Skip it — its entry still clears
+					// below (retrying can't help) — and report for visibility.
+					this.reportError(new Error(`comment outbox: unknown record id ${JSON.stringify(id)}`))
 				}
 
 				const insertThreadRows = (rows: DB['comment_thread'][]) =>
@@ -1706,6 +1716,7 @@ export class TLFileDurableObject extends DurableObject {
 							oc
 								.column('id')
 								.doUpdateSet((eb) => ({
+									threadId: eb.ref('excluded.threadId'),
 									pageId: eb.ref('excluded.pageId'),
 									body: eb.ref('excluded.body'),
 									editedAt: eb.ref('excluded.editedAt'),
@@ -1811,12 +1822,12 @@ export class TLFileDurableObject extends DurableObject {
 				// Keep entries queued for any record that failed to push (they'll be retried on the
 				// next drain); only the entries that made it to Postgres are removed. Only entries
 				// within this drain's bound are touched — later entries belong to their own drain.
-				if (failedIds.size === 0) {
+				const toClear = outboxEntriesToClear(entries, failedIds)
+				if (toClear.clearAll) {
 					this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', drainBound)
 				} else {
-					for (const entry of entries) {
-						if (failedIds.has(entry.recordId)) continue
-						this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq = ?', entry.seq)
+					for (const seq of toClear.seqs) {
+						this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq = ?', seq)
 					}
 				}
 			})

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -604,7 +604,8 @@ export class TLFileDurableObject extends DurableObject {
 					.toArray()[0].maxSeq
 			)
 			const cleanup = this._objectPushQueue.push(async () => {
-				await this.db.deleteFrom('comment').where('fileId', '=', roomId).execute()
+				// comment.threadId is NOT NULL with an ON DELETE CASCADE FK, so deleting the
+				// file's threads provably deletes all its comments too
 				await this.db.deleteFrom('comment_thread').where('fileId', '=', roomId).execute()
 				this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq <= ?', maxSeq)
 			})

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -204,11 +204,13 @@ export class TLFileDurableObject extends DurableObject {
 					// blip during the last-out drain). Retries are otherwise onChange-driven
 					// (triggerPersist), so a reopened room where users only view would never drain.
 					// Deferred to a microtask because drainCommentOutbox's queued task awaits
-					// getStorage() — i.e. the very promise this callback resolves. The drain queue
-					// runs its tasks asynchronously so even a synchronous call here wouldn't
-					// deadlock, but kicking after this callback returns (storage resolved,
-					// `_storage` fully wired) keeps the non-reentrancy obvious. An empty outbox
-					// no-ops after one synchronous SQL read, so the cost per room start is trivial.
+					// getStorage() — i.e. the very promise this callback resolves. Even a
+					// synchronous call here wouldn't deadlock (ExecutionQueue starts an idle
+					// queue's task synchronously, but the task only suspends on the
+					// already-assigned `_storage` promise — awaiting never blocks); kicking after
+					// this callback returns just keeps the non-reentrancy obvious. An empty
+					// outbox no-ops after a couple of synchronous SQL statements, so the cost per
+					// room start is trivial.
 					queueMicrotask(() => void this.drainCommentOutbox())
 					return storage
 				})
@@ -1613,9 +1615,10 @@ export class TLFileDurableObject extends DurableObject {
 	 * and is retried on the next commit, the next throttled persist, or the drain kicked when
 	 * storage loads on DO wake (see getStorage). A row that keeps failing stays queued
 	 * indefinitely and keeps reporting via reportError on every drain — that's the visibility
-	 * mechanism for a stuck row. The one exception is a comment whose author's account was deleted
-	 * (authorId FK violation): Postgres already cascaded the row away, so the drain prunes the
-	 * record from the room instead of retrying (see drainCommentOutbox).
+	 * mechanism for a stuck row. Two exceptions clear without a successful push: a comment whose
+	 * author's account was deleted (authorId FK violation — Postgres already cascaded the row
+	 * away, so the drain prunes the record from the room instead of retrying; see
+	 * drainCommentOutbox), and malformed/unknown outbox ids, where retrying can't help.
 	 */
 	private ensureCommentOutbox() {
 		this.ctx.storage.sql.exec(

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -19,7 +19,7 @@ import {
 
 const pageId = 'page:page1' as TLPageId
 const shapeId = 'shape:box1' as TLShapeId
-// minimal rich text doc; the validator doesn't run in these tests
+// minimal rich text doc; passes richTextValidator (which rowToCommentRecord now runs)
 const body = { type: 'doc', content: [] } as unknown as TLRichText
 
 function makeThread(anchor = { type: 'shape' as const, shapeId, x: 0.5, y: 0.5, isPrecise: true }) {
@@ -171,6 +171,28 @@ describe('round-trip: record -> row -> rowTo*Record', () => {
 		}
 		const row = commentRecordToRow(comment, 'file1', 44)
 		expect(rowToCommentRecord(row)).toEqual(comment)
+	})
+})
+
+describe('rehydration validation', () => {
+	it('rowToThreadRecord throws on a mangled anchor', () => {
+		const row = threadRecordToRow(makeThread(), 'file1', 42)
+		const corrupt = { ...row, anchor: { type: 'shape' } as any }
+		expect(() => rowToThreadRecord(corrupt)).toThrow()
+	})
+
+	it('rowToCommentRecord throws on a mangled body', () => {
+		const thread = makeThread()
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			body,
+			now: 1500,
+		})
+		const row = commentRecordToRow(comment, 'file1', 43)
+		const corrupt = { ...row, body: 'not rich text' as any }
+		expect(() => rowToCommentRecord(corrupt)).toThrow()
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -281,4 +281,25 @@ describe('mergeCommentDocumentsIntoSnapshot', () => {
 		expect(snapshot.documentClock).toBe(42)
 		expect(snapshot.clock).toBe(100)
 	})
+
+	it('raises tombstoneHistoryStartsAtClock to maxClock when the clamp fires and it was lower', () => {
+		const snapshot = makeSnapshot({ documentClock: 10, tombstoneHistoryStartsAtClock: 5 })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(42))
+		expect(snapshot.documentClock).toBe(42)
+		expect(snapshot.tombstoneHistoryStartsAtClock).toBe(42)
+	})
+
+	it('sets tombstoneHistoryStartsAtClock to maxClock when the clamp fires and it was undefined', () => {
+		const snapshot = makeSnapshot({ documentClock: 10, tombstoneHistoryStartsAtClock: undefined })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(42))
+		expect(snapshot.documentClock).toBe(42)
+		expect(snapshot.tombstoneHistoryStartsAtClock).toBe(42)
+	})
+
+	it('leaves tombstoneHistoryStartsAtClock untouched when the clamp does not fire', () => {
+		const snapshot = makeSnapshot({ documentClock: 10, tombstoneHistoryStartsAtClock: 5 })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(3, 10))
+		expect(snapshot.documentClock).toBe(10)
+		expect(snapshot.tombstoneHistoryStartsAtClock).toBe(5)
+	})
 })

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -8,9 +8,12 @@ import {
 } from '@tldraw/tlschema'
 import { describe, expect, it } from 'vitest'
 import {
+	CommentOutboxEntry,
 	commentRecordToRow,
 	isCommentAuthorFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
+	outboxEntriesToClear,
+	planCommentDrain,
 	rowsToSnapshotDocuments,
 	rowToCommentRecord,
 	rowToThreadRecord,
@@ -242,6 +245,114 @@ describe('rowsToSnapshotDocuments', () => {
 			{ state: thread, lastChangedClock: 42 },
 			{ state: comment, lastChangedClock: 43 },
 		])
+	})
+})
+
+describe('planCommentDrain', () => {
+	function makeComment(threadId: ReturnType<typeof makeThread>['id']) {
+		return createComment({ threadId, pageId, authorId: 'user1', body, now: 1500 })
+	}
+
+	function laneOf(...docs: { state: { id: string }; lastChangedClock: number }[]) {
+		return new Map(docs.map((doc) => [doc.state.id, doc]))
+	}
+
+	function entriesOf(...recordIds: string[]): CommentOutboxEntry[] {
+		return recordIds.map((recordId, i) => ({ seq: i + 1, recordId }))
+	}
+
+	it('classifies lane-present ids as upserts built via the row converters', () => {
+		const thread = makeThread()
+		const comment = makeComment(thread.id)
+		const lane = laneOf(
+			{ state: thread, lastChangedClock: 42 },
+			{ state: comment, lastChangedClock: 43 }
+		)
+		expect(planCommentDrain(entriesOf(thread.id, comment.id), lane, 'file1')).toEqual({
+			threadUpserts: [threadRecordToRow(thread, 'file1', 42)],
+			commentUpserts: [commentRecordToRow(comment, 'file1', 43)],
+			threadDeletes: [],
+			commentDeletes: [],
+			unknownIds: [],
+		})
+	})
+
+	it('coalesces duplicate entries for one id into a single write', () => {
+		const thread = makeThread()
+		const lane = laneOf({ state: thread, lastChangedClock: 42 })
+		const plan = planCommentDrain(entriesOf(thread.id, thread.id, thread.id), lane, 'file1')
+		expect(plan.threadUpserts).toEqual([threadRecordToRow(thread, 'file1', 42)])
+	})
+
+	it('nets a create-then-delete out to a delete when the id is absent from the lane', () => {
+		const thread = makeThread()
+		const comment = makeComment(thread.id)
+		const plan = planCommentDrain(
+			entriesOf(thread.id, comment.id, thread.id, comment.id),
+			new Map(),
+			'file1'
+		)
+		expect(plan).toEqual({
+			threadUpserts: [],
+			commentUpserts: [],
+			threadDeletes: [thread.id],
+			commentDeletes: [comment.id],
+			unknownIds: [],
+		})
+	})
+
+	it('only considers ids present in the entries, not everything in the lane', () => {
+		// the caller bounds entries to its drain's high-water mark; lane records outside the
+		// entries belong to a later drain and must not leak into this plan
+		const enqueued = makeThread()
+		const laterThread = makeThread()
+		const lane = laneOf(
+			{ state: enqueued, lastChangedClock: 1 },
+			{ state: laterThread, lastChangedClock: 2 }
+		)
+		const plan = planCommentDrain(entriesOf(enqueued.id), lane, 'file1')
+		expect(plan.threadUpserts).toEqual([threadRecordToRow(enqueued, 'file1', 1)])
+	})
+
+	it('separates unknown ids instead of misfiling them as upserts or deletes', () => {
+		const thread = makeThread()
+		const lane = laneOf({ state: thread, lastChangedClock: 42 })
+		const plan = planCommentDrain(entriesOf('shape:oops', thread.id), lane, 'file1')
+		expect(plan).toEqual({
+			threadUpserts: [threadRecordToRow(thread, 'file1', 42)],
+			commentUpserts: [],
+			threadDeletes: [],
+			commentDeletes: [],
+			unknownIds: ['shape:oops'],
+		})
+	})
+})
+
+describe('outboxEntriesToClear', () => {
+	const entries: CommentOutboxEntry[] = [
+		{ seq: 1, recordId: 'comment:a' },
+		{ seq: 2, recordId: 'comment:b' },
+		{ seq: 3, recordId: 'comment:a' },
+	]
+
+	it('signals the bulk-clear fast path when nothing failed', () => {
+		expect(outboxEntriesToClear(entries, new Set())).toEqual({ clearAll: true, seqs: [] })
+	})
+
+	it('keeps every entry of a failed record queued, clearing only the rest', () => {
+		expect(outboxEntriesToClear(entries, new Set(['comment:a']))).toEqual({
+			clearAll: false,
+			seqs: [2],
+		})
+	})
+
+	it('clears entries for pruned records — pruned ids are not failed ids', () => {
+		// a pruned record (author FK cascade) is never added to failedIds, so its entries clear
+		// like a success; only the genuinely failed record's entries survive
+		expect(outboxEntriesToClear(entries, new Set(['comment:b']))).toEqual({
+			clearAll: false,
+			seqs: [1, 3],
+		})
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -9,6 +9,7 @@ import {
 import { describe, expect, it } from 'vitest'
 import {
 	commentRecordToRow,
+	isCommentAuthorFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
 	rowsToSnapshotDocuments,
 	rowToCommentRecord,
@@ -94,6 +95,38 @@ describe('commentRecordToRow', () => {
 		const row = commentRecordToRow(comment, 'file1', 44)
 		expect(row.editedAt).toBe(1600)
 		expect(row.updatedAt).toBe(1600)
+	})
+})
+
+describe('isCommentAuthorFkViolation', () => {
+	it('matches a pg foreign key violation on comment_author_id_fkey', () => {
+		// shape of node-postgres's DatabaseError for `insert ... violates foreign key constraint`
+		const error = Object.assign(new Error('violates foreign key constraint'), {
+			code: '23503',
+			constraint: 'comment_author_id_fkey',
+		})
+		expect(isCommentAuthorFkViolation(error)).toBe(true)
+	})
+
+	it('requires both the code and the constraint to match', () => {
+		expect(
+			isCommentAuthorFkViolation(
+				Object.assign(new Error(), { code: '23503', constraint: 'comment_thread_id_fkey' })
+			)
+		).toBe(false)
+		expect(
+			isCommentAuthorFkViolation(
+				Object.assign(new Error(), { code: '23505', constraint: 'comment_author_id_fkey' })
+			)
+		).toBe(false)
+		expect(isCommentAuthorFkViolation(Object.assign(new Error(), { code: '23503' }))).toBe(false)
+	})
+
+	it('rejects non-object and empty errors', () => {
+		expect(isCommentAuthorFkViolation(null)).toBe(false)
+		expect(isCommentAuthorFkViolation(undefined)).toBe(false)
+		expect(isCommentAuthorFkViolation('23503')).toBe(false)
+		expect(isCommentAuthorFkViolation(new Error('connection refused'))).toBe(false)
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -1,0 +1,114 @@
+import {
+	createComment,
+	createCommentThread,
+	TLPageId,
+	TLRichText,
+	TLShapeId,
+} from '@tldraw/tlschema'
+import { describe, expect, it } from 'vitest'
+import { commentRecordToRow, rowsToSnapshotDocuments, threadRecordToRow } from './commentRows'
+
+const pageId = 'page:page1' as TLPageId
+const shapeId = 'shape:box1' as TLShapeId
+// minimal rich text doc; the validator doesn't run in these tests
+const body = { type: 'doc', content: [] } as unknown as TLRichText
+
+function makeThread(anchor = { type: 'shape' as const, shapeId, x: 0.5, y: 0.5, isPrecise: true }) {
+	return createCommentThread({ pageId, anchor, createdBy: 'user1', now: 1000 })
+}
+
+describe('threadRecordToRow', () => {
+	it('denormalizes shape anchor, resolution, and preserves the full record', () => {
+		const thread = { ...makeThread(), resolved: { at: 2000, by: 'user2' } }
+		const row = threadRecordToRow(thread, 'file1', 42)
+		expect(row).toEqual({
+			id: thread.id,
+			fileId: 'file1',
+			pageId,
+			shapeId,
+			resolved: true,
+			createdBy: 'user1',
+			createdAt: 1000,
+			record: thread,
+			lastChangedClock: 42,
+		})
+	})
+
+	it('leaves shapeId null for non-shape anchors and resolved false for open threads', () => {
+		const thread = makeThread({ type: 'point', x: 10, y: 20 } as any)
+		const row = threadRecordToRow(thread, 'file1', 1)
+		expect(row.shapeId).toBeNull()
+		expect(row.resolved).toBe(false)
+	})
+})
+
+describe('commentRecordToRow', () => {
+	it('denormalizes the thread anchor and preserves the full record', () => {
+		const thread = makeThread()
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			body,
+			now: 1500,
+		})
+		const row = commentRecordToRow(comment, thread, 'file1', 43)
+		expect(row).toEqual({
+			id: comment.id,
+			fileId: 'file1',
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			shapeId,
+			body: comment.body,
+			createdAt: 1500,
+			updatedAt: 1500,
+			record: comment,
+			lastChangedClock: 43,
+		})
+	})
+
+	it('uses editedAt for updatedAt and null shapeId when the thread is missing', () => {
+		const thread = makeThread()
+		const comment = {
+			...createComment({
+				threadId: thread.id,
+				pageId,
+				authorId: 'user1',
+				body,
+				now: 1500,
+			}),
+			editedAt: 1600,
+		}
+		const row = commentRecordToRow(comment, undefined, 'file1', 44)
+		expect(row.updatedAt).toBe(1600)
+		expect(row.shapeId).toBeNull()
+	})
+})
+
+describe('rowsToSnapshotDocuments', () => {
+	it('round-trips records losslessly through rows', () => {
+		const thread = makeThread()
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			body,
+			now: 1500,
+		})
+		const threadRow = threadRecordToRow(thread, 'file1', 42)
+		const commentRow = commentRecordToRow(comment, thread, 'file1', 43)
+		expect(rowsToSnapshotDocuments([threadRow], [commentRow])).toEqual([
+			{ state: thread, lastChangedClock: 42 },
+			{ state: comment, lastChangedClock: 43 },
+		])
+	})
+
+	it('coerces bigint-as-string clocks from pg to numbers', () => {
+		const thread = makeThread()
+		const threadRow = { ...threadRecordToRow(thread, 'file1', 42), lastChangedClock: '42' as any }
+		expect(rowsToSnapshotDocuments([threadRow], [])).toEqual([
+			{ state: thread, lastChangedClock: 42 },
+		])
+	})
+})

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -6,7 +6,13 @@ import {
 	TLShapeId,
 } from '@tldraw/tlschema'
 import { describe, expect, it } from 'vitest'
-import { commentRecordToRow, rowsToSnapshotDocuments, threadRecordToRow } from './commentRows'
+import {
+	commentRecordToRow,
+	rowsToSnapshotDocuments,
+	rowToCommentRecord,
+	rowToThreadRecord,
+	threadRecordToRow,
+} from './commentRows'
 
 const pageId = 'page:page1' as TLPageId
 const shapeId = 'shape:box1' as TLShapeId
@@ -18,32 +24,35 @@ function makeThread(anchor = { type: 'shape' as const, shapeId, x: 0.5, y: 0.5, 
 }
 
 describe('threadRecordToRow', () => {
-	it('denormalizes shape anchor, resolution, and preserves the full record', () => {
+	it('resolved thread with shape anchor: resolvedAt/resolvedBy set, shapeId denormalized', () => {
 		const thread = { ...makeThread(), resolved: { at: 2000, by: 'user2' } }
 		const row = threadRecordToRow(thread, 'file1', 42)
 		expect(row).toEqual({
 			id: thread.id,
 			fileId: 'file1',
 			pageId,
+			anchor: thread.anchor,
 			shapeId,
-			resolved: true,
+			resolvedAt: 2000,
+			resolvedBy: 'user2',
 			createdBy: 'user1',
 			createdAt: 1000,
-			record: thread,
+			meta: thread.meta,
 			lastChangedClock: 42,
 		})
 	})
 
-	it('leaves shapeId null for non-shape anchors and resolved false for open threads', () => {
+	it('open thread with point anchor: shapeId/resolvedAt/resolvedBy all null', () => {
 		const thread = makeThread({ type: 'point', x: 10, y: 20 } as any)
 		const row = threadRecordToRow(thread, 'file1', 1)
 		expect(row.shapeId).toBeNull()
-		expect(row.resolved).toBe(false)
+		expect(row.resolvedAt).toBeNull()
+		expect(row.resolvedBy).toBeNull()
 	})
 })
 
 describe('commentRecordToRow', () => {
-	it('denormalizes the thread anchor and preserves the full record', () => {
+	it('editedAt null: updatedAt falls back to createdAt', () => {
 		const thread = makeThread()
 		const comment = createComment({
 			threadId: thread.id,
@@ -52,23 +61,23 @@ describe('commentRecordToRow', () => {
 			body,
 			now: 1500,
 		})
-		const row = commentRecordToRow(comment, thread, 'file1', 43)
+		const row = commentRecordToRow(comment, 'file1', 43)
 		expect(row).toEqual({
 			id: comment.id,
 			fileId: 'file1',
 			threadId: thread.id,
 			pageId,
 			authorId: 'user1',
-			shapeId,
 			body: comment.body,
 			createdAt: 1500,
+			editedAt: null,
 			updatedAt: 1500,
-			record: comment,
+			meta: comment.meta,
 			lastChangedClock: 43,
 		})
 	})
 
-	it('uses editedAt for updatedAt and null shapeId when the thread is missing', () => {
+	it('editedAt set: both editedAt and updatedAt carry the edited value', () => {
 		const thread = makeThread()
 		const comment = {
 			...createComment({
@@ -80,9 +89,53 @@ describe('commentRecordToRow', () => {
 			}),
 			editedAt: 1600,
 		}
-		const row = commentRecordToRow(comment, undefined, 'file1', 44)
+		const row = commentRecordToRow(comment, 'file1', 44)
+		expect(row.editedAt).toBe(1600)
 		expect(row.updatedAt).toBe(1600)
-		expect(row.shapeId).toBeNull()
+	})
+})
+
+describe('round-trip: record -> row -> rowTo*Record', () => {
+	it('resolved shape-anchored thread', () => {
+		const thread = { ...makeThread(), resolved: { at: 2000, by: 'user2' } }
+		const row = threadRecordToRow(thread, 'file1', 42)
+		expect(rowToThreadRecord(row)).toEqual(thread)
+	})
+
+	it('open point-anchored thread', () => {
+		const thread = makeThread({ type: 'point', x: 10, y: 20 } as any)
+		const row = threadRecordToRow(thread, 'file1', 1)
+		expect(rowToThreadRecord(row)).toEqual(thread)
+	})
+
+	it('unedited comment', () => {
+		const thread = makeThread()
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			body,
+			now: 1500,
+		})
+		const row = commentRecordToRow(comment, 'file1', 43)
+		expect(rowToCommentRecord(row)).toEqual(comment)
+	})
+
+	it('edited comment with non-empty meta', () => {
+		const thread = makeThread()
+		const comment = {
+			...createComment({
+				threadId: thread.id,
+				pageId,
+				authorId: 'user1',
+				body,
+				now: 1500,
+				meta: { pinned: true },
+			}),
+			editedAt: 1600,
+		}
+		const row = commentRecordToRow(comment, 'file1', 44)
+		expect(rowToCommentRecord(row)).toEqual(comment)
 	})
 })
 
@@ -97,18 +150,40 @@ describe('rowsToSnapshotDocuments', () => {
 			now: 1500,
 		})
 		const threadRow = threadRecordToRow(thread, 'file1', 42)
-		const commentRow = commentRecordToRow(comment, thread, 'file1', 43)
+		const commentRow = commentRecordToRow(comment, 'file1', 43)
 		expect(rowsToSnapshotDocuments([threadRow], [commentRow])).toEqual([
 			{ state: thread, lastChangedClock: 42 },
 			{ state: comment, lastChangedClock: 43 },
 		])
 	})
 
-	it('coerces bigint-as-string clocks from pg to numbers', () => {
-		const thread = makeThread()
-		const threadRow = { ...threadRecordToRow(thread, 'file1', 42), lastChangedClock: '42' as any }
-		expect(rowsToSnapshotDocuments([threadRow], [])).toEqual([
+	it('coerces pg bigint-as-string clocks and timestamps to numbers', () => {
+		const thread = { ...makeThread(), resolved: { at: 2000, by: 'user2' } }
+		const comment = {
+			...createComment({
+				threadId: thread.id,
+				pageId,
+				authorId: 'user1',
+				body,
+				now: 1500,
+			}),
+			editedAt: 1600,
+		}
+		const threadRow = {
+			...threadRecordToRow(thread, 'file1', 42),
+			createdAt: '1000' as any,
+			resolvedAt: '2000' as any,
+			lastChangedClock: '42' as any,
+		}
+		const commentRow = {
+			...commentRecordToRow(comment, 'file1', 43),
+			createdAt: '1500' as any,
+			editedAt: '1600' as any,
+			lastChangedClock: '43' as any,
+		}
+		expect(rowsToSnapshotDocuments([threadRow], [commentRow])).toEqual([
 			{ state: thread, lastChangedClock: 42 },
+			{ state: comment, lastChangedClock: 43 },
 		])
 	})
 })

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -1,3 +1,4 @@
+import { RoomSnapshot } from '@tldraw/sync-core'
 import {
 	createComment,
 	createCommentThread,
@@ -8,6 +9,7 @@ import {
 import { describe, expect, it } from 'vitest'
 import {
 	commentRecordToRow,
+	mergeCommentDocumentsIntoSnapshot,
 	rowsToSnapshotDocuments,
 	rowToCommentRecord,
 	rowToThreadRecord,
@@ -185,5 +187,65 @@ describe('rowsToSnapshotDocuments', () => {
 			{ state: thread, lastChangedClock: 42 },
 			{ state: comment, lastChangedClock: 43 },
 		])
+	})
+})
+
+describe('mergeCommentDocumentsIntoSnapshot', () => {
+	function makeDocs(...clocks: number[]): RoomSnapshot['documents'] {
+		return clocks.map((clock) => ({
+			state: makeThread(),
+			lastChangedClock: clock,
+		}))
+	}
+
+	function makeSnapshot(overrides: Partial<RoomSnapshot> = {}): RoomSnapshot {
+		return { documentClock: 10, documents: makeDocs(10), ...overrides }
+	}
+
+	it('merges docs and clamps documentClock up when a comment clock exceeds it', () => {
+		const snapshot = makeSnapshot({ documentClock: 10 })
+		const docs = makeDocs(5, 42)
+		mergeCommentDocumentsIntoSnapshot(snapshot, docs)
+		expect(snapshot.documentClock).toBe(42)
+		expect(snapshot.documents).toHaveLength(3)
+		expect(snapshot.documents.slice(1)).toEqual(docs)
+	})
+
+	it('leaves documentClock alone when all comment clocks are at or below it', () => {
+		const snapshot = makeSnapshot({ documentClock: 10 })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(3, 10))
+		expect(snapshot.documentClock).toBe(10)
+		expect(snapshot.documents).toHaveLength(3)
+	})
+
+	it('no-ops on empty comment docs', () => {
+		const snapshot = makeSnapshot({ documentClock: 10 })
+		const documents = snapshot.documents
+		mergeCommentDocumentsIntoSnapshot(snapshot, [])
+		expect(snapshot.documentClock).toBe(10)
+		expect(snapshot.documents).toBe(documents)
+	})
+
+	it('clamps both clocks when a legacy snapshot has clock and documentClock below', () => {
+		const snapshot = makeSnapshot({ clock: 12, documentClock: 10 })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(42))
+		expect(snapshot.documentClock).toBe(42)
+		expect(snapshot.clock).toBe(42)
+	})
+
+	it('does not lower the effective seed for a clock-only snapshot already above the comments', () => {
+		// SQLiteSyncStorage seeds from documentClock ?? clock; introducing a lower documentClock
+		// here would shadow the higher legacy clock and regress the seed
+		const snapshot = makeSnapshot({ clock: 100, documentClock: undefined })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(42))
+		expect(snapshot.documentClock).toBeUndefined()
+		expect(snapshot.clock).toBe(100)
+	})
+
+	it('clamps documentClock but not a clock already above the comments', () => {
+		const snapshot = makeSnapshot({ clock: 100, documentClock: 10 })
+		mergeCommentDocumentsIntoSnapshot(snapshot, makeDocs(42))
+		expect(snapshot.documentClock).toBe(42)
+		expect(snapshot.clock).toBe(100)
 	})
 })

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -1,12 +1,15 @@
 import { DB } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { TLComment, TLCommentThread, TLRecord } from '@tldraw/tlschema'
+import { TLComment, TLCommentAnchor, TLCommentThread } from '@tldraw/tlschema'
+import { JsonObject } from '@tldraw/utils'
 
 /**
  * Conversions between the room's comment records and their Postgres rows. Postgres is the sole
- * durable store for comment records: `record` (jsonb) holds the exact serialized TLRecord and
- * `lastChangedClock` its sync clock, so the Durable Object can rehydrate its room losslessly on
- * cold start. The remaining columns are denormalized copies for app-level Zero queries.
+ * durable store for comment records: the columns collectively carry every record field, so the
+ * Durable Object can rebuild the records losslessly on cold start (`rowTo*Record`), and the
+ * Zero-visible subset serves app-level queries. `lastChangedClock` preserves each record's sync
+ * clock across reloads and guards upserts against no-op replays. Timestamps and clocks come back
+ * from pg's bigint parsing as strings, so reads coerce with Number().
  */
 
 export function threadRecordToRow(
@@ -18,18 +21,19 @@ export function threadRecordToRow(
 		id: record.id,
 		fileId,
 		pageId: record.pageId,
+		anchor: record.anchor,
 		shapeId: record.anchor.type === 'shape' ? record.anchor.shapeId : null,
-		resolved: record.resolved !== null,
+		resolvedAt: record.resolved?.at ?? null,
+		resolvedBy: record.resolved?.by ?? null,
 		createdBy: record.createdBy,
 		createdAt: record.createdAt,
-		record,
+		meta: record.meta,
 		lastChangedClock,
 	}
 }
 
 export function commentRecordToRow(
 	record: TLComment,
-	thread: TLCommentThread | undefined,
 	fileId: string,
 	lastChangedClock: number
 ): DB['comment'] {
@@ -39,28 +43,60 @@ export function commentRecordToRow(
 		threadId: record.threadId,
 		pageId: record.pageId,
 		authorId: record.authorId,
-		shapeId: thread?.anchor.type === 'shape' ? thread.anchor.shapeId : null,
-		// rich text stored as-is (JSONB) — preserves the authoritative representation. TLRichText
-		// types its content as unknown[], which doesn't structurally satisfy zero's
-		// ReadonlyJSONValue, but the value is schema-validated JSON.
+		// rich text stored as-is (JSONB). TLRichText types its content as unknown[], which doesn't
+		// structurally satisfy zero's ReadonlyJSONValue, but the value is schema-validated JSON.
 		body: record.body as DB['comment']['body'],
 		createdAt: record.createdAt,
+		editedAt: record.editedAt,
 		updatedAt: record.editedAt ?? record.createdAt,
-		record,
+		meta: record.meta,
 		lastChangedClock,
+	}
+}
+
+export function rowToThreadRecord(row: DB['comment_thread']): TLCommentThread {
+	return {
+		id: row.id as TLCommentThread['id'],
+		typeName: 'comment-thread',
+		pageId: row.pageId as TLCommentThread['pageId'],
+		anchor: row.anchor as TLCommentAnchor,
+		createdBy: row.createdBy,
+		createdAt: Number(row.createdAt),
+		resolved: row.resolvedAt != null ? { at: Number(row.resolvedAt), by: row.resolvedBy! } : null,
+		meta: (row.meta ?? {}) as JsonObject,
+	}
+}
+
+export function rowToCommentRecord(row: DB['comment']): TLComment {
+	return {
+		id: row.id as TLComment['id'],
+		typeName: 'comment',
+		threadId: row.threadId as TLComment['threadId'],
+		pageId: row.pageId as TLComment['pageId'],
+		authorId: row.authorId,
+		createdAt: Number(row.createdAt),
+		editedAt: row.editedAt != null ? Number(row.editedAt) : null,
+		body: row.body as TLComment['body'],
+		meta: (row.meta ?? {}) as JsonObject,
 	}
 }
 
 /**
  * Rebuild object-lane snapshot documents from Postgres rows, for merging into the room snapshot
- * on load. Clocks come back as strings from pg's bigint parsing, so coerce.
+ * on load.
  */
 export function rowsToSnapshotDocuments(
 	threadRows: DB['comment_thread'][],
 	commentRows: DB['comment'][]
 ): RoomSnapshot['documents'] {
-	return [...threadRows, ...commentRows].map((row) => ({
-		state: row.record as TLRecord,
-		lastChangedClock: Number(row.lastChangedClock),
-	}))
+	return [
+		...threadRows.map((row) => ({
+			state: rowToThreadRecord(row),
+			lastChangedClock: Number(row.lastChangedClock),
+		})),
+		...commentRows.map((row) => ({
+			state: rowToCommentRecord(row),
+			lastChangedClock: Number(row.lastChangedClock),
+		})),
+	]
 }

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -1,0 +1,66 @@
+import { DB } from '@tldraw/dotcom-shared'
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { TLComment, TLCommentThread, TLRecord } from '@tldraw/tlschema'
+
+/**
+ * Conversions between the room's comment records and their Postgres rows. Postgres is the sole
+ * durable store for comment records: `record` (jsonb) holds the exact serialized TLRecord and
+ * `lastChangedClock` its sync clock, so the Durable Object can rehydrate its room losslessly on
+ * cold start. The remaining columns are denormalized copies for app-level Zero queries.
+ */
+
+export function threadRecordToRow(
+	record: TLCommentThread,
+	fileId: string,
+	lastChangedClock: number
+): DB['comment_thread'] {
+	return {
+		id: record.id,
+		fileId,
+		pageId: record.pageId,
+		shapeId: record.anchor.type === 'shape' ? record.anchor.shapeId : null,
+		resolved: record.resolved !== null,
+		createdBy: record.createdBy,
+		createdAt: record.createdAt,
+		record,
+		lastChangedClock,
+	}
+}
+
+export function commentRecordToRow(
+	record: TLComment,
+	thread: TLCommentThread | undefined,
+	fileId: string,
+	lastChangedClock: number
+): DB['comment'] {
+	return {
+		id: record.id,
+		fileId,
+		threadId: record.threadId,
+		pageId: record.pageId,
+		authorId: record.authorId,
+		shapeId: thread?.anchor.type === 'shape' ? thread.anchor.shapeId : null,
+		// rich text stored as-is (JSONB) — preserves the authoritative representation. TLRichText
+		// types its content as unknown[], which doesn't structurally satisfy zero's
+		// ReadonlyJSONValue, but the value is schema-validated JSON.
+		body: record.body as DB['comment']['body'],
+		createdAt: record.createdAt,
+		updatedAt: record.editedAt ?? record.createdAt,
+		record,
+		lastChangedClock,
+	}
+}
+
+/**
+ * Rebuild object-lane snapshot documents from Postgres rows, for merging into the room snapshot
+ * on load. Clocks come back as strings from pg's bigint parsing, so coerce.
+ */
+export function rowsToSnapshotDocuments(
+	threadRows: DB['comment_thread'][],
+	commentRows: DB['comment'][]
+): RoomSnapshot['documents'] {
+	return [...threadRows, ...commentRows].map((row) => ({
+		state: row.record as TLRecord,
+		lastChangedClock: Number(row.lastChangedClock),
+	}))
+}

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -60,8 +60,7 @@ export function commentRecordToRow(
 		threadId: record.threadId,
 		pageId: record.pageId,
 		authorId: record.authorId,
-		// rich text stored as-is (JSONB). TLRichText types its content as unknown[], which doesn't
-		// structurally satisfy zero's ReadonlyJSONValue, but the value is schema-validated JSON.
+		// TLRichText's content is unknown[], not structurally a zero ReadonlyJSONValue
 		body: record.body as DB['comment']['body'],
 		createdAt: record.createdAt,
 		editedAt: record.editedAt,

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -12,6 +12,23 @@ import { JsonObject } from '@tldraw/utils'
  * from pg's bigint parsing as strings, so reads coerce with Number().
  */
 
+/**
+ * True when `error` is Postgres rejecting a comment upsert because its author's user row no
+ * longer exists: foreign key violation (code 23503) on `comment_author_id_fkey`. Deleting a user
+ * cascades their comment rows away in Postgres (`ON DELETE CASCADE`), so hitting this means a
+ * warm room still holds comment records for a since-deleted author. The caller mirrors the
+ * cascade into the room by pruning those records instead of retrying the upsert forever.
+ *
+ * The error shape (`code`/`constraint`) is what node-postgres surfaces on `DatabaseError` and
+ * kysely rethrows unchanged; both fields must match so unrelated FK failures keep the normal
+ * at-least-once retry behavior.
+ */
+export function isCommentAuthorFkViolation(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) return false
+	const { code, constraint } = error as { code?: unknown; constraint?: unknown }
+	return code === '23503' && constraint === 'comment_author_id_fkey'
+}
+
 export function threadRecordToRow(
 	record: TLCommentThread,
 	fileId: string,

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -1,6 +1,12 @@
 import { DB } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { TLComment, TLCommentAnchor, TLCommentThread } from '@tldraw/tlschema'
+import {
+	TLComment,
+	TLCommentAnchor,
+	TLCommentThread,
+	commentRecordConfig,
+	commentThreadRecordConfig,
+} from '@tldraw/tlschema'
 import { JsonObject } from '@tldraw/utils'
 
 /**
@@ -8,8 +14,10 @@ import { JsonObject } from '@tldraw/utils'
  * durable store for comment records: the columns collectively carry every record field, so the
  * Durable Object can rebuild the records losslessly on cold start (`rowTo*Record`), and the
  * Zero-visible subset serves app-level queries. `lastChangedClock` preserves each record's sync
- * clock across reloads and guards upserts against no-op replays. Timestamps and clocks come back
- * from pg's bigint parsing as strings, so reads coerce with Number().
+ * clock across reloads and guards upserts against no-op replays. Timestamps and clocks are read
+ * through Number() as defense against driver/config drift: `postgres.ts` installs a global
+ * int8-to-number type parser today, so pg already returns bigints as numbers, but nothing else
+ * enforces that stays true.
  */
 
 /**
@@ -71,7 +79,7 @@ export function commentRecordToRow(
 }
 
 export function rowToThreadRecord(row: DB['comment_thread']): TLCommentThread {
-	return {
+	const record: TLCommentThread = {
 		id: row.id as TLCommentThread['id'],
 		typeName: 'comment-thread',
 		pageId: row.pageId as TLCommentThread['pageId'],
@@ -81,10 +89,13 @@ export function rowToThreadRecord(row: DB['comment_thread']): TLCommentThread {
 		resolved: row.resolvedAt != null ? { at: Number(row.resolvedAt), by: row.resolvedBy! } : null,
 		meta: (row.meta ?? {}) as JsonObject,
 	}
+	// The fields above are raw casts from the row; validate the finished record so a corrupt
+	// Postgres row fails the room open loudly instead of seeding an invalid record into the room.
+	return commentThreadRecordConfig.validator.validate(record) as TLCommentThread
 }
 
 export function rowToCommentRecord(row: DB['comment']): TLComment {
-	return {
+	const record: TLComment = {
 		id: row.id as TLComment['id'],
 		typeName: 'comment',
 		threadId: row.threadId as TLComment['threadId'],
@@ -95,6 +106,9 @@ export function rowToCommentRecord(row: DB['comment']): TLComment {
 		body: row.body as TLComment['body'],
 		meta: (row.meta ?? {}) as JsonObject,
 	}
+	// The fields above are raw casts from the row; validate the finished record so a corrupt
+	// Postgres row fails the room open loudly instead of seeding an invalid record into the room.
+	return commentRecordConfig.validator.validate(record) as TLComment
 }
 
 /**

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -129,6 +129,14 @@ export function rowsToSnapshotDocuments(
  * clamp based on that effective value (setting `documentClock` when only a higher legacy `clock`
  * was present would lower the seed, not raise it) and keep `clock` \>= `documentClock` when both
  * are set.
+ *
+ * When the clamp fires, the room is claiming a clock higher than anything the stale snapshot
+ * actually has history for — the delete/tombstone history between the snapshot's old clock and
+ * `maxClock` lived only in the DO's SQLite storage that we just lost, so it's genuinely gone, not
+ * merely unsynced. We raise `tombstoneHistoryStartsAtClock` to match so `wipeAll` fires for any
+ * client reconnecting with `sinceClock` short of `maxClock`: that forces a full resync instead of
+ * a partial incremental diff, which would otherwise let clients silently keep documents the
+ * server can no longer account for.
  */
 export function mergeCommentDocumentsIntoSnapshot(
 	snapshot: RoomSnapshot,
@@ -143,4 +151,5 @@ export function mergeCommentDocumentsIntoSnapshot(
 	if (snapshot.clock !== undefined && snapshot.clock < maxClock) {
 		snapshot.clock = maxClock
 	}
+	snapshot.tombstoneHistoryStartsAtClock = maxClock
 }

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -6,6 +6,8 @@ import {
 	TLCommentThread,
 	commentRecordConfig,
 	commentThreadRecordConfig,
+	isCommentId,
+	isCommentThreadId,
 } from '@tldraw/tlschema'
 import { JsonObject } from '@tldraw/utils'
 
@@ -129,6 +131,93 @@ export function rowsToSnapshotDocuments(
 			lastChangedClock: Number(row.lastChangedClock),
 		})),
 	]
+}
+
+/** A row of the DO's `comment_outbox` table: a monotonic sequence number and the touched record id. */
+export interface CommentOutboxEntry {
+	seq: number
+	recordId: string
+}
+
+/** The pure output of `planCommentDrain`: Postgres writes grouped by table and operation. */
+export interface CommentDrainPlan {
+	threadUpserts: DB['comment_thread'][]
+	commentUpserts: DB['comment'][]
+	threadDeletes: string[]
+	commentDeletes: string[]
+	/**
+	 * Ids that are neither comment nor comment-thread ids. The outbox should only ever contain
+	 * those, so an unknown id means a bug or a corrupted outbox row; it is reported here instead
+	 * of being misfiled into an upsert/delete bucket, and the caller decides how to surface it.
+	 */
+	unknownIds: string[]
+}
+
+/**
+ * The pure planning half of the comment outbox drain (see drainCommentOutbox in
+ * TLFileDurableObject). The outbox stores only ids; whether an id is an upsert or a delete is
+ * decided by its presence in the object `lane` at plan time, so multiple entries for one record
+ * coalesce into a single write (deduped by recordId, keeping first-occurrence order) and a
+ * create-then-delete nets out to a delete. Only ids present in `entries` are considered — the
+ * caller bounds the entries to its drain's high-water mark, and lane records outside that set
+ * belong to a later drain.
+ */
+export function planCommentDrain(
+	entries: CommentOutboxEntry[],
+	lane: ReadonlyMap<string, { state: unknown; lastChangedClock: number }>,
+	fileId: string
+): CommentDrainPlan {
+	const plan: CommentDrainPlan = {
+		threadUpserts: [],
+		commentUpserts: [],
+		threadDeletes: [],
+		commentDeletes: [],
+		unknownIds: [],
+	}
+	const pendingIds = new Set(entries.map((e) => e.recordId))
+	for (const id of pendingIds) {
+		const doc = lane.get(id)
+		if (isCommentThreadId(id)) {
+			if (doc) {
+				plan.threadUpserts.push(
+					threadRecordToRow(doc.state as TLCommentThread, fileId, doc.lastChangedClock)
+				)
+			} else {
+				plan.threadDeletes.push(id)
+			}
+		} else if (isCommentId(id)) {
+			if (doc) {
+				plan.commentUpserts.push(
+					commentRecordToRow(doc.state as TLComment, fileId, doc.lastChangedClock)
+				)
+			} else {
+				plan.commentDeletes.push(id)
+			}
+		} else {
+			plan.unknownIds.push(id)
+		}
+	}
+	return plan
+}
+
+/**
+ * Which outbox entries a finished drain may delete. Entries whose recordId is in `failedIds`
+ * are kept queued so the next drain retries them; everything else (including entries for pruned
+ * or unknown ids, where retrying can't help) is cleared. When nothing failed, `clearAll` is the
+ * fast path: the caller can bulk-clear everything up to its drain bound instead of deleting
+ * per-seq.
+ */
+export function outboxEntriesToClear(
+	entries: CommentOutboxEntry[],
+	failedIds: ReadonlySet<string>
+): { clearAll: boolean; seqs: number[] } {
+	if (failedIds.size === 0) {
+		return { clearAll: true, seqs: [] }
+	}
+	return {
+		clearAll: false,
+		seqs: entries.filter((e) => !failedIds.has(e.recordId)).map((e) => e.seq),
+	}
 }
 
 /**

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -100,3 +100,30 @@ export function rowsToSnapshotDocuments(
 		})),
 	]
 }
+
+/**
+ * Merge rehydrated comment documents into a room snapshot, clamping the snapshot's clocks up to
+ * the highest merged clock. Comments push to Postgres per-commit while the document snapshot
+ * persists on a throttle, so after a storage loss the comment clocks can be ahead of the
+ * snapshot's — seeding the room clock below them would make future edits emit clocks the drain's
+ * lastChangedClock guard rejects, silently dropping those edits from Postgres.
+ *
+ * `SQLiteSyncStorage` seeds its clock from `snapshot.documentClock ?? snapshot.clock ?? 0`, so we
+ * clamp based on that effective value (setting `documentClock` when only a higher legacy `clock`
+ * was present would lower the seed, not raise it) and keep `clock` \>= `documentClock` when both
+ * are set.
+ */
+export function mergeCommentDocumentsIntoSnapshot(
+	snapshot: RoomSnapshot,
+	commentDocs: RoomSnapshot['documents']
+): void {
+	if (commentDocs.length === 0) return
+	snapshot.documents = [...snapshot.documents, ...commentDocs]
+	const maxClock = Math.max(...commentDocs.map((d) => d.lastChangedClock))
+	const effectiveClock = snapshot.documentClock ?? snapshot.clock ?? 0
+	if (effectiveClock >= maxClock) return
+	snapshot.documentClock = maxClock
+	if (snapshot.clock !== undefined && snapshot.clock < maxClock) {
+		snapshot.clock = maxClock
+	}
+}

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -116,6 +116,7 @@ export type TLServerEvent =
 				| 'failed_load_from_db'
 				| 'failed_persist_to_db'
 				| 'failed_persist_comments_to_db'
+				| 'comment_author_deleted_prune'
 				| 'room_empty'
 				| 'fail_persist'
 				| 'room_start'

--- a/apps/dotcom/zero-cache/migrations/038_add_comments.sql
+++ b/apps/dotcom/zero-cache/migrations/038_add_comments.sql
@@ -1,11 +1,33 @@
--- Comments projected from the file room's comment records (see TLComment) by the file Durable
--- Object. Zero replicates these per user so an app-level, cross-document view can query them. The
--- authoritative comment content lives in the file's R2 comment lane; these rows are a derived copy.
--- `body` is the comment's rich text (TLRichText JSON) — the projection preserves the authoritative
--- representation; consumers flatten to plaintext for display where needed.
--- `threadId`/`pageId` are denormalized from the comment record so the view can group by thread
--- and deep-link to the right page without a join. `shapeId` is only set for shape-anchored
--- threads (see TLCommentAnchor); other anchor kinds leave it null.
+-- Comments for app files, written by the file's Durable Object from the room's comment records
+-- (see TLComment / TLCommentThread in tlschema). Postgres is the sole durable store for comment
+-- records: `record` holds the exact serialized TLRecord so the Durable Object can rehydrate its
+-- room on cold start, and `lastChangedClock` preserves the record's sync clock and guards upserts
+-- against no-op replays (an update that doesn't advance the clock is skipped, producing no WAL
+-- entry for Zero). The other columns are denormalized for app-level Zero queries;
+-- `record`/`lastChangedClock` are not declared in the Zero schema, so they never reach clients.
+
+CREATE TABLE comment_thread (
+  "id" VARCHAR PRIMARY KEY,
+  "fileId" VARCHAR NOT NULL,
+  "pageId" VARCHAR NOT NULL,
+  -- only set for shape-anchored threads (see TLCommentAnchor); other anchor kinds leave it null
+  "shapeId" VARCHAR,
+  "resolved" BOOLEAN NOT NULL DEFAULT FALSE,
+  -- no FK to "user": deleting a user must not cascade-delete threads (and thereby other
+  -- authors' comments); the comment table's authorId FK handles per-author cleanup
+  "createdBy" VARCHAR NOT NULL,
+  "createdAt" BIGINT NOT NULL,
+  "record" JSONB NOT NULL,
+  "lastChangedClock" BIGINT NOT NULL,
+  CONSTRAINT comment_thread_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX comment_thread_file_id_idx ON comment_thread("fileId");
+
+-- `body` is the comment's rich text (TLRichText JSON) — preserved as-is; consumers flatten to
+-- plaintext for display where needed. `threadId`/`pageId` are denormalized from the comment
+-- record so the app-level view can group by thread and deep-link to the right page without a
+-- join. `shapeId` is only set for shape-anchored threads.
 CREATE TABLE comment (
   "id" VARCHAR PRIMARY KEY,
   "fileId" VARCHAR NOT NULL,
@@ -16,8 +38,11 @@ CREATE TABLE comment (
   "body" JSONB NOT NULL,
   "createdAt" BIGINT NOT NULL,
   "updatedAt" BIGINT NOT NULL,
+  "record" JSONB NOT NULL,
+  "lastChangedClock" BIGINT NOT NULL,
   CONSTRAINT comment_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
-  CONSTRAINT comment_author_id_fkey FOREIGN KEY ("authorId") REFERENCES public."user"("id") ON DELETE CASCADE
+  CONSTRAINT comment_author_id_fkey FOREIGN KEY ("authorId") REFERENCES public."user"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_thread_id_fkey FOREIGN KEY ("threadId") REFERENCES public."comment_thread"("id") ON DELETE CASCADE
 );
 
 CREATE INDEX comment_file_id_idx ON comment("fileId");
@@ -25,4 +50,5 @@ CREATE INDEX comment_thread_id_idx ON comment("threadId");
 CREATE INDEX comment_author_id_idx ON comment("authorId");
 
 -- Replicate to Zero (matches how 023_groups.sql added the group tables).
+ALTER PUBLICATION zero_data ADD TABLE public."comment_thread";
 ALTER PUBLICATION zero_data ADD TABLE public."comment";

--- a/apps/dotcom/zero-cache/migrations/038_add_comments.sql
+++ b/apps/dotcom/zero-cache/migrations/038_add_comments.sql
@@ -23,7 +23,11 @@ CREATE TABLE comment_thread (
   "createdAt" BIGINT NOT NULL,
   "meta" JSONB NOT NULL,
   "lastChangedClock" BIGINT NOT NULL,
-  CONSTRAINT comment_thread_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE
+  CONSTRAINT comment_thread_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
+  -- resolvedAt/resolvedBy encode one nullable `resolved` record field, so they must be set or
+  -- null together; rehydration (rowToThreadRecord) relies on resolvedBy being non-null whenever
+  -- resolvedAt is
+  CONSTRAINT comment_thread_resolved_check CHECK (("resolvedAt" IS NULL) = ("resolvedBy" IS NULL))
 );
 
 CREATE INDEX comment_thread_file_id_idx ON comment_thread("fileId");

--- a/apps/dotcom/zero-cache/migrations/038_add_comments.sql
+++ b/apps/dotcom/zero-cache/migrations/038_add_comments.sql
@@ -1,44 +1,45 @@
 -- Comments for app files, written by the file's Durable Object from the room's comment records
 -- (see TLComment / TLCommentThread in tlschema). Postgres is the sole durable store for comment
--- records: `record` holds the exact serialized TLRecord so the Durable Object can rehydrate its
--- room on cold start, and `lastChangedClock` preserves the record's sync clock and guards upserts
--- against no-op replays (an update that doesn't advance the clock is skipped, producing no WAL
--- entry for Zero). The other columns are denormalized for app-level Zero queries;
--- `record`/`lastChangedClock` are not declared in the Zero schema, so they never reach clients.
+-- records: the columns collectively carry every record field, so the Durable Object can rebuild
+-- its room's comment records from rows alone on cold start. `lastChangedClock` preserves each
+-- record's sync clock across reloads and guards upserts against no-op replays (an update that
+-- doesn't advance the clock is skipped, producing no WAL entry for Zero). `anchor`, `meta`,
+-- `resolvedBy`, `editedAt`, and `lastChangedClock` are persistence/rehydration columns not
+-- declared in the Zero schema, so they never reach clients.
 
 CREATE TABLE comment_thread (
   "id" VARCHAR PRIMARY KEY,
   "fileId" VARCHAR NOT NULL,
   "pageId" VARCHAR NOT NULL,
-  -- only set for shape-anchored threads (see TLCommentAnchor); other anchor kinds leave it null
+  -- the thread's TLCommentAnchor (discriminated union) as JSON — canonical, used to rebuild the record
+  "anchor" JSONB NOT NULL,
+  -- denormalized from anchor for queries; only set for shape-anchored threads
   "shapeId" VARCHAR,
-  "resolved" BOOLEAN NOT NULL DEFAULT FALSE,
+  "resolvedAt" BIGINT,
+  "resolvedBy" VARCHAR,
   -- no FK to "user": deleting a user must not cascade-delete threads (and thereby other
   -- authors' comments); the comment table's authorId FK handles per-author cleanup
   "createdBy" VARCHAR NOT NULL,
   "createdAt" BIGINT NOT NULL,
-  "record" JSONB NOT NULL,
+  "meta" JSONB NOT NULL,
   "lastChangedClock" BIGINT NOT NULL,
   CONSTRAINT comment_thread_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE
 );
 
 CREATE INDEX comment_thread_file_id_idx ON comment_thread("fileId");
 
--- `body` is the comment's rich text (TLRichText JSON) — preserved as-is; consumers flatten to
--- plaintext for display where needed. `threadId`/`pageId` are denormalized from the comment
--- record so the app-level view can group by thread and deep-link to the right page without a
--- join. `shapeId` is only set for shape-anchored threads.
 CREATE TABLE comment (
   "id" VARCHAR PRIMARY KEY,
   "fileId" VARCHAR NOT NULL,
   "threadId" VARCHAR NOT NULL,
   "pageId" VARCHAR NOT NULL,
   "authorId" VARCHAR NOT NULL,
-  "shapeId" VARCHAR,
   "body" JSONB NOT NULL,
   "createdAt" BIGINT NOT NULL,
+  -- null until first edited (exact record field; updatedAt below is the derived sort key)
+  "editedAt" BIGINT,
   "updatedAt" BIGINT NOT NULL,
-  "record" JSONB NOT NULL,
+  "meta" JSONB NOT NULL,
   "lastChangedClock" BIGINT NOT NULL,
   CONSTRAINT comment_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
   CONSTRAINT comment_author_id_fkey FOREIGN KEY ("authorId") REFERENCES public."user"("id") ON DELETE CASCADE,
@@ -49,6 +50,5 @@ CREATE INDEX comment_file_id_idx ON comment("fileId");
 CREATE INDEX comment_thread_id_idx ON comment("threadId");
 CREATE INDEX comment_author_id_idx ON comment("authorId");
 
--- Replicate to Zero (matches how 023_groups.sql added the group tables).
 ALTER PUBLICATION zero_data ADD TABLE public."comment_thread";
 ALTER PUBLICATION zero_data ADD TABLE public."comment";

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -50,6 +50,7 @@ export const queries = defineQueries({
 			)
 			.related('author', (author) => author.one())
 			.related('file', (file) => file.one())
+			.related('thread', (thread) => thread.one())
 	),
 })
 

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -121,13 +121,16 @@ export const group_file = table('group_file')
 	})
 	.primaryKey('fileId', 'groupId')
 
-// Projected from the `comment` document record (see TLComment in tlschema) by the file's Durable
-// Object. Zero replicates these per user so the app-level /comments view can query comments across
-// all accessible files. Postgres is the sole durable store for comment records (the Durable Object
-// rehydrates its room from these tables); the in-document view reads from the file room. Clients
-// never mutate this table (server-written only).
+// Columns are the sole canonical store for comment records: Postgres holds every field of the
+// TLComment record (see commentRows.ts in sync-worker for the full column set, including the
+// sync-worker-only persistence columns), and this table declares the client-visible subset that
+// Zero replicates per user so the app-level /comments view can query comments across all
+// accessible files. The in-document view reads from the file room, not this table. Clients never
+// mutate this table (server-written only).
 // `body` is the comment's rich text (TLRichText JSON) — the projection preserves the authoritative
-// representation; consumers flatten to plaintext for display where needed.
+// representation; consumers flatten to plaintext for display where needed. The comment's thread
+// (anchor, resolution) is available via the `thread` relationship rather than a denormalized
+// `shapeId` column here, since a thread can be re-anchored after the comment is created.
 export const comment = table('comment')
 	.columns({
 		id: string(),
@@ -135,18 +138,17 @@ export const comment = table('comment')
 		threadId: string(),
 		pageId: string(),
 		authorId: string(),
-		// only set for shape-anchored threads; other anchor kinds have no shape
-		shapeId: string().optional(),
 		body: json(),
 		createdAt: number(),
 		updatedAt: number(),
 	})
 	.primaryKey('id')
 
-// The comment's thread: anchor location and resolution state, denormalized for app-level Zero
+// The comment thread's anchor location and resolution state, denormalized for app-level Zero
 // queries (e.g. filtering resolved threads). Server-written only, like `comment`. The Postgres
-// table also carries `record`/`lastChangedClock` persistence columns (see CommentPersistenceColumns)
-// which are deliberately absent here so they never replicate to clients.
+// table also carries `anchor`/`resolvedBy`/`meta`/`lastChangedClock` persistence columns (see
+// CommentThreadPersistenceColumns) which are deliberately absent here so they never replicate to
+// clients.
 export const comment_thread = table('comment_thread')
 	.columns({
 		id: string(),
@@ -154,7 +156,7 @@ export const comment_thread = table('comment_thread')
 		pageId: string(),
 		// only set for shape-anchored threads; other anchor kinds have no shape
 		shapeId: string().optional(),
-		resolved: boolean(),
+		resolvedAt: number().optional(),
 		createdBy: string(),
 		createdAt: number(),
 	})
@@ -255,6 +257,11 @@ const commentRelationships = relationships(comment, ({ one }) => ({
 		sourceField: ['authorId'],
 		destField: ['id'],
 		destSchema: user,
+	}),
+	thread: one({
+		sourceField: ['threadId'],
+		destField: ['id'],
+		destSchema: comment_thread,
 	}),
 }))
 
@@ -362,12 +369,20 @@ export interface TlaWelcomeTemplate {
 }
 
 /**
- * Sync-worker-only persistence columns on the comment tables. `record` is the exact serialized
- * TLRecord (jsonb) used to rehydrate the file room; `lastChangedClock` is its sync clock. Absent
- * from the Zero table definitions above, so Zero never replicates them to clients.
+ * Sync-worker-only persistence columns, absent from the Zero table definitions above so they
+ * never replicate to clients. Together with the Zero-visible columns they carry every field of
+ * the corresponding TLRecord, so the file's Durable Object can rebuild its room's comment
+ * records from rows alone (see commentRows.ts in sync-worker).
  */
+export interface CommentThreadPersistenceColumns {
+	anchor: unknown
+	resolvedBy: string | null
+	meta: unknown
+	lastChangedClock: number
+}
 export interface CommentPersistenceColumns {
-	record: unknown
+	editedAt: number | null
+	meta: unknown
 	lastChangedClock: number
 }
 
@@ -382,7 +397,7 @@ export interface DB {
 	asset: TlaAsset
 	welcome_template: TlaWelcomeTemplate
 	comment: TlaComment & CommentPersistenceColumns
-	comment_thread: TlaCommentThread & CommentPersistenceColumns
+	comment_thread: TlaCommentThread & CommentThreadPersistenceColumns
 }
 
 export const schema = createSchema({

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -121,15 +121,10 @@ export const group_file = table('group_file')
 	})
 	.primaryKey('fileId', 'groupId')
 
-// Columns are the sole canonical store for comment records: Postgres holds every field of the
-// TLComment record (see commentRows.ts in sync-worker for the full column set, including the
-// sync-worker-only persistence columns), and this table declares the client-visible subset that
-// Zero replicates per user so the app-level /comments view can query comments across all
-// accessible files. The in-document view reads from the file room, not this table. Clients never
-// mutate this table (server-written only).
-// `body` is the comment's rich text (TLRichText JSON) — the projection preserves the authoritative
-// representation; consumers flatten to plaintext for display where needed. The comment's thread
-// (anchor, resolution) is available via the `thread` relationship rather than a denormalized
+// Client-visible subset of the comment record; the full column set (incl. persistence-only
+// columns) lives in commentRows.ts in sync-worker. Zero replicates this per user for the
+// app-level /comments view; the in-document view reads from the file room instead. Server-written
+// only. Thread anchor/resolution is read via the `thread` relationship rather than a denormalized
 // `shapeId` column here, since a thread can be re-anchored after the comment is created.
 export const comment = table('comment')
 	.columns({
@@ -144,11 +139,10 @@ export const comment = table('comment')
 	})
 	.primaryKey('id')
 
-// The comment thread's anchor location and resolution state, denormalized for app-level Zero
-// queries (e.g. filtering resolved threads). Server-written only, like `comment`. The Postgres
-// table also carries `anchor`/`resolvedBy`/`meta`/`lastChangedClock` persistence columns (see
-// CommentThreadPersistenceColumns) which are deliberately absent here so they never replicate to
-// clients.
+// The comment thread's anchor location and resolution state, for app-level Zero queries (e.g.
+// filtering resolved threads). Server-written only. Persistence-only columns
+// (CommentThreadPersistenceColumns: anchor/resolvedBy/meta/lastChangedClock) are deliberately
+// absent here so they never replicate to clients.
 export const comment_thread = table('comment_thread')
 	.columns({
 		id: string(),

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -121,8 +121,8 @@ export const group_file = table('group_file')
 	})
 	.primaryKey('fileId', 'groupId')
 
-// Client-visible subset of the comment record; the full column set (incl. persistence-only
-// columns) lives in commentRows.ts in sync-worker. Zero replicates this per user for the
+// Client-visible subset of the comment record; the full column set adds the persistence-only
+// columns (see CommentPersistenceColumns and DB below). Zero replicates this per user for the
 // app-level /comments view; the in-document view reads from the file room instead. Server-written
 // only. Thread anchor/resolution is read via the `thread` relationship rather than a denormalized
 // `shapeId` column here, since a thread can be re-anchored after the comment is created.

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -123,8 +123,9 @@ export const group_file = table('group_file')
 
 // Projected from the `comment` document record (see TLComment in tlschema) by the file's Durable
 // Object. Zero replicates these per user so the app-level /comments view can query comments across
-// all accessible files. The authoritative comment content lives in the file's R2 comment lane; the
-// in-document view reads from the file room. Clients never mutate this table (server-written only).
+// all accessible files. Postgres is the sole durable store for comment records (the Durable Object
+// rehydrates its room from these tables); the in-document view reads from the file room. Clients
+// never mutate this table (server-written only).
 // `body` is the comment's rich text (TLRichText JSON) — the projection preserves the authoritative
 // representation; consumers flatten to plaintext for display where needed.
 export const comment = table('comment')
@@ -139,6 +140,23 @@ export const comment = table('comment')
 		body: json(),
 		createdAt: number(),
 		updatedAt: number(),
+	})
+	.primaryKey('id')
+
+// The comment's thread: anchor location and resolution state, denormalized for app-level Zero
+// queries (e.g. filtering resolved threads). Server-written only, like `comment`. The Postgres
+// table also carries `record`/`lastChangedClock` persistence columns (see CommentPersistenceColumns)
+// which are deliberately absent here so they never replicate to clients.
+export const comment_thread = table('comment_thread')
+	.columns({
+		id: string(),
+		fileId: string(),
+		pageId: string(),
+		// only set for shape-anchored threads; other anchor kinds have no shape
+		shapeId: string().optional(),
+		resolved: boolean(),
+		createdBy: string(),
+		createdAt: number(),
 	})
 	.primaryKey('id')
 
@@ -240,6 +258,14 @@ const commentRelationships = relationships(comment, ({ one }) => ({
 	}),
 }))
 
+const commentThreadRelationships = relationships(comment_thread, ({ one }) => ({
+	file: one({
+		sourceField: ['fileId'],
+		destField: ['id'],
+		destSchema: file,
+	}),
+}))
+
 export type TlaFilePartial = Partial<TlaFile> & {
 	id: TlaFile['id']
 }
@@ -270,6 +296,10 @@ export type TlaCommentPartial = Partial<TlaComment> & {
 	id: TlaComment['id']
 }
 
+export type TlaCommentThreadPartial = Partial<TlaCommentThread> & {
+	id: TlaCommentThread['id']
+}
+
 export type TlaRow =
 	| TlaFile
 	| TlaFileState
@@ -278,6 +308,7 @@ export type TlaRow =
 	| TlaGroupUser
 	| TlaGroupFile
 	| TlaComment
+	| TlaCommentThread
 export type TlaRowPartial =
 	| TlaFilePartial
 	| TlaFileStatePartial
@@ -286,6 +317,7 @@ export type TlaRowPartial =
 	| TlaGroupUserPartial
 	| TlaGroupFilePartial
 	| TlaCommentPartial
+	| TlaCommentThreadPartial
 export interface TlaUserMutationNumber {
 	userId: string
 	mutationNumber: number
@@ -329,6 +361,16 @@ export interface TlaWelcomeTemplate {
 	updatedAt: number
 }
 
+/**
+ * Sync-worker-only persistence columns on the comment tables. `record` is the exact serialized
+ * TLRecord (jsonb) used to rehydrate the file room; `lastChangedClock` is its sync clock. Absent
+ * from the Zero table definitions above, so Zero never replicates them to clients.
+ */
+export interface CommentPersistenceColumns {
+	record: unknown
+	lastChangedClock: number
+}
+
 export interface DB {
 	file: TlaFile
 	file_state: TlaFileState
@@ -339,11 +381,12 @@ export interface DB {
 	user_mutation_number: TlaUserMutationNumber
 	asset: TlaAsset
 	welcome_template: TlaWelcomeTemplate
-	comment: TlaComment
+	comment: TlaComment & CommentPersistenceColumns
+	comment_thread: TlaCommentThread & CommentPersistenceColumns
 }
 
 export const schema = createSchema({
-	tables: [user, file, file_state, group, group_user, group_file, comment],
+	tables: [user, file, file_state, group, group_user, group_file, comment, comment_thread],
 	relationships: [
 		fileRelationships,
 		fileStateRelationships,
@@ -351,6 +394,7 @@ export const schema = createSchema({
 		groupUserRelationships,
 		groupFileRelationships,
 		commentRelationships,
+		commentThreadRelationships,
 	],
 })
 
@@ -362,6 +406,7 @@ export type TlaGroup = Row<typeof schema.tables.group>
 export type TlaGroupUser = Row<typeof schema.tables.group_user>
 export type TlaGroupFile = Row<typeof schema.tables.group_file>
 export type TlaComment = Row<typeof schema.tables.comment>
+export type TlaCommentThread = Row<typeof schema.tables.comment_thread>
 
 // Permissions are now handled via Synced Queries in queries.ts
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -2,6 +2,7 @@ import { stringEnum } from '@tldraw/utils'
 import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaComment,
+	TlaCommentThread,
 	TlaFile,
 	TlaFileState,
 	TlaGroup,
@@ -127,6 +128,9 @@ export interface ZStoreData {
 	// so the polyfill never populates this. Present only so the CRUD types (generic over all schema
 	// tables) compile.
 	comment?: TlaComment[]
+	// Same as comment: never populated by the legacy polyfill store, present only for the
+	// generic CRUD types.
+	comment_thread?: TlaCommentThread[]
 	lsn: string
 }
 
@@ -152,6 +156,7 @@ export type ZTable =
 	| 'group_user'
 	| 'group_file'
 	| 'comment'
+	| 'comment_thread'
 
 export type ZEvent = 'insert' | 'update' | 'delete'
 

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -564,6 +564,12 @@ export function isBinding(record?: UnknownRecord): record is TLBinding;
 export function isBindingId(id?: string): id is TLBindingId;
 
 // @public
+export function isCommentId(id: string): id is TLCommentId;
+
+// @public
+export function isCommentThreadId(id: string): id is TLCommentThreadId;
+
+// @public
 export function isCustomRecord(typeName: string, record?: UnknownRecord): boolean;
 
 // @public

--- a/packages/tlschema/src/index.ts
+++ b/packages/tlschema/src/index.ts
@@ -124,6 +124,8 @@ export {
 	createCommentId,
 	createCommentThread,
 	createCommentThreadId,
+	isCommentId,
+	isCommentThreadId,
 	type TLComment,
 	type TLCommentAnchor,
 	type TLCommentId,

--- a/packages/tlschema/src/records/TLComment.test.ts
+++ b/packages/tlschema/src/records/TLComment.test.ts
@@ -6,8 +6,11 @@ import {
 	commentSchemaRecords,
 	commentThreadRecordConfig,
 	createComment,
+	createCommentId,
 	createCommentThread,
 	createCommentThreadId,
+	isCommentId,
+	isCommentThreadId,
 	TLCommentAnchor,
 } from './TLComment'
 import { TLPageId } from './TLPage'
@@ -129,6 +132,22 @@ describe('schema registration', () => {
 		const types = schema.types as Record<string, { scope: string } | undefined>
 		expect(types['comment-thread']?.scope).toBe('document')
 		expect(types['comment']?.scope).toBe('document')
+	})
+})
+
+describe('isCommentThreadId / isCommentId', () => {
+	it('isCommentThreadId accepts comment-thread ids and rejects everything else', () => {
+		expect(isCommentThreadId(createCommentThreadId())).toBe(true)
+		expect(isCommentThreadId(createCommentId())).toBe(false)
+		expect(isCommentThreadId('shape:box1')).toBe(false)
+		expect(isCommentThreadId('not-an-id')).toBe(false)
+	})
+
+	it('isCommentId accepts comment ids and rejects everything else, including comment-thread ids', () => {
+		expect(isCommentId(createCommentId())).toBe(true)
+		expect(isCommentId(createCommentThreadId())).toBe(false)
+		expect(isCommentId('shape:box1')).toBe(false)
+		expect(isCommentId('not-an-id')).toBe(false)
 	})
 })
 

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -3,7 +3,7 @@ import { JsonObject } from '@tldraw/utils'
 import { T } from '@tldraw/validate'
 import { idValidator } from '../misc/id-validator'
 import { richTextValidator, TLRichText } from '../misc/TLRichText'
-import { CustomRecordInfo, createCustomRecordId } from './TLCustomRecord'
+import { CustomRecordInfo, createCustomRecordId, isCustomRecordId } from './TLCustomRecord'
 import { TLPageId } from './TLPage'
 import { TLShapeId } from './TLShape'
 
@@ -231,6 +231,27 @@ export function createCommentThreadId(id?: string): TLCommentThreadId {
 /** @public */
 export function createCommentId(id?: string): TLCommentId {
 	return createCustomRecordId('comment', id) as TLCommentId
+}
+
+/**
+ * Type guard for `TLCommentThreadId`. Note `isCommentId` does not accept these: the prefixes
+ * are `comment-thread:` vs `comment:`, and the character after `comment` differs (`-` vs `:`),
+ * so the two never overlap.
+ *
+ * @public
+ */
+export function isCommentThreadId(id: string): id is TLCommentThreadId {
+	return isCustomRecordId('comment-thread', id)
+}
+
+/**
+ * Type guard for `TLCommentId`. See `isCommentThreadId` for why `comment-thread:...` ids are
+ * correctly rejected here.
+ *
+ * @public
+ */
+export function isCommentId(id: string): id is TLCommentId {
+	return isCustomRecordId('comment', id)
 }
 
 /**


### PR DESCRIPTION
In order to have a single durable store for dotcom canvas comments, this PR removes the R2 `${key}/comments` object lane and makes Postgres (the DB zero replicates from) the sole persistence for comment records. Comments still sync as records over the room websocket — guests, latency, and the commenting toolkit are unchanged; only where the file's Durable Object loads and stores them changes.

How it works:

- **Write path:** each committed diff appends touched comment/thread ids to a durable outbox in the DO's SQLite; a serialized drain pushes rows to Postgres with clock-guarded upserts (`WHERE lastChangedClock < excluded`), so replays are WAL-silent and zero sees no redundant mutations. Delivery is at-least-once: outbox entries clear only after Postgres acks, failed ids stay queued.
- **Read path:** on cold room open the DO merges the R2 document snapshot with comment records rebuilt from Postgres rows (the two fetches overlap, so PG adds no serial latency), clamping the snapshot clock up to the highest comment clock and declaring lost sync history so reconnecting clients full-resync instead of diverging.
- **Storage shape:** typed columns are the canonical store (no serialized record blob) — `anchor` jsonb, `resolvedAt`/`resolvedBy`, `editedAt`, `meta`, `lastChangedClock` — so record-shape changes have one migration surface. Persistence columns are absent from the zero schema and never replicate to clients. `comment.shapeId` is gone; the `/comments` inbox joins the new `comment_thread` table via a zero relationship instead (no cross-row staleness).
- **Restore:** restoring a document version now drops the file's comments (lane wipe + scoped outbox clear + Postgres delete, ordered so comments created mid-restore still persist).
- **User deletion:** when a drain hits the dead `authorId` FK after a user-row cascade, the comment is pruned from the live room, mirroring the cascade.

Migration 038 is edited in place (it never reached main).

> [!IMPORTANT]
> Deploy note: any database that ran the previous version of migration 038 (the commenting preview env, local dev stacks) must drop/recreate the comment tables — the old table shape makes every app room open fail. Locals: `yarn dev:clean` in zero-cache.

### Change type

- [x] `improvement`

### Test plan

1. Add comments/threads in a file → rows appear in `comment_thread`/`comment` with correct denormalized columns
2. Kill the dev worker (or open the file cold) → comments rehydrate from Postgres, edits to them persist
3. Restore an older document version → comments disappear from the canvas and from Postgres; comments added during/after restore survive
4. `/comments` inbox still lists comments with working shape deep-links (via the thread relation)

- [x] Unit tests

### API changes

- Added `isCommentId()` and `isCommentThreadId()` type guards to `@tldraw/tlschema`, symmetric with `createCommentId()`/`createCommentThreadId()`

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +94 / -11   |
| Tests           | +346 / -0   |
| Automated files | +6 / -0     |
| Apps            | +537 / -136 |
