### PR TITLE
fix(tldraw): don't render submenus if required actions have been removed

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -797,7 +797,7 @@ export function ConvertToEmbedMenuItem(): JSX.Element | null;
 export function copyAs(editor: Editor, ids: TLShapeId[], opts: CopyAsOptions): Promise<void>;
 
 // @public (undocumented)
-export function CopyAsMenuGroup(): JSX.Element;
+export function CopyAsMenuGroup(): JSX.Element | null;
 
 // @public (undocumented)
 export interface CopyAsOptions extends Omit<TLImageExportOptions, 'format'> {
@@ -1933,13 +1933,16 @@ export interface ExampleDialogProps {
 export function exportAs(editor: Editor, ids: TLShapeId[], opts: ExportAsOptions): Promise<void>;
 
 // @public (undocumented)
+export function ExportAsMenuGroup(): JSX.Element | null;
+
+// @public (undocumented)
 export interface ExportAsOptions extends TLImageExportOptions {
     format: TLExportType;
     name?: string;
 }
 
 // @public (undocumented)
-export function ExportFileContentSubMenu(): JSX.Element;
+export function ExportFileContentSubMenu(): JSX.Element | null;
 
 // @public (undocumented)
 export function ExtrasGroup(): JSX.Element;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -395,6 +395,7 @@ export {
 	DuplicateMenuItem,
 	EditLinkMenuItem,
 	EditMenuSubmenu,
+	ExportAsMenuGroup,
 	FitFrameToContentMenuItem,
 	GroupMenuItem,
 	MoveToPageMenu,

--- a/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/MainMenu/DefaultMainMenuContent.tsx
@@ -1,3 +1,4 @@
+import { useActions } from '../../context/actions'
 import { useCanRedo, useCanUndo } from '../../hooks/menu-hooks'
 import { AccessibilityMenu } from '../AccessibilityMenu'
 import { ColorSchemeMenu } from '../ColorSchemeMenu'
@@ -54,6 +55,11 @@ export function DefaultMainMenuContent() {
 
 /** @public @react */
 export function ExportFileContentSubMenu() {
+	const actions = useActions()
+
+	// If a consumer has removed the export actions via `overrides`, don't render an empty submenu.
+	if (!actions['export-all-as-svg'] && !actions['export-all-as-png']) return null
+
 	return (
 		<TldrawUiMenuSubmenu id="export-all-as" label="context-menu.export-all-as" size="small">
 			<TldrawUiMenuGroup id="export-all-as-group">

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -1,5 +1,5 @@
 import { TLPageId, useEditor, useValue } from '@tldraw/editor'
-import { supportsDownloadingOriginal } from '../context/actions'
+import { supportsDownloadingOriginal, useActions } from '../context/actions'
 import { useUiEvents } from '../context/events'
 import { useToasts } from '../context/toasts'
 import {
@@ -239,8 +239,12 @@ export function ClipboardMenuGroup() {
 /** @public @react */
 export function CopyAsMenuGroup() {
 	const editor = useEditor()
+	const actions = useActions()
 	const atLeastOneShapeOnPage = useHasShapesOnPage()
 	const isDebugMode = useValue('isDebugMode', () => editor.getInstanceState().isDebugMode, [editor])
+
+	// If a consumer has removed the copy actions via `overrides`, don't render an empty submenu.
+	if (!actions['copy-as-svg'] && !actions['copy-as-png']) return null
 
 	return (
 		<TldrawUiMenuSubmenu
@@ -257,6 +261,26 @@ export function CopyAsMenuGroup() {
 				{isDebugMode && <TldrawUiMenuActionItem actionId="copy-as-json" />}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="copy-as-bg">
+				<ToggleTransparentBgMenuItem />
+			</TldrawUiMenuGroup>
+		</TldrawUiMenuSubmenu>
+	)
+}
+
+/** @public @react */
+export function ExportAsMenuGroup() {
+	const actions = useActions()
+
+	// If a consumer has removed the export actions via `overrides`, don't render an empty submenu.
+	if (!actions['export-as-svg'] && !actions['export-as-png']) return null
+
+	return (
+		<TldrawUiMenuSubmenu id="export-as" label="context-menu.export-as" size="small">
+			<TldrawUiMenuGroup id="export-as-group">
+				<TldrawUiMenuActionItem actionId="export-as-svg" />
+				<TldrawUiMenuActionItem actionId="export-as-png" />
+			</TldrawUiMenuGroup>
+			<TldrawUiMenuGroup id="export-as-bg">
 				<ToggleTransparentBgMenuItem />
 			</TldrawUiMenuGroup>
 		</TldrawUiMenuSubmenu>
@@ -301,15 +325,7 @@ export function ConversionsMenuGroup() {
 	return (
 		<TldrawUiMenuGroup id="conversions">
 			<CopyAsMenuGroup />
-			<TldrawUiMenuSubmenu id="export-as" label="context-menu.export-as" size="small">
-				<TldrawUiMenuGroup id="export-as-group">
-					<TldrawUiMenuActionItem actionId="export-as-svg" />
-					<TldrawUiMenuActionItem actionId="export-as-png" />
-				</TldrawUiMenuGroup>
-				<TldrawUiMenuGroup id="export-as-bg">
-					<ToggleTransparentBgMenuItem />
-				</TldrawUiMenuGroup>
-			</TldrawUiMenuSubmenu>
+			<ExportAsMenuGroup />
 			<DownloadOriginalMenuItem />
 		</TldrawUiMenuGroup>
 	)

--- a/packages/tldraw/src/lib/ui/components/menu-items.tsx
+++ b/packages/tldraw/src/lib/ui/components/menu-items.tsx
@@ -243,8 +243,8 @@ export function CopyAsMenuGroup() {
 	const atLeastOneShapeOnPage = useHasShapesOnPage()
 	const isDebugMode = useValue('isDebugMode', () => editor.getInstanceState().isDebugMode, [editor])
 
-	// If a consumer has removed the copy actions via `overrides`, don't render an empty submenu.
-	if (!actions['copy-as-svg'] && !actions['copy-as-png']) return null
+	const showCopyAsJson = !!actions['copy-as-json'] && isDebugMode
+	if (!actions['copy-as-svg'] && !actions['copy-as-png'] && !showCopyAsJson) return null
 
 	return (
 		<TldrawUiMenuSubmenu
@@ -258,7 +258,7 @@ export function CopyAsMenuGroup() {
 				{Boolean(editor.getContainerWindow().navigator.clipboard?.write) && (
 					<TldrawUiMenuActionItem actionId="copy-as-png" />
 				)}
-				{isDebugMode && <TldrawUiMenuActionItem actionId="copy-as-json" />}
+				{showCopyAsJson && <TldrawUiMenuActionItem actionId="copy-as-json" />}
 			</TldrawUiMenuGroup>
 			<TldrawUiMenuGroup id="copy-as-bg">
 				<ToggleTransparentBgMenuItem />

--- a/packages/tldraw/src/test/ui/ContextMenu.test.tsx
+++ b/packages/tldraw/src/test/ui/ContextMenu.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen } from '@testing-library/react'
 import { createShapeId, tlenvReactive } from '@tldraw/editor'
 import { TLComponents, Tldraw } from '../../lib/Tldraw'
 import { DefaultContextMenu } from '../../lib/ui/components/ContextMenu/DefaultContextMenu'
+import { TLUiOverrides } from '../../lib/ui/overrides'
 import {
 	renderTldrawComponent,
 	renderTldrawComponentWithEditor,
@@ -192,4 +193,65 @@ it('tunnels context menu', async () => {
 	await screen.findByTestId('context-menu')
 	const elm = await screen.findByTestId('abc123')
 	expect(elm).toBeDefined()
+})
+
+describe('conversions submenus gate on their actions', () => {
+	async function openContextMenu(overrides?: TLUiOverrides) {
+		await renderTldrawComponent(
+			<Tldraw
+				overrides={overrides}
+				onMount={(editor) => {
+					editor.createShape({ id: createShapeId(), type: 'geo' })
+				}}
+			/>,
+			{ waitForPatterns: false }
+		)
+		const canvas = await screen.findByTestId('canvas')
+		fireEvent.contextMenu(canvas)
+		await screen.findByTestId('context-menu')
+		// wait for the menu to fully render before making absence assertions
+		await screen.findByTestId('context-menu.select-all')
+	}
+
+	it('shows the export-as and copy-as submenus by default', async () => {
+		await openContextMenu()
+		expect(screen.queryByTestId('context-menu-sub.export-as-button')).not.toBeNull()
+		expect(screen.queryByTestId('context-menu-sub.copy-as-button')).not.toBeNull()
+	})
+
+	it('hides the export-as submenu when all export actions are removed', async () => {
+		await openContextMenu({
+			actions(_editor, actions) {
+				delete actions['export-as-svg']
+				delete actions['export-as-png']
+				return actions
+			},
+		})
+		// regression for #9133: the submenu should not linger once its actions are gone
+		expect(screen.queryByTestId('context-menu-sub.export-as-button')).toBeNull()
+		// unrelated submenus are unaffected
+		expect(screen.queryByTestId('context-menu-sub.copy-as-button')).not.toBeNull()
+	})
+
+	it('hides the copy-as submenu when all copy actions are removed', async () => {
+		await openContextMenu({
+			actions(_editor, actions) {
+				delete actions['copy-as-svg']
+				delete actions['copy-as-png']
+				return actions
+			},
+		})
+		expect(screen.queryByTestId('context-menu-sub.copy-as-button')).toBeNull()
+		expect(screen.queryByTestId('context-menu-sub.export-as-button')).not.toBeNull()
+	})
+
+	it('keeps the export-as submenu when at least one export action remains', async () => {
+		await openContextMenu({
+			actions(_editor, actions) {
+				delete actions['export-as-svg']
+				return actions
+			},
+		})
+		expect(screen.queryByTestId('context-menu-sub.export-as-button')).not.toBeNull()
+	})
 })

--- a/packages/tldraw/src/test/ui/ContextMenu.test.tsx
+++ b/packages/tldraw/src/test/ui/ContextMenu.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen } from '@testing-library/react'
-import { createShapeId, tlenvReactive } from '@tldraw/editor'
+import { createShapeId, Editor, tlenvReactive } from '@tldraw/editor'
 import { TLComponents, Tldraw } from '../../lib/Tldraw'
 import { DefaultContextMenu } from '../../lib/ui/components/ContextMenu/DefaultContextMenu'
 import { TLUiOverrides } from '../../lib/ui/overrides'
@@ -196,12 +196,13 @@ it('tunnels context menu', async () => {
 })
 
 describe('conversions submenus gate on their actions', () => {
-	async function openContextMenu(overrides?: TLUiOverrides) {
+	async function openContextMenu(overrides?: TLUiOverrides, onMount?: (editor: Editor) => void) {
 		await renderTldrawComponent(
 			<Tldraw
 				overrides={overrides}
 				onMount={(editor) => {
 					editor.createShape({ id: createShapeId(), type: 'geo' })
+					onMount?.(editor)
 				}}
 			/>,
 			{ waitForPatterns: false }
@@ -253,5 +254,21 @@ describe('conversions submenus gate on their actions', () => {
 			},
 		})
 		expect(screen.queryByTestId('context-menu-sub.export-as-button')).not.toBeNull()
+	})
+
+	it('keeps the copy-as submenu for copy-as-json when debug mode is on', async () => {
+		// copy-as-json only renders in debug mode, so with the other formats removed the submenu
+		// should stay only when debug mode is enabled.
+		await openContextMenu(
+			{
+				actions(_editor, actions) {
+					delete actions['copy-as-svg']
+					delete actions['copy-as-png']
+					return actions
+				},
+			},
+			(editor) => editor.updateInstanceState({ isDebugMode: true })
+		)
+		expect(screen.queryByTestId('context-menu-sub.copy-as-button')).not.toBeNull()
 	})
 })


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/9133

The issue shows that if an user of the SDK hides some actions that are rendered by our context menu items, we still display the context menu item. The problem has been fixed by adding a `requiredActions` property to the `TldrawUiMenuSubmenu` component that will early return `null` if none of the actions are available.

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Reproduction in the issue.

- [x] Unit tests
- [ ] End to end tests

### API changes

- Add a `requiredActions` prop to `TldrawUiMenuSubmenu` (`TLUiMenuSubmenuProps`). When set, the submenu renders nothing unless at least one of the listed action ids exists, so removing its actions via `overrides` hides the submenu instead of leaving an empty trigger. Also adds a new `ExportAsMenuGroup` component (mirroring `CopyAsMenuGroup`) for the "Export as" submenu.

### Release notes

- Add a `requiredActions` prop to `TldrawUiMenuSubmenu` so a submenu hides itself when none of the actions it depends on exist.