### PR TITLE
refactor(state): remove duplicate parent scan and redundant epoch reads

### DIFF
--- a/packages/state/src/lib/Atom.ts
+++ b/packages/state/src/lib/Atom.ts
@@ -163,22 +163,23 @@ class __Atom__<Value, Diff = unknown> implements Atom<Value, Diff> {
 			return this.current
 		}
 
-		// Tick forward the global epoch
+		// Tick forward the global epoch. This write belongs to that one epoch, so read it once and
+		// use it everywhere below — otherwise a `computeDiff` that touches other atoms could leave
+		// the history entry and `lastChangedEpoch` disagreeing.
 		advanceGlobalEpoch()
+		const epoch = getGlobalEpoch()
 
 		// Add the diff to the history buffer.
 		if (this.historyBuffer) {
 			this.historyBuffer.pushEntry(
 				this.lastChangedEpoch,
-				getGlobalEpoch(),
-				diff ??
-					this.computeDiff?.(this.current, value, this.lastChangedEpoch, getGlobalEpoch()) ??
-					RESET_VALUE
+				epoch,
+				diff ?? this.computeDiff?.(this.current, value, this.lastChangedEpoch, epoch) ?? RESET_VALUE
 			)
 		}
 
 		// Update the atom's record of the epoch when last changed.
-		this.lastChangedEpoch = getGlobalEpoch()
+		this.lastChangedEpoch = epoch
 
 		const oldValue = this.current
 		this.current = value

--- a/packages/state/src/lib/Computed.ts
+++ b/packages/state/src/lib/Computed.ts
@@ -294,31 +294,35 @@ class __UNSAFE__Computed<Value, Diff = unknown> implements Computed<Value, Diff>
 			const result = this.derive(this.state, this.lastCheckedEpoch)
 			const newState = result instanceof WithDiff ? result.value : result
 			const isUninitialized = this.state === UNINITIALIZED
+			// `derive` may have advanced the epoch, so re-read it here, but only once — the whole
+			// commit below belongs to a single epoch.
+			const epoch = getGlobalEpoch()
 			if (isUninitialized || !this.isEqual(this.state, newState)) {
 				if (this.historyBuffer && !isUninitialized) {
 					const diff = result instanceof WithDiff ? result.diff : undefined
 					this.historyBuffer.pushEntry(
 						this.lastChangedEpoch,
-						getGlobalEpoch(),
+						epoch,
 						diff ??
-							this.computeDiff?.(this.state, newState, this.lastCheckedEpoch, getGlobalEpoch()) ??
+							this.computeDiff?.(this.state, newState, this.lastCheckedEpoch, epoch) ??
 							RESET_VALUE
 					)
 				}
-				this.lastChangedEpoch = getGlobalEpoch()
+				this.lastChangedEpoch = epoch
 				this.state = newState
 			}
 			this.error = null
-			this.lastCheckedEpoch = getGlobalEpoch()
+			this.lastCheckedEpoch = epoch
 
 			return this.state
 		} catch (e) {
 			// if a derived value throws an error, we reset the state to UNINITIALIZED
+			const epoch = getGlobalEpoch()
 			if (this.state !== UNINITIALIZED) {
 				this.state = UNINITIALIZED as unknown as Value
-				this.lastChangedEpoch = getGlobalEpoch()
+				this.lastChangedEpoch = epoch
 			}
-			this.lastCheckedEpoch = getGlobalEpoch()
+			this.lastCheckedEpoch = epoch
 			// we also clear the history buffer if an error was thrown
 			if (this.historyBuffer) {
 				this.historyBuffer.clear()

--- a/packages/state/src/lib/capture.ts
+++ b/packages/state/src/lib/capture.ts
@@ -149,17 +149,17 @@ export function stopCapturingParents() {
  */
 export function maybeCaptureParent(p: Signal<any, any>) {
 	if (inst.stack) {
-		const wasCapturedAlready = inst.stack.child.parentSet.has(p)
 		// if the child didn't deref this parent last time it executed, then idx will be -1
 		// if the child did deref this parent last time but in a different order relative to other parents, then idx will be greater than stack.offset
 		// if the child did deref this parent last time in the same order, then idx will be the same as stack.offset
 		// if the child did deref this parent already during this capture session then 0 <= idx < stack.offset
 
-		if (wasCapturedAlready) {
+		// `add` returns false when the parent was already captured. In array mode both `has` and
+		// `add` scan with indexOf, so going straight to `add` halves the scans per captured parent.
+		if (!inst.stack.child.parentSet.add(p)) {
 			return
 		}
 
-		inst.stack.child.parentSet.add(p)
 		if (inst.stack.child.isActivelyListening) {
 			attach(p, inst.stack.child)
 		}

--- a/packages/state/src/lib/warnings.ts
+++ b/packages/state/src/lib/warnings.ts
@@ -1,10 +1,4 @@
-/**
- * Flag to track whether the computed getter deprecation warning has already been shown.
- * Prevents the same warning from being logged multiple times during application runtime.
- *
- * @internal
- */
-let didWarnComputedGetter = false
+import { warnOnce } from '@tldraw/utils'
 
 /**
  * Logs a deprecation warning for the deprecated `@computed` getter decorator syntax.
@@ -37,9 +31,7 @@ let didWarnComputedGetter = false
  * @internal
  */
 export function logComputedGetterWarning() {
-	if (didWarnComputedGetter) return
-	didWarnComputedGetter = true
-	console.warn(
+	warnOnce(
 		`Using \`@computed\` as a decorator for getters is deprecated and will be removed in the near future. Please refactor to use \`@computed\` as a decorator for methods.
 
 // Before


### PR DESCRIPTION
A quality pass over `packages/state` looking for duplicated work. No behaviour changes.

The one that matters is in `maybeCaptureParent`, which runs on every `.get()` inside a computed or effect. It called `parentSet.has(p)` and then `parentSet.add(p)`. In `ArraySet`'s array mode — which is the common case, up to the size threshold — both of those scan with `indexOf`, and `add` already returns `false` when the element is present. So every newly captured parent paid two linear scans where one would do. It now goes straight to `add` and branches on the return value.

`Atom.set` and `Computed.__unsafe__getWithoutCapture` each called `getGlobalEpoch()` three or four times while committing a single change. That's cheap in itself, but it means a user-supplied `computeDiff` that touches other atoms mid-commit can advance the epoch between reads, leaving the history entry stamped with one epoch and `lastChangedEpoch` with a later one. Reading once per commit ties the whole commit to a single epoch.

I left the same pattern in `EffectScheduler.maybeScheduleEffect` alone: the second read there is after `haveParentsChanged()`, which derefs parents and so can legitimately advance the epoch. Hoisting it would be a behaviour change, not a cleanup.

Lastly, `warnings.ts` hand-rolled a warn-once flag; it now uses `warnOnce` from `@tldraw/utils`. Note this adds the standard `[tldraw]` prefix to the `@computed`-on-getter deprecation message.

### Change type

- [x] `improvement`

### Test plan

Existing coverage should be sufficient — this PR should not change any observable behaviour.

- State unit tests (193), editor (840), and tldraw (2729) all pass unchanged
- `yarn typecheck` and `yarn api-check` pass

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +22 / -25  |
