### PR TITLE
fix(tooling): always run predev/prebuild css copy scripts

### DIFF
--- a/lazy.config.ts
+++ b/lazy.config.ts
@@ -59,6 +59,16 @@ const config = {
 				'apps/vscode/*': { runsAfter: { build: { in: 'self-only' } } },
 			},
 		},
+		// predev/prebuild are the css-copy scripts. They write generated, gitignored files
+		// (tldraw.css, commenting.css, ...) that lazy doesn't track as outputs, so a cache hit
+		// would skip regenerating a file that's missing on disk and vite would fail to resolve it.
+		// They're a few file copies, so just always run them.
+		predev: {
+			cache: 'none',
+		},
+		prebuild: {
+			cache: 'none',
+		},
 		e2e: {
 			cache: 'none',
 		},

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 	"lint-staged": {
 		"*.{js,jsx,ts,tsx,cjs,mjs}": [
 			"oxfmt --no-error-on-unmatched-pattern",
-			"oxlint"
+			"oxlint --no-error-on-unmatched-pattern"
 		],
 		"*.{css,md,mdx,html,yml,yaml}": [
 			"oxfmt --no-error-on-unmatched-pattern"


### PR DESCRIPTION
In order to make `yarn dev-app` start reliably on the commenting branch, this makes the `predev` and `prebuild` css-copy scripts uncacheable in lazy.

`packages/commenting/commenting.css` (like `tldraw.css`) is generated and gitignored, written by the package's `predev` script. `predev` had no entry in `lazy.config.ts`, so it used lazy's default caching — and because it declares no outputs, lazy can't tell the generated file is missing from disk. With unchanged inputs it reported `✔ cache hit` and skipped the copy, leaving no `commenting.css` for the postcss `@import` in `apps/dotcom/client/styles/globals.css`:

```
[plugin:vite:css] [postcss] ENOENT: no such file or directory, open '@tldraw/commenting/commenting.css'
```

It looked intermittent because the file sometimes got regenerated as a side effect of something else — `packages/collaboration`'s copy script imports the commenting one, so a cache miss there would quietly fix it — which is also why "run the examples app first" seemed to help.

Both scripts are a handful of file copies across four packages, so the fix is to always run them rather than teach lazy to track the outputs.

Also drive-by: `lazy.config.ts` is in oxlint's ignore list, so committing it on its own made the pre-commit hook fail with "No files found to lint". Added `--no-error-on-unmatched-pattern` to the `oxlint` lint-staged entry, matching the `oxfmt` one next to it.

### Change type

- [x] `bugfix`

### Test plan

1. `rm packages/commenting/commenting.css packages/tldraw/tldraw.css`
2. `yarn dev-app`
3. The app starts and the css files are regenerated (before this change, `predev` reported a cache hit and the client failed to resolve `@tldraw/commenting/commenting.css`).

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +11 / -1   |
