### PR TITLE
fix(tldraw): stop the toolbar overflowing the screen on phones

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -1249,6 +1249,7 @@ tldraw? probably.
 .tlui-layout__bottom {
 	grid-row: 2;
 	width: 100%;
+	min-width: 0px;
 }
 
 .tlui-layout__bottom__main {

--- a/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
+++ b/packages/tldraw/src/lib/ui/components/Toolbar/DefaultToolbar.tsx
@@ -39,7 +39,7 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 	minItems = 4,
 	minSizePx = 310,
 	maxItems,
-	maxSizePx = 470,
+	maxSizePx,
 }: DefaultToolbarProps) {
 	const editor = useEditor()
 	const msg = useTranslation()
@@ -50,9 +50,17 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 	// The default toolbar content gains a ninth primary item when the comment tool renders — which
 	// only happens when commenting is licensed *and* the tool is registered. Without that slot, keep
 	// the original eight so the overflow breakpoint (and the mobile layout) is unchanged.
+	//
+	// `OverflowingToolbar` maps the available width onto an item *count*, so the size range has to
+	// grow with the item range to keep items-per-pixel constant: the ramp spans 40px per item
+	// ((470 - 310) / (8 - 4)), so a ninth slot needs 40px more headroom. Otherwise the same ramp
+	// packs nine items into the width that fit eight, every viewport below `maxSizePx` shows one
+	// tool too many, and on phones the toolbar grows past the screen instead of collapsing into the
+	// overflow menu.
 	const tools = useTools()
 	const hasCommentTool = useCommentingEnabled() && !!tools.comment
 	const resolvedMaxItems = maxItems ?? (hasCommentTool ? 9 : 8)
+	const resolvedMaxSizePx = maxSizePx ?? (hasCommentTool ? 510 : 470)
 
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
@@ -98,7 +106,7 @@ export const DefaultToolbar = memo(function DefaultToolbar({
 							minItems={minItems}
 							maxItems={resolvedMaxItems}
 							minSizePx={minSizePx}
-							maxSizePx={maxSizePx}
+							maxSizePx={resolvedMaxSizePx}
 						>
 							{children ?? <DefaultToolbarContent />}
 						</OverflowingToolbar>


### PR DESCRIPTION
On phones the toolbar could grow past the edge of the screen instead of collapsing tools into the overflow menu, taking the top-right share panel off-screen with it. This fixes the cause and adds a guard against the layout failure mode it triggered.

Now targets `commenting`, since the regression comes from the comment tool's toolbar slot.

### The cause: the sizing ramp didn't grow with the item count

`OverflowingToolbar` doesn't measure items — it maps the available width onto an item *count*:

```
itemsToShow = floor(modulate(size, [minSizePx, maxSizePx], [minItems, maxItems]))
```

`DefaultToolbar` raised `maxItems` from 8 to 9 for the comment tool but left `maxSizePx` at 470, which raised the ramp from **0.025 to 0.03125 items/px**. That isn't "one more button at the end" — it's 25% more tools at *every* width below 470px. On a 411px phone the toolbar wanted 7 items instead of 6 and rendered 432px wide, wider than the screen.

`maxSizePx` now defaults to 510 alongside the ninth slot, keeping 40px of ramp per item (`(470 - 310) / (8 - 4)`) and restoring the original breakpoints.

### The guard: the toolbar row could inflate the UI shell

Once the toolbar exceeded the viewport it got worse than a clip. `.tlui-layout` is a single-column grid whose `1fr` track has an implicit `auto` minimum, so the toolbar's content-based minimum propped the track open past the container. The toolbar then measured the *inflated* track, showed even more items, and settled in a self-consistent runaway state — and the top row, right-aligned inside the same track, went off-screen with it.

`.tlui-layout__bottom` now gets the same `min-width: 0` guard `.tlui-layout__top` already has, so a wide bottom row can never widen the shell.

### Measurements

Measured at `basic/full` under Playwright with the ninth slot active. Content right edge vs. viewport width:

| viewport | 320 | 360 | 375 | 390 | 411 | 430 | 470 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| before | 483 | 483 | 483 | 483 | 483 | 483 | 483 |
| `min-width: 0` only | 304 | 344 | 371 | 378 | 408 | 418 | **477** |
| both changes | 304 | 344 | 351 | 378 | 389 | 418 | 457 |

Before, the layout is pinned at 483px on every phone width. `min-width: 0` alone stops the runaway but still overflows around 460–483px, because the ramp is still asking for nine items. With both, nothing overflows anywhere, and item counts match `main` exactly at every width — the ninth slot only unlocks at 510px, where there's room for it.

### Change type

- [x] `bugfix`

### Test plan

1. Open tldraw on a phone-width viewport (320–470px) with commenting enabled so the comment tool registers.
2. Before: the toolbar renders wider than the screen and the top-right share panel is pushed off-screen. After: extra tools collapse into the overflow menu and all UI stays on screen.

Note that registering an arbitrary extra tool does *not* reproduce this — `maxItems` only changes when the comment tool is present, so the ramp is unaffected. That's why it looked fine in other examples.

### Release notes

- Fix the toolbar overflowing the screen on narrow viewports instead of collapsing into the overflow menu.
