### PR TITLE
refactor(commenting): namespace cmt- classes under tlui-cmt-

### DIFF
--- a/apps/component-studio/src/sketchbooks/comments/anchored-comment.css
+++ b/apps/component-studio/src/sketchbooks/comments/anchored-comment.css
@@ -1,11 +1,11 @@
 /* an anchored comment: pin + its thread popover */
-.cmt-anchored {
+.tlui-cmt-anchored {
 	display: flex;
 	align-items: flex-start;
 	gap: 10px;
 }
 
-.cmt-thread-popover {
+.tlui-cmt-thread-popover {
 	width: 280px;
 	display: flex;
 	flex-direction: column;
@@ -17,7 +17,7 @@
 	box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
 }
 
-.cmt-resolved-banner {
+.tlui-cmt-resolved-banner {
 	font-size: 12px;
 	color: var(--tl-color-text-3);
 	background: var(--tl-color-muted-2);

--- a/apps/component-studio/src/sketchbooks/comments/anchored-comment.tsx
+++ b/apps/component-studio/src/sketchbooks/comments/anchored-comment.tsx
@@ -20,14 +20,16 @@ export function AnchoredComment({ thread, comments, open }: AnchoredCommentProps
 	const resolved = thread.resolved !== null
 	const resolver = resolvedByName(thread)
 	return (
-		<div className="cmt-anchored">
+		<div className="tlui-cmt-anchored">
 			<CommentPin resolved={resolved} open={open}>
 				{comments.length}
 			</CommentPin>
 			{open && (
-				<div className="cmt-thread-popover">
+				<div className="tlui-cmt-thread-popover">
 					{resolved && (
-						<div className="cmt-resolved-banner">Resolved{resolver ? ` by ${resolver}` : ''}</div>
+						<div className="tlui-cmt-resolved-banner">
+							Resolved{resolver ? ` by ${resolver}` : ''}
+						</div>
 					)}
 					{comments.map((comment) => (
 						<CommentCard key={comment.id} {...commentToCardProps(comment)} />

--- a/apps/component-studio/src/sketchbooks/flows/canvas-with-comments.css
+++ b/apps/component-studio/src/sketchbooks/flows/canvas-with-comments.css
@@ -52,7 +52,7 @@
 	background: var(--tl-color-panel);
 }
 
-.scene__sidebar .cmt-list {
+.scene__sidebar .tlui-cmt-list {
 	height: 100%;
 }
 

--- a/apps/component-studio/src/sketchbooks/scenarios/thread-scenarios.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/scenarios/thread-scenarios.sketchbook.tsx
@@ -16,20 +16,20 @@ const ago = (ms: number) => new Date(NOW - ms).toISOString()
 // The thread header's controls, shown static here (the wiring lives in the canvas overlay).
 const threadActions = (
 	<>
-		<button className="cmt-thread__action" title="Resolve">
+		<button className="tlui-cmt-thread__action" title="Resolve">
 			<TldrawUiIcon icon="check" label="Resolve" small />
 		</button>
-		<button className="cmt-thread__action" title="Delete thread">
+		<button className="tlui-cmt-thread__action" title="Delete thread">
 			<TldrawUiIcon icon="trash" label="Delete thread" small />
 		</button>
-		<button className="cmt-thread__action" title="Dismiss">
+		<button className="tlui-cmt-thread__action" title="Dismiss">
 			<TldrawUiIcon icon="cross-2" label="Dismiss" small />
 		</button>
 	</>
 )
 
 const dismissOnly = (
-	<button className="cmt-thread__action" title="Dismiss">
+	<button className="tlui-cmt-thread__action" title="Dismiss">
 		<TldrawUiIcon icon="cross-2" label="Dismiss" small />
 	</button>
 )

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -133,10 +133,10 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 					<button
 						key={item.id}
 						type="button"
-						className="cmt-list__item"
+						className="tlui-cmt-list__item"
 						onClick={() => handleSelect(item.id)}
 					>
-						<div className="cmt-list__item-body">
+						<div className="tlui-cmt-list__item-body">
 							<div className={styles.head}>
 								<span className={styles.docTitle}>{item.page}</span>
 								<span className={styles.time}>{formatRelativeTime(item.date)}</span>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/notifications.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/notifications.module.css
@@ -1,4 +1,4 @@
-/* Bounds the shared cmt-list inside the popover so its items scroll. */
+/* Bounds the shared tlui-cmt-list inside the popover so its items scroll. */
 .wrap {
 	display: flex;
 	flex-direction: column;

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -1,69 +1,69 @@
 /* The comments layer is portaled into the editor container. Pins live in the canvas-in-front layer
    (beneath the UI panels at z-index 300), so the toolbar and style panel draw over them; the open
-   thread's popover portals up to the menus layer separately (`.cmt-canvas-popover`) so it isn't
+   thread's popover portals up to the menus layer separately (`.tlui-cmt-canvas-popover`) so it isn't
    clipped. Click-through except on its own children. */
-.cmt-canvas-layer {
+.tlui-cmt-canvas-layer {
 	position: absolute;
 	inset: 0;
 	z-index: var(--tl-layer-canvas-in-front);
 	pointer-events: none;
 }
 
-.cmt-canvas-pin,
-.cmt-canvas-cluster,
-.cmt-canvas-composer {
+.tlui-cmt-canvas-pin,
+.tlui-cmt-canvas-cluster,
+.tlui-cmt-canvas-composer {
 	position: absolute;
 }
 
-.cmt-canvas-pin,
-.cmt-canvas-composer {
+.tlui-cmt-canvas-pin,
+.tlui-cmt-canvas-composer {
 	pointer-events: auto;
 }
 
 /* Badges are clickable (zoom to the cluster's first split). */
-.cmt-canvas-cluster {
+.tlui-cmt-canvas-cluster {
 	transform: translate(-50%, -50%);
 	pointer-events: auto;
 	cursor: pointer;
 }
 
-.cmt-cluster-fade {
+.tlui-cmt-cluster-fade {
 	opacity: 1;
 	transition: opacity 150ms ease;
 }
 
-.cmt-cluster-fade--entering {
+.tlui-cmt-cluster-fade--entering {
 	opacity: 0;
 }
 
-.cmt-cluster-fade--present {
+.tlui-cmt-cluster-fade--present {
 	opacity: 1;
 }
 
-.cmt-cluster-fade--exiting {
+.tlui-cmt-cluster-fade--exiting {
 	opacity: 0;
 }
 
-.cmt-cluster-fade--entering *,
-.cmt-cluster-fade--exiting * {
+.tlui-cmt-cluster-fade--entering *,
+.tlui-cmt-cluster-fade--exiting * {
 	pointer-events: none !important;
 }
 
 @media (prefers-reduced-motion: reduce) {
-	.cmt-cluster-fade {
+	.tlui-cmt-cluster-fade {
 		transition: none;
 	}
 }
 
 /* The open thread (its pin + popover) sits above the other pins, so nearby markers don't
    overlap its popover — they tuck behind it. */
-.cmt-canvas-pin--open {
+.tlui-cmt-canvas-pin--open {
 	z-index: 1;
 }
 
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass
    through. Drawn for the live drag draft and for a region thread while hovered or open. */
-.cmt-canvas-region {
+.tlui-cmt-canvas-region {
 	position: absolute;
 	pointer-events: none;
 	border: 2px dashed var(--tl-color-selected);
@@ -73,13 +73,13 @@
 
 /* A movable region body (the 'body'/'both' move modes): draggable to translate the whole region.
    Interactive, so it captures the interior while shown — the tradeoff of dragging the body. */
-.cmt-canvas-region--movable {
+.tlui-cmt-canvas-region--movable {
 	pointer-events: auto;
 	cursor: move;
 }
 
 /* Corner resize handles on a region box (three corners; the pin corner is the move handle). */
-.cmt-canvas-region-handle {
+.tlui-cmt-canvas-region-handle {
 	position: absolute;
 	width: 9px;
 	height: 9px;
@@ -92,18 +92,18 @@
 }
 
 /* Centre the pin marker on its anchor point. */
-.cmt-canvas-pin__marker {
+.tlui-cmt-canvas-pin__marker {
 	width: max-content;
 	transform: translate(-50%, -50%);
 	cursor: grab;
 	touch-action: none;
 }
-.cmt-canvas-pin__marker:active {
+.tlui-cmt-canvas-pin__marker:active {
 	cursor: grabbing;
 }
 
 /* The open thread's popover — portaled to the menus layer (above the UI), positioned at the pin. */
-.cmt-canvas-popover {
+.tlui-cmt-canvas-popover {
 	position: absolute;
 	z-index: var(--tl-layer-menus);
 	pointer-events: auto;
@@ -112,7 +112,7 @@
 /* The placement composer — a distinct floating view (portaled to the menus layer, below the click
    point): a pencil "draft" avatar beside a pill field that is itself the surface (no wrapping
    panel). Scoped here so the in-thread reply composer keeps its own squarer look. */
-.cmt-canvas-composer {
+.tlui-cmt-canvas-composer {
 	position: absolute;
 	z-index: var(--tl-layer-menus);
 	pointer-events: auto;
@@ -121,7 +121,7 @@
 	   placement composer a definite width or it collapses to nothing. */
 	width: 280px;
 }
-.cmt-canvas-composer .cmt-composer__field {
+.tlui-cmt-canvas-composer .tlui-cmt-composer__field {
 	background: var(--tl-color-panel);
 	border-color: transparent;
 	border-radius: var(--tl-radius-4);
@@ -132,7 +132,7 @@
    the popover layer, so an open thread still draws over it. Sits under the top-right share panel
    (top offset clears its ~48px height) and sizes to its content, scrolling past max-height rather
    than stretching the full canvas height. */
-.cmt-canvas-sidebar {
+.tlui-cmt-canvas-sidebar {
 	position: absolute;
 	top: 56px;
 	right: 8px;

--- a/packages/commenting/src/canvas/comment-body.tsx
+++ b/packages/commenting/src/canvas/comment-body.tsx
@@ -17,5 +17,5 @@ export interface CommentBodyProps {
  */
 export function CommentBody({ richText, resolveName }: CommentBodyProps) {
 	const html = useMemo(() => renderCommentHtml(richText, resolveName), [richText, resolveName])
-	return <div className="cmt-text" dangerouslySetInnerHTML={{ __html: html }} />
+	return <div className="tlui-cmt-text" dangerouslySetInnerHTML={{ __html: html }} />
 }

--- a/packages/commenting/src/canvas/comment-render.test.ts
+++ b/packages/commenting/src/canvas/comment-render.test.ts
@@ -38,7 +38,7 @@ describe('renderCommentHtml', () => {
 	it('renders a mention as a pill and resolves its id to the current name', () => {
 		const body = doc(para(text('hey '), mention('u1', 'Ada')))
 		const html = renderCommentHtml(body, (id) => (id === 'u1' ? 'Ada Lovelace' : '?'))
-		expect(html).toContain('cmt-mention')
+		expect(html).toContain('tlui-cmt-mention')
 		// the live name from the resolver, not the label stored at insert time
 		expect(html).toContain('@Ada Lovelace')
 		expect(html).not.toContain('@Ada<')

--- a/packages/commenting/src/canvas/comments-filter-menu.tsx
+++ b/packages/commenting/src/canvas/comments-filter-menu.tsx
@@ -38,7 +38,7 @@ export function CommentsFilterMenu({
 			<TldrawUiDropdownMenuTrigger>
 				<button
 					type="button"
-					className="cmt-header-btn"
+					className="tlui-cmt-header-btn"
 					title={msg('comments.filter')}
 					aria-label={msg('comments.filter')}
 				>

--- a/packages/commenting/src/canvas/comments-overflow-menu.tsx
+++ b/packages/commenting/src/canvas/comments-overflow-menu.tsx
@@ -26,7 +26,7 @@ export function CommentsOverflowMenu() {
 			<TldrawUiDropdownMenuTrigger>
 				<button
 					type="button"
-					className="cmt-header-btn"
+					className="tlui-cmt-header-btn"
 					title={msg('comments.more-options')}
 					aria-label={msg('comments.more-options')}
 				>
@@ -38,11 +38,11 @@ export function CommentsOverflowMenu() {
 					<TldrawUiDropdownMenuItem>
 						<button
 							type="button"
-							className="cmt-menu-item"
+							className="tlui-cmt-menu-item"
 							onClick={() => toggleCommentsHidden(editor)}
 						>
 							<span>{hidden ? msg('comments.show') : msg('comments.hide')}</span>
-							<span className="cmt-menu-item__shortcut">{HIDE_SHORTCUT}</span>
+							<span className="tlui-cmt-menu-item__shortcut">{HIDE_SHORTCUT}</span>
 						</button>
 					</TldrawUiDropdownMenuItem>
 				</TldrawUiDropdownMenuGroup>

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -417,7 +417,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			// The mention picker owns Escape while it's open — let it dismiss the roster alone.
 			if (isMentionPickerOpen()) return
 			const target = e.target as HTMLElement | null
-			if (target && target.closest('.cmt-editing')) return
+			if (target && target.closest('.tlui-cmt-editing')) return
 			openThreadId.set(editor, null)
 			e.preventDefault()
 			e.stopPropagation()
@@ -447,7 +447,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// Render into the container (above the panels' stacking context) so the pins and popovers
 	// live in the UI layer rather than being clipped by the canvas layer.
 	return createPortal(
-		<div ref={layerRef} className="cmt-canvas-layer">
+		<div ref={layerRef} className="tlui-cmt-canvas-layer">
 			{options.enableClustering ? (
 				<>
 					{fadeNodes.map(({ node, phase }) => {
@@ -630,7 +630,7 @@ function cancelClusterFadeFrame(frame: number) {
 }
 
 function clusterFadeClassName(phase: ClusterFadePhase): string {
-	return `cmt-cluster-fade cmt-cluster-fade--${phase}`
+	return `tlui-cmt-cluster-fade tlui-cmt-cluster-fade--${phase}`
 }
 
 /**
@@ -760,7 +760,7 @@ const ClusterBadge = memo(function ClusterBadge({
 
 	return (
 		<div
-			className="cmt-canvas-cluster"
+			className="tlui-cmt-canvas-cluster"
 			style={{ left: point.x, top: point.y }}
 			onPointerDown={stop}
 			onClick={(e) => {
@@ -799,7 +799,7 @@ function ThreadPopover({
 	usePassThroughWheelEvents(ref)
 	usePassThroughMouseOverEvents(ref)
 	return createPortal(
-		<div ref={ref} className="cmt-canvas-popover" style={style} onPointerDown={stop}>
+		<div ref={ref} className="tlui-cmt-canvas-popover" style={style} onPointerDown={stop}>
 			{children}
 		</div>,
 		container
@@ -858,7 +858,11 @@ function RegionBox({
 	}
 	return (
 		<div
-			className={movable ? 'cmt-canvas-region cmt-canvas-region--movable' : 'cmt-canvas-region'}
+			className={
+				movable
+					? 'tlui-cmt-canvas-region tlui-cmt-canvas-region--movable'
+					: 'tlui-cmt-canvas-region'
+			}
 			style={rect}
 			onPointerDown={movable ? startMove : undefined}
 			onPointerMove={movable ? onMove : undefined}
@@ -966,7 +970,7 @@ function RegionResizeHandles({
 			{points.map((h) => (
 				<div
 					key={h.key}
-					className="cmt-canvas-region-handle"
+					className="tlui-cmt-canvas-region-handle"
 					style={{ left: h.left, top: h.top, cursor: h.cursor }}
 					onPointerDown={startResize}
 					onPointerMove={onResize(h)}
@@ -1059,15 +1063,17 @@ const ThreadPin = memo(function ThreadPin({
 		const onPointerDown = (e: PointerEvent) => {
 			const target = e.target as HTMLElement | null
 			if (!target) return
-			if (target.closest('.cmt-canvas-popover')) return
+			if (target.closest('.tlui-cmt-canvas-popover')) return
 			const marker = markerRef.current
 			if (marker && marker.contains(target)) return
 			// A press on a region's resize handle or movable body edits this thread — don't dismiss it.
-			if (target.closest('.cmt-canvas-region-handle, .cmt-canvas-region--movable')) return
+			if (target.closest('.tlui-cmt-canvas-region-handle, .tlui-cmt-canvas-region--movable')) return
 			// A click inside a menu/popover layered above us (the sidebar's filter or overflow
 			// dropdown, or the composer's mention picker — all portaled elsewhere) belongs to that
 			// layer; defer to its own dismissal instead of closing the thread out from under it.
-			if (target.closest('.tlui-menu, [data-radix-popper-content-wrapper], .cmt-mention-popup'))
+			if (
+				target.closest('.tlui-menu, [data-radix-popper-content-wrapper], .tlui-cmt-mention-popup')
+			)
 				return
 			openThreadId.set(editor, null)
 		}
@@ -1155,7 +1161,7 @@ const ThreadPin = memo(function ThreadPin({
 		if (editingId === comment.id) {
 			return (
 				<div
-					className="cmt-editing"
+					className="tlui-cmt-editing"
 					onKeyDown={(e) => {
 						if (e.key === 'Escape') {
 							setEditingId(null)
@@ -1184,7 +1190,7 @@ const ThreadPin = memo(function ThreadPin({
 				actions={
 					comment.authorId === currentUserId ? (
 						<button
-							className="cmt-thread__action"
+							className="tlui-cmt-thread__action"
 							title={msg('comments.edit')}
 							onClick={() => startEdit(comment)}
 						>
@@ -1200,7 +1206,7 @@ const ThreadPin = memo(function ThreadPin({
 		<>
 			{currentUserId && (
 				<button
-					className="cmt-thread__action"
+					className="tlui-cmt-thread__action"
 					title={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
 					onClick={toggleResolve}
 				>
@@ -1213,7 +1219,7 @@ const ThreadPin = memo(function ThreadPin({
 			)}
 			{currentUserId && (
 				<button
-					className="cmt-thread__action"
+					className="tlui-cmt-thread__action"
 					title={msg('comments.delete')}
 					onClick={deleteThread}
 				>
@@ -1221,7 +1227,7 @@ const ThreadPin = memo(function ThreadPin({
 				</button>
 			)}
 			<button
-				className="cmt-thread__action"
+				className="tlui-cmt-thread__action"
 				title={msg('comments.dismiss')}
 				onClick={() => openThreadId.set(editor, null)}
 			>
@@ -1340,12 +1346,12 @@ const ThreadPin = memo(function ThreadPin({
 				/>
 			)}
 			<div
-				className={open ? 'cmt-canvas-pin cmt-canvas-pin--open' : 'cmt-canvas-pin'}
+				className={open ? 'tlui-cmt-canvas-pin tlui-cmt-canvas-pin--open' : 'tlui-cmt-canvas-pin'}
 				style={{ left: renderPoint.x, top: renderPoint.y }}
 			>
 				<div
 					ref={markerRef}
-					className="cmt-canvas-pin__marker"
+					className="tlui-cmt-canvas-pin__marker"
 					onPointerDown={startDrag}
 					onPointerMove={onDrag}
 					onPointerUp={endDrag}
@@ -1429,7 +1435,7 @@ function PendingComposer({
 			if (!el || !target) return
 			// A click in the composer, or in the mention picker it spawns (portaled elsewhere), is
 			// not "outside" — keep the draft open so the pick can insert.
-			if (el.contains(target) || target.closest('.cmt-mention-popup')) return
+			if (el.contains(target) || target.closest('.tlui-cmt-mention-popup')) return
 			pendingComment.set(editor, null)
 		}
 		document.addEventListener('pointerdown', onPointerDown, true)
@@ -1461,7 +1467,7 @@ function PendingComposer({
 	return createPortal(
 		<div
 			ref={ref}
-			className="cmt-canvas-composer"
+			className="tlui-cmt-canvas-composer"
 			style={{ left: point.x, top: point.y }}
 			onPointerDown={stop}
 			onKeyDown={(e) => {

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -149,7 +149,7 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				items={items}
 				header={header ?? msg('comments.title')}
 				headerAction={
-					<div className="cmt-list__header-actions">
+					<div className="tlui-cmt-list__header-actions">
 						<CommentsFilterMenu
 							canFilterByAuthor={currentUserId !== undefined}
 							canFilterByUnread={isCommentUnread !== undefined}
@@ -176,7 +176,7 @@ function SidebarPanel({ container, children }: { container: HTMLElement; childre
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughMouseOverEvents(ref)
 	return createPortal(
-		<div ref={ref} className="cmt-canvas-sidebar">
+		<div ref={ref} className="tlui-cmt-canvas-sidebar">
 			{children}
 		</div>,
 		container

--- a/packages/commenting/src/ui/avatar.tsx
+++ b/packages/commenting/src/ui/avatar.tsx
@@ -17,11 +17,18 @@ function initial(name: string) {
  * @public @react */
 export function Avatar({ name, color, image }: AvatarProps) {
 	if (image) {
-		return <img className="cmt-avatar cmt-avatar--image" src={image} alt="" aria-hidden="true" />
+		return (
+			<img
+				className="tlui-cmt-avatar tlui-cmt-avatar--image"
+				src={image}
+				alt=""
+				aria-hidden="true"
+			/>
+		)
 	}
 	return (
 		<div
-			className="cmt-avatar"
+			className="tlui-cmt-avatar"
 			aria-hidden="true"
 			style={color ? { backgroundColor: color } : undefined}
 		>

--- a/packages/commenting/src/ui/byline.tsx
+++ b/packages/commenting/src/ui/byline.tsx
@@ -12,11 +12,11 @@ export interface BylineProps {
 /** A comment's metadata line: author name, relative time, and an edited marker. @public @react */
 export function Byline({ author, date, edited }: BylineProps) {
 	return (
-		<div className="cmt-head">
-			<span className="cmt-author">{author}</span>
-			<span className="cmt-time">
+		<div className="tlui-cmt-head">
+			<span className="tlui-cmt-author">{author}</span>
+			<span className="tlui-cmt-time">
 				{formatRelativeTime(date)}
-				{edited && <span className="cmt-edited"> · edited</span>}
+				{edited && <span className="tlui-cmt-edited"> · edited</span>}
 			</span>
 		</div>
 	)

--- a/packages/commenting/src/ui/comment-card.tsx
+++ b/packages/commenting/src/ui/comment-card.tsx
@@ -20,13 +20,13 @@ export interface CommentCardProps {
 /** A single comment: Avatar, Byline, and a body slot the consumer renders. @public @react */
 export function CommentCard({ author, body, date, you, edited, actions }: CommentCardProps) {
 	return (
-		<div className={you ? 'cmt-card cmt-card--you' : 'cmt-card'}>
+		<div className={you ? 'tlui-cmt-card tlui-cmt-card--you' : 'tlui-cmt-card'}>
 			<Avatar name={author} />
-			<div className="cmt-body">
+			<div className="tlui-cmt-body">
 				<Byline author={author} date={date} edited={edited} />
 				{body}
 			</div>
-			{actions !== undefined && <div className="cmt-card__actions">{actions}</div>}
+			{actions !== undefined && <div className="tlui-cmt-card__actions">{actions}</div>}
 		</div>
 	)
 }

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -127,7 +127,7 @@ export function CommentComposer({
 			enableCoreExtensions: { textDirection: false },
 			textDirection: 'auto',
 			editorProps: {
-				attributes: { class: 'cmt-input' },
+				attributes: { class: 'tlui-cmt-input' },
 				// Runs before every keymap plugin, so it can distinguish Shift+Enter from Enter — an
 				// `Enter` keymap binding also fires on Shift+Enter and would otherwise swallow it.
 				handleKeyDown: (_view, event) => {
@@ -180,13 +180,13 @@ export function CommentComposer({
 	}, [autoFocus, editor])
 
 	return (
-		<div className="cmt-composer">
+		<div className="tlui-cmt-composer">
 			{leading ?? <Avatar name={author} />}
-			<div className="cmt-composer__field">
-				<div className="cmt-composer__input-wrap">
+			<div className="tlui-cmt-composer__field">
+				<div className="tlui-cmt-composer__input-wrap">
 					<EditorContent editor={editor} />
 					{isEmpty && (
-						<div className="cmt-input__placeholder" aria-hidden="true">
+						<div className="tlui-cmt-input__placeholder" aria-hidden="true">
 							{placeholder}
 						</div>
 					)}

--- a/packages/commenting/src/ui/comment-mention.ts
+++ b/packages/commenting/src/ui/comment-mention.ts
@@ -26,7 +26,7 @@ export interface CommentMentionOptions {
 }
 
 /**
- * The comment @-mention node — TipTap's `Mention` configured to render as a `.cmt-mention` pill.
+ * The comment @-mention node — TipTap's `Mention` configured to render as a `.tlui-cmt-mention` pill.
  *
  * A factory rather than a shared constant because it's configured differently per context: the
  * read-only render paths pass `resolveName` (so the stored `{ id }` node always shows the member's
@@ -35,7 +35,7 @@ export interface CommentMentionOptions {
  */
 export function commentMention({ resolveName, suggestion }: CommentMentionOptions = {}) {
 	return Mention.configure({
-		HTMLAttributes: { class: 'cmt-mention' },
+		HTMLAttributes: { class: 'tlui-cmt-mention' },
 		renderText: ({ node }) => `@${mentionName(node.attrs as MentionNodeAttrs, resolveName)}`,
 		renderHTML: ({ node, options }) => [
 			'span',

--- a/packages/commenting/src/ui/comment-pin.tsx
+++ b/packages/commenting/src/ui/comment-pin.tsx
@@ -14,7 +14,11 @@ export interface CommentPinProps {
  * presentational — it reflects open/resolved state via CSS; wrap it to make it clickable.
  * @public @react */
 export function CommentPin({ children, resolved, open }: CommentPinProps) {
-	const className = ['cmt-pin', resolved && 'cmt-pin--resolved', open && 'cmt-pin--open']
+	const className = [
+		'tlui-cmt-pin',
+		resolved && 'tlui-cmt-pin--resolved',
+		open && 'tlui-cmt-pin--open',
+	]
 		.filter(Boolean)
 		.join(' ')
 	return <div className={className}>{resolved ? '✓' : children}</div>

--- a/packages/commenting/src/ui/comment-text.tsx
+++ b/packages/commenting/src/ui/comment-text.tsx
@@ -8,5 +8,5 @@ export interface CommentTextProps {
 
 /** A comment's body, rendered as markdown (bold, italic, code, links, lists). @public @react */
 export function CommentText({ text }: CommentTextProps) {
-	return <div className="cmt-text">{renderMarkdown(text)}</div>
+	return <div className="tlui-cmt-text">{renderMarkdown(text)}</div>
 }

--- a/packages/commenting/src/ui/comment-thread.tsx
+++ b/packages/commenting/src/ui/comment-thread.tsx
@@ -33,17 +33,19 @@ export function CommentThread({
 	renderComment,
 }: CommentThreadProps) {
 	return (
-		<div className="cmt-thread">
+		<div className="tlui-cmt-thread">
 			{(header !== undefined || headerActions !== undefined) && (
-				<div className="cmt-thread__header">
-					<span className="cmt-thread__title">{header}</span>
+				<div className="tlui-cmt-thread__header">
+					<span className="tlui-cmt-thread__title">{header}</span>
 					{headerActions !== undefined && (
-						<div className="cmt-thread__actions">{headerActions}</div>
+						<div className="tlui-cmt-thread__actions">{headerActions}</div>
 					)}
 				</div>
 			)}
-			{resolvedBanner !== undefined && <div className="cmt-thread__resolved">{resolvedBanner}</div>}
-			<div className="cmt-thread__list">
+			{resolvedBanner !== undefined && (
+				<div className="tlui-cmt-thread__resolved">{resolvedBanner}</div>
+			)}
+			<div className="tlui-cmt-thread__list">
 				{comments.map((comment, i) => (
 					<div key={i}>
 						{renderComment ? renderComment(comment, i) : <CommentCard {...comment} />}

--- a/packages/commenting/src/ui/comments-list.tsx
+++ b/packages/commenting/src/ui/comments-list.tsx
@@ -52,17 +52,17 @@ export function CommentsList({
 	renderItem,
 }: CommentsListProps) {
 	return (
-		<div className="cmt-list">
+		<div className="tlui-cmt-list">
 			{(header !== undefined || headerAction) && (
-				<div className="cmt-list__header">
-					{header !== undefined && <span className="cmt-list__header-title">{header}</span>}
+				<div className="tlui-cmt-list__header">
+					{header !== undefined && <span className="tlui-cmt-list__header-title">{header}</span>}
 					{headerAction}
 				</div>
 			)}
 			{items.length === 0 ? (
-				<div className="cmt-list__empty">{empty}</div>
+				<div className="tlui-cmt-list__empty">{empty}</div>
 			) : (
-				<div className="cmt-list__items">
+				<div className="tlui-cmt-list__items">
 					{items.map((item) =>
 						renderItem ? (
 							renderItem(item)
@@ -99,27 +99,31 @@ function CommentListItem({
 	return (
 		<button
 			type="button"
-			className={selected ? 'cmt-list__item cmt-list__item--selected' : 'cmt-list__item'}
+			className={
+				selected ? 'tlui-cmt-list__item tlui-cmt-list__item--selected' : 'tlui-cmt-list__item'
+			}
 			data-resolved={resolved || undefined}
 			onClick={handleClick}
 		>
 			<Avatar name={author} />
-			<div className="cmt-list__item-body">
+			<div className="tlui-cmt-list__item-body">
 				<Byline author={author} date={date} />
-				<div className="cmt-list__item-preview">{preview}</div>
+				<div className="tlui-cmt-list__item-preview">{preview}</div>
 				{(resolved || page !== undefined) && (
-					<div className="cmt-list__item-meta">
+					<div className="tlui-cmt-list__item-meta">
 						{resolved && (
-							<span className="cmt-list__item-resolved">
+							<span className="tlui-cmt-list__item-resolved">
 								<CheckIcon />
 								{resolvedLabel}
 							</span>
 						)}
-						{page !== undefined && <span className="cmt-list__item-page">{page}</span>}
+						{page !== undefined && <span className="tlui-cmt-list__item-page">{page}</span>}
 					</div>
 				)}
 			</div>
-			{count !== undefined && count > 1 && <span className="cmt-list__item-count">{count}</span>}
+			{count !== undefined && count > 1 && (
+				<span className="tlui-cmt-list__item-count">{count}</span>
+			)}
 		</button>
 	)
 }

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -1,6 +1,6 @@
 /* Real comment UI components. Co-located so styles travel to any view (studio,
    canvas), and themed via tldraw's --tl-color tokens so they follow light/dark. */
-.cmt-card {
+.tlui-cmt-card {
 	position: relative;
 	display: flex;
 	gap: 10px;
@@ -12,7 +12,7 @@
 }
 
 /* hover-revealed controls (edit…) at the card's top-right */
-.cmt-card__actions {
+.tlui-cmt-card__actions {
 	position: absolute;
 	top: 6px;
 	right: 6px;
@@ -20,65 +20,65 @@
 	gap: 2px;
 	opacity: 0;
 }
-.cmt-card:hover .cmt-card__actions,
-.cmt-card:focus-within .cmt-card__actions {
+.tlui-cmt-card:hover .tlui-cmt-card__actions,
+.tlui-cmt-card:focus-within .tlui-cmt-card__actions {
 	opacity: 1;
 }
 
-.cmt-body {
+.tlui-cmt-body {
 	flex: 1;
 	min-width: 0;
 }
 
-.cmt-head {
+.tlui-cmt-head {
 	display: flex;
 	align-items: baseline;
 	gap: 6px;
 }
 
-.cmt-author {
+.tlui-cmt-author {
 	font-weight: 600;
 	font-size: 13px;
 	color: var(--tl-color-text-1);
 }
 
-.cmt-time {
+.tlui-cmt-time {
 	font-size: 11px;
 	color: var(--tl-color-text-3);
 }
 
-.cmt-text {
+.tlui-cmt-text {
 	margin: 3px 0 0;
 	font-size: 13px;
 	line-height: 1.4;
 	color: var(--tl-color-text-1);
 }
 
-.cmt-edited {
+.tlui-cmt-edited {
 	font-style: italic;
 }
 
 /* rendered rich text inside a comment body — bare tags emitted by the comment renderer
    (paragraphs, lists, code, highlight, links), matching the limited comment extension set. */
-.cmt-text p {
+.tlui-cmt-text p {
 	margin: 0;
 }
 
-.cmt-text p + p,
-.cmt-text p + ul,
-.cmt-text p + ol,
-.cmt-text ul + p,
-.cmt-text ol + p {
+.tlui-cmt-text p + p,
+.tlui-cmt-text p + ul,
+.tlui-cmt-text p + ol,
+.tlui-cmt-text ul + p,
+.tlui-cmt-text ol + p {
 	margin-top: 6px;
 }
 
-.cmt-text ul,
-.cmt-text ol {
+.tlui-cmt-text ul,
+.tlui-cmt-text ol {
 	margin: 0;
 	padding-left: 18px;
 }
 
-.cmt-text code {
+.tlui-cmt-text code {
 	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 	font-size: 0.92em;
 	background: var(--tl-color-muted-2);
@@ -86,18 +86,18 @@
 	padding: 0 3px;
 }
 
-.cmt-text mark {
+.tlui-cmt-text mark {
 	background: color-mix(in srgb, #ffeb3b 60%, transparent);
 	color: inherit;
 	border-radius: 2px;
 }
 
-.cmt-text a {
+.tlui-cmt-text a {
 	color: var(--tl-color-selected);
 	text-decoration: underline;
 }
 
-.cmt-avatar {
+.tlui-cmt-avatar {
 	width: 28px;
 	height: 28px;
 	border-radius: 50%;
@@ -111,7 +111,7 @@
 	flex-shrink: 0;
 }
 
-.cmt-avatar--image {
+.tlui-cmt-avatar--image {
 	object-fit: cover;
 	background: none;
 }
@@ -119,14 +119,14 @@
 /* composer — an avatar beside a rounded-rect field holding the rich-text input and the send button.
    Formatting is applied via markdown and keyboard shortcuts (no toolbar). The avatar aligns to the
    top so it stays put as the field grows to multiple lines. */
-.cmt-composer {
+.tlui-cmt-composer {
 	display: flex;
 	align-items: flex-start;
 	gap: 10px;
 	padding: 4px 0 8px 4px;
 }
 
-.cmt-composer__field {
+.tlui-cmt-composer__field {
 	flex: 1;
 	min-width: 0;
 	display: flex;
@@ -138,19 +138,19 @@
 	border-radius: var(--tl-radius-3);
 }
 
-.cmt-composer__field:focus-within {
+.tlui-cmt-composer__field:focus-within {
 	border-color: var(--tl-color-selected);
 }
 
 /* the editable area, with the placeholder overlaid while it's empty */
-.cmt-composer__input-wrap {
+.tlui-cmt-composer__input-wrap {
 	position: relative;
 	flex: 1;
 	min-width: 0;
 	padding: 3px 0;
 }
 
-.cmt-input {
+.tlui-cmt-input {
 	font: inherit;
 	font-size: 13px;
 	line-height: 1.4;
@@ -163,23 +163,23 @@
 	word-break: break-word;
 }
 
-.cmt-input p {
+.tlui-cmt-input p {
 	margin: 0;
 }
 
-.cmt-input p + p,
-.cmt-input p + ul,
-.cmt-input p + ol {
+.tlui-cmt-input p + p,
+.tlui-cmt-input p + ul,
+.tlui-cmt-input p + ol {
 	margin-top: 4px;
 }
 
-.cmt-input ul,
-.cmt-input ol {
+.tlui-cmt-input ul,
+.tlui-cmt-input ol {
 	margin: 0;
 	padding-left: 18px;
 }
 
-.cmt-input__placeholder {
+.tlui-cmt-input__placeholder {
 	position: absolute;
 	top: 3px;
 	left: 0;
@@ -189,7 +189,7 @@
 	pointer-events: none;
 }
 
-.cmt-send {
+.tlui-cmt-send {
 	border: 0;
 	border-radius: var(--tl-radius-2);
 	background: var(--tl-color-selected);
@@ -202,29 +202,29 @@
 	align-self: flex-end;
 }
 
-.cmt-send:hover,
-.pseudo-hover .cmt-send {
+.tlui-cmt-send:hover,
+.pseudo-hover .tlui-cmt-send {
 	background: color-mix(in srgb, var(--tl-color-selected) 88%, black);
 }
 
-.cmt-send:active,
-.pseudo-active .cmt-send {
+.tlui-cmt-send:active,
+.pseudo-active .tlui-cmt-send {
 	background: color-mix(in srgb, var(--tl-color-selected) 78%, black);
 }
 
-.cmt-send:focus-visible,
-.pseudo-focus-visible .cmt-send {
+.tlui-cmt-send:focus-visible,
+.pseudo-focus-visible .tlui-cmt-send {
 	outline: 2px solid var(--tl-color-selected);
 	outline-offset: 2px;
 }
 
-.cmt-send:disabled {
+.tlui-cmt-send:disabled {
 	opacity: 0.45;
 	cursor: not-allowed;
 }
 
 /* pin */
-.cmt-pin {
+.tlui-cmt-pin {
 	width: 34px;
 	height: 34px;
 	border-radius: 50% 50% 50% 3px;
@@ -242,14 +242,14 @@
 		box-shadow 0.08s ease;
 }
 
-.cmt-pin:hover,
-.pseudo-hover .cmt-pin {
+.tlui-cmt-pin:hover,
+.pseudo-hover .tlui-cmt-pin {
 	transform: scale(1.08);
 	box-shadow: 0 3px 10px rgba(0, 0, 0, 0.32);
 }
 
 /* open: the thread is showing — a selection ring marks the active pin */
-.cmt-pin--open {
+.tlui-cmt-pin--open {
 	box-shadow:
 		0 0 0 3px var(--tl-color-panel),
 		0 0 0 5px var(--tl-color-selected),
@@ -258,17 +258,17 @@
 
 /* resolved: a solid, muted grey (the default --tl-color-muted-1 is 10% black, so it goes
    translucent over the canvas). Dark mode gets its own grey — the token's dark value is near-black. */
-.cmt-pin--resolved {
+.tlui-cmt-pin--resolved {
 	background: #dfe0e1;
 	color: hsl(214, 8%, 42%);
 }
-.tl-theme__dark .cmt-pin--resolved {
+.tl-theme__dark .tlui-cmt-pin--resolved {
 	background: hsl(240, 5%, 30%);
 	color: hsl(0, 0%, 72%);
 }
 
 /* count badge */
-.cmt-count-badge {
+.tlui-cmt-count-badge {
 	width: 34px;
 	height: 34px;
 	border-radius: 50%;
@@ -284,14 +284,14 @@
 }
 
 /* thread */
-.cmt-thread {
+.tlui-cmt-thread {
 	display: flex;
 	flex-direction: column;
 	gap: 8px;
 	width: 300px;
 }
 
-.cmt-thread__head {
+.tlui-cmt-thread__head {
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -302,7 +302,7 @@
 	letter-spacing: 0.04em;
 }
 
-.cmt-badge {
+.tlui-cmt-badge {
 	font-size: 10px;
 	font-weight: 600;
 	text-transform: none;
@@ -314,12 +314,12 @@
 }
 
 /* reactions */
-.cmt-reactions {
+.tlui-cmt-reactions {
 	display: flex;
 	gap: 6px;
 }
 
-.cmt-reaction {
+.tlui-cmt-reaction {
 	display: inline-flex;
 	align-items: center;
 	gap: 5px;
@@ -333,27 +333,27 @@
 	cursor: pointer;
 }
 
-.cmt-reaction:hover,
-.pseudo-hover .cmt-reaction {
+.tlui-cmt-reaction:hover,
+.pseudo-hover .tlui-cmt-reaction {
 	border-color: var(--tl-color-selected);
 }
 
-.cmt-reaction--active {
+.tlui-cmt-reaction--active {
 	border-color: var(--tl-color-selected);
 	background: color-mix(in srgb, var(--tl-color-selected) 12%, var(--tl-color-panel));
 }
 
-.cmt-reaction__count {
+.tlui-cmt-reaction__count {
 	color: var(--tl-color-text-3);
 }
 
-.cmt-reaction--add {
+.tlui-cmt-reaction--add {
 	color: var(--tl-color-text-3);
 	font-weight: 600;
 }
 
 /* mention */
-.cmt-mention {
+.tlui-cmt-mention {
 	color: var(--tl-color-selected);
 	font-weight: 600;
 	background: color-mix(in srgb, var(--tl-color-selected) 12%, transparent);
@@ -362,7 +362,7 @@
 }
 
 /* mention picker */
-.cmt-mention-list {
+.tlui-cmt-mention-list {
 	display: flex;
 	flex-direction: column;
 	gap: 1px;
@@ -378,7 +378,7 @@
 	box-shadow: var(--tl-shadow-2, 0 2px 12px rgba(0, 0, 0, 0.14));
 }
 
-.cmt-mention-list__item {
+.tlui-cmt-mention-list__item {
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -392,19 +392,19 @@
 	font: inherit;
 }
 
-.cmt-mention-list__item--active,
-.cmt-mention-list__item:hover {
+.tlui-cmt-mention-list__item--active,
+.tlui-cmt-mention-list__item:hover {
 	background: var(--tl-color-muted-2, rgba(0, 0, 0, 0.06));
 }
 
-.cmt-mention-list__text {
+.tlui-cmt-mention-list__text {
 	display: flex;
 	flex-direction: column;
 	min-width: 0;
 	line-height: 1.3;
 }
 
-.cmt-mention-list__name {
+.tlui-cmt-mention-list__name {
 	font-size: 13px;
 	font-weight: 500;
 	white-space: nowrap;
@@ -412,13 +412,13 @@
 	text-overflow: ellipsis;
 }
 
-.cmt-mention-list__you {
+.tlui-cmt-mention-list__you {
 	margin-left: 4px;
 	font-weight: 400;
 	color: var(--tl-color-text-3);
 }
 
-.cmt-mention-list__secondary {
+.tlui-cmt-mention-list__secondary {
 	font-size: 12px;
 	color: var(--tl-color-text-3);
 	white-space: nowrap;
@@ -426,7 +426,7 @@
 	text-overflow: ellipsis;
 }
 
-.cmt-mention-list--empty {
+.tlui-cmt-mention-list--empty {
 	padding: 8px 10px;
 	width: 100%;
 	box-sizing: border-box;
@@ -435,13 +435,13 @@
 }
 
 /* the @-picker popup — caret-anchored above the page, positioned by the suggestion plugin */
-.cmt-mention-popup {
+.tlui-cmt-mention-popup {
 	position: fixed;
 	z-index: var(--tl-layer-menus);
 }
 
 /* empty state */
-.cmt-empty {
+.tlui-cmt-empty {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -451,11 +451,11 @@
 	width: 240px;
 }
 
-.cmt-empty__icon {
+.tlui-cmt-empty__icon {
 	font-size: 28px;
 }
 
-.cmt-empty__message {
+.tlui-cmt-empty__message {
 	margin: 0;
 	color: var(--tl-color-text-3);
 	font-size: 13px;
@@ -464,7 +464,7 @@
 
 /* a comment thread: an elevated panel — the same surface treatment as the toolbar — holding a
    header, an optional resolved banner, the comments, and a reply composer */
-.cmt-thread {
+.tlui-cmt-thread {
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
@@ -474,22 +474,22 @@
 	border-radius: var(--tl-radius-4);
 	box-shadow: var(--tl-shadow-2);
 }
-.cmt-thread__header {
+.tlui-cmt-thread__header {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	padding: 2px 2px 2px 4px;
 }
-.cmt-thread__title {
+.tlui-cmt-thread__title {
 	font-size: 12px;
 	font-weight: 600;
 	color: var(--tl-color-text-1);
 }
-.cmt-thread__actions {
+.tlui-cmt-thread__actions {
 	display: flex;
 	gap: 2px;
 }
-.cmt-thread__action {
+.tlui-cmt-thread__action {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -504,25 +504,25 @@
 	line-height: 1;
 	cursor: pointer;
 }
-.cmt-thread__action:hover {
+.tlui-cmt-thread__action:hover {
 	background: var(--tl-color-muted-2);
 	color: var(--tl-color-text-1);
 }
-.cmt-thread__resolved {
+.tlui-cmt-thread__resolved {
 	padding: 6px 10px;
 	border-radius: 8px;
 	background: var(--tl-color-muted-2);
 	font-size: 12px;
 	color: var(--tl-color-text-3);
 }
-.cmt-thread__list {
+.tlui-cmt-thread__list {
 	display: flex;
 	flex-direction: column;
 	gap: 6px;
 }
 /* inside the panel, comments are plain content — no surrounding box; the composer's field carries
    its own surface. */
-.cmt-thread .cmt-card {
+.tlui-cmt-thread .tlui-cmt-card {
 	width: 100%;
 	padding: 6px 0 6px 4px;
 	background: transparent;
@@ -530,13 +530,13 @@
 }
 
 /* comments list — thread summaries, one per row (used by the canvas sidebar) */
-.cmt-list {
+.tlui-cmt-list {
 	display: flex;
 	flex-direction: column;
 	width: 100%;
 	min-height: 0;
 }
-.cmt-list__header {
+.tlui-cmt-list__header {
 	flex-shrink: 0;
 	display: flex;
 	align-items: center;
@@ -545,7 +545,7 @@
 	padding: 6px 6px 6px 14px;
 	border-bottom: 1px solid var(--tl-color-divider);
 }
-.cmt-list__header-title {
+.tlui-cmt-list__header-title {
 	font-size: 11px;
 	font-weight: 600;
 	letter-spacing: 0.06em;
@@ -554,7 +554,7 @@
 }
 
 /* a small square icon button in the sidebar header (filter funnel, overflow …) */
-.cmt-header-btn {
+.tlui-cmt-header-btn {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -567,19 +567,19 @@
 	color: var(--tl-color-text-2);
 	cursor: pointer;
 }
-.cmt-header-btn:hover,
-.cmt-header-btn[data-state='open'] {
+.tlui-cmt-header-btn:hover,
+.tlui-cmt-header-btn[data-state='open'] {
 	background: var(--tl-color-muted-2);
 	color: var(--tl-color-text-1);
 }
-.cmt-list__header-actions {
+.tlui-cmt-list__header-actions {
 	display: flex;
 	align-items: center;
 	gap: 2px;
 }
 
 /* a menu row with a label and a right-aligned shortcut hint (overflow menu) */
-.cmt-menu-item {
+.tlui-cmt-menu-item {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
@@ -594,24 +594,24 @@
 	color: var(--tl-color-text-1);
 	cursor: pointer;
 }
-.cmt-menu-item:hover {
+.tlui-cmt-menu-item:hover {
 	background: var(--tl-color-muted-2);
 }
-.cmt-menu-item__shortcut {
+.tlui-cmt-menu-item__shortcut {
 	color: var(--tl-color-text-3);
 	font-size: 12px;
 }
-.cmt-list__items {
+.tlui-cmt-list__items {
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
 }
-.cmt-list__empty {
+.tlui-cmt-list__empty {
 	padding: 20px 14px;
 	color: var(--tl-color-text-3);
 	font-size: 13px;
 }
-.cmt-list__item {
+.tlui-cmt-list__item {
 	display: flex;
 	gap: 10px;
 	width: 100%;
@@ -623,22 +623,22 @@
 	text-align: left;
 	cursor: pointer;
 }
-.cmt-list__item:hover {
+.tlui-cmt-list__item:hover {
 	background: var(--tl-color-muted-2);
 }
-.cmt-list__item--selected {
+.tlui-cmt-list__item--selected {
 	background: var(--tl-color-muted-1);
 }
 /* resolved rows mute their content but keep the "Resolved" marker legible */
-.cmt-list__item[data-resolved] .cmt-head,
-.cmt-list__item[data-resolved] .cmt-list__item-preview {
+.tlui-cmt-list__item[data-resolved] .tlui-cmt-head,
+.tlui-cmt-list__item[data-resolved] .tlui-cmt-list__item-preview {
 	opacity: 0.55;
 }
-.cmt-list__item-body {
+.tlui-cmt-list__item-body {
 	flex: 1;
 	min-width: 0;
 }
-.cmt-list__item-preview {
+.tlui-cmt-list__item-preview {
 	margin-top: 2px;
 	font-size: 13px;
 	color: var(--tl-color-text-1);
@@ -649,7 +649,7 @@
 	-webkit-box-orient: vertical;
 }
 /* meta line under the preview: page label and/or a resolved marker */
-.cmt-list__item-meta {
+.tlui-cmt-list__item-meta {
 	display: flex;
 	align-items: center;
 	gap: 8px;
@@ -657,20 +657,20 @@
 	font-size: 11px;
 	color: var(--tl-color-text-3);
 }
-.cmt-list__item-resolved {
+.tlui-cmt-list__item-resolved {
 	display: inline-flex;
 	align-items: center;
 	gap: 3px;
 	font-weight: 600;
 }
-.cmt-list__item-page {
+.tlui-cmt-list__item-page {
 	display: inline-flex;
 	align-items: center;
 	padding: 1px 6px;
 	border-radius: 4px;
 	background: var(--tl-color-muted-2);
 }
-.cmt-list__item-count {
+.tlui-cmt-list__item-count {
 	flex-shrink: 0;
 	align-self: center;
 	font-size: 12px;

--- a/packages/commenting/src/ui/count-badge.tsx
+++ b/packages/commenting/src/ui/count-badge.tsx
@@ -5,5 +5,5 @@ export interface CountBadgeProps {
 
 /** @public @react */
 export function CountBadge({ count }: CountBadgeProps) {
-	return <div className="cmt-count-badge">{count}</div>
+	return <div className="tlui-cmt-count-badge">{count}</div>
 }

--- a/packages/commenting/src/ui/empty-state.tsx
+++ b/packages/commenting/src/ui/empty-state.tsx
@@ -6,11 +6,11 @@ export interface EmptyStateProps {
 /** The empty state shown when a thread has no comments yet. @public @react */
 export function EmptyState({ message }: EmptyStateProps) {
 	return (
-		<div className="cmt-empty">
-			<div className="cmt-empty__icon" aria-hidden="true">
+		<div className="tlui-cmt-empty">
+			<div className="tlui-cmt-empty__icon" aria-hidden="true">
 				💬
 			</div>
-			<p className="cmt-empty__message">{message}</p>
+			<p className="tlui-cmt-empty__message">{message}</p>
 		</div>
 	)
 }

--- a/packages/commenting/src/ui/mention-list.tsx
+++ b/packages/commenting/src/ui/mention-list.tsx
@@ -38,15 +38,15 @@ function DefaultMemberRow({ member }: { member: MentionMember }) {
 	return (
 		<>
 			<Avatar name={member.name} color={member.color} image={member.avatar} />
-			<span className="cmt-mention-list__text">
-				<span className="cmt-mention-list__name">
+			<span className="tlui-cmt-mention-list__text">
+				<span className="tlui-cmt-mention-list__name">
 					{member.name}
 					{member.you && (
-						<span className="cmt-mention-list__you">{`(${msg('comments.mention-you')})`}</span>
+						<span className="tlui-cmt-mention-list__you">{`(${msg('comments.mention-you')})`}</span>
 					)}
 				</span>
 				{member.secondary && (
-					<span className="cmt-mention-list__secondary">{member.secondary}</span>
+					<span className="tlui-cmt-mention-list__secondary">{member.secondary}</span>
 				)}
 			</span>
 		</>
@@ -69,13 +69,13 @@ export function MentionList({
 	const msg = useTranslation()
 	if (members.length === 0) {
 		return (
-			<div className="cmt-mention-list cmt-mention-list--empty">
+			<div className="tlui-cmt-mention-list tlui-cmt-mention-list--empty">
 				{emptyLabel ?? msg('comments.mention-no-matches')}
 			</div>
 		)
 	}
 	return (
-		<div className="cmt-mention-list" role="listbox">
+		<div className="tlui-cmt-mention-list" role="listbox">
 			{members.map((member, i) => {
 				const active = i === activeIndex
 				return (
@@ -86,8 +86,8 @@ export function MentionList({
 						aria-selected={active}
 						className={
 							active
-								? 'cmt-mention-list__item cmt-mention-list__item--active'
-								: 'cmt-mention-list__item'
+								? 'tlui-cmt-mention-list__item tlui-cmt-mention-list__item--active'
+								: 'tlui-cmt-mention-list__item'
 						}
 						// Keep the composer focused on a row press: it's portaled outside the editor, so a
 						// bare mousedown would blur the composer — which now dismisses the picker — before

--- a/packages/commenting/src/ui/mention-suggestion.tsx
+++ b/packages/commenting/src/ui/mention-suggestion.tsx
@@ -139,7 +139,7 @@ export function createMentionSuggestion(
 			// the caret, matching its width), and remember the field's page-space anchor for reposition.
 			const place = () => {
 				if (!container || !editorEl || container.style.display === 'none') return
-				const field = editorEl.closest('.cmt-composer__field') ?? editorEl
+				const field = editorEl.closest('.tlui-cmt-composer__field') ?? editorEl
 				const rect = field.getBoundingClientRect()
 				popupWidth = rect.width
 				anchorPage = options.editor?.screenToPage({ x: rect.left, y: rect.bottom }) ?? null
@@ -193,7 +193,7 @@ export function createMentionSuggestion(
 			// only redispatch when it can't). Done imperatively because the popup lives outside React.
 			const onWheel = (e: WheelEvent) => {
 				if ((e as any).isSpecialRedispatchedEvent || !canvasEl) return
-				const list = container?.querySelector('.cmt-mention-list')
+				const list = container?.querySelector('.tlui-cmt-mention-list')
 				if (list && list.scrollHeight > list.clientHeight) return
 				e.preventDefault()
 				const redispatched = new WheelEvent('wheel', e)
@@ -217,7 +217,7 @@ export function createMentionSuggestion(
 					// composer — leaving Escape a no-op and the roster stuck on screen.
 					editorEl.addEventListener('blur', hide)
 					container = document.createElement('div')
-					container.className = 'cmt-mention-popup'
+					container.className = 'tlui-cmt-mention-popup'
 					container.appendChild(renderer.element)
 					// Mount inside the tldraw container so the popup inherits the theme variables
 					// (--tl-color-*); portaling to document.body would strip them and lose the panel.

--- a/packages/commenting/src/ui/mention.tsx
+++ b/packages/commenting/src/ui/mention.tsx
@@ -5,5 +5,5 @@ export interface MentionProps {
 
 /** An \@-mention pill for referencing a person in a comment. @public @react */
 export function Mention({ name }: MentionProps) {
-	return <span className="cmt-mention">@{name}</span>
+	return <span className="tlui-cmt-mention">@{name}</span>
 }

--- a/packages/commenting/src/ui/reaction.tsx
+++ b/packages/commenting/src/ui/reaction.tsx
@@ -8,9 +8,12 @@ export interface ReactionProps {
 /** A single emoji reaction pill with a count, highlighted when the user reacted. @public @react */
 export function Reaction({ emoji, count, active }: ReactionProps) {
 	return (
-		<button className={active ? 'cmt-reaction cmt-reaction--active' : 'cmt-reaction'} type="button">
-			<span className="cmt-reaction__emoji">{emoji}</span>
-			<span className="cmt-reaction__count">{count}</span>
+		<button
+			className={active ? 'tlui-cmt-reaction tlui-cmt-reaction--active' : 'tlui-cmt-reaction'}
+			type="button"
+		>
+			<span className="tlui-cmt-reaction__emoji">{emoji}</span>
+			<span className="tlui-cmt-reaction__count">{count}</span>
 		</button>
 	)
 }

--- a/packages/commenting/src/ui/reactions.tsx
+++ b/packages/commenting/src/ui/reactions.tsx
@@ -3,11 +3,15 @@ import { Reaction } from './reaction'
 /** The row of reactions under a comment, plus an add-reaction button. @public @react */
 export function Reactions() {
 	return (
-		<div className="cmt-reactions">
+		<div className="tlui-cmt-reactions">
 			<Reaction emoji="👍" count={3} active={true} />
 			<Reaction emoji="🎉" count={1} active={false} />
 			<Reaction emoji="👀" count={2} active={false} />
-			<button className="cmt-reaction cmt-reaction--add" type="button" aria-label="Add reaction">
+			<button
+				className="tlui-cmt-reaction tlui-cmt-reaction--add"
+				type="button"
+				aria-label="Add reaction"
+			>
 				＋
 			</button>
 		</div>

--- a/packages/commenting/src/ui/send-button.tsx
+++ b/packages/commenting/src/ui/send-button.tsx
@@ -8,7 +8,7 @@ export interface SendButtonProps {
 /** The button that posts a comment. @public @react */
 export function SendButton({ label, disabled, onClick }: SendButtonProps) {
 	return (
-		<button className="cmt-send" type="button" disabled={disabled} onClick={onClick}>
+		<button className="tlui-cmt-send" type="button" disabled={disabled} onClick={onClick}>
 			{label}
 		</button>
 	)


### PR DESCRIPTION
## What this does

Namespaces the commenting feature's CSS classes under tldraw's `tlui-` UI prefix: every `cmt-*` class becomes `tlui-cmt-*`. This brings commenting in line with the rest of the SDK's UI classes (`tlui-button`, `tlui-menu`, …) so the styles share one predictable namespace.

Purely mechanical — a literal `cmt-` → `tlui-cmt-` substitution. Because the selector definitions (`.css`) and the `className` usages (`.tsx`) both hold the same token, both sides move together and stay in sync by construction.

## Scope

- **254 occurrences across 31 files** — `packages/commenting`, its `component-studio` sketchbooks, the commenting examples, and the dotcom notifications panel that consumes the classes.
- The dotcom consumer references the commenting package's global classes by literal string, so it stays matched to the renamed selectors.
- Covers the one dynamic case (`tlui-cmt-cluster-fade--${phase}` template literal) and the doc-comment references.

## Verification

- `packages/commenting`: 174/174 tests pass
- `lint-current`: clean
- No bare `cmt-` remaining; no double-prefixing

## Follow-up

Any still-open commenting branches will need the same `cmt-` → `tlui-cmt-` substitution re-applied when they rebase onto `commenting`. The rename is mechanical, so those conflicts resolve by re-running the substitution on the affected files.
