### PR TITLE
feat(commenting): add per-user comment read status

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -891,6 +891,14 @@ export class TldrawApp {
 		this.z.mutate.file_state.update({ ...partial, fileId, userId: this.userId })
 	}
 
+	markCommentRead(commentId: string) {
+		this.z.mutate.comment.markRead({ commentId, readAt: Date.now() })
+	}
+
+	markCommentUnread(commentId: string) {
+		this.z.mutate.comment.markUnread({ commentId })
+	}
+
 	updateFile(fileId: string, partial: Partial<TlaFile>) {
 		this.z.mutate.file.update({ id: fileId, ...partial })
 	}

--- a/apps/dotcom/client/src/tla/pages/comments.tsx
+++ b/apps/dotcom/client/src/tla/pages/comments.tsx
@@ -34,33 +34,77 @@ export function Component() {
 				<p>No comments yet.</p>
 			) : (
 				<ul style={{ listStyle: 'none', padding: 0 }}>
-					{comments.map((c) => (
-						<li
-							key={c.id}
-							style={{
-								border: '1px solid #eee',
-								borderRadius: 8,
-								padding: 12,
-								marginBottom: 8,
-							}}
-						>
-							{/* bodies are rich text; flatten for this basic UI (rich rendering forthcoming) */}
-							{/* zero types json columns as opaque JSON */}
-							<div style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-								{richTextToPlaintext(c.body as TLRichText)}
-							</div>
-							<div style={{ fontSize: 12, opacity: 0.7, marginTop: 6 }}>
-								<span>{c.author?.name ?? c.authorId}</span>
-								<span> · </span>
-								<Link
-									style={{ color: 'var(--tl-color-primary)' }}
-									to={commentLink(c.fileId, c.thread?.shapeId, c.id)}
+					{comments.map((c) => {
+						const isOwn = c.authorId === app?.userId
+						const unread = !isOwn && c.reads.length === 0
+						return (
+							<li
+								key={c.id}
+								style={{
+									border: '1px solid #eee',
+									borderRadius: 8,
+									padding: 12,
+									marginBottom: 8,
+									opacity: unread ? 1 : 0.6,
+								}}
+							>
+								{/* bodies are rich text; flatten for this basic UI (rich rendering forthcoming) */}
+								{/* zero types json columns as opaque JSON */}
+								<div
+									style={{
+										whiteSpace: 'pre-wrap',
+										wordBreak: 'break-word',
+										fontWeight: unread ? 600 : 400,
+									}}
 								>
-									{c.file?.name || c.fileId}
-								</Link>
-							</div>
-						</li>
-					))}
+									{unread && (
+										<span
+											aria-label="Unread"
+											style={{
+												display: 'inline-block',
+												width: 8,
+												height: 8,
+												borderRadius: '50%',
+												background: 'var(--tl-color-primary)',
+												marginRight: 8,
+											}}
+										/>
+									)}
+									{richTextToPlaintext(c.body as TLRichText)}
+								</div>
+								<div style={{ fontSize: 12, opacity: 0.7, marginTop: 6 }}>
+									<span>{c.author?.name ?? c.authorId}</span>
+									<span> · </span>
+									<Link
+										style={{ color: 'var(--tl-color-primary)' }}
+										to={commentLink(c.fileId, c.thread?.shapeId, c.id)}
+									>
+										{c.file?.name || c.fileId}
+									</Link>
+									{!isOwn && (
+										<>
+											<span> · </span>
+											<button
+												style={{
+													border: 'none',
+													background: 'none',
+													padding: 0,
+													cursor: 'pointer',
+													color: 'var(--tl-color-primary)',
+													font: 'inherit',
+												}}
+												onClick={() =>
+													unread ? app?.markCommentRead(c.id) : app?.markCommentUnread(c.id)
+												}
+											>
+												{unread ? 'Mark read' : 'Mark unread'}
+											</button>
+										</>
+									)}
+								</div>
+							</li>
+						)
+					})}
 				</ul>
 			)}
 		</div>

--- a/apps/dotcom/client/src/tla/pages/comments.tsx
+++ b/apps/dotcom/client/src/tla/pages/comments.tsx
@@ -36,7 +36,7 @@ export function Component() {
 				<ul style={{ listStyle: 'none', padding: 0 }}>
 					{comments.map((c) => {
 						const isOwn = c.authorId === app?.userId
-						const unread = !isOwn && c.reads.length === 0
+						const unread = !isOwn && !c.read
 						return (
 							<li
 								key={c.id}

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -59,6 +59,7 @@ import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
 import {
+	findEmptiedCommentThreads,
 	isCommentAuthorFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
 	outboxEntriesToClear,
@@ -1609,7 +1610,10 @@ export class TLFileDurableObject extends DurableObject {
 	 * Durable outbox for comment persistence. Postgres is the sole durable store for comment
 	 * records; the DO's SQLite is the room's working copy. Each committed diff appends the touched
 	 * comment/comment-thread record ids here (same-task with the commit, so the DO output gate
-	 * flushes them together), and the drain pushes the records' current state to Postgres.
+	 * flushes them together), and the drain pushes the records' current state to Postgres. The
+	 * drain itself also appends: when the author-cascade prune (below) empties a thread, the
+	 * pruned thread's id is outboxed so a follow-up drain deletes its Postgres row through this
+	 * same acked path.
 	 * Delivery is at-least-once: an entry's outbox row is only removed once its push to Postgres
 	 * has actually succeeded, so a row that fails (including its row-by-row retry) stays queued
 	 * and is retried on the next commit, the next throttled persist, or the drain kicked when
@@ -1785,7 +1789,13 @@ export class TLFileDurableObject extends DurableObject {
 				// warm room still holds the records. Retrying can never succeed, so mirror the
 				// cascade into the room instead: prune the records below and let their outbox
 				// entries clear normally (the Postgres row being absent is already the desired end
-				// state). Threads are untouched — comment_thread has no user FK by design.
+				// state). Threads the prune leaves without any comments are pruned too — the
+				// client-side invariant is that deleting a thread's last comment deletes the
+				// thread, so an author-cascade must not leave ghost pins behind. Thread rows in
+				// Postgres are NOT deleted here: comment_thread has no user FK (by design, so the
+				// cascade can't race the room), so the pruned thread ids are re-outboxed and a
+				// follow-up drain issues the Postgres delete through the normal at-least-once
+				// acked path.
 				const commentResult = await runBatchWithFallback(
 					commentUpserts,
 					insertCommentRows,
@@ -1801,6 +1811,7 @@ export class TLFileDurableObject extends DurableObject {
 					await this.db.deleteFrom('comment_thread').where('id', 'in', threadDeletes).execute()
 				}
 
+				let didPruneThreads = false
 				if (commentResult.prunedIds.length > 0) {
 					this.logEvent({ type: 'room', roomId: fileId, name: 'comment_author_deleted_prune' })
 					// Remove the pruned records from the room's storage so it stops carrying rows
@@ -1815,11 +1826,43 @@ export class TLFileDurableObject extends DurableObject {
 					// only fires for client pushes), so this can't loop; a crash between here and
 					// the outbox clear below just replays the prune on the next drain (the ids are
 					// then lane-absent, taking the no-op Postgres delete path).
-					storage.transaction((txn) => {
+					const prunedThreadIds = storage.transaction((txn) => {
+						// Collect each pruned comment's threadId from the transaction's own reads
+						// before deleting it — prunedIds are comment ids, not thread ids.
+						const candidateThreadIds = new Set<string>()
 						for (const id of commentResult.prunedIds) {
+							const record = txn.get(id as TLRecord['id'])
+							if (record?.typeName === 'comment') {
+								candidateThreadIds.add(record.threadId)
+							}
 							txn.delete(id as TLRecord['id'])
 						}
-					})
+						// Threads the deletes just emptied must go too (see the comment above the
+						// commentUpserts batch). The emptiness check runs on this transaction's own
+						// read surface, not the drain's earlier lane snapshot, so a reply committed
+						// after that snapshot keeps its thread alive.
+						const deletedThreadIds: string[] = []
+						for (const threadId of findEmptiedCommentThreads(candidateThreadIds, txn)) {
+							// A lane-absent thread was already deleted by a client; that delete's
+							// own outbox entry covers its Postgres row.
+							if (txn.get(threadId as TLRecord['id']) === undefined) continue
+							txn.delete(threadId as TLRecord['id'])
+							deletedThreadIds.push(threadId)
+						}
+						return deletedThreadIds
+					}).result
+					if (prunedThreadIds.length > 0) {
+						this.logEvent({ type: 'room', roomId: fileId, name: 'comment_thread_emptied_prune' })
+						// Outbox the pruned thread ids instead of deleting their Postgres rows
+						// directly: the follow-up drain (kicked below, after this drain's
+						// bookkeeping) sees them lane-absent and issues the delete through the
+						// normal crash-safe at-least-once path. These inserts get seqs above this
+						// drain's bound, so the outbox clear below can't remove them.
+						for (const id of prunedThreadIds) {
+							this.ctx.storage.sql.exec('INSERT INTO comment_outbox (recordId) VALUES (?)', id)
+						}
+						didPruneThreads = true
+					}
 				}
 
 				// Keep entries queued for any record that failed to push (they'll be retried on the
@@ -1832,6 +1875,15 @@ export class TLFileDurableObject extends DurableObject {
 					for (const seq of toClear.seqs) {
 						this.ctx.storage.sql.exec('DELETE FROM comment_outbox WHERE seq = ?', seq)
 					}
+				}
+
+				if (didPruneThreads) {
+					// Kick a follow-up drain for the thread ids outboxed by the prune above (their
+					// seqs are past this drain's bound, so this drain never touches them). Calling
+					// from inside the currently-running queue task is safe: ExecutionQueue.push only
+					// appends while a task is executing (run() early-returns on `running`), so the
+					// follow-up starts after this task returns — never synchronously re-entering it.
+					this.drainCommentOutbox()
 				}
 			})
 			.catch((e) => {

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from 'vitest'
 import {
 	CommentOutboxEntry,
 	commentRecordToRow,
+	findEmptiedCommentThreads,
 	isCommentAuthorFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
 	outboxEntriesToClear,
@@ -325,6 +326,75 @@ describe('planCommentDrain', () => {
 			commentDeletes: [],
 			unknownIds: ['shape:oops'],
 		})
+	})
+})
+
+describe('findEmptiedCommentThreads', () => {
+	function makeComment(threadId: ReturnType<typeof makeThread>['id']) {
+		return createComment({ threadId, pageId, authorId: 'user1', body, now: 1500 })
+	}
+
+	// mimics the prune transaction's read surface AFTER the pruned comments were deleted
+	function viewOf(...records: { id: string }[]) {
+		const map = new Map(records.map((r) => [r.id, r]))
+		return { keys: () => map.keys(), get: (id: string) => map.get(id) }
+	}
+
+	it('returns nothing (without scanning) when there are no candidate threads', () => {
+		const view = {
+			keys(): Iterable<string> {
+				throw new Error('should not scan')
+			},
+			get: () => undefined,
+		}
+		expect(findEmptiedCommentThreads(new Set(), view)).toEqual([])
+	})
+
+	it('returns a thread with no remaining comments', () => {
+		const thread = makeThread()
+		expect(findEmptiedCommentThreads(new Set([thread.id]), viewOf(thread))).toEqual([thread.id])
+	})
+
+	it('keeps a thread alive when a remaining comment references it', () => {
+		const emptied = makeThread()
+		const alive = makeThread()
+		const reply = makeComment(alive.id)
+		expect(
+			findEmptiedCommentThreads(new Set([emptied.id, alive.id]), viewOf(emptied, alive, reply))
+		).toEqual([emptied.id])
+	})
+
+	it('skips non-comment records without reading them', () => {
+		const thread = makeThread()
+		const view = {
+			keys: () => ['shape:box1', thread.id, 'document:document'],
+			get(id: string): unknown {
+				throw new Error(`should not read ${id}`)
+			},
+		}
+		expect(findEmptiedCommentThreads(new Set([thread.id]), view)).toEqual([thread.id])
+	})
+
+	it('stops scanning once every candidate thread is kept alive', () => {
+		const thread = makeThread()
+		const reply = makeComment(thread.id)
+		const straggler = makeComment(thread.id)
+		let yielded = 0
+		const map = new Map<string, { id: string }>([
+			[reply.id, reply],
+			[straggler.id, straggler],
+		])
+		const view = {
+			*keys() {
+				for (const id of map.keys()) {
+					yielded++
+					yield id
+				}
+			},
+			get: (id: string) => map.get(id),
+		}
+		expect(findEmptiedCommentThreads(new Set([thread.id]), view)).toEqual([])
+		expect(yielded).toBe(1)
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -221,6 +221,33 @@ export function outboxEntriesToClear(
 }
 
 /**
+ * Given the `threadId`s of comment records that were just pruned and a view of the records that
+ * remain (read AFTER the pruned comments were deleted), return the threadIds that no longer have
+ * any comments referencing them. The caller (see the author-FK prune in drainCommentOutbox)
+ * deletes those threads in the same transaction, mirroring the client-side invariant that
+ * deleting a thread's last comment deletes the thread.
+ *
+ * The view must be transaction-time (e.g. the prune transaction's own read surface), not an
+ * earlier lane snapshot: a reply committed between the snapshot and the transaction must keep its
+ * thread alive. The scan iterates `keys()` (an id-only scan; comment ids are typeName-prefixed so
+ * non-comment records are skipped without being read) and `get`s only comment records, stopping
+ * early once every candidate thread has been kept alive.
+ */
+export function findEmptiedCommentThreads(
+	candidateThreadIds: ReadonlySet<string>,
+	remaining: { keys(): Iterable<string>; get(id: string): unknown }
+): string[] {
+	if (candidateThreadIds.size === 0) return []
+	const emptied = new Set(candidateThreadIds)
+	for (const id of remaining.keys()) {
+		if (!isCommentId(id)) continue
+		const threadId = (remaining.get(id) as TLComment | undefined)?.threadId
+		if (threadId !== undefined && emptied.delete(threadId) && emptied.size === 0) break
+	}
+	return [...emptied]
+}
+
+/**
  * Merge rehydrated comment documents into a room snapshot, clamping the snapshot's clocks up to
  * the highest merged clock. Comments push to Postgres per-commit while the document snapshot
  * persists on a throttle, so after a storage loss the comment clocks can be ahead of the

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -117,6 +117,7 @@ export type TLServerEvent =
 				| 'failed_persist_to_db'
 				| 'failed_persist_comments_to_db'
 				| 'comment_author_deleted_prune'
+				| 'comment_thread_emptied_prune'
 				| 'room_empty'
 				| 'fail_persist'
 				| 'room_start'

--- a/apps/dotcom/zero-cache/migrations/039_add_comment_read.sql
+++ b/apps/dotcom/zero-cache/migrations/039_add_comment_read.sql
@@ -1,0 +1,20 @@
+-- Per-user comment read receipts for the app-level /comments view. Row present = the user has
+-- read the comment; marking unread deletes the row. `readAt` is stored so a future "edited
+-- comments become unread again" rule (readAt < updatedAt) is a client-only change. Authors'
+-- own comments get no row: the client treats authorId === me as implicitly read. Written via
+-- Zero custom mutators (comment.markRead / comment.markUnread), unlike comment/comment_thread
+-- which are written by the file's Durable Object.
+
+CREATE TABLE comment_read (
+  "userId" VARCHAR NOT NULL,
+  "commentId" VARCHAR NOT NULL,
+  "readAt" BIGINT NOT NULL,
+  PRIMARY KEY ("userId", "commentId"),
+  CONSTRAINT comment_read_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_read_comment_id_fkey FOREIGN KEY ("commentId") REFERENCES public."comment"("id") ON DELETE CASCADE
+);
+
+-- covers the cascade path when comments are deleted
+CREATE INDEX comment_read_comment_id_idx ON comment_read("commentId");
+
+ALTER PUBLICATION zero_data ADD TABLE public."comment_read";

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest'
 import { createMutators, parseFlags, userHasFlag } from './mutators'
 import { FILE_PREFIX, PUBLISH_PREFIX } from './routes'
 import {
+	TlaComment,
+	TlaCommentRead,
 	TlaFile,
 	TlaFileState,
 	TlaGroup,
@@ -41,6 +43,18 @@ function makeUser(overrides: Partial<TlaUser> & { id: string }): TlaUser {
 		enhancedA11yMode: null,
 		isZoomDirectionInverted: null,
 		allowAnalyticsCookie: null,
+		...overrides,
+	}
+}
+
+function makeComment(overrides: Partial<TlaComment> & { id: string; fileId: string }): TlaComment {
+	return {
+		threadId: 'thread-1',
+		pageId: 'page:page',
+		authorId: 'author-1',
+		body: {},
+		createdAt: 1,
+		updatedAt: 1,
 		...overrides,
 	}
 }
@@ -126,6 +140,8 @@ interface TableStore {
 	group: TlaGroup[]
 	group_user: TlaGroupUser[]
 	group_file: TlaGroupFile[]
+	comment: TlaComment[]
+	comment_read: TlaCommentRead[]
 }
 
 const TABLE_PKS: Record<keyof TableStore, string[]> = {
@@ -135,6 +151,8 @@ const TABLE_PKS: Record<keyof TableStore, string[]> = {
 	group: ['id'],
 	group_user: ['userId', 'groupId'],
 	group_file: ['fileId', 'groupId'],
+	comment: ['id'],
+	comment_read: ['userId', 'commentId'],
 }
 
 /**
@@ -322,6 +340,8 @@ describe('user mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		})
 		const m = createMutators(userId)
 		await expectValid(() => m.user.update(tx, { id: userId, name: 'New Name' }))
@@ -336,6 +356,8 @@ describe('user mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		})
 		const m = createMutators(userId)
 		await expectForbidden(() => m.user.update(tx, { id: otherId, name: 'Hacked' }))
@@ -349,6 +371,8 @@ describe('user mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		})
 		const m = createMutators(userId)
 		await expectForbidden(() => m.user.update(tx, { id: userId, email: 'evil@evil.com' }))
@@ -362,6 +386,8 @@ describe('user mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		})
 		const m = createMutators(userId)
 		// flags is NOT in immutableColumns.user, so this should succeed
@@ -381,6 +407,8 @@ describe('file mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [] as TlaGroupFile[],
+			comment: [],
+			comment_read: [],
 		}
 	}
 
@@ -460,6 +488,8 @@ describe('file creation', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -483,6 +513,8 @@ describe('file creation', () => {
 			group: [makeGroup({ id: groupId }), makeGroup({ id: otherGroup })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -509,6 +541,8 @@ describe('file creation', () => {
 			group: [makeGroup({ id: userId })],
 			group_user: [], // no explicit home membership row
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -537,6 +571,8 @@ describe('file_state mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -552,6 +588,8 @@ describe('file_state mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -573,6 +611,8 @@ describe('file_state mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [], // userId NOT a member
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -595,6 +635,8 @@ describe('onEnterFile', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [makeGroupFile({ fileId, groupId })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -611,6 +653,8 @@ describe('onEnterFile', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [], // not a member
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -625,6 +669,8 @@ describe('onEnterFile', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [makeGroupFile({ fileId, groupId })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -644,6 +690,8 @@ describe('onEnterFile', () => {
 			group: [makeGroup({ id: userId }), makeGroup({ id: otherGroup })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })], // home only
 			group_file: [makeGroupFile({ fileId, groupId: otherGroup })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -663,6 +711,8 @@ describe('onEnterFile', () => {
 				makeGroupUser({ userId, groupId: workspaceId, role: 'member' }),
 			],
 			group_file: [makeGroupFile({ fileId, groupId: workspaceId })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -678,6 +728,8 @@ describe('onEnterFile', () => {
 			group: [makeGroup({ id: userId })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -697,6 +749,8 @@ describe('workspace mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -715,6 +769,8 @@ describe('workspace mutations', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -732,6 +788,8 @@ describe('workspace mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -747,6 +805,8 @@ describe('workspace mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -763,6 +823,8 @@ describe('workspace mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
 			group_file: [makeGroupFile({ fileId, groupId })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -781,6 +843,8 @@ describe('workspace mutations', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -804,6 +868,8 @@ describe('membership', () => {
 				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -826,6 +892,8 @@ describe('membership', () => {
 				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -845,6 +913,8 @@ describe('membership', () => {
 				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -861,6 +931,8 @@ describe('membership', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -878,6 +950,8 @@ describe('membership', () => {
 				makeGroupUser({ userId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -896,6 +970,8 @@ describe('membership', () => {
 				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -914,6 +990,8 @@ describe('membership', () => {
 				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -933,6 +1011,8 @@ describe('membership', () => {
 				makeGroupUser({ userId: memberId, groupId, role: 'member' }),
 			],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -959,6 +1039,8 @@ describe('file operations across workspaces', () => {
 				makeGroupUser({ userId, groupId: groupB }),
 			],
 			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -974,6 +1056,8 @@ describe('file operations across workspaces', () => {
 			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
 			group_user: [makeGroupUser({ userId, groupId: groupA })],
 			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -988,6 +1072,8 @@ describe('file operations across workspaces', () => {
 			group: [makeGroup({ id: groupA }), makeGroup({ id: groupB })],
 			group_user: [makeGroupUser({ userId, groupId: groupB })],
 			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1002,6 +1088,8 @@ describe('file operations across workspaces', () => {
 			group: [makeGroup({ id: groupA })],
 			group_user: [makeGroupUser({ userId, groupId: groupA, role: 'member' })],
 			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1017,6 +1105,8 @@ describe('file operations across workspaces', () => {
 			group: [makeGroup({ id: groupA })],
 			group_user: [],
 			group_file: [makeGroupFile({ fileId, groupId: groupA })],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1036,6 +1126,8 @@ describe('file operations across workspaces', () => {
 				makeGroupFile({ fileId, groupId: groupA }),
 				makeGroupFile({ fileId, groupId: groupB }),
 			],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1069,6 +1161,8 @@ describe('file operations across workspaces', () => {
 				// influence (or collide with) the new pin's index
 				makeGroupFile({ fileId: homePinnedId, groupId: userId, index: 'a1' as IndexKey }),
 			],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1095,6 +1189,8 @@ describe('home workspace special case', () => {
 			group: [makeGroup({ id: userId })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1128,6 +1224,8 @@ describe('home workspace special case', () => {
 			group: [makeGroup({ id: userId })],
 			group_user,
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		} satisfies TableStore
 	}
 
@@ -1181,6 +1279,8 @@ describe('regenerateWorkspaceInviteSecret', () => {
 			group: [makeGroup({ id: groupId, inviteSecret: 'old_secret_1234567' })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1197,6 +1297,8 @@ describe('regenerateWorkspaceInviteSecret', () => {
 			group: [makeGroup({ id: groupId, inviteSecret: 'old_secret_1234567' })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1213,6 +1315,8 @@ describe('regenerateWorkspaceInviteSecret', () => {
 			// No group_user for nonMemberId — not a member at all
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(nonMemberId)
@@ -1232,6 +1336,8 @@ describe('setWorkspaceInviteLinkEnabled', () => {
 			group: [makeGroup({ id: groupId, inviteLinkEnabled: true })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1249,6 +1355,8 @@ describe('setWorkspaceInviteLinkEnabled', () => {
 			group: [makeGroup({ id: groupId, inviteLinkEnabled: true })],
 			group_user: [makeGroupUser({ userId, groupId, role: 'member' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1270,6 +1378,8 @@ describe('immutable column bypass attempts', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1284,6 +1394,8 @@ describe('immutable column bypass attempts', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1300,6 +1412,8 @@ describe('immutable column bypass attempts', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1314,6 +1428,8 @@ describe('immutable column bypass attempts', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1330,6 +1446,8 @@ describe('immutable column bypass attempts', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [], // not a member
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1346,6 +1464,8 @@ describe('immutable column bypass attempts', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s)
 		const m = createMutators(userId)
@@ -1372,6 +1492,8 @@ describe('file access control logic', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId: otherId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1387,6 +1509,8 @@ describe('file access control logic', () => {
 			group: [makeGroup({ id: groupId })],
 			group_user: [makeGroupUser({ userId, groupId })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1410,6 +1534,8 @@ describe('file access control logic', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1432,6 +1558,8 @@ describe('cross-user isolation', () => {
 			group: [makeGroup({ id: groupA })],
 			group_user: [makeGroupUser({ userId: userA, groupId: groupA })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const mB = createMutators(userB)
@@ -1459,6 +1587,8 @@ describe('createFile from source (duplicate) access control', () => {
 			group: [makeGroup({ id: userId }), makeGroup({ id: otherGroup })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 	}
 
@@ -1506,6 +1636,8 @@ describe('createFile from source (duplicate) access control', () => {
 			group: [makeGroup({ id: userId })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1520,6 +1652,8 @@ describe('createFile from source (duplicate) access control', () => {
 			group: [],
 			group_user: [],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1536,6 +1670,8 @@ describe('createFile from source (duplicate) access control', () => {
 			group: [makeGroup({ id: userId })],
 			group_user: [makeGroupUser({ userId, groupId: userId, role: 'owner' })],
 			group_file: [],
+			comment: [],
+			comment_read: [],
 		}
 		const { tx } = createMockTx(s, { location: 'server' })
 		const m = createMutators(userId)
@@ -1551,5 +1687,82 @@ describe('file creation security', () => {
 		// arbitrary file row (with an attacker-controlled createSource) directly.
 		const m = createMutators(userId)
 		expect((m.file as Record<string, unknown>).insertWithFileState).toBeUndefined()
+	})
+})
+
+describe('comment.markRead / comment.markUnread', () => {
+	// owner1 owns file1; comment c1 by author-1 lives on file1
+	function commentState() {
+		return {
+			user: [makeUser({ id: 'owner1' }), makeUser({ id: 'other1' })],
+			file: [makeFile({ id: 'file1', ownerId: 'owner1' })],
+			file_state: [],
+			group: [],
+			group_user: [],
+			group_file: [],
+			comment: [makeComment({ id: 'c1', fileId: 'file1' })],
+			comment_read: [],
+		}
+	}
+
+	it('markRead upserts a read row scoped to the calling user', async () => {
+		const { tx, store } = createMockTx(commentState(), { location: 'server' })
+		const mutators = createMutators('owner1')
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: Date.now() })
+		expect(store.comment_read).toHaveLength(1)
+		expect(store.comment_read[0]).toMatchObject({ userId: 'owner1', commentId: 'c1' })
+	})
+
+	it('markRead is idempotent and updates readAt', async () => {
+		const { tx, store } = createMockTx(commentState(), { location: 'server' })
+		const mutators = createMutators('owner1')
+		const t1 = Date.now() - 1000
+		const t2 = Date.now()
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: t1 })
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: t2 })
+		expect(store.comment_read).toHaveLength(1)
+		expect(store.comment_read[0].readAt).toBe(t2)
+	})
+
+	it('markRead clamps unreasonable timestamps to server time', async () => {
+		const { tx, store } = createMockTx(commentState(), { location: 'server' })
+		const mutators = createMutators('owner1')
+		const before = Date.now()
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: before + 60_000 })
+		expect(store.comment_read[0].readAt).toBeGreaterThanOrEqual(before)
+		expect(store.comment_read[0].readAt).toBeLessThanOrEqual(Date.now())
+	})
+
+	it('markRead rejects forbidden when the user cannot access the file', async () => {
+		const { tx } = createMockTx(commentState(), { location: 'server' })
+		const mutators = createMutators('other1')
+		await expectForbidden(() =>
+			mutators.comment.markRead(tx, { commentId: 'c1', readAt: Date.now() })
+		)
+	})
+
+	it('markRead rejects bad_request on a missing comment', async () => {
+		const { tx } = createMockTx(commentState(), { location: 'server' })
+		const mutators = createMutators('owner1')
+		await expectBadRequest(() =>
+			mutators.comment.markRead(tx, { commentId: 'nope', readAt: Date.now() })
+		)
+	})
+
+	it('markRead skips the access check on the client', async () => {
+		// optimistic client writes go through; the server re-run is authoritative
+		const { tx, store } = createMockTx(commentState(), { location: 'client' })
+		const mutators = createMutators('other1')
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: Date.now() })
+		expect(store.comment_read).toHaveLength(1)
+	})
+
+	it('markUnread deletes the row and is a no-op when absent', async () => {
+		const { tx, store } = createMockTx(commentState(), { location: 'server' })
+		const mutators = createMutators('owner1')
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: Date.now() })
+		await mutators.comment.markUnread(tx, { commentId: 'c1' })
+		expect(store.comment_read).toHaveLength(0)
+		await expectValid(() => mutators.comment.markUnread(tx, { commentId: 'c1' }))
 	})
 })

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -1765,4 +1765,14 @@ describe('comment.markRead / comment.markUnread', () => {
 		expect(store.comment_read).toHaveLength(0)
 		await expectValid(() => mutators.comment.markUnread(tx, { commentId: 'c1' }))
 	})
+
+	it("markUnread only deletes the calling user's row", async () => {
+		const s = commentState()
+		s.comment_read.push({ userId: 'other1', commentId: 'c1', readAt: 5 })
+		const { tx, store } = createMockTx(s, { location: 'server' })
+		const mutators = createMutators('owner1')
+		await mutators.comment.markRead(tx, { commentId: 'c1', readAt: Date.now() })
+		await mutators.comment.markUnread(tx, { commentId: 'c1' })
+		expect(store.comment_read).toEqual([{ userId: 'other1', commentId: 'c1', readAt: 5 }])
+	})
 })

--- a/packages/dotcom-shared/src/mutators.test.ts
+++ b/packages/dotcom-shared/src/mutators.test.ts
@@ -1692,7 +1692,7 @@ describe('file creation security', () => {
 
 describe('comment.markRead / comment.markUnread', () => {
 	// owner1 owns file1; comment c1 by author-1 lives on file1
-	function commentState() {
+	function commentState(): TableStore {
 		return {
 			user: [makeUser({ id: 'owner1' }), makeUser({ id: 'other1' })],
 			file: [makeFile({ id: 'file1', ownerId: 'owner1' })],

--- a/packages/dotcom-shared/src/mutators.ts
+++ b/packages/dotcom-shared/src/mutators.ts
@@ -235,6 +235,31 @@ export function createMutators(userId: string) {
 			},
 		},
 
+		comment: {
+			/**
+			 * Mark a comment as read by the current user. Row present = read; readAt is stored so
+			 * an "edits reset unread" rule can later be added client-side without a migration.
+			 */
+			markRead: async (tx: Tx, { commentId, readAt }: { commentId: string; readAt: number }) => {
+				if (tx.location === 'server') {
+					// Verify the comment exists and the user can access its file
+					const comment = await tx.run(zql.comment.where('id', '=', commentId).one())
+					assert(comment, ZErrorCode.bad_request)
+					const file = await tx.run(zql.file.where('id', '=', comment.fileId).one())
+					await assertUserCanAccessFile(tx, userId, file!)
+				}
+				await tx.mutate.comment_read.upsert({
+					userId,
+					commentId,
+					readAt: ensureSensibleTimestamp(readAt),
+				})
+			},
+			/** Mark a comment as unread by deleting the current user's read row. Own-row-only by construction. */
+			markUnread: async (tx: Tx, { commentId }: { commentId: string }) => {
+				await tx.mutate.comment_read.delete({ userId, commentId })
+			},
+		},
+
 		/** @deprecated */
 		init: async (tx: Tx, { user, time }: { user: TlaUser; time: number }) => {
 			assert(user.id === userId, ZErrorCode.forbidden)

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -51,6 +51,8 @@ export const queries = defineQueries({
 			.related('author', (author) => author.one())
 			.related('file', (file) => file.one())
 			.related('thread', (thread) => thread.one())
+			// only the caller's read receipts; reads.length === 0 (for others' comments) = unread
+			.related('reads', (reads) => reads.where('userId', '=', ctx.userId))
 	),
 })
 

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -51,8 +51,9 @@ export const queries = defineQueries({
 			.related('author', (author) => author.one())
 			.related('file', (file) => file.one())
 			.related('thread', (thread) => thread.one())
-			// only the caller's read receipts; reads.length === 0 (for others' comments) = unread
-			.related('reads', (reads) => reads.where('userId', '=', ctx.userId))
+			// the caller's read receipt (at most one row: PK is (userId, commentId) and we filter
+			// on userId); absent (for others' comments) = unread
+			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
 	),
 })
 

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -270,7 +270,8 @@ const commentRelationships = relationships(comment, ({ one, many }) => ({
 		destSchema: comment_thread,
 	}),
 	// singular name despite many() cardinality (one row per user): every consumer scopes it to
-	// one user and calls .one(), yielding at most one row (see the comments query)
+	// one user and calls .one(), yielding at most one row (see the comments query). Always scope
+	// it to ctx.userId in synced queries — unscoped it replicates every user's receipts.
 	read: many({
 		sourceField: ['id'],
 		destField: ['commentId'],

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -269,7 +269,9 @@ const commentRelationships = relationships(comment, ({ one, many }) => ({
 		destField: ['id'],
 		destSchema: comment_thread,
 	}),
-	reads: many({
+	// singular name despite many() cardinality (one row per user): every consumer scopes it to
+	// one user and calls .one(), yielding at most one row (see the comments query)
+	read: many({
 		sourceField: ['id'],
 		destField: ['commentId'],
 		destSchema: comment_read,

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -156,6 +156,18 @@ export const comment_thread = table('comment_thread')
 	})
 	.primaryKey('id')
 
+// Per-user read receipts for comments, for the app-level /comments view. Row present = read;
+// marking unread deletes the row. Written via the comment.markRead/markUnread custom mutators
+// (client-written, unlike comment/comment_thread which are server-written by the file's DO).
+// Authors' own comments have no row: the client treats authorId === me as implicitly read.
+export const comment_read = table('comment_read')
+	.columns({
+		userId: string(),
+		commentId: string(),
+		readAt: number(),
+	})
+	.primaryKey('userId', 'commentId')
+
 const fileRelationships = relationships(file, ({ one, many }) => ({
 	owner: one({
 		sourceField: ['ownerId'],
@@ -241,7 +253,7 @@ const groupFileRelationships = relationships(group_file, ({ one, many }) => ({
 	}),
 }))
 
-const commentRelationships = relationships(comment, ({ one }) => ({
+const commentRelationships = relationships(comment, ({ one, many }) => ({
 	file: one({
 		sourceField: ['fileId'],
 		destField: ['id'],
@@ -256,6 +268,11 @@ const commentRelationships = relationships(comment, ({ one }) => ({
 		sourceField: ['threadId'],
 		destField: ['id'],
 		destSchema: comment_thread,
+	}),
+	reads: many({
+		sourceField: ['id'],
+		destField: ['commentId'],
+		destSchema: comment_read,
 	}),
 }))
 
@@ -301,6 +318,11 @@ export type TlaCommentThreadPartial = Partial<TlaCommentThread> & {
 	id: TlaCommentThread['id']
 }
 
+export type TlaCommentReadPartial = Partial<TlaCommentRead> & {
+	userId: TlaCommentRead['userId']
+	commentId: TlaCommentRead['commentId']
+}
+
 export type TlaRow =
 	| TlaFile
 	| TlaFileState
@@ -310,6 +332,7 @@ export type TlaRow =
 	| TlaGroupFile
 	| TlaComment
 	| TlaCommentThread
+	| TlaCommentRead
 export type TlaRowPartial =
 	| TlaFilePartial
 	| TlaFileStatePartial
@@ -319,6 +342,7 @@ export type TlaRowPartial =
 	| TlaGroupFilePartial
 	| TlaCommentPartial
 	| TlaCommentThreadPartial
+	| TlaCommentReadPartial
 export interface TlaUserMutationNumber {
 	userId: string
 	mutationNumber: number
@@ -392,10 +416,21 @@ export interface DB {
 	welcome_template: TlaWelcomeTemplate
 	comment: TlaComment & CommentPersistenceColumns
 	comment_thread: TlaCommentThread & CommentThreadPersistenceColumns
+	comment_read: TlaCommentRead
 }
 
 export const schema = createSchema({
-	tables: [user, file, file_state, group, group_user, group_file, comment, comment_thread],
+	tables: [
+		user,
+		file,
+		file_state,
+		group,
+		group_user,
+		group_file,
+		comment,
+		comment_thread,
+		comment_read,
+	],
 	relationships: [
 		fileRelationships,
 		fileStateRelationships,
@@ -416,6 +451,7 @@ export type TlaGroupUser = Row<typeof schema.tables.group_user>
 export type TlaGroupFile = Row<typeof schema.tables.group_file>
 export type TlaComment = Row<typeof schema.tables.comment>
 export type TlaCommentThread = Row<typeof schema.tables.comment_thread>
+export type TlaCommentRead = Row<typeof schema.tables.comment_read>
 
 // Permissions are now handled via Synced Queries in queries.ts
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -2,6 +2,7 @@ import { stringEnum } from '@tldraw/utils'
 import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaComment,
+	TlaCommentRead,
 	TlaCommentThread,
 	TlaFile,
 	TlaFileState,
@@ -131,6 +132,9 @@ export interface ZStoreData {
 	// Same as comment: never populated by the legacy polyfill store, present only for the
 	// generic CRUD types.
 	comment_thread?: TlaCommentThread[]
+	// Same as comment: never populated by the legacy polyfill store, present only for the
+	// generic CRUD types.
+	comment_read?: TlaCommentRead[]
 	lsn: string
 }
 
@@ -157,6 +161,7 @@ export type ZTable =
 	| 'group_file'
 	| 'comment'
 	| 'comment_thread'
+	| 'comment_read'
 
 export type ZEvent = 'insert' | 'update' | 'delete'
 


### PR DESCRIPTION
In order to let users see which comments they have already read, this PR adds per-user read/unread tracking on top of the zero-persisted comments from #9550. A new `comment_read` postgres table (row present = read) replicates through zero, the `comments` synced query carries the caller's read receipt as a `read` related row, and two custom mutators (`comment.markRead` / `comment.markUnread`) write it. The `/comments` page renders unread comments bold with a dot, dims read ones, and gets a per-comment mark read/unread toggle.

Design decisions:

- Per-comment rows keyed `(userId, commentId)`; marking unread deletes the row.
- Presence of the row means read — edits don't reset it, but `readAt` is stored so an "edited since read" rule later is a client-only change.
- Own comments are implicitly read: no row is written on create and the toggle is hidden for them.
- The read receipt rides the existing `comments` query via a ctx-scoped `.related('read', …).one()` — no second synced query, receipts never replicate across users.
- `comment_read` is client-written via mutators (unlike `comment`/`comment_thread`, which stay server-written by the file DO); the sync-worker drain needs no changes, and postgres cascades clean up receipts on comment/user deletion.

### Change type

- [x] `feature`

### Test plan

1. As user A, comment on a shared file; as user B (who has opened the file), visit `/comments`.
2. B sees the comment bold with an unread dot; "Mark read" dims it instantly and survives reload; "Mark unread" restores the dot.
3. A sees their own comment rendered as read, with no toggle.

- [x] Unit tests

### Release notes

- Add read/unread status to the tldraw.com comments page, tracked per user, with a mark read/unread toggle.

### API changes

None — dotcom app and dotcom-shared only, no public SDK API changes.

### Code changes

| Section   | LOC change  |
| --------- | ----------- |
| Core code | +74 / -2    |
| Tests     | +223 / -0   |
| Apps      | +98 / -26   |