### PR TITLE
feat(examples): add commenting examples

### DIFF
--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -50,6 +50,7 @@
 		"@tiptap/pm": "^3.12.1",
 		"@tiptap/starter-kit": "^3.12.1",
 		"@tldraw/assets": "workspace:*",
+		"@tldraw/commenting": "workspace:*",
 		"@tldraw/dotcom-shared": "workspace:*",
 		"@tldraw/driver": "workspace:*",
 		"@tldraw/mermaid": "workspace:*",

--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -1,0 +1,97 @@
+import { CanvasComments, commentToolOverrides, commentTools } from '@tldraw/commenting/canvas'
+import { useMemo } from 'react'
+import {
+	commentSchemaRecords,
+	createComment,
+	createCommentThread,
+	createShapeId,
+	createTLSchema,
+	createTLStore,
+	Editor,
+	TLCommentAnchor,
+	TLComponents,
+	Tldraw,
+	toRichText,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+
+const NAMES: Record<string, string> = { ada: 'Ada Lovelace', me: 'You' }
+const resolveName = (id: string): string => NAMES[id] ?? id
+
+// A thread plus its opening comment, anchored however the caller specifies. Every `TLCommentThread`
+// carries an `anchor` — a discriminated union — and `CanvasComments` renders each kind in the right
+// place: shape/text-range pins track the shape, point/region pins sit at fixed page coordinates.
+function seedThread(editor: Editor, anchor: TLCommentAnchor, text: string) {
+	const pageId = editor.getCurrentPageId()
+	const thread = createCommentThread({ pageId, anchor, createdBy: 'ada' })
+	const comment = createComment({
+		threadId: thread.id,
+		pageId,
+		authorId: 'ada',
+		body: toRichText(text),
+	})
+	editor.store.put([thread, comment])
+}
+
+export default function CommentAnchorsExample() {
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	const handleMount = (editor: Editor) => {
+		// A rectangle to anchor shape comments against.
+		const boxId = createShapeId()
+		editor.run(
+			() => {
+				editor.createShapes([
+					{ id: boxId, type: 'geo', x: 120, y: 100, props: { geo: 'rectangle', w: 200, h: 140 } },
+				])
+
+				// shape (imprecise): normalized x/y ignored for the pin, which sits at the shape's
+				// top-right badge spot. The anchor still tracks the shape as it moves and resizes.
+				seedThread(
+					editor,
+					{ type: 'shape', shapeId: boxId, x: 1, y: 0, isPrecise: false },
+					'Anchored to this shape (imprecise — sits at the corner).'
+				)
+				// shape (precise): the pin sits exactly at the stored normalized spot inside the shape.
+				seedThread(
+					editor,
+					{ type: 'shape', shapeId: boxId, x: 0.5, y: 0.6, isPrecise: true },
+					'Anchored to a precise spot inside the shape.'
+				)
+				// point: a bare page coordinate, unattached to any shape.
+				seedThread(editor, { type: 'point', x: 200, y: 340 }, 'Anchored to a point on the page.')
+				// region: a rectangular area; the pin sits on its corner and the box is drawn.
+				seedThread(
+					editor,
+					{ type: 'region', x: 380, y: 300, w: 200, h: 130 },
+					'Anchored to a region of the page.'
+				)
+			},
+			{ history: 'ignore' }
+		)
+
+		editor.zoomToBounds({ x: 60, y: 60, w: 600, h: 420 }, { immediate: true })
+	}
+
+	const components = useMemo<TLComponents>(
+		() => ({
+			InFrontOfTheCanvas: () => <CanvasComments currentUserId="me" resolveName={resolveName} />,
+		}),
+		[]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				store={store}
+				onMount={handleMount}
+				tools={commentTools}
+				overrides={[commentToolOverrides]}
+				components={components}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/comment-anchors/README.md
+++ b/apps/examples/src/examples/collaboration/comment-anchors/README.md
@@ -1,0 +1,21 @@
+---
+title: Comment anchors
+component: ./CommentAnchorsExample.tsx
+priority: 4
+keywords: [comments, commenting, anchors, shape, region, point, text range, collaboration]
+---
+
+The five ways a comment can attach to the canvas.
+
+---
+
+Every comment thread carries an `anchor` — a discriminated union that says where on the page the thread lives. `CanvasComments` reads the anchor and draws each kind in the right place. This example seeds one thread of each kind, then lets the overlay position them:
+
+- **shape (imprecise)** — attached to a shape, the pin sitting at its top-right badge spot. The stored `x`/`y` are normalized (0–1), so the pin tracks the shape as it moves and resizes.
+- **shape (precise)** — attached to an exact normalized spot inside a shape (what you get by holding `alt` while placing).
+- **point** — a bare page coordinate, unattached to any shape.
+- **region** — a rectangular area; the pin sits on a corner and the region box is drawn.
+
+Two more anchor kinds exist but the default overlay doesn't give them a distinct pin: **page** anchors attach a thread to the whole board (no pin — they surface in a comments list instead), and **text-range** anchors attach a thread to a character range within a text shape.
+
+Drag the shape around to watch the shape-anchored pins follow it, or pick the comment tool and click to add your own thread anchored wherever you place it.

--- a/apps/examples/src/examples/collaboration/comment-clustering/CommentClusteringExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-clustering/CommentClusteringExample.tsx
@@ -1,0 +1,80 @@
+import { CommentPin, CountBadge } from '@tldraw/commenting'
+import {
+	computeClusterTable,
+	createClusterRuntime,
+	type LeafInput,
+} from '@tldraw/commenting/canvas'
+import { useMemo } from 'react'
+import { Editor, TLComponents, Tldraw, useEditor, useValue } from 'tldraw'
+import 'tldraw/tldraw.css'
+import './comment-clustering.css'
+
+// Comment anchors in page space: two loose groups that merge into single badges as you zoom out.
+const LEAVES: (LeafInput & { label: string })[] = [
+	{ id: 'a', label: 'J', point: { x: 250, y: 140 } },
+	{ id: 'b', label: 'M', point: { x: 300, y: 170 } },
+	{ id: 'c', label: 'A', point: { x: 265, y: 220 } },
+	{ id: 'd', label: 'S', point: { x: 470, y: 250 } },
+	{ id: 'e', label: 'K', point: { x: 515, y: 285 } },
+]
+
+// The editor's zoom range, matching how the commenting overlay derives it.
+function zoomBounds(editor: Editor) {
+	const opts = editor.getCameraOptions()
+	const base = opts.constraints ? editor.getBaseZoom() : 1
+	const steps = opts.zoomSteps
+	return { minZoom: steps[0] * base, maxZoom: steps[steps.length - 1] * base }
+}
+
+// Rendered as a tldraw component slot, so it lives inside the editor's themed container — that's
+// what gives `CommentPin`/`CountBadge` their colors, since those read tldraw's CSS tokens.
+function ClusterLayer() {
+	const editor = useEditor()
+
+	// `computeClusterTable` precomputes, for the full zoom range, which anchors merge and at what
+	// zoom. The runtime then just looks up the current zoom — cheap enough to run every camera move.
+	const runtime = useMemo(() => {
+		const rt = createClusterRuntime(computeClusterTable(LEAVES, zoomBounds(editor)))
+		rt.seed(editor.getZoomLevel())
+		return rt
+	}, [editor])
+
+	// Track the whole camera, not just zoom: clustering re-flows on zoom, but the pins' screen
+	// positions must also follow x/y so they stay glued to the page as you pan.
+	const camera = useValue('camera', () => editor.getCamera(), [editor])
+	const nodes = useMemo(() => {
+		runtime.onCamera(camera.z)
+		return Array.from(runtime.getVisible().values())
+	}, [runtime, camera.z])
+
+	const labelById = useMemo(() => new Map(LEAVES.map((l) => [l.id, l.label])), [])
+
+	return (
+		<div className="comment-clustering__layer">
+			{nodes.map((node) => {
+				const p = editor.pageToViewport(node.centroid)
+				const style = { left: p.x, top: p.y }
+				// A single-member node renders as a pin; a merged node as a count badge.
+				return (
+					<div key={node.id} className="comment-clustering__marker" style={style}>
+						{node.count === 1 ? (
+							<CommentPin>{labelById.get(node.members[0]) ?? '?'}</CommentPin>
+						) : (
+							<CountBadge count={node.count} />
+						)}
+					</div>
+				)
+			})}
+			<div className="comment-clustering__hint">Zoom out to cluster (⌘/ctrl-scroll or pinch)</div>
+		</div>
+	)
+}
+
+export default function CommentClusteringExample() {
+	const components = useMemo<TLComponents>(() => ({ InFrontOfTheCanvas: ClusterLayer }), [])
+	return (
+		<div className="tldraw__editor">
+			<Tldraw hideUi components={components} />
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/comment-clustering/README.md
+++ b/apps/examples/src/examples/collaboration/comment-clustering/README.md
@@ -1,0 +1,16 @@
+---
+title: Comment clustering
+component: ./CommentClusteringExample.tsx
+priority: 3
+keywords: [comments, commenting, clustering, pins, zoom, count badge, collaboration]
+---
+
+Merge nearby comment pins into a count badge as you zoom out.
+
+---
+
+When a board fills up with comments, pins that sit close together overlap and become unreadable at low zoom. The commenting toolkit solves this with clustering: nearby anchors merge into a single count badge as you zoom out, and split back into individual pins as you zoom in.
+
+This example drives the clustering pipeline directly. `computeClusterTable` precomputes, across the whole zoom range, which anchors merge and at which zoom level — using a minimum-spanning-tree merge with hysteresis so pins don't flicker at the threshold. `createClusterRuntime` wraps that table so a camera move is just a lookup: on each zoom change it returns the currently-visible nodes, each either a single member (drawn as a `CommentPin`) or a merged group (drawn as a `CountBadge`).
+
+Zoom out with `⌘`/`ctrl`-scroll or a pinch gesture to watch the two groups collapse.

--- a/apps/examples/src/examples/collaboration/comment-clustering/comment-clustering.css
+++ b/apps/examples/src/examples/collaboration/comment-clustering/comment-clustering.css
@@ -1,0 +1,27 @@
+.comment-clustering__layer {
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	z-index: 300;
+}
+
+/* Markers centre on their anchor point. No transition: the runtime hard-swaps a pin for a count
+   badge at the merge/split zoom thresholds. */
+.comment-clustering__marker {
+	position: absolute;
+	transform: translate(-50%, -50%);
+}
+
+.comment-clustering__hint {
+	position: absolute;
+	top: 12px;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 400;
+	padding: 5px 10px;
+	border-radius: 8px;
+	background: rgba(0, 0, 0, 0.7);
+	color: #fff;
+	font-size: 12px;
+	pointer-events: none;
+}

--- a/apps/examples/src/examples/collaboration/commenting/CommentingExample.tsx
+++ b/apps/examples/src/examples/collaboration/commenting/CommentingExample.tsx
@@ -1,0 +1,60 @@
+import { filterMentionMembers, MentionMember } from '@tldraw/commenting'
+import { CanvasComments, commentToolOverrides, commentTools } from '@tldraw/commenting/canvas'
+import { useMemo } from 'react'
+import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+// The people who can be @-mentioned. A real app would pull this from its own roster; the composer
+// filters this list as you type after `@`. Ids match the author directory below.
+const MEMBERS: MentionMember[] = [
+	{ id: 'me', name: 'You', you: true },
+	{ id: 'ada', name: 'Ada Lovelace' },
+	{ id: 'grace', name: 'Grace Hopper' },
+	{ id: 'alan', name: 'Alan Turing' },
+]
+
+// A tiny local user directory so the flow shows names instead of ids. A real app would resolve
+// these from its own identity system.
+const NAMES: Record<string, string> = Object.fromEntries(MEMBERS.map((m) => [m.id, m.name]))
+const resolveName = (id: string): string => NAMES[id] ?? id
+
+// Region comments are off by default (click-only). Enable dragging out a rectangle to comment on an
+// area. A module-level constant keeps the object identity stable across renders.
+const REGION_OPTIONS = { enabled: true }
+
+export default function CommentingExample() {
+	// Comments are stored as `comment-thread` and `comment` records in the editor's own store.
+	// Registering `commentSchemaRecords` on the schema is all it takes to persist and sync them
+	// alongside shapes — no separate backend, so the whole flow runs in-memory here.
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	// `CanvasComments` reads those records reactively and draws the pins, threads, and composer.
+	// Mounting it in front of the canvas is the entire UI layer.
+	const components = useMemo<TLComponents>(
+		() => ({
+			InFrontOfTheCanvas: () => (
+				<CanvasComments
+					currentUserId="me"
+					resolveName={resolveName}
+					regionOptions={REGION_OPTIONS}
+					getMentionSuggestions={(query) => filterMentionMembers(MEMBERS, query)}
+				/>
+			),
+		}),
+		[]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				store={store}
+				tools={commentTools}
+				overrides={[commentToolOverrides]}
+				components={components}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/commenting/README.md
+++ b/apps/examples/src/examples/collaboration/commenting/README.md
@@ -1,0 +1,16 @@
+---
+title: Commenting
+component: ./CommentingExample.tsx
+priority: 1
+keywords: [comments, commenting, comment thread, annotations, feedback, review, collaboration, pins]
+---
+
+Add comments to the canvas with the commenting toolkit.
+
+---
+
+The `@tldraw/commenting` package adds a commenting layer on top of the tldraw editor. Select the comment tool from the toolbar (or press `c`), then click anywhere to start a thread, drag out a rectangle to comment on a region, or click a shape to attach a comment to it. Each thread shows as a pin you can reopen, reply to, resolve, or delete. Type `@` in a composer to mention someone from the roster.
+
+Comments are stored as `comment-thread` and `comment` records in the editor's own store. You register those record types by passing `commentSchemaRecords` to the schema, then render `CanvasComments` in front of the canvas — it reads the records reactively and draws the pins, threads, and composer. Because comments live in the store, they persist and sync exactly like shapes: this example runs entirely in-memory, but adding a `persistenceKey` or a sync backend would carry the comments along for free.
+
+`CanvasComments` takes a `currentUserId` (the signed-in user, or `null` for a read-only viewer) and a `resolveName` function that maps author ids to display names. The optional props here enable more of the toolkit: `regionOptions={{ enabled: true }}` turns on drag-to-comment regions, and `getMentionSuggestions` supplies the `@`-mention roster.

--- a/yarn.lock
+++ b/yarn.lock
@@ -20037,6 +20037,7 @@ __metadata:
     "@tiptap/pm": "npm:^3.12.1"
     "@tiptap/starter-kit": "npm:^3.12.1"
     "@tldraw/assets": "workspace:*"
+    "@tldraw/commenting": "workspace:*"
     "@tldraw/dotcom-shared": "workspace:*"
     "@tldraw/driver": "workspace:*"
     "@tldraw/mermaid": "workspace:*"


### PR DESCRIPTION
Adds examples for the `@tldraw/commenting` toolkit to the examples app, ported from the component-studio sketchbook into the standard examples format. Wires `@tldraw/commenting` into `apps/examples`.

Three examples, all under **Collaboration**:

- **Commenting** — the full click-to-comment flow: comment tool, pins, compose, reply, resolve, delete, on an in-memory store (`commentSchemaRecords` on the schema, `CanvasComments` in front of the canvas). Region comments and `@`-mentions are enabled to show those options.
- **Comment clustering** — the clustering pipeline (`computeClusterTable` / `createClusterRuntime`) merging nearby pins into count badges as the camera zooms out. The overlay is rendered via `InFrontOfTheCanvas` so it lives inside the editor's themed container and tracks the full camera on pan.
- **Comment anchors** — seeded threads demonstrating the shape (imprecise/precise), point, and region anchor kinds, positioned by `CanvasComments` from the records. The comment tool is enabled so you can add your own.

## Notes

- Each example uses the real SDK path (register records, mount the overlay) rather than reconstructing the sketchbook's isolated harness — an example should teach the supported API a consumer would use.
- Commenting is license-gated: `CanvasComments` renders nothing unless the `commenting` feature is licensed. It works in these examples because tldraw treats localhost as development and enables every feature; a production deployment needs a license that includes commenting.

## Test

Run `yarn dev` and open http://localhost:5420/commenting, `/comment-clustering`, and `/comment-anchors`.