### PR TITLE
fix(tldraw): pass clipboard text and html sources along with pasted files

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -3472,7 +3472,6 @@ export interface TLBaseEventInfo {
 export interface TLBaseExternalContent {
     // (undocumented)
     point?: VecLike;
-    // (undocumented)
     sources?: TLExternalContentSource[];
 }
 

--- a/packages/editor/src/lib/editor/types/external-content.ts
+++ b/packages/editor/src/lib/editor/types/external-content.ts
@@ -39,8 +39,8 @@ export type TLExternalContentSource =
 export interface TLBaseExternalContent {
 	/**
 	 * The other content sources found on the clipboard alongside this content. For example, when
-	 * pasting an image copied together with html and plain text, the files content will have text
-	 * sources for the html and plain text parts.
+	 * pasting an image copied together with HTML and plain text, the `files` content will have
+	 * text sources for the HTML and plain text parts.
 	 */
 	sources?: TLExternalContentSource[]
 	point?: VecLike

--- a/packages/editor/src/lib/editor/types/external-content.ts
+++ b/packages/editor/src/lib/editor/types/external-content.ts
@@ -37,6 +37,11 @@ export type TLExternalContentSource =
 
 /** @public */
 export interface TLBaseExternalContent {
+	/**
+	 * The other content sources found on the clipboard alongside this content. For example, when
+	 * pasting an image copied together with html and plain text, the files content will have text
+	 * sources for the html and plain text parts.
+	 */
 	sources?: TLExternalContentSource[]
 	point?: VecLike
 }

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -236,11 +236,11 @@ type ClipboardThing =
  * @param point - The point to paste at
  * @internal
  */
-const handlePasteFromEventClipboardData = async (
+export async function handlePasteFromEventClipboardData(
 	editor: Editor,
 	clipboardData: DataTransfer,
 	point?: VecLike
-) => {
+) {
 	// Do not paste while in any editing state
 	if (editor.getEditingShapeId() !== null) return
 
@@ -280,7 +280,7 @@ const handlePasteFromEventClipboardData = async (
 		}
 	}
 
-	handleClipboardThings(editor, things, point, 'native-event')
+	return await handleClipboardThings(editor, things, point, 'native-event')
 }
 
 /**
@@ -292,7 +292,7 @@ const handlePasteFromEventClipboardData = async (
  * @param point - The point to paste at
  * @internal
  */
-const handlePasteFromClipboardApi = async ({
+export async function handlePasteFromClipboardApi({
 	editor,
 	clipboardItems,
 	point,
@@ -304,7 +304,7 @@ const handlePasteFromClipboardApi = async ({
 	point?: VecLike
 	fallbackFiles?: File[]
 	clipboardPasteSource: 'native-event' | 'clipboard-read'
-}) => {
+}) {
 	// We need to populate the array of clipboard things
 	// based on the ClipboardItems from the Clipboard API.
 	// This is done in a different way than when using
@@ -392,25 +392,7 @@ async function handleClipboardThings(
 	point: VecLike | undefined,
 	clipboardPasteSource: 'native-event' | 'clipboard-read'
 ) {
-	// 1. Handle files
-	//
-	// We need to handle files separately because if we want them to
-	// be placed next to each other, we need to create them all at once.
-
-	const files = things.filter(
-		(t) => (t.type === 'file' || t.type === 'blob') && t.source !== null
-	) as Extract<ClipboardThing, { type: 'file' } | { type: 'blob' }>[]
-
-	// Just paste the files, nothing else
-	if (files.length) {
-		if (files.length > editor.options.maxFilesAtOnce) {
-			throw Error('Too many files')
-		}
-		const fileBlobs = compact(await Promise.all(files.map((t) => t.source)))
-		return await pasteFiles(editor, fileBlobs, point, undefined, clipboardPasteSource)
-	}
-
-	// 2. Generate clipboard results for non-file things
+	// 1. Generate clipboard results for non-file things
 	//
 	// Getting the source from the items is async, however they must be accessed syncronously;
 	// we can't await them in a loop. So we'll map them to promises and await them all at once,
@@ -418,7 +400,7 @@ async function handleClipboardThings(
 
 	const results = await Promise.all<TLExternalContentSource>(
 		things
-			.filter((t) => t.type !== 'file')
+			.filter((t) => t.type !== 'file' && t.type !== 'blob')
 			.map(
 				(t) =>
 					new Promise((r) => {
@@ -547,6 +529,27 @@ async function handleClipboardThings(
 					})
 			)
 	)
+
+	// 2. Handle files
+	//
+	// We need to handle files separately because if we want them to
+	// be placed next to each other, we need to create them all at once.
+	// We pass along the other clipboard sources (e.g. text and html found
+	// on the clipboard next to an image) so that external content handlers
+	// can make use of them.
+
+	const files = things.filter(
+		(t) => (t.type === 'file' || t.type === 'blob') && t.source !== null
+	) as Extract<ClipboardThing, { type: 'file' } | { type: 'blob' }>[]
+
+	// Just paste the files, nothing else
+	if (files.length) {
+		if (files.length > editor.options.maxFilesAtOnce) {
+			throw Error('Too many files')
+		}
+		const fileBlobs = compact(await Promise.all(files.map((t) => t.source)))
+		return await pasteFiles(editor, fileBlobs, point, results, clipboardPasteSource)
+	}
 
 	// 3.
 	//

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -406,11 +406,6 @@ async function handleClipboardThings(
 					new Promise((r) => {
 						const thing = t as Exclude<ClipboardThing, { type: 'file' } | { type: 'blob' }>
 
-						if (thing.type === 'file') {
-							r({ type: 'error', data: null, reason: 'unexpected file' })
-							return
-						}
-
 						thing.source.then((text) => {
 							// first, see if we can find tldraw content, which is JSON inside of an html comment
 							const tldrawHtmlComment = text.match(/<div data-tldraw[^>]*>(.*)<\/div>/)?.[1]
@@ -543,11 +538,12 @@ async function handleClipboardThings(
 	// on the clipboard next to an image) so that external content handlers
 	// can make use of them.
 
-	const files = things.filter(
-		(t) => (t.type === 'file' || t.type === 'blob') && t.source !== null
-	) as Extract<ClipboardThing, { type: 'file' } | { type: 'blob' }>[]
+	const files = things.filter((t) => t.type === 'file' || t.type === 'blob') as Extract<
+		ClipboardThing,
+		{ type: 'file' } | { type: 'blob' }
+	>[]
 
-	// Just paste the files, nothing else
+	// Paste the files, carrying the other sources along with them
 	if (files.length) {
 		if (files.length > editor.options.maxFilesAtOnce) {
 			throw Error('Too many files')

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -406,126 +406,128 @@ async function handleClipboardThings(
 					new Promise((r) => {
 						const thing = t as Exclude<ClipboardThing, { type: 'file' } | { type: 'blob' }>
 
-						thing.source.then((text) => {
-							// first, see if we can find tldraw content, which is JSON inside of an html comment
-							const tldrawHtmlComment = text.match(/<div data-tldraw[^>]*>(.*)<\/div>/)?.[1]
+						thing.source
+							.then((text) => {
+								// first, see if we can find tldraw content, which is JSON inside of an html comment
+								const tldrawHtmlComment = text.match(/<div data-tldraw[^>]*>(.*)<\/div>/)?.[1]
 
-							if (tldrawHtmlComment) {
-								try {
-									// First try parsing as plain JSON (version 2/3 formats)
-									let json
+								if (tldrawHtmlComment) {
 									try {
-										json = JSON.parse(tldrawHtmlComment)
-									} catch {
-										// Fall back to LZ decompression (legacy format)
-										const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
-										if (jsonComment === null) {
+										// First try parsing as plain JSON (version 2/3 formats)
+										let json
+										try {
+											json = JSON.parse(tldrawHtmlComment)
+										} catch {
+											// Fall back to LZ decompression (legacy format)
+											const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
+											if (jsonComment === null) {
+												r({
+													type: 'error',
+													data: null,
+													reason: `found tldraw data comment but could not parse`,
+												})
+												return
+											}
+											json = JSON.parse(jsonComment)
+										}
+
+										if (json.type !== 'application/tldraw') {
 											r({
 												type: 'error',
-												data: null,
-												reason: `found tldraw data comment but could not parse`,
+												data: json,
+												reason: `found tldraw data comment but JSON was of a different type: ${json.type}`,
 											})
 											return
 										}
-										json = JSON.parse(jsonComment)
-									}
 
-									if (json.type !== 'application/tldraw') {
+										// Handle versioned clipboard format
+										if (json.version === 3) {
+											// Version 3: Assets are plain, decompress only other data
+											try {
+												const otherData = JSON.parse(
+													lz.decompressFromBase64(json.data.otherCompressed) || '{}'
+												)
+												const reconstructedData = {
+													assets: json.data.assets || [],
+													...otherData,
+												}
+
+												r({ type: 'tldraw', data: reconstructedData })
+												return
+											} catch (error) {
+												r({
+													type: 'error',
+													data: json,
+													reason: `failed to decompress version 2 clipboard data: ${error}`,
+												})
+												return
+											}
+										}
+										if (json.version === 2) {
+											// Version 2: Everything is plain, this had issues with encoding... :-/
+											// TODO: nix this support after some time.
+											r({ type: 'tldraw', data: json.data })
+										} else {
+											// Version 1 or no version: Legacy format
+											if (typeof json.data === 'string') {
+												r({
+													type: 'error',
+													data: json,
+													reason:
+														'found tldraw json but data was a string instead of a TLClipboardModel object',
+												})
+												return
+											}
+
+											r({ type: 'tldraw', data: json.data })
+											return
+										}
+									} catch {
 										r({
 											type: 'error',
-											data: json,
-											reason: `found tldraw data comment but JSON was of a different type: ${json.type}`,
+											data: tldrawHtmlComment,
+											reason:
+												'found tldraw json but data was a string instead of a TLClipboardModel object',
 										})
 										return
 									}
-
-									// Handle versioned clipboard format
-									if (json.version === 3) {
-										// Version 3: Assets are plain, decompress only other data
-										try {
-											const otherData = JSON.parse(
-												lz.decompressFromBase64(json.data.otherCompressed) || '{}'
-											)
-											const reconstructedData = {
-												assets: json.data.assets || [],
-												...otherData,
-											}
-
-											r({ type: 'tldraw', data: reconstructedData })
-											return
-										} catch (error) {
-											r({
-												type: 'error',
-												data: json,
-												reason: `failed to decompress version 2 clipboard data: ${error}`,
-											})
-											return
-										}
+								} else {
+									if (thing.type === 'html') {
+										r({ type: 'text', data: text, subtype: 'html' })
+										return
 									}
-									if (json.version === 2) {
-										// Version 2: Everything is plain, this had issues with encoding... :-/
-										// TODO: nix this support after some time.
-										r({ type: 'tldraw', data: json.data })
-									} else {
-										// Version 1 or no version: Legacy format
-										if (typeof json.data === 'string') {
-											r({
-												type: 'error',
-												data: json,
-												reason:
-													'found tldraw json but data was a string instead of a TLClipboardModel object',
-											})
+
+									if (thing.type === 'url') {
+										r({ type: 'text', data: text, subtype: 'url' })
+										return
+									}
+
+									// if we have not found a tldraw comment, Otherwise, try to parse the text as JSON directly.
+									try {
+										const json = JSON.parse(text)
+										if (json.type === 'excalidraw/clipboard') {
+											// If the clipboard contains content copied from excalidraw, then paste that
+											r({ type: 'excalidraw', data: json })
+											return
+										} else {
+											r({ type: 'text', data: text, subtype: 'json' })
 											return
 										}
-
-										r({ type: 'tldraw', data: json.data })
+									} catch {
+										// If we could not parse the text as JSON, then it's just text
+										r({ type: 'text', data: text, subtype: 'text' })
 										return
 									}
-								} catch {
-									r({
-										type: 'error',
-										data: tldrawHtmlComment,
-										reason:
-											'found tldraw json but data was a string instead of a TLClipboardModel object',
-									})
-									return
-								}
-							} else {
-								if (thing.type === 'html') {
-									r({ type: 'text', data: text, subtype: 'html' })
-									return
 								}
 
-								if (thing.type === 'url') {
-									r({ type: 'text', data: text, subtype: 'url' })
-									return
-								}
-
-								// if we have not found a tldraw comment, Otherwise, try to parse the text as JSON directly.
-								try {
-									const json = JSON.parse(text)
-									if (json.type === 'excalidraw/clipboard') {
-										// If the clipboard contains content copied from excalidraw, then paste that
-										r({ type: 'excalidraw', data: json })
-										return
-									} else {
-										r({ type: 'text', data: text, subtype: 'json' })
-										return
-									}
-								} catch {
-									// If we could not parse the text as JSON, then it's just text
-									r({ type: 'text', data: text, subtype: 'text' })
-									return
-								}
-							}
-
-							r({ type: 'error', data: text, reason: 'unhandled case' })
-						}).catch((error) => {
-							// If we can't read one of the clipboard items (e.g. the browser
-							// rejects a getType call), resolve it to an error source rather
-							// than hanging the whole paste.
-							r({ type: 'error', data: null, reason: `error reading clipboard data: ${error}` })
-						})
+								r({ type: 'error', data: text, reason: 'unhandled case' })
+							})
+							.catch((error) => {
+								// If we can't read one of the clipboard items (e.g. the browser
+								// rejects a getType call), resolve it to an error source rather
+								// than hanging the whole paste.
+								r({ type: 'error', data: null, reason: `error reading clipboard data: ${error}` })
+							})
 					})
 			)
 	)

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -406,128 +406,128 @@ async function handleClipboardThings(
 					new Promise((r) => {
 						const thing = t as Exclude<ClipboardThing, { type: 'file' } | { type: 'blob' }>
 
-						thing.source
-							.then((text) => {
-								// first, see if we can find tldraw content, which is JSON inside of an html comment
-								const tldrawHtmlComment = text.match(/<div data-tldraw[^>]*>(.*)<\/div>/)?.[1]
+						const parsed = thing.source.then((text) => {
+							// first, see if we can find tldraw content, which is JSON inside of an html comment
+							const tldrawHtmlComment = text.match(/<div data-tldraw[^>]*>(.*)<\/div>/)?.[1]
 
-								if (tldrawHtmlComment) {
+							if (tldrawHtmlComment) {
+								try {
+									// First try parsing as plain JSON (version 2/3 formats)
+									let json
 									try {
-										// First try parsing as plain JSON (version 2/3 formats)
-										let json
-										try {
-											json = JSON.parse(tldrawHtmlComment)
-										} catch {
-											// Fall back to LZ decompression (legacy format)
-											const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
-											if (jsonComment === null) {
-												r({
-													type: 'error',
-													data: null,
-													reason: `found tldraw data comment but could not parse`,
-												})
-												return
-											}
-											json = JSON.parse(jsonComment)
+										json = JSON.parse(tldrawHtmlComment)
+									} catch {
+										// Fall back to LZ decompression (legacy format)
+										const jsonComment = lz.decompressFromBase64(tldrawHtmlComment)
+										if (jsonComment === null) {
+											r({
+												type: 'error',
+												data: null,
+												reason: `found tldraw data comment but could not parse`,
+											})
+											return
 										}
+										json = JSON.parse(jsonComment)
+									}
 
-										if (json.type !== 'application/tldraw') {
+									if (json.type !== 'application/tldraw') {
+										r({
+											type: 'error',
+											data: json,
+											reason: `found tldraw data comment but JSON was of a different type: ${json.type}`,
+										})
+										return
+									}
+
+									// Handle versioned clipboard format
+									if (json.version === 3) {
+										// Version 3: Assets are plain, decompress only other data
+										try {
+											const otherData = JSON.parse(
+												lz.decompressFromBase64(json.data.otherCompressed) || '{}'
+											)
+											const reconstructedData = {
+												assets: json.data.assets || [],
+												...otherData,
+											}
+
+											r({ type: 'tldraw', data: reconstructedData })
+											return
+										} catch (error) {
 											r({
 												type: 'error',
 												data: json,
-												reason: `found tldraw data comment but JSON was of a different type: ${json.type}`,
+												reason: `failed to decompress version 2 clipboard data: ${error}`,
+											})
+											return
+										}
+									}
+									if (json.version === 2) {
+										// Version 2: Everything is plain, this had issues with encoding... :-/
+										// TODO: nix this support after some time.
+										r({ type: 'tldraw', data: json.data })
+									} else {
+										// Version 1 or no version: Legacy format
+										if (typeof json.data === 'string') {
+											r({
+												type: 'error',
+												data: json,
+												reason:
+													'found tldraw json but data was a string instead of a TLClipboardModel object',
 											})
 											return
 										}
 
-										// Handle versioned clipboard format
-										if (json.version === 3) {
-											// Version 3: Assets are plain, decompress only other data
-											try {
-												const otherData = JSON.parse(
-													lz.decompressFromBase64(json.data.otherCompressed) || '{}'
-												)
-												const reconstructedData = {
-													assets: json.data.assets || [],
-													...otherData,
-												}
-
-												r({ type: 'tldraw', data: reconstructedData })
-												return
-											} catch (error) {
-												r({
-													type: 'error',
-													data: json,
-													reason: `failed to decompress version 2 clipboard data: ${error}`,
-												})
-												return
-											}
-										}
-										if (json.version === 2) {
-											// Version 2: Everything is plain, this had issues with encoding... :-/
-											// TODO: nix this support after some time.
-											r({ type: 'tldraw', data: json.data })
-										} else {
-											// Version 1 or no version: Legacy format
-											if (typeof json.data === 'string') {
-												r({
-													type: 'error',
-													data: json,
-													reason:
-														'found tldraw json but data was a string instead of a TLClipboardModel object',
-												})
-												return
-											}
-
-											r({ type: 'tldraw', data: json.data })
-											return
-										}
-									} catch {
-										r({
-											type: 'error',
-											data: tldrawHtmlComment,
-											reason:
-												'found tldraw json but data was a string instead of a TLClipboardModel object',
-										})
+										r({ type: 'tldraw', data: json.data })
 										return
 									}
-								} else {
-									if (thing.type === 'html') {
-										r({ type: 'text', data: text, subtype: 'html' })
-										return
-									}
-
-									if (thing.type === 'url') {
-										r({ type: 'text', data: text, subtype: 'url' })
-										return
-									}
-
-									// if we have not found a tldraw comment, Otherwise, try to parse the text as JSON directly.
-									try {
-										const json = JSON.parse(text)
-										if (json.type === 'excalidraw/clipboard') {
-											// If the clipboard contains content copied from excalidraw, then paste that
-											r({ type: 'excalidraw', data: json })
-											return
-										} else {
-											r({ type: 'text', data: text, subtype: 'json' })
-											return
-										}
-									} catch {
-										// If we could not parse the text as JSON, then it's just text
-										r({ type: 'text', data: text, subtype: 'text' })
-										return
-									}
+								} catch {
+									r({
+										type: 'error',
+										data: tldrawHtmlComment,
+										reason:
+											'found tldraw json but data was a string instead of a TLClipboardModel object',
+									})
+									return
+								}
+							} else {
+								if (thing.type === 'html') {
+									r({ type: 'text', data: text, subtype: 'html' })
+									return
 								}
 
-								r({ type: 'error', data: text, reason: 'unhandled case' })
-							})
-							.catch((error) => {
-								// If we can't read one of the clipboard items (e.g. the browser
-								// rejects a getType call), resolve it to an error source rather
-								// than hanging the whole paste.
-								r({ type: 'error', data: null, reason: `error reading clipboard data: ${error}` })
-							})
+								if (thing.type === 'url') {
+									r({ type: 'text', data: text, subtype: 'url' })
+									return
+								}
+
+								// if we have not found a tldraw comment, Otherwise, try to parse the text as JSON directly.
+								try {
+									const json = JSON.parse(text)
+									if (json.type === 'excalidraw/clipboard') {
+										// If the clipboard contains content copied from excalidraw, then paste that
+										r({ type: 'excalidraw', data: json })
+										return
+									} else {
+										r({ type: 'text', data: text, subtype: 'json' })
+										return
+									}
+								} catch {
+									// If we could not parse the text as JSON, then it's just text
+									r({ type: 'text', data: text, subtype: 'text' })
+									return
+								}
+							}
+
+							r({ type: 'error', data: text, reason: 'unhandled case' })
+						})
+
+						// If we can't read one of the clipboard items (e.g. the browser rejects a
+						// getType call), or the handler above throws, resolve this thing to an
+						// error source rather than hanging the whole paste.
+						parsed.catch((error) => {
+							r({ type: 'error', data: null, reason: `error reading clipboard data: ${error}` })
+						})
 					})
 			)
 	)

--- a/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useClipboardEvents.ts
@@ -525,6 +525,11 @@ async function handleClipboardThings(
 							}
 
 							r({ type: 'error', data: text, reason: 'unhandled case' })
+						}).catch((error) => {
+							// If we can't read one of the clipboard items (e.g. the browser
+							// rejects a getType call), resolve it to an error source rather
+							// than hanging the whole paste.
+							r({ type: 'error', data: null, reason: `error reading clipboard data: ${error}` })
 						})
 					})
 			)

--- a/packages/tldraw/src/test/commands/clipboardPaste.test.ts
+++ b/packages/tldraw/src/test/commands/clipboardPaste.test.ts
@@ -19,12 +19,16 @@ afterEach(() => {
 	editor?.dispose()
 })
 
-/** Build a fake ClipboardItem, as returned by navigator.clipboard.read(). */
-function makeClipboardItem(entries: Record<string, string | Blob>): ClipboardItem {
+/**
+ * Build a fake ClipboardItem, as returned by navigator.clipboard.read().
+ * An Error value makes getType reject for that type, like a failing browser read.
+ */
+function makeClipboardItem(entries: Record<string, string | Blob | Error>): ClipboardItem {
 	return {
 		types: Object.keys(entries),
 		getType: async (type: string) => {
 			const value = entries[type]
+			if (value instanceof Error) throw value
 			return value instanceof Blob ? value : new Blob([value], { type })
 		},
 	} as unknown as ClipboardItem
@@ -181,6 +185,26 @@ describe('pasting files from the clipboard API', () => {
 		expect(content.files[0].name).toBe('image.png')
 		// the text thing was just the file name, so it is not kept as a source
 		expect(content.sources).toEqual([])
+	})
+
+	it('still pastes files when reading another clipboard type fails', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					'image/png': pngBlob(),
+					'text/html': new Error('boom'),
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.sources).toMatchObject([{ type: 'error' }])
 	})
 
 	it('throws when pasting more files than maxFilesAtOnce', async () => {

--- a/packages/tldraw/src/test/commands/clipboardPaste.test.ts
+++ b/packages/tldraw/src/test/commands/clipboardPaste.test.ts
@@ -284,9 +284,7 @@ describe('pasting non-file content from the clipboard API', () => {
 
 		await handlePasteFromClipboardApi({
 			editor,
-			clipboardItems: [
-				makeClipboardItem({ 'text/html': TLDRAW_V2_HTML, 'text/plain': 'hello' }),
-			],
+			clipboardItems: [makeClipboardItem({ 'text/html': TLDRAW_V2_HTML, 'text/plain': 'hello' })],
 			clipboardPasteSource: 'clipboard-read',
 		})
 
@@ -322,9 +320,7 @@ describe('pasting non-file content from the clipboard API', () => {
 
 		await handlePasteFromClipboardApi({
 			editor,
-			clipboardItems: [
-				makeClipboardItem({ 'text/html': '<b>hello</b>', 'text/plain': 'hello' }),
-			],
+			clipboardItems: [makeClipboardItem({ 'text/html': '<b>hello</b>', 'text/plain': 'hello' })],
 			clipboardPasteSource: 'clipboard-read',
 		})
 

--- a/packages/tldraw/src/test/commands/clipboardPaste.test.ts
+++ b/packages/tldraw/src/test/commands/clipboardPaste.test.ts
@@ -94,6 +94,39 @@ describe('pasting files from the clipboard API', () => {
 		])
 	})
 
+	it('passes text sources along with multiple pasted files', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({ 'image/png': pngBlob() }),
+				makeClipboardItem({ 'image/png': pngBlob(), 'text/plain': 'hello' }),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.files).toHaveLength(2)
+		expect(content.sources).toEqual([{ type: 'text', data: 'hello', subtype: 'text' }])
+	})
+
+	it('passes the paste point through with the files', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'image/png': pngBlob() })],
+			point: { x: 100, y: 200 },
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'files', point: { x: 100, y: 200 } })
+	})
+
 	it('passes empty sources when only an image is on the clipboard', async () => {
 		const spy = mockPutExternalContent()
 
@@ -185,6 +218,23 @@ describe('pasting files from the clipboard API', () => {
 		expect(content.files[0].name).toBe('image.png')
 		// the text thing was just the file name, so it is not kept as a source
 		expect(content.sources).toEqual([])
+	})
+
+	it('uses fallback files when the clipboard API returns nothing for them', async () => {
+		// Files pasted in Safari from the file system have no clipboard item types at all
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({})],
+			fallbackFiles: [pngFile()],
+			clipboardPasteSource: 'native-event',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.files[0].name).toBe('image.png')
 	})
 
 	it('still pastes files when reading another clipboard type fails', async () => {

--- a/packages/tldraw/src/test/commands/clipboardPaste.test.ts
+++ b/packages/tldraw/src/test/commands/clipboardPaste.test.ts
@@ -1,0 +1,474 @@
+import { TLExternalContent, TLFilesExternalContent } from '@tldraw/editor'
+import { vi } from 'vitest'
+import {
+	handlePasteFromClipboardApi,
+	handlePasteFromEventClipboardData,
+} from '../../lib/ui/hooks/useClipboardEvents'
+import { TLDRAW_CUSTOM_PNG_MIME_TYPE } from '../../lib/utils/clipboard'
+import { TestEditor } from '../TestEditor'
+
+let editor: TestEditor
+
+beforeEach(() => {
+	// The paste pipeline reads blobs with FileReader, which needs real timers.
+	vi.useRealTimers()
+	editor = new TestEditor()
+})
+
+afterEach(() => {
+	editor?.dispose()
+})
+
+/** Build a fake ClipboardItem, as returned by navigator.clipboard.read(). */
+function makeClipboardItem(entries: Record<string, string | Blob>): ClipboardItem {
+	return {
+		types: Object.keys(entries),
+		getType: async (type: string) => {
+			const value = entries[type]
+			return value instanceof Blob ? value : new Blob([value], { type })
+		},
+	} as unknown as ClipboardItem
+}
+
+/** Build a fake DataTransfer, as found on a native paste event. */
+function makeDataTransfer(
+	items: Array<
+		{ kind: 'file'; type: string; file: File } | { kind: 'string'; type: string; data: string }
+	>
+): DataTransfer {
+	return {
+		items: items.map((item) =>
+			item.kind === 'file'
+				? { kind: 'file', type: item.type, getAsFile: () => item.file }
+				: {
+						kind: 'string',
+						type: item.type,
+						getAsString: (callback: (data: string) => void) => callback(item.data),
+					}
+		),
+	} as unknown as DataTransfer
+}
+
+function mockPutExternalContent() {
+	return vi.spyOn(editor, 'putExternalContent').mockResolvedValue()
+}
+
+const pngBlob = () => new Blob(['fake-png-bytes'], { type: 'image/png' })
+const pngFile = () => new File(['fake-png-bytes'], 'image.png', { type: 'image/png' })
+
+const TLDRAW_V2_HTML = `<div data-tldraw>${JSON.stringify({
+	type: 'application/tldraw',
+	kind: 'content',
+	version: 2,
+	data: { shapes: [], rootShapeIds: [], assets: [], schema: {} },
+})}</div>`
+
+describe('pasting files from the clipboard API', () => {
+	it('passes html and text sources along with pasted files', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					'image/png': pngBlob(),
+					'text/html': '<b>hello</b>',
+					'text/plain': 'hello',
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.files).toHaveLength(1)
+		expect(content.files[0].type).toBe('image/png')
+		expect(content.sources).toEqual([
+			{ type: 'text', data: '<b>hello</b>', subtype: 'html' },
+			{ type: 'text', data: 'hello', subtype: 'text' },
+		])
+	})
+
+	it('passes empty sources when only an image is on the clipboard', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'image/png': pngBlob() })],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'files', sources: [] })
+	})
+
+	it('still prioritizes files over tldraw content, but includes it as a source', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					'image/png': pngBlob(),
+					'text/html': TLDRAW_V2_HTML,
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.sources).toMatchObject([{ type: 'tldraw' }])
+	})
+
+	it('prefers the tldraw custom png format over plain png', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					[TLDRAW_CUSTOM_PNG_MIME_TYPE]: new Blob(['tldraw-png-bytes'], {
+						type: TLDRAW_CUSTOM_PNG_MIME_TYPE,
+					}),
+					'image/png': pngBlob(),
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.files).toHaveLength(1)
+		// the custom format blob is rewritten to a canonical png mime type
+		expect(content.files[0].type).toBe('image/png')
+		expect(await content.files[0].text()).toBe('tldraw-png-bytes')
+	})
+
+	it('falls back to the next image format when a blob comes back empty', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					[TLDRAW_CUSTOM_PNG_MIME_TYPE]: new Blob([], { type: TLDRAW_CUSTOM_PNG_MIME_TYPE }),
+					'image/png': pngBlob(),
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.files).toHaveLength(1)
+		expect(await content.files[0].text()).toBe('fake-png-bytes')
+	})
+
+	it('uses fallback files when the clipboard API only returns text for them', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'text/plain': 'image.png' })],
+			fallbackFiles: [pngFile()],
+			clipboardPasteSource: 'native-event',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.files[0].name).toBe('image.png')
+		// the text thing was just the file name, so it is not kept as a source
+		expect(content.sources).toEqual([])
+	})
+
+	it('throws when pasting more files than maxFilesAtOnce', async () => {
+		editor.dispose()
+		editor = new TestEditor({ options: { maxFilesAtOnce: 2 } })
+		const spy = mockPutExternalContent()
+
+		await expect(
+			handlePasteFromClipboardApi({
+				editor,
+				clipboardItems: [
+					makeClipboardItem({ 'image/png': pngBlob() }),
+					makeClipboardItem({ 'image/png': pngBlob() }),
+					makeClipboardItem({ 'image/png': pngBlob() }),
+				],
+				clipboardPasteSource: 'clipboard-read',
+			})
+		).rejects.toThrow('Too many files')
+
+		expect(spy).not.toHaveBeenCalled()
+	})
+})
+
+describe('pasting non-file content from the clipboard API', () => {
+	it('pastes tldraw content over html and text', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({ 'text/html': TLDRAW_V2_HTML, 'text/plain': 'hello' }),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({
+			type: 'tldraw',
+			content: { shapes: [] },
+		})
+	})
+
+	it('pastes excalidraw content found in plain text', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					'text/plain': JSON.stringify({ type: 'excalidraw/clipboard', elements: [] }),
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({
+			type: 'excalidraw',
+			content: { type: 'excalidraw/clipboard' },
+		})
+	})
+
+	it('pastes html alongside plain text as a text shape with html', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({ 'text/html': '<b>hello</b>', 'text/plain': 'hello' }),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({
+			type: 'text',
+			text: 'hello',
+			html: '<b>hello</b>',
+		})
+	})
+
+	it('pastes html on its own as stripped text', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'text/html': '<b>hello</b>' })],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'text', text: 'hello' })
+	})
+
+	it('pastes html containing a single link as a url', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({ 'text/html': '<a href="https://example.com/">Example</a>' }),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'url', url: 'https://example.com/' })
+	})
+
+	it('pastes a uri-list as a url', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'text/uri-list': 'https://example.com/' })],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'url', url: 'https://example.com/' })
+	})
+
+	it('pastes a plain text url as a url', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'text/plain': 'https://example.com/' })],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'url', url: 'https://example.com/' })
+	})
+
+	it('pastes svg text as svg', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({ 'text/plain': '<svg xmlns="http://www.w3.org/2000/svg"></svg>' }),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'svg-text' })
+	})
+
+	it('pastes plain text as text', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'text/plain': 'hello' })],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'text', text: 'hello' })
+	})
+})
+
+describe('pasting from native event clipboard data', () => {
+	it('passes html and text sources along with pasted files', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromEventClipboardData(
+			editor,
+			makeDataTransfer([
+				{ kind: 'file', type: 'image/png', file: pngFile() },
+				{ kind: 'string', type: 'text/html', data: '<b>hello</b>' },
+				{ kind: 'string', type: 'text/plain', data: 'hello' },
+			])
+		)
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		const content = spy.mock.calls[0][0] as TLFilesExternalContent
+		expect(content.type).toBe('files')
+		expect(content.files[0].name).toBe('image.png')
+		expect(content.sources).toEqual([
+			{ type: 'text', data: '<b>hello</b>', subtype: 'html' },
+			{ type: 'text', data: 'hello', subtype: 'text' },
+		])
+	})
+
+	it('pastes plain text as text', async () => {
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromEventClipboardData(
+			editor,
+			makeDataTransfer([{ kind: 'string', type: 'text/plain', data: 'hello' }])
+		)
+
+		expect(spy).toHaveBeenCalledTimes(1)
+		expect(spy.mock.calls[0][0]).toMatchObject({ type: 'text', text: 'hello' })
+	})
+
+	it('does nothing while editing a shape', async () => {
+		const spy = mockPutExternalContent()
+		const editingSpy = vi
+			.spyOn(editor, 'getEditingShapeId')
+			.mockReturnValue(editor.testShapeID('editing'))
+
+		await handlePasteFromEventClipboardData(
+			editor,
+			makeDataTransfer([{ kind: 'string', type: 'text/plain', data: 'hello' }])
+		)
+
+		expect(spy).not.toHaveBeenCalled()
+		editingSpy.mockRestore()
+	})
+})
+
+describe('sources in external content handlers and callbacks', () => {
+	it('provides sources to a registered files handler', async () => {
+		const handled: TLExternalContent<unknown>[] = []
+		editor.registerExternalContentHandler('files', async (content) => {
+			handled.push(content)
+		})
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					'image/png': pngBlob(),
+					'text/html': '<span data-custom="true">hello</span>',
+					'text/plain': 'hello',
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(handled).toHaveLength(1)
+		const content = handled[0] as TLFilesExternalContent
+		const htmlSource = content.sources?.find((s) => s.type === 'text' && s.subtype === 'html')
+		expect(htmlSource).toEqual({
+			type: 'text',
+			data: '<span data-custom="true">hello</span>',
+			subtype: 'html',
+		})
+	})
+
+	it('provides sources to onBeforePasteFromClipboard for file pastes', async () => {
+		const hookFn = vi.fn(() => undefined)
+		editor.dispose()
+		editor = new TestEditor({ options: { onBeforePasteFromClipboard: hookFn } })
+		mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [
+				makeClipboardItem({
+					'image/png': pngBlob(),
+					'text/html': '<b>hello</b>',
+					'text/plain': 'hello',
+				}),
+			],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(hookFn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				editor,
+				source: 'clipboard-read',
+				content: expect.objectContaining({
+					type: 'files',
+					sources: [
+						{ type: 'text', data: '<b>hello</b>', subtype: 'html' },
+						{ type: 'text', data: 'hello', subtype: 'text' },
+					],
+				}),
+			})
+		)
+	})
+
+	it('cancels a file paste when onBeforePasteFromClipboard returns false', async () => {
+		editor.dispose()
+		editor = new TestEditor({ options: { onBeforePasteFromClipboard: () => false } })
+		const spy = mockPutExternalContent()
+
+		await handlePasteFromClipboardApi({
+			editor,
+			clipboardItems: [makeClipboardItem({ 'image/png': pngBlob() })],
+			clipboardPasteSource: 'clipboard-read',
+		})
+
+		expect(spy).not.toHaveBeenCalled()
+	})
+})


### PR DESCRIPTION
In order to let apps create custom shapes from clipboard data that carries several content types at once — an SDK user copies an image together with html and plain text, and needs the html to decide whether the paste is their custom content — this PR passes the text, html, and url sources found on the clipboard through to file pastes. Closes #9761.

Previously, when a paste contained a file, the clipboard handler pasted only the file and discarded everything else before any customization point could see it. External content already has an optional `sources` field carrying the accompanying clipboard content (text pastes populate it today), but file pastes always left it empty — so neither a registered `files` handler nor `onBeforePasteFromClipboard` could see the html or text copied alongside an image. Now the non-file clipboard content is resolved into sources first and handed to the files paste, with the paste priority unchanged (files still win). No new API surface; a `files` handler can now do:

```ts
editor.registerExternalContentHandler('files', async (content) => {
	const html = content.sources?.find((s) => s.type === 'text' && s.subtype === 'html')
	if (html && isMyCustomData(html.data)) return createMyCustomShape(editor, content)
	await defaultHandleExternalFileContent(editor, content)
})
```

This works identically for native paste events and async `navigator.clipboard.read()` pastes, since tldraw awaits the source reads before invoking the handler.

Two smaller changes fell out of review:

- A clipboard read that rejects (e.g. a flaky `ClipboardItem.getType()`) now resolves to an `error` source instead of stalling the paste — previously a file paste short-circuited before those reads, so the reorder would otherwise have turned a rejected read into a silently dropped paste.
- New tests cover the paste dispatch pipeline for both paste paths (something we had no coverage for): source passthrough, content priority (tldraw > excalidraw > html > url > text), the custom png format preference and empty-blob fallback, Safari fallback files, and `maxFilesAtOnce`. To support this, the two internal paste entry points are now exported (still `@internal`).

### Change type

- [x] `improvement`

### Test plan

1. Copy an image together with html and plain text to the clipboard (e.g. copy a portion of a web page, or write all three types with `navigator.clipboard.write`).
2. Register a `files` external content handler and paste with cmd+V and with the context menu.
3. The handler's `content.sources` contains the html and plain text alongside the file.

Verified manually in Safari on both paste routes (cmd+V and menu paste), since file pasting now waits for the clipboard source reads to settle before running — pastes complete promptly and `sources` is populated as expected.

- [x] Unit tests

### Release notes

- Pasted files now include the text, html, and url content found on the clipboard alongside them in the `sources` field of the external content, so custom `files` handlers and `onBeforePasteFromClipboard` can inspect them.

### API changes

- `TLBaseExternalContent.sources` is now documented and populated for file pastes (previously always undefined for files).

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +42 / -31  |
| Tests           | +544 / -0  |
| Automated files | +0 / -1    |

