### PR TITLE
fix(tldraw): validate url before treating as external content

### DIFF
--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
@@ -8,7 +8,10 @@ import {
 } from '@tldraw/editor'
 import { TestEditor } from '../test/TestEditor'
 import { defaultAssetUtils } from './defaultAssetUtils'
-import { notifyIfFileNotAllowed } from './defaultExternalContentHandlers'
+import {
+	defaultHandleExternalUrlContent,
+	notifyIfFileNotAllowed,
+} from './defaultExternalContentHandlers'
 
 // A custom asset type used only in this test. We avoid declaring it via
 // `TLGlobalAssetPropsMap` module augmentation because that would leak into
@@ -171,5 +174,53 @@ describe('notifyIfFileNotAllowed', () => {
 		expect(addToast).toHaveBeenCalledWith(
 			expect.objectContaining({ title: 'assets.files.size-too-big' })
 		)
+	})
+})
+
+describe('defaultHandleExternalUrlContent', () => {
+	let editor: TestEditor
+
+	afterEach(() => {
+		editor?.dispose()
+	})
+
+	it('creates a bookmark for a valid http(s) url', async () => {
+		editor = new TestEditor()
+		const { opts, addToast } = makeOpts()
+
+		await defaultHandleExternalUrlContent(
+			editor,
+			{ url: 'https://example.com', point: { x: 0, y: 0 } },
+			opts
+		)
+
+		const shapes = editor.getCurrentPageShapes()
+		expect(shapes.length).toBe(1)
+		expect(shapes[0].type).toBe('bookmark')
+		expect(addToast).not.toHaveBeenCalled()
+	})
+
+	it('ignores a url with an invalid protocol without crashing or toasting', async () => {
+		// Regression test for #8097: dragging content from a browser tab in Chrome
+		// with an ad blocker active supplies a DataTransfer url rewritten to
+		// `about:blank#blocked`. That protocol is not valid for a bookmark shape's
+		// `url` prop (T.linkUrl), so creating one threw a ValidationError. These
+		// urls are never user-intended content, so we ignore them silently rather
+		// than crashing or showing a misleading "couldn't load link" toast.
+		editor = new TestEditor()
+		const { opts, addToast } = makeOpts()
+
+		await expect(
+			defaultHandleExternalUrlContent(
+				editor,
+				{ url: 'about:blank#blocked', point: { x: 0, y: 0 } },
+				opts
+			)
+		).resolves.not.toThrow()
+
+		// No bookmark (or any shape) should be created for the invalid url, and no
+		// error toast should be shown.
+		expect(editor.getCurrentPageShapes()).toEqual([])
+		expect(addToast).not.toHaveBeenCalled()
 	})
 })

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
@@ -5,7 +5,6 @@ import {
 	T,
 	TLAsset,
 	TLAssetId,
-	TLTextShape,
 } from '@tldraw/editor'
 import { TestEditor } from '../test/TestEditor'
 import { defaultAssetUtils } from './defaultAssetUtils'
@@ -202,18 +201,18 @@ describe('defaultHandleExternalUrlContent', () => {
 		expect(addToast).not.toHaveBeenCalled()
 	})
 
-	it('falls back to a text shape for a url with an invalid protocol', async () => {
+	it('shows a toast and logs the url for a url with an invalid protocol', async () => {
 		// Regression test for #8097: dragging content from a browser tab in Chrome
 		// with an ad blocker active supplies a DataTransfer url rewritten to
 		// `about:blank#blocked`. That protocol is not valid for a bookmark shape's
 		// `url` prop (T.linkUrl), so creating one threw a ValidationError and
-		// crashed the editor. We now drop the raw string as a text shape instead,
-		// which keeps the content visible and never throws.
+		// crashed the editor. We now surface a toast to the user and warn with the
+		// offending url for local debugging instead, and never throw or create a
+		// shape.
 		editor = new TestEditor()
 		const { opts, addToast } = makeOpts()
-		// The text fallback routes through putExternalContent({ type: 'text' }),
-		// so the default handlers need to be registered for it to create a shape.
 		registerDefaultExternalContentHandlers(editor, opts)
+		const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
 		await expect(
 			defaultHandleExternalUrlContent(
@@ -223,17 +222,12 @@ describe('defaultHandleExternalUrlContent', () => {
 			)
 		).resolves.not.toThrow()
 
-		const shapes = editor.getCurrentPageShapes()
-		expect(shapes.length).toBe(1)
-		expect(shapes[0].type).toBe('text')
-		expect((shapes[0] as TLTextShape).props.richText).toMatchObject({
-			content: [
-				{
-					type: 'paragraph',
-					content: [{ type: 'text', text: 'about:blank#blocked' }],
-				},
-			],
-		})
-		expect(addToast).not.toHaveBeenCalled()
+		expect(editor.getCurrentPageShapes()).toEqual([])
+		expect(addToast).toHaveBeenCalledWith(
+			expect.objectContaining({ title: 'assets.url.failed', severity: 'error' })
+		)
+		expect(consoleWarn).toHaveBeenCalledWith(expect.stringContaining('about:blank#blocked'))
+
+		consoleWarn.mockRestore()
 	})
 })

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.test.ts
@@ -5,12 +5,14 @@ import {
 	T,
 	TLAsset,
 	TLAssetId,
+	TLTextShape,
 } from '@tldraw/editor'
 import { TestEditor } from '../test/TestEditor'
 import { defaultAssetUtils } from './defaultAssetUtils'
 import {
 	defaultHandleExternalUrlContent,
 	notifyIfFileNotAllowed,
+	registerDefaultExternalContentHandlers,
 } from './defaultExternalContentHandlers'
 
 // A custom asset type used only in this test. We avoid declaring it via
@@ -200,15 +202,18 @@ describe('defaultHandleExternalUrlContent', () => {
 		expect(addToast).not.toHaveBeenCalled()
 	})
 
-	it('ignores a url with an invalid protocol without crashing or toasting', async () => {
+	it('falls back to a text shape for a url with an invalid protocol', async () => {
 		// Regression test for #8097: dragging content from a browser tab in Chrome
 		// with an ad blocker active supplies a DataTransfer url rewritten to
 		// `about:blank#blocked`. That protocol is not valid for a bookmark shape's
-		// `url` prop (T.linkUrl), so creating one threw a ValidationError. These
-		// urls are never user-intended content, so we ignore them silently rather
-		// than crashing or showing a misleading "couldn't load link" toast.
+		// `url` prop (T.linkUrl), so creating one threw a ValidationError and
+		// crashed the editor. We now drop the raw string as a text shape instead,
+		// which keeps the content visible and never throws.
 		editor = new TestEditor()
 		const { opts, addToast } = makeOpts()
+		// The text fallback routes through putExternalContent({ type: 'text' }),
+		// so the default handlers need to be registered for it to create a shape.
+		registerDefaultExternalContentHandlers(editor, opts)
 
 		await expect(
 			defaultHandleExternalUrlContent(
@@ -218,9 +223,17 @@ describe('defaultHandleExternalUrlContent', () => {
 			)
 		).resolves.not.toThrow()
 
-		// No bookmark (or any shape) should be created for the invalid url, and no
-		// error toast should be shown.
-		expect(editor.getCurrentPageShapes()).toEqual([])
+		const shapes = editor.getCurrentPageShapes()
+		expect(shapes.length).toBe(1)
+		expect(shapes[0].type).toBe('text')
+		expect((shapes[0] as TLTextShape).props.richText).toMatchObject({
+			content: [
+				{
+					type: 'paragraph',
+					content: [{ type: 'text', text: 'about:blank#blocked' }],
+				},
+			],
+		})
 		expect(addToast).not.toHaveBeenCalled()
 	})
 })

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -1,6 +1,7 @@
 import {
 	AssetRecordType,
 	Editor,
+	T,
 	TLAsset,
 	TLAssetId,
 	TLBookmarkAsset,
@@ -577,6 +578,15 @@ export async function defaultHandleExternalUrlContent(
 	{ point, url }: { point?: VecLike; url: string },
 	{ toasts, msg }: TLDefaultExternalContentHandlerOpts
 ) {
+	// Ignore urls with a protocol we can't turn into a bookmark (bookmark shapes
+	// validate their `url` prop with T.linkUrl). Dropping content from a browser
+	// tab in Chrome with an ad blocker active supplies a url rewritten to
+	// `about:blank#blocked`; these are never user-intended content, so we ignore
+	// them silently rather than crashing on the validation error (#8097).
+	if (!T.linkUrl.isValid(url)) {
+		return
+	}
+
 	// try to paste as an embed first
 	const embedUtil = editor.getShapeUtil('embed') as EmbedShapeUtil | undefined
 	const embedInfo = embedUtil?.getEmbedDefinition(url)

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -578,12 +578,14 @@ export async function defaultHandleExternalUrlContent(
 	{ point, url }: { point?: VecLike; url: string },
 	{ toasts, msg }: TLDefaultExternalContentHandlerOpts
 ) {
-	// Ignore urls with a protocol we can't turn into a bookmark (bookmark shapes
-	// validate their `url` prop with T.linkUrl). Dropping content from a browser
-	// tab in Chrome with an ad blocker active supplies a url rewritten to
-	// `about:blank#blocked`; these are never user-intended content, so we ignore
-	// them silently rather than crashing on the validation error (#8097).
+	// If the url isn't one we can turn into a bookmark (bookmark shapes validate
+	// their `url` prop with T.linkUrl), fall back to dropping the raw string as a
+	// text shape rather than crashing on the validation error (#8097). Chrome with
+	// an ad blocker active rewrites dragged content urls to `about:blank#blocked`,
+	// which isn't a valid bookmark protocol; the text fallback keeps the drop from
+	// throwing while leaving whatever was dropped visible.
 	if (!T.linkUrl.isValid(url)) {
+		await editor.putExternalContent({ type: 'text', text: url, point })
 		return
 	}
 

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -578,14 +578,19 @@ export async function defaultHandleExternalUrlContent(
 	{ point, url }: { point?: VecLike; url: string },
 	{ toasts, msg }: TLDefaultExternalContentHandlerOpts
 ) {
-	// If the url isn't one we can turn into a bookmark (bookmark shapes validate
-	// their `url` prop with T.linkUrl), fall back to dropping the raw string as a
-	// text shape rather than crashing on the validation error (#8097). Chrome with
-	// an ad blocker active rewrites dragged content urls to `about:blank#blocked`,
-	// which isn't a valid bookmark protocol; the text fallback keeps the drop from
-	// throwing while leaving whatever was dropped visible.
+	// Bookmark shapes validate their `url` prop with T.linkUrl, so a url we can't
+	// turn into a bookmark would throw a ValidationError and crash the editor
+	// (#8097) — e.g. Chrome with an ad blocker active rewrites dragged content
+	// urls to `about:blank#blocked`. This is a known, handled condition rather
+	// than a bug, so we tell the user with a toast and warn (not error) with the
+	// offending url as a local debugging breadcrumb — deliberately not reported
+	// to error tracking, where it would just be non-actionable noise.
 	if (!T.linkUrl.isValid(url)) {
-		await editor.putExternalContent({ type: 'text', text: url, point })
+		console.warn(`Could not create a bookmark from an invalid url: ${JSON.stringify(url)}`)
+		toasts.addToast({
+			title: msg('assets.url.failed'),
+			severity: 'error',
+		})
 		return
 	}
 


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/8097 

This one case seems to occur when trying to drag files from one tab to the url which end up beind treated as an url which is blocked, somehow, by an adblocker. 

I could not reproduce entirely but seems plausible and @MitjaBezensek filed it after the error occured for an user and figured that it was because of an adblocker, we should anyway gracefully fail when an url is not valid, seems the right thing to do

### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Drag an SVG from a browser tab (not file system) onto the tldraw canvas in Chrome
(url and adblocker TBD)
2. App does not crashes with "Something went wrong" error page

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug occuring when dragging blocked content from tabs to the canvas. 