### PR TITLE
fix: unblock CI for the commenting branch

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -517,6 +517,12 @@
       "value": "Copy"
     }
   ],
+  "608e9d366e": [
+    {
+      "type": 0,
+      "value": "You’re all caught up."
+    }
+  ],
   "61057a0c84": [
     {
       "type": 0,
@@ -879,12 +885,6 @@
     {
       "type": 0,
       "value": "? This action cannot be undone."
-    }
-  ],
-  "92fa5a9042": [
-    {
-      "type": 0,
-      "value": "You're all caught up."
     }
   ],
   "95aacd4d4a": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -230,6 +230,9 @@
   "5fb63579fc": {
     "translation": "Copy"
   },
+  "608e9d366e": {
+    "translation": "You’re all caught up."
+  },
   "61057a0c84": {
     "translation": "Later"
   },
@@ -379,9 +382,6 @@
   },
   "90646db02d": {
     "translation": "Are you sure you want to delete <strong>{workspaceName}</strong>? This action cannot be undone."
-  },
-  "92fa5a9042": {
-    "translation": "You're all caught up."
   },
   "95aacd4d4a": {
     "translation": "Sign in with Google"

--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -30,7 +30,7 @@ function seedThread(editor: Editor, anchor: TLCommentAnchor, text: string) {
 		authorId: 'ada',
 		body: toRichText(text),
 	})
-	editor.store.put([thread, comment])
+	editor.store.put([thread as any, comment as any])
 }
 
 export default function CommentAnchorsExample() {

--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -1,4 +1,9 @@
-import { CanvasComments, commentToolOverrides, commentTools } from '@tldraw/commenting/canvas'
+import {
+	CanvasComments,
+	commentToolOverrides,
+	commentTools,
+	putCommentRecords,
+} from '@tldraw/commenting/canvas'
 import { useMemo } from 'react'
 import {
 	commentSchemaRecords,
@@ -30,7 +35,7 @@ function seedThread(editor: Editor, anchor: TLCommentAnchor, text: string) {
 		authorId: 'ada',
 		body: toRichText(text),
 	})
-	editor.store.put([thread as any, comment as any])
+	putCommentRecords(editor, [thread, comment])
 }
 
 export default function CommentAnchorsExample() {

--- a/apps/examples/tsconfig.json
+++ b/apps/examples/tsconfig.json
@@ -5,6 +5,7 @@
 	"compilerOptions": { "outDir": "./.tsbuild" },
 	"references": [
 		{ "path": "../../packages/assets" },
+		{ "path": "../../packages/commenting" },
 		{ "path": "../../packages/mermaid" },
 		{ "path": "../../packages/sync" },
 		{ "path": "../../packages/state" },

--- a/packages/commenting/src/canvas.ts
+++ b/packages/commenting/src/canvas.ts
@@ -11,6 +11,14 @@ export {
 } from './canvas/comment-tool'
 export { collectClusterLeaves } from './canvas/cluster-input'
 export { computeClusterTable } from './clustering/computeClusterTable'
+export {
+	getCommentRecord,
+	getComments,
+	getCommentThreads,
+	putCommentRecords,
+	removeCommentRecords,
+	type TLCommentRecord,
+} from './canvas/comment-store'
 export { createClusterRuntime, type ClusterRuntime } from './clustering/runtime'
 export type { ClusterNode, ClusterTable, LeafInput } from './clustering/types'
 export { CommentsFilterMenu, type CommentsFilterMenuProps } from './canvas/comments-filter-menu'

--- a/packages/commenting/src/canvas/comment-store.ts
+++ b/packages/commenting/src/canvas/comment-store.ts
@@ -1,4 +1,11 @@
-import { Editor, TLComment, TLCommentId, TLCommentThread, TLCommentThreadId } from 'tldraw'
+import {
+	Editor,
+	TLComment,
+	TLCommentId,
+	TLCommentThread,
+	TLCommentThreadId,
+	TLRecord,
+} from 'tldraw'
 
 /**
  * Typed access to comment records on the editor store.
@@ -6,8 +13,9 @@ import { Editor, TLComment, TLCommentId, TLCommentThread, TLCommentThreadId } fr
  * Comment threads and comments live on the editor's local store so the canvas can render them
  * reactively, but they are opt-in records that aren't part of the `TLRecord` union (they ride the
  * sync server's object-store lane on the wire — see `TLCommentThread`). `editor.store` is therefore
- * typed `Store<TLRecord>` and doesn't know about them. These helpers own the one unavoidable cast at
- * that boundary so every call site stays fully typed.
+ * statically typed `Store<TLRecord>` and doesn't know about them, so every access has to reinterpret
+ * the type. These helpers own that reinterpretation — an `unknown` hop to exactly the type the store
+ * expects, so the rest of each call stays checked — behind one boundary, and keep call sites typed.
  */
 
 /** A record that lives in a comment thread: the thread itself or one of its messages. */
@@ -15,7 +23,7 @@ export type TLCommentRecord = TLComment | TLCommentThread
 
 /** Write comment records to the store. */
 export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): void {
-	editor.store.put(records as any)
+	editor.store.put(records as unknown as TLRecord[])
 }
 
 /** Remove comment records from the store by id. */
@@ -23,12 +31,12 @@ export function removeCommentRecords(
 	editor: Editor,
 	ids: (TLCommentId | TLCommentThreadId)[]
 ): void {
-	editor.store.remove(ids as any)
+	editor.store.remove(ids as unknown as TLRecord['id'][])
 }
 
 /** Read one comment record by id, or `undefined` if the id isn't a present comment record. */
 export function getCommentRecord(editor: Editor, id: string): TLCommentRecord | undefined {
-	const record = editor.store.get(id as any) as unknown as TLCommentRecord | undefined
+	const record = editor.store.get(id as TLRecord['id']) as unknown as TLCommentRecord | undefined
 	if (!record) return undefined
 	if (record.typeName === 'comment' || record.typeName === 'comment-thread') return record
 	return undefined
@@ -36,10 +44,12 @@ export function getCommentRecord(editor: Editor, id: string): TLCommentRecord | 
 
 /** All comment threads currently in the store (non-reactive; wrap in `useValue` to react). */
 export function getCommentThreads(editor: Editor): TLCommentThread[] {
-	return editor.store.query.records('comment-thread' as any).get() as unknown as TLCommentThread[]
+	const typeName = 'comment-thread' as TLRecord['typeName']
+	return editor.store.query.records(typeName).get() as unknown as TLCommentThread[]
 }
 
 /** All comments currently in the store (non-reactive; wrap in `useValue` to react). */
 export function getComments(editor: Editor): TLComment[] {
-	return editor.store.query.records('comment' as any).get() as unknown as TLComment[]
+	const typeName = 'comment' as TLRecord['typeName']
+	return editor.store.query.records(typeName).get() as unknown as TLComment[]
 }

--- a/packages/commenting/src/canvas/comment-store.ts
+++ b/packages/commenting/src/canvas/comment-store.ts
@@ -1,0 +1,45 @@
+import { Editor, TLComment, TLCommentId, TLCommentThread, TLCommentThreadId } from 'tldraw'
+
+/**
+ * Typed access to comment records on the editor store.
+ *
+ * Comment threads and comments live on the editor's local store so the canvas can render them
+ * reactively, but they are opt-in records that aren't part of the `TLRecord` union (they ride the
+ * sync server's object-store lane on the wire — see `TLCommentThread`). `editor.store` is therefore
+ * typed `Store<TLRecord>` and doesn't know about them. These helpers own the one unavoidable cast at
+ * that boundary so every call site stays fully typed.
+ */
+
+/** A record that lives in a comment thread: the thread itself or one of its messages. */
+export type TLCommentRecord = TLComment | TLCommentThread
+
+/** Write comment records to the store. */
+export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): void {
+	editor.store.put(records as any)
+}
+
+/** Remove comment records from the store by id. */
+export function removeCommentRecords(
+	editor: Editor,
+	ids: (TLCommentId | TLCommentThreadId)[]
+): void {
+	editor.store.remove(ids as any)
+}
+
+/** Read one comment record by id, or `undefined` if the id isn't a present comment record. */
+export function getCommentRecord(editor: Editor, id: string): TLCommentRecord | undefined {
+	const record = editor.store.get(id as any) as unknown as TLCommentRecord | undefined
+	if (!record) return undefined
+	if (record.typeName === 'comment' || record.typeName === 'comment-thread') return record
+	return undefined
+}
+
+/** All comment threads currently in the store (non-reactive; wrap in `useValue` to react). */
+export function getCommentThreads(editor: Editor): TLCommentThread[] {
+	return editor.store.query.records('comment-thread' as any).get() as unknown as TLCommentThread[]
+}
+
+/** All comments currently in the store (non-reactive; wrap in `useValue` to react). */
+export function getComments(editor: Editor): TLComment[] {
+	return editor.store.query.records('comment' as any).get() as unknown as TLComment[]
+}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -44,6 +44,7 @@ import { isMentionPickerOpen } from '../ui/mention-suggestion'
 import { collectClusterLeaves } from './cluster-input'
 import { CommentBody } from './comment-body'
 import { UNKNOWN_AUTHOR } from './comment-render'
+import { getCommentRecord, putCommentRecords, removeCommentRecords } from './comment-store'
 import { PendingComment } from './comment-tool'
 import { useCommentThreads, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
@@ -330,14 +331,14 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 			return
 		}
 
-		const record = editor.store.get(id as any)
+		const record = getCommentRecord(editor, id)
 		if (!record) return
 
 		let thread: TLCommentThread | undefined
 		if (record.typeName === 'comment') {
-			thread = threadsById.get((record as TLComment).threadId)
-		} else if (record.typeName === 'comment-thread') {
-			thread = record as TLCommentThread
+			thread = threadsById.get(record.threadId)
+		} else {
+			thread = record
 		}
 		if (!thread) return
 
@@ -1080,7 +1081,7 @@ const ThreadPin = memo(function ThreadPin({
 				authorId: currentUserId,
 				body: reply,
 			})
-			editor.store.put([comment as any])
+			putCommentRecords(editor, [comment])
 			if (onPostComment) onPostComment(comment)
 		})
 		setReply(EMPTY_COMMENT)
@@ -1089,11 +1090,11 @@ const ThreadPin = memo(function ThreadPin({
 	const toggleResolve = () => {
 		if (!currentUserId) return
 		commitCommentMutation(editor, () => {
-			editor.store.put([
+			putCommentRecords(editor, [
 				{
 					...thread,
 					resolved: thread.resolved ? null : { at: Date.now(), by: currentUserId },
-				} as any,
+				},
 			])
 		})
 	}
@@ -1101,7 +1102,7 @@ const ThreadPin = memo(function ThreadPin({
 	const deleteThread = () => {
 		openThreadId.set(editor, null)
 		commitCommentMutation(editor, () =>
-			editor.store.remove([thread.id, ...comments.map((c) => c.id)] as any)
+			removeCommentRecords(editor, [thread.id, ...comments.map((c) => c.id)])
 		)
 	}
 
@@ -1114,7 +1115,7 @@ const ThreadPin = memo(function ThreadPin({
 		const comment = comments.find((c) => c.id === editingId)
 		if (!comment || isCommentEmpty(editText)) return
 		commitCommentMutation(editor, () => {
-			editor.store.put([{ ...comment, body: editText, editedAt: Date.now() } as any])
+			putCommentRecords(editor, [{ ...comment, body: editText, editedAt: Date.now() }])
 		})
 		setEditingId(null)
 	}
@@ -1258,7 +1259,7 @@ const ThreadPin = memo(function ThreadPin({
 				? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
 				: { type: 'point', x: pagePoint.x, y: pagePoint.y }
 		}
-		commitCommentMutation(editor, () => editor.store.put([{ ...thread, anchor } as any]), 'drag')
+		commitCommentMutation(editor, () => putCommentRecords(editor, [{ ...thread, anchor }]), 'drag')
 	}
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
@@ -1283,7 +1284,7 @@ const ThreadPin = memo(function ThreadPin({
 	const commitResize = (bounds: BoxModel) => {
 		setResizeBounds(null)
 		editor.run(
-			() => editor.store.put([{ ...thread, anchor: { type: 'region', ...bounds } } as any]),
+			() => putCommentRecords(editor, [{ ...thread, anchor: { type: 'region', ...bounds } }]),
 			{
 				history: 'ignore',
 			}
@@ -1422,7 +1423,7 @@ function PendingComposer({
 				authorId: currentUserId,
 				body: text,
 			})
-			editor.store.put([thread as any, comment as any])
+			putCommentRecords(editor, [thread, comment])
 			if (onPostComment) onPostComment(comment)
 		})
 		setText(EMPTY_COMMENT)

--- a/packages/commenting/src/canvas/hooks.ts
+++ b/packages/commenting/src/canvas/hooks.ts
@@ -1,12 +1,9 @@
 import { Editor, TLComment, TLCommentThread, TLCommentThreadId, useValue } from 'tldraw'
+import { getComments, getCommentThreads } from './comment-store'
 
-/** All comment threads in the store, reactively. (Comment records are opt-in, hence the casts.) */
+/** All comment threads in the store, reactively. */
 export function useCommentThreads(editor: Editor): TLCommentThread[] {
-	return useValue(
-		'comment threads',
-		() => editor.store.query.records('comment-thread' as any).get() as unknown as TLCommentThread[],
-		[editor]
-	)
+	return useValue('comment threads', () => getCommentThreads(editor), [editor])
 }
 
 /** A thread's comments, oldest first, reactively. */
@@ -14,7 +11,7 @@ export function useThreadComments(editor: Editor, threadId: TLCommentThreadId): 
 	return useValue(
 		'thread comments',
 		() =>
-			(editor.store.query.records('comment' as any).get() as unknown as TLComment[])
+			getComments(editor)
 				.filter((c) => c.threadId === threadId)
 				.sort((a, b) => a.createdAt - b.createdAt),
 		[editor, threadId]
@@ -25,10 +22,7 @@ export function useThreadComments(editor: Editor, threadId: TLCommentThreadId): 
 export function useComments(editor: Editor): TLComment[] {
 	return useValue(
 		'all comments',
-		() =>
-			(editor.store.query.records('comment' as any).get() as unknown as TLComment[]).sort(
-				(a, b) => a.createdAt - b.createdAt
-			),
+		() => getComments(editor).sort((a, b) => a.createdAt - b.createdAt),
 		[editor]
 	)
 }


### PR DESCRIPTION
This branch collects fixes to unblock CI on the `commenting` branch. The `commenting` branch had several red checks — *Build all projects*, both preview deploys, and *Tests & checks* — from a few unrelated issues. The "Tests & checks" job stops at the first failing step, so the failures surfaced one at a time as each was fixed.

### Fixes

1. **Examples type check.** `CommentAnchorsExample` seeded threads with `editor.store.put([thread, comment])`, but `editor.store` is typed `Store<TLRecord>` and comment records aren't in the `TLRecord` union, so `tsgo` reported `TS2322` — failing the build and both preview deploys. Fixed via a typed accessor in `@tldraw/commenting` (see below).
2. **Missing project reference.** The example imports from `@tldraw/commenting/canvas`, but `apps/examples/tsconfig.json` was missing the project reference to `../../packages/commenting`, failing `check-packages`.
3. **dotcom localizations out of date.** A dotcom string (`You’re all caught up.`, the sidebar notifications empty state) had its apostrophe changed in source in commit `37a0371d36` without a `yarn build-i18n` regen, so the extracted key drifted from the committed locale files. Regenerated.

### Typed comment store accessor

The commenting package wrote and read comment records through `editor.store` with `as any` / `as unknown as` casts scattered across ~10 call sites (comments live on the editor's local store for rendering but aren't first-class `TLRecord`s — they ride sync-core's separate object store on the wire). This branch centralizes those casts into a small typed accessor so call sites — and examples — are fully typed and cast-free.

### Change type

- [x] `bugfix`
