### PR TITLE
fix(utils): don't treat any as optional in MakeUndefinedOptional

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -12,6 +12,7 @@ import { ReactNode, useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
 	createDeepLinkString,
+	richTextValidator,
 	TldrawUiButton,
 	TldrawUiDropdownMenuContent,
 	TldrawUiDropdownMenuRoot,
@@ -21,7 +22,6 @@ import {
 	TldrawUiMenuGroup,
 	TldrawUiMenuItem,
 	TldrawUiTooltip,
-	TLRichText,
 	useValue,
 } from 'tldraw'
 import { routes } from '../../../../routeDefs'
@@ -234,7 +234,8 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 				name: c.authorName || unknownAuthor,
 				color: c.authorColor || undefined,
 			},
-			preview: richTextToPlaintext(c.body as TLRichText),
+			// a malformed body should only cost this row its preview, not break the whole list
+			preview: richTextValidator.isValid(c.body) ? richTextToPlaintext(c.body) : '',
 			// the notified-about event: a reaction entry dates from its newest foreign reaction,
 			// not from the (older) comment it decorates
 			date: new Date(n.timestamp).toISOString(),

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -11,6 +11,7 @@ import {
 	isCommentId,
 	isCommentReactionId,
 	isCommentThreadId,
+	richTextValidator,
 } from '@tldraw/tlschema'
 import { JsonObject } from '@tldraw/utils'
 
@@ -151,6 +152,15 @@ export function reactionRecordToRow(
 	}
 }
 
+/**
+ * A `TLRichText` is always valid JSON at runtime, but its shape (`content: unknown[]`, no string
+ * index signature) doesn't structurally overlap Zero's `ReadonlyJSONValue`, so TypeScript can't
+ * prove the widening. Assert it here in one place instead of scattering casts across the mappers.
+ */
+function richTextToRowBody(body: TLComment['body']): DB['comment']['body'] {
+	return body as unknown as DB['comment']['body']
+}
+
 export function commentRecordToRow(
 	record: TLComment,
 	fileId: string,
@@ -166,8 +176,7 @@ export function commentRecordToRow(
 		authorName: '',
 		authorColor: '',
 		authorAvatar: '',
-		// TLRichText's content is unknown[], not structurally a zero ReadonlyJSONValue
-		body: record.body as DB['comment']['body'],
+		body: richTextToRowBody(record.body),
 		// client-dated placeholder — a Postgres trigger re-stamps it with server arrival time on
 		// insert (migration 046), and the upsert's conflict branch never writes this column
 		createdAt: record.createdAt,
@@ -205,7 +214,7 @@ export function rowToCommentRecord(row: DB['comment']): TLComment {
 		authorId: row.authorId,
 		createdAt: Number(row.createdAt),
 		editedAt: row.editedAt != null ? Number(row.editedAt) : null,
-		body: row.body as TLComment['body'],
+		body: richTextValidator.validate(row.body),
 		isDeleted: row.isDeleted,
 		meta: (row.meta ?? {}) as JsonObject,
 	}

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -139,7 +139,6 @@ import { TLPointerEventInfo } from '@tldraw/editor';
 import { TLPropsMigrations } from '@tldraw/tlschema';
 import { TLResizeInfo } from '@tldraw/editor';
 import { TLRichText } from '@tldraw/tlschema';
-import { TLRichText as TLRichText_2 } from '@tldraw/editor';
 import { TLSchema } from '@tldraw/editor';
 import { TLScribble } from '@tldraw/editor';
 import { TLSelectionHandle } from '@tldraw/editor';
@@ -3266,19 +3265,19 @@ export function removeFrame(editor: Editor, ids: TLShapeId[]): void;
 export function RemoveFrameMenuItem(): JSX.Element | null;
 
 // @public
-export function renderHtmlFromRichText(editor: Editor, richText: TLRichText_2): string;
+export function renderHtmlFromRichText(editor: Editor, richText: TLRichText): string;
 
 // @public
-export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: TLRichText_2): string;
+export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: TLRichText): string;
 
 // @public
-export function renderHtmlFromRichTextWithExtensions(richText: TLRichText_2, extensions: Extensions): string;
+export function renderHtmlFromRichTextWithExtensions(richText: TLRichText, extensions: Extensions): string;
 
 // @public
-export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText_2): string;
+export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText): string;
 
 // @public
-export function renderRichTextFromHTML(editor: Editor, html: string): TLRichText_2;
+export function renderRichTextFromHTML(editor: Editor, html: string): TLRichText;
 
 // @public (undocumented)
 export function ReorderMenuItems(): JSX.Element;
@@ -3318,7 +3317,7 @@ export interface RichTextLabelProps {
     // (undocumented)
     padding?: number;
     // (undocumented)
-    richText?: TLRichText_2;
+    richText?: TLRichText;
     // (undocumented)
     shapeId: TLShapeId;
     // (undocumented)
@@ -3333,7 +3332,7 @@ export interface RichTextLabelProps {
     textWidth?: number;
     // (undocumented)
     type: ExtractShapeByProps<{
-        richText: TLRichText_2;
+        richText: TLRichText;
     }>['type'];
     // (undocumented)
     verticalAlign: 'end' | 'middle' | 'start';
@@ -3359,7 +3358,7 @@ export interface RichTextSVGProps {
     // (undocumented)
     padding: number;
     // (undocumented)
-    richText: TLRichText_2;
+    richText: TLRichText;
     // (undocumented)
     showTextOutline?: boolean;
     // (undocumented)
@@ -3760,7 +3759,7 @@ export interface TextAreaProps {
     // (undocumented)
     handleChange(changeInfo: {
         plaintext?: string;
-        richText?: TLRichText_2;
+        richText?: TLRichText;
     }): void;
     // (undocumented)
     handleDoubleClick(e: any): any;
@@ -3777,7 +3776,7 @@ export interface TextAreaProps {
     // (undocumented)
     isEditing: boolean;
     // (undocumented)
-    richText?: TLRichText_2;
+    richText?: TLRichText;
     // (undocumented)
     shapeId: TLShapeId;
     // (undocumented)
@@ -6453,11 +6452,11 @@ export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByPro
 
 // @public (undocumented)
 export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProps<{
-    richText: TLRichText_2;
-}>['type'], richText?: TLRichText_2): {
+    richText: TLRichText;
+}>['type'], richText?: TLRichText): {
     handleBlur: () => void;
     handleChange: ({ richText }: {
-        richText: TLRichText_2;
+        richText: TLRichText;
     }) => void;
     handleDoubleClick: (e: {
         nativeEvent: Event;

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -138,7 +138,8 @@ import { TLParentId } from '@tldraw/tlschema';
 import { TLPointerEventInfo } from '@tldraw/editor';
 import { TLPropsMigrations } from '@tldraw/tlschema';
 import { TLResizeInfo } from '@tldraw/editor';
-import { TLRichText } from '@tldraw/editor';
+import { TLRichText } from '@tldraw/tlschema';
+import { TLRichText as TLRichText_2 } from '@tldraw/editor';
 import { TLSchema } from '@tldraw/editor';
 import { TLScribble } from '@tldraw/editor';
 import { TLSelectionHandle } from '@tldraw/editor';
@@ -2139,11 +2140,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
             growY: number;
             h: number;
             labelColor: TLDefaultColorStyle;
-            richText: {
-                attrs?: any;
-                content: unknown[];
-                type: string;
-            };
+            richText: TLRichText;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             url: string;
@@ -2176,11 +2173,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
             growY: number;
             h: number;
             labelColor: TLDefaultColorStyle;
-            richText: {
-                attrs?: any;
-                content: unknown[];
-                type: string;
-            };
+            richText: TLRichText;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             url: string;
@@ -2213,11 +2206,7 @@ export class GeoShapeUtil extends BaseBoxShapeUtil<TLGeoShape> {
             growY: number;
             h: number;
             labelColor: TLDefaultColorStyle;
-            richText: {
-                attrs?: any;
-                content: unknown[];
-                type: string;
-            };
+            richText: TLRichText;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             url: string;
@@ -2891,11 +2880,7 @@ export class NoteShapeUtil extends ShapeUtil<TLNoteShape> {
             fontSizeAdjustment: number;
             growY: number;
             labelColor: TLDefaultColorStyle;
-            richText: {
-                attrs?: any;
-                content: unknown[];
-                type: string;
-            };
+            richText: TLRichText;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             textLastEditedBy: null | string;
@@ -3281,19 +3266,19 @@ export function removeFrame(editor: Editor, ids: TLShapeId[]): void;
 export function RemoveFrameMenuItem(): JSX.Element | null;
 
 // @public
-export function renderHtmlFromRichText(editor: Editor, richText: TLRichText): string;
+export function renderHtmlFromRichText(editor: Editor, richText: TLRichText_2): string;
 
 // @public
-export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: TLRichText): string;
+export function renderHtmlFromRichTextForMeasurement(editor: Editor, richText: TLRichText_2): string;
 
 // @public
-export function renderHtmlFromRichTextWithExtensions(richText: TLRichText, extensions: Extensions): string;
+export function renderHtmlFromRichTextWithExtensions(richText: TLRichText_2, extensions: Extensions): string;
 
 // @public
-export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText): string;
+export function renderPlaintextFromRichText(editor: Editor, richText: TLRichText_2): string;
 
 // @public
-export function renderRichTextFromHTML(editor: Editor, html: string): TLRichText;
+export function renderRichTextFromHTML(editor: Editor, html: string): TLRichText_2;
 
 // @public (undocumented)
 export function ReorderMenuItems(): JSX.Element;
@@ -3333,7 +3318,7 @@ export interface RichTextLabelProps {
     // (undocumented)
     padding?: number;
     // (undocumented)
-    richText?: TLRichText;
+    richText?: TLRichText_2;
     // (undocumented)
     shapeId: TLShapeId;
     // (undocumented)
@@ -3348,7 +3333,7 @@ export interface RichTextLabelProps {
     textWidth?: number;
     // (undocumented)
     type: ExtractShapeByProps<{
-        richText: TLRichText;
+        richText: TLRichText_2;
     }>['type'];
     // (undocumented)
     verticalAlign: 'end' | 'middle' | 'start';
@@ -3374,7 +3359,7 @@ export interface RichTextSVGProps {
     // (undocumented)
     padding: number;
     // (undocumented)
-    richText: TLRichText;
+    richText: TLRichText_2;
     // (undocumented)
     showTextOutline?: boolean;
     // (undocumented)
@@ -3775,7 +3760,7 @@ export interface TextAreaProps {
     // (undocumented)
     handleChange(changeInfo: {
         plaintext?: string;
-        richText?: TLRichText;
+        richText?: TLRichText_2;
     }): void;
     // (undocumented)
     handleDoubleClick(e: any): any;
@@ -3792,7 +3777,7 @@ export interface TextAreaProps {
     // (undocumented)
     isEditing: boolean;
     // (undocumented)
-    richText?: TLRichText;
+    richText?: TLRichText_2;
     // (undocumented)
     shapeId: TLShapeId;
     // (undocumented)
@@ -3854,11 +3839,7 @@ export class TextShapeUtil extends ShapeUtil<TLTextShape> {
             autoSize: boolean;
             color: TLDefaultColorStyle;
             font: TLDefaultFontStyle;
-            richText: {
-                attrs?: any;
-                content: unknown[];
-                type: string;
-            };
+            richText: TLRichText;
             scale: number;
             size: "l" | "m" | "s" | "xl";
             textAlign: "end" | "middle" | "start";
@@ -6472,15 +6453,11 @@ export function useEditablePlainText(shapeId: TLShapeId, type: ExtractShapeByPro
 
 // @public (undocumented)
 export function useEditableRichText(shapeId: TLShapeId, type: ExtractShapeByProps<{
-    richText: TLRichText;
-}>['type'], richText?: TLRichText): {
+    richText: TLRichText_2;
+}>['type'], richText?: TLRichText_2): {
     handleBlur: () => void;
     handleChange: ({ richText }: {
-        richText: {
-            attrs?: any;
-            content: unknown[];
-            type: string;
-        };
+        richText: TLRichText_2;
     }) => void;
     handleDoubleClick: (e: {
         nativeEvent: Event;

--- a/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
+++ b/packages/tldraw/src/lib/shapes/shared/RichTextLabel.tsx
@@ -2,7 +2,6 @@ import {
 	Box,
 	ExtractShapeByProps,
 	TLEventInfo,
-	TLRichText,
 	TLShapeId,
 	openWindow,
 	preventDefault,
@@ -11,6 +10,7 @@ import {
 	useReactor,
 	useValue,
 } from '@tldraw/editor'
+import { TLRichText } from '@tldraw/tlschema'
 import classNames from 'classnames'
 import React, { useMemo } from 'react'
 import { renderHtmlFromRichText } from '../../utils/text/richText'

--- a/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
+++ b/packages/tldraw/src/lib/shapes/shared/useEditableRichText.ts
@@ -1,4 +1,5 @@
-import { ExtractShapeByProps, TLRichText, TLShapeId, isAccelKey, useEditor } from '@tldraw/editor'
+import { ExtractShapeByProps, TLShapeId, isAccelKey, useEditor } from '@tldraw/editor'
+import { TLRichText } from '@tldraw/tlschema'
 import { useCallback, useEffect, useRef } from 'react'
 import { isEmptyRichText } from '../../utils/text/richText'
 import { useEditableTextCommon } from './useEditablePlainText'

--- a/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
+++ b/packages/tldraw/src/lib/shapes/text/RichTextArea.tsx
@@ -7,7 +7,6 @@ import {
 } from '@tiptap/react'
 import {
 	Editor,
-	TLRichText,
 	TLShapeId,
 	isEqual,
 	preventDefault,
@@ -15,6 +14,7 @@ import {
 	useEvent,
 	useUniqueSafeId,
 } from '@tldraw/editor'
+import { TLRichText } from '@tldraw/tlschema'
 import React, { useLayoutEffect, useRef } from 'react'
 import { isEditingRichTextList } from '../../utils/text/richText'
 

--- a/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
+++ b/packages/tldraw/src/lib/tools/SelectTool/selectHelpers.ts
@@ -3,10 +3,10 @@ import {
 	ExtractShapeByProps,
 	richTextValidator,
 	TLEventInfo,
-	TLRichText,
 	TLShape,
 	TLShapeId,
 } from '@tldraw/editor'
+import { TLRichText } from '@tldraw/tlschema'
 
 /** @internal */
 export function hasRichText(

--- a/packages/tldraw/src/lib/utils/text/richText.test.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.test.ts
@@ -1,4 +1,5 @@
-import { TLRichText, toRichText } from '@tldraw/editor'
+import { toRichText } from '@tldraw/editor'
+import { TLRichText } from '@tldraw/tlschema'
 import {
 	isEmptyRichText,
 	renderHtmlFromRichTextWithExtensions,

--- a/packages/tldraw/src/lib/utils/text/richText.ts
+++ b/packages/tldraw/src/lib/utils/text/richText.ts
@@ -16,9 +16,9 @@ import {
 	getOwnProperty,
 	RichTextFontVisitorState,
 	TLFontFace,
-	TLRichText,
 	WeakCache,
 } from '@tldraw/editor'
+import { TLRichText } from '@tldraw/tlschema'
 import { DefaultFontFaces } from '../../shapes/shared/defaultFonts'
 
 /** @public */

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -165,13 +165,13 @@ export function createAssetPropsMigrationSequence(migrations: TLPropsMigrations)
 
 // @internal
 export function createAssetRecordType(assets: Record<string, SchemaPropsInfo>): RecordType<    {
-id: TLAssetId;
 meta: JsonObject;
 props: {
 [x: string]: /*elided*/ any;
 };
+readonly id: TLAssetId;
+readonly typeName: "asset";
 type: string;
-typeName: "asset";
 }, "props" | "type">;
 
 // @public
@@ -179,7 +179,7 @@ export function createAssetValidator<Type extends string, Props extends JsonObje
     [K in keyof Props]: T.Validatable<Props[K]>;
 } | T.Validator<Props>, meta?: {
     [K in keyof Meta]: T.Validatable<Meta[K]>;
-}): T.ObjectValidator<Expand<    { [P in "id" | "meta" | "typeName" | (undefined extends Props ? never : "props") | (undefined extends Type ? never : "type")]: TLBaseAsset<Type, Props>[P]; } & { [P in (undefined extends Props ? "props" : never) | (undefined extends Type ? "type" : never)]?: TLBaseAsset<Type, Props>[P] | undefined; }>>;
+}): T.ObjectValidator<Expand<(TLBaseAsset<Type, Props> extends infer T extends object ? { [K in keyof T as Record<never, never> extends Pick<TLBaseAsset<Type, Props>, K> ? never : 0 extends 1 & TLBaseAsset<Type, Props>[K] ? K : undefined extends TLBaseAsset<Type, Props>[K] ? never : K]: T[K]; } : never) & (TLBaseAsset<Type, Props> extends infer T_1 extends object ? { [K in keyof T_1 as Record<never, never> extends Pick<TLBaseAsset<Type, Props>, K> ? K : 0 extends 1 & TLBaseAsset<Type, Props>[K] ? never : undefined extends TLBaseAsset<Type, Props>[K] ? K : never]?: T_1[K] | undefined; } : never)>>;
 
 // @public
 export function createBindingId(id?: string): TLBindingId;
@@ -197,7 +197,7 @@ export function createBindingValidator<Type extends string, Props extends JsonOb
     [K in keyof Props]: T.Validatable<Props[K]>;
 }, meta?: {
     [K in keyof Meta]: T.Validatable<Meta[K]>;
-}): T.ObjectValidator<Expand<    { [P in "fromId" | "id" | "meta" | "toId" | "typeName" | (undefined extends Props ? never : "props") | (undefined extends Type ? never : "type")]: TLBaseBinding<Type, Props>[P]; } & { [P in (undefined extends Props ? "props" : never) | (undefined extends Type ? "type" : never)]?: TLBaseBinding<Type, Props>[P] | undefined; }>>;
+}): T.ObjectValidator<Expand<(TLBaseBinding<Type, Props> extends infer T extends object ? { [K in keyof T as Record<never, never> extends Pick<TLBaseBinding<Type, Props>, K> ? never : 0 extends 1 & TLBaseBinding<Type, Props>[K] ? K : undefined extends TLBaseBinding<Type, Props>[K] ? never : K]: T[K]; } : never) & (TLBaseBinding<Type, Props> extends infer T_1 extends object ? { [K in keyof T_1 as Record<never, never> extends Pick<TLBaseBinding<Type, Props>, K> ? K : 0 extends 1 & TLBaseBinding<Type, Props>[K] ? never : undefined extends TLBaseBinding<Type, Props>[K] ? K : never]?: T_1[K] | undefined; } : never)>>;
 
 // @public
 export function createCachedUserResolve(resolveFn: (userId: string) => null | TLUser): (userId: string) => Signal<null | TLUser>;
@@ -277,7 +277,7 @@ export function createShapeValidator<Type extends string, Props extends JsonObje
     [K in keyof Props]: T.Validatable<Props[K]>;
 }, meta?: {
     [K in keyof Meta]: T.Validatable<Meta[K]>;
-}): T.ObjectValidator<Expand<    { [P in "id" | "index" | "isLocked" | "meta" | "opacity" | "parentId" | "rotation" | "typeName" | "x" | "y" | (undefined extends Props ? never : "props") | (undefined extends Type ? never : "type")]: TLBaseShape<Type, Props>[P]; } & { [P in (undefined extends Props ? "props" : never) | (undefined extends Type ? "type" : never)]?: TLBaseShape<Type, Props>[P] | undefined; }>>;
+}): T.ObjectValidator<Expand<(TLBaseShape<Type, Props> extends infer T extends object ? { [K in keyof T as Record<never, never> extends Pick<TLBaseShape<Type, Props>, K> ? never : 0 extends 1 & TLBaseShape<Type, Props>[K] ? K : undefined extends TLBaseShape<Type, Props>[K] ? never : K]: T[K]; } : never) & (TLBaseShape<Type, Props> extends infer T_1 extends object ? { [K in keyof T_1 as Record<never, never> extends Pick<TLBaseShape<Type, Props>, K> ? K : 0 extends 1 & TLBaseShape<Type, Props>[K] ? never : undefined extends TLBaseShape<Type, Props>[K] ? K : never]?: T_1[K] | undefined; } : never)>>;
 
 // @public
 export function createTLSchema({ shapes, bindings, assets, user, records, migrations }?: {
@@ -1738,7 +1738,14 @@ export interface TLRemovedDefaultThemeColors {
 }
 
 // @public
-export type TLRichText = T.TypeOf<typeof richTextValidator>;
+export interface TLRichText {
+    // (undocumented)
+    attrs?: any;
+    // (undocumented)
+    content: unknown[];
+    // (undocumented)
+    type: string;
+}
 
 // @public
 export type TLSchema = StoreSchema<TLRecord, TLStoreProps>;

--- a/packages/tlschema/src/misc/TLRichText.ts
+++ b/packages/tlschema/src/misc/TLRichText.ts
@@ -1,25 +1,6 @@
 import { T } from '@tldraw/validate'
 
 /**
- * Validator for TLRichText objects that ensures they have the correct structure
- * for document-based rich text content. Validates a document with a type field
- * and an array of content blocks.
- *
- * @public
- * @example
- * ```ts
- * const richText = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }] }
- * const isValid = richTextValidator.check(richText) // true
- * ```
- */
-
-export const richTextValidator = T.object({
-	type: T.string,
-	content: T.arrayOf(T.unknown),
-	attrs: T.any.optional(),
-})
-
-/**
  * Type representing rich text content in tldraw. Rich text follows a document-based
  * structure with a root document containing an array of content blocks (paragraphs,
  * text nodes, etc.). This enables formatted text with support for multiple paragraphs,
@@ -39,7 +20,32 @@ export const richTextValidator = T.object({
  * }
  * ```
  */
-export type TLRichText = T.TypeOf<typeof richTextValidator>
+export interface TLRichText {
+	type: string
+	content: unknown[]
+	// `attrs` is open-ended and optional. It is declared explicitly here and passed to
+	// `T.object` below so the validator is checked against this type, since an optional
+	// `any` cannot be inferred from the validator's value types alone.
+	attrs?: any
+}
+
+/**
+ * Validator for TLRichText objects that ensures they have the correct structure
+ * for document-based rich text content. Validates a document with a type field
+ * and an array of content blocks.
+ *
+ * @public
+ * @example
+ * ```ts
+ * const richText = { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Hello' }] }] }
+ * const isValid = richTextValidator.check(richText) // true
+ * ```
+ */
+export const richTextValidator = T.object<TLRichText>({
+	type: T.string,
+	content: T.arrayOf(T.unknown),
+	attrs: T.any.optional(),
+})
 
 /**
  * Converts a plain text string into a TLRichText object. Each line of the input

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -282,13 +282,9 @@ export class LruCache<K, V> {
 
 // @public
 export type MakeUndefinedOptional<T extends object> = Expand<{
-    [P in {
-        [K in keyof T]: undefined extends T[K] ? never : K;
-    }[keyof T]]: T[P];
+    [K in keyof T as Record<never, never> extends Pick<T, K> ? never : 0 extends 1 & T[K] ? K : undefined extends T[K] ? never : K]: T[K];
 } & {
-    [P in {
-        [K in keyof T]: undefined extends T[K] ? K : never;
-    }[keyof T]]?: T[P];
+    [K in keyof T as Record<never, never> extends Pick<T, K> ? K : 0 extends 1 & T[K] ? never : undefined extends T[K] ? K : never]?: T[K];
 }>;
 
 // @internal

--- a/packages/utils/src/lib/types.test.ts
+++ b/packages/utils/src/lib/types.test.ts
@@ -1,0 +1,36 @@
+import { expectTypeOf } from 'vitest'
+import { MakeUndefinedOptional } from './types'
+
+describe('MakeUndefinedOptional', () => {
+	it('makes properties that include undefined optional', () => {
+		type Result = MakeUndefinedOptional<{
+			name: string
+			theme: string | undefined
+		}>
+
+		expectTypeOf<Result>().toEqualTypeOf<{ name: string; theme?: string | undefined }>()
+	})
+
+	it('keeps required properties required', () => {
+		type Result = MakeUndefinedOptional<{ name: string; version: number }>
+
+		expectTypeOf<Result>().toEqualTypeOf<{ name: string; version: number }>()
+	})
+
+	it('does not make required `any` properties optional', () => {
+		type Result = MakeUndefinedOptional<{ foo: any }>
+
+		expectTypeOf<Result>().toEqualTypeOf<{ foo: any }>()
+		// @ts-expect-error - `foo` is required, so an empty object is not assignable
+		const value: Result = {}
+		void value
+	})
+
+	it('keeps already-optional `any` properties optional', () => {
+		type Result = MakeUndefinedOptional<{ foo?: any }>
+
+		expectTypeOf<Result>().toEqualTypeOf<{ foo?: any }>()
+		const value: Result = {}
+		void value
+	})
+})

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -138,12 +138,30 @@ export type Required<T, K extends keyof T> = Expand<Omit<T, K> & { [P in K]-?: T
  * }
  * ```
  *
+ * Properties already declared optional stay optional. Properties typed as `any` are
+ * treated as required (unless already optional), since `any` technically includes
+ * `undefined` but is not intended to make a property optional on its own.
+ *
  * @public
  */
 export type MakeUndefinedOptional<T extends object> = Expand<
 	{
-		[P in { [K in keyof T]: undefined extends T[K] ? never : K }[keyof T]]: T[P]
+		// Required keys: not already optional, and either `any` or not undefined-able.
+		[K in keyof T as Record<never, never> extends Pick<T, K>
+			? never
+			: 0 extends 1 & T[K]
+				? K
+				: undefined extends T[K]
+					? never
+					: K]: T[K]
 	} & {
-		[P in { [K in keyof T]: undefined extends T[K] ? K : never }[keyof T]]?: T[P]
+		// Optional keys: already optional, or undefined-able (but not bare `any`).
+		[K in keyof T as Record<never, never> extends Pick<T, K>
+			? K
+			: 0 extends 1 & T[K]
+				? never
+				: undefined extends T[K]
+					? K
+					: never]?: T[K]
 	}
 >


### PR DESCRIPTION
Closes #7260

`MakeUndefinedOptional` marked `any`-typed properties as optional because `undefined extends any` is true. The mapped type now splits keys into a required half and an optional half, using an inline `0 extends 1 & T[K]` any-check, so only genuinely undefined-able properties become optional while keys that were already declared optional stay optional.

Switching to `as` key remapping also means the mapped type preserves existing `readonly` / `?` modifiers instead of stripping them.

`TLRichText` is now declared explicitly as an interface and passed to `T.object<TLRichText>()`, since an optional `any` (`attrs`) can't be inferred from the validator's value types once `any` is treated as required.

#### Behaviour

```ts
// A required `any` property stays required (previously became optional)
MakeUndefinedOptional<{ foo: any }>
// before: { foo?: any }
// after:  { foo: any }

// An already-optional `any` property stays optional
MakeUndefinedOptional<{ foo?: any }>
// before: { foo?: any }
// after:  { foo?: any }   (unchanged, but now for the right reason)

// Undefined-able properties still become optional
MakeUndefinedOptional<{ foo: string | undefined }>
// before: { foo?: string | undefined }
// after:  { foo?: string | undefined }

// Plain required properties stay required
MakeUndefinedOptional<{ foo: string }>
// before: { foo: string }
// after:  { foo: string }

// `readonly` / optional modifiers are now preserved (mapped type is homomorphic)
MakeUndefinedOptional<{ readonly id: string; name: string | undefined }>
// before: { id: string; name?: string | undefined }
// after:  { readonly id: string; name?: string | undefined }
```

#### Known limitation

An optional `any` still can't be inferred purely from a validator, because `.optional()` produces `any | undefined`, which collapses to `any`:

```ts
T.object({ foo: T.any.optional() })
// foo is still inferred as required `any`
```

If you need an optional `any` field, state the type explicitly at the boundary, as `richTextValidator` now does:

```ts
interface MyType {
	foo?: any
}
const v = T.object<MyType>({ foo: T.any.optional() })
```

Fully supporting the inferred case would mean retaining optionality metadata on the validator (a branded optional validator), which is better handled as a separate, wider validator API change.

#### Follow-on cleanup

Declaring `TLRichText` as a named interface made api-extractor emit a duplicate `TLRichText_2` in `packages/tldraw`'s API report, because the package's source imported the type from `@tldraw/editor` while the generated shape prop types resolved it from `@tldraw/tlschema`. `packages/tldraw` now imports `TLRichText` from `@tldraw/tlschema` everywhere and declares tlschema as a dependency (it was already importing from it in a few files), which collapses the report back to a single named reference.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [x] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

`packages/utils/src/lib/types.test.ts` covers the required `any`, already-optional `any`, undefined-able, and plain-required cases.

### API changes

- `@tldraw/utils`: `MakeUndefinedOptional` no longer treats `any` as optional, and now preserves `readonly` / `?` modifiers.
- `@tldraw/tlschema`: `TLRichText` is now declared as an interface (still `{ type: string; content: unknown[]; attrs?: any }` — no consumer-visible shape change).
- `@tldraw/tldraw`: `TLRichText` is re-exported from `@tldraw/tlschema` rather than `@tldraw/editor`; both resolve to the same declaration, so this is a report-only change.

### Release notes

- Fixed `MakeUndefinedOptional` incorrectly marking `any`-typed properties as optional. Validator properties defined with `T.any` are now correctly typed as required.
