### PR TITLE
fix(tldraw): only widen toolbar overflow for the comment tool when it renders

### DIFF
--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
@@ -4,7 +4,9 @@ import { ReactNode, memo, useRef } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { useTldrawUiComponents } from '../../context/components'
+import { useCommentingEnabled } from '../../hooks/useCommentingEnabled'
 import { useReadonly } from '../../hooks/useReadonly'
+import { useTools } from '../../hooks/useTools'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { MobileStylePanel } from '../MobileStylePanel'
 import { TldrawUiOrientationProvider } from '../primitives/layout'
@@ -36,7 +38,7 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 	orientation = 'horizontal',
 	minItems = 4,
 	minSizePx = 310,
-	maxItems = 9,
+	maxItems,
 	maxSizePx = 470,
 }: DefaultToolbarProps) {
 	const editor = useEditor()
@@ -44,6 +46,13 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 	const breakpoint = useBreakpoint()
 	const isReadonlyMode = useReadonly()
 	const activeToolId = useValue('current tool id', () => editor.getCurrentToolId(), [editor])
+
+	// The default toolbar content gains a ninth primary item when the comment tool renders — which
+	// only happens when commenting is licensed *and* the tool is registered. Without that slot, keep
+	// the original eight so the overflow breakpoint (and the mobile layout) is unchanged.
+	const tools = useTools()
+	const hasCommentTool = useCommentingEnabled() && !!tools.comment
+	const resolvedMaxItems = maxItems ?? (hasCommentTool ? 9 : 8)
 
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
@@ -87,7 +96,7 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 							orientation={orientation}
 							sizingParentClassName="tlui-main-toolbar"
 							minItems={minItems}
-							maxItems={maxItems}
+							maxItems={resolvedMaxItems}
 							minSizePx={minSizePx}
 							maxSizePx={maxSizePx}
 						>


### PR DESCRIPTION
Fixes the **End to end tests (examples)** failures on #9471 — 12 Mobile Chrome tests failing with `locator.click` timeouts across the toolbar overflow and the mobile style panel.

### Cause

This branch bumped `DefaultToolbar`'s `maxItems` from 8 to 9 to give the comment tool an inline slot. But `maxItems` feeds the overflow sizing (`itemsToShow = modulate(width, [minSizePx, maxSizePx], [minItems, maxItems])`) for **every** editor — including the examples app, where commenting isn't registered and the comment button renders nothing. On the narrow Pixel 5 viewport the higher cap pulled an extra tool into the main bar and dropped the overflow "more" button, so `tools.more-button` ended up covered (clicks hit `<html>`) and the positional tool shortcuts shifted.

### Fix

Resolve `maxItems` to 9 only when the comment button actually renders — commenting licensed **and** the tool registered (`useCommentingEnabled() && tools.comment`), the same condition `CommentToolbarItem` uses to decide whether to show the button. Otherwise keep the original 8, so the mobile layout matches `main`. An explicit `maxItems` prop still overrides.

### Change type

- [x] `bugfix`

### Test plan

1. On a mobile viewport (e.g. Pixel 5) with commenting **not** registered (the examples app), open the toolbar — the overflow "more" button appears and folds the extra tools, as on `main`.
2. With commenting active (dotcom, or an editor composing `commentToolOverrides` + `commentTools`), the comment button shows inline next to the eraser.

Verified locally against the examples e2e suite: the 12 previously-failing Mobile Chrome tests pass, desktop chromium is unchanged (33 passed), and `typecheck` / `lint` / `api-check` are clean (no public API change).

- [x] End to end tests

### Release notes

- Internal only — fixes a toolbar-overflow regression introduced earlier on the `commenting` branch; nothing shipped to users.
