### PR TITLE
fix(dotcom): make the Zero polyfill handle the comment queries (unblock e2e)

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -303,6 +303,16 @@ export class TldrawApp {
 		return queries.comments()
 	}
 
+	/**
+	 * Whether this app is backed by real Zero (vs the {@link ZeroPolyfill} used under automated
+	 * tests and when Zero is disabled). Comments are a Zero feature — their queries (bounded feeds,
+	 * `whereExists` access scoping, live per-file views) need real Zero — so the comment UI gates on
+	 * this and stays hidden under the polyfill rather than driving a view it can't back.
+	 */
+	isUsingProperZero() {
+		return this.useProperZero
+	}
+
 	/** Recent comments across the user's files, for the notifications feed (bounded, cross-file). */
 	getComments() {
 		return this.comments$.get()

--- a/apps/dotcom/client/src/tla/app/ast-helpers.test.ts
+++ b/apps/dotcom/client/src/tla/app/ast-helpers.test.ts
@@ -290,21 +290,68 @@ describe('evaluateCondition', () => {
 		})
 	})
 
-	describe('unsupported features', () => {
-		it('should throw for correlatedSubquery (EXISTS)', () => {
-			const condition = {
-				type: 'correlatedSubquery' as const,
-				related: {
-					correlation: { parentField: ['id'], childField: ['userId'] },
-					subquery: { table: 'file' },
+	describe('correlatedSubquery (EXISTS)', () => {
+		// comment(fileId) -> file(id), scoped to files the user has a state for
+		const existsCondition = {
+			type: 'correlatedSubquery' as const,
+			op: 'EXISTS' as const,
+			related: {
+				correlation: { parentField: ['fileId'], childField: ['id'] },
+				subquery: {
+					table: 'file',
+					where: {
+						type: 'correlatedSubquery' as const,
+						op: 'EXISTS' as const,
+						related: {
+							correlation: { parentField: ['id'], childField: ['fileId'] },
+							subquery: {
+								table: 'file_state',
+								where: {
+									type: 'simple' as const,
+									left: { type: 'column' as const, name: 'userId' },
+									op: '=' as const,
+									right: { type: 'literal' as const, value: 'u1' },
+								},
+							},
+						},
+					},
 				},
-				op: 'EXISTS' as const,
+			},
+		}
+
+		it('is true when a correlated child row exists and its nested EXISTS matches', () => {
+			const data = {
+				file: [{ id: 'f1' }],
+				file_state: [{ fileId: 'f1', userId: 'u1' }],
 			}
-			expect(() => evaluateCondition(condition as any, row)).toThrow(
-				'Unsupported condition type: correlatedSubquery (EXISTS/NOT EXISTS) is not implemented in polyfill'
-			)
+			expect(evaluateCondition(existsCondition as any, { fileId: 'f1' }, data)).toBe(true)
 		})
 
+		it('is false when the nested access subquery does not match', () => {
+			const data = {
+				file: [{ id: 'f1' }],
+				file_state: [{ fileId: 'f1', userId: 'someone-else' }],
+			}
+			expect(evaluateCondition(existsCondition as any, { fileId: 'f1' }, data)).toBe(false)
+		})
+
+		it('is false when no correlated child row exists', () => {
+			const data = { file: [{ id: 'other' }], file_state: [] }
+			expect(evaluateCondition(existsCondition as any, { fileId: 'f1' }, data)).toBe(false)
+		})
+
+		it('treats EXISTS as satisfied when no store data is provided', () => {
+			expect(evaluateCondition(existsCondition as any, { fileId: 'f1' })).toBe(true)
+		})
+
+		it('inverts for NOT EXISTS', () => {
+			const notExists = { ...existsCondition, op: 'NOT EXISTS' as const }
+			const data = { file: [{ id: 'f1' }], file_state: [{ fileId: 'f1', userId: 'u1' }] }
+			expect(evaluateCondition(notExists as any, { fileId: 'f1' }, data)).toBe(false)
+		})
+	})
+
+	describe('unsupported features', () => {
 		it('should evaluate IS operator', () => {
 			const condition = {
 				type: 'simple' as const,

--- a/apps/dotcom/client/src/tla/app/ast-helpers.test.ts
+++ b/apps/dotcom/client/src/tla/app/ast-helpers.test.ts
@@ -1,5 +1,5 @@
 import type { AST } from '@rocicorp/zero'
-import { evaluateCondition, validateAST } from './ast-helpers'
+import { applyOrderBy, evaluateCondition, validateAST } from './ast-helpers'
 
 describe('validateAST', () => {
 	it('should pass for basic AST without unsupported features', () => {
@@ -21,14 +21,12 @@ describe('validateAST', () => {
 		expect(() => validateAST(ast)).not.toThrow()
 	})
 
-	it('should throw for AST with orderBy', () => {
+	it('should pass for AST with orderBy (supported)', () => {
 		const ast: AST = {
 			table: 'user',
 			orderBy: [['name', 'asc']],
 		}
-		expect(() => validateAST(ast)).toThrow(
-			'Unsupported AST feature: orderBy is not implemented in polyfill'
-		)
+		expect(() => validateAST(ast)).not.toThrow()
 	})
 
 	it('should throw for AST with start (pagination bounds)', () => {
@@ -39,6 +37,54 @@ describe('validateAST', () => {
 		expect(() => validateAST(ast)).toThrow(
 			'Unsupported AST feature: start (pagination bounds) is not implemented in polyfill'
 		)
+	})
+})
+
+describe('applyOrderBy', () => {
+	const rows = [
+		{ id: 'a', createdAt: 3 },
+		{ id: 'b', createdAt: 1 },
+		{ id: 'c', createdAt: 2 },
+	]
+
+	it('returns rows unchanged when there is no orderBy', () => {
+		expect(applyOrderBy(rows, undefined)).toEqual(rows)
+		expect(applyOrderBy(rows, [])).toEqual(rows)
+	})
+
+	it('sorts ascending and descending by a field', () => {
+		expect(applyOrderBy(rows, [['createdAt', 'asc']]).map((r) => r.id)).toEqual(['b', 'c', 'a'])
+		expect(applyOrderBy(rows, [['createdAt', 'desc']]).map((r) => r.id)).toEqual(['a', 'c', 'b'])
+	})
+
+	it('applies order parts in sequence for ties', () => {
+		const tied = [
+			{ id: 'a', group: 1, createdAt: 2 },
+			{ id: 'b', group: 1, createdAt: 1 },
+			{ id: 'c', group: 0, createdAt: 5 },
+		]
+		expect(
+			applyOrderBy(tied, [
+				['group', 'asc'],
+				['createdAt', 'desc'],
+			]).map((r) => r.id)
+		).toEqual(['c', 'a', 'b'])
+	})
+
+	it('sorts undefined values last regardless of direction', () => {
+		const withGaps = [{ id: 'a', createdAt: 2 }, { id: 'b' }, { id: 'c', createdAt: 1 }]
+		expect(applyOrderBy(withGaps, [['createdAt', 'asc']]).map((r) => r.id)).toEqual(['c', 'a', 'b'])
+		expect(applyOrderBy(withGaps, [['createdAt', 'desc']]).map((r) => r.id)).toEqual([
+			'a',
+			'c',
+			'b',
+		])
+	})
+
+	it('does not mutate the input array', () => {
+		const input = [...rows]
+		applyOrderBy(input, [['createdAt', 'asc']])
+		expect(input).toEqual(rows)
 	})
 })
 

--- a/apps/dotcom/client/src/tla/app/ast-helpers.ts
+++ b/apps/dotcom/client/src/tla/app/ast-helpers.ts
@@ -33,31 +33,76 @@ export function applyOrderBy<T>(rows: T[], orderBy: AST['orderBy']): T[] {
 	})
 }
 
+/** Table name -> rows, i.e. the polyfill store's full data, needed to evaluate EXISTS subqueries. */
+export type PolyfillData = Record<string, Record<string, unknown>[]>
+
+interface Correlation {
+	readonly parentField: readonly string[]
+	readonly childField: readonly string[]
+}
+interface CorrelatedSubqueryCondition {
+	readonly type: 'correlatedSubquery'
+	readonly op: 'EXISTS' | 'NOT EXISTS'
+	readonly related: { readonly correlation: Correlation; readonly subquery: AST }
+}
+
+/**
+ * Evaluate a `whereExists`/`whereNotExists` subquery against a parent row: does the correlated
+ * child table have a row that matches on the correlation key(s) and satisfies the subquery's own
+ * `where` (which may itself contain EXISTS, so this recurses)?
+ */
+function evaluateCorrelatedSubquery(
+	condition: CorrelatedSubqueryCondition,
+	parentRow: Record<string, unknown>,
+	data?: PolyfillData
+): boolean {
+	const { related, op } = condition
+	const { correlation, subquery } = related
+	// Without store data we can't evaluate EXISTS. The only use is access-scoping (a query for rows
+	// on files the user can see), and the polyfill store is already server-scoped to the user, so
+	// treat EXISTS as satisfied rather than spuriously hiding rows.
+	if (!data) return op === 'EXISTS'
+	const childRows = data[subquery.table] ?? []
+	const anyMatch = childRows.some((childRow) => {
+		// Equality correlation on (possibly compound) keys: parent[parentField[i]] === child[childField[i]]
+		for (let i = 0; i < correlation.parentField.length; i++) {
+			if (parentRow[correlation.parentField[i]] !== childRow[correlation.childField[i]])
+				return false
+		}
+		return subquery.where ? evaluateCondition(subquery.where, childRow, data) : true
+	})
+	return op === 'EXISTS' ? anyMatch : !anyMatch
+}
+
 /**
  * Evaluate a where condition against a row.
- * Supported: and, or, simple conditions with =, !=, >, <, >=, <= operators
- * NOT supported: correlatedSubquery (EXISTS), LIKE, IN, IS operators
+ * Supported: and, or, simple conditions with =, !=, >, <, >=, <= operators, and
+ * correlatedSubquery (EXISTS/NOT EXISTS) when `data` is provided.
+ * NOT supported: LIKE, IN, IS operators.
  */
 export function evaluateCondition(
 	condition: NonNullable<AST['where']>,
-	row: Record<string, unknown>
+	row: Record<string, unknown>,
+	data?: PolyfillData
 ): boolean {
 	if ('type' in condition) {
 		switch (condition.type) {
 			case 'and':
 				return (condition as { conditions: readonly NonNullable<AST['where']>[] }).conditions.every(
-					(c) => evaluateCondition(c, row)
+					(c) => evaluateCondition(c, row, data)
 				)
 			case 'or':
 				return (condition as { conditions: readonly NonNullable<AST['where']>[] }).conditions.some(
-					(c) => evaluateCondition(c, row)
+					(c) => evaluateCondition(c, row, data)
 				)
 			case 'simple':
 				// Fall through to simple condition handling below
 				break
 			case 'correlatedSubquery':
-				throw new Error(
-					`Unsupported condition type: correlatedSubquery (EXISTS/NOT EXISTS) is not implemented in polyfill`
+				return evaluateCorrelatedSubquery(
+					condition as unknown as CorrelatedSubqueryCondition,
+					row,
+					data
 				)
 			default:
 				throw new Error(`Unknown condition type: ${(condition as { type: string }).type}`)

--- a/apps/dotcom/client/src/tla/app/ast-helpers.ts
+++ b/apps/dotcom/client/src/tla/app/ast-helpers.ts
@@ -5,14 +5,32 @@ import type { AST } from '@rocicorp/zero'
  * Throws descriptive errors for features not implemented in the polyfill.
  */
 export function validateAST(ast: AST): void {
-	if (ast.orderBy?.length) {
-		throw new Error(`Unsupported AST feature: orderBy is not implemented in polyfill`)
-	}
 	if (ast.start) {
 		throw new Error(
 			`Unsupported AST feature: start (pagination bounds) is not implemented in polyfill`
 		)
 	}
+}
+
+/**
+ * Sort rows by an AST `orderBy` (a list of `[field, 'asc' | 'desc']` parts, applied in order).
+ * Stable and top-level only — matching how the polyfill executes flat table queries.
+ */
+export function applyOrderBy<T>(rows: T[], orderBy: AST['orderBy']): T[] {
+	if (!orderBy?.length) return rows
+	return [...rows].sort((a, b) => {
+		for (const [field, direction] of orderBy) {
+			const av = (a as Record<string, unknown>)[field] as string | number | undefined
+			const bv = (b as Record<string, unknown>)[field] as string | number | undefined
+			if (av === bv) continue
+			// undefined sorts last regardless of direction
+			if (av === undefined) return 1
+			if (bv === undefined) return -1
+			const cmp = av < bv ? -1 : 1
+			return direction === 'desc' ? -cmp : cmp
+		}
+		return 0
+	})
 }
 
 /**

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -29,7 +29,7 @@ import {
 	uniqueId,
 } from 'tldraw'
 import { TLAppUiContextType } from '../utils/app-ui-events'
-import { applyOrderBy, evaluateCondition, validateAST } from './ast-helpers'
+import { applyOrderBy, evaluateCondition, type PolyfillData, validateAST } from './ast-helpers'
 import { ClientCRUD } from './ClientCRUD'
 
 export class Zero {
@@ -280,9 +280,15 @@ export class Zero {
 		const tableName = ast.table as keyof typeof data
 		let rows = data[tableName] as unknown[]
 
-		// Apply where conditions
+		// Apply where conditions (pass the full store data so EXISTS subqueries can resolve)
 		if (ast.where) {
-			rows = rows.filter((row) => evaluateCondition(ast.where!, row as Record<string, unknown>))
+			rows = rows.filter((row) =>
+				evaluateCondition(
+					ast.where!,
+					row as Record<string, unknown>,
+					data as unknown as PolyfillData
+				)
+			)
 		}
 
 		// Handle table-specific relation expansion

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -29,7 +29,7 @@ import {
 	uniqueId,
 } from 'tldraw'
 import { TLAppUiContextType } from '../utils/app-ui-events'
-import { evaluateCondition, validateAST } from './ast-helpers'
+import { applyOrderBy, evaluateCondition, validateAST } from './ast-helpers'
 import { ClientCRUD } from './ClientCRUD'
 
 export class Zero {
@@ -325,9 +325,15 @@ export class Zero {
 			})
 		}
 
-		// Apply limit (one() sets limit to 1)
+		// Order then limit, after relation expansion — matching real Zero's flat-query semantics.
+		rows = applyOrderBy(rows, ast.orderBy)
+
+		// one() sets limit to 1
 		if (ast.limit === 1) {
 			return rows[0]
+		}
+		if (typeof ast.limit === 'number') {
+			return rows.slice(0, ast.limit)
 		}
 
 		return rows

--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -38,7 +38,8 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 	// own — resubscribed when the file changes and destroyed on unmount.
 	const [fileComments, setFileComments] = useState<FileComments>([])
 	useEffect(() => {
-		if (!app) return
+		// Comments need real Zero; under the polyfill (tests, Zero disabled) skip the live view.
+		if (!app || !app.isUsingProperZero()) return
 		const view = app.materializeQuery<FileComments>(queries.fileComments({ fileId }))
 		setFileComments(view.data)
 		const unlisten = view.addListener((data) => setFileComments(data))
@@ -123,6 +124,9 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 		(query: string) => filterMentionMembers(mentionMembers, query),
 		[mentionMembers]
 	)
+
+	// Comments are a Zero feature; hide the layer entirely when Zero isn't available (polyfill).
+	if (!app?.isUsingProperZero()) return null
 
 	return (
 		<>


### PR DESCRIPTION
Fixes the dotcom e2e failures on the `commenting` branch. The e2e runs on the `ZeroPolyfill` (not real Zero — `navigator.webdriver` forces it), and `#9592`'s comment queries used three things the polyfill didn't handle. Bisected the regression to `#9592` (Jul-14 baseline green, `#9571` green, `#9592` red).

Three polyfill gaps, layered (each fix exposed the next):

1. **`orderBy` threw.** The notifications feed query (`comments`, `.orderBy('createdAt','desc')`) materializes in the `TldrawApp` constructor, so the throw crashed app init → login hung. Implemented `orderBy` (and a non-1 `limit`) in `executeAST`.
2. **`whereExists` (EXISTS) threw.** Both comment queries scope access with `whereExists('file', … whereExists('states', …))`. Evaluate EXISTS/NOT EXISTS against the store's related tables, recursing for nested exists.
3. **The live `fileComments` view wedged the file page.** `CommentsOnCanvas` drives a `materializeQuery(fileComments)` subscription the polyfill can't back, so the editor never rendered. Comments are a Zero feature, so gate the canvas comment layer on `isUsingProperZero()` and skip it under the polyfill (where it can't function anyway).

Real Zero supports all three, so none of this affected real users or dev sessions — only automated tests. Unit tests added for `orderBy` and EXISTS.

Follow-up worth filing separately: run the dotcom e2e on real Zero instead of the polyfill (test-what-you-ship), which would make on-canvas comments actually testable.

### Change type

- [x] `bugfix`
