### PR TITLE
fix(tldraw): preserve embed area when correcting aspect ratio

### DIFF
--- a/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/embed/EmbedShapeUtil.tsx
@@ -131,6 +131,16 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 		})
 		if (!corrected) return
 
+		// `onResize` enforces a per-axis minimum (inflated by the aspect ratio when locked), so a very
+		// tall/narrow target could have one axis clamped while the other isn't — that would break the
+		// ratio and re-letterboxes the very content we're correcting. Scale the whole target up so it
+		// clears both floors, which preserves the ratio at the cost of a slightly larger box only in
+		// the extreme (still far smaller than leaving one axis un-corrected).
+		const { minWidth, minHeight } = this.getResizeMinBounds(latest)
+		const clearFloor = Math.max(1, minWidth / corrected.w, minHeight / corrected.h)
+		const targetW = corrected.w * clearFloor
+		const targetH = corrected.h * clearFloor
+
 		// Let the editor resize the shape: by default it scales around the shape's page-space center
 		// and along its own rotation axis, so the center stays fixed even if the embed was rotated
 		// before the ratio resolved. No need to compute x/y by hand.
@@ -143,8 +153,8 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 				this.editor.resizeShape(
 					latest.id,
 					{
-						x: corrected.w / latest.props.w,
-						y: corrected.h / latest.props.h,
+						x: targetW / latest.props.w,
+						y: targetH / latest.props.h,
 					},
 					{ isAspectRatioLocked: false }
 				)
@@ -212,14 +222,17 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 		return embedInfo?.definition.isAspectRatioLocked ?? false
 	}
 
-	override onResize(shape: TLEmbedShape, info: TLResizeInfo<TLEmbedShape>) {
-		const isAspectRatioLocked = this.isAspectRatioLocked(shape)
+	/**
+	 * The minimum width/height a resize of `shape` is allowed to reach. When the embed's aspect ratio
+	 * is locked, the longer axis's minimum is inflated by the current aspect ratio so that shrinking
+	 * to the floor keeps the shorter axis at or above the base minimum.
+	 */
+	private getResizeMinBounds(shape: TLEmbedShape) {
 		const embedInfo = this.getEmbedDefinition(shape.props.url)
 		let minWidth = embedInfo?.definition.minWidth ?? 200
 		let minHeight = embedInfo?.definition.minHeight ?? 200
-		if (isAspectRatioLocked) {
-			// Enforce aspect ratio
-			// Neither the width or height can be less than 200
+		if (this.isAspectRatioLocked(shape)) {
+			// Neither the width nor the height can be less than the base minimum.
 			const aspectRatio = shape.props.w / shape.props.h
 			if (aspectRatio > 1) {
 				// Landscape
@@ -229,8 +242,11 @@ export class EmbedShapeUtil extends BaseBoxShapeUtil<TLEmbedShape> {
 				minHeight /= aspectRatio
 			}
 		}
+		return { minWidth, minHeight }
+	}
 
-		return resizeBox(shape, info, { minWidth, minHeight })
+	override onResize(shape: TLEmbedShape, info: TLResizeInfo<TLEmbedShape>) {
+		return resizeBox(shape, info, this.getResizeMinBounds(shape))
 	}
 
 	override component(shape: TLEmbedShape) {

--- a/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.test.ts
@@ -54,11 +54,20 @@ describe('embed sandbox permissions', () => {
 })
 
 describe('getCorrectedEmbedSize', () => {
-	test('corrects height to match the resolved ratio, keeping width', () => {
-		expect(getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: 1.5 })).toEqual({
-			w: 640,
-			h: 640 / 1.5,
-		})
+	test('corrects to the resolved ratio while preserving the box area', () => {
+		const corrected = getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: 1.5 })!
+		expect(corrected.w / corrected.h).toBeCloseTo(1.5)
+		// area is unchanged, so the box takes the same footprint as the default 16:9 box
+		expect(corrected.w * corrected.h).toBeCloseTo(640 * 360)
+	})
+
+	test('does not balloon a portrait ratio: area is preserved, not the width', () => {
+		// a 9:16 video: width-preserving would give 640×1138; area-preserving keeps the footprint
+		const corrected = getCorrectedEmbedSize({ w: 640, h: 360, resolvedRatio: 9 / 16 })!
+		expect(corrected.w / corrected.h).toBeCloseTo(9 / 16)
+		expect(corrected.w * corrected.h).toBeCloseTo(640 * 360)
+		// far shorter than the 1138px a width-preserving correction would have produced
+		expect(corrected.h).toBeLessThan(640 / (9 / 16))
 	})
 
 	test('returns null when the resolved ratio already matches (within epsilon)', () => {
@@ -67,10 +76,9 @@ describe('getCorrectedEmbedSize', () => {
 
 	test('applies a new ratio regardless of the current ratio (e.g. after a url change)', () => {
 		// shape was already auto-corrected to 3:2; a new video resolves to 1:1
-		expect(getCorrectedEmbedSize({ w: 640, h: 640 / 1.5, resolvedRatio: 1 })).toEqual({
-			w: 640,
-			h: 640,
-		})
+		const corrected = getCorrectedEmbedSize({ w: 640, h: 640 / 1.5, resolvedRatio: 1 })!
+		expect(corrected.w / corrected.h).toBeCloseTo(1)
+		expect(corrected.w * corrected.h).toBeCloseTo(640 * (640 / 1.5))
 	})
 
 	test('returns null when there is no resolved ratio', () => {

--- a/packages/tldraw/src/lib/utils/embeds/embeds.ts
+++ b/packages/tldraw/src/lib/utils/embeds/embeds.ts
@@ -104,8 +104,9 @@ const ASPECT_RATIO_EPSILON = 0.001
 
 /**
  * Given an embed shape's current size and a newly-resolved aspect ratio, return the size it should
- * be corrected to (width preserved, height derived), or `null` when no change is needed — either
- * because there's no resolved ratio or the shape is already at it.
+ * be corrected to, or `null` when no change is needed — either because there's no resolved ratio or
+ * the shape is already at it. The correction preserves the box's area, so a portrait video takes the
+ * same visual footprint as a landscape one instead of ballooning the shape's height.
  *
  * @param opts - The current `w`/`h` and the `resolvedRatio` (`width / height`) discovered at runtime.
  * @internal
@@ -124,5 +125,6 @@ export function getCorrectedEmbedSize({
 	// Already at the resolved ratio: nothing to do.
 	if (Math.abs(w / h - resolvedRatio) <= ASPECT_RATIO_EPSILON) return null
 
-	return { w, h: w / resolvedRatio }
+	const area = w * h
+	return { w: Math.sqrt(area * resolvedRatio), h: Math.sqrt(area / resolvedRatio) }
 }

--- a/packages/tldraw/src/test/embed-aspect-ratio.test.ts
+++ b/packages/tldraw/src/test/embed-aspect-ratio.test.ts
@@ -77,6 +77,28 @@ describe('embed aspect ratio correction', () => {
 		expect(editor.getShape(id)).toBeUndefined()
 	})
 
+	it('preserves the ratio for a tall portrait video instead of clamping the width', async () => {
+		// A phone-tall 9:20 video: the area-preserving width falls below the resize floor
+		// (200 × 640/360 ≈ 356px) that onResize enforces for aspect-ratio-locked embeds. If we
+		// resized straight to the area-preserving box, onResize would clamp only the width and leave
+		// the height, re-letterboxing the content. The correction should scale up to clear the floor
+		// and keep the resolved ratio exact.
+		const url = 'https://vimeo.com/tall'
+		const ratio = 9 / 20
+		const util = stubVimeoDefinition(url, ratio)
+
+		const id = createShapeId()
+		editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url } })
+
+		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
+
+		const shape = editor.getShape<TLEmbedShape>(id)!
+		expect(shape.props.w / shape.props.h).toBeCloseTo(ratio)
+		// neither axis is driven below the base minimum
+		expect(shape.props.w).toBeGreaterThanOrEqual(200)
+		expect(shape.props.h).toBeGreaterThanOrEqual(200)
+	})
+
 	it('keeps the page center fixed when the embed is rotated', async () => {
 		const url = 'https://vimeo.com/333'
 		const util = stubVimeoDefinition(url, 1.5)

--- a/packages/tldraw/src/test/embed-aspect-ratio.test.ts
+++ b/packages/tldraw/src/test/embed-aspect-ratio.test.ts
@@ -62,15 +62,14 @@ describe('embed aspect ratio correction', () => {
 		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
 
 		const shape = editor.getShape<TLEmbedShape>(id)!
-		const correctedH = 640 / 1.5
-		// the whole point: width is preserved and only the height changes, so the box actually takes
-		// on the resolved 3:2 ratio (not merged into a uniform scale by the aspect-ratio lock)
-		expect(shape.props.w).toBe(640)
-		expect(shape.props.h).toBeCloseTo(correctedH)
+		// the whole point: the box actually takes on the resolved 3:2 ratio (not merged into a uniform
+		// scale by the aspect-ratio lock), and it does so while preserving its area rather than
+		// stretching one dimension
 		expect(shape.props.w / shape.props.h).toBeCloseTo(1.5)
-		// width is unchanged so x stays put; the shape grows around its center vertically
-		expect(shape.x).toBe(100)
-		expect(shape.y).toBeCloseTo(200 - (correctedH - 360) / 2)
+		expect(shape.props.w * shape.props.h).toBeCloseTo(640 * 360)
+		// the resize scales around the page-space center, so the center stays put
+		expect(shape.x + shape.props.w / 2).toBeCloseTo(100 + 640 / 2)
+		expect(shape.y + shape.props.h / 2).toBeCloseTo(200 + 360 / 2)
 
 		// the correction must not be its own undo step: a single undo removes the whole creation,
 		// rather than first reverting the resize
@@ -96,7 +95,8 @@ describe('embed aspect ratio correction', () => {
 		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
 
 		const shape = editor.getShape<TLEmbedShape>(id)!
-		expect(shape.props.h).toBeCloseTo(640 / 1.5)
+		expect(shape.props.w / shape.props.h).toBeCloseTo(1.5)
+		expect(shape.props.w * shape.props.h).toBeCloseTo(640 * 360)
 		const centerAfter = editor.getShapePageBounds(id)!.center
 		expect(centerAfter.x).toBeCloseTo(centerBefore.x)
 		expect(centerAfter.y).toBeCloseTo(centerBefore.y)
@@ -111,7 +111,9 @@ describe('embed aspect ratio correction', () => {
 		editor.createShape<TLEmbedShape>({ id, type: 'embed', props: { w: 640, h: 360, url: urlA } })
 
 		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
-		expect(editor.getShape<TLEmbedShape>(id)!.props.h).toBeCloseTo(640 / 1.5)
+		expect(
+			editor.getShape<TLEmbedShape>(id)!.props.w / editor.getShape<TLEmbedShape>(id)!.props.h
+		).toBeCloseTo(1.5)
 
 		// change the url to a 1:1 video — the new ratio should be applied even though the shape is no
 		// longer at the definition's default 16:9 ratio
@@ -119,8 +121,8 @@ describe('embed aspect ratio correction', () => {
 		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
 
 		const shape = editor.getShape<TLEmbedShape>(id)!
-		expect(shape.props.w).toBe(640)
-		expect(shape.props.h).toBeCloseTo(640)
+		expect(shape.props.w / shape.props.h).toBeCloseTo(1)
+		expect(shape.props.w * shape.props.h).toBeCloseTo(640 * 360)
 	})
 
 	it('ignores a stale resolution whose url no longer matches the shape', async () => {
@@ -136,11 +138,15 @@ describe('embed aspect ratio correction', () => {
 		// the url changes to B and B's resolution lands first
 		editor.updateShape<TLEmbedShape>({ id, type: 'embed', props: { url: urlB } })
 		await util.resolveAspectRatio(editor.getShape<TLEmbedShape>(id)!)
-		expect(editor.getShape<TLEmbedShape>(id)!.props.h).toBeCloseTo(640) // B's 1:1 ratio applied
+		const ratioAfterB =
+			editor.getShape<TLEmbedShape>(id)!.props.w / editor.getShape<TLEmbedShape>(id)!.props.h
+		expect(ratioAfterB).toBeCloseTo(1) // B's 1:1 ratio applied
 
 		// now the stale run for urlA completes — it must not clobber the shape with A's 3:2 ratio
 		await util.resolveAspectRatio(staleShapeA)
-		expect(editor.getShape<TLEmbedShape>(id)!.props.h).toBeCloseTo(640)
+		expect(
+			editor.getShape<TLEmbedShape>(id)!.props.w / editor.getShape<TLEmbedShape>(id)!.props.h
+		).toBeCloseTo(1)
 	})
 
 	it('resolves via a side effect when a user creates or re-points an embed', () => {


### PR DESCRIPTION
Follow-up to #9613.

That PR sizes opted-in embeds (Vimeo) to their content's real aspect ratio, but `getCorrectedEmbedSize` preserved the box **width** and derived the height. For a portrait video that balloons the shape: a 9:16 Vimeo video went from the default 640×360 box to 640×1138 — nearly 2× the area — growing around its center and swallowing whatever sat above and below the paste point.

This preserves the box **area** instead, deriving both dimensions from the resolved ratio (`w = √(A·r)`, `h = √(A/r)`). A corrected embed now keeps the same visual footprint regardless of orientation:

- 3:2 landscape: 640×360 → ~588×392 (was 640×427)
- 9:16 portrait: 640×360 → 360×640 (was 640×1138)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

Existing embed aspect-ratio tests updated to assert the resolved ratio **and** preserved area (rather than a preserved width). Added a portrait-ratio case demonstrating the height no longer balloons.

- [x] Unit tests

### Release notes

- Embeds that size to their content's aspect ratio (e.g. Vimeo) now preserve their box area when correcting, so portrait videos no longer balloon the shape.