### PR TITLE
fix(dotcom): stop asset association churning on bookmark and external assets

### DIFF
--- a/apps/dotcom/client/src/pages/admin.tsx
+++ b/apps/dotcom/client/src/pages/admin.tsx
@@ -865,6 +865,7 @@ function AssetDiagnostics() {
 								],
 								['Associated', report.assets.associated],
 								['Pending association', report.assets.pending],
+								['External (bookmarks etc.)', report.assets.external],
 								['Missing in bucket', report.assets.missingInBucket],
 								['Head check failures', report.assets.headFailures],
 								['Old-format URLs', report.assets.oldFormatUrls],

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -41,19 +41,13 @@ import {
 	TLRecord,
 	createTLSchema,
 } from '@tldraw/tlschema'
-import {
-	ExecutionQueue,
-	assert,
-	assertExists,
-	exhaustiveSwitchError,
-	retry,
-	uniqueId,
-} from '@tldraw/utils'
+import { ExecutionQueue, assert, assertExists, exhaustiveSwitchError, retry } from '@tldraw/utils'
 import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { IRequest, Router } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
 import PQueue from 'p-queue'
+import { collectAssetAssociationChanges } from './assetAssociation'
 import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
@@ -1120,6 +1114,11 @@ export class TLFileDurableObject extends DurableObject {
 
 	private readonly associateAssetsQueue = new ExecutionQueue()
 
+	// Source objects the association pass confirmed missing from the uploads bucket. Skipped on
+	// later passes so an asset pointing at a gone object doesn't re-attempt an R2 get on every
+	// persist tick. In-memory only: resets with the DO, never touches document data.
+	private readonly missingSourceObjects = new Set<string>()
+
 	// Shared connection budget for every R2 operation this durable object makes. Both asset copies and
 	// snapshot uploads draw from this queue so together they can't exceed Cloudflare's simultaneous-
 	// connection limit (see MAX_CONCURRENT_R2_OPERATIONS).
@@ -1227,53 +1226,13 @@ export class TLFileDurableObject extends DurableObject {
 
 		const {
 			result: { assetsToReplace, assetsToMigrate },
-		} = storage.transaction((txn) => {
-			const assetsToReplace: Array<{
-				objectName: string
-				newObjectName: string
-				newSrc: string
-				assetId: string
-			}> = []
-			const assetsToMigrate: Array<{
-				assetId: string
-				newSrc: string
-			}> = []
-			for (const record of txn.values()) {
-				if (record.typeName !== 'asset') continue
-				const asset = record as any
-				const meta = asset.meta
-				const src = asset.props.src
-				if (!src) continue
-
-				// Migrate old-format HTTP URLs to tldrawusercontent.com (same R2 bucket, no copy needed)
-				if (meta?.fileId === slug && src.startsWith('http') && !src.startsWith(userContentUrl)) {
-					const objectName = src.split('/').pop()
-					if (objectName) {
-						assetsToMigrate.push({
-							assetId: asset.id,
-							newSrc: `${userContentUrl}/${objectName}`,
-						})
-					}
-					continue
-				}
-
-				if (meta?.fileId === slug) continue
-				const objectName = src.split('/').pop()
-				if (!objectName) continue
-
-				const split = objectName.split('-')
-				const fileType = split.length > 1 ? split.pop() : null
-				const id = uniqueId()
-				const newObjectName = fileType ? `${id}-${fileType}` : id
-				assetsToReplace.push({
-					objectName,
-					newObjectName,
-					assetId: asset.id,
-					newSrc: `${userContentUrl}/${newObjectName}`,
-				})
-			}
-			return { assetsToReplace, assetsToMigrate }
-		})
+		} = storage.transaction((txn) =>
+			collectAssetAssociationChanges(txn.values(), {
+				slug,
+				userContentUrl,
+				skipObjectNames: this.missingSourceObjects,
+			})
+		)
 
 		// Apply URL migrations (no R2 copy needed — same bucket, same object)
 		if (assetsToMigrate.length > 0) {
@@ -1294,10 +1253,13 @@ export class TLFileDurableObject extends DurableObject {
 			assetsToReplace.map((asset) =>
 				this.addR2Operation('asset_copy', async () => {
 					try {
-						if (!isValidR2ObjectName(asset.objectName)) return
-
 						const currentAsset = await this.env.UPLOADS.get(asset.objectName)
-						if (!currentAsset) return
+						if (!currentAsset) {
+							// Only a confirmed null (object genuinely absent) goes in the cache — a
+							// thrown error (rate limit, subrequest budget) must stay retryable
+							this.missingSourceObjects.add(asset.objectName)
+							return
+						}
 						await this.env.UPLOADS.put(asset.newObjectName, currentAsset.body, {
 							httpMetadata: currentAsset.httpMetadata,
 						})

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -9,9 +9,10 @@ import {
 	WELCOME_CREATE_SOURCE,
 } from '@tldraw/dotcom-shared'
 import { assert, retry, sleep, uniqueId } from '@tldraw/utils'
-import { createRouter, isValidR2ObjectName } from '@tldraw/worker-shared'
+import { createRouter } from '@tldraw/worker-shared'
 import { StatusError, json } from 'itty-router'
 import PQueue from 'p-queue'
+import { getUploadObjectName } from './assetAssociation'
 import { createPostgresConnectionPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
 import { getFileSnapshot, returnFileSnapshot } from './routes/tla/getFileSnapshot'
@@ -222,9 +223,8 @@ export const adminRoutes = createRouter<Environment>()
 		}> = []
 		let totalShapes = 0
 		const shapesByType: Record<string, number> = {}
-		// Assets the association pass can never act on (see collectAssetAssociationChanges):
-		// bookmarks (src is the bookmarked page URL), non-http srcs, R2-invalid object names.
-		// Counted instead of reported as missing uploads.
+		// Assets the association pass can never act on (bookmarks, non-http srcs, R2-invalid
+		// object names). Counted instead of reported as missing uploads.
 		let external = 0
 		for (const { state } of snapshot.documents) {
 			const record = state as any
@@ -236,12 +236,8 @@ export const adminRoutes = createRouter<Environment>()
 			if (record.typeName !== 'asset') continue
 			const src = record.props?.src
 			if (!src) continue
-			const objectName = src.split('/').pop()
-			if (record.type === 'bookmark' || !src.startsWith('http') || !objectName) {
-				external++
-				continue
-			}
-			if (!isValidR2ObjectName(objectName)) {
+			const objectName = getUploadObjectName(record)
+			if (!objectName) {
 				external++
 				continue
 			}

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -348,7 +348,9 @@ export const adminRoutes = createRouter<Environment>()
 			source,
 			shapes: { total: totalShapes, byType: shapesByType },
 			assets: {
-				total: assets.length,
+				// Every asset record in the snapshot; the upload-oriented counts below exclude
+				// the `external` ones
+				total: assets.length + external,
 				associated,
 				pending: assets.length - associated,
 				external,

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -9,7 +9,7 @@ import {
 	WELCOME_CREATE_SOURCE,
 } from '@tldraw/dotcom-shared'
 import { assert, retry, sleep, uniqueId } from '@tldraw/utils'
-import { createRouter } from '@tldraw/worker-shared'
+import { createRouter, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { StatusError, json } from 'itty-router'
 import PQueue from 'p-queue'
 import { createPostgresConnectionPool } from './postgres'
@@ -222,6 +222,10 @@ export const adminRoutes = createRouter<Environment>()
 		}> = []
 		let totalShapes = 0
 		const shapesByType: Record<string, number> = {}
+		// Assets the association pass can never act on (see collectAssetAssociationChanges):
+		// bookmarks (src is the bookmarked page URL), non-http srcs, R2-invalid object names.
+		// Counted instead of reported as missing uploads.
+		let external = 0
 		for (const { state } of snapshot.documents) {
 			const record = state as any
 			if (record.typeName === 'shape') {
@@ -233,7 +237,14 @@ export const adminRoutes = createRouter<Environment>()
 			const src = record.props?.src
 			if (!src) continue
 			const objectName = src.split('/').pop()
-			if (!objectName) continue
+			if (record.type === 'bookmark' || !src.startsWith('http') || !objectName) {
+				external++
+				continue
+			}
+			if (!isValidR2ObjectName(objectName)) {
+				external++
+				continue
+			}
 			const fileIdMeta = record.meta?.fileId ?? null
 			const associated = fileIdMeta === slug
 			assets.push({
@@ -344,6 +355,7 @@ export const adminRoutes = createRouter<Environment>()
 				total: assets.length,
 				associated,
 				pending: assets.length - associated,
+				external,
 				oldFormatUrls,
 				missingInBucket,
 				headFailures,

--- a/apps/dotcom/sync-worker/src/assetAssociation.test.ts
+++ b/apps/dotcom/sync-worker/src/assetAssociation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { collectAssetAssociationChanges } from './assetAssociation'
+
+const SLUG = 'file-slug-123'
+const USER_CONTENT = 'https://tldrawusercontent.com'
+
+function imageAsset(overrides: {
+	id?: string
+	src?: string | null
+	fileId?: string | null
+	type?: string
+}) {
+	return {
+		typeName: 'asset',
+		type: overrides.type ?? 'image',
+		id: overrides.id ?? 'asset:1',
+		props: { src: overrides.src },
+		meta: overrides.fileId === undefined ? {} : { fileId: overrides.fileId },
+	}
+}
+
+function collect(records: unknown[], skipObjectNames?: ReadonlySet<string>) {
+	return collectAssetAssociationChanges(records, {
+		slug: SLUG,
+		userContentUrl: USER_CONTENT,
+		skipObjectNames,
+	})
+}
+
+describe('collectAssetAssociationChanges', () => {
+	it('queues a copy for an asset from another file, preserving the file type suffix', () => {
+		const { assetsToReplace, assetsToMigrate } = collect([
+			imageAsset({ src: `${USER_CONTENT}/abc123-png`, fileId: 'other-file' }),
+		])
+		expect(assetsToMigrate).toEqual([])
+		expect(assetsToReplace).toEqual([
+			{
+				assetId: 'asset:1',
+				objectName: 'abc123-png',
+				newObjectName: expect.stringMatching(/-png$/),
+				newSrc: expect.stringMatching(new RegExp(`^${USER_CONTENT}/.*-png$`)),
+			},
+		])
+		expect(assetsToReplace[0].newObjectName).not.toBe('abc123-png')
+	})
+
+	it('queues a copy for an unassociated asset without a file type suffix', () => {
+		const { assetsToReplace } = collect([imageAsset({ src: `${USER_CONTENT}/abc123` })])
+		expect(assetsToReplace).toHaveLength(1)
+		expect(assetsToReplace[0].objectName).toBe('abc123')
+	})
+
+	it('migrates old-format urls for assets already associated with this file', () => {
+		const { assetsToReplace, assetsToMigrate } = collect([
+			imageAsset({ src: 'https://old-host.tldraw.com/uploads/abc123-png', fileId: SLUG }),
+		])
+		expect(assetsToReplace).toEqual([])
+		expect(assetsToMigrate).toEqual([{ assetId: 'asset:1', newSrc: `${USER_CONTENT}/abc123-png` }])
+	})
+
+	it('leaves associated assets with current-format urls alone', () => {
+		const result = collect([imageAsset({ src: `${USER_CONTENT}/abc123-png`, fileId: SLUG })])
+		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
+	})
+
+	it('skips bookmark assets — their src is the bookmarked page url, not an upload', () => {
+		const result = collect([
+			imageAsset({ type: 'bookmark', src: 'https://example.com/products/melvin' }),
+			imageAsset({ type: 'bookmark', src: 'https://example.com/page', fileId: SLUG }),
+		])
+		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
+	})
+
+	it('skips data: and missing srcs', () => {
+		const result = collect([
+			imageAsset({ src: 'data:image/png;base64,AAAA' }),
+			imageAsset({ src: null }),
+			imageAsset({ src: '' }),
+		])
+		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
+	})
+
+	it('skips object names R2 would reject', () => {
+		const longName = 'a'.repeat(2000)
+		const result = collect([
+			imageAsset({ src: `https://example.com/${longName}` }),
+			imageAsset({ src: 'https://example.com/trailing/' }),
+		])
+		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
+	})
+
+	it('skips object names a previous pass found missing from the bucket', () => {
+		const { assetsToReplace } = collect(
+			[
+				imageAsset({ id: 'asset:1', src: `${USER_CONTENT}/gone-png` }),
+				imageAsset({ id: 'asset:2', src: `${USER_CONTENT}/present-png` }),
+			],
+			new Set(['gone-png'])
+		)
+		expect(assetsToReplace.map((a) => a.assetId)).toEqual(['asset:2'])
+	})
+
+	it('ignores non-asset records', () => {
+		const result = collect([{ typeName: 'shape', type: 'image', props: {} }])
+		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
+	})
+})

--- a/apps/dotcom/sync-worker/src/assetAssociation.test.ts
+++ b/apps/dotcom/sync-worker/src/assetAssociation.test.ts
@@ -89,6 +89,14 @@ describe('collectAssetAssociationChanges', () => {
 		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
 	})
 
+	it('does not migrate old-format urls whose object name R2 would reject', () => {
+		const longName = 'a'.repeat(2000)
+		const result = collect([
+			imageAsset({ src: `https://old-host.tldraw.com/uploads/${longName}`, fileId: SLUG }),
+		])
+		expect(result).toEqual({ assetsToReplace: [], assetsToMigrate: [] })
+	})
+
 	it('skips object names a previous pass found missing from the bucket', () => {
 		const { assetsToReplace } = collect(
 			[

--- a/apps/dotcom/sync-worker/src/assetAssociation.ts
+++ b/apps/dotcom/sync-worker/src/assetAssociation.ts
@@ -14,11 +14,28 @@ export interface AssetToMigrate {
 }
 
 /**
- * Decides which asset records an association pass should act on. Assets that can never be
- * associated are skipped entirely so the pass doesn't re-attempt them on every run:
- * bookmark assets (their src is the bookmarked page URL, not an uploads object), non-http
- * srcs, object names R2 would reject, and `skipObjectNames` (objects a previous pass
- * already found missing from the uploads bucket).
+ * The uploads-bucket object name an asset's src points at, or null for assets the
+ * association pass can never act on: bookmark assets (their src is the bookmarked page URL,
+ * not an uploads object), non-http srcs, and object names R2 would reject. Shared with the
+ * admin asset diagnostics so its `external` count matches what the pass actually skips.
+ */
+export function getUploadObjectName(asset: {
+	type?: string
+	props?: { src?: string | null }
+}): string | null {
+	if (asset.type === 'bookmark') return null
+	const src = asset.props?.src
+	if (!src || !src.startsWith('http')) return null
+	const objectName = src.split('/').pop()
+	if (!objectName || !isValidR2ObjectName(objectName)) return null
+	return objectName
+}
+
+/**
+ * Decides which asset records an association pass should act on. Assets `getUploadObjectName`
+ * rejects are skipped entirely so the pass doesn't re-attempt them on every run; `skipObjectNames`
+ * (objects a previous pass already found missing from the uploads bucket) only gates the copy
+ * path — URL migration is a string rewrite and needs no R2 access.
  */
 export function collectAssetAssociationChanges(
 	records: Iterable<unknown>,
@@ -37,26 +54,21 @@ export function collectAssetAssociationChanges(
 	for (const record of records) {
 		if ((record as any).typeName !== 'asset') continue
 		const asset = record as any
-		if (asset.type === 'bookmark') continue
+		const objectName = getUploadObjectName(asset)
+		if (!objectName) continue
 		const meta = asset.meta
 		const src = asset.props.src
-		if (!src || !src.startsWith('http')) continue
 
 		// Migrate old-format HTTP URLs to tldrawusercontent.com (same R2 bucket, no copy needed)
 		if (meta?.fileId === slug && !src.startsWith(userContentUrl)) {
-			const objectName = src.split('/').pop()
-			if (objectName) {
-				assetsToMigrate.push({
-					assetId: asset.id,
-					newSrc: `${userContentUrl}/${objectName}`,
-				})
-			}
+			assetsToMigrate.push({
+				assetId: asset.id,
+				newSrc: `${userContentUrl}/${objectName}`,
+			})
 			continue
 		}
 
 		if (meta?.fileId === slug) continue
-		const objectName = src.split('/').pop()
-		if (!objectName || !isValidR2ObjectName(objectName)) continue
 		if (skipObjectNames?.has(objectName)) continue
 
 		const split = objectName.split('-')

--- a/apps/dotcom/sync-worker/src/assetAssociation.ts
+++ b/apps/dotcom/sync-worker/src/assetAssociation.ts
@@ -1,0 +1,74 @@
+import { uniqueId } from '@tldraw/utils'
+import { isValidR2ObjectName } from '@tldraw/worker-shared'
+
+export interface AssetToReplace {
+	objectName: string
+	newObjectName: string
+	newSrc: string
+	assetId: string
+}
+
+export interface AssetToMigrate {
+	assetId: string
+	newSrc: string
+}
+
+/**
+ * Decides which asset records an association pass should act on. Assets that can never be
+ * associated are skipped entirely so the pass doesn't re-attempt them on every run:
+ * bookmark assets (their src is the bookmarked page URL, not an uploads object), non-http
+ * srcs, object names R2 would reject, and `skipObjectNames` (objects a previous pass
+ * already found missing from the uploads bucket).
+ */
+export function collectAssetAssociationChanges(
+	records: Iterable<unknown>,
+	{
+		slug,
+		userContentUrl,
+		skipObjectNames,
+	}: {
+		slug: string
+		userContentUrl: string
+		skipObjectNames?: ReadonlySet<string>
+	}
+): { assetsToReplace: AssetToReplace[]; assetsToMigrate: AssetToMigrate[] } {
+	const assetsToReplace: AssetToReplace[] = []
+	const assetsToMigrate: AssetToMigrate[] = []
+	for (const record of records) {
+		if ((record as any).typeName !== 'asset') continue
+		const asset = record as any
+		if (asset.type === 'bookmark') continue
+		const meta = asset.meta
+		const src = asset.props.src
+		if (!src || !src.startsWith('http')) continue
+
+		// Migrate old-format HTTP URLs to tldrawusercontent.com (same R2 bucket, no copy needed)
+		if (meta?.fileId === slug && !src.startsWith(userContentUrl)) {
+			const objectName = src.split('/').pop()
+			if (objectName) {
+				assetsToMigrate.push({
+					assetId: asset.id,
+					newSrc: `${userContentUrl}/${objectName}`,
+				})
+			}
+			continue
+		}
+
+		if (meta?.fileId === slug) continue
+		const objectName = src.split('/').pop()
+		if (!objectName || !isValidR2ObjectName(objectName)) continue
+		if (skipObjectNames?.has(objectName)) continue
+
+		const split = objectName.split('-')
+		const fileType = split.length > 1 ? split.pop() : null
+		const id = uniqueId()
+		const newObjectName = fileType ? `${id}-${fileType}` : id
+		assetsToReplace.push({
+			objectName,
+			newObjectName,
+			assetId: asset.id,
+			newSrc: `${userContentUrl}/${newObjectName}`,
+		})
+	}
+	return { assetsToReplace, assetsToMigrate }
+}

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -317,6 +317,8 @@ export interface AdminFileAssetsResponseBody {
 		total: number
 		associated: number
 		pending: number
+		/** Assets the association pass can't act on: bookmarks, non-http srcs, R2-invalid names */
+		external: number
 		oldFormatUrls: number
 		missingInBucket: number
 		headFailures: number

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -314,6 +314,7 @@ export interface AdminFileAssetsResponseBody {
 		byType: Record<string, number>
 	}
 	assets: {
+		/** Every asset record in the snapshot, including `external` ones */
 		total: number
 		associated: number
 		pending: number


### PR DESCRIPTION
In order to stop tldraw.com files with bookmark shapes from re-running a zero-progress asset association pass on every persist tick, this PR teaches the pass to skip assets it can never associate. Found via the admin asset diagnostics (#9646): a file with ~124 bookmark assets reported them all as "missing in bucket", and its association pass re-attempted an R2 `get` for each of them forever — bookmark assets store the bookmarked page URL as their src, so `src.split('/').pop()` never names a real uploads object. The tldr download path already skips `type === 'bookmark'`; the association scan never got the same filter (this predates #9163, which only bounded copy concurrency).

The record-selection logic moves into `collectAssetAssociationChanges` (now unit tested), which skips bookmark assets, non-http srcs, and object names R2 rejects. The durable object also keeps an in-memory cache of source objects a copy confirmed absent (`get` returned null — thrown errors stay retryable), so non-bookmark assets with genuinely-missing sources stop churning too; it resets with the DO and never mutates document data. The admin diagnostics endpoint applies the same classification, counting these as `external` instead of missing uploads.

### Change type

- [x] `bugfix`

### Test plan

1. Run the admin asset diagnostics on a file containing bookmark shapes — bookmarks appear under "External (bookmarks etc.)" with pending association at 0, not as missing in bucket
2. Open such a file and watch worker logs — no repeated `asset_copy` R2 gets per persist tick

- [x] Unit tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -0    |
| Tests     | +107 / -0  |
| Apps      | +109 / -60 |