### PR TITLE
feat(commenting): keep threads alive across shape deletion and page moves

### DIFF
--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -513,6 +513,12 @@ export interface RegionCommentOptions {
 }
 
 // @public
+export function registerCommentAnchorLifecycle(editor: Editor, impreciseShapeAnchor?: {
+    x: number;
+    y: number;
+}): () => void;
+
+// @public
 export function removeCommentRecords(editor: Editor, ids: (TLCommentId | TLCommentThreadId)[]): void;
 
 // @public

--- a/packages/commenting/src/canvas/anchor-lifecycle.test.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.test.ts
@@ -1,0 +1,211 @@
+import {
+	commentSchemaRecords,
+	createCommentThread,
+	createShapeId,
+	createTLSchema,
+	createTLStore,
+	defaultBindingUtils,
+	defaultShapeUtils,
+	defaultTools,
+	Editor,
+	toRichText,
+	createComment as tlCreateComment,
+	TLPageId,
+	TLShapeId,
+} from 'tldraw'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { registerCommentAnchorLifecycle } from './anchor-lifecycle'
+import { getCommentRecord, getComments, putCommentRecords } from './comment-store'
+import { commitCommentMutation } from './state'
+
+/**
+ * These tests need a real editor: the behavior under test is the interplay between store
+ * side effects (beforeDelete capture, operation-complete settlement) and real editor
+ * operations like `deleteShapes` and `moveShapesToPage` — exactly what a stub can't model.
+ */
+
+let editor: Editor
+let dispose: () => void
+
+beforeEach(() => {
+	editor = new Editor({
+		store: createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		shapeUtils: defaultShapeUtils,
+		bindingUtils: defaultBindingUtils,
+		tools: defaultTools,
+		getContainer: () => document.body,
+	})
+	dispose = registerCommentAnchorLifecycle(editor)
+})
+
+afterEach(() => {
+	dispose()
+	editor.dispose()
+})
+
+function makeShape(x = 100, y = 100, w = 100, h = 50): TLShapeId {
+	const id = createShapeId()
+	editor.createShape({ id, type: 'geo', x, y, props: { w, h } })
+	return id
+}
+
+function makeThread(shapeId: TLShapeId, anchorX = 0.5, anchorY = 0.5, isPrecise = true) {
+	const thread = createCommentThread({
+		pageId: editor.getCurrentPageId(),
+		anchor: { type: 'shape', shapeId, x: anchorX, y: anchorY, isPrecise },
+		createdBy: 'me',
+	})
+	const comment = tlCreateComment({
+		threadId: thread.id,
+		pageId: thread.pageId,
+		authorId: 'me',
+		body: toRichText('hello'),
+	})
+	putCommentRecords(editor, [thread, comment])
+	return { thread, comment }
+}
+
+function makeSecondPage(): TLPageId {
+	editor.createPage({ name: 'page 2' })
+	return editor.getPages()[1].id
+}
+
+describe('shape deletion', () => {
+	it('converts a precise shape anchor to a point anchor where the pin sat', () => {
+		const shapeId = makeShape(100, 100, 100, 50)
+		const { thread } = makeThread(shapeId, 0.5, 0.5, true)
+
+		editor.deleteShape(shapeId)
+
+		const updated = getCommentRecord(editor, thread.id)!
+		expect(updated.typeName).toBe('comment-thread')
+		expect((updated as typeof thread).anchor).toEqual({ type: 'point', x: 150, y: 125 })
+	})
+
+	it('converts an imprecise shape anchor at the imprecise pin spot (top-right by default)', () => {
+		const shapeId = makeShape(100, 100, 100, 50)
+		const { thread } = makeThread(shapeId, 0.2, 0.9, false)
+
+		editor.deleteShape(shapeId)
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor).toEqual({ type: 'point', x: 200, y: 100 })
+	})
+
+	it('converts anchors on children when their frame is deleted with them', () => {
+		const frameId = createShapeId()
+		editor.createShape({ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } })
+		const childId = createShapeId()
+		editor.createShape({
+			id: childId,
+			type: 'geo',
+			parentId: frameId,
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		})
+		const { thread } = makeThread(childId, 0.5, 0.5, true)
+
+		editor.deleteShape(frameId)
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor).toEqual({ type: 'point', x: 100, y: 100 })
+	})
+
+	it('re-attaches the thread when the delete is undone', () => {
+		const shapeId = makeShape(100, 100, 100, 50)
+		const { thread } = makeThread(shapeId, 0.5, 0.5, true)
+		editor.markHistoryStoppingPoint()
+
+		editor.deleteShape(shapeId)
+		expect((getCommentRecord(editor, thread.id) as typeof thread).anchor.type).toBe('point')
+
+		editor.undo()
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor).toEqual(thread.anchor)
+	})
+
+	it('does not re-attach on undo when the pin was moved after the conversion', () => {
+		const shapeId = makeShape(100, 100, 100, 50)
+		const { thread } = makeThread(shapeId, 0.5, 0.5, true)
+		editor.markHistoryStoppingPoint()
+
+		editor.deleteShape(shapeId)
+		const converted = getCommentRecord(editor, thread.id) as typeof thread
+		commitCommentMutation(editor, () =>
+			putCommentRecords(editor, [{ ...converted, anchor: { type: 'point', x: 900, y: 900 } }])
+		)
+
+		editor.undo()
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor).toEqual({ type: 'point', x: 900, y: 900 })
+	})
+
+	it('leaves threads on other shapes untouched', () => {
+		const shapeId = makeShape()
+		const otherId = makeShape(300, 300)
+		const { thread } = makeThread(otherId)
+
+		editor.deleteShape(shapeId)
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor.type).toBe('shape')
+	})
+})
+
+describe('moving a shape to another page', () => {
+	it('re-homes the thread and its comments to the new page, keeping the shape anchor', () => {
+		const shapeId = makeShape()
+		const { thread, comment } = makeThread(shapeId)
+		const page2 = makeSecondPage()
+
+		editor.moveShapesToPage([shapeId], page2)
+
+		const updatedThread = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updatedThread.pageId).toBe(page2)
+		expect(updatedThread.anchor).toEqual(thread.anchor)
+		const updatedComment = getComments(editor).find((c) => c.id === comment.id)!
+		expect(updatedComment.pageId).toBe(page2)
+	})
+
+	it('re-homes threads anchored to children of a moved frame', () => {
+		const frameId = createShapeId()
+		editor.createShape({ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } })
+		const childId = createShapeId()
+		editor.createShape({
+			id: childId,
+			type: 'geo',
+			parentId: frameId,
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		})
+		const { thread } = makeThread(childId)
+		const page2 = makeSecondPage()
+
+		editor.moveShapesToPage([frameId], page2)
+
+		const updatedThread = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updatedThread.pageId).toBe(page2)
+		expect(updatedThread.anchor.type).toBe('shape')
+	})
+
+	it('re-homes the thread back when the move is undone', () => {
+		const shapeId = makeShape()
+		const { thread } = makeThread(shapeId)
+		const page1 = editor.getCurrentPageId()
+		const page2 = makeSecondPage()
+		editor.markHistoryStoppingPoint()
+
+		editor.moveShapesToPage([shapeId], page2)
+		expect((getCommentRecord(editor, thread.id) as typeof thread).pageId).toBe(page2)
+
+		editor.undo()
+
+		const updatedThread = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updatedThread.pageId).toBe(page1)
+		expect(updatedThread.anchor.type).toBe('shape')
+	})
+})

--- a/packages/commenting/src/canvas/anchor-lifecycle.test.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.test.ts
@@ -82,14 +82,15 @@ describe('shape deletion', () => {
 		expect((updated as typeof thread).anchor).toEqual({ type: 'point', x: 150, y: 125 })
 	})
 
-	it('converts an imprecise shape anchor at the imprecise pin spot (top-right by default)', () => {
+	it('converts an imprecise shape anchor where the inset pin is drawn, not at the raw corner', () => {
 		const shapeId = makeShape(100, 100, 100, 50)
 		const { thread } = makeThread(shapeId, 0.2, 0.9, false)
 
 		editor.deleteShape(shapeId)
 
+		// Top-right corner (200, 100) plus the 20px screen inset toward the shape's centre.
 		const updated = getCommentRecord(editor, thread.id) as typeof thread
-		expect(updated.anchor).toEqual({ type: 'point', x: 200, y: 100 })
+		expect(updated.anchor).toEqual({ type: 'point', x: 180, y: 120 })
 	})
 
 	it('converts anchors on children when their frame is deleted with them', () => {

--- a/packages/commenting/src/canvas/anchor-lifecycle.test.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.test.ts
@@ -126,6 +126,34 @@ describe('shape deletion', () => {
 		expect(updated.anchor).toEqual(thread.anchor)
 	})
 
+	it('keeps the restore when a returning shape cannot resolve its page yet', () => {
+		const frameId = createShapeId()
+		editor.createShape({ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 400, h: 400 } })
+		const childId = createShapeId()
+		editor.createShape({
+			id: childId,
+			type: 'geo',
+			parentId: frameId,
+			x: 50,
+			y: 50,
+			props: { w: 100, h: 100 },
+		})
+		const { thread } = makeThread(childId, 0.5, 0.5, true)
+		const childRecord = editor.getShape(childId)!
+		const frameRecord = editor.getShape(frameId)!
+
+		editor.deleteShape(frameId)
+		expect((getCommentRecord(editor, thread.id) as typeof thread).anchor.type).toBe('point')
+
+		// The child returns in an earlier operation than its parent, so its ancestor page can't
+		// resolve when it first reappears.
+		editor.store.put([childRecord])
+		editor.store.put([frameRecord])
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor).toEqual(thread.anchor)
+	})
+
 	it('does not re-attach on undo when the pin was moved after the conversion', () => {
 		const shapeId = makeShape(100, 100, 100, 50)
 		const { thread } = makeThread(shapeId, 0.5, 0.5, true)

--- a/packages/commenting/src/canvas/anchor-lifecycle.test.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.test.ts
@@ -16,6 +16,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { registerCommentAnchorLifecycle } from './anchor-lifecycle'
 import { getCommentRecord, getComments, putCommentRecords } from './comment-store'
+import { CommentTool } from './comment-tool'
 import { commitCommentMutation } from './state'
 
 /**
@@ -91,6 +92,36 @@ describe('shape deletion', () => {
 		// Top-right corner (200, 100) plus the 20px screen inset toward the shape's centre.
 		const updated = getCommentRecord(editor, thread.id) as typeof thread
 		expect(updated.anchor).toEqual({ type: 'point', x: 180, y: 120 })
+	})
+
+	it('resolves the imprecise spot from the commenting options when no override is passed', () => {
+		const configured = new Editor({
+			store: createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+			shapeUtils: defaultShapeUtils,
+			bindingUtils: defaultBindingUtils,
+			tools: [...defaultTools, CommentTool.configure({ impreciseShapeAnchor: { x: 0, y: 1 } })],
+			getContainer: () => document.body,
+		})
+		const disposeConfigured = registerCommentAnchorLifecycle(configured)
+		try {
+			const shapeId = createShapeId()
+			configured.createShape({ id: shapeId, type: 'geo', x: 100, y: 100, props: { w: 100, h: 50 } })
+			const thread = createCommentThread({
+				pageId: configured.getCurrentPageId(),
+				anchor: { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: false },
+				createdBy: 'me',
+			})
+			putCommentRecords(configured, [thread])
+
+			configured.deleteShape(shapeId)
+
+			// Bottom-left corner (100, 150) plus the inset toward the shape's centre.
+			const updated = getCommentRecord(configured, thread.id) as typeof thread
+			expect(updated.anchor).toEqual({ type: 'point', x: 120, y: 130 })
+		} finally {
+			disposeConfigured()
+			configured.dispose()
+		}
 	})
 
 	it('converts anchors on children when their frame is deleted with them', () => {

--- a/packages/commenting/src/canvas/anchor-lifecycle.test.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.test.ts
@@ -21,7 +21,7 @@ import { commitCommentMutation } from './state'
 
 /**
  * These tests need a real editor: the behavior under test is the interplay between store
- * side effects (beforeDelete capture, operation-complete settlement) and real editor
+ * side effects (the beforeDelete snapshot, operation-complete settlement) and real editor
  * operations like `deleteShapes` and `moveShapesToPage` — exactly what a stub can't model.
  */
 

--- a/packages/commenting/src/canvas/anchor-lifecycle.test.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.test.ts
@@ -154,6 +154,25 @@ describe('shape deletion', () => {
 		expect(updated.anchor).toEqual(thread.anchor)
 	})
 
+	it('re-attaches on undo even when the lifecycle was re-registered in between', () => {
+		const shapeId = makeShape(100, 100, 100, 50)
+		const { thread } = makeThread(shapeId, 0.5, 0.5, true)
+		editor.markHistoryStoppingPoint()
+
+		editor.deleteShape(shapeId)
+		expect((getCommentRecord(editor, thread.id) as typeof thread).anchor.type).toBe('point')
+
+		// The registering effect re-runs whenever its inputs change identity; conversion memory
+		// must not live and die with any one registration.
+		dispose()
+		dispose = registerCommentAnchorLifecycle(editor)
+
+		editor.undo()
+
+		const updated = getCommentRecord(editor, thread.id) as typeof thread
+		expect(updated.anchor).toEqual(thread.anchor)
+	})
+
 	it('does not re-attach on undo when the pin was moved after the conversion', () => {
 		const shapeId = makeShape(100, 100, 100, 50)
 		const { thread } = makeThread(shapeId, 0.5, 0.5, true)

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -120,7 +120,11 @@ export function registerCommentAnchorLifecycle(
 	// page yet — and the conversion memory must outlive any such partial state.
 	const returnedShapeIds = new Set<TLShapeId>()
 
-	const disposeOperationComplete = editor.sideEffects.registerOperationCompleteHandler(() => {
+	const disposeOperationComplete = editor.sideEffects.registerOperationCompleteHandler((source) => {
+		// Only user-sourced handlers populate the maps and only local operations should settle
+		// them; a remote operation completing leaves any (impossible-in-practice) leftovers for
+		// the next local settle rather than judging them against remote state.
+		if (source === 'remote') return
 		if (pendingByShape.size === 0 && returnedShapeIds.size === 0) return
 		const settled = [...pendingByShape.entries()]
 		pendingByShape.clear()

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -1,0 +1,182 @@
+import { Editor, TLCommentAnchor, TLCommentThread, TLPageId, TLShapeId, VecLike } from 'tldraw'
+import {
+	getCommentRecord,
+	getComments,
+	getCommentThreads,
+	putCommentRecords,
+	TLCommentRecord,
+} from './comment-store'
+import { commitCommentMutation } from './state'
+import { anchorPagePoint, DEFAULT_IMPRECISE_SHAPE_ANCHOR } from './thread-state'
+
+type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' | 'text-range' }>
+
+function isAnchoredToShape(
+	thread: TLCommentThread,
+	shapeId: TLShapeId
+): thread is TLCommentThread & { anchor: ShapeAnchor } {
+	const anchor = thread.anchor
+	return (anchor.type === 'shape' || anchor.type === 'text-range') && anchor.shapeId === shapeId
+}
+
+/**
+ * Keep shape-anchored threads (`shape` and `text-range` anchors) alive across their shape's
+ * lifecycle:
+ *
+ * - When the shape is deleted, the thread converts to a `point` anchor at the spot its pin last
+ *   occupied, so the conversation outlives the shape instead of becoming invisible (a missing
+ *   shape has no bounds, which hides the pin).
+ * - When the shape moves to another page, the thread follows: its `pageId` and each comment's
+ *   denormalized `pageId` update to the shape's new page, and the anchor keeps riding the shape.
+ * - When a deleted shape comes back (a page move re-creates it with its id preserved; undoing a
+ *   delete restores it), the thread re-attaches — unless its pin was manually moved in the
+ *   meantime, in which case the manual placement wins.
+ *
+ * A page move is `deleteShapes` + re-create with preserved ids inside one `editor.run`, but each
+ * store write is its own operation — so at no single moment does "this shape is being moved"
+ * exist as an observable event. The handlers therefore cooperate across operations:
+ * `beforeDelete` captures where each affected pin sits (every record is still in the store at
+ * that point, so page bounds resolve even for children of a deleted frame); the
+ * operation-complete pass converts threads whose shape is really gone, remembering the original
+ * anchor; `afterCreate` restores that anchor when the shape id reappears. Undo/redo of a move
+ * replays as a `parentId` update (remove + add of one id squash to an update in the history
+ * diff), so an `afterChange` handler re-homes threads on cross-page reparents — including
+ * threads anchored to descendants, which move with their parent without change events of their
+ * own.
+ *
+ * Remote changes are ignored: the client that performed the operation runs this same
+ * maintenance and syncs the resulting thread updates. Writes go through
+ * {@link commitCommentMutation}, so the consumer's history option governs whether they're
+ * undoable.
+ *
+ * Registered by `CanvasComments` on mount; parts-built consumers can call this directly.
+ * Returns a cleanup function that unregisters all handlers.
+ *
+ * @public
+ */
+export function registerCommentAnchorLifecycle(
+	editor: Editor,
+	impreciseShapeAnchor: { x: number; y: number } = DEFAULT_IMPRECISE_SHAPE_ANCHOR
+): () => void {
+	// Captured during the current operation: shape id -> (thread id -> pin page point).
+	const pendingByShape = new Map<TLShapeId, Map<string, VecLike | null>>()
+	// Threads converted to point anchors because their shape was deleted, kept so the anchor can
+	// be restored if the shape comes back (page move re-create, undo of the delete).
+	const convertedByShape = new Map<
+		TLShapeId,
+		{ threadId: string; anchor: ShapeAnchor; point: VecLike }[]
+	>()
+
+	function rehomeThread(thread: TLCommentThread, pageId: TLPageId, updates: TLCommentRecord[]) {
+		updates.push({ ...thread, pageId })
+		for (const comment of getComments(editor)) {
+			if (comment.threadId === thread.id) updates.push({ ...comment, pageId })
+		}
+	}
+
+	const disposeBeforeDelete = editor.sideEffects.registerBeforeDeleteHandler(
+		'shape',
+		(shape, source) => {
+			if (source === 'remote') return
+			for (const thread of getCommentThreads(editor)) {
+				if (!isAnchoredToShape(thread, shape.id)) continue
+				let captured = pendingByShape.get(shape.id)
+				if (!captured) {
+					captured = new Map()
+					pendingByShape.set(shape.id, captured)
+				}
+				captured.set(thread.id, anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor))
+			}
+		}
+	)
+
+	const disposeOperationComplete = editor.sideEffects.registerOperationCompleteHandler(() => {
+		if (pendingByShape.size === 0) return
+		const settled = [...pendingByShape.entries()]
+		pendingByShape.clear()
+
+		const updates: TLCommentRecord[] = []
+		for (const [shapeId, threadPoints] of settled) {
+			if (editor.getShape(shapeId)) continue
+			for (const [threadId, point] of threadPoints) {
+				if (!point) continue
+				const thread = getCommentRecord(editor, threadId)
+				if (!thread || thread.typeName !== 'comment-thread') continue
+				if (!isAnchoredToShape(thread, shapeId)) continue
+				let converted = convertedByShape.get(shapeId)
+				if (!converted) {
+					converted = []
+					convertedByShape.set(shapeId, converted)
+				}
+				converted.push({ threadId, anchor: thread.anchor, point })
+				updates.push({ ...thread, anchor: { type: 'point', x: point.x, y: point.y } })
+			}
+		}
+
+		if (updates.length > 0) {
+			commitCommentMutation(editor, () => putCommentRecords(editor, updates))
+		}
+	})
+
+	const disposeAfterCreate = editor.sideEffects.registerAfterCreateHandler(
+		'shape',
+		(shape, source) => {
+			if (source === 'remote') return
+			const converted = convertedByShape.get(shape.id)
+			if (!converted) return
+			convertedByShape.delete(shape.id)
+
+			const pageId = editor.getAncestorPageId(shape)
+			if (!pageId) return
+			const updates: TLCommentRecord[] = []
+			for (const { threadId, anchor, point } of converted) {
+				const thread = getCommentRecord(editor, threadId)
+				if (!thread || thread.typeName !== 'comment-thread') continue
+				// Re-attach only threads still sitting exactly where the conversion left them — a
+				// pin moved since then was placed deliberately, and that placement wins.
+				const current = thread.anchor
+				if (current.type !== 'point' || current.x !== point.x || current.y !== point.y) {
+					continue
+				}
+				if (thread.pageId === pageId) {
+					updates.push({ ...thread, anchor })
+				} else {
+					rehomeThread({ ...thread, anchor }, pageId, updates)
+				}
+			}
+			if (updates.length > 0) {
+				commitCommentMutation(editor, () => putCommentRecords(editor, updates))
+			}
+		}
+	)
+
+	const disposeAfterChange = editor.sideEffects.registerAfterChangeHandler(
+		'shape',
+		(prev, next, source) => {
+			if (source === 'remote') return
+			if (prev.parentId === next.parentId) return
+			const pageId = editor.getAncestorPageId(next)
+			if (!pageId) return
+			// Descendants move with their parent without change events of their own.
+			const movedIds = editor.getShapeAndDescendantIds([next.id])
+			const updates: TLCommentRecord[] = []
+			for (const thread of getCommentThreads(editor)) {
+				const anchor = thread.anchor
+				if (anchor.type !== 'shape' && anchor.type !== 'text-range') continue
+				if (!movedIds.has(anchor.shapeId)) continue
+				if (thread.pageId === pageId) continue
+				rehomeThread(thread, pageId, updates)
+			}
+			if (updates.length > 0) {
+				commitCommentMutation(editor, () => putCommentRecords(editor, updates))
+			}
+		}
+	)
+
+	return () => {
+		disposeBeforeDelete()
+		disposeOperationComplete()
+		disposeAfterCreate()
+		disposeAfterChange()
+	}
+}

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -7,12 +7,9 @@ import {
 	putCommentRecords,
 	TLCommentRecord,
 } from './comment-store'
+import { getCommentingOptions } from './options'
 import { commitCommentMutation } from './state'
-import {
-	anchorPagePoint,
-	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
-	impreciseShapePinInset,
-} from './thread-state'
+import { anchorPagePoint, impreciseShapePinInset } from './thread-state'
 
 type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' | 'text-range' }>
 
@@ -75,7 +72,7 @@ function isAnchoredToShape(
  */
 export function registerCommentAnchorLifecycle(
 	editor: Editor,
-	impreciseShapeAnchor: { x: number; y: number } = DEFAULT_IMPRECISE_SHAPE_ANCHOR
+	impreciseShapeAnchor?: { x: number; y: number }
 ): () => void {
 	// Captured during the current operation: shape id -> (thread id -> pin page point).
 	const pendingByShape = new Map<TLShapeId, Map<string, VecLike | null>>()
@@ -102,9 +99,12 @@ export function registerCommentAnchorLifecycle(
 				// Capture where the pin is drawn, not just the anchor point: imprecise shape pins
 				// render inset toward the shape's centre, and the converted point pin renders at
 				// its point exactly — without the inset the pin would jump on deletion. The inset
-				// is screen-fixed, so bake it in at the current zoom.
-				let point = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
-				const inset = impreciseShapePinInset(thread.anchor, impreciseShapeAnchor)
+				// is screen-fixed, so bake it in at the current zoom. The imprecise spot resolves
+				// from the editor's commenting options unless the caller overrides it (the overlay
+				// passes its prop through).
+				const spot = impreciseShapeAnchor ?? getCommentingOptions(editor).impreciseShapeAnchor
+				let point = anchorPagePoint(editor, thread.anchor, spot)
+				const inset = impreciseShapePinInset(thread.anchor, spot)
 				if (point && inset) {
 					const zoom = editor.getZoomLevel()
 					point = { x: point.x + inset.x / zoom, y: point.y + inset.y / zoom }

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -49,7 +49,7 @@ function isAnchoredToShape(
  * A page move is `deleteShapes` + re-create with preserved ids inside one `editor.run`, but each
  * store write is its own operation — so at no single moment does "this shape is being moved"
  * exist as an observable event. The handlers therefore cooperate across operations:
- * `beforeDelete` captures where each affected pin sits (every record is still in the store at
+ * `beforeDelete` snapshots where each affected pin sits (every record is still in the store at
  * that point, so page bounds resolve even for children of a deleted frame); the
  * operation-complete pass converts threads whose shape is really gone, remembering the original
  * anchor; `afterCreate` notes a reappeared shape id, and the operation-complete pass restores
@@ -74,7 +74,8 @@ export function registerCommentAnchorLifecycle(
 	editor: Editor,
 	impreciseShapeAnchor?: { x: number; y: number }
 ): () => void {
-	// Captured during the current operation: shape id -> (thread id -> pin page point).
+	// Pin positions snapshotted during the current operation: shape id -> (thread id -> pin page
+	// point).
 	const pendingByShape = new Map<TLShapeId, Map<string, VecLike | null>>()
 	const convertedByShape = convertedByShapeCache.get(editor, () => new Map())
 
@@ -91,12 +92,12 @@ export function registerCommentAnchorLifecycle(
 			if (source === 'remote') return
 			for (const thread of getCommentThreads(editor)) {
 				if (!isAnchoredToShape(thread, shape.id)) continue
-				let captured = pendingByShape.get(shape.id)
-				if (!captured) {
-					captured = new Map()
-					pendingByShape.set(shape.id, captured)
+				let snapshot = pendingByShape.get(shape.id)
+				if (!snapshot) {
+					snapshot = new Map()
+					pendingByShape.set(shape.id, snapshot)
 				}
-				// Capture where the pin is drawn, not just the anchor point: imprecise shape pins
+				// Snapshot where the pin is drawn, not just the anchor point: imprecise shape pins
 				// render inset toward the shape's centre, and the converted point pin renders at
 				// its point exactly — without the inset the pin would jump on deletion. The inset
 				// is screen-fixed, so bake it in at the current zoom. The imprecise spot resolves
@@ -109,7 +110,7 @@ export function registerCommentAnchorLifecycle(
 					const zoom = editor.getZoomLevel()
 					point = { x: point.x + inset.x / zoom, y: point.y + inset.y / zoom }
 				}
-				captured.set(thread.id, point)
+				snapshot.set(thread.id, point)
 			}
 		}
 	)

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -1,3 +1,4 @@
+import { WeakCache } from '@tldraw/utils'
 import { Editor, TLCommentAnchor, TLCommentThread, TLPageId, TLShapeId, VecLike } from 'tldraw'
 import {
 	getCommentRecord,
@@ -10,6 +11,18 @@ import { commitCommentMutation } from './state'
 import { anchorPagePoint, DEFAULT_IMPRECISE_SHAPE_ANCHOR } from './thread-state'
 
 type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' | 'text-range' }>
+
+/**
+ * Threads converted to point anchors because their shape was deleted, kept so the anchor can be
+ * restored if the shape comes back (page move re-create, undo of the delete). Owned by the
+ * editor, not the registration closure: the registering effect can re-run (a prop identity
+ * change, a remount), and an undo can arrive arbitrarily long after the delete — the memory has
+ * to outlive any one registration.
+ */
+const convertedByShapeCache = new WeakCache<
+	Editor,
+	Map<TLShapeId, { threadId: string; anchor: ShapeAnchor; point: VecLike }[]>
+>()
 
 function isAnchoredToShape(
 	thread: TLCommentThread,
@@ -62,12 +75,7 @@ export function registerCommentAnchorLifecycle(
 ): () => void {
 	// Captured during the current operation: shape id -> (thread id -> pin page point).
 	const pendingByShape = new Map<TLShapeId, Map<string, VecLike | null>>()
-	// Threads converted to point anchors because their shape was deleted, kept so the anchor can
-	// be restored if the shape comes back (page move re-create, undo of the delete).
-	const convertedByShape = new Map<
-		TLShapeId,
-		{ threadId: string; anchor: ShapeAnchor; point: VecLike }[]
-	>()
+	const convertedByShape = convertedByShapeCache.get(editor, () => new Map())
 
 	function rehomeThread(thread: TLCommentThread, pageId: TLPageId, updates: TLCommentRecord[]) {
 		updates.push({ ...thread, pageId })

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -38,7 +38,9 @@ function isAnchoredToShape(
  * `beforeDelete` captures where each affected pin sits (every record is still in the store at
  * that point, so page bounds resolve even for children of a deleted frame); the
  * operation-complete pass converts threads whose shape is really gone, remembering the original
- * anchor; `afterCreate` restores that anchor when the shape id reappears. Undo/redo of a move
+ * anchor; `afterCreate` notes a reappeared shape id, and the operation-complete pass restores
+ * the anchor once the store has settled (creation order within an operation is arbitrary, so a
+ * fresh shape may not resolve an ancestor page mid-operation). Undo/redo of a move
  * replays as a `parentId` update (remove + add of one id squash to an update in the history
  * diff), so an `afterChange` handler re-homes threads on cross-page reparents — including
  * threads anchored to descendants, which move with their parent without change events of their
@@ -90,10 +92,18 @@ export function registerCommentAnchorLifecycle(
 		}
 	)
 
+	// Shape ids from `convertedByShape` re-created during the current operation. Restores are
+	// settled at operation complete rather than in `afterCreate` itself: creation order within an
+	// operation is arbitrary, so a shape can appear before its parent and not resolve an ancestor
+	// page yet — and the conversion memory must outlive any such partial state.
+	const returnedShapeIds = new Set<TLShapeId>()
+
 	const disposeOperationComplete = editor.sideEffects.registerOperationCompleteHandler(() => {
-		if (pendingByShape.size === 0) return
+		if (pendingByShape.size === 0 && returnedShapeIds.size === 0) return
 		const settled = [...pendingByShape.entries()]
 		pendingByShape.clear()
+		const returned = [...returnedShapeIds]
+		returnedShapeIds.clear()
 
 		const updates: TLCommentRecord[] = []
 		for (const [shapeId, threadPoints] of settled) {
@@ -113,22 +123,14 @@ export function registerCommentAnchorLifecycle(
 			}
 		}
 
-		if (updates.length > 0) {
-			commitCommentMutation(editor, () => putCommentRecords(editor, updates))
-		}
-	})
-
-	const disposeAfterCreate = editor.sideEffects.registerAfterCreateHandler(
-		'shape',
-		(shape, source) => {
-			if (source === 'remote') return
-			const converted = convertedByShape.get(shape.id)
-			if (!converted) return
-			convertedByShape.delete(shape.id)
+		for (const shapeId of returned) {
+			const shape = editor.getShape(shapeId)
+			if (!shape) continue
+			const converted = convertedByShape.get(shapeId)
+			if (!converted) continue
+			convertedByShape.delete(shapeId)
 
 			const pageId = editor.getAncestorPageId(shape)
-			if (!pageId) return
-			const updates: TLCommentRecord[] = []
 			for (const { threadId, anchor, point } of converted) {
 				const thread = getCommentRecord(editor, threadId)
 				if (!thread || thread.typeName !== 'comment-thread') continue
@@ -138,15 +140,24 @@ export function registerCommentAnchorLifecycle(
 				if (current.type !== 'point' || current.x !== point.x || current.y !== point.y) {
 					continue
 				}
-				if (thread.pageId === pageId) {
+				if (!pageId || thread.pageId === pageId) {
 					updates.push({ ...thread, anchor })
 				} else {
 					rehomeThread({ ...thread, anchor }, pageId, updates)
 				}
 			}
-			if (updates.length > 0) {
-				commitCommentMutation(editor, () => putCommentRecords(editor, updates))
-			}
+		}
+
+		if (updates.length > 0) {
+			commitCommentMutation(editor, () => putCommentRecords(editor, updates))
+		}
+	})
+
+	const disposeAfterCreate = editor.sideEffects.registerAfterCreateHandler(
+		'shape',
+		(shape, source) => {
+			if (source === 'remote') return
+			if (convertedByShape.has(shape.id)) returnedShapeIds.add(shape.id)
 		}
 	)
 

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -8,7 +8,11 @@ import {
 	TLCommentRecord,
 } from './comment-store'
 import { commitCommentMutation } from './state'
-import { anchorPagePoint, DEFAULT_IMPRECISE_SHAPE_ANCHOR } from './thread-state'
+import {
+	anchorPagePoint,
+	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
+	impreciseShapePinInset,
+} from './thread-state'
 
 type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' | 'text-range' }>
 
@@ -95,7 +99,17 @@ export function registerCommentAnchorLifecycle(
 					captured = new Map()
 					pendingByShape.set(shape.id, captured)
 				}
-				captured.set(thread.id, anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor))
+				// Capture where the pin is drawn, not just the anchor point: imprecise shape pins
+				// render inset toward the shape's centre, and the converted point pin renders at
+				// its point exactly — without the inset the pin would jump on deletion. The inset
+				// is screen-fixed, so bake it in at the current zoom.
+				let point = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
+				const inset = impreciseShapePinInset(thread.anchor, impreciseShapeAnchor)
+				if (point && inset) {
+					const zoom = editor.getZoomLevel()
+					point = { x: point.x + inset.x / zoom, y: point.y + inset.y / zoom }
+				}
+				captured.set(thread.id, point)
 			}
 		}
 	)

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -48,6 +48,7 @@ import { CountBadge } from '../ui/count-badge'
 import { MentionMember } from '../ui/mention-list'
 import { isMentionPickerOpen } from '../ui/mention-suggestion'
 import { TooltipButton } from '../ui/tooltip-button'
+import { registerCommentAnchorLifecycle } from './anchor-lifecycle'
 import { collectClusterLeaves } from './cluster-input'
 import { CommentBody } from './comment-body'
 import {
@@ -241,6 +242,10 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const pending = usePendingComment()
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
 	const impreciseShapeAnchor = props.impreciseShapeAnchor ?? options.impreciseShapeAnchor
+	useEffect(
+		() => registerCommentAnchorLifecycle(editor, impreciseShapeAnchor),
+		[editor, impreciseShapeAnchor]
+	)
 	// Threads held out of clustering because their anchor moved while folded inside a badge
 	// (drag, nudge, align, undo, a collaborator — detected by position, not gesture). They render
 	// as live pins riding their anchor and rejoin clustering on the next zoom-out.

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -242,9 +242,12 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const pending = usePendingComment()
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
 	const impreciseShapeAnchor = props.impreciseShapeAnchor ?? options.impreciseShapeAnchor
+	// Keyed by the anchor's values, not its identity — an inline `impreciseShapeAnchor` prop is a
+	// new object every render and would re-register the handlers each time.
+	const { x: impreciseX, y: impreciseY } = impreciseShapeAnchor
 	useEffect(
-		() => registerCommentAnchorLifecycle(editor, impreciseShapeAnchor),
-		[editor, impreciseShapeAnchor]
+		() => registerCommentAnchorLifecycle(editor, { x: impreciseX, y: impreciseY }),
+		[editor, impreciseX, impreciseY]
 	)
 	// Threads held out of clustering because their anchor moved while folded inside a badge
 	// (drag, nudge, align, undo, a collaborator — detected by position, not gesture). They render

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -85,6 +85,7 @@ import {
 } from './state'
 import {
 	anchorPagePoint,
+	impreciseShapePinInset,
 	regionAnchorPinCorner,
 	regionPinPoint,
 	shapeAnchorAt,
@@ -127,24 +128,6 @@ export interface CanvasCommentsProps {
 }
 
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
-
-/** How far an imprecise shape pin steps inside the shape from its anchor spot, in screen px —
- *  most of the marker sits within the shape, with a small overhang past the corner. */
-const IMPRECISE_PIN_INSET_PX = 20
-
-/** Imprecise shape pins tuck inside the shape rather than hanging off its edge: the marker
- *  extends up-right of its anchor point, so step it toward the shape's centre. Screen px — the
- *  pin is screen-fixed while the shape scales with zoom. Null for anchors that need no inset. */
-function impreciseShapePinInset(
-	anchor: TLCommentThread['anchor'],
-	spot: { x: number; y: number }
-): { x: number; y: number } | null {
-	if (anchor.type !== 'shape' || anchor.isPrecise) return null
-	return {
-		x: Math.sign(0.5 - spot.x) * IMPRECISE_PIN_INSET_PX,
-		y: Math.sign(0.5 - spot.y) * IMPRECISE_PIN_INSET_PX,
-	}
-}
 
 /** A pointer-down that belongs to the camera, not the comment UI: any non-primary button
  *  (middle/right-button pans), or a primary press with the spacebar pan key held. */

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -5,6 +5,24 @@ import { openThreadId } from './state'
 /** Where an imprecise shape comment sits by default: the shape's top-right corner. Overridable. @public */
 export const DEFAULT_IMPRECISE_SHAPE_ANCHOR = { x: 1, y: 0 }
 
+/** How far an imprecise shape pin steps inside the shape from its anchor spot, in screen px —
+ *  most of the marker sits within the shape, with a small overhang past the corner. */
+export const IMPRECISE_PIN_INSET_PX = 20
+
+/** Imprecise shape pins tuck inside the shape rather than hanging off its edge: the marker
+ *  extends up-right of its anchor point, so step it toward the shape's centre. Screen px — the
+ *  pin is screen-fixed while the shape scales with zoom. Null for anchors that need no inset. */
+export function impreciseShapePinInset(
+	anchor: TLCommentThread['anchor'],
+	spot: { x: number; y: number }
+): { x: number; y: number } | null {
+	if (anchor.type !== 'shape' || anchor.isPrecise) return null
+	return {
+		x: Math.sign(0.5 - spot.x) * IMPRECISE_PIN_INSET_PX,
+		y: Math.sign(0.5 - spot.y) * IMPRECISE_PIN_INSET_PX,
+	}
+}
+
 /** The default corner a region's pin and composer sit on, as a normalized 0–1 offset (bottom-right).
  *  Overridable per editor via region options; pin position, composer placement, region move, and
  *  which corner has no resize handle all derive from the chosen corner. */

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -29,6 +29,7 @@ export { SendButton, type SendButtonProps } from './ui/send-button'
 // The tldraw-coupled commenting layer: the comment tool, reactive hooks over the comment
 // records, a rich-text body renderer, and a batteries-included <CanvasComments> overlay. Pairs
 // with the presentational components above.
+export { registerCommentAnchorLifecycle } from './canvas/anchor-lifecycle'
 export { CommentBody, type CommentBodyProps } from './canvas/comment-body'
 export {
 	CommentTool,


### PR DESCRIPTION
Comment threads anchored to a shape currently die with it in two ways: deleting the shape leaves the thread stranded invisibly (a missing shape has no bounds, so the pin stops rendering — indistinguishable from deletion), and moving the shape to another page leaves the thread's \`pageId\` behind on the old page.

This adds \`registerCommentAnchorLifecycle\` (registered by \`CanvasComments\` on mount, exported for parts-built consumers), which keeps \`shape\` and \`text-range\` anchored threads consistent through their shape's lifecycle:

- **Deleting a shape** converts its threads to \`point\` anchors at the spot each pin last occupied, so the conversation outlives the shape.
- **Moving a shape to another page** re-homes its threads — \`pageId\` on the thread and its comments' denormalized \`pageId\` — to the new page, with the anchor still riding the shape. Threads anchored to children of a moved frame follow too.
- **A restored shape re-attaches its threads**: undoing a delete (or the re-create half of a page move) restores the original shape anchor, unless the pin was manually moved after the conversion — a deliberate placement wins.
- **Undo/redo of a page move** re-homes threads through the cross-page reparent path.

### Why four cooperating handlers

\`Editor.moveShapesToPage\` is delete + re-create with preserved ids, and each store write is its own operation — so "this shape is moving" never exists as a single observable event. On top of that, the squashed history diff collapses that remove+add into an *update*, so undoing a move replays as a \`parentId\` change. The same user action wears three different guises, and each needs its own handler: \`beforeDelete\` captures pin positions while bounds still resolve (the store runs all before-delete callbacks before removing anything, so this works for children of a deleted frame), the operation-complete pass converts threads whose shape is really gone (remembering the original anchor), \`afterCreate\` re-attaches when the shape id comes back, and \`afterChange\` re-homes on cross-page reparents.

Remote changes are ignored: the client performing the operation runs the same maintenance and syncs the resulting thread updates. Known gap: a shape deleted by a client *not* running this maintenance still strands its threads invisibly.

Writes go through \`commitCommentMutation\`, so the consumer's history option governs undoability as elsewhere in the package.

### API changes

- Added `registerCommentAnchorLifecycle(editor, impreciseShapeAnchor?)`, which keeps shape-anchored comment threads consistent through their shape's deletion, restoration, and page moves, and returns a disposer. `CanvasComments` registers it on mount; only parts-built consumers call it directly.

### Change type

- [x] \`improvement\`

### Test plan

1. Create a shape, comment on it, delete the shape → the pin stays put as a point-anchored thread; undo → the thread re-attaches to the shape.
2. Comment on a shape (and on a shape inside a frame), context menu → Move to page → the threads appear on the destination page riding their shapes; undo → they come back.

- [x] Unit tests

### Release notes

- Comment threads now survive shape deletion (converting to a point anchor at the pin's last position) and follow their shape when it moves to another page.
