### PR TITLE
fix(dotcom): run the comment UI under the Zero polyfill instead of gating it off

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -303,16 +303,6 @@ export class TldrawApp {
 		return queries.comments()
 	}
 
-	/**
-	 * Whether this app is backed by real Zero (vs the {@link ZeroPolyfill} used under automated
-	 * tests and when Zero is disabled). Comments are a Zero feature — their queries (bounded feeds,
-	 * `whereExists` access scoping, live per-file views) need real Zero — so the comment UI gates on
-	 * this and stays hidden under the polyfill rather than driving a view it can't back.
-	 */
-	isUsingProperZero() {
-		return this.useProperZero
-	}
-
 	/** Recent comments across the user's files, for the notifications feed (bounded, cross-file). */
 	getComments() {
 		return this.comments$.get()

--- a/apps/dotcom/client/src/tla/app/zero-polyfill.ts
+++ b/apps/dotcom/client/src/tla/app/zero-polyfill.ts
@@ -278,7 +278,9 @@ export class Zero {
 		}
 
 		const tableName = ast.table as keyof typeof data
-		let rows = data[tableName] as unknown[]
+		// A table absent from the snapshot (the comment tables — see ZStoreData) reads as empty
+		// rather than crashing the reactive flush that evaluates this query.
+		let rows = (data[tableName] ?? []) as unknown[]
 
 		// Apply where conditions (pass the full store data so EXISTS subqueries can resolve)
 		if (ast.where) {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -37,8 +37,7 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 	// own — resubscribed when the file changes and destroyed on unmount.
 	const [fileComments, setFileComments] = useState<FileComments>([])
 	useEffect(() => {
-		// Comments need real Zero; under the polyfill (tests, Zero disabled) skip the live view.
-		if (!app || !app.isUsingProperZero()) return
+		if (!app) return
 		const view = app.materializeQuery<FileComments>(queries.fileComments({ fileId }))
 		setFileComments(view.data)
 		const unlisten = view.addListener((data) => setFileComments(data))
@@ -123,9 +122,6 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 		(query: string) => filterMentionMembers(mentionMembers, query),
 		[mentionMembers]
 	)
-
-	// Comments are a Zero feature; hide the layer entirely when Zero isn't available (polyfill).
-	if (!app?.isUsingProperZero()) return null
 
 	return (
 		<>


### PR DESCRIPTION
In order to keep commenting working for every signed-in session regardless of which Zero backend it resolves to, this PR removes the `isUsingProperZero` gates around the comment UI and lets the Zero polyfill answer comment queries with empty results instead of crashing.

### Background

#9618 gated `CommentsOnCanvas` (and #9592's notifications feed materialization) on real Zero, because the polyfill couldn't back the comment queries — its replicated snapshot never carries the comment tables, so `executeAST` read `data['comment']` as `undefined` and threw `TypeError: Cannot read properties of undefined (reading 'filter')` inside the signals flush. That gate assumed only automated tests run the polyfill. In practice any session without the `zero_enabled` flag (e.g. a non-staff account in a dev environment) lands on the polyfill too — and for those users commenting became a silent no-op: the tool was visible but the whole comment layer was unmounted.

The gate was never actually necessary for the comment *records*: they sync through the file room (tldraw sync), not Zero. The Zero views only feed adornments — author names beyond presence/roster, read receipts, and the notifications feed.

### Change

- `executeAST` treats a table missing from the polyfill snapshot as empty rather than throwing.
- The `CommentsOnCanvas` gates and the `comments$` gating are removed; `TldrawApp.isUsingProperZero()` is deleted (those gates were its only callers).

Under the polyfill, the comment UI now fully works — pins, threads, creating and replying — with read receipts and the notifications feed degrading to empty. Real users on proper Zero are unaffected.

### Change type

- [x] `bugfix`

### Test plan

Preview: https://pr-9635-preview-deploy.tldraw.com/ — steps 2–5 below work there as well (run the `localStorage` flip in the browser console; commenting needs a signed-in user and a file).

Verified locally against the dev stack:

1. Open a file with comments on proper Zero → pins and threads render, creating a comment works (baseline).
2. In the console, `localStorage.setItem('useProperZero','false')` and reload → console logs `[Zero] Using ZeroPolyfill (localStorage override)` with **no** `executeAST` TypeError.
3. All existing comment pins render; opening a thread shows author, body, and reply composer.
4. Create a comment while on the polyfill → pin appears; flip back to proper Zero (`localStorage.removeItem('useProperZero')`, reload) → the comment persisted with its body intact.
5. Open the notifications popover on the polyfill → "You're all caught up.", no errors.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix: sessions running the Zero polyfill no longer hide the comment UI or log errors from the notifications feed; comments render and post normally, with read receipts and notifications degrading gracefully.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +4 / -16   |

