### PR TITLE
feat(commenting): support multi-shape comment anchors

### DIFF
--- a/apps/component-studio/src/comment-model.tsx
+++ b/apps/component-studio/src/comment-model.tsx
@@ -60,7 +60,7 @@ const PAGE_ID = 'page:studio' as TLPageId
 /** A sample thread, anchored to a shape. */
 export const sampleThread: TLCommentThread = createCommentThread({
 	pageId: PAGE_ID,
-	anchor: { type: 'shape', shapeId: createShapeId('box'), x: 1, y: 0, isPrecise: false },
+	anchor: { type: 'shape', shapeIds: [createShapeId('box')], x: 1, y: 0, isPrecise: false },
 	createdBy: 'ada',
 	now: NOW - 2 * HOUR,
 })

--- a/apps/component-studio/src/sketchbooks/anchoring/comment-anchor.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/anchoring/comment-anchor.sketchbook.tsx
@@ -11,7 +11,7 @@ const sketchbook: Sketchbook<CommentAnchorProps> = {
 			control: 'union',
 			discriminant: 'type',
 			variants: {
-				shape: { type: 'shape', shapeId: createShapeId('box'), x: 1, y: 0, isPrecise: false },
+				shape: { type: 'shape', shapeIds: [createShapeId('box')], x: 1, y: 0, isPrecise: false },
 				point: { type: 'point', x: 120, y: 90 },
 				region: { type: 'region', x: 60, y: 60, w: 180, h: 120 },
 				page: { type: 'page' },
@@ -27,13 +27,13 @@ export default sketchbook
 // moves and resizes, since x/y are normalized.
 export const ShapeImprecise: Sketch<CommentAnchorProps> = {
 	args: {
-		anchor: { type: 'shape', shapeId: createShapeId('box'), x: 1, y: 0, isPrecise: false },
+		anchor: { type: 'shape', shapeIds: [createShapeId('box')], x: 1, y: 0, isPrecise: false },
 		open: true,
 	},
 }
 export const ShapePrecise: Sketch<CommentAnchorProps> = {
 	args: {
-		anchor: { type: 'shape', shapeId: createShapeId('box'), x: 0.5, y: 0.62, isPrecise: true },
+		anchor: { type: 'shape', shapeIds: [createShapeId('box')], x: 0.5, y: 0.62, isPrecise: true },
 		open: true,
 	},
 }

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -199,6 +199,35 @@ describe('rehydration validation', () => {
 		expect(() => rowToThreadRecord(corrupt)).toThrow()
 	})
 
+	// Rows written by an older worker are validated against the current validator before the
+	// room's schema migrations run, so rehydration must normalize legacy shape anchors itself.
+	it('rowToThreadRecord normalizes a legacy single-shapeId anchor before validating', () => {
+		const row = threadRecordToRow(makeThread(), 'file1', 42)
+		const legacy = {
+			...row,
+			anchor: { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: true } as any,
+		}
+		expect(rowToThreadRecord(legacy).anchor).toEqual({
+			type: 'shape',
+			shapeIds: [shapeId],
+			x: 0.5,
+			y: 0.5,
+			isPrecise: true,
+		})
+	})
+
+	it('rowToThreadRecord normalizes a pre-x/y legacy shape anchor', () => {
+		const row = threadRecordToRow(makeThread(), 'file1', 42)
+		const legacy = { ...row, anchor: { type: 'shape', shapeId } as any }
+		expect(rowToThreadRecord(legacy).anchor).toEqual({
+			type: 'shape',
+			shapeIds: [shapeId],
+			x: 1,
+			y: 0,
+			isPrecise: false,
+		})
+	})
+
 	it('rowToCommentRecord throws on a mangled body', () => {
 		const thread = makeThread()
 		const comment = createComment({

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -26,7 +26,9 @@ const shapeId = 'shape:box1' as TLShapeId
 // minimal rich text doc; passes richTextValidator (which rowToCommentRecord now runs)
 const body = { type: 'doc', content: [] } as unknown as TLRichText
 
-function makeThread(anchor = { type: 'shape' as const, shapeId, x: 0.5, y: 0.5, isPrecise: true }) {
+function makeThread(
+	anchor = { type: 'shape' as const, shapeIds: [shapeId], x: 0.5, y: 0.5, isPrecise: true }
+) {
 	return createCommentThread({ pageId, anchor, createdBy: 'user1', now: 1000 })
 }
 
@@ -55,6 +57,18 @@ describe('threadRecordToRow', () => {
 		expect(row.shapeId).toBeNull()
 		expect(row.resolvedAt).toBeNull()
 		expect(row.resolvedBy).toBeNull()
+	})
+
+	it('multi-shape anchor: the first (primary) shape id is denormalized', () => {
+		const otherShapeId = 'shape:box2' as TLShapeId
+		const thread = makeThread({
+			type: 'shape' as const,
+			shapeIds: [shapeId, otherShapeId],
+			x: 0.5,
+			y: 0.5,
+			isPrecise: false,
+		})
+		expect(threadRecordToRow(thread, 'file1', 1).shapeId).toBe(shapeId)
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -199,35 +199,6 @@ describe('rehydration validation', () => {
 		expect(() => rowToThreadRecord(corrupt)).toThrow()
 	})
 
-	// Rows written by an older worker are validated against the current validator before the
-	// room's schema migrations run, so rehydration must normalize legacy shape anchors itself.
-	it('rowToThreadRecord normalizes a legacy single-shapeId anchor before validating', () => {
-		const row = threadRecordToRow(makeThread(), 'file1', 42)
-		const legacy = {
-			...row,
-			anchor: { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: true } as any,
-		}
-		expect(rowToThreadRecord(legacy).anchor).toEqual({
-			type: 'shape',
-			shapeIds: [shapeId],
-			x: 0.5,
-			y: 0.5,
-			isPrecise: true,
-		})
-	})
-
-	it('rowToThreadRecord normalizes a pre-x/y legacy shape anchor', () => {
-		const row = threadRecordToRow(makeThread(), 'file1', 42)
-		const legacy = { ...row, anchor: { type: 'shape', shapeId } as any }
-		expect(rowToThreadRecord(legacy).anchor).toEqual({
-			type: 'shape',
-			shapeIds: [shapeId],
-			x: 1,
-			y: 0,
-			isPrecise: false,
-		})
-	})
-
 	it('rowToCommentRecord throws on a mangled body', () => {
 		const thread = makeThread()
 		const comment = createComment({

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -82,12 +82,30 @@ export function commentRecordToRow(
 	}
 }
 
+/**
+ * Bring a persisted anchor up to the current shape-anchor form. Postgres rows are validated
+ * against the *current* record validator below, before the room's schema migrations ever run, so
+ * anchors written by an older worker must be normalized here or a legacy row would fail the room
+ * open. Mirrors the `com.tldraw.comment-thread/2` (x/y/isPrecise backfill) and `/3`
+ * (shapeId → shapeIds) up migrations.
+ */
+function normalizeLegacyShapeAnchor(anchor: any): TLCommentAnchor {
+	if (anchor?.type !== 'shape') return anchor
+	let next = anchor
+	if (next.x === undefined) next = { ...next, x: 1, y: 0, isPrecise: false }
+	if (next.shapeIds === undefined) {
+		const { shapeId, ...rest } = next
+		next = { ...rest, shapeIds: [shapeId] }
+	}
+	return next
+}
+
 export function rowToThreadRecord(row: DB['comment_thread']): TLCommentThread {
 	const record: TLCommentThread = {
 		id: row.id as TLCommentThread['id'],
 		typeName: 'comment-thread',
 		pageId: row.pageId as TLCommentThread['pageId'],
-		anchor: row.anchor as TLCommentAnchor,
+		anchor: normalizeLegacyShapeAnchor(row.anchor),
 		createdBy: row.createdBy,
 		createdAt: Number(row.createdAt),
 		resolved: row.resolvedAt != null ? { at: Number(row.resolvedAt), by: row.resolvedBy! } : null,

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -82,30 +82,12 @@ export function commentRecordToRow(
 	}
 }
 
-/**
- * Bring a persisted anchor up to the current shape-anchor form. Postgres rows are validated
- * against the *current* record validator below, before the room's schema migrations ever run, so
- * anchors written by an older worker must be normalized here or a legacy row would fail the room
- * open. Mirrors the `com.tldraw.comment-thread/2` (x/y/isPrecise backfill) and `/3`
- * (shapeId → shapeIds) up migrations.
- */
-function normalizeLegacyShapeAnchor(anchor: any): TLCommentAnchor {
-	if (anchor?.type !== 'shape') return anchor
-	let next = anchor
-	if (next.x === undefined) next = { ...next, x: 1, y: 0, isPrecise: false }
-	if (next.shapeIds === undefined) {
-		const { shapeId, ...rest } = next
-		next = { ...rest, shapeIds: [shapeId] }
-	}
-	return next
-}
-
 export function rowToThreadRecord(row: DB['comment_thread']): TLCommentThread {
 	const record: TLCommentThread = {
 		id: row.id as TLCommentThread['id'],
 		typeName: 'comment-thread',
 		pageId: row.pageId as TLCommentThread['pageId'],
-		anchor: normalizeLegacyShapeAnchor(row.anchor),
+		anchor: row.anchor as TLCommentAnchor,
 		createdBy: row.createdBy,
 		createdAt: Number(row.createdAt),
 		resolved: row.resolvedAt != null ? { at: Number(row.resolvedAt), by: row.resolvedBy! } : null,

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -49,7 +49,9 @@ export function threadRecordToRow(
 		fileId,
 		pageId: record.pageId,
 		anchor: record.anchor,
-		shapeId: record.anchor.type === 'shape' ? record.anchor.shapeId : null,
+		// A shape anchor can reference several shapes; the single-value column keeps the first
+		// (primary) one for app-level queries and notification deep links.
+		shapeId: record.anchor.type === 'shape' ? (record.anchor.shapeIds[0] ?? null) : null,
 		resolvedAt: record.resolved?.at ?? null,
 		resolvedBy: record.resolved?.by ?? null,
 		createdBy: record.createdBy,

--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -57,14 +57,27 @@ export default function CommentAnchorsExample() {
 				// top-right badge spot. The anchor still tracks the shape as it moves and resizes.
 				seedThread(
 					editor,
-					{ type: 'shape', shapeId: boxId, x: 1, y: 0, isPrecise: false },
+					{ type: 'shape', shapeIds: [boxId], x: 1, y: 0, isPrecise: false },
 					'Anchored to this shape (imprecise — sits at the corner).'
 				)
 				// shape (precise): the pin sits exactly at the stored normalized spot inside the shape.
 				seedThread(
 					editor,
-					{ type: 'shape', shapeId: boxId, x: 0.5, y: 0.6, isPrecise: true },
+					{ type: 'shape', shapeIds: [boxId], x: 0.5, y: 0.6, isPrecise: true },
 					'Anchored to a precise spot inside the shape.'
+				)
+				// shape (multiple): anchored to several shapes at once. The pin sits on their common
+				// bounds and tracks the group as any of them move; if one is deleted the anchor
+				// keeps tracking the rest.
+				const pairIds = [createShapeId(), createShapeId()]
+				editor.createShapes([
+					{ id: pairIds[0], type: 'geo', x: 620, y: 100, props: { geo: 'ellipse', w: 100, h: 80 } },
+					{ id: pairIds[1], type: 'geo', x: 780, y: 200, props: { geo: 'ellipse', w: 100, h: 80 } },
+				])
+				seedThread(
+					editor,
+					{ type: 'shape', shapeIds: pairIds, x: 1, y: 0, isPrecise: false },
+					'Anchored to both ellipses — the pin tracks their common bounds.'
 				)
 				// point: a bare page coordinate, unattached to any shape.
 				seedThread(editor, { type: 'point', x: 200, y: 340 }, 'Anchored to a point on the page.')

--- a/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-anchors/CommentAnchorsExample.tsx
@@ -91,7 +91,7 @@ export default function CommentAnchorsExample() {
 			{ history: 'ignore' }
 		)
 
-		editor.zoomToBounds({ x: 60, y: 60, w: 600, h: 420 }, { immediate: true })
+		editor.zoomToBounds({ x: 60, y: 60, w: 880, h: 420 }, { immediate: true })
 	}
 
 	const components = useMemo<TLComponents>(

--- a/apps/examples/src/examples/collaboration/comment-anchors/README.md
+++ b/apps/examples/src/examples/collaboration/comment-anchors/README.md
@@ -5,14 +5,15 @@ priority: 4
 keywords: [comments, commenting, anchors, shape, region, point, text range, collaboration]
 ---
 
-The five ways a comment can attach to the canvas.
+The ways a comment can attach to the canvas.
 
 ---
 
-Every comment thread carries an `anchor` — a discriminated union that says where on the page the thread lives. `CanvasComments` reads the anchor and draws each kind in the right place. This example seeds one thread of each kind, then lets the overlay position them:
+Every comment thread carries an `anchor` — a discriminated union that says where on the page the thread lives. `CanvasComments` reads the anchor and draws each kind in the right place. This example seeds threads of each kind, then lets the overlay position them:
 
 - **shape (imprecise)** — attached to a shape, the pin sitting at its top-right badge spot. The stored `x`/`y` are normalized (0–1), so the pin tracks the shape as it moves and resizes.
 - **shape (precise)** — attached to an exact normalized spot inside a shape (what you get by holding `alt` while placing).
+- **shape (multiple)** — a shape anchor can hold several shape ids; the pin sits on the common bounds of the shapes that still exist and tracks the group as any of them move. Placing a comment on a shape that's part of a multi-shape selection anchors it to the whole selection.
 - **point** — a bare page coordinate, unattached to any shape.
 - **region** — a rectangular area; the pin sits on a corner and the region box is drawn.
 

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Box } from 'tldraw';
 import { ComponentType } from 'react';
 import { Editor } from 'tldraw';
 import { EditorAtom } from 'tldraw';
@@ -316,6 +317,9 @@ export const commentTools: typeof CommentTool[];
 // @public
 export function commitCommentMutation<T>(editor: Editor, fn: () => T, kind?: 'drag' | 'mutation'): T;
 
+// @public
+export function commonShapePageBounds(editor: Editor, shapeIds: TLShapeId[]): Box | null;
+
 // @public (undocumented)
 export function computeClusterTable(leaves: readonly LeafInput[], options: ClusterOptions): ClusterTable;
 
@@ -514,7 +518,7 @@ export interface SendButtonProps {
 }
 
 // @public
-export function shapeAnchorAt(editor: Editor, shapeId: TLShapeId, page: {
+export function shapeAnchorAt(editor: Editor, shapeIds: TLShapeId[], page: {
     x: number;
     y: number;
 }, precise: boolean): TLCommentAnchor;

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { Box } from 'tldraw';
 import { ComponentType } from 'react';
 import { Editor } from 'tldraw';
 import { EditorAtom } from 'tldraw';
@@ -316,9 +315,6 @@ export const commentTools: typeof CommentTool[];
 
 // @public
 export function commitCommentMutation<T>(editor: Editor, fn: () => T, kind?: 'drag' | 'mutation'): T;
-
-// @public
-export function commonShapePageBounds(editor: Editor, shapeIds: TLShapeId[]): Box | null;
 
 // @public (undocumented)
 export function computeClusterTable(leaves: readonly LeafInput[], options: ClusterOptions): ClusterTable;

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -34,12 +34,23 @@ function thread(
 function stubEditor(
 	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
 ): Editor {
+	const getShapePageBounds = (id: string) => {
+		const bounds = shapes[id]
+		if (!bounds) return undefined
+		return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
+	}
 	return {
 		getCurrentPageId: () => CURRENT_PAGE,
-		getShapePageBounds: (id: string) => {
-			const bounds = shapes[id]
-			if (!bounds) return undefined
-			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
+		getShapePageBounds,
+		// Common bounds of the ids that resolve, mirroring Editor.getShapesPageBounds.
+		getShapesPageBounds: (ids: string[]) => {
+			const all = ids.map(getShapePageBounds).filter((b) => b !== undefined)
+			if (all.length === 0) return null
+			const minX = Math.min(...all.map((b) => b!.minX))
+			const minY = Math.min(...all.map((b) => b!.minY))
+			const maxX = Math.max(...all.map((b) => b!.maxX))
+			const maxY = Math.max(...all.map((b) => b!.maxY))
+			return { minX, minY, maxX, maxY, w: maxX - minX, h: maxY - minY }
 		},
 	} as unknown as Editor
 }

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -74,7 +74,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 		const leaves = collectClusterLeaves(
 			editor,
 			[
-				thread('t1', { type: 'shape', shapeId: 'shape:a' as any, x: 0, y: 0, isPrecise: false }),
+				thread('t1', { type: 'shape', shapeIds: ['shape:a' as any], x: 0, y: 0, isPrecise: false }),
 				thread('t2', { type: 'text-range', shapeId: 'shape:a' as any, from: 0, to: 3 }),
 			],
 			null
@@ -92,14 +92,14 @@ describe('collectClusterLeaves anchor resolution', () => {
 		const threads = [
 			thread('imprecise', {
 				type: 'shape',
-				shapeId: 'shape:a' as any,
+				shapeIds: ['shape:a' as any],
 				x: 0,
 				y: 0,
 				isPrecise: false,
 			}),
 			thread('precise', {
 				type: 'shape',
-				shapeId: 'shape:a' as any,
+				shapeIds: ['shape:a' as any],
 				x: 0.5,
 				y: 0.5,
 				isPrecise: true,
@@ -119,7 +119,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 			[
 				thread('gone', {
 					type: 'shape',
-					shapeId: 'shape:deleted' as any,
+					shapeIds: ['shape:deleted' as any],
 					x: 0,
 					y: 0,
 					isPrecise: false,
@@ -193,14 +193,14 @@ describe('collectClusterLeaves filtering', () => {
 			thread('region', { type: 'region', x: 0, y: 0, w: 5, h: 5 }),
 			thread('onShape', {
 				type: 'shape',
-				shapeId: 'shape:live' as any,
+				shapeIds: ['shape:live' as any],
 				x: 0,
 				y: 0,
 				isPrecise: false,
 			}),
 			thread('orphaned', {
 				type: 'shape',
-				shapeId: 'shape:gone' as any,
+				shapeIds: ['shape:gone' as any],
 				x: 0,
 				y: 0,
 				isPrecise: false,

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -124,15 +124,21 @@ class CommentPointing extends StateNode {
 		const { editor } = this
 		const point = editor.inputs.getCurrentPagePoint()
 		const hit = editor.getShapeAtPoint(point, { hitInside: true })
-		const selectedIds = editor.getSelectedShapeIds()
-		const anchorShapeIds = hit
-			? selectedIds.length > 1 && selectedIds.includes(hit.id)
-				? selectedIds
-				: [hit.id]
-			: null
-		const anchor: TLCommentAnchor = anchorShapeIds
-			? shapeAnchorAt(editor, anchorShapeIds, point, editor.inputs.getAltKey())
-			: { type: 'point', x: point.x, y: point.y }
+		let anchor: TLCommentAnchor
+		if (hit) {
+			const selectedIds = editor.getSelectedShapeIds()
+			// The hit is never a group, so match the selection through the clicked shape's
+			// outermost selectable ancestor. The clicked shape goes first: `shapeIds[0]` is the
+			// anchor's primary shape (used for denormalized queries and deep links).
+			const clicked = editor.getOutermostSelectableShape(hit)
+			const ids =
+				selectedIds.length > 1 && selectedIds.includes(clicked.id)
+					? [clicked.id, ...selectedIds.filter((id) => id !== clicked.id)]
+					: [hit.id]
+			anchor = shapeAnchorAt(editor, ids, point, editor.inputs.getAltKey())
+		} else {
+			anchor = { type: 'point', x: point.x, y: point.y }
+		}
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
 		// Hand back to select; the open composer is now the focus.
 		editor.setCurrentTool('select')

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -119,12 +119,19 @@ class CommentPointing extends StateNode {
 	}
 
 	// A pointer up with no drag is a click: anchor to the shape under it, or drop a point.
+	// Clicking a shape that's part of a multi-shape selection anchors to the whole selection.
 	override onPointerUp() {
 		const { editor } = this
 		const point = editor.inputs.getCurrentPagePoint()
 		const hit = editor.getShapeAtPoint(point, { hitInside: true })
-		const anchor: TLCommentAnchor = hit
-			? shapeAnchorAt(editor, hit.id, point, editor.inputs.getAltKey())
+		const selectedIds = editor.getSelectedShapeIds()
+		const anchorShapeIds = hit
+			? selectedIds.length > 1 && selectedIds.includes(hit.id)
+				? selectedIds
+				: [hit.id]
+			: null
+		const anchor: TLCommentAnchor = anchorShapeIds
+			? shapeAnchorAt(editor, anchorShapeIds, point, editor.inputs.getAltKey())
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
 		// Hand back to select; the open composer is now the focus.

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1257,7 +1257,7 @@ const ThreadPin = memo(function ThreadPin({
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
 			anchor = hit
-				? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
+				? shapeAnchorAt(editor, [hit.id], pagePoint, e.altKey)
 				: { type: 'point', x: pagePoint.x, y: pagePoint.y }
 		}
 		commitCommentMutation(editor, () => putCommentRecords(editor, [{ ...thread, anchor }]), 'drag')

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1256,6 +1256,8 @@ const ThreadPin = memo(function ThreadPin({
 			}
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
+			// Re-anchoring by drag is an explicit "move this pin here" gesture, so it deliberately
+			// collapses to the single dropped-on shape even if the pin was multi-shape before.
 			anchor = hit
 				? shapeAnchorAt(editor, [hit.id], pagePoint, e.altKey)
 				: { type: 'point', x: pagePoint.x, y: pagePoint.y }

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,4 +1,4 @@
-import { Box, BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId, VecLike } from 'tldraw'
+import { BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId, VecLike } from 'tldraw'
 import { getRegionCommentOptions } from './region-options'
 import { openThreadId } from './state'
 
@@ -31,7 +31,8 @@ export function anchorPagePoint(
 ): { x: number; y: number } | null {
 	switch (anchor.type) {
 		case 'shape': {
-			const bounds = commonShapePageBounds(editor, anchor.shapeIds as TLShapeId[])
+			// The common page bounds of the anchored shapes that still exist; null when none do.
+			const bounds = editor.getShapesPageBounds(anchor.shapeIds)
 			if (!bounds) return null
 			// Precise pins sit at their stored x/y; imprecise ones at the consumer's default spot.
 			const { x, y } = anchor.isPrecise ? anchor : impreciseShapeAnchor
@@ -52,29 +53,6 @@ export function anchorPagePoint(
 }
 
 /**
- * The common page bounds of the anchored shapes that still exist, or null when none do. With a
- * single shape this is exactly its own page bounds; with several it's their union, recomputed
- * live so the anchor tracks the group as it moves.
- * @public
- */
-export function commonShapePageBounds(editor: Editor, shapeIds: TLShapeId[]): Box | null {
-	let minX = Infinity
-	let minY = Infinity
-	let maxX = -Infinity
-	let maxY = -Infinity
-	for (const shapeId of shapeIds) {
-		const b = editor.getShapePageBounds(shapeId)
-		if (!b) continue
-		if (b.minX < minX) minX = b.minX
-		if (b.minY < minY) minY = b.minY
-		if (b.maxX > maxX) maxX = b.maxX
-		if (b.maxY > maxY) maxY = b.maxY
-	}
-	if (minX === Infinity) return null
-	return new Box(minX, minY, maxX - minX, maxY - minY)
-}
-
-/**
  * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
  * common page bounds of `shapeIds`, remembered either way. When `precise` (Alt held) the pin sits
  * at exactly `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the
@@ -87,7 +65,7 @@ export function shapeAnchorAt(
 	page: { x: number; y: number },
 	precise: boolean
 ): TLCommentAnchor {
-	const bounds = commonShapePageBounds(editor, shapeIds)
+	const bounds = editor.getShapesPageBounds(shapeIds)
 	if (!bounds || bounds.w === 0 || bounds.h === 0) {
 		return { type: 'shape', shapeIds, x: 0.5, y: 0.5, isPrecise: precise }
 	}

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,4 +1,4 @@
-import { BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId, VecLike } from 'tldraw'
+import { Box, BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId, VecLike } from 'tldraw'
 import { getRegionCommentOptions } from './region-options'
 import { openThreadId } from './state'
 
@@ -31,7 +31,7 @@ export function anchorPagePoint(
 ): { x: number; y: number } | null {
 	switch (anchor.type) {
 		case 'shape': {
-			const bounds = editor.getShapePageBounds(anchor.shapeId as TLShapeId)
+			const bounds = commonShapePageBounds(editor, anchor.shapeIds as TLShapeId[])
 			if (!bounds) return null
 			// Precise pins sit at their stored x/y; imprecise ones at the consumer's default spot.
 			const { x, y } = anchor.isPrecise ? anchor : impreciseShapeAnchor
@@ -52,24 +52,48 @@ export function anchorPagePoint(
 }
 
 /**
+ * The common page bounds of the anchored shapes that still exist, or null when none do. With a
+ * single shape this is exactly its own page bounds; with several it's their union, recomputed
+ * live so the anchor tracks the group as it moves.
+ * @public
+ */
+export function commonShapePageBounds(editor: Editor, shapeIds: TLShapeId[]): Box | null {
+	let minX = Infinity
+	let minY = Infinity
+	let maxX = -Infinity
+	let maxY = -Infinity
+	for (const shapeId of shapeIds) {
+		const b = editor.getShapePageBounds(shapeId)
+		if (!b) continue
+		if (b.minX < minX) minX = b.minX
+		if (b.minY < minY) minY = b.minY
+		if (b.maxX > maxX) maxX = b.maxX
+		if (b.maxY > maxY) maxY = b.maxY
+	}
+	if (minX === Infinity) return null
+	return new Box(minX, minY, maxX - minX, maxY - minY)
+}
+
+/**
  * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
- * shape's page bounds, remembered either way. When `precise` (Alt held) the pin sits at exactly
- * `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the box).
+ * common page bounds of `shapeIds`, remembered either way. When `precise` (Alt held) the pin sits
+ * at exactly `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the
+ * box).
  * @public
  */
 export function shapeAnchorAt(
 	editor: Editor,
-	shapeId: TLShapeId,
+	shapeIds: TLShapeId[],
 	page: { x: number; y: number },
 	precise: boolean
 ): TLCommentAnchor {
-	const bounds = editor.getShapePageBounds(shapeId)
+	const bounds = commonShapePageBounds(editor, shapeIds)
 	if (!bounds || bounds.w === 0 || bounds.h === 0) {
-		return { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: precise }
+		return { type: 'shape', shapeIds, x: 0.5, y: 0.5, isPrecise: precise }
 	}
 	return {
 		type: 'shape',
-		shapeId,
+		shapeIds,
 		x: (page.x - bounds.minX) / bounds.w,
 		y: (page.y - bounds.minY) / bounds.h,
 		isPrecise: precise,

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -84,7 +84,6 @@ export {
 } from './canvas/state'
 export {
 	anchorPagePoint,
-	commonShapePageBounds,
 	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
 	focusThread,
 	shapeAnchorAt,

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -84,6 +84,7 @@ export {
 } from './canvas/state'
 export {
 	anchorPagePoint,
+	commonShapePageBounds,
 	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
 	focusThread,
 	shapeAnchorAt,

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -148,7 +148,7 @@ export const comment_thread = table('comment_thread')
 		id: string(),
 		fileId: string(),
 		pageId: string(),
-		// only set for shape-anchored threads; other anchor kinds have no shape
+		// the first (primary) shape of a shape-anchored thread; other anchor kinds have no shape
 		shapeId: string().optional(),
 		resolvedAt: number().optional(),
 		createdBy: string(),

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -1109,7 +1109,7 @@ export type TLCommentAnchor = {
     y: number;
 } | {
     isPrecise: boolean;
-    shapeId: TLShapeId;
+    shapeIds: TLShapeId[];
     type: 'shape';
     x: number;
     y: number;

--- a/packages/tlschema/src/records/TLComment.test.ts
+++ b/packages/tlschema/src/records/TLComment.test.ts
@@ -160,71 +160,8 @@ describe('isCommentThreadId / isCommentId', () => {
 })
 
 describe('comment-thread migrations', () => {
-	const migration = (commentThreadRecordConfig.migrations as any).sequence.find(
-		(m: any) => m.id === 'com.tldraw.comment-thread/2'
-	) as { up(r: any): any; down(r: any): any }
-
-	it('stamps existing shape anchors with the top-right position (x:1, y:0)', () => {
-		expect(migration.up({ anchor: { type: 'shape', shapeId } })).toEqual({
-			anchor: { type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
-		})
-	})
-
-	it('leaves shape anchors that already have x/y unchanged', () => {
-		const anchor = { type: 'shape', shapeId, x: 0.25, y: 0.75, isPrecise: true }
-		expect(migration.up({ anchor })).toEqual({ anchor })
-	})
-
-	it('leaves non-shape anchors untouched', () => {
-		const anchor = { type: 'point', x: 5, y: 6 }
-		expect(migration.up({ anchor })).toEqual({ anchor })
-	})
-
-	it('down-migrates by dropping x/y', () => {
-		expect(
-			migration.down({ anchor: { type: 'shape', shapeId, x: 0.3, y: 0.4, isPrecise: true } })
-		).toEqual({
-			anchor: { type: 'shape', shapeId },
-		})
-	})
-})
-
-describe('comment-thread/3 migration (shapeId -> shapeIds)', () => {
-	const migration = (commentThreadRecordConfig.migrations as any).sequence.find(
-		(m: any) => m.id === 'com.tldraw.comment-thread/3'
-	) as { up(r: any): any; down(r: any): any }
-
-	it('up-migrates a single shapeId to a one-element shapeIds array', () => {
-		expect(
-			migration.up({ anchor: { type: 'shape', shapeId, x: 1, y: 0, isPrecise: false } })
-		).toEqual({
-			anchor: { type: 'shape', shapeIds: [shapeId], x: 1, y: 0, isPrecise: false },
-		})
-	})
-
-	it('leaves shape anchors that already have shapeIds unchanged', () => {
-		const anchor = { type: 'shape', shapeIds: [shapeId], x: 1, y: 0, isPrecise: false }
-		expect(migration.up({ anchor })).toEqual({ anchor })
-	})
-
-	it('leaves non-shape anchors untouched', () => {
-		const anchor = { type: 'text-range', shapeId, from: 1, to: 4 }
-		expect(migration.up({ anchor })).toEqual({ anchor })
-	})
-
-	it('down-migrates by keeping only the first (primary) shape', () => {
-		expect(
-			migration.down({
-				anchor: {
-					type: 'shape',
-					shapeIds: [shapeId, 'shape:box2'],
-					x: 0.3,
-					y: 0.4,
-					isPrecise: true,
-				},
-			})
-		).toEqual({
-			anchor: { type: 'shape', shapeId, x: 0.3, y: 0.4, isPrecise: true },
-		})
+	it('has only the identity guard migration (the feature has never shipped, so no data migrations)', () => {
+		const ids = (commentThreadRecordConfig.migrations as any).sequence.map((m: any) => m.id)
+		expect(ids).toEqual(['com.tldraw.comment-thread/1'])
 	})
 })

--- a/packages/tlschema/src/records/TLComment.test.ts
+++ b/packages/tlschema/src/records/TLComment.test.ts
@@ -20,7 +20,8 @@ const pageId = 'page:page1' as TLPageId
 const shapeId = 'shape:box1' as TLShapeId
 
 const anchors: TLCommentAnchor[] = [
-	{ type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
+	{ type: 'shape', shapeIds: [shapeId], x: 1, y: 0, isPrecise: false },
+	{ type: 'shape', shapeIds: [shapeId, 'shape:box2' as TLShapeId], x: 1, y: 0, isPrecise: false },
 	{ type: 'point', x: 100, y: 200 },
 	{ type: 'region', x: 0, y: 0, w: 300, h: 150 },
 	{ type: 'page' },
@@ -58,7 +59,7 @@ describe('TLCommentThread', () => {
 	it('rejects unknown anchor kinds and malformed anchors', () => {
 		const thread = createCommentThread({
 			pageId,
-			anchor: { type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
+			anchor: { type: 'shape', shapeIds: [shapeId], x: 1, y: 0, isPrecise: false },
 			createdBy: 'user1',
 			now: 1000,
 		})
@@ -71,8 +72,15 @@ describe('TLCommentThread', () => {
 		expect(() =>
 			commentThreadRecordConfig.validator.validate({
 				...thread,
-				// shape anchors must reference a shape id
-				anchor: { type: 'shape', shapeId: 'page:nope', x: 1, y: 0, isPrecise: false },
+				// shape anchors must reference shape ids
+				anchor: { type: 'shape', shapeIds: ['page:nope'], x: 1, y: 0, isPrecise: false },
+			})
+		).toThrow()
+		expect(() =>
+			commentThreadRecordConfig.validator.validate({
+				...thread,
+				// shape anchors must reference at least one shape
+				anchor: { type: 'shape', shapeIds: [], x: 1, y: 0, isPrecise: false },
 			})
 		).toThrow()
 	})
@@ -177,6 +185,46 @@ describe('comment-thread migrations', () => {
 			migration.down({ anchor: { type: 'shape', shapeId, x: 0.3, y: 0.4, isPrecise: true } })
 		).toEqual({
 			anchor: { type: 'shape', shapeId },
+		})
+	})
+})
+
+describe('comment-thread/3 migration (shapeId -> shapeIds)', () => {
+	const migration = (commentThreadRecordConfig.migrations as any).sequence.find(
+		(m: any) => m.id === 'com.tldraw.comment-thread/3'
+	) as { up(r: any): any; down(r: any): any }
+
+	it('up-migrates a single shapeId to a one-element shapeIds array', () => {
+		expect(
+			migration.up({ anchor: { type: 'shape', shapeId, x: 1, y: 0, isPrecise: false } })
+		).toEqual({
+			anchor: { type: 'shape', shapeIds: [shapeId], x: 1, y: 0, isPrecise: false },
+		})
+	})
+
+	it('leaves shape anchors that already have shapeIds unchanged', () => {
+		const anchor = { type: 'shape', shapeIds: [shapeId], x: 1, y: 0, isPrecise: false }
+		expect(migration.up({ anchor })).toEqual({ anchor })
+	})
+
+	it('leaves non-shape anchors untouched', () => {
+		const anchor = { type: 'text-range', shapeId, from: 1, to: 4 }
+		expect(migration.up({ anchor })).toEqual({ anchor })
+	})
+
+	it('down-migrates by keeping only the first (primary) shape', () => {
+		expect(
+			migration.down({
+				anchor: {
+					type: 'shape',
+					shapeIds: [shapeId, 'shape:box2'],
+					x: 0.3,
+					y: 0.4,
+					isPrecise: true,
+				},
+			})
+		).toEqual({
+			anchor: { type: 'shape', shapeId, x: 0.3, y: 0.4, isPrecise: true },
 		})
 	})
 })

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -11,10 +11,14 @@ import { TLShapeId } from './TLShape'
  * Where a comment thread is anchored on the canvas. Modeled as a discriminated union so new
  * anchor kinds can be added without breaking existing threads:
  *
- * - `shape` — pinned to a shape. `x`/`y` are normalized (0–1) within the shape's page bounds, so
- *   the pin keeps its spot as the shape moves and resizes. `isPrecise` mirrors arrow bindings: when
- *   true the pin sits at exactly `x`/`y`; when false (the default) it sits at a consumer-defined
- *   spot (top-right out of the box), and `x`/`y` are the remembered precise position
+ * - `shape` — pinned to one or more shapes. `x`/`y` are normalized (0–1) within the common page
+ *   bounds of the anchored shapes that still exist, so the pin keeps its spot as the shapes move
+ *   and resize. With a single shape that's exactly its own page bounds; with several, note the
+ *   common bounds reflow as the shapes move relative to each other, so a precise pin tracks the
+ *   group approximately rather than any one shape exactly. `isPrecise` mirrors arrow bindings:
+ *   when true the pin sits at exactly `x`/`y`; when false (the default) it sits at a
+ *   consumer-defined spot (top-right out of the box), and `x`/`y` are the remembered precise
+ *   position
  * - `point` — pinned to a fixed point on the page, in page coordinates
  * - `region` — pinned to a rectangular area of the page, in page coordinates
  * - `page` — a page-level thread with no spatial anchor
@@ -23,7 +27,7 @@ import { TLShapeId } from './TLShape'
  * @public
  */
 export type TLCommentAnchor =
-	| { type: 'shape'; shapeId: TLShapeId; x: number; y: number; isPrecise: boolean }
+	| { type: 'shape'; shapeIds: TLShapeId[]; x: number; y: number; isPrecise: boolean }
 	| { type: 'point'; x: number; y: number }
 	| { type: 'region'; x: number; y: number; w: number; h: number }
 	| { type: 'page' }
@@ -96,7 +100,7 @@ export type TLCommentId = RecordId<TLComment>
 const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
 	shape: T.object({
 		type: T.literal('shape'),
-		shapeId: idValidator<TLShapeId>('shape'),
+		shapeIds: T.arrayOf(idValidator<TLShapeId>('shape')).nonEmpty(),
 		x: T.number,
 		y: T.number,
 		isPrecise: T.boolean,
@@ -172,6 +176,27 @@ export const commentThreadRecordConfig: CustomRecordInfo = {
 				const anchor = (record as any).anchor
 				if (anchor?.type === 'shape') {
 					;(record as any).anchor = { type: 'shape', shapeId: anchor.shapeId }
+				}
+				return record
+			},
+		},
+		{
+			// Shape anchors generalized from a single `shapeId` to one-or-more `shapeIds`. Down is
+			// lossy for multi-shape anchors: older schemas keep only the first (primary) shape.
+			id: 'com.tldraw.comment-thread/3',
+			up: (record) => {
+				const anchor = (record as any).anchor
+				if (anchor?.type === 'shape' && anchor.shapeIds === undefined) {
+					const { shapeId, ...rest } = anchor
+					;(record as any).anchor = { ...rest, shapeIds: [shapeId] }
+				}
+				return record
+			},
+			down: (record) => {
+				const anchor = (record as any).anchor
+				if (anchor?.type === 'shape') {
+					const { shapeIds, ...rest } = anchor
+					;(record as any).anchor = { ...rest, shapeId: shapeIds[0] }
 				}
 				return record
 			},

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -11,14 +11,15 @@ import { TLShapeId } from './TLShape'
  * Where a comment thread is anchored on the canvas. Modeled as a discriminated union so new
  * anchor kinds can be added without breaking existing threads:
  *
- * - `shape` — pinned to one or more shapes. `x`/`y` are normalized (0–1) within the common page
- *   bounds of the anchored shapes that still exist, so the pin keeps its spot as the shapes move
- *   and resize. With a single shape that's exactly its own page bounds; with several, note the
- *   common bounds reflow as the shapes move relative to each other, so a precise pin tracks the
- *   group approximately rather than any one shape exactly. `isPrecise` mirrors arrow bindings:
- *   when true the pin sits at exactly `x`/`y`; when false (the default) it sits at a
- *   consumer-defined spot (top-right out of the box), and `x`/`y` are the remembered precise
- *   position
+ * - `shape` — pinned to one or more shapes. `shapeIds[0]` is the primary shape (the one clicked,
+ *   and the one denormalized for app-level queries and deep links). `x`/`y` are normalized (0–1)
+ *   within the common page bounds of the anchored shapes that still exist, so the pin keeps its
+ *   spot as the shapes move and resize. With a single shape that's exactly its own page bounds;
+ *   with several, the common bounds reflow as the shapes move relative to each other, so a
+ *   precise pin tracks the group approximately rather than any one shape exactly. `isPrecise`
+ *   mirrors arrow bindings: when true the pin sits at exactly `x`/`y`; when false (the default)
+ *   it sits at a consumer-defined spot (top-right out of the box), and `x`/`y` are the
+ *   remembered precise position
  * - `point` — pinned to a fixed point on the page, in page coordinates
  * - `region` — pinned to a rectangular area of the page, in page coordinates
  * - `page` — a page-level thread with no spatial anchor

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -136,10 +136,7 @@ const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
  * rejected with CLIENT_TOO_OLD (prompting a refresh) instead of being sent record types their
  * store cannot represent.
  */
-function createCommentGuardMigrations(
-	typeName: 'comment' | 'comment-thread',
-	extra: Parameters<typeof createRecordMigrationSequence>[0]['sequence'] = []
-) {
+function createCommentGuardMigrations(typeName: 'comment' | 'comment-thread') {
 	return createRecordMigrationSequence({
 		sequenceId: `com.tldraw.${typeName}`,
 		recordType: typeName,
@@ -149,7 +146,6 @@ function createCommentGuardMigrations(
 				id: `com.tldraw.${typeName}/1`,
 				up: (record) => record,
 			},
-			...extra,
 		],
 	})
 }
@@ -162,47 +158,7 @@ function createCommentGuardMigrations(
  */
 export const commentThreadRecordConfig: CustomRecordInfo = {
 	scope: 'document',
-	migrations: createCommentGuardMigrations('comment-thread', [
-		{
-			// Shape anchors gained normalized x/y + isPrecise; existing ones were imprecise (top-right).
-			id: 'com.tldraw.comment-thread/2',
-			up: (record) => {
-				const anchor = (record as any).anchor
-				if (anchor?.type === 'shape' && anchor.x === undefined) {
-					;(record as any).anchor = { ...anchor, x: 1, y: 0, isPrecise: false }
-				}
-				return record
-			},
-			down: (record) => {
-				const anchor = (record as any).anchor
-				if (anchor?.type === 'shape') {
-					;(record as any).anchor = { type: 'shape', shapeId: anchor.shapeId }
-				}
-				return record
-			},
-		},
-		{
-			// Shape anchors generalized from a single `shapeId` to one-or-more `shapeIds`. Down is
-			// lossy for multi-shape anchors: older schemas keep only the first (primary) shape.
-			id: 'com.tldraw.comment-thread/3',
-			up: (record) => {
-				const anchor = (record as any).anchor
-				if (anchor?.type === 'shape' && anchor.shapeIds === undefined) {
-					const { shapeId, ...rest } = anchor
-					;(record as any).anchor = { ...rest, shapeIds: [shapeId] }
-				}
-				return record
-			},
-			down: (record) => {
-				const anchor = (record as any).anchor
-				if (anchor?.type === 'shape') {
-					const { shapeIds, ...rest } = anchor
-					;(record as any).anchor = { ...rest, shapeId: shapeIds[0] }
-				}
-				return record
-			},
-		},
-	]),
+	migrations: createCommentGuardMigrations('comment-thread'),
 	validator: T.object({
 		id: idValidator<TLCommentThreadId>('comment-thread'),
 		typeName: T.literal('comment-thread'),


### PR DESCRIPTION
In order to let a comment refer to a group of shapes — "these three boxes need to line up" — rather than only a single shape, this PR generalizes the `shape` comment anchor from `shapeId: TLShapeId` to `shapeIds: TLShapeId[]`. It's a spike to pressure-test folding multi-shape anchoring into the existing `shape` anchor kind instead of adding a sibling `shapes` variant: a single shape is just the length-1 case, so every consumer keeps one code path and the public union doesn't carry two near-identical members. The deep-link union made the same call — it only ever shipped the plural form.

The pin resolves against the common page bounds of the anchored shapes that still exist (via the existing `editor.getShapesPageBounds`), so it tracks the group as any of them move; deleting some shapes keeps the anchor tracking the rest, and it hides only when none remain. `shapeIds[0]` is the primary shape — it's what the sync worker denormalizes into the single-value `comment_thread.shapeId` column and what notification deep links use. With the comment tool, clicking a shape that's part of a multi-shape selection anchors the thread to the whole selection, clicked shape first.

Data and compat notes for review:

- No data migrations: commenting has never shipped, so the anchor shape change lands directly in the validator with no migration chain. The only migration on the comment record types is the pre-existing `/1` identity guard, which rejects pre-commenting clients with CLIENT_TOO_OLD instead of sending them record types their store can't represent.
- Precise pins on multi-shape anchors are normalized within the common bounds, which reflow as shapes move relative to each other — a precise pin tracks the group approximately rather than any one shape exactly. If we'd rather make multi-shape anchors imprecise-only, that would be an argument for a separate leaner variant instead; this spike deliberately takes the folded trade.
- Drag-to-re-anchor deliberately collapses to the single dropped-on shape.

### Change type

- [x] `feature`

### Test plan

1. Open the comment-anchors example; the "both ellipses" thread's pin sits at the top-right of the pair's common bounds and follows either ellipse when moved.
2. Delete one ellipse — the pin keeps tracking the other.
3. Select several shapes, pick the comment tool, click one of the selected shapes — the posted thread anchors to the whole selection.

- [x] Unit tests

### Release notes

- Comment threads can now anchor to multiple shapes: the `shape` anchor's `shapeId` became `shapeIds: TLShapeId[]`, with the pin tracking the common bounds of the surviving shapes.

### API changes

- Breaking (pre-release): the `shape` variant of `TLCommentAnchor` now carries `shapeIds: TLShapeId[]` (non-empty) instead of `shapeId: TLShapeId`. No migration — the feature has never shipped.
- Changed `shapeAnchorAt(editor, shapeIds, page, precise)` to take an array of shape ids.

### Code changes

| Area | Net LOC |
| --- | --- |
| Core code | -1 |
| Tests | +10 |
| Automated files | +0 |
| Documentation | +1 |
| Apps | +15 |
