### PR TITLE
feat(dotcom): redirect /offline to offline.tldraw.com

### DIFF
--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -205,6 +205,11 @@ const nextConfig = {
 				destination: 'https://discord.com/invite/s4FXZ6fppJ',
 				permanent: false,
 			},
+			{
+				source: '/offline',
+				destination: 'https://offline.tldraw.com',
+				permanent: false,
+			},
 		]
 	},
 	async rewrites() {

--- a/apps/docs/next.config.js
+++ b/apps/docs/next.config.js
@@ -205,11 +205,6 @@ const nextConfig = {
 				destination: 'https://discord.com/invite/s4FXZ6fppJ',
 				permanent: false,
 			},
-			{
-				source: '/offline',
-				destination: 'https://offline.tldraw.com',
-				permanent: false,
-			},
 		]
 	},
 	async rewrites() {

--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -176,6 +176,12 @@ async function build() {
 			{
 				version: 3,
 				routes: [
+					// redirect /offline to the offline version of tldraw
+					{
+						src: '^/offline/?$',
+						status: 307,
+						headers: { Location: 'https://offline.tldraw.com/' },
+					},
 					// rewrite api calls to the multiplayer server
 					{
 						src: '^/api(/(.*))?$',


### PR DESCRIPTION
In order to send people to the offline version of tldraw at https://offline.tldraw.com, this PR adds a `/offline` redirect to tldraw.com (the path currently 404s).

The redirect is a route at the top of the Vercel build output config generated by `apps/dotcom/client/scripts/build.ts`: `^/offline/?$` → 307 with a `Location` header — the same form `vercel.json` redirects compile to, and disjoint from the api rewrite, crawler routes, and all SPA routes. It's a temporary redirect (307) so browsers don't cache it permanently in case `/offline` ever becomes a real page.

The matching redirect for tldraw.dev lives in tldraw-internal (the dotdev app owns that domain and its marketing-level redirects; an earlier revision of this PR wrongly put it in `apps/docs`, whose `redirects()` never see paths the dotdev app doesn't forward).

### Change type

- [x] `improvement`

### Test plan

1. On this PR's preview deploy, visit `/offline` and `/offline/` — expect a 307 redirect to https://offline.tldraw.com.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +6 / -0    |