### PR TITLE
feature(commenting): shape-comment precision via a shouldBePrecise predicate

### DIFF
--- a/apps/examples/src/examples/collaboration/comment-shape-precision/CommentShapePrecisionExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-shape-precision/CommentShapePrecisionExample.tsx
@@ -1,0 +1,134 @@
+import {
+	CanvasComments,
+	CommentAuthor,
+	CommentTool,
+	commentToolOverrides,
+} from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useMemo, useState } from 'react'
+import {
+	commentSchemaRecords,
+	createTLSchema,
+	createTLStore,
+	Editor,
+	TLComponents,
+	Tldraw,
+	TldrawUiButton,
+	TldrawUiButtonLabel,
+	toRichText,
+} from 'tldraw'
+import '@tldraw/commenting/commenting.css'
+import 'tldraw/tldraw.css'
+
+// One configured comment tool per mode, built once at module level so each array keeps a stable
+// identity. `shouldBePrecise` decides what commenting on a shape produces: a precise anchor
+// (pinned to the exact clicked spot within the shape — the default) or an imprecise one (pinned
+// to the shape as a whole, rendered at its top-right). It's called with the target shape, the
+// release point, and the Alt key's state — so it can be a constant, an Alt-gated choice, or a
+// decision from the shape itself, like "precise only on notes".
+const MODE_TOOLS = {
+	always: [CommentTool],
+	never: [CommentTool.configure({ shouldBePrecise: () => false })],
+	alt: [CommentTool.configure({ shouldBePrecise: (_editor, { altKey }) => altKey })],
+	notes: [
+		CommentTool.configure({
+			shouldBePrecise: (editor, { shapeId }) => editor.getShape(shapeId)?.type === 'note',
+		}),
+	],
+}
+
+type PrecisionMode = keyof typeof MODE_TOOLS
+
+const MODE_LABELS: Record<PrecisionMode, string> = {
+	always: 'Always precise (default)',
+	never: 'Shape only',
+	alt: 'Alt for precise',
+	notes: 'Notes precise',
+}
+
+const AUTHORS: Record<string, CommentAuthor> = { me: { name: 'You', color: '#EC5E41' } }
+const resolveAuthor = (id: string): CommentAuthor => AUTHORS[id] ?? { name: id }
+
+const handleMount = (editor: Editor) => {
+	// A shape and a note to comment on. The store survives mode switches, so only seed once.
+	if (editor.getCurrentPageShapeIds().size === 0) {
+		editor.run(
+			() => {
+				editor.createShapes([
+					{
+						type: 'geo',
+						x: 100,
+						y: 160,
+						props: { geo: 'rectangle', w: 280, h: 180, richText: toRichText('A shape') },
+					},
+					{
+						type: 'note',
+						x: 460,
+						y: 150,
+						props: { richText: toRichText('A note') },
+					},
+				])
+			},
+			{ history: 'ignore' }
+		)
+	}
+	editor.zoomToBounds({ x: 40, y: 60, w: 700, h: 400 }, { immediate: true })
+}
+
+export default function CommentShapePrecisionExample() {
+	const [mode, setMode] = useState<PrecisionMode>('always')
+
+	// Comments live in the editor's own store as records; sharing one store across mode switches
+	// keeps every placed thread visible while the tool is reconfigured.
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	const components = useMemo<TLComponents>(
+		() => ({
+			InFrontOfTheCanvas: () => <CanvasComments currentUserId="me" resolveAuthor={resolveAuthor} />,
+		}),
+		[]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				// Commenting options are fixed at tool registration (`CommentTool.configure`), so
+				// switching modes remounts the editor with the newly configured tool. The shared store
+				// carries the comments across.
+				key={mode}
+				// Commenting is a licensed feature. Every feature is enabled in local development, but a
+				// deployed app needs a license key that includes commenting — swap in your own key here.
+				licenseKey={getLicenseKey()}
+				store={store}
+				onMount={handleMount}
+				tools={MODE_TOOLS[mode]}
+				overrides={[commentToolOverrides]}
+				components={components}
+			>
+				<div
+					style={{
+						position: 'absolute',
+						top: 60,
+						left: 12,
+						display: 'flex',
+						gap: 4,
+						zIndex: 1000,
+					}}
+				>
+					{(Object.keys(MODE_LABELS) as PrecisionMode[]).map((id) => (
+						<TldrawUiButton
+							key={id}
+							type={mode === id ? 'primary' : 'normal'}
+							onClick={() => setMode(id)}
+						>
+							<TldrawUiButtonLabel>{MODE_LABELS[id]}</TldrawUiButtonLabel>
+						</TldrawUiButton>
+					))}
+				</div>
+			</Tldraw>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/comment-shape-precision/README.md
+++ b/apps/examples/src/examples/collaboration/comment-shape-precision/README.md
@@ -1,0 +1,32 @@
+---
+title: Shape comment precision
+component: ./CommentShapePrecisionExample.tsx
+priority: 5
+keywords: [comments, commenting, precise, imprecise, shape, anchor, alt, collaboration]
+---
+
+Decide whether commenting on a shape pins to the exact clicked point or to the shape as a whole — per placement, from the shape, or as a fixed rule.
+
+---
+
+When a comment lands on a shape, its anchor is either **precise** — pinned to the exact clicked spot, as a normalized (0–1) offset within the shape — or **imprecise** — pinned to the shape as a whole, with the pin rendered at a spot your app chooses (`impreciseShapeAnchor`, top-right by default). Either way the anchor tracks the shape as it moves and resizes.
+
+`shouldBePrecise` on `CommentTool.configure` makes that call. It receives the editor and the gesture's context — the target shape, the release point, and whether Alt was held — so it can be:
+
+- **a constant** — `() => true` (always precise, the default) or `() => false` (shape-only)
+- **an Alt-gated choice** — `(editor, { altKey }) => altKey`: imprecise normally, precise while Alt is held
+- **a decision from the shape** — e.g. precise on notes, shape-level everywhere else:
+
+```tsx
+<Tldraw
+	tools={[
+		CommentTool.configure({
+			shouldBePrecise: (editor, { shapeId }) => editor.getShape(shapeId)?.type === 'note',
+		}),
+	]}
+/>
+```
+
+The predicate runs wherever a shape anchor is created — placing with the comment tool, and dropping a dragged pin onto a shape. It only governs new placements: anchors already stored keep rendering the way they were made.
+
+Use the buttons to switch modes, then place comments on the rectangle and the note (press `c` or pick the comment tool) to feel the difference.

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -218,6 +218,7 @@ export interface CommentingOptions {
         readonly x: number;
         readonly y: number;
     };
+    shouldBePrecise(editor: Editor, context: ShapeCommentPrecisionContext): boolean;
 }
 
 // @public (undocumented)
@@ -378,6 +379,7 @@ export const defaultCommentingOptions: {
         readonly x: 1;
         readonly y: 0;
     };
+    readonly shouldBePrecise: () => true;
 };
 
 // @public
@@ -539,6 +541,16 @@ export function shapeAnchorAt(editor: Editor, shapeId: TLShapeId, page: {
     x: number;
     y: number;
 }, precise: boolean): TLCommentAnchor;
+
+// @public
+export interface ShapeCommentPrecisionContext {
+    // (undocumented)
+    readonly altKey: boolean;
+    // (undocumented)
+    readonly point: VecLike;
+    // (undocumented)
+    readonly shapeId: TLShapeId;
+}
 
 // @public
 export interface SidebarFilters {

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -6,7 +6,7 @@ import {
 	TLUiOverrides,
 	VecLike,
 } from 'tldraw'
-import { type CommentingOptions, defaultCommentingOptions } from './options'
+import { type CommentingOptions, defaultCommentingOptions, getCommentingOptions } from './options'
 import { getRegionCommentOptions } from './region-options'
 import { commentsSidebarOpen, pendingComment, regionDraft } from './state'
 import { regionPinPoint, shapeAnchorAt } from './thread-state'
@@ -176,7 +176,16 @@ class CommentPointing extends StateNode {
 		const point = editor.inputs.getCurrentPagePoint()
 		const hit = editor.getShapeAtPoint(point, { hitInside: true })
 		const anchor: TLCommentAnchor = hit
-			? shapeAnchorAt(editor, hit.id, point, editor.inputs.getAltKey())
+			? shapeAnchorAt(
+					editor,
+					hit.id,
+					point,
+					getCommentingOptions(editor).shouldBePrecise(editor, {
+						shapeId: hit.id,
+						point,
+						altKey: editor.inputs.getAltKey(),
+					})
+				)
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
 		// Hand back to select; the open composer is now the focus.

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1484,7 +1484,16 @@ const ThreadPin = memo(function ThreadPin({
 		} else {
 			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
 			anchor = hit
-				? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
+				? shapeAnchorAt(
+						editor,
+						hit.id,
+						pagePoint,
+						getCommentingOptions(editor).shouldBePrecise(editor, {
+							shapeId: hit.id,
+							point: pagePoint,
+							altKey: e.altKey,
+						})
+					)
 				: { type: 'point', x: pagePoint.x, y: pagePoint.y }
 		}
 		commitCommentMutation(editor, () => putCommentRecords(editor, [{ ...thread, anchor }]), 'drag')

--- a/packages/commenting/src/canvas/options.ts
+++ b/packages/commenting/src/canvas/options.ts
@@ -4,8 +4,23 @@ import {
 	type TLComment,
 	type TLCommentThread,
 	type TLHistoryBatchOptions,
+	type TLShapeId,
+	type VecLike,
 	useEditor,
 } from 'tldraw'
+
+/**
+ * The gesture that's creating a shape anchor, passed to
+ * {@link CommentingOptions.shouldBePrecise}: the target shape, the page point of the release, and
+ * whether Alt was held.
+ *
+ * @public
+ */
+export interface ShapeCommentPrecisionContext {
+	readonly shapeId: TLShapeId
+	readonly point: VecLike
+	readonly altKey: boolean
+}
 
 /**
  * Component overrides for the batteries-included comments layer. Each slot replaces a built-in
@@ -59,6 +74,15 @@ export interface CommentingOptions {
 	// ── Anchoring ────────────────────────────────────────────────────────────────────────────
 	/** Normalized (0–1) spot within a shape where imprecise shape pins sit. Default top-right. */
 	readonly impreciseShapeAnchor: { readonly x: number; readonly y: number }
+	/**
+	 * Whether a comment landing on a shape anchors precisely — pinned to the exact clicked spot
+	 * within the shape — or imprecisely — pinned to the shape as a whole, rendered at
+	 * `impreciseShapeAnchor`. Called wherever a shape anchor is created (placing with the comment
+	 * tool, dropping a dragged pin onto a shape). Always precise by default. Return `false` for
+	 * shape-level anchoring, or decide from the context — the Alt key's state, or the shape itself,
+	 * e.g. precise only on notes. Governs new placements only; existing anchors render as stored.
+	 */
+	shouldBePrecise(editor: Editor, context: ShapeCommentPrecisionContext): boolean
 
 	// ── Clustering tuning ─────────────────────────────────────────────────────────────────────
 	/** Screen-pixel margin by which the viewport is inflated when culling cluster badges. */
@@ -81,6 +105,7 @@ export const defaultCommentingOptions = {
 	dragHistory: undefined,
 	enableClustering: true,
 	impreciseShapeAnchor: { x: 1, y: 0 },
+	shouldBePrecise: () => true,
 	clusterCullMargin: 120,
 	clusterSplitZoomFactor: 1.05,
 	components: {},

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -65,8 +65,9 @@ export function anchorPagePoint(
 
 /**
  * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
- * shape's page bounds, remembered either way. When `precise` (Alt held) the pin sits at exactly
- * `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the box).
+ * shape's page bounds, remembered either way. When `precise` the pin sits at exactly `x`/`y`;
+ * otherwise it sits at the consumer's imprecise default (top-right out of the box). Placement
+ * gestures get `precise` from the `shouldBePrecise` commenting option (always precise, by default).
  * @public
  */
 export function shapeAnchorAt(

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -62,6 +62,7 @@ export {
 	type CommentingOptions,
 	defaultCommentingOptions,
 	getCommentingOptions,
+	type ShapeCommentPrecisionContext,
 	useCommentingOptions,
 } from './canvas/options'
 export { CommentsOverflowMenu } from './canvas/comments-overflow-menu'


### PR DESCRIPTION
Comparison PR to #9651, per review discussion there: the same capability expressed as a predicate instead of an enum. Not meant to both land — pick one.

### What

- Adds `shouldBePrecise(editor, context)` to `CommentingOptions`, set via `CommentTool.configure`. The context carries the gesture — target `shapeId`, release `point`, and `altKey` — so the predicate can be:
  - the default: `() => true` — every shape comment is precise
  - a constant `() => false` — shape-only anchoring
  - the previous Alt behaviour: `(_editor, { altKey }) => altKey`
  - a per-shape policy: `(editor, { shapeId }) => editor.getShape(shapeId)?.type === 'note'`
- Runs at both shape-anchor creation sites: comment-tool placement and pin-drag re-anchor.
- Same data-model note as #9651: clicked `x`/`y` are stored either way; the predicate only gates `isPrecise`.
- **Behaviour change**: precise is now the default. Consumers relying on the old Alt-gated placement opt back in with the alt predicate. dotcom needs no change — it inherits the default.

### Example

Same `comment-shape-precision` example as #9651 (diff the two branches to compare), plus a fourth mode only the predicate can express: notes precise, everything else shape-level.

### One caveat found while building this

The motivating case from review — "precise for frames" — can't fire today: the comment tool's hit test uses `hitInside` without `hitFrameInside`, so releasing over an empty frame interior creates a *point* anchor, never a frame anchor (verified live). Whether frame interiors should be comment targets is a separate placement-behaviour decision; the example uses notes instead. Worth deciding alongside whichever API wins.

### Test plan

- Verified live in the example: always / never / alt modes create the expected `isPrecise`, and in notes mode the same no-modifier gesture yields `isPrecise: false` on a geo and `isPrecise: true` on a note
- `packages/commenting` tests (179), typecheck, api-report regenerated

### API Changes

- New option on `CommentingOptions`: `shouldBePrecise(editor: Editor, context: ShapeCommentPrecisionContext): boolean`, defaulting to `() => true`. This changes default placement behaviour: shape comments are precise unless configured otherwise (the previous behaviour is `(_editor, { altKey }) => altKey`).
- New export: `ShapeCommentPrecisionContext` — the gesture context (`shapeId`, `point`, `altKey`).