### PR TITLE
docs: restore shape meta documentation

### DIFF
--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -9,6 +9,8 @@ keywords:
   - shapes
   - shapeutils
   - utils
+  - meta
+  - metadata
 ---
 
 In tldraw, a shape is something that can exist on the page, like an arrow, an image, or some text. This article provides an overview of shapes and how to create custom ones.
@@ -101,6 +103,89 @@ export default function () {
 	)
 }
 ```
+
+## Meta
+
+Every shape has a `meta` property for your own data. Tldraw stores and syncs this data but doesn't use it itself. It's an escape hatch for attaching extra information to shapes, like the name of the user who created a shape or the date it was last changed.
+
+Like `props`, the data in `meta` must be JSON-serializable. Shapes aren't the only records with a `meta` property: pages, assets, and the document record have one too.
+
+By default, a shape's `meta` is an empty object typed as `JsonObject`. To type your meta data, use an intersection:
+
+```ts
+type ShapeWithMyMeta = TLGeoShape & { meta: { createdBy: string } }
+
+const shape = editor.getShape<ShapeWithMyMeta>(myGeoShapeId)
+```
+
+You can update a shape's `meta` the same way you update its props, using [Editor#updateShapes](?):
+
+```ts
+editor.updateShapes<ShapeWithMyMeta>([
+	{
+		id: myGeoShapeId,
+		type: 'geo',
+		meta: { createdBy: 'Steve' },
+	},
+])
+```
+
+### Initial meta
+
+When [Editor#createShapes](?) creates a shape, it sets the shape's meta using [Editor#getInitialMetaForShape](?). By default this method returns an empty object. Replace it to provide your own initial meta:
+
+```tsx
+editor.getInitialMetaForShape = (shape) => {
+	if (shape.type === 'text') {
+		return { createdBy: currentUser.id, lastModified: Date.now() }
+	}
+	return { createdBy: currentUser.id }
+}
+```
+
+> For a working example, see our [shape meta on create example](/examples/events/meta-on-create).
+
+### Updating meta with side effects
+
+To keep meta up to date as shapes change, register a side effect that runs before each shape update:
+
+```tsx
+editor.sideEffects.registerBeforeChangeHandler('shape', (_prev, next, source) => {
+	if (source !== 'user') return next
+	return {
+		...next,
+		meta: { updatedBy: editor.user.getExternalId(), updatedAt: Date.now() },
+	}
+})
+```
+
+> For a working example, see our [shape meta on change example](/examples/events/meta-on-change). See [Side effects](/sdk-features/side-effects) for the full side effects API.
+
+### Validating meta
+
+By default, the store accepts any JSON value in `meta`. To validate meta data at runtime, build your own schema with [createTLSchema](?) and pass validators for each shape type's meta:
+
+```tsx
+import { useState } from 'react'
+import { createTLSchema, createTLStore, defaultShapeSchemas, T, Tldraw } from 'tldraw'
+
+const schema = createTLSchema({
+	shapes: {
+		...defaultShapeSchemas,
+		geo: {
+			...defaultShapeSchemas.geo,
+			meta: { createdBy: T.string },
+		},
+	},
+})
+
+export default function App() {
+	const [store] = useState(() => createTLStore({ schema }))
+	return <Tldraw store={store} />
+}
+```
+
+Bindings, assets, and user records accept meta validators the same way. For user records, see our [custom user metadata example](/examples/users/custom-user).
 
 ## Extending shapes
 

--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -108,7 +108,7 @@ export default function () {
 
 Every shape has a `meta` property for your own data. Tldraw stores and syncs this data but doesn't use it itself. It's an escape hatch for attaching extra information to shapes, like the name of the user who created a shape or the date it was last changed.
 
-Like `props`, the data in `meta` must be JSON-serializable. Shapes aren't the only records with a `meta` property: pages, assets, and the document record have one too.
+Like `props`, the data in `meta` must be JSON-serializable. Shapes aren't the only records with a `meta` property: pages, bindings, assets, and the document record have one too.
 
 By default, a shape's `meta` is an empty object typed as `JsonObject`. To type your meta data, use an intersection:
 
@@ -118,7 +118,7 @@ type ShapeWithMyMeta = TLGeoShape & { meta: { createdBy: string } }
 const shape = editor.getShape<ShapeWithMyMeta>(myGeoShapeId)
 ```
 
-You can update a shape's `meta` the same way you update its props, using [Editor#updateShapes](?):
+You can update a shape's `meta` with [Editor#updateShapes](?), the same way you update its props:
 
 ```ts
 editor.updateShapes<ShapeWithMyMeta>([
@@ -159,7 +159,9 @@ editor.sideEffects.registerBeforeChangeHandler('shape', (_prev, next, source) =>
 })
 ```
 
-> For a working example, see our [shape meta on change example](/examples/events/meta-on-change). See [Side effects](/sdk-features/side-effects) for the full side effects API.
+Side effects can run on create, update, and delete for shapes and other records. See [Side effects](/sdk-features/side-effects) for the full API.
+
+> For a working example, see our [shape meta on change example](/examples/events/meta-on-change).
 
 ### Validating meta
 

--- a/apps/docs/content/sdk-features/shapes.mdx
+++ b/apps/docs/content/sdk-features/shapes.mdx
@@ -26,6 +26,8 @@ Shapes support parent-child hierarchies for grouping and frames, participate in 
 
 A shape record is a plain object stored in the editor's reactive store. All shape types extend `TLBaseShape`, which defines the common properties every shape has: a unique identifier, position and rotation, z-ordering index, parent reference, lock state, opacity, and a `props` field for shape-specific properties. The `props` field contains data unique to each shape type. A geo shape stores its width, height, and geometry type. A text shape stores its text content and font size. Each shape type defines its own props structure.
 
+Shapes also have a `meta` field for your own application data, which tldraw stores but doesn't use itself. See [Meta](/docs/shapes#Meta) for how to set, type, and validate it.
+
 ### Shape types in tldraw
 
 The default tldraw installation includes these shape types:

--- a/apps/examples/src/examples/events/meta-on-change/OnChangeShapeMetaExample.tsx
+++ b/apps/examples/src/examples/events/meta-on-change/OnChangeShapeMetaExample.tsx
@@ -54,7 +54,9 @@ export const MetaUiHelper = track(function MetaUiHelper() {
 
 /*
 This example shows how to add meta data to shapes when they are created and
-updated. In this case we are adding `updatedBy` and `updatedAt` fields.
+updated. In this case we are adding `updatedBy` and `updatedAt` fields. Check
+out the docs for a more detailed explanation of the meta property:
+https://tldraw.dev/docs/shapes#Meta
 
 [1]
 getInitialMetaForShape is a method you can replace at runtime. Here we use 

--- a/apps/examples/src/examples/events/meta-on-create/OnCreateShapeMetaExample.tsx
+++ b/apps/examples/src/examples/events/meta-on-create/OnCreateShapeMetaExample.tsx
@@ -43,8 +43,8 @@ export const MetaUiHelper = track(function MetaUiHelper() {
 
 /*
 This example demonstrates how to add your own data to shapes using the meta property as they're
-created. Check out the docs for a more detailed explanation of the meta property: 
-https://tldraw.dev/docs/shapes#Meta-information
+created. Check out the docs for a more detailed explanation of the meta property:
+https://tldraw.dev/docs/shapes#Meta
 
 [1]
 getInitialMetaForShape is a method you can replace at runtime. Here we use a callback on the onMount


### PR DESCRIPTION
In order to give the shape `meta` property a home on tldraw.dev again, this PR restores a Meta section to the shapes guide. The SDK docs restructure dropped the old "Meta information" section, leaving `meta` and `Editor#getInitialMetaForShape` undocumented while the meta examples still linked to the dead `/docs/shapes#Meta-information` anchor.

The restored section covers the `meta` field on records (shapes, pages, bindings, assets, the document record), typing it with an intersection, setting initial values with `Editor#getInitialMetaForShape`, keeping it current with a before-change side effect, and validating it at runtime with `createTLSchema` meta validators. The sdk-features shapes page gains a one-line cross-reference (its `TLBaseShape` overview omitted `meta` entirely), and the two meta example comments now point at the restored `/docs/shapes#Meta` anchor. The anchor is capitalized because the docs slugger preserves heading case.

Every code sample was verified against the current `packages/editor` and `packages/tlschema` source. Note that meta validators go through `createTLSchema`, not ShapeUtil statics: the editor's schema builder only forwards `props` and `migrations` from shape utils, so the schema route documented here is the only one that works.

### Change type

- [x] `improvement`

### Test plan

1. Run `yarn dev-docs` and open `localhost:3001/docs/shapes#Meta` — the page scrolls to the new section and all API links resolve.
2. `yarn check-links` in `apps/docs` passes (validates the new internal links and the autolinked `(?)` API references).

### Release notes

- Docs: restore documentation for the `meta` property on shapes and other records, including `Editor#getInitialMetaForShape`, side-effect updates, and meta validators.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +94 / -3   |