### PR TITLE
fix(dotcom): don't notify about comments on soft-deleted files

### DIFF
--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -79,6 +79,9 @@ export const queries = defineQueries({
 			// TLComment.isDeleted) but must never surface as notifications
 			.where('isDeleted', '=', false)
 			.whereExists('thread', (t) => t.where('isDeleted', '=', false))
+			// same for soft-deleted boards: their comment rows persist, but a notification would
+			// navigate to a file the user can no longer open
+			.whereExists('file', (f) => f.where('isDeleted', '=', false))
 			.where(({ and, or, exists }) =>
 				or(
 					// on a board the user owns


### PR DESCRIPTION
In order to stop notifications pointing at boards the user can no longer open, this PR gates the notifications `comments` query on the file being live. Soft-deleted boards keep their rows (and their comment rows) in Postgres, and every `exists('file', …)` access branch in the query checked ownership or membership but not `isDeleted` — so owners and collaborators kept receiving notifications that navigated to inaccessible files.

The fix follows the query's existing pattern: a top-level `whereExists('file', isDeleted = false)` gate next to the equivalent thread gate, covering all three access branches in one place.

Surfaced by Bugbot on #9471 (https://github.com/tldraw/tldraw/pull/9471#discussion_r3675616977).

### Change type

- [x] `bugfix`

### Test plan

1. Comment on a shared file as user A, with user B a collaborator (has opened the file).
2. As the owner, delete the file.
3. User B's notifications no longer include comments from that file.

- [ ] Unit tests

### Release notes

- Fix comment notifications still appearing for deleted files.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Core code | +3 / -0  |