### PR TITLE
fix(commenting): close the reaction picker once an emoji is picked

### DIFF
--- a/packages/commenting/src/ui/reaction-picker.tsx
+++ b/packages/commenting/src/ui/reaction-picker.tsx
@@ -1,8 +1,10 @@
-import { useId, type ComponentType } from 'react'
+import { useCallback, useId, type ComponentType } from 'react'
 import {
 	TldrawUiDropdownMenuContent,
 	TldrawUiDropdownMenuRoot,
 	TldrawUiDropdownMenuTrigger,
+	tlmenus,
+	useMaybeEditor,
 	useTranslation,
 } from 'tldraw'
 import { EmojiPicker, type EmojiPickerProps } from './emoji-picker'
@@ -41,6 +43,9 @@ export interface ReactionPickerProps {
  *
  * Anchored to its own button rather than to the reactions row, so the menu keeps its position as
  * reactions are added and the row reflows.
+ *
+ * Picking an emoji dismisses the grid — adding and removing alike, since either way the picker has
+ * done its job — and hands focus back to the trigger.
  * @public @react
  */
 export function ReactionPicker({
@@ -53,10 +58,24 @@ export function ReactionPicker({
 	className = 'tlui-cmt-thread__action',
 }: ReactionPickerProps) {
 	const msg = useTranslation()
+	const editor = useMaybeEditor()
 	// Unique per mounted picker unless the host supplies something stabler — see `menuId`.
 	const generatedId = useId()
+	const id = menuId ?? `comment-reactions-${generatedId}`
+
+	// The dropdown's open state lives in tldraw's global menu registry, so dropping the entry is
+	// what closes it. The palette's tokens are plain buttons — a swappable component, not radix
+	// menu items — so nothing dismisses the menu on its own.
+	const handleSelect = useCallback(
+		(value: string) => {
+			onSelect?.(value)
+			tlmenus.deleteOpenMenu(id, editor?.contextId)
+		},
+		[onSelect, id, editor]
+	)
+
 	return (
-		<TldrawUiDropdownMenuRoot id={menuId ?? `comment-reactions-${generatedId}`}>
+		<TldrawUiDropdownMenuRoot id={id}>
 			<TldrawUiDropdownMenuTrigger>
 				<TooltipButton tooltip={msg('comments.add-reaction')} className={className}>
 					<SmileyIcon />
@@ -67,7 +86,7 @@ export function ReactionPicker({
 				<Palette
 					emoji={emoji}
 					selected={selected}
-					onSelect={onSelect}
+					onSelect={handleSelect}
 					renderReaction={renderReaction}
 				/>
 			</TldrawUiDropdownMenuContent>


### PR DESCRIPTION
In order to stop the emoji grid sitting over the thread after you've reacted, this dismisses the reaction picker when an emoji is picked and hands focus back to the smiley trigger. Closes #9725.

The dropdown's open state lives in tldraw's global menu registry, so dropping its entry is what closes it — the palette's tokens are plain buttons in a swappable component, not radix menu items, so nothing dismissed the menu on its own. That's the same `tlmenus.deleteOpenMenu(id, editor.contextId)` move the style panel and toolbar overflow already use.

Two decisions worth a look, both from the open questions on the issue:

- **It always closes on the first pick**, rather than staying open for a second reaction. The picker sits in the comment's hover actions, so reopening it is one click, and a menu that outstays its purpose is the thing being reported.
- **Removing a reaction closes it too.** Either way the picker has done its job, and a grid that dismisses on add but lingers on remove is harder to predict than one that always dismisses.

Doing this in `ReactionPicker` covers everywhere it appears — top-level comments, replies, the on-canvas thread, and the sidebar all render this one component, and a custom `palette` gets it for free since the close is wired into the `onSelect` it's handed.

### Change type

- [x] `bugfix`

### Test plan

1. Open the `comment-anchors` example and click a pin to open the thread.
2. Hover the comment, click the smiley, pick an emoji — the grid closes, the reaction pill appears, and focus returns to the smiley button.
3. Reopen the picker and click the emoji you already reacted with — the reaction is removed and the grid closes the same way.

### Release notes

- Close the comment reaction picker after a reaction is added or removed, returning focus to the add-reaction button.