### PR TITLE
fix(editor): pass wheel events through non-scrollable overlays

### DIFF
--- a/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
@@ -3,6 +3,42 @@ import { preventDefault } from '../utils/dom'
 import { useContainer } from './useContainer'
 import { useMaybeEditor } from './useEditor'
 
+function isScrollableOverflow(overflow: string) {
+	return overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay'
+}
+
+// An element only consumes a wheel event when it's a real scroll container: its content overflows
+// AND its computed overflow is scrollable. Checking scrollHeight/scrollWidth alone is not enough —
+// an `overflow: visible` element whose content merely overflows (e.g. a comment pin whose hover
+// `transform: scale()` inflates scrollHeight past clientHeight) never scrolls, so the wheel must
+// still pass through to the canvas.
+function isScrollable(elm: HTMLElement) {
+	const style = getComputedStyle(elm)
+	return (
+		(elm.scrollHeight > elm.clientHeight && isScrollableOverflow(style.overflowY)) ||
+		(elm.scrollWidth > elm.clientWidth && isScrollableOverflow(style.overflowX))
+	)
+}
+
+// Walk from the wheeled element up to (and including) the pass-through root, looking for a scroll
+// container. If one is found, the wheel belongs to it — don't redispatch it to the canvas.
+function hasScrollableElement(target: EventTarget | null, root: HTMLElement) {
+	if (!(target instanceof Node)) {
+		return isScrollable(root)
+	}
+
+	let elm: Element | null = target instanceof Element ? target : target.parentElement
+	while (elm) {
+		if (elm instanceof HTMLElement && isScrollable(elm)) {
+			return true
+		}
+		if (elm === root) return false
+		elm = elm.parentElement
+	}
+
+	return false
+}
+
 /** @public */
 export function usePassThroughWheelEvents(ref: RefObject<HTMLElement | null>) {
 	if (!ref) throw Error('usePassThroughWheelEvents must be passed a ref')
@@ -16,9 +52,9 @@ export function usePassThroughWheelEvents(ref: RefObject<HTMLElement | null>) {
 
 			if ((e as any).isSpecialRedispatchedEvent) return
 
-			// if the element is scrollable, don't redispatch the event
+			// If the wheel is over a scrollable element, let it scroll instead of redispatching.
 			const elm = ref.current
-			if (elm && elm.scrollHeight > elm.clientHeight) {
+			if (elm && hasScrollableElement(e.target, elm)) {
 				return
 			}
 

--- a/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
@@ -13,10 +13,16 @@ function isScrollableOverflow(overflow: string) {
 // `transform: scale()` inflates scrollHeight past clientHeight) never scrolls, so the wheel must
 // still pass through to the canvas.
 function isScrollable(elm: HTMLElement) {
+	// Cheap first: if nothing overflows, it can't scroll — skip the getComputedStyle read. This runs
+	// per ancestor on every wheel event, so avoid resolving styles for the common (non-overflowing) case.
+	const overflowsY = elm.scrollHeight > elm.clientHeight
+	const overflowsX = elm.scrollWidth > elm.clientWidth
+	if (!overflowsY && !overflowsX) return false
+
 	const style = getComputedStyle(elm)
 	return (
-		(elm.scrollHeight > elm.clientHeight && isScrollableOverflow(style.overflowY)) ||
-		(elm.scrollWidth > elm.clientWidth && isScrollableOverflow(style.overflowX))
+		(overflowsY && isScrollableOverflow(style.overflowY)) ||
+		(overflowsX && isScrollableOverflow(style.overflowX))
 	)
 }
 


### PR DESCRIPTION
In order to zoom or pan the canvas while the cursor is over a comment pin (and other non-scrollable overlays), this fixes the pass-through wheel handler so it stops treating "content overflows" as "this element is scrollable".

`usePassThroughWheelEvents` lets a wheel over a UI overlay fall through to the canvas, unless the overlay is itself scrollable — in which case the wheel should scroll it. It decided "scrollable" with `scrollHeight > clientHeight`. That's a bad proxy: a comment pin's marker is `overflow: visible` and 34×34, but hovering it applies `transform: scale(1.08)` to the pin, and Chrome counts the scaled child in the parent's scroll-overflow region, so `scrollHeight` becomes 35 while `clientHeight` stays 34. The pin can't actually scroll, but the guard concluded it could and swallowed the wheel — so zooming/panning over a pin did nothing. It only misfired while hovered, which is exactly when you'd try to zoom over it, and it hit closed and open pins alike.

The fix gates the check on the computed `overflow` (`auto`/`scroll`/`overlay`) in addition to content overflow, so an `overflow: visible` element never counts as scrollable.

Relates to #8852, which edits the same guard for the resizable color grid. That change extends the check to walk from `e.target` up to the root (and consider width), but keeps the `scrollHeight`-only test, so it would still misfire on the pin. This PR folds both concerns together: it walks the ancestor chain and checks both axes *and* gates on real overflow. The two PRs collide on this guard — whichever lands first, the other should rebase onto this combined version.

### Change type

- [x] `bugfix`

### Test plan

1. Open the Commenting example (`apps/examples`, `/commenting`).
2. Add a comment to drop a pin on the canvas.
3. Hover the pin and zoom (ctrl/⌘ + scroll) or trackpad-pinch — the canvas zooms/pans as it does over empty canvas.
4. Confirm a genuinely scrollable panel (e.g. a long style panel) still scrolls its own content with the wheel instead of zooming.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix zoom and pan not working when the cursor is over a comment pin.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +38 / -2   |