### PR TITLE
fix(commenting): keep a shape's comment pin anchored through rotation

### DIFF
--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -104,7 +104,7 @@ export function registerCommentAnchorLifecycle(
 				// passes its prop through).
 				const spot = impreciseShapeAnchor ?? getCommentingOptions(editor).impreciseShapeAnchor
 				let point = anchorPagePoint(editor, thread.anchor, spot)
-				const inset = impreciseShapePinInset(thread.anchor, spot)
+				const inset = impreciseShapePinInset(editor, thread.anchor, spot)
 				if (point && inset) {
 					const zoom = editor.getZoomLevel()
 					point = { x: point.x + inset.x / zoom, y: point.y + inset.y / zoom }

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -1,4 +1,4 @@
-import type { Editor, TLCommentAnchor, TLCommentThread } from 'tldraw'
+import { Box, Mat, type Editor, type TLCommentAnchor, type TLCommentThread } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 // This import is red until step 6's filter module is implemented — that is
 // intentional. Implement `cluster-input.ts` per CLUSTERING-STEPS.md step 6
@@ -28,20 +28,27 @@ function thread(
 
 /**
  * Stub editor: the filter's editor dependencies are the current page id, shape
- * page bounds, and the commenting options (via anchorPagePoint; no registered
- * comment tool → the defaults). `shapes` maps shape id → bounds for shapes that
- * exist; anything else resolves to undefined (deleted shape).
+ * geometry and page transform, and the commenting options (via anchorPagePoint;
+ * no registered comment tool → the defaults). `shapes` maps shape id → page
+ * bounds for unrotated shapes that exist, modeled as local geometry sized by the
+ * box plus a translate-only page transform; anything else resolves to undefined
+ * (deleted shape).
  */
 function stubEditor(
 	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
 ): Editor {
+	const shapeId = (shape: string | { id: string }) => (typeof shape === 'string' ? shape : shape.id)
 	return {
 		getCurrentPageId: () => CURRENT_PAGE,
 		getStateDescendant: () => undefined,
-		getShapePageBounds: (id: string) => {
-			const bounds = shapes[id]
-			if (!bounds) return undefined
-			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
+		getShape: (id: string) => (shapes[id] ? { id } : undefined),
+		getShapeGeometry: (shape: string | { id: string }) => {
+			const bounds = shapes[shapeId(shape)]
+			return { bounds: new Box(0, 0, bounds.maxX - bounds.minX, bounds.maxY - bounds.minY) }
+		},
+		getShapePageTransform: (shape: string | { id: string }) => {
+			const bounds = shapes[shapeId(shape)]
+			return bounds ? Mat.Translate(bounds.minX, bounds.minY) : undefined
 		},
 	} as unknown as Editor
 }

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1271,7 +1271,7 @@ const ThreadPin = memo(function ThreadPin({
 			const pagePoint = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
 			if (!pagePoint) return null
 			const viewportPoint = editor.pageToViewport(pagePoint)
-			const inset = impreciseShapePinInset(thread.anchor, impreciseShapeAnchor)
+			const inset = impreciseShapePinInset(editor, thread.anchor, impreciseShapeAnchor)
 			return inset ? { x: viewportPoint.x + inset.x, y: viewportPoint.y + inset.y } : viewportPoint
 		},
 		[editor, thread.anchor, thread.pageId, impreciseShapeAnchor]
@@ -1308,7 +1308,7 @@ const ThreadPin = memo(function ThreadPin({
 		const anchorPage = anchorPagePoint(editor, thread.anchor, impreciseShapeAnchor)
 		// The drag delta is taken from where the pin is drawn, which for an imprecise shape pin
 		// is inset from its anchor point — without this the pin jumps by the inset on drag start.
-		const inset = impreciseShapePinInset(thread.anchor, impreciseShapeAnchor)
+		const inset = impreciseShapePinInset(editor, thread.anchor, impreciseShapeAnchor)
 		if (anchorPage && inset) {
 			const zoom = editor.getZoomLevel()
 			anchorPage.x += inset.x / zoom

--- a/packages/commenting/src/canvas/pin-stacking.test.ts
+++ b/packages/commenting/src/canvas/pin-stacking.test.ts
@@ -1,4 +1,4 @@
-import type { Editor, TLCommentAnchor, TLCommentThread } from 'tldraw'
+import { Box, Mat, type Editor, type TLCommentAnchor, type TLCommentThread } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 import { computePinStacks } from './pin-stacking'
 
@@ -22,15 +22,21 @@ function thread(
 	} as unknown as TLCommentThread
 }
 
+/** Unrotated shapes: local geometry sized by the box, placed by a translate-only page transform. */
 function stubEditor(
 	shapes: Record<string, { minX: number; minY: number; maxX: number; maxY: number }> = {}
 ): Editor {
+	const shapeId = (shape: string | { id: string }) => (typeof shape === 'string' ? shape : shape.id)
 	return {
 		getCurrentPageId: () => CURRENT_PAGE,
-		getShapePageBounds: (id: string) => {
-			const bounds = shapes[id]
-			if (!bounds) return undefined
-			return { ...bounds, w: bounds.maxX - bounds.minX, h: bounds.maxY - bounds.minY }
+		getShape: (id: string) => (shapes[id] ? { id } : undefined),
+		getShapeGeometry: (shape: string | { id: string }) => {
+			const bounds = shapes[shapeId(shape)]
+			return { bounds: new Box(0, 0, bounds.maxX - bounds.minX, bounds.maxY - bounds.minY) }
+		},
+		getShapePageTransform: (shape: string | { id: string }) => {
+			const bounds = shapes[shapeId(shape)]
+			return bounds ? Mat.Translate(bounds.minX, bounds.minY) : undefined
 		},
 	} as unknown as Editor
 }

--- a/packages/commenting/src/canvas/thread-state.test.ts
+++ b/packages/commenting/src/canvas/thread-state.test.ts
@@ -8,9 +8,16 @@ import {
 	defaultShapeUtils,
 	defaultTools,
 	Editor,
+	TLShapeId,
 } from 'tldraw'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { commentTargetShapeAt } from './thread-state'
+import {
+	anchorPagePoint,
+	commentTargetShapeAt,
+	impreciseShapePinInset,
+	IMPRECISE_PIN_INSET_PX,
+	shapeAnchorAt,
+} from './thread-state'
 
 /**
  * A real editor: the behavior under test is hit-testing against real shape geometry, which is
@@ -77,5 +84,77 @@ describe('commentTargetShapeAt', () => {
 		})
 
 		expect(commentTargetShapeAt(editor, { x: 600, y: 600 })).toBeUndefined()
+	})
+})
+
+/** A 100×100 square whose page bounds are (100,100)–(200,200), unrotated. */
+function createSquare(): TLShapeId {
+	const id = createShapeId()
+	editor.createShape({ id, type: 'geo', x: 100, y: 100, props: { w: 100, h: 100 } })
+	return id
+}
+
+describe('shape anchors under a shape transform', () => {
+	it('carries a precise pin around when the shape rotates', () => {
+		const id = createSquare()
+		// Top-right corner of the square.
+		const anchor = shapeAnchorAt(editor, id, { x: 200, y: 100 }, true)
+		expect(anchor).toMatchObject({ type: 'shape', shapeId: id, x: 1, y: 0, isPrecise: true })
+		expect(anchorPagePoint(editor, anchor)).toMatchObject({ x: 200, y: 100 })
+
+		// A quarter turn about the square's centre takes that corner to the bottom-right. The
+		// square's page bounds don't change, so a pin normalized against them would sit still.
+		editor.rotateShapesBy([id], Math.PI / 2)
+		const rotated = anchorPagePoint(editor, anchor)!
+		expect(rotated.x).toBeCloseTo(200)
+		expect(rotated.y).toBeCloseTo(200)
+	})
+
+	it('records the spot a pin was dropped on a rotated shape', () => {
+		const id = createSquare()
+		editor.rotateShapesBy([id], Math.PI / 2)
+
+		// After the quarter turn the square's local top-right corner sits at the page's bottom-right.
+		const anchor = shapeAnchorAt(editor, id, { x: 200, y: 200 }, true)
+		expect(anchor.type).toBe('shape')
+		if (anchor.type !== 'shape') return
+		expect(anchor.x).toBeCloseTo(1)
+		expect(anchor.y).toBeCloseTo(0)
+
+		const point = anchorPagePoint(editor, anchor)!
+		expect(point.x).toBeCloseTo(200)
+		expect(point.y).toBeCloseTo(200)
+	})
+
+	it('still tracks moves and resizes', () => {
+		const id = createSquare()
+		const anchor = shapeAnchorAt(editor, id, { x: 200, y: 100 }, true)
+
+		editor.updateShape({ id, type: 'geo', x: 300, props: { w: 200 } })
+		expect(anchorPagePoint(editor, anchor)).toMatchObject({ x: 500, y: 100 })
+	})
+
+	it('turns an imprecise pin inset with the shape so it keeps stepping inward', () => {
+		const id = createSquare()
+		const anchor = shapeAnchorAt(editor, id, { x: 200, y: 100 }, false)
+		const spot = { x: 1, y: 0 }
+		// Top-right spot: step left and down, into the square.
+		expect(impreciseShapePinInset(editor, anchor, spot)).toMatchObject({
+			x: -IMPRECISE_PIN_INSET_PX,
+			y: IMPRECISE_PIN_INSET_PX,
+		})
+
+		editor.rotateShapesBy([id], Math.PI / 2)
+		// The corner is now bottom-right, so stepping inward means left and up.
+		const inset = impreciseShapePinInset(editor, anchor, spot)!
+		expect(inset.x).toBeCloseTo(-IMPRECISE_PIN_INSET_PX)
+		expect(inset.y).toBeCloseTo(-IMPRECISE_PIN_INSET_PX)
+	})
+
+	it('hides the pin for a shape that no longer exists', () => {
+		const id = createSquare()
+		const anchor = shapeAnchorAt(editor, id, { x: 200, y: 100 }, true)
+		editor.deleteShape(id)
+		expect(anchorPagePoint(editor, anchor)).toBe(null)
 	})
 })

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -1,10 +1,12 @@
 import {
 	BoxModel,
 	Editor,
+	Mat,
 	TLCommentAnchor,
 	TLCommentThread,
 	TLShape,
 	TLShapeId,
+	Vec,
 	VecLike,
 } from 'tldraw'
 import { getCommentingOptions } from './options'
@@ -21,14 +23,19 @@ export const IMPRECISE_PIN_INSET_PX = 20
  *  extends up-right of its anchor point, so step it toward the shape's centre. Screen px — the
  *  pin is screen-fixed while the shape scales with zoom. Null for anchors that need no inset. */
 export function impreciseShapePinInset(
+	editor: Editor,
 	anchor: TLCommentThread['anchor'],
 	spot: { x: number; y: number }
 ): { x: number; y: number } | null {
 	if (anchor.type !== 'shape' || anchor.isPrecise) return null
-	return {
+	const inset = {
 		x: Math.sign(0.5 - spot.x) * IMPRECISE_PIN_INSET_PX,
 		y: Math.sign(0.5 - spot.y) * IMPRECISE_PIN_INSET_PX,
 	}
+	// The spot is a corner of the shape's own bounds, so which way "toward the centre" points turns
+	// with the shape: without this a rotated shape's pin would step out of the shape, not into it.
+	const rotation = editor.getShapePageTransform(anchor.shapeId as TLShapeId)?.rotation() ?? 0
+	return rotation === 0 ? inset : Vec.Rot(inset, rotation)
 }
 
 /** The default corner a region's pin and composer sit on, as a normalized 0–1 offset (bottom-right).
@@ -60,6 +67,10 @@ export function regionPinPoint(region: BoxModel, corner: VecLike = REGION_PIN_CO
  * Where a thread's pin sits on the page, for each anchor kind. Null hides the pin. For imprecise
  * shape anchors the pin uses `impreciseShapeAnchor` (a normalized 0–1 spot, top-right by default)
  * rather than the stored `x`/`y`.
+ *
+ * A shape anchor's `x`/`y` are normalized within the shape's own bounds and resolved through the
+ * shape's page transform, so the pin rides every part of that transform — rotating the shape
+ * carries the pin around with it instead of leaving it behind in the bounding box.
  * @public
  */
 export function anchorPagePoint(
@@ -69,11 +80,14 @@ export function anchorPagePoint(
 ): { x: number; y: number } | null {
 	switch (anchor.type) {
 		case 'shape': {
-			const bounds = editor.getShapePageBounds(anchor.shapeId as TLShapeId)
-			if (!bounds) return null
+			const shape = editor.getShape(anchor.shapeId as TLShapeId)
+			if (!shape) return null
+			const transform = editor.getShapePageTransform(shape)
+			if (!transform) return null
+			const { point, size } = editor.getShapeGeometry(shape).bounds
 			// Precise pins sit at their stored x/y; imprecise ones at the consumer's default spot.
-			const { x, y } = anchor.isPrecise ? anchor : impreciseShapeAnchor
-			return { x: bounds.minX + x * bounds.w, y: bounds.minY + y * bounds.h }
+			const spot = anchor.isPrecise ? anchor : impreciseShapeAnchor
+			return Mat.applyToPoint(transform, Vec.Add(point, Vec.MulV(spot, size)))
 		}
 		case 'point':
 			return { x: anchor.x, y: anchor.y }
@@ -109,9 +123,11 @@ export function commentTargetShapeAt(editor: Editor, page: VecLike): TLShape | u
 
 /**
  * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
- * shape's page bounds, remembered either way. When `precise` the pin sits at exactly `x`/`y`;
- * otherwise it sits at the consumer's imprecise default (top-right out of the box). Placement
- * gestures get `precise` from the `shouldBePrecise` commenting option (always precise, by default).
+ * shape's own bounds — taken in the shape's own space, so a pin placed on a rotated shape records
+ * the spot it was dropped on rather than a spot in the bounding box. Remembered either way: when
+ * `precise` the pin sits at exactly `x`/`y`; otherwise it sits at the consumer's imprecise default
+ * (top-right out of the box). Placement gestures get `precise` from the `shouldBePrecise`
+ * commenting option (always precise, by default).
  * @public
  */
 export function shapeAnchorAt(
@@ -120,15 +136,17 @@ export function shapeAnchorAt(
 	page: { x: number; y: number },
 	precise: boolean
 ): TLCommentAnchor {
-	const bounds = editor.getShapePageBounds(shapeId)
-	if (!bounds || bounds.w === 0 || bounds.h === 0) {
+	const shape = editor.getShape(shapeId)
+	const bounds = shape && editor.getShapeGeometry(shape).bounds
+	if (!shape || !bounds || bounds.w === 0 || bounds.h === 0) {
 		return { type: 'shape', shapeId, x: 0.5, y: 0.5, isPrecise: precise }
 	}
+	const local = editor.getPointInShapeSpace(shape, page)
 	return {
 		type: 'shape',
 		shapeId,
-		x: (page.x - bounds.minX) / bounds.w,
-		y: (page.y - bounds.minY) / bounds.h,
+		x: (local.x - bounds.minX) / bounds.w,
+		y: (local.y - bounds.minY) / bounds.h,
 		isPrecise: precise,
 	}
 }

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -11,8 +11,9 @@ import { TLShapeId } from './TLShape'
  * Where a comment thread is anchored on the canvas. Modeled as a discriminated union so new
  * anchor kinds can be added without breaking existing threads:
  *
- * - `shape` — pinned to a shape. `x`/`y` are normalized (0–1) within the shape's page bounds, so
- *   the pin keeps its spot as the shape moves and resizes. `isPrecise` mirrors arrow bindings: when
+ * - `shape` — pinned to a shape. `x`/`y` are normalized (0–1) within the shape's own bounds and
+ *   resolved through the shape's page transform, so the pin keeps its spot as the shape moves,
+ *   resizes, and rotates. `isPrecise` mirrors arrow bindings: when
  *   true the pin sits at exactly `x`/`y`; when false (the default) it sits at a consumer-defined
  *   spot (top-right out of the box), and `x`/`y` are the remembered precise position
  * - `point` — pinned to a fixed point on the page, in page coordinates


### PR DESCRIPTION
In order to keep a comment pointing at the thing it was left on, this fixes shape-anchored pins losing their spot when the shape is rotated. Closes #9718 (and #9719, reported separately).

A shape anchor's normalized `x`/`y` were resolved against the shape's *page bounds* — the axis-aligned box around it. Rotating a shape barely moves that box, so the pin stayed put while the spot it marked swung away underneath it.

The pin now normalizes against the shape's own bounds and resolves through the shape's page transform, the way an arrow binding places a bound terminal. It rides the whole transform, so rotation carries it around with the shape and moves/resizes keep working as before; placing a pin on an already-rotated shape records the spot it was dropped on, taken in the shape's own space. For an unrotated shape the two normalizations agree, so stored anchors are unaffected and there's no migration.

One extra: an imprecise pin's inset — the screen-space step from its corner toward the shape's centre, so the marker tucks inside — turns with the shape too. Without that, a rotated pin steps out of the shape rather than into it.

`impreciseShapePinInset` (package-internal) takes an `editor` first argument now. No public API signatures changed.

### Change type

- [x] `bugfix`

### Test plan

1. Open the `comment-anchors` example.
2. Rotate the rectangle.
3. The precise pin stays on the same spot inside the shape, and the corner pin stays tucked into the same corner.
4. Move and resize the shape — pins track as before.

- [x] Unit tests

### Release notes

- Fix comment pins drifting off the spot they were placed on when the shape they're anchored to is rotated.