### PR TITLE
fix(commenting): pass wheel events through comment hover previews

### DIFF
--- a/packages/commenting/src/canvas/thread-preview.tsx
+++ b/packages/commenting/src/canvas/thread-preview.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useRef, type CSSProperties } from 'react'
 import { createPortal } from 'react-dom'
-import { Editor, EditorAtom, TLComment, TLCommentThread, useTranslation, useValue } from 'tldraw'
+import {
+	Editor,
+	EditorAtom,
+	TLComment,
+	TLCommentThread,
+	usePassThroughWheelEvents,
+	useTranslation,
+	useValue,
+} from 'tldraw'
 import { CommentCard } from '../ui/comment-card'
 import { useComments } from './hooks'
 import { useCommentingOptions } from './options'
@@ -178,6 +186,12 @@ export function ThreadPreview({
 	const comments = useComments(editor)
 	const resolveName = useResolveName(props.resolveAuthor)
 
+	// The panel floats over the canvas and scrolls nothing of its own, so a wheel on it should zoom
+	// and pan the canvas underneath — like every other tldraw panel, and like the popover it
+	// previews. Without this the canvas would freeze wherever the preview happened to be.
+	const ref = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(ref)
+
 	// Each thread's opening comment. `useComments` is oldest-first, so the first hit per thread is
 	// that thread's first comment. One pass over every comment beats a per-thread hook — the
 	// thread count here is driven by cluster size, which has no fixed bound.
@@ -218,6 +232,7 @@ export function ThreadPreview({
 		// inside it is the visible surface. Keeping them apart is what lets the surface light up on
 		// its own hover without the bridge (which reaches back over the marker) lighting it up too.
 		<div
+			ref={ref}
 			className={`tlui-cmt-canvas-preview tlui-cmt-canvas-preview--${variant}`}
 			style={
 				{


### PR DESCRIPTION
In order to keep the canvas scrollable while a comment hover preview is up, this calls `usePassThroughWheelEvents` on the preview panel's root.

Hovering a comment marker pops the preview open directly under the pointer, so the panel lands exactly where you're about to scroll. Without the hook the panel ate the wheel event and the canvas froze — zoom and pan did nothing until you moved off the preview and waited out the close delay. Every other floating surface in the commenting layer already passes the wheel through: the markers, the stack badge, and `ThreadPopover`, which is the panel this preview imitates.

One call covers everything, since the pin, the coincident stack, and the cluster badge all render through `ThreadPreview`. The hook goes at the top of the component with the other hooks rather than next to the JSX, because the panel bails early when no thread has a readable opening comment yet.

I did not add `usePassThroughMouseOverEvents`, which `ThreadPopover` pairs with the wheel hook. The preview is hover-driven UI, and forwarding mouseover would light up the shape underneath while you're reading a card. Happy to match the popover if reviewers would rather the two behave identically.

### Change type

- [x] `bugfix`

### Test plan

1. Open a file with comments and hover a comment pin until its preview appears.
2. Scroll over the preview panel — the canvas zooms and pans underneath it.
3. Repeat on a coincident stack badge and a cluster badge, which use the list variant of the same panel.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the canvas not zooming or panning when the pointer was over a comment's hover preview.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +16 / -1   |
