### PR TITLE
fix(commenting): layer pins between selection overlays and collaborator cursors

### DIFF
--- a/apps/examples/e2e/tests/test-overlay-snapshots.spec.ts
+++ b/apps/examples/e2e/tests/test-overlay-snapshots.spec.ts
@@ -7,10 +7,10 @@ declare const editor: Editor
 
 // Screenshot-based regression tests for canvas overlay appearance.
 //
-// Overlays render to a single <canvas class="tl-canvas-overlays"> element, so
-// we screenshot the `.tl-canvas` region and let the image compare cover every
-// overlay kind (selection foreground, shape handles, brush, snap indicators,
-// scribble, etc.) at once.
+// Overlays render to a pair of stacked <canvas class="tl-canvas-overlays">
+// elements (the 'under' and 'over' bands), so we screenshot the `.tl-canvas`
+// region and let the image compare cover every overlay kind (selection
+// foreground, shape handles, brush, snap indicators, scribble, etc.) at once.
 //
 // Tests use direct editor state injection (brush/zoomBrush via
 // updateInstanceState, scribbles via ScribbleManager, snap indicators via

--- a/apps/examples/e2e/tests/test-rich-text.spec.ts
+++ b/apps/examples/e2e/tests/test-rich-text.spec.ts
@@ -35,7 +35,7 @@ test.describe('more rich text', () => {
 		)
 
 		// expect canvas overlays to be visible (indicators render there when editing)
-		const canvasIndicator = page.locator('.tl-canvas-overlays')
+		const canvasIndicator = page.locator('.tl-canvas-overlays-under')
 		await expect(canvasIndicator).toBeVisible()
 	})
 
@@ -59,7 +59,7 @@ test.describe('more rich text', () => {
 		)
 
 		// expect canvas overlays to be visible (indicators render there when editing)
-		const canvasIndicator = page.locator('.tl-canvas-overlays')
+		const canvasIndicator = page.locator('.tl-canvas-overlays-under')
 		await expect(canvasIndicator).toBeVisible()
 	})
 })

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -1,11 +1,13 @@
-/* The comments layer is portaled into the editor container. Pins live in the canvas-in-front layer
-   (beneath the UI panels at z-index 300), so the toolbar and style panel draw over them; the open
-   thread's popover portals up to the menus layer separately (`.tlui-cmt-canvas-popover`) so it isn't
-   clipped. Click-through except on its own children. */
+/* The comments layer is portaled into `.tl-canvas`, so it stacks within the canvas: above the
+   shapes layer (300) but below the overlays canvas (500) where collaborator cursors are drawn —
+   cursors sweep over pins, pins sit over shapes, and the UI panels (siblings of the canvas) draw
+   over everything here. The open thread's popover and the pending composer portal up to the
+   container separately (`.tlui-cmt-canvas-popover`, `.tlui-cmt-canvas-composer`) so they keep
+   UI-layer stacking and aren't clipped. Click-through except on its own children. */
 .tlui-cmt-canvas-layer {
 	position: absolute;
 	inset: 0;
-	z-index: var(--tl-layer-canvas-in-front);
+	z-index: 400;
 	pointer-events: none;
 }
 

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -5,6 +5,7 @@ import {
 	ReactNode,
 	useCallback,
 	useEffect,
+	useLayoutEffect,
 	useMemo,
 	useRef,
 	useState,
@@ -228,6 +229,15 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		[props.regionOptions]
 	)
 	useEffect(() => setRegionCommentOptions(editor, regionOptions), [editor, regionOptions])
+	// The layer portals into the canvas element, not the container: collaborator cursors are drawn
+	// on a canvas inside `.tl-canvas`, and `contain: strict` flattens the whole canvas into one
+	// paint layer — a sibling layer can only sit entirely above or below it. Inside, the pins can
+	// stack above shapes but below the cursor overlays. Found after mount: sibling subtrees aren't
+	// in the DOM yet during this component's first render.
+	const [canvasElement, setCanvasElement] = useState<HTMLElement | null>(null)
+	useLayoutEffect(() => {
+		setCanvasElement(container.querySelector('.tl-canvas'))
+	}, [container])
 	const layerRef = useRef<HTMLDivElement>(null)
 	// Over the pins and cluster badges, hover passes through to the canvas beneath (these events
 	// bubble up from the pointer-interactive markers to this layer root). Wheel pass-through is
@@ -498,8 +508,8 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// is read above so this component stays mounted and its shortcut/Escape effects keep running.
 	if (hidden) return null
 
-	// Render into the container (above the panels' stacking context) so the pins and popovers
-	// live in the UI layer rather than being clipped by the canvas layer.
+	if (!canvasElement) return null
+
 	return createPortal(
 		<div ref={layerRef} className="tlui-cmt-canvas-layer">
 			{options.enableClustering ? (
@@ -579,7 +589,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 				<PendingComposer editor={editor} pending={pending} {...props} />
 			)}
 		</div>,
-		container
+		canvasElement
 	)
 }
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -2704,6 +2704,7 @@ export abstract class OverlayUtil<T extends TLOverlay = TLOverlay> {
     abstract isActive(): boolean;
     onPointerDown?(overlay: T, info: TLPointerEventInfo): boolean | void;
     options: {
+        band?: TLOverlayBand;
         zIndex?: number;
     };
     render(_ctx: CanvasRenderingContext2D, _overlays: T[]): void;
@@ -4423,6 +4424,9 @@ export interface TLOverlay<Props = Record<string, unknown>> {
     props: Props;
     type: string;
 }
+
+// @public
+export type TLOverlayBand = 'over' | 'under';
 
 // @public
 export interface TLOverlayEntry {

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -40,6 +40,11 @@
 	--tl-layer-watermark: 200;
 	--tl-layer-canvas-in-front: 250;
 	--tl-layer-canvas-shapes: 300;
+	/* The two overlay canvases straddle DOM content mounted inside the canvas
+	   between them (e.g. comment pins at 400): 'under' overlays (selection,
+	   brush, indicators) paint beneath it, 'over' overlays (collaborator
+	   cursors) above it. */
+	--tl-layer-canvas-overlays-under: 350;
 	--tl-layer-canvas-overlays: 500;
 	--tl-layer-canvas-blocker: 10000;
 
@@ -960,6 +965,11 @@ input,
 	position: absolute;
 	inset: 0;
 	pointer-events: none;
+}
+.tl-canvas-overlays-under {
+	z-index: var(--tl-layer-canvas-overlays-under);
+}
+.tl-canvas-overlays-over {
 	z-index: var(--tl-layer-canvas-overlays);
 }
 

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -181,6 +181,7 @@ export {
 	OverlayUtil,
 	type TLAnyOverlayUtilConstructor,
 	type TLOverlay,
+	type TLOverlayBand,
 	type TLOverlayUtilConstructor,
 } from './lib/editor/overlays/OverlayUtil'
 export { strokeShapeIndicators } from './lib/editor/overlays/strokeShapeIndicators'

--- a/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
+++ b/packages/editor/src/lib/components/default-components/CanvasOverlays.tsx
@@ -17,7 +17,12 @@ interface RenderInputs {
 /** @internal @react */
 export const CanvasOverlays = memo(function CanvasOverlays() {
 	const editor = useEditor()
-	const canvasRef = useRef<HTMLCanvasElement>(null)
+	// Two stacked canvases straddling the DOM content that mounts inside the
+	// canvas (between the shapes layer and the canvas-in-front band): utils
+	// with band 'under' paint beneath it, 'over' utils (collaborator cursors)
+	// paint above it.
+	const underCanvasRef = useRef<HTMLCanvasElement>(null)
+	const overCanvasRef = useRef<HTMLCanvasElement>(null)
 
 	useEffect(() => {
 		// Bundle the primitive scalars the renderer needs into one computed so the
@@ -51,39 +56,46 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 		)
 
 		const scheduler = new EffectScheduler('canvas overlays render', () => {
-			const canvas = canvasRef.current
-			if (!canvas) return
+			const underCanvas = underCanvasRef.current
+			const overCanvas = overCanvasRef.current
+			if (!underCanvas || !overCanvas) return
 
-			const ctx = canvas.getContext('2d')
-			if (!ctx) return
+			const underCtx = underCanvas.getContext('2d')
+			const overCtx = overCanvas.getContext('2d')
+			if (!underCtx || !overCtx) return
 
 			const { dpr, w, h, cx, cy, zoom } = renderInputs$.get()
 
 			const canvasWidth = Math.ceil(w * dpr)
 			const canvasHeight = Math.ceil(h * dpr)
 
-			if (canvas.width !== canvasWidth || canvas.height !== canvasHeight) {
-				canvas.width = canvasWidth
-				canvas.height = canvasHeight
-				canvas.style.width = `${w}px`
-				canvas.style.height = `${h}px`
+			for (const canvas of [underCanvas, overCanvas]) {
+				if (canvas.width !== canvasWidth || canvas.height !== canvasHeight) {
+					canvas.width = canvasWidth
+					canvas.height = canvasHeight
+					canvas.style.width = `${w}px`
+					canvas.style.height = `${h}px`
+				}
 			}
-
-			ctx.setTransform(1, 0, 0, 1, 0, 0)
-			ctx.clearRect(0, 0, canvas.width, canvas.height)
 
 			// One setTransform = DPR scale * zoom scale * camera translate, into page space.
 			const s = dpr * zoom
-			ctx.setTransform(s, 0, 0, s, s * cx, s * cy)
+			for (const ctx of [underCtx, overCtx]) {
+				ctx.setTransform(1, 0, 0, 1, 0, 0)
+				ctx.clearRect(0, 0, canvasWidth, canvasHeight)
+				ctx.setTransform(s, 0, 0, s, s * cx, s * cy)
+			}
 
-			// Render all active overlay utils in zIndex order (low to high).
+			// Render all active overlay utils in zIndex order (low to high), each
+			// into its band's canvas.
 			for (const { util, overlays } of editor.overlays.getActiveOverlayEntries()) {
+				const ctx = (util.options.band ?? 'under') === 'over' ? overCtx : underCtx
 				ctx.save()
 				util.render(ctx, overlays)
 				ctx.restore()
 			}
-
-			// Debug: draw all geometry
+			// Debug: draw all geometry (on the over canvas, above everything)
+			const ctx = overCtx
 			if (debugFlags.debugGeometry.get()) {
 				const currentPagePoint = editor.inputs.getCurrentPagePoint()
 
@@ -177,7 +189,12 @@ export const CanvasOverlays = memo(function CanvasOverlays() {
 		return () => scheduler.detach()
 	}, [editor])
 
-	return <canvas ref={canvasRef} className="tl-canvas-overlays" />
+	return (
+		<>
+			<canvas ref={underCanvasRef} className="tl-canvas-overlays tl-canvas-overlays-under" />
+			<canvas ref={overCanvasRef} className="tl-canvas-overlays tl-canvas-overlays-over" />
+		</>
+	)
 })
 
 function drawGeometryStroke(ctx: CanvasRenderingContext2D, geometry: Geometry2d) {

--- a/packages/editor/src/lib/editor/overlays/OverlayUtil.ts
+++ b/packages/editor/src/lib/editor/overlays/OverlayUtil.ts
@@ -32,6 +32,17 @@ export interface TLOverlayUtilConstructor<U extends OverlayUtil = OverlayUtil> {
 export type TLAnyOverlayUtilConstructor = TLOverlayUtilConstructor<any>
 
 /**
+ * Which of the two overlay canvases a util renders to. They straddle the DOM
+ * content that mounts inside the canvas (between the shapes layer and the
+ * canvas-in-front band): `'under'` paints beneath that content, `'over'`
+ * paints above it. Collaborator cursors are `'over'`; everything else
+ * defaults to `'under'`.
+ *
+ * @public
+ */
+export type TLOverlayBand = 'under' | 'over'
+
+/**
  * Base class for overlay utilities. Overlays are ephemeral UI elements rendered
  * on top of the canvas (selection handles, rotation corners, shape handles, etc.).
  *
@@ -57,9 +68,13 @@ export abstract class OverlayUtil<T extends TLOverlay = TLOverlay> {
 	 * Defaults to `0`; built-in utils use larger integers (100, 200, …) with
 	 * gaps so custom utils can slot between.
 	 *
+	 * `band` picks which of the two overlay canvases the util paints to (see
+	 * {@link TLOverlayBand}). Defaults to `'under'`. `zIndex` orders utils
+	 * within a band; the `'over'` band always paints above the `'under'` band.
+	 *
 	 * @public
 	 */
-	options: { zIndex?: number } = {}
+	options: { zIndex?: number; band?: TLOverlayBand } = {}
 
 	/**
 	 * Create a new overlay util class with the given options merged in.

--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -712,6 +712,7 @@ export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCur
     isActive(): boolean;
     // (undocumented)
     options: {
+        band: "over";
         chatMaxWidth: number;
         fontSize: number;
         nameMaxWidth: number;
@@ -733,6 +734,7 @@ export class CollaboratorHintOverlayUtil extends OverlayUtil<TLCollaboratorHintO
     isActive(): boolean;
     // (undocumented)
     options: {
+        band: "over";
         lineWidth: number;
         viewportPadding: number;
         zIndex: number;

--- a/packages/tldraw/src/lib/overlays/CollaboratorCursorOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorCursorOverlayUtil.ts
@@ -64,7 +64,13 @@ function getLabelFontFamily(editorContainer: HTMLElement, editorWindow: Window):
  */
 export class CollaboratorCursorOverlayUtil extends OverlayUtil<TLCollaboratorCursorOverlay> {
 	static override type = 'collaborator_cursor'
-	override options = { zIndex: 1100, fontSize: 12, nameMaxWidth: 120, chatMaxWidth: 200 }
+	override options = {
+		zIndex: 1100,
+		band: 'over' as const,
+		fontSize: 12,
+		nameMaxWidth: 120,
+		chatMaxWidth: 200,
+	}
 
 	// Cache truncated text results to avoid repeated measureText loops.
 	// Key format: `${maxWidth}|${text}` with an upper bound on cache size.

--- a/packages/tldraw/src/lib/overlays/CollaboratorHintOverlayUtil.ts
+++ b/packages/tldraw/src/lib/overlays/CollaboratorHintOverlayUtil.ts
@@ -30,7 +30,7 @@ function getArrowPath() {
  */
 export class CollaboratorHintOverlayUtil extends OverlayUtil<TLCollaboratorHintOverlay> {
 	static override type = 'collaborator_hint'
-	override options = { zIndex: 900, lineWidth: 3, viewportPadding: 5 }
+	override options = { zIndex: 900, band: 'over' as const, lineWidth: 3, viewportPadding: 5 }
 
 	override isActive(): boolean {
 		const viewport = this.editor.getViewportPageBounds()


### PR DESCRIPTION
Comment pins currently paint above everything drawn on the canvas — including collaborator cursors, which slide underneath pins. This PR re-layers the canvas so pins sit where they should: above shapes and selection chrome, below cursors.

Two halves, which only make sense together:

- **Pins move inside the canvas.** Collaborator cursors are 2D-drawn on the overlays canvas inside `.tl-canvas`, whose `contain: strict` flattens it into a single paint layer — a layer portaled outside it (the pins today) can only paint entirely above or below the whole canvas. The pin layer now portals into `.tl-canvas` itself at z 400 (above the shapes layer at 300). The thread popover and pending composer still portal to the container and keep their UI-layer stacking; pin pointer handling is unchanged (React events bubble through the React tree, not the DOM).
- **The overlays canvas splits into two bands.** Alone, the move would put *all* overlay drawing — selection outlines, brush, handles, snaps, not just cursors — above the pins. The overlays now render to two stacked canvases: an `under` band (z 350) beneath DOM content mounted inside the canvas and an `over` band (z 500) above it, chosen per util via a new `band` option on `OverlayUtil` (`'under' | 'over'`, default `'under'`). Collaborator cursors and their off-screen hints are `over`; everything else stays `under`.

Net stacking inside the canvas: shapes → selection/brush/indicators → comment pins → collaborator cursors. Known tradeoff: a resize handle under a pin is occluded by it, like the outline.

### Change type

- [x] `bugfix`
- [x] `api`

### Test plan

1. With a second client connected, move the other cursor over a comment pin — the cursor draws above it.
2. Create a comment on a shape's corner and select the shape — the pin covers the selection outline, not the reverse.
3. Marquee-select, scribble, snap, and handle interactions all still draw (under band); minimap unchanged.

- [x] Unit tests

### Release notes

- Comment pins now stack between selection overlays and collaborator cursors. `OverlayUtil` options gain a `band` field (`'under' | 'over'`) choosing which of the two stacked overlay canvases a util paints to.


### API changes

- `OverlayUtil` options gain an optional `band?: TLOverlayBand` field (`'under' | 'over'`, default `'under'`) choosing which of the two stacked overlay canvases a util paints to; new exported type `TLOverlayBand`. `CollaboratorCursorOverlayUtil` and `CollaboratorHintOverlayUtil` set `band: 'over'`; all other built-in utils are unchanged.
