### PR TITLE
improvement(commenting): sidebar polish — defaults, page chips, header, eye toggle, dot avatars, and an example

### DIFF
--- a/apps/examples/src/examples/collaboration/commenting-sidebar/CommentingSidebarExample.tsx
+++ b/apps/examples/src/examples/collaboration/commenting-sidebar/CommentingSidebarExample.tsx
@@ -1,0 +1,170 @@
+import {
+	CanvasComments,
+	CanvasCommentsSidebar,
+	commentsSidebarOpen,
+	commentToolOverrides,
+	commentTools,
+	getCommentThreads,
+	putCommentRecords,
+	toggleCommentsSidebar,
+} from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useMemo } from 'react'
+import {
+	commentSchemaRecords,
+	createComment,
+	createCommentThread,
+	createShapeId,
+	createTLSchema,
+	createTLStore,
+	Editor,
+	TLComponents,
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	toRichText,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import '@tldraw/commenting/commenting.css'
+import 'tldraw/tldraw.css'
+
+// A tiny local user directory so the list shows names instead of ids.
+const NAMES: Record<string, string> = {
+	me: 'You',
+	ada: 'Ada Lovelace',
+	grace: 'Grace Hopper',
+}
+const resolveName = (id: string): string => NAMES[id] ?? id
+
+// Two pages with a thread each (so the sidebar's every-page default and page labels have
+// something to show) plus a resolved thread, hidden until "show resolved" is toggled on.
+function seed(editor: Editor) {
+	// Hot reload and remounts re-run onMount — never seed twice.
+	if (getCommentThreads(editor).length > 0) return
+
+	const pageOne = editor.getCurrentPageId()
+	const boxOne = createShapeId('sidebar-box-one')
+	editor.createShape({ id: boxOne, type: 'geo', x: 180, y: 140, props: { w: 320, h: 220 } })
+
+	editor.createPage({ name: 'Page 2' })
+	const pageTwo = editor.getPages()[1].id
+	editor.setCurrentPage(pageTwo)
+	const boxTwo = createShapeId('sidebar-box-two')
+	editor.createShape({
+		id: boxTwo,
+		type: 'geo',
+		x: 240,
+		y: 200,
+		props: { w: 280, h: 200, geo: 'ellipse' },
+	})
+	editor.setCurrentPage(pageOne)
+
+	const now = Date.now()
+	const records = [
+		{
+			pageId: pageOne,
+			shapeId: boxOne,
+			author: 'ada',
+			text: 'Is this the final position for this box?',
+			minutesAgo: 45,
+		},
+		{
+			pageId: pageTwo,
+			shapeId: boxTwo,
+			author: 'grace',
+			text: 'The ellipse reads better than the rectangle did.',
+			minutesAgo: 20,
+		},
+	].flatMap(({ pageId, shapeId, author, text, minutesAgo }) => {
+		const thread = createCommentThread({
+			pageId,
+			anchor: { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: false },
+			createdBy: author,
+		})
+		const comment = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: author,
+			body: toRichText(text),
+		})
+		const createdAt = now - minutesAgo * 60_000
+		return [
+			{ ...thread, createdAt },
+			{ ...comment, createdAt },
+		]
+	})
+
+	const resolvedThread = createCommentThread({
+		pageId: pageOne,
+		anchor: { type: 'point', x: 620, y: 420 },
+		createdBy: 'me',
+	})
+	const resolvedComment = createComment({
+		threadId: resolvedThread.id,
+		pageId: pageOne,
+		authorId: 'me',
+		body: toRichText('Fixed the spacing here.'),
+	})
+	records.push(
+		{
+			...resolvedThread,
+			createdAt: now - 90 * 60_000,
+			resolved: { at: now - 60 * 60_000, by: 'me' },
+		},
+		{ ...resolvedComment, createdAt: now - 90 * 60_000 }
+	)
+
+	putCommentRecords(editor, records)
+	commentsSidebarOpen.set(editor, true)
+}
+
+// The host supplies the sidebar's open/close affordance. Here it's a button in the share-panel
+// slot — the same top-right spot tldraw.com uses. (The comment tool closes the sidebar while
+// it's active, so the button is how it comes back.)
+function SidebarToggle() {
+	const editor = useEditor()
+	const open = useValue('sidebar open', () => commentsSidebarOpen.get(editor), [editor])
+	return (
+		<div style={{ pointerEvents: 'all', display: 'flex', padding: 4 }}>
+			<TldrawUiButton type="normal" onClick={() => toggleCommentsSidebar(editor)}>
+				<TldrawUiButtonLabel>{open ? 'Hide comments' : 'Comments'}</TldrawUiButtonLabel>
+			</TldrawUiButton>
+		</div>
+	)
+}
+
+export default function CommentingSidebarExample() {
+	// Comments are stored as records in the editor's own store — registering the comment schema
+	// records is all it takes to persist and sync them alongside shapes.
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	const components = useMemo<TLComponents>(
+		() => ({
+			InFrontOfTheCanvas: () => (
+				<>
+					<CanvasComments currentUserId="me" resolveName={resolveName} />
+					<CanvasCommentsSidebar currentUserId="me" resolveName={resolveName} />
+				</>
+			),
+			SharePanel: SidebarToggle,
+		}),
+		[]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				licenseKey={getLicenseKey()}
+				store={store}
+				tools={commentTools}
+				overrides={[commentToolOverrides]}
+				components={components}
+				onMount={seed}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/commenting-sidebar/README.md
+++ b/apps/examples/src/examples/collaboration/commenting-sidebar/README.md
@@ -1,0 +1,8 @@
+---
+title: Commenting sidebar
+component: ./CommentingSidebarExample.tsx
+priority: 2
+keywords: [comments, commenting, sidebar, list, panel, threads, filters]
+---
+
+A thread list panel beside the canvas: every page's comments, filterable, with a host-supplied toggle button.

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -275,6 +275,9 @@ export function CommentsOverflowMenu(): JSX.Element;
 export const commentsSidebarOpen: EditorAtom<boolean>;
 
 // @public
+export function CommentsVisibilityToggle(): JSX.Element;
+
+// @public
 export function CommentText({ text }: CommentTextProps): JSX.Element;
 
 // @public (undocumented)

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -351,7 +351,7 @@ export const DEFAULT_IMPRECISE_SHAPE_ANCHOR: {
 // @public
 export const DEFAULT_REGION_COMMENT_OPTIONS: RegionCommentOptions;
 
-// @public (undocumented)
+// @public
 export const DEFAULT_SIDEBAR_FILTERS: SidebarFilters;
 
 // @public

--- a/packages/commenting/src/canvas/comments-filter-menu.tsx
+++ b/packages/commenting/src/canvas/comments-filter-menu.tsx
@@ -45,7 +45,12 @@ export function CommentsFilterMenu({
 					<FilterIcon />
 				</button>
 			</TldrawUiDropdownMenuTrigger>
-			<TldrawUiDropdownMenuContent side="bottom" align="start">
+			<TldrawUiDropdownMenuContent
+				className="tlui-cmt-menu"
+				side="bottom"
+				align="end"
+				alignOffset={0}
+			>
 				<TldrawUiMenuContextProvider type="menu" sourceId="menu">
 					<TldrawUiMenuGroup id="comments-filter">
 						<TldrawUiMenuCheckboxItem
@@ -85,20 +90,13 @@ export function CommentsFilterMenu({
 
 function FilterIcon() {
 	return (
-		<svg
-			width="16"
-			height="16"
-			viewBox="0 0 16 16"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-			aria-hidden="true"
-		>
-			<line x1="2.5" y1="5" x2="13.5" y2="5" />
-			<line x1="2.5" y1="11" x2="13.5" y2="11" />
-			<circle cx="6" cy="5" r="1.9" fill="currentColor" stroke="none" />
-			<circle cx="10.5" cy="11" r="1.9" fill="currentColor" stroke="none" />
+		<svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
+			<path
+				d="M5.5 3C4.67157 3 4 3.67157 4 4.5C4 5.32843 4.67157 6 5.5 6C6.32843 6 7 5.32843 7 4.5C7 3.67157 6.32843 3 5.5 3ZM3 5C3.01671 5 3.03323 4.99918 3.04952 4.99758C3.28022 6.1399 4.28967 7 5.5 7C6.71033 7 7.71978 6.1399 7.95048 4.99758C7.96677 4.99918 7.98329 5 8 5H13.5C13.7761 5 14 4.77614 14 4.5C14 4.22386 13.7761 4 13.5 4H8C7.98329 4 7.96677 4.00082 7.95048 4.00242C7.71978 2.86009 6.71033 2 5.5 2C4.28967 2 3.28022 2.86009 3.04952 4.00242C3.03323 4.00082 3.01671 4 3 4H1.5C1.22386 4 1 4.22386 1 4.5C1 4.77614 1.22386 5 1.5 5H3ZM11.9505 10.9976C11.7198 12.1399 10.7103 13 9.5 13C8.28967 13 7.28022 12.1399 7.04952 10.9976C7.03323 10.9992 7.01671 11 7 11H1.5C1.22386 11 1 10.7761 1 10.5C1 10.2239 1.22386 10 1.5 10H7C7.01671 10 7.03323 10.0008 7.04952 10.0024C7.28022 8.8601 8.28967 8 9.5 8C10.7103 8 11.7198 8.8601 11.9505 10.0024C11.9668 10.0008 11.9833 10 12 10H13.5C13.7761 10 14 10.2239 14 10.5C14 10.7761 13.7761 11 13.5 11H12C11.9833 11 11.9668 10.9992 11.9505 10.9976ZM8 10.5C8 9.67157 8.67157 9 9.5 9C10.3284 9 11 9.67157 11 10.5C11 11.3284 10.3284 12 9.5 12C8.67157 12 8 11.3284 8 10.5Z"
+				fill="currentColor"
+				fillRule="evenodd"
+				clipRule="evenodd"
+			/>
 		</svg>
 	)
 }

--- a/packages/commenting/src/canvas/comments-overflow-menu.tsx
+++ b/packages/commenting/src/canvas/comments-overflow-menu.tsx
@@ -4,6 +4,7 @@ import {
 	TldrawUiDropdownMenuItem,
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
+	TldrawUiIcon,
 	useEditor,
 	useTranslation,
 	useValue,
@@ -30,10 +31,15 @@ export function CommentsOverflowMenu() {
 					title={msg('comments.more-options')}
 					aria-label={msg('comments.more-options')}
 				>
-					<MoreIcon />
+					<TldrawUiIcon icon="dots-vertical" label={msg('comments.more-options')} small />
 				</button>
 			</TldrawUiDropdownMenuTrigger>
-			<TldrawUiDropdownMenuContent side="bottom" align="end">
+			<TldrawUiDropdownMenuContent
+				className="tlui-cmt-menu"
+				side="bottom"
+				align="end"
+				alignOffset={0}
+			>
 				<TldrawUiDropdownMenuGroup>
 					<TldrawUiDropdownMenuItem>
 						<button
@@ -48,15 +54,5 @@ export function CommentsOverflowMenu() {
 				</TldrawUiDropdownMenuGroup>
 			</TldrawUiDropdownMenuContent>
 		</TldrawUiDropdownMenuRoot>
-	)
-}
-
-function MoreIcon() {
-	return (
-		<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-			<circle cx="3" cy="8" r="1.4" />
-			<circle cx="8" cy="8" r="1.4" />
-			<circle cx="13" cy="8" r="1.4" />
-		</svg>
 	)
 }

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -115,8 +115,12 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				preview,
 				date: new Date((first ?? thread).createdAt).toISOString(),
 				resolved: thread.resolved != null,
-				// The page label only earns its place when there is more than one page.
-				page: pageNames.size > 1 ? pageNames.get(thread.pageId) : undefined,
+				// The page label only earns its place when it adds information: multiple pages
+				// exist, and the thread is somewhere other than where you already are.
+				page:
+					pageNames.size > 1 && thread.pageId !== currentPageId
+						? pageNames.get(thread.pageId)
+						: undefined,
 				count: threadComments.length,
 				selected: openId === thread.id,
 			}

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -115,7 +115,8 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				preview,
 				date: new Date((first ?? thread).createdAt).toISOString(),
 				resolved: thread.resolved != null,
-				page: pageNames.get(thread.pageId),
+				// The page label only earns its place when there is more than one page.
+				page: pageNames.size > 1 ? pageNames.get(thread.pageId) : undefined,
 				count: threadComments.length,
 				selected: openId === thread.id,
 			}

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { CommentListItemProps, CommentsList } from '../ui/comments-list'
 import { UNKNOWN_AUTHOR } from './comment-render'
 import { CommentsFilterMenu } from './comments-filter-menu'
-import { CommentsOverflowMenu } from './comments-overflow-menu'
+import { CommentsVisibilityToggle } from './comments-visibility-toggle'
 import { useComments, useCommentThreads } from './hooks'
 import { useCommentingEnabled } from './license'
 import { useCommentingOptions } from './options'
@@ -145,7 +145,7 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 							canFilterByAuthor={currentUserId !== undefined}
 							canFilterByUnread={isCommentUnread !== undefined}
 						/>
-						<CommentsOverflowMenu />
+						<CommentsVisibilityToggle />
 					</div>
 				}
 				empty={

--- a/packages/commenting/src/canvas/comments-visibility-toggle.tsx
+++ b/packages/commenting/src/canvas/comments-visibility-toggle.tsx
@@ -1,0 +1,51 @@
+import { useEditor, useTranslation, useValue } from 'tldraw'
+import { commentsHidden, toggleCommentsHidden } from './state'
+
+/** The sidebar header's show/hide toggle for comment pins — an eye that closes while comments
+ *  are hidden. The same state as the Shift+C shortcut.
+ * @public @react */
+export function CommentsVisibilityToggle() {
+	const editor = useEditor()
+	const msg = useTranslation()
+	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
+	const label = hidden ? msg('comments.show') : msg('comments.hide')
+
+	return (
+		<button
+			type="button"
+			className="tlui-cmt-header-btn"
+			title={label}
+			aria-label={label}
+			aria-pressed={hidden}
+			onClick={() => toggleCommentsHidden(editor)}
+		>
+			{hidden ? <EyeClosedIcon /> : <EyeOpenIcon />}
+		</button>
+	)
+}
+
+function EyeOpenIcon() {
+	return (
+		<svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
+			<path
+				d="M7.5 11C4.80285 11 2.52952 9.62184 1.09622 7.50001C2.52952 5.37816 4.80285 4 7.5 4C10.1971 4 12.4705 5.37816 13.9038 7.5C12.4705 9.62183 10.1971 11 7.5 11ZM7.5 3C4.30786 3 1.65639 4.70638 0.0760002 7.23501C-0.0253338 7.39715 -0.0253334 7.60288 0.0760014 7.76501C1.65639 10.2936 4.30786 12 7.5 12C10.6921 12 13.3436 10.2936 14.924 7.76501C15.0253 7.60288 15.0253 7.39715 14.924 7.23501C13.3436 4.70638 10.6921 3 7.5 3ZM7.5 9.5C8.60457 9.5 9.5 8.60457 9.5 7.5C9.5 6.39543 8.60457 5.5 7.5 5.5C6.39543 5.5 5.5 6.39543 5.5 7.5C5.5 8.60457 6.39543 9.5 7.5 9.5Z"
+				fill="currentColor"
+				fillRule="evenodd"
+				clipRule="evenodd"
+			/>
+		</svg>
+	)
+}
+
+function EyeClosedIcon() {
+	return (
+		<svg width="15" height="15" viewBox="0 0 15 15" fill="none" aria-hidden="true">
+			<path
+				d="M14.7649 6.07596C14.9991 6.22231 15.0703 6.53079 14.9239 6.76495C14.4849 7.46743 13.9632 8.10645 13.3702 8.66305L14.5712 9.86406C14.7664 10.0593 14.7664 10.3759 14.5712 10.5712C14.3759 10.7664 14.0593 10.7664 13.8641 10.5712L12.6011 9.30817C11.805 9.90283 10.9089 10.3621 9.93375 10.651L10.383 12.3277C10.4544 12.5944 10.2961 12.8685 10.0294 12.94C9.76267 13.0115 9.4885 12.8532 9.41704 12.5865L8.95917 10.8775C8.48743 10.958 8.00036 11 7.50001 11C6.99965 11 6.51257 10.958 6.04082 10.8775L5.58299 12.5864C5.51153 12.8532 5.23737 13.0115 4.97064 12.94C4.7039 12.8686 4.5456 12.5944 4.61706 12.3277L5.06625 10.651C4.09111 10.3621 3.19503 9.90282 2.39889 9.30815L1.1359 10.5712C0.940638 10.7664 0.624058 10.7664 0.428798 10.5712C0.233537 10.3759 0.233537 10.0593 0.428798 9.86405L1.62982 8.66303C1.03682 8.10643 0.515113 7.46742 0.0760677 6.76495C-0.0702867 6.53079 0.000898544 6.22231 0.235065 6.07596C0.469231 5.9296 0.777703 6.00079 0.924058 6.23496C1.40354 7.00213 1.989 7.68057 2.66233 8.2427C2.67315 8.25096 2.6837 8.25972 2.69397 8.26898C4.00897 9.35527 5.65537 10 7.50001 10C10.3078 10 12.6564 8.5063 14.076 6.23495C14.2223 6.00079 14.5308 5.9296 14.7649 6.07596Z"
+				fill="currentColor"
+				fillRule="evenodd"
+				clipRule="evenodd"
+			/>
+		</svg>
+	)
+}

--- a/packages/commenting/src/canvas/sidebar-filters.ts
+++ b/packages/commenting/src/canvas/sidebar-filters.ts
@@ -16,10 +16,11 @@ export interface SidebarFilters {
 	onlyCurrentPage: boolean
 }
 
-/** @public */
+/** The out-of-the-box view: every page's threads, resolved ones hidden until asked for.
+ * @public */
 export const DEFAULT_SIDEBAR_FILTERS: SidebarFilters = {
-	showResolved: true,
+	showResolved: false,
 	onlyMine: false,
 	onlyUnread: false,
-	onlyCurrentPage: true,
+	onlyCurrentPage: false,
 }

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -64,6 +64,7 @@ export {
 	useCommentingOptions,
 } from './canvas/options'
 export { CommentsOverflowMenu } from './canvas/comments-overflow-menu'
+export { CommentsVisibilityToggle } from './canvas/comments-visibility-toggle'
 export { CanvasCommentsSidebar, type CanvasCommentsSidebarProps } from './canvas/comments-sidebar'
 export { useComments, useCommentThreads, useThreadComments } from './canvas/hooks'
 export { useCommentingEnabled } from './canvas/license'

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -597,11 +597,9 @@
 	border-bottom: 1px solid var(--tl-color-divider);
 }
 .tlui-cmt-list__header-title {
-	font-size: 11px;
+	font-size: 13px;
 	font-weight: 600;
-	letter-spacing: 0.06em;
-	text-transform: uppercase;
-	color: var(--tl-color-text-3);
+	color: var(--tl-color-text-1);
 }
 
 /* a small square icon button in the sidebar header (filter funnel, overflow …) */
@@ -687,11 +685,16 @@
 .tlui-cmt-list__item:hover {
 	background: var(--tl-color-muted-2);
 }
-/* Selected sits a step above hover (muted-1 over muted-2) so the open thread's row stays
-   distinguishable while pointing at other rows. */
+/* Selected sits a step above hover so the open thread's row stays distinguishable while
+   pointing at other rows — but only a step: the muted-1 token (10%) reads too heavy here.
+   These rows sit on the opaque sidebar panel, so a translucent tint composes safely. */
 .tlui-cmt-list__item--selected,
 .tlui-cmt-list__item--selected:hover {
-	background: var(--tl-color-muted-1);
+	background: hsl(0, 0%, 0%, 6.5%);
+}
+.tl-theme__dark .tlui-cmt-list__item--selected,
+.tl-theme__dark .tlui-cmt-list__item--selected:hover {
+	background: hsl(0, 0%, 100%, 6.5%);
 }
 /* resolved rows mute their content but keep the "Resolved" marker legible */
 .tlui-cmt-list__item[data-resolved] .tlui-cmt-head,

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -687,8 +687,11 @@
 .tlui-cmt-list__item:hover {
 	background: var(--tl-color-muted-2);
 }
-.tlui-cmt-list__item--selected {
-	background: var(--tl-color-muted-2);
+/* Selected sits a step above hover (muted-1 over muted-2) so the open thread's row stays
+   distinguishable while pointing at other rows. */
+.tlui-cmt-list__item--selected,
+.tlui-cmt-list__item--selected:hover {
+	background: var(--tl-color-muted-1);
 }
 /* resolved rows mute their content but keep the "Resolved" marker legible */
 .tlui-cmt-list__item[data-resolved] .tlui-cmt-head,
@@ -708,6 +711,9 @@
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
+	/* Long unbroken strings (URLs, mashed keys) wrap onto the clamped lines instead of clipping
+	   mid-string — same treatment as the card body. */
+	overflow-wrap: anywhere;
 }
 /* meta line under the preview: page label and/or a resolved marker */
 .tlui-cmt-list__item-meta {

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -690,11 +690,11 @@
    These rows sit on the opaque sidebar panel, so a translucent tint composes safely. */
 .tlui-cmt-list__item--selected,
 .tlui-cmt-list__item--selected:hover {
-	background: hsl(0, 0%, 0%, 6.5%);
+	background: hsl(0, 0%, 0%, 5%);
 }
 .tl-theme__dark .tlui-cmt-list__item--selected,
 .tl-theme__dark .tlui-cmt-list__item--selected:hover {
-	background: hsl(0, 0%, 100%, 6.5%);
+	background: hsl(0, 0%, 100%, 5%);
 }
 /* resolved rows mute their content but keep the "Resolved" marker legible */
 .tlui-cmt-list__item[data-resolved] .tlui-cmt-head,

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -571,6 +571,14 @@
 	display: none;
 }
 
+/* The sidebar's rows use the same small colour dot as the thread view. */
+.tlui-cmt-list .tlui-cmt-avatar {
+	width: 14px;
+	height: 14px;
+	font-size: 0;
+	margin-top: 2px;
+}
+
 /* inside the panel, comments are plain content — no surrounding box; the composer's field carries
    its own surface. */
 .tlui-cmt-thread .tlui-cmt-card {


### PR DESCRIPTION
Works through the sidebar items from the commenting UI/UX list, rebased onto the current `commenting` (includes #9643).

**Defaults and scoping**
- The sidebar shows every page's threads out of the box (`onlyCurrentPage: false`) with resolved threads hidden until asked for (`showResolved: false`); both remain toggles in the filter menu.
- The page chip only renders when it adds information: multiple pages exist *and* the thread lives on a page other than the current one.

**List polish**
- Previews wrap unbroken strings (`overflow-wrap: anywhere`, matching the comment cards) instead of clipping mid-string against the two-line clamp.
- Rows use the same 14px colour-dot avatars as the thread view.
- The selected (open) thread's row sits a small step above hover (5% vs the 4.3% muted token, with a dark-theme variant) so it stays distinguishable without reading as a slab.

**Header**
- Title reads "Comments" (13px), not small-caps COMMENTS.
- The filter menu hugs its trigger's right edge (it was start-aligned beside the viewport edge, so Radix's collision handling shoved it left) and uses the settings/mixer glyph as its trigger icon.
- The overflow kebab is gone: a direct eye toggle shows/hides comment pins (open/closed eye, `aria-pressed`, same `commentsHidden` state as Shift+C). `CommentsOverflowMenu` stays exported for compatibility; the sidebar just no longer mounts it.

**Example**
- New `commenting-sidebar` example wiring `CanvasCommentsSidebar` beside `CanvasComments`, with a host toggle button in the `SharePanel` slot (the comment tool closes the sidebar on activation by design, so reopening is a host affordance — same as tldraw.com's button). Seeded with threads across two pages plus one resolved so the filters and chips have something to show.

Not addressed, deliberately: the "complete vs resolve" wording and page grouping — both are open decisions on the list.

### Change type

- [x] `improvement`

### Test plan

1. Open the `commenting-sidebar` example and toggle the sidebar via the header button.
2. Default list shows unresolved threads from all pages; the current page's threads carry no page chip, other pages' do; "Show resolved comments" reveals the resolved row.
3. Filter menu opens flush under its trigger; the trigger is the settings glyph.
4. The eye button hides and restores comment pins, staying in sync with Shift+C.
5. Select a row: it highlights a step above hover and navigates to the thread.
6. A comment whose text is one long unbroken string wraps inside the preview clamp.

- [x] Unit tests

### Release notes

- Improved the comments sidebar: sensible defaults (all pages, resolved hidden), smarter page labels, tidier header with a comment-visibility eye toggle, and consistent avatars.

### API Changes

- `DEFAULT_SIDEBAR_FILTERS` values changed: `showResolved` and `onlyCurrentPage` both default to `false` now.
- New export: `CommentsVisibilityToggle`. `CommentsOverflowMenu` remains exported but is no longer mounted by `CanvasCommentsSidebar`.