### PR TITLE
fix(tldraw): stop input labels wrapping mid-word in dialogs

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -540,6 +540,14 @@
 	flex-shrink: 0;
 }
 
+/* The label is a fixed bit of chrome next to the input; it should never be squeezed. Without this,
+   an inherited `overflow-wrap: anywhere` (e.g. from .tlui-dialog__body) drops its min-content width
+   to a single character and short labels wrap mid-word, e.g. "URL" breaking after "UR". */
+.tlui-input__wrapper > label {
+	flex-shrink: 0;
+	overflow-wrap: normal;
+}
+
 /* If mobile use 16px as font size */
 /* On iOS, font size under 16px in an input will make the page zoom into the input 🤦‍♂️ */
 /* https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/ */


### PR DESCRIPTION
In order to make the "Edit link" dialog readable again, this fixes the `URL` label wrapping mid-word — it renders as `UR` / `L` on a second line.

#9546 added `overflow-wrap: anywhere` to `.tlui-dialog__body` so long unbreakable URLs wrap instead of overflowing. Input labels inherit it, which drops their min-content width to a single character. `.tlui-input__wrapper` is a flex row where the input has `flex-grow: 2` and the label had no shrink protection, so flex was free to squeeze the label down and break the word.

The fix pins the label instead of weakening the wrapping rule. `flex-shrink: 0` is the real change — the label is fixed chrome next to the input and should never be compressed. Resetting `overflow-wrap` on it keeps it correct if that shrink constraint ever changes.

Keeping `anywhere` on the dialog body matters: `.tlui-dialog__content` is shrink-to-fit inside the positioner, so with `break-word` a long URL would stretch the dialog toward the viewport width rather than wrapping inside it. Only `EditLinkDialog` and `EmbedDialog` pass a `label` to `TldrawUiInput`, both short "URL" strings in dialogs at least 300px wide, so the label refusing to shrink can't cause overflow of its own.

### Change type

- [x] `bugfix`

### Test plan

1. Select a shape, open the context menu, and choose "Edit link".
2. Check that the `URL` label renders on one line next to the input.
3. Open the embed dialog and check the same label there.
4. In the toasts and dialogs example, show the long toast and the dialog with the long URL, and check the URL still wraps inside the dialog rather than widening it.

### Release notes

- Fix the `URL` label wrapping onto two lines in the edit link and embed dialogs.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +8 / -0    |
