### PR TITLE
fix(dotcom): asset diagnostics subrequest budget and asset table indexes

### DIFF
--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -867,6 +867,7 @@ function AssetDiagnostics() {
 								['Pending association', report.assets.pending],
 								['Missing in bucket', report.assets.missingInBucket],
 								['Head check failures', report.assets.headFailures],
+								['Not checked (over budget)', report.assets.notChecked],
 								['Old-format URLs', report.assets.oldFormatUrls],
 								[
 									'DB asset rows',
@@ -893,28 +894,43 @@ function AssetDiagnostics() {
 						</div>
 					</div>
 					{report.assets.problems.length > 0 && (
-						<table className={styles.diagnosticsTable}>
-							<thead>
-								<tr>
-									<th>Asset</th>
-									<th>Object name</th>
-									<th>In bucket</th>
-									<th>Meta fileId</th>
-									<th>DB fileId</th>
-								</tr>
-							</thead>
-							<tbody>
-								{report.assets.problems.map((p) => (
-									<tr key={p.assetId}>
-										<td>{p.assetId}</td>
-										<td>{p.objectName}</td>
-										<td>{p.inBucket === null ? 'check failed' : p.inBucket ? 'yes' : 'MISSING'}</td>
-										<td>{p.fileIdMeta ?? 'none'}</td>
-										<td>{p.dbRow?.fileId ?? 'none'}</td>
+						<>
+							{report.assets.problemsTotal > report.assets.problems.length && (
+								<p className="tla-text_ui__regular">
+									Showing {report.assets.problems.length} of {report.assets.problemsTotal} problems.
+								</p>
+							)}
+							<table className={styles.diagnosticsTable}>
+								<thead>
+									<tr>
+										<th>Asset</th>
+										<th>Object name</th>
+										<th>In bucket</th>
+										<th>Meta fileId</th>
+										<th>DB fileId</th>
 									</tr>
-								))}
-							</tbody>
-						</table>
+								</thead>
+								<tbody>
+									{report.assets.problems.map((p) => (
+										<tr key={p.assetId}>
+											<td>{p.assetId}</td>
+											<td>{p.objectName}</td>
+											<td>
+												{p.inBucket !== null
+													? p.inBucket
+														? 'yes'
+														: 'MISSING'
+													: p.checked
+														? 'check failed'
+														: 'not checked'}
+											</td>
+											<td>{p.fileIdMeta ?? 'none'}</td>
+											<td>{p.dbRow?.fileId ?? 'none'}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</>
 					)}
 					<StructuredDataDisplay data={report} />
 				</>

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -34,6 +34,14 @@ async function requireUser(env: Environment, q: string) {
 	return userRow
 }
 
+// A single worker invocation gets ~1000 subrequests and every R2 head costs one, so the
+// file-assets report can't head-check every asset of a large file. The budget is spent on
+// unassociated assets (the diagnostic targets) first; the rest report as not checked.
+const MAX_HEAD_CHECKS = 500
+// Response-size caps: a multi-thousand-asset file would otherwise return megabytes
+const MAX_PROBLEMS = 200
+const MAX_WARNINGS = 20
+
 export const adminRoutes = createRouter<Environment>()
 	.all('/app/admin/*', async (req, env) => {
 		const auth = await requireAuth(req, env)
@@ -191,7 +199,12 @@ export const adminRoutes = createRouter<Environment>()
 	})
 	// Read-only asset health report for a file: is each asset's object still in the uploads
 	// bucket, and is it associated with the file? Explains files stuck in a zero-progress
-	// association loop.
+	// association loop. See MAX_HEAD_CHECKS for why not every asset gets checked.
+	//
+	// Workers allow ~1000 subrequests per invocation and every R2 head is one, so files with
+	// thousands of assets can't have them all checked in one request. Head checks are capped,
+	// spending the budget on unassociated assets (the diagnostic targets) first; the rest
+	// report as not checked. Problems and warnings are capped too so the response stays small.
 	.get('/app/admin/file-assets/:slug', async (res, env) => {
 		const slug = res.params.slug
 		assert(typeof slug === 'string', 'slug is required')
@@ -217,6 +230,7 @@ export const adminRoutes = createRouter<Environment>()
 			fileIdMeta: string | null
 			associated: boolean
 			oldFormatUrl: boolean
+			checked: boolean
 			inBucket: boolean | null
 			sizeBytes: number | null
 		}> = []
@@ -247,8 +261,9 @@ export const adminRoutes = createRouter<Environment>()
 					src.startsWith('http') &&
 					!!userContentUrl &&
 					!src.startsWith(userContentUrl),
-				// null until the head check settles; a failed check stays null so R2 flakiness
-				// doesn't read as a confirmed-missing object
+				checked: false,
+				// null until the head check settles; a skipped or failed check stays null so R2
+				// flakiness doesn't read as a confirmed-missing object
 				inBucket: null,
 				sizeBytes: null,
 			})
@@ -258,12 +273,19 @@ export const adminRoutes = createRouter<Environment>()
 		// failures become warnings rather than failing the report
 		const warnings: string[] = []
 		const headQueue = new PQueue({ concurrency: 5 })
+		const toCheck = [...assets]
+			.sort((a, b) => Number(a.associated) - Number(b.associated))
+			.slice(0, MAX_HEAD_CHECKS)
 		await headQueue.addAll(
-			assets.map((asset) => async () => {
+			toCheck.map((asset) => async () => {
+				asset.checked = true
 				try {
 					const head = await retry(() => env.UPLOADS.head(asset.objectName), {
 						attempts: 2,
 						waitDuration: 500,
+						// Exceeding the invocation's subrequest budget is terminal: retrying only
+						// burns 500ms per asset on a request that can no longer make progress
+						matchError: (e) => !String(e).includes('Too many subrequests'),
 					})
 					asset.inBucket = !!head
 					asset.sizeBytes = head?.size ?? null
@@ -323,18 +345,25 @@ export const adminRoutes = createRouter<Environment>()
 		let oldFormatUrls = 0
 		let missingInBucket = 0
 		let headFailures = 0
+		let notChecked = 0
 		let totalSizeBytes = 0
 		let largestSizeBytes = 0
 		for (const a of assets) {
 			if (a.associated) associated++
 			if (a.oldFormatUrl) oldFormatUrls++
 			if (a.inBucket === false) missingInBucket++
-			if (a.inBucket === null) headFailures++
+			if (!a.checked) notChecked++
+			else if (a.inBucket === null) headFailures++
 			if (a.sizeBytes !== null) {
 				totalSizeBytes += a.sizeBytes
 				largestSizeBytes = Math.max(largestSizeBytes, a.sizeBytes)
 			}
 		}
+
+		// Skipped-but-associated assets aren't problems, just unchecked
+		const problemAssets = assets.filter(
+			(a) => !a.associated || a.inBucket === false || (a.checked && a.inBucket === null)
+		)
 
 		const report: AdminFileAssetsResponseBody = {
 			file: file ?? null,
@@ -347,23 +376,30 @@ export const adminRoutes = createRouter<Environment>()
 				oldFormatUrls,
 				missingInBucket,
 				headFailures,
+				notChecked,
 				totalSizeBytes,
 				largestSizeBytes,
-				problems: assets
-					.filter((a) => !a.associated || a.inBucket !== true)
-					.map((a) => ({
-						assetId: a.assetId,
-						objectName: a.objectName,
-						src: a.src,
-						fileIdMeta: a.fileIdMeta,
-						inBucket: a.inBucket,
-						dbRow: dbFileIdByObjectName.has(a.objectName)
-							? { fileId: dbFileIdByObjectName.get(a.objectName)! }
-							: null,
-					})),
+				problemsTotal: problemAssets.length,
+				problems: problemAssets.slice(0, MAX_PROBLEMS).map((a) => ({
+					assetId: a.assetId,
+					objectName: a.objectName,
+					src: a.src,
+					fileIdMeta: a.fileIdMeta,
+					checked: a.checked,
+					inBucket: a.inBucket,
+					dbRow: dbFileIdByObjectName.has(a.objectName)
+						? { fileId: dbFileIdByObjectName.get(a.objectName)! }
+						: null,
+				})),
 			},
 			dbRows: { forThisFile: rowsForThisFile.length, orphaned },
-			warnings,
+			warnings:
+				warnings.length > MAX_WARNINGS
+					? [
+							...warnings.slice(0, MAX_WARNINGS),
+							`…and ${warnings.length - MAX_WARNINGS} more warnings`,
+						]
+					: warnings,
 		}
 		return json(report)
 	})

--- a/apps/dotcom/zero-cache/migrations/040_asset_indexes.sql
+++ b/apps/dotcom/zero-cache/migrations/040_asset_indexes.sql
@@ -1,0 +1,8 @@
+-- The asset table only has a primary key on "objectName". Both foreign keys are
+-- unindexed, so every lookup by file ("fileId" = ?) or user ("userId" = ?) is a
+-- sequential scan over the whole table (one row per upload, millions of rows), as
+-- are the per-row FK checks when cascading file deletes and user deletes.
+-- IF NOT EXISTS so an operator can pre-build these with CREATE INDEX CONCURRENTLY
+-- (not possible here: migrations run inside a transaction) and this becomes a no-op.
+CREATE INDEX IF NOT EXISTS "asset_file_id_idx" ON "asset" ("fileId");
+CREATE INDEX IF NOT EXISTS "asset_user_id_idx" ON "asset" ("userId");

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -296,7 +296,9 @@ export interface AdminFileAssetProblem {
 	objectName: string
 	src: string
 	fileIdMeta: string | null
-	/** null = the bucket head check failed, not a confirmed absence */
+	/** false = the head check was skipped (over the per-invocation budget), so inBucket is null */
+	checked: boolean
+	/** null = the bucket head check was skipped or failed, not a confirmed absence */
 	inBucket: boolean | null
 	dbRow: { fileId: string } | null
 }
@@ -320,9 +322,13 @@ export interface AdminFileAssetsResponseBody {
 		oldFormatUrls: number
 		missingInBucket: number
 		headFailures: number
-		/** Sums sizes of assets found in the uploads bucket; missing or failed heads contribute 0 */
+		/** Head checks skipped because the file has more assets than the per-invocation budget */
+		notChecked: number
+		/** Sums sizes of assets found in the uploads bucket; skipped, missing or failed heads contribute 0 */
 		totalSizeBytes: number
 		largestSizeBytes: number
+		/** Total problem count; `problems` is capped, so it may hold fewer entries than this */
+		problemsTotal: number
 		problems: AdminFileAssetProblem[]
 	}
 	dbRows: { forThisFile: number; orphaned: number }


### PR DESCRIPTION
Follow-up to #9646. Running the asset diagnostics report against a file with ~5.8k assets never returned a result. Two causes:

## Worker subrequest budget

A worker invocation gets ~1000 subrequests and every R2 \`head()\` costs one. The report tried to head every asset, so large files burned the budget partway through; every subsequent subrequest threw, and the \`retry\` wrapper slept 500ms before re-throwing each one — adding minutes of pure sleep before the Postgres cross-check queries failed too.

- Cap head checks at 500 per report, spending the budget on unassociated assets (the diagnostic targets) first. Skipped assets report as \`notChecked\` instead of counting as head failures.
- Stop retrying "Too many subrequests" errors — the invocation can't make progress, so failing fast beats sleeping 500ms per asset.
- Cap the \`problems\` list (200 entries, with the true total in \`problemsTotal\`) and \`warnings\` (20) so the response for a multi-thousand-asset file isn't megabytes.

## Missing indexes on the asset table

\`asset\` only has a primary key on \`objectName\`; the \`fileId\` and \`userId\` foreign keys are unindexed, so lookups by file or user seq-scan the whole table. \`EXPLAIN ANALYZE\` on production for the diagnostics query: parallel seq scan filtering 7.9M rows, 441ms warm. The same scan runs on the tldr download path, admin hard delete, user deletion, and every cascading FK check when file or user rows are deleted.

Migration \`040_asset_indexes.sql\` adds indexes on both columns. It uses \`IF NOT EXISTS\` so the indexes can be pre-built with \`CREATE INDEX CONCURRENTLY\` outside the migration transaction (migrations run inside one, where \`CONCURRENTLY\` is not allowed), making the locking migration a no-op at deploy time.

## Admin UI

Shows the new "not checked" count and labels problem rows as not checked vs check failed; notes when the problems table is truncated.