### PR TITLE
ci(release-notes): fix invalid --skip-permissions flag

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Run update-release-notes skill
         run: |
-          claude --skip-permissions --print "/update-release-notes"
+          claude --dangerously-skip-permissions --print "/update-release-notes"
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Summary

The `update-release-notes` workflow was failing because it invoked Claude Code with `--skip-permissions`, which is not a valid flag:

```
error: unknown option '--skip-permissions'
```

The correct flag is `--dangerously-skip-permissions`, which is already used correctly in the sibling `post-release-crew.yml` workflow.

Failing run: https://github.com/tldraw/tldraw/actions/runs/29445810899/job/87455868633

## Change

- `.github/workflows/update-release-notes.yml`: `--skip-permissions` → `--dangerously-skip-permissions`

## Change type

- [x] `other`