### PR TITLE
perf(tldraw): don't subscribe to color mode in getDisplayValues by default

### DIFF
--- a/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/arrow/ArrowShapeUtil.tsx
@@ -42,6 +42,7 @@ import {
 	toDomPrecision,
 	toRichText,
 	track,
+	useColorMode,
 	useEditor,
 	useIsEditing,
 	useSharedSafeId,
@@ -820,7 +821,8 @@ export class ArrowShapeUtil extends ShapeUtil<TLArrowShape> {
 
 	component(shape: TLArrowShape) {
 		const { editor } = this
-		const dv = getDisplayValues(this, shape)
+		const colorMode = useColorMode()
+		const dv = getDisplayValues(this, shape, colorMode)
 
 		const isSelected = useValue(
 			'is selected',

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeUtil.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/rules-of-hooks */
 import {
 	Box,
 	Circle2d,
@@ -18,6 +19,7 @@ import {
 	last,
 	lerp,
 	rng,
+	useColorMode,
 	useEditor,
 	useValue,
 } from '@tldraw/editor'
@@ -161,7 +163,8 @@ export class DrawShapeUtil extends ShapeUtil<TLDrawShape> {
 	}
 
 	component(shape: TLDrawShape) {
-		const dv = getDisplayValues(this, shape)
+		const colorMode = useColorMode()
+		const dv = getDisplayValues(this, shape, colorMode)
 		return (
 			<SVGContainer>
 				<DrawShapeSvg

--- a/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/highlight/HighlightShapeUtil.tsx
@@ -128,7 +128,8 @@ export class HighlightShapeUtil extends ShapeUtil<TLHighlightShape> {
 	}
 
 	component(shape: TLHighlightShape) {
-		const dv = getDisplayValues(this, shape)
+		const colorMode = useColorMode()
+		const dv = getDisplayValues(this, shape, colorMode)
 		const sw = dv.strokeWidth * shape.props.scale
 		const forceSolid = useHighlightForceSolid(this.editor, sw)
 

--- a/packages/tldraw/src/lib/shapes/shared/getDisplayValues.ts
+++ b/packages/tldraw/src/lib/shapes/shared/getDisplayValues.ts
@@ -1,4 +1,4 @@
-import { Editor, TLShape, TLTheme } from '@tldraw/editor'
+import { Editor, TLShape, TLTheme, unsafe__withoutCapture } from '@tldraw/editor'
 
 /** @public */
 export interface ShapeOptionsWithDisplayValues<
@@ -27,15 +27,26 @@ const dvCache = new WeakMap<
 /**
  * Get the resolved display values for a shape, merging the base values with any overrides.
  *
+ * When `colorMode` is omitted, the current color mode is read without creating a reactive
+ * dependency on it. Within a single theme, light and dark only differ in their color palette, so
+ * dimension-affecting values (font family, font size, line height, padding, stroke width, etc.)
+ * are safe to read from any reactive scope — computed caches that measure text or build geometry
+ * won't be invalidated by a light/dark toggle. The returned colors still reflect the color mode at
+ * call time, but without a subscription they can go stale.
+ *
+ * Callers that render colors and need to update when the color mode changes must pass `colorMode`
+ * explicitly from a reactive read: `useColorMode()` in components, `ctx.colorMode` in exports, or
+ * `editor.getColorMode()` in other reactive scopes.
+ *
  * @public
  */
 export function getDisplayValues<Shape extends TLShape, DisplayValues extends object>(
 	util: { editor: Editor; options: ShapeOptionsWithDisplayValues<Shape, DisplayValues> },
 	shape: Shape,
-	colorMode?: 'light' | 'dark' // An override, used when exporting images from the non-current color mode
+	colorMode?: 'light' | 'dark' // Pass explicitly for color-mode reactivity, or to export from the non-current color mode
 ): DisplayValues {
 	const theme = util.editor.getCurrentTheme()
-	const resolvedColorMode = colorMode ?? util.editor.getColorMode()
+	const resolvedColorMode = colorMode ?? unsafe__withoutCapture(() => util.editor.getColorMode())
 	const cached = dvCache.get(shape)
 	if (cached && cached.theme === theme && cached.colorMode === resolvedColorMode) {
 		return cached.values as DisplayValues

--- a/packages/tldraw/src/lib/shapes/shared/getDisplayValues.ts
+++ b/packages/tldraw/src/lib/shapes/shared/getDisplayValues.ts
@@ -31,8 +31,9 @@ const dvCache = new WeakMap<
  * dependency on it. Within a single theme, light and dark only differ in their color palette, so
  * dimension-affecting values (font family, font size, line height, padding, stroke width, etc.)
  * are safe to read from any reactive scope — computed caches that measure text or build geometry
- * won't be invalidated by a light/dark toggle. The returned colors still reflect the color mode at
- * call time, but without a subscription they can go stale.
+ * won't be invalidated by a light/dark toggle. (This assumes `getCustomDisplayValues` overrides
+ * don't derive dimension values from `colorMode`.) The returned colors still reflect the color
+ * mode at call time, but without a subscription they can go stale.
  *
  * Callers that render colors and need to update when the color mode changes must pass `colorMode`
  * explicitly from a reactive read: `useColorMode()` in components, `ctx.colorMode` in exports, or

--- a/packages/tldraw/src/test/displayValues.test.ts
+++ b/packages/tldraw/src/test/displayValues.test.ts
@@ -1,4 +1,12 @@
-import { TLNoteShape, TLTheme, createShapeId } from '@tldraw/editor'
+import {
+	TLNoteShape,
+	TLTextShape,
+	TLTheme,
+	computed,
+	createShapeId,
+	toRichText,
+} from '@tldraw/editor'
+import { vi } from 'vitest'
 import { ArrowShapeUtil } from '../lib/shapes/arrow/ArrowShapeUtil'
 import { DrawShapeUtil } from '../lib/shapes/draw/DrawShapeUtil'
 import { FrameShapeUtil } from '../lib/shapes/frame/FrameShapeUtil'
@@ -6,6 +14,7 @@ import { GeoShapeUtil } from '../lib/shapes/geo/GeoShapeUtil'
 import { HighlightShapeUtil } from '../lib/shapes/highlight/HighlightShapeUtil'
 import { NoteShapeUtil } from '../lib/shapes/note/NoteShapeUtil'
 import { getDisplayValues } from '../lib/shapes/shared/getDisplayValues'
+import { TextShapeUtil } from '../lib/shapes/text/TextShapeUtil'
 import { TestEditor } from './TestEditor'
 
 let editor: TestEditor
@@ -305,5 +314,99 @@ describe('theme changes flow to shapes', () => {
 		expect(dv2.labelFontSize).toBeGreaterThan(dv1.labelFontSize)
 		// But note background color should be the same
 		expect(dv2.noteBackgroundColor).toBe(originalBg)
+	})
+})
+
+describe('color mode reactivity', () => {
+	it('does not create a reactive dependency on color mode by default', () => {
+		editor.createShapes([{ id: noteId, type: 'note', x: 0, y: 0, props: { color: 'black' } }])
+		const util = editor.getShapeUtil('note') as NoteShapeUtil
+		const shape = editor.getShape<TLNoteShape>(noteId)!
+
+		let computeCount = 0
+		const labelFontSize = computed('labelFontSize', () => {
+			computeCount++
+			return getDisplayValues(util, shape).labelFontSize
+		})
+
+		const before = labelFontSize.get()
+		editor.user.updateUserPreferences({ colorScheme: 'dark' })
+		expect(labelFontSize.get()).toBe(before)
+		expect(computeCount).toBe(1)
+	})
+
+	it('creates a reactive dependency when colorMode is passed from a reactive read', () => {
+		editor.createShapes([{ id: noteId, type: 'note', x: 0, y: 0, props: { color: 'black' } }])
+		const util = editor.getShapeUtil('note') as NoteShapeUtil
+		const shape = editor.getShape<TLNoteShape>(noteId)!
+
+		let computeCount = 0
+		const backgroundColor = computed('backgroundColor', () => {
+			computeCount++
+			return getDisplayValues(util, shape, editor.getColorMode()).noteBackgroundColor
+		})
+
+		const lightBg = backgroundColor.get()
+		editor.user.updateUserPreferences({ colorScheme: 'dark' })
+		expect(backgroundColor.get()).not.toBe(lightBg)
+		expect(computeCount).toBe(2)
+	})
+
+	it('does not invalidate the text shape size cache when color mode toggles', () => {
+		const textId = createShapeId('text')
+		editor.createShapes([
+			{
+				id: textId,
+				type: 'text',
+				x: 0,
+				y: 0,
+				props: { richText: toRichText('hello world') },
+			},
+		])
+
+		// Prime the geometry cache and capture initial bounds.
+		const initialBounds = editor.getShapeGeometry(textId).bounds.clone()
+
+		// Spy on the underlying measurement call to detect cache misses.
+		const measureSpy = vi.spyOn(editor.textMeasure, 'measureHtml')
+		measureSpy.mockClear()
+
+		editor.user.updateUserPreferences({ colorScheme: 'dark' })
+
+		// Re-reading geometry must not trigger a new text measurement — only colors changed.
+		const afterToggleBounds = editor.getShapeGeometry(textId).bounds
+		expect(measureSpy).not.toHaveBeenCalled()
+		expect(afterToggleBounds.width).toBe(initialBounds.width)
+		expect(afterToggleBounds.height).toBe(initialBounds.height)
+
+		// And the shape util's min dimensions should be stable too.
+		const util = editor.getShapeUtil('text') as TextShapeUtil
+		const shape = editor.getShape<TLTextShape>(textId)!
+		const minDims = util.getMinDimensions(shape)
+		expect(minDims.width).toBe(initialBounds.width)
+		expect(minDims.height).toBe(initialBounds.height)
+		expect(measureSpy).not.toHaveBeenCalled()
+		measureSpy.mockRestore()
+	})
+
+	it('still updates dimensions when the theme definition changes font size', () => {
+		const textId = createShapeId('text')
+		editor.createShapes([
+			{
+				id: textId,
+				type: 'text',
+				x: 0,
+				y: 0,
+				props: { richText: toRichText('hello world') },
+			},
+		])
+
+		const initialBounds = editor.getShapeGeometry(textId).bounds.clone()
+
+		// Doubling the theme font size must invalidate the size cache.
+		editor.updateTheme({ ...editor.getTheme('default')!, fontSize: 32 })
+
+		const afterBounds = editor.getShapeGeometry(textId).bounds
+		expect(afterBounds.height).toBeGreaterThan(initialBounds.height)
 	})
 })

--- a/packages/tldraw/src/test/displayValuesRender.test.tsx
+++ b/packages/tldraw/src/test/displayValuesRender.test.tsx
@@ -1,0 +1,59 @@
+import { act } from '@testing-library/react'
+import { createShapeId } from '@tldraw/editor'
+import { DrawShapeUtil } from '../lib/shapes/draw/DrawShapeUtil'
+import { getDisplayValues } from '../lib/shapes/shared/getDisplayValues'
+import { Tldraw } from '../lib/Tldraw'
+import { createDrawSegments } from '../lib/utils/test-helpers'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+it('re-renders draw shape colors when color mode toggles', async () => {
+	// The draw component passes useColorMode() into getDisplayValues explicitly; without
+	// that, its colors would render stale after a light/dark toggle.
+	const { editor, rendered } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+
+	const drawId = createShapeId('draw')
+	await act(async () => {
+		editor.user.updateUserPreferences({ colorScheme: 'light' })
+		editor.createShapes([
+			{
+				id: drawId,
+				type: 'draw',
+				x: 0,
+				y: 0,
+				props: {
+					segments: createDrawSegments([
+						[
+							{ x: 0, y: 0, z: 0.5 },
+							{ x: 100, y: 100, z: 0.5 },
+						],
+					]),
+					isComplete: true,
+				},
+			},
+		])
+	})
+
+	const util = editor.getShapeUtil('draw') as DrawShapeUtil
+	const shape = editor.getShape(drawId)!
+	const lightStroke = getDisplayValues(util, shape, 'light').strokeColor
+	const darkStroke = getDisplayValues(util, shape, 'dark').strokeColor
+	expect(lightStroke).not.toBe(darkStroke)
+
+	const paintedColors = () =>
+		Array.from(rendered.container.querySelectorAll('path')).map(
+			(path) => path.getAttribute('fill') ?? path.getAttribute('stroke')
+		)
+
+	expect(paintedColors()).toContain(lightStroke)
+	expect(paintedColors()).not.toContain(darkStroke)
+
+	await act(async () => {
+		editor.user.updateUserPreferences({ colorScheme: 'dark' })
+	})
+
+	expect(paintedColors()).toContain(darkStroke)
+	expect(paintedColors()).not.toContain(lightStroke)
+})


### PR DESCRIPTION
In order to stop light/dark toggles from janking canvases full of text shapes (closes #8678), this PR makes `getDisplayValues` read the color mode without creating a reactive dependency on it when no explicit `colorMode` is passed. Within a theme, light and dark only differ in colors — font size, line height, padding, and stroke width are identical — so the computed caches that call `getDisplayValues` for measurement and geometry (text size, arrow labels, `getGeometry`, arrow info) no longer invalidate and re-measure on every toggle.

This is an alternative to #8906, which kept the capturing default and added a separate `getDimensionDisplayValues` for cache-safe call sites. That approach works but leaves a footgun: every size-sensitive caller (including custom shape authors) must remember to reach for the dimension variant, and forgetting is an invisible perf cliff. This PR flips the failure mode instead: the default is now cache-safe, and callers that render colors opt into color-mode reactivity by passing `colorMode` explicitly — `useColorMode()` in components, `ctx.colorMode` in exports. Forgetting that is loud and benign (colors don't live-update on toggle) rather than silent jank. Almost every default shape component already passed `colorMode` explicitly; this updates the three that didn't (draw, arrow, and highlight's main `component()`), matching the pattern highlight's `backgroundComponent` already used. No new public API is added.

The behavior change for SDK users: custom shape components that call `getDisplayValues(this, shape)` bare will keep rendering the colors from mount time when the user toggles light/dark. The fix is one line — pass `useColorMode()` — and is documented on `getDisplayValues`. Dimension values remain correct in all cases (assuming `getCustomDisplayValues` overrides don't derive dimensions from `colorMode`, which the docs now note).

### Change type

- [x] `improvement`

### Test plan

1. Open a canvas with many text, geo, note, and arrow-label shapes.
2. Toggle light/dark mode; confirm no re-measurement jank and that shape colors still update.

- [x] Unit tests

New tests assert that a computed reading dimension values does not recompute on color-mode toggle, that the text-size cache is not invalidated (spying `textMeasure.measureHtml`), that passing `colorMode` from a reactive read does create the dependency, that theme-definition changes (font size) still invalidate, and a rendered-component test that toggles color scheme and asserts the draw shape repaints.

### API changes

- Changed `getDisplayValues` to read the current color mode without reactive capture when `colorMode` is omitted. Callers that render colors and need live updates on light/dark toggle must pass `colorMode` explicitly (`useColorMode()` in components, `ctx.colorMode` in exports). Signature is unchanged.

### Release notes

- Improve light/dark mode toggle performance: size and geometry caches are no longer invalidated by color-mode changes. If a custom shape component calls `getDisplayValues` without a `colorMode`, pass `useColorMode()` to keep its colors updating live on toggle.

### Code changes

| Section | Net LOC |
| --- | --- |
| Core code | +18 |
| Tests | +162 |
