### PR TITLE
refactor(store): collapse duplicated scope, cache, and query bookkeeping

### DIFF
--- a/packages/store/api-report.api.md
+++ b/packages/store/api-report.api.md
@@ -373,7 +373,7 @@ export function squashRecordDiffs<T extends UnknownRecord>(diffs: RecordsDiff<T>
 }): RecordsDiff<T>;
 
 // @internal
-export function squashRecordDiffsMutable<T extends UnknownRecord>(target: RecordsDiff<T>, diffs: RecordsDiff<T>[]): void;
+export function squashRecordDiffsMutable<T extends UnknownRecord>(target: RecordsDiff<T>, diffs: RecordsDiff<T>[], fromIndex?: number): void;
 
 // @public
 export interface StandaloneDependsOn {

--- a/packages/store/src/lib/RecordType.ts
+++ b/packages/store/src/lib/RecordType.ts
@@ -138,7 +138,7 @@ export class RecordType<
 			id: (properties as Partial<R>).id ?? this.createId(),
 		} as any
 
-		for (const [k, v] of Object.entries(properties)) {
+		for (const [k, v] of objectMapEntries(properties)) {
 			if (v !== undefined) {
 				result[k] = v
 			}

--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -1,3 +1,4 @@
+import { objectMapValues } from '@tldraw/utils'
 import { IdOf, UnknownRecord } from './BaseRecord'
 
 /**
@@ -78,7 +79,7 @@ export function createEmptyRecordsDiff<R extends UnknownRecord>(): RecordsDiff<R
  */
 export function reverseRecordsDiff(diff: RecordsDiff<any>) {
 	const result: RecordsDiff<any> = { added: diff.removed, removed: diff.added, updated: {} }
-	for (const [from, to] of Object.values(diff.updated)) {
+	for (const [from, to] of objectMapValues(diff.updated)) {
 		result.updated[from.id] = [to, from]
 	}
 	return result
@@ -159,11 +160,14 @@ export function squashRecordDiffs<T extends UnknownRecord>(
 		mutateFirstDiff?: boolean
 	}
 ): RecordsDiff<T> {
-	const result = options?.mutateFirstDiff
-		? diffs[0]
-		: ({ added: {}, removed: {}, updated: {} } as RecordsDiff<T>)
+	if (options?.mutateFirstDiff) {
+		const result = diffs[0]
+		squashRecordDiffsMutable(result, diffs, 1)
+		return result
+	}
 
-	squashRecordDiffsMutable(result, options?.mutateFirstDiff ? diffs.slice(1) : diffs)
+	const result = { added: {}, removed: {}, updated: {} } as RecordsDiff<T>
+	squashRecordDiffsMutable(result, diffs)
 	return result
 }
 
@@ -205,7 +209,8 @@ export function squashRecordDiffs<T extends UnknownRecord>(
  */
 export function squashRecordDiffsMutable<T extends UnknownRecord>(
 	target: RecordsDiff<T>,
-	diffs: RecordsDiff<T>[]
+	diffs: RecordsDiff<T>[],
+	fromIndex = 0
 ): void {
 	// This runs on every history interceptor call — e.g. once per input tick while
 	// resizing N shapes, with N entries in diff.updated — so the updated loop must not
@@ -214,7 +219,8 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 	// know are empty. In-place tuple mutation is safe because the target exclusively
 	// owns its updated tuples: they are always created here (never shared with a source
 	// diff), and sources are never mutated.
-	for (const diff of diffs) {
+	for (let i = fromIndex; i < diffs.length; i++) {
+		const diff = diffs[i]
 		// target.removed can only lose entries before the removed loop below, so a
 		// stale `true` is harmless (extra no-op deletes).
 		const targetHasRemoved = hasAnyKey(target.removed)

--- a/packages/store/src/lib/Store.ts
+++ b/packages/store/src/lib/Store.ts
@@ -14,7 +14,7 @@ import {
 import { AtomMap } from './AtomMap'
 import { IdOf, RecordId, UnknownRecord } from './BaseRecord'
 import { devFreeze } from './devFreeze'
-import { hasAnyKey, RecordsDiff, squashRecordDiffs } from './RecordsDiff'
+import { isRecordsDiffEmpty, RecordsDiff, squashRecordDiffs } from './RecordsDiff'
 import { RecordScope } from './RecordType'
 import { StoreQueries } from './StoreQueries'
 import { SerializedSchema, StoreSchema } from './StoreSchema'
@@ -504,23 +504,15 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			},
 			{ scheduleEffect: (cb) => (this.cancelHistoryReactor = throttleToNextFrame(cb)) }
 		)
-		this.scopedTypes = {
-			document: new Set(
-				objectMapValues(this.schema.types)
-					.filter((t) => t.scope === 'document')
-					.map((t) => t.typeName)
-			),
-			session: new Set(
-				objectMapValues(this.schema.types)
-					.filter((t) => t.scope === 'session')
-					.map((t) => t.typeName)
-			),
-			presence: new Set(
-				objectMapValues(this.schema.types)
-					.filter((t) => t.scope === 'presence')
-					.map((t) => t.typeName)
-			),
+		const scopedTypes: { [K in RecordScope]: Set<R['typeName']> } = {
+			document: new Set(),
+			session: new Set(),
+			presence: new Set(),
 		}
+		for (const type of objectMapValues(this.schema.types)) {
+			scopedTypes[type.scope].add(type.typeName)
+		}
+		this.scopedTypes = scopedTypes
 	}
 
 	public _flushHistory() {
@@ -528,30 +520,23 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 		if (this.historyAccumulator.hasChanges()) {
 			const entries = this.historyAccumulator.flush()
 			for (const { changes, source } of entries) {
-				let instanceChanges = null as null | RecordsDiff<R>
-				let documentChanges = null as null | RecordsDiff<R>
-				let presenceChanges = null as null | RecordsDiff<R>
+				// Filtered diffs are computed at most once per scope per entry, and shared by every
+				// listener watching that scope.
+				const scopedChanges = new Map<RecordScope, RecordsDiff<R> | null>()
 				for (const { onHistory, filters } of this.listeners) {
 					if (filters.source !== 'all' && filters.source !== source) {
 						continue
 					}
-					if (filters.scope !== 'all') {
-						if (filters.scope === 'document') {
-							documentChanges ??= this.filterChangesByScope(changes, 'document')
-							if (!documentChanges) continue
-							onHistory({ changes: documentChanges, source })
-						} else if (filters.scope === 'session') {
-							instanceChanges ??= this.filterChangesByScope(changes, 'session')
-							if (!instanceChanges) continue
-							onHistory({ changes: instanceChanges, source })
-						} else {
-							presenceChanges ??= this.filterChangesByScope(changes, 'presence')
-							if (!presenceChanges) continue
-							onHistory({ changes: presenceChanges, source })
-						}
-					} else {
+					if (filters.scope === 'all') {
 						onHistory({ changes, source })
+						continue
 					}
+					if (!scopedChanges.has(filters.scope)) {
+						scopedChanges.set(filters.scope, this.filterChangesByScope(changes, filters.scope))
+					}
+					const filtered = scopedChanges.get(filters.scope)
+					if (!filtered) continue
+					onHistory({ changes: filtered, source })
 				}
 			}
 		}
@@ -573,7 +558,7 @@ export class Store<R extends UnknownRecord = UnknownRecord, Props = unknown> {
 			updated: filterEntries(change.updated, (_, r) => this.scopedTypes[scope].has(r[1].typeName)),
 			removed: filterEntries(change.removed, (_, r) => this.scopedTypes[scope].has(r.typeName)),
 		}
-		if (!hasAnyKey(result.added) && !hasAnyKey(result.updated) && !hasAnyKey(result.removed)) {
+		if (isRecordsDiffEmpty(result)) {
 			return null
 		}
 		return result

--- a/packages/store/src/lib/StoreQueries.ts
+++ b/packages/store/src/lib/StoreQueries.ts
@@ -12,7 +12,7 @@ import { AtomMap } from './AtomMap'
 import { IdOf, UnknownRecord } from './BaseRecord'
 import { executeQuery, objectMatchesQuery, QueryExpression } from './executeQuery'
 import { IncrementalSetConstructor } from './IncrementalSetConstructor'
-import { RecordsDiff } from './RecordsDiff'
+import { hasAnyKey, RecordsDiff } from './RecordsDiff'
 import { diffSets } from './setUtils'
 import { CollectionDiff } from './Store'
 
@@ -470,7 +470,7 @@ export class StoreQueries<R extends UnknownRecord> {
 	record<TypeName extends R['typeName']>(
 		typeName: TypeName,
 		queryCreator: () => QueryExpression<Extract<R, { typeName: TypeName }>> = () => ({}),
-		name = 'record:' + typeName + (queryCreator ? ':' + queryCreator.toString() : '')
+		name = 'record:' + typeName + ':' + queryCreator.toString()
 	): Computed<Extract<R, { typeName: TypeName }> | undefined> {
 		type S = Extract<R, { typeName: TypeName }>
 		const ids = this.ids(typeName, queryCreator, name)
@@ -510,7 +510,7 @@ export class StoreQueries<R extends UnknownRecord> {
 	records<TypeName extends R['typeName']>(
 		typeName: TypeName,
 		queryCreator: () => QueryExpression<Extract<R, { typeName: TypeName }>> = () => ({}),
-		name = 'records:' + typeName + (queryCreator ? ':' + queryCreator.toString() : '')
+		name = 'records:' + typeName + ':' + queryCreator.toString()
 	): Computed<Array<Extract<R, { typeName: TypeName }>>> {
 		type S = Extract<R, { typeName: TypeName }>
 		const ids = this.ids(typeName, queryCreator, 'ids:' + name)
@@ -554,7 +554,7 @@ export class StoreQueries<R extends UnknownRecord> {
 	ids<TypeName extends R['typeName']>(
 		typeName: TypeName,
 		queryCreator: () => QueryExpression<Extract<R, { typeName: TypeName }>> = () => ({}),
-		name = 'ids:' + typeName + (queryCreator ? ':' + queryCreator.toString() : '')
+		name = 'ids:' + typeName + ':' + queryCreator.toString()
 	): Computed<
 		Set<IdOf<Extract<R, { typeName: TypeName }>>>,
 		CollectionDiff<IdOf<Extract<R, { typeName: TypeName }>>>
@@ -567,7 +567,7 @@ export class StoreQueries<R extends UnknownRecord> {
 			// deref type history early to allow first incremental update to use diffs
 			typeHistory.get()
 			const query: QueryExpression<S> = queryCreator()
-			if (Object.keys(query).length === 0) {
+			if (!hasAnyKey(query)) {
 				return this.getAllIdsForType(typeName)
 			}
 

--- a/packages/store/src/lib/StoreSchema.ts
+++ b/packages/store/src/lib/StoreSchema.ts
@@ -423,16 +423,21 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 	 * @public
 	 */
 	public getMigrationsSince(persistedSchema: SerializedSchema): Result<Migration[], string> {
-		// Check cache first
+		// Every result — success, empty, or error — is cached, so cache once around the whole
+		// computation rather than at each of its exit points.
 		const cached = this.migrationCache.get(persistedSchema)
 		if (cached) {
 			return cached
 		}
 
+		const result = this.computeMigrationsSince(persistedSchema)
+		this.migrationCache.set(persistedSchema, result)
+		return result
+	}
+
+	private computeMigrationsSince(persistedSchema: SerializedSchema): Result<Migration[], string> {
 		const upgradeResult = upgradeSchema(persistedSchema)
 		if (!upgradeResult.ok) {
-			// Cache the error result
-			this.migrationCache.set(persistedSchema, upgradeResult)
 			return upgradeResult
 		}
 		const schema = upgradeResult.value
@@ -449,10 +454,7 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 
 		if (sequenceIdsToInclude.size === 0) {
-			const result = Result.ok([])
-			// Cache the empty result
-			this.migrationCache.set(persistedSchema, result)
-			return result
+			return Result.ok([])
 		}
 
 		const allMigrationsToInclude = new Set<MigrationId>()
@@ -471,10 +473,7 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 			const idx = this.migrations[sequenceId].sequence.findIndex((m) => m.id === theirVersionId)
 			// todo: better error handling
 			if (idx === -1) {
-				const result = Result.err('Incompatible schema?')
-				// Cache the error result
-				this.migrationCache.set(persistedSchema, result)
-				return result
+				return Result.err('Incompatible schema?')
 			}
 			for (const migration of this.migrations[sequenceId].sequence.slice(idx + 1)) {
 				allMigrationsToInclude.add(migration.id)
@@ -482,12 +481,7 @@ export class StoreSchema<R extends UnknownRecord, P = unknown> {
 		}
 
 		// collect any migrations
-		const result = Result.ok(
-			this.sortedMigrations.filter(({ id }) => allMigrationsToInclude.has(id))
-		)
-		// Cache the result
-		this.migrationCache.set(persistedSchema, result)
-		return result
+		return Result.ok(this.sortedMigrations.filter(({ id }) => allMigrationsToInclude.has(id)))
 	}
 
 	/**

--- a/packages/store/src/lib/executeQuery.ts
+++ b/packages/store/src/lib/executeQuery.ts
@@ -1,3 +1,4 @@
+import { objectMapFromEntries, objectMapValues } from '@tldraw/utils'
 import { IdOf, UnknownRecord } from './BaseRecord'
 import { intersectSets } from './setUtils'
 import { StoreQueries } from './StoreQueries'
@@ -147,7 +148,9 @@ export function executeQuery<R extends UnknownRecord, TypeName extends R['typeNa
 	const matcherPaths = extractMatcherPaths(query)
 
 	// Build a set of matching IDs for each path
-	const matchIds = Object.fromEntries(matcherPaths.map(({ path }) => [path, new Set<IdOf<S>>()]))
+	const matchIds = objectMapFromEntries(
+		matcherPaths.map(({ path }) => [path, new Set<IdOf<S>>()] as const)
+	)
 
 	// For each path, use the index to find matching IDs
 	for (const { path, matcher } of matcherPaths) {
@@ -185,5 +188,5 @@ export function executeQuery<R extends UnknownRecord, TypeName extends R['typeNa
 	}
 
 	// Intersect all the match sets
-	return intersectSets(Object.values(matchIds)) as Set<IdOf<S>>
+	return intersectSets(objectMapValues(matchIds)) as Set<IdOf<S>>
 }

--- a/packages/store/src/lib/migrate.ts
+++ b/packages/store/src/lib/migrate.ts
@@ -100,6 +100,8 @@ export function createMigrationIds<
 	const ID extends string,
 	const Versions extends Record<string, number>,
 >(sequenceId: ID, versions: Versions): { [K in keyof Versions]: `${ID}/${Versions[K]}` } {
+	// Note: not objectMapFromEntries — `keyof Versions` is not narrowed to `string`, which that
+	// helper requires.
 	return Object.fromEntries(
 		objectMapEntries(versions).map(([key, version]) => [key, `${sequenceId}/${version}`] as const)
 	) as any
@@ -132,18 +134,12 @@ export function createRecordMigrationSequence(opts: {
 	return createMigrationSequence({
 		sequenceId,
 		retroactive: opts.retroactive ?? true,
-		sequence: opts.sequence.map((m) =>
-			'id' in m
-				? {
-						...m,
-						scope: 'record',
-						filter: (r: UnknownRecord) =>
-							r.typeName === opts.recordType &&
-							(m.filter?.(r) ?? true) &&
-							(opts.filter?.(r) ?? true),
-					}
-				: m
-		),
+		sequence: opts.sequence.map((m) => ({
+			...m,
+			scope: 'record',
+			filter: (r: UnknownRecord) =>
+				r.typeName === opts.recordType && (m.filter?.(r) ?? true) && (opts.filter?.(r) ?? true),
+		})),
 	})
 }
 


### PR DESCRIPTION
A quality pass over `packages/store` looking for repeated code, dead branches, and work done more than once. No behaviour changes — everything here is the same logic written once instead of three or four times.

The two worth a reviewer's attention:

`StoreSchema.getMigrationsSince` repeated `migrationCache.set(...); return ...` at four separate exit points, so adding an early return meant remembering to cache it too. Caching now happens once in the public method, wrapping a `computeMigrationsSince` body that just returns results.

`Store._flushHistory` had three near-identical branches, one per scope. Beyond the duplication, the `session` branch cached into a local called `instanceChanges`, which is the old name for that scope and reads like a fourth, different thing. It's now a `Map<RecordScope, ...>` — still computing each filtered diff at most once per history entry, still skipping listeners whose filtered diff is empty.

The rest is smaller: `scopedTypes` walked every schema type three times; `filterChangesByScope` re-inlined the exact expression `isRecordsDiffEmpty` already provides; `squashRecordDiffs` allocated a `slice(1)` on every in-place squash, which per the note on `squashRecordDiffsMutable` runs once per input tick while resizing shapes; an always-true `queryCreator` ternary in three `StoreQueries` methods; and an unreachable `'id' in m` branch in `createRecordMigrationSequence`, whose parameter type is record-scoped migrations that always carry an `id`.

One thing I deliberately left alone: `StoreQueries.filterHistory` genuinely duplicates the add/update/remove squashing rules from `squashRecordDiffsMutable`. Folding them together is a real refactor of a per-frame incremental path with its own allocation constraints, not a cleanup, so it wants its own PR.

### Change type

- [x] `improvement`

### Test plan

Existing coverage should be sufficient — this PR should not change any observable behaviour.

- Store unit tests (451), editor (840), and tldraw (2729) all pass unchanged
- `yarn typecheck` and `yarn api-check` pass

### API changes

- Changed `squashRecordDiffsMutable()` (`@internal`) to accept an optional `fromIndex` parameter, so callers reusing the first diff don't have to allocate a sliced copy

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +64 / -80  |
| Automated files | +1 / -1    |
