### PR TITLE
feat(commenting): region pins live on the drag's release corner and overlap the region

### DIFF
--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -491,6 +491,11 @@ export interface ReactionProps {
 export function Reactions(): JSX.Element;
 
 // @public
+export function regionAnchorPinCorner(editor: Editor, anchor: Extract<TLCommentAnchor, {
+    type: 'region';
+}>): VecLike;
+
+// @public
 export interface RegionCommentOptions {
     enabled: boolean;
     move: 'body' | 'both' | 'pin';

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -154,15 +154,15 @@
 	   into the row, so its bottom-left corner is 4px right of and 4 + 34 = 38px below the
 	   composer's top-left corner. */
 	transform: translate(-4px, -38px);
+	/* The rich-text editor has no intrinsic width (unlike the old <input>), so give the floating
+	   placement composer a definite width or it collapses to nothing. */
+	width: 280px;
 }
 
 /* A region placement centres the draft avatar on the region's pin corner — the pin it becomes
    straddles that corner. The avatar's centre sits 4 + 34/2 = 21px into the composer. */
 .tlui-cmt-canvas-composer--region {
 	transform: translate(-21px, -21px);
-	/* The rich-text editor has no intrinsic width (unlike the old <input>), so give the floating
-	   placement composer a definite width or it collapses to nothing. */
-	width: 280px;
 }
 .tlui-cmt-canvas-composer .tlui-cmt-composer__field {
 	background: var(--tl-color-panel);

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -154,6 +154,12 @@
 	   into the row, so its bottom-left corner is 4px right of and 4 + 34 = 38px below the
 	   composer's top-left corner. */
 	transform: translate(-4px, -38px);
+}
+
+/* A region placement centres the draft avatar on the region's pin corner — the pin it becomes
+   straddles that corner. The avatar's centre sits 4 + 34/2 = 21px into the composer. */
+.tlui-cmt-canvas-composer--region {
+	transform: translate(-21px, -21px);
 	/* The rich-text editor has no intrinsic width (unlike the old <input>), so give the floating
 	   placement composer a definite width or it collapses to nothing. */
 	width: 280px;

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -217,14 +217,15 @@ class CommentDragging extends StateNode {
 	// Commit the dragged rectangle as a region anchor; the composer opens at its pin corner.
 	override onPointerUp() {
 		const { editor } = this
-		const region = regionBetween(
-			editor.inputs.getOriginPagePoint(),
-			editor.inputs.getCurrentPagePoint()
-		)
+		const origin = editor.inputs.getOriginPagePoint()
+		const current = editor.inputs.getCurrentPagePoint()
+		const region = regionBetween(origin, current)
+		// The pin lives on the corner the drag released on — drag up-left, pin top-left.
+		const pin = { x: current.x >= origin.x ? 1 : 0, y: current.y >= origin.y ? 1 : 0 }
 		regionDraft.set(editor, null)
 		pendingComment.set(editor, {
-			anchor: { type: 'region', ...region },
-			point: regionPinPoint(region, getRegionCommentOptions(editor).pinCorner),
+			anchor: { type: 'region', ...region, pinX: pin.x, pinY: pin.y },
+			point: regionPinPoint(region, pin),
 		})
 		editor.setCurrentTool('select')
 	}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -80,7 +80,12 @@ import {
 	toggleCommentsHidden,
 	usePendingComment,
 } from './state'
-import { anchorPagePoint, regionPinPoint, shapeAnchorAt } from './thread-state'
+import {
+	anchorPagePoint,
+	regionAnchorPinCorner,
+	regionPinPoint,
+	shapeAnchorAt,
+} from './thread-state'
 
 /**
  * A ready-to-use comments layer for a tldraw canvas: pins each thread at its anchor, opens a
@@ -1122,15 +1127,19 @@ const ThreadPin = memo(function ThreadPin({
 		resizeBounds != null ||
 		(regionOptions.reveal === 'pointer' && pointerInRegion) ||
 		(regionOptions.reveal === 'pin-hover' && pinHovered)
+	// A region thread's pin corner is its own (the corner its creating drag released on), with
+	// the configured default as the fallback for older records.
+	const pinCorner =
+		thread.anchor.type === 'region'
+			? regionAnchorPinCorner(editor, thread.anchor)
+			: regionOptions.pinCorner
 	// The resize handles: side midpoints ('edges'), or the corners other than the pin's ('corners').
 	const resizeHandles = useMemo(
 		() =>
 			regionOptions.resize === 'edges'
 				? REGION_EDGES
-				: REGION_CORNERS.filter(
-						(c) => c.x !== regionOptions.pinCorner.x || c.y !== regionOptions.pinCorner.y
-					),
-		[regionOptions.resize, regionOptions.pinCorner]
+				: REGION_CORNERS.filter((c) => c.x !== pinCorner.x || c.y !== pinCorner.y),
+		[regionOptions.resize, pinCorner]
 	)
 	const dragRef = useRef<{
 		startX: number
@@ -1462,8 +1471,8 @@ const ThreadPin = memo(function ThreadPin({
 			// Translate so the pin (the region's pin corner) lands at the drop; size unchanged.
 			anchor = {
 				...thread.anchor,
-				x: pagePoint.x - regionOptions.pinCorner.x * thread.anchor.w,
-				y: pagePoint.y - regionOptions.pinCorner.y * thread.anchor.h,
+				x: pagePoint.x - pinCorner.x * thread.anchor.w,
+				y: pagePoint.y - pinCorner.y * thread.anchor.h,
 			}
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
@@ -1476,10 +1485,13 @@ const ThreadPin = memo(function ThreadPin({
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
 	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
-	const livePinPage = resizeBounds
-		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
-		: dragPagePoint
-	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
+	const livePinPage = resizeBounds ? regionPinPoint(resizeBounds, pinCorner) : dragPagePoint
+	const renderPointBase = livePinPage ? editor.pageToViewport(livePinPage) : point
+	// A region's pin centres on its corner — overlapping the box — rather than hanging off it.
+	// The marker anchors bottom-left, so step half its 34px size left and down (screen px).
+	const renderPoint = isRegion
+		? { x: renderPointBase.x - 17, y: renderPointBase.y + 17 }
+		: renderPointBase
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
 	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.
@@ -1488,15 +1500,16 @@ const ThreadPin = memo(function ThreadPin({
 		regionAnchor && dragPagePoint
 			? {
 					...regionAnchor,
-					x: dragPagePoint.x - regionOptions.pinCorner.x * regionAnchor.w,
-					y: dragPagePoint.y - regionOptions.pinCorner.y * regionAnchor.h,
+					x: dragPagePoint.x - pinCorner.x * regionAnchor.w,
+					y: dragPagePoint.y - pinCorner.y * regionAnchor.h,
 				}
 			: regionAnchor
 	const regionBoxBounds = resizeBounds ?? movedRegion
 	const commitResize = (bounds: BoxModel) => {
 		setResizeBounds(null)
 		editor.run(
-			() => putCommentRecords(editor, [{ ...thread, anchor: { type: 'region', ...bounds } }]),
+			// Spread the existing anchor first so the region's pin corner survives a resize.
+			() => putCommentRecords(editor, [{ ...thread, anchor: { ...regionAnchor!, ...bounds } }]),
 			{
 				history: 'ignore',
 			}
@@ -1662,7 +1675,12 @@ function PendingComposer({
 	return createPortal(
 		<div
 			ref={ref}
-			className="tlui-cmt-canvas-composer"
+			className={[
+				'tlui-cmt-canvas-composer',
+				pending.anchor.type === 'region' && 'tlui-cmt-canvas-composer--region',
+			]
+				.filter(Boolean)
+				.join(' ')}
 			style={{ left: point.x, top: point.y }}
 			onPointerDown={stop}
 			onContextMenu={stop}

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -10,6 +10,18 @@ export const DEFAULT_IMPRECISE_SHAPE_ANCHOR = { x: 1, y: 0 }
  *  which corner has no resize handle all derive from the chosen corner. */
 export const REGION_PIN_CORNER: VecLike = { x: 1, y: 1 }
 
+/** A region anchor's pin corner: the corner its creating drag released on, when recorded, else
+ *  the editor's configured default. @public */
+export function regionAnchorPinCorner(
+	editor: Editor,
+	anchor: Extract<TLCommentAnchor, { type: 'region' }>
+): VecLike {
+	if (anchor.pinX !== undefined && anchor.pinY !== undefined) {
+		return { x: anchor.pinX, y: anchor.pinY }
+	}
+	return getRegionCommentOptions(editor).pinCorner
+}
+
 /** The page point of a region's pin corner. */
 export function regionPinPoint(region: BoxModel, corner: VecLike = REGION_PIN_CORNER): VecLike {
 	return {
@@ -45,7 +57,7 @@ export function anchorPagePoint(
 		case 'point':
 			return { x: anchor.x, y: anchor.y }
 		case 'region':
-			return regionPinPoint(anchor, getRegionCommentOptions(editor).pinCorner)
+			return regionPinPoint(anchor, regionAnchorPinCorner(editor, anchor))
 		case 'page':
 			return null
 	}

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -89,6 +89,7 @@ export {
 	anchorPagePoint,
 	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
 	focusThread,
+	regionAnchorPinCorner,
 	shapeAnchorAt,
 } from './canvas/thread-state'
 

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -85,6 +85,13 @@ export function CommentComposer({
 		const mirror = mirrorRef.current
 		const editor = editorRef.current
 		if (!wrap || !mirror || !editor) return
+		// Empty always fits — and measuring before TipTap's DOM has laid out reads zero widths,
+		// which would flash the expanded layout for a frame on mount.
+		if (editor.isEmpty) {
+			if (expandedRef.current) setExpanded(false)
+			return
+		}
+		if (wrap.clientWidth === 0) return
 		const doc = editor.state.doc
 		const multiBlock =
 			doc.childCount > 1 || (doc.firstChild !== null && doc.firstChild.type.name !== 'paragraph')

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -1097,16 +1097,18 @@ export interface TLComment extends BaseRecord<'comment', TLCommentId> {
 
 // @public
 export type TLCommentAnchor = {
-    from: number;
-    shapeId: TLShapeId;
-    to: number;
-    type: 'text-range';
-} | {
+    pinX?: number;
     h: number;
+    pinY?: number;
     type: 'region';
     w: number;
     x: number;
     y: number;
+} | {
+    from: number;
+    shapeId: TLShapeId;
+    to: number;
+    type: 'text-range';
 } | {
     isPrecise: boolean;
     shapeId: TLShapeId;

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -25,7 +25,17 @@ import { TLShapeId } from './TLShape'
 export type TLCommentAnchor =
 	| { type: 'shape'; shapeId: TLShapeId; x: number; y: number; isPrecise: boolean }
 	| { type: 'point'; x: number; y: number }
-	| { type: 'region'; x: number; y: number; w: number; h: number }
+	| {
+			type: 'region'
+			x: number
+			y: number
+			w: number
+			h: number
+			/** The normalized (0–1) corner the pin sits on — where the creating drag was released.
+			 *  Absent on older records; consumers fall back to their configured corner. */
+			pinX?: number
+			pinY?: number
+	  }
 	| { type: 'page' }
 	| { type: 'text-range'; shapeId: TLShapeId; from: number; to: number }
 
@@ -112,6 +122,8 @@ const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
 		y: T.number,
 		w: T.number,
 		h: T.number,
+		pinX: T.number.optional(),
+		pinY: T.number.optional(),
 	}),
 	page: T.object({
 		type: T.literal('page'),
@@ -172,6 +184,19 @@ export const commentThreadRecordConfig: CustomRecordInfo = {
 				const anchor = (record as any).anchor
 				if (anchor?.type === 'shape') {
 					;(record as any).anchor = { type: 'shape', shapeId: anchor.shapeId }
+				}
+				return record
+			},
+		},
+		{
+			// Region anchors gained an optional pin corner (where the creating drag released).
+			id: 'com.tldraw.comment-thread/3',
+			up: (record) => record,
+			down: (record) => {
+				const anchor = (record as any).anchor
+				if (anchor?.type === 'region') {
+					const { pinX: _pinX, pinY: _pinY, ...rest } = anchor
+					;(record as any).anchor = rest
 				}
 				return record
 			},


### PR DESCRIPTION
Two region-comment behaviours from the UI/UX pass:

**The pin corner follows the drag.** Dragging a region out and releasing at the top-left puts the pin on the top-left corner; releasing bottom-right puts it bottom-right. The corner is recorded on the anchor itself — new optional `pinX`/`pinY` (normalized 0–1) on the region variant of `TLCommentAnchor`, with a `com.tldraw.comment-thread/3` migration following the `/2` pattern (identity up; down strips the fields). Older records without a recorded corner fall back to the configured `regionOptions.pinCorner`, so nothing breaks. The per-thread corner also drives the resize-handle exclusion (no handle on the pin's corner), drag translation, and survives resizes (the old commit path rebuilt the anchor from bounds, which would have dropped it).

**The pin overlaps the region.** Region pins centre on their corner — straddling the dashed box — instead of hanging entirely outside it. One screen-space offset applied uniformly across the static, dragging, and resizing render paths, so no interaction makes the pin jump. Region placements centre the pencil draft avatar on the same corner (a `--region` composer variant), so the draft reads as the pin it becomes.

Also fixes two composer issues found along the way:
- The placement composer's `width: 280px` had been split out of its rule by the variant addition, collapsing point/shape composers to intrinsic width (regions kept theirs, hence the two placements rendering differently).
- The expand-to-full-width measurement ran before TipTap's DOM laid out, flashing the expanded layout for a frame on mount — empty content now always collapses and zero-width layouts are skipped.

### Change type

- [x] `feature`

### Test plan

1. With region comments enabled, drag a region from top-left to bottom-right — the composer's pencil sits centred on the bottom-right corner; posting leaves the pin straddling that corner.
2. Drag a region from bottom-right to top-left — pin lands on the top-left corner instead.
3. Resize the region by its handles — the pin's corner keeps no handle, and the pin corner survives the resize.
4. Drag the pin to move the region — no jump at drag start.
5. Place a point comment and a region comment — both composers are 280px wide, no expanded-layout flash on open.

- [x] Unit tests

### Release notes

- Region comment pins now sit on the corner you release the drag on, overlapping the region.

### API Changes

- `TLCommentAnchor`'s region variant gains optional `pinX`/`pinY` (the recorded pin corner), with a corresponding `comment-thread` migration.
- New export: `regionAnchorPinCorner(editor, anchor)` — a region anchor's pin corner with the configured fallback.