### PR TITLE
fix(commenting): sort the sidebar by a thread's latest comment

### DIFF
--- a/packages/commenting/src/canvas/comments-sidebar.test.ts
+++ b/packages/commenting/src/canvas/comments-sidebar.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { CommentListItemProps } from '../ui/comments-list'
+import { sortSidebarRows } from './comments-sidebar'
+
+function row(id: string, lastActivity: number, resolved = false) {
+	return {
+		item: {
+			id,
+			resolved,
+			author: { id: 'user:1', name: 'A' },
+			preview: '',
+			date: '',
+		} as unknown as CommentListItemProps,
+		lastActivity,
+	}
+}
+
+describe('sortSidebarRows', () => {
+	it('orders threads by their most recent comment, not their first', () => {
+		// t1 was started first but was just replied to; t2 has been quiet since it was created.
+		const sorted = sortSidebarRows([row('t1', 300), row('t2', 200)])
+		expect(sorted.map((r) => r.item.id)).toEqual(['t1', 't2'])
+	})
+
+	it('sinks resolved threads below unresolved ones however recent they are', () => {
+		const sorted = sortSidebarRows([row('t1', 100), row('t2', 999, true), row('t3', 200)])
+		expect(sorted.map((r) => r.item.id)).toEqual(['t3', 't1', 't2'])
+	})
+
+	it('orders resolved threads among themselves by recency too', () => {
+		const sorted = sortSidebarRows([row('t1', 100, true), row('t2', 300, true)])
+		expect(sorted.map((r) => r.item.id)).toEqual(['t2', 't1'])
+	})
+
+	it('breaks activity ties by id so the list does not reshuffle', () => {
+		const sorted = sortSidebarRows([row('t3', 5), row('t1', 5), row('t2', 5)])
+		expect(sorted.map((r) => r.item.id)).toEqual(['t1', 't2', 't3'])
+	})
+
+	it('does not mutate the input', () => {
+		const input = [row('t1', 100), row('t2', 200)]
+		sortSidebarRows(input)
+		expect(input.map((r) => r.item.id)).toEqual(['t1', 't2'])
+	})
+})

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -85,7 +85,7 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 		(thread) => !filters.onlyCurrentPage || thread.pageId === currentPageId
 	)
 
-	const items: CommentListItemProps[] = pageThreads
+	const rows: SidebarRow[] = pageThreads
 		.filter((thread) => filters.showResolved || thread.resolved == null)
 		// "Only mine" is ignored without a known user — otherwise a persisted onlyMine=true would
 		// empty the list for a signed-out viewer, with the (hidden) toggle giving no way to clear it.
@@ -103,6 +103,8 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 		.map((thread) => {
 			const threadComments = byThread.get(thread.id) ?? []
 			const first = threadComments[0]
+			// Comments arrive oldest-first, so the last one is the thread's most recent activity.
+			const last = threadComments[threadComments.length - 1]
 			let preview: ReactNode = ''
 			// The `ThreadPreview` component slot overrides the built-in plaintext default.
 			const ThreadPreview = options.components.ThreadPreview
@@ -114,26 +116,26 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				)
 			}
 			return {
-				id: thread.id,
-				author: resolveAuthor(thread.createdBy) ?? UNKNOWN_COMMENT_AUTHOR,
-				preview,
-				date: new Date((first ?? thread).createdAt).toISOString(),
-				resolved: thread.resolved != null,
-				// The page label only earns its place when it adds information: multiple pages
-				// exist, and the thread is somewhere other than where you already are.
-				page:
-					pageNames.size > 1 && thread.pageId !== currentPageId
-						? pageNames.get(thread.pageId)
-						: undefined,
-				count: threadComments.length,
-				selected: openId === thread.id,
+				item: {
+					id: thread.id,
+					author: resolveAuthor(thread.createdBy) ?? UNKNOWN_COMMENT_AUTHOR,
+					preview,
+					date: new Date((first ?? thread).createdAt).toISOString(),
+					resolved: thread.resolved != null,
+					// The page label only earns its place when it adds information: multiple pages
+					// exist, and the thread is somewhere other than where you already are.
+					page:
+						pageNames.size > 1 && thread.pageId !== currentPageId
+							? pageNames.get(thread.pageId)
+							: undefined,
+					count: threadComments.length,
+					selected: openId === thread.id,
+				},
+				lastActivity: (last ?? thread).createdAt,
 			}
 		})
-		// unresolved first, then most-recent first
-		.sort((a, b) => {
-			if (!!a.resolved !== !!b.resolved) return a.resolved ? 1 : -1
-			return b.date.localeCompare(a.date)
-		})
+
+	const items = sortSidebarRows(rows).map((row) => row.item)
 
 	const focus = (id: string) => {
 		const thread = threads.find((t) => t.id === id)
@@ -165,6 +167,28 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 				onSelect={focus}
 			/>
 		</SidebarPanel>
+	)
+}
+
+/** A list row paired with the sort key that isn't part of what the row displays. */
+interface SidebarRow {
+	item: CommentListItemProps
+	/** When the thread's most recent comment was posted — what the list orders by. */
+	lastActivity: number
+}
+
+/**
+ * Order the list: unresolved threads first, then by most recent activity, id as a stable tiebreak.
+ * Recency is the thread's *latest* comment, not its first, so a thread someone just replied to rises
+ * to the top instead of staying wherever it was started. (The row still shows the thread's opening
+ * comment and its date — that's what identifies the thread; only the ordering follows the replies.)
+ */
+export function sortSidebarRows(rows: readonly SidebarRow[]): readonly SidebarRow[] {
+	return [...rows].sort(
+		(a, b) =>
+			Number(!!a.item.resolved) - Number(!!b.item.resolved) ||
+			b.lastActivity - a.lastActivity ||
+			(a.item.id < b.item.id ? -1 : 1)
 	)
 }
 


### PR DESCRIPTION
In order to keep the threads people are actually talking in at the top of the comments sidebar, this sorts the list by each thread's most recent comment instead of its first one. Today the sort key is the row's displayed date, which is the thread's opening comment — so replying to a week-old thread leaves it buried a week down the list, and a busy conversation is harder to find than a stale one.

Each row now carries a `lastActivity` key alongside what it displays (the most recent live comment's `createdAt`, since deleted comments shouldn't count as activity), and the list sorts on that. Resolved threads still sink below unresolved ones. The row itself is unchanged — it still shows who started the thread and when, which is what identifies it; only the ordering follows the replies.

The ordering moved into a `sortSidebarRows` helper so it can be unit tested, matching how `sortThreadsForPreview` is factored out next door. That also picked up a thread-id tiebreak, so threads with identical timestamps no longer reshuffle between renders.

### Change type

- [x] `bugfix`

### Test plan

1. Open a board with several comment threads and open the comments sidebar.
2. Reply to the oldest thread — it should jump to the top of the list.
3. Resolve that thread — it should drop below the unresolved ones, still ordered by recency among the resolved ones.

- [x] Unit tests

### Release notes

- Fix the comments sidebar ordering threads by when they were started rather than by their latest reply.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +43 / -19  |
| Tests     | +45 / -0   |
