### PR TITLE
fix(commenting): only notify about comments made after you joined the thread

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -52,9 +52,9 @@ function ReasonByline({
  * categories that concern the user server-side — comments on boards they own, replies in threads
  * they're a part of, and `@`-mentions of them — so out-of-category comments never reach the
  * client; {@link categorizeCommentNotifications} tags each synced comment with why it's there,
- * newest first. Also returns the caller's unread count over that set (a notification is unread
- * when it has no read receipt). Shared by the trigger button (for its badge) and the panel (for
- * its list).
+ * newest first, and drops reply-only thread history from before the user joined. Also returns
+ * the caller's unread count over that set (a notification is unread when it has no read
+ * receipt). Shared by the trigger button (for its badge) and the panel (for its list).
  */
 export function useCommentNotifications() {
 	const app = useMaybeApp()

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -68,25 +68,106 @@ describe('categorizeCommentNotifications', () => {
 	})
 
 	it("labels a reply in a thread I've commented in as reply", () => {
-		const mine = comment({
-			id: 'comment:mine',
-			authorId: ME,
-			createdAt: 1000,
-			thread: { createdBy: OTHER },
-			file: { ownerId: THIRD },
-		})
 		const theirReply = comment({
 			id: 'comment:theirs',
 			authorId: OTHER,
 			createdAt: 2000,
-			thread: { createdBy: OTHER },
+			thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 1000 }] },
 			file: { ownerId: THIRD },
 		})
-		const result = categorizeCommentNotifications([mine, theirReply], ME)
-		// only their reply surfaces (mine is excluded), tagged reply
+		const result = categorizeCommentNotifications([theirReply], ME)
 		expect(result).toHaveLength(1)
 		expect(result[0].comment.id).toBe('comment:theirs')
 		expect(result[0].primaryReason).toBe('reply')
+	})
+
+	it('drops comments written before I joined the thread', () => {
+		// other(1000), other(2000), me(3000)
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 3000 }] }
+		const before1 = comment({ id: 'comment:b1', createdAt: 1000, thread, file: { ownerId: THIRD } })
+		const before2 = comment({ id: 'comment:b2', createdAt: 2000, thread, file: { ownerId: THIRD } })
+		expect(categorizeCommentNotifications([before1, before2], ME)).toEqual([])
+	})
+
+	it('keeps replies from after I joined even once I have replied to them', () => {
+		// other(1000), me(2000), other(3000), me(4000): only the pre-join comment at 1000 drops
+		const thread = {
+			createdBy: OTHER,
+			comments: [
+				{ authorId: ME, createdAt: 2000 },
+				{ authorId: ME, createdAt: 4000 },
+			],
+		}
+		const preJoin = comment({
+			id: 'comment:pre',
+			createdAt: 1000,
+			thread,
+			file: { ownerId: THIRD },
+		})
+		const postJoin = comment({
+			id: 'comment:post',
+			createdAt: 3000,
+			thread,
+			file: { ownerId: THIRD },
+		})
+		const result = categorizeCommentNotifications([preJoin, postJoin], ME)
+		expect(result.map((n) => n.comment.id)).toEqual(['comment:post'])
+		expect(result[0].primaryReason).toBe('reply')
+	})
+
+	it('drops a comment timestamped identically to my join', () => {
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 1000 }] }
+		const tied = comment({ createdAt: 1000, thread, file: { ownerId: THIRD } })
+		expect(categorizeCommentNotifications([tied], ME)).toEqual([])
+	})
+
+	it("ignores others' comments in the thread relation when deriving my join time", () => {
+		// defense in depth: the query only syncs my own, but a foreign row must not count
+		const thread = { createdBy: OTHER, comments: [{ authorId: THIRD, createdAt: 500 }] }
+		const theirs = comment({ createdAt: 1000, thread, file: { ownerId: THIRD } })
+		expect(categorizeCommentNotifications([theirs], ME)).toEqual([])
+	})
+
+	it('keeps a mention from before I joined the thread', () => {
+		const result = categorizeCommentNotifications(
+			[
+				comment({
+					createdAt: 1000,
+					body: body('hey ', [ME]),
+					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 2000 }] },
+					file: { ownerId: THIRD },
+				}),
+			],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		// reply must not leak in for a pre-join comment
+		expect(result[0].reasons).toEqual(['mention'])
+		expect(result[0].primaryReason).toBe('mention')
+	})
+
+	it('never labels reply when the thread relation is missing', () => {
+		const result = categorizeCommentNotifications(
+			[comment({ thread: null, file: { ownerId: ME } })],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(result[0].reasons).toEqual(['owned-board'])
+	})
+
+	it('keeps an owned-board comment from before I joined the thread', () => {
+		const result = categorizeCommentNotifications(
+			[
+				comment({
+					createdAt: 1000,
+					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 2000 }] },
+					file: { ownerId: ME },
+				}),
+			],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(result[0].reasons).toEqual(['owned-board'])
 	})
 
 	it('labels a comment that @-mentions me as mention', () => {
@@ -103,10 +184,8 @@ describe('categorizeCommentNotifications', () => {
 		expect(result.map((n) => n.primaryReason)).toEqual(['mention'])
 	})
 
-	it('falls back to reply when no reason is derivable from the synced window', () => {
-		// The server only syncs in-category comments, so a comment with no locally visible
-		// evidence (not my board, no mention of me, my thread participation older than the
-		// window) must be a reply — it is labeled, not dropped.
+	it('drops a comment with no derivable reason', () => {
+		// not my board, no mention of me, no participation evidence
 		const result = categorizeCommentNotifications(
 			[
 				comment({
@@ -117,9 +196,7 @@ describe('categorizeCommentNotifications', () => {
 			],
 			ME
 		)
-		expect(result).toHaveLength(1)
-		expect(result[0].reasons).toEqual(['reply'])
-		expect(result[0].primaryReason).toBe('reply')
+		expect(result).toEqual([])
 	})
 
 	it('tags multiple reasons with mention > reply > owned-board precedence', () => {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -4,7 +4,8 @@ import { extractMentionIds } from '@tldraw/dotcom-shared'
  * Why a comment shows up in a user's notifications feed:
  *
  * - `mention` — the comment `@`-mentions the user
- * - `reply` — the comment is in a thread the user is a part of (started, or has commented in)
+ * - `reply` — the comment is in a thread the user is a part of (started, or has commented in),
+ *   posted after they joined it
  * - `owned-board` — the comment is on a file the user owns
  *
  * A single comment can match more than one; {@link CommentNotification.primaryReason} picks the one
@@ -31,7 +32,11 @@ export interface CommentNotificationInput {
 	body: unknown
 	read?: unknown
 	file?: { ownerId?: string | null } | null
-	thread?: { createdBy?: string | null } | null
+	thread?: {
+		createdBy?: string | null
+		/** The caller's own comments in the thread (the query syncs no one else's). */
+		comments?: readonly { authorId: string; createdAt: number }[] | null
+	} | null
 }
 
 /** A comment in the notifications feed, tagged with why it's there. */
@@ -46,31 +51,19 @@ export interface CommentNotification<
 }
 
 /**
- * Tags each comment in the notifications feed with why it's there, newest first. The `comments`
- * synced query already filters to the three categories server-side — comments on boards the user
- * owns, replies in threads they're a part of, and `@`-mentions of them — so this derives labels,
- * not membership: nothing the server sent is dropped (except the user's own comments, which the
- * server also excludes; the local re-check is just defense in depth).
+ * Tags each comment in the notifications feed with why it's there, newest first.
  *
- * Two of the three reasons re-derive exactly from synced data (`file.ownerId`; mention ids in the
- * body). Thread participation can't always be re-derived: the evidence — the user's own earlier
- * comment in the thread — may be older than the feed's bounded window. A comment with no locally
- * derivable reason is therefore labeled `reply`, the only category the client can fail to see
- * evidence for.
+ * Stricter than the `comments` synced query, whose reply category has no timing condition (ZQL
+ * can't compare `createdAt` across correlated rows): the reply reason only applies to comments
+ * from after the user joined the thread — earlier ones are context they saw when joining, not
+ * notifications. A comment with no reason left is dropped. Post-join replies stay in the feed
+ * once responded to; read receipts, not membership, handle their unread state.
  */
 export function categorizeCommentNotifications<T extends CommentNotificationInput>(
 	comments: readonly T[],
 	userId: string | undefined | null
 ): CommentNotification<T>[] {
 	if (!userId) return []
-
-	// Threads the user is a part of: ones they started, or have a comment in (within this feed).
-	const participantThreadIds = new Set<string>()
-	for (const c of comments) {
-		if (c.thread?.createdBy === userId || c.authorId === userId) {
-			participantThreadIds.add(c.threadId)
-		}
-	}
 
 	const notifications: CommentNotification<T>[] = []
 	for (const comment of comments) {
@@ -79,15 +72,26 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
-		if (participantThreadIds.has(comment.threadId)) reasons.push('reply')
+		if (comment.createdAt > joinedThreadAt(comment.thread, userId)) reasons.push('reply')
 		if (comment.file?.ownerId === userId) reasons.push('owned-board')
-		// The server only syncs in-category comments; when no reason is derivable locally, the
-		// participation evidence is outside the synced window — so it's a reply (see docs above).
-		if (reasons.length === 0) reasons.push('reply')
+		if (reasons.length === 0) continue
 
 		const primaryReason = REASON_PRIORITY.find((r) => reasons.includes(r))!
 		notifications.push({ comment, reasons, primaryReason })
 	}
 
 	return notifications.sort((a, b) => b.comment.createdAt - a.comment.createdAt)
+}
+
+/**
+ * When the user joined a thread: -Infinity for one they started, else their first surviving
+ * comment in it, else Infinity (not a participant).
+ */
+function joinedThreadAt(thread: CommentNotificationInput['thread'], userId: string): number {
+	if (thread?.createdBy === userId) return -Infinity
+	let joinedAt = Infinity
+	for (const c of thread?.comments ?? []) {
+		if (c.authorId === userId && c.createdAt < joinedAt) joinedAt = c.createdAt
+	}
+	return joinedAt
 }

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -63,7 +63,9 @@ export const queries = defineQueries({
 	 *   outlive access to the file.
 	 *
 	 * Filtering here (server-side) rather than on the client is what keeps out-of-category
-	 * comments off the wire entirely — the unread badge is a pure function of the synced set.
+	 * comments off the wire entirely. One gate stays client-side: `categorizeCommentNotifications`
+	 * drops reply-category comments from before the user joined the thread (ZQL can't compare
+	 * createdAt across correlated rows).
 	 *
 	 * Bounded to the most recent {@link RECENT_COMMENTS_LIMIT} so the synced set stays finite as a
 	 * workspace ages, rather than growing without limit. This is a display feed — the canvas comment
@@ -124,7 +126,16 @@ export const queries = defineQueries({
 				)
 			)
 			.related('file', (file) => file.one())
-			.related('thread', (thread) => thread.one())
+			// only the caller's own comments, so the client can tell when they joined the thread.
+			// The client gate depends on this relation — a client shipped without a worker that
+			// syncs it drops reply notifications for threads the user didn't start
+			.related('thread', (thread) =>
+				thread
+					.one()
+					.related('comments', (c) =>
+						c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
+					)
+			)
 			// the caller's read receipt (at most one row: PK is (userId, commentId) and we filter
 			// on userId); absent (for others' comments) = unread
 			.related('read', (read) => read.where('userId', '=', ctx.userId).one())

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -362,8 +362,8 @@ const commentThreadRelationships = relationships(comment_thread, ({ one, many })
 		destField: ['id'],
 		destSchema: file,
 	}),
-	// the thread's messages; used with whereExists for "threads the user has commented in" in
-	// the comments query, never synced as a related row set
+	// the thread's messages; used with whereExists and as a related row set in the comments
+	// query. Always scope to ctx.userId when syncing — unscoped it replicates everyone's comments
 	comments: many({
 		sourceField: ['id'],
 		destField: ['threadId'],


### PR DESCRIPTION
In order to stop the notifications feed surfacing thread history — replying to a thread made every earlier comment in it retroactively qualify as a "reply to you", so joining a conversation filled your feed with comments you'd already seen — this PR gates the reply reason on the comment postdating when you joined the thread (thread creation if you started it, otherwise your first comment in it). Closes #9728.

The synced `comments` query's reply category can't express this timing condition (ZQL has no cross-row `createdAt` comparison), so the query now syncs the caller's own comments under the thread relation and `categorizeCommentNotifications` drops pre-join rows client-side. Mentions and comments on your own boards are exempt from the gate — those were legitimate notifications the moment they were created. Replies from after you joined stay in the feed once you respond; read receipts, not membership, govern their unread state. The old "no derivable reason → assume reply" fallback is removed since join time is now always derivable — it was exactly what surfaced the stale rows.

### Change type

- [x] `bugfix`

### Test plan

1. As user A, add two comments in a thread; as user B, reply to that thread
2. B's notifications: A's pre-reply comments do not appear
3. As user A, comment again; B gets a notification for it that stays after B replies

- [x] Unit tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +15 / -4   |
| Tests     | +94 / -17  |
| Apps      | +31 / -27  |

### Release notes

- Fix comment notifications surfacing thread history from before you joined the thread
