### PR TITLE
fix(commenting): open the linked thread when a notification is clicked

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -1509,6 +1509,12 @@
       "value": " to learn more."
     }
   ],
+  "edec9387f9": [
+    {
+      "type": 0,
+      "value": "This comment was deleted."
+    }
+  ],
   "ef53538ae4": [
     {
       "type": 0,

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -627,6 +627,9 @@
   "ede55d955f": {
     "translation": "Read our <a>cookie policy</a> to learn more."
   },
+  "edec9387f9": {
+    "translation": "This comment was deleted."
+  },
   "ef53538ae4": {
     "translation": "Members"
   },

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -52,6 +52,7 @@ import { TlaEditorErrorFallback } from './editor-components/TlaEditorErrorFallba
 import { TlaEditorMenuPanel } from './editor-components/TlaEditorMenuPanel'
 import { TlaEditorSharePanel } from './editor-components/TlaEditorSharePanel'
 import { TlaEditorTopPanel } from './editor-components/TlaEditorTopPanel'
+import { SneakyCommentDeepLink } from './sneaky/SneakyCommentDeepLink'
 import { SneakyDarkModeSync } from './sneaky/SneakyDarkModeSync'
 import { SneakyDebugModeToast } from './sneaky/SneakyDebugModeToast'
 import { SneakyTldrawFileDropHandler } from './sneaky/SneakyFileDropHandler'
@@ -315,6 +316,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				{app && <SneakyTldrawFileDropHandler />}
 				<SneakyLargeFileHander />
 				<SneakyDebugModeToast />
+				<SneakyCommentDeepLink />
 				<TlaAnonDotDevLink />
 			</Tldraw>
 		</TlaEditorWrapper>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
@@ -1,43 +1,24 @@
-import {
-	commentsHidden,
-	focusThread,
-	getCommentingOptions,
-	getCommentRecord,
-} from '@tldraw/commenting'
+import { revealThreadRequest } from '@tldraw/commenting'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useEditor, useValue } from 'tldraw'
+import { useEditor } from 'tldraw'
 
 /**
- * Opens the comment thread a notification links to. A notification row navigates to the file
- * route with `?comment=<id>`; this watches that param from inside the editor, waits for the
- * linked comment and its thread to be present in the store (on a cross-file navigation they
- * sync in after the editor mounts), then opens the thread popover via `focusThread` and strips
- * the consumed param so back/refresh doesn't re-open it.
+ * Routes a comment link into the comments overlay. A notification row navigates to the file route
+ * with `?comment=<id>`, but the overlay only reads the URL once at mount — a same-file navigation
+ * changes the query string without remounting anything, so the link would otherwise do nothing.
+ * This watches the param through router state, hands the id to the overlay as a reveal request
+ * (the overlay owns waiting for the records to sync in and the cluster-aware reveal), and strips
+ * the consumed param so back/refresh doesn't re-open the thread.
  */
 export function SneakyCommentDeepLink() {
 	const editor = useEditor()
 	const [searchParams, setSearchParams] = useSearchParams()
 	const commentId = searchParams.get('comment')
 
-	const thread = useValue(
-		'linked comment thread',
-		() => {
-			if (!commentId) return null
-			const comment = getCommentRecord(editor, commentId)
-			if (comment?.typeName !== 'comment') return null
-			const thread = getCommentRecord(editor, comment.threadId)
-			return thread?.typeName === 'comment-thread' ? thread : null
-		},
-		[editor, commentId]
-	)
-
 	useEffect(() => {
-		if (!thread) return
-		// Following the link is an explicit ask to see this comment — override hidden pins,
-		// or the opened popover would be invisible.
-		commentsHidden.set(editor, false)
-		focusThread(editor, thread, getCommentingOptions(editor).impreciseShapeAnchor)
+		if (!commentId) return
+		revealThreadRequest.set(editor, commentId)
 		setSearchParams(
 			(params) => {
 				params.delete('comment')
@@ -45,7 +26,7 @@ export function SneakyCommentDeepLink() {
 			},
 			{ replace: true }
 		)
-	}, [editor, thread, setSearchParams])
+	}, [editor, commentId, setSearchParams])
 
 	return null
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
@@ -1,7 +1,14 @@
 import { revealThreadRequest } from '@tldraw/commenting'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useEditor } from 'tldraw'
+import { useEditor, useToasts, useValue } from 'tldraw'
+import { useMaybeApp } from '../../../hooks/useAppState'
+import { useIsReady } from '../../../hooks/useIsReady'
+import { defineMessages, useMsg } from '../../../utils/i18n'
+
+const messages = defineMessages({
+	commentDeleted: { defaultMessage: 'This comment was deleted.' },
+})
 
 /**
  * dotcom's comment deep-link handler: `?comment=<thread or comment id>` (a shared link, or a
@@ -12,8 +19,12 @@ import { useEditor } from 'tldraw'
  */
 export function SneakyCommentDeepLink() {
 	const editor = useEditor()
+	const app = useMaybeApp()
+	const isReady = useIsReady()
+	const { addToast } = useToasts()
 	const [searchParams, setSearchParams] = useSearchParams()
 	const commentId = searchParams.get('comment')
+	const deletedMsg = useMsg(messages.commentDeleted)
 
 	useEffect(() => {
 		if (!commentId) return
@@ -26,6 +37,26 @@ export function SneakyCommentDeepLink() {
 			{ replace: true }
 		)
 	}, [editor, commentId, setSearchParams])
+
+	// A request that outlives the file load points at deleted records: comments arrive with the
+	// document snapshot, so once the file is ready (plus a short grace for ordering) an unserved
+	// request will never be served. Explain the dead end instead of doing nothing, and mark the
+	// comment's notification read so it doesn't keep dead-ending on every click.
+	const pendingRevealId = useValue('pending reveal', () => revealThreadRequest.get(editor), [
+		editor,
+	])
+	useEffect(() => {
+		if (!isReady || !pendingRevealId) return
+		const timer = setTimeout(() => {
+			if (revealThreadRequest.get(editor) !== pendingRevealId) return
+			revealThreadRequest.set(editor, null)
+			addToast({ id: 'comment-deep-link-deleted', severity: 'info', title: deletedMsg })
+			if (app?.getComments().some((c) => c.id === pendingRevealId)) {
+				app.markCommentRead(pendingRevealId)
+			}
+		}, 2000)
+		return () => clearTimeout(timer)
+	}, [isReady, pendingRevealId, editor, app, addToast, deletedMsg])
 
 	return null
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
@@ -1,4 +1,4 @@
-import { revealThreadRequest } from '@tldraw/commenting'
+import { getCommentRecord, revealThreadRequest, useCommentingEnabled } from '@tldraw/commenting'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useEditor, useToasts, useValue } from 'tldraw'
@@ -21,6 +21,7 @@ export function SneakyCommentDeepLink() {
 	const editor = useEditor()
 	const app = useMaybeApp()
 	const isReady = useIsReady()
+	const commentingEnabled = useCommentingEnabled()
 	const { addToast } = useToasts()
 	const [searchParams, setSearchParams] = useSearchParams()
 	const commentId = searchParams.get('comment')
@@ -38,25 +39,27 @@ export function SneakyCommentDeepLink() {
 		)
 	}, [editor, commentId, setSearchParams])
 
-	// A request that outlives the file load points at deleted records: comments arrive with the
-	// document snapshot, so once the file is ready (plus a short grace for ordering) an unserved
-	// request will never be served. Explain the dead end instead of doing nothing, and mark the
-	// comment's notification read so it doesn't keep dead-ending on every click.
+	// A request that stays unserved once the file is loaded, the overlay is serving (the license
+	// gate has resolved), and the comment records are absent almost certainly points at a deleted
+	// comment — explain the dead end instead of doing nothing, and mark the comment's notification
+	// read so it doesn't keep dead-ending on every click. "Absent" is still a heuristic (the sync
+	// layer has no records-settled signal), so the request is left pending: if the records are
+	// merely late, the overlay still serves them when they land, and an unserved request is inert.
 	const pendingRevealId = useValue('pending reveal', () => revealThreadRequest.get(editor), [
 		editor,
 	])
 	useEffect(() => {
-		if (!isReady || !pendingRevealId) return
+		if (!isReady || !commentingEnabled || !pendingRevealId) return
 		const timer = setTimeout(() => {
 			if (revealThreadRequest.get(editor) !== pendingRevealId) return
-			revealThreadRequest.set(editor, null)
+			if (getCommentRecord(editor, pendingRevealId)) return
 			addToast({ id: 'comment-deep-link-deleted', severity: 'info', title: deletedMsg })
 			if (app?.getComments().some((c) => c.id === pendingRevealId)) {
 				app.markCommentRead(pendingRevealId)
 			}
 		}, 2000)
 		return () => clearTimeout(timer)
-	}, [isReady, pendingRevealId, editor, app, addToast, deletedMsg])
+	}, [isReady, commentingEnabled, pendingRevealId, editor, app, addToast, deletedMsg])
 
 	return null
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
@@ -4,12 +4,11 @@ import { useSearchParams } from 'react-router-dom'
 import { useEditor } from 'tldraw'
 
 /**
- * Routes a comment link into the comments overlay. A notification row navigates to the file route
- * with `?comment=<id>`, but the overlay only reads the URL once at mount — a same-file navigation
- * changes the query string without remounting anything, so the link would otherwise do nothing.
- * This watches the param through router state, hands the id to the overlay as a reveal request
- * (the overlay owns waiting for the records to sync in and the cluster-aware reveal), and strips
- * the consumed param so back/refresh doesn't re-open the thread.
+ * dotcom's comment deep-link handler: `?comment=<thread or comment id>` (a shared link, or a
+ * notification row's navigation) becomes a reveal request served by the comments overlay, which
+ * owns waiting for the records to sync in and the cluster-aware reveal. Watches router state, so
+ * it fires on same-file navigations too, and strips the consumed param so back/refresh doesn't
+ * re-open the thread.
  */
 export function SneakyCommentDeepLink() {
 	const editor = useEditor()

--- a/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/sneaky/SneakyCommentDeepLink.tsx
@@ -1,0 +1,51 @@
+import {
+	commentsHidden,
+	focusThread,
+	getCommentingOptions,
+	getCommentRecord,
+} from '@tldraw/commenting'
+import { useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { useEditor, useValue } from 'tldraw'
+
+/**
+ * Opens the comment thread a notification links to. A notification row navigates to the file
+ * route with `?comment=<id>`; this watches that param from inside the editor, waits for the
+ * linked comment and its thread to be present in the store (on a cross-file navigation they
+ * sync in after the editor mounts), then opens the thread popover via `focusThread` and strips
+ * the consumed param so back/refresh doesn't re-open it.
+ */
+export function SneakyCommentDeepLink() {
+	const editor = useEditor()
+	const [searchParams, setSearchParams] = useSearchParams()
+	const commentId = searchParams.get('comment')
+
+	const thread = useValue(
+		'linked comment thread',
+		() => {
+			if (!commentId) return null
+			const comment = getCommentRecord(editor, commentId)
+			if (comment?.typeName !== 'comment') return null
+			const thread = getCommentRecord(editor, comment.threadId)
+			return thread?.typeName === 'comment-thread' ? thread : null
+		},
+		[editor, commentId]
+	)
+
+	useEffect(() => {
+		if (!thread) return
+		// Following the link is an explicit ask to see this comment — override hidden pins,
+		// or the opened popover would be invisible.
+		commentsHidden.set(editor, false)
+		focusThread(editor, thread, getCommentingOptions(editor).impreciseShapeAnchor)
+		setSearchParams(
+			(params) => {
+				params.delete('comment')
+				return params
+			},
+			{ replace: true }
+		)
+	}, [editor, thread, setSearchParams])
+
+	return null
+}

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -514,6 +514,9 @@ export function removeCommentRecords(editor: Editor, ids: (TLCommentId | TLComme
 export function renderMarkdown(text: string): ReactNode;
 
 // @public
+export const revealThreadRequest: EditorAtom<null | string>;
+
+// @public
 export function richTextToPlaintext(body: TLRichText, resolveName?: (id: string) => string | undefined): string;
 
 // @public

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -77,6 +77,7 @@ import {
 	openThreadId,
 	pendingComment,
 	regionDraft,
+	revealThreadRequest,
 	toggleCommentsHidden,
 	usePendingComment,
 } from './state'
@@ -233,7 +234,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// canvas, so any pin past its bottom/right edge inflates the root's scrollHeight — which the
 	// wheel hook's is-this-scrollable guard reads as scrollable, silently disabling pass-through.
 	usePassThroughMouseOverEvents(layerRef)
-	const deepLinkHandled = useRef(false)
 	const threads = useCommentThreads(editor)
 	const pending = usePendingComment()
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
@@ -399,46 +399,65 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const openThread = openId ? threadsById.get(openId) : null
 	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
 
-	// Reset the transient UI state (open thread, half-placed comment) when this unmounts.
+	// Reset the transient UI state (open thread, half-placed comment, unserved reveal) when this
+	// unmounts.
 	useEffect(() => {
 		return () => {
 			openThreadId.set(editor, null)
 			pendingComment.set(editor, null)
+			revealThreadRequest.set(editor, null)
 		}
 	}, [editor])
 
-	// Open the thread named by a deep link (?comment=<thread or comment id>). If the thread is
-	// currently inside a cluster, zoom to the first split that reveals it before opening.
+	// Seed a reveal request from a deep link (?comment=<thread or comment id>) once at mount, so a
+	// plain shared link works with no consumer wiring. Requests after mount come from writers of
+	// {@link revealThreadRequest} — the URL is not watched for changes here.
 	useEffect(() => {
-		if (deepLinkHandled.current) return
 		const id = new URLSearchParams(window.location.search).get('comment')
-		if (!id) {
-			deepLinkHandled.current = true
-			return
-		}
+		if (id) revealThreadRequest.set(editor, id)
+	}, [editor])
 
-		const record = getCommentRecord(editor, id)
-		if (!record) return
+	// The requested thread, once it (and, for a comment id, its parent thread) has synced into the
+	// store; null while records are still arriving or when no request is pending.
+	const requestedRevealThread = useValue(
+		'requested reveal thread',
+		() => {
+			const id = revealThreadRequest.get(editor)
+			if (!id) return null
+			const record = getCommentRecord(editor, id)
+			if (!record) return null
+			const thread =
+				record.typeName === 'comment' ? getCommentRecord(editor, record.threadId) : record
+			return thread?.typeName === 'comment-thread' ? thread : null
+		},
+		[editor]
+	)
 
-		let thread: TLCommentThread | undefined
-		if (record.typeName === 'comment') {
-			thread = threadsById.get(record.threadId)
-		} else {
-			thread = record
-		}
-		if (!thread) return
-
-		deepLinkHandled.current = true
+	// Serve a pending reveal request: open the thread, zooming to the first cluster split that
+	// reveals its pin when it's currently folded into a badge. A reveal is an explicit ask to see
+	// the thread, so it also unhides pins — the popover opens on the on-canvas layer, which stays
+	// invisible while hidden.
+	useEffect(() => {
+		if (!requestedRevealThread) return
+		revealThreadRequest.set(editor, null)
+		commentsHidden.set(editor, false)
 		revealDeepLinkedThread(
 			editor,
-			thread,
+			requestedRevealThread,
 			clusterModel.table,
 			clusterZoomBounds,
 			options,
 			impreciseShapeAnchor
 		)
-		openThreadId.set(editor, thread.id)
-	}, [clusterModel.table, clusterZoomBounds, editor, threadsById, impreciseShapeAnchor, options])
+		openThreadId.set(editor, requestedRevealThread.id)
+	}, [
+		requestedRevealThread,
+		clusterModel.table,
+		clusterZoomBounds,
+		editor,
+		impreciseShapeAnchor,
+		options,
+	])
 
 	// Clicking a badge zooms to just past the zoom at which that cluster first unclusters,
 	// centered on its centroid. The event that created a visible cluster is the event that splits

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -409,14 +409,6 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		}
 	}, [editor])
 
-	// Seed a reveal request from a deep link (?comment=<thread or comment id>) once at mount, so a
-	// plain shared link works with no consumer wiring. Requests after mount come from writers of
-	// {@link revealThreadRequest} — the URL is not watched for changes here.
-	useEffect(() => {
-		const id = new URLSearchParams(window.location.search).get('comment')
-		if (id) revealThreadRequest.set(editor, id)
-	}, [editor])
-
 	// The requested thread, once it (and, for a comment id, its parent thread) has synced into the
 	// store; null while records are still arriving or when no request is pending.
 	const requestedRevealThread = useValue(
@@ -441,7 +433,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		if (!requestedRevealThread) return
 		revealThreadRequest.set(editor, null)
 		commentsHidden.set(editor, false)
-		revealDeepLinkedThread(
+		revealThread(
 			editor,
 			requestedRevealThread,
 			clusterModel.table,
@@ -741,7 +733,7 @@ function getClusterZoomBounds(editor: Editor): { minZoom: number; maxZoom: numbe
 	}
 }
 
-function revealDeepLinkedThread(
+function revealThread(
 	editor: Editor,
 	thread: TLCommentThread,
 	table: ClusterTable,

--- a/packages/commenting/src/canvas/state.ts
+++ b/packages/commenting/src/canvas/state.ts
@@ -25,6 +25,15 @@ export const openThreadId = new EditorAtom<string | null>('openThreadId', () => 
  * @public */
 export const pendingComment = new EditorAtom<PendingComment | null>('pendingComment', () => null)
 
+/**
+ * A pending request to reveal a thread: a thread or comment id to open and bring into view, or
+ * null when none is pending. Written by consumers outside the canvas layer (e.g. a notification
+ * link); served and cleared by `CanvasComments`, which owns the wait for the records to sync in
+ * and the cluster-aware reveal.
+ * @public
+ */
+export const revealThreadRequest = new EditorAtom<string | null>('revealThreadRequest', () => null)
+
 /** The region rectangle being dragged out right now (page coords), or null when not dragging. The
  *  comment tool writes it on each move; the overlay reads it to draw the live dashed box. */
 export const regionDraft = new EditorAtom<BoxModel | null>('regionDraft', () => null)

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -77,6 +77,7 @@ export {
 	commitCommentMutation,
 	openThreadId,
 	pendingComment,
+	revealThreadRequest,
 	sidebarFilters,
 	toggleCommentsHidden,
 	toggleCommentsSidebar,


### PR DESCRIPTION
## Problem

Clicking a notification did nothing when it pointed at the file you were already viewing, and on a cross-file click it panned to the shape but never opened the thread.

A notification row navigates to the file route with `?comment=<id>&d=<deeplink>`, but nothing consumed `?comment=` — and `d` is read exactly once, in `TlaEditor`'s `handleMount`. Same-route navigation only rewrites the query string, so the editor never remounts and neither param is ever read.

## Fix

Adds `SneakyCommentDeepLink` inside the editor (following the `Sneaky*` pattern). It watches `?comment=`, reactively waits for the linked comment and its thread records to sync into the store (on a cross-file open they arrive after mount), then `focusThread`s it — page switch, popover open, center on pin — unhiding pins if they were toggled off, and strips the consumed param with a `replace` so back/refresh doesn't re-open it. Passes the editor's configured `impreciseShapeAnchor` through, matching the comments sidebar's row-click.

### Test plan

1. Open a file, have another user (or account) mention you in a comment on that same file
2. Click the notification → the thread popover opens, camera centers on the pin
3. Repeat from a different file → navigates, then opens the thread once comments sync in
4. Hide comment pins, click a notification → pins unhide and the thread opens
5. Back/refresh after following a link → thread does not re-open
6. From a second account, delete a comment that mentioned you, then click its (stale) notification → "This comment was deleted." toast, notification marked read, no camera move

### API changes

`@tldraw/commenting`:
- New: `revealThreadRequest` — a per-editor `EditorAtom<string | null>` holding a pending request to reveal a thread (a thread or comment id). Write an id to open that thread and bring it into view; `CanvasComments` serves the request once the records have synced (zooming to the cluster split that reveals the pin when clustered, unhiding pins) and clears it.
- Behavior change: the package no longer reads `?comment=` from the URL itself. URL deep-linking is now the host app's responsibility — write the param's id into `revealThreadRequest` (tldraw.com does this in `SneakyCommentDeepLink`). Consumers relying on the built-in URL read need that one-line adapter.

