### PR TITLE
fix(commenting): tolerate clock skew in the comment join-time gate

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -6,6 +6,13 @@ const ME = 'user_me'
 const OTHER = 'user_other'
 const THIRD = 'user_third'
 
+/**
+ * Event times, in minutes from an arbitrary epoch. The join gate tolerates a minute of clock skew
+ * between authors, so tests that turn on it space their events well past that — timestamps a few
+ * milliseconds apart would all land inside the tolerance and say nothing about the gate.
+ */
+const at = (minutes: number) => 1_700_000_000_000 + minutes * 60_000
+
 /** A comment body: paragraphs of plain text, with optional `@`-mentions (by member id) interleaved. */
 function body(text: string, mentionIds: string[] = []): TLRichText {
 	return {
@@ -27,7 +34,7 @@ function comment(overrides: Partial<CommentNotificationInput> = {}): CommentNoti
 		id: 'comment:1',
 		authorId: OTHER,
 		threadId: 'comment-thread:1',
-		createdAt: 1000,
+		createdAt: at(0),
 		body: body('hello'),
 		read: undefined,
 		file: { ownerId: THIRD },
@@ -71,8 +78,8 @@ describe('categorizeCommentNotifications', () => {
 		const theirReply = comment({
 			id: 'comment:theirs',
 			authorId: OTHER,
-			createdAt: 2000,
-			thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 1000 }] },
+			createdAt: at(10),
+			thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(0) }] },
 			file: { ownerId: THIRD },
 		})
 		const result = categorizeCommentNotifications([theirReply], ME)
@@ -82,31 +89,41 @@ describe('categorizeCommentNotifications', () => {
 	})
 
 	it('drops comments written before I joined the thread', () => {
-		// other(1000), other(2000), me(3000)
-		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 3000 }] }
-		const before1 = comment({ id: 'comment:b1', createdAt: 1000, thread, file: { ownerId: THIRD } })
-		const before2 = comment({ id: 'comment:b2', createdAt: 2000, thread, file: { ownerId: THIRD } })
+		// other(0m), other(10m), me(20m)
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(20) }] }
+		const before1 = comment({
+			id: 'comment:b1',
+			createdAt: at(0),
+			thread,
+			file: { ownerId: THIRD },
+		})
+		const before2 = comment({
+			id: 'comment:b2',
+			createdAt: at(10),
+			thread,
+			file: { ownerId: THIRD },
+		})
 		expect(categorizeCommentNotifications([before1, before2], ME)).toEqual([])
 	})
 
 	it('keeps replies from after I joined even once I have replied to them', () => {
-		// other(1000), me(2000), other(3000), me(4000): only the pre-join comment at 1000 drops
+		// other(0m), me(10m), other(20m), me(30m): only the pre-join comment at 0m drops
 		const thread = {
 			createdBy: OTHER,
 			comments: [
-				{ authorId: ME, createdAt: 2000 },
-				{ authorId: ME, createdAt: 4000 },
+				{ authorId: ME, createdAt: at(10) },
+				{ authorId: ME, createdAt: at(30) },
 			],
 		}
 		const preJoin = comment({
 			id: 'comment:pre',
-			createdAt: 1000,
+			createdAt: at(0),
 			thread,
 			file: { ownerId: THIRD },
 		})
 		const postJoin = comment({
 			id: 'comment:post',
-			createdAt: 3000,
+			createdAt: at(20),
 			thread,
 			file: { ownerId: THIRD },
 		})
@@ -115,16 +132,37 @@ describe('categorizeCommentNotifications', () => {
 		expect(result[0].primaryReason).toBe('reply')
 	})
 
-	it('drops a comment timestamped identically to my join', () => {
-		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 1000 }] }
-		const tied = comment({ createdAt: 1000, thread, file: { ownerId: THIRD } })
-		expect(categorizeCommentNotifications([tied], ME)).toEqual([])
+	it('keeps a comment from just before my join, absorbing clock skew between authors', () => {
+		// createdAt is stamped by each author's own clock, so a reply that really did follow my
+		// join can carry an earlier timestamp than it. Inside the tolerance it still counts.
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
+		const tied = comment({
+			id: 'comment:tied',
+			createdAt: at(10),
+			thread,
+			file: { ownerId: THIRD },
+		})
+		const skewed = comment({
+			id: 'comment:skewed',
+			createdAt: at(10) - 30_000,
+			thread,
+			file: { ownerId: THIRD },
+		})
+		const result = categorizeCommentNotifications([tied, skewed], ME)
+		expect(result.map((n) => n.comment.id)).toEqual(['comment:tied', 'comment:skewed'])
+		expect(result.map((n) => n.primaryReason)).toEqual(['reply', 'reply'])
+	})
+
+	it('drops a comment older than my join by more than the skew tolerance', () => {
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
+		const stale = comment({ createdAt: at(10) - 90_000, thread, file: { ownerId: THIRD } })
+		expect(categorizeCommentNotifications([stale], ME)).toEqual([])
 	})
 
 	it("ignores others' comments in the thread relation when deriving my join time", () => {
 		// defense in depth: the query only syncs my own, but a foreign row must not count
-		const thread = { createdBy: OTHER, comments: [{ authorId: THIRD, createdAt: 500 }] }
-		const theirs = comment({ createdAt: 1000, thread, file: { ownerId: THIRD } })
+		const thread = { createdBy: OTHER, comments: [{ authorId: THIRD, createdAt: at(0) }] }
+		const theirs = comment({ createdAt: at(10), thread, file: { ownerId: THIRD } })
 		expect(categorizeCommentNotifications([theirs], ME)).toEqual([])
 	})
 
@@ -132,9 +170,9 @@ describe('categorizeCommentNotifications', () => {
 		const result = categorizeCommentNotifications(
 			[
 				comment({
-					createdAt: 1000,
+					createdAt: at(0),
 					body: body('hey ', [ME]),
-					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 2000 }] },
+					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] },
 					file: { ownerId: THIRD },
 				}),
 			],
@@ -159,8 +197,8 @@ describe('categorizeCommentNotifications', () => {
 		const result = categorizeCommentNotifications(
 			[
 				comment({
-					createdAt: 1000,
-					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: 2000 }] },
+					createdAt: at(0),
+					thread: { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] },
 					file: { ownerId: ME },
 				}),
 			],
@@ -210,8 +248,8 @@ describe('categorizeCommentNotifications', () => {
 	})
 
 	it('sorts newest first', () => {
-		const older = comment({ id: 'comment:old', createdAt: 1000, file: { ownerId: ME } })
-		const newer = comment({ id: 'comment:new', createdAt: 2000, file: { ownerId: ME } })
+		const older = comment({ id: 'comment:old', createdAt: at(0), file: { ownerId: ME } })
+		const newer = comment({ id: 'comment:new', createdAt: at(10), file: { ownerId: ME } })
 		const result = categorizeCommentNotifications([older, newer], ME)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:new', 'comment:old'])
 	})

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -17,6 +17,21 @@ export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board'
 const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board']
 
 /**
+ * How far a comment may predate the user's join time and still count as a reply.
+ *
+ * `createdAt` is stamped by the authoring client's clock (`createComment` in tlschema defaults to
+ * `Date.now()`), so the join gate compares timestamps written by two different machines. A user
+ * whose clock runs fast stamps their own join late, and a reply that genuinely followed it reads
+ * as thread history — silently dropped, with nothing in the UI to hint at what's missing.
+ *
+ * The two failure directions aren't symmetric: too small a tolerance loses real notifications,
+ * too large lets a few already-seen comments through. So this errs permissive, at a minute — well
+ * past the drift of a roughly-synced clock, and short enough that it can't readmit a thread's
+ * history, which is what the gate exists to keep out.
+ */
+const JOIN_TIME_SKEW_TOLERANCE_MS = 60_000
+
+/**
  * The comment fields {@link categorizeCommentNotifications} needs. A structural subset of the
  * `app.getComments()` row (with its `file`/`thread`/`read` relationships) so the categorization
  * can be unit-tested without Zero types. `read` is the caller's read receipt — a related row
@@ -55,9 +70,10 @@ export interface CommentNotification<
  *
  * Stricter than the `comments` synced query, whose reply category has no timing condition (ZQL
  * can't compare `createdAt` across correlated rows): the reply reason only applies to comments
- * from after the user joined the thread — earlier ones are context they saw when joining, not
- * notifications. A comment with no reason left is dropped. Post-join replies stay in the feed
- * once responded to; read receipts, not membership, handle their unread state.
+ * from after the user joined the thread (within {@link JOIN_TIME_SKEW_TOLERANCE_MS}) — earlier
+ * ones are context they saw when joining, not notifications. A comment with no reason left is
+ * dropped. Post-join replies stay in the feed once responded to; read receipts, not membership,
+ * handle their unread state.
  */
 export function categorizeCommentNotifications<T extends CommentNotificationInput>(
 	comments: readonly T[],
@@ -72,7 +88,10 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
-		if (comment.createdAt > joinedThreadAt(comment.thread, userId)) reasons.push('reply')
+		// the two sides of this comparison come from different machines' clocks, hence the
+		// tolerance — see JOIN_TIME_SKEW_TOLERANCE_MS
+		const joinedAt = joinedThreadAt(comment.thread, userId)
+		if (comment.createdAt > joinedAt - JOIN_TIME_SKEW_TOLERANCE_MS) reasons.push('reply')
 		if (comment.file?.ownerId === userId) reasons.push('owned-board')
 		if (reasons.length === 0) continue
 


### PR DESCRIPTION
Follow-up to #9753. That PR gated the reply notification reason on the comment postdating when you joined the thread, which is the right fix — but the two sides of that comparison come from different machines' clocks. `createComment` stamps `createdAt` with the authoring client's `Date.now()` (`packages/tlschema/src/records/TLComment.ts`), and neither dotcom call site passes an explicit `now`.

So if your clock runs a minute fast, your own join comment is stamped a minute late, and a reply that genuinely followed it reads as thread history and is dropped — silently, with nothing in the feed to hint at what's missing. The previous set-based membership test was immune to clock skew; making the gate time-based is what exposes it.

This allows a comment to predate the join time by up to a minute and still count as a reply. The failure directions aren't symmetric: too small a tolerance loses real notifications, too large readmits comments the user already saw when they joined. A minute is well past the drift of a roughly-synced clock and far short of what it would take to readmit a thread's history, which is what the gate exists to keep out.

Server-side timestamping would fix this at the root, but it needs a schema migration and changes how the commenting SDK creates records — out of scope here.

### Change type

- [x] `bugfix`

### Test plan

1. As user A, start a thread and comment in it
2. As user B (clock set a minute ahead), reply to the thread
3. As user A, reply again
4. B's notifications: A's reply from step 3 appears

- [x] Unit tests

### Release notes

- Fix comment notifications being dropped when collaborators' device clocks disagree.