### PR TITLE
ci(release-notes): run update-release-notes on production push

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -1,6 +1,16 @@
 name: Update release notes
 
 on:
+  # Update release notes whenever production is updated, keeping next.mdx (and the
+  # draft GitHub release synced by the skill) in step with each dotcom release —
+  # the same production push that deploys dotcom and publishes the `next` package.
+  # Production only: a push to main must not trigger a notes run on every merge.
+  # Release-notes commits carry `[skip ci]`, so a notes-only push does not re-trigger
+  # this workflow, and the job only ever opens a PR against main (it never pushes to
+  # production), so there is no deploy loop.
+  push:
+    branches:
+      - production
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Follow-up to #9481. Today `next.mdx` (and the draft GitHub release the skill keeps in sync) only get updated when someone manually dispatches the `update-release-notes` workflow — nothing ties that to an actual release. Meanwhile a push to `production` is exactly what deploys dotcom and publishes the `next` package.

This wires `update-release-notes.yml` to also run on `push` to `production`, mirroring how `deploy-mcp-app.yml` stays lockstep with the production dotcom build. So every dotcom release now refreshes the release notes as a matter of course, on the real event rather than a wall-clock cron that can drift from when the push actually lands.

Notes:

- **Production only.** A push to `main` must not spin up a notes run on every merge, so `main` is deliberately excluded (same reasoning as `deploy-mcp-app`).
- **No deploy loop.** Release-notes commits carry `[skip ci]`, which skips all workflows on that commit — including this one — so a notes-only push does not re-trigger it. And the job only ever opens a PR against `main`; it never pushes to `production` itself.
- **Phase logic is unchanged.** The skill still selects `main` vs `production` from the release calendar, so a weekly dev-week push accumulates from `main` and a release-week push prunes against `production`. Archival after the monthly minor is picked up by the first production push that follows the publish.
- **Low churn.** The existing `has_changes` gate means no-op pushes just log "No changes" without opening a PR, and the existing `concurrency` group prevents overlapping runs.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests