### PR TITLE
fix(commenting): resolve text ranges from immutable anchors

### DIFF
--- a/apps/component-studio/src/sketchbooks/anchoring/anchor-scene.tsx
+++ b/apps/component-studio/src/sketchbooks/anchoring/anchor-scene.tsx
@@ -175,7 +175,7 @@ function measureAnchor(
 		case 'text-range': {
 			const richText = findRenderedText(editor)
 			if (!richText) return null
-			const range = rangeForOffsets(richText, anchor.from, anchor.to)
+			const range = rangeForOffsets(richText, anchor.source.from, anchor.source.to)
 			if (!range) return null
 			const frags = [...range.getClientRects()].map((r) => screenRectToFrac(c, r))
 			if (frags.length === 0) return null

--- a/apps/component-studio/src/sketchbooks/anchoring/comment-anchor.sketchbook.tsx
+++ b/apps/component-studio/src/sketchbooks/anchoring/comment-anchor.sketchbook.tsx
@@ -1,6 +1,16 @@
-import { createShapeId } from 'tldraw'
+import { createShapeId, toRichText } from 'tldraw'
 import { Sketch, Sketchbook } from '../../sketch'
 import { CommentAnchor, CommentAnchorProps } from './comment-anchor'
+
+const textRangeAnchor = {
+	type: 'text-range' as const,
+	shapeId: createShapeId('note'),
+	source: {
+		richText: toRichText('The quick brown fox jumps over the lazy dog.'),
+		from: 16,
+		to: 30,
+	},
+}
 
 // One sketch per TLCommentAnchor kind, so each way a comment can attach is showcased.
 const sketchbook: Sketchbook<CommentAnchorProps> = {
@@ -15,7 +25,7 @@ const sketchbook: Sketchbook<CommentAnchorProps> = {
 				point: { type: 'point', x: 120, y: 90 },
 				region: { type: 'region', x: 60, y: 60, w: 180, h: 120 },
 				page: { type: 'page' },
-				'text-range': { type: 'text-range', shapeId: createShapeId('note'), from: 16, to: 30 },
+				'text-range': textRangeAnchor,
 			},
 		},
 	},
@@ -48,7 +58,7 @@ export const Page: Sketch<CommentAnchorProps> = {
 }
 export const TextRange: Sketch<CommentAnchorProps> = {
 	args: {
-		anchor: { type: 'text-range', shapeId: createShapeId('note'), from: 16, to: 30 },
+		anchor: textRangeAnchor,
 		open: true,
 	},
 }

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/CommentTextRangesExample.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/CommentTextRangesExample.tsx
@@ -3,6 +3,7 @@ import {
 	CommentAuthor,
 	commentToolOverrides,
 	commentTools,
+	createTextRangeAnchor,
 	pendingComment,
 	putCommentRecords,
 } from '@tldraw/commenting'
@@ -13,6 +14,7 @@ import {
 	DefaultRichTextToolbarContent,
 	Editor,
 	TLComponents,
+	TLRichText,
 	Tldraw,
 	TldrawUiButtonIcon,
 	TldrawUiToolbarButton,
@@ -29,8 +31,8 @@ import {
 } from 'tldraw'
 import '@tldraw/commenting/commenting.css'
 import 'tldraw/tldraw.css'
-import { TextRangeHighlights } from './TextRangeHighlights'
 import './comment-text-ranges.css'
+import { TextRangeHighlights } from './TextRangeHighlights'
 
 const AUTHORS: Record<string, CommentAuthor> = {
 	ada: { name: 'Ada Lovelace', color: '#0E9F6E' },
@@ -44,10 +46,9 @@ const resolveAuthor = (id: string): CommentAuthor => AUTHORS[id] ?? { name: id }
  * open the comment composer anchored to that range. Posting from the composer creates the thread
  * and comment through the normal pending-comment flow — no extra records needed.
  *
- * A `text-range` anchor's `from`/`to` are plaintext offsets (not ProseMirror positions), so the
- * highlight overlay can walk the shape's rendered text nodes to measure the range. Note that plain
- * offsets don't re-track if the text is edited later — a production version would keep them in
- * sync with a tiptap mark or by mapping positions through document changes.
+ * A `text-range` anchor captures the shape's rich text plus the selection's plaintext offsets.
+ * The highlight overlay resolves that immutable source range against the shape's current rich text,
+ * so editing the shape never needs to rewrite the comment record.
  */
 function startTextRangeComment(editor: Editor) {
 	const textEditor = editor.getRichTextEditor()
@@ -63,6 +64,7 @@ function startTextRangeComment(editor: Editor) {
 	const anchorFrom = doc.textBetween(0, from).length
 	const anchorTo = doc.textBetween(0, to).length
 	if (anchorFrom === anchorTo) return
+	const sourceRichText = doc.toJSON() as TLRichText
 
 	// The composer opens at the shape's top-right corner, where the overlay pins text-range threads.
 	const bounds = editor.getShapePageBounds(shapeId)
@@ -73,7 +75,10 @@ function startTextRangeComment(editor: Editor) {
 	editor.setEditingShape(null)
 
 	pendingComment.set(editor, {
-		anchor: { type: 'text-range', shapeId, from: anchorFrom, to: anchorTo },
+		anchor: createTextRangeAnchor(shapeId, sourceRichText, {
+			from: anchorFrom,
+			to: anchorTo,
+		}),
 		point: { x: bounds.maxX, y: bounds.minY },
 	})
 }
@@ -143,6 +148,7 @@ export default function CommentTextRangesExample() {
 
 	const handleMount = (editor: Editor) => {
 		const textId = createShapeId()
+		const richText = toRichText(SEEDED_TEXT)
 		editor.run(
 			() => {
 				editor.createShapes([
@@ -151,7 +157,7 @@ export default function CommentTextRangesExample() {
 						type: 'text',
 						x: 120,
 						y: 160,
-						props: { richText: toRichText(SEEDED_TEXT), w: 440, autoSize: false },
+						props: { richText, w: 440, autoSize: false },
 					},
 				])
 
@@ -161,7 +167,7 @@ export default function CommentTextRangesExample() {
 				const pageId = editor.getCurrentPageId()
 				const thread = createCommentThread({
 					pageId,
-					anchor: { type: 'text-range', shapeId: textId, from, to },
+					anchor: createTextRangeAnchor(textId, richText, { from, to }),
 					createdBy: 'ada',
 				})
 				const comment = createComment({

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/README.md
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/README.md
@@ -10,13 +10,14 @@ Comment on a selected range of text from the rich text toolbar.
 
 ---
 
-Comment threads can anchor to a character range inside a shape's text with a `text-range` anchor: `{ type: 'text-range', shapeId, from, to }`, where `from`/`to` are plaintext character offsets. This example wires that anchor kind up end to end: double-click the text shape to edit it, select a few words, and press the comment button that appears in the rich text toolbar. The composer opens anchored to the selection, and the commented characters are highlighted on the canvas.
+Comment threads can anchor to a character range inside a shape's text with a `text-range` anchor. The anchor stores the shape's rich text and the selection's plaintext offsets as an immutable source snapshot. This example wires that anchor kind up end to end: double-click the text shape to edit it, select a few words, and press the comment button that appears in the rich text toolbar. The composer opens anchored to the selection, and the commented characters are highlighted on the canvas.
 
-Two pieces make it work:
+Three pieces make it work:
 
-- **The toolbar button.** A custom `RichTextToolbar` component renders the default toolbar content plus a comment button (disabled while the selection is collapsed). Pressing it reads the tiptap selection, converts the ProseMirror positions to plaintext offsets, and sets `pendingComment` with a `text-range` anchor — the same pending-comment flow the comment tool uses, so posting from the composer creates the thread and comment records normally.
-- **The highlight overlay.** `TextRangeHighlights` draws a highlight over each text-range thread's characters (and the pending draft's). It finds the shape's rendered `.tl-rich-text` element, maps the plaintext offsets to DOM positions with a `Range`, and re-measures whenever the camera or shape moves, so the highlight stays glued to the text. Clicking a committed highlight opens its thread.
+- **The toolbar button.** A custom `RichTextToolbar` component renders the default toolbar content plus a comment button (disabled while the selection is collapsed). Pressing it reads the tiptap selection, converts the ProseMirror positions to plaintext offsets, and calls `createTextRangeAnchor` with the current rich text. It sets `pendingComment` with that anchor — the same pending-comment flow the comment tool uses, so posting from the composer creates the thread and comment records normally.
+- **Resolving the immutable anchor.** `resolveTextRangeAnchor` compares the source snapshot with the shape's current rich text and derives the range to display. It never rewrites the thread. Every client therefore gets the same result without coordinating anchor updates, and undo can recover a temporarily collapsed range because the source snapshot was not destroyed.
+- **The highlight overlay.** `TextRangeHighlights` draws the resolved range for each text-range thread (and the pending draft). It finds the shape's rendered `.tl-rich-text` element, maps the resolved plaintext offsets to DOM positions with a `Range`, and re-measures whenever the camera or shape moves. Clicking a committed highlight opens its thread.
 
-`CanvasComments` already pins text-range threads to their shape's corner, so the pins, popovers, and composer all come from the stock overlay — the example only adds the button and the highlights.
+This prototype deliberately uses a simple plaintext diff. A production implementation should resolve structural rich-text positions through multiple edits, but that mapping can improve independently of the immutable anchor model.
 
-One caveat to note: plaintext offsets don't re-track when the text is edited later, so a production implementation would keep anchors in sync with a tiptap mark or by mapping positions through document changes.
+`CanvasComments` already pins text-range threads to their shape's corner, so the pins, popovers, and composer all come from the stock overlay — the example only adds the button, the resolver, and the highlights.

--- a/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
+++ b/apps/examples/src/examples/collaboration/comment-text-ranges/TextRangeHighlights.tsx
@@ -1,12 +1,23 @@
 import {
 	openThreadId,
+	resolveTextRangeAnchor,
 	useCommentsHidden,
 	useCommentThreads,
 	usePendingComment,
 } from '@tldraw/commenting'
 import { useLayoutEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Editor, TLShapeId, useContainer, useEditor, useValue } from 'tldraw'
+import {
+	Editor,
+	TLCommentAnchor,
+	TLRichText,
+	TLShapeId,
+	useContainer,
+	useEditor,
+	useValue,
+} from 'tldraw'
+
+type TextRangeAnchor = Extract<TLCommentAnchor, { type: 'text-range' }>
 
 interface HighlightRect {
 	left: number
@@ -77,9 +88,7 @@ function measureRange(
 interface TextRangeHighlightProps {
 	editor: Editor
 	container: HTMLElement
-	shapeId: TLShapeId
-	from: number
-	to: number
+	anchor: TextRangeAnchor
 	/** A draft highlight (no thread yet) is non-interactive; a committed one opens its thread. */
 	onSelect?(): void
 }
@@ -88,31 +97,36 @@ interface TextRangeHighlightProps {
  * The highlight over a commented character range, kept aligned with the shape's rendered text as
  * the camera and shape move. `from`/`to` are plaintext offsets into the shape's text.
  */
-function TextRangeHighlight({
-	editor,
-	container,
-	shapeId,
-	from,
-	to,
-	onSelect,
-}: TextRangeHighlightProps) {
-	// A token that changes whenever the range's on-screen position could have — the camera, the
-	// shape's page transform (which covers parent groups/frames too), and its props (size, text,
+function TextRangeHighlight({ editor, container, anchor, onSelect }: TextRangeHighlightProps) {
+	const resolved = useValue(
+		'resolved text-range highlight',
+		() => {
+			const shape = editor.getShape(anchor.shapeId)
+			if (!shape) return null
+			const richText = (shape.props as { richText?: TLRichText }).richText
+			if (!richText) return null
+			return resolveTextRangeAnchor(anchor, richText)
+		},
+		[anchor, editor]
+	)
+
+	// A token that changes whenever the resolved range's on-screen position could have — the camera,
+	// the shape's page transform (which covers parent groups/frames too), and its props (size, text,
 	// font — anything that reflows the text). Reading these subscribes the effect below.
-	const token = useValue(
-		'text-range highlight token',
+	const layoutToken = useValue(
+		'text-range highlight layout token',
 		() => {
 			const cam = editor.getCamera()
-			const shape = editor.getShape(shapeId)
+			const shape = editor.getShape(anchor.shapeId)
 			if (!shape) return null
-			const transform = editor.getShapePageTransform(shapeId)
+			const transform = editor.getShapePageTransform(anchor.shapeId)
 			const vsb = editor.getViewportScreenBounds()
 			// Editing state matters: the static `.tl-rich-text` we measure only mounts once the shape
 			// leaves edit mode, so re-measure when editing ends (e.g. the composer takes focus).
-			const editing = editor.getEditingShapeId() === shapeId
+			const editing = editor.getEditingShapeId() === anchor.shapeId
 			return `${cam.x},${cam.y},${cam.z}|${transform.toCssString()}|${JSON.stringify(shape.props)}|${vsb.w},${vsb.h}|${editing}`
 		},
-		[editor, shapeId]
+		[anchor, editor]
 	)
 
 	const [rects, setRects] = useState<HighlightRect[]>([])
@@ -121,11 +135,12 @@ function TextRangeHighlight({
 	// to catch the canvas transform tldraw applies out of band during camera changes. Also re-measure
 	// when fonts finish loading — a font swap reflows the text without touching camera or shape.
 	useLayoutEffect(() => {
-		if (token === null) {
+		if (!resolved || resolved.status === 'collapsed') {
 			setRects([])
 			return
 		}
-		const measure = () => setRects(measureRange(container, shapeId, from, to))
+		const measure = () =>
+			setRects(measureRange(container, anchor.shapeId, resolved.from, resolved.to))
 		measure()
 		const raf = requestAnimationFrame(measure)
 		document.fonts.addEventListener('loadingdone', measure)
@@ -133,7 +148,7 @@ function TextRangeHighlight({
 			cancelAnimationFrame(raf)
 			document.fonts.removeEventListener('loadingdone', measure)
 		}
-	}, [container, shapeId, from, to, token])
+	}, [anchor.shapeId, container, layoutToken, resolved])
 
 	if (rects.length === 0) return null
 
@@ -144,6 +159,7 @@ function TextRangeHighlight({
 					key={i}
 					className="comment-text-range-highlight"
 					data-interactive={onSelect ? true : undefined}
+					data-range-status={resolved?.status}
 					style={{ left: r.left, top: r.top, width: r.width, height: r.height }}
 					onPointerDown={
 						onSelect
@@ -178,15 +194,12 @@ export function TextRangeHighlights() {
 		<div className="comment-text-ranges-layer">
 			{threads.map((thread) => {
 				if (thread.anchor.type !== 'text-range') return null
-				const { shapeId, from, to } = thread.anchor
 				return (
 					<TextRangeHighlight
 						key={thread.id}
 						editor={editor}
 						container={container}
-						shapeId={shapeId as TLShapeId}
-						from={from}
-						to={to}
+						anchor={thread.anchor}
 						onSelect={() => openThreadId.set(editor, thread.id)}
 					/>
 				)
@@ -196,9 +209,7 @@ export function TextRangeHighlights() {
 					key="pending"
 					editor={editor}
 					container={container}
-					shapeId={pending.anchor.shapeId as TLShapeId}
-					from={pending.anchor.from}
-					to={pending.anchor.to}
+					anchor={pending.anchor}
 				/>
 			)}
 		</div>,

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -364,6 +364,12 @@ export function createClusterRuntime(table: ClusterTable): ClusterRuntime;
 export function createMentionSuggestion(getSuggestions: (query: string) => MentionMember[] | Promise<MentionMember[]>, options?: MentionSuggestionOptions): Omit<SuggestionOptions<MentionMember, MentionNodeAttrs>, 'editor'>;
 
 // @public
+export function createTextRangeAnchor(shapeId: TLShapeId, richText: TLRichText, range: {
+    from: number;
+    to: number;
+}): TextRangeAnchor;
+
+// @public
 export const DEFAULT_IMPRECISE_SHAPE_ANCHOR: {
     x: number;
     y: number;
@@ -533,6 +539,19 @@ export function removeCommentRecords(editor: Editor, ids: (TLCommentId | TLComme
 export function renderMarkdown(text: string): ReactNode;
 
 // @public
+export interface ResolvedTextRange {
+    // (undocumented)
+    from: number;
+    // (undocumented)
+    status: 'ambiguous' | 'attached' | 'collapsed';
+    // (undocumented)
+    to: number;
+}
+
+// @public
+export function resolveTextRangeAnchor(anchor: TextRangeAnchor, currentRichText: TLRichText): ResolvedTextRange;
+
+// @public
 export const revealThreadRequest: EditorAtom<null | string>;
 
 // @public
@@ -577,6 +596,11 @@ export interface SidebarFilters {
 
 // @public
 export const sidebarFilters: EditorAtom<SidebarFilters>;
+
+// @public
+export type TextRangeAnchor = Extract<TLCommentAnchor, {
+    type: 'text-range';
+}>;
 
 // @public
 export type TLCommentRecord = TLComment | TLCommentThread;

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -1,4 +1,4 @@
-import type { Editor, TLCommentAnchor, TLCommentThread } from 'tldraw'
+import { toRichText, type Editor, type TLCommentAnchor, type TLCommentThread } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 // This import is red until step 6's filter module is implemented — that is
 // intentional. Implement `cluster-input.ts` per CLUSTERING-STEPS.md step 6
@@ -75,7 +75,11 @@ describe('collectClusterLeaves anchor resolution', () => {
 			editor,
 			[
 				thread('t1', { type: 'shape', shapeId: 'shape:a' as any, x: 0, y: 0, isPrecise: false }),
-				thread('t2', { type: 'text-range', shapeId: 'shape:a' as any, from: 0, to: 3 }),
+				thread('t2', {
+					type: 'text-range',
+					shapeId: 'shape:a' as any,
+					source: { richText: toRichText('abc'), from: 0, to: 3 },
+				}),
 			],
 			null
 		)

--- a/packages/commenting/src/canvas/text-range-anchor.test.ts
+++ b/packages/commenting/src/canvas/text-range-anchor.test.ts
@@ -1,0 +1,143 @@
+import { structuredClone } from '@tldraw/utils'
+import { createShapeId, toRichText } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import {
+	createTextRangeAnchor,
+	getShapePlaintext,
+	resolveTextRangeAnchor,
+} from './text-range-anchor'
+
+function rangeOf(text: string, word: string) {
+	const from = text.indexOf(word)
+	return { from, to: from + word.length }
+}
+
+describe('text-range anchors', () => {
+	const shapeId = createShapeId('text-range-anchor')
+	const text = 'Select a few words and press the comment button in the toolbar.'
+	const sourceRichText = toRichText(text)
+	const sourceRange = rangeOf(text, 'comment button')
+	const anchor = createTextRangeAnchor(shapeId, sourceRichText, sourceRange)
+
+	function resolveText(currentText: string) {
+		const resolved = resolveTextRangeAnchor(anchor, toRichText(currentText))
+		return {
+			...resolved,
+			text: currentText.slice(resolved.from, resolved.to),
+		}
+	}
+
+	it('captures the source rich text and offsets', () => {
+		expect(anchor).toEqual({
+			type: 'text-range',
+			shapeId,
+			source: {
+				richText: sourceRichText,
+				...sourceRange,
+			},
+		})
+	})
+
+	it('rejects invalid source ranges', () => {
+		expect(() =>
+			createTextRangeAnchor(shapeId, sourceRichText, { from: -1, to: sourceRange.to })
+		).toThrow(RangeError)
+		expect(() =>
+			createTextRangeAnchor(shapeId, sourceRichText, { from: sourceRange.to, to: sourceRange.from })
+		).toThrow(RangeError)
+		expect(() =>
+			createTextRangeAnchor(shapeId, sourceRichText, {
+				from: sourceRange.from,
+				to: sourceRange.from,
+			})
+		).toThrow(RangeError)
+		expect(() =>
+			createTextRangeAnchor(shapeId, sourceRichText, {
+				from: sourceRange.from,
+				to: text.length + 1,
+			})
+		).toThrow(RangeError)
+	})
+
+	it('resolves the unchanged source range directly', () => {
+		expect(resolveText(text)).toEqual({
+			...sourceRange,
+			status: 'attached',
+			text: 'comment button',
+		})
+	})
+
+	it('resolves through edits before and inside the range', () => {
+		expect(resolveText(`First! ${text}`).text).toBe('comment button')
+		expect(resolveText(text.replace('comment button', 'comment toolbar button')).text).toBe(
+			'comment toolbar button'
+		)
+	})
+
+	it('resolves an untouched range through multiple disjoint edits', () => {
+		expect(resolveText(`First! ${text} Last!`)).toMatchObject({
+			status: 'attached',
+			text: 'comment button',
+		})
+	})
+
+	it('resolves ambiguous boundary edits conservatively', () => {
+		expect(resolveText(text.replace('the comment button', 'the ccomment button'))).toMatchObject({
+			status: 'ambiguous',
+			text: 'comment button',
+		})
+	})
+
+	it('collapses while the source range is absent', () => {
+		const resolved = resolveText('Something else entirely.')
+		expect(resolved.from).toBe(resolved.to)
+		expect(resolved.status).toBe('collapsed')
+	})
+
+	it('recovers exactly when the source text returns', () => {
+		const rewritten = resolveText('Something else entirely.')
+		expect(rewritten.status).toBe('collapsed')
+
+		expect(resolveText(text)).toEqual({
+			...sourceRange,
+			status: 'attached',
+			text: 'comment button',
+		})
+	})
+
+	it('never mutates the anchor while resolving different document states', () => {
+		const before = structuredClone(anchor)
+		resolveText(`First! ${text}`)
+		resolveText('Something else entirely.')
+		resolveText(text)
+		expect(anchor).toEqual(before)
+	})
+
+	it('captures the source snapshot by value', () => {
+		const mutableRichText = toRichText(text)
+		const captured = createTextRangeAnchor(shapeId, mutableRichText, sourceRange)
+		mutableRichText.content = []
+
+		expect(getShapePlaintext(captured.source.richText)).toBe(text)
+	})
+})
+
+describe('getShapePlaintext', () => {
+	it('matches the plaintext coordinate space used by the example', () => {
+		expect(getShapePlaintext(toRichText('one\ntwo'))).toBe('onetwo')
+		expect(
+			getShapePlaintext({
+				type: 'doc',
+				content: [
+					{
+						type: 'paragraph',
+						content: [
+							{ type: 'text', text: 'bold ' },
+							{ type: 'text', text: 'and italic', marks: [{ type: 'italic' }] },
+						],
+					},
+				],
+			})
+		).toBe('bold and italic')
+	})
+})

--- a/packages/commenting/src/canvas/text-range-anchor.ts
+++ b/packages/commenting/src/canvas/text-range-anchor.ts
@@ -1,0 +1,176 @@
+import { structuredClone } from '@tldraw/utils'
+import { TLCommentAnchor, TLRichText, TLShapeId } from 'tldraw'
+
+/** A comment anchor backed by an immutable source rich-text snapshot. @public */
+export type TextRangeAnchor = Extract<TLCommentAnchor, { type: 'text-range' }>
+
+/**
+ * The result of resolving an immutable text-range anchor against a shape's current rich text.
+ *
+ * - `attached` means the source range has one unambiguous position in the current text.
+ * - `ambiguous` means more than one edit attribution was possible; the returned range is the
+ *   conservative overlap shared by those readings.
+ * - `collapsed` means none of the source range can be identified in the current text.
+ *
+ * @public
+ */
+export interface ResolvedTextRange {
+	from: number
+	to: number
+	status: 'attached' | 'ambiguous' | 'collapsed'
+}
+
+/**
+ * Create an immutable text-range anchor from a shape's current rich text and a pair of plaintext
+ * offsets.
+ *
+ * The source snapshot stays fixed for the lifetime of the thread. Consumers derive a display range
+ * from it with {@link resolveTextRangeAnchor}; editing the shape never rewrites the comment record.
+ *
+ * @public
+ */
+export function createTextRangeAnchor(
+	shapeId: TLShapeId,
+	richText: TLRichText,
+	range: { from: number; to: number }
+): TextRangeAnchor {
+	const textLength = getShapePlaintext(richText).length
+	if (
+		range.from < 0 ||
+		range.to <= range.from ||
+		range.to > textLength ||
+		!Number.isInteger(range.from) ||
+		!Number.isInteger(range.to)
+	) {
+		throw new RangeError(
+			`Invalid text range [${range.from}, ${range.to}) for text of length ${textLength}`
+		)
+	}
+
+	return {
+		type: 'text-range',
+		shapeId,
+		source: {
+			richText: structuredClone(richText),
+			from: range.from,
+			to: range.to,
+		},
+	}
+}
+
+/**
+ * Resolve an immutable text-range anchor against a shape's current rich text.
+ *
+ * Resolution is a pure operation: it never updates the anchor, the thread, or the shape. Because
+ * every resolution starts from the original source snapshot, clients cannot double-map an anchor
+ * when shape and comment records arrive in different orders, and undo can recover a range after a
+ * temporary edit collapsed it.
+ *
+ * This prototype deliberately keeps the PR's single-span plaintext mapper so the storage and
+ * consistency model can be evaluated independently from the diff algorithm. A production resolver
+ * should use a structural, multi-span rich-text mapping.
+ *
+ * @public
+ */
+export function resolveTextRangeAnchor(
+	anchor: TextRangeAnchor,
+	currentRichText: TLRichText
+): ResolvedTextRange {
+	const oldText = getShapePlaintext(anchor.source.richText)
+	const newText = getShapePlaintext(currentRichText)
+	const sourceRange = { from: anchor.source.from, to: anchor.source.to }
+	if (oldText === newText) return { ...sourceRange, status: 'attached' }
+
+	const readings = [
+		diffText(oldText, newText, 'earliest'),
+		diffText(oldText, newText, 'latest'),
+	].filter((edit): edit is TextEdit => edit !== null)
+
+	const ranges = readings.map((edit) => ({
+		from: mapOffset(sourceRange.from, edit, 'start'),
+		to: mapOffset(sourceRange.to, edit, 'end'),
+	}))
+	const from = Math.max(...ranges.map((range) => range.from))
+	const to = Math.min(...ranges.map((range) => range.to))
+
+	if (from >= to) {
+		// A single-span diff can treat multiple accumulated edits as one whole-document replacement.
+		// Before collapsing, recover an untouched source quote when it has one exact current position.
+		const sourceQuote = oldText.slice(sourceRange.from, sourceRange.to)
+		const quoteAt = newText.indexOf(sourceQuote)
+		if (quoteAt !== -1 && newText.indexOf(sourceQuote, quoteAt + 1) === -1) {
+			return { from: quoteAt, to: quoteAt + sourceQuote.length, status: 'attached' }
+		}
+
+		const at = Math.min(from, to)
+		return { from: at, to: at, status: 'collapsed' }
+	}
+
+	const ambiguous = ranges.some((range) => range.from !== from || range.to !== to)
+	return { from, to, status: ambiguous ? 'ambiguous' : 'attached' }
+}
+
+/** The plaintext model currently shared by selection creation and DOM range measurement. */
+export function getShapePlaintext(richText: TLRichText): string {
+	let out = ''
+	const visit = (node: unknown) => {
+		if (!node || typeof node !== 'object') return
+		const { text, content } = node as { text?: unknown; content?: unknown }
+		if (typeof text === 'string') out += text
+		if (Array.isArray(content)) content.forEach(visit)
+	}
+	visit(richText)
+	return out
+}
+
+interface TextEdit {
+	start: number
+	oldEnd: number
+	newEnd: number
+}
+
+function diffText(
+	oldText: string,
+	newText: string,
+	attribute: 'earliest' | 'latest'
+): TextEdit | null {
+	if (oldText === newText) return null
+
+	const matchPrefix = (limit: number) => {
+		let start = 0
+		while (start < limit && oldText[start] === newText[start]) start++
+		return start
+	}
+	const matchSuffix = (limit: number) => {
+		let suffix = 0
+		while (
+			suffix < limit &&
+			oldText[oldText.length - 1 - suffix] === newText[newText.length - 1 - suffix]
+		) {
+			suffix++
+		}
+		return suffix
+	}
+
+	if (attribute === 'latest') {
+		const start = matchPrefix(Math.min(oldText.length, newText.length))
+		const suffix = matchSuffix(Math.min(oldText.length - start, newText.length - start))
+		return { start, oldEnd: oldText.length - suffix, newEnd: newText.length - suffix }
+	}
+
+	const suffix = matchSuffix(Math.min(oldText.length, newText.length))
+	const start = matchPrefix(Math.min(oldText.length - suffix, newText.length - suffix))
+	return { start, oldEnd: oldText.length - suffix, newEnd: newText.length - suffix }
+}
+
+function mapOffset(offset: number, edit: TextEdit, bias: 'start' | 'end'): number {
+	const delta = edit.newEnd - edit.oldEnd
+	if (bias === 'start') {
+		if (offset < edit.start) return offset
+		if (offset >= edit.oldEnd) return offset + delta
+		return edit.newEnd
+	}
+	if (offset <= edit.start) return offset
+	if (offset >= edit.oldEnd) return offset + delta
+	return edit.start
+}

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -74,6 +74,12 @@ export { useComments, useCommentThreads, useThreadComments } from './canvas/hook
 export { useCommentingEnabled } from './canvas/license'
 export { DEFAULT_REGION_COMMENT_OPTIONS, type RegionCommentOptions } from './canvas/region-options'
 export { richTextToPlaintext } from './canvas/rich-text'
+export {
+	createTextRangeAnchor,
+	type ResolvedTextRange,
+	resolveTextRangeAnchor,
+	type TextRangeAnchor,
+} from './canvas/text-range-anchor'
 export { DEFAULT_SIDEBAR_FILTERS, type SidebarFilters } from './canvas/sidebar-filters'
 export {
 	commentsHidden,

--- a/packages/tlschema/api-report.api.md
+++ b/packages/tlschema/api-report.api.md
@@ -1097,6 +1097,14 @@ export interface TLComment extends BaseRecord<'comment', TLCommentId> {
 
 // @public
 export type TLCommentAnchor = {
+    source: {
+        from: number;
+        richText: TLRichText;
+        to: number;
+    };
+    shapeId: TLShapeId;
+    type: 'text-range';
+} | {
     pinX?: number;
     h: number;
     pinY?: number;
@@ -1104,11 +1112,6 @@ export type TLCommentAnchor = {
     w: number;
     x: number;
     y: number;
-} | {
-    from: number;
-    shapeId: TLShapeId;
-    to: number;
-    type: 'text-range';
 } | {
     isPrecise: boolean;
     shapeId: TLShapeId;

--- a/packages/tlschema/src/records/TLComment.test.ts
+++ b/packages/tlschema/src/records/TLComment.test.ts
@@ -18,13 +18,18 @@ import { TLShapeId } from './TLShape'
 
 const pageId = 'page:page1' as TLPageId
 const shapeId = 'shape:box1' as TLShapeId
+const sourceRichText = toRichText('A commented range')
 
 const anchors: TLCommentAnchor[] = [
 	{ type: 'shape', shapeId, x: 1, y: 0, isPrecise: false },
 	{ type: 'point', x: 100, y: 200 },
 	{ type: 'region', x: 0, y: 0, w: 300, h: 150 },
 	{ type: 'page' },
-	{ type: 'text-range', shapeId, from: 3, to: 12 },
+	{
+		type: 'text-range',
+		shapeId,
+		source: { richText: sourceRichText, from: 2, to: 11 },
+	},
 ]
 
 describe('TLCommentThread', () => {
@@ -73,6 +78,12 @@ describe('TLCommentThread', () => {
 				...thread,
 				// shape anchors must reference a shape id
 				anchor: { type: 'shape', shapeId: 'page:nope', x: 1, y: 0, isPrecise: false },
+			})
+		).toThrow()
+		expect(() =>
+			commentThreadRecordConfig.validator.validate({
+				...thread,
+				anchor: { type: 'text-range', shapeId, from: 2, to: 11 },
 			})
 		).toThrow()
 	})

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -18,7 +18,7 @@ import { TLShapeId } from './TLShape'
  * - `point` — pinned to a fixed point on the page, in page coordinates
  * - `region` — pinned to a rectangular area of the page, in page coordinates
  * - `page` — a page-level thread with no spatial anchor
- * - `text-range` — pinned to a character range inside a shape's text
+ * - `text-range` — pinned to a character range in an immutable snapshot of a shape's text
  *
  * @public
  */
@@ -37,7 +37,20 @@ export type TLCommentAnchor =
 			pinY?: number
 	  }
 	| { type: 'page' }
-	| { type: 'text-range'; shapeId: TLShapeId; from: number; to: number }
+	| {
+			type: 'text-range'
+			shapeId: TLShapeId
+			/**
+			 * The rich text and plaintext offsets observed when the thread was created. Consumers
+			 * resolve this immutable source range against the shape's current rich text instead of
+			 * rewriting the anchor after every edit.
+			 */
+			source: {
+				richText: TLRichText
+				from: number
+				to: number
+			}
+	  }
 
 /**
  * A comment thread. The thread owns the anchor (where the conversation lives on the canvas) and
@@ -131,8 +144,11 @@ const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
 	'text-range': T.object({
 		type: T.literal('text-range'),
 		shapeId: idValidator<TLShapeId>('shape'),
-		from: T.number,
-		to: T.number,
+		source: T.object({
+			richText: richTextValidator,
+			from: T.number,
+			to: T.number,
+		}),
 	}),
 })
 


### PR DESCRIPTION
In order to keep text-range comments stable through edits, undo, and out-of-order collaboration updates, this PR resolves each range from an immutable source snapshot instead of rewriting thread offsets after every shape change.

This is a first-principles alternative to #9660. Both approaches retain the conservative plaintext mapper for ambiguous edits, but this version makes resolution a pure read: shape changes never write to comment records, and a temporarily collapsed range can recover when its source text returns.

The prototype also recovers a uniquely preserved source quote through multiple disjoint edits around the range. Resolution is separated from camera-reactive highlight measurement, so panning and zooming do not rerun the text diff.

### Design questions

This is a draft because two storage decisions need agreement before it is mergeable:

- The persisted `text-range` anchor changes shape. Existing `{ from, to }` records cannot be upgraded to a source snapshot without access to the corresponding shape text, so this needs an explicit backward-compatibility or coordinated data-migration plan.
- A full rich-text snapshot makes the model easy to evaluate, but duplicates shape content for every thread and retains deleted text. We should decide whether production anchors use the full snapshot or a bounded quote/context representation.

The resolver still deliberately uses the current single-span plaintext mapping as a fallback. A production version should use structural, multi-span rich-text mapping for ranges whose selected text is itself changed in several disjoint places.

### API changes

- Changed `TLCommentAnchor` text ranges to store `source.richText`, `source.from`, and `source.to`.
- Added `createTextRangeAnchor`, which validates the source offsets and captures the rich-text snapshot by value.
- Added `resolveTextRangeAnchor`, `TextRangeAnchor`, and `ResolvedTextRange`.

### Change type

- [x] `bugfix`

### Test plan

1. Open the “Comment on a text range” example. The seeded thread highlights `comment button`.
2. Edit before and inside the highlighted phrase; verify the highlight follows the intended text.
3. Edit in two separate places around the highlighted phrase; verify an untouched unique phrase remains attached.
4. Replace all text; verify the highlight collapses. Undo; verify it returns without changing the thread record.
5. Pan and zoom with several text-range threads; verify highlights remain aligned.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Keep comments on text ranges attached through edits and undo without rewriting comment records.

### Code changes

| Section | LOC change |
| --- | ---: |
| Core code | +271 / -46 |
| Tests | +161 / -3 |
| Automated files | +32 / -5 |
| Documentation | +7 / -6 |
