### PR TITLE
fix(commenting): make coincident comment pins reachable via a count-badge thread list

### DIFF
--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -327,6 +327,12 @@ export function commitCommentMutation<T>(editor: Editor, fn: () => T, kind?: 'dr
 // @public (undocumented)
 export function computeClusterTable(leaves: readonly LeafInput[], options: ClusterOptions): ClusterTable;
 
+// @public
+export function computePinStacks(editor: Editor, threads: readonly TLCommentThread[], impreciseShapeAnchor?: {
+    x: number;
+    y: number;
+}): Map<string, number>;
+
 // @public (undocumented)
 export function CountBadge({ count }: CountBadgeProps): JSX.Element;
 
@@ -470,6 +476,9 @@ export interface PendingComment {
 
 // @public
 export const pendingComment: EditorAtom<null | PendingComment>;
+
+// @public
+export const PIN_STACK_STEP_PX = 12;
 
 // @public
 export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): void;

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -331,7 +331,7 @@ export function computeClusterTable(leaves: readonly LeafInput[], options: Clust
 export function computePinStacks(editor: Editor, threads: readonly TLCommentThread[], impreciseShapeAnchor?: {
     x: number;
     y: number;
-}): Map<string, number>;
+}): Map<string, readonly string[]>;
 
 // @public (undocumented)
 export function CountBadge({ count }: CountBadgeProps): JSX.Element;
@@ -465,6 +465,9 @@ export interface MergeEvent {
 }
 
 // @public
+export const openStackId: EditorAtom<null | string>;
+
+// @public
 export const openThreadId: EditorAtom<null | string>;
 
 // @public
@@ -476,9 +479,6 @@ export interface PendingComment {
 
 // @public
 export const pendingComment: EditorAtom<null | PendingComment>;
-
-// @public
-export const PIN_STACK_STEP_PX = 12;
 
 // @public
 export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): void;

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -76,6 +76,11 @@
 	gap: 10px;
 	max-height: 420px;
 	overflow-y: auto;
+	/* A scroll container clips at its own box — including the cards' shadows (setting one overflow
+	   axis makes both non-visible). Pad the clip box outward and pull the list back into place so
+	   the shadows have room to paint. */
+	padding: 16px;
+	margin: -16px;
 }
 
 /* Collapsed entries match the expanded thread's surface (same width, panel, elevation) so the

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -95,11 +95,11 @@
 	cursor: pointer;
 }
 
-/* Opaque hover darkening (not a translucent muted token) — the card floats directly over the
-   canvas, so a translucent background would let shapes show through it. */
+/* Hover uses the opaque low-surface token, not a translucent muted one — the card floats
+   directly over the canvas, so a translucent background would let shapes show through it. */
 .tlui-cmt-stack-list__card:hover,
 .pseudo-hover.tlui-cmt-stack-list__card {
-	background: color-mix(in srgb, var(--tl-color-panel) 96%, black);
+	background: var(--tl-color-low);
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -90,6 +90,20 @@
 	cursor: pointer;
 }
 
+.tlui-cmt-stack-list__card:hover,
+.pseudo-hover.tlui-cmt-stack-list__card {
+	background: var(--tl-color-muted-2);
+}
+
+/* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the
+   thread panel flattens its own cards. */
+.tlui-cmt-stack-list__card .tlui-cmt-card {
+	width: 100%;
+	padding: 6px 0 6px 4px;
+	background: transparent;
+	border: none;
+}
+
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass
    through. Drawn for the live drag draft and for a region thread while hovered or open. */
 .tlui-cmt-canvas-region {

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -61,6 +61,13 @@
 	z-index: 1;
 }
 
+/* A hovered pin rises above everything nearby — in a fanned stack of coincident pins, the pin
+   being reached for must win over its later-stacked (higher-painted) siblings. */
+.tlui-cmt-canvas-pin:hover,
+.pseudo-hover.tlui-cmt-canvas-pin {
+	z-index: 2;
+}
+
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass
    through. Drawn for the live drag draft and for a region thread while hovered or open. */
 .tlui-cmt-canvas-region {

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -73,7 +73,7 @@
 .tlui-cmt-stack-list {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 10px;
 	max-height: 420px;
 	overflow-y: auto;
 }
@@ -84,9 +84,9 @@
 	box-sizing: border-box;
 	width: 300px;
 	background: var(--tl-color-panel);
-	border-radius: var(--tl-radius-4);
+	border-radius: 12px;
 	box-shadow: var(--tl-shadow-2);
-	padding: 8px;
+	padding: 10px 14px;
 	cursor: pointer;
 }
 
@@ -96,12 +96,14 @@
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the
-   thread panel flattens its own cards. */
+   thread panel flattens its own cards. The avatar centers against the short two-line block so a
+   collapsed entry doesn't read as top-heavy. */
 .tlui-cmt-stack-list__card .tlui-cmt-card {
 	width: 100%;
-	padding: 6px 0 6px 4px;
+	padding: 0;
 	background: transparent;
 	border: none;
+	align-items: center;
 }
 
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -61,11 +61,33 @@
 	z-index: 1;
 }
 
-/* A hovered pin rises above everything nearby — in a fanned stack of coincident pins, the pin
-   being reached for must win over its later-stacked (higher-painted) siblings. */
-.tlui-cmt-canvas-pin:hover,
-.pseudo-hover.tlui-cmt-canvas-pin {
-	z-index: 2;
+/* The count badge standing in for a stack of coincident pins — same face as a cluster badge,
+   but clicking opens the stack's thread list rather than zooming (no zoom can separate them). */
+.tlui-cmt-canvas-stack-badge {
+	transform: translate(-50%, -50%);
+	width: max-content;
+	cursor: pointer;
+}
+
+/* The stack's popover content: one card per thread, the expanded thread inline among them. */
+.tlui-cmt-stack-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-height: 420px;
+	overflow-y: auto;
+}
+
+/* Collapsed entries match the expanded thread's surface (same width, panel, elevation) so the
+   list reads as one column of cards with one of them opened up. */
+.tlui-cmt-stack-list__card {
+	box-sizing: border-box;
+	width: 300px;
+	background: var(--tl-color-panel);
+	border-radius: var(--tl-radius-4);
+	box-shadow: var(--tl-shadow-2);
+	padding: 8px;
+	cursor: pointer;
 }
 
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -95,9 +95,11 @@
 	cursor: pointer;
 }
 
+/* Opaque hover darkening (not a translucent muted token) — the card floats directly over the
+   canvas, so a translucent background would let shapes show through it. */
 .tlui-cmt-stack-list__card:hover,
 .pseudo-hover.tlui-cmt-stack-list__card {
-	background: var(--tl-color-muted-2);
+	background: color-mix(in srgb, var(--tl-color-panel) 96%, black);
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,6 +1,6 @@
 import {
+	Fragment,
 	memo,
-	type CSSProperties,
 	type PointerEvent as ReactPointerEvent,
 	ReactNode,
 	useCallback,
@@ -21,7 +21,6 @@ import {
 	TLCommentId,
 	TLCommentThread,
 	TLRichText,
-	TldrawUiIcon,
 	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
@@ -33,28 +32,20 @@ import {
 import { computeClusterTable } from '../clustering/computeClusterTable'
 import { type ClusterRuntime, createClusterRuntime } from '../clustering/runtime'
 import type { ClusterNode, ClusterTable, MergeEvent } from '../clustering/types'
-import { CommentCard, CommentCardProps } from '../ui/comment-card'
 import { CommentComposer } from '../ui/comment-composer'
 import { EMPTY_COMMENT, isCommentEmpty } from '../ui/comment-extensions'
 import { CommentPin } from '../ui/comment-pin'
-import { CommentThread } from '../ui/comment-thread'
 import { CountBadge } from '../ui/count-badge'
 import { MentionMember } from '../ui/mention-list'
 import { isMentionPickerOpen } from '../ui/mention-suggestion'
 import { collectClusterLeaves } from './cluster-input'
-import { CommentBody } from './comment-body'
 import { UNKNOWN_AUTHOR } from './comment-render'
-import { getCommentRecord, putCommentRecords, removeCommentRecords } from './comment-store'
+import { getCommentRecord, putCommentRecords } from './comment-store'
 import { PendingComment } from './comment-tool'
 import { useCommentThreads, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
-import {
-	type CommentingComponents,
-	type CommentingOptions,
-	getCommentingOptions,
-	useCommentingOptions,
-} from './options'
-import { computePinStacks, PIN_STACK_STEP_PX } from './pin-stacking'
+import { type CommentingOptions, getCommentingOptions, useCommentingOptions } from './options'
+import { computePinStacks } from './pin-stacking'
 import {
 	DEFAULT_REGION_COMMENT_OPTIONS,
 	RegionCommentOptions,
@@ -63,13 +54,16 @@ import {
 import {
 	commentsHidden,
 	commitCommentMutation,
+	openStackId,
 	openThreadId,
 	pendingComment,
 	regionDraft,
 	toggleCommentsHidden,
 	usePendingComment,
 } from './state'
+import { ThreadStackPin } from './thread-stack'
 import { anchorPagePoint, regionPinPoint, shapeAnchorAt } from './thread-state'
+import { ThreadPopover, ThreadView } from './thread-view'
 
 /**
  * A ready-to-use comments layer for a tldraw canvas: pins each thread at its anchor, opens a
@@ -134,28 +128,6 @@ const draftAvatar = (
 		</svg>
 	</CommentPin>
 )
-
-function toCardProps(
-	comment: TLComment,
-	props: CanvasCommentsProps,
-	components: CommentingComponents
-): CommentCardProps {
-	const Body = components.CommentBody
-	// The `CommentBody` component slot overrides the built-in rich-text default (which resolves
-	// mention ids to names).
-	const body = Body ? (
-		<Body comment={comment} />
-	) : (
-		<CommentBody richText={comment.body} resolveName={props.resolveName} />
-	)
-	return {
-		author: props.resolveName(comment.authorId) ?? UNKNOWN_AUTHOR,
-		body,
-		date: new Date(comment.createdAt).toISOString(),
-		you: comment.authorId === props.currentUserId,
-		edited: comment.editedAt != null,
-	}
-}
 
 /** @public @react */
 export function CanvasComments(props: CanvasCommentsProps) {
@@ -346,8 +318,8 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		[threads]
 	)
 	// Zooming separates near pins, but pins with the *same* anchor point (several imprecise
-	// comments on one shape) coincide at every zoom — spread those sideways so each stays
-	// reachable. Keyed on page-space anchors, so camera moves never recompute this.
+	// comments on one shape) coincide at every zoom — those render as one count-badge stack that
+	// opens the threads as a list. Keyed on page-space anchors, so camera moves never recompute this.
 	const pinStacks = useValue(
 		'comment pin stacks',
 		() => computePinStacks(editor, threads, impreciseShapeAnchor),
@@ -356,10 +328,11 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const openThread = openId ? threadsById.get(openId) : null
 	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
 
-	// Reset the transient UI state (open thread, half-placed comment) when this unmounts.
+	// Reset the transient UI state (open thread, open stack, half-placed comment) when this unmounts.
 	useEffect(() => {
 		return () => {
 			openThreadId.set(editor, null)
+			openStackId.set(editor, null)
 			pendingComment.set(editor, null)
 		}
 	}, [editor])
@@ -453,6 +426,42 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// is read above so this component stays mounted and its shortcut/Escape effects keep running.
 	if (hidden) return null
 
+	// Which threads are on screen this render, across every path below. A stack renders exactly
+	// once, owned by its first member that is actually on screen — members can arrive by different
+	// paths (a leaf via clustering while its open sibling renders via the open slot), so ownership
+	// can't be decided per-path.
+	const renderedThreadIds = new Set<string>()
+	if (options.enableClustering) {
+		for (const { node } of fadeNodes) if (node.count === 1) renderedThreadIds.add(node.id)
+		for (const thread of orphanThreads) renderedThreadIds.add(thread.id)
+		for (const thread of heldThreads) renderedThreadIds.add(thread.id)
+	} else {
+		for (const thread of threads) renderedThreadIds.add(thread.id)
+	}
+	if (openThread) renderedThreadIds.add(openThread.id)
+
+	// A coincident-stack member renders as the group's single count-badge stack (if it owns it)
+	// or not at all; everything else is an ordinary pin.
+	const renderThreadPin = (thread: TLCommentThread): ReactNode => {
+		const group = pinStacks.get(thread.id)
+		if (group) {
+			const owner = group.find((id) => renderedThreadIds.has(id))
+			if (owner !== thread.id) return null
+			const stackThreads = group
+				.map((id) => threadsById.get(id))
+				.filter((t): t is TLCommentThread => t !== undefined)
+			return (
+				<ThreadStackPin
+					editor={editor}
+					threads={stackThreads}
+					{...props}
+					impreciseShapeAnchor={impreciseShapeAnchor}
+				/>
+			)
+		}
+		return <ThreadPin editor={editor} thread={thread} {...props} regionOptions={regionOptions} />
+	}
+
 	// Render into the container (above the panels' stacking context) so the pins and popovers
 	// live in the UI layer rather than being clipped by the canvas layer.
 	return createPortal(
@@ -464,15 +473,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 						if (node.count === 1) {
 							const thread = threadsById.get(node.id)
 							if (!thread) return null
-							content = (
-								<ThreadPin
-									editor={editor}
-									thread={thread}
-									stackIndex={pinStacks.get(thread.id) ?? 0}
-									{...props}
-									regionOptions={regionOptions}
-								/>
-							)
+							content = renderThreadPin(thread)
 						} else {
 							content = <ClusterBadge editor={editor} node={node} onExpand={zoomToClusterSplit} />
 						}
@@ -483,24 +484,10 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 						)
 					})}
 					{orphanThreads.map((thread) => (
-						<ThreadPin
-							key={thread.id}
-							editor={editor}
-							thread={thread}
-							stackIndex={pinStacks.get(thread.id) ?? 0}
-							{...props}
-							regionOptions={regionOptions}
-						/>
+						<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
 					))}
 					{heldThreads.map((thread) => (
-						<ThreadPin
-							key={thread.id}
-							editor={editor}
-							thread={thread}
-							stackIndex={pinStacks.get(thread.id) ?? 0}
-							{...props}
-							regionOptions={regionOptions}
-						/>
+						<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
 					))}
 				</>
 			) : (
@@ -510,26 +497,10 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 				// otherwise it would mount a second, stacked pin.
 				threads
 					.filter((thread) => thread.id !== openId)
-					.map((thread) => (
-						<ThreadPin
-							key={thread.id}
-							editor={editor}
-							thread={thread}
-							stackIndex={pinStacks.get(thread.id) ?? 0}
-							{...props}
-							regionOptions={regionOptions}
-						/>
-					))
+					.map((thread) => <Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>)
 			)}
 			{openThread && (
-				<ThreadPin
-					key={`open:${openThread.id}`}
-					editor={editor}
-					thread={openThread}
-					stackIndex={pinStacks.get(openThread.id) ?? 0}
-					{...props}
-					regionOptions={regionOptions}
-				/>
+				<Fragment key={`open:${openThread.id}`}>{renderThreadPin(openThread)}</Fragment>
 			)}
 			<RegionDraftBox editor={editor} />
 			{/* Keep the region visible while composing — the drag draft is gone by now, and no thread
@@ -798,28 +769,6 @@ function isInInflatedViewport(editor: Editor, point: { x: number; y: number }): 
 	)
 }
 
-/** The open thread's popover, portaled above the UI panels. Over it, wheel and hover events pass
- *  through to the canvas (unless the popover is scrolling its own content), like tldraw's panels. */
-function ThreadPopover({
-	container,
-	style,
-	children,
-}: {
-	container: HTMLElement
-	style: CSSProperties
-	children: ReactNode
-}) {
-	const ref = useRef<HTMLDivElement>(null)
-	usePassThroughWheelEvents(ref)
-	usePassThroughMouseOverEvents(ref)
-	return createPortal(
-		<div ref={ref} className="tlui-cmt-canvas-popover" style={style} onPointerDown={stop}>
-			{children}
-		</div>,
-		container
-	)
-}
-
 /** A dashed rectangle over a region anchor's bounds, in viewport space. Sits in the canvas layer as
  *  a sibling of the pins. `pointer-events` stays off (canvas interaction passes through) unless
  *  `movable`, in which case dragging the body translates the region — previews live, commits on drop. */
@@ -999,37 +948,22 @@ const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
 	regionOptions,
-	stackIndex,
 	...props
 }: Omit<CanvasCommentsProps, 'regionOptions'> & {
 	editor: Editor
 	thread: TLCommentThread
 	regionOptions: RegionCommentOptions
-	/** This pin's slot among pins sharing its exact anchor point — 0 sits at the anchor. */
-	stackIndex: number
 }) {
-	const {
-		currentUserId,
-		resolveName,
-		onPostComment,
-		isCommentUnread,
-		onCommentRead,
-		getMentionSuggestions,
-		renderMentionSuggestion,
-	} = props
+	const { resolveName } = props
 	const options = useCommentingOptions()
 	const impreciseShapeAnchor = props.impreciseShapeAnchor ?? options.impreciseShapeAnchor
 	const container = useContainer()
 	const comments = useThreadComments(editor, thread.id)
-	const msg = useTranslation()
 	// Only one thread's popover is open at a time — shared across pins via the atom.
 	const open = useValue('thread open', () => openThreadId.get(editor) === thread.id, [
 		editor,
 		thread.id,
 	])
-	const [reply, setReply] = useState<TLRichText>(EMPTY_COMMENT)
-	const [editingId, setEditingId] = useState<string | null>(null)
-	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
 	// While dragging the marker, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
 	// The live bounds while a corner handle is resizing the region, else null.
@@ -1107,151 +1041,7 @@ const ThreadPin = memo(function ThreadPin({
 		},
 		[editor, thread.anchor, thread.pageId, impreciseShapeAnchor]
 	)
-	const visible = point !== null
-
-	// While the popover is open, every unread comment on display gets reported read — including
-	// replies that arrive while it stays open, since the effect re-runs as `comments` changes.
-	// The host's receipt write flips isCommentUnread to false, so re-runs find nothing to report.
-	useEffect(() => {
-		if (!open || !visible || !isCommentUnread || !onCommentRead) return
-		for (const comment of comments) {
-			if (isCommentUnread(comment.id)) {
-				onCommentRead(comment.id)
-			}
-		}
-	}, [open, visible, comments, isCommentUnread, onCommentRead])
-
 	if (!point) return null
-
-	const postReply = () => {
-		if (isCommentEmpty(reply) || !currentUserId) return
-		commitCommentMutation(editor, () => {
-			const comment = createComment({
-				threadId: thread.id,
-				pageId: thread.pageId,
-				authorId: currentUserId,
-				body: reply,
-			})
-			putCommentRecords(editor, [comment])
-			if (onPostComment) onPostComment(comment)
-		})
-		setReply(EMPTY_COMMENT)
-	}
-
-	const toggleResolve = () => {
-		if (!currentUserId) return
-		commitCommentMutation(editor, () => {
-			putCommentRecords(editor, [
-				{
-					...thread,
-					resolved: thread.resolved ? null : { at: Date.now(), by: currentUserId },
-				},
-			])
-		})
-	}
-
-	const deleteThread = () => {
-		openThreadId.set(editor, null)
-		commitCommentMutation(editor, () =>
-			removeCommentRecords(editor, [thread.id, ...comments.map((c) => c.id)])
-		)
-	}
-
-	const startEdit = (comment: TLComment) => {
-		setEditingId(comment.id)
-		setEditText(comment.body)
-	}
-
-	const saveEdit = () => {
-		const comment = comments.find((c) => c.id === editingId)
-		if (!comment || isCommentEmpty(editText)) return
-		commitCommentMutation(editor, () => {
-			putCommentRecords(editor, [{ ...comment, body: editText, editedAt: Date.now() }])
-		})
-		setEditingId(null)
-	}
-
-	// Swap a comment for a pre-filled composer while it's being edited; otherwise show the card,
-	// with an edit affordance on your own comments.
-	const renderComment = (card: CommentCardProps, index: number): ReactNode => {
-		const comment = comments[index]
-		if (editingId === comment.id) {
-			return (
-				<div
-					className="tlui-cmt-editing"
-					onKeyDown={(e) => {
-						if (e.key === 'Escape') {
-							setEditingId(null)
-							e.stopPropagation()
-						}
-					}}
-				>
-					<CommentComposer
-						author={card.author}
-						placeholder={msg('comments.edit-placeholder')}
-						value={editText}
-						onChange={setEditText}
-						onSubmit={saveEdit}
-						sendLabel={msg('comments.save')}
-						disabled={isCommentEmpty(editText)}
-						getMentionSuggestions={getMentionSuggestions}
-						renderMentionSuggestion={renderMentionSuggestion}
-						autoFocus
-					/>
-				</div>
-			)
-		}
-		return (
-			<CommentCard
-				{...card}
-				actions={
-					comment.authorId === currentUserId ? (
-						<button
-							className="tlui-cmt-thread__action"
-							title={msg('comments.edit')}
-							onClick={() => startEdit(comment)}
-						>
-							<TldrawUiIcon icon="dots-horizontal" label={msg('comments.edit')} small />
-						</button>
-					) : undefined
-				}
-			/>
-		)
-	}
-
-	const headerActions = (
-		<>
-			{currentUserId && (
-				<button
-					className="tlui-cmt-thread__action"
-					title={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
-					onClick={toggleResolve}
-				>
-					<TldrawUiIcon
-						icon="check"
-						label={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
-						small
-					/>
-				</button>
-			)}
-			{currentUserId && (
-				<button
-					className="tlui-cmt-thread__action"
-					title={msg('comments.delete')}
-					onClick={deleteThread}
-				>
-					<TldrawUiIcon icon="trash" label={msg('comments.delete')} small />
-				</button>
-			)}
-			<button
-				className="tlui-cmt-thread__action"
-				title={msg('comments.dismiss')}
-				onClick={() => openThreadId.set(editor, null)}
-			>
-				<TldrawUiIcon icon="cross-2" label={msg('comments.dismiss')} small />
-			</button>
-		</>
-	)
 
 	const PinContent = options.components.PinContent
 	// The `PinContent` component slot overrides the built-in author-initial default.
@@ -1314,15 +1104,11 @@ const ThreadPin = memo(function ThreadPin({
 	}
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
-	// move to the drag point; otherwise it sits at the stored anchor's viewport point — stepped
-	// sideways by its stack slot when other pins share that exact point. The step is in screen
-	// pixels (not page space) so a stack stays fanned out at every zoom.
+	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
 	const livePinPage = resizeBounds
 		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
 		: dragPagePoint
-	const renderPoint = livePinPage
-		? editor.pageToViewport(livePinPage)
-		: { x: point.x + stackIndex * PIN_STACK_STEP_PX, y: point.y }
+	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
 	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.
@@ -1390,35 +1176,7 @@ const ThreadPin = memo(function ThreadPin({
 						container={container}
 						style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
 					>
-						<CommentThread
-							header={msg('comments.thread-title')}
-							headerActions={headerActions}
-							renderComment={renderComment}
-							comments={comments.map((c) => toCardProps(c, props, options.components))}
-							resolvedBanner={
-								thread.resolved
-									? msg('comments.resolved-by').replace(
-											'{name}',
-											resolveName(thread.resolved.by) ?? UNKNOWN_AUTHOR
-										)
-									: undefined
-							}
-							composer={
-								currentUserId && !thread.resolved
-									? {
-											author: resolveName(currentUserId) ?? UNKNOWN_AUTHOR,
-											placeholder: msg('comments.reply-placeholder'),
-											sendLabel: msg('comments.send'),
-											value: reply,
-											onChange: setReply,
-											onSubmit: postReply,
-											disabled: isCommentEmpty(reply),
-											getMentionSuggestions,
-											renderMentionSuggestion,
-										}
-									: undefined
-							}
-						/>
+						<ThreadView editor={editor} thread={thread} {...props} />
 					</ThreadPopover>
 				)}
 			</div>

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -54,6 +54,7 @@ import {
 	getCommentingOptions,
 	useCommentingOptions,
 } from './options'
+import { computePinStacks, PIN_STACK_STEP_PX } from './pin-stacking'
 import {
 	DEFAULT_REGION_COMMENT_OPTIONS,
 	RegionCommentOptions,
@@ -344,6 +345,14 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		() => new Map<string, TLCommentThread>(threads.map((thread) => [thread.id, thread])),
 		[threads]
 	)
+	// Zooming separates near pins, but pins with the *same* anchor point (several imprecise
+	// comments on one shape) coincide at every zoom — spread those sideways so each stays
+	// reachable. Keyed on page-space anchors, so camera moves never recompute this.
+	const pinStacks = useValue(
+		'comment pin stacks',
+		() => computePinStacks(editor, threads, impreciseShapeAnchor),
+		[editor, threads, impreciseShapeAnchor]
+	)
 	const openThread = openId ? threadsById.get(openId) : null
 	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
 
@@ -459,6 +468,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 								<ThreadPin
 									editor={editor}
 									thread={thread}
+									stackIndex={pinStacks.get(thread.id) ?? 0}
 									{...props}
 									regionOptions={regionOptions}
 								/>
@@ -477,6 +487,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							key={thread.id}
 							editor={editor}
 							thread={thread}
+							stackIndex={pinStacks.get(thread.id) ?? 0}
 							{...props}
 							regionOptions={regionOptions}
 						/>
@@ -486,6 +497,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							key={thread.id}
 							editor={editor}
 							thread={thread}
+							stackIndex={pinStacks.get(thread.id) ?? 0}
 							{...props}
 							regionOptions={regionOptions}
 						/>
@@ -503,6 +515,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							key={thread.id}
 							editor={editor}
 							thread={thread}
+							stackIndex={pinStacks.get(thread.id) ?? 0}
 							{...props}
 							regionOptions={regionOptions}
 						/>
@@ -513,6 +526,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 					key={`open:${openThread.id}`}
 					editor={editor}
 					thread={openThread}
+					stackIndex={pinStacks.get(openThread.id) ?? 0}
 					{...props}
 					regionOptions={regionOptions}
 				/>
@@ -985,11 +999,14 @@ const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
 	regionOptions,
+	stackIndex,
 	...props
 }: Omit<CanvasCommentsProps, 'regionOptions'> & {
 	editor: Editor
 	thread: TLCommentThread
 	regionOptions: RegionCommentOptions
+	/** This pin's slot among pins sharing its exact anchor point — 0 sits at the anchor. */
+	stackIndex: number
 }) {
 	const {
 		currentUserId,
@@ -1297,11 +1314,15 @@ const ThreadPin = memo(function ThreadPin({
 	}
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
-	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
+	// move to the drag point; otherwise it sits at the stored anchor's viewport point — stepped
+	// sideways by its stack slot when other pins share that exact point. The step is in screen
+	// pixels (not page space) so a stack stays fanned out at every zoom.
 	const livePinPage = resizeBounds
 		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
 		: dragPagePoint
-	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
+	const renderPoint = livePinPage
+		? editor.pageToViewport(livePinPage)
+		: { x: point.x + stackIndex * PIN_STACK_STEP_PX, y: point.y }
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
 	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.

--- a/packages/commenting/src/canvas/pin-stacking.test.ts
+++ b/packages/commenting/src/canvas/pin-stacking.test.ts
@@ -1,0 +1,106 @@
+import type { Editor, TLCommentAnchor, TLCommentThread } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import { computePinStacks } from './pin-stacking'
+
+const CURRENT_PAGE = 'page:one'
+const OTHER_PAGE = 'page:two'
+
+function thread(
+	id: string,
+	anchor: TLCommentAnchor,
+	opts: { pageId?: string; createdAt?: number } = {}
+): TLCommentThread {
+	return {
+		id,
+		typeName: 'comment-thread',
+		pageId: opts.pageId ?? CURRENT_PAGE,
+		anchor,
+		createdBy: 'user:1',
+		createdAt: opts.createdAt ?? 0,
+		resolved: null,
+		meta: {},
+	} as unknown as TLCommentThread
+}
+
+function stubEditor(
+	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
+): Editor {
+	return {
+		getCurrentPageId: () => CURRENT_PAGE,
+		getShapePageBounds: (id: string) => {
+			const bounds = shapes[id]
+			if (!bounds) return undefined
+			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
+		},
+	} as unknown as Editor
+}
+
+const SHAPE = { 'shape:a': { minX: 0, minY: 0, maxX: 200, maxY: 100 } }
+
+function impreciseAnchor(shapeId: string): TLCommentAnchor {
+	return { type: 'shape', shapeId, x: 0.2, y: 0.9, isPrecise: false } as TLCommentAnchor
+}
+
+describe('computePinStacks', () => {
+	it('indexes coincident imprecise pins on one shape by creation order', () => {
+		const stacks = computePinStacks(stubEditor(SHAPE), [
+			thread('t2', impreciseAnchor('shape:a'), { createdAt: 20 }),
+			thread('t1', impreciseAnchor('shape:a'), { createdAt: 10 }),
+		])
+		expect(stacks.get('t1')).toBe(0)
+		expect(stacks.get('t2')).toBe(1)
+	})
+
+	it('leaves separated pins unindexed', () => {
+		const stacks = computePinStacks(stubEditor(), [
+			thread('t1', { type: 'point', x: 0, y: 0 }),
+			thread('t2', { type: 'point', x: 50, y: 0 }),
+		])
+		expect(stacks.size).toBe(0)
+	})
+
+	it('stacks coincident point anchors', () => {
+		const stacks = computePinStacks(stubEditor(), [
+			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
+			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 2 }),
+			thread('t3', { type: 'point', x: 5, y: 5 }, { createdAt: 3 }),
+		])
+		expect([stacks.get('t1'), stacks.get('t2'), stacks.get('t3')]).toEqual([0, 1, 2])
+	})
+
+	it('breaks creation-time ties by id so indexes are deterministic', () => {
+		const stacks = computePinStacks(stubEditor(), [
+			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
+			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
+		])
+		expect(stacks.get('t1')).toBe(0)
+		expect(stacks.get('t2')).toBe(1)
+	})
+
+	it('ignores threads on other pages and unresolvable anchors', () => {
+		const stacks = computePinStacks(stubEditor(SHAPE), [
+			thread('t1', impreciseAnchor('shape:a')),
+			thread('t2', impreciseAnchor('shape:a'), { pageId: OTHER_PAGE }),
+			thread('t3', impreciseAnchor('shape:gone')),
+		])
+		expect(stacks.size).toBe(0)
+	})
+
+	it('does not stack a precise pin sitting away from a coincident pair', () => {
+		const precise: TLCommentAnchor = {
+			type: 'shape',
+			shapeId: 'shape:a',
+			x: 0.5,
+			y: 0.5,
+			isPrecise: true,
+		} as TLCommentAnchor
+		const stacks = computePinStacks(stubEditor(SHAPE), [
+			thread('t1', impreciseAnchor('shape:a'), { createdAt: 1 }),
+			thread('t2', impreciseAnchor('shape:a'), { createdAt: 2 }),
+			thread('t3', precise),
+		])
+		expect(stacks.get('t1')).toBe(0)
+		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.has('t3')).toBe(false)
+	})
+})

--- a/packages/commenting/src/canvas/pin-stacking.test.ts
+++ b/packages/commenting/src/canvas/pin-stacking.test.ts
@@ -42,16 +42,16 @@ function impreciseAnchor(shapeId: string): TLCommentAnchor {
 }
 
 describe('computePinStacks', () => {
-	it('indexes coincident imprecise pins on one shape by creation order', () => {
+	it('groups coincident imprecise pins on one shape, oldest first', () => {
 		const stacks = computePinStacks(stubEditor(SHAPE), [
 			thread('t2', impreciseAnchor('shape:a'), { createdAt: 20 }),
 			thread('t1', impreciseAnchor('shape:a'), { createdAt: 10 }),
 		])
-		expect(stacks.get('t1')).toBe(0)
-		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.get('t1')).toEqual(['t1', 't2'])
+		expect(stacks.get('t2')).toEqual(['t1', 't2'])
 	})
 
-	it('leaves separated pins unindexed', () => {
+	it('leaves separated pins ungrouped', () => {
 		const stacks = computePinStacks(stubEditor(), [
 			thread('t1', { type: 'point', x: 0, y: 0 }),
 			thread('t2', { type: 'point', x: 50, y: 0 }),
@@ -59,22 +59,21 @@ describe('computePinStacks', () => {
 		expect(stacks.size).toBe(0)
 	})
 
-	it('stacks coincident point anchors', () => {
+	it('groups coincident point anchors', () => {
 		const stacks = computePinStacks(stubEditor(), [
 			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
 			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 2 }),
 			thread('t3', { type: 'point', x: 5, y: 5 }, { createdAt: 3 }),
 		])
-		expect([stacks.get('t1'), stacks.get('t2'), stacks.get('t3')]).toEqual([0, 1, 2])
+		expect(stacks.get('t2')).toEqual(['t1', 't2', 't3'])
 	})
 
-	it('breaks creation-time ties by id so indexes are deterministic', () => {
+	it('breaks creation-time ties by id so ordering is deterministic', () => {
 		const stacks = computePinStacks(stubEditor(), [
 			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
 			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
 		])
-		expect(stacks.get('t1')).toBe(0)
-		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.get('t1')).toEqual(['t1', 't2'])
 	})
 
 	it('ignores threads on other pages and unresolvable anchors', () => {
@@ -86,7 +85,7 @@ describe('computePinStacks', () => {
 		expect(stacks.size).toBe(0)
 	})
 
-	it('does not stack a precise pin sitting away from a coincident pair', () => {
+	it('does not group a precise pin sitting away from a coincident pair', () => {
 		const precise: TLCommentAnchor = {
 			type: 'shape',
 			shapeId: 'shape:a',
@@ -99,8 +98,7 @@ describe('computePinStacks', () => {
 			thread('t2', impreciseAnchor('shape:a'), { createdAt: 2 }),
 			thread('t3', precise),
 		])
-		expect(stacks.get('t1')).toBe(0)
-		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.get('t1')).toEqual(['t1', 't2'])
 		expect(stacks.has('t3')).toBe(false)
 	})
 })

--- a/packages/commenting/src/canvas/pin-stacking.ts
+++ b/packages/commenting/src/canvas/pin-stacking.ts
@@ -1,0 +1,51 @@
+import type { Editor, TLCommentThread } from 'tldraw'
+import { anchorPagePoint } from './thread-state'
+
+/** How far each successive pin in a stack of coincident pins steps sideways, in screen pixels.
+ * @public */
+export const PIN_STACK_STEP_PX = 12
+
+/** Two anchors within this page-space distance (per axis) share a stack. Identical imprecise
+ *  anchors on one shape resolve to the same point exactly; the tolerance only absorbs float noise. */
+const PIN_STACK_QUANTUM = 0.1
+
+/**
+ * Index each thread whose pin lands on the same page point as another thread's — coincident pins
+ * (typically several imprecise comments on one shape) that zooming can never separate. The overlay
+ * spreads a stack sideways by a fixed screen offset per index, oldest thread at the anchor.
+ *
+ * Keyed by page-space anchor point, not screen position, so the result only changes when threads
+ * or their anchors move — never on camera moves. Threads without an entry render unshifted.
+ * @public
+ */
+export function computePinStacks(
+	editor: Editor,
+	threads: readonly TLCommentThread[],
+	impreciseShapeAnchor?: { x: number; y: number }
+): Map<string, number> {
+	const pageId = editor.getCurrentPageId()
+	const groups = new Map<string, TLCommentThread[]>()
+
+	for (const thread of threads) {
+		if (thread.pageId !== pageId) continue
+		const point = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
+		if (!point) continue
+		const key = `${Math.round(point.x / PIN_STACK_QUANTUM)}:${Math.round(point.y / PIN_STACK_QUANTUM)}`
+		const group = groups.get(key)
+		if (group) {
+			group.push(thread)
+		} else {
+			groups.set(key, [thread])
+		}
+	}
+
+	const indexes = new Map<string, number>()
+	for (const group of groups.values()) {
+		if (group.length < 2) continue
+		group.sort((a, b) => a.createdAt - b.createdAt || (a.id < b.id ? -1 : 1))
+		for (let i = 0; i < group.length; i++) {
+			indexes.set(group[i].id, i)
+		}
+	}
+	return indexes
+}

--- a/packages/commenting/src/canvas/pin-stacking.ts
+++ b/packages/commenting/src/canvas/pin-stacking.ts
@@ -1,28 +1,25 @@
 import type { Editor, TLCommentThread } from 'tldraw'
 import { anchorPagePoint } from './thread-state'
 
-/** How far each successive pin in a stack of coincident pins steps sideways, in screen pixels.
- * @public */
-export const PIN_STACK_STEP_PX = 12
-
 /** Two anchors within this page-space distance (per axis) share a stack. Identical imprecise
  *  anchors on one shape resolve to the same point exactly; the tolerance only absorbs float noise. */
 const PIN_STACK_QUANTUM = 0.1
 
 /**
- * Index each thread whose pin lands on the same page point as another thread's — coincident pins
- * (typically several imprecise comments on one shape) that zooming can never separate. The overlay
- * spreads a stack sideways by a fixed screen offset per index, oldest thread at the anchor.
+ * Group threads whose pins land on the same page point — coincident pins (typically several
+ * imprecise comments on one shape) that zooming can never separate. The overlay renders each
+ * group as a single count-badge pin that opens the threads as a list. Every member id maps to
+ * its group's ordered member ids (oldest first); threads without an entry pin individually.
  *
  * Keyed by page-space anchor point, not screen position, so the result only changes when threads
- * or their anchors move — never on camera moves. Threads without an entry render unshifted.
+ * or their anchors move — never on camera moves.
  * @public
  */
 export function computePinStacks(
 	editor: Editor,
 	threads: readonly TLCommentThread[],
 	impreciseShapeAnchor?: { x: number; y: number }
-): Map<string, number> {
+): Map<string, readonly string[]> {
 	const pageId = editor.getCurrentPageId()
 	const groups = new Map<string, TLCommentThread[]>()
 
@@ -39,13 +36,14 @@ export function computePinStacks(
 		}
 	}
 
-	const indexes = new Map<string, number>()
+	const stacks = new Map<string, readonly string[]>()
 	for (const group of groups.values()) {
 		if (group.length < 2) continue
 		group.sort((a, b) => a.createdAt - b.createdAt || (a.id < b.id ? -1 : 1))
-		for (let i = 0; i < group.length; i++) {
-			indexes.set(group[i].id, i)
+		const ids = group.map((thread) => thread.id)
+		for (const id of ids) {
+			stacks.set(id, ids)
 		}
 	}
-	return indexes
+	return stacks
 }

--- a/packages/commenting/src/canvas/state.ts
+++ b/packages/commenting/src/canvas/state.ts
@@ -21,6 +21,12 @@ import { DEFAULT_SIDEBAR_FILTERS, type SidebarFilters } from './sidebar-filters'
  * @public */
 export const openThreadId = new EditorAtom<string | null>('openThreadId', () => null)
 
+/** The coincident-pin stack whose thread list is showing (keyed by its oldest member's thread
+ * id), or null. Editor state rather than component state: the stack pin remounts when its owning
+ * render path changes (e.g. a member thread opens), and the open list must survive that.
+ * @public */
+export const openStackId = new EditorAtom<string | null>('openStackId', () => null)
+
 /** The comment currently being placed (composer open, not yet posted), or null.
  * @public */
 export const pendingComment = new EditorAtom<PendingComment | null>('pendingComment', () => null)

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -1,0 +1,162 @@
+import { memo, useEffect, useRef } from 'react'
+import { Editor, TLCommentThread, useContainer, useValue } from 'tldraw'
+import { CommentCard } from '../ui/comment-card'
+import { CountBadge } from '../ui/count-badge'
+import { useThreadComments } from './hooks'
+import { useCommentingOptions } from './options'
+import { openStackId, openThreadId } from './state'
+import { anchorPagePoint } from './thread-state'
+import { ThreadPopover, ThreadView, ThreadViewHostProps, toCardProps } from './thread-view'
+
+/**
+ * The pin for threads whose anchors resolve to the same page point — pins zooming can never
+ * separate, so instead of stacked markers they share one count badge. Clicking it opens a
+ * popover listing each thread as a card; clicking a card expands that thread in place (via the
+ * single open-thread state, so expanding one collapses another).
+ */
+export const ThreadStackPin = memo(function ThreadStackPin({
+	editor,
+	threads,
+	impreciseShapeAnchor,
+	...props
+}: ThreadViewHostProps & {
+	editor: Editor
+	/** The stack's threads, oldest first. All resolve to the same anchor point. */
+	threads: readonly TLCommentThread[]
+	impreciseShapeAnchor?: { x: number; y: number }
+}) {
+	const container = useContainer()
+	const badgeRef = useRef<HTMLDivElement>(null)
+	// The list stays open while a member thread is expanded, and on its own after the member
+	// collapses — so Escape steps back: expanded thread → card list → closed. Held in editor
+	// state (not component state) because this pin remounts as its owning render path changes.
+	const stackId = threads[0].id
+	const listOpen = useValue('stack list open', () => openStackId.get(editor) === stackId, [
+		editor,
+		stackId,
+	])
+	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
+	const openMember = threads.find((thread) => thread.id === openId)
+	const open = listOpen || openMember !== undefined
+
+	const point = useValue(
+		'stack point',
+		() => {
+			const first = threads[0]
+			if (first.pageId !== editor.getCurrentPageId()) return null
+			const pagePoint = anchorPagePoint(editor, first.anchor, impreciseShapeAnchor)
+			return pagePoint ? editor.pageToViewport(pagePoint) : null
+		},
+		[editor, threads, impreciseShapeAnchor]
+	)
+
+	// Clicking outside the popover (and off the badge) closes the whole stack — mirrors the
+	// single pin's dismiss. Capture phase + class checks, since the popover portals elsewhere.
+	useEffect(() => {
+		if (!open) return
+		const onPointerDown = (e: PointerEvent) => {
+			const target = e.target as HTMLElement | null
+			if (!target) return
+			if (target.closest('.tlui-cmt-canvas-popover')) return
+			const badge = badgeRef.current
+			if (badge && badge.contains(target)) return
+			// A click inside a menu/popover layered above us belongs to that layer; defer to its
+			// own dismissal instead of closing the stack out from under it.
+			if (
+				target.closest('.tlui-menu, [data-radix-popper-content-wrapper], .tlui-cmt-mention-popup')
+			)
+				return
+			openStackId.set(editor, null)
+			openThreadId.set(editor, null)
+		}
+		document.addEventListener('pointerdown', onPointerDown, true)
+		return () => document.removeEventListener('pointerdown', onPointerDown, true)
+	}, [open, editor])
+
+	// Escape with only the card list showing closes it. When a member thread is expanded, the
+	// layer's Escape handler collapses that first and marks the event consumed — stepping back
+	// to the list rather than closing everything at once.
+	useEffect(() => {
+		if (!listOpen) return
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape' || e.defaultPrevented) return
+			openStackId.set(editor, null)
+		}
+		document.addEventListener('keydown', onKeyDown, true)
+		return () => document.removeEventListener('keydown', onKeyDown, true)
+	}, [listOpen, editor])
+
+	if (!point) return null
+
+	const toggle = () => {
+		if (open) {
+			openStackId.set(editor, null)
+			openThreadId.set(editor, null)
+		} else {
+			openStackId.set(editor, stackId)
+		}
+	}
+
+	return (
+		<>
+			<div className="tlui-cmt-canvas-pin" style={{ left: point.x, top: point.y }}>
+				<div
+					ref={badgeRef}
+					className="tlui-cmt-canvas-stack-badge"
+					onPointerDown={(e) => e.stopPropagation()}
+					onClick={(e) => {
+						e.stopPropagation()
+						toggle()
+					}}
+				>
+					<CountBadge count={threads.length} />
+				</div>
+			</div>
+			{open && (
+				<ThreadPopover container={container} style={{ left: point.x + 36, top: point.y - 28 }}>
+					<div className="tlui-cmt-stack-list">
+						{threads.map((thread) =>
+							thread.id === openId ? (
+								<div key={thread.id} className="tlui-cmt-stack-list__thread">
+									<ThreadView editor={editor} thread={thread} {...props} />
+								</div>
+							) : (
+								<StackThreadCard
+									key={thread.id}
+									editor={editor}
+									thread={thread}
+									{...props}
+									onOpen={() => openThreadId.set(editor, thread.id)}
+								/>
+							)
+						)}
+					</div>
+				</ThreadPopover>
+			)}
+		</>
+	)
+})
+
+/** A collapsed stack entry: the thread's first comment as a card; clicking expands the thread. */
+function StackThreadCard({
+	editor,
+	thread,
+	onOpen,
+	...props
+}: ThreadViewHostProps & { editor: Editor; thread: TLCommentThread; onOpen(): void }) {
+	const options = useCommentingOptions()
+	const comments = useThreadComments(editor, thread.id)
+	const first = comments[0]
+	if (!first) return null
+	return (
+		<div
+			className="tlui-cmt-stack-list__card"
+			onClick={(e) => {
+				e.stopPropagation()
+				onOpen()
+			}}
+		>
+			<CommentCard {...toCardProps(first, props, options.components)} />
+		</div>
+	)
+}

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -1,0 +1,288 @@
+import { ReactNode, useEffect, useRef, useState, type CSSProperties } from 'react'
+import { createPortal } from 'react-dom'
+import {
+	createComment,
+	Editor,
+	TLComment,
+	TLCommentId,
+	TLCommentThread,
+	TLRichText,
+	TldrawUiIcon,
+	usePassThroughMouseOverEvents,
+	usePassThroughWheelEvents,
+	useTranslation,
+} from 'tldraw'
+import { CommentCard, CommentCardProps } from '../ui/comment-card'
+import { CommentComposer } from '../ui/comment-composer'
+import { EMPTY_COMMENT, isCommentEmpty } from '../ui/comment-extensions'
+import { CommentThread } from '../ui/comment-thread'
+import { MentionMember } from '../ui/mention-list'
+import { CommentBody } from './comment-body'
+import { UNKNOWN_AUTHOR } from './comment-render'
+import { putCommentRecords, removeCommentRecords } from './comment-store'
+import { useThreadComments } from './hooks'
+import { type CommentingComponents, useCommentingOptions } from './options'
+import { commitCommentMutation, openThreadId } from './state'
+
+/** The identity/callback props a thread view needs from the host — the same contract
+ *  `CanvasComments` takes, minus the pin-placement concerns. */
+export interface ThreadViewHostProps {
+	currentUserId: string | null
+	resolveName(id: string): string | undefined
+	onPostComment?(comment: TLComment): void
+	isCommentUnread?(commentId: TLCommentId): boolean
+	onCommentRead?(commentId: TLCommentId): void
+	getMentionSuggestions?(query: string): MentionMember[] | Promise<MentionMember[]>
+	renderMentionSuggestion?(member: MentionMember): ReactNode
+}
+
+export function toCardProps(
+	comment: TLComment,
+	props: Pick<ThreadViewHostProps, 'currentUserId' | 'resolveName'>,
+	components: CommentingComponents
+): CommentCardProps {
+	const Body = components.CommentBody
+	// The `CommentBody` component slot overrides the built-in rich-text default (which resolves
+	// mention ids to names).
+	const body = Body ? (
+		<Body comment={comment} />
+	) : (
+		<CommentBody richText={comment.body} resolveName={props.resolveName} />
+	)
+	return {
+		author: props.resolveName(comment.authorId) ?? UNKNOWN_AUTHOR,
+		body,
+		date: new Date(comment.createdAt).toISOString(),
+		you: comment.authorId === props.currentUserId,
+		edited: comment.editedAt != null,
+	}
+}
+
+/** The open thread's popover container, portaled above the UI panels. Over it, wheel and hover
+ *  events pass through to the canvas (unless it scrolls its own content), like tldraw's panels. */
+export function ThreadPopover({
+	container,
+	style,
+	children,
+}: {
+	container: HTMLElement
+	style: CSSProperties
+	children: ReactNode
+}) {
+	const ref = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(ref)
+	usePassThroughMouseOverEvents(ref)
+	return createPortal(
+		<div
+			ref={ref}
+			className="tlui-cmt-canvas-popover"
+			style={style}
+			onPointerDown={(e) => e.stopPropagation()}
+		>
+			{children}
+		</div>,
+		container
+	)
+}
+
+/**
+ * One thread's interactive view: its comments, the reply composer, edit-in-place on your own
+ * comments, and the resolve/delete/dismiss actions. Reads and writes comment records via the
+ * editor's store; read receipts are reported for every unread comment while mounted, so only
+ * mount it where the thread is actually being shown.
+ */
+export function ThreadView({
+	editor,
+	thread,
+	...props
+}: ThreadViewHostProps & { editor: Editor; thread: TLCommentThread }) {
+	const {
+		currentUserId,
+		resolveName,
+		onPostComment,
+		isCommentUnread,
+		onCommentRead,
+		getMentionSuggestions,
+		renderMentionSuggestion,
+	} = props
+	const options = useCommentingOptions()
+	const comments = useThreadComments(editor, thread.id)
+	const msg = useTranslation()
+	const [reply, setReply] = useState<TLRichText>(EMPTY_COMMENT)
+	const [editingId, setEditingId] = useState<string | null>(null)
+	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
+
+	// Every unread comment on display gets reported read — including replies that arrive while
+	// the view stays mounted, since the effect re-runs as `comments` changes. The host's receipt
+	// write flips isCommentUnread to false, so re-runs find nothing to report.
+	useEffect(() => {
+		if (!isCommentUnread || !onCommentRead) return
+		for (const comment of comments) {
+			if (isCommentUnread(comment.id)) {
+				onCommentRead(comment.id)
+			}
+		}
+	}, [comments, isCommentUnread, onCommentRead])
+
+	const postReply = () => {
+		if (isCommentEmpty(reply) || !currentUserId) return
+		commitCommentMutation(editor, () => {
+			const comment = createComment({
+				threadId: thread.id,
+				pageId: thread.pageId,
+				authorId: currentUserId,
+				body: reply,
+			})
+			putCommentRecords(editor, [comment])
+			if (onPostComment) onPostComment(comment)
+		})
+		setReply(EMPTY_COMMENT)
+	}
+
+	const toggleResolve = () => {
+		if (!currentUserId) return
+		commitCommentMutation(editor, () => {
+			putCommentRecords(editor, [
+				{
+					...thread,
+					resolved: thread.resolved ? null : { at: Date.now(), by: currentUserId },
+				},
+			])
+		})
+	}
+
+	const deleteThread = () => {
+		openThreadId.set(editor, null)
+		commitCommentMutation(editor, () =>
+			removeCommentRecords(editor, [thread.id, ...comments.map((c) => c.id)])
+		)
+	}
+
+	const startEdit = (comment: TLComment) => {
+		setEditingId(comment.id)
+		setEditText(comment.body)
+	}
+
+	const saveEdit = () => {
+		const comment = comments.find((c) => c.id === editingId)
+		if (!comment || isCommentEmpty(editText)) return
+		commitCommentMutation(editor, () => {
+			putCommentRecords(editor, [{ ...comment, body: editText, editedAt: Date.now() }])
+		})
+		setEditingId(null)
+	}
+
+	// Swap a comment for a pre-filled composer while it's being edited; otherwise show the card,
+	// with an edit affordance on your own comments.
+	const renderComment = (card: CommentCardProps, index: number): ReactNode => {
+		const comment = comments[index]
+		if (editingId === comment.id) {
+			return (
+				<div
+					className="tlui-cmt-editing"
+					onKeyDown={(e) => {
+						if (e.key === 'Escape') {
+							setEditingId(null)
+							e.stopPropagation()
+						}
+					}}
+				>
+					<CommentComposer
+						author={card.author}
+						placeholder={msg('comments.edit-placeholder')}
+						value={editText}
+						onChange={setEditText}
+						onSubmit={saveEdit}
+						sendLabel={msg('comments.save')}
+						disabled={isCommentEmpty(editText)}
+						getMentionSuggestions={getMentionSuggestions}
+						renderMentionSuggestion={renderMentionSuggestion}
+						autoFocus
+					/>
+				</div>
+			)
+		}
+		return (
+			<CommentCard
+				{...card}
+				actions={
+					comment.authorId === currentUserId ? (
+						<button
+							className="tlui-cmt-thread__action"
+							title={msg('comments.edit')}
+							onClick={() => startEdit(comment)}
+						>
+							<TldrawUiIcon icon="dots-horizontal" label={msg('comments.edit')} small />
+						</button>
+					) : undefined
+				}
+			/>
+		)
+	}
+
+	const headerActions = (
+		<>
+			{currentUserId && (
+				<button
+					className="tlui-cmt-thread__action"
+					title={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
+					onClick={toggleResolve}
+				>
+					<TldrawUiIcon
+						icon="check"
+						label={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
+						small
+					/>
+				</button>
+			)}
+			{currentUserId && (
+				<button
+					className="tlui-cmt-thread__action"
+					title={msg('comments.delete')}
+					onClick={deleteThread}
+				>
+					<TldrawUiIcon icon="trash" label={msg('comments.delete')} small />
+				</button>
+			)}
+			<button
+				className="tlui-cmt-thread__action"
+				title={msg('comments.dismiss')}
+				onClick={() => openThreadId.set(editor, null)}
+			>
+				<TldrawUiIcon icon="cross-2" label={msg('comments.dismiss')} small />
+			</button>
+		</>
+	)
+
+	return (
+		<CommentThread
+			header={msg('comments.thread-title')}
+			headerActions={headerActions}
+			renderComment={renderComment}
+			comments={comments.map((c) => toCardProps(c, props, options.components))}
+			resolvedBanner={
+				thread.resolved
+					? msg('comments.resolved-by').replace(
+							'{name}',
+							resolveName(thread.resolved.by) ?? UNKNOWN_AUTHOR
+						)
+					: undefined
+			}
+			composer={
+				currentUserId && !thread.resolved
+					? {
+							author: resolveName(currentUserId) ?? UNKNOWN_AUTHOR,
+							placeholder: msg('comments.reply-placeholder'),
+							sendLabel: msg('comments.send'),
+							value: reply,
+							onChange: setReply,
+							onSubmit: postReply,
+							disabled: isCommentEmpty(reply),
+							getMentionSuggestions,
+							renderMentionSuggestion,
+						}
+					: undefined
+			}
+		/>
+	)
+}

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -36,7 +36,7 @@ export {
 	type PendingComment,
 } from './canvas/comment-tool'
 export { collectClusterLeaves } from './canvas/cluster-input'
-export { computePinStacks, PIN_STACK_STEP_PX } from './canvas/pin-stacking'
+export { computePinStacks } from './canvas/pin-stacking'
 export { computeClusterTable } from './clustering/computeClusterTable'
 export {
 	getCommentRecord,
@@ -75,6 +75,7 @@ export {
 	commentsHidden,
 	commentsSidebarOpen,
 	commitCommentMutation,
+	openStackId,
 	openThreadId,
 	pendingComment,
 	sidebarFilters,

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -36,6 +36,7 @@ export {
 	type PendingComment,
 } from './canvas/comment-tool'
 export { collectClusterLeaves } from './canvas/cluster-input'
+export { computePinStacks, PIN_STACK_STEP_PX } from './canvas/pin-stacking'
 export { computeClusterTable } from './clustering/computeClusterTable'
 export {
 	getCommentRecord,


### PR DESCRIPTION
Multiple imprecise comments on one shape all resolve to the same anchor point (the imprecise-anchor spot, top-right by default), so their pins render pixel-identical at every zoom. Only the top pin is reachable; the clustering badge's zoom-to-split lands on the same coincident overlap it started from, so the buried threads can never be opened.

This makes coincident pins a single count badge (the cluster badge's face) that opens the threads as a list of cards. Clicking a card expands that thread inline — reply composer, edit, resolve, delete — while the others stay collapsed; expanding one collapses the other via the existing single-open-thread state. Escape steps back: expanded thread → card list → closed.

How it's put together:

- `computePinStacks` groups threads by their resolved page-space anchor point (camera-independent, so it never recomputes on camera moves) with a small quantum to absorb float noise. Groups of 2+ render as one `ThreadStackPin`; everything else pins as before.
- The layer picks one *owner* member per group to render the stack, decided across all render paths — members can arrive via different paths (a leaf via clustering while its open sibling renders via the open slot), so ownership can't be decided per-path.
- The thread popover's interactive content moved out of `ThreadPin` into `ThreadView`, shared by the single-pin popover and the stack's expanded card. `ThreadPin` keeps the positioning/drag/region concerns.
- The list's open state is a new editor atom (`openStackId`) rather than component state: the stack pin remounts when its owning render path changes (exactly when a member opens), and the open list must survive that.
- Stack-list styling: cards flattened to a single surface (same pattern as the thread panel's card flattening), opaque `--tl-color-low` hover (the card floats over the canvas, so translucent tokens would let shapes show through), and the scroll container's clip box padded outward so card shadows aren't clipped.

Known limitation: threads can't be dragged apart while stacked — the badge has no drag affordance. `ThreadView`/`ThreadStackPin` are not exported from the package barrel yet; `computePinStacks` and `openStackId` are.

### Change type

- [x] `bugfix`

### Test plan

1. Place two comments on the same shape with default clicks (no Alt).
2. A count badge renders at the shape's anchor instead of stacked pins.
3. Click the badge → both threads listed as cards; click a card → it expands with a working reply composer; click the other card → it expands and the first collapses.
4. Escape collapses the expanded thread back to the list; Escape again closes the list.
5. Zoom out until the badge folds into clustering and back — the stack badge returns after the split.
6. A lone comment's pin, popover, drag, and region behaviour are unchanged.

- [x] Unit tests

### Release notes

- Fixed comments placed on the same shape overlapping into an unreachable stack of pins; they now show as a count badge that opens the threads as a list.