### PR TITLE
feat(dotcom): add asset diagnostics to the admin page

### DIFF
--- a/apps/dotcom/client/src/pages/admin.module.css
+++ b/apps/dotcom/client/src/pages/admin.module.css
@@ -391,3 +391,24 @@
 		grid-template-columns: 1fr;
 	}
 }
+
+/* Asset diagnostics */
+.diagnosticsTable {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 12px;
+	font-family: monospace;
+}
+
+.diagnosticsTable th,
+.diagnosticsTable td {
+	text-align: left;
+	padding: var(--tl-space-2) var(--tl-space-3);
+	border-bottom: 1px solid var(--tl-color-divider);
+	word-break: break-all;
+}
+
+.diagnosticsTable th {
+	font-weight: 600;
+	color: var(--tl-color-text-3);
+}

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -806,9 +806,8 @@ function AssetDiagnostics() {
 		<div className={styles.fileOperation}>
 			<h4 className="tla-text_ui__medium">Asset diagnostics</h4>
 			<p className="tla-text_ui__regular">
-				Checks every asset in a file&apos;s last persisted snapshot: is its object still in the
-				uploads bucket, and is it associated with the file? Reads the persisted snapshot, which can
-				lag a live room by a persist tick.
+				Checks whether each asset in the file&apos;s last persisted snapshot exists in the uploads
+				bucket and is associated with the file.
 			</p>
 			{error && <div className={styles.errorMessage}>{error}</div>}
 			<div className={styles.searchContainer}>

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -779,6 +779,12 @@ function DownloadTldrFile({ legacy }: { legacy: boolean }) {
 	)
 }
 
+function formatBytes(bytes: number) {
+	if (bytes < 1024) return `${bytes} B`
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
 function AssetDiagnostics() {
 	const inputRef = useRef<HTMLInputElement>(null)
 	const [error, setError] = useState(null as string | null)
@@ -841,7 +847,22 @@ function AssetDiagnostics() {
 					<div className={styles.userSummary}>
 						<div className={styles.summaryGrid}>
 							{[
+								[
+									'Shapes',
+									`${report.shapes.total}${
+										report.shapes.total > 0
+											? ` (${Object.entries(report.shapes.byType)
+													.sort((a, b) => b[1] - a[1])
+													.map(([type, count]) => `${count} ${type}`)
+													.join(', ')})`
+											: ''
+									}`,
+								],
 								['Total assets', report.assets.total],
+								[
+									'Asset size',
+									`${formatBytes(report.assets.totalSizeBytes)} (largest ${formatBytes(report.assets.largestSizeBytes)})`,
+								],
 								['Associated', report.assets.associated],
 								['Pending association', report.assets.pending],
 								['Missing in bucket', report.assets.missingInBucket],

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -246,6 +246,7 @@ export function Component() {
 						<DownloadTldrFile legacy={false} />
 						<DownloadTldrFile legacy={true} />
 						<CreateLegacyFile />
+						<AssetDiagnostics />
 					</div>
 				</section>
 
@@ -768,6 +769,123 @@ function DownloadTldrFile({ legacy }: { legacy: boolean }) {
 					Download
 				</TlaButton>
 			</div>
+		</div>
+	)
+}
+
+function AssetDiagnostics() {
+	const inputRef = useRef<HTMLInputElement>(null)
+	const [error, setError] = useState(null as string | null)
+	const [isLoading, setIsLoading] = useState(false)
+	const [report, setReport] = useState<any>(null)
+
+	const onCheck = useCallback(async () => {
+		const slug = inputRef.current?.value?.trim()
+		if (!slug) {
+			setError('Please enter a file slug')
+			return
+		}
+		setError(null)
+		setReport(null)
+		setIsLoading(true)
+		try {
+			const res = await fetch(`/api/app/admin/file-assets/${encodeURIComponent(slug)}`)
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			setReport(await res.json())
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to check assets')
+		} finally {
+			setIsLoading(false)
+		}
+	}, [])
+
+	return (
+		<div className={styles.fileOperation}>
+			<h4 className="tla-text_ui__medium">Asset diagnostics</h4>
+			<p className="tla-text_ui__regular">
+				Checks every asset in a file&apos;s last persisted snapshot: is its object still in the
+				uploads bucket, and is it associated with the file? Reads the persisted snapshot, which can
+				lag a live room by a persist tick.
+			</p>
+			{error && <div className={styles.errorMessage}>{error}</div>}
+			<div className={styles.searchContainer}>
+				<input
+					type="text"
+					placeholder="File slug"
+					ref={inputRef}
+					className={styles.searchInput}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') onCheck()
+					}}
+				/>
+				<TlaButton onClick={onCheck} variant="primary" isLoading={isLoading}>
+					Check assets
+				</TlaButton>
+			</div>
+			{report && (
+				<>
+					<div className={styles.userSummary}>
+						<div className={styles.summaryGrid}>
+							{[
+								['Total assets', report.assets.total],
+								['Associated', report.assets.associated],
+								['Pending association', report.assets.pending],
+								['Missing in bucket', report.assets.missingInBucket],
+								['Old-format URLs', report.assets.oldFormatUrls],
+								[
+									'DB asset rows',
+									`${report.dbRows.forThisFile} (${report.dbRows.orphaned} orphaned)`,
+								],
+								[
+									'Create source',
+									report.source
+										? `${report.source.raw} ${
+												report.source.exists === null
+													? '(not checked)'
+													: report.source.exists
+														? '(exists)'
+														: '⚠️ (missing)'
+											}`
+										: 'none',
+								],
+							].map(([label, value]) => (
+								<div key={label} className={styles.summaryItem}>
+									<span className={styles.fieldLabel}>{label}:</span>
+									<span className={styles.fieldValue}>{value}</span>
+								</div>
+							))}
+						</div>
+					</div>
+					{report.assets.problems.length > 0 && (
+						<table className={styles.diagnosticsTable}>
+							<thead>
+								<tr>
+									<th>Asset</th>
+									<th>Object name</th>
+									<th>In bucket</th>
+									<th>Meta fileId</th>
+									<th>DB fileId</th>
+								</tr>
+							</thead>
+							<tbody>
+								{report.assets.problems.map((p: any) => (
+									<tr key={p.assetId}>
+										<td>{p.assetId}</td>
+										<td>{p.objectName}</td>
+										<td>{p.inBucket ? 'yes' : 'MISSING'}</td>
+										<td>{p.fileIdMeta ?? 'none'}</td>
+										<td>{p.dbRow?.fileId ?? 'none'}</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					)}
+					<StructuredDataDisplay data={report} />
+				</>
+			)}
 		</div>
 	)
 }

--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -1,4 +1,10 @@
-import { FeatureFlagValue, PercentageFeatureFlag, TlaFile, ZStoreData } from '@tldraw/dotcom-shared'
+import {
+	AdminFileAssetsResponseBody,
+	FeatureFlagValue,
+	PercentageFeatureFlag,
+	TlaFile,
+	ZStoreData,
+} from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Navigate } from 'react-router-dom'
 import { fetch } from 'tldraw'
@@ -8,7 +14,7 @@ import { useTldrawCurrentUser } from '../tla/hooks/useUser'
 import styles from './admin.module.css'
 
 // Helper component for structured data display.
-function StructuredDataDisplay({ data }: { data: ZStoreData }) {
+function StructuredDataDisplay({ data }: { data: object }) {
 	const [copied, setCopied] = useState(false)
 
 	const handleCopy = async () => {
@@ -777,7 +783,7 @@ function AssetDiagnostics() {
 	const inputRef = useRef<HTMLInputElement>(null)
 	const [error, setError] = useState(null as string | null)
 	const [isLoading, setIsLoading] = useState(false)
-	const [report, setReport] = useState<any>(null)
+	const [report, setReport] = useState(null as AdminFileAssetsResponseBody | null)
 
 	const onCheck = useCallback(async () => {
 		const slug = inputRef.current?.value?.trim()
@@ -794,7 +800,7 @@ function AssetDiagnostics() {
 				setError(res.statusText + ': ' + (await res.text()))
 				return
 			}
-			setReport(await res.json())
+			setReport((await res.json()) as AdminFileAssetsResponseBody)
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Failed to check assets')
 		} finally {
@@ -826,6 +832,12 @@ function AssetDiagnostics() {
 			</div>
 			{report && (
 				<>
+					{report.warnings.length > 0 && (
+						<div className={styles.errorMessage}>
+							{report.warnings.length} check(s) failed — counts below may be incomplete.{' '}
+							{report.warnings.slice(0, 3).join('; ')}
+						</div>
+					)}
 					<div className={styles.userSummary}>
 						<div className={styles.summaryGrid}>
 							{[
@@ -833,6 +845,7 @@ function AssetDiagnostics() {
 								['Associated', report.assets.associated],
 								['Pending association', report.assets.pending],
 								['Missing in bucket', report.assets.missingInBucket],
+								['Head check failures', report.assets.headFailures],
 								['Old-format URLs', report.assets.oldFormatUrls],
 								[
 									'DB asset rows',
@@ -870,11 +883,11 @@ function AssetDiagnostics() {
 								</tr>
 							</thead>
 							<tbody>
-								{report.assets.problems.map((p: any) => (
+								{report.assets.problems.map((p) => (
 									<tr key={p.assetId}>
 										<td>{p.assetId}</td>
 										<td>{p.objectName}</td>
-										<td>{p.inBucket ? 'yes' : 'MISSING'}</td>
+										<td>{p.inBucket === null ? 'check failed' : p.inBucket ? 'yes' : 'MISSING'}</td>
 										<td>{p.fileIdMeta ?? 'none'}</td>
 										<td>{p.dbRow?.fileId ?? 'none'}</td>
 									</tr>

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -188,10 +188,9 @@ export const adminRoutes = createRouter<Environment>()
 			}
 		)
 	})
-	// Read-only asset health report for a file: does each asset record in the persisted snapshot
-	// still have its object in the uploads bucket, and is it associated with this file? Explains
-	// files stuck in a zero-progress association loop (repeated "R2 connection queue depth" alerts
-	// with an unchanging count), e.g. duplicates of a hard-deleted file whose objects were purged.
+	// Read-only asset health report for a file: is each asset's object still in the uploads
+	// bucket, and is it associated with the file? Explains files stuck in a zero-progress
+	// association loop.
 	.get('/app/admin/file-assets/:slug', async (res, env) => {
 		const slug = res.params.slug
 		assert(typeof slug === 'string', 'slug is required')
@@ -208,9 +207,7 @@ export const adminRoutes = createRouter<Environment>()
 			throw new StatusError(404, `No persisted snapshot for ${slug}`)
 		}
 
-		// Walk asset records, mirroring how the association pass parses them
-		// (TLFileDurableObject.associatePendingAssets): objectName is the last path segment of the
-		// src, meta.fileId marks association.
+		// Mirrors how the association pass parses asset records (see associatePendingAssets)
 		const userContentUrl = env.USER_CONTENT_URL
 		const assets: Array<{
 			assetId: string
@@ -245,9 +242,8 @@ export const adminRoutes = createRouter<Environment>()
 			})
 		}
 
-		// Head every referenced object with bounded concurrency so we stay well inside the worker's
-		// simultaneous connection budget. One retry per object; a persistent failure is reported as
-		// a warning rather than failing the whole report.
+		// Bounded concurrency keeps us inside the worker's connection budget; persistent head
+		// failures become warnings rather than failing the report
 		const warnings: string[] = []
 		const headQueue = new PQueue({ concurrency: 5 })
 		await headQueue.addAll(
@@ -263,10 +259,8 @@ export const adminRoutes = createRouter<Environment>()
 			})
 		)
 
-		// Cross-check the asset table in both directions: which fileId the DB thinks owns each
-		// referenced object (objectName is the table's primary key), and rows claimed by this file
-		// whose objects the snapshot no longer references (leftover copies from passes that died
-		// before repointing records).
+		// Cross-check the asset table both ways: which fileId the DB thinks owns each referenced
+		// object, and rows claimed by this file whose objects the snapshot no longer references
 		const referencedSet = new Set(assets.map((a) => a.objectName))
 		const [dbRowsForReferenced, rowsForThisFile] = await Promise.all([
 			referencedSet.size > 0
@@ -281,9 +275,8 @@ export const adminRoutes = createRouter<Environment>()
 		const dbFileIdByObjectName = new Map(dbRowsForReferenced.map((r) => [r.objectName, r.fileId]))
 		const orphaned = rowsForThisFile.filter((row) => !referencedSet.has(row.objectName)).length
 
-		// Existence semantics mirror loadCreateSourceData: would seeding from this source find
-		// content? Readonly and snapshot prefixes need slug translation to check, so they report
-		// null (not checked) rather than a misleading false.
+		// Mirrors loadCreateSourceData. Readonly and snapshot prefixes need slug translation to
+		// check, so they report null (not checked) rather than a misleading false.
 		let source: { raw: string; exists: boolean | null } | null = null
 		if (file?.createSource) {
 			const raw = file.createSource

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -1,9 +1,19 @@
-import { FeatureFlagKey, TlaFile } from '@tldraw/dotcom-shared'
-import { assert, sleep, uniqueId } from '@tldraw/utils'
+import {
+	FILE_PREFIX,
+	FeatureFlagKey,
+	LOCAL_FILE_PREFIX,
+	PUBLISH_PREFIX,
+	ROOM_PREFIX,
+	TlaFile,
+	WELCOME_CREATE_SOURCE,
+} from '@tldraw/dotcom-shared'
+import { assert, retry, sleep, uniqueId } from '@tldraw/utils'
 import { createRouter } from '@tldraw/worker-shared'
 import { StatusError, json } from 'itty-router'
+import PQueue from 'p-queue'
 import { createPostgresConnectionPool } from './postgres'
-import { returnFileSnapshot } from './routes/tla/getFileSnapshot'
+import { getR2KeyForRoom } from './r2'
+import { getFileSnapshot, returnFileSnapshot } from './routes/tla/getFileSnapshot'
 import { type Environment } from './types'
 import { getReplicator, getRoomDurableObject, getUserDurableObject } from './utils/durableObjects'
 import { FEATURE_FLAG_KEYS, getFeatureFlagsAdmin, setFeatureFlag } from './utils/featureFlags'
@@ -177,6 +187,163 @@ export const adminRoutes = createRouter<Environment>()
 				},
 			}
 		)
+	})
+	// Read-only asset health report for a file: does each asset record in the persisted snapshot
+	// still have its object in the uploads bucket, and is it associated with this file? Explains
+	// files stuck in a zero-progress association loop (repeated "R2 connection queue depth" alerts
+	// with an unchanging count), e.g. duplicates of a hard-deleted file whose objects were purged.
+	.get('/app/admin/file-assets/:slug', async (res, env) => {
+		const slug = res.params.slug
+		assert(typeof slug === 'string', 'slug is required')
+
+		const pg = createPostgresConnectionPool(env, '/app/admin/file-assets')
+		const file = await pg
+			.selectFrom('file')
+			.where('id', '=', slug)
+			.select(['id', 'name', 'ownerId', 'owningGroupId', 'isDeleted', 'createSource'])
+			.executeTakeFirst()
+
+		const snapshot = await getFileSnapshot(env, slug, !!file)
+		if (!snapshot) {
+			throw new StatusError(404, `No persisted snapshot for ${slug}`)
+		}
+
+		// Walk asset records, mirroring how the association pass parses them
+		// (TLFileDurableObject.associatePendingAssets): objectName is the last path segment of the
+		// src, meta.fileId marks association.
+		const userContentUrl = env.USER_CONTENT_URL
+		const assets: Array<{
+			assetId: string
+			objectName: string
+			src: string
+			fileIdMeta: string | null
+			associated: boolean
+			oldFormatUrl: boolean
+			inBucket: boolean
+		}> = []
+		for (const { state } of snapshot.documents) {
+			const record = state as any
+			if (record.typeName !== 'asset') continue
+			const src = record.props?.src
+			if (!src) continue
+			const objectName = src.split('/').pop()
+			if (!objectName) continue
+			const fileIdMeta = record.meta?.fileId ?? null
+			const associated = fileIdMeta === slug
+			assets.push({
+				assetId: record.id,
+				objectName,
+				src,
+				fileIdMeta,
+				associated,
+				oldFormatUrl:
+					associated &&
+					src.startsWith('http') &&
+					!!userContentUrl &&
+					!src.startsWith(userContentUrl),
+				inBucket: false,
+			})
+		}
+
+		// Head every referenced object with bounded concurrency so we stay well inside the worker's
+		// simultaneous connection budget. One retry per object; a persistent failure is reported as
+		// a warning rather than failing the whole report.
+		const warnings: string[] = []
+		const headQueue = new PQueue({ concurrency: 5 })
+		await headQueue.addAll(
+			assets.map((asset) => async () => {
+				try {
+					asset.inBucket = !!(await retry(() => env.UPLOADS.head(asset.objectName), {
+						attempts: 2,
+						waitDuration: 500,
+					}))
+				} catch (e) {
+					warnings.push(`head failed for ${asset.objectName}: ${e}`)
+				}
+			})
+		)
+
+		// Cross-check the asset table in both directions: which fileId the DB thinks owns each
+		// referenced object (objectName is the table's primary key), and rows claimed by this file
+		// whose objects the snapshot no longer references (leftover copies from passes that died
+		// before repointing records).
+		const referencedSet = new Set(assets.map((a) => a.objectName))
+		const [dbRowsForReferenced, rowsForThisFile] = await Promise.all([
+			referencedSet.size > 0
+				? pg
+						.selectFrom('asset')
+						.where('objectName', 'in', [...referencedSet])
+						.select(['objectName', 'fileId'])
+						.execute()
+				: [],
+			pg.selectFrom('asset').where('fileId', '=', slug).select(['objectName']).execute(),
+		])
+		const dbFileIdByObjectName = new Map(dbRowsForReferenced.map((r) => [r.objectName, r.fileId]))
+		const orphaned = rowsForThisFile.filter((row) => !referencedSet.has(row.objectName)).length
+
+		// Existence semantics mirror loadCreateSourceData: would seeding from this source find
+		// content? Readonly and snapshot prefixes need slug translation to check, so they report
+		// null (not checked) rather than a misleading false.
+		let source: { raw: string; exists: boolean | null } | null = null
+		if (file?.createSource) {
+			const raw = file.createSource
+			const [prefix, id] = raw.split('/')
+			let exists: boolean | null = null
+			if (raw === WELCOME_CREATE_SOURCE || prefix === LOCAL_FILE_PREFIX) {
+				exists = true
+			} else if (prefix === FILE_PREFIX && id) {
+				exists = !!(await pg
+					.selectFrom('file')
+					.where('id', '=', id)
+					.select('id')
+					.executeTakeFirst())
+			} else if (prefix === PUBLISH_PREFIX && id) {
+				exists = !!(await pg
+					.selectFrom('file')
+					.where('publishedSlug', '=', id)
+					.where('published', '=', true)
+					.select('id')
+					.executeTakeFirst())
+			} else if (prefix === ROOM_PREFIX && id) {
+				exists = !!(await env.ROOMS.head(getR2KeyForRoom({ slug: id, isApp: false })))
+			}
+			source = { raw, exists }
+		}
+
+		let associated = 0
+		let oldFormatUrls = 0
+		let missingInBucket = 0
+		for (const a of assets) {
+			if (a.associated) associated++
+			if (a.oldFormatUrl) oldFormatUrls++
+			if (!a.inBucket) missingInBucket++
+		}
+
+		return json({
+			file: file ?? null,
+			source,
+			assets: {
+				total: assets.length,
+				associated,
+				pending: assets.length - associated,
+				oldFormatUrls,
+				missingInBucket,
+				problems: assets
+					.filter((a) => !a.associated || !a.inBucket)
+					.map((a) => ({
+						assetId: a.assetId,
+						objectName: a.objectName,
+						src: a.src,
+						fileIdMeta: a.fileIdMeta,
+						inBucket: a.inBucket,
+						dbRow: dbFileIdByObjectName.has(a.objectName)
+							? { fileId: dbFileIdByObjectName.get(a.objectName)! }
+							: null,
+					})),
+			},
+			dbRows: { forThisFile: rowsForThisFile.length, orphaned },
+			warnings,
+		})
 	})
 	.get('/app/admin/download-tldr/:fileSlug', async (res, env) => {
 		const fileSlug = res.params.fileSlug

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -1,4 +1,5 @@
 import {
+	AdminFileAssetsResponseBody,
 	FILE_PREFIX,
 	FeatureFlagKey,
 	LOCAL_FILE_PREFIX,
@@ -202,7 +203,7 @@ export const adminRoutes = createRouter<Environment>()
 			.select(['id', 'name', 'ownerId', 'owningGroupId', 'isDeleted', 'createSource'])
 			.executeTakeFirst()
 
-		const snapshot = await getFileSnapshot(env, slug, !!file)
+		const snapshot = await getFileSnapshot(env, slug, true)
 		if (!snapshot) {
 			throw new StatusError(404, `No persisted snapshot for ${slug}`)
 		}
@@ -216,7 +217,7 @@ export const adminRoutes = createRouter<Environment>()
 			fileIdMeta: string | null
 			associated: boolean
 			oldFormatUrl: boolean
-			inBucket: boolean
+			inBucket: boolean | null
 		}> = []
 		for (const { state } of snapshot.documents) {
 			const record = state as any
@@ -238,7 +239,9 @@ export const adminRoutes = createRouter<Environment>()
 					src.startsWith('http') &&
 					!!userContentUrl &&
 					!src.startsWith(userContentUrl),
-				inBucket: false,
+				// null until the head check settles; a failed check stays null so R2 flakiness
+				// doesn't read as a confirmed-missing object
+				inBucket: null,
 			})
 		}
 
@@ -275,30 +278,32 @@ export const adminRoutes = createRouter<Environment>()
 		const dbFileIdByObjectName = new Map(dbRowsForReferenced.map((r) => [r.objectName, r.fileId]))
 		const orphaned = rowsForThisFile.filter((row) => !referencedSet.has(row.objectName)).length
 
-		// Mirrors loadCreateSourceData. Readonly and snapshot prefixes need slug translation to
-		// check, so they report null (not checked) rather than a misleading false.
+		// Mirrors loadCreateSourceData: exists means seeding from this source would find content.
+		// Readonly and snapshot prefixes need slug translation to check, so they report null (not
+		// checked), as does a failed check.
 		let source: { raw: string; exists: boolean | null } | null = null
 		if (file?.createSource) {
 			const raw = file.createSource
 			const [prefix, id] = raw.split('/')
 			let exists: boolean | null = null
-			if (raw === WELCOME_CREATE_SOURCE || prefix === LOCAL_FILE_PREFIX) {
-				exists = true
-			} else if (prefix === FILE_PREFIX && id) {
-				exists = !!(await pg
-					.selectFrom('file')
-					.where('id', '=', id)
-					.select('id')
-					.executeTakeFirst())
-			} else if (prefix === PUBLISH_PREFIX && id) {
-				exists = !!(await pg
-					.selectFrom('file')
-					.where('publishedSlug', '=', id)
-					.where('published', '=', true)
-					.select('id')
-					.executeTakeFirst())
-			} else if (prefix === ROOM_PREFIX && id) {
-				exists = !!(await env.ROOMS.head(getR2KeyForRoom({ slug: id, isApp: false })))
+			try {
+				if (raw === WELCOME_CREATE_SOURCE || prefix === LOCAL_FILE_PREFIX) {
+					exists = true
+				} else if (prefix === FILE_PREFIX && id) {
+					exists = !!(await env.ROOMS.head(getR2KeyForRoom({ slug: id, isApp: true })))
+				} else if (prefix === PUBLISH_PREFIX && id) {
+					exists = !!(await pg
+						.selectFrom('file')
+						.where('publishedSlug', '=', id)
+						.where('published', '=', true)
+						.select('id')
+						.executeTakeFirst())
+				} else if (prefix === ROOM_PREFIX && id) {
+					exists = !!(await env.ROOMS.head(getR2KeyForRoom({ slug: id, isApp: false })))
+				}
+			} catch (e) {
+				warnings.push(`createSource check failed for ${raw}: ${e}`)
+				exists = null
 			}
 			source = { raw, exists }
 		}
@@ -306,13 +311,15 @@ export const adminRoutes = createRouter<Environment>()
 		let associated = 0
 		let oldFormatUrls = 0
 		let missingInBucket = 0
+		let headFailures = 0
 		for (const a of assets) {
 			if (a.associated) associated++
 			if (a.oldFormatUrl) oldFormatUrls++
-			if (!a.inBucket) missingInBucket++
+			if (a.inBucket === false) missingInBucket++
+			if (a.inBucket === null) headFailures++
 		}
 
-		return json({
+		const report: AdminFileAssetsResponseBody = {
 			file: file ?? null,
 			source,
 			assets: {
@@ -321,8 +328,9 @@ export const adminRoutes = createRouter<Environment>()
 				pending: assets.length - associated,
 				oldFormatUrls,
 				missingInBucket,
+				headFailures,
 				problems: assets
-					.filter((a) => !a.associated || !a.inBucket)
+					.filter((a) => !a.associated || a.inBucket !== true)
 					.map((a) => ({
 						assetId: a.assetId,
 						objectName: a.objectName,
@@ -336,7 +344,8 @@ export const adminRoutes = createRouter<Environment>()
 			},
 			dbRows: { forThisFile: rowsForThisFile.length, orphaned },
 			warnings,
-		})
+		}
+		return json(report)
 	})
 	.get('/app/admin/download-tldr/:fileSlug', async (res, env) => {
 		const fileSlug = res.params.fileSlug

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -218,9 +218,17 @@ export const adminRoutes = createRouter<Environment>()
 			associated: boolean
 			oldFormatUrl: boolean
 			inBucket: boolean | null
+			sizeBytes: number | null
 		}> = []
+		let totalShapes = 0
+		const shapesByType: Record<string, number> = {}
 		for (const { state } of snapshot.documents) {
 			const record = state as any
+			if (record.typeName === 'shape') {
+				totalShapes++
+				shapesByType[record.type] = (shapesByType[record.type] ?? 0) + 1
+				continue
+			}
 			if (record.typeName !== 'asset') continue
 			const src = record.props?.src
 			if (!src) continue
@@ -242,6 +250,7 @@ export const adminRoutes = createRouter<Environment>()
 				// null until the head check settles; a failed check stays null so R2 flakiness
 				// doesn't read as a confirmed-missing object
 				inBucket: null,
+				sizeBytes: null,
 			})
 		}
 
@@ -252,10 +261,12 @@ export const adminRoutes = createRouter<Environment>()
 		await headQueue.addAll(
 			assets.map((asset) => async () => {
 				try {
-					asset.inBucket = !!(await retry(() => env.UPLOADS.head(asset.objectName), {
+					const head = await retry(() => env.UPLOADS.head(asset.objectName), {
 						attempts: 2,
 						waitDuration: 500,
-					}))
+					})
+					asset.inBucket = !!head
+					asset.sizeBytes = head?.size ?? null
 				} catch (e) {
 					warnings.push(`head failed for ${asset.objectName}: ${e}`)
 				}
@@ -312,16 +323,23 @@ export const adminRoutes = createRouter<Environment>()
 		let oldFormatUrls = 0
 		let missingInBucket = 0
 		let headFailures = 0
+		let totalSizeBytes = 0
+		let largestSizeBytes = 0
 		for (const a of assets) {
 			if (a.associated) associated++
 			if (a.oldFormatUrl) oldFormatUrls++
 			if (a.inBucket === false) missingInBucket++
 			if (a.inBucket === null) headFailures++
+			if (a.sizeBytes !== null) {
+				totalSizeBytes += a.sizeBytes
+				largestSizeBytes = Math.max(largestSizeBytes, a.sizeBytes)
+			}
 		}
 
 		const report: AdminFileAssetsResponseBody = {
 			file: file ?? null,
 			source,
+			shapes: { total: totalShapes, byType: shapesByType },
 			assets: {
 				total: assets.length,
 				associated,
@@ -329,6 +347,8 @@ export const adminRoutes = createRouter<Environment>()
 				oldFormatUrls,
 				missingInBucket,
 				headFailures,
+				totalSizeBytes,
+				largestSizeBytes,
 				problems: assets
 					.filter((a) => !a.associated || a.inBucket !== true)
 					.map((a) => ({

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -309,6 +309,10 @@ export interface AdminFileAssetsResponseBody {
 	> | null
 	/** null exists = not checked (prefix needs slug translation) or the check failed */
 	source: { raw: string; exists: boolean | null } | null
+	shapes: {
+		total: number
+		byType: Record<string, number>
+	}
 	assets: {
 		total: number
 		associated: number
@@ -316,6 +320,9 @@ export interface AdminFileAssetsResponseBody {
 		oldFormatUrls: number
 		missingInBucket: number
 		headFailures: number
+		/** Sums sizes of assets found in the uploads bucket; missing or failed heads contribute 0 */
+		totalSizeBytes: number
+		largestSizeBytes: number
 		problems: AdminFileAssetProblem[]
 	}
 	dbRows: { forThisFile: number; orphaned: number }

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -289,3 +289,35 @@ export interface PercentageFeatureFlag {
 export interface EvaluatedFeatureFlag {
 	enabled: boolean
 }
+
+/** One unassociated or unverifiable asset in an admin asset-diagnostics report. */
+export interface AdminFileAssetProblem {
+	assetId: string
+	objectName: string
+	src: string
+	fileIdMeta: string | null
+	/** null = the bucket head check failed, not a confirmed absence */
+	inBucket: boolean | null
+	dbRow: { fileId: string } | null
+}
+
+/** Response of the admin file-assets diagnostics endpoint. */
+export interface AdminFileAssetsResponseBody {
+	file: Pick<
+		TlaFile,
+		'id' | 'name' | 'ownerId' | 'owningGroupId' | 'isDeleted' | 'createSource'
+	> | null
+	/** null exists = not checked (prefix needs slug translation) or the check failed */
+	source: { raw: string; exists: boolean | null } | null
+	assets: {
+		total: number
+		associated: number
+		pending: number
+		oldFormatUrls: number
+		missingInBucket: number
+		headFailures: number
+		problems: AdminFileAssetProblem[]
+	}
+	dbRows: { forThisFile: number; orphaned: number }
+	warnings: string[]
+}


### PR DESCRIPTION
In order to diagnose the repeated `R2 connection queue depth` Sentry alerts (same file, same count every open = the asset-association pass never makes progress, likely because source objects are gone from the uploads bucket), this PR adds a read-only asset diagnostics tool to the admin page.

Given a file slug, `GET /app/admin/file-assets/:slug` reports per asset whether its object exists in the uploads bucket and whether it's associated with the file, plus the Postgres `asset` table cross-check and whether the file's `createSource` still exists. The admin page shows a summary grid, a problem-assets table, and raw JSON.

Read-only for now; it reads the last persisted snapshot. In local dev the bucket check always reports missing (each worker's `wrangler dev` has its own simulated R2 state).

### Change type

- [x] `other`

### Test plan

1. In `/admin`, enter a file slug under "Asset diagnostics"
2. A healthy file reports all assets associated and present; a stuck file (from the Sentry alerts) reports pending assets missing from the bucket

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +309 / -3  |