### PR TITLE
fix(commenting): re-derive the comment UI metrics the pin resize left behind

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -96,6 +96,14 @@
 	margin: -16px;
 }
 
+/* The expanded thread is the only entry with pills floating above its panel — its header actions,
+   and its first comment's hover actions. Those reach ~15px up, past the list's 10px gap, so give
+   this one entry extra room: without it the pills land on the card above, and against the scroll
+   box's clip edge. Collapsed cards keep their own actions inside, so they need none of this. */
+.tlui-cmt-stack-list__thread {
+	margin-top: 8px;
+}
+
 /* Collapsed entries match the expanded thread's surface (same width, panel, elevation) so the
    list reads as one column of cards with one of them opened up. */
 .tlui-cmt-stack-list__card {
@@ -156,7 +164,7 @@
    The popover and preview share a first-comment position now that the actions float outside the
    panel rather than reserving a header row, so no vertical shift is needed. */
 .tlui-cmt-canvas-preview--thread {
-	--tlui-cmt-preview-bridge: calc(var(--tlui-cmt-preview-offset) - var(--tlui-cmt-marker-size));
+	--tlui-cmt-preview-bridge: calc(var(--tlui-cmt-preview-offset) - var(--tlui-cmt-pin-size));
 }
 
 /* A badge is centred on its anchor, so only half of it does. */
@@ -353,19 +361,23 @@
 	position: absolute;
 	z-index: var(--tl-layer-menus);
 	pointer-events: auto;
-	/* Anchor the draft avatar bottom-left like the pins it becomes: it is 28px wide and sits 4px
-	   into the row, so its bottom-left corner is 4px right of and 4 + 28 = 32px below the
-	   composer's top-left corner. */
-	transform: translate(-4px, -32px);
+	/* Anchor the draft avatar bottom-left like the pins it becomes: it is a pin wide and sits 4px
+	   into the row, so its bottom-left corner is 4px right of and 4px + a pin below the composer's
+	   top-left corner. */
+	transform: translate(-4px, calc(-4px - var(--tlui-cmt-pin-size)));
 	/* The rich-text editor has no intrinsic width (unlike the old <input>), so give the floating
 	   placement composer a definite width or it collapses to nothing. */
 	width: 280px;
 }
 
 /* A region placement centres the draft avatar on the region's pin corner — the pin it becomes
-   straddles that corner. The avatar's centre sits 4 + 28/2 = 18px into the composer. */
+   straddles that corner. The avatar's centre sits 4px + half a pin into the composer. */
 .tlui-cmt-canvas-composer--region {
-	transform: translate(-18px, -18px);
+	--tlui-cmt-draft-avatar-centre: calc(4px + var(--tlui-cmt-pin-size) / 2);
+	transform: translate(
+		calc(-1 * var(--tlui-cmt-draft-avatar-centre)),
+		calc(-1 * var(--tlui-cmt-draft-avatar-centre))
+	);
 }
 
 /* Fallback placement (no composer to show): no draft avatar to anchor by, so no offset — a small

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -82,9 +82,10 @@ export function toCardProps(
 	}
 }
 
-/** Every marker is this square (mirrors `--tlui-cmt-marker-size`). Needed because the two marker
- *  kinds anchor at different points, and lining their previews up means correcting for that. */
-const MARKER_SIZE = 34
+/** A pin is this square (mirrors `--tlui-cmt-pin-size`). Needed because the two marker kinds are
+ *  different sizes *and* anchor at different points, and lining their previews up means
+ *  correcting for that. Keep in sync with the stylesheet. */
+const PIN_SIZE = 28
 
 /** A coincident stack's / cluster's card list, whose first card sits flush with the popover top. */
 const LIST_OFFSET = { x: 36, y: -28 } as const
@@ -98,19 +99,18 @@ const LIST_OFFSET = { x: 36, y: -28 } as const
  *
  * The two marker kinds don't anchor alike, which the vertical offsets have to correct for. A
  * badge is centred on its point (`translate(-50%, -50%)`), so `LIST_OFFSET.y` is measured from its
- * middle. A pin hangs off its point (`translate(0, -100%)`), so its point is the pin's *bottom* —
- * a full marker lower than a badge's. Measuring a raw offset from there would drop the pin's
- * preview half a marker below a badge's; the terms below re-base it so the two previews' top cards
- * land on the same line.
+ * middle. A pin hangs off its point (`translate(0, -100%)`), so its point is the pin's *bottom*.
+ * Measuring a raw offset from there would drop the pin's preview half a pin below a badge's; the
+ * terms below re-base it so the two previews' top cards land on the same line.
  */
 export const POPOVER_OFFSET = {
 	/**
 	 * A single pin's thread popover. Its preview should read level with a cluster/stack preview's
-	 * top card, so start from the list offset and re-base it to the pin's bottom anchor:
-	 * `- MARKER_SIZE / 2` accounts for the pin's point sitting half a marker below a badge's. The
-	 * opened popover shares the offset and opens from there.
+	 * top card, so start from the list offset and re-base it from the pin's bottom anchor to the
+	 * pin's middle — where a badge measures from — with `- PIN_SIZE / 2`. The opened popover shares
+	 * the offset and opens from there.
 	 */
-	thread: { x: 48, y: LIST_OFFSET.y - MARKER_SIZE / 2 },
+	thread: { x: 48, y: LIST_OFFSET.y - PIN_SIZE / 2 },
 	list: LIST_OFFSET,
 } as const
 
@@ -317,7 +317,7 @@ export function ThreadView({
 								<>
 									<TooltipButton
 										tooltip={msg('comments.edit')}
-										className="tlui-cmt-thread__action tlui-cmt-thread__action--edit"
+										className="tlui-cmt-thread__action"
 										onClick={() => startEdit(comment)}
 									>
 										<svg

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -306,9 +306,8 @@
    overrides to panel-white while you're still editing (see canvas.css). */
 .tlui-cmt-pin {
 	--tlui-cmt-marker-tint: var(--tlui-cmt-pin-color, var(--tl-color-selected));
-	/* Pin shrinks to 28px; the count badge keeps the 34px marker-size default (a cluster reads
-	   fine a touch bigger). */
-	--tlui-cmt-marker-size: 28px;
+	/* A pin is smaller than the count badge, which keeps the marker-size default. */
+	--tlui-cmt-marker-size: var(--tlui-cmt-pin-size);
 	width: var(--tlui-cmt-marker-size);
 	height: var(--tlui-cmt-marker-size);
 	border-radius: 50% 50% 50% 3px;
@@ -495,10 +494,13 @@
    the pixel the panel would. Deriving the preview's offset from these means the two can't drift —
    retune the padding or the header here and the preview follows. */
 .tl-container {
-	/* Every canvas marker — a comment pin, a cluster badge, a stack badge — is this square. The
-	   hover preview measures its bridge against it, so the bridge stops at the marker's edge
-	   instead of covering it. */
+	/* A cluster badge and a stack badge are this square. The hover preview measures its bridge
+	   against it, so the bridge stops at the marker's edge instead of covering it. */
 	--tlui-cmt-marker-size: 34px;
+	/* A pin is smaller than a badge (a cluster reads fine a touch bigger). Everything that has to
+	   line up against a pin — its preview's bridge, the draft composer's offsets, `PIN_SIZE` in
+	   thread-view.tsx — derives from this, so the pin's size stays one number. */
+	--tlui-cmt-pin-size: 28px;
 	/* How a marker sits, lifts, and rings. Shared so a pin and a badge respond identically.
 	   shadow-3's depth without its `inset 1px panel-contrast` edge — that inset reads as a white
 	   border on a coloured pin (it's invisible on the panel-white menus shadow-3 is meant for). */
@@ -509,7 +511,11 @@
 	--tlui-cmt-thread-padding: 8px;
 	--tlui-cmt-thread-gap: 6px;
 	--tlui-cmt-thread-action-size: 26px;
-	--tlui-cmt-pill-shadow: 0 0 0 1px hsl(0, 0%, 0%, 0.06), 0 1px 3px hsl(0, 0%, 0%, 0.05);
+	/* A floating pill's edge — its hairline ring is the only thing separating it from the panel it
+	   overlaps, so the ring is a theme token rather than a literal black: a near-black hairline
+	   vanishes on a dark panel, where the divider token lightens instead. The drop below it stays
+	   literal; a soft dark blur reads on both themes. */
+	--tlui-cmt-pill-shadow: 0 0 0 1px var(--tl-color-divider), 0 1px 3px hsl(0, 0%, 0%, 0.05);
 }
 
 .tlui-cmt-thread {
@@ -538,9 +544,30 @@
 }
 /* The first comment's hover actions surface right where the header pill sits, so hide the pill
    while that comment is hovered — one pill in the corner, never two stacked. */
-.tlui-cmt-thread:has(.tlui-cmt-thread__list > :first-child:hover) .tlui-cmt-thread__header {
+.tlui-cmt-thread:has(.tlui-cmt-thread__list > :first-child:hover)
+	.tlui-cmt-thread__header:not(:has(.tlui-cmt-thread__title)) {
 	opacity: 0;
 	pointer-events: none;
+}
+/* A title puts the header back in the panel, in flow. The pill above is tuned for the actions-only
+   case tldraw itself uses: right-anchored and only as wide as its buttons, so a title inside it
+   would grow leftwards off the panel's edge and float over whatever sits above. `header` is public
+   API (see `CommentThreadProps`), so it has to keep laying out sensibly for anyone passing one. */
+.tlui-cmt-thread__header:has(.tlui-cmt-thread__title) {
+	position: static;
+	align-items: center;
+	padding: 2px 2px 2px 4px;
+	background: none;
+	border-radius: 0;
+	box-shadow: none;
+}
+/* …and with a header occupying that corner, the first comment's actions stay inside their card
+   rather than floating up into it. */
+.tlui-cmt-thread:has(.tlui-cmt-thread__title)
+	.tlui-cmt-thread__list
+	> :first-child
+	.tlui-cmt-card__actions {
+	top: 3px;
 }
 .tlui-cmt-thread__title {
 	font-size: 12px;
@@ -571,11 +598,23 @@
 	cursor: pointer;
 }
 /* Enlarge the click/tap target past the compact 26px visual — the button reads small but is
-   comfortable to hit. A transparent ::after, so nothing changes visually. */
+   comfortable to hit. A transparent ::after, so nothing changes visually.
+
+   Sideways it stops at half the row's 2px gap, so neighbouring targets tile instead of overlapping.
+   Overlapping would be worse than no expansion at all: the targets are siblings with no z-index, so
+   the later one paints — and hits — on top, and a 6px reach across a 2px gap would put delete's
+   invisible target over the right edge of edit's *visible* button. The row's outer edges have no
+   neighbour to steal from, so they expand fully. */
 .tlui-cmt-thread__action::after {
 	content: '';
 	position: absolute;
-	inset: -6px;
+	inset: -6px -1px;
+}
+.tlui-cmt-thread__action:first-child::after {
+	left: -6px;
+}
+.tlui-cmt-thread__action:last-child::after {
+	right: -6px;
 }
 .tlui-cmt-thread__action:hover {
 	background: var(--tl-color-muted-2);
@@ -647,22 +686,24 @@
 	background: transparent;
 	border: none;
 }
-/* Centre the 22px action buttons on the byline's text line: the byline centres ~14px below the
-   card top (6px padding + half its ~16px line), so the buttons start at 14 − 11 = 3px. */
+/* Inside a panel the actions float as their own pill, riding the card's top edge rather than
+   sitting on the byline — the same pill the thread header is, in the same corner (which is why the
+   header hides while the first comment is hovered). Raised by half its own height so it straddles
+   the edge: the pill is an action button plus its 2px padding either side. */
 .tlui-cmt-thread .tlui-cmt-card .tlui-cmt-card__actions,
 .tlui-cmt-canvas-preview--thread .tlui-cmt-card .tlui-cmt-card__actions {
-	top: -17px;
+	top: calc(-2px - (var(--tlui-cmt-thread-action-size) + 4px) / 2);
 	right: 2px;
 }
-/* The hover actions overlay the byline's corner, so reserve their footprint — the byline can
-   never run underneath them, even mid-hover. Sized from the 22px action buttons + 2px gaps +
-   the cluster's 6px right inset: one button (react) on others' comments, three (edit, delete,
-   react) on your own. */
+/* The pill's lower half still overlays the byline's corner, so reserve its footprint — the byline
+   can never run underneath it, even mid-hover. Derived from the action size so it can't drift:
+   n buttons + (n−1) 2px gaps + the pill's 2px padding either side + its 2px right inset. One
+   button (react) on others' comments, three (edit, delete, react) on your own. */
 .tlui-cmt-thread .tlui-cmt-card .tlui-cmt-head {
-	padding-right: 30px;
+	padding-right: calc(var(--tlui-cmt-thread-action-size) + 6px);
 }
 .tlui-cmt-thread .tlui-cmt-card--you .tlui-cmt-head {
-	padding-right: 78px;
+	padding-right: calc(3 * var(--tlui-cmt-thread-action-size) + 10px);
 }
 
 /* comments list — thread summaries, one per row (used by the canvas sidebar) */
@@ -702,11 +743,18 @@
 	color: var(--tl-color-text-2);
 	cursor: pointer;
 }
-/* Same hit-target expansion as the thread actions: compact visual, comfortable click area. */
+/* Same hit-target expansion as the thread actions, tiled the same way — this row's gap is 2px too
+   (see `.tlui-cmt-list__header-actions`). */
 .tlui-cmt-header-btn::after {
 	content: '';
 	position: absolute;
-	inset: -6px;
+	inset: -6px -1px;
+}
+.tlui-cmt-header-btn:first-child::after {
+	left: -6px;
+}
+.tlui-cmt-header-btn:last-child::after {
+	right: -6px;
 }
 .tlui-cmt-header-btn:hover,
 .tlui-cmt-header-btn[data-state='open'] {

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -686,17 +686,16 @@
 	background: transparent;
 	border: none;
 }
-/* Inside a panel the actions float as their own pill, riding the card's top edge rather than
-   sitting on the byline — the same pill the thread header is, in the same corner (which is why the
-   header hides while the first comment is hovered). Raised by half its own height so it straddles
-   the edge: the pill is an action button plus its 2px padding either side. */
+/* Inside a panel the actions float as their own pill — the same pill the thread header is, in the
+   same corner (which is why the header hides while the first comment is hovered). It sits just
+   above the card's top edge rather than on the byline. */
 .tlui-cmt-thread .tlui-cmt-card .tlui-cmt-card__actions,
 .tlui-cmt-canvas-preview--thread .tlui-cmt-card .tlui-cmt-card__actions {
-	top: calc(-2px - (var(--tlui-cmt-thread-action-size) + 4px) / 2);
+	top: -2px;
 	right: 2px;
 }
-/* The pill's lower half still overlays the byline's corner, so reserve its footprint — the byline
-   can never run underneath it, even mid-hover. Derived from the action size so it can't drift:
+/* The pill overlays the byline's corner, so reserve its footprint — the byline can never run
+   underneath it, even mid-hover. Derived from the action size so it can't drift:
    n buttons + (n−1) 2px gaps + the pill's 2px padding either side + its 2px right inset. One
    button (react) on others' comments, three (edit, delete, react) on your own. */
 .tlui-cmt-thread .tlui-cmt-card .tlui-cmt-head {


### PR DESCRIPTION
In order to make the pins and pills from #9711 behave the way they look, this fixes the measurements that were derived from the sizes that PR changed. The pin shrank 34→28px, the thread actions grew 22→26px, and the header moved out of the panel into a floating pill — but several numbers computed from the old values stayed put, so a few things are now quietly wrong:

- **Hovering a pin flickers.** The hover preview has an invisible bridge spanning the gap between marker and panel, so moving the pointer across doesn't cross bare canvas and retract the preview. It's sized as `offset − marker-size`, and it was still using the 34px badge: 14px of bridge over a 20px gap. The last 6px is exactly the bare canvas the bridge exists to cover.
- **The right edge of "edit" deletes your comment.** The new enlarged tap targets are `inset: -6px` pseudo-elements on buttons laid out with a 2px gap, so each one reaches 4px into its neighbour's *visible* area. They're siblings with no `z-index`, so the later one wins — and in a card's action row, delete comes after edit.
- A single pin's popover re-bases itself by half a marker to line up with a stack preview's top card, still using the badge's half rather than the pin's.
- The byline's reserved width still assumed 22px action buttons, so a long name can now run under them — the thing that reserve exists to prevent.

The fix is mostly to stop hardcoding these: the pin's size becomes `--tlui-cmt-pin-size` (mirrored by `PIN_SIZE` in `thread-view.tsx`, which the comments now cross-reference), and the byline's reserve derives from `--tlui-cmt-thread-action-size`. The composer offsets and the preview geometry compute to the same pixels as before — verified, not assumed.

One deliberate visual change while we were in here: the card's action pill now sits at `top: -2px`, just above the card's top edge, rather than straddling it at half its own height.

Three smaller things in the same area:

- Inside a stack, the expanded thread's pills float ~15px above its panel but the list's gap is 10px, so they land on the card above and clip against the scroll box. That one entry gets the room it needs.
- `CommentThread`'s `header` prop is `@public` and documented, but the pill it now renders into is right-anchored and only as wide as its buttons — a title would grow leftwards off the panel edge. A title now takes the header back in flow. tldraw itself passes no title, so nothing changes for us.
- `--tlui-cmt-pill-shadow`'s hairline ring is the only thing separating a pill from the panel it overlaps, and it was a literal near-black — invisible on a dark panel. It's a theme token now.

Worth a look on the preview deploy: the stack spacing and the dark-mode pill edge are the two changes I couldn't verify locally (there's no commenting example in `apps/examples`, and these need real threads).

### Change type

- [x] `bugfix`

### Test plan

1. Hover a comment pin and move the pointer right onto the preview card — it should stay open the whole way across.
2. Hover your own comment in an open thread and click the right edge of the edit button — it should edit, not delete.
3. Open a cluster/stack popover and expand a thread that isn't the first card — its action pills shouldn't touch the card above, and shouldn't clip while scrolling.
4. Give a comment a long author name and check it doesn't run under the hover actions.
5. Switch to dark mode and check the thread header pill and card action pills still have a visible edge against the panel.

- [ ] Unit tests
- [ ] End to end tests

### API changes

None. `CommentThreadProps.header` keeps its type and documented meaning; only its layout is repaired.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +100 / -40 |

Follow-up to #9711.

