### PR TITLE
feat(tldraw): add assets prop to TldrawImage

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -84,6 +84,7 @@ import { TLArrowShapeKind } from '@tldraw/editor';
 import { TLArrowShapeProps } from '@tldraw/editor';
 import { TLAsset } from '@tldraw/editor';
 import { TLAssetId } from '@tldraw/editor';
+import { TLAssetStore } from '@tldraw/editor';
 import { TLBookmarkAsset } from '@tldraw/editor';
 import { TLBookmarkShape } from '@tldraw/editor';
 import { TLBookmarkShapeProps } from '@tldraw/editor';
@@ -4173,6 +4174,7 @@ export const TldrawImage: NamedExoticComponent<TldrawImageProps>;
 
 // @public (undocumented)
 export interface TldrawImageProps extends TLImageExportOptions {
+    assets?: TLAssetStore;
     assetUrls?: TLUiAssetUrlOverrides;
     bindingUtils?: readonly TLAnyBindingUtilConstructor[];
     format?: 'png' | 'svg';

--- a/packages/tldraw/src/lib/TldrawImage.tsx
+++ b/packages/tldraw/src/lib/TldrawImage.tsx
@@ -2,6 +2,7 @@ import {
 	Editor,
 	TLAnyBindingUtilConstructor,
 	TLAnyShapeUtilConstructor,
+	TLAssetStore,
 	TLEditorSnapshot,
 	TLImageExportOptions,
 	TLPageId,
@@ -52,6 +53,12 @@ export interface TldrawImageProps extends TLImageExportOptions {
 	 * Asset URL overrides.
 	 */
 	assetUrls?: TLUiAssetUrlOverrides
+	/**
+	 * The asset store to use for resolving the snapshot's assets, matching the `assets` prop on
+	 * {@link Tldraw}. Without one, assets that aren't stored inline (as data URLs) can't be
+	 * resolved and won't appear in the image.
+	 */
+	assets?: TLAssetStore
 	/**
 	 * Options for the editor.
 	 */
@@ -105,7 +112,11 @@ export const TldrawImage = memo(function TldrawImage(props: TldrawImageProps) {
 		() => mergeArraysAndReplaceDefaults('type', _bindingUtils, defaultBindingUtils),
 		[_bindingUtils]
 	)
-	const store = useTLStore({ snapshot: props.snapshot, shapeUtils: shapeUtilsWithDefaults })
+	const store = useTLStore({
+		snapshot: props.snapshot,
+		shapeUtils: shapeUtilsWithDefaults,
+		assets: props.assets,
+	})
 
 	const {
 		pageId,


### PR DESCRIPTION
`TldrawImage` builds its own store internally but never passed an asset store to it, so it always fell back to the inline base64 store. A snapshot whose assets live anywhere else — a vault, a CDN, a custom backend — renders without its images, and there was no prop to fix that. `Tldraw` has taken `assets` all along, so an app could set up an asset store for the editor and then lose it the moment it swapped to the read-only renderer.

This is what our own Obsidian plugin hits: it stores media in the user's vault, so embedded drawings and previews render without their images. It has carried this exact change as a `patch-package` patch since 2024, which is why the plugin still needs a `patches/` directory at all.

Closes #4603, which asked for this and included a working implementation, then got closed by the stale bot 6 months later without being picked up. Credit for the original change goes to @jon-dez (jon-dez/tldraw@820929f).

```tsx
<TldrawImage snapshot={snapshot} assets={assetStore} />
```

Additive and optional: `TLStoreOptions.assets` already defaults to `inlineBase64AssetStore`, so passing nothing behaves exactly as before.

### API changes

- Added optional `assets?: TLAssetStore` to `TldrawImageProps`, matching the `assets` prop on `Tldraw`

### Change type

- [x] `api`

### Test plan

1. Render a `<TldrawImage>` from a snapshot whose assets are not inline data URLs — for example an image shape whose `src` only resolves through a custom asset store.
2. Without `assets`, the image is missing; passing the same store used for `<Tldraw>` renders it.
3. Confirm existing `<TldrawImage>` usage is unaffected when the prop is omitted.

- [ ] Unit tests
- [ ] End to end tests

`TldrawImage` has no test file today, so this adds none rather than standing up a render harness for a three-line pass-through. Happy to add one if you'd rather it came with coverage.

### Release notes

- Add an `assets` prop to `TldrawImage`, so images render from a custom asset store the same way they do in `Tldraw`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +12 / -1   |
| Automated files | +2 / -0    |
