### PR TITLE
fix(commenting): resolve comment author names from Zero, not just presence

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -7,7 +7,9 @@ import { useMaybeApp } from '../../hooks/useAppState'
  * dotcom's comments layer: a thin consumer of `@tldraw/commenting/canvas`'s `<CanvasComments>`.
  * All the flow (tool, pins, thread popovers, composer, rich-text bodies) lives in the toolkit;
  * dotcom only supplies the pieces that are its own — the signed-in user's id and a name resolver
- * (current user from preferences, others from live presence).
+ * (current user from preferences, other authors from the Zero comments query's author join, with
+ * live presence as a fallback for users who haven't committed a comment yet, e.g. a draft
+ * composer's byline).
  */
 export function CommentsOnCanvas() {
 	const editor = useEditor()
@@ -19,6 +21,18 @@ export function CommentsOnCanvas() {
 		() => {
 			if (!app) return 'You'
 			return app.tlUser.userPreferences.get().name || 'You'
+		},
+		[app]
+	)
+	const authorNames = useValue(
+		'comment author names',
+		() => {
+			const names = new Map<string, string>()
+			if (!app) return names
+			for (const c of app.getComments()) {
+				if (c.author?.name) names.set(c.authorId, c.author.name)
+			}
+			return names
 		},
 		[app]
 	)
@@ -34,8 +48,11 @@ export function CommentsOnCanvas() {
 		[editor]
 	)
 	const resolveName = useCallback(
-		(id: string) => (id === currentUserId ? currentUserName : (presenceNames.get(id) ?? 'Someone')),
-		[currentUserId, currentUserName, presenceNames]
+		(id: string) => {
+			if (id === currentUserId) return currentUserName
+			return authorNames.get(id) ?? presenceNames.get(id) ?? 'Someone'
+		},
+		[currentUserId, currentUserName, authorNames, presenceNames]
 	)
 
 	return (


### PR DESCRIPTION
In order to show comment author names even when the author is not currently in the file, this PR resolves names on the canvas from the Zero comments query (which joins each comment's `author` row) instead of relying only on live `instance_presence` records. Presence records disappear the moment a user disconnects, so authors of older comments showed up as "Someone".

Resolution order is now: current user's preferences name → Zero comment author map → presence (covers connected users who haven't committed a comment yet, e.g. a draft composer byline) → "Someone". Names also stay current when a user renames, since Zero syncs the `user` row. Logged-out guests have no Zero client and keep the presence-only behavior.

### Change type

- [x] `bugfix`

### Test plan

1. User A comments in a shared file, then closes it.
2. User B opens the file: the comment shows A's name instead of "Someone".
3. A renames themselves: B sees the updated name.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +20 / -3   |