### PR TITLE
fix(tldraw): prevent restoring shapes with missing parents

### DIFF
--- a/packages/tldraw/src/test/cleanup.test.ts
+++ b/packages/tldraw/src/test/cleanup.test.ts
@@ -130,3 +130,48 @@ describe('restoring bound arrows multiplayer', () => {
 		expect(bindings().end).toBeDefined()
 	})
 })
+
+describe('restoring shapes with a deleted parent (multiplayer)', () => {
+	it('removes an undone shape whose parent was deleted by another client', () => {
+		// client A creates a frame with two boxes inside it, one of them locked
+		editor.createShapes([
+			{ id: ids.frame1, type: 'frame', x: 0, y: 0, props: { w: 200, h: 200 } },
+			{ id: ids.box1, type: 'geo', parentId: ids.frame1, x: 20, y: 20 },
+			{ id: ids.box2, type: 'geo', parentId: ids.frame1, x: 60, y: 60, isLocked: true },
+		])
+
+		// client A moves both boxes (the undoable change)
+		editor.markHistoryStoppingPoint('moving boxes')
+		editor.run(
+			() =>
+				editor.updateShapes([
+					{ id: ids.box1, type: 'geo', x: 100, y: 100 },
+					{ id: ids.box2, type: 'geo', x: 140, y: 140 },
+				]),
+			{ ignoreShapeLock: true }
+		)
+
+		// client B deletes the frame, which cascades to both children
+		editor.store.mergeRemoteChanges(() => {
+			editor.store.remove([ids.frame1, ids.box1, ids.box2])
+		})
+
+		// undoing the move would restore the boxes parented to the deleted frame. Instead they
+		// are removed - a shape must never be left pointing at a parent that no longer exists,
+		// including the locked one. This holds across repeated undo/redo, since the history diffs
+		// still reference the deleted frame.
+		const expectBoxesRemoved = () => {
+			expect(editor.getShape(ids.box1)).toBeUndefined()
+			expect(editor.getShape(ids.box2)).toBeUndefined()
+		}
+
+		editor.undo()
+		expectBoxesRemoved()
+
+		editor.redo()
+		expectBoxesRemoved()
+
+		editor.undo()
+		expectBoxesRemoved()
+	})
+})

--- a/packages/tlschema/src/TLStore.ts
+++ b/packages/tlschema/src/TLStore.ts
@@ -15,6 +15,7 @@ import { PageRecordType, TLPageId } from './records/TLPage'
 import { InstancePageStateRecordType, TLInstancePageStateId } from './records/TLPageState'
 import { PointerRecordType, TLPOINTER_ID } from './records/TLPointer'
 import { TLRecord } from './records/TLRecord'
+import { isShapeId } from './records/TLShape'
 import { TLUser } from './records/TLUser'
 
 /**
@@ -462,6 +463,7 @@ function getDefaultPages() {
 export function createIntegrityChecker(store: Store<TLRecord, TLStoreProps>): () => void {
 	const $pageIds = store.query.ids('page')
 	const $pageStates = store.query.records('instance_page_state')
+	const $shapes = store.query.records('shape')
 
 	const ensureStoreIsUsable = (): void => {
 		// make sure we have exactly one document
@@ -529,6 +531,20 @@ export function createIntegrityChecker(store: Store<TLRecord, TLStoreProps>): ()
 
 		if (missingCameraIds.size > 0) {
 			store.put([...missingCameraIds].map((id) => CameraRecordType.create({ id })))
+		}
+
+		// remove any shape whose parent is another shape that no longer exists. This can happen
+		// when a change is undone that references a shape (e.g. a frame) which has since been
+		// deleted by another collaborator: the undo would otherwise leave a shape parented to a
+		// record that doesn't exist. Such a shape has no valid place in the hierarchy, so we
+		// discard it. Removing a shape can orphan its own children, which the re-run then handles.
+		const orphanedShapeIds = $shapes
+			.get()
+			.filter((shape) => isShapeId(shape.parentId) && !store.has(shape.parentId))
+			.map((shape) => shape.id)
+		if (orphanedShapeIds.length > 0) {
+			store.remove(orphanedShapeIds)
+			return ensureStoreIsUsable()
 		}
 
 		const pageStates = $pageStates.get()


### PR DESCRIPTION
In multiplayer, undo could leave a shape parented to a record that no longer exists. If one collaborator moves or reparents a shape while another deletes the frame it lived in, undoing the first collaborator's change replays the old state and points the shape back at the deleted frame. The resulting broken shape then syncs out to everyone - and because tldraw tolerates a missing parent by falling back to an identity transform, it doesn't crash, it just silently becomes an untracked, invisible shape in everyone's document. Fixes #9567.

The store integrity check (`ensureStoreIsUsable`) already runs after undo, redo, and remote merges, and already enforces invariants like "instance points at a valid page". This adds one more: a shape's parent must exist. Any shape whose `parentId` refers to a shape that's no longer in the store is removed; removing a shape can orphan its own children, which the checker's existing re-run pass then handles.

Keeping it here rather than in editor side effects means it lives in one place next to the related invariants, and because it runs on the client that made the change, the corrected state is what propagates to collaborators - they never receive the broken shape.

The behavior is uniform on purpose: an orphaned shape is discarded, not reparented. Reparenting to the page was considered and rejected, because the deleted frame's transform is gone, so the shape would reappear at the wrong position.

### Change type

- [x] `bugfix`

### Test plan

1. Open the same multiplayer room in two clients.
2. In client A, create a frame with a shape inside it, then move the shape.
3. In client B, delete the frame.
4. Undo in client A.
5. The shape should be discarded, not left parented to the deleted frame, on both clients.

- [x] Unit tests

### Release notes

- Fix a multiplayer bug where undo could leave a shape parented to a frame another collaborator had deleted, resulting in a broken, invisible shape synced to everyone.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -0   |
| Tests     | +45 / -0   |