### PR TITLE
feat(dotcom): scope notifications to owned boards, replies, and mentions

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -33,6 +33,22 @@
       "value": "Invite teammates"
     }
   ],
+  "05b2656486": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " mentioned you"
+    }
+  ],
   "05f43078e9": [
     {
       "type": 0,
@@ -177,6 +193,22 @@
     {
       "type": 0,
       "value": "About tldraw"
+    }
+  ],
+  "2755e3ab39": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " commented on your board"
     }
   ],
   "299cb00a7a": [
@@ -359,22 +391,6 @@
     {
       "type": 0,
       "value": "Name"
-    }
-  ],
-  "4a95fa0c08": [
-    {
-      "children": [
-        {
-          "type": 1,
-          "value": "author"
-        }
-      ],
-      "type": 8,
-      "value": "name"
-    },
-    {
-      "type": 0,
-      "value": " commented"
     }
   ],
   "4d0d3ddec9": [
@@ -1099,6 +1115,22 @@
     {
       "type": 0,
       "value": "Guest user"
+    }
+  ],
+  "b03400e2db": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " replied"
     }
   ],
   "b2326c3a34": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -14,6 +14,9 @@
   "04a2dd56d6": {
     "translation": "Invite teammates"
   },
+  "05b2656486": {
+    "translation": "<name>{author}</name> mentioned you"
+  },
   "05f43078e9": {
     "translation": "You have reached the maximum number of workspaces. You need to delete old workspaces before creating new ones."
   },
@@ -79,6 +82,9 @@
   },
   "250ddea65c": {
     "translation": "About tldraw"
+  },
+  "2755e3ab39": {
+    "translation": "<name>{author}</name> commented on your board"
   },
   "299cb00a7a": {
     "translation": "Upload failed"
@@ -163,9 +169,6 @@
   },
   "49ee308734": {
     "translation": "Name"
-  },
-  "4a95fa0c08": {
-    "translation": "<name>{author}</name> commented"
   },
   "4d0d3ddec9": {
     "translation": "This site uses cookies to make the app work and to collect analytics."
@@ -473,6 +476,9 @@
   },
   "b028909917": {
     "translation": "Guest user"
+  },
+  "b03400e2db": {
+    "translation": "<name>{author}</name> replied"
   },
   "b2326c3a34": {
     "translation": "Regenerate"

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -1,11 +1,12 @@
 import { CommentListItemProps, CommentsList, formatRelativeTime } from '@tldraw/commenting'
-import { useCallback } from 'react'
+import { ReactNode, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { createDeepLinkString, TLRichText, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { defineMessages, F, useMsg } from '../../../utils/i18n'
 import { richTextToPlaintext } from '../../../utils/richText'
+import { categorizeCommentNotifications, CommentNotificationReason } from './commentNotifications'
 import styles from './notifications.module.css'
 
 const messages = defineMessages({
@@ -14,19 +15,48 @@ const messages = defineMessages({
 	empty: { defaultMessage: 'You’re all caught up.' },
 })
 
+/** Byline for a notification row, phrased by why it's there. `<name>` wraps the author's name. */
+function ReasonByline({
+	reason,
+	author,
+	nameClassName,
+}: {
+	reason: CommentNotificationReason
+	author: string
+	nameClassName: string
+}) {
+	const name = (chunks: ReactNode) => <span className={nameClassName}>{chunks}</span>
+	switch (reason) {
+		case 'mention':
+			return <F defaultMessage="<name>{author}</name> mentioned you" values={{ author, name }} />
+		case 'reply':
+			return <F defaultMessage="<name>{author}</name> replied" values={{ author, name }} />
+		case 'owned-board':
+			return (
+				<F
+					defaultMessage="<name>{author}</name> commented on your board"
+					values={{ author, name }}
+				/>
+			)
+	}
+}
+
 /**
- * Comments surfaced as notifications: every comment on a file the user can access, newest first,
- * plus the caller's unread count (a comment is unread when it isn't the caller's own and has no
- * read receipt). Shared by the trigger button (for its badge) and the panel (for its list).
+ * Comments surfaced as notifications, narrowed to the three that concern the user — comments on
+ * boards they own, replies in threads they're a part of, and `@`-mentions of them (see
+ * {@link categorizeCommentNotifications}) — newest first, each tagged with why it's there. Also
+ * returns the caller's unread count over that set (a notification is unread when it has no read
+ * receipt; the categorization already excludes the caller's own comments). Shared by the trigger
+ * button (for its badge) and the panel (for its list).
  */
 export function useCommentNotifications() {
 	const app = useMaybeApp()
 	return useValue(
 		'comment notifications',
 		() => {
-			const comments = [...(app?.getComments() ?? [])].sort((a, b) => b.createdAt - a.createdAt)
-			const unreadCount = comments.filter((c) => c.authorId !== app?.userId && !c.read).length
-			return { comments, unreadCount }
+			const notifications = categorizeCommentNotifications(app?.getComments() ?? [], app?.userId)
+			const unreadCount = notifications.filter((n) => !n.comment.read).length
+			return { notifications, unreadCount }
 		},
 		[app]
 	)
@@ -48,12 +78,12 @@ function commentLink(fileId: string, shapeId: string | null | undefined, comment
 export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 	const app = useMaybeApp()
 	const navigate = useNavigate()
-	const { comments, unreadCount } = useCommentNotifications()
+	const { notifications, unreadCount } = useCommentNotifications()
 	const title = useMsg(messages.title)
 	const markAllReadLbl = useMsg(messages.markAllRead)
 	const empty = useMsg(messages.empty)
 
-	const items: CommentListItemProps[] = comments.map((c) => ({
+	const items: CommentListItemProps[] = notifications.map(({ comment: c }) => ({
 		id: c.id,
 		author: c.author?.name ?? c.authorId,
 		preview: richTextToPlaintext(c.body as TLRichText),
@@ -62,15 +92,19 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 		page: c.file?.name || c.fileId,
 	}))
 
+	// Row id → why it's a notification, so the byline can be phrased per reason.
+	const reasonById = new Map(notifications.map((n) => [n.comment.id, n.primaryReason]))
+
 	const handleSelect = useCallback(
 		(id: string) => {
-			const c = comments.find((c) => c.id === id)
-			if (!c) return
-			if (c.authorId !== app?.userId && !c.read) app?.markCommentRead(c.id)
+			const n = notifications.find((n) => n.comment.id === id)
+			if (!n) return
+			const c = n.comment
+			if (!c.read) app?.markCommentRead(c.id)
 			navigate(commentLink(c.fileId, c.thread?.shapeId, c.id))
 			onClose()
 		},
-		[comments, app, navigate, onClose]
+		[notifications, app, navigate, onClose]
 	)
 
 	return (
@@ -84,8 +118,8 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 						className={styles.markAll}
 						onClick={() => {
 							if (!app) return
-							for (const c of comments) {
-								if (c.authorId !== app.userId && !c.read) app.markCommentRead(c.id)
+							for (const { comment: c } of notifications) {
+								if (!c.read) app.markCommentRead(c.id)
 							}
 						}}
 						disabled={unreadCount === 0}
@@ -107,12 +141,10 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 								<span className={styles.time}>{formatRelativeTime(item.date)}</span>
 							</div>
 							<div className={styles.byline}>
-								<F
-									defaultMessage="<name>{author}</name> commented"
-									values={{
-										author: item.author,
-										name: (chunks) => <span className={styles.author}>{chunks}</span>,
-									}}
+								<ReasonByline
+									reason={reasonById.get(item.id) ?? 'owned-board'}
+									author={item.author}
+									nameClassName={styles.author}
 								/>
 							</div>
 							<div className={styles.preview}>{item.preview}</div>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -42,12 +42,13 @@ function ReasonByline({
 }
 
 /**
- * Comments surfaced as notifications, narrowed to the three that concern the user — comments on
- * boards they own, replies in threads they're a part of, and `@`-mentions of them (see
- * {@link categorizeCommentNotifications}) — newest first, each tagged with why it's there. Also
- * returns the caller's unread count over that set (a notification is unread when it has no read
- * receipt; the categorization already excludes the caller's own comments). Shared by the trigger
- * button (for its badge) and the panel (for its list).
+ * Comments surfaced as notifications. The `comments` synced query already filters to the three
+ * categories that concern the user server-side — comments on boards they own, replies in threads
+ * they're a part of, and `@`-mentions of them — so out-of-category comments never reach the
+ * client; {@link categorizeCommentNotifications} tags each synced comment with why it's there,
+ * newest first. Also returns the caller's unread count over that set (a notification is unread
+ * when it has no read receipt). Shared by the trigger button (for its badge) and the panel (for
+ * its list).
  */
 export function useCommentNotifications() {
 	const app = useMaybeApp()

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -1,6 +1,5 @@
 import { TLRichText } from 'tldraw'
 import { describe, expect, it } from 'vitest'
-import { getMentionedMemberIds } from '../../../utils/richText'
 import { categorizeCommentNotifications, CommentNotificationInput } from './commentNotifications'
 
 const ME = 'user_me'
@@ -37,22 +36,12 @@ function comment(overrides: Partial<CommentNotificationInput> = {}): CommentNoti
 	}
 }
 
-describe('getMentionedMemberIds', () => {
-	it('collects mention node ids from the body', () => {
-		expect(getMentionedMemberIds(body('hi ', [ME, OTHER]))).toEqual([ME, OTHER])
-	})
-
-	it('returns an empty array when there are no mentions', () => {
-		expect(getMentionedMemberIds(body('just text'))).toEqual([])
-	})
-})
-
 describe('categorizeCommentNotifications', () => {
 	it('returns nothing when there is no user id', () => {
 		expect(categorizeCommentNotifications([comment()], undefined)).toEqual([])
 	})
 
-	it("includes another user's comment on a board I own, as owned-board", () => {
+	it("labels another user's comment on a board I own as owned-board", () => {
 		const result = categorizeCommentNotifications(
 			[comment({ file: { ownerId: ME }, thread: { createdBy: OTHER } })],
 			ME
@@ -70,7 +59,7 @@ describe('categorizeCommentNotifications', () => {
 		expect(result).toEqual([])
 	})
 
-	it('includes a reply in a thread I started, as reply', () => {
+	it('labels a reply in a thread I started as reply', () => {
 		const result = categorizeCommentNotifications(
 			[comment({ thread: { createdBy: ME }, file: { ownerId: THIRD } })],
 			ME
@@ -78,7 +67,7 @@ describe('categorizeCommentNotifications', () => {
 		expect(result.map((n) => n.primaryReason)).toEqual(['reply'])
 	})
 
-	it("includes a reply in a thread I've commented in, as reply", () => {
+	it("labels a reply in a thread I've commented in as reply", () => {
 		const mine = comment({
 			id: 'comment:mine',
 			authorId: ME,
@@ -100,7 +89,7 @@ describe('categorizeCommentNotifications', () => {
 		expect(result[0].primaryReason).toBe('reply')
 	})
 
-	it('includes a comment that @-mentions me, as mention', () => {
+	it('labels a comment that @-mentions me as mention', () => {
 		const result = categorizeCommentNotifications(
 			[
 				comment({
@@ -114,32 +103,23 @@ describe('categorizeCommentNotifications', () => {
 		expect(result.map((n) => n.primaryReason)).toEqual(['mention'])
 	})
 
-	it('excludes a comment that only mentions someone else', () => {
+	it('falls back to reply when no reason is derivable from the synced window', () => {
+		// The server only syncs in-category comments, so a comment with no locally visible
+		// evidence (not my board, no mention of me, my thread participation older than the
+		// window) must be a reply — it is labeled, not dropped.
 		const result = categorizeCommentNotifications(
 			[
 				comment({
+					file: { ownerId: THIRD },
+					thread: { createdBy: OTHER },
 					body: body('hey ', [THIRD]),
-					file: { ownerId: THIRD },
-					thread: { createdBy: OTHER },
 				}),
 			],
 			ME
 		)
-		expect(result).toEqual([])
-	})
-
-	it('excludes a comment matching none of the three categories', () => {
-		const result = categorizeCommentNotifications(
-			[
-				comment({
-					file: { ownerId: THIRD },
-					thread: { createdBy: OTHER },
-					body: body('unrelated'),
-				}),
-			],
-			ME
-		)
-		expect(result).toEqual([])
+		expect(result).toHaveLength(1)
+		expect(result[0].reasons).toEqual(['reply'])
+		expect(result[0].primaryReason).toBe('reply')
 	})
 
 	it('tags multiple reasons with mention > reply > owned-board precedence', () => {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -1,0 +1,161 @@
+import { TLRichText } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import { getMentionedMemberIds } from '../../../utils/richText'
+import { categorizeCommentNotifications, CommentNotificationInput } from './commentNotifications'
+
+const ME = 'user_me'
+const OTHER = 'user_other'
+const THIRD = 'user_third'
+
+/** A comment body: paragraphs of plain text, with optional `@`-mentions (by member id) interleaved. */
+function body(text: string, mentionIds: string[] = []): TLRichText {
+	return {
+		type: 'doc',
+		content: [
+			{
+				type: 'paragraph',
+				content: [
+					{ type: 'text', text },
+					...mentionIds.map((id) => ({ type: 'mention', attrs: { id, label: id } })),
+				],
+			},
+		],
+	} as unknown as TLRichText
+}
+
+function comment(overrides: Partial<CommentNotificationInput> = {}): CommentNotificationInput {
+	return {
+		id: 'comment:1',
+		authorId: OTHER,
+		threadId: 'comment-thread:1',
+		createdAt: 1000,
+		body: body('hello'),
+		read: undefined,
+		file: { ownerId: THIRD },
+		thread: { createdBy: OTHER },
+		...overrides,
+	}
+}
+
+describe('getMentionedMemberIds', () => {
+	it('collects mention node ids from the body', () => {
+		expect(getMentionedMemberIds(body('hi ', [ME, OTHER]))).toEqual([ME, OTHER])
+	})
+
+	it('returns an empty array when there are no mentions', () => {
+		expect(getMentionedMemberIds(body('just text'))).toEqual([])
+	})
+})
+
+describe('categorizeCommentNotifications', () => {
+	it('returns nothing when there is no user id', () => {
+		expect(categorizeCommentNotifications([comment()], undefined)).toEqual([])
+	})
+
+	it("includes another user's comment on a board I own, as owned-board", () => {
+		const result = categorizeCommentNotifications(
+			[comment({ file: { ownerId: ME }, thread: { createdBy: OTHER } })],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(result[0].reasons).toEqual(['owned-board'])
+		expect(result[0].primaryReason).toBe('owned-board')
+	})
+
+	it('excludes my own comments', () => {
+		const result = categorizeCommentNotifications(
+			[comment({ authorId: ME, file: { ownerId: ME }, body: body('hi ', [ME]) })],
+			ME
+		)
+		expect(result).toEqual([])
+	})
+
+	it('includes a reply in a thread I started, as reply', () => {
+		const result = categorizeCommentNotifications(
+			[comment({ thread: { createdBy: ME }, file: { ownerId: THIRD } })],
+			ME
+		)
+		expect(result.map((n) => n.primaryReason)).toEqual(['reply'])
+	})
+
+	it("includes a reply in a thread I've commented in, as reply", () => {
+		const mine = comment({
+			id: 'comment:mine',
+			authorId: ME,
+			createdAt: 1000,
+			thread: { createdBy: OTHER },
+			file: { ownerId: THIRD },
+		})
+		const theirReply = comment({
+			id: 'comment:theirs',
+			authorId: OTHER,
+			createdAt: 2000,
+			thread: { createdBy: OTHER },
+			file: { ownerId: THIRD },
+		})
+		const result = categorizeCommentNotifications([mine, theirReply], ME)
+		// only their reply surfaces (mine is excluded), tagged reply
+		expect(result).toHaveLength(1)
+		expect(result[0].comment.id).toBe('comment:theirs')
+		expect(result[0].primaryReason).toBe('reply')
+	})
+
+	it('includes a comment that @-mentions me, as mention', () => {
+		const result = categorizeCommentNotifications(
+			[
+				comment({
+					body: body('hey ', [ME]),
+					file: { ownerId: THIRD },
+					thread: { createdBy: OTHER },
+				}),
+			],
+			ME
+		)
+		expect(result.map((n) => n.primaryReason)).toEqual(['mention'])
+	})
+
+	it('excludes a comment that only mentions someone else', () => {
+		const result = categorizeCommentNotifications(
+			[
+				comment({
+					body: body('hey ', [THIRD]),
+					file: { ownerId: THIRD },
+					thread: { createdBy: OTHER },
+				}),
+			],
+			ME
+		)
+		expect(result).toEqual([])
+	})
+
+	it('excludes a comment matching none of the three categories', () => {
+		const result = categorizeCommentNotifications(
+			[
+				comment({
+					file: { ownerId: THIRD },
+					thread: { createdBy: OTHER },
+					body: body('unrelated'),
+				}),
+			],
+			ME
+		)
+		expect(result).toEqual([])
+	})
+
+	it('tags multiple reasons with mention > reply > owned-board precedence', () => {
+		const result = categorizeCommentNotifications(
+			[comment({ file: { ownerId: ME }, thread: { createdBy: ME }, body: body('hey ', [ME]) })],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(new Set(result[0].reasons)).toEqual(new Set(['mention', 'reply', 'owned-board']))
+		expect(result[0].primaryReason).toBe('mention')
+	})
+
+	it('sorts newest first', () => {
+		const older = comment({ id: 'comment:old', createdAt: 1000, file: { ownerId: ME } })
+		const newer = comment({ id: 'comment:new', createdAt: 2000, file: { ownerId: ME } })
+		const result = categorizeCommentNotifications([older, newer], ME)
+		expect(result.map((n) => n.comment.id)).toEqual(['comment:new', 'comment:old'])
+	})
+})

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -1,0 +1,90 @@
+import { TLRichText } from 'tldraw'
+import { getMentionedMemberIds } from '../../../utils/richText'
+
+/**
+ * Why a comment shows up in a user's notifications feed:
+ *
+ * - `mention` — the comment `@`-mentions the user
+ * - `reply` — the comment is in a thread the user is a part of (started, or has commented in)
+ * - `owned-board` — the comment is on a file the user owns
+ *
+ * A single comment can match more than one; {@link CommentNotification.primaryReason} picks the one
+ * shown to the user, in the order mention \> reply \> owned-board (most-to-least specific).
+ */
+export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board'
+
+/** Priority order for {@link CommentNotification.primaryReason}: most specific first. */
+const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board']
+
+/**
+ * The comment fields {@link categorizeCommentNotifications} needs. A structural subset of the
+ * `app.getComments()` row (with its `author`/`file`/`thread`/`read` relationships) so the
+ * categorization can be unit-tested without Zero types. `read` is the caller's read receipt — a
+ * related row when present, absent (falsy) when unread.
+ */
+export interface CommentNotificationInput {
+	id: string
+	authorId: string
+	threadId: string
+	createdAt: number
+	// Comment body, as rich text JSON. Typed `unknown` so the real Zero row (whose `body` is a wide
+	// `ReadonlyJSONValue`) still satisfies this constraint; narrowed to TLRichText where read.
+	body: unknown
+	read?: unknown
+	file?: { ownerId?: string | null } | null
+	thread?: { createdBy?: string | null } | null
+}
+
+/** A comment that belongs in the notifications feed, tagged with why. */
+export interface CommentNotification<
+	T extends CommentNotificationInput = CommentNotificationInput,
+> {
+	comment: T
+	/** Every reason this comment qualifies (unordered). */
+	reasons: CommentNotificationReason[]
+	/** The single reason to surface, per {@link REASON_PRIORITY}. */
+	primaryReason: CommentNotificationReason
+}
+
+/**
+ * Narrows a raw cross-file comment feed to the notifications a user actually cares about, tagging
+ * each with why it's there. A comment qualifies when it isn't the user's own and matches at least
+ * one of: it's on a board they own, it's in a thread they're a part of, or it `@`-mentions them.
+ *
+ * Thread participation is derived (there's no stored participant list): a user is "part of" a thread
+ * if they created it (`thread.createdBy`) or authored any comment in it within `comments`. Since the
+ * feed is capped upstream, participation is best-effort over the fetched window.
+ *
+ * Returns newest-first.
+ */
+export function categorizeCommentNotifications<T extends CommentNotificationInput>(
+	comments: readonly T[],
+	userId: string | undefined | null
+): CommentNotification<T>[] {
+	if (!userId) return []
+
+	// Threads the user is a part of: ones they started, or have a comment in (within this feed).
+	const participantThreadIds = new Set<string>()
+	for (const c of comments) {
+		if (c.thread?.createdBy === userId || c.authorId === userId) {
+			participantThreadIds.add(c.threadId)
+		}
+	}
+
+	const notifications: CommentNotification<T>[] = []
+	for (const comment of comments) {
+		// A notification is always about someone else's comment, never your own.
+		if (comment.authorId === userId) continue
+
+		const reasons: CommentNotificationReason[] = []
+		if (getMentionedMemberIds(comment.body as TLRichText).includes(userId)) reasons.push('mention')
+		if (participantThreadIds.has(comment.threadId)) reasons.push('reply')
+		if (comment.file?.ownerId === userId) reasons.push('owned-board')
+		if (reasons.length === 0) continue
+
+		const primaryReason = REASON_PRIORITY.find((r) => reasons.includes(r))!
+		notifications.push({ comment, reasons, primaryReason })
+	}
+
+	return notifications.sort((a, b) => b.comment.createdAt - a.comment.createdAt)
+}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -1,5 +1,4 @@
-import { TLRichText } from 'tldraw'
-import { getMentionedMemberIds } from '../../../utils/richText'
+import { extractMentionIds } from '@tldraw/dotcom-shared'
 
 /**
  * Why a comment shows up in a user's notifications feed:
@@ -28,14 +27,14 @@ export interface CommentNotificationInput {
 	threadId: string
 	createdAt: number
 	// Comment body, as rich text JSON. Typed `unknown` so the real Zero row (whose `body` is a wide
-	// `ReadonlyJSONValue`) still satisfies this constraint; narrowed to TLRichText where read.
+	// `ReadonlyJSONValue`) still satisfies this constraint; extractMentionIds accepts unknown.
 	body: unknown
 	read?: unknown
 	file?: { ownerId?: string | null } | null
 	thread?: { createdBy?: string | null } | null
 }
 
-/** A comment that belongs in the notifications feed, tagged with why. */
+/** A comment in the notifications feed, tagged with why it's there. */
 export interface CommentNotification<
 	T extends CommentNotificationInput = CommentNotificationInput,
 > {
@@ -47,15 +46,17 @@ export interface CommentNotification<
 }
 
 /**
- * Narrows a raw cross-file comment feed to the notifications a user actually cares about, tagging
- * each with why it's there. A comment qualifies when it isn't the user's own and matches at least
- * one of: it's on a board they own, it's in a thread they're a part of, or it `@`-mentions them.
+ * Tags each comment in the notifications feed with why it's there, newest first. The `comments`
+ * synced query already filters to the three categories server-side — comments on boards the user
+ * owns, replies in threads they're a part of, and `@`-mentions of them — so this derives labels,
+ * not membership: nothing the server sent is dropped (except the user's own comments, which the
+ * server also excludes; the local re-check is just defense in depth).
  *
- * Thread participation is derived (there's no stored participant list): a user is "part of" a thread
- * if they created it (`thread.createdBy`) or authored any comment in it within `comments`. Since the
- * feed is capped upstream, participation is best-effort over the fetched window.
- *
- * Returns newest-first.
+ * Two of the three reasons re-derive exactly from synced data (`file.ownerId`; mention ids in the
+ * body). Thread participation can't always be re-derived: the evidence — the user's own earlier
+ * comment in the thread — may be older than the feed's bounded window. A comment with no locally
+ * derivable reason is therefore labeled `reply`, the only category the client can fail to see
+ * evidence for.
  */
 export function categorizeCommentNotifications<T extends CommentNotificationInput>(
 	comments: readonly T[],
@@ -77,10 +78,12 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 		if (comment.authorId === userId) continue
 
 		const reasons: CommentNotificationReason[] = []
-		if (getMentionedMemberIds(comment.body as TLRichText).includes(userId)) reasons.push('mention')
+		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
 		if (participantThreadIds.has(comment.threadId)) reasons.push('reply')
 		if (comment.file?.ownerId === userId) reasons.push('owned-board')
-		if (reasons.length === 0) continue
+		// The server only syncs in-category comments; when no reason is derivable locally, the
+		// participation evidence is outside the synced window — so it's a reply (see docs above).
+		if (reasons.length === 0) reasons.push('reply')
 
 		const primaryReason = REASON_PRIORITY.find((r) => reasons.includes(r))!
 		notifications.push({ comment, reasons, primaryReason })

--- a/apps/dotcom/client/src/tla/utils/richText.ts
+++ b/apps/dotcom/client/src/tla/utils/richText.ts
@@ -17,21 +17,3 @@ export function richTextToPlaintext(body: TLRichText): string {
 	visit(body)
 	return parts.join('').trimEnd()
 }
-
-/**
- * Collects the member ids `@`-mentioned in a comment body. Mentions are TipTap `mention` nodes
- * embedded in the rich text JSON — `{ type: 'mention', attrs: { id, label } }` — where `attrs.id`
- * is the member id (the same id space as `app.userId`). Walks the body the same way
- * {@link richTextToPlaintext} does.
- */
-export function getMentionedMemberIds(body: TLRichText): string[] {
-	const ids: string[] = []
-	const visit = (node: any) => {
-		if (node?.type === 'mention' && typeof node?.attrs?.id === 'string') ids.push(node.attrs.id)
-		if (Array.isArray(node?.content)) {
-			for (const child of node.content) visit(child)
-		}
-	}
-	visit(body)
-	return ids
-}

--- a/apps/dotcom/client/src/tla/utils/richText.ts
+++ b/apps/dotcom/client/src/tla/utils/richText.ts
@@ -17,3 +17,21 @@ export function richTextToPlaintext(body: TLRichText): string {
 	visit(body)
 	return parts.join('').trimEnd()
 }
+
+/**
+ * Collects the member ids `@`-mentioned in a comment body. Mentions are TipTap `mention` nodes
+ * embedded in the rich text JSON — `{ type: 'mention', attrs: { id, label } }` — where `attrs.id`
+ * is the member id (the same id space as `app.userId`). Walks the body the same way
+ * {@link richTextToPlaintext} does.
+ */
+export function getMentionedMemberIds(body: TLRichText): string[] {
+	const ids: string[] = []
+	const visit = (node: any) => {
+		if (node?.type === 'mention' && typeof node?.attrs?.id === 'string') ids.push(node.attrs.id)
+		if (Array.isArray(node?.content)) {
+			for (const child of node.content) visit(child)
+		}
+	}
+	visit(body)
+	return ids
+}

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -61,9 +61,11 @@ import { Kysely, PostgresDialect } from 'kysely'
 import {
 	findEmptiedCommentThreads,
 	isCommentAuthorFkViolation,
+	isCommentMentionFkViolation,
 	mergeCommentDocumentsIntoSnapshot,
 	outboxEntriesToClear,
 	planCommentDrain,
+	planMentionReconciles,
 	rowsToSnapshotDocuments,
 } from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
@@ -1809,6 +1811,64 @@ export class TLFileDurableObject extends DurableObject {
 				}
 				if (threadDeletes.length > 0) {
 					await this.db.deleteFrom('comment_thread').where('id', 'in', threadDeletes).execute()
+				}
+
+				// Reconcile @-mention rows for every comment row that made it to Postgres, so the
+				// notifications query can filter "comments that mention me" server-side (mentions
+				// live inside the body JSON, out of ZQL's reach). The write is idempotent — delete
+				// rows the body no longer mentions, insert the rest with ON CONFLICT DO NOTHING —
+				// so clock-guarded no-op replays cause no WAL churn. A mention insert failing its
+				// user FK (mentioned account deleted, or a bogus id) is skipped for good; any other
+				// failure marks the comment failed so its outbox entry stays queued and the next
+				// drain retries the reconcile. Comment deletes need no handling here: the FK
+				// cascades their mention rows away.
+				const mentionReconciles = planMentionReconciles(
+					commentUpserts.filter(
+						(row) => !failedIds.has(row.id) && !commentResult.prunedIds.includes(row.id)
+					)
+				)
+				for (const { commentId, userIds } of mentionReconciles) {
+					try {
+						let deleteStale = this.db
+							.deleteFrom('comment_mention')
+							.where('commentId', '=', commentId)
+						if (userIds.length > 0) {
+							deleteStale = deleteStale.where('userId', 'not in', userIds)
+						}
+						await deleteStale.execute()
+						if (userIds.length === 0) continue
+						const rows = userIds.map((userId) => ({ commentId, userId }))
+						try {
+							await this.db
+								.insertInto('comment_mention')
+								.values(rows)
+								.onConflict((oc) => oc.columns(['commentId', 'userId']).doNothing())
+								.execute()
+						} catch (batchError) {
+							if (!isCommentMentionFkViolation(batchError)) throw batchError
+							// One row's FK failure aborts the whole batch insert; retry row-by-row so
+							// the valid mentions land and only the FK-violating ones are skipped.
+							for (const row of rows) {
+								try {
+									await this.db
+										.insertInto('comment_mention')
+										.values(row)
+										.onConflict((oc) => oc.columns(['commentId', 'userId']).doNothing())
+										.execute()
+								} catch (rowError) {
+									if (!isCommentMentionFkViolation(rowError)) throw rowError
+								}
+							}
+						}
+					} catch (error) {
+						failedIds.add(commentId)
+						this.logEvent({
+							type: 'room',
+							roomId: fileId,
+							name: 'failed_persist_comments_to_db',
+						})
+						this.reportError(error)
+					}
 				}
 
 				let didPruneThreads = false

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -17,6 +17,8 @@ import {
 	planCommentDrain,
 	rowsToSnapshotDocuments,
 	rowToCommentRecord,
+	isCommentMentionFkViolation,
+	planMentionReconciles,
 	rowToThreadRecord,
 	threadRecordToRow,
 } from './commentRows'
@@ -131,6 +133,97 @@ describe('isCommentAuthorFkViolation', () => {
 		expect(isCommentAuthorFkViolation(undefined)).toBe(false)
 		expect(isCommentAuthorFkViolation('23503')).toBe(false)
 		expect(isCommentAuthorFkViolation(new Error('connection refused'))).toBe(false)
+	})
+})
+
+describe('isCommentMentionFkViolation', () => {
+	it('matches a pg foreign key violation on either comment_mention fkey', () => {
+		expect(
+			isCommentMentionFkViolation(
+				Object.assign(new Error(), { code: '23503', constraint: 'comment_mention_user_id_fkey' })
+			)
+		).toBe(true)
+		expect(
+			isCommentMentionFkViolation(
+				Object.assign(new Error(), {
+					code: '23503',
+					constraint: 'comment_mention_comment_id_fkey',
+				})
+			)
+		).toBe(true)
+	})
+
+	it('requires both the code and a comment_mention constraint to match', () => {
+		expect(
+			isCommentMentionFkViolation(
+				Object.assign(new Error(), { code: '23503', constraint: 'comment_author_id_fkey' })
+			)
+		).toBe(false)
+		expect(
+			isCommentMentionFkViolation(
+				Object.assign(new Error(), { code: '23505', constraint: 'comment_mention_user_id_fkey' })
+			)
+		).toBe(false)
+		expect(isCommentMentionFkViolation(null)).toBe(false)
+	})
+})
+
+describe('planMentionReconciles', () => {
+	function makeCommentRow(bodyJson: unknown) {
+		const thread = makeThread()
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'user1',
+			body: bodyJson as TLRichText,
+			now: 1000,
+		})
+		return commentRecordToRow(comment, 'file1', 1)
+	}
+
+	it("extracts each comment's mentioned user ids, deduped", () => {
+		const row = makeCommentRow({
+			type: 'doc',
+			content: [
+				{
+					type: 'paragraph',
+					content: [
+						{ type: 'mention', attrs: { id: 'user_a', label: 'A' } },
+						{ type: 'text', text: ' and ' },
+						{ type: 'mention', attrs: { id: 'user_b', label: 'B' } },
+						{ type: 'mention', attrs: { id: 'user_a', label: 'A again' } },
+					],
+				},
+			],
+		})
+		expect(planMentionReconciles([row])).toEqual([
+			{ commentId: row.id, userIds: ['user_a', 'user_b'] },
+		])
+	})
+
+	it('plans an empty set for a body without mentions, so stale rows get deleted', () => {
+		const row = makeCommentRow({
+			type: 'doc',
+			content: [{ type: 'paragraph', content: [{ type: 'text', text: 'no mentions here' }] }],
+		})
+		expect(planMentionReconciles([row])).toEqual([{ commentId: row.id, userIds: [] }])
+	})
+
+	it('ignores mention nodes without a string id', () => {
+		const row = makeCommentRow({
+			type: 'doc',
+			content: [
+				{
+					type: 'paragraph',
+					content: [{ type: 'mention', attrs: { id: 123 } }, { type: 'mention' }],
+				},
+			],
+		})
+		expect(planMentionReconciles([row])).toEqual([{ commentId: row.id, userIds: [] }])
+	})
+
+	it('returns one plan per row', () => {
+		expect(planMentionReconciles([])).toEqual([])
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -1,4 +1,4 @@
-import { DB } from '@tldraw/dotcom-shared'
+import { DB, extractMentionIds } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
 import {
 	TLComment,
@@ -37,6 +37,44 @@ export function isCommentAuthorFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
 	const { code, constraint } = error as { code?: unknown; constraint?: unknown }
 	return code === '23503' && constraint === 'comment_author_id_fkey'
+}
+
+/**
+ * True when `error` is Postgres rejecting a `comment_mention` insert on either of its foreign
+ * keys (code 23503): the mentioned user's row no longer exists (deleted account, or a client
+ * supplied an id that never was a user), or the comment itself was deleted between its upsert
+ * and the mention write (e.g. a version restore's fileId-wide wipe). In both cases the mention
+ * row is genuinely unwanted — retrying can't help — so the caller skips the row instead of
+ * failing the drain. Same error-shape contract as {@link isCommentAuthorFkViolation}.
+ */
+export function isCommentMentionFkViolation(error: unknown): boolean {
+	if (typeof error !== 'object' || error === null) return false
+	const { code, constraint } = error as { code?: unknown; constraint?: unknown }
+	return (
+		code === '23503' &&
+		(constraint === 'comment_mention_user_id_fkey' ||
+			constraint === 'comment_mention_comment_id_fkey')
+	)
+}
+
+/** One comment's desired `comment_mention` rows: the full set its body currently mentions. */
+export interface CommentMentionReconcile {
+	commentId: string
+	userIds: string[]
+}
+
+/**
+ * The desired end state of the `comment_mention` table for a drain's successfully upserted
+ * comment rows: for each comment, the user ids its body currently `@`-mentions (deduped by
+ * {@link extractMentionIds}). The caller reconciles Postgres to this — delete rows not in the
+ * set, insert the rest with ON CONFLICT DO NOTHING — so the write is idempotent: an
+ * at-least-once replay deletes nothing and inserts nothing, producing no WAL churn for Zero.
+ */
+export function planMentionReconciles(commentRows: DB['comment'][]): CommentMentionReconcile[] {
+	return commentRows.map((row) => ({
+		commentId: row.id,
+		userIds: extractMentionIds(row.body),
+	}))
 }
 
 export function threadRecordToRow(

--- a/apps/dotcom/zero-cache/migrations/040_add_comment_mention.sql
+++ b/apps/dotcom/zero-cache/migrations/040_add_comment_mention.sql
@@ -1,0 +1,31 @@
+-- Per-comment @-mention rows, one per (comment, mentioned user), extracted from the comment's
+-- rich-text body by the file's Durable Object when it drains comment records to Postgres (see
+-- extractMentionIds / drainCommentOutbox in sync-worker). Mentions live inside the body JSON as
+-- TipTap mention nodes, which ZQL cannot reach, so this table is what lets the app-level
+-- notifications query filter "comments that mention me" server-side. Server-written only, like
+-- comment/comment_thread; rows are reconciled on every comment upsert and cascade away with
+-- their comment.
+
+CREATE TABLE comment_mention (
+  "commentId" VARCHAR NOT NULL,
+  "userId" VARCHAR NOT NULL,
+  PRIMARY KEY ("commentId", "userId"),
+  CONSTRAINT comment_mention_comment_id_fkey FOREIGN KEY ("commentId") REFERENCES public."comment"("id") ON DELETE CASCADE,
+  -- deleting a mentioned user only removes their mention rows, never the comment itself
+  CONSTRAINT comment_mention_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE
+);
+
+-- covers the "comments that mention this user" lookup and the user-delete cascade path
+CREATE INDEX comment_mention_user_id_idx ON comment_mention("userId");
+
+-- Backfill from existing comment bodies: `$.**` recursively finds mention nodes wherever they
+-- nest; DISTINCT collapses the multiple paths lax mode can reach a node through (and repeat
+-- mentions); the user join drops ids that aren't users (deleted accounts, malformed ids) —
+-- mirroring the FK-violation skip in the Durable Object's drain.
+INSERT INTO comment_mention ("commentId", "userId")
+SELECT DISTINCT c."id", u."id"
+FROM comment c
+CROSS JOIN LATERAL jsonb_path_query(c."body", 'lax $.** ? (@.type == "mention").attrs.id') AS mention(id)
+JOIN public."user" u ON u."id" = (mention.id #>> '{}');
+
+ALTER PUBLICATION zero_data ADD TABLE public."comment_mention";

--- a/packages/dotcom-shared/src/commentMentions.test.ts
+++ b/packages/dotcom-shared/src/commentMentions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { extractMentionIds } from './commentMentions'
+
+describe('extractMentionIds', () => {
+	it('collects mention node ids wherever they nest, deduped, in first-seen order', () => {
+		const body = {
+			type: 'doc',
+			content: [
+				{
+					type: 'paragraph',
+					content: [
+						{ type: 'text', text: 'hi ' },
+						{ type: 'mention', attrs: { id: 'user_a', label: 'A' } },
+						{ type: 'mention', attrs: { id: 'user_b', label: 'B' } },
+						{ type: 'mention', attrs: { id: 'user_a', label: 'A again' } },
+					],
+				},
+				{
+					type: 'bulletList',
+					content: [
+						{
+							type: 'listItem',
+							content: [
+								{
+									type: 'paragraph',
+									content: [{ type: 'mention', attrs: { id: 'user_c' } }],
+								},
+							],
+						},
+					],
+				},
+			],
+		}
+		expect(extractMentionIds(body)).toEqual(['user_a', 'user_b', 'user_c'])
+	})
+
+	it('returns an empty array for a body without mentions', () => {
+		expect(
+			extractMentionIds({
+				type: 'doc',
+				content: [{ type: 'paragraph', content: [{ type: 'text', text: 'plain' }] }],
+			})
+		).toEqual([])
+	})
+
+	it('ignores mention nodes without a string id', () => {
+		expect(
+			extractMentionIds({
+				type: 'doc',
+				content: [
+					{
+						type: 'paragraph',
+						content: [{ type: 'mention', attrs: { id: 123 } }, { type: 'mention' }],
+					},
+				],
+			})
+		).toEqual([])
+	})
+
+	it('tolerates non-conforming input', () => {
+		expect(extractMentionIds(null)).toEqual([])
+		expect(extractMentionIds(undefined)).toEqual([])
+		expect(extractMentionIds('a string')).toEqual([])
+		expect(extractMentionIds({ type: 'doc' })).toEqual([])
+	})
+})

--- a/packages/dotcom-shared/src/commentMentions.ts
+++ b/packages/dotcom-shared/src/commentMentions.ts
@@ -1,0 +1,29 @@
+/**
+ * Collects the member ids `@`-mentioned in a comment's rich-text body. Mentions are TipTap
+ * `mention` nodes embedded in the body JSON — `{ type: 'mention', attrs: { id, label } }` — where
+ * `attrs.id` is the mentioned member's user id. Duplicate mentions of the same member collapse to
+ * one id.
+ *
+ * Shared between the sync-worker (which extracts mention rows into the `comment_mention` table
+ * when draining comment records to Postgres, so the notifications query can filter "comments that
+ * mention me" server-side) and the client (which labels notification rows). The body is typed
+ * `unknown` because callers hold it as different JSON types (TLRichText, ReadonlyJSONValue, raw
+ * Postgres JSONB); any non-conforming input just yields no mentions.
+ */
+export function extractMentionIds(body: unknown): string[] {
+	const ids = new Set<string>()
+	const visit = (node: unknown) => {
+		if (typeof node !== 'object' || node === null) return
+		const { type, attrs, content } = node as {
+			type?: unknown
+			attrs?: { id?: unknown }
+			content?: unknown
+		}
+		if (type === 'mention' && typeof attrs?.id === 'string') ids.add(attrs.id)
+		if (Array.isArray(content)) {
+			for (const child of content) visit(child)
+		}
+	}
+	visit(body)
+	return [...ids]
+}

--- a/packages/dotcom-shared/src/index.ts
+++ b/packages/dotcom-shared/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable tldraw/no-export-star */
 export * from './capabilities'
+export * from './commentMentions'
 export * from './constants'
 export * from './roles'
 export { default as getLicenseKey } from './license'

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -45,12 +45,14 @@ export const queries = defineQueries({
 	 * comment qualifies when it isn't the user's own and matches at least one of three categories:
 	 *
 	 * - it's on a file the user owns
-	 * - it's in a thread the user is a part of (started, or has commented in) — a reply
+	 * - it's in a thread the user is a part of (started, or has commented in) and on a file they
+	 *   can still access — a reply
 	 * - it `@`-mentions the user (via the `comment_mention` rows the file's Durable Object
 	 *   extracts from the body, since mentions live inside rich-text JSON that ZQL can't reach),
 	 *   provided the user can access the file: they have a file_state for it, or it belongs to a
-	 *   workspace they're a member of. The other two categories carry their own access evidence
-	 *   (ownership; having commented), so only mentions need the explicit gate.
+	 *   workspace they're a member of. Ownership carries its own access evidence; replies and
+	 *   mentions need an explicit current-access gate because historical thread participation can
+	 *   outlive access to the file.
 	 *
 	 * Filtering here (server-side) rather than on the client is what keeps out-of-category
 	 * comments off the wire entirely — the unread badge is a pure function of the synced set.
@@ -67,12 +69,25 @@ export const queries = defineQueries({
 				or(
 					// on a board the user owns
 					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
-					// a reply: in a thread the user started or has commented in
-					exists('thread', (t) =>
-						t.where(({ cmp, or, exists }) =>
-							or(
-								cmp('createdBy', '=', ctx.userId),
-								exists('comments', (c) => c.where('authorId', '=', ctx.userId))
+					// a reply: in a thread the user started or has commented in, on a file they
+					// can still access
+					and(
+						exists('thread', (t) =>
+							t.where(({ cmp, or, exists }) =>
+								or(
+									cmp('createdBy', '=', ctx.userId),
+									exists('comments', (c) => c.where('authorId', '=', ctx.userId))
+								)
+							)
+						),
+						exists('file', (f) =>
+							f.where(({ or, exists }) =>
+								or(
+									exists('states', (s) => s.where('userId', '=', ctx.userId)),
+									exists('groupFiles', (gf) =>
+										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+									)
+								)
 							)
 						)
 					),

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -41,9 +41,19 @@ export const queries = defineQueries({
 	),
 
 	/**
-	 * Recent comments across every file the current user can access, for the app-level notifications
-	 * feed. Access is scoped to files the user has a file_state for (i.e. has opened/owns), mirroring
-	 * the fileStates query.
+	 * Recent comments that concern the current user, for the app-level notifications feed. A
+	 * comment qualifies when it isn't the user's own and matches at least one of three categories:
+	 *
+	 * - it's on a file the user owns
+	 * - it's in a thread the user is a part of (started, or has commented in) — a reply
+	 * - it `@`-mentions the user (via the `comment_mention` rows the file's Durable Object
+	 *   extracts from the body, since mentions live inside rich-text JSON that ZQL can't reach),
+	 *   provided the user can access the file: they have a file_state for it, or it belongs to a
+	 *   workspace they're a member of. The other two categories carry their own access evidence
+	 *   (ownership; having commented), so only mentions need the explicit gate.
+	 *
+	 * Filtering here (server-side) rather than on the client is what keeps out-of-category
+	 * comments off the wire entirely — the unread badge is a pure function of the synced set.
 	 *
 	 * Bounded to the most recent {@link RECENT_COMMENTS_LIMIT} so the synced set stays finite as a
 	 * workspace ages, rather than growing without limit. This is a display feed — the canvas comment
@@ -52,8 +62,35 @@ export const queries = defineQueries({
 	 */
 	comments: defineQuery(({ ctx }) =>
 		zql.comment
-			.whereExists('file', (file) =>
-				file.whereExists('states', (s) => s.where('userId', '=', ctx.userId))
+			.where('authorId', '!=', ctx.userId)
+			.where(({ and, or, exists }) =>
+				or(
+					// on a board the user owns
+					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
+					// a reply: in a thread the user started or has commented in
+					exists('thread', (t) =>
+						t.where(({ cmp, or, exists }) =>
+							or(
+								cmp('createdBy', '=', ctx.userId),
+								exists('comments', (c) => c.where('authorId', '=', ctx.userId))
+							)
+						)
+					),
+					// @-mentions the user, on a file they can access (opened it, or workspace member)
+					and(
+						exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
+						exists('file', (f) =>
+							f.where(({ or, exists }) =>
+								or(
+									exists('states', (s) => s.where('userId', '=', ctx.userId)),
+									exists('groupFiles', (gf) =>
+										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+									)
+								)
+							)
+						)
+					)
+				)
 			)
 			.related('author', (author) => author.one())
 			.related('file', (file) => file.one())

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -168,6 +168,18 @@ export const comment_read = table('comment_read')
 	})
 	.primaryKey('userId', 'commentId')
 
+// One row per (comment, @-mentioned user), extracted from the comment's rich-text body by the
+// file's Durable Object when it drains comment records to Postgres (mentions live inside the
+// body JSON, which ZQL can't reach — this table is what lets the notifications query filter
+// "comments that mention me" server-side). Server-written only, like comment/comment_thread;
+// rows are reconciled on every comment upsert and cascade away with their comment.
+export const comment_mention = table('comment_mention')
+	.columns({
+		commentId: string(),
+		userId: string(),
+	})
+	.primaryKey('commentId', 'userId')
+
 const fileRelationships = relationships(file, ({ one, many }) => ({
 	owner: one({
 		sourceField: ['ownerId'],
@@ -277,13 +289,27 @@ const commentRelationships = relationships(comment, ({ one, many }) => ({
 		destField: ['commentId'],
 		destSchema: comment_read,
 	}),
+	// the users this comment @-mentions; used with whereExists in the comments query, never
+	// synced as a related row set
+	mentions: many({
+		sourceField: ['id'],
+		destField: ['commentId'],
+		destSchema: comment_mention,
+	}),
 }))
 
-const commentThreadRelationships = relationships(comment_thread, ({ one }) => ({
+const commentThreadRelationships = relationships(comment_thread, ({ one, many }) => ({
 	file: one({
 		sourceField: ['fileId'],
 		destField: ['id'],
 		destSchema: file,
+	}),
+	// the thread's messages; used with whereExists for "threads the user has commented in" in
+	// the comments query, never synced as a related row set
+	comments: many({
+		sourceField: ['id'],
+		destField: ['threadId'],
+		destSchema: comment,
 	}),
 }))
 
@@ -326,6 +352,11 @@ export type TlaCommentReadPartial = Partial<TlaCommentRead> & {
 	commentId: TlaCommentRead['commentId']
 }
 
+export type TlaCommentMentionPartial = Partial<TlaCommentMention> & {
+	commentId: TlaCommentMention['commentId']
+	userId: TlaCommentMention['userId']
+}
+
 export type TlaRow =
 	| TlaFile
 	| TlaFileState
@@ -336,6 +367,7 @@ export type TlaRow =
 	| TlaComment
 	| TlaCommentThread
 	| TlaCommentRead
+	| TlaCommentMention
 export type TlaRowPartial =
 	| TlaFilePartial
 	| TlaFileStatePartial
@@ -346,6 +378,7 @@ export type TlaRowPartial =
 	| TlaCommentPartial
 	| TlaCommentThreadPartial
 	| TlaCommentReadPartial
+	| TlaCommentMentionPartial
 export interface TlaUserMutationNumber {
 	userId: string
 	mutationNumber: number
@@ -420,6 +453,7 @@ export interface DB {
 	comment: TlaComment & CommentPersistenceColumns
 	comment_thread: TlaCommentThread & CommentThreadPersistenceColumns
 	comment_read: TlaCommentRead
+	comment_mention: TlaCommentMention
 }
 
 export const schema = createSchema({
@@ -433,6 +467,7 @@ export const schema = createSchema({
 		comment,
 		comment_thread,
 		comment_read,
+		comment_mention,
 	],
 	relationships: [
 		fileRelationships,
@@ -455,6 +490,7 @@ export type TlaGroupFile = Row<typeof schema.tables.group_file>
 export type TlaComment = Row<typeof schema.tables.comment>
 export type TlaCommentThread = Row<typeof schema.tables.comment_thread>
 export type TlaCommentRead = Row<typeof schema.tables.comment_read>
+export type TlaCommentMention = Row<typeof schema.tables.comment_mention>
 
 // Permissions are now handled via Synced Queries in queries.ts
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -2,6 +2,7 @@ import { stringEnum } from '@tldraw/utils'
 import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
 	TlaComment,
+	TlaCommentMention,
 	TlaCommentRead,
 	TlaCommentThread,
 	TlaFile,
@@ -135,6 +136,9 @@ export interface ZStoreData {
 	// Same as comment: never populated by the legacy polyfill store, present only for the
 	// generic CRUD types.
 	comment_read?: TlaCommentRead[]
+	// Same as comment: never populated by the legacy polyfill store, present only for the
+	// generic CRUD types.
+	comment_mention?: TlaCommentMention[]
 	lsn: string
 }
 
@@ -162,6 +166,7 @@ export type ZTable =
 	| 'comment'
 	| 'comment_thread'
 	| 'comment_read'
+	| 'comment_mention'
 
 export type ZEvent = 'insert' | 'update' | 'delete'
 


### PR DESCRIPTION
In order to keep the notifications panel focused on what actually concerns a user, this PR narrows the comments notifications feed from "every comment on any file you can access" to three categories, filtered **server-side** so out-of-category comments never reach the client, and labels each row with why it's there:

- **Comments on boards you own** — someone commented on a file whose `ownerId` is you ("commented on your board").
- **Replies to threads you're a part of** — a comment by someone else in a thread you started or have commented in ("replied"), provided you can still access the board.
- **At-mentions of you** — a comment whose body `@`-mentions you ("mentioned you"), provided you can access the file (you've opened it, or it belongs to a workspace you're a member of).

Your own comments are excluded, and the sidebar's unread badge is a pure function of the synced set — since read/unread state hangs off notifications, filtering had to happen at the source, not in the client.

### How it works

**Owned boards and replies** are expressible directly in the `comments` synced query (`packages/dotcom-shared/src/queries.ts`) with ZQL `or`/`exists` conditions over `file.ownerId`, `thread.createdBy`, and "a comment by me exists in this thread". Replies also require current file access, so historical thread participation cannot keep syncing comments after access is revoked. The query is enforced server-side at `/app/zero/query`, so the filter governs what Zero replicates, not just what renders.

**Mentions** live inside the rich-text JSON body, which ZQL can't reach. A new `comment_mention` table (one row per comment × mentioned user) makes them queryable:

- The file's Durable Object extracts mention ids from each comment body (shared `extractMentionIds` walker in `packages/dotcom-shared`) when draining comment records to Postgres, and reconciles the rows idempotently — delete stale, insert with `ON CONFLICT DO NOTHING` — so clock-guarded no-op replays cause no WAL churn. A mention insert failing its user FK (deleted account, bogus id) is skipped for good; other failures keep the comment's outbox entry queued for retry.
- Migration `040_add_comment_mention.sql` creates the table, backfills it from existing comment bodies with a `jsonb_path_query` recursive-descent extraction (validated against Postgres 16), and adds it to the `zero_data` publication. Comment deletes cascade mention rows away via FK.

The client's `categorizeCommentNotifications` now derives **labels**, not membership: nothing the server sent is dropped. Two of the three reasons re-derive exactly from synced data; thread participation can't always (the evidence — your own earlier comment — may be older than the feed's 50-comment window), so a comment with no locally derivable reason is labeled "replied", the only category the client can fail to see evidence for.

### Change type

- [x] `improvement`

### Test plan

1. As user B, comment on a fresh thread on a board **owned by A** → A's panel shows the row labeled "commented on your board" and the unread badge increments.
2. A replies, then B replies again in that thread → A sees B's later reply labeled "replied".
3. As B, `@`-mention A in a comment on a board A does **not** own and is not part of → A sees it labeled "mentioned you" (including when A has never opened the file, if it's in A's workspace).
4. Confirm a comment fitting none of the three (B comments on B's own board, no mention, A not in the thread) is **not synced** to A (check the Zero store / network tab) and does not count toward A's unread badge.
5. After A participates in a thread, revoke A's access to its board and have B reply → the new comment is not synced to A.
6. Edit a comment to add/remove an `@`-mention → the `comment_mention` rows reconcile and the notification appears/disappears for the mentioned user.
7. "Mark all as read" clears the badge; clicking a row deep-links to the file/shape and marks it read.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Scope the notifications panel to comments on boards you own, replies in threads you're part of, and @-mentions of you — filtered server-side — and label each notification with the reason it appears.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +138 / -15 |
| Tests           | +300 / -0  |
| Automated files | +57 / -19  |
| Apps            | +277 / -22 |
