### PR TITLE
ci(release-notes): label update-release-notes PR with docs-hotfix-please

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -104,7 +104,8 @@ jobs:
           EOF
           )" \
             --base main \
-            --head "${{ steps.branch.outputs.branch_name }}"
+            --head "${{ steps.branch.outputs.branch_name }}" \
+            --label "docs-hotfix-please"
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
The `update-release-notes` action opens a docs-only PR that edits `apps/docs/content/releases/next.mdx`. Without the `docs-hotfix-please` label, merging it to `main` doesn't cherry-pick the change onto the current release branch (`vX.Y.x`) — so the updated notes never reach tldraw.dev, which is the whole point of the action. This adds the label at PR creation, matching what `add-framer-rewrites.yml` already does for its docs PRs.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +2 / -1    |