### PR TITLE
fix(commenting): break comment ordering ties on id

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -1,4 +1,5 @@
 import { extractMentionIds } from '@tldraw/dotcom-shared'
+import { sortByCreatedAt } from '@tldraw/utils'
 
 /**
  * Why a comment shows up in a user's notifications feed:
@@ -89,5 +90,6 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 		notifications.push({ comment, reasons, primaryReason })
 	}
 
-	return notifications.sort((a, b) => b.comment.createdAt - a.comment.createdAt)
+	// Newest first, ties broken on comment id so the feed reads the same on every device.
+	return notifications.sort((a, b) => sortByCreatedAt(b.comment, a.comment))
 }

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -1,9 +1,11 @@
 import { type CommentAuthor } from '@tldraw/mentions'
+import { sortByCreatedAt } from '@tldraw/utils'
 import { ReactNode, useCallback, useRef } from 'react'
 import { createPortal } from 'react-dom'
 import {
 	TLComment,
 	TLCommentId,
+	TLCommentThread,
 	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
@@ -85,6 +87,14 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 		(thread) => !filters.onlyCurrentPage || thread.pageId === currentPageId
 	)
 
+	// A thread sorts by its first comment's timestamp (the conversation's start), falling back to
+	// the thread's own for a thread whose comments haven't synced in yet. Paired with the thread id
+	// so `sortByCreatedAt` can break ties the same way on every peer.
+	const threadSortKey = (thread: TLCommentThread) => ({
+		id: thread.id,
+		createdAt: (byThread.get(thread.id)?.[0] ?? thread).createdAt,
+	})
+
 	const items: CommentListItemProps[] = pageThreads
 		.filter((thread) => filters.showResolved || thread.resolved == null)
 		// "Only mine" is ignored without a known user — otherwise a persisted onlyMine=true would
@@ -100,6 +110,11 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				isCommentUnread === undefined ||
 				(byThread.get(thread.id) ?? []).some((c) => isCommentUnread(c.id))
 		)
+		// unresolved first, then most-recent first
+		.sort((a, b) => {
+			if ((a.resolved != null) !== (b.resolved != null)) return a.resolved != null ? 1 : -1
+			return sortByCreatedAt(threadSortKey(b), threadSortKey(a))
+		})
 		.map((thread) => {
 			const threadComments = byThread.get(thread.id) ?? []
 			const first = threadComments[0]
@@ -128,11 +143,6 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				count: threadComments.length,
 				selected: openId === thread.id,
 			}
-		})
-		// unresolved first, then most-recent first
-		.sort((a, b) => {
-			if (!!a.resolved !== !!b.resolved) return a.resolved ? 1 : -1
-			return b.date.localeCompare(a.date)
 		})
 
 	const focus = (id: string) => {

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -5,7 +5,6 @@ import { createPortal } from 'react-dom'
 import {
 	TLComment,
 	TLCommentId,
-	TLCommentThread,
 	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
@@ -88,12 +87,14 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 	)
 
 	// A thread sorts by its first comment's timestamp (the conversation's start), falling back to
-	// the thread's own for a thread whose comments haven't synced in yet. Paired with the thread id
-	// so `sortByCreatedAt` can break ties the same way on every peer.
-	const threadSortKey = (thread: TLCommentThread) => ({
-		id: thread.id,
-		createdAt: (byThread.get(thread.id)?.[0] ?? thread).createdAt,
-	})
+	// the thread's own for a thread whose comments haven't synced in yet. Keyed by thread id so
+	// `sortByCreatedAt` breaks ties the same way on every peer.
+	const sortKeys = new Map(
+		pageThreads.map((thread) => [
+			thread.id,
+			{ id: thread.id, createdAt: (byThread.get(thread.id)?.[0] ?? thread).createdAt },
+		])
+	)
 
 	const items: CommentListItemProps[] = pageThreads
 		.filter((thread) => filters.showResolved || thread.resolved == null)
@@ -113,7 +114,7 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 		// unresolved first, then most-recent first
 		.sort((a, b) => {
 			if ((a.resolved != null) !== (b.resolved != null)) return a.resolved != null ? 1 : -1
-			return sortByCreatedAt(threadSortKey(b), threadSortKey(a))
+			return sortByCreatedAt(sortKeys.get(b.id)!, sortKeys.get(a.id)!)
 		})
 		.map((thread) => {
 			const threadComments = byThread.get(thread.id) ?? []

--- a/packages/commenting/src/canvas/hooks.ts
+++ b/packages/commenting/src/canvas/hooks.ts
@@ -21,5 +21,7 @@ export function useThreadComments(editor: Editor, threadId: TLCommentThreadId): 
 
 /** Every comment in the store, oldest first, reactively. Group by `threadId` for per-thread lists. @public */
 export function useComments(editor: Editor): TLComment[] {
-	return useValue('all comments', () => getComments(editor).sort(sortByCreatedAt), [editor])
+	// Copy before sorting: `getComments` returns the store query's memoized array, and sorting it in
+	// place both reorders it for every other reader and defeats the query's shallow-equality check.
+	return useValue('all comments', () => [...getComments(editor)].sort(sortByCreatedAt), [editor])
 }

--- a/packages/commenting/src/canvas/hooks.ts
+++ b/packages/commenting/src/canvas/hooks.ts
@@ -1,3 +1,4 @@
+import { sortByCreatedAt } from '@tldraw/utils'
 import { Editor, TLComment, TLCommentThread, TLCommentThreadId, useValue } from 'tldraw'
 import { getComments, getCommentThreads } from './comment-store'
 
@@ -13,16 +14,12 @@ export function useThreadComments(editor: Editor, threadId: TLCommentThreadId): 
 		() =>
 			getComments(editor)
 				.filter((c) => c.threadId === threadId)
-				.sort((a, b) => a.createdAt - b.createdAt),
+				.sort(sortByCreatedAt),
 		[editor, threadId]
 	)
 }
 
 /** Every comment in the store, oldest first, reactively. Group by `threadId` for per-thread lists. @public */
 export function useComments(editor: Editor): TLComment[] {
-	return useValue(
-		'all comments',
-		() => getComments(editor).sort((a, b) => a.createdAt - b.createdAt),
-		[editor]
-	)
+	return useValue('all comments', () => getComments(editor).sort(sortByCreatedAt), [editor])
 }

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -113,6 +113,10 @@ export const queries = defineQueries({
 			// on userId); absent (for others' comments) = unread
 			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
 			.orderBy('createdAt', 'desc')
+			// Timestamps are client-supplied wall-clock, so ties are reachable. Without a second key
+			// the tied rows order arbitrarily — and at the LIMIT boundary that decides which of them
+			// syncs at all, so the same account could see a different feed on each refresh.
+			.orderBy('id', 'desc')
 			.limit(RECENT_COMMENTS_LIMIT)
 	),
 

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -113,10 +113,12 @@ export const queries = defineQueries({
 			// on userId); absent (for others' comments) = unread
 			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
 			.orderBy('createdAt', 'desc')
-			// Timestamps are client-supplied wall-clock, so ties are reachable. Without a second key
-			// the tied rows order arbitrarily — and at the LIMIT boundary that decides which of them
-			// syncs at all, so the same account could see a different feed on each refresh.
-			.orderBy('id', 'desc')
+			// Timestamps are client-supplied wall-clock, so ties are reachable, and a tie at the
+			// LIMIT boundary decides which rows sync at all. Real Zero already completes the ordering
+			// with the primary key, but the local polyfill sorts the raw AST `orderBy` (see
+			// applyOrderBy in tla/app/ast-helpers.ts) and would leave ties to input order. Stated
+			// explicitly, and `asc` to match what Zero appends, so both paths agree.
+			.orderBy('id', 'asc')
 			.limit(RECENT_COMMENTS_LIMIT)
 	),
 

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -487,6 +487,12 @@ export function setInSessionStorage(key: string, value: string): void;
 export function sleep(ms: number): Promise<void>;
 
 // @public
+export function sortByCreatedAt<T extends {
+    createdAt: number;
+    id: any;
+}>(a: T, b: T): number;
+
+// @public
 export function sortById<T extends {
     id: any;
 }>(a: T, b: T): -1 | 1;

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -490,7 +490,7 @@ export function sleep(ms: number): Promise<void>;
 export function sortByCreatedAt<T extends {
     createdAt: number;
     id: any;
-}>(a: T, b: T): number;
+}>(a: T, b: T): -1 | 0 | 1;
 
 // @public
 export function sortById<T extends {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -80,7 +80,7 @@ export {
 	type IndexKey,
 } from './lib/reordering'
 export { retry } from './lib/retry'
-export { sortById } from './lib/sort'
+export { sortByCreatedAt, sortById } from './lib/sort'
 export {
 	clearLocalStorage,
 	clearSessionStorage,

--- a/packages/utils/src/lib/sort.test.ts
+++ b/packages/utils/src/lib/sort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { sortById } from './sort'
+import { sortByCreatedAt, sortById } from './sort'
 
 describe('sortById', () => {
 	it('sorts objects with string ids in ascending order', () => {
@@ -32,5 +32,51 @@ describe('sortById', () => {
 			{ id: 2, label: 'two' },
 			{ id: 3, label: 'three' },
 		])
+	})
+})
+
+describe('sortByCreatedAt', () => {
+	it('sorts oldest first', () => {
+		const items = [
+			{ id: 'a', createdAt: 300 },
+			{ id: 'b', createdAt: 100 },
+			{ id: 'c', createdAt: 200 },
+		]
+
+		expect(items.sort(sortByCreatedAt)).toEqual([
+			{ id: 'b', createdAt: 100 },
+			{ id: 'c', createdAt: 200 },
+			{ id: 'a', createdAt: 300 },
+		])
+	})
+
+	it('breaks ties on id', () => {
+		const items = [
+			{ id: 'c', createdAt: 100 },
+			{ id: 'a', createdAt: 100 },
+			{ id: 'b', createdAt: 100 },
+		]
+
+		expect(items.sort(sortByCreatedAt)).toEqual([
+			{ id: 'a', createdAt: 100 },
+			{ id: 'b', createdAt: 100 },
+			{ id: 'c', createdAt: 100 },
+		])
+	})
+
+	it('gives the same order regardless of input order', () => {
+		const tied = [
+			{ id: 'comment:x', createdAt: 100 },
+			{ id: 'comment:y', createdAt: 100 },
+			{ id: 'comment:z', createdAt: 100 },
+		]
+
+		expect([...tied].sort(sortByCreatedAt)).toEqual([...tied].reverse().sort(sortByCreatedAt))
+	})
+
+	it('returns 0 only when both fields match', () => {
+		expect(sortByCreatedAt({ id: 'a', createdAt: 1 }, { id: 'a', createdAt: 1 })).toBe(0)
+		expect(sortByCreatedAt({ id: 'a', createdAt: 1 }, { id: 'b', createdAt: 1 })).toBeLessThan(0)
+		expect(sortByCreatedAt({ id: 'b', createdAt: 1 }, { id: 'a', createdAt: 2 })).toBeLessThan(0)
 	})
 })

--- a/packages/utils/src/lib/sort.test.ts
+++ b/packages/utils/src/lib/sort.test.ts
@@ -77,6 +77,40 @@ describe('sortByCreatedAt', () => {
 	it('returns 0 only when both fields match', () => {
 		expect(sortByCreatedAt({ id: 'a', createdAt: 1 }, { id: 'a', createdAt: 1 })).toBe(0)
 		expect(sortByCreatedAt({ id: 'a', createdAt: 1 }, { id: 'b', createdAt: 1 })).toBeLessThan(0)
+		expect(sortByCreatedAt({ id: 'b', createdAt: 1 }, { id: 'a', createdAt: 1 })).toBeGreaterThan(0)
 		expect(sortByCreatedAt({ id: 'b', createdAt: 1 }, { id: 'a', createdAt: 2 })).toBeLessThan(0)
+		expect(sortByCreatedAt({ id: 'a', createdAt: 2 }, { id: 'b', createdAt: 1 })).toBeGreaterThan(0)
+	})
+
+	it('reverses cleanly for newest-first, ties included', () => {
+		const items = [
+			{ id: 'b', createdAt: 100 },
+			{ id: 'c', createdAt: 200 },
+			{ id: 'a', createdAt: 100 },
+		]
+
+		expect([...items].sort((a, b) => sortByCreatedAt(b, a))).toEqual([
+			{ id: 'c', createdAt: 200 },
+			{ id: 'b', createdAt: 100 },
+			{ id: 'a', createdAt: 100 },
+		])
+	})
+
+	it('stays total when a timestamp is not a number', () => {
+		// A NaN timestamp makes every relational comparison false; the id has to carry the order,
+		// or the comparator returns NaN and the sort result becomes implementation-defined.
+		expect(sortByCreatedAt({ id: 'a', createdAt: NaN }, { id: 'b', createdAt: NaN })).toBeLessThan(
+			0
+		)
+		expect(
+			sortByCreatedAt({ id: 'b', createdAt: NaN }, { id: 'a', createdAt: NaN })
+		).toBeGreaterThan(0)
+
+		const tied = [
+			{ id: 'x', createdAt: NaN },
+			{ id: 'y', createdAt: NaN },
+			{ id: 'z', createdAt: NaN },
+		]
+		expect([...tied].sort(sortByCreatedAt)).toEqual([...tied].reverse().sort(sortByCreatedAt))
 	})
 })

--- a/packages/utils/src/lib/sort.ts
+++ b/packages/utils/src/lib/sort.ts
@@ -41,8 +41,7 @@ export function sortById<T extends { id: any }>(a: T, b: T) {
  *
  * @param a - First record to compare
  * @param b - Second record to compare
- * @returns A negative number if a sorts first, a positive number if b does, 0 only when both
- * `createdAt` and `id` match
+ * @returns -1 if a sorts first, 1 if b does, 0 only when both `createdAt` and `id` match
  *
  * @example
  * ```ts
@@ -59,7 +58,10 @@ export function sortById<T extends { id: any }>(a: T, b: T) {
  * @public
  */
 export function sortByCreatedAt<T extends { createdAt: number; id: any }>(a: T, b: T) {
-	if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt
+	// Relational comparisons rather than subtraction so a NaN timestamp falls through to the id
+	// instead of returning NaN, which would make the comparator non-total.
+	if (a.createdAt < b.createdAt) return -1
+	if (a.createdAt > b.createdAt) return 1
 	if (a.id === b.id) return 0
 	return a.id > b.id ? 1 : -1
 }

--- a/packages/utils/src/lib/sort.ts
+++ b/packages/utils/src/lib/sort.ts
@@ -23,3 +23,43 @@
 export function sortById<T extends { id: any }>(a: T, b: T) {
 	return a.id > b.id ? 1 : -1
 }
+
+/**
+ * Compares two records by their `createdAt` timestamp for use with Array.sort(), oldest first,
+ * breaking ties on `id`.
+ *
+ * The tie-break is what makes this worth reaching for over a bare `a.createdAt - b.createdAt`.
+ * Timestamps are usually millisecond wall-clock from whichever client created the record, so
+ * collisions are reachable — a batch created in one tick, a seeded or imported set, a skewed
+ * clock. `Array.prototype.sort` is stable, so a comparator that returns 0 for a tie leaves those
+ * records in whatever order the input array happened to be in; for records read out of a store
+ * that's insertion order into the query index, which differs between peers and changes when a
+ * record is removed and re-added. Falling back to `id` gives every peer the same total order.
+ *
+ * The order within a tie is arbitrary (ids are not time-ordered) — the point is that it's the
+ * same everywhere. For newest-first, swap the arguments: `(a, b) => sortByCreatedAt(b, a)`.
+ *
+ * @param a - First record to compare
+ * @param b - Second record to compare
+ * @returns A negative number if a sorts first, a positive number if b does, 0 only when both
+ * `createdAt` and `id` match
+ *
+ * @example
+ * ```ts
+ * const messages = [
+ *   { id: 'b', createdAt: 100 },
+ *   { id: 'c', createdAt: 50 },
+ *   { id: 'a', createdAt: 100 },
+ * ]
+ *
+ * const sorted = messages.sort(sortByCreatedAt)
+ * // [{ id: 'c', createdAt: 50 }, { id: 'a', createdAt: 100 }, { id: 'b', createdAt: 100 }]
+ * ```
+ *
+ * @public
+ */
+export function sortByCreatedAt<T extends { createdAt: number; id: any }>(a: T, b: T) {
+	if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt
+	if (a.id === b.id) return 0
+	return a.id > b.id ? 1 : -1
+}


### PR DESCRIPTION
🙇‍♂️ Tiny one. We have a bunch of places where we sort based on some property that may be duplicated, so this adds a little deterministic backup for tie breaking (using the id of the item).

---

In order to keep a thread's replies in the same order for everyone reading it, this gives comment ordering a tie-break.

Comment ordering sorted on `createdAt` alone. `createdAt` is client-supplied wall-clock (`createComment` uses `props.now ?? Date.now()`, and nothing stamps it server-side), so ties are reachable — a seeded or imported batch, a scripted burst, a skewed clock. `Array.prototype.sort` is stable, so a tie left the records in whatever order the input array already had. For records read out of the store that's insertion order into the query index, which differs between peers and moves a record to the end when it's removed and re-added — which the anchor lifecycle does routinely, on undo of a delete and on the re-create half of a page move.

`sortByCreatedAt` in `@tldraw/utils` falls back to `id`. Ids aren't time-ordered, so the order within a tie is arbitrary — the point is that it's the same arbitrary order everywhere. It sits next to the existing `sortById` and uses relational comparisons rather than subtraction, so a non-numeric timestamp falls through to the id instead of returning `NaN` and making the comparator non-total.

Two things worth a reviewer's attention:

**The sidebar sort moved off display strings.** It sorted the mapped `CommentListItemProps`, whose `date` is a preformatted ISO string, so the tie-break would have had to key off rendered text. It now sorts the threads before mapping, against a precomputed key of `(first comment ?? thread).createdAt`. Same ordering as before — resolved last, then newest first.

**The Zero query change is for the polyfill, not the server.** Real Zero completes every query's ordering with the primary key (`addPrimaryKeys` in `complete-ordering`), so the notifications feed was already deterministic in production. The local polyfill sorts the raw AST `orderBy` and does no such completion, so ties there fell to input order — and at the `LIMIT 50` boundary that decides which rows sync at all. The explicit `.orderBy('id', 'asc')` is `asc` deliberately, to match what Zero appends rather than diverge from it.

Also fixes an adjacent bug in a line this PR was already rewriting: `useComments` sorted the store query's memoized array in place, which reordered it for every other reader of `getComments` and defeated the query's own shallow-equality check, re-rendering consumers on unchanged data.

Not taken: `TldrawApp.ts:505` and `TlaSidebarRecentFiles.tsx:137` sort files by a `date` that falls back to `0`, so every file without a visit date ties. Same hazard, different data — worth its own PR rather than widening this one.

### Change type

- [x] `bugfix`

### Test plan

1. Open a board with several comment threads and the comments sidebar.
2. Confirm thread and reply order is unchanged, and identical across two browsers on the same board.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix comment and reply ordering being inconsistent between collaborators when two comments share a timestamp.

### API changes

- Added `sortByCreatedAt()` to `@tldraw/utils` — sorts by `createdAt` oldest-first, breaking ties on `id`

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +70 / -12  |
| Tests           | +81 / -1   |
| Automated files | +6 / -0    |
| Apps            | +3 / -1    |