### PR TITLE
fix(dotcom): add Duplicate to the file header menu

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -161,14 +161,17 @@ export function FileItems({
 	}, [app, fileId, workspaceId])
 
 	const handleDuplicateClick = useCallback(async () => {
-		if (!workspaceId) return
+		// The sidebar passes the workspace the file is listed under; the file header doesn't, so
+		// fall back to the workspace the file already lives in.
+		const targetWorkspaceId = workspaceId ?? currentWorkspaceId
+		if (!targetWorkspaceId) return
 		const newFileId = uniqueId()
 		const file = app.getFile(fileId)
 		if (!file) return
 		trackEvent('duplicate-file', { source })
 		const res = await app.createFile({
 			fileId: newFileId,
-			workspaceId,
+			workspaceId: targetWorkspaceId,
 			name: getDuplicateName(file, app),
 			createSource: `${FILE_PREFIX}/${fileId}`,
 		})
@@ -180,11 +183,11 @@ export function FileItems({
 		if (res.ok) {
 			app.sidebarState.update((prev) => ({
 				...prev,
-				renameState: { fileId: newFileId, workspaceId },
+				renameState: { fileId: newFileId, workspaceId: targetWorkspaceId },
 			}))
 			navigate(routes.tlaFile(newFileId))
 		}
-	}, [app, fileId, workspaceId, navigate, trackEvent, source])
+	}, [app, fileId, workspaceId, currentWorkspaceId, navigate, trackEvent, source])
 
 	const handleDeleteClick = useCallback(() => {
 		if (!workspaceId) return
@@ -223,15 +226,12 @@ export function FileItems({
 					<TldrawUiMenuItem label={renameMsg} id="rename" readonlyOk onSelect={onRenameAction} />
 				)}
 				{/* todo: in published rooms, support duplication / forking */}
-				{/* todo: requires a non-trivial refactor, quick fix is to just remove this menu item, it's available elsewhere */}
-				{source !== 'file-header' && (
-					<TldrawUiMenuItem
-						label={duplicateMsg}
-						id="duplicate"
-						readonlyOk
-						onSelect={handleDuplicateClick}
-					/>
-				)}
+				<TldrawUiMenuItem
+					label={duplicateMsg}
+					id="duplicate"
+					readonlyOk
+					onSelect={handleDuplicateClick}
+				/>
 				<TldrawUiMenuItem
 					label={downloadFile}
 					id="download-file"

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -21,6 +21,7 @@ import {
 } from 'tldraw'
 import { routes } from '../../../routeDefs'
 import { TldrawApp } from '../../app/TldrawApp'
+import { useActiveWorkspaceId } from '../../hooks/useActiveWorkspaceId'
 import { useApp } from '../../hooks/useAppState'
 import { useHasFileAdminRights } from '../../hooks/useIsFileOwner'
 import { useIsFilePinned } from '../../hooks/useIsFilePinned'
@@ -119,6 +120,7 @@ export function FileItems({
 	const copiedMsg = useMsg(messages.copied)
 	const hasAdminRights = useHasFileAdminRights(fileId)
 	const isPinned = useIsFilePinned(fileId, workspaceId ?? '')
+	const activeWorkspaceId = useActiveWorkspaceId()
 
 	const file = useValue('file', () => app.getFile(fileId), [app, fileId])
 
@@ -162,8 +164,10 @@ export function FileItems({
 
 	const handleDuplicateClick = useCallback(async () => {
 		// The sidebar passes the workspace the file is listed under; the file header doesn't, so
-		// fall back to the workspace the file already lives in.
-		const targetWorkspaceId = workspaceId ?? currentWorkspaceId
+		// fall back to the user's active workspace. This matches the sidebar (and unlike the file's
+		// own owning workspace, it's always one the user can write to — e.g. a guest duplicating a
+		// shared file gets the copy in their home workspace, not the owner's).
+		const targetWorkspaceId = workspaceId ?? activeWorkspaceId
 		if (!targetWorkspaceId) return
 		const newFileId = uniqueId()
 		const file = app.getFile(fileId)
@@ -187,7 +191,7 @@ export function FileItems({
 			}))
 			navigate(routes.tlaFile(newFileId))
 		}
-	}, [app, fileId, workspaceId, currentWorkspaceId, navigate, trackEvent, source])
+	}, [app, fileId, workspaceId, activeWorkspaceId, navigate, trackEvent, source])
 
 	const handleDeleteClick = useCallback(() => {
 		if (!workspaceId) return

--- a/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx
@@ -132,10 +132,12 @@ export function FileItems({
 	)
 
 	// A file lives in exactly one workspace. The "Move to" menu is a checklist of every
-	// destination — the home workspace plus each non-home workspace — with the file's current
+	// destination — the home workspace plus each non-home workspace — with the file's own
 	// workspace checked. The home workspace is rendered separately (it's always the first item),
 	// labelled with its own name like any other workspace.
-	const currentWorkspaceId = file?.owningGroupId ?? app.getHomeWorkspaceId()
+	// (This is the workspace the file belongs to, which is not necessarily one the current user
+	// can write to — for that, see activeWorkspaceId above.)
+	const fileWorkspaceId = file?.owningGroupId ?? app.getHomeWorkspaceId()
 	const homeWorkspaceName = workspaceMemberships.find((g) => g.groupId === app.getHomeWorkspaceId())
 		?.group?.name
 	const moveToWorkspaces = workspaceMemberships.filter(
@@ -260,9 +262,9 @@ export function FileItems({
 								label={homeWorkspaceName ?? myWorkspaceMsg}
 								id="my-files"
 								readonlyOk
-								checked={currentWorkspaceId === app.getHomeWorkspaceId()}
+								checked={fileWorkspaceId === app.getHomeWorkspaceId()}
 								onSelect={() => {
-									if (currentWorkspaceId === app.getHomeWorkspaceId()) return
+									if (fileWorkspaceId === app.getHomeWorkspaceId()) return
 									app.z.mutate.moveFileToWorkspace({
 										fileId,
 										workspaceId: app.getHomeWorkspaceId(),
@@ -275,9 +277,9 @@ export function FileItems({
 									label={membership.group.name}
 									id={`workspace-${membership.groupId}`}
 									readonlyOk
-									checked={membership.groupId === currentWorkspaceId}
+									checked={membership.groupId === fileWorkspaceId}
 									onSelect={() => {
-										if (membership.groupId === currentWorkspaceId) return
+										if (membership.groupId === fileWorkspaceId) return
 										app.z.mutate.moveFileToWorkspace({ fileId, workspaceId: membership.groupId })
 									}}
 								/>


### PR DESCRIPTION
The file menu in the editor's top-left header offered **Rename** and **Move to** but not **Duplicate**, even though the sidebar's file menu — which renders the same `FileItems` component — has it. This adds Duplicate to the header menu so the two menus match.

Duplicate was hidden in the header for two reasons:

- a `source !== 'file-header'` guard on the menu item, and
- the header passes `workspaceId={null}`, so `handleDuplicateClick` early-returned even if the item had rendered.

The change removes the guard and, when no workspace prop is passed, duplicates the file into the user's **active workspace** (via `useActiveWorkspaceId`, the same value the sidebar passes). This is scoped to Duplicate only — Pin/unpin and Delete are still gated on the `workspaceId` prop, so they remain hidden in the header as before.

Falling back to the active workspace (rather than the file's owning workspace) means a signed-in guest duplicating someone else's shared file gets the copy in their own home workspace — a workspace they can write to — matching the sidebar's behaviour.

### Before / after

| Menu | Before | After |
| --- | --- | --- |
| Sidebar file menu | Rename · Duplicate · Move to · … | unchanged |
| Header file menu | Rename · Move to · … | Rename · **Duplicate** · Move to · … |

### Code changes

| File | +/- | Description |
| --- | --- | --- |
| `apps/dotcom/client/src/tla/components/TlaFileMenu/TlaFileMenu.tsx` | +17/-13 | Show Duplicate in the header menu; when no `workspaceId` prop is passed, duplicate into the user's active workspace |

### Test plan

- [ ] Open a file you own; the header "File" menu shows Duplicate between Rename and Move to.
- [ ] Duplicate creates a copy in your workspace, navigates to it, and opens it in rename mode (matching the sidebar's Duplicate).
- [ ] As a signed-in guest on a shared file, Duplicate creates the copy in your own home workspace.
- [ ] Pin/unpin and Delete are still absent from the header menu.
