### PR TITLE
ci(release-crew): add Discord username mapping, run earlier at 08:07 UTC

### DIFF
--- a/.github/workflows/post-release-crew.yml
+++ b/.github/workflows/post-release-crew.yml
@@ -1,15 +1,17 @@
 name: Post release crew to Discord
 
-# Every Wednesday at 09:30 UTC, post to #development naming the people whose critical
+# Every Wednesday at 08:07 UTC, post to #development naming the people whose critical
 # fixes / significant features are in this week's dotcom release.
 # GitHub cron is UTC-only. We use a single fixed UTC time (no BST/GMT adjustment) so
-# the job never fires twice: 09:30 UTC is 09:30 in London during winter (GMT) and
-# 10:30 during summer (BST). To change the day, edit the day-of-week field
+# the job never fires twice: 08:07 UTC is 08:07 in London during winter (GMT) and
+# 09:07 during summer (BST). GitHub often starts scheduled runs 15-60 minutes late,
+# so this is scheduled early (and off the congested :00/:30 slots) to land before
+# the working day ramps up. To change the day, edit the day-of-week field
 # (`3` = Wednesday) in the cron line.
 
 on:
   schedule:
-    - cron: '30 9 * * 3' # Wednesday 09:30 UTC
+    - cron: '7 8 * * 3' # Wednesday 08:07 UTC
   workflow_dispatch: # allow manual runs
 
 concurrency:

--- a/skills/dotcom-release-crew/SKILL.md
+++ b/skills/dotcom-release-crew/SKILL.md
@@ -54,7 +54,28 @@ Only go above 3 people in extraordinary weeks — for example a large migration 
 
 ### 3. Compose the message
 
-Keep it under 2000 characters (Discord's limit). One bullet per person; if someone has multiple notable changes, list them under one bullet. Use plain names — do not attempt Discord `@` mentions.
+Keep it under 2000 characters (Discord's limit). One bullet per person; if someone has multiple notable changes, list them under one bullet. Use plain names — do not attempt Discord `@` mentions (webhook mentions need numeric user IDs, which we don't have).
+
+For the name in parentheses, use the contributor's Discord username from the table below so people are recognizable in the channel. If a GitHub login is not in the table, fall back to the GitHub login.
+
+| GitHub login      | Name              | Discord username  |
+| ----------------- | ----------------- | ----------------- |
+| `angrycaptain19`  | Tim               | `trg1379`         |
+| `AniKrisn`        | Ani Krishnan      | `anikrisn`        |
+| `audrey17leo`     | Audrey            | `dreiiz`          |
+| `danieljamesross` | Dan Ross          | `djrdjrdjr`       |
+| `driev`           | Niall             | `driev_`          |
+| `frolic`          | Kevin Ingersoll   | `frolic`          |
+| `jsscclr`         | Jessica Edwards   | `jsscclr`         |
+| `kaneel`          | Guillaume Richard | `guillaumetldraw` |
+| `kostyafarber`    | Kostya Farber     | `kostyafarber`    |
+| `m31-galaxy`      | Andy (Andromeda)  | `m31_galaxy`      |
+| `max-drake`       | Max Drake         | `max__drake`      |
+| `meg-an31`        | Megan Walker      | `megelia`         |
+| `mimecuvalo`      | Mime Čuvalo       | `mimecuvalo`      |
+| `MitjaBezensek`   | Mitja Bezenšek    | `mitja_bezensek`  |
+| `nattofu`         | Leo               | `nattotofu`       |
+| `steveruizok`     | Steve Ruiz        | `steveruizok`     |
 
 Format:
 


### PR DESCRIPTION
Follow-up to #9539. Two tweaks from the first real week of the release-crew post:

- The 09:30 UTC cron fired ~40 minutes late (GitHub schedules routinely slip 15–60 minutes, worst at :00/:30), so the message landed too late in the morning. The schedule moves to 08:07 UTC — an off-peak minute, early enough that even a delayed run posts before the working day ramps up.
- The skill now has a GitHub login → Discord username table so the name in parentheses is the person's Discord handle rather than their GitHub login, making contributors recognizable in the channel. Usernames were verified against tldraw org membership. Still plain text, no `@`-mentions — webhook mentions need numeric user IDs.

### Change type

- [x] `other`

### Test plan

1. Trigger the workflow via `workflow_dispatch` and confirm the post uses Discord usernames in parentheses.
2. Confirm the scheduled run fires Wednesday morning (08:07 UTC + GitHub's usual delay).

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +28 / -5   |