### PR TITLE
feat: attribute duplicated and pasted notes to the current user

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3085,6 +3085,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     onDragShapesOut?(shape: Shape, shapes: TLShape[], info: TLDragShapesOutInfo): void;
     onDragShapesOver?(shape: Shape, shapes: TLShape[], info: TLDragShapesOverInfo): void;
     onDropShapesOver?(shape: Shape, shapes: TLShape[], info: TLDropShapesOverInfo): void;
+    onDuplicate?(source: Shape, duplicate: Shape): Shape | void;
     onEditEnd?(shape: Shape): void;
     onEditStart?(shape: Shape): void;
     onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3071,6 +3071,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     isFrameLike(_shape: Shape): boolean;
     static migrations?: LegacyMigrations | MigrationSequence | TLPropsMigrations;
     onBeforeCreate?(next: Shape): Shape | void;
+    onBeforeDuplicate?(source: Shape, duplicate: Shape): Shape | void;
     onBeforeUpdate?(prev: Shape, next: Shape): Shape | void;
     // @internal
     onBindingChange?(shape: Shape): TLShapePartial<Shape> | void;
@@ -3085,7 +3086,6 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
     onDragShapesOut?(shape: Shape, shapes: TLShape[], info: TLDragShapesOutInfo): void;
     onDragShapesOver?(shape: Shape, shapes: TLShape[], info: TLDragShapesOverInfo): void;
     onDropShapesOver?(shape: Shape, shapes: TLShape[], info: TLDropShapesOverInfo): void;
-    onDuplicate?(source: Shape, duplicate: Shape): Shape | void;
     onEditEnd?(shape: Shape): void;
     onEditStart?(shape: Shape): void;
     onHandleDrag?(shape: Shape, info: TLHandleDragInfo<Shape>): TLShapePartial<Shape> | void;

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7145,7 +7145,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 				shape.index = index
 			})
-			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape }) => shape)
+			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape, originalShape }) => {
+				// Give the shape util a chance to modify the duplicate, e.g. to re-stamp note
+				// attribution to the current user so we don't forge the original author's identity.
+				return this.getShapeUtil(shape).onDuplicate?.(originalShape, shape) ?? shape
+			})
 
 			if (!this.canCreateShapes(shapesToCreate)) {
 				alertMaxShapes(this)
@@ -10039,7 +10043,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const newId = shapeIdMap.get(oldShape.id)!
 
 			// Create the new shape (new except for the id)
-			const newShape = { ...oldShape, id: newId }
+			let newShape = { ...oldShape, id: newId }
+
+			// Give the shape util a chance to modify the copy, e.g. to re-stamp note
+			// attribution to the current user so we don't forge the original author's identity.
+			newShape = this.getShapeUtil(newShape).onDuplicate?.(oldShape, newShape) ?? newShape
 
 			if (rootShapeIds.includes(oldShape.id)) {
 				newShape.parentId = currentPageId

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -10047,7 +10047,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			// Give the shape util a chance to modify the copy, e.g. to re-stamp note
 			// attribution to the current user so we don't forge the original author's identity.
-			newShape = this.getShapeUtil(newShape).onBeforeDuplicate?.(oldShape, newShape) ?? newShape
+			// When ids are preserved the shape keeps its identity (e.g. moveShapesToPage
+			// relocating it), so it's not a duplicate and the hook must not run.
+			if (!preserveIds) {
+				newShape = this.getShapeUtil(newShape).onBeforeDuplicate?.(oldShape, newShape) ?? newShape
+			}
 
 			if (rootShapeIds.includes(oldShape.id)) {
 				newShape.parentId = currentPageId

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -7148,7 +7148,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 			const shapesToCreate = shapesToCreateWithOriginals.map(({ shape, originalShape }) => {
 				// Give the shape util a chance to modify the duplicate, e.g. to re-stamp note
 				// attribution to the current user so we don't forge the original author's identity.
-				return this.getShapeUtil(shape).onDuplicate?.(originalShape, shape) ?? shape
+				return this.getShapeUtil(shape).onBeforeDuplicate?.(originalShape, shape) ?? shape
 			})
 
 			if (!this.canCreateShapes(shapesToCreate)) {
@@ -10047,7 +10047,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 			// Give the shape util a chance to modify the copy, e.g. to re-stamp note
 			// attribution to the current user so we don't forge the original author's identity.
-			newShape = this.getShapeUtil(newShape).onDuplicate?.(oldShape, newShape) ?? newShape
+			newShape = this.getShapeUtil(newShape).onBeforeDuplicate?.(oldShape, newShape) ?? newShape
 
 			if (rootShapeIds.includes(oldShape.id)) {
 				newShape.parentId = currentPageId

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -670,6 +670,28 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	onBeforeCreate?(next: Shape): Shape | void
 
 	/**
+	 * A callback called when a shape is reproduced from an existing shape, either by duplicating
+	 * ({@link Editor.duplicateShapes}) or by pasting/putting content onto the page
+	 * ({@link Editor.putContentOntoCurrentPage}). This provides a last chance to modify the copy
+	 * before it's created — for example, to re-stamp attribution so the copy is credited to the
+	 * current user rather than the original author.
+	 *
+	 * @example
+	 *
+	 * ```ts
+	 * onDuplicate = (source, duplicate) => {
+	 * 	return { ...duplicate, props: { ...duplicate.props, editedBy: this.editor.getAttributionUserId() } }
+	 * }
+	 * ```
+	 *
+	 * @param source - The shape being copied from.
+	 * @param duplicate - The new copy (with its own id), before it's created.
+	 * @returns The next shape or void.
+	 * @public
+	 */
+	onDuplicate?(source: Shape, duplicate: Shape): Shape | void
+
+	/**
 	 * A callback called just before a shape is updated. This method provides a last chance to modify
 	 * the updated shape.
 	 *

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -674,7 +674,9 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	 * ({@link Editor.duplicateShapes}) or by pasting/putting content onto the page
 	 * ({@link Editor.putContentOntoCurrentPage}). This provides a last chance to modify the copy
 	 * before it's created — for example, to re-stamp attribution so the copy is credited to the
-	 * current user rather than the original author.
+	 * current user rather than the original author. It is not called when content is put with
+	 * `preserveIds` (e.g. {@link Editor.moveShapesToPage}), since the shape keeps its identity
+	 * and no copy is made.
 	 *
 	 * @example
 	 *

--- a/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
+++ b/packages/editor/src/lib/editor/shapes/ShapeUtil.ts
@@ -679,7 +679,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	 * @example
 	 *
 	 * ```ts
-	 * onDuplicate = (source, duplicate) => {
+	 * onBeforeDuplicate = (source, duplicate) => {
 	 * 	return { ...duplicate, props: { ...duplicate.props, editedBy: this.editor.getAttributionUserId() } }
 	 * }
 	 * ```
@@ -689,7 +689,7 @@ export abstract class ShapeUtil<Shape extends TLShape = TLShape> {
 	 * @returns The next shape or void.
 	 * @public
 	 */
-	onDuplicate?(source: Shape, duplicate: Shape): Shape | void
+	onBeforeDuplicate?(source: Shape, duplicate: Shape): Shape | void
 
 	/**
 	 * A callback called just before a shape is updated. This method provides a last chance to modify

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2888,6 +2888,8 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
     // (undocumented)
     onBeforeUpdate(prev: TLNoteShape, next: TLNoteShape): TLNoteShape | undefined;
     // (undocumented)
+    onDuplicate(_source: TLNoteShape, duplicate: TLNoteShape): TLNoteShape | undefined;
+    // (undocumented)
     onResize(shape: any, info: TLResizeInfo<any>): {
         props: {
             scale: number;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -2886,9 +2886,9 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
         y: number;
     } | undefined;
     // (undocumented)
-    onBeforeUpdate(prev: TLNoteShape, next: TLNoteShape): TLNoteShape | undefined;
+    onBeforeDuplicate(_source: TLNoteShape, duplicate: TLNoteShape): TLNoteShape | undefined;
     // (undocumented)
-    onDuplicate(_source: TLNoteShape, duplicate: TLNoteShape): TLNoteShape | undefined;
+    onBeforeUpdate(prev: TLNoteShape, next: TLNoteShape): TLNoteShape | undefined;
     // (undocumented)
     onResize(shape: any, info: TLResizeInfo<any>): {
         props: {

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -518,6 +518,18 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		return this.getNoteSizeAdjustments(next)
 	}
 
+	override onDuplicate(_source: TLNoteShape, duplicate: TLNoteShape): TLNoteShape | undefined {
+		// Attribution follows the last person to produce the note's text. Duplicating (or pasting)
+		// a note with text is a new act of authorship by the current user, so re-stamp the copy to
+		// them rather than carrying over the original author's identity. Empty notes have no
+		// attribution to begin with, so leave them alone.
+		if (isEmptyRichText(duplicate.props.richText)) return
+		return {
+			...duplicate,
+			props: { ...duplicate.props, textLastEditedBy: this.editor.getAttributionUserId() },
+		}
+	}
+
 	override onBeforeUpdate(prev: TLNoteShape, next: TLNoteShape) {
 		const richTextChanged = !isEqual(prev.props.richText, next.props.richText)
 

--- a/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/note/NoteShapeUtil.tsx
@@ -518,7 +518,10 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
 		return this.getNoteSizeAdjustments(next)
 	}
 
-	override onDuplicate(_source: TLNoteShape, duplicate: TLNoteShape): TLNoteShape | undefined {
+	override onBeforeDuplicate(
+		_source: TLNoteShape,
+		duplicate: TLNoteShape
+	): TLNoteShape | undefined {
 		// Attribution follows the last person to produce the note's text. Duplicating (or pasting)
 		// a note with text is a new act of authorship by the current user, so re-stamp the copy to
 		// them rather than carrying over the original author's identity. Empty notes have no

--- a/packages/tldraw/src/test/attribution.test.ts
+++ b/packages/tldraw/src/test/attribution.test.ts
@@ -1,5 +1,7 @@
 import {
+	Atom,
 	TLNoteShape,
+	TLUser,
 	UserRecordType,
 	atom,
 	computed,
@@ -8,6 +10,27 @@ import {
 	toRichText,
 } from '@tldraw/editor'
 import { TestEditor } from './TestEditor'
+
+// Build an editor whose current user can be switched between Alice (user-1) and Bob (user-2),
+// so we can assert who a note's attribution is stamped to across edits, duplication, and paste.
+function makeMultiUserEditor(currentUser: Atom<TLUser>) {
+	const alice = UserRecordType.create({ id: createUserId('user-1'), name: 'Alice' })
+	const bob = UserRecordType.create({ id: createUserId('user-2'), name: 'Bob' })
+	return new TestEditor(
+		{},
+		{
+			users: {
+				currentUser,
+				resolve: (userId) =>
+					computed('resolve-' + userId, () => {
+						if (userId === 'user-1') return alice
+						if (userId === 'user-2') return bob
+						return null
+					}),
+			},
+		}
+	)
+}
 
 let editor: TestEditor
 
@@ -213,6 +236,72 @@ describe('TLUserStore', () => {
 		)
 
 		expect(customEditor.getAttributionUserId()).toBeNull()
+		customEditor.dispose()
+	})
+})
+
+describe('note attribution on duplicate', () => {
+	it('re-stamps attribution to the current user when duplicating a note with text', () => {
+		const alice = UserRecordType.create({ id: createUserId('user-1'), name: 'Alice' })
+		const bob = UserRecordType.create({ id: createUserId('user-2'), name: 'Bob' })
+		const currentUser = atom<TLUser>('currentUser', bob)
+		const customEditor = makeMultiUserEditor(currentUser)
+
+		// Bob authors the note
+		customEditor.createShapes([{ id: ids.note1, type: 'note', x: 0, y: 0 }])
+		customEditor.updateShape<TLNoteShape>({
+			id: ids.note1,
+			type: 'note',
+			props: { richText: toRichText('Hello') },
+		})
+		expect(customEditor.getShape<TLNoteShape>(ids.note1)!.props.textLastEditedBy).toBe('user-2')
+
+		// Alice duplicates it — the copy is attributed to Alice, the original stays Bob's
+		currentUser.set(alice)
+		customEditor.duplicateShapes([ids.note1])
+
+		const dupId = customEditor.getSelectedShapeIds()[0]
+		expect(dupId).not.toBe(ids.note1)
+		expect(customEditor.getShape<TLNoteShape>(dupId)!.props.textLastEditedBy).toBe('user-1')
+		expect(customEditor.getShape<TLNoteShape>(ids.note1)!.props.textLastEditedBy).toBe('user-2')
+
+		customEditor.dispose()
+	})
+
+	it('keeps attribution null when duplicating an empty note', () => {
+		editor.createShapes([{ id: ids.note1, type: 'note', x: 0, y: 0 }])
+		editor.duplicateShapes([ids.note1])
+
+		const dupId = editor.getSelectedShapeIds()[0]
+		expect(dupId).not.toBe(ids.note1)
+		expect(editor.getShape<TLNoteShape>(dupId)!.props.textLastEditedBy).toBeNull()
+	})
+
+	it('re-stamps attribution to the current user when pasting a note with text', () => {
+		const alice = UserRecordType.create({ id: createUserId('user-1'), name: 'Alice' })
+		const bob = UserRecordType.create({ id: createUserId('user-2'), name: 'Bob' })
+		const currentUser = atom<TLUser>('currentUser', bob)
+		const customEditor = makeMultiUserEditor(currentUser)
+
+		// Bob authors the note
+		customEditor.createShapes([{ id: ids.note1, type: 'note', x: 0, y: 0 }])
+		customEditor.updateShape<TLNoteShape>({
+			id: ids.note1,
+			type: 'note',
+			props: { richText: toRichText('Hello') },
+		})
+
+		// Alice copies and pastes it — the pasted copy is attributed to Alice
+		const content = customEditor.getContentFromCurrentPage([ids.note1])!
+		currentUser.set(alice)
+		customEditor.selectNone()
+		customEditor.putContentOntoCurrentPage(content, { select: true })
+
+		const pastedId = customEditor.getSelectedShapeIds()[0]
+		expect(pastedId).not.toBe(ids.note1)
+		expect(customEditor.getShape<TLNoteShape>(pastedId)!.props.textLastEditedBy).toBe('user-1')
+		expect(customEditor.getShape<TLNoteShape>(ids.note1)!.props.textLastEditedBy).toBe('user-2')
+
 		customEditor.dispose()
 	})
 })

--- a/packages/tldraw/src/test/attribution.test.ts
+++ b/packages/tldraw/src/test/attribution.test.ts
@@ -16,17 +16,26 @@ import { TestEditor } from './TestEditor'
 function makeMultiUserEditor(currentUser: Atom<TLUser>) {
 	const alice = UserRecordType.create({ id: createUserId('user-1'), name: 'Alice' })
 	const bob = UserRecordType.create({ id: createUserId('user-2'), name: 'Bob' })
+
+	const resolveCache = new Map<string, ReturnType<typeof computed>>()
+	const resolve = (userId: string) => {
+		const cached = resolveCache.get(userId)
+		if (cached) return cached
+		const signal = computed('resolve-' + userId, () => {
+			if (userId === 'user-1') return alice
+			if (userId === 'user-2') return bob
+			return null
+		})
+		resolveCache.set(userId, signal)
+		return signal
+	}
+
 	return new TestEditor(
 		{},
 		{
 			users: {
 				currentUser,
-				resolve: (userId) =>
-					computed('resolve-' + userId, () => {
-						if (userId === 'user-1') return alice
-						if (userId === 'user-2') return bob
-						return null
-					}),
+				resolve,
 			},
 		}
 	)

--- a/packages/tldraw/src/test/attribution.test.ts
+++ b/packages/tldraw/src/test/attribution.test.ts
@@ -1,5 +1,6 @@
 import {
 	Atom,
+	Computed,
 	PageRecordType,
 	TLNoteShape,
 	TLUser,
@@ -18,7 +19,7 @@ function makeMultiUserEditor(currentUser: Atom<TLUser>) {
 	const alice = UserRecordType.create({ id: createUserId('user-1'), name: 'Alice' })
 	const bob = UserRecordType.create({ id: createUserId('user-2'), name: 'Bob' })
 
-	const resolveCache = new Map<string, ReturnType<typeof computed>>()
+	const resolveCache = new Map<string, Computed<TLUser | null>>()
 	const resolve = (userId: string) => {
 		const cached = resolveCache.get(userId)
 		if (cached) return cached

--- a/packages/tldraw/src/test/attribution.test.ts
+++ b/packages/tldraw/src/test/attribution.test.ts
@@ -1,5 +1,6 @@
 import {
 	Atom,
+	PageRecordType,
 	TLNoteShape,
 	TLUser,
 	UserRecordType,
@@ -310,6 +311,33 @@ describe('note attribution on duplicate', () => {
 		expect(pastedId).not.toBe(ids.note1)
 		expect(customEditor.getShape<TLNoteShape>(pastedId)!.props.textLastEditedBy).toBe('user-1')
 		expect(customEditor.getShape<TLNoteShape>(ids.note1)!.props.textLastEditedBy).toBe('user-2')
+
+		customEditor.dispose()
+	})
+
+	it('keeps attribution when moving a note to another page', () => {
+		const alice = UserRecordType.create({ id: createUserId('user-1'), name: 'Alice' })
+		const bob = UserRecordType.create({ id: createUserId('user-2'), name: 'Bob' })
+		const currentUser = atom<TLUser>('currentUser', bob)
+		const customEditor = makeMultiUserEditor(currentUser)
+
+		// Bob authors the note
+		customEditor.createShapes([{ id: ids.note1, type: 'note', x: 0, y: 0 }])
+		customEditor.updateShape<TLNoteShape>({
+			id: ids.note1,
+			type: 'note',
+			props: { richText: toRichText('Hello') },
+		})
+
+		// Alice moves it to another page — it's the same note, so Bob stays the author
+		const page2Id = PageRecordType.createId('page2')
+		customEditor.createPage({ id: page2Id, name: 'Page 2' })
+		currentUser.set(alice)
+		customEditor.moveShapesToPage([ids.note1], page2Id)
+
+		expect(customEditor.getCurrentPageId()).toBe(page2Id)
+		const movedNote = customEditor.getShape<TLNoteShape>(ids.note1)!
+		expect(movedNote.props.textLastEditedBy).toBe('user-2')
 
 		customEditor.dispose()
 	})


### PR DESCRIPTION
Note text attribution (`textLastEditedBy`) follows the last person to produce the note's text. Duplicating or pasting a note that has text is a new act of authorship by the current user, so the copy should be credited to them rather than carrying over the original author's identity.

Previously `editor.duplicateShapes()` and `editor.putContentOntoCurrentPage()` (which backs paste and page duplication) spread the original note's props verbatim, so a duplicate/paste kept the original author's `textLastEditedBy`. This matters for the upcoming server-side provenance checks (#9489), which must not attribute content to a user who did not produce it — otherwise a user could duplicate someone else's note and effectively forge their identity.

This PR adds a `ShapeUtil.onDuplicate(source, duplicate)` hook, invoked by `Editor.duplicateShapes` and `Editor.putContentOntoCurrentPage`, giving a shape a last chance to modify a reproduced copy before it's created. `NoteShapeUtil` overrides it to re-stamp `textLastEditedBy` to the current user (`editor.getAttributionUserId()`) when the note has text; empty notes keep no attribution.

### API changes

- Added `ShapeUtil.onDuplicate(source, duplicate)`, an optional hook called when a shape is reproduced via duplicate or paste.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

1. As user A, create a sticky note and type some text — attribution shows user A.
2. As user B, duplicate the note (Cmd/Ctrl+D) — the duplicate is attributed to user B; the original still shows user A.
3. As user B, copy the note and paste it — the pasted copy is attributed to user B.
4. Duplicate an empty note — the copy has no attribution.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Duplicating or pasting a sticky note with text now attributes the copy to the current user rather than the original author. Custom shapes can hook into this via the new `ShapeUtil.onDuplicate` callback.