### PR TITLE
feat(dotcom): capture real board thumbnails locally

### DIFF
--- a/apps/dotcom/browser-run-thumbnails.md
+++ b/apps/dotcom/browser-run-thumbnails.md
@@ -72,7 +72,7 @@ ORDER BY requests DESC
 
 The sync worker needs:
 
-- `BROWSER` binding - the Cloudflare Browser Rendering binding, declared per environment in `wrangler.toml` (`[env.<env>.browser]`). The worker calls its `quickAction` Quick Actions method (`env.BROWSER.quickAction('screenshot', …)`) directly — no `@cloudflare/puppeteer`, no API token. This requires `compatibility_date` `2026-03-24` or later, which the deployed envs use; `[env.dev]` pins an older date the local workerd supports (see Local development). The dev binding is deliberately not `remote`, so plain `wrangler dev` (and the credential-free e2e stack) boots without a `CLOUDFLARE_API_TOKEN`; the binding is then a non-functional local one and the render path fails closed. Real local captures need `wrangler dev --remote` with credentials, or a preview deploy.
+- `BROWSER` binding - the Cloudflare Browser Rendering binding, declared per environment in `wrangler.toml` (`[env.<env>.browser]`). The worker calls its `quickAction` Quick Actions method (`env.BROWSER.quickAction('screenshot', …)`) directly — no `@cloudflare/puppeteer`, no API token. This requires `compatibility_date` `2026-03-24` or later, which the deployed envs use; `[env.dev]` pins an older date the local workerd supports (see Local development). The dev binding is deliberately not `remote`, so plain `wrangler dev` (and the credential-free e2e stack) boots without a `CLOUDFLARE_API_TOKEN`; the binding is then a non-functional local one and the render path fails closed. Adding `--remote` and credentials is not enough to change that: `--remote` still deploys with `[env.dev]`'s `compatibility_date`, which predates `quickAction`, and dev's `MCP_SCREENSHOT_RENDER_ORIGIN` points at `http://localhost:3000`, which Browser Run cannot reach. A preview deploy is the practical way to exercise the real Browser Run call; everything up to that call can be run locally (see Local development).
 - `MCP_SCREENSHOT_ENABLED` - kill switch for the MCP server (`POST /app/mcp`), set to `"true"` in `wrangler.toml` for dev, staging, and production. The worker reads it per request, so setting it to anything else takes the endpoint down (it 404s, including the `initialize` handshake) without a rebuild or a code deploy — flip it in the Cloudflare dashboard under the worker's variables, and it applies to the next request. The next deploy overwrites the dashboard value from `wrangler.toml`, so follow an emergency flip with a config change. An unset var counts as enabled, so preview deploys (which don't set it) behave as they always have. Only the MCP server is gated: OG image rendering has its own path and keeps running.
 - `MCP_SCREENSHOT_TOKEN_SECRET` (deploy var, GitHub secret) - HMAC secret for render tokens. Local dev uses the placeholder in `[env.dev.vars]`.
 - `MCP_SCREENSHOT_RENDER_ORIGIN` - set in `wrangler.toml` for dev (`http://localhost:3000`), staging, and production. Preview deploys have no `wrangler.toml` entry, so `deploy-dotcom.ts` injects the preview's own client origin (`https://${previewId}-preview-deploy.tldraw.com`) as a deploy var.
@@ -125,9 +125,31 @@ When tunnelling with Vite's host checks, start the client with:
 VITE_ALLOWED_HOSTS=your-tunnel-host.example yarn workspace dotcom exec vite dev --host 127.0.0.1 --port 3000 --strictPort
 ```
 
-The production path (`/__thumbnail-render` plus `/api/app/thumbnail-render/snapshot`) can be exercised locally against a locally published file by calling `POST /app/mcp` on the local sync worker with `tools/call`. The tool returns the page name and the PNG itself, not the render URL — the URL is internal to the worker, so to open the render page in a browser you have to mint a token yourself (`mintThumbnailRenderToken`, using the `MCP_SCREENSHOT_TOKEN_SECRET` from `[env.dev.vars]`) and build `/__thumbnail-render?token=…` by hand.
+### Capturing a real board locally
 
-To drive the full worker render path locally — the MCP tool or OG queue actually taking a screenshot — run `wrangler dev --remote` with Cloudflare credentials (`CLOUDFLARE_ACCOUNT_ID` and an API token with `Browser Rendering` access) so the `BROWSER` binding reaches the real remote Browser Rendering service. The dev binding is deliberately NOT marked `remote = true` in `[env.dev.browser]`: a remote binding makes plain `wrangler dev` require a `CLOUDFLARE_API_TOKEN`, which the credential-free process-compose e2e stack does not have, so it would fail to boot. Under plain `wrangler dev` the `BROWSER` binding is a non-functional local binding and the render path fails closed with a config error — fine for everything except real captures, which need `--remote` or a preview deploy. Note also that `[env.dev]` pins `compatibility_date` to `2025-06-05` (the deployed envs use `2026-03-24`, required for `quickAction`, but that is newer than the workerd bundled with our pinned wrangler, so local `wrangler dev` can't use it — real local captures therefore need a preview deploy until the toolchain catches up).
+`--board` renders the production `/__thumbnail-render` page instead of the fixture page, so a local capture exercises real board resolution, the real render page, and the real token gate. It takes a board URL or a bare slug, and signs its own render token, so it needs the same secret the worker verifies with — locally, the `MCP_SCREENSHOT_TOKEN_SECRET` placeholder in the sync worker's `[env.dev.vars]`:
+
+```bash
+MCP_SCREENSHOT_TOKEN_SECRET=<the [env.dev.vars] placeholder> \
+yarn workspace dotcom browser-run-thumbnail \
+  --board http://localhost:3000/f/your-shared-file-slug \
+  --output tmp/browser-run-thumbnail/board.png
+```
+
+`--secret` takes the same value if you would rather pass it as a flag; against a preview deploy it is that environment's real secret, not the placeholder. A `/p/:slug` or `/f/:slug` URL also settles the board kind; pass `--kind published|shared_file` alongside a bare slug. `--page-id <TLPageId>` picks a page (the default renders whichever page the snapshot opens to).
+
+This covers everything the MCP screenshot tool does except the Browser Run call itself. It cannot catch Browser Run-specific behavior — its viewport defaults, or font availability in Cloudflare's fleet — so a preview deploy is still the check for those.
+
+Calling `POST /app/mcp` on the local sync worker with `tools/call` is worth doing alongside it, but note the two tools differ locally: `get_board_info` needs no browser and works, while `get_shared_board_screenshot` always fails at the Browser Run call (see Configuration). The tool returns the page name and the PNG itself, never the render URL — the URL is internal to the worker, which is why `--board` mints its own token rather than reading one back.
+
+### Why the worker cannot take a screenshot locally
+
+The MCP tool and the OG queue both fail at the Browser Run call under `yarn dev-app`, for two independent reasons:
+
+- `[env.dev.browser]` is deliberately NOT marked `remote = true`. A remote binding makes plain `wrangler dev` require a `CLOUDFLARE_API_TOKEN`, which the credential-free process-compose e2e stack does not have, so it would fail to boot. The binding is therefore a non-functional local one and the render path fails closed with a config error.
+- `[env.dev]` pins `compatibility_date` to `2025-06-05`. The deployed envs use `2026-03-24`, required for `quickAction`, but that is newer than the workerd bundled with our pinned wrangler, so `wrangler dev` could not boot with it.
+
+The second reason also applies with `--remote`, which deploys using the same `[env.dev]` config, and dev's `MCP_SCREENSHOT_RENDER_ORIGIN` (`http://localhost:3000`) is unreachable from Browser Run regardless. So a preview deploy is the way to exercise the real Browser Run call until the toolchain catches up. Use `--board` above to cover everything up to it.
 
 ## MCP tools
 

--- a/apps/dotcom/browser-run-thumbnails.md
+++ b/apps/dotcom/browser-run-thumbnails.md
@@ -72,7 +72,7 @@ ORDER BY requests DESC
 
 The sync worker needs:
 
-- `BROWSER` binding - the Cloudflare Browser Rendering binding, declared per environment in `wrangler.toml` (`[env.<env>.browser]`). The worker calls its `quickAction` Quick Actions method (`env.BROWSER.quickAction('screenshot', …)`) directly — no `@cloudflare/puppeteer`, no API token. This requires `compatibility_date` `2026-03-24` or later, which the deployed envs use; `[env.dev]` pins an older date the local workerd supports (see Local development). The dev binding is deliberately not `remote`, so plain `wrangler dev` (and the credential-free e2e stack) boots without a `CLOUDFLARE_API_TOKEN`; the binding is then a non-functional local one and the render path fails closed. Adding `--remote` and credentials is not enough to change that: `--remote` still deploys with `[env.dev]`'s `compatibility_date`, which predates `quickAction`, and dev's `MCP_SCREENSHOT_RENDER_ORIGIN` points at `http://localhost:3000`, which Browser Run cannot reach. A preview deploy is the practical way to exercise the real Browser Run call; everything up to that call can be run locally (see Local development).
+- `BROWSER` binding - the Cloudflare Browser Rendering binding, declared per environment in `wrangler.toml` (`[env.<env>.browser]`). The worker calls its `quickAction` Quick Actions method (`env.BROWSER.quickAction('screenshot', …)`) directly — no `@cloudflare/puppeteer`, no API token. This requires `compatibility_date` `2026-03-24` or later, which the deployed envs use; `[env.dev]` pins an older date the local workerd supports (see Local development). The dev binding is deliberately not `remote`, so plain `wrangler dev` (and the credential-free e2e stack) boots without a `CLOUDFLARE_API_TOKEN`; the binding is then a non-functional local one and the render path fails closed. Adding `--remote` and credentials is not enough to change that, so a preview deploy is the practical way to exercise the real Browser Run call (see Local development for why, and for what can be run locally instead).
 - `MCP_SCREENSHOT_ENABLED` - kill switch for the MCP server (`POST /app/mcp`), set to `"true"` in `wrangler.toml` for dev, staging, and production. The worker reads it per request, so setting it to anything else takes the endpoint down (it 404s, including the `initialize` handshake) without a rebuild or a code deploy — flip it in the Cloudflare dashboard under the worker's variables, and it applies to the next request. The next deploy overwrites the dashboard value from `wrangler.toml`, so follow an emergency flip with a config change. An unset var counts as enabled, so preview deploys (which don't set it) behave as they always have. Only the MCP server is gated: OG image rendering has its own path and keeps running.
 - `MCP_SCREENSHOT_TOKEN_SECRET` (deploy var, GitHub secret) - HMAC secret for render tokens. Local dev uses the placeholder in `[env.dev.vars]`.
 - `MCP_SCREENSHOT_RENDER_ORIGIN` - set in `wrangler.toml` for dev (`http://localhost:3000`), staging, and production. Preview deploys have no `wrangler.toml` entry, so `deploy-dotcom.ts` injects the preview's own client origin (`https://${previewId}-preview-deploy.tldraw.com`) as a deploy var.
@@ -132,15 +132,15 @@ VITE_ALLOWED_HOSTS=your-tunnel-host.example yarn workspace dotcom exec vite dev 
 ```bash
 MCP_SCREENSHOT_TOKEN_SECRET=<the [env.dev.vars] placeholder> \
 yarn workspace dotcom browser-run-thumbnail \
-  --board http://localhost:3000/f/your-shared-file-slug \
+  --board /f/your-shared-file-slug \
   --output tmp/browser-run-thumbnail/board.png
 ```
 
-`--secret` takes the same value if you would rather pass it as a flag; against a preview deploy it is that environment's real secret, not the placeholder. A `/p/:slug` or `/f/:slug` URL also settles the board kind; pass `--kind published|shared_file` alongside a bare slug. `--page-id <TLPageId>` picks a page (the default renders whichever page the snapshot opens to).
+`--board` takes a whole board link too (`https://www.tldraw.com/f/:slug`), reading only its path — the capture still goes to `--base-url`. The `/p/` or `/f/` prefix is what says which kind of board it is. `--secret` takes the secret as a flag instead of the env var; against a preview deploy that is the environment's real secret, not the placeholder.
 
 This covers everything the MCP screenshot tool does except the Browser Run call itself. It cannot catch Browser Run-specific behavior — its viewport defaults, or font availability in Cloudflare's fleet — so a preview deploy is still the check for those.
 
-Calling `POST /app/mcp` on the local sync worker with `tools/call` is worth doing alongside it, but note the two tools differ locally: `get_board_info` needs no browser and works, while `get_shared_board_screenshot` always fails at the Browser Run call (see Configuration). The tool returns the page name and the PNG itself, never the render URL — the URL is internal to the worker, which is why `--board` mints its own token rather than reading one back.
+Calling `POST /app/mcp` on the local sync worker with `tools/call` is worth doing alongside it, but note the two tools differ locally: `get_board_info` needs no browser and works, while `get_shared_board_screenshot` always fails at the Browser Run call (see below). The tool returns the page name and the PNG itself, never the render URL, which stays internal to the worker.
 
 ### Why the worker cannot take a screenshot locally
 
@@ -149,7 +149,7 @@ The MCP tool and the OG queue both fail at the Browser Run call under `yarn dev-
 - `[env.dev.browser]` is deliberately NOT marked `remote = true`. A remote binding makes plain `wrangler dev` require a `CLOUDFLARE_API_TOKEN`, which the credential-free process-compose e2e stack does not have, so it would fail to boot. The binding is therefore a non-functional local one and the render path fails closed with a config error.
 - `[env.dev]` pins `compatibility_date` to `2025-06-05`. The deployed envs use `2026-03-24`, required for `quickAction`, but that is newer than the workerd bundled with our pinned wrangler, so `wrangler dev` could not boot with it.
 
-The second reason also applies with `--remote`, which deploys using the same `[env.dev]` config, and dev's `MCP_SCREENSHOT_RENDER_ORIGIN` (`http://localhost:3000`) is unreachable from Browser Run regardless. So a preview deploy is the way to exercise the real Browser Run call until the toolchain catches up. Use `--board` above to cover everything up to it.
+The second reason also applies with `--remote`, which deploys using the same `[env.dev]` config, and dev's `MCP_SCREENSHOT_RENDER_ORIGIN` (`http://localhost:3000`) is unreachable from Browser Run regardless. So a preview deploy is the way to exercise the real Browser Run call until the toolchain catches up.
 
 ## MCP tools
 

--- a/apps/dotcom/client/scripts/browser-run-thumbnail.ts
+++ b/apps/dotcom/client/scripts/browser-run-thumbnail.ts
@@ -24,15 +24,18 @@ type FixtureName = (typeof FIXTURE_NAMES)[number]
 type Mode = 'auto' | 'browser-run' | 'local'
 type BoardKind = 'published' | 'shared_file'
 
+interface Board {
+	kind: BoardKind
+	slug: string
+}
+
 interface Options {
 	baseUrl: string
-	board?: string
+	board?: Board
 	fixture: FixtureName
 	height: number
-	kind: BoardKind
 	mode: Mode
 	output: string
-	pageId?: string
 	secret?: string
 	theme: 'light' | 'dark'
 	width: number
@@ -46,8 +49,9 @@ async function main() {
 	const renderUrl = buildRenderUrl(options)
 	const mode = chooseMode(options.mode, options.baseUrl)
 
-	// The board render URL carries a signed token, so log the page without it.
-	writeLine(`Rendering ${options.board ? `${options.kind} board ${options.board}` : renderUrl}`)
+	// The board render URL carries a signed token, so log the board rather than the URL.
+	const { board } = options
+	writeLine(`Rendering ${board ? `${board.kind} board ${board.slug}` : renderUrl}`)
 	writeLine(`Mode: ${mode}`)
 
 	const png =
@@ -66,14 +70,12 @@ function parseArgs(args: string[]): Options {
 		baseUrl: 'http://127.0.0.1:3000',
 		fixture: 'snapshot-example',
 		height: DEFAULT_THUMBNAIL_HEIGHT,
-		kind: 'published',
 		mode: 'auto',
 		output: 'tmp/browser-run-thumbnail/thumbnail.png',
-		secret: process.env.MCP_SCREENSHOT_TOKEN_SECRET,
+		secret: process.env[RENDER_TOKEN_SECRET_ENV],
 		theme: 'light',
 		width: DEFAULT_THUMBNAIL_WIDTH,
 	}
-	let kindWasSet = false
 
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i]
@@ -83,22 +85,8 @@ function parseArgs(args: string[]): Options {
 				options.baseUrl = requireValue(arg, next)
 				i++
 				break
-			case '--board': {
-				// Accepts a bare slug or a board URL; a /f/ or /p/ URL also settles --kind, which is
-				// how board links are usually to hand.
-				const board = parseBoard(requireValue(arg, next))
-				options.board = board.slug
-				if (board.kind && !kindWasSet) options.kind = board.kind
-				i++
-				break
-			}
-			case '--kind':
-				options.kind = requireKind(requireValue(arg, next))
-				kindWasSet = true
-				i++
-				break
-			case '--page-id':
-				options.pageId = requireValue(arg, next)
+			case '--board':
+				options.board = parseBoard(requireValue(arg, next))
 				i++
 				break
 			case '--secret':
@@ -143,25 +131,37 @@ function parseArgs(args: string[]): Options {
 		}
 	}
 
+	// A board always renders content-fit, so a camera override would be silently dropped.
+	if (options.board && (options.x ?? options.y ?? options.z) !== undefined) {
+		throw new Error('--x, --y and --z are fixture-only; --board always fits the board content.')
+	}
+
 	return options
 }
 
-// A board URL (https://www.tldraw.com/p/:slug or /f/:slug) or a bare slug. The path segment tells us
-// which kind of board it is; a bare slug leaves that to --kind.
-function parseBoard(value: string): { slug: string; kind?: BoardKind } {
-	if (!/^https?:\/\//.test(value)) return { slug: value }
-	const segments = new URL(value).pathname.split('/').filter(Boolean)
-	const slug = segments[1]
-	if (!slug) throw new Error(`Could not read a board slug from: ${value}`)
-	if (segments[0] === 'p') return { slug, kind: 'published' }
-	if (segments[0] === 'f') return { slug, kind: 'shared_file' }
-	return { slug }
+// A board URL (https://www.tldraw.com/p/:slug or /f/:slug) or just its path. The path prefix is what
+// says which kind of board it is, so taking the whole link avoids having to name the kind separately
+// — and refusing anything else means a room or snapshot link fails here rather than as a 404 later.
+// Only the path is read: the capture still goes to --base-url.
+function parseBoard(value: string): Board {
+	let pathname = value
+	if (/^https?:\/\//i.test(value)) {
+		try {
+			pathname = new URL(value).pathname
+		} catch {
+			throw new Error(`--board is not a valid URL: ${value}`)
+		}
+	}
+	const [prefix, slug] = pathname.split('/').filter(Boolean)
+	if (slug && prefix === 'p') return { kind: 'published', slug }
+	if (slug && prefix === 'f') return { kind: 'shared_file', slug }
+	throw new Error(`--board must be a /p/:slug or /f/:slug board link or path, got: ${value}`)
 }
 
 // The signed render job the sync-worker mints in thumbnailRender.ts, minted here so a local capture
 // can drive the real render page without Cloudflare credentials. `version` only rotates the worker's
 // R2 cache key and is not checked when the render page exchanges the token, so it is fixed here.
-function mintRenderToken(options: Options) {
+function mintRenderToken(options: Options, board: Board) {
 	const secret = options.secret
 	if (!secret) {
 		throw new Error(
@@ -170,11 +170,10 @@ function mintRenderToken(options: Options) {
 	}
 	const job = {
 		v: 1,
-		kind: options.kind,
-		slug: options.board,
+		kind: board.kind,
+		slug: board.slug,
 		version: 'local',
 		camera: 'content',
-		...(options.pageId ? { pageId: options.pageId } : null),
 		x: 0,
 		y: 0,
 		z: 1,
@@ -183,7 +182,7 @@ function mintRenderToken(options: Options) {
 		theme: options.theme,
 		exp: Date.now() + 5 * 60_000,
 	}
-	// Base64url (RFC 4648 §5) both sides: matches base64UrlEncode in the worker's utils/base64.ts.
+	// Matches base64UrlEncode in the worker's utils/base64.ts.
 	const payload = Buffer.from(JSON.stringify(job)).toString('base64url')
 	const signature = createHmac('sha256', secret).update(payload).digest('base64url')
 	return `${payload}.${signature}`
@@ -194,7 +193,7 @@ function buildRenderUrl(options: Options) {
 	// capture exercises real board resolution and the real render page rather than the fixture page.
 	if (options.board) {
 		const url = new URL(THUMBNAIL_RENDER_PATH, options.baseUrl)
-		url.searchParams.set('token', mintRenderToken(options))
+		url.searchParams.set('token', mintRenderToken(options, options.board))
 		return url.toString()
 	}
 
@@ -336,11 +335,6 @@ function requireMode(value: string): Mode {
 	throw new Error(`Unknown mode: ${value}`)
 }
 
-function requireKind(value: string): BoardKind {
-	if (value === 'published' || value === 'shared_file') return value
-	throw new Error(`Unknown board kind: ${value}`)
-}
-
 function requireTheme(value: string): 'light' | 'dark' {
 	if (value === 'light' || value === 'dark') return value
 	throw new Error(`Unknown theme: ${value}`)
@@ -368,11 +362,9 @@ function printHelp() {
 
 Options:
   --base-url <url>      Origin running the dotcom client. Default: http://127.0.0.1:3000
-  --board <slug|url>    Capture a real board through the production render page instead of a
-                        fixture. Takes a bare slug or a /p/:slug or /f/:slug board URL.
-  --kind <kind>         published | shared_file. Inferred from a /p/ or /f/ board URL.
-                        Default: published
-  --page-id <TLPageId>  Board page to render. Default: whichever page the snapshot opens to
+  --board <link>        Capture a real board through the production render page instead of a
+                        fixture. Takes a /p/:slug or /f/:slug board link or path; only the
+                        path is read, so the capture still goes to --base-url
   --secret <secret>     Render token secret, required by --board. Defaults to
                         MCP_SCREENSHOT_TOKEN_SECRET. Locally this is the placeholder in the
                         sync worker's [env.dev.vars]
@@ -382,9 +374,9 @@ Options:
   --theme <theme>       light | dark. Default: light
   --width <number>      Output width, ${MIN_THUMBNAIL_DIMENSION}-${MAX_THUMBNAIL_DIMENSION}. Default: ${DEFAULT_THUMBNAIL_WIDTH}
   --height <number>     Output height, ${MIN_THUMBNAIL_DIMENSION}-${MAX_THUMBNAIL_DIMENSION}. Default: ${DEFAULT_THUMBNAIL_HEIGHT}
-  --x <number>          Camera x override (defaults to the fixture's own camera)
-  --y <number>          Camera y override (defaults to the fixture's own camera)
-  --z <number>          Camera zoom override (defaults to the fixture's own camera)
+  --x <number>          Camera x override, fixture only (defaults to the fixture's own camera)
+  --y <number>          Camera y override, fixture only (defaults to the fixture's own camera)
+  --z <number>          Camera zoom override, fixture only (defaults to the fixture's camera)
 
 Captures the dev-only /dev/browser-run-thumbnail fixture page for local iteration on render
 behavior. The fixture page produces the image with editor.toImage; local mode reads the exact

--- a/apps/dotcom/client/scripts/browser-run-thumbnail.ts
+++ b/apps/dotcom/client/scripts/browser-run-thumbnail.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'crypto'
 import { mkdir, writeFile } from 'fs/promises'
 import path from 'path'
 import { pathToFileURL } from 'url'
@@ -6,6 +7,7 @@ import {
 	DEFAULT_THUMBNAIL_WIDTH,
 	MAX_THUMBNAIL_DIMENSION,
 	MIN_THUMBNAIL_DIMENSION,
+	THUMBNAIL_RENDER_PATH,
 	THUMBNAIL_RENDER_TIMEOUT_MS,
 	THUMBNAIL_SETTLED_SELECTOR,
 	getThumbnailScreenshotRequestBody,
@@ -14,15 +16,24 @@ import {
 // The fixture page owns the per-fixture snapshots and camera defaults; this script only names one.
 const FIXTURE_NAMES = ['snapshot-example', 'layer-panel'] as const
 
+// The render token secret is never hardcoded here: locally it is the placeholder in the sync
+// worker's `[env.dev.vars]`, and deployed environments have a real one.
+const RENDER_TOKEN_SECRET_ENV = 'MCP_SCREENSHOT_TOKEN_SECRET'
+
 type FixtureName = (typeof FIXTURE_NAMES)[number]
 type Mode = 'auto' | 'browser-run' | 'local'
+type BoardKind = 'published' | 'shared_file'
 
 interface Options {
 	baseUrl: string
+	board?: string
 	fixture: FixtureName
 	height: number
+	kind: BoardKind
 	mode: Mode
 	output: string
+	pageId?: string
+	secret?: string
 	theme: 'light' | 'dark'
 	width: number
 	x?: number
@@ -35,7 +46,8 @@ async function main() {
 	const renderUrl = buildRenderUrl(options)
 	const mode = chooseMode(options.mode, options.baseUrl)
 
-	writeLine(`Rendering ${renderUrl}`)
+	// The board render URL carries a signed token, so log the page without it.
+	writeLine(`Rendering ${options.board ? `${options.kind} board ${options.board}` : renderUrl}`)
 	writeLine(`Mode: ${mode}`)
 
 	const png =
@@ -54,11 +66,14 @@ function parseArgs(args: string[]): Options {
 		baseUrl: 'http://127.0.0.1:3000',
 		fixture: 'snapshot-example',
 		height: DEFAULT_THUMBNAIL_HEIGHT,
+		kind: 'published',
 		mode: 'auto',
 		output: 'tmp/browser-run-thumbnail/thumbnail.png',
+		secret: process.env.MCP_SCREENSHOT_TOKEN_SECRET,
 		theme: 'light',
 		width: DEFAULT_THUMBNAIL_WIDTH,
 	}
+	let kindWasSet = false
 
 	for (let i = 0; i < args.length; i++) {
 		const arg = args[i]
@@ -66,6 +81,28 @@ function parseArgs(args: string[]): Options {
 		switch (arg) {
 			case '--base-url':
 				options.baseUrl = requireValue(arg, next)
+				i++
+				break
+			case '--board': {
+				// Accepts a bare slug or a board URL; a /f/ or /p/ URL also settles --kind, which is
+				// how board links are usually to hand.
+				const board = parseBoard(requireValue(arg, next))
+				options.board = board.slug
+				if (board.kind && !kindWasSet) options.kind = board.kind
+				i++
+				break
+			}
+			case '--kind':
+				options.kind = requireKind(requireValue(arg, next))
+				kindWasSet = true
+				i++
+				break
+			case '--page-id':
+				options.pageId = requireValue(arg, next)
+				i++
+				break
+			case '--secret':
+				options.secret = requireValue(arg, next)
 				i++
 				break
 			case '--fixture':
@@ -109,7 +146,58 @@ function parseArgs(args: string[]): Options {
 	return options
 }
 
+// A board URL (https://www.tldraw.com/p/:slug or /f/:slug) or a bare slug. The path segment tells us
+// which kind of board it is; a bare slug leaves that to --kind.
+function parseBoard(value: string): { slug: string; kind?: BoardKind } {
+	if (!/^https?:\/\//.test(value)) return { slug: value }
+	const segments = new URL(value).pathname.split('/').filter(Boolean)
+	const slug = segments[1]
+	if (!slug) throw new Error(`Could not read a board slug from: ${value}`)
+	if (segments[0] === 'p') return { slug, kind: 'published' }
+	if (segments[0] === 'f') return { slug, kind: 'shared_file' }
+	return { slug }
+}
+
+// The signed render job the sync-worker mints in thumbnailRender.ts, minted here so a local capture
+// can drive the real render page without Cloudflare credentials. `version` only rotates the worker's
+// R2 cache key and is not checked when the render page exchanges the token, so it is fixed here.
+function mintRenderToken(options: Options) {
+	const secret = options.secret
+	if (!secret) {
+		throw new Error(
+			`--board needs the render token secret. Pass --secret, or set ${RENDER_TOKEN_SECRET_ENV} to the value from the sync worker's [env.dev.vars].`
+		)
+	}
+	const job = {
+		v: 1,
+		kind: options.kind,
+		slug: options.board,
+		version: 'local',
+		camera: 'content',
+		...(options.pageId ? { pageId: options.pageId } : null),
+		x: 0,
+		y: 0,
+		z: 1,
+		width: options.width,
+		height: options.height,
+		theme: options.theme,
+		exp: Date.now() + 5 * 60_000,
+	}
+	// Base64url (RFC 4648 §5) both sides: matches base64UrlEncode in the worker's utils/base64.ts.
+	const payload = Buffer.from(JSON.stringify(job)).toString('base64url')
+	const signature = createHmac('sha256', secret).update(payload).digest('base64url')
+	return `${payload}.${signature}`
+}
+
 function buildRenderUrl(options: Options) {
+	// A board renders through the same production render page that Browser Run visits, so a local
+	// capture exercises real board resolution and the real render page rather than the fixture page.
+	if (options.board) {
+		const url = new URL(THUMBNAIL_RENDER_PATH, options.baseUrl)
+		url.searchParams.set('token', mintRenderToken(options))
+		return url.toString()
+	}
+
 	const url = new URL('/dev/browser-run-thumbnail', options.baseUrl)
 	url.searchParams.set('fixture', options.fixture)
 
@@ -189,7 +277,9 @@ async function captureWithBrowserRun(renderUrl: string, options: Options) {
 }
 
 // The fixture page produces the thumbnail itself with editor.toImage and exposes it as a data
-// URL, so the local path reads the exact export bytes instead of screenshotting the viewport.
+// URL, so the local path reads the exact export bytes instead of screenshotting the viewport. The
+// production render page has no such affordance, so a board capture screenshots the viewport —
+// equivalent to Browser Run's THUMBNAIL_CAPTURE_SELECTOR, which targets a body that fills it.
 async function captureWithLocalPlaywright(renderUrl: string, options: Options) {
 	const { chromium } = await import('@playwright/test')
 	const browser = await chromium.launch()
@@ -211,7 +301,12 @@ async function captureWithLocalPlaywright(renderUrl: string, options: Options) {
 		})
 		const renderError = await page.evaluate(() => document.body.dataset.thumbnailError)
 		if (renderError !== undefined) {
-			throw new Error(`Fixture page failed to render: ${renderError}`)
+			throw new Error(
+				`${options.board ? 'Render' : 'Fixture'} page failed to render: ${renderError || '(no message)'}`
+			)
+		}
+		if (options.board) {
+			return await page.screenshot({ type: 'png' })
 		}
 		const dataUrl = await page.evaluate(
 			() => (window as any).__tldrawThumbnailDataUrl as string | undefined
@@ -241,6 +336,11 @@ function requireMode(value: string): Mode {
 	throw new Error(`Unknown mode: ${value}`)
 }
 
+function requireKind(value: string): BoardKind {
+	if (value === 'published' || value === 'shared_file') return value
+	throw new Error(`Unknown board kind: ${value}`)
+}
+
 function requireTheme(value: string): 'light' | 'dark' {
 	if (value === 'light' || value === 'dark') return value
 	throw new Error(`Unknown theme: ${value}`)
@@ -268,6 +368,14 @@ function printHelp() {
 
 Options:
   --base-url <url>      Origin running the dotcom client. Default: http://127.0.0.1:3000
+  --board <slug|url>    Capture a real board through the production render page instead of a
+                        fixture. Takes a bare slug or a /p/:slug or /f/:slug board URL.
+  --kind <kind>         published | shared_file. Inferred from a /p/ or /f/ board URL.
+                        Default: published
+  --page-id <TLPageId>  Board page to render. Default: whichever page the snapshot opens to
+  --secret <secret>     Render token secret, required by --board. Defaults to
+                        MCP_SCREENSHOT_TOKEN_SECRET. Locally this is the placeholder in the
+                        sync worker's [env.dev.vars]
   --fixture <name>      ${FIXTURE_NAMES.join(' | ')}. Default: snapshot-example
   --mode <mode>         auto | browser-run | local. Default: auto
   --output <path>       PNG output path. Default: tmp/browser-run-thumbnail/thumbnail.png
@@ -281,7 +389,12 @@ Options:
 Captures the dev-only /dev/browser-run-thumbnail fixture page for local iteration on render
 behavior. The fixture page produces the image with editor.toImage; local mode reads the exact
 export bytes, while browser-run mode screenshots the page after it has swapped to displaying
-the export. It does not accept arbitrary screenshot URLs.`)
+the export. It does not accept arbitrary screenshot URLs.
+
+With --board it instead renders the production ${THUMBNAIL_RENDER_PATH} page, signing its own
+render token, so a local capture exercises real board resolution and the real render page. That
+covers everything the MCP screenshot tool does except the Browser Run call itself, which local
+dev cannot make (the dev BROWSER binding is deliberately non-functional).`)
 }
 
 function writeLine(message: string) {


### PR DESCRIPTION
In order to iterate on the thumbnail render page without a preview deploy for every change, this adds a `--board` mode to the thumbnail capture script that renders a real published or shared board locally.

The script could only render the dev fixture page, so real board resolution and the production render page had no local coverage. The MCP screenshot tool can't stand in for that: under `yarn dev-app` the `BROWSER` binding is deliberately non-functional and `[env.dev]` pins a `compatibility_date` that predates `quickAction`, so `get_shared_board_screenshot` always fails at the Browser Run call.

`--board` points local Playwright at the production `/__thumbnail-render` page, signing its own render token. That exercises real board resolution, the real render page, and the real token gate — everything the MCP tool does except the Browser Run call itself. It can't catch Browser Run-specific behaviour (viewport defaults, fonts in Cloudflare's fleet), so a preview deploy is still the check for those.

```bash
MCP_SCREENSHOT_TOKEN_SECRET=<the [env.dev.vars] placeholder> \
yarn workspace dotcom browser-run-thumbnail --board /f/your-slug --output board.png
```

The board kind is derived from the `/p/` or `/f/` path rather than a separate flag, since it's a property of the board — a whole board link works too, and only its path is read. The secret is never hardcoded: `--board` requires `--secret` or `MCP_SCREENSHOT_TOKEN_SECRET`.

The docs changes correct two claims this work disproved: `wrangler dev --remote` does not enable real local captures (the dev compatibility date and an unreachable render origin both block it), and `POST /app/mcp` does not exercise the production path locally — `get_board_info` works, `get_shared_board_screenshot` never does.

### Change type

- [x] `other`

### Test plan

With `yarn dev-app` running and a board shared or published locally:

1. `MCP_SCREENSHOT_TOKEN_SECRET=<placeholder> yarn workspace dotcom browser-run-thumbnail --board /f/<slug> --output board.png` — writes a 1200x630 PNG of the board.
2. Repeat with `--theme dark`, and with a full `https://www.tldraw.com/f/<slug>` link.
3. Omit the secret, and pass a wrong one — the first fails with an actionable message, the second reaches the render page and fails its token check (403).
4. `--board https://www.tldraw.com/r/<slug>` is refused as an unsupported link, rather than minting a token for the wrong board kind.
5. `yarn workspace dotcom browser-run-thumbnail --fixture layer-panel` still captures the fixture page unchanged.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Apps            | +137 / -10 |

### Related issues

- Relates to #9503