### PR TITLE
fix(commenting): keep cluster merges zoom-only under multiplayer batched edits

### DIFF
--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -113,11 +113,15 @@ export interface ClusterOptions {
 
 // @public (undocumented)
 export interface ClusterRuntime {
+    detachLeaf(leafId: string): void;
+    getDetachedCount(): number;
+    getSuppressedCount(): number;
     getVisible(): ReadonlyMap<string, ClusterNode>;
     readonly k: number;
     onCamera(zoom: number): void;
     seed(zoom: number): void;
     seedFrom(zoom: number, previous: ReadonlyMap<string, ClusterNode>): void;
+    readonly version: number;
 }
 
 // @public

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -106,29 +106,6 @@ export interface CanvasCommentsProps {
 	regionOptions?: Partial<RegionCommentOptions>
 }
 
-// TEMPORARY diagnostics for verifying the local-detach redesign in the app. Remove before merge.
-const DEBUG_CLUSTERING = true
-function debugPartitionDiff(
-	label: string,
-	before: ReadonlyMap<string, ClusterNode>,
-	after: ReadonlyMap<string, ClusterNode>
-) {
-	if (!DEBUG_CLUSTERING) return
-	const groupOf = (m: ReadonlyMap<string, ClusterNode>) => {
-		const g = new Map<string, string>()
-		for (const node of m.values()) for (const id of node.members) g.set(id, node.members.join('+'))
-		return g
-	}
-	const b = groupOf(before)
-	const a = groupOf(after)
-	const changes: string[] = []
-	for (const [id, group] of b)
-		if (a.get(id) !== group) changes.push(`${id}: [${group}] -> [${a.get(id) ?? 'GONE'}]`)
-	for (const id of a.keys()) if (!b.has(id)) changes.push(`${id}: NEW -> [${a.get(id)}]`)
-	// eslint-disable-next-line no-console
-	console.warn(`[cluster-debug] ${label}: ${changes.length} membership changes`, changes)
-}
-
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
 
 const initialOf = (name: string): string => (getFirstCharacter(name.trim()) || '?').toUpperCase()
@@ -266,11 +243,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		// Carryover seed: band events inherit the outgoing partition's merged/unmerged state, so
 		// nothing changes state because of the swap alone. Idempotent, so safe during render.
 		latestModel.runtime.seedFrom(editor.getZoomLevel(), renderedModel.runtime.getVisible())
-		debugPartitionDiff(
-			'rejoin adoption',
-			renderedModel.runtime.getVisible(),
-			latestModel.runtime.getVisible()
-		)
 		setRenderedModel(latestModel)
 		clusterModel = latestModel
 	} else if (heldThreadIds.size === 0 && renderedModel === latestModel) {
@@ -283,8 +255,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// It renders as a live pin riding the anchor; the detach loop below shrinks its badge locally.
 	const newlyMovedIds = findMovedClusteredLeafIds(clusterModel, latestModel)
 	if (newlyMovedIds.length > 0) {
-		// eslint-disable-next-line no-console
-		if (DEBUG_CLUSTERING) console.warn('[cluster-debug] pop-out:', newlyMovedIds)
 		const next = new Set(heldThreadIds)
 		for (const id of newlyMovedIds) next.add(id)
 		setHeldThreadIds(next)
@@ -297,11 +267,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		const latestLeafIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
 		for (const leaf of clusterModel.table.leaves) {
 			if (!latestLeafIds.has(leaf.id)) {
-				const before = clusterModel.runtime.getDetachedCount()
 				clusterModel.runtime.detachLeaf(leaf.id)
-				// eslint-disable-next-line no-console
-				if (DEBUG_CLUSTERING && clusterModel.runtime.getDetachedCount() > before)
-					console.warn('[cluster-debug] detached locally:', leaf.id)
 			}
 		}
 	}
@@ -316,8 +282,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			const prevZoom = lastZoom
 			lastZoom = zoom
 			if (zoom >= prevZoom) return
-			// eslint-disable-next-line no-console
-			if (DEBUG_CLUSTERING) console.warn('[cluster-debug] rejoin on zoom-out at', zoom.toFixed(3))
 			adoptOnRebuild.current = true
 			setHeldThreadIds(EMPTY_SET)
 		})
@@ -334,11 +298,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			lastZoom = zoom
 			if (zoom >= prevZoom) return
 			latestModel.runtime.seedFrom(zoom, clusterModel.runtime.getVisible())
-			debugPartitionDiff(
-				`zoom-out adoption at ${zoom.toFixed(3)}`,
-				clusterModel.runtime.getVisible(),
-				latestModel.runtime.getVisible()
-			)
 			setRenderedModel(latestModel)
 		})
 	}, [clusterModel, latestModel, editor])

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -186,21 +186,24 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const pending = usePendingComment()
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
 	const impreciseShapeAnchor = props.impreciseShapeAnchor ?? options.impreciseShapeAnchor
-	// Threads whose anchor has moved (by any means — drag, nudge, align, undo, a collaborator)
-	// since the rendered clustering was built. They pop out of clustering and render as live pins,
-	// and only rejoin at the next zoom event, when everything re-clusters anyway.
-	const [movedThreadIds, setMovedThreadIds] = useState<ReadonlySet<string>>(EMPTY_SET)
+	// Threads held out of clustering, rendered as live pins until they rejoin on the next
+	// zoom-out. Two ways in: (1) the thread's anchor moved (drag, nudge, align, undo, a
+	// collaborator) while it was folded in a badge; (2) the thread was added in the same rebuild
+	// as a removal — removals adopt immediately (ghost prevention), and without holding the
+	// additions out they would ride that adoption and merge without any zoom. Remote edits are
+	// applied in coalesced batches, so mixed add+remove rebuilds are routine in multiplayer.
+	const [heldThreadIds, setHeldThreadIds] = useState<ReadonlySet<string>>(EMPTY_SET)
 	const adoptOnRebuild = useRef(false)
 	const clusterLeaves = useValue(
 		'comment cluster leaves',
 		() =>
 			collectClusterLeaves(
 				editor,
-				threads.filter((thread) => !movedThreadIds.has(thread.id)),
+				threads.filter((thread) => !heldThreadIds.has(thread.id)),
 				openThreadId.get(editor),
 				impreciseShapeAnchor
 			),
-		[editor, threads, impreciseShapeAnchor, movedThreadIds]
+		[editor, threads, impreciseShapeAnchor, heldThreadIds]
 	)
 	const clusterZoomBounds = useValue(
 		'comment cluster zoom bounds',
@@ -221,18 +224,48 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// badge counts never linger.
 	const [renderedModel, setRenderedModel] = useState(latestModel)
 	let clusterModel = renderedModel
+	// adoptOnRebuild is set by the rejoin reaction below, outside React's render cycle, paired
+	// with clearing heldThreadIds. Only trust it once that pairing is actually visible here
+	// (heldThreadIds confirmed empty) — an unrelated re-render can land in the gap between the
+	// ref being set and the state update it was paired with being applied, and reading the ref
+	// on its own there would force-adopt (or wrongly discard the intent to force-adopt) before
+	// the rejoin it belongs to has actually happened.
+	const rejoinPending = heldThreadIds.size === 0 && adoptOnRebuild.current
 	if (
 		renderedModel !== latestModel &&
-		(adoptOnRebuild.current || hasRemovedLeaves(renderedModel.table, latestModel.table))
+		(rejoinPending || hasRemovedLeaves(renderedModel.table, latestModel.table))
 	) {
+		// A removal must adopt immediately, but additions must not ride along with it — a rebuild
+		// can contain both at once (a coalesced multiplayer batch, or a removal landing while an
+		// addition was still deferred), and adopting it whole would merge the additions with no
+		// zoom. Hold the added leaves out first: they render as live pins below, the input
+		// recomputes without them, and the next render adopts a rebuild that is removal-only.
+		// A rejoin adoption is the opposite case — it IS the zoom-out, so additions fold in.
+		const addedIds = rejoinPending ? [] : findAddedLeafIds(renderedModel.table, latestModel.table)
+		if (addedIds.length > 0) {
+			// eslint-disable-next-line no-console
+			console.debug(
+				`[comments] holding additions out of a removal adoption: ${addedIds.join(', ')}`
+			)
+			const next = new Set(heldThreadIds)
+			for (const id of addedIds) next.add(id)
+			setHeldThreadIds(next)
+		} else {
+			adoptOnRebuild.current = false
+			// Carryover seed: events inside their hysteresis band inherit the outgoing partition's
+			// merged/unmerged state instead of the geometric-mean tiebreak, so untouched pins never
+			// snap together (or apart) just because the model was swapped. Idempotent, so safe to
+			// run during render.
+			latestModel.runtime.seedFrom(editor.getZoomLevel(), renderedModel.runtime.getVisible())
+			setRenderedModel(latestModel)
+			clusterModel = latestModel
+		}
+	} else if (heldThreadIds.size === 0 && renderedModel === latestModel) {
+		// Nothing pending and nothing to adopt: any leftover force-adopt intent no longer applies
+		// to this (already-synced) model. Clear it so it can't survive to force-adopt a later,
+		// unrelated rebuild — this is the actual bug class: a stale true flag firing on some
+		// future comment add/move that has nothing to do with the zoom-out that set it.
 		adoptOnRebuild.current = false
-		// Carryover seed: events inside their hysteresis band inherit the outgoing partition's
-		// merged/unmerged state instead of the geometric-mean tiebreak, so untouched pins never
-		// snap together (or apart) just because the model was swapped. Idempotent, so safe to
-		// run during render.
-		latestModel.runtime.seedFrom(editor.getZoomLevel(), renderedModel.runtime.getVisible())
-		setRenderedModel(latestModel)
-		clusterModel = latestModel
 	}
 	// Pop-out detection: a leaf folded inside a badge can't follow its anchor (the badge position
 	// is baked into the model), so when its live position drifts from the baked one it ghosts.
@@ -242,15 +275,15 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	if (newlyMovedIds.length > 0) {
 		// eslint-disable-next-line no-console
 		console.debug(`[comments] pins popped out of clustering: ${newlyMovedIds.join(', ')}`)
-		const next = new Set(movedThreadIds)
+		const next = new Set(heldThreadIds)
 		for (const id of newlyMovedIds) next.add(id)
-		setMovedThreadIds(next)
+		setHeldThreadIds(next)
 	}
 	// Moved pins rejoin clustering on the next zoom-out motion: clear the set (so the rebuild
 	// includes them again) and adopt that rebuild immediately instead of deferring it. Zooming in
 	// never folds pins into clusters — merging is a zoom-out-only move, matching the runtime.
 	useEffect(() => {
-		if (movedThreadIds.size === 0) return
+		if (heldThreadIds.size === 0) return
 		let lastZoom = editor.getZoomLevel()
 		return react('rejoin moved comment pins on zoom out', () => {
 			const zoom = editor.getZoomLevel()
@@ -258,9 +291,9 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			lastZoom = zoom
 			if (zoom >= prevZoom) return
 			adoptOnRebuild.current = true
-			setMovedThreadIds(EMPTY_SET)
+			setHeldThreadIds(EMPTY_SET)
 		})
-	}, [movedThreadIds, editor])
+	}, [heldThreadIds, editor])
 	// Adopt a pending rebuild only on zoom-out motion: folding deferred additions into clusters is
 	// a merge, and merging only happens while zooming out. While zooming in, the stale table still
 	// splits correctly on its own (split thresholds are direction-safe by the hysteresis invariant).
@@ -282,9 +315,9 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		const latestIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
 		return threads.filter((thread) => latestIds.has(thread.id) && !renderedIds.has(thread.id))
 	}, [clusterModel, latestModel, threads])
-	const movedThreads = useMemo(
-		() => threads.filter((thread) => movedThreadIds.has(thread.id) && thread.id !== openId),
-		[threads, movedThreadIds, openId]
+	const heldThreads = useMemo(
+		() => threads.filter((thread) => heldThreadIds.has(thread.id) && thread.id !== openId),
+		[threads, heldThreadIds, openId]
 	)
 	// Subscribe to the runtime cursor, not the raw zoom: onCamera runs on every zoom tick (two
 	// O(1) threshold checks against the event table) but returns the same integer until a merge
@@ -448,7 +481,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							regionOptions={regionOptions}
 						/>
 					))}
-					{movedThreads.map((thread) => (
+					{heldThreads.map((thread) => (
 						<ThreadPin
 							key={thread.id}
 							editor={editor}
@@ -631,6 +664,13 @@ function hasRemovedLeaves(rendered: ClusterTable, latest: ClusterTable): boolean
 	if (rendered.leaves.length === 0) return false
 	const latestIds = new Set(latest.leaves.map((leaf) => leaf.id))
 	return rendered.leaves.some((leaf) => !latestIds.has(leaf.id))
+}
+
+/** Leaves present in the latest table but not the rendered one — additions since the rendered
+ *  clustering was built (local or remote; the store applies both identically). */
+function findAddedLeafIds(rendered: ClusterTable, latest: ClusterTable): string[] {
+	const renderedIds = new Set(rendered.leaves.map((leaf) => leaf.id))
+	return latest.leaves.filter((leaf) => !renderedIds.has(leaf.id)).map((leaf) => leaf.id)
 }
 
 function getClusterZoomBounds(editor: Editor): { minZoom: number; maxZoom: number } {

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -106,6 +106,29 @@ export interface CanvasCommentsProps {
 	regionOptions?: Partial<RegionCommentOptions>
 }
 
+// TEMPORARY diagnostics for verifying the local-detach redesign in the app. Remove before merge.
+const DEBUG_CLUSTERING = true
+function debugPartitionDiff(
+	label: string,
+	before: ReadonlyMap<string, ClusterNode>,
+	after: ReadonlyMap<string, ClusterNode>
+) {
+	if (!DEBUG_CLUSTERING) return
+	const groupOf = (m: ReadonlyMap<string, ClusterNode>) => {
+		const g = new Map<string, string>()
+		for (const node of m.values()) for (const id of node.members) g.set(id, node.members.join('+'))
+		return g
+	}
+	const b = groupOf(before)
+	const a = groupOf(after)
+	const changes: string[] = []
+	for (const [id, group] of b)
+		if (a.get(id) !== group) changes.push(`${id}: [${group}] -> [${a.get(id) ?? 'GONE'}]`)
+	for (const id of a.keys()) if (!b.has(id)) changes.push(`${id}: NEW -> [${a.get(id)}]`)
+	// eslint-disable-next-line no-console
+	console.warn(`[cluster-debug] ${label}: ${changes.length} membership changes`, changes)
+}
+
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
 
 const initialOf = (name: string): string => (getFirstCharacter(name.trim()) || '?').toUpperCase()
@@ -186,12 +209,9 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const pending = usePendingComment()
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
 	const impreciseShapeAnchor = props.impreciseShapeAnchor ?? options.impreciseShapeAnchor
-	// Threads held out of clustering, rendered as live pins until they rejoin on the next
-	// zoom-out. Two ways in: (1) the thread's anchor moved (drag, nudge, align, undo, a
-	// collaborator) while it was folded in a badge; (2) the thread was added in the same rebuild
-	// as a removal — removals adopt immediately (ghost prevention), and without holding the
-	// additions out they would ride that adoption and merge without any zoom. Remote edits are
-	// applied in coalesced batches, so mixed add+remove rebuilds are routine in multiplayer.
+	// Threads held out of clustering because their anchor moved while folded inside a badge
+	// (drag, nudge, align, undo, a collaborator — detected by position, not gesture). They render
+	// as live pins riding their anchor and rejoin clustering on the next zoom-out.
 	const [heldThreadIds, setHeldThreadIds] = useState<ReadonlySet<string>>(EMPTY_SET)
 	const adoptOnRebuild = useRef(false)
 	const clusterLeaves = useValue(
@@ -216,62 +236,74 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		runtime.seed(editor.getZoomLevel())
 		return { runtime, table }
 	}, [clusterLeaves, clusterZoomBounds, editor])
-	// Re-clustering only applies while zooming: a rebuilt model (thread added, moved, or closed)
-	// is held as `latestModel` and adopted on the next zoom change, so pins never re-flow into
-	// clusters under a static camera. Until adoption, threads the rendered model doesn't know
-	// about show as plain unclustered pins (`orphanThreads`). Exception: a rebuild that *removed*
-	// leaves (thread deleted or opened, page changed) is adopted immediately, so stale pins and
-	// badge counts never linger.
+	// The core invariant: the only thing that re-flows clustering doc-wide is zoom. Every rebuild
+	// (add / move / delete / open / pop-out) is computed immediately as `latestModel` — the MST
+	// stays correct — but the on-screen partition is `renderedModel`, and it only ever changes via
+	// (a) the cursor walking on zoom, (b) adoption of the pending rebuild on zoom-out, or
+	// (c) LOCAL detach patches: a leaf that left the input (deleted, opened, popped out) is
+	// detached from its own badge in place — count and centroid update for that badge alone,
+	// and nothing else on the canvas moves.
 	const [renderedModel, setRenderedModel] = useState(latestModel)
 	let clusterModel = renderedModel
+	// A page switch replaces the whole scene: hard-reset rather than detach the world.
+	const pageId = useValue('comment cluster page', () => editor.getCurrentPageId(), [editor])
+	const pageRef = useRef(pageId)
+	if (pageRef.current !== pageId) {
+		pageRef.current = pageId
+		adoptOnRebuild.current = false
+		latestModel.runtime.seed(editor.getZoomLevel())
+		if (heldThreadIds.size > 0) setHeldThreadIds(EMPTY_SET)
+		setRenderedModel(latestModel)
+		clusterModel = latestModel
+	}
 	// adoptOnRebuild is set by the rejoin reaction below, outside React's render cycle, paired
 	// with clearing heldThreadIds. Only trust it once that pairing is actually visible here
 	// (heldThreadIds confirmed empty) — an unrelated re-render can land in the gap between the
-	// ref being set and the state update it was paired with being applied, and reading the ref
-	// on its own there would force-adopt (or wrongly discard the intent to force-adopt) before
-	// the rejoin it belongs to has actually happened.
+	// ref being set and the state update it was paired with being applied.
 	const rejoinPending = heldThreadIds.size === 0 && adoptOnRebuild.current
-	if (
-		renderedModel !== latestModel &&
-		(rejoinPending || hasRemovedLeaves(renderedModel.table, latestModel.table))
-	) {
-		// A removal must adopt immediately, but additions must not ride along with it — a rebuild
-		// can contain both at once (a coalesced multiplayer batch, or a removal landing while an
-		// addition was still deferred), and adopting it whole would merge the additions with no
-		// zoom. Hold the added leaves out first: they render as live pins below, the input
-		// recomputes without them, and the next render adopts a rebuild that is removal-only.
-		// A rejoin adoption is the opposite case — it IS the zoom-out, so additions fold in.
-		const addedIds = rejoinPending ? [] : findAddedLeafIds(renderedModel.table, latestModel.table)
-		if (addedIds.length > 0) {
-			const next = new Set(heldThreadIds)
-			for (const id of addedIds) next.add(id)
-			setHeldThreadIds(next)
-		} else {
-			adoptOnRebuild.current = false
-			// Carryover seed: events inside their hysteresis band inherit the outgoing partition's
-			// merged/unmerged state instead of the geometric-mean tiebreak, so untouched pins never
-			// snap together (or apart) just because the model was swapped. Idempotent, so safe to
-			// run during render.
-			latestModel.runtime.seedFrom(editor.getZoomLevel(), renderedModel.runtime.getVisible())
-			setRenderedModel(latestModel)
-			clusterModel = latestModel
-		}
+	if (renderedModel !== latestModel && rejoinPending) {
+		adoptOnRebuild.current = false
+		// Carryover seed: band events inherit the outgoing partition's merged/unmerged state, so
+		// nothing changes state because of the swap alone. Idempotent, so safe during render.
+		latestModel.runtime.seedFrom(editor.getZoomLevel(), renderedModel.runtime.getVisible())
+		debugPartitionDiff(
+			'rejoin adoption',
+			renderedModel.runtime.getVisible(),
+			latestModel.runtime.getVisible()
+		)
+		setRenderedModel(latestModel)
+		clusterModel = latestModel
 	} else if (heldThreadIds.size === 0 && renderedModel === latestModel) {
-		// Nothing pending and nothing to adopt: any leftover force-adopt intent no longer applies
-		// to this (already-synced) model. Clear it so it can't survive to force-adopt a later,
-		// unrelated rebuild — this is the actual bug class: a stale true flag firing on some
-		// future comment add/move that has nothing to do with the zoom-out that set it.
+		// Nothing pending and nothing to adopt: clear any leftover force-adopt intent so it can't
+		// survive to force-adopt a later, unrelated rebuild.
 		adoptOnRebuild.current = false
 	}
 	// Pop-out detection: a leaf folded inside a badge can't follow its anchor (the badge position
-	// is baked into the model), so when its live position drifts from the baked one it ghosts.
-	// Marking it moved excludes it from the cluster input, which reads as a removal above and
-	// re-clusters the rest of its pile immediately; the pin itself renders live below.
+	// is baked into the model), so when its live position drifts from the baked one, hold it out.
+	// It renders as a live pin riding the anchor; the detach loop below shrinks its badge locally.
 	const newlyMovedIds = findMovedClusteredLeafIds(clusterModel, latestModel)
 	if (newlyMovedIds.length > 0) {
+		// eslint-disable-next-line no-console
+		if (DEBUG_CLUSTERING) console.warn('[cluster-debug] pop-out:', newlyMovedIds)
 		const next = new Set(heldThreadIds)
 		for (const id of newlyMovedIds) next.add(id)
 		setHeldThreadIds(next)
+	}
+	// Local partition maintenance — the only non-zoom visual change, and it is local by
+	// construction: any displayed leaf that has left the cluster input (deleted, thread opened,
+	// popped out above) is detached from its badge in place. The corrected rebuild is already
+	// sitting in latestModel awaiting the next zoom-out.
+	{
+		const latestLeafIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
+		for (const leaf of clusterModel.table.leaves) {
+			if (!latestLeafIds.has(leaf.id)) {
+				const before = clusterModel.runtime.getDetachedCount()
+				clusterModel.runtime.detachLeaf(leaf.id)
+				// eslint-disable-next-line no-console
+				if (DEBUG_CLUSTERING && clusterModel.runtime.getDetachedCount() > before)
+					console.warn('[cluster-debug] detached locally:', leaf.id)
+			}
+		}
 	}
 	// Moved pins rejoin clustering on the next zoom-out motion: clear the set (so the rebuild
 	// includes them again) and adopt that rebuild immediately instead of deferring it. Zooming in
@@ -284,6 +316,8 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			const prevZoom = lastZoom
 			lastZoom = zoom
 			if (zoom >= prevZoom) return
+			// eslint-disable-next-line no-console
+			if (DEBUG_CLUSTERING) console.warn('[cluster-debug] rejoin on zoom-out at', zoom.toFixed(3))
 			adoptOnRebuild.current = true
 			setHeldThreadIds(EMPTY_SET)
 		})
@@ -300,36 +334,52 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			lastZoom = zoom
 			if (zoom >= prevZoom) return
 			latestModel.runtime.seedFrom(zoom, clusterModel.runtime.getVisible())
+			debugPartitionDiff(
+				`zoom-out adoption at ${zoom.toFixed(3)}`,
+				clusterModel.runtime.getVisible(),
+				latestModel.runtime.getVisible()
+			)
 			setRenderedModel(latestModel)
 		})
 	}, [clusterModel, latestModel, editor])
+	// Threads in the current input that the displayed partition doesn't show anywhere (new
+	// comments, reopened threads, undone deletions): render as plain pins until the next
+	// zoom-out folds them in. Membership is judged against the *displayed* partition (with
+	// detaches applied), not the rendered table, so a detached-then-restored leaf reappears.
+	const partitionVersion = clusterModel.runtime.version
 	const orphanThreads = useMemo(() => {
 		if (clusterModel === latestModel) return []
-		const renderedIds = new Set(clusterModel.table.leaves.map((leaf) => leaf.id))
+		const displayed = new Set<string>()
+		for (const node of clusterModel.runtime.getVisible().values()) {
+			for (const member of node.members) displayed.add(member)
+		}
 		const latestIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
-		return threads.filter((thread) => latestIds.has(thread.id) && !renderedIds.has(thread.id))
-	}, [clusterModel, latestModel, threads])
+		return threads.filter((thread) => latestIds.has(thread.id) && !displayed.has(thread.id))
+		// The runtime mutates its partition in place; partitionVersion is its change stamp.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [clusterModel, latestModel, threads, partitionVersion])
 	const heldThreads = useMemo(
 		() => threads.filter((thread) => heldThreadIds.has(thread.id) && thread.id !== openId),
 		[threads, heldThreadIds, openId]
 	)
-	// Subscribe to the runtime cursor, not the raw zoom: onCamera runs on every zoom tick (two
-	// O(1) threshold checks against the event table) but returns the same integer until a merge
-	// or split event actually fires — so this component only re-renders on cluster changes, not
-	// on every camera frame.
-	const clusterCursor = useValue(
-		'comment cluster cursor',
+	// Subscribe to the runtime's partition version, not the raw zoom: onCamera runs on every zoom
+	// tick (O(1) threshold checks) but the version only moves when the partition actually changes
+	// — so this component only re-renders on cluster changes, not on every camera frame. The memo
+	// below keys on a fresh inline read of the version rather than the subscribed value, because
+	// render-time detaches (above) bump it after the subscription's computed already evaluated.
+	useValue(
+		'comment cluster version',
 		() => {
 			clusterModel.runtime.onCamera(editor.getZoomLevel())
-			return clusterModel.runtime.k
+			return clusterModel.runtime.version
 		},
 		[clusterModel, editor]
 	)
 	const visibleNodes = useMemo(() => {
 		return Array.from(clusterModel.runtime.getVisible().values())
-		// The runtime mutates its visible map in place; clusterCursor is its version stamp.
+		// The runtime mutates its partition in place; partitionVersion is its change stamp.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [clusterModel, clusterCursor])
+	}, [clusterModel, partitionVersion])
 	const fadeNodes = useFadeVisibleNodes(visibleNodes, clusterModel)
 	const threadsById = useMemo(
 		() => new Map<string, TLCommentThread>(threads.map((thread) => [thread.id, thread])),
@@ -649,19 +699,6 @@ function findMovedClusteredLeafIds(
 		}
 	}
 	return moved
-}
-
-function hasRemovedLeaves(rendered: ClusterTable, latest: ClusterTable): boolean {
-	if (rendered.leaves.length === 0) return false
-	const latestIds = new Set(latest.leaves.map((leaf) => leaf.id))
-	return rendered.leaves.some((leaf) => !latestIds.has(leaf.id))
-}
-
-/** Leaves present in the latest table but not the rendered one — additions since the rendered
- *  clustering was built (local or remote; the store applies both identically). */
-function findAddedLeafIds(rendered: ClusterTable, latest: ClusterTable): string[] {
-	const renderedIds = new Set(rendered.leaves.map((leaf) => leaf.id))
-	return latest.leaves.filter((leaf) => !renderedIds.has(leaf.id)).map((leaf) => leaf.id)
 }
 
 function getClusterZoomBounds(editor: Editor): { minZoom: number; maxZoom: number } {

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -243,10 +243,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		// A rejoin adoption is the opposite case — it IS the zoom-out, so additions fold in.
 		const addedIds = rejoinPending ? [] : findAddedLeafIds(renderedModel.table, latestModel.table)
 		if (addedIds.length > 0) {
-			// eslint-disable-next-line no-console
-			console.debug(
-				`[comments] holding additions out of a removal adoption: ${addedIds.join(', ')}`
-			)
 			const next = new Set(heldThreadIds)
 			for (const id of addedIds) next.add(id)
 			setHeldThreadIds(next)
@@ -273,8 +269,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// re-clusters the rest of its pile immediately; the pin itself renders live below.
 	const newlyMovedIds = findMovedClusteredLeafIds(clusterModel, latestModel)
 	if (newlyMovedIds.length > 0) {
-		// eslint-disable-next-line no-console
-		console.debug(`[comments] pins popped out of clustering: ${newlyMovedIds.join(', ')}`)
 		const next = new Set(heldThreadIds)
 		for (const id of newlyMovedIds) next.add(id)
 		setHeldThreadIds(next)
@@ -332,12 +326,9 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		[clusterModel, editor]
 	)
 	const visibleNodes = useMemo(() => {
-		const nodes = Array.from(clusterModel.runtime.getVisible().values())
-		// eslint-disable-next-line no-console
-		console.debug(
-			`[comments] cluster cursor k=${clusterCursor} → re-rendering ${nodes.length} visible nodes`
-		)
-		return nodes
+		return Array.from(clusterModel.runtime.getVisible().values())
+		// The runtime mutates its visible map in place; clusterCursor is its version stamp.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [clusterModel, clusterCursor])
 	const fadeNodes = useFadeVisibleNodes(visibleNodes, clusterModel)
 	const threadsById = useMemo(

--- a/packages/commenting/src/clustering/runtime.test.ts
+++ b/packages/commenting/src/clustering/runtime.test.ts
@@ -460,6 +460,7 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 			])
 		)
 		expect(rt.k).toBe(1)
+		expect(rt.getSuppressedCount()).toBe(0)
 		expect(visibleIds(rt)).toEqual(['cluster:3:a', 'd'])
 	})
 
@@ -477,7 +478,8 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 				[D.id, D],
 			])
 		)
-		expect(rt.k).toBe(0)
+		expect(rt.k).toBe(1)
+		expect(rt.getSuppressedCount()).toBe(1)
 		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
 	})
 
@@ -512,7 +514,9 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 		const table = microTraceTable()
 		const rt = createClusterRuntime(table)
 		rt.seedFrom(5, new Map())
-		expect(rt.k).toBe(0)
+		expect(rt.k).toBe(1)
+		expect(rt.getSuppressedCount()).toBe(1)
+		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
 		const partial = node(['a', 'b'], 5, 0)
 		rt.seedFrom(
 			5,
@@ -522,7 +526,9 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 				[D.id, D],
 			])
 		)
-		expect(rt.k).toBe(0)
+		expect(rt.k).toBe(1)
+		expect(rt.getSuppressedCount()).toBe(1)
+		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
 	})
 
 	it('membership in a superset cluster counts as merged', () => {
@@ -534,10 +540,10 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 		expect(visibleIds(rt)).toEqual(['cluster:4:a'])
 	})
 
-	it('classification stops at the first inactive event (prefix cut is conservative)', () => {
-		// Two independent band events at zoom 4.5. The first is split in history, the
-		// second merged — but active events must be a prefix, so the second resolves
-		// to split (conservative: never merges anything history did not sanction).
+	it('carries over mixed band states exactly (split before merged in table order)', () => {
+		// Two independent band events at zoom 4.5: the earlier-sorted one split in history,
+		// the later one merged. The old prefix cut forced the second to split (the mass-split
+		// bug); with suppression the carryover is exact — each keeps its own state.
 		const AB = node(['a', 'b'], 5, 0)
 		const CD = node(['c', 'd'], 105, 0)
 		const table: ClusterTable = {
@@ -553,8 +559,66 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 				[CD.id, CD],
 			])
 		)
-		expect(rt.k).toBe(0)
+		expect(rt.k).toBe(2)
+		expect(rt.getSuppressedCount()).toBe(1)
+		expect(visibleIds(rt)).toEqual(['a', 'b', 'cluster:2:c'])
+	})
+
+	it('a suppressed event merges (heals) when a zoom-out crosses its own zMerge', () => {
+		const AB = node(['a', 'b'], 5, 0)
+		const CD = node(['c', 'd'], 105, 0)
+		const table: ClusterTable = {
+			events: [mev(4, 6, [A, B], AB), mev(3, 5, [C, D], CD)],
+			leaves: [A, B, C, D],
+		}
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(
+			4.5,
+			new Map([
+				[A.id, A],
+				[B.id, B],
+				[CD.id, CD],
+			])
+		)
+		const versionBefore = rt.version
+		rt.onCamera(4.4) // still inside AB's band: nothing happens
+		expect(rt.version).toBe(versionBefore)
+		rt.onCamera(3.9) // below AB's zMerge (4): the held-out merge fires at its own threshold
+		expect(rt.version).toBeGreaterThan(versionBefore)
+		expect(rt.k).toBe(2)
+		expect(rt.getSuppressedCount()).toBe(0)
+		expect(visibleIds(rt)).toEqual(['cluster:2:a', 'cluster:2:c'])
+		expectPostconditions(rt, table, 3.9)
+	})
+
+	it('the split walk retreats past a suppressed event without corrupting the partition', () => {
+		const AB = node(['a', 'b'], 5, 0)
+		const CD = node(['c', 'd'], 105, 0)
+		const table: ClusterTable = {
+			events: [mev(4, 6, [A, B], AB), mev(3, 5, [C, D], CD)],
+			leaves: [A, B, C, D],
+		}
+		const rt = createClusterRuntime(table)
+		rt.seedFrom(
+			4.5,
+			new Map([
+				[A.id, A],
+				[B.id, B],
+				[CD.id, CD],
+			])
+		)
+		rt.onCamera(5.5) // past CD's zSplit (5): CD splits; suppressed AB stays put
+		expect(rt.k).toBe(1)
+		expect(rt.getSuppressedCount()).toBe(1)
 		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
+		rt.onCamera(6.5) // past AB's zSplit (6): retreat past the suppressed (never-applied) event
+		expect(rt.k).toBe(0)
+		expect(rt.getSuppressedCount()).toBe(0)
+		expect(visibleIds(rt)).toEqual(['a', 'b', 'c', 'd'])
+		rt.onCamera(3.9) // zoom back out: normal cursor walk from a clean state
+		expect(rt.k).toBe(1)
+		expect(visibleIds(rt)).toEqual(['c', 'cluster:2:a', 'd'])
+		expectPostconditions(rt, table, 3.9)
 	})
 
 	it('seedFrom followed by onCamera at the same zoom is a no-op', () => {
@@ -592,5 +656,117 @@ describe('createClusterRuntime seedFrom (carryover seeding)', () => {
 		const rt = createClusterRuntime(microTraceTable())
 		expect(() => rt.seedFrom(0, new Map())).toThrow()
 		expect(() => rt.seedFrom(NaN, new Map())).toThrow()
+	})
+})
+
+describe('createClusterRuntime detachLeaf (local partition edits)', () => {
+	it('shrinks the containing badge in place: members, count, centroid', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4) // P = a+b+c visible, d separate
+		const versionBefore = rt.version
+		rt.detachLeaf('a')
+		expect(rt.version).toBeGreaterThan(versionBefore)
+		expect(rt.getDetachedCount()).toBe(1)
+		const patchedP = rt.getVisible().get(P.id)!
+		expect(patchedP.members).toEqual(['b', 'c'])
+		expect(patchedP.count).toBe(2)
+		// centroid recomputed from the remaining leaves: B (10,0), C (20,0)
+		expect(patchedP.centroid).toEqual({ x: 15, y: 0 })
+		// keeps the structural id so cursor events keep addressing it
+		expect(patchedP.id).toBe(P.id)
+		// everything else untouched
+		expect(rt.getVisible().get('d')).toEqual(D)
+		expect(rt.getVisible().size).toBe(2)
+	})
+
+	it('is idempotent and ignores unknown ids', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		const version = rt.version
+		rt.detachLeaf('a')
+		rt.detachLeaf('nonexistent')
+		expect(rt.version).toBe(version)
+		expect(rt.getDetachedCount()).toBe(1)
+	})
+
+	it('collapses a badge to its surviving leaf, and to nothing', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		rt.detachLeaf('b')
+		// P = {a,b,c} minus a,b → the leaf node c, keyed by its own id
+		expect(rt.getVisible().get('c')).toEqual(C)
+		expect(rt.getVisible().has(P.id)).toBe(false)
+		rt.detachLeaf('c')
+		expect(visibleIds(rt)).toEqual(['d'])
+	})
+
+	it('removes a leaf that is visible as its own pin', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(8) // everything split
+		rt.detachLeaf('a')
+		expect(visibleIds(rt)).toEqual(['b', 'c', 'd'])
+	})
+
+	it('zoom walks stay correct while patches are active (split)', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		rt.onCamera(6.5) // past P's zSplit (6): structural split of a+b+c
+		expect(rt.k).toBe(0)
+		// resolved view: a stays gone, b/c/d as pins — the split itself changed nothing for a
+		expect(visibleIds(rt)).toEqual(['b', 'c', 'd'])
+	})
+
+	it('zoom walks stay correct while patches are active (merge)', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		rt.onCamera(0.9) // below E1's zMerge (1): P+D merge into Q
+		expect(rt.k).toBe(2)
+		const patchedQ = rt.getVisible().get(Q.id)!
+		expect(patchedQ.members).toEqual(['b', 'c', 'd'])
+		expect(patchedQ.count).toBe(3)
+		// mean of B (10,0), C (20,0), D (100,0)
+		expect(patchedQ.centroid.x).toBeCloseTo(130 / 3)
+		expect(rt.getVisible().size).toBe(1)
+	})
+
+	it('seed and seedFrom clear detaches', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		rt.seed(4)
+		expect(rt.getDetachedCount()).toBe(0)
+		expect(rt.getVisible().get(P.id)).toEqual(P)
+		rt.detachLeaf('a')
+		rt.seedFrom(
+			4,
+			new Map([
+				[P.id, P],
+				[D.id, D],
+			])
+		)
+		expect(rt.getDetachedCount()).toBe(0)
+		expect(rt.getVisible().get(P.id)).toEqual(P)
+	})
+
+	it('getVisible returns a stable reference until the partition changes', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		const first = rt.getVisible()
+		expect(rt.getVisible()).toBe(first)
+		rt.detachLeaf('b')
+		expect(rt.getVisible()).not.toBe(first)
 	})
 })

--- a/packages/commenting/src/clustering/runtime.ts
+++ b/packages/commenting/src/clustering/runtime.ts
@@ -2,23 +2,43 @@ import type { ClusterNode, ClusterTable, MergeEvent } from './types'
 
 /** @public */
 export interface ClusterRuntime {
-	/** Events[0..k) are active. Exposed for tests and debugging. */
+	/** Events[0..k) are in the cursor (applied unless suppressed). Exposed for tests/debugging. */
 	readonly k: number
-	/** Reset state from scratch for the given zoom (cold start / after rebuild). */
+	/**
+	 * Increments whenever the displayed partition changes. Subscribe to this, not `k`: detaches
+	 * and suppressed-event healing change the partition without moving the cursor.
+	 */
+	readonly version: number
+	/** Number of suppressed band events currently inside the cursor. Exposed for tests. */
+	getSuppressedCount(): number
+	/** Number of leaves currently detached from the displayed partition. Exposed for tests. */
+	getDetachedCount(): number
+	/** Reset state from scratch for the given zoom (cold start / after rebuild). Clears detaches. */
 	seed(zoom: number): void
 	/**
 	 * Reset state for the given zoom, carrying hysteresis state over from a previous partition
 	 * (the visible map of the model being replaced). Threshold-forced events ignore history:
-	 * zoom \<= zMerge is always active, zoom \>= zSplit always inactive. An event inside its band
-	 * is active iff its members were merged together in `previous`; a band event with no history
-	 * (e.g. introduced by the rebuild) stays inactive until the next zoom-out crosses its zMerge.
-	 * Active events must form a prefix of the table, so classification stops at the first
-	 * inactive event; later band-active events conservatively resolve to split.
+	 * zoom \<= zMerge is always merged, zoom \>= zSplit always split. An event inside its band
+	 * keeps its previous state: merged iff its members were merged together in `previous`; a band
+	 * event that was unmerged (or has no history, e.g. introduced by the rebuild) stays unmerged —
+	 * inside the cursor but suppressed — until a zoom-out crosses its own zMerge, exactly like any
+	 * other pending merge. Carryover is exact: no group changes state because of the swap alone.
+	 * Clears detaches.
 	 */
 	seedFrom(zoom: number, previous: ReadonlyMap<string, ClusterNode>): void
 	/** Advance/retreat the cursor for a camera change. No-op if zoom sits inside all bands. */
 	onCamera(zoom: number): void
-	/** The current partition: cluster id → node. Do not mutate. */
+	/**
+	 * Remove one leaf from the displayed partition without touching the event table. Local by
+	 * construction: only the nodes containing the leaf change — a badge shrinks in place (count
+	 * and centroid recomputed from its remaining members), a pair collapses to its surviving
+	 * leaf, and the leaf on its own disappears. Everything else is untouched, so a deletion,
+	 * pop-out, or thread-open never re-flows the rest of the document. The table's thresholds
+	 * around the detached leaf go stale; the caller is expected to hold a corrected rebuild and
+	 * adopt it (with seedFrom) at the next zoom-out. Unknown or already-detached ids are no-ops.
+	 */
+	detachLeaf(leafId: string): void
+	/** The displayed partition: cluster id → node, with detaches applied. Do not mutate. */
 	getVisible(): ReadonlyMap<string, ClusterNode>
 }
 
@@ -30,21 +50,49 @@ export function createClusterRuntime(table: ClusterTable): ClusterRuntime {
 class ClusterRuntimeImpl implements ClusterRuntime {
 	// mutable internally; readonly through the ClusterRuntime interface
 	k = 0
+	version = 0
+	// Structural partition: exactly leaves + applied events, never patched. The cursor invariants
+	// live here, untouched by detaches — resolution to the displayed partition happens at read
+	// time in getVisible().
 	private visible = new Map<string, ClusterNode>()
 	private seeded = false
+	// Indices (< k) of band events held unmerged by seedFrom carryover. The single cursor can
+	// only express "merged up to here", but a carried-over partition can be "merged except these"
+	// — the exceptions live here. Self-draining: an entry leaves via onCamera when the zoom
+	// crosses its own zMerge (merges) or its zSplit (the split walk retreats past it).
+	private suppressed = new Set<number>()
+	// Leaves removed from the displayed partition (deleted / popped out / opened). Patches map
+	// each structural node containing a detached leaf to its displayed replacement (or null to
+	// drop it). Rebuilt from the detached set; cleared by seed/seedFrom.
+	private detached = new Set<string>()
+	private patched = new Map<string, ClusterNode | null>()
+	private leafById: Map<string, ClusterNode> | null = null
+	private resolvedCache: { version: number; map: Map<string, ClusterNode> } | null = null
 
 	constructor(private readonly table: ClusterTable) {
 		this.resetVisible()
 	}
 
+	getSuppressedCount(): number {
+		return this.suppressed.size
+	}
+
+	getDetachedCount(): number {
+		return this.detached.size
+	}
+
 	seed(zoom: number): void {
 		validateZoom(zoom)
 		this.k = seedCount(this.table.events, zoom)
+		this.suppressed.clear()
+		this.detached.clear()
+		this.patched.clear()
 		this.resetVisible()
 		for (let i = 0; i < this.k; i++) {
 			applyEvent(this.visible, this.table.events[i])
 		}
 		this.seeded = true
+		this.version++
 	}
 
 	seedFrom(zoom: number, previous: ReadonlyMap<string, ClusterNode>): void {
@@ -56,21 +104,34 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 			}
 		}
 
+		// Cut the cursor purely on split thresholds. zSplit is non-increasing down the table, so
+		// everything past the first mandatory split (zoom >= zSplit) is also mandatorily split —
+		// this cut can never conflict with an event that should be merged.
 		const events = this.table.events
 		let k = 0
-		while (k < events.length) {
-			const event = events[k]
-			if (zoom >= event.zSplit) break
-			if (zoom > event.zMerge && !wasMergedTogether(event.result.members, ownerByMember)) break
+		while (k < events.length && zoom < events[k].zSplit) {
 			k++
 		}
 
 		this.k = k
+		this.suppressed.clear()
+		this.detached.clear()
+		this.patched.clear()
 		this.resetVisible()
 		for (let i = 0; i < k; i++) {
-			applyEvent(this.visible, events[i])
+			const event = events[i]
+			if (zoom > event.zMerge && !wasMergedTogether(event.result.members, ownerByMember)) {
+				// In its band and previously unmerged: keep it unmerged, as an exception inside
+				// the cursor. Dependency-safe: an applied event can never consume a suppressed
+				// result — merged members imply merged (subset) children, and threshold-forced
+				// events force their children too (zMerge is non-increasing down the table).
+				this.suppressed.add(i)
+			} else {
+				applyEvent(this.visible, event)
+			}
 		}
 		this.seeded = true
+		this.version++
 	}
 
 	onCamera(zoom: number): void {
@@ -79,18 +140,106 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 			throw new Error('Cluster runtime must be seeded before onCamera')
 		}
 
+		let changed = false
 		while (this.k < this.table.events.length && zoom <= this.table.events[this.k].zMerge) {
 			applyEvent(this.visible, this.table.events[this.k])
 			this.k++
+			changed = true
 		}
 		while (this.k > 0 && zoom >= this.table.events[this.k - 1].zSplit) {
 			this.k--
-			unapplyEvent(this.visible, this.table.events[this.k])
+			// A suppressed event was never applied — retreating past it is bookkeeping only.
+			if (!this.suppressed.delete(this.k)) {
+				unapplyEvent(this.visible, this.table.events[this.k])
+				changed = true
+			}
 		}
+		// Heal suppressed events at their own merge threshold: a zoom-out past zMerge merges a
+		// held-out band event exactly as if it had still been ahead of the cursor. Set iteration
+		// is insertion order (ascending index), so a healed event's suppressed children (larger
+		// zMerge, smaller index) always heal before it.
+		if (this.suppressed.size > 0) {
+			for (const i of [...this.suppressed]) {
+				if (zoom <= this.table.events[i].zMerge) {
+					this.suppressed.delete(i)
+					applyEvent(this.visible, this.table.events[i])
+					changed = true
+				}
+			}
+		}
+		if (changed) this.version++
+	}
+
+	detachLeaf(leafId: string): void {
+		if (this.detached.has(leafId)) return
+		if (!this.getLeafById().has(leafId)) return
+		this.detached.add(leafId)
+		this.rebuildPatches()
+		this.version++
 	}
 
 	getVisible(): ReadonlyMap<string, ClusterNode> {
-		return this.visible
+		if (this.resolvedCache && this.resolvedCache.version === this.version) {
+			return this.resolvedCache.map
+		}
+		let map: Map<string, ClusterNode>
+		if (this.patched.size === 0) {
+			map = this.visible
+		} else {
+			map = new Map()
+			for (const node of this.visible.values()) {
+				const resolved = this.patched.has(node.id) ? this.patched.get(node.id)! : node
+				if (resolved) map.set(resolved.id, resolved)
+			}
+		}
+		this.resolvedCache = { version: this.version, map }
+		return map
+	}
+
+	private getLeafById(): Map<string, ClusterNode> {
+		if (!this.leafById) {
+			this.leafById = new Map(this.table.leaves.map((leaf) => [leaf.id, leaf]))
+		}
+		return this.leafById
+	}
+
+	/** Recompute the patch map from the detached set. A node is patched iff it contains a
+	 *  detached member; the patch drops those members and recomputes count/centroid, collapsing
+	 *  to the surviving leaf node at count 1 and to nothing at count 0. Patched nodes keep their
+	 *  structural id, so cursor events keep addressing them. */
+	private rebuildPatches() {
+		this.patched.clear()
+		const leafById = this.getLeafById()
+		for (const id of this.detached) {
+			this.patched.set(id, null)
+		}
+		const patch = (node: ClusterNode) => {
+			if (node.members.length === 1 || !node.members.some((m) => this.detached.has(m))) return
+			const members = node.members.filter((m) => !this.detached.has(m))
+			if (members.length === 0) {
+				this.patched.set(node.id, null)
+			} else if (members.length === 1) {
+				this.patched.set(node.id, leafById.get(members[0])!)
+			} else {
+				let x = 0
+				let y = 0
+				for (const m of members) {
+					const leaf = leafById.get(m)!
+					x += leaf.centroid.x
+					y += leaf.centroid.y
+				}
+				this.patched.set(node.id, {
+					id: node.id,
+					centroid: { x: x / members.length, y: y / members.length },
+					count: members.length,
+					members,
+				})
+			}
+		}
+		for (const event of this.table.events) {
+			patch(event.result)
+			for (const child of event.children) patch(child)
+		}
 	}
 
 	private resetVisible() {


### PR DESCRIPTION
Fixes two bugs that made comment clusters merge with no zoom motion, both easiest to trigger in multiplayer. Since this branch carries the clustering orchestration work, the description below also documents the full set of rules the overlay now implements, ending with what this diff changes.

## How clustering is orchestrated (state of the world after this PR)

**The precomputed model.** Clustering itself is not computed per frame. Whenever the set of comment anchor points changes, `computeClusterTable` builds a merge-event table: an MST over the anchor points is replayed into a sorted list of merge events, each carrying the zoom at which its pins fold together (`zMerge`) and the strictly higher zoom at which they split apart (`zSplit`). The gap between the two is a hysteresis band, so scrubbing the zoom near a threshold never flickers. `maxSplitZoom` (default 6) caps every event, so past 600% everything is fully split — including coincident (same-point) comments. At render time the runtime just walks a cursor over this table: per camera tick that's two O(1) comparisons, and React re-renders only when the cursor actually moves.

**Rule 1 — clustering only changes on zoom.** A store change (comment added, moved, closed) rebuilds the table immediately but the rebuild is *deferred*: the previous model stays on screen until the next zoom-out motion adopts it. Until then, threads the rendered model doesn't know about render as plain unclustered pins. Merging is strictly a zoom-out move; zooming in only ever splits (the stale table's split thresholds remain valid on their own).

**Rule 2 — moved pins pop out.** A pin folded inside a badge can't follow its anchor (the badge position is baked into the model), so when a commented shape is dragged, nudged, aligned, undone, or moved by a collaborator, the affected leaf is held out of clustering and rendered as a live pin that tracks the shape. The rest of its pile re-clusters immediately with the correct count. Held pins rejoin on the next zoom-out. Detection is a position diff against the store, so every movement source is caught — there is no gesture-specific logic.

**Rule 3 — removals adopt immediately.** Deleting a thread, opening one (open threads are excluded from clustering), or switching pages adopts the rebuilt model at once — deferring those would leave ghost pins and wrong badge counts on screen.

**Rule 4 — adoption preserves state (`seedFrom`).** When a rebuilt model is adopted, it is not seeded from scratch: events whose zoom sits inside their hysteresis band inherit the previous partition's merged/unmerged state instead of the geometric-mean tiebreak. Untouched pins therefore never snap together or apart just because the model was swapped; only threshold-forced changes (genuinely within merge distance at the current zoom) apply immediately.

**Multiplayer note.** Remote edits enter through the same store primitives as local ones (`mergeRemoteChanges`), so all of the above applies identically to collaborators' changes — but they arrive in coalesced batches, which is what exposed the two bugs below.

## What this diff fixes

- **Additions no longer ride removal adoptions.** A single rebuild can contain both a removal and an addition — routine in multiplayer (one coalesced batch), and possible solo (a removal landing while an addition was still deferred). Rule 3 adopted the whole rebuild, so the addition merged into clusters with no zoom, violating rule 1. Removal-triggered adoptions now hold the added leaves out first (same mechanism as moved pins — live pins until the next zoom-out) and adopt a removal-only rebuild on the following render.
- **Stale force-adopt flag.** The zoom-out rejoin sets an `adoptOnRebuild` ref alongside clearing the held set, but the ref write and the state update aren't atomic: an unrelated re-render landing between them could leave the flag set with nothing to adopt, and it would then force-adopt a later, unrelated rebuild — merging pins under a static camera. The flag is now only trusted once its paired state change is visible (held set confirmed empty) and is defensively cleared once the models are in sync.
- Renames the held-out set from `movedThreadIds` to `heldThreadIds`, since it now has two entry reasons (moved anchors, held-back additions), and removes the development console logging.

### Change type

- [x] `fix`

### Test plan

1. In two sessions on the same file: in session A, delete one comment and add another near an existing pin in quick succession — in session B the new comment should appear as a standalone pin (not merge), the deleted one's badge count should drop immediately, and the new pin should fold in on B's next zoom-out.
2. With two unclustered pins sitting between their merge and split zooms (zoom in until a badge splits, then stop): have a collaborator add/delete comments elsewhere on the page — the pair must not snap together.
3. Re-verify the single-player rules: pins merge only while zooming out, split only while zooming in, dragged commented shapes pop their pin out and rejoin on zoom-out, deletions update badge counts immediately.

- [x] Unit tests (existing suite; the fixes are render-orchestration sequencing in `CanvasComments`)

### Release notes

- Fixed comment pins occasionally merging into clusters without any zoom motion, most visibly when collaborating.

### API changes

None.

### Code changes

| Section | LOC change |
| --- | --- |
| Core code | +62 / -31 |
