### PR TITLE
feat(commenting): add comment-only share mode for files

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -905,6 +905,12 @@
       "value": "This month"
     }
   ],
+  "9780c5dfe3": [
+    {
+      "type": 0,
+      "value": "Commenter"
+    }
+  ],
   "985a4b720f": [
     {
       "type": 0,

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -392,6 +392,9 @@
   "96165d6df5": {
     "translation": "This month"
   },
+  "9780c5dfe3": {
+    "translation": "Commenter"
+  },
   "985a4b720f": {
     "translation": "Terms of Use"
   },

--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -20,10 +20,22 @@ type FileComments = QueryResultType<typeof queries.fileComments>
  * notifications feed, which is bounded to recent comments), so every unread pin resolves however
  * old the comment is.
  */
-export function CommentsOnCanvas({ fileId }: { fileId: string }) {
+export function CommentsOnCanvas({
+	fileId,
+	canComment = true,
+}: {
+	fileId: string
+	/** Whether this session may write comments. When false the layer is read-only: existing
+	 *  comments show, but there's no composer (the server also rejects writes). */
+	canComment?: boolean
+}) {
 	const editor = useEditor()
 	const app = useMaybeApp()
 	const currentUserId = app?.userId ?? null
+	// The compose identity: a signed-in user who's allowed to comment. Null makes CanvasComments
+	// a read-only viewer (no composer/reply/resolve). Read status and name resolution below still
+	// use the real currentUserId regardless.
+	const composeUserId = canComment ? currentUserId : null
 
 	const currentUserName = useValue(
 		'current user name',
@@ -127,7 +139,7 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 	return (
 		<>
 			<CanvasComments
-				currentUserId={currentUserId}
+				currentUserId={composeUserId}
 				resolveName={resolveName}
 				isCommentUnread={app ? isCommentUnread : undefined}
 				onCommentRead={app ? onCommentRead : undefined}
@@ -135,7 +147,7 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 			/>
 			<CanvasCommentsSidebar
 				resolveName={resolveName}
-				currentUserId={currentUserId ?? undefined}
+				currentUserId={composeUserId ?? undefined}
 				isCommentUnread={app ? isCommentUnread : undefined}
 			/>
 		</>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -280,13 +280,18 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const overrides = useFileEditorOverrides({ fileSlug })
 	const extraDragIconOverrides = useExtraDragIconOverrides()
 
+	// Whether this session may write comments. The server grants object-lane (comment) write
+	// access per session based on the file's share tier (edit/comment allow it, view doesn't);
+	// a `view` guest sees comments but gets no comment tool or composer.
+	const canComment = store.status !== 'synced-remote' || store.objectAccess !== 'read'
+
 	const instanceComponents = useMemo((): TLComponents => {
 		return {
 			...components,
 			DebugMenu: () => <CustomDebugMenu />,
-			InFrontOfTheCanvas: () => <CommentsOnCanvas fileId={fileId} />,
+			InFrontOfTheCanvas: () => <CommentsOnCanvas fileId={fileId} canComment={canComment} />,
 		}
-	}, [fileId])
+	}, [fileId, canComment])
 
 	return (
 		<TlaEditorWrapper>
@@ -296,7 +301,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				store={store}
 				assetUrls={assetUrls}
 				shapeUtils={embedShapeUtils}
-				tools={commentTools}
+				tools={canComment ? commentTools : undefined}
 				user={app?.tlUser}
 				onMount={handleMount}
 				onUiEvent={handleUiEvent}
@@ -305,7 +310,11 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 					actionShortcutsLocation: 'toolbar',
 					deepLinks: deepLinks ? true : undefined,
 				}}
-				overrides={[overrides, extraDragIconOverrides, commentToolOverrides]}
+				overrides={
+					canComment
+						? [overrides, extraDragIconOverrides, commentToolOverrides]
+						: [overrides, extraDragIconOverrides]
+				}
 				getShapeVisibility={getShapeVisibility}
 			>
 				<ThemeUpdater />

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -23,6 +23,7 @@ import { QrCode } from '../QrCode'
 
 const messages = defineMessages({
 	editor: { defaultMessage: 'Editor' },
+	commenter: { defaultMessage: 'Commenter' },
 	viewer: { defaultMessage: 'Viewer' },
 	noAccess: { defaultMessage: 'No access' },
 })
@@ -115,7 +116,13 @@ function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 		[app, fileId, trackEvent]
 	)
 
-	const label = useMsg(sharedLinkType === 'edit' ? messages.editor : messages.viewer)
+	const label = useMsg(
+		sharedLinkType === 'edit'
+			? messages.editor
+			: sharedLinkType === 'comment'
+				? messages.commenter
+				: messages.viewer
+	)
 
 	return (
 		<TlaMenuControl>
@@ -130,6 +137,7 @@ function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 				onChange={handleSelectChange}
 				options={[
 					{ value: 'edit', label: <F defaultMessage="Editor" /> },
+					{ value: 'comment', label: <F defaultMessage="Commenter" /> },
 					{ value: 'view', label: <F defaultMessage="Viewer" /> },
 				]}
 			/>

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -67,6 +67,7 @@ import {
 	rowsToSnapshotDocuments,
 } from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
+import { computeFileAccess } from './fileAccess'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
@@ -702,6 +703,10 @@ export class TLFileDurableObject extends DurableObject {
 		const auth = await getAuth(req, this.env)
 		authTimer.report('on_request_auth')
 
+		// Comment (object-lane) write access, decided per session alongside the canvas open mode.
+		// Defaults to read-only; legacy (non-app) rooms have no comment tier and keep this default.
+		let objectAccess: TLObjectStoreAccess = 'read'
+
 		if (this.documentInfo.isApp) {
 			openMode = ROOM_OPEN_MODE.READ_WRITE
 			const file = await this.getAppFileRecord()
@@ -759,14 +764,22 @@ export class TLFileDurableObject extends DurableObject {
 					groupCheckTimer.report('on_request_group_check')
 				}
 
-				if (!hasOwnerAccess) {
-					if (!file.shared) {
-						return closeSocket(TLSyncErrorCloseEventReason.FORBIDDEN)
-					}
-					if (file.sharedLinkType === 'view') {
-						openMode = ROOM_OPEN_MODE.READ_ONLY
-					}
+				if (!hasOwnerAccess && !file.shared) {
+					return closeSocket(TLSyncErrorCloseEventReason.FORBIDDEN)
 				}
+
+				// Map the file's tier to this session's two lanes: `edit` guests keep canvas
+				// write, `comment`/`view` guests are canvas read-only, and comments are gated
+				// separately by objectAccess (see computeFileAccess).
+				const access = computeFileAccess({
+					sharedLinkType: file.sharedLinkType,
+					hasOwnerAccess,
+					isAuthenticated: !!auth?.userId,
+				})
+				if (access.isReadonly) {
+					openMode = ROOM_OPEN_MODE.READ_ONLY
+				}
+				objectAccess = access.objectAccess
 			}
 		} else {
 			// Legacy rooms are now read-only
@@ -779,10 +792,6 @@ export class TLFileDurableObject extends DurableObject {
 				userId: auth?.userId ? auth.userId : null,
 			}
 			const isReadonly = openMode === ROOM_OPEN_MODE.READ_ONLY
-			// Only authenticated users can write comments. Comment authors are stored in Postgres
-			// with a foreign key to the user table, so an anonymous author couldn't be represented
-			// there. Guests can still read comments.
-			const objectAccess: TLObjectStoreAccess = auth?.userId ? 'write' : 'read'
 			const attachment: SocketAttachment = {
 				sessionId,
 				meta,
@@ -2054,7 +2063,14 @@ export class TLFileDurableObject extends DurableObject {
 
 		// if the app file record updated, it might mean that the sharing state was updated
 		// in which case we should kick people out or change their permissions
-		const roomIsReadOnlyForGuests = file.shared && file.sharedLinkType === 'view'
+		//
+		// A guest's canvas is read-only unless the link is `edit`, and a guest can comment only
+		// when the link is `comment` (or `edit`) and they're signed in. Either can change on its
+		// own — e.g. `view`<->`comment` flips comment access without touching read-only — so we
+		// reconnect when the guest's *current* session lanes no longer match the new file state.
+		const roomIsReadOnlyForGuests = file.shared && file.sharedLinkType !== 'edit'
+		const guestCanComment =
+			file.shared && (file.sharedLinkType === 'edit' || file.sharedLinkType === 'comment')
 
 		for (const session of room.getSessions()) {
 			if (file.isDeleted) {
@@ -2070,14 +2086,18 @@ export class TLFileDurableObject extends DurableObject {
 				return can(role, 'accessFiles')
 			}
 
+			// A guest can only comment when they're signed in (comment authors need a user row).
+			const sessionCanComment = guestCanComment && !!session.meta.userId
+
 			if (!file.shared) {
 				if (!(await canAccessFiles())) {
 					room.closeSession(session.sessionId, TLSyncErrorCloseEventReason.FORBIDDEN)
 				}
 			} else if (
-				// if the file is still shared but the readonly state changed, make them reconnect
-				(session.isReadonly && !roomIsReadOnlyForGuests) ||
-				(!session.isReadonly && roomIsReadOnlyForGuests)
+				// if the file is still shared but the guest's read-only or comment access changed,
+				// make them reconnect so the new session lanes take effect
+				session.isReadonly !== roomIsReadOnlyForGuests ||
+				(session.objectAccess === 'write') !== sessionCanComment
 			) {
 				if (!(await canAccessFiles())) {
 					// not passing a reason means they will try to reconnect

--- a/apps/dotcom/sync-worker/src/fileAccess.test.ts
+++ b/apps/dotcom/sync-worker/src/fileAccess.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { computeFileAccess } from './fileAccess'
+
+describe('computeFileAccess', () => {
+	it('gives owners/group members full access on both lanes, regardless of tier', () => {
+		for (const sharedLinkType of ['edit', 'comment', 'view']) {
+			expect(
+				computeFileAccess({ sharedLinkType, hasOwnerAccess: true, isAuthenticated: true })
+			).toEqual({ isReadonly: false, objectAccess: 'write' })
+		}
+	})
+
+	it('lets an authenticated editor guest edit the canvas and comment', () => {
+		expect(
+			computeFileAccess({ sharedLinkType: 'edit', hasOwnerAccess: false, isAuthenticated: true })
+		).toEqual({ isReadonly: false, objectAccess: 'write' })
+	})
+
+	it('lets an authenticated commenter guest comment but not edit the canvas', () => {
+		expect(
+			computeFileAccess({ sharedLinkType: 'comment', hasOwnerAccess: false, isAuthenticated: true })
+		).toEqual({ isReadonly: true, objectAccess: 'write' })
+	})
+
+	it('makes a viewer guest read-only on both lanes', () => {
+		expect(
+			computeFileAccess({ sharedLinkType: 'view', hasOwnerAccess: false, isAuthenticated: true })
+		).toEqual({ isReadonly: true, objectAccess: 'read' })
+	})
+
+	it('denies comment writes to anonymous guests even on comment/edit tiers', () => {
+		// Comment authors need a user row (Postgres FK), so an anonymous session can never comment.
+		expect(
+			computeFileAccess({
+				sharedLinkType: 'comment',
+				hasOwnerAccess: false,
+				isAuthenticated: false,
+			})
+		).toEqual({ isReadonly: true, objectAccess: 'read' })
+		// An anonymous editor can still edit the canvas, but not comment.
+		expect(
+			computeFileAccess({ sharedLinkType: 'edit', hasOwnerAccess: false, isAuthenticated: false })
+		).toEqual({ isReadonly: false, objectAccess: 'read' })
+	})
+})

--- a/apps/dotcom/sync-worker/src/fileAccess.ts
+++ b/apps/dotcom/sync-worker/src/fileAccess.ts
@@ -1,0 +1,51 @@
+import { TlaFileSharedLinkType } from '@tldraw/dotcom-shared'
+import { TLObjectStoreAccess } from '@tldraw/sync-core'
+
+/** Inputs needed to decide what a connecting session may do with a file. */
+export interface FileAccessInput {
+	/** The file's `sharedLinkType` tier (`edit` | `comment` | `view`). */
+	sharedLinkType: TlaFileSharedLinkType | string
+	/** True if the session owns the file directly or via its owning group. */
+	hasOwnerAccess: boolean
+	/** True if the session belongs to a signed-in user. */
+	isAuthenticated: boolean
+}
+
+/** The per-session access a file grants, split across the two sync lanes. */
+export interface FileAccess {
+	/** Canvas (document-lane) read-only flag. */
+	isReadonly: boolean
+	/** Comment (object-lane) write access, independent of `isReadonly`. */
+	objectAccess: TLObjectStoreAccess
+}
+
+/**
+ * Decide a connecting session's access to a shared file. Callers must reject sessions that
+ * can neither own nor access a shared file *before* calling this (this maps an allowed
+ * session to its two lanes).
+ *
+ * Tiers:
+ * - `edit` — full canvas write + comments.
+ * - `comment` — read-only canvas, but comments allowed.
+ * - `view` — read-only canvas, no comments.
+ *
+ * Owners/group members always get full access. Commenting additionally requires an
+ * authenticated author, because comment authors are persisted in Postgres with a foreign
+ * key to the user table, so an anonymous author can't be represented.
+ */
+export function computeFileAccess({
+	sharedLinkType,
+	hasOwnerAccess,
+	isAuthenticated,
+}: FileAccessInput): FileAccess {
+	if (hasOwnerAccess) {
+		return { isReadonly: false, objectAccess: 'write' }
+	}
+
+	// Non-owner guests: only `edit` links grant canvas write.
+	const isReadonly = sharedLinkType !== 'edit'
+	// `edit` and `comment` links grant comment write, but only to a signed-in author.
+	const canComment = isAuthenticated && (sharedLinkType === 'edit' || sharedLinkType === 'comment')
+
+	return { isReadonly, objectAccess: canComment ? 'write' : 'read' }
+}

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -448,6 +448,18 @@ export const schema = createSchema({
 export type TlaSchema = typeof schema
 export type TlaUser = Row<typeof schema.tables.user>
 export type TlaFile = Row<typeof schema.tables.file>
+
+/**
+ * The access tier granted by a file's shared link. Stored in the plain-string
+ * `file.sharedLinkType` column (no schema enum), so use this type at call sites for
+ * exhaustiveness:
+ * - `edit` — full read/write of the canvas (and comments).
+ * - `comment` — read-only canvas, but can add/reply/resolve comments.
+ * - `view` — read-only canvas, no commenting.
+ */
+export const SHARED_LINK_TYPES = ['edit', 'comment', 'view'] as const
+export type TlaFileSharedLinkType = (typeof SHARED_LINK_TYPES)[number]
+
 export type TlaFileState = Row<typeof schema.tables.file_state>
 export type TlaGroup = Row<typeof schema.tables.group>
 export type TlaGroupUser = Row<typeof schema.tables.group_user>

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -6,6 +6,7 @@
 
 import { Editor } from 'tldraw';
 import { TLAssetStore } from 'tldraw';
+import { TLObjectStoreAccess } from '@tldraw/sync-core';
 import { TLPersistentClientSocket } from '@tldraw/sync-core';
 import { TLPresenceStateInfo } from 'tldraw';
 import { TLStore } from 'tldraw';
@@ -16,10 +17,16 @@ import { TLUser } from 'tldraw';
 import { TLUserStore } from 'tldraw';
 
 // @public
-export type RemoteTLStoreWithStatus = Exclude<TLStoreWithStatus, {
+export type RemoteTLStoreWithStatus = (Extract<TLStoreWithStatus, {
+    status: 'synced-remote';
+}> & {
+    readonly objectAccess: TLObjectStoreAccess;
+}) | Exclude<TLStoreWithStatus, {
     status: 'not-synced';
 } | {
     status: 'synced-local';
+} | {
+    status: 'synced-remote';
 }>;
 
 // @public

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -7,6 +7,7 @@ import {
 	TLRemoteSyncError,
 	TLSocketClientSentEvent,
 	TLSocketServerSentEvent,
+	TLObjectStoreAccess,
 	TLSyncClient,
 	TLSyncErrorCloseEventReason,
 } from '@tldraw/sync-core'
@@ -78,10 +79,19 @@ const defaultCustomMessageHandler: TLCustomMessageHandler = () => {}
  *
  * @public
  */
-export type RemoteTLStoreWithStatus = Exclude<
-	TLStoreWithStatus,
-	{ status: 'synced-local' } | { status: 'not-synced' }
->
+export type RemoteTLStoreWithStatus =
+	| Exclude<
+			TLStoreWithStatus,
+			{ status: 'synced-local' } | { status: 'not-synced' } | { status: 'synced-remote' }
+	  >
+	| (Extract<TLStoreWithStatus, { status: 'synced-remote' }> & {
+			/**
+			 * Write access for object-store lane record types (e.g. comments), as granted by the
+			 * server for this session. Independent of the canvas read-only state, so a session can
+			 * be allowed to comment without being allowed to edit. Defaults to `'write'`.
+			 */
+			readonly objectAccess: TLObjectStoreAccess
+	  })
 
 /**
  * Creates a reactive store synchronized with a multiplayer server for real-time collaboration.
@@ -170,6 +180,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 	const [state, setState] = useRefState<{
 		readyClient?: TLSyncClient<TLRecord, TLStore>
 		error?: Error
+		objectAccess?: TLObjectStoreAccess
 	} | null>(null)
 	const {
 		uri,
@@ -338,7 +349,8 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			didCancel: () => didCancel,
 			onLoad(client) {
 				track?.(MULTIPLAYER_EVENT_NAME, { name: 'load', roomId })
-				setState({ readyClient: client })
+				// Merge so we don't clobber objectAccess if onAfterConnect ran first.
+				setState((prev) => ({ ...prev, readyClient: client }))
 			},
 			onSyncError(reason) {
 				console.error('sync error', reason)
@@ -364,7 +376,11 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				setState({ error: new TLRemoteSyncError(reason) })
 				socket.close()
 			},
-			onAfterConnect(_, { isReadonly }) {
+			onAfterConnect(client, { isReadonly, objectAccess }) {
+				// Object-lane (comment) write access is decided per session by the server and can
+				// change on reconnect (e.g. when the file's share tier changes), so surface it on
+				// the returned status for consumers that gate comment UI.
+				setState((prev) => ({ ...prev, readyClient: client, objectAccess }))
 				transact(() => {
 					syncMode.set(isReadonly ? 'readonly' : 'readwrite')
 					// if the server crashes and loses all data it can return an empty document
@@ -412,6 +428,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				status: 'synced-remote',
 				connectionStatus: connectionStatus === 'error' ? 'offline' : connectionStatus,
 				store: state.readyClient.store,
+				objectAccess: state.objectAccess ?? 'write',
 			}
 		},
 		[state]


### PR DESCRIPTION
In order to let people share a board for feedback without granting edit rights, this PR adds a **comment-only ("Commenter") share mode** for files on tldraw.com, alongside the existing Editor and Viewer modes. A commenter can view the canvas and add, reply to, and resolve comments, but cannot edit shapes.

This builds on the commenting feature's two-lane sync model: comment records already sync over an "object lane" gated per session by an `objectAccess` flag that is **independent** of the canvas read-only state (`isReadonly`). So the change is mostly wiring — it maps a file's `sharedLinkType` tier onto the two lanes rather than adding new infrastructure. It also tightens the previous behavior where any signed-in Viewer could comment: comment-writing now depends on the share tier.

> Note: this PR targets the `commenting` branch, not `main`.

### Concepts

| Tier (`sharedLinkType`) | Canvas | Comments |
| --- | --- | --- |
| `edit` (Editor) | read/write | write |
| `comment` (Commenter) | read-only | write |
| `view` (Viewer) | read-only | read-only |

Commenting additionally requires a signed-in author (comment authors are persisted in Postgres with a foreign key to the user table), so anonymous guests can never comment regardless of tier. Owners and workspace members always get full access.

### How it works

- **Server** (`TLFileDurableObject`): a new pure, unit-tested `computeFileAccess()` helper maps `{ sharedLinkType, hasOwnerAccess, isAuthenticated }` to `{ isReadonly, objectAccess }` at connect time. The reconnect-on-share-change logic now also detects a `view`↔`comment` switch, which changes comment access without changing canvas read-only.
- **Sync** (`useSync`): the per-session `objectAccess` granted by the server is now surfaced on the `synced-remote` store status so clients can gate comment UI.
- **Client**: `TlaEditor` derives `canComment` from `store.objectAccess`; a Viewer sees existing comments but gets no comment tool, overrides, or composer (`CommentsOnCanvas` runs the overlay in its read-only mode). The server rejects any stray write as a backstop.
- **Share menu** (`TlaInviteTab`): adds the "Commenter" option and label.

### API changes

- Changed `RemoteTLStoreWithStatus` (`@tldraw/sync`): the `synced-remote` status now includes a `readonly objectAccess: TLObjectStoreAccess` field (the server-granted object-lane write access for the session; defaults to `'write'`).

### Change type

- [x] `feature`

### Test plan

1. As the owner, open a file's share menu and set "Anyone with the link" to **Commenter**; copy the link.
2. Open the link as a different signed-in user: confirm shapes cannot be edited, but the comment tool works and comments post/reply/resolve.
3. Switch the file to **Viewer**: the connected guest reconnects; the comment tool and composer disappear (existing comments still visible); canvas stays read-only.
4. Switch back to **Editor**: the guest regains full edit access.
5. Confirm signed-out (anonymous) users can never comment on any tier.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Add a comment-only ("Commenter") share mode for files on tldraw.com: viewers with a comment link can add and reply to comments without being able to edit the canvas.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +35 / -6   |
| Tests           | +45 / -0   |
| Automated files | +17 / -1   |
| Apps            | +123 / -23 |
