### PR TITLE
feat(dotcom): add the commenting Postgres tables

### DIFF
--- a/apps/dotcom/zero-cache/migrations/040_add_comments.sql
+++ b/apps/dotcom/zero-cache/migrations/040_add_comments.sql
@@ -1,0 +1,115 @@
+-- Comments for app files, written by the file's Durable Object from the room's comment records
+-- (see TLComment / TLCommentThread in tlschema). Postgres is the sole durable store for comment
+-- records: the columns collectively carry every record field, so the Durable Object can rebuild
+-- its room's comment records from rows alone on cold start. `lastChangedClock` preserves each
+-- record's sync clock across reloads and guards upserts against no-op replays (an update that
+-- doesn't advance the clock is skipped, producing no WAL entry for Zero). `anchor`, `meta`,
+-- `resolvedBy`, `editedAt`, and `lastChangedClock` are persistence/rehydration columns not
+-- declared in the Zero schema, so they never reach clients.
+
+CREATE TABLE comment_thread (
+  "id" VARCHAR PRIMARY KEY,
+  "fileId" VARCHAR NOT NULL,
+  "pageId" VARCHAR NOT NULL,
+  -- the thread's TLCommentAnchor (discriminated union) as JSON — canonical, used to rebuild the record
+  "anchor" JSONB NOT NULL,
+  -- denormalized from anchor for queries; only set for shape-anchored threads
+  "shapeId" VARCHAR,
+  "resolvedAt" BIGINT,
+  "resolvedBy" VARCHAR,
+  -- soft-deletion flag (see TLCommentThread.isDeleted): threads are never hard-deleted by
+  -- clients, so the row (and its comments) stays for recovery while room loads and Zero
+  -- queries filter it out
+  "isDeleted" BOOLEAN DEFAULT FALSE NOT NULL,
+  -- no FK to "user": deleting a user must not cascade-delete threads (and thereby other
+  -- authors' comments); the comment table's authorId FK handles per-author cleanup
+  "createdBy" VARCHAR NOT NULL,
+  "createdAt" BIGINT NOT NULL,
+  "meta" JSONB NOT NULL,
+  "lastChangedClock" BIGINT NOT NULL,
+  CONSTRAINT comment_thread_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
+  -- resolvedAt/resolvedBy encode one nullable `resolved` record field, so they must be set or
+  -- null together; rehydration (rowToThreadRecord) relies on resolvedBy being non-null whenever
+  -- resolvedAt is
+  CONSTRAINT comment_thread_resolved_check CHECK (("resolvedAt" IS NULL) = ("resolvedBy" IS NULL))
+);
+
+CREATE INDEX comment_thread_file_id_idx ON comment_thread("fileId");
+
+CREATE TABLE comment (
+  "id" VARCHAR PRIMARY KEY,
+  "fileId" VARCHAR NOT NULL,
+  "threadId" VARCHAR NOT NULL,
+  "pageId" VARCHAR NOT NULL,
+  "authorId" VARCHAR NOT NULL,
+  -- author display fields, denormalized from the user table by the triggers below (same
+  -- pattern as file."ownerName") — joining the user row would sync private fields to readers
+  "authorName" VARCHAR DEFAULT '' NOT NULL,
+  "authorColor" VARCHAR DEFAULT '' NOT NULL,
+  "authorAvatar" VARCHAR DEFAULT '' NOT NULL,
+  "body" JSONB NOT NULL,
+  "createdAt" BIGINT NOT NULL,
+  -- null until first edited (exact record field; updatedAt below is the derived sort key)
+  "editedAt" BIGINT,
+  -- soft-deletion flag (see TLComment.isDeleted): same model as the thread's — the row stays
+  -- for recovery while room loads and Zero queries filter it out
+  "isDeleted" BOOLEAN DEFAULT FALSE NOT NULL,
+  "updatedAt" BIGINT NOT NULL,
+  "meta" JSONB NOT NULL,
+  "lastChangedClock" BIGINT NOT NULL,
+  CONSTRAINT comment_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_author_id_fkey FOREIGN KEY ("authorId") REFERENCES public."user"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_thread_id_fkey FOREIGN KEY ("threadId") REFERENCES public."comment_thread"("id") ON DELETE CASCADE
+);
+
+CREATE INDEX comment_file_id_idx ON comment("fileId");
+CREATE INDEX comment_thread_id_idx ON comment("threadId");
+CREATE INDEX comment_author_id_idx ON comment("authorId");
+
+-- Stamp author details on insert — the Durable Object only knows authorId. BEFORE INSERT
+-- keeps it a single write with no extra WAL entry for Zero.
+CREATE OR REPLACE FUNCTION set_comment_author_details() RETURNS TRIGGER AS $$
+DECLARE
+  author_name VARCHAR;
+  author_color VARCHAR;
+  author_avatar VARCHAR;
+BEGIN
+  SELECT u."name", u."color", u."avatar" INTO author_name, author_color, author_avatar
+  FROM public."user" u
+  WHERE u."id" = NEW."authorId";
+  -- a missing user row keeps the defaults, so the insert still fails its author FK check
+  -- (see isCommentAuthorFkViolation) rather than erroring here
+  IF FOUND THEN
+    NEW."authorName" := author_name;
+    NEW."authorColor" := author_color;
+    NEW."authorAvatar" := author_avatar;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "set_comment_author_details_trigger"
+BEFORE INSERT OR UPDATE OF "authorId" ON comment
+FOR EACH ROW
+EXECUTE FUNCTION set_comment_author_details();
+
+-- Propagate user renames, recolors, and avatar changes to their existing comments.
+CREATE OR REPLACE FUNCTION update_comment_author_details() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE comment
+  SET "authorName" = NEW."name",
+      "authorColor" = NEW."color",
+      "authorAvatar" = NEW."avatar"
+  WHERE "authorId" = NEW."id";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_comment_author_details_trigger"
+AFTER UPDATE OF "name", "color", "avatar" ON public."user"
+FOR EACH ROW
+WHEN (OLD."name" IS DISTINCT FROM NEW."name" OR OLD."color" IS DISTINCT FROM NEW."color" OR OLD."avatar" IS DISTINCT FROM NEW."avatar")
+EXECUTE FUNCTION update_comment_author_details();
+
+ALTER PUBLICATION zero_data ADD TABLE public."comment_thread";
+ALTER PUBLICATION zero_data ADD TABLE public."comment";

--- a/apps/dotcom/zero-cache/migrations/041_add_comment_read.sql
+++ b/apps/dotcom/zero-cache/migrations/041_add_comment_read.sql
@@ -1,0 +1,20 @@
+-- Per-user comment read receipts for the app-level /comments view. Row present = the user has
+-- read the comment; marking unread deletes the row. `readAt` is stored so a future "edited
+-- comments become unread again" rule (readAt < updatedAt) is a client-only change. Authors'
+-- own comments get no row: the client treats authorId === me as implicitly read. Written via
+-- Zero custom mutators (comment.markRead / comment.markUnread), unlike comment/comment_thread
+-- which are written by the file's Durable Object.
+
+CREATE TABLE comment_read (
+  "userId" VARCHAR NOT NULL,
+  "commentId" VARCHAR NOT NULL,
+  "readAt" BIGINT NOT NULL,
+  PRIMARY KEY ("userId", "commentId"),
+  CONSTRAINT comment_read_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_read_comment_id_fkey FOREIGN KEY ("commentId") REFERENCES public."comment"("id") ON DELETE CASCADE
+);
+
+-- covers the cascade path when comments are deleted
+CREATE INDEX comment_read_comment_id_idx ON comment_read("commentId");
+
+ALTER PUBLICATION zero_data ADD TABLE public."comment_read";

--- a/apps/dotcom/zero-cache/migrations/042_add_comment_mention.sql
+++ b/apps/dotcom/zero-cache/migrations/042_add_comment_mention.sql
@@ -1,0 +1,31 @@
+-- Per-comment @-mention rows, one per (comment, mentioned user), extracted from the comment's
+-- rich-text body by the file's Durable Object when it drains comment records to Postgres (see
+-- extractMentionIds / drainCommentOutbox in sync-worker). Mentions live inside the body JSON as
+-- TipTap mention nodes, which ZQL cannot reach, so this table is what lets the app-level
+-- notifications query filter "comments that mention me" server-side. Server-written only, like
+-- comment/comment_thread; rows are reconciled on every comment upsert and cascade away with
+-- their comment.
+
+CREATE TABLE comment_mention (
+  "commentId" VARCHAR NOT NULL,
+  "userId" VARCHAR NOT NULL,
+  PRIMARY KEY ("commentId", "userId"),
+  CONSTRAINT comment_mention_comment_id_fkey FOREIGN KEY ("commentId") REFERENCES public."comment"("id") ON DELETE CASCADE,
+  -- deleting a mentioned user only removes their mention rows, never the comment itself
+  CONSTRAINT comment_mention_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE
+);
+
+-- covers the "comments that mention this user" lookup and the user-delete cascade path
+CREATE INDEX comment_mention_user_id_idx ON comment_mention("userId");
+
+-- Backfill from existing comment bodies: `$.**` recursively finds mention nodes wherever they
+-- nest; DISTINCT collapses the multiple paths lax mode can reach a node through (and repeat
+-- mentions); the user join drops ids that aren't users (deleted accounts, malformed ids) —
+-- mirroring the FK-violation skip in the Durable Object's drain.
+INSERT INTO comment_mention ("commentId", "userId")
+SELECT DISTINCT c."id", u."id"
+FROM comment c
+CROSS JOIN LATERAL jsonb_path_query(c."body", 'lax $.** ? (@.type == "mention").attrs.id') AS mention(id)
+JOIN public."user" u ON u."id" = (mention.id #>> '{}');
+
+ALTER PUBLICATION zero_data ADD TABLE public."comment_mention";

--- a/apps/dotcom/zero-cache/migrations/043_add_comment_reactions.sql
+++ b/apps/dotcom/zero-cache/migrations/043_add_comment_reactions.sql
@@ -1,0 +1,43 @@
+-- Emoji reactions on comments, written by the file's Durable Object from the room's
+-- comment-reaction records (see TLCommentReaction in tlschema). Same contract as comment and
+-- comment_thread: Postgres is the sole durable store, the columns carry every record field so the
+-- Durable Object can rebuild the records from rows alone on cold start, and `lastChangedClock`
+-- preserves each record's sync clock and guards upserts against no-op replays.
+--
+-- A reaction is its own row rather than a column on comment because it is one user's data about
+-- someone else's comment — the same reason comment_read is its own table. It keeps every write
+-- scoped to one user's own record, so concurrent reactions from different people can't overwrite
+-- each other, and a user can never write a reaction attributed to anyone else.
+--
+-- `meta` and `lastChangedClock` are persistence/rehydration columns not declared in the Zero
+-- schema, so they never reach clients.
+
+CREATE TABLE comment_reaction (
+  "id" VARCHAR PRIMARY KEY,
+  "fileId" VARCHAR NOT NULL,
+  "commentId" VARCHAR NOT NULL,
+  "threadId" VARCHAR NOT NULL,
+  "pageId" VARCHAR NOT NULL,
+  "userId" VARCHAR NOT NULL,
+  "emoji" VARCHAR NOT NULL,
+  "createdAt" BIGINT NOT NULL,
+  "meta" JSONB NOT NULL,
+  "lastChangedClock" BIGINT NOT NULL,
+  CONSTRAINT comment_reaction_file_id_fkey FOREIGN KEY ("fileId") REFERENCES public."file"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_reaction_comment_id_fkey FOREIGN KEY ("commentId") REFERENCES public."comment"("id") ON DELETE CASCADE,
+  CONSTRAINT comment_reaction_thread_id_fkey FOREIGN KEY ("threadId") REFERENCES public."comment_thread"("id") ON DELETE CASCADE,
+  -- deleting a user removes their reactions, never the comment they reacted to
+  CONSTRAINT comment_reaction_user_id_fkey FOREIGN KEY ("userId") REFERENCES public."user"("id") ON DELETE CASCADE,
+  -- one record per (comment, user, emoji): a user may hold multiple reactions on a comment (one
+  -- per emoji), but not the same emoji twice. The record id is derived from the same triple
+  -- (createCommentReactionId), so this backstops the invariant at the database.
+  CONSTRAINT comment_reaction_comment_user_emoji_unique UNIQUE ("commentId", "userId", "emoji")
+);
+
+CREATE INDEX comment_reaction_file_id_idx ON comment_reaction("fileId");
+CREATE INDEX comment_reaction_comment_id_idx ON comment_reaction("commentId");
+CREATE INDEX comment_reaction_thread_id_idx ON comment_reaction("threadId");
+-- covers the user-delete cascade path
+CREATE INDEX comment_reaction_user_id_idx ON comment_reaction("userId");
+
+ALTER PUBLICATION zero_data ADD TABLE public."comment_reaction";

--- a/apps/dotcom/zero-cache/migrations/044_file_visitor.sql
+++ b/apps/dotcom/zero-cache/migrations/044_file_visitor.sql
@@ -1,0 +1,97 @@
+-- A shareable, per-file record of who has opened a board, so the comment composer can offer past
+-- viewers (not just workspace members) as @-mention targets. This is its OWN table rather than
+-- columns on file_state: file_state also carries private per-user data — lastSessionState (a user's
+-- camera position, current page, and selected shapes) and visit/edit timestamps — that must never
+-- sync to other users. Zero synced queries replicate whole rows, so exposing the viewer list from
+-- file_state would leak all of that. Every column here is safe to show to any file collaborator.
+-- Identity is denormalized (same reasoning as comment.authorName, migration 040): joining the user
+-- row would sync private user fields to every reader.
+
+CREATE TABLE file_visitor (
+  "userId" VARCHAR NOT NULL,
+  "fileId" VARCHAR NOT NULL,
+  "userName" VARCHAR DEFAULT '' NOT NULL,
+  "userColor" VARCHAR DEFAULT '' NOT NULL,
+  -- mirrored from file_state for most-recent-first ordering of the roster. NOT NULL (falling back
+  -- to lastEditAt/firstVisitAt/now at write time) so the fileVisitors query's ORDER BY ... DESC is
+  -- deterministic — ZQL has no NULLS LAST, and Postgres DESC would sort nulls first.
+  "lastVisitAt" BIGINT NOT NULL,
+  PRIMARY KEY ("userId", "fileId")
+);
+
+CREATE INDEX file_visitor_file_id_idx ON file_visitor("fileId");
+
+-- Backfill from existing visits. user.name/user.color are NOT NULL (000_seed.sql), so COALESCE only
+-- guards the (impossible here) missing-join case and keeps the NOT NULL columns satisfied.
+INSERT INTO file_visitor ("userId", "fileId", "userName", "userColor", "lastVisitAt")
+SELECT fs."userId", fs."fileId", COALESCE(u."name", ''), COALESCE(u."color", ''),
+  -- same fallback chain as the client's getFileVisitDate, then "now" for rows with no visit data
+  COALESCE(fs."lastVisitAt", fs."lastEditAt", fs."firstVisitAt", (EXTRACT(EPOCH FROM now()) * 1000)::BIGINT)
+FROM file_state fs
+JOIN public."user" u ON u."id" = fs."userId"
+ON CONFLICT ("userId", "fileId") DO NOTHING;
+
+-- Mirror a visit (file_state insert, or a lastVisitAt refresh on exit) into file_visitor, stamping
+-- the visitor's current name/color. Keyed the same as file_state, so it's a natural upsert.
+CREATE OR REPLACE FUNCTION sync_file_visitor_on_file_state() RETURNS TRIGGER AS $$
+DECLARE
+  visitor_name VARCHAR;
+  visitor_color VARCHAR;
+BEGIN
+  SELECT u."name", u."color" INTO visitor_name, visitor_color
+  FROM public."user" u
+  WHERE u."id" = NEW."userId";
+  INSERT INTO file_visitor ("userId", "fileId", "userName", "userColor", "lastVisitAt")
+  VALUES (NEW."userId", NEW."fileId", COALESCE(visitor_name, ''), COALESCE(visitor_color, ''),
+    -- a fresh file_state row (createFile / first onEnterFile) has no lastVisitAt yet; the visit is
+    -- happening right now, so stamp "now" rather than leave the roster entry unsortable
+    COALESCE(NEW."lastVisitAt", NEW."lastEditAt", NEW."firstVisitAt", (EXTRACT(EPOCH FROM now()) * 1000)::BIGINT))
+  ON CONFLICT ("userId", "fileId") DO UPDATE SET
+    "userName" = COALESCE(visitor_name, file_visitor."userName"),
+    "userColor" = COALESCE(visitor_color, file_visitor."userColor"),
+    "lastVisitAt" = COALESCE(NEW."lastVisitAt", file_visitor."lastVisitAt");
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "sync_file_visitor_on_file_state_trigger"
+AFTER INSERT OR UPDATE OF "lastVisitAt" ON file_state
+FOR EACH ROW
+EXECUTE FUNCTION sync_file_visitor_on_file_state();
+
+-- Drop the roster entry when the visit is removed (e.g. un-sharing a file deletes non-owner
+-- file_state rows — see 034_fix_unshare_group_file_cleanup.sql), so a viewer who loses access also
+-- drops out of the mention roster.
+CREATE OR REPLACE FUNCTION delete_file_visitor_on_file_state() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM file_visitor WHERE "userId" = OLD."userId" AND "fileId" = OLD."fileId";
+  RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "delete_file_visitor_on_file_state_trigger"
+AFTER DELETE ON file_state
+FOR EACH ROW
+EXECUTE FUNCTION delete_file_visitor_on_file_state();
+
+-- Propagate user renames and recolors to their existing roster entries, so the roster stays fresh
+-- even for a viewer who never re-opens the board (same pattern as update_comment_author_details).
+CREATE OR REPLACE FUNCTION update_file_visitor_user_details() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE file_visitor
+  SET "userName" = NEW."name",
+      "userColor" = NEW."color"
+  WHERE "userId" = NEW."id";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_file_visitor_user_details_trigger"
+AFTER UPDATE OF "name", "color" ON public."user"
+FOR EACH ROW
+WHEN (OLD."name" IS DISTINCT FROM NEW."name" OR OLD."color" IS DISTINCT FROM NEW."color")
+EXECUTE FUNCTION update_file_visitor_user_details();
+
+-- New table, so it must be added to the Zero replication publication (unlike file_state, which was
+-- already a member).
+ALTER PUBLICATION zero_data ADD TABLE file_visitor;


### PR DESCRIPTION
The commenting branch is a large feature merge, and the riskiest part of it to land in one go is the database: five migrations that create six tables, add four triggers to hot paths (`user` and `file_state`), and run two backfills — one of which scans every `file_state` row. Bundling those with the app code means a rollback of the feature is also a rollback of the schema, on a database we can't easily re-run.

So, in order to de-risk the commenting rollout, this PR ships the Zero migrations on their own, ahead of everything else. It's the same five files as on the commenting branch, byte for byte; nothing is removed from that branch, and it will merge cleanly once main flows back into it.

Migrations 040–043 create the comment tables (`comment_thread`, `comment`, `comment_read`, `comment_mention`, `comment_reaction`). No app code writes them yet, so they stay empty until commenting lands — the only live effect is a trigger on `user` that would keep `comment.authorName`/`authorColor`/`authorAvatar` in sync, which has nothing to update.

Migration 044 (`file_visitor`) is the one that does something immediately. It backfills a per-file viewer roster from `file_state` and then keeps it current via triggers on `file_state` insert, `lastVisitAt` update, and delete. Every board visit from here on writes a row. That's deliberate — the roster is only useful for @-mention suggestions if it has history — but it's the part worth watching after deploy.

All six tables are added to the `zero_data` publication, so zero-cache will replicate them. They aren't declared in `tlaSchema.ts` yet (that stays on the commenting branch), so nothing reaches clients.

### Change type

- [x] `other`

### Test plan

1. Run `yarn workspace @tldraw/zero-cache dev` (or the local Postgres/zero-cache stack) against a database seeded with existing files, users, and `file_state` rows.
2. Confirm all five migrations apply cleanly and `migrations.applied_migrations` lists 040–044.
3. Check the `file_visitor` backfill populated one row per existing `file_state` row, with `lastVisitAt` non-null throughout.
4. Open a board you've never opened, then close it — a `file_visitor` row appears and its `lastVisitAt` updates.
5. Rename yourself in settings — the matching `file_visitor.userName` updates.
6. Unshare a file that had guest visitors — their `file_state` rows are deleted and their `file_visitor` rows go with them.
7. Confirm zero-cache boots and syncs normally afterwards (the DDL detection from 032 should update the replica in place rather than forcing a full reset).

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +306 / -0  |
