### PR TITLE
feat(examples): comment on a text range

### DIFF
--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -4,6 +4,7 @@ import {
 	commentTools,
 	putCommentRecords,
 } from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useMemo } from 'react'
 import {
 	commentSchemaRecords,
@@ -92,6 +93,9 @@ export default function CommentAnchorsExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
+				// Commenting is a licensed feature. Every feature is enabled in local development, but a
+				// deployed app needs a license key that includes commenting — swap in your own key here.
+				licenseKey={getLicenseKey()}
 				store={store}
 				onMount={handleMount}
 				tools={commentTools}

--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -18,6 +18,7 @@ import {
 	Tldraw,
 	toRichText,
 } from 'tldraw'
+import '@tldraw/commenting/commenting.css'
 import 'tldraw/tldraw.css'
 
 const NAMES: Record<string, string> = { ada: 'Ada Lovelace', me: 'You' }

--- a/apps/examples/src/examples/collaboration/comment-anchors/README.md
+++ b/apps/examples/src/examples/collaboration/comment-anchors/README.md
@@ -16,6 +16,6 @@ Every comment thread carries an `anchor` — a discriminated union that says whe
 - **point** — a bare page coordinate, unattached to any shape.
 - **region** — a rectangular area; the pin sits on a corner and the region box is drawn.
 
-Two more anchor kinds exist but the default overlay doesn't give them a distinct pin: **page** anchors attach a thread to the whole board (no pin — they surface in a comments list instead), and **text-range** anchors attach a thread to a character range within a text shape.
+Two more anchor kinds exist but the default overlay doesn't give them a distinct pin: **page** anchors attach a thread to the whole board (no pin — they surface in a comments list instead), and **text-range** anchors attach a thread to a character range within a text shape — the "Comment on a text range" example shows a full text-range flow.
 
 Drag the shape around to watch the shape-anchored pins follow it, or pick the comment tool and click to add your own thread anchored wherever you place it.

--- a/apps/examples/src/examples/collaboration/comment-clustering/CommentClusteringExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-clustering/CommentClusteringExample.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tldraw/commenting'
 import { useMemo } from 'react'
 import { Editor, TLComponents, Tldraw, useEditor, useValue } from 'tldraw'
+import '@tldraw/commenting/commenting.css'
 import 'tldraw/tldraw.css'
 import './comment-clustering.css'
 

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/CommentTextRangesExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/CommentTextRangesExample.tsx
@@ -5,6 +5,7 @@ import {
 	pendingComment,
 	putCommentRecords,
 } from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useEffect, useMemo, useState } from 'react'
 import {
 	DefaultRichTextToolbar,
@@ -176,6 +177,9 @@ export default function CommentTextRangesExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
+				// Commenting is a licensed feature. Every feature is enabled in local development, but a
+				// deployed app needs a license key that includes commenting — swap in your own key here.
+				licenseKey={getLicenseKey()}
 				store={store}
 				onMount={handleMount}
 				tools={commentTools}

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/CommentTextRangesExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/CommentTextRangesExample.tsx
@@ -1,0 +1,187 @@
+import {
+	CanvasComments,
+	commentToolOverrides,
+	commentTools,
+	pendingComment,
+	putCommentRecords,
+} from '@tldraw/commenting'
+import { useEffect, useMemo, useState } from 'react'
+import {
+	DefaultRichTextToolbar,
+	DefaultRichTextToolbarContent,
+	Editor,
+	TLComponents,
+	Tldraw,
+	TldrawUiButtonIcon,
+	TldrawUiToolbarButton,
+	commentSchemaRecords,
+	createComment,
+	createCommentThread,
+	createShapeId,
+	createTLSchema,
+	createTLStore,
+	preventDefault,
+	toRichText,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import '@tldraw/commenting/commenting.css'
+import 'tldraw/tldraw.css'
+import { TextRangeHighlights } from './TextRangeHighlights'
+import './comment-text-ranges.css'
+
+const NAMES: Record<string, string> = { ada: 'Ada Lovelace', me: 'You' }
+const resolveName = (id: string): string => NAMES[id] ?? id
+
+/**
+ * Turn the current text selection into a pending `text-range` comment: read the tiptap selection
+ * of the shape being edited, convert the ProseMirror positions to plaintext character offsets, and
+ * open the comment composer anchored to that range. Posting from the composer creates the thread
+ * and comment through the normal pending-comment flow — no extra records needed.
+ *
+ * A `text-range` anchor's `from`/`to` are plaintext offsets (not ProseMirror positions), so the
+ * highlight overlay can walk the shape's rendered text nodes to measure the range. Note that plain
+ * offsets don't re-track if the text is edited later — a production version would keep them in
+ * sync with a tiptap mark or by mapping positions through document changes.
+ */
+function startTextRangeComment(editor: Editor) {
+	const textEditor = editor.getRichTextEditor()
+	if (!textEditor) return
+
+	const shapeId = editor.getEditingShapeId()
+	if (!shapeId) return
+
+	const { from, to, empty } = textEditor.state.selection
+	if (empty) return
+
+	const doc = textEditor.state.doc
+	const anchorFrom = doc.textBetween(0, from).length
+	const anchorTo = doc.textBetween(0, to).length
+	if (anchorFrom === anchorTo) return
+
+	// The composer opens at the shape's top-right corner, where the overlay pins text-range threads.
+	const bounds = editor.getShapePageBounds(shapeId)
+	if (!bounds) return
+
+	// End the editing session — the composer takes over from here, and the highlight overlay can
+	// only measure the shape's static text DOM, which is unmounted while the shape is being edited.
+	editor.setEditingShape(null)
+
+	pendingComment.set(editor, {
+		anchor: { type: 'text-range', shapeId, from: anchorFrom, to: anchorTo },
+		point: { x: bounds.maxX, y: bounds.minY },
+	})
+}
+
+/**
+ * The default rich text toolbar plus a comment button. The button is disabled until some text is
+ * selected; pressing it hands the selection to `startTextRangeComment`.
+ */
+function CommentRichTextToolbar() {
+	const editor = useEditor()
+	const textEditor = useValue('textEditor', () => editor.getRichTextEditor(), [editor])
+
+	// Re-render on every tiptap transaction so the button's disabled state tracks the selection.
+	const [, setTick] = useState(0)
+	useEffect(() => {
+		if (!textEditor) return
+		const onTransaction = () => setTick((t) => t + 1)
+		textEditor.on('transaction', onTransaction)
+		return () => {
+			textEditor.off('transaction', onTransaction)
+		}
+	}, [textEditor])
+
+	if (!textEditor) return null
+
+	const canComment = textEditor.view ? !textEditor.state.selection.empty : false
+
+	return (
+		<DefaultRichTextToolbar>
+			<DefaultRichTextToolbarContent textEditor={textEditor} />
+			<TldrawUiToolbarButton
+				title="Comment"
+				data-testid="rich-text.comment"
+				type="icon"
+				disabled={!canComment}
+				// Keep the text selection and editing session alive when the button is pressed.
+				onPointerDown={preventDefault}
+				onClick={() => startTextRangeComment(editor)}
+				role="option"
+			>
+				<TldrawUiButtonIcon small icon="comment" />
+			</TldrawUiToolbarButton>
+		</DefaultRichTextToolbar>
+	)
+}
+
+const components: TLComponents = {
+	RichTextToolbar: CommentRichTextToolbar,
+	InFrontOfTheCanvas: () => (
+		<>
+			<TextRangeHighlights />
+			<CanvasComments currentUserId="me" resolveName={resolveName} />
+		</>
+	),
+}
+
+const SEEDED_TEXT =
+	'Double-click to edit this text, select a few words, and press the comment button in the toolbar.'
+
+export default function CommentTextRangesExample() {
+	// Comments are `comment-thread` and `comment` records in the editor's own store; registering
+	// `commentSchemaRecords` on the schema is all it takes to store them alongside shapes.
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	const handleMount = (editor: Editor) => {
+		const textId = createShapeId()
+		editor.run(
+			() => {
+				editor.createShapes([
+					{
+						id: textId,
+						type: 'text',
+						x: 120,
+						y: 160,
+						props: { richText: toRichText(SEEDED_TEXT), w: 440, autoSize: false },
+					},
+				])
+
+				// Seed one thread on the words "comment button" so a highlight is visible right away.
+				const from = SEEDED_TEXT.indexOf('comment button')
+				const to = from + 'comment button'.length
+				const pageId = editor.getCurrentPageId()
+				const thread = createCommentThread({
+					pageId,
+					anchor: { type: 'text-range', shapeId: textId, from, to },
+					createdBy: 'ada',
+				})
+				const comment = createComment({
+					threadId: thread.id,
+					pageId,
+					authorId: 'ada',
+					body: toRichText('This range is commented — click the highlight to open the thread.'),
+				})
+				putCommentRecords(editor, [thread, comment])
+			},
+			{ history: 'ignore' }
+		)
+
+		editor.zoomToBounds({ x: 40, y: 60, w: 620, h: 320 }, { immediate: true })
+	}
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				store={store}
+				onMount={handleMount}
+				tools={commentTools}
+				overrides={[commentToolOverrides]}
+				components={components}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/README.md
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/README.md
@@ -1,7 +1,7 @@
 ---
 title: Comment on a text range
 component: ./CommentTextRangesExample.tsx
-priority: 5
+priority: 6
 keywords:
   [comments, commenting, text range, rich text, toolbar, selection, highlight, collaboration]
 ---

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/README.md
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/README.md
@@ -1,0 +1,22 @@
+---
+title: Comment on a text range
+component: ./CommentTextRangesExample.tsx
+priority: 5
+keywords:
+  [comments, commenting, text range, rich text, toolbar, selection, highlight, collaboration]
+---
+
+Comment on a selected range of text from the rich text toolbar.
+
+---
+
+Comment threads can anchor to a character range inside a shape's text with a `text-range` anchor: `{ type: 'text-range', shapeId, from, to }`, where `from`/`to` are plaintext character offsets. This example wires that anchor kind up end to end: double-click the text shape to edit it, select a few words, and press the comment button that appears in the rich text toolbar. The composer opens anchored to the selection, and the commented characters are highlighted on the canvas.
+
+Two pieces make it work:
+
+- **The toolbar button.** A custom `RichTextToolbar` component renders the default toolbar content plus a comment button (disabled while the selection is collapsed). Pressing it reads the tiptap selection, converts the ProseMirror positions to plaintext offsets, and sets `pendingComment` with a `text-range` anchor — the same pending-comment flow the comment tool uses, so posting from the composer creates the thread and comment records normally.
+- **The highlight overlay.** `TextRangeHighlights` draws a highlight over each text-range thread's characters (and the pending draft's). It finds the shape's rendered `.tl-rich-text` element, maps the plaintext offsets to DOM positions with a `Range`, and re-measures whenever the camera or shape moves, so the highlight stays glued to the text. Clicking a committed highlight opens its thread.
+
+`CanvasComments` already pins text-range threads to their shape's corner, so the pins, popovers, and composer all come from the stock overlay — the example only adds the button and the highlights.
+
+One caveat to note: plaintext offsets don't re-track when the text is edited later, so a production implementation would keep anchors in sync with a tiptap mark or by mapping positions through document changes.

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
@@ -91,19 +91,21 @@ function TextRangeHighlight({
 	to,
 	onSelect,
 }: TextRangeHighlightProps) {
-	// A token that changes whenever the range's on-screen position could have — camera, the shape's
-	// position/rotation/text, and the viewport size. Reading these subscribes the effect below.
+	// A token that changes whenever the range's on-screen position could have — the camera, the
+	// shape's page transform (which covers parent groups/frames too), and its props (size, text,
+	// font — anything that reflows the text). Reading these subscribes the effect below.
 	const token = useValue(
 		'text-range highlight token',
 		() => {
 			const cam = editor.getCamera()
 			const shape = editor.getShape(shapeId)
+			if (!shape) return null
+			const transform = editor.getShapePageTransform(shapeId)
 			const vsb = editor.getViewportScreenBounds()
 			// Editing state matters: the static `.tl-rich-text` we measure only mounts once the shape
 			// leaves edit mode, so re-measure when editing ends (e.g. the composer takes focus).
 			const editing = editor.getEditingShapeId() === shapeId
-			if (!shape) return null
-			return `${cam.x},${cam.y},${cam.z},${shape.x},${shape.y},${shape.rotation},${vsb.w},${vsb.h},${editing}`
+			return `${cam.x},${cam.y},${cam.z}|${transform.toCssString()}|${JSON.stringify(shape.props)}|${vsb.w},${vsb.h}|${editing}`
 		},
 		[editor, shapeId]
 	)

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
@@ -1,0 +1,195 @@
+import { openThreadId, useCommentThreads, usePendingComment } from '@tldraw/commenting'
+import { useLayoutEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Editor, TLShapeId, useContainer, useEditor, useValue } from 'tldraw'
+
+interface HighlightRect {
+	left: number
+	top: number
+	width: number
+	height: number
+}
+
+/**
+ * The rendered rich-text element for a shape — the on-canvas one, not the hidden measurement clone
+ * (`.tl-text-measure`) tldraw keeps around for autosizing. Returns null while the shape's text DOM
+ * isn't mounted (e.g. the shape is culled, or it's being edited through the tiptap overlay).
+ */
+function findRenderedText(container: HTMLElement, shapeId: TLShapeId): Element | null {
+	const shapeEl = container.querySelector(`[data-shape-id="${shapeId}"]`)
+	if (!shapeEl) return null
+	const nodes = [...shapeEl.querySelectorAll('.tl-rich-text')]
+	return nodes.find((el) => !el.closest('.tl-text-measure')) ?? null
+}
+
+/** Map a plaintext character offset to a DOM text node + local offset, walking the text nodes in
+ *  order. Clamps past-the-end offsets to the end of the last text node. */
+function locate(root: Element, offset: number): { node: Node; offset: number } | null {
+	const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+	let acc = 0
+	let node = walker.nextNode()
+	let last: Node | null = null
+	while (node) {
+		const len = node.textContent?.length ?? 0
+		if (acc + len >= offset) return { node, offset: offset - acc }
+		acc += len
+		last = node
+		node = walker.nextNode()
+	}
+	if (last) return { node: last, offset: last.textContent?.length ?? 0 }
+	return null
+}
+
+/** The client rects (relative to the container) covering a plaintext `[from, to)` range in a
+ *  shape's rendered text. Empty when the text isn't measurable this frame. */
+function measureRange(
+	container: HTMLElement,
+	shapeId: TLShapeId,
+	from: number,
+	to: number
+): HighlightRect[] {
+	const root = findRenderedText(container, shapeId)
+	if (!root) return []
+	const start = locate(root, from)
+	const end = locate(root, to)
+	if (!start || !end) return []
+	const range = document.createRange()
+	try {
+		range.setStart(start.node, start.offset)
+		range.setEnd(end.node, end.offset)
+	} catch {
+		return []
+	}
+	const c = container.getBoundingClientRect()
+	return [...range.getClientRects()].map((r) => ({
+		left: r.left - c.left,
+		top: r.top - c.top,
+		width: r.width,
+		height: r.height,
+	}))
+}
+
+interface TextRangeHighlightProps {
+	editor: Editor
+	container: HTMLElement
+	shapeId: TLShapeId
+	from: number
+	to: number
+	/** A draft highlight (no thread yet) is non-interactive; a committed one opens its thread. */
+	onSelect?(): void
+}
+
+/**
+ * The highlight over a commented character range, kept aligned with the shape's rendered text as
+ * the camera and shape move. `from`/`to` are plaintext offsets into the shape's text.
+ */
+function TextRangeHighlight({
+	editor,
+	container,
+	shapeId,
+	from,
+	to,
+	onSelect,
+}: TextRangeHighlightProps) {
+	// A token that changes whenever the range's on-screen position could have — camera, the shape's
+	// position/rotation/text, and the viewport size. Reading these subscribes the effect below.
+	const token = useValue(
+		'text-range highlight token',
+		() => {
+			const cam = editor.getCamera()
+			const shape = editor.getShape(shapeId)
+			const vsb = editor.getViewportScreenBounds()
+			// Editing state matters: the static `.tl-rich-text` we measure only mounts once the shape
+			// leaves edit mode, so re-measure when editing ends (e.g. the composer takes focus).
+			const editing = editor.getEditingShapeId() === shapeId
+			if (!shape) return null
+			return `${cam.x},${cam.y},${cam.z},${shape.x},${shape.y},${shape.rotation},${vsb.w},${vsb.h},${editing}`
+		},
+		[editor, shapeId]
+	)
+
+	const [rects, setRects] = useState<HighlightRect[]>([])
+
+	// Measure after commit (getClientRects reflects the current layout), then again on the next frame
+	// to catch the canvas transform tldraw applies out of band during camera changes. Also re-measure
+	// when fonts finish loading — a font swap reflows the text without touching camera or shape.
+	useLayoutEffect(() => {
+		if (token === null) {
+			setRects([])
+			return
+		}
+		const measure = () => setRects(measureRange(container, shapeId, from, to))
+		measure()
+		const raf = requestAnimationFrame(measure)
+		document.fonts.addEventListener('loadingdone', measure)
+		return () => {
+			cancelAnimationFrame(raf)
+			document.fonts.removeEventListener('loadingdone', measure)
+		}
+	}, [container, shapeId, from, to, token])
+
+	if (rects.length === 0) return null
+
+	return (
+		<>
+			{rects.map((r, i) => (
+				<div
+					key={i}
+					className="comment-text-range-highlight"
+					data-interactive={onSelect ? true : undefined}
+					style={{ left: r.left, top: r.top, width: r.width, height: r.height }}
+					onPointerDown={
+						onSelect
+							? (e) => {
+									e.stopPropagation()
+									onSelect()
+								}
+							: undefined
+					}
+				/>
+			))}
+		</>
+	)
+}
+
+/**
+ * Renders the highlight for every text-range thread and the pending text-range draft. Portaled
+ * into the editor container so the container-relative rects from `measureRange` line up.
+ */
+export function TextRangeHighlights() {
+	const editor = useEditor()
+	const container = useContainer()
+	const threads = useCommentThreads(editor)
+	const pending = usePendingComment()
+
+	return createPortal(
+		<div className="comment-text-ranges-layer">
+			{threads.map((thread) => {
+				if (thread.anchor.type !== 'text-range') return null
+				const { shapeId, from, to } = thread.anchor
+				return (
+					<TextRangeHighlight
+						key={thread.id}
+						editor={editor}
+						container={container}
+						shapeId={shapeId as TLShapeId}
+						from={from}
+						to={to}
+						onSelect={() => openThreadId.set(editor, thread.id)}
+					/>
+				)
+			})}
+			{pending?.anchor.type === 'text-range' && (
+				<TextRangeHighlight
+					key="pending"
+					editor={editor}
+					container={container}
+					shapeId={pending.anchor.shapeId as TLShapeId}
+					from={pending.anchor.from}
+					to={pending.anchor.to}
+				/>
+			)}
+		</div>,
+		container
+	)
+}

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
@@ -1,4 +1,9 @@
-import { openThreadId, useCommentThreads, usePendingComment } from '@tldraw/commenting'
+import {
+	openThreadId,
+	useCommentsHidden,
+	useCommentThreads,
+	usePendingComment,
+} from '@tldraw/commenting'
 import { useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Editor, TLShapeId, useContainer, useEditor, useValue } from 'tldraw'
@@ -163,6 +168,11 @@ export function TextRangeHighlights() {
 	const container = useContainer()
 	const threads = useCommentThreads(editor)
 	const pending = usePendingComment()
+
+	// Respect the Shift+C "hide comments" toggle, matching CanvasComments — otherwise highlights
+	// would stay visible and clickable while the pins and popovers are hidden.
+	const commentsHidden = useCommentsHidden()
+	if (commentsHidden) return null
 
 	return createPortal(
 		<div className="comment-text-ranges-layer">

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/comment-text-ranges.css
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/comment-text-ranges.css
@@ -1,0 +1,26 @@
+/* The highlight layer is portaled into the editor container, beneath the UI panels, and is
+   click-through except on the highlights themselves. */
+.comment-text-ranges-layer {
+	position: absolute;
+	inset: 0;
+	z-index: var(--tl-layer-canvas-in-front);
+	pointer-events: none;
+}
+
+/* A highlight over a commented character range, tracked to the shape's rendered text. Draft
+   highlights (no thread yet) stay click-through; committed ones open their thread on click. */
+.comment-text-range-highlight {
+	position: absolute;
+	background-color: color-mix(in srgb, var(--tl-color-selected) 22%, transparent);
+	border-radius: 2px;
+	pointer-events: none;
+}
+
+.comment-text-range-highlight[data-interactive='true'] {
+	pointer-events: auto;
+	cursor: pointer;
+}
+
+.comment-text-range-highlight[data-interactive='true']:hover {
+	background-color: color-mix(in srgb, var(--tl-color-selected) 34%, transparent);
+}

--- a/apps/examples/src/examples/collaboration/commenting/CommentingExample.tsx
+++ b/apps/examples/src/examples/collaboration/commenting/CommentingExample.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tldraw/commenting'
 import { useMemo } from 'react'
 import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
+import '@tldraw/commenting/commenting.css'
 import 'tldraw/tldraw.css'
 
 // The people who can be @-mentioned. A real app would pull this from its own roster; the composer

--- a/apps/examples/src/examples/collaboration/commenting/CommentingExample.tsx
+++ b/apps/examples/src/examples/collaboration/commenting/CommentingExample.tsx
@@ -5,6 +5,7 @@ import {
 	filterMentionMembers,
 	MentionMember,
 } from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
 import { useMemo } from 'react'
 import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
 import '@tldraw/commenting/commenting.css'
@@ -56,6 +57,9 @@ export default function CommentingExample() {
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
+				// Commenting is a licensed feature. Every feature is enabled in local development, but a
+				// deployed app needs a license key that includes commenting — swap in your own key here.
+				licenseKey={getLicenseKey()}
 				store={store}
 				tools={commentTools}
 				overrides={[commentToolOverrides]}

--- a/apps/examples/vercel.json
+++ b/apps/examples/vercel.json
@@ -1,6 +1,6 @@
 {
 	"installCommand": "yarn workspaces focus examples.tldraw.com @tldraw/monorepo config",
-	"buildCommand": "cd ../../packages/tldraw && yarn prebuild && cd ../../apps/examples && yarn build",
+	"buildCommand": "cd ../../packages/tldraw && yarn prebuild && cd ../../packages/commenting && yarn prebuild && cd ../../apps/examples && yarn build",
 	"outputDirectory": "dist",
 	"headers": [
 		{

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -129,9 +129,11 @@ export function CommentComposer({
 					if (event.key !== 'Enter' || event.isComposing) return false
 					// While the @-mention picker is open, Enter selects the highlighted member — defer.
 					if (isMentionPickerOpen()) return false
-					// Shift+Enter inserts a new line (a paragraph split; tldraw doesn't do soft breaks).
+					// Shift+Enter inserts a new line. Use the list-aware `enter` command (matching tldraw's
+					// KeyboardShiftEnterTweakExtension) so it splits list items correctly, not just blocks;
+					// tldraw doesn't do soft breaks, so there's no hard-break case to handle.
 					if (event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
-						editorRef.current?.commands.splitBlock()
+						editorRef.current?.commands.enter()
 						return true
 					}
 					// Enter, Cmd+Enter, and Ctrl+Enter submit.

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -73,6 +73,11 @@ export function CommentComposer({
 	// returns). Updated on every render so the ref never points at a stale editor.
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null)
 
+	// Set while we replay Enter through the keymaps for a Shift+Enter newline: `commands.enter()`
+	// re-dispatches Enter through `handleKeyDown`, and without this guard our own handler would catch
+	// that synthetic Enter and submit instead.
+	const replayingEnter = useRef(false)
+
 	// Enter and Cmd/Ctrl+Enter submit the comment; Shift+Enter inserts a new line for the occasional
 	// multi-line comment. This is handled through `editorProps.handleKeyDown` (below) rather than a
 	// keyboard-shortcut extension: ProseMirror runs `handleKeyDown` before every keymap plugin, so it
@@ -126,14 +131,21 @@ export function CommentComposer({
 				// Runs before every keymap plugin, so it can distinguish Shift+Enter from Enter — an
 				// `Enter` keymap binding also fires on Shift+Enter and would otherwise swallow it.
 				handleKeyDown: (_view, event) => {
+					// Let the keymaps handle the synthetic Enter we replay for a Shift+Enter newline.
+					if (replayingEnter.current) return false
 					if (event.key !== 'Enter' || event.isComposing) return false
 					// While the @-mention picker is open, Enter selects the highlighted member — defer.
 					if (isMentionPickerOpen()) return false
-					// Shift+Enter inserts a new line. Use the list-aware `enter` command (matching tldraw's
-					// KeyboardShiftEnterTweakExtension) so it splits list items correctly, not just blocks;
-					// tldraw doesn't do soft breaks, so there's no hard-break case to handle.
+					// Shift+Enter inserts a new line. Replay a plain Enter through the keymaps (guarded so
+					// we don't re-enter and submit) to reuse the editor's list-aware Enter handling — a new
+					// list item in a list, a new paragraph otherwise. tldraw doesn't do soft breaks.
 					if (event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
-						editorRef.current?.commands.enter()
+						replayingEnter.current = true
+						try {
+							editorRef.current?.commands.enter()
+						} finally {
+							replayingEnter.current = false
+						}
 						return true
 					}
 					// Enter, Cmd+Enter, and Ctrl+Enter submit.

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -1,4 +1,4 @@
-import { Extension, JSONContent } from '@tiptap/core'
+import { JSONContent } from '@tiptap/core'
 import { EditorContent, useEditor } from '@tiptap/react'
 import { ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 import { isEqual, TLRichText, useMaybeEditor } from 'tldraw'
@@ -69,28 +69,15 @@ export function CommentComposer({
 
 	const [isEmpty, setIsEmpty] = useState(() => !value || isCommentEmpty(value))
 
-	// Enter submits the comment. Shift+Enter (and Cmd/Ctrl+Enter) keep their default behavior — a
-	// new line — for the occasional multi-line comment.
-	const submitExtension = useMemo(
-		() =>
-			Extension.create({
-				name: 'commentComposerSubmit',
-				priority: 1000,
-				addKeyboardShortcuts() {
-					return {
-						Enter: () => {
-							// While the @-mention picker is open, Enter selects the highlighted member.
-							// This extension outranks the mention plugin (priority 1000), so defer to the
-							// picker here or Enter would submit before the member could be inserted.
-							if (isMentionPickerOpen()) return false
-							if (!disabledRef.current) onSubmitRef.current?.()
-							return true
-						},
-					}
-				},
-			}),
-		[]
-	)
+	// The editor instance, reachable from `handleKeyDown` (which is created before `useEditor`
+	// returns). Updated on every render so the ref never points at a stale editor.
+	const editorRef = useRef<ReturnType<typeof useEditor>>(null)
+
+	// Enter and Cmd/Ctrl+Enter submit the comment; Shift+Enter inserts a new line for the occasional
+	// multi-line comment. This is handled through `editorProps.handleKeyDown` (below) rather than a
+	// keyboard-shortcut extension: ProseMirror runs `handleKeyDown` before every keymap plugin, so it
+	// can tell Shift+Enter apart from Enter — an `Enter` keymap binding also fires on Shift/Cmd+Enter
+	// and would otherwise swallow the newline.
 
 	// The suggestion plugin is built once (the editor is recreated only on `interactive`) and runs
 	// outside React, so it must read the mention callbacks through refs — like onChange/onSubmit —
@@ -100,7 +87,7 @@ export function CommentComposer({
 	const mentionsEnabled = !!getMentionSuggestions
 	const hasCustomRow = !!renderMentionSuggestion
 	const extensions = useMemo(() => {
-		const list = [...commentTipTapExtensions, submitExtension]
+		const list = [...commentTipTapExtensions]
 		// Always register the mention node so an existing body that contains a mention keeps it on
 		// edit (an unregistered node would be stripped by ProseMirror when the content loads). The `@`
 		// picker itself only turns on when the host provides a resolver; otherwise the node is present
@@ -122,7 +109,7 @@ export function CommentComposer({
 			list.push(commentMention({ suggestion: { char: '@', allow: () => false } }))
 		}
 		return list
-	}, [submitExtension, mentionsEnabled, hasCustomRow, tlEditor])
+	}, [mentionsEnabled, hasCustomRow, tlEditor])
 
 	const editor = useEditor(
 		{
@@ -134,7 +121,24 @@ export function CommentComposer({
 			// mirrors RichTextArea's setup.
 			enableCoreExtensions: { textDirection: false },
 			textDirection: 'auto',
-			editorProps: { attributes: { class: 'cmt-input' } },
+			editorProps: {
+				attributes: { class: 'cmt-input' },
+				// Runs before every keymap plugin, so it can distinguish Shift+Enter from Enter — an
+				// `Enter` keymap binding also fires on Shift+Enter and would otherwise swallow it.
+				handleKeyDown: (_view, event) => {
+					if (event.key !== 'Enter' || event.isComposing) return false
+					// While the @-mention picker is open, Enter selects the highlighted member — defer.
+					if (isMentionPickerOpen()) return false
+					// Shift+Enter inserts a new line (a paragraph split; tldraw doesn't do soft breaks).
+					if (event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
+						editorRef.current?.commands.splitBlock()
+						return true
+					}
+					// Enter, Cmd+Enter, and Ctrl+Enter submit.
+					if (!disabledRef.current) onSubmitRef.current?.()
+					return true
+				},
+			},
 			onUpdate: ({ editor }) => {
 				setIsEmpty(editor.isEmpty)
 				onChangeRef.current?.(editor.getJSON() as TLRichText)
@@ -142,6 +146,7 @@ export function CommentComposer({
 		},
 		[interactive]
 	)
+	editorRef.current = editor
 
 	// Sync controlled resets (e.g. the parent clearing to EMPTY_COMMENT after posting) into the
 	// editor without echoing back the value the editor itself just emitted.


### PR DESCRIPTION
In order to let people comment on a specific passage of text, this PR adds a **comment on a text range** example that wires the schema's existing `text-range` comment anchor up end to end: a comment button in the rich text toolbar that turns the current selection into a `text-range` thread, and a highlight overlay that draws the commented characters on the canvas. An earlier revision of this PR built the same feature into dotcom and the SDK; it's now an example only — everything it needs (`pendingComment`, `openThreadId`, `useCommentThreads`, a custom `RichTextToolbar`) was already public API, so there are no SDK, commenting-package, or dotcom changes.

### How it works

- **The toolbar button.** A custom `RichTextToolbar` renders the default toolbar content plus a comment button (disabled while the selection is collapsed). Pressing it converts the tiptap selection to plaintext offsets, ends the editing session, and sets `pendingComment` with a `{ type: 'text-range', shapeId, from, to }` anchor — posting from the composer then creates the thread through the normal pending-comment flow.
- **The highlight overlay.** `TextRangeHighlights` maps each text-range thread's plaintext offsets to DOM positions over the shape's rendered `.tl-rich-text` and draws highlight rects, re-measuring on camera moves, shape transform/prop changes, and font loads. Clicking a committed highlight opens its thread. Pins, popovers, and the composer all come from stock `CanvasComments`.

The example seeds a text shape with one text-range thread so the highlight is visible on load.

Also fixes the existing commenting examples on two fronts: they were missing the `@tldraw/commenting/commenting.css` import since the package styles moved there in #9594 (pins and popovers rendered unpositioned), and they never passed a `licenseKey`, so the license-gated comment tool disappeared from the toolbar on deployed builds. The examples that use the commenting UI now pass the shared tldraw key (valid for `*.tldraw.com`/`*.tldraw.dev`) with a note telling readers to use their own — note the tool will still be hidden on raw `*.vercel.app` preview URLs, which the key's origins don't cover.

### Known limitations (unchanged from the prototype, now documented in the example)

- `from`/`to` are plaintext offsets and don't re-track if the text is edited later. A production version would use a tiptap comment mark or map positions through document changes.
- The highlight needs the shape's static text DOM rendered (not culled, not in edit mode).

### Change type

- [x] `feature`

### Test plan

1. Open the **Comment on a text range** example (collaboration section).
2. The seeded highlight over "comment button" is aligned; click it — the thread popover opens.
3. Double-click the text shape, select a few words — the comment button enables in the rich text toolbar.
4. Click it: editing ends, the composer opens at the shape's corner, and the selection is highlighted.
5. Post — a pin appears and the highlight persists.
6. Pan, zoom, move and resize the shape — highlights stay glued to the text (including re-wraps).

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Add a "Comment on a text range" example showing how to comment on a selected range of text from the rich text toolbar.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Documentation  | +448 / -1  |
| Config/tooling | +1 / -1    |
