### PR TITLE
feat(commenting): limited rich text for comment input and display

### DIFF
--- a/apps/component-studio/src/sketchbooks/flows/comment-flow.tsx
+++ b/apps/component-studio/src/sketchbooks/flows/comment-flow.tsx
@@ -1,9 +1,4 @@
-import {
-	CanvasComments,
-	commentToolComponents,
-	commentToolOverrides,
-	commentTools,
-} from '@tldraw/commenting/canvas'
+import { CanvasComments, commentToolOverrides, commentTools } from '@tldraw/commenting/canvas'
 import { useMemo } from 'react'
 import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
 import './comment-flow.css'
@@ -25,7 +20,6 @@ export function CommentFlow() {
 	)
 	const components: TLComponents = useMemo(
 		() => ({
-			...commentToolComponents,
 			InFrontOfTheCanvas: () => <CanvasComments currentUserId="me" resolveName={resolveName} />,
 		}),
 		[]

--- a/apps/component-studio/src/sketchbooks/scenarios/thread-scenarios.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/scenarios/thread-scenarios.sketchbook.tsx
@@ -5,7 +5,7 @@ import {
 	CommentText,
 	CommentThread,
 } from '@tldraw/commenting'
-import { TldrawUiIcon } from 'tldraw'
+import { TldrawUiIcon, toRichText } from 'tldraw'
 import { Sketch, Sketchbook } from '../../sketch'
 import './thread-scenarios.css'
 
@@ -212,7 +212,7 @@ export const Editing: Sketch<Record<string, never>> = {
 					<CommentComposer
 						author={card.author}
 						placeholder="Edit comment…"
-						value="Good call — updating it now."
+						value={toRichText('Good call — updating it now.')}
 						onChange={() => {}}
 						sendLabel="Save"
 					/>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -1,8 +1,4 @@
-import {
-	commentToolComponents,
-	commentToolOverrides,
-	commentTools,
-} from '@tldraw/commenting/canvas'
+import { commentToolOverrides, commentTools } from '@tldraw/commenting/canvas'
 import { TLCustomServerEvent, getLicenseKey } from '@tldraw/dotcom-shared'
 import { useSync } from '@tldraw/sync'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
@@ -287,7 +283,6 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const instanceComponents = useMemo((): TLComponents => {
 		return {
 			...components,
-			...commentToolComponents,
 			DebugMenu: () => <CustomDebugMenu />,
 			InFrontOfTheCanvas: CommentsOnCanvas,
 		}

--- a/internal/scripts/api-check.ts
+++ b/internal/scripts/api-check.ts
@@ -20,7 +20,7 @@ const packagesOurTypesCanDependOn = [
 
 // These packages use subpath exports which require moduleResolution: "bundler".
 // We pin to the workspace's resolved versions to avoid installing broken releases.
-const pinnedPackages = ['@tiptap/core', '@tiptap/react', '@tiptap/pm']
+const pinnedPackages = ['@tiptap/core', '@tiptap/react', '@tiptap/pm', '@tiptap/starter-kit']
 
 function getPinnedVersions(): string[] {
 	return pinnedPackages.map((pkg) => {

--- a/packages/commenting/package.json
+++ b/packages/commenting/package.json
@@ -50,6 +50,9 @@
 		"node": ">=22.12.0"
 	},
 	"dependencies": {
+		"@tiptap/core": "^3.12.1",
+		"@tiptap/pm": "^3.12.1",
+		"@tiptap/react": "^3.12.1",
 		"tldraw": "workspace:*"
 	}
 }

--- a/packages/commenting/src/canvas.ts
+++ b/packages/commenting/src/canvas.ts
@@ -5,7 +5,6 @@
 export { CommentBody, type CommentBodyProps } from './canvas/comment-body'
 export {
 	CommentTool,
-	commentToolComponents,
 	commentToolOverrides,
 	commentTools,
 	pendingComment,

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -56,6 +56,9 @@
 	z-index: var(--tl-layer-menus);
 	pointer-events: auto;
 	transform: translateY(8px);
+	/* The rich-text editor has no intrinsic width (unlike the old <input>), so give the floating
+	   placement composer a definite width or it collapses to nothing. */
+	width: 280px;
 }
 .cmt-canvas-composer .cmt-composer__field {
 	background: var(--tl-color-panel);

--- a/packages/commenting/src/canvas/comment-body.tsx
+++ b/packages/commenting/src/canvas/comment-body.tsx
@@ -1,18 +1,18 @@
 import { useMemo } from 'react'
-import { renderHtmlFromRichText, TLRichText, useEditor } from 'tldraw'
+import { TLRichText } from 'tldraw'
 import '../ui/comments.css'
+import { renderCommentHtml } from './comment-render'
 
 export interface CommentBodyProps {
 	richText: TLRichText
 }
 
 /**
- * Renders a comment's rich-text body read-only — the same path the text shape renders through
- * (`renderHtmlFromRichText`), so formatting (bold, links, lists) is preserved rather than
- * flattened. Use this as the `body` of a `CommentCard` on a canvas that has an editor.
+ * Renders a comment's rich-text body read-only through the limited comment extension set (no
+ * headings), so formatting (bold, links, lists, highlight) is preserved rather than flattened, and
+ * headings can never render. Use this as the `body` of a `CommentCard` on a canvas.
  */
 export function CommentBody({ richText }: CommentBodyProps) {
-	const editor = useEditor()
-	const html = useMemo(() => renderHtmlFromRichText(editor, richText), [editor, richText])
+	const html = useMemo(() => renderCommentHtml(richText), [richText])
 	return <div className="cmt-text" dangerouslySetInnerHTML={{ __html: html }} />
 }

--- a/packages/commenting/src/canvas/comment-render.test.ts
+++ b/packages/commenting/src/canvas/comment-render.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { EMPTY_COMMENT, isCommentEmpty } from '../ui/comment-extensions'
+import { renderCommentHtml, renderCommentPlaintext } from './comment-render'
+
+const doc = (...content: any[]) => ({ type: 'doc', content }) as any
+const para = (...content: any[]) => ({ type: 'paragraph', content })
+const text = (value: string, marks?: any[]) => ({
+	type: 'text',
+	text: value,
+	...(marks ? { marks } : {}),
+})
+
+describe('renderCommentHtml', () => {
+	it('preserves bold, links, and lists from the limited set', () => {
+		const html = renderCommentHtml(doc(para(text('hi', [{ type: 'bold' }]))))
+		expect(html).toContain('<strong>hi</strong>')
+
+		const list = renderCommentHtml(
+			doc({
+				type: 'bulletList',
+				content: [{ type: 'listItem', content: [para(text('one'))] }],
+			})
+		)
+		expect(list).toContain('<ul')
+		expect(list).toContain('one')
+	})
+
+	it('renders a heading node as a paragraph, never a heading', () => {
+		const html = renderCommentHtml(
+			doc({ type: 'heading', attrs: { level: 1 }, content: [text('Title')] })
+		)
+		expect(html).not.toMatch(/<h[1-6]/)
+		expect(html).toContain('<p')
+		expect(html).toContain('Title')
+	})
+})
+
+describe('renderCommentPlaintext', () => {
+	it('flattens paragraphs and demotes headings without throwing', () => {
+		const flat = renderCommentPlaintext(
+			doc({ type: 'heading', attrs: { level: 2 }, content: [text('Title')] }, para(text('body')))
+		)
+		expect(flat).toBe('Title\nbody')
+	})
+
+	it('returns an empty string for an empty body', () => {
+		expect(renderCommentPlaintext(EMPTY_COMMENT)).toBe('')
+	})
+})
+
+describe('isCommentEmpty', () => {
+	it('treats the empty seed and empty encodings as empty', () => {
+		expect(isCommentEmpty(EMPTY_COMMENT)).toBe(true)
+		expect(isCommentEmpty(doc())).toBe(true)
+		expect(isCommentEmpty(doc(para()))).toBe(true)
+	})
+
+	it('treats a body with text as non-empty', () => {
+		expect(isCommentEmpty(doc(para(text('hi'))))).toBe(false)
+	})
+})

--- a/packages/commenting/src/canvas/comment-render.ts
+++ b/packages/commenting/src/canvas/comment-render.ts
@@ -1,0 +1,54 @@
+import { generateHTML, generateText, JSONContent } from '@tiptap/core'
+import { TLRichText } from 'tldraw'
+import { commentTipTapExtensions, isCommentEmpty } from '../ui/comment-extensions'
+
+/**
+ * The comment extension set has no heading node, so a body that nonetheless contains one (e.g. a
+ * record created programmatically or synced from a client with a fuller set) would make TipTap
+ * throw on an unknown node type. Demote any heading to a paragraph first, so headings can never
+ * render as headings and rendering never crashes.
+ */
+function demoteHeadings(node: JSONContent): JSONContent {
+	const content = Array.isArray(node.content) ? node.content.map(demoteHeadings) : node.content
+	if (node.type === 'heading') {
+		const { attrs: _attrs, ...rest } = node
+		return { ...rest, type: 'paragraph', content }
+	}
+	return content === node.content ? node : { ...node, content }
+}
+
+const htmlCache = new WeakMap<TLRichText, string>()
+
+/**
+ * Render a comment body to HTML through the limited comment extension set (no headings), so a body
+ * always renders with comment formatting regardless of the host editor's rich-text config. Mirrors
+ * tldraw's `renderHtmlFromRichText`, including the empty-paragraph fix that keeps blank lines from
+ * collapsing.
+ */
+export function renderCommentHtml(richText: TLRichText): string {
+	const cached = htmlCache.get(richText)
+	if (cached !== undefined) return cached
+	const html = generateHTML(
+		demoteHeadings(richText as JSONContent),
+		commentTipTapExtensions
+	).replaceAll('<p dir="auto"></p>', '<p><br /></p>')
+	htmlCache.set(richText, html)
+	return html
+}
+
+const textCache = new WeakMap<TLRichText, string>()
+
+/**
+ * Flatten a comment body to plaintext through the limited comment extension set — paragraphs and
+ * list items separated by newlines. Used for previews (e.g. the sidebar) where formatting is dropped.
+ */
+export function renderCommentPlaintext(richText: TLRichText): string {
+	if (isCommentEmpty(richText)) return ''
+	const cached = textCache.get(richText)
+	if (cached !== undefined) return cached
+	const text = generateText(demoteHeadings(richText as JSONContent), commentTipTapExtensions, {
+		blockSeparator: '\n',
+	})
+	textCache.set(richText, text)
+	return text
+}

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -1,16 +1,4 @@
-import {
-	atom,
-	DefaultToolbar,
-	DefaultToolbarContent,
-	StateNode,
-	TldrawUiMenuItem,
-	TLCommentAnchor,
-	TLComponents,
-	TLUiOverrides,
-	useIsToolSelected,
-	useTools,
-	VecLike,
-} from 'tldraw'
+import { atom, StateNode, TLCommentAnchor, TLUiOverrides, VecLike } from 'tldraw'
 import { shapeAnchorAt } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
@@ -58,7 +46,8 @@ export class CommentTool extends StateNode {
 
 export const commentTools = [CommentTool]
 
-/** Registers the comment tool in the UI (icon, label, shortcut). Compose into your overrides. */
+/** Registers the comment tool in the UI (icon, label, shortcut). Compose into your overrides.
+ *  Once registered, tldraw's `DefaultToolbarContent` shows the comment button next to the eraser. */
 export const commentToolOverrides: TLUiOverrides = {
 	tools(editor, tools) {
 		tools.comment = {
@@ -69,20 +58,5 @@ export const commentToolOverrides: TLUiOverrides = {
 			onSelect: () => editor.setCurrentTool('comment'),
 		}
 		return tools
-	},
-}
-
-/** A Toolbar with the comment tool added after the default tools. Use as-is, or build your
- *  own toolbar with `tools.comment`. */
-export const commentToolComponents: TLComponents = {
-	Toolbar: (props) => {
-		const tools = useTools()
-		const isSelected = useIsToolSelected(tools.comment)
-		return (
-			<DefaultToolbar {...props}>
-				<DefaultToolbarContent />
-				<TldrawUiMenuItem {...tools.comment} isSelected={isSelected} />
-			</DefaultToolbar>
-		)
 	},
 }

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import {
+	type CSSProperties,
 	type PointerEvent as ReactPointerEvent,
 	ReactNode,
 	useEffect,
@@ -14,10 +15,12 @@ import {
 	Editor,
 	TLComment,
 	TLCommentThread,
+	TLRichText,
 	TldrawUiIcon,
-	toRichText,
 	useContainer,
 	useEditor,
+	usePassThroughMouseOverEvents,
+	usePassThroughWheelEvents,
 	useValue,
 } from 'tldraw'
 import { computeClusterTable } from '../clustering/computeClusterTable'
@@ -25,6 +28,7 @@ import { createClusterRuntime } from '../clustering/runtime'
 import type { ClusterNode, ClusterTable, MergeEvent } from '../clustering/types'
 import { CommentCard, CommentCardProps } from '../ui/comment-card'
 import { CommentComposer } from '../ui/comment-composer'
+import { EMPTY_COMMENT, isCommentEmpty } from '../ui/comment-extensions'
 import { CommentPin } from '../ui/comment-pin'
 import { CommentThread } from '../ui/comment-thread'
 import { CountBadge } from '../ui/count-badge'
@@ -32,7 +36,6 @@ import { collectClusterLeaves } from './cluster-input'
 import { CommentBody } from './comment-body'
 import { pendingComment, PendingComment } from './comment-tool'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
-import { richTextToPlaintext } from './rich-text'
 import { anchorPagePoint, openThreadId, shapeAnchorAt } from './thread-state'
 import './canvas.css'
 
@@ -99,6 +102,11 @@ function toCardProps(comment: TLComment, props: CanvasCommentsProps): CommentCar
 export function CanvasComments(props: CanvasCommentsProps) {
 	const editor = useEditor()
 	const container = useContainer()
+	const layerRef = useRef<HTMLDivElement>(null)
+	// Over the pins and cluster badges, wheel and hover pass through to the canvas beneath (these
+	// events bubble up from the pointer-interactive markers to this layer root).
+	usePassThroughWheelEvents(layerRef)
+	usePassThroughMouseOverEvents(layerRef)
 	const deepLinkHandled = useRef(false)
 	const threads = useCommentThreads(editor)
 	const pending = usePendingComment()
@@ -190,7 +198,7 @@ export function CanvasComments(props: CanvasCommentsProps) {
 	// Render into the container (above the panels' stacking context) so the pins and popovers
 	// live in the UI layer rather than being clipped by the canvas layer.
 	return createPortal(
-		<div className="cmt-canvas-layer">
+		<div ref={layerRef} className="cmt-canvas-layer">
 			{visibleNodes.map((node) => {
 				if (node.count === 1) {
 					const thread = threadsById.get(node.id)
@@ -298,6 +306,28 @@ function isInInflatedViewport(editor: Editor, point: { x: number; y: number }): 
 	)
 }
 
+/** The open thread's popover, portaled above the UI panels. Over it, wheel and hover events pass
+ *  through to the canvas (unless the popover is scrolling its own content), like tldraw's panels. */
+function ThreadPopover({
+	container,
+	style,
+	children,
+}: {
+	container: HTMLElement
+	style: CSSProperties
+	children: ReactNode
+}) {
+	const ref = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(ref)
+	usePassThroughMouseOverEvents(ref)
+	return createPortal(
+		<div ref={ref} className="cmt-canvas-popover" style={style} onPointerDown={stop}>
+			{children}
+		</div>,
+		container
+	)
+}
+
 function ThreadPin({
 	editor,
 	thread,
@@ -309,9 +339,9 @@ function ThreadPin({
 	const comments = useThreadComments(editor, thread.id)
 	// Only one thread's popover is open at a time — shared across pins via the atom.
 	const open = useValue('thread open', () => openThreadId.get() === thread.id, [thread.id])
-	const [reply, setReply] = useState('')
+	const [reply, setReply] = useState<TLRichText>(EMPTY_COMMENT)
 	const [editingId, setEditingId] = useState<string | null>(null)
-	const [editText, setEditText] = useState('')
+	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
 	// While dragging the marker, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
 	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
@@ -329,22 +359,21 @@ function ThreadPin({
 	if (!point) return null
 
 	const postReply = () => {
-		const trimmed = reply.trim()
-		if (!trimmed || !currentUserId) return
+		if (isCommentEmpty(reply) || !currentUserId) return
 		editor.run(
 			() => {
 				const comment = createComment({
 					threadId: thread.id,
 					pageId: thread.pageId,
 					authorId: currentUserId,
-					body: toRichText(trimmed),
+					body: reply,
 				})
 				editor.store.put([comment as any])
 				if (onPostComment) onPostComment(comment)
 			},
 			{ history: 'ignore' }
 		)
-		setReply('')
+		setReply(EMPTY_COMMENT)
 	}
 
 	const toggleResolve = () => {
@@ -371,16 +400,15 @@ function ThreadPin({
 
 	const startEdit = (comment: TLComment) => {
 		setEditingId(comment.id)
-		setEditText(richTextToPlaintext(comment.body))
+		setEditText(comment.body)
 	}
 
 	const saveEdit = () => {
 		const comment = comments.find((c) => c.id === editingId)
-		const trimmed = editText.trim()
-		if (!comment || !trimmed) return
+		if (!comment || isCommentEmpty(editText)) return
 		editor.run(
 			() => {
-				editor.store.put([{ ...comment, body: toRichText(trimmed), editedAt: Date.now() } as any])
+				editor.store.put([{ ...comment, body: editText, editedAt: Date.now() } as any])
 			},
 			{ history: 'ignore' }
 		)
@@ -409,7 +437,7 @@ function ThreadPin({
 						onChange={setEditText}
 						onSubmit={saveEdit}
 						sendLabel="Save"
-						disabled={!editText.trim()}
+						disabled={isCommentEmpty(editText)}
 						autoFocus
 					/>
 				</div>
@@ -509,35 +537,32 @@ function ThreadPin({
 			</div>
 			{/* The popover portals up to the menus layer (above the UI panels) so it isn't clipped;
 			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
-			{open &&
-				createPortal(
-					<div
-						className="cmt-canvas-popover"
-						style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
-						onPointerDown={stop}
-					>
-						<CommentThread
-							header="Comment"
-							headerActions={headerActions}
-							renderComment={renderComment}
-							comments={comments.map((c) => toCardProps(c, props))}
-							resolvedBy={thread.resolved ? resolveName(thread.resolved.by) : undefined}
-							composer={
-								currentUserId && !thread.resolved
-									? {
-											author: resolveName(currentUserId),
-											placeholder: 'Reply…',
-											value: reply,
-											onChange: setReply,
-											onSubmit: postReply,
-											disabled: !reply.trim(),
-										}
-									: undefined
-							}
-						/>
-					</div>,
-					container
-				)}
+			{open && (
+				<ThreadPopover
+					container={container}
+					style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
+				>
+					<CommentThread
+						header="Comment"
+						headerActions={headerActions}
+						renderComment={renderComment}
+						comments={comments.map((c) => toCardProps(c, props))}
+						resolvedBy={thread.resolved ? resolveName(thread.resolved.by) : undefined}
+						composer={
+							currentUserId && !thread.resolved
+								? {
+										author: resolveName(currentUserId),
+										placeholder: 'Reply…',
+										value: reply,
+										onChange: setReply,
+										onSubmit: postReply,
+										disabled: isCommentEmpty(reply),
+									}
+								: undefined
+						}
+					/>
+				</ThreadPopover>
+			)}
 		</div>
 	)
 }
@@ -549,9 +574,12 @@ function PendingComposer({
 	resolveName,
 	onPostComment,
 }: CanvasCommentsProps & { editor: Editor; pending: PendingComment }) {
-	const [text, setText] = useState('')
+	const [text, setText] = useState<TLRichText>(EMPTY_COMMENT)
 	const ref = useRef<HTMLDivElement>(null)
 	const container = useContainer()
+	// Over this floating panel, scroll and hover reach the canvas (except where it scrolls itself).
+	usePassThroughWheelEvents(ref)
+	usePassThroughMouseOverEvents(ref)
 
 	const point = useValue('composer point', () => editor.pageToViewport(pending.point), [
 		editor,
@@ -569,8 +597,7 @@ function PendingComposer({
 	}, [])
 
 	const submit = () => {
-		const trimmed = text.trim()
-		if (!trimmed || !currentUserId) return
+		if (isCommentEmpty(text) || !currentUserId) return
 		editor.run(
 			() => {
 				const pageId = editor.getCurrentPageId()
@@ -583,14 +610,14 @@ function PendingComposer({
 					threadId: thread.id,
 					pageId,
 					authorId: currentUserId,
-					body: toRichText(trimmed),
+					body: text,
 				})
 				editor.store.put([thread as any, comment as any])
 				if (onPostComment) onPostComment(comment)
 			},
 			{ history: 'ignore' }
 		)
-		setText('')
+		setText(EMPTY_COMMENT)
 		pendingComment.set(null)
 	}
 
@@ -610,7 +637,7 @@ function PendingComposer({
 				value={text}
 				onChange={setText}
 				onSubmit={submit}
-				disabled={!text.trim()}
+				disabled={isCommentEmpty(text)}
 				autoFocus
 				leading={draftAvatar}
 			/>

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -1,7 +1,14 @@
 /* eslint-disable tldraw/jsx-no-literals */
-import { ReactNode } from 'react'
+import { ReactNode, useRef } from 'react'
 import { createPortal } from 'react-dom'
-import { TLComment, useContainer, useEditor, useValue } from 'tldraw'
+import {
+	TLComment,
+	useContainer,
+	useEditor,
+	usePassThroughMouseOverEvents,
+	usePassThroughWheelEvents,
+	useValue,
+} from 'tldraw'
 import { CommentListItemProps, CommentsList } from '../ui/comments-list'
 import { useComments, useCommentThreads } from './hooks'
 import { richTextToPlaintext } from './rich-text'
@@ -82,9 +89,22 @@ export function CanvasCommentsSidebar({
 		if (thread) focusThread(editor, thread, impreciseShapeAnchor)
 	}
 
-	return createPortal(
-		<div className="cmt-canvas-sidebar">
+	return (
+		<SidebarPanel container={container}>
 			<CommentsList items={items} header={header} empty={empty} onSelect={focus} />
+		</SidebarPanel>
+	)
+}
+
+/** The sidebar surface, portaled into the container. Over it, wheel and hover events pass through to
+ *  the canvas (except where the list scrolls itself), matching tldraw's own panels. */
+function SidebarPanel({ container, children }: { container: HTMLElement; children: ReactNode }) {
+	const ref = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(ref)
+	usePassThroughMouseOverEvents(ref)
+	return createPortal(
+		<div ref={ref} className="cmt-canvas-sidebar">
+			{children}
 		</div>,
 		container
 	)

--- a/packages/commenting/src/canvas/rich-text.ts
+++ b/packages/commenting/src/canvas/rich-text.ts
@@ -1,19 +1,11 @@
 import { TLRichText } from 'tldraw'
+import { renderCommentPlaintext } from './comment-render'
 
 /**
- * Flatten a rich-text comment body to plaintext: walk the ProseMirror-style JSON collecting text
- * nodes, separating paragraphs with newlines. A convenience for consumers rendering bodies as
- * plain or markdown text; richer rendering can read the `TLRichText` directly.
+ * Flatten a rich-text comment body to plaintext through the limited comment extension set,
+ * separating paragraphs and list items with newlines. A convenience for consumers rendering bodies
+ * as plain text (e.g. the sidebar preview); richer rendering can read the `TLRichText` directly.
  */
 export function richTextToPlaintext(body: TLRichText): string {
-	const parts: string[] = []
-	const visit = (node: any) => {
-		if (typeof node?.text === 'string') parts.push(node.text)
-		if (Array.isArray(node?.content)) {
-			for (const child of node.content) visit(child)
-			if (node.type === 'paragraph') parts.push('\n')
-		}
-	}
-	visit(body)
-	return parts.join('').trimEnd()
+	return renderCommentPlaintext(body)
 }

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -1,14 +1,18 @@
-import { ReactNode, useEffect, useRef } from 'react'
+import { Extension, JSONContent } from '@tiptap/core'
+import { EditorContent, useEditor } from '@tiptap/react'
+import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
+import { isEqual, TLRichText } from 'tldraw'
 import { Avatar } from './avatar'
+import { commentTipTapExtensions, EMPTY_COMMENT, isCommentEmpty } from './comment-extensions'
 import './comments.css'
 import { SendButton } from './send-button'
 
 export interface CommentComposerProps {
 	author: string
 	placeholder: string
-	/** Controlled input value. Omit for the presentational (display-only) composer. */
-	value?: string
-	onChange?(value: string): void
+	/** Controlled rich-text value. Omit for the presentational (display-only) composer. */
+	value?: TLRichText
+	onChange?(value: TLRichText): void
 	/** Called on Send click or Enter. When set, the composer is interactive. */
 	onSubmit?(): void
 	sendLabel?: string
@@ -18,8 +22,12 @@ export interface CommentComposerProps {
 	leading?: ReactNode
 }
 
-/** The input for writing a new comment, composed from Avatar and SendButton. Presentational
- *  by default; pass value/onChange/onSubmit to drive it as a real form. */
+/**
+ * The input for writing a comment: a TipTap rich-text editor restricted to the comment extension
+ * set (bold, italic, lists, links, code, highlight — no headings), with a Send button. Formatting
+ * is applied through markdown and keyboard shortcuts (e.g. `**bold**`, `- `, Cmd+B); there's no
+ * floating toolbar. Presentational by default; pass value/onChange/onSubmit to drive it as a form.
+ */
 export function CommentComposer({
 	author,
 	placeholder,
@@ -31,38 +39,84 @@ export function CommentComposer({
 	autoFocus,
 	leading,
 }: CommentComposerProps) {
-	const inputRef = useRef<HTMLInputElement>(null)
+	const interactive = !!onChange || !!onSubmit
 
-	// Focus on the next frame rather than via the `autoFocus` attribute: the composer often
-	// mounts from a canvas pointer event whose default focus handling would otherwise steal it
-	// back, so we grab focus after that has run.
+	// Callbacks are read through refs so the editor instance doesn't need to be recreated when they
+	// change identity between renders.
+	const onChangeRef = useRef(onChange)
+	onChangeRef.current = onChange
+	const onSubmitRef = useRef(onSubmit)
+	onSubmitRef.current = onSubmit
+	const disabledRef = useRef(disabled)
+	disabledRef.current = disabled
+
+	const [isEmpty, setIsEmpty] = useState(() => !value || isCommentEmpty(value))
+
+	// Only Cmd/Ctrl+Enter submits. Enter and Shift+Enter keep their default behavior — a new line
+	// (or a new list item inside a list) — so multi-line comments are easy to write.
+	const submitExtension = useMemo(
+		() =>
+			Extension.create({
+				name: 'commentComposerSubmit',
+				priority: 1000,
+				addKeyboardShortcuts() {
+					return {
+						'Mod-Enter': () => {
+							if (!disabledRef.current) onSubmitRef.current?.()
+							return true
+						},
+					}
+				},
+			}),
+		[]
+	)
+
+	const extensions = useMemo(() => [...commentTipTapExtensions, submitExtension], [submitExtension])
+
+	const editor = useEditor(
+		{
+			extensions,
+			content: (value ?? EMPTY_COMMENT) as JSONContent,
+			editable: interactive,
+			editorProps: { attributes: { class: 'cmt-input' } },
+			onUpdate: ({ editor }) => {
+				setIsEmpty(editor.isEmpty)
+				onChangeRef.current?.(editor.getJSON() as TLRichText)
+			},
+		},
+		[interactive]
+	)
+
+	// Sync controlled resets (e.g. the parent clearing to EMPTY_COMMENT after posting) into the
+	// editor without echoing back the value the editor itself just emitted.
 	useEffect(() => {
-		if (!autoFocus) return
-		const el = inputRef.current
-		if (!el) return
-		const raf = requestAnimationFrame(() => el.focus())
+		if (!editor || value === undefined) return
+		if (isEqual(editor.getJSON(), value)) return
+		editor.commands.setContent(value as JSONContent)
+		setIsEmpty(editor.isEmpty)
+	}, [editor, value])
+
+	// Focus on the next frame rather than via TipTap's autofocus: the composer often mounts from a
+	// canvas pointer event whose default focus handling would otherwise steal it back.
+	useEffect(() => {
+		if (!autoFocus || !editor) return
+		const raf = requestAnimationFrame(() => editor.commands.focus('end'))
 		return () => cancelAnimationFrame(raf)
-	}, [autoFocus])
+	}, [autoFocus, editor])
 
 	return (
 		<div className="cmt-composer">
 			{leading ?? <Avatar name={author} />}
 			<div className="cmt-composer__field">
-				<input
-					ref={inputRef}
-					className="cmt-input"
-					placeholder={placeholder}
-					value={value}
-					onChange={onChange ? (e) => onChange(e.target.value) : undefined}
-					onKeyDown={
-						onSubmit
-							? (e) => {
-									if (e.key === 'Enter') onSubmit()
-								}
-							: undefined
-					}
-				/>
-				<SendButton label={sendLabel} onClick={onSubmit} disabled={disabled} />
+				<div className="cmt-composer__input-wrap">
+					<EditorContent editor={editor} />
+					{isEmpty && (
+						<div className="cmt-input__placeholder" aria-hidden="true">
+							{placeholder}
+						</div>
+					)}
+				</div>
+				{interactive && <SendButton label={sendLabel} onClick={onSubmit} disabled={disabled} />}
 			</div>
 		</div>
 	)

--- a/packages/commenting/src/ui/comment-extensions.ts
+++ b/packages/commenting/src/ui/comment-extensions.ts
@@ -1,0 +1,25 @@
+import { getTipTapDefaultExtensions, TLRichText, toRichText } from 'tldraw'
+
+/**
+ * tldraw's default rich-text extension set, minus headings — the deliberately limited set used for
+ * both the comment composer and comment display. Comments support paragraphs, bold, italic, lists,
+ * links, code, and highlight, but not headings. Built from tldraw's shared factory so the config
+ * stays in lockstep with the text shape's defaults rather than drifting from a copy.
+ */
+export const commentTipTapExtensions = getTipTapDefaultExtensions({ heading: false })
+
+/** An empty comment document — the seed value for a fresh composer and its post-submit reset. */
+export const EMPTY_COMMENT: TLRichText = toRichText('')
+
+/**
+ * Whether a rich-text comment body has no text. Mirrors tldraw's private `isEmptyRichText`: an
+ * empty doc can be encoded as an empty `content` array or a single empty paragraph.
+ */
+export function isCommentEmpty(richText: TLRichText): boolean {
+	if (richText.content.length === 0) return true
+	if (richText.content.length === 1) {
+		const node = richText.content[0] as any
+		if (!node.content || node.content.length === 0) return true
+	}
+	return false
+}

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -58,28 +58,38 @@
 	font-style: italic;
 }
 
-/* rendered markdown inside a comment body */
-.cmt-text .md-p {
+/* rendered rich text inside a comment body — bare tags emitted by the comment renderer
+   (paragraphs, lists, code, highlight, links), matching the limited comment extension set. */
+.cmt-text p {
 	margin: 0;
 }
 
-.cmt-text .md-p + .md-p,
-.cmt-text .md-p + .md-list,
-.cmt-text .md-list + .md-p {
+.cmt-text p + p,
+.cmt-text p + ul,
+.cmt-text p + ol,
+.cmt-text ul + p,
+.cmt-text ol + p {
 	margin-top: 6px;
 }
 
-.cmt-text .md-list {
+.cmt-text ul,
+.cmt-text ol {
 	margin: 0;
 	padding-left: 18px;
 }
 
-.cmt-text .md-code {
+.cmt-text code {
 	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 	font-size: 0.92em;
 	background: var(--tl-color-muted-2);
 	border-radius: 3px;
 	padding: 0 3px;
+}
+
+.cmt-text mark {
+	background: color-mix(in srgb, #ffeb3b 60%, transparent);
+	color: inherit;
+	border-radius: 2px;
 }
 
 .cmt-text a {
@@ -101,11 +111,12 @@
 	flex-shrink: 0;
 }
 
-/* composer — an avatar beside a rounded-rect field (input + send). The avatar matches the comment
-   row's, so the two line up; the field is squarer than a pill, like tldraw's own buttons. */
+/* composer — an avatar beside a rounded-rect field holding the rich-text input and the send button.
+   Formatting is applied via markdown and keyboard shortcuts (no toolbar). The avatar aligns to the
+   top so it stays put as the field grows to multiple lines. */
 .cmt-composer {
 	display: flex;
-	align-items: center;
+	align-items: flex-start;
 	gap: 10px;
 	padding: 4px 0 8px 4px;
 }
@@ -126,15 +137,51 @@
 	border-color: var(--tl-color-selected);
 }
 
-.cmt-input {
+/* the editable area, with the placeholder overlaid while it's empty */
+.cmt-composer__input-wrap {
+	position: relative;
 	flex: 1;
 	min-width: 0;
-	border: 0;
-	background: transparent;
+	padding: 3px 0;
+}
+
+.cmt-input {
 	font: inherit;
 	font-size: 13px;
+	line-height: 1.4;
 	color: var(--tl-color-text-1);
 	outline: none;
+	min-height: 20px;
+	max-height: 40vh;
+	overflow-y: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+}
+
+.cmt-input p {
+	margin: 0;
+}
+
+.cmt-input p + p,
+.cmt-input p + ul,
+.cmt-input p + ol {
+	margin-top: 4px;
+}
+
+.cmt-input ul,
+.cmt-input ol {
+	margin: 0;
+	padding-left: 18px;
+}
+
+.cmt-input__placeholder {
+	position: absolute;
+	top: 3px;
+	left: 0;
+	font-size: 13px;
+	line-height: 1.4;
+	color: var(--tl-color-text-3);
+	pointer-events: none;
 }
 
 .cmt-send {

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -68,6 +68,7 @@ import { ShapeUtil } from '@tldraw/editor';
 import { ShapeWithCrop } from '@tldraw/editor';
 import { SharedStyle } from '@tldraw/editor';
 import { SnapIndicator } from '@tldraw/editor';
+import { StarterKitOptions } from '@tiptap/starter-kit';
 import { StateNode } from '@tldraw/editor';
 import { StyleProp } from '@tldraw/editor';
 import { SvgExportContext } from '@tldraw/editor';
@@ -780,6 +781,9 @@ export class CollaboratorShapeIndicatorOverlayUtil extends OverlayUtil<TLCollabo
 
 // @public (undocumented)
 export function ColorSchemeMenu(): JSX.Element;
+
+// @public
+export function CommentToolbarItem(): JSX.Element;
 
 // @public
 export function containBoxSize(originalSize: BoxWidthHeight, containBoxSize: BoxWidthHeight): BoxWidthHeight;
@@ -2389,6 +2393,9 @@ export function getStrokePoints(rawInputPoints: VecLike[], options?: StrokeOptio
 
 // @public
 export function getSvgPathFromStrokePoints(points: StrokePoint[], closed?: boolean): string;
+
+// @public
+export function getTipTapDefaultExtensions(starterKitOptions?: Partial<StarterKitOptions>): Extensions;
 
 // @public
 export function getUncroppedSize(shapeSize: {

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -659,6 +659,7 @@ export {
 	AssetToolbarItem,
 	CheckBoxToolbarItem,
 	CloudToolbarItem,
+	CommentToolbarItem,
 	DefaultToolbarContent,
 	DiamondToolbarItem,
 	DrawToolbarItem,
@@ -830,6 +831,7 @@ export {
 export { sanitizeSvg } from './lib/utils/svg/sanitizeSvg'
 export {
 	defaultAddFontsFromNode,
+	getTipTapDefaultExtensions,
 	KeyboardShiftEnterTweakExtension,
 	renderHtmlFromRichText,
 	renderHtmlFromRichTextForMeasurement,

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
@@ -36,7 +36,7 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 	orientation = 'horizontal',
 	minItems = 4,
 	minSizePx = 310,
-	maxItems = 8,
+	maxItems = 9,
 	maxSizePx = 470,
 }: DefaultToolbarProps) {
 	const editor = useEditor()

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbarContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbarContent.tsx
@@ -10,6 +10,7 @@ export function DefaultToolbarContent() {
 			<HandToolbarItem />
 			<DrawToolbarItem />
 			<EraserToolbarItem />
+			<CommentToolbarItem />
 			<ArrowToolbarItem />
 			<TextToolbarItem />
 			<NoteToolbarItem />
@@ -92,6 +93,16 @@ export function DrawToolbarItem() {
 /** @public @react */
 export function EraserToolbarItem() {
 	return <ToolbarItem tool="eraser" />
+}
+
+/**
+ * Renders the comment tool if it has been registered (e.g. via `@tldraw/commenting`). Renders
+ * nothing otherwise, so it's safe to include in the default toolbar for every editor.
+ *
+ * @public @react
+ */
+export function CommentToolbarItem() {
+	return <ToolbarItem tool="comment" />
 }
 
 /** @public @react */

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -10,7 +10,7 @@ import {
 import { Code } from '@tiptap/extension-code'
 import { Highlight } from '@tiptap/extension-highlight'
 import { Node } from '@tiptap/pm/model'
-import { StarterKit } from '@tiptap/starter-kit'
+import { StarterKit, type StarterKitOptions } from '@tiptap/starter-kit'
 import {
 	Editor,
 	getOwnProperty,
@@ -43,32 +43,48 @@ Code.config.excludes = undefined
 Highlight.config.priority = 1100
 
 /**
+ * Build tldraw's default TipTap extension set, optionally overriding the bundled `StarterKit`
+ * options. The one lever most consumers want is turning individual nodes off (e.g. comments use a
+ * headingless set via `getTipTapDefaultExtensions({ heading: false })`); because `StarterKit` is a
+ * single umbrella extension, its sub-extensions can only be disabled through its config, not by
+ * filtering the returned array.
+ *
+ * @public
+ */
+export function getTipTapDefaultExtensions(
+	starterKitOptions?: Partial<StarterKitOptions>
+): Extensions {
+	return [
+		StarterKit.configure({
+			blockquote: false,
+			codeBlock: false,
+			horizontalRule: false,
+			link: {
+				openOnClick: false,
+				autolink: true,
+			},
+			// Prevent trailing paragraph insertion after lists (fixes #7641)
+			trailingNode: {
+				notAfter: ['paragraph', 'bulletList', 'orderedList', 'listItem'],
+			},
+			...starterKitOptions,
+		}),
+		Highlight,
+		KeyboardShiftEnterTweakExtension,
+
+		// N.B. We disable the text direction core extension in RichTextArea,
+		// but we add it back in again here in our own extensions list so that
+		// people can omit/override it if they want to.
+		extensions.TextDirection.configure({ direction: 'auto' }),
+	]
+}
+
+/**
  * Default extensions for the TipTap editor.
  *
  * @public
  */
-export const tipTapDefaultExtensions: Extensions = [
-	StarterKit.configure({
-		blockquote: false,
-		codeBlock: false,
-		horizontalRule: false,
-		link: {
-			openOnClick: false,
-			autolink: true,
-		},
-		// Prevent trailing paragraph insertion after lists (fixes #7641)
-		trailingNode: {
-			notAfter: ['paragraph', 'bulletList', 'orderedList', 'listItem'],
-		},
-	}),
-	Highlight,
-	KeyboardShiftEnterTweakExtension,
-
-	// N.B. We disable the text direction core extension in RichTextArea,
-	// but we add it back in again here in our own extensions list so that
-	// people can omit/override it if they want to.
-	extensions.TextDirection.configure({ direction: 'auto' }),
-]
+export const tipTapDefaultExtensions: Extensions = getTipTapDefaultExtensions()
 
 // todo: bust this if the editor changes, too
 const htmlCache = new WeakCache<TLRichText, string>()

--- a/yarn.lock
+++ b/yarn.lock
@@ -11767,6 +11767,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@tldraw/commenting@workspace:packages/commenting"
   dependencies:
+    "@tiptap/core": "npm:^3.12.1"
+    "@tiptap/pm": "npm:^3.12.1"
+    "@tiptap/react": "npm:^3.12.1"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     react: "npm:^19.2.1"


### PR DESCRIPTION
Stacked on #9471.

Gives comments a deliberately limited rich-text set — tldraw's defaults **minus headings**. Comments support paragraphs, bold, italic, lists, links, code, and highlight, but not headers, for both input and display.

## What changed

**Restricted set, single-sourced from tldraw**
- Refactor `tipTapDefaultExtensions` into a `getTipTapDefaultExtensions(starterKitOptions?)` factory (the const is now `getTipTapDefaultExtensions()`, unchanged) and export it. Comments use `getTipTapDefaultExtensions({ heading: false })`, so the comment set stays in lockstep with the text shape's defaults instead of drifting from a copy.

**Input — a real rich-text composer using the standard toolbar**
- Replace the plain `<input>` comment composer with a standalone TipTap editor whose value is `TLRichText`. While focused, it registers via `editor.setRichTextEditor(...)`, so tldraw's standard floating `DefaultRichTextToolbar` targets it — the same formatting UI as the text shape (no bespoke comment toolbar).
- Enter submits; Shift-Enter and Enter inside a list keep authoring the list; Mod-Enter always submits.
- The pending-composer's click-outside dismiss ignores clicks on the floating toolbar so formatting a draft doesn't dismiss it.

**Display — always through the limited set**
- Render comment bodies and previews with the comment extension set, demoting any stray `heading` node to a paragraph first, so headers can never render and rendering never crashes on a programmatically-created or synced body.
- Editing a comment now preserves formatting instead of flattening to plaintext.

## Testing
- `yarn typecheck`, `yarn api-check`, lint, and format all pass.
- New unit tests in `@tldraw/commenting`: a `heading` node renders as `<p>` (never `<h1-6>`), plaintext demotes headings, and the empty-body checks. Full suite: 135 passing.
- `component-studio` production build passes (confirms the new `@tiptap` deps bundle).

## Notes
- `internal/scripts/api-check.ts` pins `@tiptap/starter-kit` so the new public `StarterKitOptions` param type resolves in the isolated API build.

## API changes

- Adds `getTipTapDefaultExtensions` as an export.