### PR TITLE
ci: run hotfix trigger on pull_request_target so [skip ci] PRs still deploy

### DIFF
--- a/.github/workflows/trigger-sdk-hotfix.yml
+++ b/.github/workflows/trigger-sdk-hotfix.yml
@@ -8,10 +8,13 @@ name: Trigger sdk hotfix
 # labels), and `labeled` allows re-triggering a hotfix by re-adding the label to an
 # already-merged PR. Secrets exposure is safe here: the job only runs for merged PRs
 # carrying a maintainer-applied hotfix label, checkout uses the trusted base branch,
-# and the script only cherry-picks the PR's already-merged commit from main.
+# and the only PR-derived code the script builds is the PR's already-merged commit
+# from main.
 on:
   pull_request_target:
     types: [closed, labeled]
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/trigger-sdk-hotfix.yml
+++ b/.github/workflows/trigger-sdk-hotfix.yml
@@ -1,11 +1,17 @@
 name: Trigger sdk hotfix
 
+# pull_request_target rather than push/pull_request: hotfix PRs (e.g. the automated
+# release-notes updates) carry `[skip ci]` in their commit messages, which suppresses
+# push- and pull_request-triggered workflows entirely — the label had no effect.
+# GitHub's skip-ci markers do not apply to pull_request_target. The `closed` event
+# replaces the old push-to-main trigger (which ran on every merge just to check
+# labels), and `labeled` allows re-triggering a hotfix by re-adding the label to an
+# already-merged PR. Secrets exposure is safe here: the job only runs for merged PRs
+# carrying a maintainer-applied hotfix label, checkout uses the trusted base branch,
+# and the script only cherry-picks the PR's already-merged commit from main.
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [labeled]
+  pull_request_target:
+    types: [closed, labeled]
 
 defaults:
   run:
@@ -18,10 +24,12 @@ jobs:
     concurrency: npm-publish
     environment: npm deploy
     if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && 
-       github.event.pull_request.merged == true && 
-       (github.event.label.name == 'sdk-hotfix-please' || github.event.label.name == 'docs-hotfix-please'))
+      github.event.pull_request.merged == true &&
+      ((github.event.action == 'closed' &&
+        (contains(github.event.pull_request.labels.*.name, 'sdk-hotfix-please') ||
+         contains(github.event.pull_request.labels.*.name, 'docs-hotfix-please'))) ||
+       (github.event.action == 'labeled' &&
+        (github.event.label.name == 'sdk-hotfix-please' || github.event.label.name == 'docs-hotfix-please')))
 
     steps:
       - name: Generate a token

--- a/internal/scripts/trigger-sdk-hotfix.ts
+++ b/internal/scripts/trigger-sdk-hotfix.ts
@@ -88,6 +88,17 @@ async function main() {
 			await exec('git', ['reset', `origin/${latestReleaseBranch}`, '--hard'])
 			await exec('git', ['log', '-1', '--oneline'])
 			await exec('git', ['cherry-pick', commitSha])
+
+			// the push to the release branch below must trigger publish.yml, but some
+			// merge commits (e.g. release-notes updates) carry `[skip ci]`, which would
+			// suppress it. strip skip-ci markers from the cherry-picked commit message.
+			const message = (await exec('git', ['log', '-1', '--format=%B'])).trim()
+			const cleanedMessage = message
+				.replace(/ *\[(?:skip ci|ci skip|no ci|skip actions|actions skip)\]/gi, '')
+				.trim()
+			if (cleanedMessage !== message) {
+				await exec('git', ['commit', '--amend', '-m', cleanedMessage])
+			}
 		}
 	)
 

--- a/skills/update-release-notes/SKILL.md
+++ b/skills/update-release-notes/SKILL.md
@@ -198,6 +198,8 @@ Then create the PR using the `../pr/SKILL.md` workflow and the standards in `../
 
 **Why `[skip ci]`**: pushing to `production` (and the `hotfixes` → `production` promotion) triggers `deploy-dotcom.yml`. A merge commit containing `[skip ci]` is skipped by GitHub Actions entirely, so the release-notes change can land on `production` — ready to ride the next SDK release, which pushes the `production` ref to `docs-production` — without deploying tldraw.com.
 
+`[skip ci]` does not interfere with the `docs-hotfix-please` label: `trigger-sdk-hotfix.yml` runs on `pull_request_target`, which GitHub's skip-ci markers do not affect. It fires when a labeled PR is merged; to re-trigger it later, remove and re-add the label on the merged PR.
+
 ## The `last_version` field
 
 The `next.mdx` frontmatter includes a `last_version` field that tracks the most recent published release. This determines which PRs are "new" and need to be added.

--- a/skills/update-release-notes/SKILL.md
+++ b/skills/update-release-notes/SKILL.md
@@ -176,7 +176,7 @@ Run this after every `next.mdx` update, including the release-week runs. On the 
 
 ### 10. Push changes
 
-After editing `next.mdx` (and any archive files), commit and push from the tldraw clone. Use a single commit whose message ends with `[skip ci]` so merging the change does not trigger a dotcom deploy or other CI workflows (release-notes edits are docs-only):
+After editing `next.mdx` (and any archive files), commit and push from the tldraw clone. Use a single commit whose message ends with `[skip ci]` so merging the change does not trigger a dotcom deploy or other push- and pull_request-triggered workflows (release-notes edits are docs-only):
 
 ```bash
 cd /tmp/tldraw
@@ -198,7 +198,7 @@ Then create the PR using the `../pr/SKILL.md` workflow and the standards in `../
 
 **Why `[skip ci]`**: pushing to `production` (and the `hotfixes` → `production` promotion) triggers `deploy-dotcom.yml`. A merge commit containing `[skip ci]` is skipped by GitHub Actions entirely, so the release-notes change can land on `production` — ready to ride the next SDK release, which pushes the `production` ref to `docs-production` — without deploying tldraw.com.
 
-`[skip ci]` does not interfere with the `docs-hotfix-please` label: `trigger-sdk-hotfix.yml` runs on `pull_request_target`, which GitHub's skip-ci markers do not affect. It fires when a labeled PR is merged; to re-trigger it later, remove and re-add the label on the merged PR.
+`[skip ci]` does not interfere with the `docs-hotfix-please` label: `trigger-sdk-hotfix.yml` runs on `pull_request_target`, which GitHub's skip-ci markers do not affect, and the hotfix script strips skip-ci markers from the cherry-picked commit so the release-branch push still triggers the publish workflow. The trigger fires when a labeled PR is merged; to re-trigger it later, remove and re-add the label on the merged PR.
 
 ## The `last_version` field
 


### PR DESCRIPTION
In order for the `docs-hotfix-please` label to actually deploy docs for PRs whose commits carry `[skip ci]` — every automated release-notes PR, most recently #9601, which merged with the label but never showed up on tldraw.dev/releases/next — this PR moves `trigger-sdk-hotfix.yml` from `push` + `pull_request` to `pull_request_target`, which GitHub's skip-ci markers do not suppress.

Both old trigger paths were dead for these PRs: the `[skip ci]` merge commit skipped the push-to-main run entirely, and the `pull_request: labeled` event either fired at PR creation (before `merged == true`) or was itself suppressed by `[skip ci]` on the head commit. The new trigger fires on `closed` (replacing the push trigger, which also stops the job from running on every merge to main just to check labels) and on `labeled` (so a hotfix can be re-triggered by removing and re-adding the label on a merged PR). It stays gated on `merged == true` plus a hotfix label, and is scoped to PRs based on `main` like the old push trigger was.

Fixing the trigger alone isn't enough: the cherry-picked commit keeps `[skip ci]` in its message, which would then suppress `publish.yml` on the release-branch push — the workflow that actually deploys `docs-production`. The hotfix script now strips skip-ci markers from the cherry-picked commit message before pushing, so the deploy fires end to end.

On `pull_request_target` safety: the job only runs for merged PRs carrying a maintainer-applied hotfix label, checkout remains the trusted base branch, and the only PR-derived code that gets built is the PR's already-merged commit from `main` — the same code the old push trigger built.

Because `pull_request_target` reads the workflow definition from the base branch, this takes effect once merged. #9601 can then be recovered by removing and re-adding `docs-hotfix-please` on it.

Relates to #9459 (same docs-hotfix pipeline, different defect).

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +32 / -8   |