### PR TITLE
feat(commenting): tab into the reply box from an open thread

### DIFF
--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -203,7 +203,13 @@ export function ThreadView({
 	const tabTaken = useRef(false)
 	const swallowTabUp = useRef(false)
 	useEffect(() => {
-		if (!canReply) return
+		if (!canReply) {
+			// Resolving unmounts the reply box under an open thread. Reopening it should feel like a
+			// freshly opened thread: no autoFocus left armed from the last Tab, and Tab available again.
+			setFocusReply(false)
+			tabTaken.current = false
+			return
+		}
 		const doc = container.ownerDocument
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== 'Tab' || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -14,6 +14,7 @@ import {
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
 	TldrawUiIcon,
+	useContainer,
 	usePassThroughMouseOverEvents,
 	usePassThroughWheelEvents,
 	useTranslation,
@@ -191,6 +192,31 @@ export function ThreadView({
 	)
 	const [editingId, setEditingId] = useState<string | null>(null)
 	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
+	const canReply = canComment && !thread.resolved
+	const container = useContainer()
+
+	// Tab from the canvas drops the caret in the reply box. Clicking a pin opens the thread but
+	// leaves focus on the editor container, so the first Tab would otherwise walk the app's own UI
+	// instead of the panel the click just opened. Capture phase, ahead of the editor's own handling.
+	// Once it has fired the listener comes off, so Tab inside the thread stays plain tab-through.
+	const [focusReply, setFocusReply] = useState(false)
+	useEffect(() => {
+		if (!canReply || focusReply) return
+		const doc = container.ownerDocument
+		const onKeyDown = (e: KeyboardEvent) => {
+			if (e.key !== 'Tab' || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return
+			if (e.defaultPrevented) return
+			// Focus rests on the container (or nothing at all) after a pin click. Anywhere else means
+			// it's already somewhere deliberate — the thread's own controls, the sidebar, a panel —
+			// and Tab belongs to whatever holds it.
+			if (e.target !== container && e.target !== doc.body) return
+			setFocusReply(true)
+			e.preventDefault()
+			e.stopPropagation()
+		}
+		doc.addEventListener('keydown', onKeyDown, true)
+		return () => doc.removeEventListener('keydown', onKeyDown, true)
+	}, [canReply, container, focusReply])
 
 	// Every unread comment on display gets reported read — including replies that arrive while
 	// the view stays mounted, since the effect re-runs as `comments` changes. The host's receipt
@@ -441,7 +467,7 @@ export function ThreadView({
 					: undefined
 			}
 			composer={
-				canComment && !thread.resolved
+				canReply
 					? {
 							author: me ?? UNKNOWN_COMMENT_AUTHOR,
 							placeholder: msg('comments.reply-placeholder'),
@@ -462,6 +488,9 @@ export function ThreadView({
 							disabled: isCommentEmpty(reply) || !currentUserId,
 							getMentionSuggestions,
 							renderMentionSuggestion,
+							// Reuses the composer's own focus path, so the caret lands at the end of a
+							// restored draft rather than in front of it.
+							autoFocus: focusReply,
 						}
 					: undefined
 			}

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -198,25 +198,42 @@ export function ThreadView({
 	// Tab from the canvas drops the caret in the reply box. Clicking a pin opens the thread but
 	// leaves focus on the editor container, so the first Tab would otherwise walk the app's own UI
 	// instead of the panel the click just opened. Capture phase, ahead of the editor's own handling.
-	// Once it has fired the listener comes off, so Tab inside the thread stays plain tab-through.
+	// Fires once per open thread, so Tab inside the thread stays plain tab-through.
 	const [focusReply, setFocusReply] = useState(false)
+	const tabTaken = useRef(false)
+	const swallowTabUp = useRef(false)
 	useEffect(() => {
-		if (!canReply || focusReply) return
+		if (!canReply) return
 		const doc = container.ownerDocument
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== 'Tab' || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return
-			if (e.defaultPrevented) return
+			if (e.defaultPrevented || tabTaken.current) return
 			// Focus rests on the container (or nothing at all) after a pin click. Anywhere else means
 			// it's already somewhere deliberate — the thread's own controls, the sidebar, a panel —
 			// and Tab belongs to whatever holds it.
 			if (e.target !== container && e.target !== doc.body) return
+			tabTaken.current = true
+			swallowTabUp.current = true
 			setFocusReply(true)
 			e.preventDefault()
 			e.stopPropagation()
 		}
+		// The select tool navigates shapes on Tab's *keyup*, and the composer isn't focused until the
+		// next frame — so a quick tap with shapes selected would both focus the reply and step the
+		// selection. Swallow the release of the press we took, and only that one.
+		const onKeyUp = (e: KeyboardEvent) => {
+			if (e.key !== 'Tab' || !swallowTabUp.current) return
+			swallowTabUp.current = false
+			e.preventDefault()
+			e.stopPropagation()
+		}
 		doc.addEventListener('keydown', onKeyDown, true)
-		return () => doc.removeEventListener('keydown', onKeyDown, true)
-	}, [canReply, container, focusReply])
+		doc.addEventListener('keyup', onKeyUp, true)
+		return () => {
+			doc.removeEventListener('keydown', onKeyDown, true)
+			doc.removeEventListener('keyup', onKeyUp, true)
+		}
+	}, [canReply, container])
 
 	// Every unread comment on display gets reported read — including replies that arrive while
 	// the view stays mounted, since the effect re-runs as `comments` changes. The host's receipt


### PR DESCRIPTION
In order to reply to a comment without going back to the mouse, this PR makes Tab move the caret into the open thread's reply box. Clicking a pin opens the thread but leaves focus on the editor container, so today the only way into the field is a second click.

The thread view listens for Tab while it has a reply box and flips the composer's existing `autoFocus`, so the caret lands at the end of a restored draft rather than in front of it. It only claims the key when focus is still on the container (or nothing) — once you've tabbed into the thread's own controls, the sidebar, or a panel, Tab belongs to whatever holds it — and it's one-shot per open thread, so tabbing through the panel afterwards behaves normally. A resolved thread or a viewer without comment permission has no reply box, so nothing is registered at all.

### Change type

- [x] `improvement`

### Test plan

1. Open the commenting example, place a comment, then click elsewhere to close the thread.
2. Click the comment pin, then press Tab — the caret lands in the reply box; type and press Enter to post.
3. Press Tab again from inside the thread — focus moves through the panel as usual, not back to the field.
4. Resolve the thread, reopen it, press Tab — nothing is hijacked, since there's no reply box.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Press Tab after opening a comment thread to jump straight to the reply box.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +30 / -1   |
