### PR TITLE
fix(commenting): anchor shape comments in shape space and bind to strokes

### DIFF
--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -327,6 +327,12 @@ export function commitCommentMutation<T>(editor: Editor, fn: () => T, kind?: 'dr
 // @public (undocumented)
 export function computeClusterTable(leaves: readonly LeafInput[], options: ClusterOptions): ClusterTable;
 
+// @public
+export function computePinStacks(editor: Editor, threads: readonly TLCommentThread[], impreciseShapeAnchor?: {
+    x: number;
+    y: number;
+}): Map<string, number>;
+
 // @public (undocumented)
 export function CountBadge({ count }: CountBadgeProps): JSX.Element;
 
@@ -470,6 +476,9 @@ export interface PendingComment {
 
 // @public
 export const pendingComment: EditorAtom<null | PendingComment>;
+
+// @public
+export const PIN_STACK_STEP_PX = 12;
 
 // @public
 export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): void;

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -19,6 +19,7 @@ import { TLCommentThread } from 'tldraw';
 import { TLCommentThreadId } from 'tldraw';
 import { TLHistoryBatchOptions } from 'tldraw';
 import { TLRichText } from 'tldraw';
+import { TLShape } from 'tldraw';
 import { TLShapeId } from 'tldraw';
 import { TLStateNodeConstructor } from 'tldraw';
 import { TLUiOverrides } from 'tldraw';
@@ -185,6 +186,13 @@ export interface CommentComposerProps {
 }
 
 // @public
+export interface CommentDropTarget {
+    // (undocumented)
+    anchor: TLCommentAnchor;
+    highlightShapeId: null | TLShapeId;
+}
+
+// @public
 export interface CommentingComponents {
     CommentBody?: ComponentType<{
         comment: TLComment;
@@ -273,6 +281,9 @@ export function CommentsOverflowMenu(): JSX.Element;
 
 // @public
 export const commentsSidebarOpen: EditorAtom<boolean>;
+
+// @public
+export function commentTargetShape(editor: Editor, page: VecLike): TLShape | undefined;
 
 // @public
 export function CommentText({ text }: CommentTextProps): JSX.Element;
@@ -513,6 +524,15 @@ export function removeCommentRecords(editor: Editor, ids: (TLCommentId | TLComme
 
 // @public
 export function renderMarkdown(text: string): ReactNode;
+
+// @public
+export function resolveCommentDrop(editor: Editor, page: VecLike, { current, constrain }?: ResolveCommentDropOptions): CommentDropTarget;
+
+// @public (undocumented)
+export interface ResolveCommentDropOptions {
+    constrain?: boolean;
+    current?: TLCommentAnchor;
+}
 
 // @public
 export function richTextToPlaintext(body: TLRichText, resolveName?: (id: string) => string | undefined): string;

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -331,7 +331,7 @@ export function computeClusterTable(leaves: readonly LeafInput[], options: Clust
 export function computePinStacks(editor: Editor, threads: readonly TLCommentThread[], impreciseShapeAnchor?: {
     x: number;
     y: number;
-}): Map<string, number>;
+}): Map<string, readonly string[]>;
 
 // @public (undocumented)
 export function CountBadge({ count }: CountBadgeProps): JSX.Element;
@@ -465,6 +465,9 @@ export interface MergeEvent {
 }
 
 // @public
+export const openStackId: EditorAtom<null | string>;
+
+// @public
 export const openThreadId: EditorAtom<null | string>;
 
 // @public
@@ -476,9 +479,6 @@ export interface PendingComment {
 
 // @public
 export const pendingComment: EditorAtom<null | PendingComment>;
-
-// @public
-export const PIN_STACK_STEP_PX = 12;
 
 // @public
 export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): void;

--- a/packages/commenting/src/canvas/anchor-roundtrip.test.ts
+++ b/packages/commenting/src/canvas/anchor-roundtrip.test.ts
@@ -1,0 +1,187 @@
+import type { TLShapeId } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import { createFakeEditor, type FakeShapeSpec } from './test-editor'
+import { anchorPagePoint, shapeAnchorAt } from './thread-state'
+
+/**
+ * `shapeAnchorAt` and `anchorPagePoint` are inverses, and nothing but these tests enforces it.
+ * The round trip is the whole contract: a point placed on a shape has to come back as the same
+ * point, whatever the shape is doing.
+ *
+ * These fail if anchors are resolved against page bounds, because a page-aligned box grows as a
+ * shape rotates — the stored fraction then addresses a different part of the shape than it did
+ * when it was written, and the pin slides off whatever it was placed on.
+ */
+
+const SHAPE = 'shape:a' as TLShapeId
+
+function roundTrip(spec: Omit<FakeShapeSpec, 'id'>, page: { x: number; y: number }) {
+	const editor = createFakeEditor({ shapes: [{ id: SHAPE, ...spec }] })
+	const anchor = shapeAnchorAt(editor, SHAPE, page, true)
+	return anchorPagePoint(editor, anchor)
+}
+
+function expectClose(actual: { x: number; y: number } | null, expected: { x: number; y: number }) {
+	expect(actual).not.toBeNull()
+	expect(actual!.x).toBeCloseTo(expected.x, 6)
+	expect(actual!.y).toBeCloseTo(expected.y, 6)
+}
+
+describe('shape anchor round trip', () => {
+	it('returns the same point for a shape at the origin', () => {
+		expectClose(roundTrip({ w: 200, h: 100 }, { x: 50, y: 25 }), { x: 50, y: 25 })
+	})
+
+	it('returns the same point for a translated shape', () => {
+		expectClose(roundTrip({ x: 300, y: 400, w: 200, h: 100 }, { x: 350, y: 425 }), {
+			x: 350,
+			y: 425,
+		})
+	})
+
+	it('returns the same point for a rotated shape', () => {
+		expectClose(
+			roundTrip({ x: 100, y: 100, w: 200, h: 100, rotation: Math.PI / 4 }, { x: 180, y: 160 }),
+			{ x: 180, y: 160 }
+		)
+	})
+
+	it('returns the same point for a shape rotated past a half turn', () => {
+		expectClose(
+			roundTrip({ x: -40, y: 90, w: 120, h: 260, rotation: (4 * Math.PI) / 3 }, { x: 12, y: 44 }),
+			{ x: 12, y: 44 }
+		)
+	})
+
+	it('handles a point outside the shape, which Alt-dragging can produce before clamping', () => {
+		expectClose(
+			roundTrip({ x: 100, y: 100, w: 200, h: 100, rotation: Math.PI / 6 }, { x: 900, y: -300 }),
+			{ x: 900, y: -300 }
+		)
+	})
+
+	// The round trip alone cannot tell the two coordinate spaces apart: any self-consistent pair of
+	// functions round-trips. What separates them is storing an anchor and *then* moving the shape,
+	// which is the case that actually drifts in production.
+	it('keeps pointing at the same spot on the shape after it is rotated', () => {
+		const upright = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 100 }] })
+		const anchor = shapeAnchorAt(upright, SHAPE, { x: 50, y: 20 }, true)
+
+		const angle = Math.PI / 4
+		const rotated = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 100, rotation: angle }] })
+
+		// Still local (50, 20) on the shape, now carried around by the shape's own rotation. Resolved
+		// against a page-aligned box it would land somewhere else entirely, because that box grew.
+		expectClose(anchorPagePoint(rotated, anchor), {
+			x: 50 * Math.cos(angle) - 20 * Math.sin(angle),
+			y: 50 * Math.sin(angle) + 20 * Math.cos(angle),
+		})
+	})
+
+	describe('the stored fraction', () => {
+		it('is measured in the shape’s own space, so rotation does not change it', () => {
+			// The same physical spot on the shape — its local centre — however the shape is turned.
+			const upright = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 100 }] })
+			const turned = createFakeEditor({
+				shapes: [{ id: SHAPE, w: 200, h: 100, rotation: Math.PI / 3 }],
+			})
+
+			const uprightCentre = anchorPagePoint(upright, {
+				type: 'shape',
+				shapeId: SHAPE,
+				x: 0.5,
+				y: 0.5,
+				isPrecise: true,
+			})
+			const turnedCentre = anchorPagePoint(turned, {
+				type: 'shape',
+				shapeId: SHAPE,
+				x: 0.5,
+				y: 0.5,
+				isPrecise: true,
+			})
+
+			// Local centre is (100, 50); rotating about the origin moves where that lands on the page,
+			// but it is still the centre of the shape rather than a drifted spot.
+			expectClose(uprightCentre, { x: 100, y: 50 })
+			const angle = Math.PI / 3
+			expectClose(turnedCentre, {
+				x: 100 * Math.cos(angle) - 50 * Math.sin(angle),
+				y: 100 * Math.sin(angle) + 50 * Math.cos(angle),
+			})
+		})
+
+		it('survives a resize, because the fraction scales with the box', () => {
+			const before = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 100 }] })
+			const anchor = shapeAnchorAt(before, SHAPE, { x: 150, y: 25 }, true)
+			expect(anchor).toEqual({
+				type: 'shape',
+				shapeId: SHAPE,
+				x: 0.75,
+				y: 0.25,
+				isPrecise: true,
+			})
+
+			// Same anchor, shape now twice as wide: the pin stays three-quarters along.
+			const after = createFakeEditor({ shapes: [{ id: SHAPE, w: 400, h: 100 }] })
+			expectClose(anchorPagePoint(after, anchor), { x: 300, y: 25 })
+		})
+	})
+
+	describe('degenerate shapes', () => {
+		it('centres the axis a perfectly straight line has no extent along', () => {
+			const editor = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 0 }] })
+			const anchor = shapeAnchorAt(editor, SHAPE, { x: 50, y: 0 }, true)
+			// x still normalizes along the line; y has nothing to divide by.
+			expect(anchor).toEqual({
+				type: 'shape',
+				shapeId: SHAPE,
+				x: 0.25,
+				y: 0.5,
+				isPrecise: true,
+			})
+		})
+
+		it('returns null for a shape that no longer exists', () => {
+			const editor = createFakeEditor({ shapes: [] })
+			expect(
+				anchorPagePoint(editor, {
+					type: 'shape',
+					shapeId: SHAPE,
+					x: 0.5,
+					y: 0.5,
+					isPrecise: true,
+				})
+			).toBeNull()
+		})
+	})
+
+	describe('legacy imprecise anchors', () => {
+		it('still render at the consumer default rather than the stored fraction', () => {
+			const editor = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 100 }] })
+			// Stored x/y are deliberately ignored; the default is the top-right corner.
+			expectClose(
+				anchorPagePoint(editor, {
+					type: 'shape',
+					shapeId: SHAPE,
+					x: 0.25,
+					y: 0.25,
+					isPrecise: false,
+				}),
+				{ x: 200, y: 0 }
+			)
+		})
+
+		it('honour a custom imprecise anchor', () => {
+			const editor = createFakeEditor({ shapes: [{ id: SHAPE, w: 200, h: 100 }] })
+			expectClose(
+				anchorPagePoint(
+					editor,
+					{ type: 'shape', shapeId: SHAPE, x: 0.25, y: 0.25, isPrecise: false },
+					{ x: 0.5, y: 1 }
+				),
+				{ x: 100, y: 100 }
+			)
+		})
+	})
+})

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -76,6 +76,11 @@
 	gap: 10px;
 	max-height: 420px;
 	overflow-y: auto;
+	/* A scroll container clips at its own box — including the cards' shadows (setting one overflow
+	   axis makes both non-visible). Pad the clip box outward and pull the list back into place so
+	   the shadows have room to paint. */
+	padding: 16px;
+	margin: -16px;
 }
 
 /* Collapsed entries match the expanded thread's surface (same width, panel, elevation) so the

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -95,11 +95,11 @@
 	cursor: pointer;
 }
 
-/* Opaque hover darkening (not a translucent muted token) — the card floats directly over the
-   canvas, so a translucent background would let shapes show through it. */
+/* Hover uses the opaque low-surface token, not a translucent muted one — the card floats
+   directly over the canvas, so a translucent background would let shapes show through it. */
 .tlui-cmt-stack-list__card:hover,
 .pseudo-hover.tlui-cmt-stack-list__card {
-	background: color-mix(in srgb, var(--tl-color-panel) 96%, black);
+	background: var(--tl-color-low);
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -90,6 +90,20 @@
 	cursor: pointer;
 }
 
+.tlui-cmt-stack-list__card:hover,
+.pseudo-hover.tlui-cmt-stack-list__card {
+	background: var(--tl-color-muted-2);
+}
+
+/* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the
+   thread panel flattens its own cards. */
+.tlui-cmt-stack-list__card .tlui-cmt-card {
+	width: 100%;
+	padding: 6px 0 6px 4px;
+	background: transparent;
+	border: none;
+}
+
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass
    through. Drawn for the live drag draft and for a region thread while hovered or open. */
 .tlui-cmt-canvas-region {

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -61,6 +61,13 @@
 	z-index: 1;
 }
 
+/* A hovered pin rises above everything nearby — in a fanned stack of coincident pins, the pin
+   being reached for must win over its later-stacked (higher-painted) siblings. */
+.tlui-cmt-canvas-pin:hover,
+.pseudo-hover.tlui-cmt-canvas-pin {
+	z-index: 2;
+}
+
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass
    through. Drawn for the live drag draft and for a region thread while hovered or open. */
 .tlui-cmt-canvas-region {

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -73,7 +73,7 @@
 .tlui-cmt-stack-list {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
+	gap: 10px;
 	max-height: 420px;
 	overflow-y: auto;
 }
@@ -84,9 +84,9 @@
 	box-sizing: border-box;
 	width: 300px;
 	background: var(--tl-color-panel);
-	border-radius: var(--tl-radius-4);
+	border-radius: 12px;
 	box-shadow: var(--tl-shadow-2);
-	padding: 8px;
+	padding: 10px 14px;
 	cursor: pointer;
 }
 
@@ -96,12 +96,14 @@
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the
-   thread panel flattens its own cards. */
+   thread panel flattens its own cards. The avatar centers against the short two-line block so a
+   collapsed entry doesn't read as top-heavy. */
 .tlui-cmt-stack-list__card .tlui-cmt-card {
 	width: 100%;
-	padding: 6px 0 6px 4px;
+	padding: 0;
 	background: transparent;
 	border: none;
+	align-items: center;
 }
 
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -61,11 +61,33 @@
 	z-index: 1;
 }
 
-/* A hovered pin rises above everything nearby — in a fanned stack of coincident pins, the pin
-   being reached for must win over its later-stacked (higher-painted) siblings. */
-.tlui-cmt-canvas-pin:hover,
-.pseudo-hover.tlui-cmt-canvas-pin {
-	z-index: 2;
+/* The count badge standing in for a stack of coincident pins — same face as a cluster badge,
+   but clicking opens the stack's thread list rather than zooming (no zoom can separate them). */
+.tlui-cmt-canvas-stack-badge {
+	transform: translate(-50%, -50%);
+	width: max-content;
+	cursor: pointer;
+}
+
+/* The stack's popover content: one card per thread, the expanded thread inline among them. */
+.tlui-cmt-stack-list {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	max-height: 420px;
+	overflow-y: auto;
+}
+
+/* Collapsed entries match the expanded thread's surface (same width, panel, elevation) so the
+   list reads as one column of cards with one of them opened up. */
+.tlui-cmt-stack-list__card {
+	box-sizing: border-box;
+	width: 300px;
+	background: var(--tl-color-panel);
+	border-radius: var(--tl-radius-4);
+	box-shadow: var(--tl-shadow-2);
+	padding: 8px;
+	cursor: pointer;
 }
 
 /* A region anchor's area: a dashed box under the pins, non-interactive so canvas events pass

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -95,9 +95,11 @@
 	cursor: pointer;
 }
 
+/* Opaque hover darkening (not a translucent muted token) — the card floats directly over the
+   canvas, so a translucent background would let shapes show through it. */
 .tlui-cmt-stack-list__card:hover,
 .pseudo-hover.tlui-cmt-stack-list__card {
-	background: var(--tl-color-muted-2);
+	background: color-mix(in srgb, var(--tl-color-panel) 96%, black);
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 // intentional. Implement `cluster-input.ts` per CLUSTERING-STEPS.md step 6
 // until this suite passes, without modifying this file.
 import { collectClusterLeaves } from './cluster-input'
+import { createFakeEditor } from './test-editor'
 
 const CURRENT_PAGE = 'page:one'
 const OTHER_PAGE = 'page:two'
@@ -27,21 +28,24 @@ function thread(
 }
 
 /**
- * Stub editor: the filter's only editor dependencies are the current page id
- * and shape page bounds (via anchorPagePoint). `shapes` maps shape id → bounds
- * for shapes that exist; anything else resolves to undefined (deleted shape).
+ * Stub editor: the filter's only editor dependency is resolving a thread's anchor to a page point
+ * (via anchorPagePoint). `shapes` maps shape id → bounds for shapes that exist; anything else
+ * resolves to a deleted shape. Bounds are unrotated here, so a shape's page box and its local
+ * geometry box coincide and these expectations are unaffected by the coordinate space.
  */
 function stubEditor(
 	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
 ): Editor {
-	return {
-		getCurrentPageId: () => CURRENT_PAGE,
-		getShapePageBounds: (id: string) => {
-			const bounds = shapes[id]
-			if (!bounds) return undefined
-			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
-		},
-	} as unknown as Editor
+	return createFakeEditor({
+		pageId: CURRENT_PAGE,
+		shapes: Object.entries(shapes).map(([id, bounds]) => ({
+			id,
+			x: bounds.minX,
+			y: bounds.minY,
+			w: bounds.maxX - bounds.minX,
+			h: bounds.maxY - bounds.minY,
+		})),
+	})
 }
 
 function leafIds(leaves: { id: string }[]): string[] {

--- a/packages/commenting/src/canvas/comment-drop.test.ts
+++ b/packages/commenting/src/canvas/comment-drop.test.ts
@@ -1,0 +1,204 @@
+import type { TLCommentAnchor, TLShapeId } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import { createFakeEditor } from './test-editor'
+import { commentTargetShape, resolveCommentDrop } from './thread-state'
+
+const A = 'shape:a' as TLShapeId
+const B = 'shape:b' as TLShapeId
+
+/** The default outline margin is 8 screen px, so at zoom 1 anything within 8 units counts as ink. */
+const INSIDE_MARGIN = 3
+const OUTSIDE_MARGIN = 40
+
+function shapeAnchor(shapeId: TLShapeId, x = 0.5, y = 0.5): TLCommentAnchor {
+	return { type: 'shape', shapeId, x, y, isPrecise: true }
+}
+
+describe('commentTargetShape', () => {
+	it('attaches on a stroke', () => {
+		const editor = createFakeEditor({
+			shapes: [{ id: A, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN }],
+		})
+		expect(commentTargetShape(editor, { x: 0, y: 50 })?.id).toBe(A)
+	})
+
+	it('ignores blank space away from the stroke', () => {
+		const editor = createFakeEditor({
+			shapes: [{ id: A, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN }],
+		})
+		expect(commentTargetShape(editor, { x: 100, y: 50 })).toBeUndefined()
+	})
+
+	// The reason this isn't `getShapeAtPoint({ hitInside: false })`: a filled shape reports interior
+	// points as a negative distance, so that call returns the shape and swallows the whole fill.
+	it('ignores the inside of a filled shape, where the distance comes back negative', () => {
+		const editor = createFakeEditor({
+			shapes: [{ id: A, w: 200, h: 100, distanceToOutline: -OUTSIDE_MARGIN }],
+		})
+		expect(commentTargetShape(editor, { x: 100, y: 50 })).toBeUndefined()
+	})
+
+	it('still attaches just inside the stroke of a filled shape', () => {
+		const editor = createFakeEditor({
+			shapes: [{ id: A, w: 200, h: 100, distanceToOutline: -INSIDE_MARGIN }],
+		})
+		expect(commentTargetShape(editor, { x: 2, y: 50 })?.id).toBe(A)
+	})
+
+	it('takes the top-most shape whose stroke is under the point', () => {
+		const editor = createFakeEditor({
+			shapes: [
+				{ id: A, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN },
+				{ id: B, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN },
+			],
+		})
+		// A is on top but the point isn't on its stroke, so the hit falls through to B.
+		expect(commentTargetShape(editor, { x: 0, y: 50 })?.id).toBe(B)
+	})
+
+	it('scales the margin by zoom, so the stroke is equally reachable when zoomed out', () => {
+		// 12 page units is outside the 8px margin at zoom 1, but inside it at zoom 0.5 (16 units).
+		const shapes = [{ id: A, w: 200, h: 100, distanceToOutline: 12 }]
+		expect(
+			commentTargetShape(createFakeEditor({ shapes, zoom: 1 }), { x: 0, y: 0 })
+		).toBeUndefined()
+		expect(commentTargetShape(createFakeEditor({ shapes, zoom: 0.5 }), { x: 0, y: 0 })?.id).toBe(A)
+	})
+
+	describe('shapes with no stroke to aim at', () => {
+		it('attaches anywhere on an image', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, type: 'image', w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN }],
+			})
+			expect(commentTargetShape(editor, { x: 100, y: 50 })?.id).toBe(A)
+		})
+
+		it('attaches anywhere on text and notes', () => {
+			for (const type of ['text', 'note', 'video', 'bookmark', 'embed']) {
+				const editor = createFakeEditor({
+					shapes: [{ id: A, type, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN }],
+				})
+				expect(commentTargetShape(editor, { x: 100, y: 50 })?.id).toBe(A)
+			}
+		})
+
+		it('does not exempt frames, so a comment inside one is not bound to the frame', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, type: 'frame', w: 400, h: 400, distanceToOutline: OUTSIDE_MARGIN }],
+			})
+			expect(commentTargetShape(editor, { x: 200, y: 200 })).toBeUndefined()
+		})
+	})
+})
+
+describe('resolveCommentDrop', () => {
+	describe('normal drag', () => {
+		it('attaches to the stroke under the point and highlights it', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN }],
+			})
+			expect(resolveCommentDrop(editor, { x: 50, y: 0 })).toEqual({
+				anchor: { type: 'shape', shapeId: A, x: 0.25, y: 0, isPrecise: true },
+				highlightShapeId: A,
+			})
+		})
+
+		it('always stores a precise anchor, so the pin stays where it was put', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN }],
+			})
+			const { anchor } = resolveCommentDrop(editor, { x: 150, y: 75 })
+			expect(anchor).toMatchObject({ isPrecise: true, x: 0.75, y: 0.75 })
+		})
+
+		it('leaves the comment a free point on blank canvas, with nothing highlighted', () => {
+			const editor = createFakeEditor({ shapes: [] })
+			expect(resolveCommentDrop(editor, { x: 12, y: 34 })).toEqual({
+				anchor: { type: 'point', x: 12, y: 34 },
+				highlightShapeId: null,
+			})
+		})
+
+		// This is how a comment detaches: there is no modifier for it, you drag it off the ink.
+		it('detaches an attached comment dragged onto blank space', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN }],
+			})
+			expect(resolveCommentDrop(editor, { x: 100, y: 50 }, { current: shapeAnchor(A) })).toEqual({
+				anchor: { type: 'point', x: 100, y: 50 },
+				highlightShapeId: null,
+			})
+		})
+	})
+
+	describe('constrained drag (Alt)', () => {
+		it('keeps the comment on its shape even over the fill, where a normal drag would detach', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN }],
+			})
+			expect(
+				resolveCommentDrop(editor, { x: 100, y: 50 }, { current: shapeAnchor(A), constrain: true })
+			).toEqual({
+				anchor: { type: 'shape', shapeId: A, x: 0.5, y: 0.5, isPrecise: true },
+				highlightShapeId: A,
+			})
+		})
+
+		it('clamps to the shape’s box rather than following the pointer out of it', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN }],
+			})
+			const { anchor } = resolveCommentDrop(
+				editor,
+				{ x: 900, y: -500 },
+				{ current: shapeAnchor(A), constrain: true }
+			)
+			expect(anchor).toEqual({ type: 'shape', shapeId: A, x: 1, y: 0, isPrecise: true })
+		})
+
+		it('ignores a shape sitting on top, because the bound shape is what matters', () => {
+			const editor = createFakeEditor({
+				shapes: [
+					{ id: B, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN },
+					{ id: A, w: 200, h: 100, distanceToOutline: OUTSIDE_MARGIN },
+				],
+			})
+			const { anchor, highlightShapeId } = resolveCommentDrop(
+				editor,
+				{ x: 50, y: 50 },
+				{ current: shapeAnchor(A), constrain: true }
+			)
+			expect(highlightShapeId).toBe(A)
+			expect(anchor).toMatchObject({ type: 'shape', shapeId: A })
+		})
+
+		it('falls back to a normal drag for a comment that is not attached to anything', () => {
+			const editor = createFakeEditor({
+				shapes: [{ id: A, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN }],
+			})
+			const current: TLCommentAnchor = { type: 'point', x: 0, y: 0 }
+			expect(resolveCommentDrop(editor, { x: 50, y: 0 }, { current, constrain: true })).toEqual({
+				anchor: { type: 'shape', shapeId: A, x: 0.25, y: 0, isPrecise: true },
+				highlightShapeId: A,
+			})
+		})
+
+		it('falls back to a normal drag when the bound shape has been deleted', () => {
+			const editor = createFakeEditor({ shapes: [] })
+			expect(
+				resolveCommentDrop(editor, { x: 7, y: 9 }, { current: shapeAnchor(A), constrain: true })
+			).toEqual({
+				anchor: { type: 'point', x: 7, y: 9 },
+				highlightShapeId: null,
+			})
+		})
+	})
+
+	it('resolves the highlight and the anchor together, so they cannot disagree', () => {
+		const editor = createFakeEditor({
+			shapes: [{ id: A, w: 200, h: 100, distanceToOutline: INSIDE_MARGIN }],
+		})
+		const { anchor, highlightShapeId } = resolveCommentDrop(editor, { x: 50, y: 0 })
+		expect(anchor.type === 'shape' && anchor.shapeId).toBe(highlightShapeId)
+	})
+})

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -9,7 +9,7 @@ import {
 import { type CommentingOptions, defaultCommentingOptions } from './options'
 import { getRegionCommentOptions } from './region-options'
 import { commentsSidebarOpen, pendingComment, regionDraft } from './state'
-import { regionPinPoint, shapeAnchorAt } from './thread-state'
+import { regionPinPoint, resolveCommentDrop } from './thread-state'
 
 /** A comment being placed but not yet posted: where its composer sits and what it will anchor
  *  to. Shared between the tool (which sets it on click) and the overlay (which renders the
@@ -132,8 +132,10 @@ class CommentIdle extends StateNode {
 
 	private updateHint() {
 		const { editor } = this
-		const hit = editor.getShapeAtPoint(editor.inputs.getCurrentPagePoint(), { hitInside: true })
-		editor.setHintingShapes(hit ? [hit.id] : [])
+		// Same call the drop makes, so the outline only lights up where a click would actually
+		// attach. Placement has no existing anchor, so it never takes the constrained branch.
+		const { highlightShapeId } = resolveCommentDrop(editor, editor.inputs.getCurrentPagePoint())
+		editor.setHintingShapes(highlightShapeId ? [highlightShapeId] : [])
 	}
 }
 
@@ -170,14 +172,12 @@ class CommentPointing extends StateNode {
 		pendingComment.update(editor, (p) => (p ? { ...p, point: { x: point.x, y: point.y } } : p))
 	}
 
-	// Settle where the pointer is released: anchor to the shape under it, or drop a point.
+	// Settle where the pointer is released: onto the stroke under it, or as a free point. Either
+	// way the comment stays exactly here — a shape anchor no longer relocates the pin to a corner.
 	override onPointerUp() {
 		const { editor } = this
 		const point = editor.inputs.getCurrentPagePoint()
-		const hit = editor.getShapeAtPoint(point, { hitInside: true })
-		const anchor: TLCommentAnchor = hit
-			? shapeAnchorAt(editor, hit.id, point, editor.inputs.getAltKey())
-			: { type: 'point', x: point.x, y: point.y }
+		const { anchor } = resolveCommentDrop(editor, point)
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
 		// Hand back to select; the open composer is now the focus.
 		editor.setCurrentTool('select')

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,6 +1,6 @@
 import {
+	Fragment,
 	memo,
-	type CSSProperties,
 	type PointerEvent as ReactPointerEvent,
 	ReactNode,
 	useCallback,
@@ -21,7 +21,6 @@ import {
 	TLCommentId,
 	TLCommentThread,
 	TLRichText,
-	TldrawUiIcon,
 	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
@@ -33,28 +32,20 @@ import {
 import { computeClusterTable } from '../clustering/computeClusterTable'
 import { type ClusterRuntime, createClusterRuntime } from '../clustering/runtime'
 import type { ClusterNode, ClusterTable, MergeEvent } from '../clustering/types'
-import { CommentCard, CommentCardProps } from '../ui/comment-card'
 import { CommentComposer } from '../ui/comment-composer'
 import { EMPTY_COMMENT, isCommentEmpty } from '../ui/comment-extensions'
 import { CommentPin } from '../ui/comment-pin'
-import { CommentThread } from '../ui/comment-thread'
 import { CountBadge } from '../ui/count-badge'
 import { MentionMember } from '../ui/mention-list'
 import { isMentionPickerOpen } from '../ui/mention-suggestion'
 import { collectClusterLeaves } from './cluster-input'
-import { CommentBody } from './comment-body'
 import { UNKNOWN_AUTHOR } from './comment-render'
-import { getCommentRecord, putCommentRecords, removeCommentRecords } from './comment-store'
+import { getCommentRecord, putCommentRecords } from './comment-store'
 import { PendingComment } from './comment-tool'
 import { useCommentThreads, useThreadComments } from './hooks'
 import { useCommentingEnabled } from './license'
-import {
-	type CommentingComponents,
-	type CommentingOptions,
-	getCommentingOptions,
-	useCommentingOptions,
-} from './options'
-import { computePinStacks, PIN_STACK_STEP_PX } from './pin-stacking'
+import { type CommentingOptions, getCommentingOptions, useCommentingOptions } from './options'
+import { computePinStacks } from './pin-stacking'
 import {
 	DEFAULT_REGION_COMMENT_OPTIONS,
 	RegionCommentOptions,
@@ -63,13 +54,16 @@ import {
 import {
 	commentsHidden,
 	commitCommentMutation,
+	openStackId,
 	openThreadId,
 	pendingComment,
 	regionDraft,
 	toggleCommentsHidden,
 	usePendingComment,
 } from './state'
+import { ThreadStackPin } from './thread-stack'
 import { anchorPagePoint, regionPinPoint, shapeAnchorAt } from './thread-state'
+import { ThreadPopover, ThreadView } from './thread-view'
 
 /**
  * A ready-to-use comments layer for a tldraw canvas: pins each thread at its anchor, opens a
@@ -134,28 +128,6 @@ const draftAvatar = (
 		</svg>
 	</CommentPin>
 )
-
-function toCardProps(
-	comment: TLComment,
-	props: CanvasCommentsProps,
-	components: CommentingComponents
-): CommentCardProps {
-	const Body = components.CommentBody
-	// The `CommentBody` component slot overrides the built-in rich-text default (which resolves
-	// mention ids to names).
-	const body = Body ? (
-		<Body comment={comment} />
-	) : (
-		<CommentBody richText={comment.body} resolveName={props.resolveName} />
-	)
-	return {
-		author: props.resolveName(comment.authorId) ?? UNKNOWN_AUTHOR,
-		body,
-		date: new Date(comment.createdAt).toISOString(),
-		you: comment.authorId === props.currentUserId,
-		edited: comment.editedAt != null,
-	}
-}
 
 /** @public @react */
 export function CanvasComments(props: CanvasCommentsProps) {
@@ -346,8 +318,8 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		[threads]
 	)
 	// Zooming separates near pins, but pins with the *same* anchor point (several imprecise
-	// comments on one shape) coincide at every zoom — spread those sideways so each stays
-	// reachable. Keyed on page-space anchors, so camera moves never recompute this.
+	// comments on one shape) coincide at every zoom — those render as one count-badge stack that
+	// opens the threads as a list. Keyed on page-space anchors, so camera moves never recompute this.
 	const pinStacks = useValue(
 		'comment pin stacks',
 		() => computePinStacks(editor, threads, impreciseShapeAnchor),
@@ -356,10 +328,11 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	const openThread = openId ? threadsById.get(openId) : null
 	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
 
-	// Reset the transient UI state (open thread, half-placed comment) when this unmounts.
+	// Reset the transient UI state (open thread, open stack, half-placed comment) when this unmounts.
 	useEffect(() => {
 		return () => {
 			openThreadId.set(editor, null)
+			openStackId.set(editor, null)
 			pendingComment.set(editor, null)
 		}
 	}, [editor])
@@ -453,6 +426,42 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 	// is read above so this component stays mounted and its shortcut/Escape effects keep running.
 	if (hidden) return null
 
+	// Which threads are on screen this render, across every path below. A stack renders exactly
+	// once, owned by its first member that is actually on screen — members can arrive by different
+	// paths (a leaf via clustering while its open sibling renders via the open slot), so ownership
+	// can't be decided per-path.
+	const renderedThreadIds = new Set<string>()
+	if (options.enableClustering) {
+		for (const { node } of fadeNodes) if (node.count === 1) renderedThreadIds.add(node.id)
+		for (const thread of orphanThreads) renderedThreadIds.add(thread.id)
+		for (const thread of heldThreads) renderedThreadIds.add(thread.id)
+	} else {
+		for (const thread of threads) renderedThreadIds.add(thread.id)
+	}
+	if (openThread) renderedThreadIds.add(openThread.id)
+
+	// A coincident-stack member renders as the group's single count-badge stack (if it owns it)
+	// or not at all; everything else is an ordinary pin.
+	const renderThreadPin = (thread: TLCommentThread): ReactNode => {
+		const group = pinStacks.get(thread.id)
+		if (group) {
+			const owner = group.find((id) => renderedThreadIds.has(id))
+			if (owner !== thread.id) return null
+			const stackThreads = group
+				.map((id) => threadsById.get(id))
+				.filter((t): t is TLCommentThread => t !== undefined)
+			return (
+				<ThreadStackPin
+					editor={editor}
+					threads={stackThreads}
+					{...props}
+					impreciseShapeAnchor={impreciseShapeAnchor}
+				/>
+			)
+		}
+		return <ThreadPin editor={editor} thread={thread} {...props} regionOptions={regionOptions} />
+	}
+
 	// Render into the container (above the panels' stacking context) so the pins and popovers
 	// live in the UI layer rather than being clipped by the canvas layer.
 	return createPortal(
@@ -464,15 +473,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 						if (node.count === 1) {
 							const thread = threadsById.get(node.id)
 							if (!thread) return null
-							content = (
-								<ThreadPin
-									editor={editor}
-									thread={thread}
-									stackIndex={pinStacks.get(thread.id) ?? 0}
-									{...props}
-									regionOptions={regionOptions}
-								/>
-							)
+							content = renderThreadPin(thread)
 						} else {
 							content = <ClusterBadge editor={editor} node={node} onExpand={zoomToClusterSplit} />
 						}
@@ -483,24 +484,10 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 						)
 					})}
 					{orphanThreads.map((thread) => (
-						<ThreadPin
-							key={thread.id}
-							editor={editor}
-							thread={thread}
-							stackIndex={pinStacks.get(thread.id) ?? 0}
-							{...props}
-							regionOptions={regionOptions}
-						/>
+						<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
 					))}
 					{heldThreads.map((thread) => (
-						<ThreadPin
-							key={thread.id}
-							editor={editor}
-							thread={thread}
-							stackIndex={pinStacks.get(thread.id) ?? 0}
-							{...props}
-							regionOptions={regionOptions}
-						/>
+						<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
 					))}
 				</>
 			) : (
@@ -510,26 +497,10 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 				// otherwise it would mount a second, stacked pin.
 				threads
 					.filter((thread) => thread.id !== openId)
-					.map((thread) => (
-						<ThreadPin
-							key={thread.id}
-							editor={editor}
-							thread={thread}
-							stackIndex={pinStacks.get(thread.id) ?? 0}
-							{...props}
-							regionOptions={regionOptions}
-						/>
-					))
+					.map((thread) => <Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>)
 			)}
 			{openThread && (
-				<ThreadPin
-					key={`open:${openThread.id}`}
-					editor={editor}
-					thread={openThread}
-					stackIndex={pinStacks.get(openThread.id) ?? 0}
-					{...props}
-					regionOptions={regionOptions}
-				/>
+				<Fragment key={`open:${openThread.id}`}>{renderThreadPin(openThread)}</Fragment>
 			)}
 			<RegionDraftBox editor={editor} />
 			{/* Keep the region visible while composing — the drag draft is gone by now, and no thread
@@ -798,28 +769,6 @@ function isInInflatedViewport(editor: Editor, point: { x: number; y: number }): 
 	)
 }
 
-/** The open thread's popover, portaled above the UI panels. Over it, wheel and hover events pass
- *  through to the canvas (unless the popover is scrolling its own content), like tldraw's panels. */
-function ThreadPopover({
-	container,
-	style,
-	children,
-}: {
-	container: HTMLElement
-	style: CSSProperties
-	children: ReactNode
-}) {
-	const ref = useRef<HTMLDivElement>(null)
-	usePassThroughWheelEvents(ref)
-	usePassThroughMouseOverEvents(ref)
-	return createPortal(
-		<div ref={ref} className="tlui-cmt-canvas-popover" style={style} onPointerDown={stop}>
-			{children}
-		</div>,
-		container
-	)
-}
-
 /** A dashed rectangle over a region anchor's bounds, in viewport space. Sits in the canvas layer as
  *  a sibling of the pins. `pointer-events` stays off (canvas interaction passes through) unless
  *  `movable`, in which case dragging the body translates the region — previews live, commits on drop. */
@@ -999,37 +948,22 @@ const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
 	regionOptions,
-	stackIndex,
 	...props
 }: Omit<CanvasCommentsProps, 'regionOptions'> & {
 	editor: Editor
 	thread: TLCommentThread
 	regionOptions: RegionCommentOptions
-	/** This pin's slot among pins sharing its exact anchor point — 0 sits at the anchor. */
-	stackIndex: number
 }) {
-	const {
-		currentUserId,
-		resolveName,
-		onPostComment,
-		isCommentUnread,
-		onCommentRead,
-		getMentionSuggestions,
-		renderMentionSuggestion,
-	} = props
+	const { resolveName } = props
 	const options = useCommentingOptions()
 	const impreciseShapeAnchor = props.impreciseShapeAnchor ?? options.impreciseShapeAnchor
 	const container = useContainer()
 	const comments = useThreadComments(editor, thread.id)
-	const msg = useTranslation()
 	// Only one thread's popover is open at a time — shared across pins via the atom.
 	const open = useValue('thread open', () => openThreadId.get(editor) === thread.id, [
 		editor,
 		thread.id,
 	])
-	const [reply, setReply] = useState<TLRichText>(EMPTY_COMMENT)
-	const [editingId, setEditingId] = useState<string | null>(null)
-	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
 	// While dragging the marker, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
 	// The live bounds while a corner handle is resizing the region, else null.
@@ -1107,151 +1041,7 @@ const ThreadPin = memo(function ThreadPin({
 		},
 		[editor, thread.anchor, thread.pageId, impreciseShapeAnchor]
 	)
-	const visible = point !== null
-
-	// While the popover is open, every unread comment on display gets reported read — including
-	// replies that arrive while it stays open, since the effect re-runs as `comments` changes.
-	// The host's receipt write flips isCommentUnread to false, so re-runs find nothing to report.
-	useEffect(() => {
-		if (!open || !visible || !isCommentUnread || !onCommentRead) return
-		for (const comment of comments) {
-			if (isCommentUnread(comment.id)) {
-				onCommentRead(comment.id)
-			}
-		}
-	}, [open, visible, comments, isCommentUnread, onCommentRead])
-
 	if (!point) return null
-
-	const postReply = () => {
-		if (isCommentEmpty(reply) || !currentUserId) return
-		commitCommentMutation(editor, () => {
-			const comment = createComment({
-				threadId: thread.id,
-				pageId: thread.pageId,
-				authorId: currentUserId,
-				body: reply,
-			})
-			putCommentRecords(editor, [comment])
-			if (onPostComment) onPostComment(comment)
-		})
-		setReply(EMPTY_COMMENT)
-	}
-
-	const toggleResolve = () => {
-		if (!currentUserId) return
-		commitCommentMutation(editor, () => {
-			putCommentRecords(editor, [
-				{
-					...thread,
-					resolved: thread.resolved ? null : { at: Date.now(), by: currentUserId },
-				},
-			])
-		})
-	}
-
-	const deleteThread = () => {
-		openThreadId.set(editor, null)
-		commitCommentMutation(editor, () =>
-			removeCommentRecords(editor, [thread.id, ...comments.map((c) => c.id)])
-		)
-	}
-
-	const startEdit = (comment: TLComment) => {
-		setEditingId(comment.id)
-		setEditText(comment.body)
-	}
-
-	const saveEdit = () => {
-		const comment = comments.find((c) => c.id === editingId)
-		if (!comment || isCommentEmpty(editText)) return
-		commitCommentMutation(editor, () => {
-			putCommentRecords(editor, [{ ...comment, body: editText, editedAt: Date.now() }])
-		})
-		setEditingId(null)
-	}
-
-	// Swap a comment for a pre-filled composer while it's being edited; otherwise show the card,
-	// with an edit affordance on your own comments.
-	const renderComment = (card: CommentCardProps, index: number): ReactNode => {
-		const comment = comments[index]
-		if (editingId === comment.id) {
-			return (
-				<div
-					className="tlui-cmt-editing"
-					onKeyDown={(e) => {
-						if (e.key === 'Escape') {
-							setEditingId(null)
-							e.stopPropagation()
-						}
-					}}
-				>
-					<CommentComposer
-						author={card.author}
-						placeholder={msg('comments.edit-placeholder')}
-						value={editText}
-						onChange={setEditText}
-						onSubmit={saveEdit}
-						sendLabel={msg('comments.save')}
-						disabled={isCommentEmpty(editText)}
-						getMentionSuggestions={getMentionSuggestions}
-						renderMentionSuggestion={renderMentionSuggestion}
-						autoFocus
-					/>
-				</div>
-			)
-		}
-		return (
-			<CommentCard
-				{...card}
-				actions={
-					comment.authorId === currentUserId ? (
-						<button
-							className="tlui-cmt-thread__action"
-							title={msg('comments.edit')}
-							onClick={() => startEdit(comment)}
-						>
-							<TldrawUiIcon icon="dots-horizontal" label={msg('comments.edit')} small />
-						</button>
-					) : undefined
-				}
-			/>
-		)
-	}
-
-	const headerActions = (
-		<>
-			{currentUserId && (
-				<button
-					className="tlui-cmt-thread__action"
-					title={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
-					onClick={toggleResolve}
-				>
-					<TldrawUiIcon
-						icon="check"
-						label={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
-						small
-					/>
-				</button>
-			)}
-			{currentUserId && (
-				<button
-					className="tlui-cmt-thread__action"
-					title={msg('comments.delete')}
-					onClick={deleteThread}
-				>
-					<TldrawUiIcon icon="trash" label={msg('comments.delete')} small />
-				</button>
-			)}
-			<button
-				className="tlui-cmt-thread__action"
-				title={msg('comments.dismiss')}
-				onClick={() => openThreadId.set(editor, null)}
-			>
-				<TldrawUiIcon icon="cross-2" label={msg('comments.dismiss')} small />
-			</button>
-		</>
-	)
 
 	const PinContent = options.components.PinContent
 	// The `PinContent` component slot overrides the built-in author-initial default.
@@ -1314,15 +1104,11 @@ const ThreadPin = memo(function ThreadPin({
 	}
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
-	// move to the drag point; otherwise it sits at the stored anchor's viewport point — stepped
-	// sideways by its stack slot when other pins share that exact point. The step is in screen
-	// pixels (not page space) so a stack stays fanned out at every zoom.
+	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
 	const livePinPage = resizeBounds
 		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
 		: dragPagePoint
-	const renderPoint = livePinPage
-		? editor.pageToViewport(livePinPage)
-		: { x: point.x + stackIndex * PIN_STACK_STEP_PX, y: point.y }
+	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
 	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.
@@ -1390,35 +1176,7 @@ const ThreadPin = memo(function ThreadPin({
 						container={container}
 						style={{ left: renderPoint.x + 36, top: renderPoint.y - 28 }}
 					>
-						<CommentThread
-							header={msg('comments.thread-title')}
-							headerActions={headerActions}
-							renderComment={renderComment}
-							comments={comments.map((c) => toCardProps(c, props, options.components))}
-							resolvedBanner={
-								thread.resolved
-									? msg('comments.resolved-by').replace(
-											'{name}',
-											resolveName(thread.resolved.by) ?? UNKNOWN_AUTHOR
-										)
-									: undefined
-							}
-							composer={
-								currentUserId && !thread.resolved
-									? {
-											author: resolveName(currentUserId) ?? UNKNOWN_AUTHOR,
-											placeholder: msg('comments.reply-placeholder'),
-											sendLabel: msg('comments.send'),
-											value: reply,
-											onChange: setReply,
-											onSubmit: postReply,
-											disabled: isCommentEmpty(reply),
-											getMentionSuggestions,
-											renderMentionSuggestion,
-										}
-									: undefined
-							}
-						/>
+						<ThreadView editor={editor} thread={thread} {...props} />
 					</ThreadPopover>
 				)}
 			</div>

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -62,7 +62,7 @@ import {
 	usePendingComment,
 } from './state'
 import { ThreadStackPin } from './thread-stack'
-import { anchorPagePoint, regionPinPoint, shapeAnchorAt } from './thread-state'
+import { anchorPagePoint, regionPinPoint, resolveCommentDrop } from './thread-state'
 import { ThreadPopover, ThreadView } from './thread-view'
 
 /**
@@ -964,8 +964,11 @@ const ThreadPin = memo(function ThreadPin({
 		editor,
 		thread.id,
 	])
-	// While dragging the marker, its page point overrides the anchor's; committed on drop.
+	// While dragging a region's pin, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
+	// While dragging a point/shape pin, the anchor the drop would produce. Held as an anchor rather
+	// than a raw point so the preview shows exactly what will be committed.
+	const [dragAnchor, setDragAnchor] = useState<TLCommentThread['anchor'] | null>(null)
 	// The live bounds while a corner handle is resizing the region, else null.
 	const [resizeBounds, setResizeBounds] = useState<BoxModel | null>(null)
 	// Whether the pin marker is hovered — only consulted by the 'pin-hover' reveal mode.
@@ -1032,6 +1035,14 @@ const ThreadPin = memo(function ThreadPin({
 		return () => document.removeEventListener('pointerdown', onPointerDown, true)
 	}, [open, editor])
 
+	// A drag cut short by this pin unmounting (page switch, a collaborator deleting the thread)
+	// would otherwise strand its highlight on the canvas.
+	useEffect(() => {
+		return () => {
+			if (dragRef.current) editor.setHintingShapes([])
+		}
+	}, [editor])
+
 	const point = useValue(
 		'pin point',
 		() => {
@@ -1064,6 +1075,14 @@ const ThreadPin = memo(function ThreadPin({
 		dragRef.current = { startX: e.clientX, startY: e.clientY, moved: false }
 		e.currentTarget.setPointerCapture(e.pointerId)
 	}
+	// Where a drop at this pointer position would land, plus the shape to highlight getting there.
+	// One call, so the outline can't advertise a target the release won't honour. Alt holds an
+	// already-attached comment on its shape and lets it roam that shape's whole box.
+	const dropAt = (e: ReactPointerEvent<HTMLDivElement>) =>
+		resolveCommentDrop(editor, editor.screenToPage({ x: e.clientX, y: e.clientY }), {
+			current: thread.anchor,
+			constrain: e.altKey,
+		})
 	const onDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
 		const drag = dragRef.current
 		if (!drag) return
@@ -1071,7 +1090,17 @@ const ThreadPin = memo(function ThreadPin({
 		if (isRegion && !pinMovable) return
 		if (!drag.moved && Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY) < 4) return
 		drag.moved = true
-		setDragPagePoint(editor.screenToPage({ x: e.clientX, y: e.clientY }))
+		if (isRegion) {
+			// A region translates rather than re-anchoring, so it tracks the raw pointer.
+			setDragPagePoint(editor.screenToPage({ x: e.clientX, y: e.clientY }))
+			return
+		}
+		// Preview the resolved anchor rather than the raw pointer: under Alt the anchor is clamped to
+		// the shape's box, and the pin has to stop at the edge with it instead of running off and
+		// snapping back on release.
+		const { anchor, highlightShapeId } = dropAt(e)
+		setDragAnchor(anchor)
+		editor.setHintingShapes(highlightShapeId ? [highlightShapeId] : [])
 	}
 	const endDrag = (e: ReactPointerEvent<HTMLDivElement>) => {
 		const drag = dragRef.current
@@ -1079,15 +1108,16 @@ const ThreadPin = memo(function ThreadPin({
 		if (e.currentTarget.hasPointerCapture(e.pointerId)) {
 			e.currentTarget.releasePointerCapture(e.pointerId)
 		}
+		editor.setHintingShapes([])
 		if (!drag) return
 		if (!drag.moved) {
 			openThreadId.set(editor, openThreadId.get(editor) === thread.id ? null : thread.id)
 			return
 		}
-		const pagePoint = editor.screenToPage({ x: e.clientX, y: e.clientY })
-		setDragPagePoint(null)
 		let anchor: TLCommentThread['anchor']
 		if (thread.anchor.type === 'region') {
+			const pagePoint = editor.screenToPage({ x: e.clientX, y: e.clientY })
+			setDragPagePoint(null)
 			// Translate so the pin (the region's pin corner) lands at the drop; size unchanged.
 			anchor = {
 				...thread.anchor,
@@ -1095,19 +1125,20 @@ const ThreadPin = memo(function ThreadPin({
 				y: pagePoint.y - regionOptions.pinCorner.y * thread.anchor.h,
 			}
 		} else {
-			const hit = editor.getShapeAtPoint(pagePoint, { hitInside: true })
-			anchor = hit
-				? shapeAnchorAt(editor, hit.id, pagePoint, e.altKey)
-				: { type: 'point', x: pagePoint.x, y: pagePoint.y }
+			anchor = dropAt(e).anchor
+			setDragAnchor(null)
 		}
 		commitCommentMutation(editor, () => putCommentRecords(editor, [{ ...thread, anchor }]), 'drag')
 	}
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
-	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
+	// region move to the drag point, a point/shape drag to wherever its pending anchor resolves;
+	// otherwise it sits at the stored anchor's viewport point.
 	const livePinPage = resizeBounds
 		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
-		: dragPagePoint
+		: dragAnchor
+			? anchorPagePoint(editor, dragAnchor, impreciseShapeAnchor)
+			: dragPagePoint
 	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -54,6 +54,7 @@ import {
 	getCommentingOptions,
 	useCommentingOptions,
 } from './options'
+import { computePinStacks, PIN_STACK_STEP_PX } from './pin-stacking'
 import {
 	DEFAULT_REGION_COMMENT_OPTIONS,
 	RegionCommentOptions,
@@ -344,6 +345,14 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 		() => new Map<string, TLCommentThread>(threads.map((thread) => [thread.id, thread])),
 		[threads]
 	)
+	// Zooming separates near pins, but pins with the *same* anchor point (several imprecise
+	// comments on one shape) coincide at every zoom — spread those sideways so each stays
+	// reachable. Keyed on page-space anchors, so camera moves never recompute this.
+	const pinStacks = useValue(
+		'comment pin stacks',
+		() => computePinStacks(editor, threads, impreciseShapeAnchor),
+		[editor, threads, impreciseShapeAnchor]
+	)
 	const openThread = openId ? threadsById.get(openId) : null
 	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
 
@@ -459,6 +468,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 								<ThreadPin
 									editor={editor}
 									thread={thread}
+									stackIndex={pinStacks.get(thread.id) ?? 0}
 									{...props}
 									regionOptions={regionOptions}
 								/>
@@ -477,6 +487,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							key={thread.id}
 							editor={editor}
 							thread={thread}
+							stackIndex={pinStacks.get(thread.id) ?? 0}
 							{...props}
 							regionOptions={regionOptions}
 						/>
@@ -486,6 +497,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							key={thread.id}
 							editor={editor}
 							thread={thread}
+							stackIndex={pinStacks.get(thread.id) ?? 0}
 							{...props}
 							regionOptions={regionOptions}
 						/>
@@ -503,6 +515,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 							key={thread.id}
 							editor={editor}
 							thread={thread}
+							stackIndex={pinStacks.get(thread.id) ?? 0}
 							{...props}
 							regionOptions={regionOptions}
 						/>
@@ -513,6 +526,7 @@ function CanvasCommentsLayer(props: CanvasCommentsProps) {
 					key={`open:${openThread.id}`}
 					editor={editor}
 					thread={openThread}
+					stackIndex={pinStacks.get(openThread.id) ?? 0}
 					{...props}
 					regionOptions={regionOptions}
 				/>
@@ -985,11 +999,14 @@ const ThreadPin = memo(function ThreadPin({
 	editor,
 	thread,
 	regionOptions,
+	stackIndex,
 	...props
 }: Omit<CanvasCommentsProps, 'regionOptions'> & {
 	editor: Editor
 	thread: TLCommentThread
 	regionOptions: RegionCommentOptions
+	/** This pin's slot among pins sharing its exact anchor point — 0 sits at the anchor. */
+	stackIndex: number
 }) {
 	const {
 		currentUserId,
@@ -1297,11 +1314,15 @@ const ThreadPin = memo(function ThreadPin({
 	}
 
 	// The pin (and its popover) track the live edit: a resize moves it to the region's pin corner, a
-	// move to the drag point; otherwise it sits at the stored anchor's viewport point.
+	// move to the drag point; otherwise it sits at the stored anchor's viewport point — stepped
+	// sideways by its stack slot when other pins share that exact point. The step is in screen
+	// pixels (not page space) so a stack stays fanned out at every zoom.
 	const livePinPage = resizeBounds
 		? regionPinPoint(resizeBounds, regionOptions.pinCorner)
 		: dragPagePoint
-	const renderPoint = livePinPage ? editor.pageToViewport(livePinPage) : point
+	const renderPoint = livePinPage
+		? editor.pageToViewport(livePinPage)
+		: { x: point.x + stackIndex * PIN_STACK_STEP_PX, y: point.y }
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin
 	// corner tracks the cursor), else the stored anchor. Undefined for non-region threads.

--- a/packages/commenting/src/canvas/pin-stacking.test.ts
+++ b/packages/commenting/src/canvas/pin-stacking.test.ts
@@ -1,6 +1,7 @@
 import type { Editor, TLCommentAnchor, TLCommentThread } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 import { computePinStacks } from './pin-stacking'
+import { createFakeEditor } from './test-editor'
 
 const CURRENT_PAGE = 'page:one'
 const OTHER_PAGE = 'page:two'
@@ -22,17 +23,20 @@ function thread(
 	} as unknown as TLCommentThread
 }
 
+/** Bounds are unrotated, so a shape's page box and its local geometry box coincide. */
 function stubEditor(
 	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
 ): Editor {
-	return {
-		getCurrentPageId: () => CURRENT_PAGE,
-		getShapePageBounds: (id: string) => {
-			const bounds = shapes[id]
-			if (!bounds) return undefined
-			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
-		},
-	} as unknown as Editor
+	return createFakeEditor({
+		pageId: CURRENT_PAGE,
+		shapes: Object.entries(shapes).map(([id, bounds]) => ({
+			id,
+			x: bounds.minX,
+			y: bounds.minY,
+			w: bounds.maxX - bounds.minX,
+			h: bounds.maxY - bounds.minY,
+		})),
+	})
 }
 
 const SHAPE = { 'shape:a': { minX: 0, minY: 0, maxX: 200, maxY: 100 } }

--- a/packages/commenting/src/canvas/pin-stacking.test.ts
+++ b/packages/commenting/src/canvas/pin-stacking.test.ts
@@ -1,0 +1,106 @@
+import type { Editor, TLCommentAnchor, TLCommentThread } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import { computePinStacks } from './pin-stacking'
+
+const CURRENT_PAGE = 'page:one'
+const OTHER_PAGE = 'page:two'
+
+function thread(
+	id: string,
+	anchor: TLCommentAnchor,
+	opts: { pageId?: string; createdAt?: number } = {}
+): TLCommentThread {
+	return {
+		id,
+		typeName: 'comment-thread',
+		pageId: opts.pageId ?? CURRENT_PAGE,
+		anchor,
+		createdBy: 'user:1',
+		createdAt: opts.createdAt ?? 0,
+		resolved: null,
+		meta: {},
+	} as unknown as TLCommentThread
+}
+
+function stubEditor(
+	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
+): Editor {
+	return {
+		getCurrentPageId: () => CURRENT_PAGE,
+		getShapePageBounds: (id: string) => {
+			const bounds = shapes[id]
+			if (!bounds) return undefined
+			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
+		},
+	} as unknown as Editor
+}
+
+const SHAPE = { 'shape:a': { minX: 0, minY: 0, maxX: 200, maxY: 100 } }
+
+function impreciseAnchor(shapeId: string): TLCommentAnchor {
+	return { type: 'shape', shapeId, x: 0.2, y: 0.9, isPrecise: false } as TLCommentAnchor
+}
+
+describe('computePinStacks', () => {
+	it('indexes coincident imprecise pins on one shape by creation order', () => {
+		const stacks = computePinStacks(stubEditor(SHAPE), [
+			thread('t2', impreciseAnchor('shape:a'), { createdAt: 20 }),
+			thread('t1', impreciseAnchor('shape:a'), { createdAt: 10 }),
+		])
+		expect(stacks.get('t1')).toBe(0)
+		expect(stacks.get('t2')).toBe(1)
+	})
+
+	it('leaves separated pins unindexed', () => {
+		const stacks = computePinStacks(stubEditor(), [
+			thread('t1', { type: 'point', x: 0, y: 0 }),
+			thread('t2', { type: 'point', x: 50, y: 0 }),
+		])
+		expect(stacks.size).toBe(0)
+	})
+
+	it('stacks coincident point anchors', () => {
+		const stacks = computePinStacks(stubEditor(), [
+			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
+			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 2 }),
+			thread('t3', { type: 'point', x: 5, y: 5 }, { createdAt: 3 }),
+		])
+		expect([stacks.get('t1'), stacks.get('t2'), stacks.get('t3')]).toEqual([0, 1, 2])
+	})
+
+	it('breaks creation-time ties by id so indexes are deterministic', () => {
+		const stacks = computePinStacks(stubEditor(), [
+			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
+			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
+		])
+		expect(stacks.get('t1')).toBe(0)
+		expect(stacks.get('t2')).toBe(1)
+	})
+
+	it('ignores threads on other pages and unresolvable anchors', () => {
+		const stacks = computePinStacks(stubEditor(SHAPE), [
+			thread('t1', impreciseAnchor('shape:a')),
+			thread('t2', impreciseAnchor('shape:a'), { pageId: OTHER_PAGE }),
+			thread('t3', impreciseAnchor('shape:gone')),
+		])
+		expect(stacks.size).toBe(0)
+	})
+
+	it('does not stack a precise pin sitting away from a coincident pair', () => {
+		const precise: TLCommentAnchor = {
+			type: 'shape',
+			shapeId: 'shape:a',
+			x: 0.5,
+			y: 0.5,
+			isPrecise: true,
+		} as TLCommentAnchor
+		const stacks = computePinStacks(stubEditor(SHAPE), [
+			thread('t1', impreciseAnchor('shape:a'), { createdAt: 1 }),
+			thread('t2', impreciseAnchor('shape:a'), { createdAt: 2 }),
+			thread('t3', precise),
+		])
+		expect(stacks.get('t1')).toBe(0)
+		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.has('t3')).toBe(false)
+	})
+})

--- a/packages/commenting/src/canvas/pin-stacking.test.ts
+++ b/packages/commenting/src/canvas/pin-stacking.test.ts
@@ -42,16 +42,16 @@ function impreciseAnchor(shapeId: string): TLCommentAnchor {
 }
 
 describe('computePinStacks', () => {
-	it('indexes coincident imprecise pins on one shape by creation order', () => {
+	it('groups coincident imprecise pins on one shape, oldest first', () => {
 		const stacks = computePinStacks(stubEditor(SHAPE), [
 			thread('t2', impreciseAnchor('shape:a'), { createdAt: 20 }),
 			thread('t1', impreciseAnchor('shape:a'), { createdAt: 10 }),
 		])
-		expect(stacks.get('t1')).toBe(0)
-		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.get('t1')).toEqual(['t1', 't2'])
+		expect(stacks.get('t2')).toEqual(['t1', 't2'])
 	})
 
-	it('leaves separated pins unindexed', () => {
+	it('leaves separated pins ungrouped', () => {
 		const stacks = computePinStacks(stubEditor(), [
 			thread('t1', { type: 'point', x: 0, y: 0 }),
 			thread('t2', { type: 'point', x: 50, y: 0 }),
@@ -59,22 +59,21 @@ describe('computePinStacks', () => {
 		expect(stacks.size).toBe(0)
 	})
 
-	it('stacks coincident point anchors', () => {
+	it('groups coincident point anchors', () => {
 		const stacks = computePinStacks(stubEditor(), [
 			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
 			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 2 }),
 			thread('t3', { type: 'point', x: 5, y: 5 }, { createdAt: 3 }),
 		])
-		expect([stacks.get('t1'), stacks.get('t2'), stacks.get('t3')]).toEqual([0, 1, 2])
+		expect(stacks.get('t2')).toEqual(['t1', 't2', 't3'])
 	})
 
-	it('breaks creation-time ties by id so indexes are deterministic', () => {
+	it('breaks creation-time ties by id so ordering is deterministic', () => {
 		const stacks = computePinStacks(stubEditor(), [
 			thread('t2', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
 			thread('t1', { type: 'point', x: 5, y: 5 }, { createdAt: 1 }),
 		])
-		expect(stacks.get('t1')).toBe(0)
-		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.get('t1')).toEqual(['t1', 't2'])
 	})
 
 	it('ignores threads on other pages and unresolvable anchors', () => {
@@ -86,7 +85,7 @@ describe('computePinStacks', () => {
 		expect(stacks.size).toBe(0)
 	})
 
-	it('does not stack a precise pin sitting away from a coincident pair', () => {
+	it('does not group a precise pin sitting away from a coincident pair', () => {
 		const precise: TLCommentAnchor = {
 			type: 'shape',
 			shapeId: 'shape:a',
@@ -99,8 +98,7 @@ describe('computePinStacks', () => {
 			thread('t2', impreciseAnchor('shape:a'), { createdAt: 2 }),
 			thread('t3', precise),
 		])
-		expect(stacks.get('t1')).toBe(0)
-		expect(stacks.get('t2')).toBe(1)
+		expect(stacks.get('t1')).toEqual(['t1', 't2'])
 		expect(stacks.has('t3')).toBe(false)
 	})
 })

--- a/packages/commenting/src/canvas/pin-stacking.ts
+++ b/packages/commenting/src/canvas/pin-stacking.ts
@@ -1,0 +1,51 @@
+import type { Editor, TLCommentThread } from 'tldraw'
+import { anchorPagePoint } from './thread-state'
+
+/** How far each successive pin in a stack of coincident pins steps sideways, in screen pixels.
+ * @public */
+export const PIN_STACK_STEP_PX = 12
+
+/** Two anchors within this page-space distance (per axis) share a stack. Identical imprecise
+ *  anchors on one shape resolve to the same point exactly; the tolerance only absorbs float noise. */
+const PIN_STACK_QUANTUM = 0.1
+
+/**
+ * Index each thread whose pin lands on the same page point as another thread's — coincident pins
+ * (typically several imprecise comments on one shape) that zooming can never separate. The overlay
+ * spreads a stack sideways by a fixed screen offset per index, oldest thread at the anchor.
+ *
+ * Keyed by page-space anchor point, not screen position, so the result only changes when threads
+ * or their anchors move — never on camera moves. Threads without an entry render unshifted.
+ * @public
+ */
+export function computePinStacks(
+	editor: Editor,
+	threads: readonly TLCommentThread[],
+	impreciseShapeAnchor?: { x: number; y: number }
+): Map<string, number> {
+	const pageId = editor.getCurrentPageId()
+	const groups = new Map<string, TLCommentThread[]>()
+
+	for (const thread of threads) {
+		if (thread.pageId !== pageId) continue
+		const point = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
+		if (!point) continue
+		const key = `${Math.round(point.x / PIN_STACK_QUANTUM)}:${Math.round(point.y / PIN_STACK_QUANTUM)}`
+		const group = groups.get(key)
+		if (group) {
+			group.push(thread)
+		} else {
+			groups.set(key, [thread])
+		}
+	}
+
+	const indexes = new Map<string, number>()
+	for (const group of groups.values()) {
+		if (group.length < 2) continue
+		group.sort((a, b) => a.createdAt - b.createdAt || (a.id < b.id ? -1 : 1))
+		for (let i = 0; i < group.length; i++) {
+			indexes.set(group[i].id, i)
+		}
+	}
+	return indexes
+}

--- a/packages/commenting/src/canvas/pin-stacking.ts
+++ b/packages/commenting/src/canvas/pin-stacking.ts
@@ -1,28 +1,25 @@
 import type { Editor, TLCommentThread } from 'tldraw'
 import { anchorPagePoint } from './thread-state'
 
-/** How far each successive pin in a stack of coincident pins steps sideways, in screen pixels.
- * @public */
-export const PIN_STACK_STEP_PX = 12
-
 /** Two anchors within this page-space distance (per axis) share a stack. Identical imprecise
  *  anchors on one shape resolve to the same point exactly; the tolerance only absorbs float noise. */
 const PIN_STACK_QUANTUM = 0.1
 
 /**
- * Index each thread whose pin lands on the same page point as another thread's — coincident pins
- * (typically several imprecise comments on one shape) that zooming can never separate. The overlay
- * spreads a stack sideways by a fixed screen offset per index, oldest thread at the anchor.
+ * Group threads whose pins land on the same page point — coincident pins (typically several
+ * imprecise comments on one shape) that zooming can never separate. The overlay renders each
+ * group as a single count-badge pin that opens the threads as a list. Every member id maps to
+ * its group's ordered member ids (oldest first); threads without an entry pin individually.
  *
  * Keyed by page-space anchor point, not screen position, so the result only changes when threads
- * or their anchors move — never on camera moves. Threads without an entry render unshifted.
+ * or their anchors move — never on camera moves.
  * @public
  */
 export function computePinStacks(
 	editor: Editor,
 	threads: readonly TLCommentThread[],
 	impreciseShapeAnchor?: { x: number; y: number }
-): Map<string, number> {
+): Map<string, readonly string[]> {
 	const pageId = editor.getCurrentPageId()
 	const groups = new Map<string, TLCommentThread[]>()
 
@@ -39,13 +36,14 @@ export function computePinStacks(
 		}
 	}
 
-	const indexes = new Map<string, number>()
+	const stacks = new Map<string, readonly string[]>()
 	for (const group of groups.values()) {
 		if (group.length < 2) continue
 		group.sort((a, b) => a.createdAt - b.createdAt || (a.id < b.id ? -1 : 1))
-		for (let i = 0; i < group.length; i++) {
-			indexes.set(group[i].id, i)
+		const ids = group.map((thread) => thread.id)
+		for (const id of ids) {
+			stacks.set(id, ids)
 		}
 	}
-	return indexes
+	return stacks
 }

--- a/packages/commenting/src/canvas/state.ts
+++ b/packages/commenting/src/canvas/state.ts
@@ -21,6 +21,12 @@ import { DEFAULT_SIDEBAR_FILTERS, type SidebarFilters } from './sidebar-filters'
  * @public */
 export const openThreadId = new EditorAtom<string | null>('openThreadId', () => null)
 
+/** The coincident-pin stack whose thread list is showing (keyed by its oldest member's thread
+ * id), or null. Editor state rather than component state: the stack pin remounts when its owning
+ * render path changes (e.g. a member thread opens), and the open list must survive that.
+ * @public */
+export const openStackId = new EditorAtom<string | null>('openStackId', () => null)
+
 /** The comment currently being placed (composer open, not yet posted), or null.
  * @public */
 export const pendingComment = new EditorAtom<PendingComment | null>('pendingComment', () => null)

--- a/packages/commenting/src/canvas/test-editor.ts
+++ b/packages/commenting/src/canvas/test-editor.ts
@@ -1,0 +1,97 @@
+import { Mat, type Editor, type TLShape, type TLShapeId } from 'tldraw'
+
+/**
+ * A fake editor for anchor tests. Test-only — not exported from the package barrel.
+ *
+ * Shapes are modelled the way tldraw models them: a local geometry box with its origin at (0, 0),
+ * plus a page transform carrying position and rotation. Anchor code has to compose those two
+ * correctly, so the fake uses the real `Mat` rather than faking the maths it is meant to be
+ * testing — a stub that returned page-aligned bounds would pass whether or not rotation is handled.
+ */
+export interface FakeShapeSpec {
+	id: string
+	/** Drives the area-bound shape-type exemption. Defaults to a stroked shape ('geo'). */
+	type?: string
+	/** Position of the shape's origin in page space. */
+	x?: number
+	y?: number
+	/** Rotation about the shape's origin, in radians. */
+	rotation?: number
+	w?: number
+	h?: number
+	/**
+	 * What `distanceToPoint` reports for this shape, regardless of the point. Negative means the
+	 * point is inside a fill. Geometry maths belongs to tldraw; these tests only care how the
+	 * commenting code interprets the number.
+	 */
+	distanceToOutline?: number
+}
+
+export interface FakeEditorOptions {
+	pageId?: string
+	zoom?: number
+	/** Order returned by `getShapesAtPoint`, which is top-most first. */
+	shapes?: FakeShapeSpec[]
+}
+
+export const FAKE_PAGE_ID = 'page:one'
+
+export function createFakeEditor({
+	pageId = FAKE_PAGE_ID,
+	zoom = 1,
+	shapes = [],
+}: FakeEditorOptions = {}): Editor {
+	const specs = new Map(shapes.map((spec) => [spec.id, spec]))
+
+	const records = new Map<string, TLShape>(
+		shapes.map((spec) => [
+			spec.id,
+			{ id: spec.id as TLShapeId, type: spec.type ?? 'geo' } as TLShape,
+		])
+	)
+
+	const specOf = (shape: TLShape | TLShapeId): FakeShapeSpec | undefined =>
+		specs.get(typeof shape === 'string' ? shape : shape.id)
+
+	const transformOf = (shape: TLShape | TLShapeId): Mat | undefined => {
+		const spec = specOf(shape)
+		if (!spec) return undefined
+		// Translate then rotate, matching how tldraw composes a shape's page transform.
+		return Mat.Identity()
+			.translate(spec.x ?? 0, spec.y ?? 0)
+			.rotate(spec.rotation ?? 0)
+	}
+
+	return {
+		getCurrentPageId: () => pageId,
+		getZoomLevel: () => zoom,
+		getShape: (id: TLShapeId) => records.get(id as unknown as string),
+		getShapePageTransform: (shape: TLShape | TLShapeId) => transformOf(shape),
+		getShapeGeometry: (shape: TLShape | TLShapeId) => {
+			const spec = specOf(shape)
+			const w = spec?.w ?? 0
+			const h = spec?.h ?? 0
+			return {
+				bounds: { minX: 0, minY: 0, maxX: w, maxY: h, w, h, width: w, height: h },
+				distanceToPoint: () => spec?.distanceToOutline ?? 0,
+			}
+		},
+		getPointInShapeSpace: (shape: TLShape | TLShapeId, page: { x: number; y: number }) => {
+			const transform = transformOf(shape)
+			if (!transform) return page
+			return Mat.applyToPoint(Mat.Inverse(transform), page)
+		},
+		getShapesAtPoint: () => shapes.map((spec) => records.get(spec.id)!),
+		// Only the 'text-range' anchor still reads page bounds. Unrotated shapes only, which is all
+		// that anchor kind is used with.
+		getShapePageBounds: (shape: TLShape | TLShapeId) => {
+			const spec = specOf(shape)
+			if (!spec) return undefined
+			const w = spec.w ?? 0
+			const h = spec.h ?? 0
+			const x = spec.x ?? 0
+			const y = spec.y ?? 0
+			return { minX: x, minY: y, maxX: x + w, maxY: y + h, w, h, width: w, height: h }
+		},
+	} as unknown as Editor
+}

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -1,0 +1,162 @@
+import { memo, useEffect, useRef } from 'react'
+import { Editor, TLCommentThread, useContainer, useValue } from 'tldraw'
+import { CommentCard } from '../ui/comment-card'
+import { CountBadge } from '../ui/count-badge'
+import { useThreadComments } from './hooks'
+import { useCommentingOptions } from './options'
+import { openStackId, openThreadId } from './state'
+import { anchorPagePoint } from './thread-state'
+import { ThreadPopover, ThreadView, ThreadViewHostProps, toCardProps } from './thread-view'
+
+/**
+ * The pin for threads whose anchors resolve to the same page point — pins zooming can never
+ * separate, so instead of stacked markers they share one count badge. Clicking it opens a
+ * popover listing each thread as a card; clicking a card expands that thread in place (via the
+ * single open-thread state, so expanding one collapses another).
+ */
+export const ThreadStackPin = memo(function ThreadStackPin({
+	editor,
+	threads,
+	impreciseShapeAnchor,
+	...props
+}: ThreadViewHostProps & {
+	editor: Editor
+	/** The stack's threads, oldest first. All resolve to the same anchor point. */
+	threads: readonly TLCommentThread[]
+	impreciseShapeAnchor?: { x: number; y: number }
+}) {
+	const container = useContainer()
+	const badgeRef = useRef<HTMLDivElement>(null)
+	// The list stays open while a member thread is expanded, and on its own after the member
+	// collapses — so Escape steps back: expanded thread → card list → closed. Held in editor
+	// state (not component state) because this pin remounts as its owning render path changes.
+	const stackId = threads[0].id
+	const listOpen = useValue('stack list open', () => openStackId.get(editor) === stackId, [
+		editor,
+		stackId,
+	])
+	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
+	const openMember = threads.find((thread) => thread.id === openId)
+	const open = listOpen || openMember !== undefined
+
+	const point = useValue(
+		'stack point',
+		() => {
+			const first = threads[0]
+			if (first.pageId !== editor.getCurrentPageId()) return null
+			const pagePoint = anchorPagePoint(editor, first.anchor, impreciseShapeAnchor)
+			return pagePoint ? editor.pageToViewport(pagePoint) : null
+		},
+		[editor, threads, impreciseShapeAnchor]
+	)
+
+	// Clicking outside the popover (and off the badge) closes the whole stack — mirrors the
+	// single pin's dismiss. Capture phase + class checks, since the popover portals elsewhere.
+	useEffect(() => {
+		if (!open) return
+		const onPointerDown = (e: PointerEvent) => {
+			const target = e.target as HTMLElement | null
+			if (!target) return
+			if (target.closest('.tlui-cmt-canvas-popover')) return
+			const badge = badgeRef.current
+			if (badge && badge.contains(target)) return
+			// A click inside a menu/popover layered above us belongs to that layer; defer to its
+			// own dismissal instead of closing the stack out from under it.
+			if (
+				target.closest('.tlui-menu, [data-radix-popper-content-wrapper], .tlui-cmt-mention-popup')
+			)
+				return
+			openStackId.set(editor, null)
+			openThreadId.set(editor, null)
+		}
+		document.addEventListener('pointerdown', onPointerDown, true)
+		return () => document.removeEventListener('pointerdown', onPointerDown, true)
+	}, [open, editor])
+
+	// Escape with only the card list showing closes it. When a member thread is expanded, the
+	// layer's Escape handler collapses that first and marks the event consumed — stepping back
+	// to the list rather than closing everything at once.
+	useEffect(() => {
+		if (!listOpen) return
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'Escape' || e.defaultPrevented) return
+			openStackId.set(editor, null)
+		}
+		document.addEventListener('keydown', onKeyDown, true)
+		return () => document.removeEventListener('keydown', onKeyDown, true)
+	}, [listOpen, editor])
+
+	if (!point) return null
+
+	const toggle = () => {
+		if (open) {
+			openStackId.set(editor, null)
+			openThreadId.set(editor, null)
+		} else {
+			openStackId.set(editor, stackId)
+		}
+	}
+
+	return (
+		<>
+			<div className="tlui-cmt-canvas-pin" style={{ left: point.x, top: point.y }}>
+				<div
+					ref={badgeRef}
+					className="tlui-cmt-canvas-stack-badge"
+					onPointerDown={(e) => e.stopPropagation()}
+					onClick={(e) => {
+						e.stopPropagation()
+						toggle()
+					}}
+				>
+					<CountBadge count={threads.length} />
+				</div>
+			</div>
+			{open && (
+				<ThreadPopover container={container} style={{ left: point.x + 36, top: point.y - 28 }}>
+					<div className="tlui-cmt-stack-list">
+						{threads.map((thread) =>
+							thread.id === openId ? (
+								<div key={thread.id} className="tlui-cmt-stack-list__thread">
+									<ThreadView editor={editor} thread={thread} {...props} />
+								</div>
+							) : (
+								<StackThreadCard
+									key={thread.id}
+									editor={editor}
+									thread={thread}
+									{...props}
+									onOpen={() => openThreadId.set(editor, thread.id)}
+								/>
+							)
+						)}
+					</div>
+				</ThreadPopover>
+			)}
+		</>
+	)
+})
+
+/** A collapsed stack entry: the thread's first comment as a card; clicking expands the thread. */
+function StackThreadCard({
+	editor,
+	thread,
+	onOpen,
+	...props
+}: ThreadViewHostProps & { editor: Editor; thread: TLCommentThread; onOpen(): void }) {
+	const options = useCommentingOptions()
+	const comments = useThreadComments(editor, thread.id)
+	const first = comments[0]
+	if (!first) return null
+	return (
+		<div
+			className="tlui-cmt-stack-list__card"
+			onClick={(e) => {
+				e.stopPropagation()
+				onOpen()
+			}}
+		>
+			<CommentCard {...toCardProps(first, props, options.components)} />
+		</div>
+	)
+}

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,6 +1,19 @@
-import { BoxModel, Editor, TLCommentAnchor, TLCommentThread, TLShapeId, VecLike } from 'tldraw'
+import {
+	BoxModel,
+	Editor,
+	Geometry2dFilters,
+	Mat,
+	TLCommentAnchor,
+	TLCommentThread,
+	TLShape,
+	TLShapeId,
+	VecLike,
+} from 'tldraw'
 import { getRegionCommentOptions } from './region-options'
 import { openThreadId } from './state'
+
+/** A shape anchor, narrowed out of the anchor union. */
+type TLShapeCommentAnchor = Extract<TLCommentAnchor, { type: 'shape' }>
 
 /** Where an imprecise shape comment sits by default: the shape's top-right corner. Overridable. @public */
 export const DEFAULT_IMPRECISE_SHAPE_ANCHOR = { x: 1, y: 0 }
@@ -31,11 +44,21 @@ export function anchorPagePoint(
 ): { x: number; y: number } | null {
 	switch (anchor.type) {
 		case 'shape': {
-			const bounds = editor.getShapePageBounds(anchor.shapeId as TLShapeId)
-			if (!bounds) return null
+			const shape = editor.getShape(anchor.shapeId as TLShapeId)
+			if (!shape) return null
+			const transform = editor.getShapePageTransform(shape)
+			if (!transform) return null
+			// Resolve against the shape's own geometry box and then push the result through its page
+			// transform, the way arrow bindings do. Using page bounds instead would measure against an
+			// axis-aligned box that grows as the shape rotates, so a stored fraction would drift across
+			// the shape — the pin would slide off the thing it was placed on.
+			const bounds = editor.getShapeGeometry(shape).bounds
 			// Precise pins sit at their stored x/y; imprecise ones at the consumer's default spot.
 			const { x, y } = anchor.isPrecise ? anchor : impreciseShapeAnchor
-			return { x: bounds.minX + x * bounds.w, y: bounds.minY + y * bounds.h }
+			return Mat.applyToPoint(transform, {
+				x: bounds.minX + x * bounds.w,
+				y: bounds.minY + y * bounds.h,
+			})
 		}
 		case 'text-range': {
 			const bounds = editor.getShapePageBounds(anchor.shapeId as TLShapeId)
@@ -52,9 +75,13 @@ export function anchorPagePoint(
 }
 
 /**
- * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
- * shape's page bounds, remembered either way. When `precise` (Alt held) the pin sits at exactly
- * `x`/`y`; otherwise it sits at the consumer's imprecise default (top-right out of the box).
+ * A shape anchor for a page point: the exact inverse of {@link anchorPagePoint}'s shape case. The
+ * page point is pulled into the shape's own space and normalized against its geometry box, so the
+ * pair round-trips through rotation, nesting, and resizing.
+ *
+ * `precise` is always true for comments placed or dragged by this package — a comment stays where
+ * you put it. The parameter remains for consumers building anchors themselves, and
+ * {@link anchorPagePoint} still renders `isPrecise: false` records stored before that changed.
  * @public
  */
 export function shapeAnchorAt(
@@ -63,17 +90,128 @@ export function shapeAnchorAt(
 	page: { x: number; y: number },
 	precise: boolean
 ): TLCommentAnchor {
-	const bounds = editor.getShapePageBounds(shapeId)
-	if (!bounds || bounds.w === 0 || bounds.h === 0) {
-		return { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: precise }
-	}
+	return shapeAnchorFor(editor, shapeId, page, precise)
+}
+
+function shapeAnchorFor(
+	editor: Editor,
+	shapeId: TLShapeId,
+	page: { x: number; y: number },
+	precise: boolean
+): TLShapeCommentAnchor {
+	const shape = editor.getShape(shapeId)
+	if (!shape) return { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: precise }
+	const bounds = editor.getShapeGeometry(shape).bounds
+	const local = editor.getPointInShapeSpace(shape, page)
 	return {
 		type: 'shape',
 		shapeId,
-		x: (page.x - bounds.minX) / bounds.w,
-		y: (page.y - bounds.minY) / bounds.h,
+		// A shape with no extent on an axis (a perfectly straight line) can't be normalized along it;
+		// centre that axis rather than dividing by zero. The other axis still works normally.
+		x: bounds.w === 0 ? 0.5 : (local.x - bounds.minX) / bounds.w,
+		y: bounds.h === 0 ? 0.5 : (local.y - bounds.minY) / bounds.h,
 		isPrecise: precise,
 	}
+}
+
+/** How close, in screen pixels, a point must be to a shape's stroke to attach to it. */
+const OUTLINE_HIT_MARGIN_PX = 8
+
+/**
+ * Shape types with no drawn stroke to aim at — pictures, text, widgets. Outline-only binding would
+ * leave these reachable by their border alone, so a comment dropped in the middle of a photo would
+ * miss it entirely. These attach anywhere within their area instead.
+ *
+ * Frames are deliberately absent: a frame's border is a real line, and binding anywhere inside one
+ * would attach every comment in a frame to the frame itself.
+ */
+const AREA_BOUND_SHAPE_TYPES: ReadonlySet<string> = new Set([
+	'image',
+	'video',
+	'text',
+	'note',
+	'bookmark',
+	'embed',
+])
+
+/**
+ * The shape a comment placed at `page` would attach to, or undefined for empty canvas.
+ *
+ * A comment binds to a shape's stroke, not its fill: anywhere there's ink, nothing in the blank
+ * space a shape's outline encloses. That can't be had from `getShapeAtPoint`, whose `hitInside`
+ * flag is only consulted for hollow shapes — a filled shape reports interior points as a negative
+ * distance and is returned outright. So this measures distance to the outline itself and discards
+ * the sign, which is exactly the "I'm inside a fill" information we don't want.
+ * @public
+ */
+export function commentTargetShape(editor: Editor, page: VecLike): TLShape | undefined {
+	// Screen-space margin, so the stroke stays equally easy to hit at any zoom. Without one it is a
+	// couple of pixels wide and effectively unhittable.
+	const margin = OUTLINE_HIT_MARGIN_PX / editor.getZoomLevel()
+	// Top-most first, so the first match is the shape the pointer is visually over.
+	for (const shape of editor.getShapesAtPoint(page, { hitInside: true, margin })) {
+		if (AREA_BOUND_SHAPE_TYPES.has(shape.type)) return shape
+		const local = editor.getPointInShapeSpace(shape, page)
+		// Labels excluded: a geo shape's label is a filled rectangle in the middle of the shape, and
+		// would otherwise read as ink exactly where the fill is supposed to be inert.
+		const distance = editor
+			.getShapeGeometry(shape)
+			.distanceToPoint(local, false, Geometry2dFilters.EXCLUDE_NON_STANDARD)
+		if (Math.abs(distance) <= margin) return shape
+	}
+	return undefined
+}
+
+/** Where a placement or drag would land, and what to highlight while it's in progress. @public */
+export interface CommentDropTarget {
+	anchor: TLCommentAnchor
+	/** The shape to hint, or null when the drop would leave the comment unattached. */
+	highlightShapeId: TLShapeId | null
+}
+
+/** @public */
+export interface ResolveCommentDropOptions {
+	/** The anchor being dragged, when re-anchoring an existing comment rather than placing a new one. */
+	current?: TLCommentAnchor
+	/** Alt: hold the comment on the shape it is already attached to (see {@link resolveCommentDrop}). */
+	constrain?: boolean
+}
+
+/**
+ * Resolve a page point into the anchor a drop would produce and the shape to highlight while
+ * getting there. Both come from one call so the highlight can never promise something the drop
+ * doesn't deliver.
+ *
+ * Two modes:
+ * - Normal: attach to whatever shape's stroke is under the point, else leave the comment a free
+ *   page point. Dragging a comment off a stroke onto blank canvas is how it detaches.
+ * - Constrained (Alt, on a comment already attached to a shape): keep that shape and let the
+ *   comment sit anywhere within its box, fill included, clamped to the box's edges.
+ * @public
+ */
+export function resolveCommentDrop(
+	editor: Editor,
+	page: VecLike,
+	{ current, constrain = false }: ResolveCommentDropOptions = {}
+): CommentDropTarget {
+	if (constrain && current?.type === 'shape') {
+		const shapeId = current.shapeId as TLShapeId
+		if (editor.getShape(shapeId)) {
+			const anchor = shapeAnchorFor(editor, shapeId, page, true)
+			return {
+				anchor: { ...anchor, x: clamp01(anchor.x), y: clamp01(anchor.y) },
+				highlightShapeId: shapeId,
+			}
+		}
+	}
+
+	const hit = commentTargetShape(editor, page)
+	if (!hit) return { anchor: { type: 'point', x: page.x, y: page.y }, highlightShapeId: null }
+	return { anchor: shapeAnchorFor(editor, hit.id, page, true), highlightShapeId: hit.id }
+}
+
+function clamp01(value: number): number {
+	return Math.max(0, Math.min(1, value))
 }
 
 /** Open a thread and bring it into view — switch to its page if needed, then center its pin. @public */

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -1,0 +1,288 @@
+import { ReactNode, useEffect, useRef, useState, type CSSProperties } from 'react'
+import { createPortal } from 'react-dom'
+import {
+	createComment,
+	Editor,
+	TLComment,
+	TLCommentId,
+	TLCommentThread,
+	TLRichText,
+	TldrawUiIcon,
+	usePassThroughMouseOverEvents,
+	usePassThroughWheelEvents,
+	useTranslation,
+} from 'tldraw'
+import { CommentCard, CommentCardProps } from '../ui/comment-card'
+import { CommentComposer } from '../ui/comment-composer'
+import { EMPTY_COMMENT, isCommentEmpty } from '../ui/comment-extensions'
+import { CommentThread } from '../ui/comment-thread'
+import { MentionMember } from '../ui/mention-list'
+import { CommentBody } from './comment-body'
+import { UNKNOWN_AUTHOR } from './comment-render'
+import { putCommentRecords, removeCommentRecords } from './comment-store'
+import { useThreadComments } from './hooks'
+import { type CommentingComponents, useCommentingOptions } from './options'
+import { commitCommentMutation, openThreadId } from './state'
+
+/** The identity/callback props a thread view needs from the host — the same contract
+ *  `CanvasComments` takes, minus the pin-placement concerns. */
+export interface ThreadViewHostProps {
+	currentUserId: string | null
+	resolveName(id: string): string | undefined
+	onPostComment?(comment: TLComment): void
+	isCommentUnread?(commentId: TLCommentId): boolean
+	onCommentRead?(commentId: TLCommentId): void
+	getMentionSuggestions?(query: string): MentionMember[] | Promise<MentionMember[]>
+	renderMentionSuggestion?(member: MentionMember): ReactNode
+}
+
+export function toCardProps(
+	comment: TLComment,
+	props: Pick<ThreadViewHostProps, 'currentUserId' | 'resolveName'>,
+	components: CommentingComponents
+): CommentCardProps {
+	const Body = components.CommentBody
+	// The `CommentBody` component slot overrides the built-in rich-text default (which resolves
+	// mention ids to names).
+	const body = Body ? (
+		<Body comment={comment} />
+	) : (
+		<CommentBody richText={comment.body} resolveName={props.resolveName} />
+	)
+	return {
+		author: props.resolveName(comment.authorId) ?? UNKNOWN_AUTHOR,
+		body,
+		date: new Date(comment.createdAt).toISOString(),
+		you: comment.authorId === props.currentUserId,
+		edited: comment.editedAt != null,
+	}
+}
+
+/** The open thread's popover container, portaled above the UI panels. Over it, wheel and hover
+ *  events pass through to the canvas (unless it scrolls its own content), like tldraw's panels. */
+export function ThreadPopover({
+	container,
+	style,
+	children,
+}: {
+	container: HTMLElement
+	style: CSSProperties
+	children: ReactNode
+}) {
+	const ref = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(ref)
+	usePassThroughMouseOverEvents(ref)
+	return createPortal(
+		<div
+			ref={ref}
+			className="tlui-cmt-canvas-popover"
+			style={style}
+			onPointerDown={(e) => e.stopPropagation()}
+		>
+			{children}
+		</div>,
+		container
+	)
+}
+
+/**
+ * One thread's interactive view: its comments, the reply composer, edit-in-place on your own
+ * comments, and the resolve/delete/dismiss actions. Reads and writes comment records via the
+ * editor's store; read receipts are reported for every unread comment while mounted, so only
+ * mount it where the thread is actually being shown.
+ */
+export function ThreadView({
+	editor,
+	thread,
+	...props
+}: ThreadViewHostProps & { editor: Editor; thread: TLCommentThread }) {
+	const {
+		currentUserId,
+		resolveName,
+		onPostComment,
+		isCommentUnread,
+		onCommentRead,
+		getMentionSuggestions,
+		renderMentionSuggestion,
+	} = props
+	const options = useCommentingOptions()
+	const comments = useThreadComments(editor, thread.id)
+	const msg = useTranslation()
+	const [reply, setReply] = useState<TLRichText>(EMPTY_COMMENT)
+	const [editingId, setEditingId] = useState<string | null>(null)
+	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
+
+	// Every unread comment on display gets reported read — including replies that arrive while
+	// the view stays mounted, since the effect re-runs as `comments` changes. The host's receipt
+	// write flips isCommentUnread to false, so re-runs find nothing to report.
+	useEffect(() => {
+		if (!isCommentUnread || !onCommentRead) return
+		for (const comment of comments) {
+			if (isCommentUnread(comment.id)) {
+				onCommentRead(comment.id)
+			}
+		}
+	}, [comments, isCommentUnread, onCommentRead])
+
+	const postReply = () => {
+		if (isCommentEmpty(reply) || !currentUserId) return
+		commitCommentMutation(editor, () => {
+			const comment = createComment({
+				threadId: thread.id,
+				pageId: thread.pageId,
+				authorId: currentUserId,
+				body: reply,
+			})
+			putCommentRecords(editor, [comment])
+			if (onPostComment) onPostComment(comment)
+		})
+		setReply(EMPTY_COMMENT)
+	}
+
+	const toggleResolve = () => {
+		if (!currentUserId) return
+		commitCommentMutation(editor, () => {
+			putCommentRecords(editor, [
+				{
+					...thread,
+					resolved: thread.resolved ? null : { at: Date.now(), by: currentUserId },
+				},
+			])
+		})
+	}
+
+	const deleteThread = () => {
+		openThreadId.set(editor, null)
+		commitCommentMutation(editor, () =>
+			removeCommentRecords(editor, [thread.id, ...comments.map((c) => c.id)])
+		)
+	}
+
+	const startEdit = (comment: TLComment) => {
+		setEditingId(comment.id)
+		setEditText(comment.body)
+	}
+
+	const saveEdit = () => {
+		const comment = comments.find((c) => c.id === editingId)
+		if (!comment || isCommentEmpty(editText)) return
+		commitCommentMutation(editor, () => {
+			putCommentRecords(editor, [{ ...comment, body: editText, editedAt: Date.now() }])
+		})
+		setEditingId(null)
+	}
+
+	// Swap a comment for a pre-filled composer while it's being edited; otherwise show the card,
+	// with an edit affordance on your own comments.
+	const renderComment = (card: CommentCardProps, index: number): ReactNode => {
+		const comment = comments[index]
+		if (editingId === comment.id) {
+			return (
+				<div
+					className="tlui-cmt-editing"
+					onKeyDown={(e) => {
+						if (e.key === 'Escape') {
+							setEditingId(null)
+							e.stopPropagation()
+						}
+					}}
+				>
+					<CommentComposer
+						author={card.author}
+						placeholder={msg('comments.edit-placeholder')}
+						value={editText}
+						onChange={setEditText}
+						onSubmit={saveEdit}
+						sendLabel={msg('comments.save')}
+						disabled={isCommentEmpty(editText)}
+						getMentionSuggestions={getMentionSuggestions}
+						renderMentionSuggestion={renderMentionSuggestion}
+						autoFocus
+					/>
+				</div>
+			)
+		}
+		return (
+			<CommentCard
+				{...card}
+				actions={
+					comment.authorId === currentUserId ? (
+						<button
+							className="tlui-cmt-thread__action"
+							title={msg('comments.edit')}
+							onClick={() => startEdit(comment)}
+						>
+							<TldrawUiIcon icon="dots-horizontal" label={msg('comments.edit')} small />
+						</button>
+					) : undefined
+				}
+			/>
+		)
+	}
+
+	const headerActions = (
+		<>
+			{currentUserId && (
+				<button
+					className="tlui-cmt-thread__action"
+					title={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
+					onClick={toggleResolve}
+				>
+					<TldrawUiIcon
+						icon="check"
+						label={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
+						small
+					/>
+				</button>
+			)}
+			{currentUserId && (
+				<button
+					className="tlui-cmt-thread__action"
+					title={msg('comments.delete')}
+					onClick={deleteThread}
+				>
+					<TldrawUiIcon icon="trash" label={msg('comments.delete')} small />
+				</button>
+			)}
+			<button
+				className="tlui-cmt-thread__action"
+				title={msg('comments.dismiss')}
+				onClick={() => openThreadId.set(editor, null)}
+			>
+				<TldrawUiIcon icon="cross-2" label={msg('comments.dismiss')} small />
+			</button>
+		</>
+	)
+
+	return (
+		<CommentThread
+			header={msg('comments.thread-title')}
+			headerActions={headerActions}
+			renderComment={renderComment}
+			comments={comments.map((c) => toCardProps(c, props, options.components))}
+			resolvedBanner={
+				thread.resolved
+					? msg('comments.resolved-by').replace(
+							'{name}',
+							resolveName(thread.resolved.by) ?? UNKNOWN_AUTHOR
+						)
+					: undefined
+			}
+			composer={
+				currentUserId && !thread.resolved
+					? {
+							author: resolveName(currentUserId) ?? UNKNOWN_AUTHOR,
+							placeholder: msg('comments.reply-placeholder'),
+							sendLabel: msg('comments.send'),
+							value: reply,
+							onChange: setReply,
+							onSubmit: postReply,
+							disabled: isCommentEmpty(reply),
+							getMentionSuggestions,
+							renderMentionSuggestion,
+						}
+					: undefined
+			}
+		/>
+	)
+}

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -36,7 +36,7 @@ export {
 	type PendingComment,
 } from './canvas/comment-tool'
 export { collectClusterLeaves } from './canvas/cluster-input'
-export { computePinStacks, PIN_STACK_STEP_PX } from './canvas/pin-stacking'
+export { computePinStacks } from './canvas/pin-stacking'
 export { computeClusterTable } from './clustering/computeClusterTable'
 export {
 	getCommentRecord,
@@ -75,6 +75,7 @@ export {
 	commentsHidden,
 	commentsSidebarOpen,
 	commitCommentMutation,
+	openStackId,
 	openThreadId,
 	pendingComment,
 	sidebarFilters,

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -36,6 +36,7 @@ export {
 	type PendingComment,
 } from './canvas/comment-tool'
 export { collectClusterLeaves } from './canvas/cluster-input'
+export { computePinStacks, PIN_STACK_STEP_PX } from './canvas/pin-stacking'
 export { computeClusterTable } from './clustering/computeClusterTable'
 export {
 	getCommentRecord,

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -89,8 +89,12 @@ export {
 } from './canvas/state'
 export {
 	anchorPagePoint,
+	type CommentDropTarget,
+	commentTargetShape,
 	DEFAULT_IMPRECISE_SHAPE_ANCHOR,
 	focusThread,
+	resolveCommentDrop,
+	type ResolveCommentDropOptions,
 	shapeAnchorAt,
 } from './canvas/thread-state'
 


### PR DESCRIPTION
Shape comments drift off the thing they were placed on, and attach to blank space they were never really over. Both come from how a shape anchor is resolved.

Opened alongside #9651 and #9662 rather than against them — see [Overlap](#overlap) below. The coordinate-space fix here is independent of which of those lands.

### What

**Anchors resolve in the shape's own space.** `anchorPagePoint` and `shapeAnchorAt` measured against `getShapePageBounds`, the axis-aligned box in page space. That box grows as a shape rotates, so a stored fraction addresses a different part of the shape than it did when it was written — the pin slides off. They now resolve against the shape's local geometry box and push the result through `getShapePageTransform`, which is what arrow bindings do (`getArrowTerminalInArrowSpace`, `shapes/arrow/shared.ts`). Rotation, nesting and resizing all come out right, because the transform carries them and the local box doesn't move.

**Shape anchors are always precise.** A comment stays exactly where it was put instead of relocating to `impreciseShapeAnchor`. `isPrecise` stays in the schema and `anchorPagePoint` still renders `isPrecise: false` records, so comments stored before this keep rendering as they did.

**Comments bind to a shape's stroke, not its fill.** A click in the blank middle of a rectangle leaves the comment a free page point; dragging a pin off the ink is how it detaches, with no modifier. This can't be had from `getShapeAtPoint({ hitInside: false })` — that flag is only consulted for hollow shapes, since a filled shape reports interior points as a negative distance and is returned outright. So `commentTargetShape` measures distance to the outline and discards the sign, with an 8px margin scaled by zoom and labels filtered out (a geo shape's label is a filled rect sitting in the middle of it).

Shapes with no stroke to aim at — `image`, `video`, `text`, `note`, `bookmark`, `embed` — bind anywhere in their area, or a comment on a photo could only attach to its border. Frames are deliberately excluded, so a comment inside a frame isn't bound to the frame.

**Alt constrains a drag to the shape.** Alt-dragging a comment that's already attached holds it on that shape and lets it sit anywhere within the shape's box, fill included, clamped to the edges.

**One resolver.** Placement and pin-drag both go through `resolveCommentDrop`, which returns the anchor and the shape to highlight together, so the highlight can't advertise a target the drop won't honour.

### Overlap

- **#9651 / #9662** make shape-comment precision configurable (enum vs predicate). This PR hardcodes always-precise, which is their `'always'`. Those two should decide the knob; this branch will adopt whichever lands. The coordinate-space and stroke-binding work is orthogonal.
- **#9655** adds the drag-to-re-anchor hint. This PR has an equivalent, arrived at separately. Take #9655's.
- No open commenting PR touches the coordinate space — that part is only here.

Happy to split this into separate commits, or to rebase onto whichever of the above lands first.

### API changes

- `commentTargetShape(editor, page)` — the shape a comment at this point would attach to
- `resolveCommentDrop(editor, page, options)` → `{ anchor, highlightShapeId }`
- `CommentDropTarget`, `ResolveCommentDropOptions`
- `shapeAnchorAt` keeps its signature; `precise` is always passed `true` from this package

### Test plan

1. Place a comment on a rotated shape, then rotate, resize, and nest it in a rotated frame — the pin stays on the same spot of the drawing.
2. Place a comment on the stroke of an unfilled rectangle — it attaches. Click the blank middle — it drops a free point.
3. Same with a solid-filled rectangle: the fill doesn't attach, the outline does.
4. Place a comment in the middle of an image, a sticky note, and a text shape — all attach.
5. Place a comment inside a frame, away from its border — it does not attach to the frame.
6. Drag an attached pin off the shape onto blank canvas — it detaches to a point.
7. Alt-drag an attached pin around inside its shape — it stays attached and stops at the box edges.
8. A comment placed before this change still renders where it did.

- [x] Unit tests

### Change type

- [x] `bugfix`

### Release notes

- Fixed comments on rotated shapes drifting away from the spot they were placed on, and comments attaching to blank space inside a shape's outline. Comments now stay exactly where you put them and attach to a shape's stroke; hold alt while dragging to move a comment freely within its shape.
