### PR TITLE
fix(commenting): don't let view-only guests comment

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -30,10 +30,22 @@ type FileVisitors = QueryResultType<typeof queries.fileVisitors>
  * notifications feed, which is bounded to recent comments), so every unread pin resolves however
  * old the comment is.
  */
-export function CommentsOnCanvas({ fileId }: { fileId: string }) {
+export function CommentsOnCanvas({
+	fileId,
+	canComment = true,
+}: {
+	fileId: string
+	/** Whether this session may write comments. When false the layer is read-only: existing
+	 *  comments show, but there's no composer (the server also rejects writes). */
+	canComment?: boolean
+}) {
 	const editor = useEditor()
 	const app = useMaybeApp()
 	const currentUserId = app?.userId ?? null
+	// The compose identity: a signed-in user who's allowed to comment. Null makes CanvasComments a
+	// read-only viewer (no composer/reply/resolve). Everything read-only — read status, name
+	// resolution, the sidebar's "only mine" filter — still uses the real currentUserId.
+	const composeUserId = canComment ? currentUserId : null
 
 	const currentUser = useValue(
 		'current user',
@@ -183,7 +195,7 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 	return (
 		<>
 			<CanvasComments
-				currentUserId={currentUserId}
+				currentUserId={composeUserId}
 				resolveAuthor={resolveAuthor}
 				isCommentUnread={app ? isCommentUnread : undefined}
 				onCommentRead={app ? onCommentRead : undefined}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -292,24 +292,33 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const anonCommentToolOverrides = useAnonCommentToolOverrides()
 	const commentingEnabled = useIsCommentingEnabled()
 
+	// Whether this session may write comments. The server grants object-lane (comment) write access
+	// per session from the file's share tier: an `edit` link gets it, a view-only link doesn't. So a
+	// viewer still sees existing comments, but gets no comment tool, overrides, or composer — the
+	// server rejects any stray write as a backstop. Resolved before the editor mounts, since the
+	// store is already synced by then.
+	const canComment =
+		commentingEnabled && (store.status !== 'synced-remote' || store.objectAccess !== 'read')
+
 	const instanceComponents = useMemo((): TLComponents => {
 		return {
 			...components,
 			DebugMenu: () => <CustomDebugMenu />,
 			InFrontOfTheCanvas: commentingEnabled
-				? () => <CommentsOnCanvas fileId={fileId} />
+				? () => <CommentsOnCanvas fileId={fileId} canComment={canComment} />
 				: undefined,
 		}
-	}, [fileId, commentingEnabled])
+	}, [fileId, commentingEnabled, canComment])
 
 	// Without the tool and its overrides there's no comment button in the toolbar and no `c`
-	// shortcut, so commenting is fully absent for users the flag doesn't cover.
+	// shortcut, so commenting is fully absent for users the flag doesn't cover and for viewers
+	// the file's share tier doesn't let comment.
 	const editorOverrides = useMemo(
 		() =>
-			commentingEnabled
+			canComment
 				? [overrides, extraDragIconOverrides, commentToolOverrides, anonCommentToolOverrides]
 				: [overrides, extraDragIconOverrides],
-		[commentingEnabled, overrides, extraDragIconOverrides, anonCommentToolOverrides]
+		[canComment, overrides, extraDragIconOverrides, anonCommentToolOverrides]
 	)
 
 	return (
@@ -320,7 +329,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 				store={store}
 				assetUrls={assetUrls}
 				shapeUtils={embedShapeUtils}
-				tools={commentingEnabled ? tlaCommentTools : undefined}
+				tools={canComment ? tlaCommentTools : undefined}
 				user={app?.tlUser}
 				onMount={handleMount}
 				onUiEvent={handleUiEvent}

--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaInviteTab.tsx
@@ -23,6 +23,7 @@ import { QrCode } from '../QrCode'
 
 const messages = defineMessages({
 	editor: { defaultMessage: 'Editor' },
+	// commenter: { defaultMessage: 'Commenter' },
 	viewer: { defaultMessage: 'Viewer' },
 	noAccess: { defaultMessage: 'No access' },
 })
@@ -115,7 +116,17 @@ function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 		[app, fileId, trackEvent]
 	)
 
+	// Comment-only mode ("Commenter": a read-only canvas that still allows comments) is implemented
+	// end to end but not shipped. To turn it on, restore the commented-out option and label below,
+	// along with the `comment` tier in the sync worker's `computeFileAccess`.
 	const label = useMsg(sharedLinkType === 'edit' ? messages.editor : messages.viewer)
+	// const label = useMsg(
+	// 	sharedLinkType === 'edit'
+	// 		? messages.editor
+	// 		: sharedLinkType === 'comment'
+	// 			? messages.commenter
+	// 			: messages.viewer
+	// )
 
 	return (
 		<TlaMenuControl>
@@ -130,6 +141,7 @@ function TlaSelectSharedLinkType({ fileId }: { fileId: string }) {
 				onChange={handleSelectChange}
 				options={[
 					{ value: 'edit', label: <F defaultMessage="Editor" /> },
+					// { value: 'comment', label: <F defaultMessage="Commenter" /> },
 					{ value: 'view', label: <F defaultMessage="Viewer" /> },
 				]}
 			/>

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -70,6 +70,7 @@ import {
 	planMentionReconciles,
 } from './commentRows'
 import { PERSIST_INTERVAL_MS } from './config'
+import { computeFileAccess } from './fileAccess'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
@@ -736,6 +737,10 @@ export class TLFileDurableObject extends DurableObject {
 		const auth = await getAuth(req, this.env)
 		authTimer.report('on_request_auth')
 
+		// Comment (object-lane) write access, decided per session alongside the canvas open mode.
+		// Defaults to read-only; legacy (non-app) rooms have no comment tier and keep this default.
+		let objectAccess: TLObjectStoreAccess = 'read'
+
 		if (this.documentInfo.isApp) {
 			openMode = ROOM_OPEN_MODE.READ_WRITE
 			const file = await this.getAppFileRecord()
@@ -793,14 +798,22 @@ export class TLFileDurableObject extends DurableObject {
 					groupCheckTimer.report('on_request_group_check')
 				}
 
-				if (!hasOwnerAccess) {
-					if (!file.shared) {
-						return closeSocket(TLSyncErrorCloseEventReason.FORBIDDEN)
-					}
-					if (file.sharedLinkType === 'view') {
-						openMode = ROOM_OPEN_MODE.READ_ONLY
-					}
+				if (!hasOwnerAccess && !file.shared) {
+					return closeSocket(TLSyncErrorCloseEventReason.FORBIDDEN)
 				}
+
+				// Map the file's tier to this session's two lanes: `edit` guests keep canvas write,
+				// everyone else is canvas read-only, and comments are gated separately by
+				// objectAccess — a view-only guest reads comments but can't write them.
+				const access = computeFileAccess({
+					sharedLinkType: file.sharedLinkType,
+					hasOwnerAccess,
+					isAuthenticated: !!auth?.userId,
+				})
+				if (access.isReadonly) {
+					openMode = ROOM_OPEN_MODE.READ_ONLY
+				}
+				objectAccess = access.objectAccess
 			}
 		} else {
 			// Legacy rooms are now read-only
@@ -813,10 +826,6 @@ export class TLFileDurableObject extends DurableObject {
 				userId: auth?.userId ? auth.userId : null,
 			}
 			const isReadonly = openMode === ROOM_OPEN_MODE.READ_ONLY
-			// Only authenticated users can write comments. Comment authors are stored in Postgres
-			// with a foreign key to the user table, so an anonymous author couldn't be represented
-			// there. Guests can still read comments.
-			const objectAccess: TLObjectStoreAccess = auth?.userId ? 'write' : 'read'
 			const attachment: SocketAttachment = {
 				sessionId,
 				meta,
@@ -2466,7 +2475,15 @@ export class TLFileDurableObject extends DurableObject {
 
 		// if the app file record updated, it might mean that the sharing state was updated
 		// in which case we should kick people out or change their permissions
-		const roomIsReadOnlyForGuests = file.shared && file.sharedLinkType === 'view'
+		//
+		// A guest's canvas is read-only unless the link is `edit`, and a guest can comment only
+		// when the link is `edit` and they're signed in. The two lanes are tracked separately so
+		// that a tier which changes one without the other (comment-only mode's `view`<->`comment`
+		// switch) still reconnects the sessions it affects.
+		const roomIsReadOnlyForGuests = file.shared && file.sharedLinkType !== 'edit'
+		const guestCanComment = file.shared && file.sharedLinkType === 'edit'
+		// const guestCanComment =
+		// 	file.shared && (file.sharedLinkType === 'edit' || file.sharedLinkType === 'comment')
 
 		for (const session of room.getSessions()) {
 			if (file.isDeleted) {
@@ -2482,14 +2499,18 @@ export class TLFileDurableObject extends DurableObject {
 				return can(role, 'accessFiles')
 			}
 
+			// A guest can only comment when they're signed in (comment authors need a user row).
+			const sessionCanComment = guestCanComment && !!session.meta.userId
+
 			if (!file.shared) {
 				if (!(await canAccessFiles())) {
 					room.closeSession(session.sessionId, TLSyncErrorCloseEventReason.FORBIDDEN)
 				}
 			} else if (
-				// if the file is still shared but the readonly state changed, make them reconnect
-				(session.isReadonly && !roomIsReadOnlyForGuests) ||
-				(!session.isReadonly && roomIsReadOnlyForGuests)
+				// if the file is still shared but the guest's read-only or comment access changed,
+				// make them reconnect so the new session lanes take effect
+				session.isReadonly !== roomIsReadOnlyForGuests ||
+				(session.objectAccess === 'write') !== sessionCanComment
 			) {
 				if (!(await canAccessFiles())) {
 					// not passing a reason means they will try to reconnect

--- a/apps/dotcom/sync-worker/src/fileAccess.test.ts
+++ b/apps/dotcom/sync-worker/src/fileAccess.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { computeFileAccess } from './fileAccess'
+
+describe('computeFileAccess', () => {
+	it('gives owners/group members full access on both lanes, regardless of tier', () => {
+		for (const sharedLinkType of ['edit', 'view']) {
+			expect(
+				computeFileAccess({ sharedLinkType, hasOwnerAccess: true, isAuthenticated: true })
+			).toEqual({ isReadonly: false, objectAccess: 'write' })
+		}
+	})
+
+	it('lets an authenticated editor guest edit the canvas and comment', () => {
+		expect(
+			computeFileAccess({ sharedLinkType: 'edit', hasOwnerAccess: false, isAuthenticated: true })
+		).toEqual({ isReadonly: false, objectAccess: 'write' })
+	})
+
+	it('makes a viewer guest read-only on both lanes', () => {
+		expect(
+			computeFileAccess({ sharedLinkType: 'view', hasOwnerAccess: false, isAuthenticated: true })
+		).toEqual({ isReadonly: true, objectAccess: 'read' })
+	})
+
+	it('treats an unrecognized tier as view-only', () => {
+		// `sharedLinkType` is a plain string column with legacy values in it, so anything we don't
+		// recognize has to fail closed rather than grant writes.
+		expect(
+			computeFileAccess({ sharedLinkType: 'private', hasOwnerAccess: false, isAuthenticated: true })
+		).toEqual({ isReadonly: true, objectAccess: 'read' })
+	})
+
+	it('denies comment writes to anonymous guests', () => {
+		// Comment authors need a user row (Postgres FK), so an anonymous session can never comment.
+		// An anonymous editor can still edit the canvas, but not comment.
+		expect(
+			computeFileAccess({ sharedLinkType: 'edit', hasOwnerAccess: false, isAuthenticated: false })
+		).toEqual({ isReadonly: false, objectAccess: 'read' })
+		expect(
+			computeFileAccess({ sharedLinkType: 'view', hasOwnerAccess: false, isAuthenticated: false })
+		).toEqual({ isReadonly: true, objectAccess: 'read' })
+	})
+
+	// Comment-only mode, off until the `comment` tier ships (see computeFileAccess):
+	// it('lets an authenticated commenter guest comment but not edit the canvas', () => {
+	// 	expect(
+	// 		computeFileAccess({ sharedLinkType: 'comment', hasOwnerAccess: false, isAuthenticated: true })
+	// 	).toEqual({ isReadonly: true, objectAccess: 'write' })
+	// })
+	// it('denies comment writes to anonymous guests on the comment tier', () => {
+	// 	expect(
+	// 		computeFileAccess({ sharedLinkType: 'comment', hasOwnerAccess: false, isAuthenticated: false })
+	// 	).toEqual({ isReadonly: true, objectAccess: 'read' })
+	// })
+})

--- a/apps/dotcom/sync-worker/src/fileAccess.ts
+++ b/apps/dotcom/sync-worker/src/fileAccess.ts
@@ -1,0 +1,54 @@
+import { TLObjectStoreAccess } from '@tldraw/sync-core'
+
+/** Inputs needed to decide what a connecting session may do with a file. */
+export interface FileAccessInput {
+	/** The file's `sharedLinkType`. A plain string column, so treat anything but `edit` as view-only. */
+	sharedLinkType: string
+	/** True if the session owns the file directly or via its owning group. */
+	hasOwnerAccess: boolean
+	/** True if the session belongs to a signed-in user. */
+	isAuthenticated: boolean
+}
+
+/** The per-session access a file grants, split across the two sync lanes. */
+export interface FileAccess {
+	/** Canvas (document-lane) read-only flag. */
+	isReadonly: boolean
+	/** Comment (object-lane) write access, independent of `isReadonly`. */
+	objectAccess: TLObjectStoreAccess
+}
+
+/**
+ * Decide a connecting session's access to a shared file. Callers must reject sessions that
+ * can neither own nor access a shared file *before* calling this (this maps an allowed
+ * session to its two lanes).
+ *
+ * Tiers:
+ * - `edit` — full canvas write + comments.
+ * - anything else (`view`, plus legacy values) — read-only canvas, no comments.
+ *
+ * Owners/group members always get full access. Commenting additionally requires an
+ * authenticated author, because comment authors are persisted in Postgres with a foreign
+ * key to the user table, so an anonymous author can't be represented.
+ *
+ * A third `comment` tier — read-only canvas but comments allowed — is wired up but not shipped;
+ * see the commented-out lines here and in `TlaInviteTab` to turn it on.
+ */
+export function computeFileAccess({
+	sharedLinkType,
+	hasOwnerAccess,
+	isAuthenticated,
+}: FileAccessInput): FileAccess {
+	if (hasOwnerAccess) {
+		return { isReadonly: false, objectAccess: 'write' }
+	}
+
+	// Non-owner guests: only `edit` links grant canvas write.
+	const isReadonly = sharedLinkType !== 'edit'
+	// `edit` links grant comment write, but only to a signed-in author.
+	const canComment = isAuthenticated && sharedLinkType === 'edit'
+	// Comment-only mode: `comment` links grant comment write on a read-only canvas.
+	// const canComment = isAuthenticated && (sharedLinkType === 'edit' || sharedLinkType === 'comment')
+
+	return { isReadonly, objectAccess: canComment ? 'write' : 'read' }
+}

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -6,6 +6,7 @@
 
 import { Editor } from 'tldraw';
 import { TLAssetStore } from 'tldraw';
+import { TLObjectStoreAccess } from '@tldraw/sync-core';
 import { TLPersistentClientSocket } from '@tldraw/sync-core';
 import { TLPresenceStateInfo } from 'tldraw';
 import { TLStore } from 'tldraw';
@@ -16,10 +17,16 @@ import { TLUser } from 'tldraw';
 import { TLUserStore } from 'tldraw';
 
 // @public
-export type RemoteTLStoreWithStatus = Exclude<TLStoreWithStatus, {
+export type RemoteTLStoreWithStatus = (Extract<TLStoreWithStatus, {
+    status: 'synced-remote';
+}> & {
+    readonly objectAccess: TLObjectStoreAccess;
+}) | Exclude<TLStoreWithStatus, {
     status: 'not-synced';
 } | {
     status: 'synced-local';
+} | {
+    status: 'synced-remote';
 }>;
 
 // @public

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -2,6 +2,7 @@ import { atom, transact } from '@tldraw/state'
 import {
 	ClientWebSocketAdapter,
 	TLCustomMessageHandler,
+	TLObjectStoreAccess,
 	TLPersistentClientSocket,
 	TLPresenceMode,
 	TLRemoteSyncError,
@@ -78,10 +79,19 @@ const defaultCustomMessageHandler: TLCustomMessageHandler = () => {}
  *
  * @public
  */
-export type RemoteTLStoreWithStatus = Exclude<
-	TLStoreWithStatus,
-	{ status: 'synced-local' } | { status: 'not-synced' }
->
+export type RemoteTLStoreWithStatus =
+	| Exclude<
+			TLStoreWithStatus,
+			{ status: 'synced-local' } | { status: 'not-synced' } | { status: 'synced-remote' }
+	  >
+	| (Extract<TLStoreWithStatus, { status: 'synced-remote' }> & {
+			/**
+			 * Write access for object-store lane record types (e.g. comments), as granted by the
+			 * server for this session. Independent of the canvas read-only state, so a session can
+			 * be allowed to comment without being allowed to edit. Defaults to `'write'`.
+			 */
+			readonly objectAccess: TLObjectStoreAccess
+	  })
 
 /**
  * Creates a reactive store synchronized with a multiplayer server for real-time collaboration.
@@ -170,6 +180,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 	const [state, setState] = useRefState<{
 		readyClient?: TLSyncClient<TLRecord, TLStore>
 		error?: Error
+		objectAccess?: TLObjectStoreAccess
 	} | null>(null)
 	const {
 		uri,
@@ -338,7 +349,8 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			didCancel: () => didCancel,
 			onLoad(client) {
 				track?.(MULTIPLAYER_EVENT_NAME, { name: 'load', roomId })
-				setState({ readyClient: client })
+				// Merge so we don't clobber objectAccess if onAfterConnect ran first.
+				setState((prev) => ({ ...prev, readyClient: client }))
 			},
 			onSyncError(reason) {
 				console.error('sync error', reason)
@@ -364,7 +376,12 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				setState({ error: new TLRemoteSyncError(reason) })
 				socket.close()
 			},
-			onAfterConnect(_, { isReadonly }) {
+			onAfterConnect(_, { isReadonly, objectAccess }) {
+				// Object-lane (comment) write access is decided per session by the server and can
+				// change on reconnect (e.g. when the file's share tier changes), so surface it on
+				// the returned status for consumers that gate comment UI. This fires before the
+				// first onLoad, hence the merge in both directions.
+				setState((prev) => ({ ...prev, objectAccess }))
 				transact(() => {
 					syncMode.set(isReadonly ? 'readonly' : 'readwrite')
 					// if the server crashes and loses all data it can return an empty document
@@ -412,6 +429,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				status: 'synced-remote',
 				connectionStatus: connectionStatus === 'error' ? 'offline' : connectionStatus,
 				store: state.readyClient.store,
+				objectAccess: state.objectAccess ?? 'write',
 			}
 		},
 		[state]


### PR DESCRIPTION
In order to stop a guest holding a view-only share link from commenting on a board they can't edit, this PR decides comment access from the file's share tier instead of from "is this session signed in".

Comments sync over the file room's object lane, gated per session by `objectAccess` independently of the canvas `isReadonly` flag. That flag was set to `write` for any authenticated session, so a signed-in viewer could post, reply, and resolve on a `view` file.

Now a small pure helper maps `{ sharedLinkType, hasOwnerAccess, isAuthenticated }` onto both lanes at connect time: owners and workspace members get full access, `edit` guests keep canvas write and can comment when signed in, and everyone else is read-only on both. The reconnect-on-share-change path compares both lanes per session, so changing a file's tier reconnects the guests it affects — including sessions still holding the old blanket comment access. On the client, `useSync` surfaces the server-granted access so `TlaEditor` can drop the comment tool, its overrides, and the composer. A viewer still sees existing threads; the server rejects stray writes as a backstop.

Two things worth a reviewer's eye:

- **Non-`edit` tiers now fail closed on the canvas too.** Previously only `sharedLinkType === 'view'` forced read-only, so a shared file carrying any other value (there are legacy ones in the column, e.g. `private`) granted guests edit access. This matches what `hasWriteAccessToFile` in `getAuth.ts` already does for HTTP requests.
- **`canComment` feeds the `tools` prop**, and changing that prop recreates the editor. It's resolved before the editor mounts (the store is synced by then), so this only bites on a mid-session tier change, where the server is already reconnecting the guest.

This is #9604 with the feature removed. That PR added a third "Commenter" tier — read-only canvas, comments allowed — and built this gating as its foundation; we decided not to ship comment-only mode, so the tier is commented out at four sites (`computeFileAccess`, the reconnect check, and the share menu's option and label), each pointing at the others.

### Change type

- [x] `bugfix`

### API changes

- Changed `RemoteTLStoreWithStatus` (`@tldraw/sync`): the `synced-remote` status now carries a `readonly objectAccess: TLObjectStoreAccess` field — the object-lane write access the server granted this session. Defaults to `'write'`, so servers that don't send it are unaffected.

### Test plan

1. As the owner, share a file as **Editor** and open the link as a different signed-in user: the comment tool works, comments post/reply/resolve.
2. Switch the file to **Viewer**: the guest reconnects, the comment tool and composer disappear, existing threads stay visible and readable in the sidebar, and the canvas is read-only.
3. Switch back to **Editor**: the guest regains both.
4. Confirm the owner and workspace members can always comment, whatever the tier says.
5. Confirm signed-out viewers still get the sign-in prompt rather than a broken composer.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix commenting being available to anyone signed in on a view-only board — commenting now follows the file's share tier.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +24 / -6   |
| Tests           | +55 / -0   |
| Automated files | +8 / -1    |
| Apps            | +131 / -23 |
