### PR TITLE
fix(commenting): clustering only re-flows on zoom, cap max split zoom

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -20,8 +20,39 @@
 	pointer-events: auto;
 }
 
+/* Badges are clickable (zoom to the cluster's first split). */
 .cmt-canvas-cluster {
 	transform: translate(-50%, -50%);
+	pointer-events: auto;
+	cursor: pointer;
+}
+
+.cmt-cluster-fade {
+	opacity: 1;
+	transition: opacity 150ms ease;
+}
+
+.cmt-cluster-fade--entering {
+	opacity: 0;
+}
+
+.cmt-cluster-fade--present {
+	opacity: 1;
+}
+
+.cmt-cluster-fade--exiting {
+	opacity: 0;
+}
+
+.cmt-cluster-fade--entering *,
+.cmt-cluster-fade--exiting * {
+	pointer-events: none !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.cmt-cluster-fade {
+		transition: none;
+	}
 }
 
 /* The open thread (its pin + popover) sits above the other pins, so nearby markers don't

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -12,6 +12,7 @@ import {
 	createComment,
 	createCommentThread,
 	Editor,
+	react,
 	TLComment,
 	TLCommentThread,
 	TldrawUiIcon,
@@ -114,17 +115,60 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		() => getClusterZoomBounds(editor),
 		[editor]
 	)
-	const clusterModel = useMemo(() => {
+	const latestModel = useMemo(() => {
 		const table = computeClusterTable(clusterLeaves, clusterZoomBounds)
 		const runtime = createClusterRuntime(table)
 		runtime.seed(editor.getZoomLevel())
 		return { runtime, table }
 	}, [clusterLeaves, clusterZoomBounds, editor])
-	const zoom = useValue('comment cluster zoom', () => editor.getZoomLevel(), [editor])
+	// Re-clustering only applies while zooming: a rebuilt model (thread added, moved, or closed)
+	// is held as `latestModel` and adopted on the next zoom change, so pins never re-flow into
+	// clusters under a static camera. Until adoption, threads the rendered model doesn't know
+	// about show as plain unclustered pins (`orphanThreads`). Exception: a rebuild that *removed*
+	// leaves (thread deleted or opened, page changed) is adopted immediately, so stale pins and
+	// badge counts never linger.
+	const [renderedModel, setRenderedModel] = useState(latestModel)
+	let clusterModel = renderedModel
+	if (renderedModel !== latestModel && hasRemovedLeaves(renderedModel.table, latestModel.table)) {
+		setRenderedModel(latestModel)
+		clusterModel = latestModel
+	}
+	useEffect(() => {
+		if (clusterModel === latestModel) return
+		const zoomAtBuild = editor.getZoomLevel()
+		return react('adopt pending cluster model on zoom', () => {
+			const zoom = editor.getZoomLevel()
+			if (zoom === zoomAtBuild) return
+			latestModel.runtime.seed(zoom)
+			setRenderedModel(latestModel)
+		})
+	}, [clusterModel, latestModel, editor])
+	const orphanThreads = useMemo(() => {
+		if (clusterModel === latestModel) return []
+		const renderedIds = new Set(clusterModel.table.leaves.map((leaf) => leaf.id))
+		const latestIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
+		return threads.filter((thread) => latestIds.has(thread.id) && !renderedIds.has(thread.id))
+	}, [clusterModel, latestModel, threads])
+	// Subscribe to the runtime cursor, not the raw zoom: onCamera runs on every zoom tick (two
+	// O(1) threshold checks against the event table) but returns the same integer until a merge
+	// or split event actually fires — so this component only re-renders on cluster changes, not
+	// on every camera frame.
+	const clusterCursor = useValue(
+		'comment cluster cursor',
+		() => {
+			clusterModel.runtime.onCamera(editor.getZoomLevel())
+			return clusterModel.runtime.k
+		},
+		[clusterModel, editor]
+	)
 	const visibleNodes = useMemo(() => {
-		clusterModel.runtime.onCamera(zoom)
-		return Array.from(clusterModel.runtime.getVisible().values())
-	}, [clusterModel, zoom])
+		const nodes = Array.from(clusterModel.runtime.getVisible().values())
+		// eslint-disable-next-line no-console
+		console.debug(
+			`[comments] cluster cursor k=${clusterCursor} → re-rendering ${nodes.length} visible nodes`
+		)
+		return nodes
+	}, [clusterModel, clusterCursor])
 	const threadsById = useMemo(
 		() => new Map<string, TLCommentThread>(threads.map((thread) => [thread.id, thread])),
 		[threads]
@@ -199,6 +243,9 @@ export function CanvasComments(props: CanvasCommentsProps) {
 				}
 				return <ClusterBadge key={node.id} editor={editor} node={node} />
 			})}
+			{orphanThreads.map((thread) => (
+				<ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
+			))}
 			{openThread && (
 				<ThreadPin key={`open:${openThread.id}`} editor={editor} thread={openThread} {...props} />
 			)}
@@ -208,6 +255,12 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		</div>,
 		container
 	)
+}
+
+function hasRemovedLeaves(rendered: ClusterTable, latest: ClusterTable): boolean {
+	if (rendered.leaves.length === 0) return false
+	const latestIds = new Set(latest.leaves.map((leaf) => leaf.id))
+	return rendered.leaves.some((leaf) => !latestIds.has(leaf.id))
 }
 
 function getClusterZoomBounds(editor: Editor): { minZoom: number; maxZoom: number } {

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable tldraw/jsx-no-literals */
 import {
+	memo,
 	type PointerEvent as ReactPointerEvent,
 	ReactNode,
+	useCallback,
 	useEffect,
 	useMemo,
 	useRef,
@@ -65,6 +67,9 @@ const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
 
 const initialOf = (name: string): string => (name.trim()[0] ?? '?').toUpperCase()
 const CLUSTER_DMAX = 120
+const CLUSTER_FADE_MS = 150
+/** Duration of the click-a-badge zoom-to-split animation. */
+const CLUSTER_EXPAND_ZOOM_MS = 450
 
 /** The leading element for the placement composer — the comment pin's shape, but a pencil
  *  instead of an initial, marking an unsent draft. */
@@ -145,6 +150,11 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		(adoptOnRebuild.current || hasRemovedLeaves(renderedModel.table, latestModel.table))
 	) {
 		adoptOnRebuild.current = false
+		// Carryover seed: events inside their hysteresis band inherit the outgoing partition's
+		// merged/unmerged state instead of the geometric-mean tiebreak, so untouched pins never
+		// snap together (or apart) just because the model was swapped. Idempotent, so safe to
+		// run during render.
+		latestModel.runtime.seedFrom(editor.getZoomLevel(), renderedModel.runtime.getVisible())
 		setRenderedModel(latestModel)
 		clusterModel = latestModel
 	}
@@ -186,7 +196,7 @@ export function CanvasComments(props: CanvasCommentsProps) {
 			const prevZoom = lastZoom
 			lastZoom = zoom
 			if (zoom >= prevZoom) return
-			latestModel.runtime.seed(zoom)
+			latestModel.runtime.seedFrom(zoom, clusterModel.runtime.getVisible())
 			setRenderedModel(latestModel)
 		})
 	}, [clusterModel, latestModel, editor])
@@ -220,6 +230,7 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		)
 		return nodes
 	}, [clusterModel, clusterCursor])
+	const fadeNodes = useFadeVisibleNodes(visibleNodes, clusterModel)
 	const threadsById = useMemo(
 		() => new Map<string, TLCommentThread>(threads.map((thread) => [thread.id, thread])),
 		[threads]
@@ -266,6 +277,22 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		openThreadId.set(thread.id)
 	}, [clusterModel.table, clusterZoomBounds, editor, threadsById, impreciseShapeAnchor])
 
+	// Clicking a badge zooms to just past the zoom at which that cluster first unclusters,
+	// centered on its centroid. The event that created a visible cluster is the event that splits
+	// it, and (by the table's sort + monotone thresholds) it has the smallest zSplit of everything
+	// applied inside it — so its zSplit is exactly the first split within those comments. The
+	// animated zoom-in then drives the runtime cursor like any manual zoom, so the badge splits
+	// (and can be drilled into further) with no extra bookkeeping.
+	const zoomToClusterSplit = useCallback(
+		(node: ClusterNode) => {
+			const event = clusterModel.table.events.find((e) => e.result.id === node.id)
+			if (!event || !Number.isFinite(event.zSplit)) return
+			const zoom = clamp(event.zSplit * 1.05, clusterZoomBounds.minZoom, clusterZoomBounds.maxZoom)
+			centerOnPointAtZoom(editor, node.centroid, zoom, CLUSTER_EXPAND_ZOOM_MS)
+		},
+		[clusterModel, clusterZoomBounds, editor]
+	)
+
 	// Escape collapses the open thread. Capture-phase + stopPropagation so it runs ahead of the
 	// editor (which would otherwise cancel the current tool or clear the selection). If a comment is
 	// being edited, let its own Escape handler exit edit mode first, keeping the thread open.
@@ -286,13 +313,20 @@ export function CanvasComments(props: CanvasCommentsProps) {
 	// live in the UI layer rather than being clipped by the canvas layer.
 	return createPortal(
 		<div className="cmt-canvas-layer">
-			{visibleNodes.map((node) => {
+			{fadeNodes.map(({ node, phase }) => {
+				let content: ReactNode
 				if (node.count === 1) {
 					const thread = threadsById.get(node.id)
 					if (!thread) return null
-					return <ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
+					content = <ThreadPin editor={editor} thread={thread} {...props} />
+				} else {
+					content = <ClusterBadge editor={editor} node={node} onExpand={zoomToClusterSplit} />
 				}
-				return <ClusterBadge key={node.id} editor={editor} node={node} />
+				return (
+					<div key={`cluster-fade:${node.id}`} className={clusterFadeClassName(phase)}>
+						{content}
+					</div>
+				)
 			})}
 			{orphanThreads.map((thread) => (
 				<ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
@@ -313,6 +347,107 @@ export function CanvasComments(props: CanvasCommentsProps) {
 
 const EMPTY_SET: ReadonlySet<string> = new Set()
 const MOVED_LEAF_EPSILON = 1e-6
+type ClusterFadePhase = 'entering' | 'present' | 'exiting'
+
+interface ClusterFadeNode {
+	node: ClusterNode
+	phase: ClusterFadePhase
+}
+
+function useFadeVisibleNodes(
+	nodes: readonly ClusterNode[],
+	resetKey: { runtime: ClusterRuntime; table: ClusterTable }
+): ClusterFadeNode[] {
+	const resetKeyRef = useRef(resetKey)
+	const didReset = resetKeyRef.current !== resetKey
+	if (didReset) {
+		resetKeyRef.current = resetKey
+	}
+
+	const [fadeNodes, setFadeNodes] = useState<ClusterFadeNode[]>(() => toPresentFadeNodes(nodes))
+	const renderedNodes = didReset ? toPresentFadeNodes(nodes) : fadeNodes
+
+	useEffect(() => {
+		setFadeNodes(toPresentFadeNodes(nodes))
+		// Resets only on a new model (resetKey); node-list changes within the same model are
+		// handled by the reconcile effect below, which fades entries in/out instead of snapping.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [resetKey])
+
+	useEffect(() => {
+		if (didReset) return
+		setFadeNodes((previous) => reconcileFadeNodes(previous, nodes))
+	}, [didReset, nodes])
+
+	const hasEntering = renderedNodes.some((item) => item.phase === 'entering')
+	useEffect(() => {
+		if (!hasEntering) return
+		const frame = requestClusterFadeFrame(() => {
+			setFadeNodes((previous) =>
+				previous.map((item) => (item.phase === 'entering' ? { ...item, phase: 'present' } : item))
+			)
+		})
+		return () => cancelClusterFadeFrame(frame)
+	}, [hasEntering, renderedNodes])
+
+	const hasExiting = renderedNodes.some((item) => item.phase === 'exiting')
+	useEffect(() => {
+		if (!hasExiting) return
+		const timeout = window.setTimeout(() => {
+			setFadeNodes((previous) => previous.filter((item) => item.phase !== 'exiting'))
+		}, CLUSTER_FADE_MS)
+		return () => window.clearTimeout(timeout)
+	}, [hasExiting, renderedNodes])
+
+	return renderedNodes
+}
+
+function toPresentFadeNodes(nodes: readonly ClusterNode[]): ClusterFadeNode[] {
+	return nodes.map((node) => ({ node, phase: 'present' }))
+}
+
+function reconcileFadeNodes(
+	previous: readonly ClusterFadeNode[],
+	nextNodes: readonly ClusterNode[]
+): ClusterFadeNode[] {
+	const previousById = new Map(previous.map((item) => [item.node.id, item]))
+	const nextIds = new Set(nextNodes.map((node) => node.id))
+	const next: ClusterFadeNode[] = []
+
+	for (const node of nextNodes) {
+		const previousItem = previousById.get(node.id)
+		next.push({
+			node,
+			phase:
+				previousItem && previousItem.phase !== 'exiting'
+					? previousItem.phase
+					: previousItem
+						? 'present'
+						: 'entering',
+		})
+	}
+
+	for (const item of previous) {
+		if (nextIds.has(item.node.id)) continue
+		next.push(item.phase === 'exiting' ? item : { ...item, phase: 'exiting' })
+	}
+
+	return next
+}
+
+function requestClusterFadeFrame(callback: FrameRequestCallback): number {
+	if (typeof requestAnimationFrame === 'function') return requestAnimationFrame(callback)
+	return window.setTimeout(() => callback(0), 16)
+}
+
+function cancelClusterFadeFrame(frame: number) {
+	if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frame)
+	else window.clearTimeout(frame)
+}
+
+function clusterFadeClassName(phase: ClusterFadePhase): string {
+	return `cmt-cluster-fade cmt-cluster-fade--${phase}`
+}
 
 /**
  * Leaves folded inside a badge whose live anchor no longer matches the position the rendered
@@ -389,7 +524,12 @@ function findDirectParentEvent(table: ClusterTable, threadId: string): MergeEven
 	return table.events.find((event) => event.children.some((child) => child.id === threadId))
 }
 
-function centerOnPointAtZoom(editor: Editor, point: { x: number; y: number }, zoom: number) {
+function centerOnPointAtZoom(
+	editor: Editor,
+	point: { x: number; y: number },
+	zoom: number,
+	duration = 200
+) {
 	const viewport = editor.getViewportScreenBounds()
 	editor.setCamera(
 		{
@@ -397,7 +537,7 @@ function centerOnPointAtZoom(editor: Editor, point: { x: number; y: number }, zo
 			y: viewport.h / (2 * zoom) - point.y,
 			z: zoom,
 		},
-		{ animation: { duration: 200 } }
+		{ animation: { duration } }
 	)
 }
 
@@ -405,7 +545,19 @@ function clamp(value: number, min: number, max: number): number {
 	return Math.max(min, Math.min(max, value))
 }
 
-function ClusterBadge({ editor, node }: { editor: Editor; node: ClusterNode }) {
+// Memoized: cluster nodes and thread records are identity-stable while unchanged, so pins and
+// badges skip re-rendering when the parent re-renders for reasons that don't concern them
+// (leaf recomputes during shape drags, partition changes elsewhere). Camera tracking still
+// works — each component subscribes to its own viewport position via signals, not via props.
+const ClusterBadge = memo(function ClusterBadge({
+	editor,
+	node,
+	onExpand,
+}: {
+	editor: Editor
+	node: ClusterNode
+	onExpand(node: ClusterNode): void
+}) {
 	const point = useValue(
 		'cluster badge point',
 		() => {
@@ -419,11 +571,19 @@ function ClusterBadge({ editor, node }: { editor: Editor; node: ClusterNode }) {
 	if (!point) return null
 
 	return (
-		<div className="cmt-canvas-cluster" style={{ left: point.x, top: point.y }}>
+		<div
+			className="cmt-canvas-cluster"
+			style={{ left: point.x, top: point.y }}
+			onPointerDown={stop}
+			onClick={(e) => {
+				e.stopPropagation()
+				onExpand(node)
+			}}
+		>
 			<CountBadge count={node.count} />
 		</div>
 	)
-}
+})
 
 function isInInflatedViewport(editor: Editor, point: { x: number; y: number }): boolean {
 	const viewport = editor.getViewportScreenBounds()
@@ -435,7 +595,7 @@ function isInInflatedViewport(editor: Editor, point: { x: number; y: number }): 
 	)
 }
 
-function ThreadPin({
+const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
 	...props
@@ -677,7 +837,7 @@ function ThreadPin({
 				)}
 		</div>
 	)
-}
+})
 
 function PendingComposer({
 	editor,

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -22,7 +22,7 @@ import {
 	useValue,
 } from 'tldraw'
 import { computeClusterTable } from '../clustering/computeClusterTable'
-import { createClusterRuntime } from '../clustering/runtime'
+import { type ClusterRuntime, createClusterRuntime } from '../clustering/runtime'
 import type { ClusterNode, ClusterTable, MergeEvent } from '../clustering/types'
 import { CommentCard, CommentCardProps } from '../ui/comment-card'
 import { CommentComposer } from '../ui/comment-composer'
@@ -105,10 +105,21 @@ export function CanvasComments(props: CanvasCommentsProps) {
 	const pending = usePendingComment()
 	const openId = useValue('open thread id', () => openThreadId.get(), [])
 	const { impreciseShapeAnchor } = props
+	// Threads whose anchor has moved (by any means — drag, nudge, align, undo, a collaborator)
+	// since the rendered clustering was built. They pop out of clustering and render as live pins,
+	// and only rejoin at the next zoom event, when everything re-clusters anyway.
+	const [movedThreadIds, setMovedThreadIds] = useState<ReadonlySet<string>>(EMPTY_SET)
+	const adoptOnRebuild = useRef(false)
 	const clusterLeaves = useValue(
 		'comment cluster leaves',
-		() => collectClusterLeaves(editor, threads, openThreadId.get(), impreciseShapeAnchor),
-		[editor, threads, impreciseShapeAnchor]
+		() =>
+			collectClusterLeaves(
+				editor,
+				threads.filter((thread) => !movedThreadIds.has(thread.id)),
+				openThreadId.get(),
+				impreciseShapeAnchor
+			),
+		[editor, threads, impreciseShapeAnchor, movedThreadIds]
 	)
 	const clusterZoomBounds = useValue(
 		'comment cluster zoom bounds',
@@ -129,16 +140,52 @@ export function CanvasComments(props: CanvasCommentsProps) {
 	// badge counts never linger.
 	const [renderedModel, setRenderedModel] = useState(latestModel)
 	let clusterModel = renderedModel
-	if (renderedModel !== latestModel && hasRemovedLeaves(renderedModel.table, latestModel.table)) {
+	if (
+		renderedModel !== latestModel &&
+		(adoptOnRebuild.current || hasRemovedLeaves(renderedModel.table, latestModel.table))
+	) {
+		adoptOnRebuild.current = false
 		setRenderedModel(latestModel)
 		clusterModel = latestModel
 	}
+	// Pop-out detection: a leaf folded inside a badge can't follow its anchor (the badge position
+	// is baked into the model), so when its live position drifts from the baked one it ghosts.
+	// Marking it moved excludes it from the cluster input, which reads as a removal above and
+	// re-clusters the rest of its pile immediately; the pin itself renders live below.
+	const newlyMovedIds = findMovedClusteredLeafIds(clusterModel, latestModel)
+	if (newlyMovedIds.length > 0) {
+		// eslint-disable-next-line no-console
+		console.debug(`[comments] pins popped out of clustering: ${newlyMovedIds.join(', ')}`)
+		const next = new Set(movedThreadIds)
+		for (const id of newlyMovedIds) next.add(id)
+		setMovedThreadIds(next)
+	}
+	// Moved pins rejoin clustering on the next zoom-out motion: clear the set (so the rebuild
+	// includes them again) and adopt that rebuild immediately instead of deferring it. Zooming in
+	// never folds pins into clusters — merging is a zoom-out-only move, matching the runtime.
+	useEffect(() => {
+		if (movedThreadIds.size === 0) return
+		let lastZoom = editor.getZoomLevel()
+		return react('rejoin moved comment pins on zoom out', () => {
+			const zoom = editor.getZoomLevel()
+			const prevZoom = lastZoom
+			lastZoom = zoom
+			if (zoom >= prevZoom) return
+			adoptOnRebuild.current = true
+			setMovedThreadIds(EMPTY_SET)
+		})
+	}, [movedThreadIds, editor])
+	// Adopt a pending rebuild only on zoom-out motion: folding deferred additions into clusters is
+	// a merge, and merging only happens while zooming out. While zooming in, the stale table still
+	// splits correctly on its own (split thresholds are direction-safe by the hysteresis invariant).
 	useEffect(() => {
 		if (clusterModel === latestModel) return
-		const zoomAtBuild = editor.getZoomLevel()
-		return react('adopt pending cluster model on zoom', () => {
+		let lastZoom = editor.getZoomLevel()
+		return react('adopt pending cluster model on zoom out', () => {
 			const zoom = editor.getZoomLevel()
-			if (zoom === zoomAtBuild) return
+			const prevZoom = lastZoom
+			lastZoom = zoom
+			if (zoom >= prevZoom) return
 			latestModel.runtime.seed(zoom)
 			setRenderedModel(latestModel)
 		})
@@ -149,6 +196,10 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		const latestIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
 		return threads.filter((thread) => latestIds.has(thread.id) && !renderedIds.has(thread.id))
 	}, [clusterModel, latestModel, threads])
+	const movedThreads = useMemo(
+		() => threads.filter((thread) => movedThreadIds.has(thread.id) && thread.id !== openId),
+		[threads, movedThreadIds, openId]
+	)
 	// Subscribe to the runtime cursor, not the raw zoom: onCamera runs on every zoom tick (two
 	// O(1) threshold checks against the event table) but returns the same integer until a merge
 	// or split event actually fires — so this component only re-renders on cluster changes, not
@@ -246,6 +297,9 @@ export function CanvasComments(props: CanvasCommentsProps) {
 			{orphanThreads.map((thread) => (
 				<ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
 			))}
+			{movedThreads.map((thread) => (
+				<ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
+			))}
 			{openThread && (
 				<ThreadPin key={`open:${openThread.id}`} editor={editor} thread={openThread} {...props} />
 			)}
@@ -255,6 +309,36 @@ export function CanvasComments(props: CanvasCommentsProps) {
 		</div>,
 		container
 	)
+}
+
+const EMPTY_SET: ReadonlySet<string> = new Set()
+const MOVED_LEAF_EPSILON = 1e-6
+
+/**
+ * Leaves folded inside a badge whose live anchor no longer matches the position the rendered
+ * model was built with. Visible (unclustered) leaf pins track their anchor live, so they can
+ * stay deferred; a badge can't follow a member, so these must pop out of clustering.
+ */
+function findMovedClusteredLeafIds(
+	rendered: { runtime: ClusterRuntime; table: ClusterTable },
+	latest: { table: ClusterTable }
+): string[] {
+	if (rendered.table === latest.table) return []
+	const visible = rendered.runtime.getVisible()
+	const latestById = new Map(latest.table.leaves.map((leaf) => [leaf.id, leaf]))
+	const moved: string[] = []
+	for (const leaf of rendered.table.leaves) {
+		if (visible.has(leaf.id)) continue
+		const current = latestById.get(leaf.id)
+		if (!current) continue
+		if (
+			Math.abs(current.centroid.x - leaf.centroid.x) > MOVED_LEAF_EPSILON ||
+			Math.abs(current.centroid.y - leaf.centroid.y) > MOVED_LEAF_EPSILON
+		) {
+			moved.push(leaf.id)
+		}
+	}
+	return moved
 }
 
 function hasRemovedLeaves(rendered: ClusterTable, latest: ClusterTable): boolean {

--- a/packages/commenting/src/clustering/computeClusterTable.test.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.test.ts
@@ -38,7 +38,15 @@ function randomLeaves(n: number, seed: number, scale = 1000): LeafInput[] {
 /** The pipeline composed by hand — computeClusterTable must match it exactly. */
 function manualPipeline(
 	leaves: readonly LeafInput[],
-	opts: { Tc: number; Tu: number; eps: number; Dmax: number; minZoom: number; maxZoom: number }
+	opts: {
+		Tc: number
+		Tu: number
+		eps: number
+		Dmax: number
+		minZoom: number
+		maxZoom: number
+		maxSplitZoom?: number
+	}
 ): MergeEvent[] {
 	const raw = cappedReplay(leaves, mstEdges(leaves), { Tc: opts.Tc, Dmax: opts.Dmax })
 	return finalize(contract(raw, opts.eps), {
@@ -46,6 +54,7 @@ function manualPipeline(
 		Tu: opts.Tu,
 		minZoom: opts.minZoom,
 		maxZoom: opts.maxZoom,
+		maxSplitZoom: opts.maxSplitZoom ?? 6,
 	})
 }
 
@@ -101,6 +110,16 @@ describe('computeClusterTable composition', () => {
 			...ZOOM_BOUNDS,
 		})
 		expect(tableShapes(table)).toEqual(expected.map(eventShape))
+	})
+
+	it('caps coincident pairs at the default maxSplitZoom of 6 (600%)', () => {
+		// Two threads at the same point: raw merge zoom is Infinity (never split), but the
+		// default cap schedules them to merge at 4 and split at 6 like any ultra-tight pair.
+		const leaves = [leaf('a', 50, 50), leaf('b', 50, 50)]
+		const table = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
+		expect(table.events).toHaveLength(1)
+		expect(table.events[0].zMerge).toBe(4)
+		expect(table.events[0].zSplit).toBe(6)
 	})
 
 	it('honors partial overrides without disturbing the other defaults', () => {

--- a/packages/commenting/src/clustering/computeClusterTable.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.ts
@@ -10,6 +10,7 @@ interface ResolvedClusterOptions {
 	Dmax: number
 	minZoom: number
 	maxZoom: number
+	maxSplitZoom: number
 }
 
 export function computeClusterTable(
@@ -31,6 +32,7 @@ export function computeClusterTable(
 		Tu: opts.Tu,
 		minZoom: opts.minZoom,
 		maxZoom: opts.maxZoom,
+		maxSplitZoom: opts.maxSplitZoom,
 	})
 
 	return { events, leaves: leafNodes }
@@ -41,6 +43,7 @@ function resolveOptions(options: ClusterOptions): ResolvedClusterOptions {
 	const Tu = options.Tu ?? 1.5 * Tc
 	const eps = options.eps ?? 0.12
 	const Dmax = options.Dmax ?? 3 * Tc
+	const maxSplitZoom = options.maxSplitZoom ?? 6
 	const { minZoom, maxZoom } = options
 
 	if (!Number.isFinite(Tc) || Tc <= 0) {
@@ -61,8 +64,11 @@ function resolveOptions(options: ClusterOptions): ResolvedClusterOptions {
 	if (!Number.isFinite(maxZoom) || maxZoom <= minZoom) {
 		throw new Error('maxZoom must be finite and greater than minZoom')
 	}
+	if (!Number.isFinite(maxSplitZoom) || maxSplitZoom <= 0) {
+		throw new Error('maxSplitZoom must be finite and greater than 0')
+	}
 
-	return { Tc, Tu, eps, Dmax, minZoom, maxZoom }
+	return { Tc, Tu, eps, Dmax, minZoom, maxZoom, maxSplitZoom }
 }
 
 function leafToNode(leaf: LeafInput): ClusterNode {

--- a/packages/commenting/src/clustering/locality.test.ts
+++ b/packages/commenting/src/clustering/locality.test.ts
@@ -34,7 +34,7 @@ function randomLeaves(n: number, seed: number, scale = 1000): LeafInput[] {
 	return Array.from({ length: n }, (_, i) => leaf(`leaf-${i}`, rand() * scale, rand() * scale))
 }
 
-const OPTS = { Tc: 40, Tu: 60, eps: 0.12, Dmax: 120, minZoom: 0.05, maxZoom: 8 }
+const OPTS = { Tc: 40, Tu: 60, eps: 0.12, Dmax: 120, minZoom: 0.05, maxZoom: 8, maxSplitZoom: 1e9 }
 const R = OPTS.Tu / OPTS.Tc
 const SLACK = 1 + 1e-9
 

--- a/packages/commenting/src/clustering/runtime.test.ts
+++ b/packages/commenting/src/clustering/runtime.test.ts
@@ -256,7 +256,15 @@ function mulberry32(seed: number): () => number {
 	}
 }
 
-const PIPE_OPTS = { Tc: 40, Tu: 60, eps: 0.12, Dmax: 120, minZoom: 0.05, maxZoom: 8 }
+const PIPE_OPTS = {
+	Tc: 40,
+	Tu: 60,
+	eps: 0.12,
+	Dmax: 120,
+	minZoom: 0.05,
+	maxZoom: 8,
+	maxSplitZoom: 1e9,
+}
 
 function buildTable(leaves: LeafInput[]): ClusterTable {
 	const rawEvents = cappedReplay(leaves, mstEdges(leaves), {
@@ -268,6 +276,7 @@ function buildTable(leaves: LeafInput[]): ClusterTable {
 		Tu: PIPE_OPTS.Tu,
 		minZoom: PIPE_OPTS.minZoom,
 		maxZoom: PIPE_OPTS.maxZoom,
+		maxSplitZoom: PIPE_OPTS.maxSplitZoom,
 	})
 	const leafNodes: ClusterNode[] = leaves.map((l) => ({
 		id: l.id,
@@ -434,5 +443,154 @@ describe('createClusterRuntime properties (random tables, random zoom walks)', (
 			expect(seeded.k).toBe(walked.k)
 			expect(visibleIds(seeded)).toEqual(visibleIds(walked))
 		}
+	})
+})
+
+describe('createClusterRuntime seedFrom (carryover seeding)', () => {
+	it('band event merged in the previous partition stays merged', () => {
+		// zoom 5 is inside E0's band and above the geometric midpoint (≈4.899):
+		// a fresh seed would leave A/B/C split. History says merged — carryover keeps it.
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(
+			5,
+			new Map([
+				[P.id, P],
+				[D.id, D],
+			])
+		)
+		expect(rt.k).toBe(1)
+		expect(visibleIds(rt)).toEqual(['cluster:3:a', 'd'])
+	})
+
+	it('band event unmerged in the previous partition stays unmerged (no snap-together)', () => {
+		// zoom 4.5 is inside E0's band and below the geometric midpoint: a fresh seed
+		// would merge A/B/C even though nothing changed for them. History says split.
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(
+			4.5,
+			new Map([
+				[A.id, A],
+				[B.id, B],
+				[C.id, C],
+				[D.id, D],
+			])
+		)
+		expect(rt.k).toBe(0)
+		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
+	})
+
+	it('thresholds override history in both directions', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		// zoom <= zMerge: mandatory merge, even though the previous partition was split
+		rt.seedFrom(
+			3,
+			new Map([
+				[A.id, A],
+				[B.id, B],
+				[C.id, C],
+				[D.id, D],
+			])
+		)
+		expect(rt.k).toBe(1)
+		// zoom >= zSplit: mandatory split, even though the previous partition was merged
+		rt.seedFrom(
+			7,
+			new Map([
+				[P.id, P],
+				[D.id, D],
+			])
+		)
+		expect(rt.k).toBe(0)
+	})
+
+	it('a band event with no counterpart in the previous partition stays inactive', () => {
+		// Empty history (or partial membership) → the rebuild introduced this merge; it
+		// defers to the next zoom-out rather than firing under a static camera.
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(5, new Map())
+		expect(rt.k).toBe(0)
+		const partial = node(['a', 'b'], 5, 0)
+		rt.seedFrom(
+			5,
+			new Map([
+				[partial.id, partial],
+				[C.id, C],
+				[D.id, D],
+			])
+		)
+		expect(rt.k).toBe(0)
+	})
+
+	it('membership in a superset cluster counts as merged', () => {
+		// The previous partition holds all four in Q; E1 (band at zoom 1.2) inherits merged.
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(1.2, new Map([[Q.id, Q]]))
+		expect(rt.k).toBe(2)
+		expect(visibleIds(rt)).toEqual(['cluster:4:a'])
+	})
+
+	it('classification stops at the first inactive event (prefix cut is conservative)', () => {
+		// Two independent band events at zoom 4.5. The first is split in history, the
+		// second merged — but active events must be a prefix, so the second resolves
+		// to split (conservative: never merges anything history did not sanction).
+		const AB = node(['a', 'b'], 5, 0)
+		const CD = node(['c', 'd'], 105, 0)
+		const table: ClusterTable = {
+			events: [mev(4, 6, [A, B], AB), mev(3, 5, [C, D], CD)],
+			leaves: [A, B, C, D],
+		}
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(
+			4.5,
+			new Map([
+				[A.id, A],
+				[B.id, B],
+				[CD.id, CD],
+			])
+		)
+		expect(rt.k).toBe(0)
+		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
+	})
+
+	it('seedFrom followed by onCamera at the same zoom is a no-op', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(
+			5,
+			new Map([
+				[P.id, P],
+				[D.id, D],
+			])
+		)
+		const k = rt.k
+		const ids = visibleIds(rt)
+		rt.onCamera(5)
+		expect(rt.k).toBe(k)
+		expect(visibleIds(rt)).toEqual(ids)
+		expectPostconditions(rt, table, 5)
+	})
+
+	it('matches a fresh seed when the previous partition mirrors the geometric tiebreak', () => {
+		// Sanity: outside bands and with agreeing history, seedFrom degenerates to seed.
+		const table = microTraceTable()
+		for (const zoom of [0.5, 2, 8]) {
+			const fresh = createClusterRuntime(table)
+			fresh.seed(zoom)
+			const carried = createClusterRuntime(table)
+			carried.seedFrom(zoom, fresh.getVisible())
+			expect(carried.k).toBe(fresh.k)
+			expect(visibleIds(carried)).toEqual(visibleIds(fresh))
+		}
+	})
+
+	it('throws on non-positive or non-finite zoom', () => {
+		const rt = createClusterRuntime(microTraceTable())
+		expect(() => rt.seedFrom(0, new Map())).toThrow()
+		expect(() => rt.seedFrom(NaN, new Map())).toThrow()
 	})
 })

--- a/packages/commenting/src/clustering/runtime.ts
+++ b/packages/commenting/src/clustering/runtime.ts
@@ -5,6 +5,16 @@ export interface ClusterRuntime {
 	readonly k: number
 	/** Reset state from scratch for the given zoom (cold start / after rebuild). */
 	seed(zoom: number): void
+	/**
+	 * Reset state for the given zoom, carrying hysteresis state over from a previous partition
+	 * (the visible map of the model being replaced). Threshold-forced events ignore history:
+	 * zoom <= zMerge is always active, zoom >= zSplit always inactive. An event inside its band
+	 * is active iff its members were merged together in `previous`; a band event with no history
+	 * (e.g. introduced by the rebuild) stays inactive until the next zoom-out crosses its zMerge.
+	 * Active events must form a prefix of the table, so classification stops at the first
+	 * inactive event; later band-active events conservatively resolve to split.
+	 */
+	seedFrom(zoom: number, previous: ReadonlyMap<string, ClusterNode>): void
 	/** Advance/retreat the cursor for a camera change. No-op if zoom sits inside all bands. */
 	onCamera(zoom: number): void
 	/** The current partition: cluster id → node. Do not mutate. */
@@ -35,6 +45,32 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 		this.seeded = true
 	}
 
+	seedFrom(zoom: number, previous: ReadonlyMap<string, ClusterNode>): void {
+		validateZoom(zoom)
+		const ownerByMember = new Map<string, string>()
+		for (const node of previous.values()) {
+			for (const member of node.members) {
+				ownerByMember.set(member, node.id)
+			}
+		}
+
+		const events = this.table.events
+		let k = 0
+		while (k < events.length) {
+			const event = events[k]
+			if (zoom >= event.zSplit) break
+			if (zoom > event.zMerge && !wasMergedTogether(event.result.members, ownerByMember)) break
+			k++
+		}
+
+		this.k = k
+		this.resetVisible()
+		for (let i = 0; i < k; i++) {
+			applyEvent(this.visible, events[i])
+		}
+		this.seeded = true
+	}
+
 	onCamera(zoom: number): void {
 		validateZoom(zoom)
 		if (!this.seeded) {
@@ -61,6 +97,19 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 			this.visible.set(leaf.id, leaf)
 		}
 	}
+}
+
+/** True iff every member id belonged to the same node of the previous partition. */
+function wasMergedTogether(
+	members: readonly string[],
+	ownerByMember: ReadonlyMap<string, string>
+): boolean {
+	const owner = ownerByMember.get(members[0])
+	if (owner === undefined) return false
+	for (let i = 1; i < members.length; i++) {
+		if (ownerByMember.get(members[i]) !== owner) return false
+	}
+	return true
 }
 
 function seedCount(events: readonly MergeEvent[], zoom: number): number {

--- a/packages/commenting/src/clustering/schedule.test.ts
+++ b/packages/commenting/src/clustering/schedule.test.ts
@@ -212,7 +212,7 @@ describe('contract validation and purity', () => {
 
 // --- finalize: fixtures --------------------------------------------------------
 
-const FIN_OPTS = { Tc: 40, Tu: 60, minZoom: 0.1, maxZoom: 8 } // r = 1.5
+const FIN_OPTS = { Tc: 40, Tu: 60, minZoom: 0.1, maxZoom: 8, maxSplitZoom: 1e9 } // r = 1.5
 
 function contracted(zMerge: number, children: ClusterNode[], result: ClusterNode): ContractedEvent {
 	return { zMerge, children, result }
@@ -246,12 +246,49 @@ describe('finalize fixtures', () => {
 		expect(finalize([ev], FIN_OPTS)[0].zSplit).toBe(3)
 	})
 
-	it('leaves zMerge >= maxZoom events unclamped (permanently merged)', () => {
+	it('leaves zMerge >= maxZoom events unclamped by maxZoom (band above camera range)', () => {
 		// zMerge exactly at maxZoom: the clamp condition is zMerge < maxZoom, strict
 		const atMax = contracted(8, [A, B], node(['a', 'b']))
 		expect(finalize([atMax], FIN_OPTS)[0].zSplit).toBe(12)
+		// coincident anchors are no longer permanently merged — maxSplitZoom caps them
 		const inf = contracted(Infinity, [X, Y], node(['x', 'y']))
-		expect(finalize([inf], FIN_OPTS)[0].zSplit).toBe(Infinity)
+		expect(finalize([inf], FIN_OPTS)[0]).toMatchObject({ zMerge: 1e9 / 1.5, zSplit: 1e9 })
+	})
+
+	it('caps every split at maxSplitZoom, folding the band below the cap', () => {
+		// r = 1.5, maxSplitZoom 6 -> zMerge cap 4: past zoom 6 nothing stays clustered,
+		// however close (or coincident) the members are.
+		const opts = { ...FIN_OPTS, maxSplitZoom: 6 }
+		const coincident = contracted(Infinity, [A, B], node(['a', 'b']))
+		const tight = contracted(10, [A, B], node(['a', 'b']))
+		const normal = contracted(2, [A, B], node(['a', 'b']))
+		expect(finalize([coincident], opts)[0]).toMatchObject({ zMerge: 4, zSplit: 6 })
+		expect(finalize([tight], opts)[0]).toMatchObject({ zMerge: 4, zSplit: 6 })
+		// events already below the cap are untouched
+		expect(finalize([normal], opts)[0]).toMatchObject({ zMerge: 2, zSplit: 3 })
+	})
+
+	it('capping preserves sort order and the zSplit > zMerge invariant', () => {
+		const opts = { ...FIN_OPTS, maxSplitZoom: 6 }
+		const events = [
+			contracted(Infinity, [A, B], node(['a', 'b'])),
+			contracted(10, [C, X], node(['c', 'x'])),
+			contracted(2, [Y, node(['a', 'b'])], node(['a', 'b', 'y'])),
+		]
+		const out = finalize(events, opts)
+		expect(out.map((e) => e.zMerge)).toEqual([4, 4, 2])
+		for (let i = 0; i < out.length; i++) {
+			expect(out[i].zSplit).toBeGreaterThan(out[i].zMerge)
+			if (i > 0) expect(out[i].zSplit).toBeLessThanOrEqual(out[i - 1].zSplit)
+		}
+	})
+
+	it('throws on non-positive or non-finite maxSplitZoom', () => {
+		const events = [contracted(2, [A, B], node(['a', 'b']))]
+		expect(() => finalize(events, { ...FIN_OPTS, maxSplitZoom: 0 })).toThrow()
+		expect(() => finalize(events, { ...FIN_OPTS, maxSplitZoom: -1 })).toThrow()
+		expect(() => finalize(events, { ...FIN_OPTS, maxSplitZoom: NaN })).toThrow()
+		expect(() => finalize(events, { ...FIN_OPTS, maxSplitZoom: Infinity })).toThrow()
 	})
 
 	it('prunes the trailing suffix below minZoom, keeping the boundary value', () => {
@@ -318,7 +355,15 @@ function randomLeaves(n: number, seed: number, scale = 1000): LeafInput[] {
 	return Array.from({ length: n }, (_, i) => leaf(`leaf-${i}`, rand() * scale, rand() * scale))
 }
 
-const PIPE_OPTS = { Tc: 40, Tu: 60, eps: 0.12, Dmax: 120, minZoom: 1e-6, maxZoom: 8 }
+const PIPE_OPTS = {
+	Tc: 40,
+	Tu: 60,
+	eps: 0.12,
+	Dmax: 120,
+	minZoom: 1e-6,
+	maxZoom: 8,
+	maxSplitZoom: 1e9,
+}
 
 function buildTableEvents(
 	leaves: readonly LeafInput[],
@@ -330,6 +375,7 @@ function buildTableEvents(
 		Tu: opts.Tu,
 		minZoom: opts.minZoom,
 		maxZoom: opts.maxZoom,
+		maxSplitZoom: opts.maxSplitZoom,
 	})
 }
 

--- a/packages/commenting/src/clustering/schedule.ts
+++ b/packages/commenting/src/clustering/schedule.ts
@@ -24,20 +24,25 @@ export function contract(raw: readonly RawMergeEvent[], eps: number): Contracted
 
 export function finalize(
 	events: readonly ContractedEvent[],
-	opts: { Tc: number; Tu: number; minZoom: number; maxZoom: number }
+	opts: { Tc: number; Tu: number; minZoom: number; maxZoom: number; maxSplitZoom: number }
 ): MergeEvent[] {
 	validateFinalizeOptions(opts)
 
 	const r = opts.Tu / opts.Tc
+	// Every cluster must have split by maxSplitZoom, however close (or coincident) its members.
+	// Capping zMerge at maxSplitZoom / r keeps the whole band below the cap, preserving
+	// zSplit > zMerge and the table's sort order (min with a constant is order-preserving).
+	const zMergeCap = opts.maxSplitZoom / r
 	const out: MergeEvent[] = []
 	for (const event of events) {
-		if (event.zMerge < opts.minZoom) break
-		let zSplit = event.zMerge * r
-		if (event.zMerge < opts.maxZoom) {
+		const zMerge = Math.min(event.zMerge, zMergeCap)
+		if (zMerge < opts.minZoom) break
+		let zSplit = zMerge * r
+		if (zMerge < opts.maxZoom) {
 			zSplit = Math.min(zSplit, opts.maxZoom)
 		}
 		out.push({
-			zMerge: event.zMerge,
+			zMerge,
 			zSplit,
 			children: event.children,
 			result: event.result,
@@ -121,7 +126,11 @@ function validateFinalizeOptions(opts: {
 	Tu: number
 	minZoom: number
 	maxZoom: number
+	maxSplitZoom: number
 }) {
+	if (!Number.isFinite(opts.maxSplitZoom) || opts.maxSplitZoom <= 0) {
+		throw new Error('maxSplitZoom must be finite and greater than 0')
+	}
 	if (!Number.isFinite(opts.Tc) || opts.Tc <= 0) {
 		throw new Error('Tc must be finite and greater than 0')
 	}

--- a/packages/commenting/src/clustering/types.ts
+++ b/packages/commenting/src/clustering/types.ts
@@ -82,4 +82,11 @@ export interface ClusterOptions {
 	/** Camera zoom bounds — pass the editor's camera constraints. Required. */
 	minZoom: number
 	maxZoom: number
+	/**
+	 * Zoom by which every cluster has split, no matter how close its members are — including
+	 * coincident anchors, which otherwise never split. Merge thresholds are capped at
+	 * `maxSplitZoom / (Tu/Tc)` so the hysteresis band keeps its shape below the cap.
+	 * Default 6 (600%).
+	 */
+	maxSplitZoom?: number
 }


### PR DESCRIPTION
Follows up on the initial clustering pipeline with the rendering-side fixes it needed: clustering was recomputing and re-seeding on every store change, which caused pins to snap into or out of clusters with no camera movement. Also adds a click-to-expand action on cluster badges and a hard cap on how long a cluster can stay merged.

- **Defer re-clustering to zoom.** A store change (add/move/delete a comment) still rebuilds the cluster table immediately, but the rebuild is only rendered on the next zoom-out — merging only ever happens while zooming out, matching the runtime's own hysteresis direction. New/reopened threads render as plain pins in the meantime.
- **Pop pins out of clustering when their shape moves.** A comment folded inside a badge can't visually follow its anchor when the shape it's attached to is dragged, nudged, aligned, or moved by a collaborator — previously the badge would ghost at its old position. The moved leaf now excludes itself from clustering and renders as a live pin, rejoining on the next zoom-out.
- **Carry hysteresis state across a rebuild (`seedFrom`).** Adopting a rebuilt cluster table used to re-seed from scratch, which could snap an untouched pair together or apart if their zoom sat inside a merge/split band. `seedFrom` inherits the previous partition's merged/unmerged state for any event still in its band, so untouched pins never move without a zoom.
- **Cap the maximum split zoom (`maxSplitZoom`, default 600%).** Every cluster, including coincident (same-point) comments, is now guaranteed to fully split out past this zoom, instead of being able to stay merged forever.
- **Click a badge to zoom to its first split.** Looks up the event that produced the badge and animates the camera to just past that event's split zoom, centered on the badge's centroid.
- Memoize `ThreadPin`/`ClusterBadge` so re-renders elsewhere in the overlay (e.g. a shape drag) don't cascade into pins whose data didn't change.

### Change type

- [x] `fix`

### Test plan

1. Zoom in and out over a cluster of comments — badges should only merge/split on zoom, never under a static camera.
2. Add a comment, or reopen a closed thread, near an existing cluster while not zooming — it should appear as a standalone pin, then fold into clustering on the next zoom-out.
3. Drag a shape with a clustered comment attached — the comment should pop out and follow the shape immediately; the rest of its former cluster should re-flow to the correct count without snapping other, untouched clusters together or apart.
4. Zoom in past 600% on a tight or coincident cluster of comments — it should be fully split into individual pins.
5. Click a cluster badge — the camera should animate to just past the zoom where that cluster first splits, centered on the badge.

- [x] Unit tests

### Release notes

- Fix comment pin clustering to only re-cluster on zoom (not on every comment edit or shape move), preserve merge/split state across rebuilds, and add a cap so clusters always fully split at high zoom. Clicking a cluster badge now zooms in to reveal its contents.

### API changes

- `ClusterOptions` gains `maxSplitZoom` (default 6): caps every cluster's split zoom so nothing stays merged indefinitely.
- `ClusterRuntime` gains `seedFrom(zoom, previousVisible)`: seeds the runtime for a given zoom while carrying over a previous partition's hysteresis state instead of re-seeding from scratch.

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +423 / -24 |
| Tests | +230 / -7 |
