### PR TITLE
fix(ci): grant pull-requests write for publish comment and label steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Remove the publish-packages label
@@ -271,7 +271,7 @@ jobs:
 
     permissions:
       contents: read
-      issues: write
+      pull-requests: write
 
     steps:
       - name: Tell user released version


### PR DESCRIPTION
## Problem

Internal publishes (triggered by the `publish-packages` label) succeed at publishing to npm, but the two follow-up steps fail with `Resource not accessible by integration`:

- **Tell user released version** — posts the "Published version … to npm" comment on the PR
- **Remove the publish-packages label** — removes the trigger label

Seen most recently on [this run for #9471](https://github.com/tldraw/tldraw/actions/runs/29259349828/job/86849622438).

## Change type

- [x] `other`

## Cause

Both jobs act on a **pull request** (a PR comment and a PR label). GitHub maps those operations to the `pull-requests` permission, not `issues` — a token with only `issues: write` is denied.

This regressed in #8936 (consolidating npm publishing into a single `publish.yml`), which split the old single-job `publish-branch.yml` into separate jobs and changed the grant from `pull-requests: write` to `issues: write`. It went unnoticed because the internal-publish path only runs on a real labeled publish, and this appears to be the first one since that merge.

## Fix

Restore `pull-requests: write` on the `comment` and `remove-label` jobs — matching what the old `publish-branch.yml` workflow used. The `publish` job is unaffected; it already carries `id-token: write` plus the huppy app token.