### PR TITLE
fix(editor): end stuck pans when the pointerup was missed

### DIFF
--- a/packages/editor/src/lib/components/MenuClickCapture.tsx
+++ b/packages/editor/src/lib/components/MenuClickCapture.tsx
@@ -1,7 +1,11 @@
 import { useValue } from '@tldraw/state-react'
 import { type PointerEvent, useCallback, useEffect, useRef, useState } from 'react'
 import { flushSync } from 'react-dom'
-import { useCanvasEvents } from '../hooks/useCanvasEvents'
+import {
+	consumeRecoveredPointerUp,
+	isButtonStillDown,
+	useCanvasEvents,
+} from '../hooks/useCanvasEvents'
 import { useEditor } from '../hooks/useEditor'
 import { Vec } from '../primitives/Vec'
 import { releasePointerCapture, setPointerCapture } from '../utils/dom'
@@ -111,6 +115,25 @@ export function MenuClickCapture() {
 			const state = rPointerState.current
 			if (!state.isDown) return
 
+			// The tracked button is no longer down: its pointerup was missed. Don't
+			// dispatch this move (it would drag the camera to the re-entry point);
+			// left unmarked, the event reaches the document-level stale-button
+			// recovery in useCanvasEvents, which ends the gesture.
+			if (
+				e.pointerType === 'mouse' &&
+				typeof e.buttons === 'number' &&
+				!isButtonStillDown(state.button, e.buttons)
+			) {
+				setIsPointing(false)
+				rPointerState.current = {
+					isDown: false,
+					isDragging: false,
+					button: 0,
+					start: new Vec(e.clientX, e.clientY),
+				}
+				return
+			}
+
 			// Left-click: wait for the drag threshold before forwarding anything, then
 			// replay pointerdown at the original start so the editor records the
 			// correct drag origin. Right-click forwards moves immediately (pointerdown
@@ -143,6 +166,22 @@ export function MenuClickCapture() {
 
 	const handlePointerUp = useCallback(
 		(e: PointerEvent) => {
+			const button = rPointerState.current.button === 2 ? 2 : getPointerEventButton(e)
+
+			// Stale-button recovery already synthesized this button's pointer_up:
+			// swallow the late real one so it isn't dispatched again.
+			if (consumeRecoveredPointerUp(editor, e.pointerId, button)) {
+				releasePointerCapture(e.currentTarget, e)
+				setIsPointing(false)
+				rPointerState.current = {
+					isDown: false,
+					isDragging: false,
+					button: 0,
+					start: new Vec(e.clientX, e.clientY),
+				}
+				return
+			}
+
 			const isStaticRightClick =
 				rPointerState.current.button === 2 && !rPointerState.current.isDragging
 
@@ -151,7 +190,7 @@ export function MenuClickCapture() {
 				target: 'canvas',
 				name: 'pointer_up',
 				...getPointerInfo(editor, e),
-				button: rPointerState.current.button === 2 ? 2 : getPointerEventButton(e),
+				button,
 			})
 
 			if (isStaticRightClick && editor.options.rightClickPanning) {

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11441,6 +11441,17 @@ export class Editor extends EventEmitter<TLEventMap> {
 							this.inputs.setIsRightPointing(false)
 							this._selectedShapeIdsAtPointerDown = []
 							this._didCaptureSelectionAtPointerDown = false
+							// A release beyond the drag threshold can only be stale-button
+							// recovery for a missed pointerup: interactive moves past the
+							// threshold become a pan before any release arrives. Don't let
+							// it reach the state chart as a right_click at that point, or
+							// it would change the selection where the pointer re-entered.
+							if (
+								Vec.Dist2(this.inputs.getOriginScreenPoint(), this.inputs.getCurrentScreenPoint()) >
+								this.options.dragDistanceSquared
+							) {
+								return this
+							}
 							break // fall through to state chart dispatch as right_click
 						}
 

--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -11441,11 +11441,12 @@ export class Editor extends EventEmitter<TLEventMap> {
 							this.inputs.setIsRightPointing(false)
 							this._selectedShapeIdsAtPointerDown = []
 							this._didCaptureSelectionAtPointerDown = false
-							// A release beyond the drag threshold can only be stale-button
-							// recovery for a missed pointerup: interactive moves past the
-							// threshold become a pan before any release arrives. Don't let
-							// it reach the state chart as a right_click at that point, or
-							// it would change the selection where the pointer re-entered.
+							// Suppress the right_click when the release is past the drag
+							// threshold. Moves past the threshold become a pan before the
+							// release arrives, so this is almost always stale-button
+							// recovery for a missed pointerup; a fast flick whose pointerup
+							// outruns its final move is also suppressed rather than firing
+							// a selection change at the release point.
 							if (
 								Vec.Dist2(this.inputs.getOriginScreenPoint(), this.inputs.getCurrentScreenPoint()) >
 								this.options.dragDistanceSquared

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -1,5 +1,5 @@
 import { useValue } from '@tldraw/state-react'
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useRef } from 'react'
 import { LEFT_MOUSE_BUTTON, MIDDLE_MOUSE_BUTTON, RIGHT_MOUSE_BUTTON } from '../constants'
 import { tlenv } from '../globals/environment'
 import {
@@ -21,9 +21,9 @@ function isButtonStillDown(button: number, buttons: number): boolean {
 		case MIDDLE_MOUSE_BUTTON:
 			return (buttons & 4) !== 0
 		case RIGHT_MOUSE_BUTTON:
-			// On darwin, ctrl+click reports button 2 while the physical bit is
-			// the left button's, so right still counts as down while either bit
-			// is set.
+			// On darwin, ctrl+click is mapped to button 2 (getPointerEventButton),
+			// but browsers disagree on the buttons bit: some report the physical
+			// left bit, others the translated right bit. Accept either.
 			return tlenv.isDarwin ? (buttons & (1 | 2)) !== 0 : (buttons & 2) !== 0
 		default:
 			// Other buttons (stylus eraser etc.) are never treated as stale.
@@ -35,15 +35,16 @@ export function useCanvasEvents() {
 	const editor = useEditor()
 	const ownerDocument = editor.getContainerDocument()
 	const currentTool = useValue('current tool', () => editor.getCurrentTool(), [editor])
+	// Shared with the document-level pointermove listener below so stale-button
+	// recovery can clear it when the pointerup it describes never arrived.
+	const isSecondaryClickPointerDown = useRef(false)
 
 	const events = useMemo(
 		function canvasEvents() {
-			let isSecondaryClickPointerDown = false
-
 			function onPointerDown(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
 				const button = getPointerEventButton(e)
-				isSecondaryClickPointerDown = button === 2
+				isSecondaryClickPointerDown.current = button === 2
 
 				// With right-click panning disabled, fire right_click on press and let the
 				// native contextmenu through so the menu opens at the pointer-down location.
@@ -76,7 +77,7 @@ export function useCanvasEvents() {
 
 			function onPointerUp(e: React.PointerEvent) {
 				if (editor.wasEventAlreadyHandled(e)) return
-				const button = isSecondaryClickPointerDown ? 2 : getPointerEventButton(e)
+				const button = isSecondaryClickPointerDown.current ? 2 : getPointerEventButton(e)
 				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
 
 				const rightClickPanning = editor.options.rightClickPanning
@@ -108,7 +109,7 @@ export function useCanvasEvents() {
 					})
 					e.currentTarget.dispatchEvent(contextMenuEvent)
 				}
-				isSecondaryClickPointerDown = false
+				isSecondaryClickPointerDown.current = false
 			}
 
 			function onPointerEnter(e: React.PointerEvent) {
@@ -257,14 +258,21 @@ export function useCanvasEvents() {
 			// through the normal pointer_up path before dispatching this move.
 			if (
 				e.pointerType === 'mouse' &&
-				// bare Event objects lack a buttons field entirely; skip the check
-				// for those (a real PointerEvent always has a numeric buttons)
+				// polyfilled or synthetic events can lack a numeric buttons field;
+				// skip the check for those
 				typeof e.buttons === 'number' &&
 				(editor.inputs.getIsPanning() || editor.inputs.getIsRightPointing()) &&
 				editor.inputs.getIsPointing()
 			) {
 				for (const button of Array.from(editor.inputs.buttons.keys())) {
 					if (isButtonStillDown(button, e.buttons)) continue
+					if (button === RIGHT_MOUSE_BUTTON) isSecondaryClickPointerDown.current = false
+					// The missed pointerup also means the capture taken on
+					// pointerdown was never explicitly released. Browsers usually
+					// drop it implicitly, but if it's still held this event was
+					// retargeted to the captured element, so release it there.
+					const captureTarget = e.target as Element | null
+					if (captureTarget?.hasPointerCapture) releasePointerCapture(captureTarget, e)
 					editor.dispatch({
 						type: 'pointer',
 						target: 'canvas',

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -228,14 +228,17 @@ export function useCanvasEvents() {
 			lastX = e.clientX
 			lastY = e.clientY
 
-			// A pan button released outside the window can lose its pointerup —
-			// no pointercancel or lostpointercapture fires either — leaving the
-			// pan stuck following the cursor. If the buttons bitmask says a
-			// tracked pan button is no longer down, end it through the normal
-			// pointer_up path before dispatching this move.
+			// A pan button released outside the window can lose its pointerup:
+			// even with pointer capture set on pointerdown, browsers don't
+			// reliably deliver the pointerup, pointercancel, or
+			// lostpointercapture that would end it (w3c/pointerevents#407),
+			// leaving the pan stuck following the cursor. If the buttons
+			// bitmask says a tracked pan button is no longer down, end it
+			// through the normal pointer_up path before dispatching this move.
 			if (
 				e.pointerType === 'mouse' &&
-				// synthetic/test events may omit buttons entirely; skip the check for those
+				// bare Event objects lack a buttons field entirely; skip the check
+				// for those (a real PointerEvent always has a numeric buttons)
 				typeof e.buttons === 'number' &&
 				editor.inputs.getIsPanning() &&
 				editor.inputs.getIsPointing()

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -228,6 +228,43 @@ export function useCanvasEvents() {
 			lastX = e.clientX
 			lastY = e.clientY
 
+			// A pan button released outside the window can lose its pointerup —
+			// no pointercancel or lostpointercapture fires either — leaving the
+			// pan stuck following the cursor. If the buttons bitmask says a
+			// tracked pan button is no longer down, end it through the normal
+			// pointer_up path before dispatching this move.
+			if (
+				e.pointerType === 'mouse' &&
+				// synthetic/test events may omit buttons entirely; skip the check for those
+				typeof e.buttons === 'number' &&
+				editor.inputs.getIsPanning() &&
+				editor.inputs.getIsPointing()
+			) {
+				for (const button of Array.from(editor.inputs.buttons.keys())) {
+					// Button 0 (left) → bit 1, button 1 (middle) → bit 4, button 2
+					// (right) → bit 2. On darwin, ctrl+click maps to button 2 while
+					// the physical bit is 1 (left), so button 2 only counts as stale
+					// when neither bit is set.
+					const stale =
+						button === 0
+							? !(e.buttons & 1)
+							: button === 1
+								? !(e.buttons & 4)
+								: button === 2
+									? !(e.buttons & 2) && !(e.buttons & 1)
+									: false
+					if (stale) {
+						editor.dispatch({
+							type: 'pointer',
+							target: 'canvas',
+							name: 'pointer_up',
+							...getPointerInfo(editor, e),
+							button,
+						})
+					}
+				}
+			}
+
 			// For tools that benefit from a higher fidelity of events,
 			// we dispatch the coalesced events.
 			// N.B. Sometimes getCoalescedEvents isn't present on iOS, ugh.

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -1,5 +1,6 @@
 import { useValue } from '@tldraw/state-react'
 import React, { useEffect, useMemo } from 'react'
+import { LEFT_MOUSE_BUTTON, MIDDLE_MOUSE_BUTTON, RIGHT_MOUSE_BUTTON } from '../constants'
 import { tlenv } from '../globals/environment'
 import {
 	elementShouldCaptureKeys,
@@ -10,6 +11,25 @@ import {
 import { getPointerInfo } from '../utils/getPointerInfo'
 import { getPointerEventButton, isDirectDisplayPen, isSecondaryClickEvent } from '../utils/pointer'
 import { useEditor } from './useEditor'
+
+// The `button` index and the `buttons` bitmask disagree: button 0 (left) is
+// bit 1, button 1 (middle) is bit 4, button 2 (right) is bit 2.
+function isButtonStillDown(button: number, buttons: number): boolean {
+	switch (button) {
+		case LEFT_MOUSE_BUTTON:
+			return (buttons & 1) !== 0
+		case MIDDLE_MOUSE_BUTTON:
+			return (buttons & 4) !== 0
+		case RIGHT_MOUSE_BUTTON:
+			// On darwin, ctrl+click reports button 2 while the physical bit is
+			// the left button's, so right still counts as down while either bit
+			// is set.
+			return tlenv.isDarwin ? (buttons & (1 | 2)) !== 0 : (buttons & 2) !== 0
+		default:
+			// Other buttons (stylus eraser etc.) are never treated as stale.
+			return true
+	}
+}
 
 export function useCanvasEvents() {
 	const editor = useEditor()
@@ -244,27 +264,14 @@ export function useCanvasEvents() {
 				editor.inputs.getIsPointing()
 			) {
 				for (const button of Array.from(editor.inputs.buttons.keys())) {
-					// Button 0 (left) → bit 1, button 1 (middle) → bit 4, button 2
-					// (right) → bit 2. On darwin, ctrl+click maps to button 2 while
-					// the physical bit is 1 (left), so button 2 only counts as stale
-					// when neither bit is set.
-					const stale =
-						button === 0
-							? !(e.buttons & 1)
-							: button === 1
-								? !(e.buttons & 4)
-								: button === 2
-									? !(e.buttons & 2) && !(e.buttons & 1)
-									: false
-					if (stale) {
-						editor.dispatch({
-							type: 'pointer',
-							target: 'canvas',
-							name: 'pointer_up',
-							...getPointerInfo(editor, e),
-							button,
-						})
-					}
+					if (isButtonStillDown(button, e.buttons)) continue
+					editor.dispatch({
+						type: 'pointer',
+						target: 'canvas',
+						name: 'pointer_up',
+						...getPointerInfo(editor, e),
+						button,
+					})
 				}
 			}
 

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef } from 'react'
 import { LEFT_MOUSE_BUTTON, MIDDLE_MOUSE_BUTTON, RIGHT_MOUSE_BUTTON } from '../constants'
 import type { Editor } from '../editor/Editor'
 import { tlenv } from '../globals/environment'
+import { Vec } from '../primitives/Vec'
 import {
 	elementShouldCaptureKeys,
 	preventDefault,
@@ -58,6 +59,32 @@ export function consumeRecoveredPointerUp(
 			(buttons.has(LEFT_MOUSE_BUTTON) || buttons.has(RIGHT_MOUSE_BUTTON)))
 	if (matched) map!.delete(pointerId)
 	return matched
+}
+
+// Synthetic contextmenu (isTrusted false) that passes through onContextMenu
+// so Radix opens the menu at the given position.
+function dispatchSyntheticContextMenu(
+	target: Element,
+	e: {
+		clientX: number
+		clientY: number
+		pointerId: number
+		pointerType: string
+		isPrimary: boolean
+	}
+) {
+	target.dispatchEvent(
+		new PointerEvent('contextmenu', {
+			bubbles: true,
+			clientX: e.clientX,
+			clientY: e.clientY,
+			button: 2,
+			buttons: 0,
+			pointerId: e.pointerId,
+			pointerType: e.pointerType,
+			isPrimary: e.isPrimary,
+		})
+	)
 }
 
 // The `button` index and the `buttons` bitmask disagree: button 0 (left) is
@@ -153,17 +180,7 @@ export function useCanvasEvents() {
 
 				// Static right-click: fire contextmenu at the pointer-up location
 				if (rightClickPanning && button === 2 && !wasRightClickPanning) {
-					const contextMenuEvent = new PointerEvent('contextmenu', {
-						bubbles: true,
-						clientX: e.clientX,
-						clientY: e.clientY,
-						button: 2,
-						buttons: 0,
-						pointerId: e.pointerId,
-						pointerType: e.pointerType,
-						isPrimary: e.isPrimary,
-					})
-					e.currentTarget.dispatchEvent(contextMenuEvent)
+					dispatchSyntheticContextMenu(e.currentTarget, e)
 				}
 				isSecondaryClickPointerDown.current = false
 			}
@@ -324,6 +341,20 @@ export function useCanvasEvents() {
 					if (isButtonStillDown(button, e.buttons)) continue
 					if (button === RIGHT_MOUSE_BUTTON) isSecondaryClickPointerDown.current = false
 					recordRecoveredPointerUp(editor, e.pointerId, button)
+					// Within the drag threshold the editor delivers this pointer_up
+					// as a right_click (selection updates), so the contextmenu that
+					// onPointerUp would have fired must open here too — the real
+					// pointerup, if it ever arrives, is swallowed. Same screen-space
+					// distance check as the editor's pointer_up handling.
+					const screenBounds = editor.getViewportScreenBounds()
+					const isStaticRightClick =
+						button === RIGHT_MOUSE_BUTTON &&
+						editor.options.rightClickPanning &&
+						!editor.inputs.getIsPanning() &&
+						Vec.Dist2(editor.inputs.getOriginScreenPoint(), {
+							x: e.clientX - screenBounds.x,
+							y: e.clientY - screenBounds.y,
+						}) <= editor.options.dragDistanceSquared
 					// The missed pointerup also means the capture taken on
 					// pointerdown was never explicitly released. Browsers usually
 					// drop it implicitly, but if it's still held this event was
@@ -337,6 +368,10 @@ export function useCanvasEvents() {
 						...getPointerInfo(editor, e),
 						button,
 					})
+					if (isStaticRightClick) {
+						const canvas = editor.getContainer().querySelector('.tl-canvas')
+						if (canvas) dispatchSyntheticContextMenu(canvas, e)
+					}
 				}
 			}
 

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -240,7 +240,7 @@ export function useCanvasEvents() {
 				// bare Event objects lack a buttons field entirely; skip the check
 				// for those (a real PointerEvent always has a numeric buttons)
 				typeof e.buttons === 'number' &&
-				editor.inputs.getIsPanning() &&
+				(editor.inputs.getIsPanning() || editor.inputs.getIsRightPointing()) &&
 				editor.inputs.getIsPointing()
 			) {
 				for (const button of Array.from(editor.inputs.buttons.keys())) {

--- a/packages/editor/src/lib/hooks/useCanvasEvents.ts
+++ b/packages/editor/src/lib/hooks/useCanvasEvents.ts
@@ -1,6 +1,7 @@
 import { useValue } from '@tldraw/state-react'
 import React, { useEffect, useMemo, useRef } from 'react'
 import { LEFT_MOUSE_BUTTON, MIDDLE_MOUSE_BUTTON, RIGHT_MOUSE_BUTTON } from '../constants'
+import type { Editor } from '../editor/Editor'
 import { tlenv } from '../globals/environment'
 import {
 	elementShouldCaptureKeys,
@@ -12,9 +13,57 @@ import { getPointerInfo } from '../utils/getPointerInfo'
 import { getPointerEventButton, isDirectDisplayPen, isSecondaryClickEvent } from '../utils/pointer'
 import { useEditor } from './useEditor'
 
+// pointerId → buttons whose pointer_up was synthesized by stale-button
+// recovery; a late real pointerup for one of these is swallowed. Keyed by
+// editor, not per hook instance: useCanvasEvents runs in both Canvas and
+// MenuClickCapture, and recovery may fire in one while the pointerup lands
+// in the other.
+const recoveredPointerUpsByEditor = new WeakMap<Editor, Map<number, Set<number>>>()
+
+function recordRecoveredPointerUp(editor: Editor, pointerId: number, button: number) {
+	let map = recoveredPointerUpsByEditor.get(editor)
+	if (!map) {
+		map = new Map()
+		recoveredPointerUpsByEditor.set(editor, map)
+	}
+	const buttons = map.get(pointerId) ?? new Set<number>()
+	buttons.add(button)
+	map.set(pointerId, buttons)
+}
+
+function clearRecoveredPointerUps(editor: Editor, pointerId: number) {
+	recoveredPointerUpsByEditor.get(editor)?.delete(pointerId)
+}
+
+/**
+ * Whether a pointerup was already synthesized by stale-button recovery and the
+ * real one should be swallowed. Consumes the record.
+ * @internal
+ */
+export function consumeRecoveredPointerUp(
+	editor: Editor,
+	pointerId: number,
+	button: number
+): boolean {
+	const map = recoveredPointerUpsByEditor.get(editor)
+	const buttons = map?.get(pointerId)
+	if (!buttons) return false
+	// darwin ctrl maps the physical left button to button 2, so a late
+	// pointerup can resolve to either: treat them as the same button.
+	const isLeftOrRight = (b: number) => b === LEFT_MOUSE_BUTTON || b === RIGHT_MOUSE_BUTTON
+	const matched =
+		buttons.has(button) ||
+		(tlenv.isDarwin &&
+			isLeftOrRight(button) &&
+			(buttons.has(LEFT_MOUSE_BUTTON) || buttons.has(RIGHT_MOUSE_BUTTON)))
+	if (matched) map!.delete(pointerId)
+	return matched
+}
+
 // The `button` index and the `buttons` bitmask disagree: button 0 (left) is
 // bit 1, button 1 (middle) is bit 4, button 2 (right) is bit 2.
-function isButtonStillDown(button: number, buttons: number): boolean {
+/** @internal */
+export function isButtonStillDown(button: number, buttons: number): boolean {
 	switch (button) {
 		case LEFT_MOUSE_BUTTON:
 			return (buttons & 1) !== 0
@@ -79,6 +128,13 @@ export function useCanvasEvents() {
 				if (editor.wasEventAlreadyHandled(e)) return
 				const button = isSecondaryClickPointerDown.current ? 2 : getPointerEventButton(e)
 				if (button !== 0 && button !== 1 && button !== 2 && button !== 5) return
+
+				// Recovery already synthesized this button's pointer_up.
+				if (consumeRecoveredPointerUp(editor, e.pointerId, button)) {
+					releasePointerCapture(e.currentTarget, e)
+					isSecondaryClickPointerDown.current = false
+					return
+				}
 
 				const rightClickPanning = editor.options.rightClickPanning
 				// Check before dispatch (which resets isPanning)
@@ -267,6 +323,7 @@ export function useCanvasEvents() {
 				for (const button of Array.from(editor.inputs.buttons.keys())) {
 					if (isButtonStillDown(button, e.buttons)) continue
 					if (button === RIGHT_MOUSE_BUTTON) isSecondaryClickPointerDown.current = false
+					recordRecoveredPointerUp(editor, e.pointerId, button)
 					// The missed pointerup also means the capture taken on
 					// pointerdown was never explicitly released. Browsers usually
 					// drop it implicitly, but if it's still held this event was
@@ -304,9 +361,17 @@ export function useCanvasEvents() {
 			}
 		}
 
+		// Any real press starts a new gesture: a pointerup after it must not be
+		// swallowed. Capture phase on the document so no handler can hide it.
+		function onPointerDownCapture(e: PointerEvent) {
+			clearRecoveredPointerUps(editor, e.pointerId)
+		}
+
 		ownerDocument.body.addEventListener('pointermove', onPointerMove)
+		ownerDocument.addEventListener('pointerdown', onPointerDownCapture, { capture: true })
 		return () => {
 			ownerDocument.body.removeEventListener('pointermove', onPointerMove)
+			ownerDocument.removeEventListener('pointerdown', onPointerDownCapture, { capture: true })
 		}
 	}, [editor, currentTool, ownerDocument])
 

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -148,6 +148,69 @@ describe('stale pan recovery via real DOM events', () => {
 		expect(editor.getSelectedShapeIds()).toEqual(selectedIds)
 	})
 
+	it('delivers a static right-click within the drag threshold to the state chart', async () => {
+		const { editor, canvas } = await setup()
+
+		await act(async () => {
+			editor.createShape({ type: 'geo', x: 500, y: 500 })
+			editor.select(editor.getCurrentPageShapes()[0].id)
+		})
+		expect(editor.getSelectedShapeIds()).toHaveLength(1)
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 102, clientY: 101, buttons: 2 })
+		)
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerup', { clientX: 102, clientY: 101, button: 2, buttons: 0 })
+		)
+		// The right_click reached SelectTool's idle, which resolves the selection
+		// at the click point: empty canvas clears it.
+		expect(editor.getSelectedShapeIds()).toEqual([])
+	})
+
+	it('suppresses a right-click released past the screen-space threshold at zoom 2', async () => {
+		const { editor, canvas } = await setup()
+
+		await act(async () => {
+			editor.createShape({ type: 'geo', x: 500, y: 500 })
+			editor.select(editor.getCurrentPageShapes()[0].id)
+			editor.setCamera(new Vec(0, 0, 2), { immediate: true })
+		})
+		const selectedIds = editor.getSelectedShapeIds()
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 101, clientY: 100, buttons: 2 })
+		)
+		expect(editor.inputs.getIsRightPointing()).toBe(true)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+
+		// A fast flick: the release lands 6px screen from the origin (past the
+		// 4px threshold → suppressed) but only 3px page at zoom 2. A page-space
+		// threshold would deliver the right_click and clear the selection.
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerup', { clientX: 106, clientY: 100, button: 2, buttons: 0 })
+		)
+		expect(editor.getSelectedShapeIds()).toEqual(selectedIds)
+	})
+
 	it('recovers a stale right button on non-darwin even while the left button is held', async () => {
 		const prevIsDarwin = tlenv.isDarwin
 		tlenv.isDarwin = false

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -120,6 +120,67 @@ describe('stale pan recovery via real DOM events', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
 	})
 
+	it('preserves the selection when a missed right pointerup is recovered', async () => {
+		const { editor, canvas } = await setup()
+
+		await act(async () => {
+			editor.createShape({ type: 'geo', x: 500, y: 500 })
+			editor.select(editor.getCurrentPageShapes()[0].id)
+		})
+		const selectedIds = editor.getSelectedShapeIds()
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		expect(editor.inputs.getIsRightPointing()).toBe(true)
+
+		// The pointerup was missed outside the window. Recovery must not complete
+		// a right_click at the re-entry point, which would clear the selection.
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsRightPointing()).toBe(false)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.getSelectedShapeIds()).toEqual(selectedIds)
+	})
+
+	it('recovers a stale right button on non-darwin even while the left button is held', async () => {
+		const prevIsDarwin = tlenv.isDarwin
+		tlenv.isDarwin = false
+		try {
+			const { editor, canvas } = await setup()
+
+			await fire(
+				editor,
+				canvas,
+				pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+			)
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 2 })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(true)
+
+			// Right released outside the window while the left button is down. Off
+			// darwin the left bit can't stand in for button 2, so the pan must end.
+			editor.inputs.setPointerVelocity(new Vec(0, 0))
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 1 })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(false)
+			expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+		} finally {
+			tlenv.isDarwin = prevIsDarwin
+		}
+	})
+
 	it('keeps panning while the right button is still held', async () => {
 		const { editor, canvas } = await setup()
 

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -95,6 +95,31 @@ describe('stale pan recovery via real DOM events', () => {
 		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
 	})
 
+	it('ends right-click pointing when the pointerup was missed before panning starts', async () => {
+		const { editor, canvas } = await setup()
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		expect(editor.inputs.getIsRightPointing()).toBe(true)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+
+		// The pointer leaves before crossing the drag threshold and its pointerup is
+		// lost. The first move back must end the pending right-click rather than turn
+		// it into a pan based on the distance from the original pointerdown.
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsRightPointing()).toBe(false)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.getCamera()).toMatchObject({ x: 0, y: 0, z: 1 })
+	})
+
 	it('keeps panning while the right button is still held', async () => {
 		const { editor, canvas } = await setup()
 

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -505,6 +505,65 @@ describe('stale pan recovery via real DOM events', () => {
 		}
 	})
 
+	it('opens the context menu for a static right-click recovered from a mid-release stale move', async () => {
+		const { editor, canvas } = await setup()
+
+		await act(async () => {
+			editor.createShape({ type: 'geo', x: 500, y: 500 })
+			editor.select(editor.getCurrentPageShapes()[0].id)
+		})
+		const contextmenu = vi.fn()
+		canvas.addEventListener('contextmenu', contextmenu)
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		// Chrome can emit a buttons:0 move during the release of a static
+		// right-click. Recovery consumes the gesture within the drag threshold:
+		// the state chart gets the right_click AND the menu must still open.
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 101, clientY: 100, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.getSelectedShapeIds()).toEqual([])
+		expect(contextmenu).toHaveBeenCalledTimes(1)
+
+		// The late real pointerup is swallowed: no second menu or pointer_up.
+		const dispatched = captureDispatchNames(editor)
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerup', { clientX: 101, clientY: 100, button: 2, buttons: 0 })
+		)
+		expect(contextmenu).toHaveBeenCalledTimes(1)
+		expect(dispatched.filter((name) => name === 'pointer_up')).toHaveLength(0)
+	})
+
+	it('does not open a context menu when recovery lands beyond the drag threshold', async () => {
+		const { editor, canvas } = await setup()
+		const contextmenu = vi.fn()
+		canvas.addEventListener('contextmenu', contextmenu)
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		// Released outside the window, re-entering far from the press point:
+		// the right_click is suppressed, so no menu either.
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(contextmenu).not.toHaveBeenCalled()
+	})
+
 	it('swallows a late pointerup landing on the menu click capture overlay', async () => {
 		const { editor } = await setup()
 

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -125,4 +125,81 @@ describe('stale pan recovery via real DOM events', () => {
 		expect(editor.inputs.getIsPanning()).toBe(true)
 		expect(editor.getCamera()).toMatchObject({ x: 200, y: 200, z: 1 })
 	})
+
+	it('ends a middle-mouse pan when the pointerup was missed', async () => {
+		const { editor, canvas } = await setup()
+
+		// Middle-mouse down starts panning immediately (no drag threshold).
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 1, buttons: 4 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 4 })
+		)
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+
+		editor.inputs.setPointerVelocity(new Vec(0, 0))
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.getInstanceState().cursor.type).not.toBe('grabbing')
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+	})
+
+	it('keeps a spacebar pan alive when a left-button pointerup was missed', async () => {
+		const { editor, canvas } = await setup()
+
+		// Hold space: activates panning (Editor key_down handling).
+		await act(async () => {
+			editor.dispatch({
+				type: 'keyboard',
+				name: 'key_down',
+				key: ' ',
+				code: 'Space',
+				shiftKey: false,
+				ctrlKey: false,
+				altKey: false,
+				metaKey: false,
+				accelKey: false,
+			})
+			editor.emit('tick', 16)
+		})
+		expect(editor.inputs.getIsPanning()).toBe(true)
+
+		// Left-button drag pans while space is held.
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 0, buttons: 1 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 1 })
+		)
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+
+		// The left button's pointerup is lost outside the window. Recovery must
+		// end the pointing state but keep panning active while space is held.
+		editor.inputs.setPointerVelocity(new Vec(0, 0))
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.inputs.getIsSpacebarPanning()).toBe(true)
+		// With no button down, moving the mouse must not pan.
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+	})
 })

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -1,29 +1,14 @@
 import { act } from '@testing-library/react'
-import { Box, Vec } from '@tldraw/editor'
+import { Box, Vec, tlenv } from '@tldraw/editor'
 import { Tldraw } from '../lib/Tldraw'
 import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
 
 // These tests drive the real DOM handlers in useCanvasEvents rather than
 // dispatching synthetic editor events: the stale-pan recovery lives in the
-// document-level pointermove listener, which TestEditor/Driver bypass. jsdom
-// is missing a few browser APIs those handlers rely on, so we polyfill them.
+// document-level pointermove listener, which TestEditor/Driver bypass.
 
-if (typeof (globalThis as any).PointerEvent === 'undefined') {
-	// jsdom has no PointerEvent; the canvas handlers do `e instanceof PointerEvent`.
-	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
-		pointerId: number
-		pointerType: string
-		pressure: number
-		isPrimary: boolean
-		constructor(type: string, params: any = {}) {
-			super(type, params)
-			this.pointerId = params.pointerId ?? 0
-			this.pointerType = params.pointerType ?? ''
-			this.pressure = params.pressure ?? 0
-			this.isPrimary = params.isPrimary ?? false
-		}
-	}
-}
+// jsdom implements PointerEvent but not pointer capture, which the canvas
+// pointerdown handler calls.
 if (!Element.prototype.setPointerCapture) {
 	Element.prototype.setPointerCapture = () => {}
 	Element.prototype.releasePointerCapture = () => {}
@@ -32,9 +17,15 @@ if (!Element.prototype.setPointerCapture) {
 
 function pointerEvent(
 	type: 'pointerdown' | 'pointermove' | 'pointerup',
-	options: { clientX: number; clientY: number; button?: number; buttons: number }
+	options: {
+		clientX: number
+		clientY: number
+		button?: number
+		buttons: number
+		ctrlKey?: boolean
+	}
 ) {
-	return new (globalThis as any).PointerEvent(type, {
+	return new PointerEvent(type, {
 		bubbles: true,
 		cancelable: true,
 		pointerId: 1,
@@ -201,5 +192,57 @@ describe('stale pan recovery via real DOM events', () => {
 		expect(editor.inputs.getIsSpacebarPanning()).toBe(true)
 		// With no button down, moving the mouse must not pan.
 		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+	})
+
+	it('recovers a darwin ctrl+click pan only after the physical left button is released', async () => {
+		const prevIsDarwin = tlenv.isDarwin
+		tlenv.isDarwin = true
+		try {
+			const { editor, canvas } = await setup()
+
+			// On darwin, ctrl+left maps to button 2, so this starts a right-click
+			// pan while the physical buttons bit is 1 (left).
+			await fire(
+				editor,
+				canvas,
+				pointerEvent('pointerdown', {
+					clientX: 100,
+					clientY: 100,
+					button: 0,
+					buttons: 1,
+					ctrlKey: true,
+				})
+			)
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 1, ctrlKey: true })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(true)
+			expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+
+			// Bit 2 (right) is not set, but bit 1 (left) still is: the tracked
+			// button 2 must not count as stale, or mac ctrl+drag panning breaks.
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 1, ctrlKey: true })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(true)
+			expect(editor.getCamera()).toMatchObject({ x: 200, y: 200, z: 1 })
+
+			// Once the left button is really up, the missed pointerup must recover.
+			editor.inputs.setPointerVelocity(new Vec(0, 0))
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 400, clientY: 400, buttons: 0, ctrlKey: true })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(false)
+			expect(editor.inputs.getIsPointing()).toBe(false)
+			expect(editor.getCamera()).toMatchObject({ x: 200, y: 200, z: 1 })
+		} finally {
+			tlenv.isDarwin = prevIsDarwin
+		}
 	})
 })

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -1,0 +1,128 @@
+import { act } from '@testing-library/react'
+import { Box, Vec } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+// These tests drive the real DOM handlers in useCanvasEvents rather than
+// dispatching synthetic editor events: the stale-pan recovery lives in the
+// document-level pointermove listener, which TestEditor/Driver bypass. jsdom
+// is missing a few browser APIs those handlers rely on, so we polyfill them.
+
+if (typeof (globalThis as any).PointerEvent === 'undefined') {
+	// jsdom has no PointerEvent; the canvas handlers do `e instanceof PointerEvent`.
+	;(globalThis as any).PointerEvent = class PointerEvent extends MouseEvent {
+		pointerId: number
+		pointerType: string
+		pressure: number
+		isPrimary: boolean
+		constructor(type: string, params: any = {}) {
+			super(type, params)
+			this.pointerId = params.pointerId ?? 0
+			this.pointerType = params.pointerType ?? ''
+			this.pressure = params.pressure ?? 0
+			this.isPrimary = params.isPrimary ?? false
+		}
+	}
+}
+if (!Element.prototype.setPointerCapture) {
+	Element.prototype.setPointerCapture = () => {}
+	Element.prototype.releasePointerCapture = () => {}
+	Element.prototype.hasPointerCapture = () => false
+}
+
+function pointerEvent(
+	type: 'pointerdown' | 'pointermove' | 'pointerup',
+	options: { clientX: number; clientY: number; button?: number; buttons: number }
+) {
+	return new (globalThis as any).PointerEvent(type, {
+		bubbles: true,
+		cancelable: true,
+		pointerId: 1,
+		pointerType: 'mouse',
+		isPrimary: true,
+		button: 0,
+		...options,
+	})
+}
+
+async function setup() {
+	const { editor } = await renderTldrawComponentWithEditor(
+		(onMount) => <Tldraw onMount={onMount} />,
+		{ waitForPatterns: false }
+	)
+	const canvas = document.querySelector('[data-testid="canvas"]') as HTMLElement
+	await act(async () => {
+		editor.updateViewportScreenBounds(new Box(0, 0, 1000, 1000))
+	})
+	return { editor, canvas }
+}
+
+// Dispatch a DOM event and flush the editor's pending event queue.
+async function fire(editor: any, target: Element | HTMLElement, event: Event) {
+	await act(async () => {
+		target.dispatchEvent(event)
+		editor.emit('tick', 16)
+	})
+}
+
+describe('stale pan recovery via real DOM events', () => {
+	it('ends a right-click pan when the pointerup was missed', async () => {
+		const { editor, canvas } = await setup()
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 2 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+
+		// The mouse re-enters the window with no buttons held: the pointerup
+		// was eaten outside. The next move must end the pan, not continue it.
+		editor.inputs.setPointerVelocity(new Vec(0, 0))
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+		expect(editor.getInstanceState().cursor.type).not.toBe('grabbing')
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+
+		// Further movement must not pan either.
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 450, clientY: 450, buttons: 0 })
+		)
+		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+	})
+
+	it('keeps panning while the right button is still held', async () => {
+		const { editor, canvas } = await setup()
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 2 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+		expect(editor.getCamera()).toMatchObject({ x: 200, y: 200, z: 1 })
+	})
+})

--- a/packages/tldraw/src/test/pan-recovery-dom.test.tsx
+++ b/packages/tldraw/src/test/pan-recovery-dom.test.tsx
@@ -48,6 +48,18 @@ async function setup() {
 	return { editor, canvas }
 }
 
+// Editor.dispatch mutates info.name in place (e.g. pointer_up → right_click),
+// so spy call args can't be inspected after the fact: capture names at call time.
+function captureDispatchNames(editor: any): string[] {
+	const names: string[] = []
+	const original = editor.dispatch.bind(editor)
+	vi.spyOn(editor, 'dispatch').mockImplementation((info: any) => {
+		names.push(info.name)
+		return original(info)
+	})
+	return names
+}
+
 // Dispatch a DOM event and flush the editor's pending event queue.
 async function fire(editor: any, target: Element | HTMLElement, event: Event) {
 	await act(async () => {
@@ -341,6 +353,251 @@ describe('stale pan recovery via real DOM events', () => {
 		expect(editor.inputs.getIsSpacebarPanning()).toBe(true)
 		// With no button down, moving the mouse must not pan.
 		expect(editor.getCamera()).toMatchObject({ x: 100, y: 100, z: 1 })
+	})
+
+	it('swallows a late real pointerup after recovery instead of firing a contextmenu', async () => {
+		const { editor, canvas } = await setup()
+
+		const contextmenu = vi.fn()
+		canvas.addEventListener('contextmenu', contextmenu)
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 2 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+
+		// Recovery ends the pan on a stale-buttons move.
+		editor.inputs.setPointerVelocity(new Vec(0, 0))
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+
+		// The real pointerup arrives late anyway: must be swallowed, not
+		// processed as a fresh static right-click with a contextmenu.
+		const dispatched = captureDispatchNames(editor)
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerup', { clientX: 300, clientY: 300, button: 2, buttons: 0 })
+		)
+		expect(contextmenu).not.toHaveBeenCalled()
+		expect(dispatched.filter((name) => name === 'pointer_up')).toHaveLength(0)
+	})
+
+	it('swallows a late darwin pointerup that resolves to button 0 once ctrl is released', async () => {
+		const prevIsDarwin = tlenv.isDarwin
+		tlenv.isDarwin = true
+		try {
+			const { editor, canvas } = await setup()
+
+			await fire(
+				editor,
+				canvas,
+				pointerEvent('pointerdown', {
+					clientX: 100,
+					clientY: 100,
+					button: 0,
+					buttons: 1,
+					ctrlKey: true,
+				})
+			)
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 1, ctrlKey: true })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(true)
+
+			editor.inputs.setPointerVelocity(new Vec(0, 0))
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0, ctrlKey: true })
+			)
+			expect(editor.inputs.getIsPanning()).toBe(false)
+
+			// Ctrl released before the late pointerup → it resolves to button 0,
+			// but still belongs to the recovered ctrl+click: swallow it.
+			const dispatched = captureDispatchNames(editor)
+			await fire(
+				editor,
+				canvas,
+				pointerEvent('pointerup', { clientX: 300, clientY: 300, button: 0, buttons: 0 })
+			)
+			expect(dispatched.filter((name) => name === 'pointer_up')).toHaveLength(0)
+		} finally {
+			tlenv.isDarwin = prevIsDarwin
+		}
+	})
+
+	it('swallows a late darwin spacebar-pan pointerup that resolves to button 2 under ctrl', async () => {
+		const prevIsDarwin = tlenv.isDarwin
+		tlenv.isDarwin = true
+		try {
+			const { editor, canvas } = await setup()
+			const contextmenu = vi.fn()
+			canvas.addEventListener('contextmenu', contextmenu)
+
+			await act(async () => {
+				editor.dispatch({
+					type: 'keyboard',
+					name: 'key_down',
+					key: ' ',
+					code: 'Space',
+					shiftKey: false,
+					ctrlKey: false,
+					altKey: false,
+					metaKey: false,
+					accelKey: false,
+				})
+				editor.emit('tick', 16)
+			})
+
+			await fire(
+				editor,
+				canvas,
+				pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 0, buttons: 1 })
+			)
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 1 })
+			)
+
+			// The left button's pointerup is lost outside; recovery records button 0.
+			editor.inputs.setPointerVelocity(new Vec(0, 0))
+			await fire(
+				editor,
+				document.body,
+				pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+			)
+			expect(editor.inputs.getIsPointing()).toBe(false)
+
+			// The late pointerup arrives with ctrl held → resolves to button 2. It
+			// still belongs to the recovered left press: swallow it instead of
+			// firing a static right-click contextmenu.
+			const dispatched = captureDispatchNames(editor)
+			await fire(
+				editor,
+				canvas,
+				pointerEvent('pointerup', {
+					clientX: 300,
+					clientY: 300,
+					button: 0,
+					buttons: 0,
+					ctrlKey: true,
+				})
+			)
+			expect(dispatched.filter((name) => name === 'pointer_up')).toHaveLength(0)
+			expect(contextmenu).not.toHaveBeenCalled()
+		} finally {
+			tlenv.isDarwin = prevIsDarwin
+		}
+	})
+
+	it('swallows a late pointerup landing on the menu click capture overlay', async () => {
+		const { editor } = await setup()
+
+		await act(async () => {
+			editor.menus.addOpenMenu('test-menu')
+		})
+		const overlay = document.querySelector(
+			'[data-testid="menu-click-capture.content"]'
+		) as HTMLElement
+		expect(overlay).toBeTruthy()
+
+		// Right pointerdown on the overlay is forwarded to the canvas handler,
+		// so dragging starts a pan.
+		await fire(
+			editor,
+			overlay,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			overlay,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 2 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(true)
+
+		// Missed pointerup outside: the re-entry move over the overlay must not
+		// be forwarded as a drag, and recovery must end the pan.
+		editor.inputs.setPointerVelocity(new Vec(0, 0))
+		await fire(
+			editor,
+			overlay,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.inputs.getIsPointing()).toBe(false)
+
+		// The late real pointerup lands on the overlay's own handler: it must
+		// consult the recovery record too, not re-dispatch pointer_up.
+		const dispatched = captureDispatchNames(editor)
+		await fire(
+			editor,
+			overlay,
+			pointerEvent('pointerup', { clientX: 300, clientY: 300, button: 2, buttons: 0 })
+		)
+		expect(dispatched.filter((name) => name === 'pointer_up')).toHaveLength(0)
+	})
+
+	it('processes a fresh right-click normally after a recovered pan', async () => {
+		const { editor, canvas } = await setup()
+
+		await act(async () => {
+			editor.createShape({ type: 'geo', x: 500, y: 500 })
+			editor.select(editor.getCurrentPageShapes()[0].id)
+		})
+		const selectedIds = editor.getSelectedShapeIds()
+
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 100, clientY: 100, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 200, clientY: 200, buttons: 2 })
+		)
+		editor.inputs.setPointerVelocity(new Vec(0, 0))
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 300, clientY: 300, buttons: 0 })
+		)
+		expect(editor.inputs.getIsPanning()).toBe(false)
+		expect(editor.getSelectedShapeIds()).toEqual(selectedIds)
+
+		// A new press clears the recovery record: this static right-click's
+		// pointerup must reach the state chart.
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerdown', { clientX: 400, clientY: 400, button: 2, buttons: 2 })
+		)
+		await fire(
+			editor,
+			document.body,
+			pointerEvent('pointermove', { clientX: 402, clientY: 401, buttons: 2 })
+		)
+		await fire(
+			editor,
+			canvas,
+			pointerEvent('pointerup', { clientX: 402, clientY: 401, button: 2, buttons: 0 })
+		)
+		expect(editor.getSelectedShapeIds()).toEqual([])
 	})
 
 	it('recovers a darwin ctrl+click pan only after the physical left button is released', async () => {


### PR DESCRIPTION
In order to stop pans from getting stuck when the mouse button is released outside the browser window, this PR ends a pan on the next pointermove whose `buttons` bitmask shows the pan button is no longer down. Even with pointer capture set on pointerdown, browsers don't reliably deliver the `pointerup`, `pointercancel`, or `lostpointercapture` that would end the pan in that case (see [w3c/pointerevents#407](https://github.com/w3c/pointerevents/issues/407) and [Mozilla bug 1684355](https://bugzilla.mozilla.org/show_bug.cgi?id=1684355)), so the camera keeps following the cursor with no button held until the user clicks again. Closes #9692.

The recovery lives in the document-level `pointermove` listener in `useCanvasEvents`, which is the first thing to fire when the mouse re-enters the window. When a tracked pan button is missing from the [`buttons` bitmask](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons), it dispatches a synthetic `pointer_up` through the existing pointer path, so cursor restore, pan-state reset, the spacebar keep-panning case, and the right-button state-chart skip all run unchanged. One subtlety: macOS ctrl+click maps to button 2 while the physical bit stays 1 (left), so button 2 only counts as released when neither bit is set — covered by a dedicated test.

Tests drive real DOM events through the rendered component (the recovery is invisible to `TestEditor`/`Driver`, which bypass the DOM listener) and cover right-click, middle-click, spacebar+left, and darwin ctrl+click pans.

### Before

https://github.com/user-attachments/assets/379377d3-b81f-4e1b-bd94-76da773e9d6d

### After


https://github.com/user-attachments/assets/ca815644-420b-4f80-aec5-55d3ea3bc387



### Change type

- [x] `bugfix`

### Test plan

1. Start a right-click (or middle-click) pan and drag the cursor outside the browser window.
2. Release the button outside, then move the mouse back into the window.
3. The pan should end instead of the camera following the cursor.

- [x] Unit tests

### Release notes

- Fixed pans getting stuck following the cursor when the pan button was released outside the browser window.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +40 / -0   |
| Tests     | +248 / -0  |
