### PR TITLE
fix(dotcom): revert the thumbnail zoom floor

### DIFF
--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -250,38 +250,20 @@ function getRepresentativeContentInset(width: number, height: number) {
 	return Math.max(48, Math.min(160, width * 0.12, height * 0.18))
 }
 
-// Zoom floor for the content fit. The camera's zoom steps double as the clamp range for both
-// zoomToBounds and setCamera, and the default floor (0.05) is far too high here: at 1200x630 it
-// stops fitting at roughly 22k x 10k page units, so a bigger board quietly renders with its edges
-// cropped. Nothing on this page zooms interactively, so the floor exists only to bound the fit —
-// this one fits a board a thousand times the size of the viewport.
-const MIN_CONTENT_FIT_ZOOM = 0.001
-
 // Fits the current page's content into the viewport with representative margins. Run both on mount
 // and again right before export (see ThumbnailExportSignal), because autosized text re-measures once
 // web fonts load and shifts the page bounds — a fit computed before fonts settle would clip content.
 function fitContentCamera(editor: Editor, width: number, height: number) {
 	const bounds = editor.getCurrentPageBounds()
-	if (!bounds) {
+	if (bounds) {
+		editor.zoomToBounds(bounds, {
+			immediate: true,
+			force: true,
+			inset: getRepresentativeContentInset(width, height),
+		})
+	} else {
 		editor.setCamera({ x: 0, y: 0, z: 1 }, { immediate: true })
-		return
 	}
-
-	// Lower the zoom floor before fitting. `force` only bypasses the camera lock, not the fit's own
-	// clamp, so the steps themselves have to allow the zoom the fit needs — and lowering them here
-	// (rather than forcing a camera past them) also stops a later unforced setCamera from snapping the
-	// fit back up. Keep the existing ceiling so a page holding one small shape isn't magnified
-	// absurdly. Filtering rather than replacing keeps this idempotent across the two calls.
-	const { zoomSteps } = editor.getCameraOptions()
-	editor.setCameraOptions({
-		zoomSteps: [MIN_CONTENT_FIT_ZOOM, ...zoomSteps.filter((step) => step > MIN_CONTENT_FIT_ZOOM)],
-	})
-
-	editor.zoomToBounds(bounds, {
-		immediate: true,
-		force: true,
-		inset: getRepresentativeContentInset(width, height),
-	})
 }
 
 // Produces a thumbnail of the editor's current page with editor.toImage once the scene has settled


### PR DESCRIPTION
In order to get board thumbnails rendering again, this reverts `07f2a2a0ac` ("fit thumbnail content below the default zoom floor"), which shipped as part of #9503.

That commit lowered the render page's zoom floor from the default 0.05 to 0.001, so that boards larger than roughly 22k × 10k page units would fit the thumbnail viewport instead of rendering with their edges cropped. After it shipped, renders through Cloudflare Browser Rendering stopped completing: the page never reached `data-thumbnail-ready`, the capture spent its full 45s `THUMBNAIL_RENDER_TIMEOUT_MS` and came back as a Cloudflare 6002 selector timeout, and link unfurls for affected boards fell back to the generic tldraw image. Reverting restores rendering.

The mechanism is not confirmed. `exportThumbnailImage` takes all three of its `editor.toImage` inputs from the camera — `bounds` is the viewport in page space, `scale` is `camera.z`, and the shape list is everything not culled at that viewport — so a 50× lower floor makes the viewport cover 2500× the page area and stops the culling filter excluding anything. That would hand `toImage` considerably more than it was meant to draw, but it has not been measured from inside the fleet.

This reinstates the cropping the original commit was fixing: boards past that size render with their edges cut again. Fixing it properly needs an approach that doesn't widen what the export is handed.

### Change type

- [x] `bugfix`

### Test plan

1. Call `get_shared_board_screenshot` through `POST /api/app/mcp` for a board that was timing out, and confirm it returns a PNG rather than a render failure.
2. Confirm a board larger than ~22k × 10k page units renders cropped again — the known regression this reintroduces.

- [ ] Unit tests
- [ ] End to end tests
