### PR TITLE
fix(tldraw): size Vimeo embeds to their real aspect ratio

### DIFF
--- a/apps/dotcom/client/src/utils/createAssetFromUrl.ts
+++ b/apps/dotcom/client/src/utils/createAssetFromUrl.ts
@@ -6,6 +6,20 @@ interface ResponseBody {
 	description?: string
 	image?: string
 	favicon?: string
+	imageWidth?: number
+	imageHeight?: number
+}
+
+// Pass the OpenGraph image dimensions through on the asset's meta so consumers (e.g. embeds) can
+// size content by its real aspect ratio. Kept off `props` to avoid a bookmark asset schema change.
+function getImageDimensionsMeta(meta: ResponseBody | null): {
+	imageWidth?: number
+	imageHeight?: number
+} {
+	const result: { imageWidth?: number; imageHeight?: number } = {}
+	if (typeof meta?.imageWidth === 'number') result.imageWidth = meta.imageWidth
+	if (typeof meta?.imageHeight === 'number') result.imageHeight = meta.imageHeight
+	return result
 }
 
 export async function createAssetFromUrl({ url }: { type: 'url'; url: string }): Promise<TLAsset> {
@@ -32,7 +46,7 @@ export async function createAssetFromUrl({ url }: { type: 'url'; url: string }):
 				favicon: meta?.favicon ?? '',
 				title: meta?.title ?? '',
 			},
-			meta: {},
+			meta: getImageDimensionsMeta(meta),
 		}
 	} catch (error) {
 		// Otherwise, fallback to a blank bookmark

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -992,6 +992,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
         readonly 'allow-popups-to-escape-sandbox': true;
         readonly 'allow-presentation': true;
     };
+    readonly sizeToContentAspectRatio: true;
     readonly title: "YouTube";
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly type: "youtube";
@@ -1076,6 +1077,7 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
     readonly height: 360;
     readonly hostnames: readonly ["vimeo.com", "player.vimeo.com"];
     readonly isAspectRatioLocked: true;
+    readonly sizeToContentAspectRatio: true;
     readonly title: "Vimeo";
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly type: "vimeo";
@@ -1786,6 +1788,7 @@ export interface EmbedDefinition<Config = never> {
     readonly overrideOutlineRadius?: number;
     // (undocumented)
     readonly overridePermissions?: TLEmbedShapePermissions;
+    readonly sizeToContentAspectRatio?: boolean;
     // (undocumented)
     readonly title: string;
     // (undocumented)
@@ -1860,6 +1863,7 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
     options: EmbedShapeOptions;
     // (undocumented)
     static props: RecordProps<TLEmbedShape>;
+    resolveAspectRatio(shape: TLEmbedShape): Promise<void>;
     // @deprecated (undocumented)
     static setEmbedDefinitions(embedDefinitions: readonly TLEmbedDefinition[]): void;
     // (undocumented)

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -992,7 +992,6 @@ export const DEFAULT_EMBED_DEFINITIONS: readonly [{
         readonly 'allow-popups-to-escape-sandbox': true;
         readonly 'allow-presentation': true;
     };
-    readonly sizeToContentAspectRatio: true;
     readonly title: "YouTube";
     readonly toEmbedUrl: (url: string) => string | undefined;
     readonly type: "youtube";

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -280,6 +280,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		},
 		isAspectRatioLocked: true,
 		embedOnPaste: true,
+		sizeToContentAspectRatio: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (!urlObj) return
@@ -539,6 +540,7 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		doesResize: true,
 		isAspectRatioLocked: true,
 		embedOnPaste: true,
+		sizeToContentAspectRatio: true,
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (urlObj && urlObj.hostname === 'vimeo.com') {
@@ -742,6 +744,14 @@ export interface EmbedDefinition<Config = never> {
 	readonly canEditWhileLocked?: boolean
 	// TODO: FIXME this is ugly be required because some embeds have their own border radius for example spotify embeds
 	readonly overrideOutlineRadius?: number
+	/**
+	 * When true, the embed shape corrects its size after creation to match the real aspect ratio of
+	 * its content, so fixed-aspect media (like video) isn't letterboxed inside the default box. The
+	 * dimensions are resolved from the URL's OpenGraph metadata via the editor's url asset handler
+	 * (the same "unfurl" path used for bookmarks), so it degrades gracefully when no metadata is
+	 * available.
+	 */
+	readonly sizeToContentAspectRatio?: boolean
 	// eslint-disable-next-line tldraw/method-signature-style
 	readonly toEmbedUrl: (url: string, config?: Config) => string | undefined
 	// eslint-disable-next-line tldraw/method-signature-style

--- a/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
+++ b/packages/tldraw/src/lib/defaultEmbedDefinitions.ts
@@ -280,7 +280,9 @@ export const DEFAULT_EMBED_DEFINITIONS = [
 		},
 		isAspectRatioLocked: true,
 		embedOnPaste: true,
-		sizeToContentAspectRatio: true,
+		// Not opted into `sizeToContentAspectRatio`: YouTube advertises the same 16:9 thumbnail
+		// dimensions for every video (it pads vertical videos into a 16:9 thumbnail), so unfurled
+		// dimensions can never reveal a non-16:9 ratio — the correction would always be a no-op.
 		toEmbedUrl: (url) => {
 			const urlObj = safeParseUrl(url)
 			if (!urlObj) return

--- a/packages/tldraw/src/lib/defaultSideEffects.ts
+++ b/packages/tldraw/src/lib/defaultSideEffects.ts
@@ -1,4 +1,5 @@
-import { Editor } from '@tldraw/editor'
+import { Editor, TLEmbedShape } from '@tldraw/editor'
+import { EmbedShapeUtil } from './shapes/embed/EmbedShapeUtil'
 import {
 	cancelUpdateHoveredShapeId,
 	updateHoveredShapeId,
@@ -6,7 +7,33 @@ import {
 
 /** @public */
 export function registerDefaultSideEffects(editor: Editor) {
+	const resolveEmbedAspectRatio = (shape: TLEmbedShape) => {
+		// Resolving the embed's real aspect ratio is a document mutation, so it belongs here as a
+		// store side effect rather than in the shape's render component — that way it runs once per
+		// create/url-change and never during rendering (e.g. SVG export).
+		;(editor.getShapeUtil('embed') as EmbedShapeUtil).resolveAspectRatio(shape)
+	}
+
 	const unsub = editor.sideEffects.register({
+		shape: {
+			afterCreate: (shape, source) => {
+				// Only for local user actions: remote peers and document loads already carry the
+				// resolved size, so we don't need to re-fetch.
+				if (source !== 'user') return
+				if (editor.isShapeOfType<TLEmbedShape>(shape, 'embed')) {
+					resolveEmbedAspectRatio(shape)
+				}
+			},
+			afterChange: (prev, next, source) => {
+				if (source !== 'user') return
+				if (
+					editor.isShapeOfType<TLEmbedShape>(next, 'embed') &&
+					(prev as TLEmbedShape).props.url !== next.props.url
+				) {
+					resolveEmbedAspectRatio(next)
+				}
+			},
+		},
 		instance: {
 			afterChange: (prev, next) => {
 				if (prev.cameraState !== next.cameraState && next.cameraState === 'idle') {

--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -24,7 +24,7 @@ import {
 	embedShapePermissionDefaults,
 	unknownEmbedShapePermissionOverrides,
 } from '../../defaultEmbedDefinitions'
-import { TLEmbedResult, getEmbedInfo } from '../../utils/embeds/embeds'
+import { TLEmbedResult, getCorrectedEmbedSize, getEmbedInfo } from '../../utils/embeds/embeds'
 import { BookmarkShapeComponent } from '../bookmark/BookmarkShapeUtil'
 import { ShapeOptionsWithDisplayValues, getDisplayValues } from '../shared/getDisplayValues'
 import { getRotatedBoxShadow } from '../shared/rotated-box-shadow'
@@ -101,6 +101,76 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 
 	getEmbedDefinition(url: string): TLEmbedResult {
 		return getEmbedInfo(this.getEmbedDefs(), url, this.options.embedConfig)
+	}
+
+	/**
+	 * Resolve the embed's true aspect ratio (for definitions with `sizeToContentAspectRatio`) and
+	 * correct the shape's size to match. The dimensions come from the URL's OpenGraph metadata via
+	 * the editor's url asset handler (the same "unfurl" path bookmarks use). The correction is
+	 * applied without adding to the undo history.
+	 */
+	async resolveAspectRatio(shape: TLEmbedShape) {
+		const { url } = shape.props
+		const definition = this.getEmbedDefinition(url)?.definition
+		if (!definition?.sizeToContentAspectRatio || !url) return
+
+		const resolvedRatio = await this.getContentAspectRatio(url)
+
+		// The editor may have been torn down while the metadata was in flight.
+		if (this.editor.isDisposed) return
+
+		const latest = this.editor.getShape<TLEmbedShape>(shape.id)
+		// Bail if the shape is gone or its url changed while we were awaiting: a later run for the
+		// new url will handle it, and we must not apply this url's ratio to a different video.
+		if (!latest || latest.props.url !== url) return
+
+		const corrected = getCorrectedEmbedSize({
+			w: latest.props.w,
+			h: latest.props.h,
+			resolvedRatio,
+		})
+		if (!corrected) return
+
+		// Let the editor resize the shape: by default it scales around the shape's page-space center
+		// and along its own rotation axis, so the center stays fixed even if the embed was rotated
+		// before the ratio resolved. No need to compute x/y by hand.
+		//
+		// We pass `isAspectRatioLocked: false` because embeds like Vimeo lock their aspect ratio,
+		// which would otherwise make the editor merge our non-uniform scale into a single uniform
+		// factor — leaving the wrong ratio and defeating the whole correction.
+		this.editor.run(
+			() => {
+				this.editor.resizeShape(
+					latest.id,
+					{
+						x: corrected.w / latest.props.w,
+						y: corrected.h / latest.props.h,
+					},
+					{ isAspectRatioLocked: false }
+				)
+			},
+			{ history: 'ignore' }
+		)
+	}
+
+	/**
+	 * Resolve the content's aspect ratio from the URL's OpenGraph metadata, fetched through the
+	 * editor's url asset handler (the "unfurl" service). Returns `undefined` if no usable dimensions
+	 * are available (e.g. no unfurl service is configured, or the page reports no image size).
+	 */
+	private async getContentAspectRatio(url: string): Promise<number | undefined> {
+		try {
+			const asset = await this.editor.getAssetForExternalContent({ type: 'url', url })
+			if (!asset || asset.type !== 'bookmark') return undefined
+			const width = asset.meta.imageWidth
+			const height = asset.meta.imageHeight
+			if (typeof width === 'number' && typeof height === 'number' && width > 0 && height > 0) {
+				return width / height
+			}
+		} catch {
+			// Resolving the aspect ratio is best-effort: never let a metadata fetch failure surface.
+		}
+		return undefined
 	}
 
 	override getText(shape: TLEmbedShape) {
@@ -270,6 +340,11 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 						allowFullScreen
 						style={{
 							border: 0,
+							// Fill the container exactly. Relying on the fixed pixel width/height causes
+							// the flex-centered iframe to be rounded independently from its box at
+							// fractional sizes/zooms, leaving a 1-2px background sliver on one edge.
+							width: '100%',
+							height: '100%',
 							pointerEvents: isInteractive ? 'auto' : 'none',
 							// Fix for safari <https://stackoverflow.com/a/49150908>
 							zIndex: isInteractive ? '' : '-1',

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -3,7 +3,7 @@ import {
 	embedShapePermissionDefaults,
 	unknownEmbedShapePermissionOverrides,
 } from '../../defaultEmbedDefinitions'
-import { getEmbedInfo, matchEmbedUrl, matchUrl } from './embeds'
+import { getCorrectedEmbedSize, getEmbedInfo, matchEmbedUrl, matchUrl } from './embeds'
 
 const GOOGLE_MAPS_API_KEY = 'test-google-maps-api-key'
 const TEST_EMBED_CONFIG = { google_maps: { apiKey: GOOGLE_MAPS_API_KEY } }
@@ -50,6 +50,32 @@ describe('embed sandbox permissions', () => {
 		expect(unknownEmbedShapePermissionOverrides['allow-same-origin']).toBe(false)
 		expect(unknownEmbedShapePermissionOverrides['allow-forms']).toBe(false)
 		expect(unknownEmbedShapePermissionOverrides['allow-popups']).toBe(false)
+	})
+})
+
+describe('getCorrectedEmbedSize', () => {
+	test('corrects height to match the resolved ratio, keeping width', () => {
+		expect(getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: 1.5 })).toEqual({
+			w: 640,
+			h: 640 / 1.5,
+		})
+	})
+
+	test('returns null when the resolved ratio already matches (within epsilon)', () => {
+		expect(getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: 640 / 360 })).toBeNull()
+	})
+
+	test('applies a new ratio regardless of the current ratio (e.g. after a url change)', () => {
+		// shape was already auto-corrected to 3:2; a new video resolves to 1:1
+		expect(getCorrectedEmbedSize({ w: 640, h: 640 / 1.5, resolvedRatio: 1 })).toEqual({
+			w: 640,
+			h: 640,
+		})
+	})
+
+	test('returns null when there is no resolved ratio', () => {
+		expect(getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: undefined })).toBeNull()
+		expect(getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: 0 })).toBeNull()
 	})
 })
 

--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -99,3 +99,30 @@ export function getEmbedInfo(
 		return undefined
 	}
 }
+
+const ASPECT_RATIO_EPSILON = 0.001
+
+/**
+ * Given an embed shape's current size and a newly-resolved aspect ratio, return the size it should
+ * be corrected to (width preserved, height derived), or `null` when no change is needed — either
+ * because there's no resolved ratio or the shape is already at it.
+ *
+ * @param opts - The current `w`/`h` and the `resolvedRatio` (`width / height`) discovered at runtime.
+ * @internal
+ */
+export function getCorrectedEmbedSize({
+	w,
+	h,
+	resolvedRatio,
+}: {
+	w: number
+	h: number
+	resolvedRatio: number | undefined
+}): { w: number; h: number } | null {
+	if (!resolvedRatio || resolvedRatio <= 0) return null
+
+	// Already at the resolved ratio: nothing to do.
+	if (Math.abs(w / h - resolvedRatio) <= ASPECT_RATIO_EPSILON) return null
+
+	return { w, h: w / resolvedRatio }
+}

--- a/packages/tldraw/src/test/embed-aspect-ratio.test.ts
+++ b/packages/tldraw/src/test/embed-aspect-ratio.test.ts
@@ -1,0 +1,226 @@
+import { TLEmbedShape, createShapeId } from '@tldraw/editor'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { EmbedShapeUtil } from '../lib/shapes/embed/EmbedShapeUtil'
+import { TestEditor } from './TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	editor = new TestEditor()
+	editor.selectAll().deleteShapes(editor.getSelectedShapeIds())
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+	editor?.dispose()
+})
+
+// Mirrors the real Vimeo definition: aspect-ratio-locked (which the editor treats specially when
+// resizing) and opted in to content-aspect-ratio sizing. Dimensions are resolved from url metadata
+// (the unfurl path), so we also stub `getAssetForExternalContent` to return a bookmark asset whose
+// `meta` carries the image dimensions for the given ratio.
+function stubVimeoDefinition(url: string, aspectRatio: number | undefined) {
+	return stubVimeoDefinitionByUrl(aspectRatio === undefined ? {} : { [url]: aspectRatio })
+}
+
+function stubVimeoDefinitionByUrl(ratios: Record<string, number>) {
+	const util = editor.getShapeUtil('embed') as EmbedShapeUtil
+	vi.spyOn(util, 'getEmbedDefinition').mockImplementation((url) => ({
+		definition: {
+			type: 'vimeo',
+			width: 640,
+			height: 360,
+			isAspectRatioLocked: true,
+			sizeToContentAspectRatio: true,
+		} as any,
+		url,
+		embedUrl: url,
+	}))
+	vi.spyOn(editor, 'getAssetForExternalContent').mockImplementation(async (info: any) => {
+		const ratio = ratios[info.url]
+		const meta =
+			typeof ratio === 'number' ? { imageWidth: Math.round(ratio * 1000), imageHeight: 1000 } : {}
+		return { type: 'bookmark', meta } as any
+	})
+	return util
+}
+
+describe('embed aspect ratio correction', () => {
+	it('corrects an embed to its resolved aspect ratio after creation', async () => {
+		const url = 'https://vimeo.com/817841251'
+		const util = stubVimeoDefinition(url, 1.5)
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({
+			id,
+			type: 'embed',
+			x: 100,
+			y: 200,
+			props: { w: 640, h: 360, url },
+		})
+
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+
+		const shape = editor.getShape<TLEmbedShape>(id)!
+		const correctedH = 640 / 1.5
+		// the whole point: width is preserved and only the height changes, so the box actually takes
+		// on the resolved 3:2 ratio (not merged into a uniform scale by the aspect-ratio lock)
+		expect(shape.props.w).toBe(640)
+		expect(shape.props.h).toBeCloseTo(correctedH)
+		expect(shape.props.w / shape.props.h).toBeCloseTo(1.5)
+		// width is unchanged so x stays put; the shape grows around its center vertically
+		expect(shape.x).toBe(100)
+		expect(shape.y).toBeCloseTo(200 - (correctedH - 360) / 2)
+
+		// the correction must not be its own undo step: a single undo removes the whole creation,
+		// rather than first reverting the resize
+		editor.undo()
+		expect(editor.getShape(id)).toBeUndefined()
+	})
+
+	it('keeps the page center fixed when the embed is rotated', async () => {
+		const url = 'https://vimeo.com/333'
+		const util = stubVimeoDefinition(url, 1.5)
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({
+			id,
+			type: 'embed',
+			x: 100,
+			y: 200,
+			rotation: Math.PI / 4,
+			props: { w: 640, h: 360, url },
+		})
+
+		const centerBefore = editor.getShapePageBounds(id)!.center.clone()
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+
+		const shape = editor.getShape<TLEmbedShape>(id)!
+		expect(shape.props.h).toBeCloseTo(640 / 1.5)
+		const centerAfter = editor.getShapePageBounds(id)!.center
+		expect(centerAfter.x).toBeCloseTo(centerBefore.x)
+		expect(centerAfter.y).toBeCloseTo(centerBefore.y)
+	})
+
+	it('applies the new ratio when the url changes to a different video', async () => {
+		const urlA = 'https://vimeo.com/111'
+		const urlB = 'https://vimeo.com/222'
+		const util = stubVimeoDefinitionByUrl({ [urlA]: 1.5, [urlB]: 1 })
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url: urlA } })
+
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+		expect(editor.getShape<TLEmbedShape>(id)!.props.h).toBeCloseTo(640 / 1.5)
+
+		// change the url to a 1:1 video — the new ratio should be applied even though the shape is no
+		// longer at the definition's default 16:9 ratio
+		editor.updateShape<TLEmbedShape>({ id, type: 'embed', props: { url: urlB } })
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+
+		const shape = editor.getShape<TLEmbedShape>(id)!
+		expect(shape.props.w).toBe(640)
+		expect(shape.props.h).toBeCloseTo(640)
+	})
+
+	it('ignores a stale resolution whose url no longer matches the shape', async () => {
+		const urlA = 'https://vimeo.com/aaa'
+		const urlB = 'https://vimeo.com/bbb'
+		const util = stubVimeoDefinitionByUrl({ [urlA]: 1.5, [urlB]: 1 })
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url: urlA } })
+		// snapshot representing an in-flight run started while the shape still had urlA
+		const staleShapeA = editor.getShape<TLEmbedShape>(id)!
+
+		// the url changes to B and B's resolution lands first
+		editor.updateShape<TLEmbedShape>({ id, type: 'embed', props: { url: urlB } })
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+		expect(editor.getShape<TLEmbedShape>(id)!.props.h).toBeCloseTo(640) // B's 1:1 ratio applied
+
+		// now the stale run for urlA completes — it must not clobber the shape with A's 3:2 ratio
+		await util.resolveAspectRatio(staleShapeA)
+		expect(editor.getShape<TLEmbedShape>(id)!.props.h).toBeCloseTo(640)
+	})
+
+	it('resolves via a side effect when a user creates or re-points an embed', () => {
+		const url = 'https://vimeo.com/create'
+		const util = stubVimeoDefinition(url, 1.5)
+		const spy = vi.spyOn(util, 'resolveAspectRatio').mockResolvedValue(undefined)
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url } })
+		expect(spy).toHaveBeenCalledTimes(1)
+
+		// re-pointing the embed at a new url re-resolves
+		editor.updateShape<TLEmbedShape>({
+			id,
+			type: 'embed',
+			props: { url: 'https://vimeo.com/create2' },
+		})
+		expect(spy).toHaveBeenCalledTimes(2)
+
+		// a non-url change (e.g. a resize) does not
+		editor.updateShape<TLEmbedShape>({ id, type: 'embed', props: { w: 700 } })
+		expect(spy).toHaveBeenCalledTimes(2)
+	})
+
+	it('does not resolve during rendering / svg export', async () => {
+		// getSvgString relies on real async; TestEditor installs fake timers by default
+		vi.useRealTimers()
+		try {
+			const url = 'https://vimeo.com/export'
+			const util = stubVimeoDefinition(url, 1.5)
+
+			const id = createShapeId()
+			editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url } })
+
+			// spy only on the export phase: resolution happens on create (via side effect), never as
+			// part of rendering, so exporting must not call it
+			const spy = vi.spyOn(util, 'resolveAspectRatio').mockResolvedValue(undefined)
+			await editor.getSvgString([id])
+			await new Promise((r) => setTimeout(r, 0))
+
+			expect(spy).not.toHaveBeenCalled()
+		} finally {
+			vi.useFakeTimers()
+		}
+	}, 20000)
+
+	it('does not resize when the editor is disposed while resolving', async () => {
+		const url = 'https://vimeo.com/disposed'
+		const util = stubVimeoDefinitionByUrl({ [url]: 1.5 })
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url } })
+		const shape = editor.getShape<TLEmbedShape>(id)!
+
+		// tear the editor down mid-flight
+		const resizeSpy = vi.spyOn(editor, 'resizeShape')
+		vi.spyOn(editor, 'getAssetForExternalContent').mockImplementation(async () => {
+			editor.dispose()
+			return { type: 'bookmark', meta: { imageWidth: 1500, imageHeight: 1000 } } as any
+		})
+
+		await expect(util.resolveAspectRatio(shape)).resolves.toBeUndefined()
+		expect(resizeSpy).not.toHaveBeenCalled()
+	})
+
+	it('does nothing when the resolved ratio matches the assumed ratio', async () => {
+		const url = 'https://vimeo.com/59749737'
+		const util = stubVimeoDefinition(url, 640 / 360)
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({
+			id,
+			type: 'embed',
+			props: { w: 640, h: 360, url },
+		})
+
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+
+		const shape = editor.getShape<TLEmbedShape>(id)!
+		expect(shape.props.w).toBe(640)
+		expect(shape.props.h).toBe(360)
+	})
+})

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"@tldraw/utils": "workspace:*",
 		"@tldraw/validate": "workspace:*",
-		"cloudflare-workers-unfurl": "^0.0.8",
+		"cloudflare-workers-unfurl": "^0.0.9",
 		"itty-router": "^5.0.18",
 		"toucan-js": "^3.4.0"
 	},

--- a/templates/sync-cloudflare/client/getBookmarkPreview.tsx
+++ b/templates/sync-cloudflare/client/getBookmarkPreview.tsx
@@ -27,6 +27,11 @@ export async function getBookmarkPreview({ url }: { url: string }): Promise<TLAs
 		asset.props.image = data?.image ?? ''
 		asset.props.favicon = data?.favicon ?? ''
 		asset.props.title = data?.title ?? ''
+
+		// carry the social image's dimensions on `meta` so embeds (e.g. Vimeo/YouTube) can size
+		// themselves to the content's real aspect ratio instead of staying letterboxed
+		if (typeof data?.imageWidth === 'number') asset.meta.imageWidth = data.imageWidth
+		if (typeof data?.imageHeight === 'number') asset.meta.imageHeight = data.imageHeight
 	} catch (e) {
 		console.error(e)
 	}

--- a/templates/sync-cloudflare/package.json
+++ b/templates/sync-cloudflare/package.json
@@ -31,7 +31,7 @@
 		"@tldraw/sync": "workspace:*",
 		"@tldraw/sync-core": "workspace:*",
 		"@tldraw/tlschema": "workspace:*",
-		"cloudflare-workers-unfurl": "^0.0.8",
+		"cloudflare-workers-unfurl": "^0.0.9",
 		"itty-router": "^5.0.18",
 		"react": "^19.2.1",
 		"react-dom": "^19.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12279,7 +12279,7 @@ __metadata:
     "@cloudflare/workers-types": "npm:^4.20260302.0"
     "@tldraw/utils": "workspace:*"
     "@tldraw/validate": "workspace:*"
-    cloudflare-workers-unfurl: "npm:^0.0.8"
+    cloudflare-workers-unfurl: "npm:^0.0.9"
     itty-router: "npm:^5.0.18"
     lazyrepo: "npm:0.0.0-alpha.27"
     toucan-js: "npm:^3.4.0"
@@ -17039,10 +17039,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cloudflare-workers-unfurl@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "cloudflare-workers-unfurl@npm:0.0.8"
-  checksum: 10/3f6354096c2f15a4a5766c8fa2620924f2e43a014aba69ec76419c6887a5d1ca6c399634959a3bb8223c248ee82d2a80cd4a8e9df7bd652e5362ded8d2ce4c58
+"cloudflare-workers-unfurl@npm:^0.0.9":
+  version: 0.0.9
+  resolution: "cloudflare-workers-unfurl@npm:0.0.9"
+  checksum: 10/88b2c169ee807602297771393fe43a6589ab174fa0e47eaab24ff4d78c97abd0f9ac77cdc3f7015c039dc0277dd61a3a9cf0404a11413e810510389e1ec6614d
   languageName: node
   linkType: hard
 
@@ -31590,7 +31590,7 @@ __metadata:
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
     "@vitejs/plugin-react": "npm:^6.0.1"
-    cloudflare-workers-unfurl: "npm:^0.0.8"
+    cloudflare-workers-unfurl: "npm:^0.0.9"
     concurrently: "npm:^9.1.2"
     itty-router: "npm:^5.0.18"
     react: "npm:^19.2.1"


### PR DESCRIPTION
Closes https://github.com/tldraw/tldraw/issues/6891

Embeds are created at a fixed 640×360 (16:9) box, so Vimeo videos with a different intrinsic aspect ratio were letterboxed (white "ears") inside the iframe.

When an embed is created or re-pointed at a new URL, we now resolve the content's real aspect ratio from the URL's OpenGraph image dimensions and resize the shape to match, keeping its center fixed. The dimensions come from the same server-side "unfurl" path bookmarks already use (`editor.getAssetForExternalContent({ type: 'url' })`), so there's no extra client-side fetch and it degrades gracefully when no metadata is available.

How it works:

- A new `sizeToContentAspectRatio` flag on embed definitions opts a provider in (enabled for Vimeo). It's generic — any provider whose page reports `og:image:width`/`og:image:height` benefits.
- Resolution is driven by a store side effect (on shape create / URL change), not by rendering, so it never runs during SVG export and doesn't fire per-view.
- `EmbedShapeUtil.resolveAspectRatio` reads `imageWidth`/`imageHeight` from the unfurled asset's `meta`, then resizes via the editor (correct under rotation, no undo-stack entry). Guards handle deleted shapes and stale/overlapping resolutions.

**Why not YouTube?** YouTube advertises the *same* 16:9 thumbnail dimensions for every video — vertical videos are padded into a 16:9 `maxresdefault` thumbnail, and its oEmbed/OG dimensions are identical for a 16:9 video and a 9:16 Short. So the unfurled dimensions can never reveal a non-16:9 ratio, and the correction would always be a no-op. (This is despite YouTube *doing* return OG tags to our unfurl UA — the limitation is the fixed thumbnail ratio, not missing metadata.) It's left out to avoid a pointless unfurl round-trip per YouTube embed.

https://github.com/user-attachments/assets/c04ab77e-1fd4-4e5a-9540-517b5ef7b58b


### Change type

- [ ] `bugfix`
- [x] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On tldraw.com (with the unfurl service returning image dimensions), copy https://vimeo.com/817841251 onto a canvas.
2. The embed should take the video's real 3:2 ratio — no white "ears".
3. A 16:9 video (e.g. https://vimeo.com/71278954) should be unchanged.

- [x] Unit tests
- [x] End to end tests

### API changes

- **`EmbedDefinition`** gains an optional `sizeToContentAspectRatio?: boolean`. When set, the embed shape corrects its size after creation to its content's real aspect ratio, resolved from the URL's OpenGraph metadata via the editor's url asset handler. Enabled for the built-in Vimeo definition.
- **`EmbedShapeUtil.resolveAspectRatio(shape: TLEmbedShape): Promise<void>`** — public method that resolves an embed's true ratio and corrects its size. Triggered by a store side effect on create / URL change; exposed so subclasses can override or trigger it.

All additive; existing custom embed definitions are unaffected.

### Release notes

- Embeds for providers that report their dimensions (e.g. Vimeo) now size themselves to their content's real aspect ratio, so videos are no longer letterboxed.
