### PR TITLE
feat(dotcom): show empty pages named --- as dividers in the page menu

### DIFF
--- a/apps/dotcom/client/e2e/fixtures/Editor.ts
+++ b/apps/dotcom/client/e2e/fixtures/Editor.ts
@@ -9,6 +9,8 @@ export class Editor {
 	private readonly fileName: Locator
 	private readonly shapes: Locator
 	private readonly pageMenu: Locator
+	public readonly pageMenuItems: Locator
+	public readonly pageMenuTriggerLabel: Locator
 
 	constructor(
 		public readonly page: Page,
@@ -18,6 +20,8 @@ export class Editor {
 		this.fileName = this.page.getByTestId('tla-file-name')
 		this.shapes = this.page.locator('.tl-shape')
 		this.pageMenu = this.page.getByTestId('tla-main-menu')
+		this.pageMenuItems = this.page.getByTestId('page-menu.item')
+		this.pageMenuTriggerLabel = this.page.getByTestId('page-menu.button')
 	}
 
 	async toggleSidebar() {
@@ -85,6 +89,26 @@ export class Editor {
 		await expect(this.page.getByTestId('page-menu.item')).toHaveCount(count + 1)
 		await this.page.keyboard.press('Enter')
 		await this.page.keyboard.press('Escape')
+	}
+
+	// Opens the pages popover in the top bar (not the file kebab menu).
+	@step
+	async openPagesPopover() {
+		await this.page.getByTestId('page-menu.button').click()
+		await expect(this.page.getByTestId('page-menu.list')).toBeVisible()
+	}
+
+	// Creates a new page with the given name and leaves the pages popover open.
+	// Assumes the pages popover is already open.
+	@step
+	async createNewPageNamed(name: string) {
+		const count = await this.pageMenuItems.count()
+		await this.page.getByTestId('page-menu.create').click()
+		await expect(this.pageMenuItems).toHaveCount(count + 1)
+		const renameInput = this.page.getByTestId('page-menu.list').locator('input')
+		await expect(renameInput).toBeVisible()
+		await renameInput.fill(name)
+		await this.page.keyboard.press('Enter')
 	}
 
 	@step

--- a/apps/dotcom/client/e2e/tests/smoke/page-dividers.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/page-dividers.spec.ts
@@ -1,0 +1,142 @@
+import { expect, test } from '../../fixtures/tla-test'
+
+// Pages named `---` (three or more hyphens) act as dividers in the pages
+// list, but only while they are empty. See #9445.
+
+test.beforeEach(async ({ editor }) => {
+	await editor.isLoaded()
+})
+
+test('an empty page renamed to --- becomes a locked divider', async ({ page, editor }) => {
+	const dividerRow = page.locator('[data-testid="page-menu.item"][data-isdivider="true"]')
+
+	await test.step('create an empty page named ---', async () => {
+		await editor.openPagesPopover()
+		await expect(editor.pageMenuItems).toHaveCount(1)
+		await editor.createNewPageNamed('---')
+	})
+
+	await test.step('the page renders as a divider and the current page steps back', async () => {
+		await expect(editor.pageMenuItems).toHaveCount(2)
+		await expect(dividerRow).toHaveCount(1)
+		// The divider renders a line, not the page name, and shows no tooltip.
+		await expect(dividerRow.locator('.tlui-page-menu__item__button')).toHaveText('')
+		await expect(dividerRow.locator('.tlui-page-menu__item__button')).not.toHaveAttribute('title')
+		// The freshly created page was current; converting it moved the user
+		// back to the regular page.
+		await expect(editor.pageMenuTriggerLabel).toContainText('Page 1')
+	})
+
+	await test.step('the divider row is about half as tall as a page row', async () => {
+		const pageBox = await editor.pageMenuItems.nth(0).boundingBox()
+		const dividerBox = await dividerRow.boundingBox()
+		expect(dividerBox!.height).toBeLessThan(pageBox!.height * 0.6)
+	})
+
+	await test.step('hovering a divider does not highlight it', async () => {
+		const pillOpacity = (el: Element) => getComputedStyle(el, '::before').opacity
+		// Sanity-check the mechanism on a regular row first: its pill shows on hover.
+		await editor.pageMenuItems.nth(0).hover()
+		expect(await editor.pageMenuItems.nth(0).evaluate(pillOpacity)).toBe('1')
+		await dividerRow.hover()
+		expect(await dividerRow.evaluate(pillOpacity)).toBe('0')
+	})
+
+	await test.step('clicking the divider does not change the current page', async () => {
+		await dividerRow.locator('.tlui-page-menu__item__button').click()
+		await expect(editor.pageMenuTriggerLabel).toContainText('Page 1')
+	})
+
+	await test.step('the divider submenu only offers move and delete', async () => {
+		await dividerRow.hover()
+		await dividerRow.getByTestId('page-menu.item-submenu').click()
+		await expect(page.getByTestId('page-menu.delete')).toBeVisible()
+		await expect(page.getByTestId('page-menu.move-up')).toBeVisible()
+		await expect(page.getByTestId('page-menu.rename')).not.toBeVisible()
+		await expect(page.getByTestId('page-menu.duplicate')).not.toBeVisible()
+	})
+
+	await test.step('the divider can be deleted', async () => {
+		await page.getByTestId('page-menu.delete').click()
+		await expect(editor.pageMenuItems).toHaveCount(1)
+		await expect(dividerRow).toHaveCount(0)
+	})
+})
+
+test('a page with content renamed to --- stays a regular page', async ({ page, editor }) => {
+	await test.step('draw something on the current page', async () => {
+		await editor.createTextShape('hello')
+		await editor.expectShapesCount(1)
+		await page.keyboard.press('Escape')
+	})
+
+	await test.step('rename the page to ---', async () => {
+		await editor.openPagesPopover()
+		const row = editor.pageMenuItems.first()
+		await row.hover()
+		await row.getByTestId('page-menu.item-submenu').click()
+		await page.getByTestId('page-menu.rename').click()
+		const renameInput = page.getByTestId('page-menu.list').locator('input')
+		await renameInput.fill('---')
+		await page.keyboard.press('Enter')
+	})
+
+	await test.step('the page stays a regular, selectable page', async () => {
+		await expect(page.locator('[data-isdivider="true"]')).toHaveCount(0)
+		await expect(editor.pageMenuItems.first().locator('.tlui-page-menu__item__button')).toHaveText(
+			'---'
+		)
+		await expect(editor.pageMenuTriggerLabel).toContainText('---')
+	})
+})
+
+test('pages can be drag-reordered across a divider', async ({ page, editor }) => {
+	await test.step('set up a page, a divider, and another page', async () => {
+		await editor.openPagesPopover()
+		await editor.createNewPageNamed('---')
+		await editor.createNewPageNamed('Other page')
+		await expect(editor.pageMenuItems).toHaveCount(3)
+		await expect(editor.pageMenuItems.nth(1)).toHaveAttribute('data-isdivider', 'true')
+	})
+
+	await test.step('drag the first page below the divider', async () => {
+		const firstRowButton = editor.pageMenuItems.nth(0).locator('.tlui-page-menu__item__button')
+		const box = (await firstRowButton.boundingBox())!
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+		await page.mouse.down()
+		// A divider slot is 18px tall; 26px lands the dragged row's center in
+		// the divider's slot, dropping the page just below it.
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 26, { steps: 6 })
+		await page.mouse.up()
+	})
+
+	await test.step('the divider is now first and the page follows it', async () => {
+		await expect(editor.pageMenuItems.nth(0)).toHaveAttribute('data-isdivider', 'true')
+		await expect(editor.pageMenuItems.nth(1).locator('.tlui-page-menu__item__button')).toHaveText(
+			'Page 1'
+		)
+	})
+})
+
+test('dividers are excluded from the move-to-page menu', async ({ page, editor }) => {
+	await test.step('set up a page with content, a divider, and another page', async () => {
+		await editor.createTextShape('hello')
+		await editor.expectShapesCount(1)
+		await page.keyboard.press('Escape')
+		await editor.openPagesPopover()
+		await editor.createNewPageNamed('---')
+		await editor.createNewPageNamed('Other page')
+		// Go back to the first page, where the shape is.
+		await editor.pageMenuItems.first().locator('.tlui-page-menu__item__button').click()
+		await expect(editor.pageMenuTriggerLabel).toContainText('Page 1')
+		await page.keyboard.press('Escape')
+	})
+
+	await test.step('the move-to-page menu lists pages but not dividers', async () => {
+		await page.locator('.tl-shape').first().click()
+		await page.locator('.tl-shape').first().click({ button: 'right' })
+		await page.getByTestId('context-menu-sub.move-to-page-button').hover()
+		await expect(page.getByRole('menuitem', { name: 'Other page' })).toBeVisible()
+		await expect(page.getByRole('menuitem', { name: '---' })).not.toBeVisible()
+	})
+})

--- a/apps/dotcom/client/e2e/tests/smoke/page-dividers.spec.ts
+++ b/apps/dotcom/client/e2e/tests/smoke/page-dividers.spec.ts
@@ -33,13 +33,9 @@ test('an empty page renamed to --- becomes a locked divider', async ({ page, edi
 		expect(dividerBox!.height).toBeLessThan(pageBox!.height * 0.6)
 	})
 
-	await test.step('hovering a divider does not highlight it', async () => {
-		const pillOpacity = (el: Element) => getComputedStyle(el, '::before').opacity
-		// Sanity-check the mechanism on a regular row first: its pill shows on hover.
-		await editor.pageMenuItems.nth(0).hover()
-		expect(await editor.pageMenuItems.nth(0).evaluate(pillOpacity)).toBe('1')
+	await test.step('hovering the divider does not highlight it', async () => {
 		await dividerRow.hover()
-		expect(await dividerRow.evaluate(pillOpacity)).toBe('0')
+		expect(await dividerRow.evaluate((el) => getComputedStyle(el, '::before').opacity)).toBe('0')
 	})
 
 	await test.step('clicking the divider does not change the current page', async () => {
@@ -97,6 +93,15 @@ test('pages can be drag-reordered across a divider', async ({ page, editor }) =>
 		await editor.createNewPageNamed('Other page')
 		await expect(editor.pageMenuItems).toHaveCount(3)
 		await expect(editor.pageMenuItems.nth(1)).toHaveAttribute('data-isdivider', 'true')
+	})
+
+	await test.step('hovering highlights a page row but not the divider', async () => {
+		const pillOpacity = (el: Element) => getComputedStyle(el, '::before').opacity
+		// "Page 1" is not the current page here, so its pill only shows on hover.
+		await editor.pageMenuItems.nth(0).hover()
+		expect(await editor.pageMenuItems.nth(0).evaluate(pillOpacity)).toBe('1')
+		await editor.pageMenuItems.nth(1).hover()
+		expect(await editor.pageMenuItems.nth(1).evaluate(pillOpacity)).toBe('0')
 	})
 
 	await test.step('drag the first page below the divider', async () => {

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -551,6 +551,12 @@
       "value": "Help"
     }
   ],
+  "6a2c6eead4": [
+    {
+      "type": 0,
+      "value": "Page divider"
+    }
+  ],
   "6dc0836c1b": [
     {
       "type": 0,

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -254,6 +254,9 @@
   "6a26f54883": {
     "translation": "Help"
   },
+  "6a2c6eead4": {
+    "translation": "Page divider"
+  },
   "6dc0836c1b": {
     "translation": "You do not have the necessary permissions to perform this action."
   },

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -45,6 +45,7 @@ import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracki
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
 import { TlaAnonDotDevLink } from '../TlaAnonDotDevLink/TlaAnonDotDevLink'
+import { TlaEditorContextMenu } from './editor-components/TlaEditorContextMenu'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
 import { TlaEditorSharePanel } from './editor-components/TlaEditorSharePanel'
@@ -63,6 +64,7 @@ import { useFileEditorOverrides } from './useFileEditorOverrides'
 /** @internal */
 export const components: TLComponents = {
 	ErrorFallback: TlaEditorErrorFallback,
+	ContextMenu: TlaEditorContextMenu,
 	MenuPanel: TlaEditorMenuPanel,
 	TopPanel: TlaEditorTopPanel,
 	SharePanel: TlaEditorSharePanel,

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -4,7 +4,6 @@ import { useParams } from 'react-router-dom'
 import {
 	AccessibilityMenu,
 	ColorSchemeMenu,
-	DefaultPageMenu,
 	EditSubmenu,
 	ExportFileContentSubMenu,
 	ExtrasGroup,
@@ -57,6 +56,7 @@ import { TlaIcon } from '../TlaIcon/TlaIcon'
 import { TlaLogo } from '../TlaLogo/TlaLogo'
 import { sidebarMessages } from '../TlaSidebar/components/TlaSidebarFileLink'
 import { useRoomInfo } from './TlaEditorTopRightPanel'
+import { TlaPageMenu } from './TlaPageMenu/TlaPageMenu'
 import styles from './top.module.css'
 
 const messages = defineMessages({
@@ -134,7 +134,7 @@ export function TlaEditorTopLeftPanelAnonymous() {
 			{hasPages && (
 				<>
 					<span className={styles.topLeftPanelSeparator}>{separator}</span>
-					<DefaultPageMenu />
+					<TlaPageMenu />
 				</>
 			)}
 			<TldrawUiDropdownMenuRoot id={`file-menu-anon`}>
@@ -249,7 +249,7 @@ export function TlaEditorTopLeftPanelSignedIn() {
 				onEnd={handleRenameEnd}
 			/>
 			<span className={styles.topLeftPanelSeparator}>{separator}</span>
-			<DefaultPageMenu />
+			<TlaPageMenu />
 			<TlaFileMenu
 				fileId={fileId}
 				workspaceId={null}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaHistorySnapshotEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaHistorySnapshotEditor.tsx
@@ -17,6 +17,7 @@ import { SneakyTldrawFileDropHandler } from './sneaky/SneakyFileDropHandler'
 import { SneakyLegacySetDocumentTitle } from './sneaky/SneakyLegacytSetDocumentTitle'
 import { SneakySetDocumentTitle } from './sneaky/SneakySetDocumentTitle'
 import { TlaEditorWrapper } from './TlaEditorWrapper'
+import { TlaPageMenu } from './TlaPageMenu/TlaPageMenu'
 import { useFileEditorOverrides } from './useFileEditorOverrides'
 
 export function TlaHistorySnapshotEditor({
@@ -71,6 +72,7 @@ function TlaEditorInner({
 	const components = useMemo((): TLComponents => {
 		return {
 			ErrorFallback: TlaEditorErrorFallback,
+			PageMenu: TlaPageMenu,
 			SharePanel: () => (
 				<TlaCtaButton
 					canvas

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -20,6 +20,7 @@ import { globalEditor } from '../../../utils/globalEditor'
 import { multiplayerAssetStore } from '../../../utils/multiplayerAssetStore'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
+import { TlaEditorContextMenu } from './editor-components/TlaEditorContextMenu'
 import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallback'
 import { TlaEditorLegacySharePanel } from './editor-components/TlaEditorLegacySharePanel'
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
@@ -35,6 +36,7 @@ import { useFileEditorOverrides } from './useFileEditorOverrides'
 /** @internal */
 export const components: TLComponents = {
 	ErrorFallback: TlaEditorErrorFallback,
+	ContextMenu: TlaEditorContextMenu,
 	MenuPanel: TlaEditorMenuPanel,
 	SharePanel: TlaEditorLegacySharePanel,
 	TopPanel: TlaEditorTopPanel,

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageItemSubmenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageItemSubmenu.tsx
@@ -1,0 +1,124 @@
+// Fork of packages/tldraw/src/lib/ui/components/PageMenu/PageItemSubmenu.tsx
+// adding divider pages (#9445): divider rows offer only move and delete, and
+// deleting the current page steps to the nearest non-divider page. Diff
+// against the SDK file when updating.
+import { useCallback } from 'react'
+import {
+	PageRecordType,
+	TLPageId,
+	TldrawUiButton,
+	TldrawUiButtonIcon,
+	TldrawUiDropdownMenuContent,
+	TldrawUiDropdownMenuRoot,
+	TldrawUiDropdownMenuTrigger,
+	TldrawUiMenuContextProvider,
+	TldrawUiMenuGroup,
+	TldrawUiMenuItem,
+	track,
+	useEditor,
+	useTranslation,
+	useUiEvents,
+} from 'tldraw'
+import { getNearestNonDividerPageId } from '../../../utils/pageDividers'
+import { onMovePage } from './edit-pages-shared'
+
+export interface TlaPageItemSubmenuProps {
+	index: number
+	item: { id: string; name: string }
+	listSize: number
+	isDivider?: boolean
+	onRename?(): void
+}
+
+export const TlaPageItemSubmenu = track(function TlaPageItemSubmenu({
+	index,
+	listSize,
+	item,
+	isDivider,
+	onRename,
+}: TlaPageItemSubmenuProps) {
+	const editor = useEditor()
+	const msg = useTranslation()
+	const trackEvent = useUiEvents()
+
+	const onDuplicate = useCallback(() => {
+		editor.markHistoryStoppingPoint('creating page')
+		const newId = PageRecordType.createId()
+		editor.duplicatePage(item.id as TLPageId, newId)
+		trackEvent('duplicate-page', { source: 'page-menu' })
+	}, [editor, item, trackEvent])
+
+	const onMoveUp = useCallback(() => {
+		onMovePage(editor, item.id as TLPageId, index, index - 1, trackEvent)
+	}, [editor, item, index, trackEvent])
+
+	const onMoveDown = useCallback(() => {
+		onMovePage(editor, item.id as TLPageId, index, index + 1, trackEvent)
+	}, [editor, item, index, trackEvent])
+
+	const onDelete = useCallback(() => {
+		editor.run(() => {
+			editor.markHistoryStoppingPoint('deleting page')
+			// When deleting the current page, the editor falls back to an
+			// adjacent page, which could be a divider. Step to the nearest
+			// regular page first so the user never lands on a divider.
+			if (editor.getCurrentPageId() === item.id) {
+				const nearestId = getNearestNonDividerPageId(editor, item.id as TLPageId)
+				if (nearestId) editor.setCurrentPage(nearestId)
+			}
+			editor.deletePage(item.id as TLPageId)
+		})
+		trackEvent('delete-page', { source: 'page-menu' })
+	}, [editor, item, trackEvent])
+
+	return (
+		<TldrawUiDropdownMenuRoot id={`page item submenu ${index}`}>
+			<TldrawUiDropdownMenuTrigger>
+				<TldrawUiButton
+					type="icon"
+					tooltip={msg('page-menu.submenu.title')}
+					title={msg('page-menu.submenu.title')}
+					data-testid="page-menu.item-submenu"
+				>
+					<TldrawUiButtonIcon icon="dots-vertical" small />
+				</TldrawUiButton>
+			</TldrawUiDropdownMenuTrigger>
+			<TldrawUiDropdownMenuContent side="bottom" align="start" alignOffset={0} sideOffset={0}>
+				<TldrawUiMenuContextProvider type="menu" sourceId="page-menu">
+					<TldrawUiMenuGroup id="modify">
+						{!isDivider && onRename && (
+							<TldrawUiMenuItem id="rename" label="page-menu.submenu.rename" onSelect={onRename} />
+						)}
+						{!isDivider && (
+							<TldrawUiMenuItem
+								id="duplicate"
+								label="page-menu.submenu.duplicate-page"
+								onSelect={onDuplicate}
+								disabled={listSize >= editor.options.maxPages}
+							/>
+						)}
+						{index > 0 && (
+							<TldrawUiMenuItem
+								id="move-up"
+								onSelect={onMoveUp}
+								label="page-menu.submenu.move-up"
+							/>
+						)}
+						{index < listSize - 1 && (
+							<TldrawUiMenuItem
+								id="move-down"
+								label="page-menu.submenu.move-down"
+								onSelect={onMoveDown}
+							/>
+						)}
+					</TldrawUiMenuGroup>
+					{listSize > 1 && (
+						<TldrawUiMenuGroup id="delete">
+							<TldrawUiMenuItem id="delete" onSelect={onDelete} label="page-menu.submenu.delete" />
+						</TldrawUiMenuGroup>
+					)}
+				</TldrawUiMenuContextProvider>
+			</TldrawUiDropdownMenuContent>
+		</TldrawUiDropdownMenuRoot>
+	)
+})

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageItemSubmenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageItemSubmenu.tsx
@@ -86,7 +86,7 @@ export const TlaPageItemSubmenu = track(function TlaPageItemSubmenu({
 			<TldrawUiDropdownMenuContent side="bottom" align="start" alignOffset={0} sideOffset={0}>
 				<TldrawUiMenuContextProvider type="menu" sourceId="page-menu">
 					<TldrawUiMenuGroup id="modify">
-						{!isDivider && onRename && (
+						{onRename && (
 							<TldrawUiMenuItem id="rename" label="page-menu.submenu.rename" onSelect={onRename} />
 						)}
 						{!isDivider && (

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageMenu.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageMenu.module.css
@@ -1,0 +1,30 @@
+.dividerLine {
+	flex: 1;
+	height: 0;
+	border-top: 1px solid var(--tl-color-divider);
+	pointer-events: none;
+}
+
+/* Divider rows are half the height of a regular page row. The slot pitch is
+   18px (see PAGE_MENU_DIVIDER_ITEM_HEIGHT); like regular rows (40px tall on a
+   36px pitch) the row element is 4px taller than its slot. */
+:global(.tlui-page-menu__item[data-isdivider='true']) {
+	height: 22px;
+}
+
+/* The SDK buttons are 40px tall; fit them to the short divider row so the
+   row's overflow: hidden doesn't clip them. */
+:global(.tlui-page-menu__item[data-isdivider='true'] .tlui-page-menu__item__button),
+:global(.tlui-page-menu__item[data-isdivider='true'] .tlui-page-menu__item__drag-handle),
+:global(
+	.tlui-page-menu__item[data-isdivider='true'] .tlui-page-menu__item__submenu > .tlui-button
+) {
+	height: 100%;
+}
+
+/* No hover highlight on dividers — the row pill only shows while dragging. */
+@media (hover: hover) {
+	:global(.tlui-page-menu__item[data-isdivider='true']:hover:not([data-dragging='true']))::before {
+		opacity: 0;
+	}
+}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageMenu.tsx
@@ -1,0 +1,833 @@
+// Fork of packages/tldraw/src/lib/ui/components/PageMenu/DefaultPageMenu.tsx
+// (as of 87b69cb31) adding page dividers (#9445): an empty page named `---`
+// renders as a divider line that cannot be selected or renamed, only moved
+// and deleted. When updating the SDK page menu, diff against that file.
+import {
+	KeyboardEvent as ReactKeyboardEvent,
+	MouseEvent as ReactMouseEvent,
+	PointerEvent as ReactPointerEvent,
+	memo,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from 'react'
+import {
+	PORTRAIT_BREAKPOINT,
+	PageItemInput,
+	PageRecordType,
+	TLPageId,
+	TldrawUiButton,
+	TldrawUiButtonIcon,
+	TldrawUiButtonLabel,
+	TldrawUiPopover,
+	TldrawUiPopoverContent,
+	TldrawUiPopoverTrigger,
+	releasePointerCapture,
+	setPointerCapture,
+	useBreakpoint,
+	useEditor,
+	useMenuIsOpen,
+	useReadonly,
+	useTranslation,
+	useUiEvents,
+	useValue,
+} from 'tldraw'
+import { defineMessages, useMsg } from '../../../utils/i18n'
+import {
+	getNearestNonDividerPageId,
+	isDividerName,
+	isPageDivider,
+} from '../../../utils/pageDividers'
+import { onMovePage } from './edit-pages-shared'
+import { TlaPageItemSubmenu } from './TlaPageItemSubmenu'
+import styles from './TlaPageMenu.module.css'
+
+const messages = defineMessages({
+	pageDivider: { defaultMessage: 'Page divider' },
+})
+
+const PAGE_MENU_LIST_HEIGHT_KEY = 'tldraw_page_menu_list_height'
+const MAX_PAGE_MENU_RENDER_HEIGHT = 800
+const LIST_BOTTOM_PADDING = 4
+const MAX_PAGE_MENU_AVAILABLE_HEIGHT_RATIO = 0.62
+const PAGE_MENU_CREATE_BUTTON_HEIGHT = 40
+const PAGE_MENU_RESIZE_HANDLE_HEIGHT = 1
+const PAGE_MENU_ITEM_HEIGHT = 36
+// Divider rows take half the vertical space of a regular page row. Rows are
+// absolutely positioned from prefix-summed offsets, so mixed heights work.
+const PAGE_MENU_DIVIDER_ITEM_HEIGHT = 18
+const MIN_PAGE_MENU_LIST_HEIGHT = PAGE_MENU_ITEM_HEIGHT + LIST_BOTTOM_PADDING
+const PAGE_MENU_DRAG_THRESHOLD = 5
+const PAGE_MENU_AUTO_SCROLL_ZONE = 16
+const PAGE_MENU_AUTO_SCROLL_RAMP_DISTANCE = 48
+const PAGE_MENU_MIN_AUTO_SCROLL_SPEED = 1
+const PAGE_MENU_MAX_AUTO_SCROLL_SPEED = 6
+
+function readSavedPageMenuListHeight(): number | null {
+	if (typeof window === 'undefined') return null
+	try {
+		const raw = window.localStorage.getItem(PAGE_MENU_LIST_HEIGHT_KEY)
+		if (!raw) return null
+		const n = Number(raw)
+		return Number.isFinite(n) && n >= MIN_PAGE_MENU_LIST_HEIGHT ? n : null
+	} catch {
+		return null
+	}
+}
+
+function getPageMenuRenderCap(availableHeight: number): number {
+	const maxMenuHeight = Math.min(
+		MAX_PAGE_MENU_RENDER_HEIGHT,
+		availableHeight * MAX_PAGE_MENU_AVAILABLE_HEIGHT_RATIO
+	)
+	const footerHeight = PAGE_MENU_CREATE_BUTTON_HEIGHT + PAGE_MENU_RESIZE_HANDLE_HEIGHT
+	return Math.max(MIN_PAGE_MENU_LIST_HEIGHT, maxMenuHeight - footerHeight)
+}
+
+function getPageMenuAutoFitListHeight(contentHeight: number): number {
+	return Math.max(MIN_PAGE_MENU_LIST_HEIGHT, contentHeight + LIST_BOTTOM_PADDING)
+}
+
+export const TlaPageMenu = memo(function TlaPageMenu() {
+	const editor = useEditor()
+	const trackEvent = useUiEvents()
+	const msg = useTranslation()
+	const breakpoint = useBreakpoint()
+	const pageDividerLbl = useMsg(messages.pageDivider)
+
+	// The id of the page currently being renamed inline, if any.
+	const [editingPageId, setEditingPageId] = useState<TLPageId | null>(null)
+
+	const closePageItemSubmenus = useCallback(
+		(exceptIndex?: number) => {
+			const contextSuffix = `-${editor.contextId}`
+			for (const menuId of editor.menus.getOpenMenus()) {
+				const id = menuId.endsWith(contextSuffix) ? menuId.slice(0, -contextSuffix.length) : menuId
+				if (!id.startsWith('page item submenu ')) continue
+				if (exceptIndex !== undefined && id === `page item submenu ${exceptIndex}`) continue
+				editor.menus.deleteOpenMenu(id)
+			}
+		},
+		[editor]
+	)
+
+	const handleOpenChange = useCallback(
+		(isOpen: boolean) => {
+			setEditingPageId(null)
+			if (!isOpen) {
+				closePageItemSubmenus()
+			}
+		},
+		[closePageItemSubmenus]
+	)
+
+	const [isOpen, onOpenChange] = useMenuIsOpen('page-menu', handleOpenChange)
+
+	const rSortableContainer = useRef<HTMLDivElement>(null)
+
+	const pages = useValue('pages', () => editor.getPages(), [editor])
+	const currentPage = useValue('currentPage', () => editor.getCurrentPage(), [editor])
+
+	// Divider status is derived: a page is a divider while it is named `---`
+	// (or more hyphens), has no shapes, and is not the current page.
+	const dividerPageIds = useValue(
+		'dividerPageIds',
+		() => {
+			const ids = new Set<TLPageId>()
+			for (const page of editor.getPages()) {
+				if (isPageDivider(editor, page)) ids.add(page.id)
+			}
+			return ids
+		},
+		[editor]
+	)
+
+	const isReadonlyMode = useReadonly()
+
+	// Row layout: dividers are half-height, so row positions come from prefix
+	// sums rather than index * item height. Kept in a ref so the pointer-drag
+	// handlers always read the current layout without re-binding.
+	const rowHeights = pages.map((page) =>
+		dividerPageIds.has(page.id) ? PAGE_MENU_DIVIDER_ITEM_HEIGHT : PAGE_MENU_ITEM_HEIGHT
+	)
+	const rowOffsets: number[] = []
+	let contentHeight = 0
+	for (const height of rowHeights) {
+		rowOffsets.push(contentHeight)
+		contentHeight += height
+	}
+	const rLayout = useRef({ rowHeights, rowOffsets, contentHeight })
+	rLayout.current = { rowHeights, rowOffsets, contentHeight }
+
+	const isCoarsePointer = useValue(
+		'isCoarsePointer',
+		() => editor.getInstanceState().isCoarsePointer,
+		[editor]
+	)
+
+	// null = auto-fit to the number of pages (capped). A number means the user
+	// has pinned the list to that height via the resize handle.
+	const [userListHeight, setUserListHeight] = useState<number | null>(readSavedPageMenuListHeight)
+	const [isResizing, setIsResizing] = useState(false)
+	const [availableHeight, setAvailableHeight] = useState(() =>
+		typeof window === 'undefined' ? 800 : window.innerHeight
+	)
+
+	const updateAvailableHeight = useCallback(() => {
+		if (typeof window === 'undefined') return
+
+		const popoverContent =
+			rSortableContainer.current?.closest<HTMLElement>('.tlui-popover__content')
+		const radixAvailableHeight = popoverContent
+			? Number.parseFloat(
+					getComputedStyle(popoverContent).getPropertyValue(
+						'--radix-popover-content-available-height'
+					)
+				)
+			: NaN
+
+		setAvailableHeight(
+			Number.isFinite(radixAvailableHeight) ? radixAvailableHeight : window.innerHeight
+		)
+	}, [])
+
+	useEffect(() => {
+		const onResize = () => updateAvailableHeight()
+		window.addEventListener('resize', onResize)
+		return () => window.removeEventListener('resize', onResize)
+	}, [updateAvailableHeight])
+
+	useEffect(() => {
+		if (!isOpen) return
+		editor.timers.requestAnimationFrame(updateAvailableHeight)
+	}, [editor, isOpen, updateAvailableHeight])
+
+	const renderCap = getPageMenuRenderCap(availableHeight)
+	const autoFitListHeight = getPageMenuAutoFitListHeight(contentHeight)
+	const renderedListHeight = Math.min(userListHeight ?? autoFitListHeight, renderCap)
+	const hasReachedMaxPages = pages.length >= editor.options.maxPages
+	const createPageButtonLabel = msg(
+		hasReachedMaxPages ? 'page-menu.max-pages-reached' : 'page-menu.create-new-page'
+	)
+
+	const handleResizePointerDown = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+		e.preventDefault()
+		const handle = e.currentTarget
+		handle.setPointerCapture(e.pointerId)
+		const startY = e.clientY
+		// Start the drag from what the user currently sees, so the divider
+		// tracks the cursor even when the stored preference exceeds the cap.
+		const startHeight = handle.previousElementSibling?.getBoundingClientRect().height ?? 0
+		let nextHeight = startHeight
+
+		setIsResizing(true)
+
+		const onMove = (moveEvent: PointerEvent) => {
+			nextHeight = Math.max(MIN_PAGE_MENU_LIST_HEIGHT, startHeight + (moveEvent.clientY - startY))
+			setUserListHeight(nextHeight)
+		}
+
+		const onUp = () => {
+			handle.removeEventListener('pointermove', onMove)
+			handle.removeEventListener('pointerup', onUp)
+			handle.removeEventListener('pointercancel', onUp)
+			setIsResizing(false)
+			try {
+				window.localStorage.setItem(PAGE_MENU_LIST_HEIGHT_KEY, String(nextHeight))
+			} catch {
+				// ignore — storage may be unavailable in private/embedded contexts
+			}
+		}
+
+		handle.addEventListener('pointermove', onMove)
+		handle.addEventListener('pointerup', onUp, { once: true })
+		handle.addEventListener('pointercancel', onUp, { once: true })
+	}, [])
+
+	const handleResizeDoubleClick = useCallback(() => {
+		setUserListHeight(null)
+		try {
+			window.localStorage.removeItem(PAGE_MENU_LIST_HEIGHT_KEY)
+		} catch {
+			// ignore — storage may be unavailable in private/embedded contexts
+		}
+	}, [])
+
+	useEffect(
+		function closePageMenuOnEnterPressAfterPressingEnterToConfirmRename() {
+			const doc = editor.getContainerDocument()
+			function handleKeyDown() {
+				if (editingPageId) return
+				if (doc.activeElement === doc.body) {
+					editor.menus.clearOpenMenus()
+				}
+			}
+
+			doc.addEventListener('keydown', handleKeyDown, { passive: true })
+			return () => {
+				doc.removeEventListener('keydown', handleKeyDown)
+			}
+		},
+		[editor, editingPageId]
+	)
+
+	const rMutables = useRef({
+		status: 'idle' as 'idle' | 'pointing' | 'dragging',
+		id: null as TLPageId | null,
+		startIndex: 0,
+		dragIndex: 0,
+		startY: 0,
+		startScrollTop: 0,
+		lastClientY: 0,
+		// Set true on pointer-up after a drag, so the synthetic click that
+		// follows pointer-up doesn't also navigate to the dragged page.
+		justDragged: false,
+		startedOnDragHandle: false,
+		// Whether an auto-scroll rAF is in flight; the loop reschedules itself
+		// while status === 'dragging' and exits otherwise.
+		autoScrollScheduled: false,
+	})
+
+	// The single source of truth for an in-progress drag. Null when idle.
+	// Other rows' positions are derived from startIndex/dragIndex during render.
+	const [dragState, setDragState] = useState<{
+		id: TLPageId
+		startIndex: number
+		dragIndex: number
+		offsetY: number
+	} | null>(null)
+
+	// Scroll the current page into view when the menu opens / when current page changes.
+	// Rows are absolutely positioned at top:0 and translated via transform, so
+	// `offsetTop` is always 0 — derive the row's visual position from its index.
+	useEffect(() => {
+		if (!isOpen) return
+		editor.timers.requestAnimationFrame(() => {
+			const container = rSortableContainer.current
+			if (!container) return
+			const currentIndex = editor.getPages().findIndex((p) => p.id === currentPage.id)
+			if (currentIndex === -1) return
+
+			const doc = editor.getContainerDocument()
+			const elm = doc.querySelector(`[data-pageid="${currentPage.id}"]`) as HTMLDivElement | null
+			elm?.querySelector<HTMLButtonElement>('button.tlui-page-menu__item__button')?.focus()
+
+			const elmTop = rLayout.current.rowOffsets[currentIndex]
+			const elmBottom = elmTop + rLayout.current.rowHeights[currentIndex]
+			const viewTop = container.scrollTop
+			const viewBottom = viewTop + container.clientHeight
+			if (elmTop < viewTop) {
+				container.scrollTo({ top: elmTop })
+			} else if (elmBottom > viewBottom) {
+				container.scrollTo({ top: elmBottom - container.clientHeight })
+			}
+		})
+	}, [currentPage.id, isOpen, editor])
+
+	// Recomputes the dragged row's offset and dragIndex from the current
+	// pointer position and container scrollTop, then publishes the new
+	// dragState so the rest of the rows shift around it.
+	const updateDragFromPointer = useCallback((clientY: number) => {
+		const mut = rMutables.current
+		if (mut.status !== 'dragging' || !mut.id) return
+		const { rowHeights, rowOffsets, contentHeight } = rLayout.current
+		const dragRowHeight = rowHeights[mut.startIndex]
+		const scrollTop = rSortableContainer.current?.scrollTop ?? 0
+		// Offsets the cursor delta by any auto-scroll that has happened
+		// since the drag started, so the row tracks the cursor as the
+		// list scrolls underneath it.
+		const rawOffsetY = clientY - mut.startY + (scrollTop - mut.startScrollTop)
+		// Clamp the dragged row's visible position to the first/last slot
+		// so its transform never extends the popover scroll area.
+		const minDragY = 0
+		const maxDragY = contentHeight - dragRowHeight
+		const dragY = Math.max(minDragY, Math.min(maxDragY, rowOffsets[mut.startIndex] + rawOffsetY))
+		const offsetY = dragY - rowOffsets[mut.startIndex]
+		// The drop slot is the row whose vertical span contains the dragged
+		// row's center. (With uniform heights this reduces to the old
+		// round(dragY / itemHeight) behavior.)
+		const dragCenter = dragY + dragRowHeight / 2
+		let dragIndex = rowHeights.length - 1
+		for (let i = 0; i < rowHeights.length; i++) {
+			if (dragCenter < rowOffsets[i] + rowHeights[i]) {
+				dragIndex = i
+				break
+			}
+		}
+		mut.dragIndex = dragIndex
+		mut.lastClientY = clientY
+		setDragState({ id: mut.id, startIndex: mut.startIndex, dragIndex, offsetY })
+	}, [])
+
+	// During a drag, the list should only scroll from the auto-scroll loop
+	// below. Native wheel/trackpad scroll would fight the drag position.
+	useEffect(() => {
+		if (!isOpen) return
+		const container = rSortableContainer.current
+		if (!container) return
+		function onWheel(e: WheelEvent) {
+			if (rMutables.current.status !== 'dragging') return
+			e.preventDefault()
+		}
+		container.addEventListener('wheel', onWheel, { passive: false })
+		return () => container.removeEventListener('wheel', onWheel)
+	}, [isOpen])
+
+	const tickAutoScrollDuringDrag = useCallback(() => {
+		const mut = rMutables.current
+		const container = rSortableContainer.current
+		if (mut.status !== 'dragging' || !container) {
+			mut.autoScrollScheduled = false
+			return
+		}
+		const rect = container.getBoundingClientRect()
+		const fromTop = mut.lastClientY - rect.top
+		const fromBottom = rect.bottom - mut.lastClientY
+		const maxScroll = container.scrollHeight - container.clientHeight
+		// During a drag, scroll speed ramps up as the pointer approaches and
+		// passes the edge of the scroll container.
+		// `overshoot` is 0 at the inner edge of PAGE_MENU_AUTO_SCROLL_ZONE and grows
+		// as the cursor approaches and passes the edge of the container.
+		const overshootTop = PAGE_MENU_AUTO_SCROLL_ZONE - fromTop
+		const overshootBottom = PAGE_MENU_AUTO_SCROLL_ZONE - fromBottom
+		let dy = 0
+		if (overshootTop > 0 && container.scrollTop > 0) {
+			const t = Math.min(1, overshootTop / PAGE_MENU_AUTO_SCROLL_RAMP_DISTANCE)
+			const speed =
+				PAGE_MENU_MIN_AUTO_SCROLL_SPEED +
+				(PAGE_MENU_MAX_AUTO_SCROLL_SPEED - PAGE_MENU_MIN_AUTO_SCROLL_SPEED) * t
+			dy = -Math.ceil(speed)
+		} else if (overshootBottom > 0 && container.scrollTop < maxScroll) {
+			const t = Math.min(1, overshootBottom / PAGE_MENU_AUTO_SCROLL_RAMP_DISTANCE)
+			const speed =
+				PAGE_MENU_MIN_AUTO_SCROLL_SPEED +
+				(PAGE_MENU_MAX_AUTO_SCROLL_SPEED - PAGE_MENU_MIN_AUTO_SCROLL_SPEED) * t
+			dy = Math.ceil(speed)
+		}
+		if (dy !== 0) {
+			const before = container.scrollTop
+			container.scrollTop = Math.max(0, Math.min(maxScroll, before + dy))
+			if (container.scrollTop !== before) {
+				updateDragFromPointer(mut.lastClientY)
+			}
+		}
+		editor.timers.requestAnimationFrame(tickAutoScrollDuringDrag)
+	}, [editor, updateDragFromPointer])
+
+	const ensureAutoScrollLoop = useCallback(() => {
+		const mut = rMutables.current
+		if (mut.autoScrollScheduled) return
+		mut.autoScrollScheduled = true
+		editor.timers.requestAnimationFrame(tickAutoScrollDuringDrag)
+	}, [editor, tickAutoScrollDuringDrag])
+
+	const handlePointerDown = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
+		if (e.button !== 0) return
+
+		const { clientY, currentTarget } = e
+		const { id, index } = currentTarget.dataset
+		if (!id || index === undefined) return
+
+		const startedOnDragHandle = currentTarget.dataset.dragHandle === 'true'
+		if (startedOnDragHandle) {
+			e.preventDefault()
+			e.stopPropagation()
+		}
+
+		const mut = rMutables.current
+		setPointerCapture(currentTarget, e)
+		mut.status = 'pointing'
+		mut.id = id as TLPageId
+		mut.startIndex = +index
+		mut.dragIndex = +index
+		mut.startY = clientY
+		mut.lastClientY = clientY
+		mut.startScrollTop = rSortableContainer.current?.scrollTop ?? 0
+		mut.startedOnDragHandle = startedOnDragHandle
+	}, [])
+
+	const handlePointerMove = useCallback(
+		(e: ReactPointerEvent<HTMLButtonElement>) => {
+			const mut = rMutables.current
+			const { clientY } = e
+			if (mut.status === 'pointing') {
+				if (Math.abs(clientY - mut.startY) <= PAGE_MENU_DRAG_THRESHOLD) return
+				mut.status = 'dragging'
+				mut.lastClientY = clientY
+				ensureAutoScrollLoop()
+			}
+			if (mut.status === 'dragging') {
+				e.preventDefault()
+				updateDragFromPointer(clientY)
+			}
+		},
+		[ensureAutoScrollLoop, updateDragFromPointer]
+	)
+
+	const handlePointerUp = useCallback(
+		(e: ReactPointerEvent<HTMLButtonElement>) => {
+			const mut = rMutables.current
+			if (mut.status === 'dragging' && mut.id) {
+				onMovePage(editor, mut.id, mut.startIndex, mut.dragIndex, trackEvent)
+				if (!mut.startedOnDragHandle) {
+					mut.justDragged = true
+				}
+			}
+			releasePointerCapture(e.currentTarget, e)
+			mut.status = 'idle'
+			mut.id = null
+			mut.startedOnDragHandle = false
+			setDragState(null)
+		},
+		[editor, trackEvent]
+	)
+
+	const handleItemContextMenu = useCallback(
+		(e: ReactMouseEvent<HTMLDivElement>, index: number) => {
+			e.preventDefault()
+			e.stopPropagation()
+
+			closePageItemSubmenus(index)
+			editor.menus.addOpenMenu(`page item submenu ${index}`)
+		},
+		[closePageItemSubmenus, editor]
+	)
+
+	const handlePointerCancel = useCallback((e: ReactPointerEvent<HTMLButtonElement>) => {
+		const mut = rMutables.current
+		releasePointerCapture(e.currentTarget, e)
+		mut.status = 'idle'
+		mut.id = null
+		mut.startedOnDragHandle = false
+		setDragState(null)
+	}, [])
+
+	const handleKeyDown = useCallback((e: ReactKeyboardEvent<HTMLButtonElement>) => {
+		const mut = rMutables.current
+		// Pointer capture is naturally released on the eventual pointer up,
+		// at which point the idle status makes the up handler a no-op.
+		if (e.key === 'Escape' && mut.status !== 'idle') {
+			mut.status = 'idle'
+			mut.id = null
+			mut.startedOnDragHandle = false
+			setDragState(null)
+		}
+	}, [])
+
+	const shouldUseWindowPrompt = breakpoint < PORTRAIT_BREAKPOINT.TABLET_SM && isCoarsePointer
+	const shouldUseDragHandle = !isReadonlyMode && isCoarsePointer
+
+	// A rename can turn an empty page into a divider. Dividers can't be the
+	// current page, so when the renamed page is current, step to the nearest
+	// regular page so the row turns into a divider right away. (This is the
+	// normal divider-creation flow: creating a page makes it current before
+	// the inline rename starts.)
+	const stepOffConvertedDivider = useCallback(
+		(id: TLPageId) => {
+			const page = editor.getPage(id)
+			if (!page) return
+			if (editor.getCurrentPageId() !== id) return
+			if (!isDividerName(page.name) || editor.getPageShapeIds(id).size > 0) return
+			const nearestId = getNearestNonDividerPageId(editor, id)
+			if (nearestId) editor.setCurrentPage(nearestId)
+		},
+		[editor]
+	)
+
+	const startRenamingPage = useCallback(
+		(id: TLPageId, currentName: string) => {
+			if (isReadonlyMode) return
+			if (shouldUseWindowPrompt) {
+				const name = window.prompt(msg('action.rename'), currentName)
+				if (name && name !== currentName) {
+					editor.renamePage(id, name)
+					trackEvent('rename-page', { source: 'page-menu' })
+					stepOffConvertedDivider(id)
+				}
+				return
+			}
+			setEditingPageId(id)
+		},
+		[editor, msg, isReadonlyMode, shouldUseWindowPrompt, stepOffConvertedDivider, trackEvent]
+	)
+
+	const handleCreatePageClick = useCallback(() => {
+		if (isReadonlyMode) return
+
+		const newPageId = PageRecordType.createId()
+		const initialName = msg('page-menu.new-page-initial-name')
+		let name = initialName
+
+		if (shouldUseWindowPrompt) {
+			const result = window.prompt(msg('page-menu.create-new-page'), initialName)
+			if (result === null) return
+			name = result || initialName
+		}
+
+		editor.run(() => {
+			editor.markHistoryStoppingPoint('creating page')
+			editor.createPage({ name, id: newPageId })
+			editor.setCurrentPage(newPageId)
+		})
+
+		if (!shouldUseWindowPrompt) {
+			startRenamingPage(newPageId, initialName)
+		} else {
+			stepOffConvertedDivider(newPageId)
+		}
+		trackEvent('new-page', { source: 'page-menu' })
+	}, [
+		editor,
+		msg,
+		isReadonlyMode,
+		shouldUseWindowPrompt,
+		startRenamingPage,
+		stepOffConvertedDivider,
+		trackEvent,
+	])
+
+	const changePage = useCallback(
+		(id: TLPageId) => {
+			editor.setCurrentPage(id)
+			trackEvent('change-page', { source: 'page-menu' })
+		},
+		[editor, trackEvent]
+	)
+
+	return (
+		<TldrawUiPopover id="pages" onOpenChange={onOpenChange} open={isOpen}>
+			<TldrawUiPopoverTrigger data-testid="main.page-menu">
+				<TldrawUiButton
+					type="menu"
+					tooltip={currentPage.name}
+					title={currentPage.name}
+					data-testid="page-menu.button"
+					className="tlui-page-menu__trigger"
+				>
+					<TldrawUiButtonLabel>{currentPage.name}</TldrawUiButtonLabel>
+					<TldrawUiButtonIcon icon="chevron-down" small />
+				</TldrawUiButton>
+			</TldrawUiPopoverTrigger>
+			<TldrawUiPopoverContent
+				side="bottom"
+				align="start"
+				sideOffset={0}
+				disableEscapeKeyDown={editingPageId !== null}
+			>
+				<div className="tlui-page-menu__wrapper">
+					<div
+						data-testid="page-menu.list"
+						className="tlui-page-menu__list"
+						ref={rSortableContainer}
+						style={{ height: renderedListHeight }}
+					>
+						<div
+							className="tlui-page-menu__list__content"
+							data-dragging={dragState !== null}
+							style={{ height: autoFitListHeight }}
+						>
+							{pages.map((page, index) => {
+								const isCurrentPage = page.id === currentPage.id
+								const isRenamingThisPage = editingPageId === page.id
+								const isDragging = dragState?.id === page.id
+								const isDivider = dividerPageIds.has(page.id)
+
+								let y = rowOffsets[index]
+								if (dragState) {
+									// Displaced rows shift by the dragged row's height, which
+									// differs between page rows and divider rows.
+									const dragRowHeight = rowHeights[dragState.startIndex]
+									if (isDragging) {
+										y = rowOffsets[dragState.startIndex] + dragState.offsetY
+									} else {
+										const { startIndex, dragIndex } = dragState
+										if (dragIndex < startIndex && index >= dragIndex && index < startIndex) {
+											y = rowOffsets[index] + dragRowHeight
+										} else if (dragIndex > startIndex && index > startIndex && index <= dragIndex) {
+											y = rowOffsets[index] - dragRowHeight
+										}
+									}
+								}
+
+								return (
+									<div
+										key={page.id}
+										data-pageid={page.id}
+										data-testid="page-menu.item"
+										data-iscurrent={isCurrentPage}
+										data-dragging={isDragging}
+										data-editing={isRenamingThisPage}
+										data-isdivider={isDivider}
+										className="tlui-page-menu__item"
+										onContextMenu={
+											!isReadonlyMode && !isRenamingThisPage
+												? (e) => handleItemContextMenu(e, index)
+												: undefined
+										}
+										style={{
+											zIndex: isDragging
+												? pages.length + 2
+												: isCurrentPage
+													? pages.length + 1
+													: index,
+											transform: `translateY(${y}px)`,
+										}}
+									>
+										{isRenamingThisPage ? (
+											<div className="tlui-page-menu__item__title">
+												<PageItemInput
+													id={page.id}
+													name={page.name}
+													isCurrentPage={isCurrentPage}
+													onComplete={() => {
+														setEditingPageId(null)
+														stepOffConvertedDivider(page.id)
+													}}
+													onCancel={() => setEditingPageId(null)}
+												/>
+											</div>
+										) : (
+											<>
+												{shouldUseDragHandle && (
+													<TldrawUiButton
+														type="icon"
+														className="tlui-page-menu__item__drag-handle"
+														data-testid="page-menu.item-drag-handle"
+														data-id={page.id}
+														data-index={index}
+														data-drag-handle="true"
+														onPointerDown={handlePointerDown}
+														onPointerMove={handlePointerMove}
+														onPointerUp={handlePointerUp}
+														onPointerCancel={handlePointerCancel}
+														onKeyDown={handleKeyDown}
+														tooltip={msg('context-menu.reorder')}
+														title={msg('context-menu.reorder')}
+													>
+														<TldrawUiButtonIcon icon="drag-handle-dots" small />
+													</TldrawUiButton>
+												)}
+												{isDivider ? (
+													// Dividers cannot be selected or renamed; they can
+													// only be dragged to reorder or managed via the
+													// submenu.
+													<TldrawUiButton
+														type="normal"
+														className="tlui-page-menu__item__button"
+														onClick={() => {
+															// Keep the drag state machine consistent, but
+															// never navigate to a divider.
+															rMutables.current.justDragged = false
+														}}
+														onPointerDown={
+															isReadonlyMode || shouldUseDragHandle ? undefined : handlePointerDown
+														}
+														onPointerMove={
+															isReadonlyMode || shouldUseDragHandle ? undefined : handlePointerMove
+														}
+														onPointerUp={
+															isReadonlyMode || shouldUseDragHandle ? undefined : handlePointerUp
+														}
+														onPointerCancel={
+															isReadonlyMode || shouldUseDragHandle
+																? undefined
+																: handlePointerCancel
+														}
+														aria-label={pageDividerLbl}
+														data-id={page.id}
+														data-index={index}
+														onKeyDown={handleKeyDown}
+													>
+														<div className={styles.dividerLine} aria-hidden="true" />
+													</TldrawUiButton>
+												) : (
+													<TldrawUiButton
+														type="normal"
+														className="tlui-page-menu__item__button"
+														onClick={() => {
+															if (rMutables.current.justDragged) {
+																rMutables.current.justDragged = false
+																return
+															}
+															changePage(page.id)
+														}}
+														onDoubleClick={() => startRenamingPage(page.id, page.name)}
+														onPointerDown={
+															isReadonlyMode || shouldUseDragHandle ? undefined : handlePointerDown
+														}
+														onPointerMove={
+															isReadonlyMode || shouldUseDragHandle ? undefined : handlePointerMove
+														}
+														onPointerUp={
+															isReadonlyMode || shouldUseDragHandle ? undefined : handlePointerUp
+														}
+														onPointerCancel={
+															isReadonlyMode || shouldUseDragHandle
+																? undefined
+																: handlePointerCancel
+														}
+														tooltip={msg('page-menu.go-to-page')}
+														title={msg('page-menu.go-to-page')}
+														data-id={page.id}
+														data-index={index}
+														onKeyDown={(e) => {
+															if (e.key === 'Escape') {
+																handleKeyDown(e)
+																return
+															}
+															if (e.key === 'Enter' && isCurrentPage) {
+																startRenamingPage(page.id, page.name)
+																editor.markEventAsHandled(e)
+															}
+														}}
+													>
+														<TldrawUiButtonLabel>{page.name}</TldrawUiButtonLabel>
+													</TldrawUiButton>
+												)}
+											</>
+										)}
+										{!isReadonlyMode && !isRenamingThisPage && (
+											<div className="tlui-page-menu__item__submenu">
+												<TlaPageItemSubmenu
+													index={index}
+													item={page}
+													listSize={pages.length}
+													isDivider={isDivider}
+													onRename={
+														isDivider ? undefined : () => startRenamingPage(page.id, page.name)
+													}
+												/>
+											</div>
+										)}
+									</div>
+								)
+							})}
+						</div>
+					</div>
+					<div
+						className="tlui-page-menu__resize-handle"
+						data-resizing={isResizing}
+						onPointerDown={handleResizePointerDown}
+						onDoubleClick={handleResizeDoubleClick}
+						role="separator"
+						aria-orientation="horizontal"
+						aria-label={msg('page-menu.resize')}
+					/>
+					<TldrawUiButton
+						type="menu"
+						className="tlui-page-menu__create-button"
+						data-testid="page-menu.create"
+						tooltip={createPageButtonLabel}
+						title={createPageButtonLabel}
+						disabled={isReadonlyMode || hasReachedMaxPages}
+						onClick={handleCreatePageClick}
+					>
+						<TldrawUiButtonLabel>{createPageButtonLabel}</TldrawUiButtonLabel>
+						{!hasReachedMaxPages && <TldrawUiButtonIcon icon="plus" small />}
+					</TldrawUiButton>
+				</div>
+			</TldrawUiPopoverContent>
+		</TldrawUiPopover>
+	)
+})

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/TlaPageMenu.tsx
@@ -26,6 +26,7 @@ import {
 	releasePointerCapture,
 	setPointerCapture,
 	useBreakpoint,
+	useComputed,
 	useEditor,
 	useMenuIsOpen,
 	useReadonly,
@@ -130,8 +131,10 @@ export const TlaPageMenu = memo(function TlaPageMenu() {
 	const currentPage = useValue('currentPage', () => editor.getCurrentPage(), [editor])
 
 	// Divider status is derived: a page is a divider while it is named `---`
-	// (or more hyphens), has no shapes, and is not the current page.
-	const dividerPageIds = useValue(
+	// (or more hyphens), has no shapes, and is not the current page. The
+	// custom equality keeps this always-mounted menu from rerendering on
+	// shape edits that don't change divider membership.
+	const dividerPageIds$ = useComputed(
 		'dividerPageIds',
 		() => {
 			const ids = new Set<TLPageId>()
@@ -140,16 +143,26 @@ export const TlaPageMenu = memo(function TlaPageMenu() {
 			}
 			return ids
 		},
+		{
+			isEqual: (a: Set<TLPageId>, b: Set<TLPageId>) =>
+				a.size === b.size && Array.from(a).every((id) => b.has(id)),
+		},
 		[editor]
 	)
+	const dividerPageIds = useValue(dividerPageIds$)
 
 	const isReadonlyMode = useReadonly()
 
 	// Row layout: dividers are half-height, so row positions come from prefix
 	// sums rather than index * item height. Kept in a ref so the pointer-drag
-	// handlers always read the current layout without re-binding.
+	// handlers always read the current layout without re-binding. The row
+	// being renamed always stays full height: renames apply live per
+	// keystroke, so typing `---` would otherwise collapse the row around the
+	// open input mid-edit.
 	const rowHeights = pages.map((page) =>
-		dividerPageIds.has(page.id) ? PAGE_MENU_DIVIDER_ITEM_HEIGHT : PAGE_MENU_ITEM_HEIGHT
+		dividerPageIds.has(page.id) && editingPageId !== page.id
+			? PAGE_MENU_DIVIDER_ITEM_HEIGHT
+			: PAGE_MENU_ITEM_HEIGHT
 	)
 	const rowOffsets: number[] = []
 	let contentHeight = 0
@@ -631,7 +644,10 @@ export const TlaPageMenu = memo(function TlaPageMenu() {
 								const isCurrentPage = page.id === currentPage.id
 								const isRenamingThisPage = editingPageId === page.id
 								const isDragging = dragState?.id === page.id
-								const isDivider = dividerPageIds.has(page.id)
+								// The renaming row renders the input at full height even
+								// when its live-renamed name already matches the divider
+								// convention; it converts when editing ends.
+								const isDivider = dividerPageIds.has(page.id) && !isRenamingThisPage
 
 								let y = rowOffsets[index]
 								if (dragState) {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/edit-pages-shared.ts
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaPageMenu/edit-pages-shared.ts
@@ -1,0 +1,45 @@
+// Copy of packages/tldraw/src/lib/ui/components/PageMenu/edit-pages-shared.ts
+// (not exported from the tldraw package). Keep in sync when updating TlaPageMenu.
+import {
+	Editor,
+	getIndexAbove,
+	getIndexBelow,
+	getIndexBetween,
+	IndexKey,
+	TLPageId,
+	TLUiEventContextType,
+} from 'tldraw'
+
+export function onMovePage(
+	editor: Editor,
+	id: TLPageId,
+	from: number,
+	to: number,
+	trackEvent: TLUiEventContextType
+) {
+	if (from === to) return
+
+	let index: IndexKey
+
+	const pages = editor.getPages()
+
+	const below = from > to ? pages[to - 1] : pages[to]
+	const above = from > to ? pages[to] : pages[to + 1]
+
+	if (below && !above) {
+		index = getIndexAbove(below.index)
+	} else if (!below && above) {
+		index = getIndexBelow(pages[0].index)
+	} else {
+		index = getIndexBetween(below.index, above.index)
+	}
+
+	if (index !== pages[from].index) {
+		editor.markHistoryStoppingPoint('moving page')
+		editor.updatePage({
+			id: id as TLPageId,
+			index,
+		})
+		trackEvent('move-page', { source: 'page-menu' })
+	}
+}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/editor-components/TlaEditorContextMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/editor-components/TlaEditorContextMenu.tsx
@@ -1,0 +1,125 @@
+// The SDK context menu with one change: divider pages (#9445) are excluded
+// from the "Move to page" submenu. TlaEditorContextMenuContent is a copy of
+// the SDK's DefaultContextMenuContent, and TlaMoveToPageMenu a copy of the
+// SDK's MoveToPageMenu (packages/tldraw/src/lib/ui/components/menu-items.tsx)
+// with the divider filter added. Diff against those when updating.
+import {
+	ArrangeMenuSubmenu,
+	ClipboardMenuGroup,
+	ConversionsMenuGroup,
+	CursorChatItem,
+	DefaultContextMenu,
+	EditMenuSubmenu,
+	ReorderMenuSubmenu,
+	SelectAllMenuItem,
+	TLPageId,
+	TLUiContextMenuProps,
+	TldrawUiMenuActionItem,
+	TldrawUiMenuGroup,
+	TldrawUiMenuItem,
+	TldrawUiMenuSubmenu,
+	useEditor,
+	useReadonly,
+	useShowCollaborationUi,
+	useToasts,
+	useUiEvents,
+	useUnlockedSelectedShapesCount,
+	useValue,
+} from 'tldraw'
+import { isPageDivider } from '../../../utils/pageDividers'
+
+export function TlaEditorContextMenu(props: TLUiContextMenuProps) {
+	return (
+		<DefaultContextMenu {...props}>
+			<TlaEditorContextMenuContent />
+		</DefaultContextMenu>
+	)
+}
+
+function TlaEditorContextMenuContent() {
+	const editor = useEditor()
+	const showCollaborationUi = useShowCollaborationUi()
+
+	const isSinglePageMode = useValue('isSinglePageMode', () => editor.options.maxPages <= 1, [
+		editor,
+	])
+
+	return (
+		<>
+			{showCollaborationUi && <CursorChatItem />}
+			<TldrawUiMenuGroup id="modify">
+				<EditMenuSubmenu />
+				<ArrangeMenuSubmenu />
+				<ReorderMenuSubmenu />
+				{!isSinglePageMode && <TlaMoveToPageMenu />}
+			</TldrawUiMenuGroup>
+			<ClipboardMenuGroup />
+			<ConversionsMenuGroup />
+			<TldrawUiMenuGroup id="select-all">
+				<SelectAllMenuItem />
+			</TldrawUiMenuGroup>
+		</>
+	)
+}
+
+function TlaMoveToPageMenu() {
+	const editor = useEditor()
+	// Unlike the SDK menu, divider pages are filtered out of the list.
+	const pages = useValue(
+		'pages',
+		() => editor.getPages().filter((page) => !isPageDivider(editor, page)),
+		[editor]
+	)
+	const currentPageId = useValue('current page id', () => editor.getCurrentPageId(), [editor])
+	const { addToast } = useToasts()
+	const trackEvent = useUiEvents()
+	const isReadonlyMode = useReadonly()
+	const oneSelected = useUnlockedSelectedShapesCount(1)
+
+	if (!oneSelected) return null
+	if (isReadonlyMode) return null
+
+	return (
+		<TldrawUiMenuSubmenu id="move-to-page" label="context-menu.move-to-page" size="small">
+			<TldrawUiMenuGroup id="pages">
+				{pages.map((page) => (
+					<TldrawUiMenuItem
+						id={page.id}
+						key={page.id}
+						disabled={currentPageId === page.id}
+						label={page.name.length > 30 ? `${page.name.slice(0, 30)}…` : page.name}
+						onSelect={() => {
+							editor.markHistoryStoppingPoint('move_shapes_to_page')
+							editor.moveShapesToPage(editor.getSelectedShapeIds(), page.id as TLPageId)
+
+							const toPage = editor.getPage(page.id)
+
+							if (toPage) {
+								// TODO: dotcom i18n — copied verbatim from the SDK, which
+								// hardcodes these strings in English too.
+								addToast({
+									title: 'Changed page',
+									description: `Moved to ${toPage.name}.`,
+									actions: [
+										{
+											label: 'Go back',
+											type: 'primary',
+											onClick: () => {
+												editor.markHistoryStoppingPoint('change-page')
+												editor.setCurrentPage(currentPageId)
+											},
+										},
+									],
+								})
+							}
+							trackEvent('move-to-page', { source: 'context-menu' })
+						}}
+					/>
+				))}
+			</TldrawUiMenuGroup>
+			<TldrawUiMenuGroup id="new-page">
+				<TldrawUiMenuActionItem actionId="move-to-new-page" />
+			</TldrawUiMenuGroup>
+		</TldrawUiMenuSubmenu>
+	)
+}

--- a/apps/dotcom/client/src/tla/pages/local-file.tsx
+++ b/apps/dotcom/client/src/tla/pages/local-file.tsx
@@ -7,11 +7,15 @@ import {
 	TldrawUiMenuGroup,
 } from 'tldraw'
 import { LocalEditor } from '../../components/LocalEditor'
+import { TlaEditorContextMenu } from '../components/TlaEditor/editor-components/TlaEditorContextMenu'
+import { TlaPageMenu } from '../components/TlaEditor/TlaPageMenu/TlaPageMenu'
 
 const components: TLComponents = {
 	ErrorFallback: ({ error }) => {
 		throw error
 	},
+	ContextMenu: TlaEditorContextMenu,
+	PageMenu: TlaPageMenu,
 	SharePanel: null,
 	MainMenu: () => (
 		<DefaultMainMenu>

--- a/apps/dotcom/client/src/tla/utils/pageDividers.test.ts
+++ b/apps/dotcom/client/src/tla/utils/pageDividers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { isDividerName } from './pageDividers'
+
+describe('isDividerName', () => {
+	it('accepts three or more hyphens', () => {
+		expect(isDividerName('---')).toBe(true)
+		expect(isDividerName('----')).toBe(true)
+		expect(isDividerName('----------')).toBe(true)
+	})
+
+	it('ignores surrounding whitespace', () => {
+		expect(isDividerName('  ---  ')).toBe(true)
+		expect(isDividerName('\t---\n')).toBe(true)
+	})
+
+	it('rejects fewer than three hyphens', () => {
+		expect(isDividerName('')).toBe(false)
+		expect(isDividerName('-')).toBe(false)
+		expect(isDividerName('--')).toBe(false)
+	})
+
+	it('rejects names with other characters', () => {
+		expect(isDividerName('- - -')).toBe(false)
+		expect(isDividerName('--- notes')).toBe(false)
+		expect(isDividerName('notes ---')).toBe(false)
+		expect(isDividerName('---a---')).toBe(false)
+	})
+
+	it('rejects non-hyphen dash characters', () => {
+		expect(isDividerName('———')).toBe(false) // em dashes
+		expect(isDividerName('–––')).toBe(false) // en dashes
+		expect(isDividerName('___')).toBe(false)
+	})
+})

--- a/apps/dotcom/client/src/tla/utils/pageDividers.ts
+++ b/apps/dotcom/client/src/tla/utils/pageDividers.ts
@@ -38,6 +38,10 @@ export function isPageDivider(editor: Editor, page: TLPage): boolean {
 /**
  * The nearest page to `fromPageId` (by list order, preferring earlier pages)
  * that is not a divider, or undefined if every other page is a divider.
+ *
+ * Expects `fromPageId` to be the current page (both callers step off it):
+ * unlike `isPageDivider`, the current-page exemption is intentionally
+ * ignored here, since the page being stepped off is still current.
  */
 export function getNearestNonDividerPageId(
 	editor: Editor,

--- a/apps/dotcom/client/src/tla/utils/pageDividers.ts
+++ b/apps/dotcom/client/src/tla/utils/pageDividers.ts
@@ -1,0 +1,64 @@
+import { Editor, TLPage, TLPageId } from 'tldraw'
+
+const DIVIDER_NAME_REGEX = /^-{3,}$/
+
+/**
+ * Whether a page name follows the divider naming convention: three or more
+ * hyphens and nothing else (ignoring surrounding whitespace).
+ */
+export function isDividerName(name: string): boolean {
+	return DIVIDER_NAME_REGEX.test(name.trim())
+}
+
+/**
+ * Whether a page should be displayed as a divider in the pages list.
+ *
+ * A page is a divider only while it has a divider name AND is empty. Renaming
+ * a page that has content to `---` is treated as a normal rename; a divider
+ * can never gain content because it is not selectable, so divider status is
+ * effectively permanent through the UI (undoing the rename is the only way
+ * back).
+ *
+ * The current page is never treated as a divider. This keeps the user from
+ * being stranded on an unselectable row when the editor's automatic page
+ * fallback (e.g. a collaborator deleting the current page) lands on one; the
+ * page reverts to a divider as soon as the user switches away.
+ *
+ * Reads reactive editor state — call inside a reactive context (`useValue`)
+ * to track name, shape-count, and current-page changes.
+ */
+export function isPageDivider(editor: Editor, page: TLPage): boolean {
+	return (
+		isDividerName(page.name) &&
+		page.id !== editor.getCurrentPageId() &&
+		editor.getPageShapeIds(page.id).size === 0
+	)
+}
+
+/**
+ * The nearest page to `fromPageId` (by list order, preferring earlier pages)
+ * that is not a divider, or undefined if every other page is a divider.
+ */
+export function getNearestNonDividerPageId(
+	editor: Editor,
+	fromPageId: TLPageId
+): TLPageId | undefined {
+	const pages = editor.getPages()
+	const fromIndex = pages.findIndex((page) => page.id === fromPageId)
+	if (fromIndex === -1) return undefined
+
+	// A divider check that ignores the current-page exemption: when stepping
+	// off a freshly-converted divider the converted page is still current, and
+	// the page we land on must be a real page regardless of which is current.
+	const isRealPage = (page: TLPage) =>
+		page.id !== fromPageId &&
+		!(isDividerName(page.name) && editor.getPageShapeIds(page.id).size === 0)
+
+	for (let distance = 1; distance < pages.length; distance++) {
+		const before = pages[fromIndex - distance]
+		if (before && isRealPage(before)) return before.id
+		const after = pages[fromIndex + distance]
+		if (after && isRealPage(after)) return after.id
+	}
+	return undefined
+}


### PR DESCRIPTION
In order to let people organize long page lists on tldraw.com the way they do in Figma — separator rows between groups of pages — this PR renders empty pages named `---` (three or more hyphens) as divider lines in the pages dropdown. Closes #9445.

Renaming a brand-new (empty) page to `---` converts it, and that is the only path in: a page that already has content just gets the literal name `---` and stays a normal page. Dividers are half the height of a page row, show no tooltip or hover highlight, and can't be selected, renamed, or drawn on — they only support drag-to-reorder plus move up/down and delete from their ⋮ menu. They're also excluded from the context menu's "Move to page" list.

Decisions worth knowing when reviewing:

- **Divider status is derived** (name + zero shapes), not stored — no schema change, collaboration-safe, and content can never end up hidden behind an unselectable row. Undoing the rename is the only way back, by design.
- **The current page is never treated as a divider**, so the editor's automatic page fallback can't strand anyone on an unselectable page. Completing a rename that creates a divider steps back to the nearest regular page (creating a page makes it current before its inline rename starts), and deleting the current page from the menu pre-selects a non-divider neighbor.
- **The SDK is untouched.** This is a dotcom-side fork of `DefaultPageMenu` (plus its submenu and a copy of the default context menu content), wired into all dotcom editor surfaces. Regular-row behavior is preserved exactly; the fork files carry provenance headers pinned to the SDK commit so future drift-diffing stays mechanical.
- Because divider rows are half-height, row positions come from prefix-summed offsets instead of index × row height. The drag-reorder math generalizes accordingly and reduces to the SDK's exact behavior when all rows are full height.

### Change type

- [x] `feature`

### Test plan

1. In a file on tldraw.com, open the pages dropdown, create a page, and rename it to `---` — it becomes a divider line and you're returned to your previous page.
2. Click the divider (nothing happens), drag it to reorder, hover it (no highlight, no tooltip), and check its ⋮ menu only offers move and delete.
3. Draw on a page, then rename that page to `---` — it stays a normal, selectable page.
4. Right-click a shape → Move to page — dividers aren't listed.

- [x] Unit tests
- [x] End to end tests

### Release notes

- Organize the pages list on tldraw.com by renaming an empty page to `---` to turn it into a divider.

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Tests           | +205 / -0   |
| Automated files | +9 / -0     |
| Apps            | +1254 / -3  |
