### PR TITLE
feat(editor): grandfather pre-launch licenses into collaboration

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -5205,6 +5205,8 @@ export interface ValidLicenseKeyResult {
     // (undocumented)
     isEvaluationLicenseExpired: boolean;
     // (undocumented)
+    isGrandfathered: boolean;
+    // (undocumented)
     isInternalLicense: boolean;
     // (undocumented)
     isLicensedWithWatermark: boolean;

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -32,6 +32,20 @@ const STANDARD_LICENSE_INFO = JSON.stringify([
 	expiryDate,
 ])
 
+// Licenses issued once collaboration had launched expire past the grandfathering cutoff (the
+// launch date plus the longest term we issue), so they get only the features their flags name.
+// Two years out clears the cutoff while staying in the future, so the license never expires.
+const postGrandfatheringExpiryDate = new Date(
+	Date.UTC(now.getUTCFullYear() + 2, now.getUTCMonth(), now.getUTCDate())
+).toISOString()
+
+const POST_GRANDFATHERING_LICENSE_INFO = JSON.stringify([
+	'id',
+	['www.example.com'],
+	FLAGS.ANNUAL_LICENSE,
+	postGrandfatheringExpiryDate,
+])
+
 describe('LicenseManager', () => {
 	let keyPair: { publicKey: string; privateKey: string }
 	let licenseManager: LicenseManager
@@ -511,7 +525,7 @@ describe('LicenseManager', () => {
 		})
 
 		it('Checks for the commenting feature flag', async () => {
-			const commentingLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			const commentingLicenseInfo = JSON.parse(POST_GRANDFATHERING_LICENSE_INFO)
 			commentingLicenseInfo[PROPERTIES.FLAGS] |= FLAGS.FEAT_COMMENTING
 			const commentingLicenseKey = await generateLicenseKey(
 				JSON.stringify(commentingLicenseInfo),
@@ -525,7 +539,7 @@ describe('LicenseManager', () => {
 		})
 
 		it('Checks for the collaboration feature flag', async () => {
-			const collaborationLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			const collaborationLicenseInfo = JSON.parse(POST_GRANDFATHERING_LICENSE_INFO)
 			collaborationLicenseInfo[PROPERTIES.FLAGS] |= FLAGS.FEAT_COLLABORATION
 			const collaborationLicenseKey = await generateLicenseKey(
 				JSON.stringify(collaborationLicenseInfo),
@@ -540,10 +554,9 @@ describe('LicenseManager', () => {
 		})
 
 		it('Leaves feature flags off when no feature bits are set', async () => {
-			const standardLicenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
-			const result = (await licenseManager.getLicenseFromKey(
-				standardLicenseKey
-			)) as ValidLicenseKeyResult
+			const licenseKey = await generateLicenseKey(POST_GRANDFATHERING_LICENSE_INFO, keyPair)
+			const result = (await licenseManager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+			expect(result.isGrandfathered).toBe(false)
 			expect(result.isCollaborationEnabled).toBe(false)
 			expect(result.isCommentingEnabled).toBe(false)
 		})
@@ -564,6 +577,63 @@ describe('LicenseManager', () => {
 			} finally {
 				process.env.NODE_ENV = 'test'
 			}
+		})
+	})
+
+	describe('Grandfathered collaboration access', () => {
+		// Licenses sold before collaboration launched couldn't carry the feature flags, so their
+		// holders are let into the whole umbrella. We can't read an issue date off a license, so
+		// issuance is inferred from the expiry date: anything expiring before the launch date plus
+		// the longest term we issue (370 days) must have been issued before the launch.
+		async function getResultForExpiry(expiry: string, flags = FLAGS.ANNUAL_LICENSE) {
+			const licenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+			licenseInfo[PROPERTIES.FLAGS] = flags
+			licenseInfo[PROPERTIES.EXPIRY_DATE] = expiry
+			const licenseKey = await generateLicenseKey(JSON.stringify(licenseInfo), keyPair)
+			return (await licenseManager.getLicenseFromKey(licenseKey)) as ValidLicenseKeyResult
+		}
+
+		it('Grants the collaboration umbrella to a license issued before the launch', async () => {
+			const result = await getResultForExpiry(expiryDate)
+			expect(result.isGrandfathered).toBe(true)
+			expect(result.isCollaborationEnabled).toBe(true)
+			expect(result.isCommentingEnabled).toBe(true)
+		})
+
+		it('Grandfathers a license expiring the day before the cutoff', async () => {
+			// The last day a license issued before 2026-08-05 can run to.
+			expect(await getResultForExpiry('2027-08-09')).toMatchObject({
+				isGrandfathered: true,
+				isCollaborationEnabled: true,
+				isCommentingEnabled: true,
+			})
+		})
+
+		it('Does not grandfather a license expiring on or after the cutoff', async () => {
+			// 2026-08-05 plus the longest term we issue: this license was issued from the launch
+			// date onwards, so it needs the feature flags.
+			expect(await getResultForExpiry('2027-08-10')).toMatchObject({
+				isGrandfathered: false,
+				isCollaborationEnabled: false,
+				isCommentingEnabled: false,
+			})
+		})
+
+		it('Never grandfathers evaluation licenses', async () => {
+			// Evaluation terms are weeks long, so they'd stay under the cutoff long after the launch.
+			const result = await getResultForExpiry(expiryDate, FLAGS.EVALUATION_LICENSE)
+			expect(result.isGrandfathered).toBe(false)
+			expect(result.isCollaborationEnabled).toBe(false)
+			expect(result.isCommentingEnabled).toBe(false)
+		})
+
+		it('Still honours the feature flags on an evaluation license', async () => {
+			const result = await getResultForExpiry(
+				expiryDate,
+				FLAGS.EVALUATION_LICENSE | FLAGS.FEAT_COMMENTING
+			)
+			expect(result.isGrandfathered).toBe(false)
+			expect(result.isCommentingEnabled).toBe(true)
 		})
 	})
 
@@ -850,6 +920,7 @@ function getDefaultLicenseResult(overrides: Partial<ValidLicenseKeyResult>): Val
 		isLicensedWithWatermark: false,
 		isEvaluationLicense: false,
 		isEvaluationLicenseExpired: false,
+		isGrandfathered: false,
 		isCollaborationEnabled: false,
 		isCommentingEnabled: false,
 		daysSinceExpiry: 0,

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -32,18 +32,22 @@ const STANDARD_LICENSE_INFO = JSON.stringify([
 	expiryDate,
 ])
 
-// Licenses issued once collaboration had launched expire past the grandfathering cutoff (the
-// launch date plus the longest term we issue), so they get only the features their flags name.
-// Two years out clears the cutoff while staying in the future, so the license never expires.
-const postGrandfatheringExpiryDate = new Date(
-	Date.UTC(now.getUTCFullYear() + 2, now.getUTCMonth(), now.getUTCDate())
-).toISOString()
+// Collaboration launched on 2026-08-05, and a license expiring before that date plus the longest
+// term we issue (370 days, so 2027-08-10) is taken to predate the launch and grandfathered in.
+// These expiry dates are fixed rather than relative to the clock: which side of the cutoff a date
+// falls on is the whole point of these tests, so it can't be allowed to change as time passes.
+const GRANDFATHERED_EXPIRY_DATE = '2027-01-15'
+const LAST_GRANDFATHERED_EXPIRY_DATE = '2027-08-09'
+const FIRST_UNGRANDFATHERED_EXPIRY_DATE = '2027-08-10'
+const POST_GRANDFATHERING_EXPIRY_DATE = '2030-01-01'
 
+// A license issued once collaboration had launched: it expires past the grandfathering cutoff, so
+// it gets only the features its flags name.
 const POST_GRANDFATHERING_LICENSE_INFO = JSON.stringify([
 	'id',
 	['www.example.com'],
 	FLAGS.ANNUAL_LICENSE,
-	postGrandfatheringExpiryDate,
+	POST_GRANDFATHERING_EXPIRY_DATE,
 ])
 
 describe('LicenseManager', () => {
@@ -594,7 +598,7 @@ describe('LicenseManager', () => {
 		}
 
 		it('Grants the collaboration umbrella to a license issued before the launch', async () => {
-			const result = await getResultForExpiry(expiryDate)
+			const result = await getResultForExpiry(GRANDFATHERED_EXPIRY_DATE)
 			expect(result.isGrandfathered).toBe(true)
 			expect(result.isCollaborationEnabled).toBe(true)
 			expect(result.isCommentingEnabled).toBe(true)
@@ -602,7 +606,7 @@ describe('LicenseManager', () => {
 
 		it('Grandfathers a license expiring the day before the cutoff', async () => {
 			// The last day a license issued before 2026-08-05 can run to.
-			expect(await getResultForExpiry('2027-08-09')).toMatchObject({
+			expect(await getResultForExpiry(LAST_GRANDFATHERED_EXPIRY_DATE)).toMatchObject({
 				isGrandfathered: true,
 				isCollaborationEnabled: true,
 				isCommentingEnabled: true,
@@ -612,7 +616,7 @@ describe('LicenseManager', () => {
 		it('Does not grandfather a license expiring on or after the cutoff', async () => {
 			// 2026-08-05 plus the longest term we issue: this license was issued from the launch
 			// date onwards, so it needs the feature flags.
-			expect(await getResultForExpiry('2027-08-10')).toMatchObject({
+			expect(await getResultForExpiry(FIRST_UNGRANDFATHERED_EXPIRY_DATE)).toMatchObject({
 				isGrandfathered: false,
 				isCollaborationEnabled: false,
 				isCommentingEnabled: false,
@@ -621,7 +625,8 @@ describe('LicenseManager', () => {
 
 		it('Never grandfathers evaluation licenses', async () => {
 			// Evaluation terms are weeks long, so they'd stay under the cutoff long after the launch.
-			const result = await getResultForExpiry(expiryDate, FLAGS.EVALUATION_LICENSE)
+			// This expiry would be grandfathered on any other license.
+			const result = await getResultForExpiry(GRANDFATHERED_EXPIRY_DATE, FLAGS.EVALUATION_LICENSE)
 			expect(result.isGrandfathered).toBe(false)
 			expect(result.isCollaborationEnabled).toBe(false)
 			expect(result.isCommentingEnabled).toBe(false)
@@ -629,7 +634,7 @@ describe('LicenseManager', () => {
 
 		it('Still honours the feature flags on an evaluation license', async () => {
 			const result = await getResultForExpiry(
-				expiryDate,
+				GRANDFATHERED_EXPIRY_DATE,
 				FLAGS.EVALUATION_LICENSE | FLAGS.FEAT_COMMENTING
 			)
 			expect(result.isGrandfathered).toBe(false)

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -5,6 +5,15 @@ import { importPublicKey, str2ab } from '../utils/licensing'
 
 const GRACE_PERIOD_DAYS = 30
 
+// Collaboration features launched on this date. Licenses issued before it predate the feature
+// flags, so their holders are grandfathered into collaboration — see `isGrandfatheredLicense`.
+const COLLABORATION_LAUNCH_DATE = Date.UTC(2026, 7 /* August */, 5)
+// The longest term we issue, slightly more than a year.
+const MAX_LICENSE_TERM_DAYS = 370
+// A license expiring before this instant can only have been issued before the launch date.
+const GRANDFATHERED_EXPIRY_CUTOFF =
+	COLLABORATION_LAUNCH_DATE + MAX_LICENSE_TERM_DAYS * 24 * 60 * 60 * 1000
+
 export const FLAGS = {
 	// -- MUTUALLY EXCLUSIVE FLAGS
 	// Annual means the license expires after a time period, usually 1 year.
@@ -107,6 +116,7 @@ export interface ValidLicenseKeyResult {
 	isLicensedWithWatermark: boolean
 	isEvaluationLicense: boolean
 	isEvaluationLicenseExpired: boolean
+	isGrandfathered: boolean
 	isCollaborationEnabled: boolean
 	isCommentingEnabled: boolean
 	daysSinceExpiry: number
@@ -336,8 +346,11 @@ export class LicenseManager {
 				isPerpetualLicense && this.isPerpetualLicenseExpired(expiryDate)
 
 			// The collaboration umbrella grants all of its sub-features, so commenting is enabled
-			// by either the commenting flag or the collaboration flag.
-			const isCollaborationEnabled = this.isFlagEnabled(licenseInfo.flags, FLAGS.FEAT_COLLABORATION)
+			// by either the commenting flag or the collaboration flag. Licenses that predate the
+			// feature flags get the umbrella, and with it every sub-feature.
+			const isGrandfathered = this.isGrandfatheredLicense(licenseInfo, expiryDate)
+			const isCollaborationEnabled =
+				isGrandfathered || this.isFlagEnabled(licenseInfo.flags, FLAGS.FEAT_COLLABORATION)
 			const isCommentingEnabled =
 				isCollaborationEnabled || this.isFlagEnabled(licenseInfo.flags, FLAGS.FEAT_COMMENTING)
 
@@ -364,6 +377,7 @@ export class LicenseManager {
 				isEvaluationLicense,
 				isEvaluationLicenseExpired:
 					isEvaluationLicense && this.isEvaluationLicenseExpired(expiryDate),
+				isGrandfathered,
 				isCollaborationEnabled,
 				isCommentingEnabled,
 				daysSinceExpiry,
@@ -473,6 +487,25 @@ export class LicenseManager {
 		const diffTime = now.getTime() - expiration.getTime()
 		const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24))
 		return Math.max(0, diffDays)
+	}
+
+	/**
+	 * Whether a license was issued before collaboration launched, and so should be grandfathered
+	 * into the collaboration features it couldn't have been sold with.
+	 *
+	 * Licenses carry an expiry date but no issue date, so we infer issuance from expiry: we never
+	 * issue a term longer than `MAX_LICENSE_TERM_DAYS`, so a license expiring before that far past
+	 * the launch date must have been issued before it. Renewing past the cutoff moves the license
+	 * onto the flags, as does any license issued from the launch date onwards.
+	 *
+	 * Evaluation licenses are excluded. Their terms are weeks, so they'd stay under the cutoff long
+	 * after the launch and hand collaboration to every future trial; trials that should include it
+	 * can be minted with the feature flags set.
+	 */
+	private isGrandfatheredLicense(licenseInfo: LicenseInfo, expiryDate: Date) {
+		if (this.isFlagEnabled(licenseInfo.flags, FLAGS.EVALUATION_LICENSE)) return false
+		// An unparseable expiry date gives NaN here, which compares false: fail closed.
+		return expiryDate.getTime() < GRANDFATHERED_EXPIRY_CUTOFF
 	}
 
 	private isEvaluationLicenseExpired(expiryDate: Date): boolean {


### PR DESCRIPTION
In order to let customers who already bought tldraw use commenting without buying a new license, this grandfathers every license issued before collaboration launches (2026-08-05) into the collaboration umbrella — the same access `FLAGS.FEAT_COLLABORATION` grants, so commenting and any future sub-feature come with it.

A license carries an expiry date but no issue date, so issuance is inferred from expiry: we never issue a term longer than 370 days, so anything expiring before launch + 370 days (2027-08-10) must have been issued before the launch. Renewals that run past the cutoff, and anything issued from launch day on, need the flags.

Two calls worth a look:

- **Evaluation licenses are excluded.** Their terms are weeks, so they'd sit under the cutoff long after the launch and hand collaboration to every future trial. Trials that should include it can be minted with the flags set, which still works.
- **Grandfathering doesn't revive dead licenses.** It flows through `getEnabledFeatures`, which still requires a `licensed` or `licensed-with-watermark` state, so a license expired past its grace period gets nothing.

One gap to be aware of when minting keys: a *non-evaluation* license issued after the launch with a term shorter than ~370 days — a six-month deal, a pro-rated renewal — also lands under the cutoff and gets grandfathered by accident. Closing that would mean putting a real issue date in newly minted keys.

Relates to #9701, which gates commenting on the dotcom side; this is the SDK-license half.

### Change type

- [x] `feature`

### Test plan

1. Mint a license with `yarn generate-test-licenses` whose expiry is before 2027-08-10 and no feature flags, and load it in a production build.
2. Commenting UI is available.
3. Repeat with an expiry on or after 2027-08-10: commenting UI is hidden until the license carries `FEAT_COMMENTING` or `FEAT_COLLABORATION`.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Licenses issued before collaboration launched now include commenting and the other collaboration features.

### API changes

- Added `isGrandfathered` to `ValidLicenseKeyResult` (internal)

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +35 / -2   |
| Tests           | +77 / -6   |
| Automated files | +2 / -0    |
