### PR TITLE
feat: add clear search buttons to the dotcom and examples sidebars

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRecentFiles.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRecentFiles.tsx
@@ -158,20 +158,24 @@ export function TlaSidebarRecentFiles() {
 			) : null}
 			{isSearching ? (
 				<>
-					<div className={styles.sidebarDivider} />
-					<button
-						className={classNames(
-							styles.sidebarActionButton,
-							styles.hoverable,
-							'tla-text_ui__regular'
-						)}
-						onClick={handleClearSearch}
-						data-testid="tla-sidebar-search-clear-button"
-					>
-						<span className={styles.sidebarActionButtonLabel}>
-							<F defaultMessage="Clear search" />
-						</span>
-					</button>
+					{/* The same section wrapper as the workspace action rows, so the
+					    button gets the same full width and vertical rhythm. The gap
+					    above comes from the file sections' own bottom margin. */}
+					<div className={styles.sidebarSection}>
+						<button
+							className={classNames(
+								styles.sidebarActionButton,
+								styles.hoverable,
+								'tla-text_ui__regular'
+							)}
+							onClick={handleClearSearch}
+							data-testid="tla-sidebar-search-clear-button"
+						>
+							<span className={styles.sidebarActionButtonLabel}>
+								<F defaultMessage="Clear search" />
+							</span>
+						</button>
+					</div>
 				</>
 			) : null}
 		</div>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRecentFiles.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarRecentFiles.tsx
@@ -1,3 +1,5 @@
+import classNames from 'classnames'
+import { useCallback } from 'react'
 import { useValue } from 'tldraw'
 import { useActiveWorkspaceId } from '../../../hooks/useActiveWorkspaceId'
 import { useApp } from '../../../hooks/useAppState'
@@ -61,6 +63,10 @@ export function TlaSidebarRecentFiles() {
 		[app]
 	)
 	const hasResults = Object.values(results).some((group) => group.length > 0)
+
+	const handleClearSearch = useCallback(() => {
+		app.sidebarState.update((prev) => ({ ...prev, searchQuery: '' }))
+	}, [app])
 
 	return (
 		<div
@@ -149,6 +155,24 @@ export function TlaSidebarRecentFiles() {
 				<div className={styles.sidebarSearchEmpty} data-testid="tla-sidebar-search-empty">
 					<F defaultMessage="No files found" />
 				</div>
+			) : null}
+			{isSearching ? (
+				<>
+					<div className={styles.sidebarDivider} />
+					<button
+						className={classNames(
+							styles.sidebarActionButton,
+							styles.hoverable,
+							'tla-text_ui__regular'
+						)}
+						onClick={handleClearSearch}
+						data-testid="tla-sidebar-search-clear-button"
+					>
+						<span className={styles.sidebarActionButtonLabel}>
+							<F defaultMessage="Clear search" />
+						</span>
+					</button>
+				</>
 			) : null}
 		</div>
 	)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarSearch.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarSearch.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames'
-import { useCallback, useRef, useState } from 'react'
-import { TldrawUiButton, TldrawUiInput } from 'tldraw'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { TldrawUiButton, TldrawUiInput, useValue } from 'tldraw'
 import { useApp } from '../../../hooks/useAppState'
 import { defineMessages, useMsg } from '../../../utils/i18n'
 import { TlaIcon } from '../../TlaIcon/TlaIcon'
@@ -64,6 +64,20 @@ export function TlaSidebarSearch() {
 		},
 		[handleClose]
 	)
+
+	// The search can also be cleared from outside this component (the "Clear
+	// search" button at the bottom of the file list). When that happens the shared
+	// query empties while our input still shows its text, so reset the input and
+	// collapse back to the search action row, matching what the X button does.
+	const searchQuery = useValue('sidebar search query', () => app.sidebarState.get().searchQuery, [
+		app,
+	])
+	useEffect(() => {
+		if (searchQuery === '' && query !== '') {
+			if (inputRef.current) inputRef.current.value = ''
+			handleClose()
+		}
+	}, [searchQuery, query, handleClose])
 
 	if (!isSearching) {
 		return (

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -750,7 +750,7 @@
 	border: none;
 	position: relative;
 	outline: none;
-	margin-inline-end: -2px;
+	margin-inline-end: -6px;
 	width: 36px;
 	height: 36px;
 	min-width: 0;

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -792,6 +792,12 @@
 	background-color: var(--tl-color-divider);
 }
 
+/* The scroll content's own padding already provides the 12px inset, so the
+   divider before the "Clear search" button sits flush like the others. */
+.sidebarContent .sidebarDivider {
+	margin: 0;
+}
+
 .sidebarFileSectionTitlePadding span[role='img'] {
 	margin-bottom: 1px;
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -697,7 +697,7 @@
 	gap: 6px;
 	height: 36px;
 	flex: 0 0 auto;
-	/* Match the file rows below so the clear button lines up with their menu triggers. */
+	/* Match the file rows below. */
 	padding: 0px 4px 0px 8px;
 	color: var(--tl-color-text-0);
 }
@@ -741,14 +741,16 @@
 	z-index: 1;
 }
 
-/* Identical to the file item menu trigger, but with an X icon. */
+/* Like the file item menu trigger, but with an X icon, and pulled in only as
+   far as the row's edge so the button and its focus ring stay inside the
+   search box border instead of escaping it on the right. */
 .sidebarSearchClear {
 	padding: 0px;
 	background: none;
 	border: none;
 	position: relative;
 	outline: none;
-	margin-inline-end: -10px;
+	margin-inline-end: -2px;
 	width: 36px;
 	height: 36px;
 	min-width: 0;

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/sidebar.module.css
@@ -793,9 +793,16 @@
 }
 
 /* The scroll content's own padding already provides the 12px inset, so the
-   divider before the "Clear search" button sits flush like the others. */
-.sidebarContent .sidebarDivider {
-	margin: 0;
+   "Clear search" section keeps only the vertical rhythm. */
+.sidebarContent .sidebarSection {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+/* Halve the 28px section gap between the last file section and "Clear search";
+   the full inter-section gap reads as too detached for a related control. */
+.sidebarContent .sidebarFileSectionWrapper + .sidebarSection {
+	margin-top: -14px;
 }
 
 .sidebarFileSectionTitlePadding span[role='img'] {

--- a/apps/examples/src/ExamplePage.tsx
+++ b/apps/examples/src/ExamplePage.tsx
@@ -31,6 +31,10 @@ export function ExamplePage({
 	const categories = examples.map((e) => e.id)
 	const [filterValue, setFilterValue] = useState('')
 	const searchTerms = getSearchTerms(filterValue)
+	const isSearching = filterValue.trim().length > 0
+	const hasResults = examples.some((category) =>
+		category.value.some((example) => exampleMatchesSearch(example, searchTerms))
+	)
 	const handleFilterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setFilterValue(e.target.value)
 		history.replaceState(
@@ -38,6 +42,10 @@ export function ExamplePage({
 			'',
 			e.target.value ? `/?filter=${encodeURIComponent(e.target.value)}` : '/'
 		)
+	}
+	const handleClearFilter = () => {
+		setFilterValue('')
+		history.replaceState({}, '', '/')
 	}
 
 	useEffect(() => {
@@ -79,6 +87,17 @@ export function ExamplePage({
 									value={filterValue}
 									onChange={handleFilterChange}
 								/>
+								{filterValue.length > 0 && (
+									<button
+										type="button"
+										className="example__sidebar__search__clear"
+										onClick={handleClearFilter}
+										title="Clear search"
+										aria-label="Clear search"
+									>
+										<CloseIcon />
+									</button>
+								)}
 							</label>
 							<a className="example__sidebar__action-row hoverable" href="/develop">
 								<CodeIcon />
@@ -108,6 +127,23 @@ export function ExamplePage({
 								</ul>
 							</li>
 						))}
+						{isSearching && !hasResults && (
+							<li className="example__sidebar__search-empty">No examples found</li>
+						)}
+						{isSearching && (
+							/* The same section wrapper as the action rows above, so the
+							   button gets the same full width and vertical rhythm. The gap
+							   above comes from the categories' own bottom margin. */
+							<li className="example__sidebar__section">
+								<button
+									type="button"
+									className="example__sidebar__action-row hoverable"
+									onClick={handleClearFilter}
+								>
+									<span>Clear search</span>
+								</button>
+							</li>
+						)}
 					</ul>
 					<div className="example__sidebar__footer-links">
 						<a className="example__sidebar__footer-link hoverable" href="/develop">

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -236,6 +236,37 @@ html,
 	opacity: 1;
 }
 
+/* Mirrors the dotcom sidebar's .sidebarSearchClear. */
+.example__sidebar__search__clear {
+	padding: 0;
+	background: none;
+	border: none;
+	position: relative;
+	outline: none;
+	margin-inline-end: -10px;
+	width: 36px;
+	height: 36px;
+	min-width: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+	z-index: 3;
+	cursor: pointer;
+	color: var(--example-sidebar-text);
+}
+
+.example__sidebar__search__clear > svg {
+	width: 12px;
+	height: 12px;
+}
+
+.example__sidebar__search__clear:focus-visible {
+	border-radius: 8px;
+	outline: 2px solid var(--example-sidebar-primary);
+	outline-offset: -4px;
+}
+
 .example__sidebar__action-row,
 .example__sidebar__footer-link {
 	position: relative;
@@ -254,6 +285,9 @@ html,
 	text-decoration: none;
 	border-radius: 0;
 	white-space: nowrap;
+	/* Buttons don't inherit the page font like anchors do; this is the
+	   equivalent of the tla-text_ui__regular class on the dotcom buttons. */
+	font: inherit;
 }
 
 .example__sidebar__action-row > svg,
@@ -331,6 +365,25 @@ ul.example__sidebar__category__items {
 	list-style: none;
 	padding: 0;
 	margin: 0;
+}
+
+/* Mirrors the dotcom sidebar's .sidebarSearchEmpty. */
+li.example__sidebar__search-empty {
+	padding: 8px;
+	color: var(--example-sidebar-text-muted);
+}
+
+/* The categories list's own padding already provides the 12px inset, so the
+   "Clear search" section keeps only the vertical rhythm. */
+ul.example__sidebar__categories .example__sidebar__section {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+/* Halve the 28px category gap above "Clear search"; the full inter-category
+   gap reads as too detached for a related control. */
+.example__sidebar__category + .example__sidebar__section {
+	margin-top: -14px;
 }
 
 li.examples__sidebar__item {

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -236,14 +236,16 @@ html,
 	opacity: 1;
 }
 
-/* Mirrors the dotcom sidebar's .sidebarSearchClear. */
+/* Mirrors the dotcom sidebar's .sidebarSearchClear: pulled in only as far as
+   the row's edge so the button and its focus ring stay inside the search box
+   border instead of escaping it on the right. */
 .example__sidebar__search__clear {
 	padding: 0;
 	background: none;
 	border: none;
 	position: relative;
 	outline: none;
-	margin-inline-end: -10px;
+	margin-inline-end: -2px;
 	width: 36px;
 	height: 36px;
 	min-width: 0;

--- a/apps/examples/src/styles.css
+++ b/apps/examples/src/styles.css
@@ -245,7 +245,7 @@ html,
 	border: none;
 	position: relative;
 	outline: none;
-	margin-inline-end: -2px;
+	margin-inline-end: -6px;
 	width: 36px;
 	height: 36px;
 	min-width: 0;


### PR DESCRIPTION
In order to make exiting a sidebar search faster than manually deleting the query text, this PR adds a "Clear search" action row at the end of the search results on tldraw.com — shown in both the has-results and no-results states — that clears the query and returns the sidebar to the unfiltered view. Clearing from there also resets and collapses the search input, exactly like the X button in the search box. Closes #9452.

The examples app sidebar had the same gap but worse — its search had no clear affordance at all — so this brings it to parity with the dotcom pattern: an X button in the search box, the same full-width "Clear search" row after the results, and a "No examples found" empty state. The examples page is a plain React shell that can't use tldraw UI components, so parity is achieved by porting the dotcom markup and CSS values onto the examples sidebar's existing classes (the two sidebars already share the same visual system); the X gets a native `title` tooltip instead of the styled tldraw one. This also surfaced that `<button>` elements don't inherit the page font like the sidebar's anchor rows do, so the examples action-row class now sets `font: inherit` — the counterpart of `tla-text_ui__regular` on the dotcom buttons.

One deliberate spacing detail: the gap between the last result section and "Clear search" is half the normal inter-section gap (via a negative margin on an adjacent-sibling selector), so the control reads as attached to the results. The selector intentionally doesn't match in the no-results state, where the empty-state message provides the spacing.

### Change type

- [x] `feature`

### Test plan

1. On tldraw.com, click Search in the sidebar and type a query with matches: an X appears in the box and a full-width "Clear search" row appears after the results.
2. Type a query with no matches: "No files found", then the same "Clear search" row.
3. Click "Clear search": the query clears, the full file list returns, and the search input collapses back to the Search action row (same as the X).
4. In the examples app sidebar, repeat: X in the search box, "Clear search" / "No examples found" at the end of the list; both clear buttons restore the full list and reset the `?filter=` URL param.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add a "Clear search" button at the end of sidebar search results on tldraw.com and in the examples app sidebar.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +89 / -0   |
| Apps          | +57 / -2   |
