### PR TITLE
fix(commenting): finish the text-range sweep in anchor-lifecycle

### DIFF
--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -11,7 +11,7 @@ import { getCommentingOptions } from './options'
 import { commitCommentMutation } from './state'
 import { anchorPagePoint, impreciseShapePinInset } from './thread-state'
 
-type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' | 'text-range' }>
+type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' }>
 
 /**
  * Threads converted to point anchors because their shape was deleted, kept so the anchor can be
@@ -30,12 +30,11 @@ function isAnchoredToShape(
 	shapeId: TLShapeId
 ): thread is TLCommentThread & { anchor: ShapeAnchor } {
 	const anchor = thread.anchor
-	return (anchor.type === 'shape' || anchor.type === 'text-range') && anchor.shapeId === shapeId
+	return anchor.type === 'shape' && anchor.shapeId === shapeId
 }
 
 /**
- * Keep shape-anchored threads (`shape` and `text-range` anchors) alive across their shape's
- * lifecycle:
+ * Keep shape-anchored threads alive across their shape's lifecycle:
  *
  * - When the shape is deleted, the thread converts to a `point` anchor at the spot its pin last
  *   occupied, so the conversation outlives the shape instead of becoming invisible (a missing
@@ -200,7 +199,7 @@ export function registerCommentAnchorLifecycle(
 			const updates: TLCommentRecord[] = []
 			for (const thread of getCommentThreads(editor)) {
 				const anchor = thread.anchor
-				if (anchor.type !== 'shape' && anchor.type !== 'text-range') continue
+				if (anchor.type !== 'shape') continue
 				if (!movedIds.has(anchor.shapeId)) continue
 				if (thread.pageId === pageId) continue
 				rehomeThread(thread, pageId, updates)


### PR DESCRIPTION
In order to make `commenting` typecheck again, this PR finishes #9679's text-range sweep in `anchor-lifecycle.ts`. #9661 added that file (with `text-range` handled as a shape-anchor kind) while #9679 (which dropped the text-range anchor) was in flight — the two merged in the same minute with no textual conflict, so the first typecheck to see the combination failed: the union no longer has `'text-range'`, making the comparisons `TS2367` no-overlap errors.

The change is the mechanical completion of the sweep: `ShapeAnchor` narrows to the `shape` variant, and the two type guards drop their `text-range` arms. No behavior change — the text-range code paths were already unreachable once the anchor kind was removed.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn typecheck` passes at the branch tip (it fails on `commenting` today).
2. Package tests: 195 passing, unchanged.

- [x] Unit tests

### Release notes

- Fix a type error on the commenting branch from two crossing PRs (#9661, #9679).
