### PR TITLE
ci: pin credentialed third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Setup Fly cli
         if: env.DEPLOY_ZERO == 'flyio' || env.DEPLOY_ZERO == 'flyio-multinode'
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
 
       - name: Deploy
         run: yarn tsx internal/scripts/deploy-dotcom.ts

--- a/.github/workflows/playwright-dotcom.yml
+++ b/.github/workflows/playwright-dotcom.yml
@@ -104,7 +104,7 @@ jobs:
           path: apps/dotcom/client/playwright-report
           retention-days: 30
 
-      - uses: shallwefootball/s3-upload-action@master
+      - uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -81,7 +81,7 @@ jobs:
           path: apps/examples/playwright-report
           retention-days: 30
 
-      - uses: shallwefootball/s3-upload-action@master
+      - uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}

--- a/.github/workflows/playwright-perf.yml
+++ b/.github/workflows/playwright-perf.yml
@@ -82,7 +82,7 @@ jobs:
           path: apps/examples/playwright-report
           retention-days: 30
 
-      - uses: shallwefootball/s3-upload-action@master
+      - uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         # only upload if we have AWS credentials:
         env:
           HAS_AWS_KEY: ${{ secrets.AWS_S3_SECRET_KEY && '1' || '' }}

--- a/.github/workflows/prune-preview-deploys.yml
+++ b/.github/workflows/prune-preview-deploys.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Setup Fly IO
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
 
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
In order to stop the security of our CI credentials depending on the continued integrity of external `master` branches, this PR pins the two third-party actions we reference by a mutable `@master` tag to full commit SHAs. `shallwefootball/s3-upload-action` receives `AWS_S3_KEY_ID`/`AWS_S3_SECRET_KEY` in the three Playwright workflows, and `superfly/flyctl-actions/setup-flyctl` runs in `deploy-dotcom.yml` (which has `permissions: write-all`) and `prune-preview-deploys.yml` — if either upstream `master` were moved maliciously, the new code would run with those credentials (the `tj-actions/changed-files` class of incident). Closes #9579.

Thanks to @kobihikri for the report and for preparing the change on their fork (`kobihikri:harden/pin-thirdparty-actions`) — this PR applies the same pins. Both SHAs were verified independently against the upstream repos:

- `shallwefootball/s3-upload-action@0d261a6f` is the current `master` head (it's ahead of the latest tag `v1.3.3`, adding the Node 20 runtime, so `# master` is the annotation).
- `superfly/flyctl-actions@ed8efb33` is the current `master` head and is also tagged `1.6`/`v1`, so the annotation is `# 1.6`.

Behavior is unchanged; first-party `tldraw/*` reusable workflows are intentionally left unpinned.

### Change type

- [x] `other`

### Test plan

The Playwright workflows on this PR exercise the pinned `s3-upload-action` directly.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +5 / -5    |