### PR TITLE
docs(skills): require docs-hotfix-please label in update-release-notes

### DIFF
--- a/skills/update-release-notes/SKILL.md
+++ b/skills/update-release-notes/SKILL.md
@@ -189,6 +189,7 @@ git push -u origin "$BRANCH"
 
 Then create the PR using the `../pr/SKILL.md` workflow and the standards in `../write-pr/SKILL.md`:
 
+- **Label**: add `docs-hotfix-please` (`gh pr edit <number> --add-label docs-hotfix-please`, or `--label docs-hotfix-please` on `gh pr create`). Without it, merging to `main` never cherry-picks the notes onto the current release branch (`vX.Y.x`), so the update never reaches tldraw.dev — which is the whole point of the run.
 - **Title**: `docs(releases): update release notes [skip ci]` — the `[skip ci]` must be in the PR title because GitHub's squash-merge uses the PR title as the merge commit subject, and that merge commit is what needs to skip CI. **Squash-merge** the PR (do not rebase- or create-a-merge-commit) so exactly one `[skip ci]` commit lands on the base branch.
 - **Change type**: `other`
 - **Test plan**: Remove the numbered list (no manual testing steps). Untick both unit tests and end to end tests.


### PR DESCRIPTION
In order to get release-notes updates onto tldraw.dev, the PR that the `update-release-notes` skill opens needs the `docs-hotfix-please` label — without it, merging to `main` never cherry-picks the change onto the current release branch (`vX.Y.x`). #9603 added `--label docs-hotfix-please` to the `gh pr create` step in `update-release-notes.yml`, but that step never runs: the skill commits, pushes, and opens the PR itself, so by the time the workflow reaches `Check for changes` the tree is clean and every step guarded by `has_changes == 'true'` is skipped. That's why #9653 came out unlabeled and had to be labeled by hand.

The skill only ever mentioned the label in an aside about `[skip ci]` not interfering with it, never as something to actually do. This adds it as an explicit PR requirement in step 10, which covers both the scheduled run and manual runs. The workflow's `--label` from #9603 stays as-is — it's correct for the fallback path where the skill leaves changes uncommitted.

### Change type

- [x] `other`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +1 / -0    |