### PR TITLE
fix(mcp-app): bind exec sandbox timer to window

### DIFF
--- a/apps/mcp-app/src/widget/exec-helpers.test.ts
+++ b/apps/mcp-app/src/widget/exec-helpers.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import type { Editor } from 'tldraw'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+/**
+ * Regression coverage for the "Illegal invocation" exec failure.
+ *
+ * Chromium's window.setTimeout brand-checks its receiver: invoking a captured
+ * reference as a method of another object (`captured.setTimeout(...)`) throws
+ * "TypeError: Illegal invocation". The exec timeout race used to do exactly
+ * that, so its promise rejected synchronously and any exec code containing an
+ * `await` lost the race and reported "Illegal invocation" while its shapes
+ * kept appearing.
+ *
+ * jsdom's timers don't brand-check, so this suite installs a simulated
+ * brand-checking setTimeout BEFORE exec-helpers captures its globals at module
+ * load. A regression to the unbound invocation makes the async test below fail
+ * with exactly the production error.
+ */
+
+let executeCode: typeof import('./exec-helpers').executeCode
+
+beforeAll(async () => {
+	const native = window.setTimeout.bind(window)
+	function brandCheckedSetTimeout(this: unknown, ...args: Parameters<typeof setTimeout>) {
+		if (this !== window && this !== undefined && this !== globalThis) {
+			throw new TypeError('Illegal invocation')
+		}
+		return native(...args)
+	}
+	window.setTimeout = brandCheckedSetTimeout as unknown as typeof window.setTimeout
+
+	// executeCode resolves the focused proxy's method map from the widget
+	// bootstrap; an empty map means every editor call passes through, which is
+	// fine — these tests never touch the editor.
+	;(window as { __TLDRAW_BOOTSTRAP__?: unknown }).__TLDRAW_BOOTSTRAP__ = { methodMap: {} }
+
+	// Import AFTER the brand check is installed so the module captures the
+	// simulated timer, exactly as it captures Chromium's native one.
+	;({ executeCode } = await import('./exec-helpers'))
+	// The import transforms the whole tldraw package on a cold cache, which can
+	// exceed vitest's default 10s hook timeout in CI.
+}, 60_000)
+
+// The Blob-URL module loader cannot run under vitest (Node cannot import
+// blob: URLs); compile the exec module with an async Function instead. The
+// sandbox and timeout-race behavior under test is unaffected.
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor as new (
+	...args: string[]
+) => (editor: unknown, helpers: unknown) => Promise<unknown>
+
+async function loadModule(code: string) {
+	const compiled = new AsyncFunction('editor', 'helpers', code)
+	return async ({ editor, helpers }: { editor: Editor; helpers: unknown }) =>
+		compiled(editor, helpers)
+}
+
+const stubEditor = {} as Editor
+
+describe('the simulated brand check', () => {
+	it('throws Illegal invocation for object-method calls, like Chromium', () => {
+		const captured = { setTimeout: window.setTimeout }
+		expect(() => captured.setTimeout(() => {}, 1)).toThrow('Illegal invocation')
+	})
+
+	it('allows window-bound calls', () => {
+		const bound = window.setTimeout.bind(window)
+		const id = bound(() => {}, 1)
+		expect(id).toBeDefined()
+		clearTimeout(id)
+	})
+})
+
+describe('executeCode timeout race', () => {
+	it('completes async exec code (the case that used to report Illegal invocation)', async () => {
+		const result = await executeCode(
+			stubEditor,
+			'await new Promise((resolve) => queueMicrotask(resolve)); return 42',
+			{ loadModule }
+		)
+		expect(result).toEqual({ success: true, result: 42 })
+	})
+
+	it('completes synchronous exec code', async () => {
+		const result = await executeCode(stubEditor, 'return 1 + 2', { loadModule })
+		expect(result).toEqual({ success: true, result: 3 })
+	})
+
+	it('reports runtime errors from exec code', async () => {
+		const result = await executeCode(stubEditor, 'throw new Error("boom")', { loadModule })
+		expect(result).toEqual({ success: false, error: 'boom' })
+	})
+
+	it('restores the sandboxed globals after execution', async () => {
+		await executeCode(stubEditor, 'return 0', { loadModule })
+		expect(typeof window.setTimeout).toBe('function')
+		expect(typeof window.fetch).toBe('function')
+	})
+})

--- a/apps/mcp-app/src/widget/exec-helpers.ts
+++ b/apps/mcp-app/src/widget/exec-helpers.ts
@@ -161,6 +161,20 @@ const REAL_TIMERS = {
 	setInterval: typeof window !== 'undefined' ? window.setInterval : undefined,
 	setTimeout: typeof window !== 'undefined' ? window.setTimeout : undefined,
 }
+
+// Never invoke a captured timer as a method of the capture object: native
+// window functions brand-check `this`, so `REAL_TIMERS.setTimeout(...)`
+// throws "TypeError: Illegal invocation" in Chromium. That synchronous throw
+// rejects the exec timeout race immediately, so any exec code containing an
+// `await` loses the race and reports "Illegal invocation" while its shapes
+// keep appearing (fully synchronous scripts settle first, which is why this
+// only surfaces intermittently). Bind once at capture time for safe
+// invocation; the unbound originals above are only ever assigned back onto
+// window.
+const safeSetTimeout = REAL_TIMERS.setTimeout
+	? REAL_TIMERS.setTimeout.bind(window)
+	: (undefined as never)
+
 let execSandboxDepth = 0
 
 function enterExecSandbox() {
@@ -239,8 +253,9 @@ export async function executeCode(
 		const result = await Promise.race([
 			runExec({ editor: focusedEditor, helpers }),
 			new Promise((_, reject) =>
-				// Use the pristine timer (not the sandboxed, possibly-undefined one).
-				REAL_TIMERS.setTimeout!(
+				// Use the pristine, window-bound timer (not the sandboxed,
+				// possibly-undefined one).
+				safeSetTimeout(
 					() => reject(new Error(`Execution timed out after ${EXEC_TIMEOUT_MS}ms`)),
 					EXEC_TIMEOUT_MS
 				)

--- a/apps/mcp-app/src/widget/exec-helpers.ts
+++ b/apps/mcp-app/src/widget/exec-helpers.ts
@@ -229,18 +229,25 @@ ${code}
 
 	const moduleUrl = URL.createObjectURL(new Blob([moduleSource], { type: 'text/javascript' }))
 	try {
-		return (await import(/* @vite-ignore */ moduleUrl)).default as (args: {
-			editor: Editor
-			helpers: ExecHelpers
-		}) => Promise<unknown>
+		return (await import(/* @vite-ignore */ moduleUrl)).default as ExecModule
 	} finally {
 		URL.revokeObjectURL(moduleUrl)
 	}
 }
 
+type ExecModule = (args: { editor: Editor; helpers: ExecHelpers }) => Promise<unknown>
+
 export async function executeCode(
 	editor: Editor,
-	code: string
+	code: string,
+	options?: {
+		/**
+		 * Test seam: the Blob-URL module loader cannot run under vitest (Node
+		 * cannot import blob: URLs), so tests inject a compiler here. Production
+		 * callers never pass this.
+		 */
+		loadModule?(code: string): Promise<ExecModule>
+	}
 ): Promise<{ success: boolean; result?: unknown; error?: string }> {
 	const focusedEditor = createFocusedEditorProxy(editor, getRequiredEmbeddedMethodMap())
 	const helpers = createExecHelpers(editor)
@@ -249,7 +256,7 @@ export async function executeCode(
 	enterExecSandbox()
 
 	try {
-		const runExec = await loadExecModule(code)
+		const runExec = await (options?.loadModule ?? loadExecModule)(code)
 		const result = await Promise.race([
 			runExec({ editor: focusedEditor, helpers }),
 			new Promise((_, reject) =>


### PR DESCRIPTION
In order to stop the MCP app's exec tool from failing with "Illegal invocation" in production, this PR fixes a `this`-binding bug in the widget's exec sandbox. The exec timeout race invokes the captured `setTimeout` as a method of the `REAL_TIMERS` capture object, and native window functions brand-check their receiver — Chromium throws `TypeError: Illegal invocation` synchronously (verified empirically in Chromium: the object-method call throws, a bare unbound call does not). That synchronous throw rejects the timeout promise immediately, so any exec code containing an `await` loses the `Promise.race` and reports "Illegal invocation" while the script keeps running fire-and-forget — the user sees shapes appear and then the error banner replaces the canvas. Fully synchronous scripts settle before the race inspects the poisoned promise, which is why the failure is intermittent and correlates with how a given model happens to write its code.

The fix binds the captured timer to `window` once at capture time for invocation (`safeSetTimeout`), keeping the unbound original solely for restoring onto `window` when the sandbox exits. A side effect worth noting: the 10-second exec timeout now actually works for async scripts — previously it either fired as an instant false failure or never constrained anything.

A regression test covers the failure mode: jsdom timers don't brand-check their receiver the way Chromium's do, so the suite installs a simulated brand-checking `setTimeout` before `exec-helpers` captures its globals at module load — a regression to the unbound invocation fails the async-code test with exactly the production error. `executeCode` gains a test-only `loadModule` seam because Node cannot import the widget's Blob-URL exec modules.

The same fix is already included in the canvas persistence redesign branch (#9547); this PR extracts it so production doesn't wait on that work. Expect a trivial conflict in `exec-helpers.ts` when rebasing #9547 after this merges.

### Change type

- [x] `bugfix`

### Test plan

1. Connect the MCP app and ask the agent to draw something using code that contains an `await` (e.g. `await Promise.resolve()` before creating shapes)
2. Before the fix: shapes appear, then the canvas is replaced by an "Error editing canvas: Illegal invocation" banner and the tool reports failure
3. After the fix: the exec completes and reports success
4. Verify a genuinely long-running script (e.g. `await new Promise(r => {})`) now correctly reports the 10s execution timeout

- [x] Unit tests

### Release notes

- Fixed MCP app code execution intermittently failing with "Illegal invocation" when the generated script contained asynchronous code.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +98 / -0   |
| Apps    | +31 / -8   |
