### PR TITLE
feat(commenting): @-mention users currently present on the board (alternative to #9703)

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -4,6 +4,7 @@ import {
 	CanvasCommentsSidebar,
 	CommentAuthor,
 	filterMentionMembers,
+	MentionMember,
 } from '@tldraw/commenting'
 import { queries } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -115,6 +116,19 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 		},
 		[app, fileId]
 	)
+	// The @-mention roster: workspace members plus anyone currently present on the board. Live
+	// presence is the "viewer" signal — people actually on the board right now — so you can mention a
+	// collaborator whose cursor you can see even if they aren't a workspace member. Presence already
+	// carries their name and color, and the server never echoes a session its own presence, so this
+	// set excludes the current user by construction. Members win on id collision: they carry role
+	// context and the current user's `you` flag, and their identity is authoritative.
+	const roster = useMemo(() => {
+		const byId = new Map<string, MentionMember>(mentionMembers.map((m) => [m.id, m]))
+		for (const [id, author] of presenceAuthors) {
+			if (!byId.has(id)) byId.set(id, { id, name: author.name, color: author.color })
+		}
+		return [...byId.values()]
+	}, [mentionMembers, presenceAuthors])
 	// Roster authors keyed by id — a MentionMember is a CommentAuthor. The workspace roster is the
 	// id→name source for a mentioned member who's committed no comment and isn't currently present —
 	// without it, they resolve to nothing and render as the byline default rather than their name.
@@ -139,8 +153,8 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 	)
 	const onCommentRead = useCallback((commentId: string) => app?.markCommentRead(commentId), [app])
 	const getMentionSuggestions = useCallback(
-		(query: string) => filterMentionMembers(mentionMembers, query),
-		[mentionMembers]
+		(query: string) => filterMentionMembers(roster, query),
+		[roster]
 	)
 
 	return (


### PR DESCRIPTION
In order to let people @-mention the collaborators they're actually working with — not only formal workspace members — this adds everyone **currently present on the board** to the comment mention roster. If you can see someone's cursor, you can mention them.

This is an **alternative to #9703**, which sourced the same "mention people beyond workspace members" feature from a persisted `file_visitor` table. Same goal, different signal:

| | This PR (presence) | #9703 (`file_visitor`) |
| --- | --- | --- |
| Who's mentionable | Users **on the board right now** | Anyone who has **ever opened** it |
| Where the data lives | `instance_presence` in the sync room (already synced) | New Postgres table + triggers, Zero-synced |
| Footprint | One client file, +16/−2 | Migration, schema, new synced query, CRUD types |
| New privacy surface | **None** — present users' names and cursors are already broadcast to the room | Exposes the historical viewer list to all collaborators |

The tradeoff is the honest one: presence is live and ephemeral. It only knows who is connected this moment (it's dropped on disconnect and never persisted), so this cannot mention someone who viewed yesterday and left. #9703 can. If the product wants "mention whoever's here in a live session," presence is the lighter, privacy-neutral fit; if it wants a durable roster of everyone who's touched the board, #9703 is the one.

### How it works

`CommentsOnCanvas` already reads `instance_presence` from the editor store (for author-name resolution) and already resolves a mentioned present user's name via that same source. The only gap was the suggestion list, which offered workspace members only. This merges present users into that list (workspace members win on id collision). Presence excludes the current user by construction, and notifications are unaffected: a present user has the file open, so they have the `file_state` row the mention gate already keys on.

### Change type

- [x] `feature`

### Test plan

1. Open a board as user A (a workspace member) and, in a second session, as user B who is **not** a member.
2. In A's comment composer, type `@` — B (currently present) appears. Mention B and post.
3. Confirm B receives the mention in the sidebar notifications feed and it renders with B's name.
4. Disconnect B, then in A's composer type `@` again — B no longer appears (presence is live-only). This is the expected limitation versus #9703.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Comments: you can now @-mention anyone currently on the board, not just workspace members.

### Code changes

| Section             | LOC change |
| ------------------- | ---------- |
| Apps (`apps/dotcom`) | +16 / -2   |
