### PR TITLE
chore: share the worker esbuild externals list between dev and CI scripts

### DIFF
--- a/internal/scripts/check-worker-bundle.ts
+++ b/internal/scripts/check-worker-bundle.ts
@@ -3,6 +3,7 @@ import { resolve } from 'path'
 import kleur from 'kleur'
 import minimist from 'minimist'
 import { exec } from './lib/exec'
+import { WORKER_EXTERNAL_DEPS } from './lib/worker-externals'
 
 const args = minimist(process.argv.slice(2))
 const sizeLimit = Number(args['size-limit-bytes'])
@@ -29,28 +30,6 @@ interface Meta {
 	}
 }
 
-const EXTERNAL_DEPS = [
-	'cloudflare:*',
-	'crypto',
-	'tls',
-	'net',
-	'stream',
-	'fs',
-	'os',
-	'perf_hooks',
-	'path',
-	'dns',
-	'util',
-	'util/types',
-	'node:child_process',
-	'node:events',
-	'node:path',
-	'node:process',
-	'node:os',
-	'node:timers',
-	'node:util',
-]
-
 async function checkBundleSize() {
 	rmSync(bundleMetaFileName, { force: true })
 
@@ -62,7 +41,7 @@ async function checkBundleSize() {
 		'--outfile=/dev/null',
 		'--minify',
 		'--metafile=' + bundleMetaFileName,
-		...EXTERNAL_DEPS.map((dep) => '--external:' + dep),
+		...WORKER_EXTERNAL_DEPS.map((dep) => '--external:' + dep),
 	])
 
 	console.log(kleur.cyan().bold('Checking bundle size'), 'of', resolve(entry) + '\n')

--- a/internal/scripts/lib/worker-externals.ts
+++ b/internal/scripts/lib/worker-externals.ts
@@ -1,0 +1,27 @@
+/**
+ * Node builtins (and cloudflare modules) that must stay external when bundling a worker
+ * entrypoint with esbuild. With nodejs_compat these resolve at runtime in workerd; esbuild just
+ * needs to be told not to bundle them. Shared between the dev size reporter
+ * (workers/dev.ts) and the CI bundle-size check (check-worker-bundle.ts) so the lists can't drift.
+ */
+export const WORKER_EXTERNAL_DEPS = [
+	'cloudflare:*',
+	'crypto',
+	'tls',
+	'net',
+	'stream',
+	'fs',
+	'os',
+	'perf_hooks',
+	'path',
+	'dns',
+	'util',
+	'util/types',
+	'node:child_process',
+	'node:events',
+	'node:path',
+	'node:process',
+	'node:os',
+	'node:timers',
+	'node:util',
+]

--- a/internal/scripts/workers/dev.ts
+++ b/internal/scripts/workers/dev.ts
@@ -7,6 +7,7 @@ import { lock } from 'proper-lockfile'
 import stripAnsi from 'strip-ansi'
 import * as toml from 'toml'
 import { killProcessTree } from '../lib/kill-tree'
+import { WORKER_EXTERNAL_DEPS } from '../lib/worker-externals'
 
 const lockfileName = __dirname
 
@@ -122,25 +123,9 @@ class SizeReporter {
 			'--bundle',
 			'--minify',
 			'--watch',
-			'--external:cloudflare:*',
 			// need to list out node packages that are used in the worker.
-			// otherwise, if we user platform=node, the bundle size is not reported correctly
-			'--external:os',
-			'--external:node:os',
-			'--external:node:timers',
-			'--external:crypto',
-			'--external:stream',
-			'--external:net',
-			'--external:fs',
-			'--external:perf_hooks',
-			'--external:tls',
-			'--external:path',
-			'--external:node:path',
-			'--external:node:process',
-			'--external:node:child_process',
-			'--external:node:events',
-			'--external:dns',
-			'--external:node:util',
+			// otherwise, if we use platform=node, the bundle size is not reported correctly
+			...WORKER_EXTERNAL_DEPS.map((dep) => '--external:' + dep),
 			'--target=esnext',
 			'--format=esm',
 		])


### PR DESCRIPTION
In order to fix the sync-worker dev size reporter failing with `Could not resolve "util/types"`, this PR extracts the esbuild `--external:` list shared by the dev bundle-size watcher (`internal/scripts/workers/dev.ts`) and the CI bundle-size check (`internal/scripts/check-worker-bundle.ts`) into a single `WORKER_EXTERNAL_DEPS` module.

The two scripts each hard-coded the same list and they drifted: `check-worker-bundle.ts` gained `util` and `util/types` (needed since `pg` 8.22 does a bare `require('util/types')`), but the dev watcher's copy never got the same update, so `yarn dev` printed a resolve error instead of the worker size. Sharing one list fixes the error and prevents the drift from recurring. The worker itself was unaffected — wrangler with `nodejs_compat` resolves these builtins at runtime.

### Change type

- [x] `other`

### Test plan

1. `yarn check-bundle-size` in `apps/dotcom/sync-worker` — passes.
2. `yarn dev` — the "worker is roughly Xkb" report appears again with no `util/types` error.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +32 / -41  |