### PR TITLE
ci(release-notes): use repo-level HUPPY_PRIVATE_KEY secret

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -32,7 +32,7 @@ jobs:
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
         with:
           app_id: ${{ secrets.HUPPY_APP_ID }}
-          private_key: ${{ secrets.HUPPY_APP_PRIVATE_KEY }}
+          private_key: ${{ secrets.HUPPY_PRIVATE_KEY }}
 
       - name: Check out code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

The [update-release-notes workflow failed](https://github.com/tldraw/tldraw/actions/runs/29404748106/job/87317376110) on the production push with:

```
Error: Input required and not supplied: private_key
```

The "Generate GH token" step read the GitHub App private key from `secrets.HUPPY_APP_PRIVATE_KEY`. That secret only exists inside the `npm deploy` environment, but this job declares no `environment:`, so the reference resolved to an empty string and `tibdex/github-app-token` errored on the missing `private_key`.

This was latent from #9580, which wired the workflow to trigger on production pushes while referencing an environment-scoped secret the job can't see.

## Fix

Point the step at the repo-level `HUPPY_PRIVATE_KEY` secret (which exists alongside repo-level `HUPPY_APP_ID`), matching the pattern already used in `trigger-production-build.yml`. This avoids joining the `npm deploy` environment and its protection rules.

## Change type

- [x] `other`