### PR TITLE
feat(examples): add stamp tool example 

### DIFF
--- a/apps/examples/src/examples/shapes/tools/stamp-tool/README.md
+++ b/apps/examples/src/examples/shapes/tools/stamp-tool/README.md
@@ -1,0 +1,29 @@
+---
+title: Stamp tool
+component: ./StampToolExample.tsx
+priority: 3
+keywords:
+  [
+    stamp,
+    emoji,
+    custom tool,
+    statenode,
+    assets,
+    image shape,
+    png,
+    toppanel,
+    picker,
+    sticker,
+    upload,
+  ]
+---
+
+Pick an emoji or upload an image, then click the canvas to stamp it as an image shape.
+
+---
+
+This example builds a stamp tool from a custom `StateNode`. A panel in the `TopPanel` slot lists the available stamps — clicking one activates the tool, and each click on the canvas places a stamp centered on the pointer.
+
+Every stamp is placed as an image shape backed by a shared asset created with `editor.createAssets`. Emoji stamps are drawn once to a PNG using a canvas element, which keeps them consistent in exports and across platforms; stamping the same stamp many times reuses a single asset.
+
+The stamp options are plain data in an `atom` — to ship a new default stamp, add an entry to the array. The panel's upload button shows the runtime version: it reads an image file as a data URL, adds it as a new stamp option, and activates the tool with it.

--- a/apps/examples/src/examples/shapes/tools/stamp-tool/README.md
+++ b/apps/examples/src/examples/shapes/tools/stamp-tool/README.md
@@ -15,14 +15,15 @@ keywords:
     picker,
     sticker,
     upload,
+    drag,
   ]
 ---
 
-Pick an emoji or upload an image, then click the canvas to stamp it as an image shape.
+Pick an emoji or upload an image, then click or drag on the canvas to stamp it as image shapes.
 
 ---
 
-This example builds a stamp tool from a custom `StateNode`. A panel in the `TopPanel` slot lists the available stamps — clicking one activates the tool, and each click on the canvas places a stamp centered on the pointer.
+This example builds a stamp tool from a custom `StateNode`. A panel in the `TopPanel` slot lists the available stamps — clicking one activates the tool, and each click on the canvas places a stamp centered on the pointer. Holding the pointer down and dragging lays a trail of stamps spaced by the stamp size, and the whole drag undoes as a single step.
 
 Every stamp is placed as an image shape backed by a shared asset created with `editor.createAssets`. Emoji stamps are drawn once to a PNG using a canvas element, which keeps them consistent in exports and across platforms; stamping the same stamp many times reuses a single asset.
 

--- a/apps/examples/src/examples/shapes/tools/stamp-tool/StampToolExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/stamp-tool/StampToolExample.tsx
@@ -1,0 +1,246 @@
+import {
+	AssetRecordType,
+	DEFAULT_SUPPORTED_IMAGE_TYPES,
+	Editor,
+	FileHelpers,
+	MediaHelpers,
+	StateNode,
+	TLAssetId,
+	TLComponents,
+	Tldraw,
+	TldrawUiButton,
+	VecLike,
+	atom,
+	track,
+	uniqueId,
+	useEditor,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import './stamp-tool.css'
+
+// There's a guide at the bottom of this file!
+
+const STAMP_SIZE = 64
+const PNG_SIZE = 128
+
+// [1]
+type Stamp =
+	| { type: 'emoji'; emoji: string }
+	| { type: 'image'; id: string; src: string; w: number; h: number; mimeType: string }
+
+const stamps = atom<Stamp[]>('stamps', [
+	{ type: 'emoji', emoji: '👍' },
+	{ type: 'emoji', emoji: '❤️' },
+	{ type: 'emoji', emoji: '🔥' },
+	{ type: 'emoji', emoji: '⭐' },
+	{ type: 'emoji', emoji: '😂' },
+	{ type: 'emoji', emoji: '🎉' },
+])
+const currentStamp = atom<Stamp>('current stamp', stamps.get()[0])
+
+function getStampId(stamp: Stamp) {
+	return stamp.type === 'emoji'
+		? 'emoji-' +
+				Array.from(stamp.emoji)
+					.map((char) => char.codePointAt(0)!.toString(16))
+					.join('-')
+		: stamp.id
+}
+
+// [2]
+class StampTool extends StateNode {
+	static override id = 'stamp'
+
+	override onEnter() {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onExit() {
+		this.editor.setCursor({ type: 'default', rotation: 0 })
+	}
+
+	override onPointerDown() {
+		stampAtPoint(this.editor, this.editor.inputs.getCurrentPagePoint(), currentStamp.get())
+	}
+
+	override onCancel() {
+		this.editor.setCurrentTool('select')
+	}
+}
+
+// [3]
+function getStampAssetId(editor: Editor, stamp: Stamp): TLAssetId {
+	const assetId = AssetRecordType.createId(getStampId(stamp))
+	if (editor.getAsset(assetId)) return assetId
+
+	let src: string
+	let w: number
+	let h: number
+	let mimeType: string
+
+	if (stamp.type === 'emoji') {
+		const canvas = document.createElement('canvas')
+		canvas.width = PNG_SIZE
+		canvas.height = PNG_SIZE
+		const ctx = canvas.getContext('2d')!
+		ctx.font = `${PNG_SIZE * 0.8}px sans-serif`
+		ctx.textAlign = 'center'
+		ctx.textBaseline = 'middle'
+		ctx.fillText(stamp.emoji, PNG_SIZE / 2, PNG_SIZE / 2 + PNG_SIZE * 0.05)
+		src = canvas.toDataURL('image/png')
+		w = PNG_SIZE
+		h = PNG_SIZE
+		mimeType = 'image/png'
+	} else {
+		;({ src, w, h, mimeType } = stamp)
+	}
+
+	editor.createAssets([
+		{
+			id: assetId,
+			type: 'image',
+			typeName: 'asset',
+			props: { name: 'stamp', src, w, h, mimeType, isAnimated: false },
+			meta: {},
+		},
+	])
+	return assetId
+}
+
+// [4]
+function stampAtPoint(editor: Editor, point: VecLike, stamp: Stamp) {
+	const scale = stamp.type === 'image' ? STAMP_SIZE / Math.max(stamp.w, stamp.h) : 1
+	const w = stamp.type === 'image' ? stamp.w * scale : STAMP_SIZE
+	const h = stamp.type === 'image' ? stamp.h * scale : STAMP_SIZE
+
+	editor.run(() => {
+		editor.markHistoryStoppingPoint('stamp')
+		const assetId = getStampAssetId(editor, stamp)
+		editor.createShape({
+			type: 'image',
+			x: point.x - w / 2,
+			y: point.y - h / 2,
+			props: { assetId, w, h },
+		})
+	})
+}
+
+// [5]
+function uploadStamp(editor: Editor) {
+	const input = document.createElement('input')
+	input.type = 'file'
+	input.accept = DEFAULT_SUPPORTED_IMAGE_TYPES.join(',')
+	input.addEventListener('change', async (e) => {
+		const file = (e.target as HTMLInputElement).files?.[0]
+		if (!file) return
+
+		const src = await FileHelpers.blobToDataUrl(file)
+		const { w, h } = await MediaHelpers.getImageSize(file)
+		const stamp: Stamp = { type: 'image', id: uniqueId(), src, w, h, mimeType: file.type }
+
+		stamps.update((s) => [...s, stamp])
+		currentStamp.set(stamp)
+		editor.setCurrentTool('stamp')
+	})
+	input.click()
+}
+
+// [6]
+const StampPanel = track(() => {
+	const editor = useEditor()
+	const isStampToolActive = editor.getCurrentToolId() === 'stamp'
+	const currentStampId = getStampId(currentStamp.get())
+
+	return (
+		<div className="tlui-menu stamp-panel">
+			{stamps.get().map((stamp) => (
+				<TldrawUiButton
+					key={getStampId(stamp)}
+					type="icon"
+					className="stamp-panel-button"
+					data-active={isStampToolActive && currentStampId === getStampId(stamp)}
+					onClick={() => {
+						currentStamp.set(stamp)
+						editor.setCurrentTool('stamp')
+					}}
+				>
+					{stamp.type === 'emoji' ? (
+						stamp.emoji
+					) : (
+						<img className="stamp-panel-thumbnail" src={stamp.src} alt="custom stamp" />
+					)}
+				</TldrawUiButton>
+			))}
+			<TldrawUiButton
+				type="icon"
+				className="stamp-panel-button stamp-panel-upload"
+				title="Upload a stamp"
+				onClick={() => uploadStamp(editor)}
+			>
+				+
+			</TldrawUiButton>
+		</div>
+	)
+})
+
+const components: TLComponents = {
+	TopPanel: StampPanel,
+}
+
+const tools = [StampTool]
+
+export default function StampToolExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw tools={tools} components={components} />
+		</div>
+	)
+}
+
+/*
+This example shows how to build a stamp tool: pick a stamp from a panel, then
+click the canvas to place it. Each stamp is placed as an image shape — emoji
+stamps are rendered to a PNG, and you can also upload your own image to use as
+a stamp.
+
+[1]
+Stamps are plain data held in an `atom` from tldraw's signals library: either
+an emoji, or an uploaded image with a data URL source. This is the extension
+point — to ship a new default stamp, add an entry to the array. Because the
+panel reads the atom inside a `track`ed component, stamps added at runtime
+(see [5]) show up automatically.
+
+[2]
+The stamp tool is a `StateNode`, the same state machine primitive tldraw's own
+tools are built from. It sets a crosshair cursor while active, and on pointer
+down it stamps at the click point (in page space, from `editor.inputs`). The
+tool stays active after stamping so you can stamp repeatedly; pressing Escape
+cancels back to the select tool.
+
+[3]
+Every stamp becomes a shared image asset, created once via
+`editor.createAssets`. Emoji are drawn to a 128px PNG using a canvas element —
+using a PNG instead of a text shape means stamps look identical in exports and
+for collaborators regardless of platform emoji fonts. Uploaded stamps already
+have an image source, so their data URL is stored on the asset directly. The
+asset id is derived from the stamp's id, so stamping the same stamp twice
+reuses one shared asset — image shapes only reference assets by id.
+
+[4]
+Stamping creates an image shape centered on the click point, linked to the
+asset. Uploaded images are scaled to fit the stamp size while keeping their
+aspect ratio. `markHistoryStoppingPoint` makes each stamp its own undo step.
+
+[5]
+The upload button opens a file picker. The chosen image is read as a data URL
+with `FileHelpers.blobToDataUrl`, measured with `MediaHelpers.getImageSize`,
+appended to the stamps atom, and selected as the current stamp with the tool
+activated — so you can stamp with your own image right away.
+
+[6]
+The picker panel goes in the `TopPanel` component slot. Clicking a stamp sets
+the current stamp atom and switches to the stamp tool with
+`editor.setCurrentTool`. The active stamp is highlighted by checking
+`editor.getCurrentToolId()` — the `track` wrapper re-renders the panel when
+the tool or the atoms change.
+*/

--- a/apps/examples/src/examples/shapes/tools/stamp-tool/StampToolExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/stamp-tool/StampToolExample.tsx
@@ -9,6 +9,7 @@ import {
 	TLComponents,
 	Tldraw,
 	TldrawUiButton,
+	Vec,
 	VecLike,
 	atom,
 	track,
@@ -21,6 +22,7 @@ import './stamp-tool.css'
 // There's a guide at the bottom of this file!
 
 const STAMP_SIZE = 64
+const STAMP_SPACING = STAMP_SIZE
 const PNG_SIZE = 128
 
 // [1]
@@ -51,6 +53,8 @@ function getStampId(stamp: Stamp) {
 class StampTool extends StateNode {
 	static override id = 'stamp'
 
+	lastStampPoint = new Vec()
+
 	override onEnter() {
 		this.editor.setCursor({ type: 'cross', rotation: 0 })
 	}
@@ -60,40 +64,52 @@ class StampTool extends StateNode {
 	}
 
 	override onPointerDown() {
-		stampAtPoint(this.editor, this.editor.inputs.getCurrentPagePoint(), currentStamp.get())
+		this.editor.markHistoryStoppingPoint('stamping')
+		this.stamp()
+	}
+
+	// [3]
+	override onPointerMove() {
+		if (!this.editor.inputs.getIsPointing()) return
+		const distance = Vec.Dist(this.editor.inputs.getCurrentPagePoint(), this.lastStampPoint)
+		if (distance < STAMP_SPACING) return
+		this.stamp()
 	}
 
 	override onCancel() {
 		this.editor.setCurrentTool('select')
 	}
+
+	private stamp() {
+		const point = this.editor.inputs.getCurrentPagePoint()
+		this.lastStampPoint = Vec.From(point)
+		stampAtPoint(this.editor, point, currentStamp.get())
+	}
 }
 
-// [3]
+function renderEmojiToPng(emoji: string) {
+	const canvas = document.createElement('canvas')
+	canvas.width = PNG_SIZE
+	canvas.height = PNG_SIZE
+	const ctx = canvas.getContext('2d')!
+	ctx.font = `${PNG_SIZE * 0.8}px sans-serif`
+	ctx.textAlign = 'center'
+	ctx.textBaseline = 'middle'
+	ctx.fillText(emoji, PNG_SIZE / 2, PNG_SIZE / 2 + PNG_SIZE * 0.05)
+	return {
+		src: canvas.toDataURL('image/png'),
+		w: PNG_SIZE,
+		h: PNG_SIZE,
+		mimeType: 'image/png',
+	}
+}
+
+// [4]
 function getStampAssetId(editor: Editor, stamp: Stamp): TLAssetId {
 	const assetId = AssetRecordType.createId(getStampId(stamp))
 	if (editor.getAsset(assetId)) return assetId
 
-	let src: string
-	let w: number
-	let h: number
-	let mimeType: string
-
-	if (stamp.type === 'emoji') {
-		const canvas = document.createElement('canvas')
-		canvas.width = PNG_SIZE
-		canvas.height = PNG_SIZE
-		const ctx = canvas.getContext('2d')!
-		ctx.font = `${PNG_SIZE * 0.8}px sans-serif`
-		ctx.textAlign = 'center'
-		ctx.textBaseline = 'middle'
-		ctx.fillText(stamp.emoji, PNG_SIZE / 2, PNG_SIZE / 2 + PNG_SIZE * 0.05)
-		src = canvas.toDataURL('image/png')
-		w = PNG_SIZE
-		h = PNG_SIZE
-		mimeType = 'image/png'
-	} else {
-		;({ src, w, h, mimeType } = stamp)
-	}
+	const { src, w, h, mimeType } = stamp.type === 'emoji' ? renderEmojiToPng(stamp.emoji) : stamp
 
 	editor.createAssets([
 		{
@@ -107,14 +123,17 @@ function getStampAssetId(editor: Editor, stamp: Stamp): TLAssetId {
 	return assetId
 }
 
-// [4]
+// [5]
 function stampAtPoint(editor: Editor, point: VecLike, stamp: Stamp) {
-	const scale = stamp.type === 'image' ? STAMP_SIZE / Math.max(stamp.w, stamp.h) : 1
-	const w = stamp.type === 'image' ? stamp.w * scale : STAMP_SIZE
-	const h = stamp.type === 'image' ? stamp.h * scale : STAMP_SIZE
+	let w = STAMP_SIZE
+	let h = STAMP_SIZE
+	if (stamp.type === 'image') {
+		const scale = STAMP_SIZE / Math.max(stamp.w, stamp.h)
+		w = stamp.w * scale
+		h = stamp.h * scale
+	}
 
 	editor.run(() => {
-		editor.markHistoryStoppingPoint('stamp')
 		const assetId = getStampAssetId(editor, stamp)
 		editor.createShape({
 			type: 'image',
@@ -125,7 +144,7 @@ function stampAtPoint(editor: Editor, point: VecLike, stamp: Stamp) {
 	})
 }
 
-// [5]
+// [6]
 function uploadStamp(editor: Editor) {
 	const input = document.createElement('input')
 	input.type = 'file'
@@ -145,7 +164,7 @@ function uploadStamp(editor: Editor) {
 	input.click()
 }
 
-// [6]
+// [7]
 const StampPanel = track(() => {
 	const editor = useEditor()
 	const isStampToolActive = editor.getCurrentToolId() === 'stamp'
@@ -199,25 +218,33 @@ export default function StampToolExample() {
 
 /*
 This example shows how to build a stamp tool: pick a stamp from a panel, then
-click the canvas to place it. Each stamp is placed as an image shape — emoji
-stamps are rendered to a PNG, and you can also upload your own image to use as
-a stamp.
+click the canvas to place it, or hold and drag to lay down a trail of stamps.
+Each stamp is placed as an image shape — emoji stamps are rendered to a PNG,
+and you can also upload your own image to use as a stamp.
 
 [1]
 Stamps are plain data held in an `atom` from tldraw's signals library: either
 an emoji, or an uploaded image with a data URL source. This is the extension
 point — to ship a new default stamp, add an entry to the array. Because the
 panel reads the atom inside a `track`ed component, stamps added at runtime
-(see [5]) show up automatically.
+(see [6]) show up automatically.
 
 [2]
 The stamp tool is a `StateNode`, the same state machine primitive tldraw's own
 tools are built from. It sets a crosshair cursor while active, and on pointer
 down it stamps at the click point (in page space, from `editor.inputs`). The
 tool stays active after stamping so you can stamp repeatedly; pressing Escape
-cancels back to the select tool.
+cancels back to the select tool. The history stopping point is marked once on
+pointer down, so a whole drag (see [3]) is a single undo step.
 
 [3]
+Holding the pointer down and dragging stamps a trail. On every pointer move
+while pointing (`editor.inputs.getIsPointing()`), the tool measures how far
+the pointer has travelled from the last stamp in page space, and places the
+next stamp once it exceeds the spacing. Using page-space distance keeps the
+trail density consistent with the stamp size at any zoom level.
+
+[4]
 Every stamp becomes a shared image asset, created once via
 `editor.createAssets`. Emoji are drawn to a 128px PNG using a canvas element —
 using a PNG instead of a text shape means stamps look identical in exports and
@@ -226,18 +253,18 @@ have an image source, so their data URL is stored on the asset directly. The
 asset id is derived from the stamp's id, so stamping the same stamp twice
 reuses one shared asset — image shapes only reference assets by id.
 
-[4]
-Stamping creates an image shape centered on the click point, linked to the
-asset. Uploaded images are scaled to fit the stamp size while keeping their
-aspect ratio. `markHistoryStoppingPoint` makes each stamp its own undo step.
-
 [5]
+Stamping creates an image shape centered on the pointer, linked to the asset.
+Uploaded images are scaled to fit the stamp size while keeping their aspect
+ratio.
+
+[6]
 The upload button opens a file picker. The chosen image is read as a data URL
 with `FileHelpers.blobToDataUrl`, measured with `MediaHelpers.getImageSize`,
 appended to the stamps atom, and selected as the current stamp with the tool
 activated — so you can stamp with your own image right away.
 
-[6]
+[7]
 The picker panel goes in the `TopPanel` component slot. Clicking a stamp sets
 the current stamp atom and switches to the stamp tool with
 `editor.setCurrentTool`. The active stamp is highlighted by checking

--- a/apps/examples/src/examples/shapes/tools/stamp-tool/StampToolExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/stamp-tool/StampToolExample.tsx
@@ -231,27 +231,23 @@ panel reads the atom inside a `track`ed component, stamps added at runtime
 
 [2]
 The stamp tool is a `StateNode`, the same state machine primitive tldraw's own
-tools are built from. It sets a crosshair cursor while active, and on pointer
-down it stamps at the click point (in page space, from `editor.inputs`). The
-tool stays active after stamping so you can stamp repeatedly; pressing Escape
-cancels back to the select tool. The history stopping point is marked once on
-pointer down, so a whole drag (see [3]) is a single undo step.
+tools are built from. It sets a crosshair cursor while active and stamps at
+the click point on pointer down. The tool stays active after stamping so you
+can stamp repeatedly; pressing Escape cancels back to the select tool.
 
 [3]
-Holding the pointer down and dragging stamps a trail. On every pointer move
-while pointing (`editor.inputs.getIsPointing()`), the tool measures how far
-the pointer has travelled from the last stamp in page space, and places the
-next stamp once it exceeds the spacing. Using page-space distance keeps the
-trail density consistent with the stamp size at any zoom level.
+Dragging stamps a trail: on each pointer move while pointing, the tool places
+the next stamp once the pointer has travelled far enough from the last one.
+Distance is measured in page space, so trail density stays consistent at any
+zoom level. The history stopping point is marked once on pointer down, so a
+whole drag is a single undo step.
 
 [4]
 Every stamp becomes a shared image asset, created once via
-`editor.createAssets`. Emoji are drawn to a 128px PNG using a canvas element —
-using a PNG instead of a text shape means stamps look identical in exports and
-for collaborators regardless of platform emoji fonts. Uploaded stamps already
-have an image source, so their data URL is stored on the asset directly. The
-asset id is derived from the stamp's id, so stamping the same stamp twice
-reuses one shared asset — image shapes only reference assets by id.
+`editor.createAssets`. Emoji are drawn to a PNG with a canvas element, so
+stamps look identical in exports and for collaborators regardless of platform
+emoji fonts. The asset id is derived from the stamp's id, so stamping the
+same stamp twice reuses one asset.
 
 [5]
 Stamping creates an image shape centered on the pointer, linked to the asset.
@@ -259,15 +255,12 @@ Uploaded images are scaled to fit the stamp size while keeping their aspect
 ratio.
 
 [6]
-The upload button opens a file picker. The chosen image is read as a data URL
-with `FileHelpers.blobToDataUrl`, measured with `MediaHelpers.getImageSize`,
-appended to the stamps atom, and selected as the current stamp with the tool
-activated — so you can stamp with your own image right away.
+The upload button opens a file picker and adds the chosen image as a new
+stamp option. The image is stored as a data URL so stamps survive in the
+document; the new stamp is selected and the tool activated right away.
 
 [7]
 The picker panel goes in the `TopPanel` component slot. Clicking a stamp sets
-the current stamp atom and switches to the stamp tool with
-`editor.setCurrentTool`. The active stamp is highlighted by checking
-`editor.getCurrentToolId()` — the `track` wrapper re-renders the panel when
-the tool or the atoms change.
+the current stamp atom and switches to the stamp tool. The active stamp is
+highlighted by checking `editor.getCurrentToolId()`.
 */

--- a/apps/examples/src/examples/shapes/tools/stamp-tool/stamp-tool.css
+++ b/apps/examples/src/examples/shapes/tools/stamp-tool/stamp-tool.css
@@ -1,0 +1,25 @@
+.stamp-panel {
+	display: flex;
+	align-items: center;
+	gap: 2px;
+	margin: 8px;
+	padding: 4px;
+}
+
+.stamp-panel-button {
+	font-size: 18px;
+}
+
+.stamp-panel-button[data-active='true'] {
+	background: var(--tl-color-muted-2);
+}
+
+.stamp-panel-thumbnail {
+	width: 22px;
+	height: 22px;
+	object-fit: contain;
+}
+
+.stamp-panel-upload {
+	color: var(--tl-color-text-3);
+}


### PR DESCRIPTION
Shows how you can create a stamp tool which lets you click to add a fixed size png at your cursor. 

