### PR TITLE
feat(commenting): add region comments (rectangular-area anchored)

### DIFF
--- a/apps/component-studio/src/sketchbooks/flows/region-comments.css
+++ b/apps/component-studio/src/sketchbooks/flows/region-comments.css
@@ -1,0 +1,6 @@
+/* the flow fills its scene cell; the editor fills the wrapper */
+.region-comments-flow {
+	position: relative;
+	width: 100%;
+	height: 100%;
+}

--- a/apps/component-studio/src/sketchbooks/flows/region-comments.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/flows/region-comments.sketchbook.tsx
@@ -1,0 +1,15 @@
+import { Sketch, Sketchbook } from '../../sketch'
+import { RegionCommentsFlow, RegionCommentsFlowProps } from './region-comments'
+
+const sketchbook: Sketchbook<RegionCommentsFlowProps> = {
+	title: 'Flows/Region comments',
+	component: RegionCommentsFlow,
+}
+export default sketchbook
+
+/** The default region behaviour: bottom-right pin, reveal on pointer-in-region, move by pin, resize
+ *  from corner handles. Drag out a rectangle to create one. */
+export const Default: Sketch<RegionCommentsFlowProps> = {
+	parameters: { viewport: 'desktop' },
+	args: { regionOptions: {} },
+}

--- a/apps/component-studio/src/sketchbooks/flows/region-comments.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/flows/region-comments.sketchbook.tsx
@@ -9,11 +9,11 @@ export default sketchbook
 
 const desktop = { viewport: 'desktop' } as const
 
-/** The default region behaviour: bottom-right pin, reveal on pointer-in-region, move by pin, resize
- *  from corner handles. Drag out a rectangle to create one. */
+/** The creation flow, from an empty canvas: drag out a rectangle to make a region comment. Default
+ *  behaviour — bottom-right pin, reveal on pointer-in-region, move by pin, resize from corners. */
 export const Default: Sketch<RegionCommentsFlowProps> = {
 	parameters: desktop,
-	args: { regionOptions: {} },
+	args: { regionOptions: {}, seeded: false },
 }
 
 // — Pin/anchor corner —

--- a/apps/component-studio/src/sketchbooks/flows/region-comments.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/flows/region-comments.sketchbook.tsx
@@ -7,9 +7,61 @@ const sketchbook: Sketchbook<RegionCommentsFlowProps> = {
 }
 export default sketchbook
 
+const desktop = { viewport: 'desktop' } as const
+
 /** The default region behaviour: bottom-right pin, reveal on pointer-in-region, move by pin, resize
  *  from corner handles. Drag out a rectangle to create one. */
 export const Default: Sketch<RegionCommentsFlowProps> = {
-	parameters: { viewport: 'desktop' },
+	parameters: desktop,
 	args: { regionOptions: {} },
+}
+
+// — Pin/anchor corner —
+
+/** Pin and composer on the top-right corner instead of bottom-right. */
+export const TopRightPin: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { pinCorner: { x: 1, y: 0 } } },
+}
+
+// — Reveal behaviour —
+
+/** Box and handles reveal only while the pin is hovered (note the gap reaching a far corner). */
+export const RevealOnPinHover: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { reveal: 'pin-hover' } },
+}
+
+/** Box and handles reveal only while the thread is open. */
+export const RevealWhenOpen: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { reveal: 'open' } },
+}
+
+// — Move interaction —
+
+/** Move by dragging the region body (the pin only toggles the thread). */
+export const MoveByBody: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { move: 'body' } },
+}
+
+/** Move by dragging either the pin or the body. */
+export const MoveByEither: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { move: 'both' } },
+}
+
+// — Resize affordance —
+
+/** Resize from side-midpoint edge handles (each locks the perpendicular axis). */
+export const ResizeFromEdges: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { resize: 'edges' } },
+}
+
+/** No resize affordance — the region keeps the size it was drawn at. */
+export const NoResize: Sketch<RegionCommentsFlowProps> = {
+	parameters: desktop,
+	args: { regionOptions: { resize: 'none' } },
 }

--- a/apps/component-studio/src/sketchbooks/flows/region-comments.tsx
+++ b/apps/component-studio/src/sketchbooks/flows/region-comments.tsx
@@ -1,0 +1,53 @@
+import {
+	CanvasComments,
+	commentToolOverrides,
+	commentTools,
+	RegionCommentOptions,
+} from '@tldraw/commenting/canvas'
+import { useMemo } from 'react'
+import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
+import './region-comments.css'
+
+// A tiny local user directory so the flow shows names instead of ids.
+const NAMES: Record<string, string> = { me: 'You', ada: 'Ada Lovelace' }
+const resolveName = (id: string): string => NAMES[id] ?? id
+
+export interface RegionCommentsFlowProps {
+	/** The region behaviour to showcase. Region is always enabled in this flow; each sketch overrides
+	 *  the dimension(s) it's demonstrating. */
+	regionOptions?: Partial<RegionCommentOptions>
+}
+
+/**
+ * The region-comment flow on a live editor: the comment tool with region enabled (drag out an area),
+ * plus the `CanvasComments` overlay driven by a chosen `RegionCommentOptions`. Runs on an in-memory
+ * store, so each sketch is an isolated playground for one interaction variant.
+ */
+export function RegionCommentsFlow({ regionOptions }: RegionCommentsFlowProps) {
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+	const components: TLComponents = useMemo(
+		() => ({
+			InFrontOfTheCanvas: () => (
+				<CanvasComments
+					currentUserId="me"
+					resolveName={resolveName}
+					regionOptions={{ enabled: true, ...regionOptions }}
+				/>
+			),
+		}),
+		[regionOptions]
+	)
+	return (
+		<div className="region-comments-flow">
+			<Tldraw
+				store={store}
+				tools={commentTools}
+				overrides={[commentToolOverrides]}
+				components={components}
+			/>
+		</div>
+	)
+}

--- a/apps/component-studio/src/sketchbooks/flows/region-comments.tsx
+++ b/apps/component-studio/src/sketchbooks/flows/region-comments.tsx
@@ -4,8 +4,18 @@ import {
 	commentTools,
 	RegionCommentOptions,
 } from '@tldraw/commenting/canvas'
-import { useMemo } from 'react'
-import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
+import { useCallback, useMemo } from 'react'
+import {
+	commentSchemaRecords,
+	createComment,
+	createCommentThread,
+	createTLSchema,
+	createTLStore,
+	Editor,
+	TLComponents,
+	Tldraw,
+	toRichText,
+} from 'tldraw'
 import './region-comments.css'
 
 // A tiny local user directory so the flow shows names instead of ids.
@@ -16,6 +26,9 @@ export interface RegionCommentsFlowProps {
 	/** The region behaviour to showcase. Region is always enabled in this flow; each sketch overrides
 	 *  the dimension(s) it's demonstrating. */
 	regionOptions?: Partial<RegionCommentOptions>
+	/** Seed a region comment so the variant can be exercised without drawing one first. Default true;
+	 *  the creation-flow sketch turns it off to start from an empty canvas. */
+	seeded?: boolean
 }
 
 /**
@@ -23,7 +36,7 @@ export interface RegionCommentsFlowProps {
  * plus the `CanvasComments` overlay driven by a chosen `RegionCommentOptions`. Runs on an in-memory
  * store, so each sketch is an isolated playground for one interaction variant.
  */
-export function RegionCommentsFlow({ regionOptions }: RegionCommentsFlowProps) {
+export function RegionCommentsFlow({ regionOptions, seeded = true }: RegionCommentsFlowProps) {
 	const store = useMemo(
 		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
 		[]
@@ -40,6 +53,33 @@ export function RegionCommentsFlow({ regionOptions }: RegionCommentsFlowProps) {
 		}),
 		[regionOptions]
 	)
+	// Seed one region comment so hover/move/resize variants have something to act on immediately.
+	const handleMount = useCallback(
+		(editor: Editor) => {
+			if (!seeded) return
+			// Idempotent — React strict mode mounts twice in dev; a second seed would duplicate the
+			// thread and cluster the pair into a count badge instead of showing one region.
+			if (editor.store.allRecords().some((r) => (r.typeName as string) === 'comment-thread')) {
+				return
+			}
+			const pageId = editor.getCurrentPageId()
+			const thread = createCommentThread({
+				pageId,
+				// Upper-left of the canvas, clear of the floating toolbar (lower-centre) so the region and
+				// its bottom-right pin are visible without scrolling.
+				anchor: { type: 'region', x: 90, y: 60, w: 300, h: 150 },
+				createdBy: 'ada',
+			})
+			const comment = createComment({
+				threadId: thread.id,
+				pageId,
+				authorId: 'ada',
+				body: toRichText('Should this area use the brand palette?'),
+			})
+			editor.store.put([thread as any, comment as any])
+		},
+		[seeded]
+	)
 	return (
 		<div className="region-comments-flow">
 			<Tldraw
@@ -47,6 +87,7 @@ export function RegionCommentsFlow({ regionOptions }: RegionCommentsFlowProps) {
 				tools={commentTools}
 				overrides={[commentToolOverrides]}
 				components={components}
+				onMount={handleMount}
 			/>
 		</div>
 	)

--- a/packages/commenting/src/canvas.ts
+++ b/packages/commenting/src/canvas.ts
@@ -27,6 +27,7 @@ export {
 	useThreadComments,
 } from './canvas/hooks'
 export { useCommentingEnabled } from './canvas/license'
+export { DEFAULT_REGION_COMMENT_OPTIONS, type RegionCommentOptions } from './canvas/region-options'
 export { richTextToPlaintext } from './canvas/rich-text'
 export {
 	DEFAULT_SIDEBAR_FILTERS,

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -61,6 +61,16 @@
 	z-index: 1;
 }
 
+/* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass
+   through. Drawn for the live drag draft and for a region thread while hovered or open. */
+.cmt-canvas-region {
+	position: absolute;
+	pointer-events: none;
+	border: 2px dashed var(--tl-color-selected);
+	border-radius: 6px;
+	background: color-mix(in srgb, var(--tl-color-selected) 10%, transparent);
+}
+
 /* Centre the pin marker on its anchor point. */
 .cmt-canvas-pin__marker {
 	width: max-content;

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -71,7 +71,14 @@
 	background: color-mix(in srgb, var(--tl-color-selected) 10%, transparent);
 }
 
-/* Corner resize handles on a region box (three corners; the top-right is the move pin). */
+/* A movable region body (the 'body'/'both' move modes): draggable to translate the whole region.
+   Interactive, so it captures the interior while shown — the tradeoff of dragging the body. */
+.cmt-canvas-region--movable {
+	pointer-events: auto;
+	cursor: move;
+}
+
+/* Corner resize handles on a region box (three corners; the pin corner is the move handle). */
 .cmt-canvas-region-handle {
 	position: absolute;
 	width: 9px;

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -71,6 +71,19 @@
 	background: color-mix(in srgb, var(--tl-color-selected) 10%, transparent);
 }
 
+/* Corner resize handles on a region box (three corners; the top-right is the move pin). */
+.cmt-canvas-region-handle {
+	position: absolute;
+	width: 9px;
+	height: 9px;
+	transform: translate(-50%, -50%);
+	background: var(--tl-color-panel);
+	border: 1.5px solid var(--tl-color-selected);
+	border-radius: 2px;
+	pointer-events: auto;
+	touch-action: none;
+}
+
 /* Centre the pin marker on its anchor point. */
 .cmt-canvas-pin__marker {
 	width: max-content;

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -58,13 +58,13 @@ describe('collectClusterLeaves anchor resolution', () => {
 		expect(leaves).toEqual([{ id: 't1', point: { x: 12, y: 34 } }])
 	})
 
-	it('maps region anchors to their top-right corner (x + w, y)', () => {
+	it('maps region anchors to their bottom-right corner (x + w, y + h)', () => {
 		const leaves = collectClusterLeaves(
 			stubEditor(),
 			[thread('t1', { type: 'region', x: 10, y: 20, w: 30, h: 40 })],
 			null
 		)
-		expect(leaves).toEqual([{ id: 't1', point: { x: 40, y: 20 } }])
+		expect(leaves).toEqual([{ id: 't1', point: { x: 40, y: 60 } }])
 	})
 
 	it('maps shape and text-range anchors to the shape bounds top-right corner', () => {

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -1,4 +1,5 @@
 import { atom, BoxModel, StateNode, TLCommentAnchor, TLUiOverrides, VecLike } from 'tldraw'
+import { getRegionCommentOptions } from './region-options'
 import { regionPinPoint, shapeAnchorAt } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
@@ -62,9 +63,10 @@ class CommentIdle extends StateNode {
 class CommentPointing extends StateNode {
 	static override id = 'pointing'
 
-	// Once the pointer passes the editor's drag threshold this is a region, not a click.
+	// Once the pointer passes the editor's drag threshold this is a region, not a click — but only
+	// when region comments are enabled; otherwise a drag is treated as a click (point/shape).
 	override onPointerMove() {
-		if (this.editor.inputs.getIsDragging()) {
+		if (getRegionCommentOptions(this.editor).enabled && this.editor.inputs.getIsDragging()) {
 			this.parent.transition('dragging')
 		}
 	}
@@ -103,7 +105,7 @@ class CommentDragging extends StateNode {
 		regionDraft.set(null)
 		pendingComment.set({
 			anchor: { type: 'region', ...region },
-			point: regionPinPoint(region),
+			point: regionPinPoint(region, getRegionCommentOptions(editor).pinCorner),
 		})
 		editor.setCurrentTool('select')
 	}

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -1,4 +1,4 @@
-import { atom, StateNode, TLCommentAnchor, TLUiOverrides, VecLike } from 'tldraw'
+import { atom, BoxModel, StateNode, TLCommentAnchor, TLUiOverrides, VecLike } from 'tldraw'
 import { shapeAnchorAt } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
@@ -6,7 +6,7 @@ import { shapeAnchorAt } from './thread-state'
  *  composer). Null when nothing is being placed. */
 export interface PendingComment {
 	anchor: TLCommentAnchor
-	/** Page point where the composer opens (the click location). */
+	/** Page point where the composer opens (the click location, or a region's bottom-left). */
 	point: VecLike
 }
 
@@ -14,13 +14,31 @@ export interface PendingComment {
  *  itself (e.g. from a different gesture) instead of, or alongside, the comment tool. */
 export const pendingComment = atom<PendingComment | null>('pendingComment', null)
 
+/** The region rectangle being dragged out right now (page coords), or null when not dragging.
+ *  The tool writes it on each move; the overlay reads it to draw the live dashed box. */
+export const regionDraft = atom<BoxModel | null>('regionDraft', null)
+
+/** The page-space rectangle spanned by two points, normalized so w/h are non-negative. */
+function regionBetween(a: VecLike, b: VecLike): BoxModel {
+	return {
+		x: Math.min(a.x, b.x),
+		y: Math.min(a.y, b.y),
+		w: Math.abs(a.x - b.x),
+		h: Math.abs(a.y - b.y),
+	}
+}
+
 /**
- * The comment tool. Clicking the canvas starts a thread: on a shape it anchors to that shape (so
- * the pin tracks it), on empty canvas it drops a point anchor. Placement only opens a composer
- * (via `pendingComment`); the records are created when the comment is posted.
+ * The comment tool. A click starts a point/shape thread (the pin tracks the shape it lands on);
+ * dragging out a rectangle starts a region thread anchored to that area. Placement only opens a
+ * composer (via `pendingComment`); the records are created when the comment is posted.
  */
 export class CommentTool extends StateNode {
 	static override id = 'comment'
+	static override initial = 'idle'
+	static override children() {
+		return [CommentIdle, CommentPointing, CommentDragging]
+	}
 
 	override onEnter() {
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
@@ -30,8 +48,28 @@ export class CommentTool extends StateNode {
 	override onCancel() {
 		this.editor.setCurrentTool('select')
 	}
+}
+
+class CommentIdle extends StateNode {
+	static override id = 'idle'
 
 	override onPointerDown() {
+		this.parent.transition('pointing')
+	}
+}
+
+class CommentPointing extends StateNode {
+	static override id = 'pointing'
+
+	// Once the pointer passes the editor's drag threshold this is a region, not a click.
+	override onPointerMove() {
+		if (this.editor.inputs.getIsDragging()) {
+			this.parent.transition('dragging')
+		}
+	}
+
+	// A pointer up with no drag is a click: anchor to the shape under it, or drop a point.
+	override onPointerUp() {
 		const { editor } = this
 		const point = editor.inputs.getCurrentPagePoint()
 		const hit = editor.getShapeAtPoint(point, { hitInside: true })
@@ -39,8 +77,54 @@ export class CommentTool extends StateNode {
 			? shapeAnchorAt(editor, hit.id, point, editor.inputs.getAltKey())
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set({ anchor, point: { x: point.x, y: point.y } })
-		// Hand back to select; the open composer is now the focus.
 		editor.setCurrentTool('select')
+	}
+}
+
+class CommentDragging extends StateNode {
+	static override id = 'dragging'
+
+	override onEnter() {
+		this.updateDraft()
+	}
+
+	override onPointerMove() {
+		this.updateDraft()
+	}
+
+	// Commit the dragged rectangle as a region anchor; the composer opens at its bottom-left.
+	override onPointerUp() {
+		const { editor } = this
+		const region = regionBetween(
+			editor.inputs.getOriginPagePoint(),
+			editor.inputs.getCurrentPagePoint()
+		)
+		regionDraft.set(null)
+		pendingComment.set({
+			anchor: { type: 'region', ...region },
+			point: { x: region.x, y: region.y + region.h },
+		})
+		editor.setCurrentTool('select')
+	}
+
+	override onCancel() {
+		this.cancel()
+	}
+
+	override onInterrupt() {
+		this.cancel()
+	}
+
+	private updateDraft() {
+		const { editor } = this
+		regionDraft.set(
+			regionBetween(editor.inputs.getOriginPagePoint(), editor.inputs.getCurrentPagePoint())
+		)
+	}
+
+	private cancel() {
+		regionDraft.set(null)
+		this.editor.setCurrentTool('select')
 	}
 }
 

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -1,12 +1,12 @@
 import { atom, BoxModel, StateNode, TLCommentAnchor, TLUiOverrides, VecLike } from 'tldraw'
-import { shapeAnchorAt } from './thread-state'
+import { regionPinPoint, shapeAnchorAt } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
  *  to. Shared between the tool (which sets it on click) and the overlay (which renders the
  *  composer). Null when nothing is being placed. */
 export interface PendingComment {
 	anchor: TLCommentAnchor
-	/** Page point where the composer opens (the click location, or a region's bottom-left). */
+	/** Page point where the composer opens (the click location, or a region's pin corner). */
 	point: VecLike
 }
 
@@ -93,7 +93,7 @@ class CommentDragging extends StateNode {
 		this.updateDraft()
 	}
 
-	// Commit the dragged rectangle as a region anchor; the composer opens at its bottom-left.
+	// Commit the dragged rectangle as a region anchor; the composer opens at its pin corner.
 	override onPointerUp() {
 		const { editor } = this
 		const region = regionBetween(
@@ -103,7 +103,7 @@ class CommentDragging extends StateNode {
 		regionDraft.set(null)
 		pendingComment.set({
 			anchor: { type: 'region', ...region },
-			point: { x: region.x, y: region.y + region.h },
+			point: regionPinPoint(region),
 		})
 		editor.setCurrentTool('select')
 	}

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -18,8 +18,9 @@ export const pendingComment = atom<PendingComment | null>('pendingComment', null
  *  The tool writes it on each move; the overlay reads it to draw the live dashed box. */
 export const regionDraft = atom<BoxModel | null>('regionDraft', null)
 
-/** The page-space rectangle spanned by two points, normalized so w/h are non-negative. */
-function regionBetween(a: VecLike, b: VecLike): BoxModel {
+/** The page-space rectangle spanned by two points, normalized so w/h are non-negative. Shared by
+ *  region creation (pointer-down → cursor) and corner resize (fixed corner → cursor). */
+export function regionBetween(a: VecLike, b: VecLike): BoxModel {
 	return {
 		x: Math.min(a.x, b.x),
 		y: Math.min(a.y, b.y),

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -710,6 +710,10 @@ const REGION_HANDLES = REGION_CORNERS.filter(
 	(c) => c.x !== REGION_PIN_CORNER.x || c.y !== REGION_PIN_CORNER.y
 )
 
+// Screen-space slack around a region's bounds within which its box and handles stay revealed, so
+// the corner handles (which sit on the edge) are comfortably reachable.
+const REGION_HANDLE_MARGIN_PX = 12
+
 /** Draggable corner handles that resize a region: each spans a rectangle from its fixed opposite
  *  corner (captured at pointer-down) to the cursor. Previews live, commits on release. */
 function RegionResizeHandles({
@@ -717,13 +721,11 @@ function RegionResizeHandles({
 	box,
 	onPreview,
 	onCommit,
-	onHoverChange,
 }: {
 	editor: Editor
 	box: BoxModel
 	onPreview(bounds: BoxModel | null): void
 	onCommit(bounds: BoxModel): void
-	onHoverChange(hovered: boolean): void
 }) {
 	// The fixed (opposite) corner in page coords, captured at pointer-down so the box prop reflowing
 	// mid-drag doesn't move it.
@@ -766,8 +768,6 @@ function RegionResizeHandles({
 					onPointerDown={startResize(h)}
 					onPointerMove={onResize}
 					onPointerUp={endResize}
-					onPointerEnter={() => onHoverChange(true)}
-					onPointerLeave={() => onHoverChange(false)}
 				/>
 			))}
 		</>
@@ -798,10 +798,23 @@ const ThreadPin = memo(function ThreadPin({
 	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
 	// While dragging the marker, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
-	// A region thread reveals its dashed box while hovered or while its thread is open.
-	const [hovered, setHovered] = useState(false)
 	// The live bounds while a corner handle is resizing the region, else null.
 	const [resizeBounds, setResizeBounds] = useState<BoxModel | null>(null)
+	// A region reveals its box and corner handles while the pointer is within its bounds (plus a
+	// grab margin). Driven by pointer position, not DOM hover, so moving from anywhere in the region
+	// out to a corner handle never loses the affordance — the box stays `pointer-events: none`.
+	const pointerInRegion = useValue(
+		'pointer in region',
+		() => {
+			if (thread.anchor.type !== 'region' || thread.pageId !== editor.getCurrentPageId())
+				return false
+			const m = REGION_HANDLE_MARGIN_PX / editor.getZoomLevel()
+			const p = editor.inputs.getCurrentPagePoint()
+			const a = thread.anchor
+			return p.x >= a.x - m && p.x <= a.x + a.w + m && p.y >= a.y - m && p.y <= a.y + a.h + m
+		},
+		[editor, thread.anchor, thread.pageId]
+	)
 	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
 	const markerRef = useRef<HTMLDivElement>(null)
 
@@ -1070,16 +1083,15 @@ const ThreadPin = memo(function ThreadPin({
 
 	return (
 		<>
-			{regionBoxBounds && (dragPagePoint || open || hovered || resizeBounds) && (
+			{regionBoxBounds && (dragPagePoint || open || pointerInRegion || resizeBounds) && (
 				<RegionBox editor={editor} box={regionBoxBounds} />
 			)}
-			{regionBoxBounds && (open || hovered || resizeBounds) && !dragPagePoint && (
+			{regionBoxBounds && (open || pointerInRegion || resizeBounds) && !dragPagePoint && (
 				<RegionResizeHandles
 					editor={editor}
 					box={regionBoxBounds}
 					onPreview={setResizeBounds}
 					onCommit={commitResize}
-					onHoverChange={setHovered}
 				/>
 			)}
 			<div
@@ -1092,8 +1104,6 @@ const ThreadPin = memo(function ThreadPin({
 					onPointerDown={startDrag}
 					onPointerMove={onDrag}
 					onPointerUp={endDrag}
-					onPointerEnter={() => setHovered(true)}
-					onPointerLeave={() => setHovered(false)}
 				>
 					<CommentPin resolved={thread.resolved != null} open={open}>
 						{pinContent}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -385,6 +385,9 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 				<ThreadPin key={`open:${openThread.id}`} editor={editor} thread={openThread} {...props} />
 			)}
 			<RegionDraftBox editor={editor} />
+			{/* Keep the region visible while composing — the drag draft is gone by now, and no thread
+			    exists yet, so the pending anchor is what shows the area under the open composer. */}
+			{pending?.anchor.type === 'region' && <RegionBox editor={editor} box={pending.anchor} />}
 			{pending && props.currentUserId && (
 				<PendingComposer editor={editor} pending={pending} {...props} />
 			)}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -40,7 +40,7 @@ import { CommentThread } from '../ui/comment-thread'
 import { CountBadge } from '../ui/count-badge'
 import { collectClusterLeaves } from './cluster-input'
 import { CommentBody } from './comment-body'
-import { pendingComment, PendingComment, regionDraft } from './comment-tool'
+import { pendingComment, PendingComment, regionBetween, regionDraft } from './comment-tool'
 import { commentsHidden, toggleCommentsHidden } from './comments-visibility'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
@@ -688,6 +688,77 @@ function RegionDraftBox({ editor }: { editor: Editor }) {
 	return <RegionBox editor={editor} box={box} />
 }
 
+// The three resizable corners (the top-right corner is the move pin, so it has no handle). `cx/cy`
+// place the handle within the box; `fx/fy` are its diagonally-opposite corner, which stays fixed.
+const REGION_HANDLES = [
+	{ key: 'tl', cx: 0, cy: 0, fx: 1, fy: 1, cursor: 'nwse-resize' },
+	{ key: 'bl', cx: 0, cy: 1, fx: 1, fy: 0, cursor: 'nesw-resize' },
+	{ key: 'br', cx: 1, cy: 1, fx: 0, fy: 0, cursor: 'nwse-resize' },
+] as const
+
+/** Draggable corner handles that resize a region: each spans a rectangle from its fixed opposite
+ *  corner (captured at pointer-down) to the cursor. Previews live, commits on release. */
+function RegionResizeHandles({
+	editor,
+	box,
+	onPreview,
+	onCommit,
+	onHoverChange,
+}: {
+	editor: Editor
+	box: BoxModel
+	onPreview(bounds: BoxModel | null): void
+	onCommit(bounds: BoxModel): void
+	onHoverChange(hovered: boolean): void
+}) {
+	// The fixed (opposite) corner in page coords, captured at pointer-down so the box prop reflowing
+	// mid-drag doesn't move it.
+	const fixedRef = useRef<{ x: number; y: number } | null>(null)
+	const corners = useValue(
+		'region handle points',
+		() =>
+			REGION_HANDLES.map((h) => {
+				const p = editor.pageToViewport({ x: box.x + h.cx * box.w, y: box.y + h.cy * box.h })
+				return { ...h, left: p.x, top: p.y }
+			}),
+		[editor, box.x, box.y, box.w, box.h]
+	)
+	const startResize =
+		(h: (typeof REGION_HANDLES)[number]) => (e: ReactPointerEvent<HTMLDivElement>) => {
+			e.stopPropagation()
+			fixedRef.current = { x: box.x + h.fx * box.w, y: box.y + h.fy * box.h }
+			e.currentTarget.setPointerCapture(e.pointerId)
+		}
+	const onResize = (e: ReactPointerEvent<HTMLDivElement>) => {
+		if (!fixedRef.current) return
+		onPreview(regionBetween(fixedRef.current, editor.screenToPage({ x: e.clientX, y: e.clientY })))
+	}
+	const endResize = (e: ReactPointerEvent<HTMLDivElement>) => {
+		const fixed = fixedRef.current
+		fixedRef.current = null
+		if (e.currentTarget.hasPointerCapture(e.pointerId))
+			e.currentTarget.releasePointerCapture(e.pointerId)
+		if (!fixed) return
+		onCommit(regionBetween(fixed, editor.screenToPage({ x: e.clientX, y: e.clientY })))
+	}
+	return (
+		<>
+			{corners.map((h) => (
+				<div
+					key={h.key}
+					className="cmt-canvas-region-handle"
+					style={{ left: h.left, top: h.top, cursor: h.cursor }}
+					onPointerDown={startResize(h)}
+					onPointerMove={onResize}
+					onPointerUp={endResize}
+					onPointerEnter={() => onHoverChange(true)}
+					onPointerLeave={() => onHoverChange(false)}
+				/>
+			))}
+		</>
+	)
+}
+
 const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
@@ -714,6 +785,8 @@ const ThreadPin = memo(function ThreadPin({
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
 	// A region thread reveals its dashed box while hovered or while its thread is open.
 	const [hovered, setHovered] = useState(false)
+	// The live bounds while a corner handle is resizing the region, else null.
+	const [resizeBounds, setResizeBounds] = useState<BoxModel | null>(null)
 	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
 	const markerRef = useRef<HTMLDivElement>(null)
 
@@ -729,6 +802,8 @@ const ThreadPin = memo(function ThreadPin({
 			if (target.closest('.cmt-canvas-popover')) return
 			const marker = markerRef.current
 			if (marker && marker.contains(target)) return
+			// A press on a region resize handle edits this thread's anchor — it must not dismiss it.
+			if (target.closest('.cmt-canvas-region-handle')) return
 			// A click inside a menu/popover layered above us (e.g. the sidebar's filter or overflow
 			// dropdown, portaled elsewhere) belongs to that layer — defer to its own dismissal
 			// instead of closing the thread out from under it.
@@ -947,20 +1022,44 @@ const ThreadPin = memo(function ThreadPin({
 		editor.run(() => editor.store.put([{ ...thread, anchor } as any]), { history: 'ignore' })
 	}
 
-	const renderPoint = dragPagePoint ? editor.pageToViewport(dragPagePoint) : point
+	// The pin (and its popover) track the live edit: a resize moves it to the region's top-right
+	// corner, a move to the drag point; otherwise it sits at the stored anchor's viewport point.
+	const livePinPage = resizeBounds
+		? { x: resizeBounds.x + resizeBounds.w, y: resizeBounds.y }
+		: dragPagePoint
+	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
 
-	// A region's dashed box bounds: its stored anchor, or — while the pin is dragged — translated so
-	// the pin (the box's top-right corner) tracks the cursor. Undefined for non-region threads.
+	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (top-right
+	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.
 	const regionAnchor = thread.anchor.type === 'region' ? thread.anchor : undefined
-	const regionBoxBounds =
+	const movedRegion =
 		regionAnchor && dragPagePoint
 			? { ...regionAnchor, x: dragPagePoint.x - regionAnchor.w, y: dragPagePoint.y }
 			: regionAnchor
+	const regionBoxBounds = resizeBounds ?? movedRegion
+	const commitResize = (bounds: BoxModel) => {
+		setResizeBounds(null)
+		editor.run(
+			() => editor.store.put([{ ...thread, anchor: { type: 'region', ...bounds } } as any]),
+			{
+				history: 'ignore',
+			}
+		)
+	}
 
 	return (
 		<>
-			{regionBoxBounds && (dragPagePoint || open || hovered) && (
+			{regionBoxBounds && (dragPagePoint || open || hovered || resizeBounds) && (
 				<RegionBox editor={editor} box={regionBoxBounds} />
+			)}
+			{regionBoxBounds && (open || hovered || resizeBounds) && !dragPagePoint && (
+				<RegionResizeHandles
+					editor={editor}
+					box={regionBoxBounds}
+					onPreview={setResizeBounds}
+					onCommit={commitResize}
+					onHoverChange={setHovered}
+				/>
 			)}
 			<div
 				className={open ? 'cmt-canvas-pin cmt-canvas-pin--open' : 'cmt-canvas-pin'}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -44,7 +44,13 @@ import { pendingComment, PendingComment, regionBetween, regionDraft } from './co
 import { commentsHidden, toggleCommentsHidden } from './comments-visibility'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
-import { anchorPagePoint, openThreadId, shapeAnchorAt } from './thread-state'
+import {
+	anchorPagePoint,
+	openThreadId,
+	REGION_PIN_CORNER,
+	regionPinPoint,
+	shapeAnchorAt,
+} from './thread-state'
 import './canvas.css'
 
 /**
@@ -691,13 +697,18 @@ function RegionDraftBox({ editor }: { editor: Editor }) {
 	return <RegionBox editor={editor} box={box} />
 }
 
-// The three resizable corners (the top-right corner is the move pin, so it has no handle). `cx/cy`
-// place the handle within the box; `fx/fy` are its diagonally-opposite corner, which stays fixed.
-const REGION_HANDLES = [
-	{ key: 'tl', cx: 0, cy: 0, fx: 1, fy: 1, cursor: 'nwse-resize' },
-	{ key: 'bl', cx: 0, cy: 1, fx: 1, fy: 0, cursor: 'nesw-resize' },
-	{ key: 'br', cx: 1, cy: 1, fx: 0, fy: 0, cursor: 'nwse-resize' },
+// A region's four corners as normalized 0–1 offsets; the cursor follows each corner's diagonal.
+const REGION_CORNERS = [
+	{ x: 0, y: 0, cursor: 'nwse-resize' },
+	{ x: 1, y: 0, cursor: 'nesw-resize' },
+	{ x: 0, y: 1, cursor: 'nesw-resize' },
+	{ x: 1, y: 1, cursor: 'nwse-resize' },
 ] as const
+
+// Resize handles are every corner except the pin corner, which is the move handle instead.
+const REGION_HANDLES = REGION_CORNERS.filter(
+	(c) => c.x !== REGION_PIN_CORNER.x || c.y !== REGION_PIN_CORNER.y
+)
 
 /** Draggable corner handles that resize a region: each spans a rectangle from its fixed opposite
  *  corner (captured at pointer-down) to the cursor. Previews live, commits on release. */
@@ -721,15 +732,16 @@ function RegionResizeHandles({
 		'region handle points',
 		() =>
 			REGION_HANDLES.map((h) => {
-				const p = editor.pageToViewport({ x: box.x + h.cx * box.w, y: box.y + h.cy * box.h })
-				return { ...h, left: p.x, top: p.y }
+				const p = editor.pageToViewport({ x: box.x + h.x * box.w, y: box.y + h.y * box.h })
+				return { ...h, key: `${h.x}-${h.y}`, left: p.x, top: p.y }
 			}),
 		[editor, box.x, box.y, box.w, box.h]
 	)
 	const startResize =
 		(h: (typeof REGION_HANDLES)[number]) => (e: ReactPointerEvent<HTMLDivElement>) => {
 			e.stopPropagation()
-			fixedRef.current = { x: box.x + h.fx * box.w, y: box.y + h.fy * box.h }
+			// The fixed corner is the pin corner's diagonal opposite: (1 - x, 1 - y) of this handle.
+			fixedRef.current = { x: box.x + (1 - h.x) * box.w, y: box.y + (1 - h.y) * box.h }
 			e.currentTarget.setPointerCapture(e.pointerId)
 		}
 	const onResize = (e: ReactPointerEvent<HTMLDivElement>) => {
@@ -1014,8 +1026,12 @@ const ThreadPin = memo(function ThreadPin({
 		setDragPagePoint(null)
 		let anchor: TLCommentThread['anchor']
 		if (thread.anchor.type === 'region') {
-			// Translate so the pin (the region's top-right corner) lands at the drop; size unchanged.
-			anchor = { ...thread.anchor, x: pagePoint.x - thread.anchor.w, y: pagePoint.y }
+			// Translate so the pin (the region's pin corner) lands at the drop; size unchanged.
+			anchor = {
+				...thread.anchor,
+				x: pagePoint.x - REGION_PIN_CORNER.x * thread.anchor.w,
+				y: pagePoint.y - REGION_PIN_CORNER.y * thread.anchor.h,
+			}
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
 			anchor = hit
@@ -1025,19 +1041,21 @@ const ThreadPin = memo(function ThreadPin({
 		editor.run(() => editor.store.put([{ ...thread, anchor } as any]), { history: 'ignore' })
 	}
 
-	// The pin (and its popover) track the live edit: a resize moves it to the region's top-right
-	// corner, a move to the drag point; otherwise it sits at the stored anchor's viewport point.
-	const livePinPage = resizeBounds
-		? { x: resizeBounds.x + resizeBounds.w, y: resizeBounds.y }
-		: dragPagePoint
+	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
+	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
+	const livePinPage = resizeBounds ? regionPinPoint(resizeBounds) : dragPagePoint
 	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
 
-	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (top-right
+	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
 	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.
 	const regionAnchor = thread.anchor.type === 'region' ? thread.anchor : undefined
 	const movedRegion =
 		regionAnchor && dragPagePoint
-			? { ...regionAnchor, x: dragPagePoint.x - regionAnchor.w, y: dragPagePoint.y }
+			? {
+					...regionAnchor,
+					x: dragPagePoint.x - REGION_PIN_CORNER.x * regionAnchor.w,
+					y: dragPagePoint.y - REGION_PIN_CORNER.y * regionAnchor.h,
+				}
 			: regionAnchor
 	const regionBoxBounds = resizeBounds ?? movedRegion
 	const commitResize = (bounds: BoxModel) => {

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -28,6 +28,7 @@ import {
 	usePassThroughWheelEvents,
 	useTranslation,
 	useValue,
+	VecLike,
 } from 'tldraw'
 import { computeClusterTable } from '../clustering/computeClusterTable'
 import { type ClusterRuntime, createClusterRuntime } from '../clustering/runtime'
@@ -49,13 +50,7 @@ import {
 	RegionCommentOptions,
 	setRegionCommentOptions,
 } from './region-options'
-import {
-	anchorPagePoint,
-	openThreadId,
-	REGION_PIN_CORNER,
-	regionPinPoint,
-	shapeAnchorAt,
-} from './thread-state'
+import { anchorPagePoint, openThreadId, regionPinPoint, shapeAnchorAt } from './thread-state'
 import './canvas.css'
 
 /**
@@ -386,7 +381,9 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 				if (node.count === 1) {
 					const thread = threadsById.get(node.id)
 					if (!thread) return null
-					content = <ThreadPin editor={editor} thread={thread} {...props} />
+					content = (
+						<ThreadPin editor={editor} thread={thread} {...props} regionOptions={regionOptions} />
+					)
 				} else {
 					content = <ClusterBadge editor={editor} node={node} onExpand={zoomToClusterSplit} />
 				}
@@ -397,13 +394,31 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 				)
 			})}
 			{orphanThreads.map((thread) => (
-				<ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
+				<ThreadPin
+					key={thread.id}
+					editor={editor}
+					thread={thread}
+					{...props}
+					regionOptions={regionOptions}
+				/>
 			))}
 			{movedThreads.map((thread) => (
-				<ThreadPin key={thread.id} editor={editor} thread={thread} {...props} />
+				<ThreadPin
+					key={thread.id}
+					editor={editor}
+					thread={thread}
+					{...props}
+					regionOptions={regionOptions}
+				/>
 			))}
 			{openThread && (
-				<ThreadPin key={`open:${openThread.id}`} editor={editor} thread={openThread} {...props} />
+				<ThreadPin
+					key={`open:${openThread.id}`}
+					editor={editor}
+					thread={openThread}
+					{...props}
+					regionOptions={regionOptions}
+				/>
 			)}
 			<RegionDraftBox editor={editor} />
 			{/* Keep the region visible while composing — the drag draft is gone by now, and no thread
@@ -720,25 +735,23 @@ const REGION_CORNERS = [
 	{ x: 1, y: 1, cursor: 'nwse-resize' },
 ] as const
 
-// Resize handles are every corner except the pin corner, which is the move handle instead.
-const REGION_HANDLES = REGION_CORNERS.filter(
-	(c) => c.x !== REGION_PIN_CORNER.x || c.y !== REGION_PIN_CORNER.y
-)
-
 // Screen-space slack around a region's bounds within which its box and handles stay revealed, so
 // the corner handles (which sit on the edge) are comfortably reachable.
 const REGION_HANDLE_MARGIN_PX = 12
 
 /** Draggable corner handles that resize a region: each spans a rectangle from its fixed opposite
- *  corner (captured at pointer-down) to the cursor. Previews live, commits on release. */
+ *  corner (captured at pointer-down) to the cursor. The pin corner has no handle (it's the move
+ *  handle). Previews live, commits on release. */
 function RegionResizeHandles({
 	editor,
 	box,
+	pinCorner,
 	onPreview,
 	onCommit,
 }: {
 	editor: Editor
 	box: BoxModel
+	pinCorner: VecLike
 	onPreview(bounds: BoxModel | null): void
 	onCommit(bounds: BoxModel): void
 }) {
@@ -748,14 +761,15 @@ function RegionResizeHandles({
 	const corners = useValue(
 		'region handle points',
 		() =>
-			REGION_HANDLES.map((h) => {
+			// Every corner except the pin corner, which is the move handle instead.
+			REGION_CORNERS.filter((h) => h.x !== pinCorner.x || h.y !== pinCorner.y).map((h) => {
 				const p = editor.pageToViewport({ x: box.x + h.x * box.w, y: box.y + h.y * box.h })
 				return { ...h, key: `${h.x}-${h.y}`, left: p.x, top: p.y }
 			}),
-		[editor, box.x, box.y, box.w, box.h]
+		[editor, box.x, box.y, box.w, box.h, pinCorner]
 	)
 	const startResize =
-		(h: (typeof REGION_HANDLES)[number]) => (e: ReactPointerEvent<HTMLDivElement>) => {
+		(h: (typeof REGION_CORNERS)[number]) => (e: ReactPointerEvent<HTMLDivElement>) => {
 			e.stopPropagation()
 			// The fixed corner is the pin corner's diagonal opposite: (1 - x, 1 - y) of this handle.
 			fixedRef.current = { x: box.x + (1 - h.x) * box.w, y: box.y + (1 - h.y) * box.h }
@@ -792,8 +806,13 @@ function RegionResizeHandles({
 const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
+	regionOptions,
 	...props
-}: CanvasCommentsProps & { editor: Editor; thread: TLCommentThread }) {
+}: Omit<CanvasCommentsProps, 'regionOptions'> & {
+	editor: Editor
+	thread: TLCommentThread
+	regionOptions: RegionCommentOptions
+}) {
 	const {
 		currentUserId,
 		resolveName,
@@ -815,9 +834,11 @@ const ThreadPin = memo(function ThreadPin({
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
 	// The live bounds while a corner handle is resizing the region, else null.
 	const [resizeBounds, setResizeBounds] = useState<BoxModel | null>(null)
-	// A region reveals its box and corner handles while the pointer is within its bounds (plus a
-	// grab margin). Driven by pointer position, not DOM hover, so moving from anywhere in the region
-	// out to a corner handle never loses the affordance — the box stays `pointer-events: none`.
+	// Whether the pin marker is hovered — only consulted by the 'pin-hover' reveal mode.
+	const [pinHovered, setPinHovered] = useState(false)
+	// The 'pointer' reveal mode: is the pointer within the region's bounds (plus a grab margin)?
+	// Driven by pointer position, not DOM hover, so moving from anywhere in the region out to a corner
+	// handle never loses the affordance — the box stays `pointer-events: none`.
 	const pointerInRegion = useValue(
 		'pointer in region',
 		() => {
@@ -830,6 +851,13 @@ const ThreadPin = memo(function ThreadPin({
 		},
 		[editor, thread.anchor, thread.pageId]
 	)
+	// A region's box and handles are revealed while open or mid-resize, plus — per the reveal mode —
+	// while the pointer is within the region ('pointer') or the pin is hovered ('pin-hover').
+	const revealed =
+		open ||
+		resizeBounds != null ||
+		(regionOptions.reveal === 'pointer' && pointerInRegion) ||
+		(regionOptions.reveal === 'pin-hover' && pinHovered)
 	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
 	const markerRef = useRef<HTMLDivElement>(null)
 
@@ -1057,8 +1085,8 @@ const ThreadPin = memo(function ThreadPin({
 			// Translate so the pin (the region's pin corner) lands at the drop; size unchanged.
 			anchor = {
 				...thread.anchor,
-				x: pagePoint.x - REGION_PIN_CORNER.x * thread.anchor.w,
-				y: pagePoint.y - REGION_PIN_CORNER.y * thread.anchor.h,
+				x: pagePoint.x - regionOptions.pinCorner.x * thread.anchor.w,
+				y: pagePoint.y - regionOptions.pinCorner.y * thread.anchor.h,
 			}
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
@@ -1071,7 +1099,9 @@ const ThreadPin = memo(function ThreadPin({
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
 	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
-	const livePinPage = resizeBounds ? regionPinPoint(resizeBounds) : dragPagePoint
+	const livePinPage = resizeBounds
+		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
+		: dragPagePoint
 	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
@@ -1081,8 +1111,8 @@ const ThreadPin = memo(function ThreadPin({
 		regionAnchor && dragPagePoint
 			? {
 					...regionAnchor,
-					x: dragPagePoint.x - REGION_PIN_CORNER.x * regionAnchor.w,
-					y: dragPagePoint.y - REGION_PIN_CORNER.y * regionAnchor.h,
+					x: dragPagePoint.x - regionOptions.pinCorner.x * regionAnchor.w,
+					y: dragPagePoint.y - regionOptions.pinCorner.y * regionAnchor.h,
 				}
 			: regionAnchor
 	const regionBoxBounds = resizeBounds ?? movedRegion
@@ -1098,13 +1128,14 @@ const ThreadPin = memo(function ThreadPin({
 
 	return (
 		<>
-			{regionBoxBounds && (dragPagePoint || open || pointerInRegion || resizeBounds) && (
+			{regionBoxBounds && (dragPagePoint || revealed) && (
 				<RegionBox editor={editor} box={regionBoxBounds} />
 			)}
-			{regionBoxBounds && (open || pointerInRegion || resizeBounds) && !dragPagePoint && (
+			{regionBoxBounds && revealed && !dragPagePoint && regionOptions.resize !== 'none' && (
 				<RegionResizeHandles
 					editor={editor}
 					box={regionBoxBounds}
+					pinCorner={regionOptions.pinCorner}
 					onPreview={setResizeBounds}
 					onCommit={commitResize}
 				/>
@@ -1119,6 +1150,8 @@ const ThreadPin = memo(function ThreadPin({
 					onPointerDown={startDrag}
 					onPointerMove={onDrag}
 					onPointerUp={endDrag}
+					onPointerEnter={() => setPinHovered(true)}
+					onPointerLeave={() => setPinHovered(false)}
 				>
 					<CommentPin resolved={thread.resolved != null} open={open}>
 						{pinContent}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -45,6 +45,11 @@ import { commentsHidden, toggleCommentsHidden } from './comments-visibility'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
 import {
+	DEFAULT_REGION_COMMENT_OPTIONS,
+	RegionCommentOptions,
+	setRegionCommentOptions,
+} from './region-options'
+import {
 	anchorPagePoint,
 	openThreadId,
 	REGION_PIN_CORNER,
@@ -82,6 +87,9 @@ export interface CanvasCommentsProps {
 	onCommentRead?(commentId: TLCommentId): void
 	/** Where imprecise shape pins sit — a normalized (0–1) spot within the shape. Default top-right. */
 	impreciseShapeAnchor?: { x: number; y: number }
+	/** Region comment behaviour. Region is off by default — omit this for click-only point/shape
+	 *  comments. Anything unset falls back to {@link DEFAULT_REGION_COMMENT_OPTIONS}. */
+	regionOptions?: Partial<RegionCommentOptions>
 }
 
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
@@ -134,6 +142,13 @@ export function CanvasComments(props: CanvasCommentsProps) {
 function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const editor = useEditor()
 	const container = useContainer()
+	// Merge the consumer's region options over the disabled defaults and publish them for this editor,
+	// so the comment tool (which has no props) reads the same per-instance config.
+	const regionOptions = useMemo(
+		() => ({ ...DEFAULT_REGION_COMMENT_OPTIONS, ...props.regionOptions }),
+		[props.regionOptions]
+	)
+	useEffect(() => setRegionCommentOptions(editor, regionOptions), [editor, regionOptions])
 	const layerRef = useRef<HTMLDivElement>(null)
 	// Over the pins and cluster badges, wheel and hover pass through to the canvas beneath (these
 	// events bubble up from the pointer-interactive markers to this layer root).

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -906,8 +906,9 @@ const ThreadPin = memo(function ThreadPin({
 		: initialOf(resolveName(thread.createdBy))
 
 	// Drag the marker to move the thread: its position is overridden locally while dragging, then
-	// re-anchored on drop (to a shape if dropped on one, else a point). A pointer that barely moves
-	// is a click — toggle the popover.
+	// re-anchored on drop. A point/shape thread re-anchors to whatever it's dropped on (a shape, else
+	// a point); a region thread translates, keeping its size. A pointer that barely moves is a click —
+	// toggle the popover.
 	const startDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
 		e.stopPropagation()
 		dragRef.current = { startX: e.clientX, startY: e.clientY, moved: false }
@@ -933,24 +934,34 @@ const ThreadPin = memo(function ThreadPin({
 		}
 		const pagePoint = editor.screenToPage({ x: e.clientX, y: e.clientY })
 		setDragPagePoint(null)
-		const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
-		const anchor = hit
-			? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
-			: { type: 'point', x: pagePoint.x, y: pagePoint.y }
+		let anchor: TLCommentThread['anchor']
+		if (thread.anchor.type === 'region') {
+			// Translate so the pin (the region's top-right corner) lands at the drop; size unchanged.
+			anchor = { ...thread.anchor, x: pagePoint.x - thread.anchor.w, y: pagePoint.y }
+		} else {
+			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
+			anchor = hit
+				? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
+				: { type: 'point', x: pagePoint.x, y: pagePoint.y }
+		}
 		editor.run(() => editor.store.put([{ ...thread, anchor } as any]), { history: 'ignore' })
 	}
 
 	const renderPoint = dragPagePoint ? editor.pageToViewport(dragPagePoint) : point
 
-	// The region's dashed box, shown while the thread is open or its pin is hovered.
-	const regionBox =
-		thread.anchor.type === 'region' && (open || hovered) ? (
-			<RegionBox editor={editor} box={thread.anchor} />
-		) : null
+	// A region's dashed box bounds: its stored anchor, or — while the pin is dragged — translated so
+	// the pin (the box's top-right corner) tracks the cursor. Undefined for non-region threads.
+	const regionAnchor = thread.anchor.type === 'region' ? thread.anchor : undefined
+	const regionBoxBounds =
+		regionAnchor && dragPagePoint
+			? { ...regionAnchor, x: dragPagePoint.x - regionAnchor.w, y: dragPagePoint.y }
+			: regionAnchor
 
 	return (
 		<>
-			{regionBox}
+			{regionBoxBounds && (dragPagePoint || open || hovered) && (
+				<RegionBox editor={editor} box={regionBoxBounds} />
+			)}
 			<div
 				className={open ? 'cmt-canvas-pin cmt-canvas-pin--open' : 'cmt-canvas-pin'}
 				style={{ left: renderPoint.x, top: renderPoint.y }}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import {
+	type BoxModel,
 	createComment,
 	createCommentThread,
 	Editor,
@@ -39,7 +40,7 @@ import { CommentThread } from '../ui/comment-thread'
 import { CountBadge } from '../ui/count-badge'
 import { collectClusterLeaves } from './cluster-input'
 import { CommentBody } from './comment-body'
-import { pendingComment, PendingComment } from './comment-tool'
+import { pendingComment, PendingComment, regionDraft } from './comment-tool'
 import { commentsHidden, toggleCommentsHidden } from './comments-visibility'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
@@ -383,6 +384,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			{openThread && (
 				<ThreadPin key={`open:${openThread.id}`} editor={editor} thread={openThread} {...props} />
 			)}
+			<RegionDraftBox editor={editor} />
 			{pending && props.currentUserId && (
 				<PendingComposer editor={editor} pending={pending} {...props} />
 			)}
@@ -663,6 +665,29 @@ function ThreadPopover({
 	)
 }
 
+/** A dashed rectangle over a region anchor's bounds, in viewport space. Sits in the canvas layer
+ *  as a sibling of the pins; `pointer-events` stays off so it never intercepts canvas interaction. */
+function RegionBox({ editor, box }: { editor: Editor; box: BoxModel }) {
+	const rect = useValue(
+		'region rect',
+		() => {
+			// Position from the page→viewport top-left; screen size scales with zoom, page size doesn't.
+			const topLeft = editor.pageToViewport({ x: box.x, y: box.y })
+			const zoom = editor.getZoomLevel()
+			return { left: topLeft.x, top: topLeft.y, width: box.w * zoom, height: box.h * zoom }
+		},
+		[editor, box.x, box.y, box.w, box.h]
+	)
+	return <div className="cmt-canvas-region" style={rect} />
+}
+
+/** The live region being dragged out by the comment tool, or nothing when not dragging. */
+function RegionDraftBox({ editor }: { editor: Editor }) {
+	const box = useValue('region draft', () => regionDraft.get(), [])
+	if (!box) return null
+	return <RegionBox editor={editor} box={box} />
+}
+
 const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
@@ -687,6 +712,8 @@ const ThreadPin = memo(function ThreadPin({
 	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
 	// While dragging the marker, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
+	// A region thread reveals its dashed box while hovered or while its thread is open.
+	const [hovered, setHovered] = useState(false)
 	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
 	const markerRef = useRef<HTMLDivElement>(null)
 
@@ -915,56 +942,67 @@ const ThreadPin = memo(function ThreadPin({
 
 	const renderPoint = dragPagePoint ? editor.pageToViewport(dragPagePoint) : point
 
+	// The region's dashed box, shown while the thread is open or its pin is hovered.
+	const regionBox =
+		thread.anchor.type === 'region' && (open || hovered) ? (
+			<RegionBox editor={editor} box={thread.anchor} />
+		) : null
+
 	return (
-		<div
-			className={open ? 'cmt-canvas-pin cmt-canvas-pin--open' : 'cmt-canvas-pin'}
-			style={{ left: renderPoint.x, top: renderPoint.y }}
-		>
+		<>
+			{regionBox}
 			<div
-				ref={markerRef}
-				className="cmt-canvas-pin__marker"
-				onPointerDown={startDrag}
-				onPointerMove={onDrag}
-				onPointerUp={endDrag}
+				className={open ? 'cmt-canvas-pin cmt-canvas-pin--open' : 'cmt-canvas-pin'}
+				style={{ left: renderPoint.x, top: renderPoint.y }}
 			>
-				<CommentPin resolved={thread.resolved != null} open={open}>
-					{pinContent}
-				</CommentPin>
-			</div>
-			{/* The popover portals up to the menus layer (above the UI panels) so it isn't clipped;
-			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
-			{open && (
-				<ThreadPopover
-					container={container}
-					style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
+				<div
+					ref={markerRef}
+					className="cmt-canvas-pin__marker"
+					onPointerDown={startDrag}
+					onPointerMove={onDrag}
+					onPointerUp={endDrag}
+					onPointerEnter={() => setHovered(true)}
+					onPointerLeave={() => setHovered(false)}
 				>
-					<CommentThread
-						header={msg('comments.thread-title')}
-						headerActions={headerActions}
-						renderComment={renderComment}
-						comments={comments.map((c) => toCardProps(c, props))}
-						resolvedBanner={
-							thread.resolved
-								? msg('comments.resolved-by').replace('{name}', resolveName(thread.resolved.by))
-								: undefined
-						}
-						composer={
-							currentUserId && !thread.resolved
-								? {
-										author: resolveName(currentUserId),
-										placeholder: msg('comments.reply-placeholder'),
-										sendLabel: msg('comments.send'),
-										value: reply,
-										onChange: setReply,
-										onSubmit: postReply,
-										disabled: isCommentEmpty(reply),
-									}
-								: undefined
-						}
-					/>
-				</ThreadPopover>
-			)}
-		</div>
+					<CommentPin resolved={thread.resolved != null} open={open}>
+						{pinContent}
+					</CommentPin>
+				</div>
+				{/* The popover portals up to the menus layer (above the UI panels) so it isn't clipped;
+			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
+				{open && (
+					<ThreadPopover
+						container={container}
+						style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
+					>
+						<CommentThread
+							header={msg('comments.thread-title')}
+							headerActions={headerActions}
+							renderComment={renderComment}
+							comments={comments.map((c) => toCardProps(c, props))}
+							resolvedBanner={
+								thread.resolved
+									? msg('comments.resolved-by').replace('{name}', resolveName(thread.resolved.by))
+									: undefined
+							}
+							composer={
+								currentUserId && !thread.resolved
+									? {
+											author: resolveName(currentUserId),
+											placeholder: msg('comments.reply-placeholder'),
+											sendLabel: msg('comments.send'),
+											value: reply,
+											onChange: setReply,
+											onSubmit: postReply,
+											disabled: isCommentEmpty(reply),
+										}
+									: undefined
+							}
+						/>
+					</ThreadPopover>
+				)}
+			</div>
+		</>
 	)
 })
 

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -41,7 +41,7 @@ import { CommentThread } from '../ui/comment-thread'
 import { CountBadge } from '../ui/count-badge'
 import { collectClusterLeaves } from './cluster-input'
 import { CommentBody } from './comment-body'
-import { pendingComment, PendingComment, regionBetween, regionDraft } from './comment-tool'
+import { pendingComment, PendingComment, regionDraft } from './comment-tool'
 import { commentsHidden, toggleCommentsHidden } from './comments-visibility'
 import { useCommentThreads, usePendingComment, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
@@ -704,9 +704,22 @@ function ThreadPopover({
 	)
 }
 
-/** A dashed rectangle over a region anchor's bounds, in viewport space. Sits in the canvas layer
- *  as a sibling of the pins; `pointer-events` stays off so it never intercepts canvas interaction. */
-function RegionBox({ editor, box }: { editor: Editor; box: BoxModel }) {
+/** A dashed rectangle over a region anchor's bounds, in viewport space. Sits in the canvas layer as
+ *  a sibling of the pins. `pointer-events` stays off (canvas interaction passes through) unless
+ *  `movable`, in which case dragging the body translates the region — previews live, commits on drop. */
+function RegionBox({
+	editor,
+	box,
+	movable,
+	onPreview,
+	onCommit,
+}: {
+	editor: Editor
+	box: BoxModel
+	movable?: boolean
+	onPreview?(bounds: BoxModel | null): void
+	onCommit?(bounds: BoxModel): void
+}) {
 	const rect = useValue(
 		'region rect',
 		() => {
@@ -717,7 +730,39 @@ function RegionBox({ editor, box }: { editor: Editor; box: BoxModel }) {
 		},
 		[editor, box.x, box.y, box.w, box.h]
 	)
-	return <div className="cmt-canvas-region" style={rect} />
+	// The grab point and the box at grab time, captured so the drag translates by a stable delta even
+	// as the box prop reflows under the live preview.
+	const grabRef = useRef<{ page: VecLike; box: BoxModel } | null>(null)
+	const translated = (e: ReactPointerEvent<HTMLDivElement>): BoxModel => {
+		const g = grabRef.current!
+		const p = editor.screenToPage({ x: e.clientX, y: e.clientY })
+		return { ...g.box, x: g.box.x + (p.x - g.page.x), y: g.box.y + (p.y - g.page.y) }
+	}
+	const startMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+		e.stopPropagation()
+		grabRef.current = { page: editor.screenToPage({ x: e.clientX, y: e.clientY }), box }
+		e.currentTarget.setPointerCapture(e.pointerId)
+	}
+	const onMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+		if (grabRef.current) onPreview?.(translated(e))
+	}
+	const endMove = (e: ReactPointerEvent<HTMLDivElement>) => {
+		if (!grabRef.current) return
+		const bounds = translated(e)
+		grabRef.current = null
+		if (e.currentTarget.hasPointerCapture(e.pointerId))
+			e.currentTarget.releasePointerCapture(e.pointerId)
+		onCommit?.(bounds)
+	}
+	return (
+		<div
+			className={movable ? 'cmt-canvas-region cmt-canvas-region--movable' : 'cmt-canvas-region'}
+			style={rect}
+			onPointerDown={movable ? startMove : undefined}
+			onPointerMove={movable ? onMove : undefined}
+			onPointerUp={movable ? endMove : undefined}
+		/>
+	)
 }
 
 /** The live region being dragged out by the comment tool, or nothing when not dragging. */
@@ -727,76 +772,103 @@ function RegionDraftBox({ editor }: { editor: Editor }) {
 	return <RegionBox editor={editor} box={box} />
 }
 
-// A region's four corners as normalized 0–1 offsets; the cursor follows each corner's diagonal.
-const REGION_CORNERS = [
+// A resize handle's normalized 0–1 spot on the box, and its cursor. An axis at 0.5 (a side midpoint)
+// is *not* controlled by that handle: corners resize both axes, edges resize only their own.
+interface RegionHandle {
+	x: number
+	y: number
+	cursor: string
+}
+
+// The four corners (both axes) and the four side midpoints (one axis each).
+const REGION_CORNERS: readonly RegionHandle[] = [
 	{ x: 0, y: 0, cursor: 'nwse-resize' },
 	{ x: 1, y: 0, cursor: 'nesw-resize' },
 	{ x: 0, y: 1, cursor: 'nesw-resize' },
 	{ x: 1, y: 1, cursor: 'nwse-resize' },
-] as const
+]
+const REGION_EDGES: readonly RegionHandle[] = [
+	{ x: 0.5, y: 0, cursor: 'ns-resize' },
+	{ x: 1, y: 0.5, cursor: 'ew-resize' },
+	{ x: 0.5, y: 1, cursor: 'ns-resize' },
+	{ x: 0, y: 0.5, cursor: 'ew-resize' },
+]
 
 // Screen-space slack around a region's bounds within which its box and handles stay revealed, so
-// the corner handles (which sit on the edge) are comfortably reachable.
+// the handles (which sit on the edge) are comfortably reachable.
 const REGION_HANDLE_MARGIN_PX = 12
 
-/** Draggable corner handles that resize a region: each spans a rectangle from its fixed opposite
- *  corner (captured at pointer-down) to the cursor. The pin corner has no handle (it's the move
- *  handle). Previews live, commits on release. */
+/** Resize `box` by dragging `handle` to `cursor` (page coords). Each controlled axis spans from the
+ *  handle's fixed opposite edge to the cursor (normalized, so dragging past it flips); an axis the
+ *  handle doesn't control (a midpoint, at 0.5) keeps its original position and size. */
+function resizeRegion(box: BoxModel, handle: RegionHandle, cursor: VecLike): BoxModel {
+	const controlsX = handle.x !== 0.5
+	const controlsY = handle.y !== 0.5
+	const fixedX = box.x + (1 - handle.x) * box.w
+	const fixedY = box.y + (1 - handle.y) * box.h
+	return {
+		x: controlsX ? Math.min(fixedX, cursor.x) : box.x,
+		y: controlsY ? Math.min(fixedY, cursor.y) : box.y,
+		w: controlsX ? Math.abs(cursor.x - fixedX) : box.w,
+		h: controlsY ? Math.abs(cursor.y - fixedY) : box.h,
+	}
+}
+
+/** Draggable handles that resize a region — corners (both axes) or edges (one axis), per the resize
+ *  option. Previews live, commits on release. */
 function RegionResizeHandles({
 	editor,
 	box,
-	pinCorner,
+	handles,
 	onPreview,
 	onCommit,
 }: {
 	editor: Editor
 	box: BoxModel
-	pinCorner: VecLike
+	handles: readonly RegionHandle[]
 	onPreview(bounds: BoxModel | null): void
 	onCommit(bounds: BoxModel): void
 }) {
-	// The fixed (opposite) corner in page coords, captured at pointer-down so the box prop reflowing
-	// mid-drag doesn't move it.
-	const fixedRef = useRef<{ x: number; y: number } | null>(null)
-	const corners = useValue(
+	// The box at pointer-down, captured so the box prop reflowing under the live preview doesn't move
+	// the fixed edges mid-drag.
+	const boxRef = useRef<BoxModel | null>(null)
+	const points = useValue(
 		'region handle points',
 		() =>
-			// Every corner except the pin corner, which is the move handle instead.
-			REGION_CORNERS.filter((h) => h.x !== pinCorner.x || h.y !== pinCorner.y).map((h) => {
+			handles.map((h) => {
 				const p = editor.pageToViewport({ x: box.x + h.x * box.w, y: box.y + h.y * box.h })
 				return { ...h, key: `${h.x}-${h.y}`, left: p.x, top: p.y }
 			}),
-		[editor, box.x, box.y, box.w, box.h, pinCorner]
+		[editor, box.x, box.y, box.w, box.h, handles]
 	)
-	const startResize =
-		(h: (typeof REGION_CORNERS)[number]) => (e: ReactPointerEvent<HTMLDivElement>) => {
-			e.stopPropagation()
-			// The fixed corner is the pin corner's diagonal opposite: (1 - x, 1 - y) of this handle.
-			fixedRef.current = { x: box.x + (1 - h.x) * box.w, y: box.y + (1 - h.y) * box.h }
-			e.currentTarget.setPointerCapture(e.pointerId)
-		}
-	const onResize = (e: ReactPointerEvent<HTMLDivElement>) => {
-		if (!fixedRef.current) return
-		onPreview(regionBetween(fixedRef.current, editor.screenToPage({ x: e.clientX, y: e.clientY })))
+	const startResize = (e: ReactPointerEvent<HTMLDivElement>) => {
+		e.stopPropagation()
+		boxRef.current = box
+		e.currentTarget.setPointerCapture(e.pointerId)
 	}
-	const endResize = (e: ReactPointerEvent<HTMLDivElement>) => {
-		const fixed = fixedRef.current
-		fixedRef.current = null
+	const resizedTo = (h: RegionHandle, e: ReactPointerEvent<HTMLDivElement>): BoxModel =>
+		resizeRegion(boxRef.current!, h, editor.screenToPage({ x: e.clientX, y: e.clientY }))
+	const onResize = (h: RegionHandle) => (e: ReactPointerEvent<HTMLDivElement>) => {
+		if (boxRef.current) onPreview(resizedTo(h, e))
+	}
+	const endResize = (h: RegionHandle) => (e: ReactPointerEvent<HTMLDivElement>) => {
+		if (!boxRef.current) return
+		const bounds = resizedTo(h, e)
+		boxRef.current = null
 		if (e.currentTarget.hasPointerCapture(e.pointerId))
 			e.currentTarget.releasePointerCapture(e.pointerId)
-		if (!fixed) return
-		onCommit(regionBetween(fixed, editor.screenToPage({ x: e.clientX, y: e.clientY })))
+		onCommit(bounds)
 	}
 	return (
 		<>
-			{corners.map((h) => (
+			{points.map((h) => (
 				<div
 					key={h.key}
 					className="cmt-canvas-region-handle"
 					style={{ left: h.left, top: h.top, cursor: h.cursor }}
-					onPointerDown={startResize(h)}
-					onPointerMove={onResize}
-					onPointerUp={endResize}
+					onPointerDown={startResize}
+					onPointerMove={onResize(h)}
+					onPointerUp={endResize(h)}
 				/>
 			))}
 		</>
@@ -858,6 +930,16 @@ const ThreadPin = memo(function ThreadPin({
 		resizeBounds != null ||
 		(regionOptions.reveal === 'pointer' && pointerInRegion) ||
 		(regionOptions.reveal === 'pin-hover' && pinHovered)
+	// The resize handles: side midpoints ('edges'), or the corners other than the pin's ('corners').
+	const resizeHandles = useMemo(
+		() =>
+			regionOptions.resize === 'edges'
+				? REGION_EDGES
+				: REGION_CORNERS.filter(
+						(c) => c.x !== regionOptions.pinCorner.x || c.y !== regionOptions.pinCorner.y
+					),
+		[regionOptions.resize, regionOptions.pinCorner]
+	)
 	const dragRef = useRef<{ startX: number; startY: number; moved: boolean } | null>(null)
 	const markerRef = useRef<HTMLDivElement>(null)
 
@@ -873,8 +955,8 @@ const ThreadPin = memo(function ThreadPin({
 			if (target.closest('.cmt-canvas-popover')) return
 			const marker = markerRef.current
 			if (marker && marker.contains(target)) return
-			// A press on a region resize handle edits this thread's anchor — it must not dismiss it.
-			if (target.closest('.cmt-canvas-region-handle')) return
+			// A press on a region's resize handle or movable body edits this thread — don't dismiss it.
+			if (target.closest('.cmt-canvas-region-handle, .cmt-canvas-region--movable')) return
 			// A click inside a menu/popover layered above us (e.g. the sidebar's filter or overflow
 			// dropdown, portaled elsewhere) belongs to that layer — defer to its own dismissal
 			// instead of closing the thread out from under it.
@@ -1055,6 +1137,10 @@ const ThreadPin = memo(function ThreadPin({
 	// re-anchored on drop. A point/shape thread re-anchors to whatever it's dropped on (a shape, else
 	// a point); a region thread translates, keeping its size. A pointer that barely moves is a click —
 	// toggle the popover.
+	// Which affordances move a region, per the option: 'pin' → pin only, 'body' → body only, 'both'.
+	const isRegion = thread.anchor.type === 'region'
+	const pinMovable = regionOptions.move !== 'body'
+	const bodyMovable = regionOptions.move !== 'pin'
 	const startDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
 		e.stopPropagation()
 		dragRef.current = { startX: e.clientX, startY: e.clientY, moved: false }
@@ -1063,6 +1149,8 @@ const ThreadPin = memo(function ThreadPin({
 	const onDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
 		const drag = dragRef.current
 		if (!drag) return
+		// A region that moves by its body ignores pin drags (the pin only toggles the thread).
+		if (isRegion && !pinMovable) return
 		if (!drag.moved && Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < 4) return
 		drag.moved = true
 		setDragPagePoint(editor.screenToPage({ x: e.clientX, y: e.clientY }))
@@ -1129,13 +1217,19 @@ const ThreadPin = memo(function ThreadPin({
 	return (
 		<>
 			{regionBoxBounds && (dragPagePoint || revealed) && (
-				<RegionBox editor={editor} box={regionBoxBounds} />
+				<RegionBox
+					editor={editor}
+					box={regionBoxBounds}
+					movable={bodyMovable && !dragPagePoint}
+					onPreview={setResizeBounds}
+					onCommit={commitResize}
+				/>
 			)}
 			{regionBoxBounds && revealed && !dragPagePoint && regionOptions.resize !== 'none' && (
 				<RegionResizeHandles
 					editor={editor}
 					box={regionBoxBounds}
-					pinCorner={regionOptions.pinCorner}
+					handles={resizeHandles}
 					onPreview={setResizeBounds}
 					onCommit={commitResize}
 				/>

--- a/packages/commenting/src/canvas/region-options.ts
+++ b/packages/commenting/src/canvas/region-options.ts
@@ -1,0 +1,44 @@
+import { Editor, VecLike } from 'tldraw'
+
+/**
+ * The configurable dimensions of region comments — a design surface for prototyping the interaction
+ * before settling it. Region is **off by default**, so a consumer that leaves it unset keeps plain
+ * click-only point/shape commenting. Set it per editor through `<CanvasComments regionOptions>`.
+ */
+export interface RegionCommentOptions {
+	/** Whether dragging the comment tool out creates a region anchor. Off → click-only. */
+	enabled: boolean
+	/** Which corner the pin and composer sit on, as a normalized 0–1 offset. Default bottom-right. */
+	pinCorner: VecLike
+	/** When the dashed box and its handles reveal: while the pointer is within the region, while the
+	 *  pin is hovered, or only while the thread is open. */
+	reveal: 'pointer' | 'pin-hover' | 'open'
+	/** How a region is moved: dragging its pin, dragging its body, or either. */
+	move: 'pin' | 'body' | 'both'
+	/** The resize affordance: corner handles, edge handles, or none. */
+	resize: 'corners' | 'edges' | 'none'
+}
+
+/** The out-of-the-box region config: disabled, and — when a consumer enables it — the current
+ *  bottom-right / pointer-reveal / pin-move / corner-resize behaviour. */
+export const DEFAULT_REGION_COMMENT_OPTIONS: RegionCommentOptions = {
+	enabled: false,
+	pinCorner: { x: 1, y: 1 },
+	reveal: 'pointer',
+	move: 'pin',
+	resize: 'corners',
+}
+
+// Per-editor region config. The overlay publishes its merged `regionOptions` here so the comment
+// tool — which has no props of its own — can read the same per-instance config at interaction time.
+const byEditor = new WeakMap<Editor, RegionCommentOptions>()
+
+/** Publish an editor's region config (called by the overlay from its `regionOptions` prop). */
+export function setRegionCommentOptions(editor: Editor, options: RegionCommentOptions): void {
+	byEditor.set(editor, options)
+}
+
+/** The editor's region config, or the disabled default when none was set. */
+export function getRegionCommentOptions(editor: Editor): RegionCommentOptions {
+	return byEditor.get(editor) ?? DEFAULT_REGION_COMMENT_OPTIONS
+}

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,10 +1,23 @@
-import { atom, Editor, TLCommentAnchor, TLCommentThread, TLShapeId } from 'tldraw'
+import { atom, BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId } from 'tldraw'
 
 /** The id of the one open thread (only one popover is open at a time), or null when all closed. */
 export const openThreadId = atom<string | null>('openThreadId', null)
 
 /** Where an imprecise shape comment sits by default: the shape's top-right corner. Overridable. */
 export const DEFAULT_IMPRECISE_SHAPE_ANCHOR = { x: 1, y: 0 }
+
+/** Which corner of a region its pin and composer sit on, as a normalized 0–1 offset (bottom-right).
+ *  The single source for the corner: pin position, composer placement, region move, and which
+ *  corner has no resize handle all derive from it. */
+export const REGION_PIN_CORNER = { x: 1, y: 1 }
+
+/** The page point of a region's pin corner. */
+export function regionPinPoint(region: BoxModel): { x: number; y: number } {
+	return {
+		x: region.x + REGION_PIN_CORNER.x * region.w,
+		y: region.y + REGION_PIN_CORNER.y * region.h,
+	}
+}
 
 /**
  * Where a thread's pin sits on the page, for each anchor kind. Null hides the pin. For imprecise
@@ -32,7 +45,7 @@ export function anchorPagePoint(
 		case 'point':
 			return { x: anchor.x, y: anchor.y }
 		case 'region':
-			return { x: anchor.x + anchor.w, y: anchor.y }
+			return regionPinPoint(anchor)
 		case 'page':
 			return null
 	}

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,4 +1,12 @@
-import { atom, BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId } from 'tldraw'
+import {
+	atom,
+	BoxModel,
+	Editor,
+	TLCommentAnchor,
+	TLCommentThread,
+	TLShapeId,
+	VecLike,
+} from 'tldraw'
 
 /** The id of the one open thread (only one popover is open at a time), or null when all closed. */
 export const openThreadId = atom<string | null>('openThreadId', null)
@@ -6,16 +14,16 @@ export const openThreadId = atom<string | null>('openThreadId', null)
 /** Where an imprecise shape comment sits by default: the shape's top-right corner. Overridable. */
 export const DEFAULT_IMPRECISE_SHAPE_ANCHOR = { x: 1, y: 0 }
 
-/** Which corner of a region its pin and composer sit on, as a normalized 0–1 offset (bottom-right).
- *  The single source for the corner: pin position, composer placement, region move, and which
- *  corner has no resize handle all derive from it. */
-export const REGION_PIN_CORNER = { x: 1, y: 1 }
+/** The default corner a region's pin and composer sit on, as a normalized 0–1 offset (bottom-right).
+ *  Overridable per editor via region options; pin position, composer placement, region move, and
+ *  which corner has no resize handle all derive from the chosen corner. */
+export const REGION_PIN_CORNER: VecLike = { x: 1, y: 1 }
 
 /** The page point of a region's pin corner. */
-export function regionPinPoint(region: BoxModel): { x: number; y: number } {
+export function regionPinPoint(region: BoxModel, corner: VecLike = REGION_PIN_CORNER): VecLike {
 	return {
-		x: region.x + REGION_PIN_CORNER.x * region.w,
-		y: region.y + REGION_PIN_CORNER.y * region.h,
+		x: region.x + corner.x * region.w,
+		y: region.y + corner.y * region.h,
 	}
 }
 

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -7,6 +7,7 @@ import {
 	TLShapeId,
 	VecLike,
 } from 'tldraw'
+import { getRegionCommentOptions } from './region-options'
 
 /** The id of the one open thread (only one popover is open at a time), or null when all closed. */
 export const openThreadId = atom<string | null>('openThreadId', null)
@@ -53,7 +54,7 @@ export function anchorPagePoint(
 		case 'point':
 			return { x: anchor.x, y: anchor.y }
 		case 'region':
-			return regionPinPoint(anchor)
+			return regionPinPoint(anchor, getRegionCommentOptions(editor).pinCorner)
 		case 'page':
 			return null
 	}


### PR DESCRIPTION
In order to explore region comments — comments anchored to a rectangular area of the canvas rather than a point — without committing dotcom to one interaction design, this PR adds region as an **opt-in, configurable option** in `@tldraw/commenting` and showcases the design variants in a component-studio sketchbook. The `region` anchor (`{ type: 'region', x, y, w, h }`) already existed in the schema and in pin positioning/clustering, so this is the interaction and rendering layer plus a configuration surface.

**Region is off by default.** A consumer that doesn't pass `regionOptions` — including dotcom — keeps plain click-only point/shape commenting, with no downstream change. Nothing about dotcom's behaviour changes in this PR.

### Options

`CanvasComments` takes a `regionOptions` prop; the comment tool (which has no props) reads the same per-editor config through a small store the overlay publishes to.

| Option | Values | Default |
| --- | --- | --- |
| `enabled` | `boolean` | `false` (click-only) |
| `pinCorner` | normalized 0–1 corner | bottom-right `{1,1}` |
| `reveal` | `pointer` · `pin-hover` · `open` | `pointer` |
| `move` | `pin` · `body` · `both` | `pin` |
| `resize` | `corners` · `edges` · `none` | `corners` |

### How it works

- **Create** — with region enabled, dragging the comment tool out creates a region (a small `idle → pointing → dragging` state machine); a plain click still drops a point/shape anchor.
- **Render** — a dashed box in the canvas layer, visible across the whole create flow (drag draft → pending composer → committed thread). Reveal timing and pin corner come from the options; the box stays `pointer-events: none` unless the `body` move mode needs it interactive.
- **Move / resize** — the pin drags to move (or the body, per `move`); corner or edge handles resize (per `resize`), sharing one resize function that treats each axis independently — corners move both axes, edges lock the perpendicular.

### Sketchbook

A `Flows → Region comments` sketchbook runs each variant on a live editor, one `Sketch` per option so they can be compared in isolation. Non-creation sketches seed a region comment so they can be exercised immediately.

### Change type

- [x] `feature`

### Test plan

1. **dotcom / default is unchanged** — mount `<CanvasComments>` without `regionOptions`; the comment tool is click-only, drag does nothing special.
2. **Enable region** — pass `regionOptions={{ enabled: true }}`; drag out a rectangle to create a region comment; the composer opens at the bottom-right corner.
3. **Options** — in component-studio (`Flows → Region comments`), flip between sketches to exercise each pin corner, reveal mode, move interaction, and resize affordance.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +572 / -67 |
| Apps      | +167 / -0  |
| Tests     | +2 / -2    |

### Release notes

- Add region comments as an opt-in option in `@tldraw/commenting`: anchor a comment thread to a rectangular area of the canvas, with configurable pin corner, reveal behaviour, move interaction, and resize affordance. Off by default.
