### PR TITLE
fix(commenting): let the comments sidebar own its scroll

### DIFF
--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -6,7 +6,6 @@ import {
 	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
-	usePassThroughWheelEvents,
 	useTranslation,
 	useValue,
 } from 'tldraw'
@@ -169,11 +168,11 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 	)
 }
 
-/** The sidebar surface, portaled into the container. Over it, wheel and hover events pass through to
- *  the canvas (except where the list scrolls itself), matching tldraw's own panels. */
+/** The sidebar surface, portaled into the container. It scrolls its own list, so — unlike tldraw's
+ *  wheel-transparent panels — a wheel over it doesn't pan the canvas. Hover still passes through so
+ *  shapes beneath it stay interactive. */
 function SidebarPanel({ container, children }: { container: HTMLElement; children: ReactNode }) {
 	const ref = useRef<HTMLDivElement>(null)
-	usePassThroughWheelEvents(ref)
 	usePassThroughMouseOverEvents(ref)
 	return createPortal(
 		<div ref={ref} className="cmt-canvas-sidebar">


### PR DESCRIPTION
In order to let the comments sidebar scroll its own list, this PR stops the sidebar from forwarding wheel events to the canvas.

The sidebar opted into `usePassThroughWheelEvents`, a hook tldraw's on-canvas panels use to stay "wheel-transparent" — it re-dispatches wheel events to `.tl-canvas` so the board keeps panning while the pointer is over the panel, suppressing that only when the panel itself is scrollable. It decided scrollability by measuring the panel's outer element, which for the sidebar is an `overflow: hidden` shell around a nested scrolling list (`.cmt-list__items`). The shell never overflows, so the hook always forwarded and called `preventDefault`, and the list could never scroll — the wheel panned the canvas instead.

Dropping the opt-in lets the list scroll natively, the same way the page menu and other portaled panels do (they live outside `.tl-canvas`, so their wheel events never reach the canvas listener in the first place). Hover pass-through (`usePassThroughMouseOverEvents`) is kept, so shapes beneath the sidebar stay interactive.

### Preview

Preview deploy: https://pr-9608-preview-deploy.tldraw.com/

### Change type

- [x] `bugfix`

### Test plan

1. Open the preview, sign in, and open a file.
2. Select the comment tool to show the comments sidebar (top-right).
3. Add enough comment threads that the sidebar list overflows its height.
4. Hover the list and scroll with a trackpad or mouse wheel — the list scrolls, and the canvas does not pan.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the comments sidebar not scrolling with the mouse wheel or trackpad over its list.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +3 / -4    |
