### PR TITLE
feat(dotcom): enforce note text attribution on shape create

### DIFF
--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
@@ -175,16 +175,31 @@ describe('authorizeFileRecord', () => {
 			return { ...note, id: createShapeId('geo1'), type: 'geo', props } as unknown as TLShape
 		}
 
-		it('passes creates through untouched, even with foreign attribution (duplication)', () => {
+		it('vetoes a create with foreign attribution (duplication now re-stamps the copy)', () => {
 			const next = makeNote('real-alice')
+			expect(
+				authorize({ session: session('real-bob'), type: 'create', prev: null, next })
+			).toBeNull()
+		})
+
+		it('allows a create attributed to the session user', () => {
+			const next = makeNote('real-bob')
 			expect(authorize({ session: session('real-bob'), type: 'create', prev: null, next })).toBe(
 				next
 			)
 		})
 
-		it('passes creates through for anonymous sessions', () => {
-			const next = makeNote('real-alice')
+		it('allows a create with no attribution (empty or anonymous note)', () => {
+			const next = makeNote(null)
+			expect(authorize({ session: session('real-bob'), type: 'create', prev: null, next })).toBe(
+				next
+			)
 			expect(authorize({ session: session(null), type: 'create', prev: null, next })).toBe(next)
+		})
+
+		it('vetoes an anonymous session creating a note with any attribution', () => {
+			const next = makeNote('real-alice')
+			expect(authorize({ session: session(null), type: 'create', prev: null, next })).toBeNull()
 		})
 
 		it('allows updates that do not touch attribution, from any user', () => {
@@ -229,6 +244,10 @@ describe('authorizeFileRecord', () => {
 			const prev = makeGeo()
 			const next = { ...prev, x: 50 }
 			expect(authorize({ session: session(null), type: 'update', prev, next })).toBe(next)
+			// creates of non-note shapes carry no attribution to enforce, so they pass through
+			expect(authorize({ session: session(null), type: 'create', prev: null, next: prev })).toBe(
+				prev
+			)
 		})
 
 		it('allows deletes', () => {

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -70,10 +70,12 @@ function getNoteAttribution(shape: TLShape): string | null | undefined {
 
 /**
  * Notes stamp `textLastEditedBy` client-side (the editor on text edit, `null` when emptied or
- * anonymous); enforce it here: an update may only change the attribution to `null` or the
- * session's own user. Creates pass through — duplication legitimately carries another user's
- * attribution, so a forged create is indistinguishable from a duplicate (the delete + re-create
- * loophole this leaves is accepted).
+ * anonymous). Enforce it here on both create and update: the attribution may only be `null` or
+ * the session's own user. Duplication and paste re-stamp the copy to the current user (via
+ * `NoteShapeUtil.onBeforeDuplicate`), so a legitimate create never carries another user's
+ * attribution and we can reject one that does — closing the forged-create loophole the create
+ * passthrough previously had to accept. Updates still allow an unchanged attribution from any
+ * user, so anyone with access can edit a note's other props.
  */
 const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({
 	session,
@@ -81,9 +83,9 @@ const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({
 	prev,
 	next,
 }) => {
-	if (type === 'create') return next
 	if (type === 'delete') return prev
-	const before = getNoteAttribution(prev)
+	// On create there's no prior attribution; on update an unchanged attribution is always allowed.
+	const before = type === 'create' ? null : getNoteAttribution(prev)
 	const after = getNoteAttribution(next)
 	if (after !== before && after != null && after !== session.meta.userId) return null
 	return next


### PR DESCRIPTION
Stacked on `commenting` (which now has `main` merged in, bringing #9566). Closes the note-attribution create loophole that #9489 had to leave open.

### Background

#9489 added `authorizeFileRecord`, which stamps/vetoes note text attribution (`props.textLastEditedBy`) from the session's authenticated identity. Its `authorizeShape` **passed all creates through untouched**: before duplication re-stamped attribution, a duplicate legitimately carried the original author's identity, so a forged create was indistinguishable from a duplicate.

#9566 added `ShapeUtil.onBeforeDuplicate`, and `NoteShapeUtil` uses it to re-stamp `textLastEditedBy` to the current user whenever a note with text is duplicated or pasted. A legitimate create can therefore only ever carry `null` or the session user's own id.

### Change

`authorizeShape` now enforces attribution on **create** the same way it already did on **update**: the attribution may only be `null` or the session's own user; anything else is vetoed. On update an *unchanged* attribution is still allowed from any user (so anyone with access can edit a note's other props), and deletes stay open for cascade cleanup.

This closes the forged-create loophole (create a note directly with someone else's `textLastEditedBy`) without affecting real duplication/paste, which now stamps the copy to the current user client-side.

### Tests

`apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts`: the create passthrough cases are replaced with enforcement — a create with foreign attribution is vetoed, a create attributed to the session user or with no attribution passes, an anonymous session can't create a note with any attribution, and non-note creates pass through.

### Change type

- [x] `feature`

### Release notes

- Internal: the sync-worker record authorizer now enforces note text attribution on shape create (not just update), so a note can't be created in another user's name. Not user-facing.
