### PR TITLE
feature(commenting): configurable shape-comment precision (preciseShapeAnchors)

### DIFF
--- a/apps/examples/src/examples/collaboration/comment-shape-precision/CommentShapePrecisionExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-shape-precision/CommentShapePrecisionExample.tsx
@@ -1,0 +1,127 @@
+import {
+	CanvasComments,
+	CommentAuthor,
+	CommentingOptions,
+	CommentTool,
+	commentToolOverrides,
+} from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useMemo, useState } from 'react'
+import {
+	commentSchemaRecords,
+	createTLSchema,
+	createTLStore,
+	Editor,
+	TLComponents,
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	toRichText,
+} from 'tldraw'
+import '@tldraw/commenting/commenting.css'
+import 'tldraw/tldraw.css'
+
+type PrecisionMode = CommentingOptions['preciseShapeAnchors']
+
+// One configured comment tool per mode, built once at module level so each array keeps a stable
+// identity. `preciseShapeAnchors` decides what commenting on a shape produces: a precise anchor
+// (pinned to the exact clicked spot within the shape — the `'always'` default), an imprecise one
+// (pinned to the shape as a whole, rendered at its top-right), or the user's call per placement —
+// `'alt'`: imprecise unless Alt is held while placing.
+const MODE_TOOLS: Record<PrecisionMode, (typeof CommentTool)[]> = {
+	always: [CommentTool.configure({ preciseShapeAnchors: 'always' })],
+	never: [CommentTool.configure({ preciseShapeAnchors: 'never' })],
+	alt: [CommentTool.configure({ preciseShapeAnchors: 'alt' })],
+}
+
+const MODE_LABELS: Record<PrecisionMode, string> = {
+	always: 'Always precise (default)',
+	never: 'Shape only',
+	alt: 'Alt for precise',
+}
+
+const AUTHORS: Record<string, CommentAuthor> = { me: { name: 'You', color: '#EC5E41' } }
+const resolveAuthor = (id: string): CommentAuthor => AUTHORS[id] ?? { name: id }
+
+const handleMount = (editor: Editor) => {
+	// A shape to comment on. The store survives mode switches, so only seed it once.
+	if (editor.getCurrentPageShapeIds().size === 0) {
+		editor.run(
+			() => {
+				editor.createShapes([
+					{
+						type: 'geo',
+						x: 120,
+						y: 140,
+						props: {
+							geo: 'rectangle',
+							w: 320,
+							h: 200,
+							richText: toRichText('Comment on me'),
+						},
+					},
+				])
+			},
+			{ history: 'ignore' }
+		)
+	}
+	editor.zoomToBounds({ x: 40, y: 40, w: 520, h: 400 }, { immediate: true })
+}
+
+export default function CommentShapePrecisionExample() {
+	const [mode, setMode] = useState<PrecisionMode>('always')
+
+	// Comments live in the editor's own store as records; sharing one store across mode switches
+	// keeps every placed thread visible while the tool is reconfigured.
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	const components = useMemo<TLComponents>(
+		() => ({
+			InFrontOfTheCanvas: () => <CanvasComments currentUserId="me" resolveAuthor={resolveAuthor} />,
+		}),
+		[]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				// Commenting options are fixed at tool registration (`CommentTool.configure`), so
+				// switching modes remounts the editor with the newly configured tool. The shared store
+				// carries the comments across.
+				key={mode}
+				// Commenting is a licensed feature. Every feature is enabled in local development, but a
+				// deployed app needs a license key that includes commenting — swap in your own key here.
+				licenseKey={getLicenseKey()}
+				store={store}
+				onMount={handleMount}
+				tools={MODE_TOOLS[mode]}
+				overrides={[commentToolOverrides]}
+				components={components}
+			>
+				<div
+					style={{
+						position: 'absolute',
+						top: 60,
+						left: 12,
+						display: 'flex',
+						gap: 4,
+						zIndex: 1000,
+					}}
+				>
+					{(Object.keys(MODE_LABELS) as PrecisionMode[]).map((id) => (
+						<TldrawUiButton
+							key={id}
+							type={mode === id ? 'primary' : 'normal'}
+							onClick={() => setMode(id)}
+						>
+							<TldrawUiButtonLabel>{MODE_LABELS[id]}</TldrawUiButtonLabel>
+						</TldrawUiButton>
+					))}
+				</div>
+			</Tldraw>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/comment-shape-precision/README.md
+++ b/apps/examples/src/examples/collaboration/comment-shape-precision/README.md
@@ -1,0 +1,26 @@
+---
+title: Shape comment precision
+component: ./CommentShapePrecisionExample.tsx
+priority: 5
+keywords: [comments, commenting, precise, imprecise, shape, anchor, alt, collaboration]
+---
+
+Choose whether commenting on a shape pins to the exact clicked point, to the shape as a whole, or lets Alt decide.
+
+---
+
+When a comment lands on a shape, its anchor is either **precise** — pinned to the exact clicked spot, as a normalized (0–1) offset within the shape — or **imprecise** — pinned to the shape as a whole, with the pin rendered at a spot your app chooses (`impreciseShapeAnchor`, top-right by default). Either way the anchor tracks the shape as it moves and resizes.
+
+`preciseShapeAnchors` on `CommentTool.configure` picks which of those a placement produces:
+
+- **`'always'`** (the default) — every shape comment is precise. Commenting feels like pointing at an exact spot, whether or not a shape is under the cursor.
+- **`'never'`** — every shape comment is imprecise. Comments address the shape itself, and your app owns where the pin sits.
+- **`'alt'`** — both: imprecise normally, precise while Alt is held during placement.
+
+```tsx
+<Tldraw tools={[CommentTool.configure({ preciseShapeAnchors: 'never' })]} />
+```
+
+The setting applies wherever a shape anchor is created — placing with the comment tool, and dropping a dragged pin onto a shape. It only governs new placements: anchors already stored keep rendering the way they were made.
+
+Use the buttons to switch modes, then place comments on the rectangle (press `c` or pick the comment tool) to feel the difference.

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -218,6 +218,7 @@ export interface CommentingOptions {
         readonly x: number;
         readonly y: number;
     };
+    readonly preciseShapeAnchors: 'alt' | 'always' | 'never';
 }
 
 // @public (undocumented)
@@ -378,6 +379,7 @@ export const defaultCommentingOptions: {
         readonly x: 1;
         readonly y: 0;
     };
+    readonly preciseShapeAnchors: "always";
 };
 
 // @public
@@ -517,6 +519,9 @@ export function removeCommentRecords(editor: Editor, ids: (TLCommentId | TLComme
 
 // @public
 export function renderMarkdown(text: string): ReactNode;
+
+// @public
+export function resolveShapeAnchorPrecision(editor: Editor, altKey: boolean): boolean;
 
 // @public
 export function richTextToPlaintext(body: TLRichText, resolveName?: (id: string) => string | undefined): string;

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -9,7 +9,7 @@ import {
 import { type CommentingOptions, defaultCommentingOptions } from './options'
 import { getRegionCommentOptions } from './region-options'
 import { commentsSidebarOpen, pendingComment, regionDraft } from './state'
-import { regionPinPoint, shapeAnchorAt } from './thread-state'
+import { regionPinPoint, resolveShapeAnchorPrecision, shapeAnchorAt } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
  *  to. Shared between the tool (which sets it on click) and the overlay (which renders the
@@ -176,7 +176,12 @@ class CommentPointing extends StateNode {
 		const point = editor.inputs.getCurrentPagePoint()
 		const hit = editor.getShapeAtPoint(point, { hitInside: true })
 		const anchor: TLCommentAnchor = hit
-			? shapeAnchorAt(editor, hit.id, point, editor.inputs.getAltKey())
+			? shapeAnchorAt(
+					editor,
+					hit.id,
+					point,
+					resolveShapeAnchorPrecision(editor, editor.inputs.getAltKey())
+				)
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
 		// Hand back to select; the open composer is now the focus.

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -85,6 +85,7 @@ import {
 	anchorPagePoint,
 	regionAnchorPinCorner,
 	regionPinPoint,
+	resolveShapeAnchorPrecision,
 	shapeAnchorAt,
 } from './thread-state'
 
@@ -1484,7 +1485,7 @@ const ThreadPin = memo(function ThreadPin({
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
 			anchor = hit
-				? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
+				? shapeAnchorAt(editor, hit.id, pagePoint, resolveShapeAnchorPrecision(editor, e.altKey))
 				: { type: 'point', x: pagePoint.x, y: pagePoint.y }
 		}
 		commitCommentMutation(editor, () => putCommentRecords(editor, [{ ...thread, anchor }]), 'drag')

--- a/packages/commenting/src/canvas/options.ts
+++ b/packages/commenting/src/canvas/options.ts
@@ -59,6 +59,15 @@ export interface CommentingOptions {
 	// ── Anchoring ────────────────────────────────────────────────────────────────────────────
 	/** Normalized (0–1) spot within a shape where imprecise shape pins sit. Default top-right. */
 	readonly impreciseShapeAnchor: { readonly x: number; readonly y: number }
+	/**
+	 * When placing (or drag-re-anchoring) a comment on a shape, whether the anchor is precise —
+	 * pinned to the exact clicked spot within the shape — or imprecise — pinned to the shape as a
+	 * whole, rendered at `impreciseShapeAnchor`. `'always'` (the default) and `'never'` fix it
+	 * either way and ignore the modifier; `'alt'` makes it the user's call per placement:
+	 * imprecise normally, precise while Alt is held. Governs new placements only; existing anchors
+	 * render as stored.
+	 */
+	readonly preciseShapeAnchors: 'always' | 'never' | 'alt'
 
 	// ── Clustering tuning ─────────────────────────────────────────────────────────────────────
 	/** Screen-pixel margin by which the viewport is inflated when culling cluster badges. */
@@ -81,6 +90,7 @@ export const defaultCommentingOptions = {
 	dragHistory: undefined,
 	enableClustering: true,
 	impreciseShapeAnchor: { x: 1, y: 0 },
+	preciseShapeAnchors: 'always',
 	clusterCullMargin: 120,
 	clusterSplitZoomFactor: 1.05,
 	components: {},

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,4 +1,5 @@
 import { BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId, VecLike } from 'tldraw'
+import { getCommentingOptions } from './options'
 import { getRegionCommentOptions } from './region-options'
 import { openThreadId } from './state'
 
@@ -64,9 +65,28 @@ export function anchorPagePoint(
 }
 
 /**
+ * Whether a shape placement lands precise, per the editor's `preciseShapeAnchors` option: fixed
+ * either way for `'always'` (the default) and `'never'`, or the Alt key's live state for `'alt'`.
+ * Both placement paths — the comment tool's pointer-up and a pin drag's re-anchor — resolve
+ * through this before building the anchor with {@link shapeAnchorAt}.
+ * @public
+ */
+export function resolveShapeAnchorPrecision(editor: Editor, altKey: boolean): boolean {
+	switch (getCommentingOptions(editor).preciseShapeAnchors) {
+		case 'always':
+			return true
+		case 'never':
+			return false
+		case 'alt':
+			return altKey
+	}
+}
+
+/**
  * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
- * shape's page bounds, remembered either way. When `precise` (Alt held) the pin sits at exactly
- * `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the box).
+ * shape's page bounds, remembered either way. When `precise` the pin sits at exactly `x`/`y`;
+ * otherwise it sits at the consumer's imprecise default (top-right out of the box). Placement
+ * gestures get `precise` from {@link resolveShapeAnchorPrecision}.
  * @public
  */
 export function shapeAnchorAt(

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -92,6 +92,7 @@ export {
 	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
 	focusThread,
 	regionAnchorPinCorner,
+	resolveShapeAnchorPrecision,
 	shapeAnchorAt,
 } from './canvas/thread-state'
 


### PR DESCRIPTION
Following the discussion with Tim about whether SDK consumers want shape+offset commenting, shape-only, or both: this makes it a commenting option, with an example so we can align on the three behaviours.

### What

- Adds `preciseShapeAnchors` to `CommentingOptions`, set via `CommentTool.configure`:
  - `'always'` (the default) — every shape comment is precise (pinned to the exact clicked spot within the shape)
  - `'never'` — every shape comment is imprecise (addresses the shape as a whole; the pin renders at `impreciseShapeAnchor`)
  - `'alt'` — the previous behaviour: imprecise unless Alt is held while placing
- Both paths that create shape anchors resolve through the new `resolveShapeAnchorPrecision`: placing with the comment tool, and dropping a dragged pin onto a shape.
- The clicked `x`/`y` are stored either way — the mode only gates `isPrecise` — so the choice affects rendering, not the data model, and existing anchors render as stored.
- **Behaviour change**: precise is now the default. Consumers relying on the old Alt-gated placement opt back in with `'alt'`. dotcom needs no change — it inherits the default.

### Example

New `comment-shape-precision` example with a mode switcher (shared store across switches) to feel the difference between the three modes.

### Test plan

- Verified all four mode × Alt combinations live in the example, checking the created anchor records
- `packages/commenting` tests (179), typecheck, api-report regenerated

### API Changes

- New option on `CommentingOptions`: `preciseShapeAnchors: 'always' | 'never' | 'alt'`, defaulting to `'always'`. This changes default placement behaviour: shape comments are precise unless configured otherwise (the previous behaviour is `'alt'`).
- New export: `resolveShapeAnchorPrecision(editor, altKey)` — resolves whether a shape placement lands precise, per the configured mode.