### PR TITLE
feat(dotcom): gate commenting behind a feature flag

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -100,6 +100,22 @@ export function shouldUseProperZero(
 	return { value: flagEnabled, reason: 'server feature flag' }
 }
 
+/**
+ * Whether commenting is available to this user. While commenting is being built out it's staff-only:
+ * anyone with a @tldraw.com email gets it, everyone else waits on the `commenting_enabled` flag
+ * (off by default, with a percentage rollout knob on the admin page). Signed-out viewers have no
+ * email and no flags, so they don't see comments at all.
+ */
+export function shouldEnableCommenting(
+	flags: FeatureFlags,
+	email?: string | null
+): { value: boolean; reason: string } {
+	if (email?.endsWith('@tldraw.com')) {
+		return { value: true, reason: '@tldraw.com email' }
+	}
+	return { value: flags.commenting_enabled?.enabled ?? false, reason: 'server feature flag' }
+}
+
 // @ts-expect-error — dev escape hatch, call window.zero() in console to toggle
 window.zero = () => {
 	const current = getFromLocalStorage('useProperZero') === 'true'
@@ -141,6 +157,8 @@ export class TldrawApp {
 	private readonly comments$: Signal<QueryResultType<typeof queries.comments>>
 
 	private readonly useProperZero: boolean
+	/** Whether this user gets the commenting UI — see {@link shouldEnableCommenting}. */
+	readonly isCommentingEnabled: boolean
 	private readonly abortController = new AbortController()
 	readonly disposables: (() => void)[] = [() => this.abortController.abort(), () => this.z.close()]
 	private getToken: () => Promise<string | undefined>
@@ -201,6 +219,7 @@ export class TldrawApp {
 		const sessionId = uniqueId()
 		const { value: properZero, reason } = shouldUseProperZero(flags, email)
 		this.useProperZero = properZero
+		this.isCommentingEnabled = shouldEnableCommenting(flags, email).value
 		// eslint-disable-next-line no-console
 		console.log(`[Zero] Using ${properZero ? 'proper Zero' : 'ZeroPolyfill'} (${reason})`)
 		if (properZero) {

--- a/apps/dotcom/client/src/tla/app/shouldEnableCommenting.test.ts
+++ b/apps/dotcom/client/src/tla/app/shouldEnableCommenting.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import type { FeatureFlags } from '../utils/FeatureFlagPoller'
+import { shouldEnableCommenting } from './TldrawApp'
+
+const FLAGS_OFF: FeatureFlags = {
+	zero_enabled: { enabled: false },
+	zero_kill_switch: { enabled: false },
+	rum_enabled: { enabled: false },
+	commenting_enabled: { enabled: false },
+}
+
+const FLAGS_COMMENTING_ON: FeatureFlags = {
+	...FLAGS_OFF,
+	commenting_enabled: { enabled: true },
+}
+
+describe('shouldEnableCommenting', () => {
+	it('is off with default flags and no email', () => {
+		expect(shouldEnableCommenting(FLAGS_OFF)).toEqual({
+			value: false,
+			reason: 'server feature flag',
+		})
+	})
+
+	it('is off for a non-tldraw email when the flag is off', () => {
+		expect(shouldEnableCommenting(FLAGS_OFF, 'alice@example.com')).toEqual({
+			value: false,
+			reason: 'server feature flag',
+		})
+	})
+
+	it('is on for a @tldraw.com email even when the flag is off', () => {
+		expect(shouldEnableCommenting(FLAGS_OFF, 'dev@tldraw.com')).toEqual({
+			value: true,
+			reason: '@tldraw.com email',
+		})
+	})
+
+	it('is on for anyone when the flag is on', () => {
+		expect(shouldEnableCommenting(FLAGS_COMMENTING_ON, 'alice@example.com')).toEqual({
+			value: true,
+			reason: 'server feature flag',
+		})
+	})
+
+	it('does not match a lookalike domain', () => {
+		expect(shouldEnableCommenting(FLAGS_OFF, 'alice@nottldraw.com').value).toBe(false)
+		expect(shouldEnableCommenting(FLAGS_OFF, 'alice@tldraw.com.example.com').value).toBe(false)
+	})
+
+	it('handles a null email', () => {
+		expect(shouldEnableCommenting(FLAGS_OFF, null).value).toBe(false)
+		expect(shouldEnableCommenting(FLAGS_COMMENTING_ON, null).value).toBe(true)
+	})
+})

--- a/apps/dotcom/client/src/tla/app/shouldUseProperZero.test.ts
+++ b/apps/dotcom/client/src/tla/app/shouldUseProperZero.test.ts
@@ -25,6 +25,7 @@ const FLAGS_OFF: FeatureFlags = {
 	zero_enabled: { enabled: false },
 	zero_kill_switch: { enabled: false },
 	rum_enabled: { enabled: false },
+	commenting_enabled: { enabled: false },
 }
 
 describe('shouldUseProperZero', () => {
@@ -142,6 +143,7 @@ describe('shouldUseProperZero', () => {
 				zero_enabled: { enabled: true },
 				zero_kill_switch: { enabled: true },
 				rum_enabled: { enabled: false },
+				commenting_enabled: { enabled: false },
 			}
 			// Kill switch wins over everything
 			const result = shouldUseProperZero(flags, 'dev@tldraw.com')

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -42,6 +42,7 @@ import { globalEditor } from '../../../utils/globalEditor'
 import { multiplayerAssetStore } from '../../../utils/multiplayerAssetStore'
 import { TldrawApp } from '../../app/TldrawApp'
 import { useMaybeApp } from '../../hooks/useAppState'
+import { useIsCommentingEnabled } from '../../hooks/useIsCommentingEnabled'
 import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
 import { useTldrawCurrentUser } from '../../hooks/useUser'
@@ -289,14 +290,27 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const overrides = useFileEditorOverrides({ fileSlug })
 	const extraDragIconOverrides = useExtraDragIconOverrides()
 	const anonCommentToolOverrides = useAnonCommentToolOverrides()
+	const commentingEnabled = useIsCommentingEnabled()
 
 	const instanceComponents = useMemo((): TLComponents => {
 		return {
 			...components,
 			DebugMenu: () => <CustomDebugMenu />,
-			InFrontOfTheCanvas: () => <CommentsOnCanvas fileId={fileId} />,
+			InFrontOfTheCanvas: commentingEnabled
+				? () => <CommentsOnCanvas fileId={fileId} />
+				: undefined,
 		}
-	}, [fileId])
+	}, [fileId, commentingEnabled])
+
+	// Without the tool and its overrides there's no comment button in the toolbar and no `c`
+	// shortcut, so commenting is fully absent for users the flag doesn't cover.
+	const editorOverrides = useMemo(
+		() =>
+			commentingEnabled
+				? [overrides, extraDragIconOverrides, commentToolOverrides, anonCommentToolOverrides]
+				: [overrides, extraDragIconOverrides],
+		[commentingEnabled, overrides, extraDragIconOverrides, anonCommentToolOverrides]
+	)
 
 	return (
 		<TlaEditorWrapper>
@@ -306,7 +320,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				store={store}
 				assetUrls={assetUrls}
 				shapeUtils={embedShapeUtils}
-				tools={tlaCommentTools}
+				tools={commentingEnabled ? tlaCommentTools : undefined}
 				user={app?.tlUser}
 				onMount={handleMount}
 				onUiEvent={handleUiEvent}
@@ -315,12 +329,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 					actionShortcutsLocation: 'toolbar',
 					deepLinks: deepLinks ? true : undefined,
 				}}
-				overrides={[
-					overrides,
-					extraDragIconOverrides,
-					commentToolOverrides,
-					anonCommentToolOverrides,
-				]}
+				overrides={editorOverrides}
 				getShapeVisibility={getShapeVisibility}
 			>
 				<ThemeUpdater />
@@ -330,7 +339,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				{app && <SneakyTldrawFileDropHandler />}
 				<SneakyLargeFileHander />
 				<SneakyDebugModeToast />
-				<SneakyCommentDeepLink />
+				{commentingEnabled && <SneakyCommentDeepLink />}
 				<TlaAnonDotDevLink />
 			</Tldraw>
 		</TlaEditorWrapper>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopLeftPanel.tsx
@@ -42,6 +42,7 @@ import {
 } from 'tldraw'
 import { useApp, useMaybeApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
+import { useIsCommentingEnabled } from '../../hooks/useIsCommentingEnabled'
 import { useHasFileAdminRights } from '../../hooks/useIsFileOwner'
 import { TLAppUiEventSource, useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { getIsCoarsePointer } from '../../utils/getIsCoarsePointer'
@@ -62,9 +63,11 @@ import { sidebarMessages } from '../TlaSidebar/components/TlaSidebarFileLink'
 import { useRoomInfo } from './TlaEditorTopRightPanel'
 import styles from './top.module.css'
 
-/** tldraw's default View submenu plus a "Comments" show/hide toggle (its own group). Rebuilt here
- *  because tldraw's `ViewSubmenu` is a fixed component with no slot to inject into. */
+/** tldraw's default View submenu plus a "Comments" show/hide toggle (its own group, only for users
+ *  the commenting flag covers). Rebuilt here because tldraw's `ViewSubmenu` is a fixed component
+ *  with no slot to inject into. */
 function TlaViewSubmenu() {
+	const commentingEnabled = useIsCommentingEnabled()
 	return (
 		<TldrawUiMenuSubmenu id="view" label="menu.view">
 			<TldrawUiMenuGroup id="view-actions">
@@ -74,9 +77,11 @@ function TlaViewSubmenu() {
 				<ZoomToFitMenuItem />
 				<ZoomToSelectionMenuItem />
 			</TldrawUiMenuGroup>
-			<TldrawUiMenuGroup id="view-comments">
-				<CommentsMenuItem />
-			</TldrawUiMenuGroup>
+			{commentingEnabled && (
+				<TldrawUiMenuGroup id="view-comments">
+					<CommentsMenuItem />
+				</TldrawUiMenuGroup>
+			)}
 		</TldrawUiMenuSubmenu>
 	)
 }

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditorTopRightPanel.tsx
@@ -24,6 +24,7 @@ import {
 import { routes } from '../../../routeDefs'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { useCurrentFileId } from '../../hooks/useCurrentFileId'
+import { useIsCommentingEnabled } from '../../hooks/useIsCommentingEnabled'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
 import { TlaSignInDialog } from '../dialogs/TlaSignInDialog'
@@ -100,15 +101,17 @@ export function TlaEditorTopRightPanel({
 /**
  * Toggles the comments sidebar (the thread list) open and closed. Lives next to Share as an opt-in
  * entry point, decoupled from the comment tool: the tool places comments on the canvas, this button
- * reveals the list. Hidden entirely when commenting isn't licensed for this editor.
+ * reveals the list. Hidden entirely when commenting isn't licensed for this editor, or when the
+ * user isn't covered by dotcom's commenting flag.
  */
 function CommentsSidebarButton() {
 	const editor = useEditor()
 	const commentingEnabled = useCommentingEnabled()
+	const commentingEnabledForUser = useIsCommentingEnabled()
 	const open = useCommentsSidebarOpen()
 	const label = useMsg(commentsMessages.comments)
 
-	if (!commentingEnabled) return null
+	if (!commentingEnabled || !commentingEnabledForUser) return null
 
 	return (
 		<TldrawUiButton

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/TlaSidebar.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect } from 'react'
 import { tlmenus, useMaybeEditor } from 'tldraw'
 import { useActiveWorkspaceId } from '../../hooks/useActiveWorkspaceId'
+import { useIsCommentingEnabled } from '../../hooks/useIsCommentingEnabled'
 import { useTldrFileDrop } from '../../hooks/useTldrFileDrop'
 import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import {
@@ -59,6 +60,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 	const { onDrop, onDragOver, onDragEnter, onDragLeave } = useTldrFileDrop()
 
 	const activeWorkspaceId = useActiveWorkspaceId()
+	const commentingEnabled = useIsCommentingEnabled()
 
 	return (
 		<nav aria-hidden={!isSidebarOpen} style={{ visibility: isSidebarOpen ? 'visible' : 'hidden' }}>
@@ -81,7 +83,7 @@ export const TlaSidebar = memo(function TlaSidebar() {
 				<div className={styles.sidebarTopRow}>
 					<TlaSidebarWorkspaceLink />
 					<div style={{ display: 'flex', alignItems: 'center' }}>
-						<TlaSidebarNotificationsButton />
+						{commentingEnabled && <TlaSidebarNotificationsButton />}
 						<TlaSidebarCreateFileButton />
 					</div>
 				</div>

--- a/apps/dotcom/client/src/tla/hooks/useIsCommentingEnabled.ts
+++ b/apps/dotcom/client/src/tla/hooks/useIsCommentingEnabled.ts
@@ -1,0 +1,14 @@
+import { useMaybeApp } from './useAppState'
+
+/**
+ * Whether to show any commenting UI (tool, pins, threads, sidebar, notifications) on tldraw.com.
+ * Resolved once when the app is created, from the `commenting_enabled` feature flag plus the
+ * signed-in user's email — see `shouldEnableCommenting`. Signed-out viewers have no app, and so no
+ * commenting.
+ *
+ * This is dotcom's own gate, separate from `useCommentingEnabled` in `@tldraw/commenting`, which
+ * says whether commenting is licensed for the editor at all. Both have to pass.
+ */
+export function useIsCommentingEnabled(): boolean {
+	return useMaybeApp()?.isCommentingEnabled ?? false
+}

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
@@ -15,6 +15,7 @@ function makeFlags(overrides: Partial<FeatureFlags> = {}): FeatureFlags {
 		zero_enabled: { enabled: false },
 		zero_kill_switch: { enabled: false },
 		rum_enabled: { enabled: false },
+		commenting_enabled: { enabled: false },
 		...overrides,
 	}
 }

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
@@ -8,6 +8,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
 	zero_enabled: { enabled: false },
 	zero_kill_switch: { enabled: false },
 	rum_enabled: { enabled: false },
+	commenting_enabled: { enabled: false },
 }
 
 let currentFlags: FeatureFlags = { ...DEFAULT_FLAGS }

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
@@ -283,6 +283,11 @@ describe('getFeatureFlagsAdmin (route handler)', () => {
 		const response = await getFeatureFlagsAdmin({} as any, env as any)
 		const body: any = await response.json()
 
-		expect(Object.keys(body).sort()).toEqual(['rum_enabled', 'zero_enabled', 'zero_kill_switch'])
+		expect(Object.keys(body).sort()).toEqual([
+			'commenting_enabled',
+			'rum_enabled',
+			'zero_enabled',
+			'zero_kill_switch',
+		])
 	})
 })

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.ts
@@ -27,6 +27,13 @@ function getFlagDefaults(_env: Environment): Record<FeatureFlagKey, FeatureFlagV
 			enabled: false,
 			description: 'Real User Monitoring for editor performance metrics',
 		},
+		commenting_enabled: {
+			type: 'percentage',
+			percentage: 0,
+			enabled: false,
+			description:
+				'Commenting on files (tool, pins, threads, sidebar, notifications). Users with a @tldraw.com email always have it, regardless of this flag',
+		},
 	}
 }
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -297,7 +297,12 @@ export type TLCustomServerEvent = { type: 'persistence_good' } | { type: 'persis
 
 /* ----------------------- Feature Flags ---------------------- */
 
-export const FEATURE_FLAG_KEYS = ['zero_enabled', 'zero_kill_switch', 'rum_enabled'] as const
+export const FEATURE_FLAG_KEYS = [
+	'zero_enabled',
+	'zero_kill_switch',
+	'rum_enabled',
+	'commenting_enabled',
+] as const
 export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[number]
 
 export type FeatureFlagValue = BooleanFeatureFlag | PercentageFeatureFlag


### PR DESCRIPTION
Commenting is close enough to shipping that it's on the `commenting` branch by default, but it isn't ready for tldraw.com users yet. In order to keep dogfooding it on production without exposing it, this puts the whole dotcom commenting surface behind a `commenting_enabled` feature flag, with staff exempted: anyone signed in with a `@tldraw.com` email gets commenting regardless of the flag.

The evaluation mirrors the existing `shouldUseProperZero` gate — email first, then the server flag — and resolves once when `TldrawApp` is constructed, so it can't flip mid-session. Components read it through a new `useIsCommentingEnabled()` hook. Signed-out viewers have no app and no email, so they don't see comments at all, which is what we want while this is internal.

When the gate is closed, commenting is absent rather than disabled: the comment tool and its overrides aren't registered, so there's no toolbar button and no `c` shortcut; no pins, threads, or comments sidebar; no Comments item in the View submenu; no notifications button in the sidebar (and none of its queries); and no comment deep-link handling. The one thing that stays unconditional is `commentSchemaRecords` on the sync store — the client schema has to keep matching the server's, the same way the legacy file editor already registers them without rendering any comments UI.

The flag is a percentage flag defaulting to 0/off, so it doubles as the rollout lever later. Worth flagging: this is a client-side UI gate, not authorization — the sync worker and Zero mutators still accept comment writes from anyone who can reach them.

This is separate from the SDK-level license gate in #9688 (`useCommentingEnabled` from `@tldraw/commenting`); both have to pass. It also overlaps mechanically with #9564, which deletes the `zero_*` flags — same files, no conceptual conflict, whichever lands second resolves a few list entries.

### Change type

- [x] `feature`

### Test plan

1. Sign in with a `@tldraw.com` account: comment tool, pins, sidebar button, View → Comments, and the sidebar notifications button all appear as before.
2. Sign in with a non-tldraw account with the flag off: none of the above are present, `c` selects nothing, and a `?d=` comment deep link is inert.
3. Flip `commenting_enabled` on from `/admin` (enabled + 100%), reload as the non-tldraw account: commenting appears.
4. Open a shared file signed out: no comment UI.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Internal: commenting on tldraw.com is behind a feature flag while it's in development.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +6 / -1    |
| Tests     | +64 / -1   |
| Apps      | +78 / -18  |
