### PR TITLE
fix(editor): guard possible non-finite delta values in the wheel events normalization

### DIFF
--- a/packages/editor/src/lib/utils/normalizeWheel.test.ts
+++ b/packages/editor/src/lib/utils/normalizeWheel.test.ts
@@ -1,0 +1,39 @@
+import { normalizeWheel } from './normalizeWheel'
+
+function wheelEvent(props: Partial<WheelEvent>): WheelEvent {
+	return {
+		deltaX: 0,
+		deltaY: 0,
+		ctrlKey: false,
+		altKey: false,
+		metaKey: false,
+		shiftKey: false,
+		...props,
+	} as WheelEvent
+}
+
+describe('normalizeWheel', () => {
+	it('negates finite deltas for panning', () => {
+		const { x, y } = normalizeWheel(wheelEvent({ deltaX: 5, deltaY: 10 }))
+		expect(x).toBe(-5)
+		expect(y).toBe(-10)
+	})
+
+	it('coerces a non-finite deltaX to zero movement', () => {
+		const { x, y } = normalizeWheel(wheelEvent({ deltaX: NaN, deltaY: 10 }))
+		expect(x === 0).toBe(true)
+		expect(y).toBe(-10)
+	})
+
+	it('coerces a non-finite deltaY to zero movement', () => {
+		const { x, y } = normalizeWheel(wheelEvent({ deltaX: 5, deltaY: Infinity }))
+		expect(x).toBe(-5)
+		expect(y === 0).toBe(true)
+	})
+
+	it('does not produce a non-finite zoom delta when wheeling with a bad deltaY', () => {
+		const { z } = normalizeWheel(wheelEvent({ deltaY: NaN, ctrlKey: true }))
+		expect(Number.isFinite(z)).toBe(true)
+		expect(z === 0).toBe(true)
+	})
+})

--- a/packages/editor/src/lib/utils/normalizeWheel.ts
+++ b/packages/editor/src/lib/utils/normalizeWheel.ts
@@ -9,6 +9,12 @@ const MAX_ZOOM_STEP = 10
  * @internal */
 export function normalizeWheel(event: WheelEvent | React.WheelEvent<HTMLElement>) {
 	let { deltaY, deltaX } = event
+
+	// Coerce non-finite deltas to no movement so they can't propagate into the camera and
+	// crash validation. Also covers deltaZ below, which is derived from deltaY.
+	if (!Number.isFinite(deltaX)) deltaX = 0
+	if (!Number.isFinite(deltaY)) deltaY = 0
+
 	let deltaZ = 0
 
 	// wheeling


### PR DESCRIPTION
Fixes #9122

### The issue

Panning with the wheel can crash the app with `ValidationError: At camera.x: Expected a number, got NaN` (Sentry LITE-3VH, 550 events / 67 users since June 2024). The wheel-pan tick path computes `cx + (dx * panSpeed) / cz`; when the wheel delta arrives non-finite, that NaN is written to the camera record and rejected by the store validator, crashing the app.

### Root cause

`normalizeWheel` takes the raw `WheelEvent.deltaX`/`deltaY` and passes them through without a finiteness check. Some devices, drivers, and browsers can emit non-finite wheel deltas (the reported events are Firefox on Windows). That value propagates unchanged into the camera math.

The camera math itself is fine — the bad data enters at the device-input boundary.

### The fix

Guard the deltas in `normalizeWheel`, the single boundary every wheel event passes through. Non-finite `deltaX`/`deltaY` are coerced to `0`, and `useGestureEvents` already ignores zero-delta wheel events, so a garbage event becomes a no-op instead of a crash.

This follows the existing pattern of sanitizing untrusted input at the boundary (e.g. `updateViewportScreenBounds` floors DOM measurements) rather than massaging values inside the editor. Bad data from other sources (e.g. a consumer passing a non-finite value to `setCamera` or `panSpeed`) still fails validation by design.

### Scope

Wheel input only, matching the reported crash. The pinch/gesture boundary (`dispatchPinchEvent`) has the same shape but no reported occurrences, so it is intentionally left for a follow-up.

### Testing

Added `normalizeWheel.test.ts` covering finite pass-through and non-finite `deltaX`/`deltaY`/zoom deltas.

[x] unit tests

### Release notes

- Improved the normalization of the wheel events by guarding possible non-finite delta values