### PR TITLE
refactor(sync): return an explicit verdict from record authorizers

### DIFF
--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.test.ts
@@ -1,5 +1,6 @@
+import type { UnknownRecord } from '@tldraw/store'
+import type { TLRecordAuthorizer, TLRecordAuthorizerArgs } from '@tldraw/sync-core'
 import {
-	TLComment,
 	TLNoteShape,
 	TLPageId,
 	TLShape,
@@ -15,6 +16,26 @@ const pageId = 'page:test' as TLPageId
 
 function session(userId: string | null): { sessionId: string; meta: SessionMeta } {
 	return { sessionId: 's1', meta: { storeId: 'store', userId } }
+}
+
+/** The `allow`/`deny` helpers the room hands to every authorizer. */
+const helpers = {
+	allow: (record?: any) =>
+		record ? { allowed: true as const, record } : { allowed: true as const },
+	deny: () => ({ allowed: false as const }),
+}
+
+/**
+ * Call an authorizer the way the room does, and flatten its verdict to the record that would be
+ * stored, or `null` when denied.
+ */
+function authorizing<Rec extends UnknownRecord>(authorize: TLRecordAuthorizer<Rec, SessionMeta>) {
+	type Write = Omit<TLRecordAuthorizerArgs<Rec, SessionMeta>, 'allow' | 'deny'>
+	return (write: Write): Rec | null => {
+		const result = authorize({ ...write, ...helpers } as TLRecordAuthorizerArgs<Rec, SessionMeta>)
+		if (!result.allowed) return null
+		return result.record ?? write.next ?? write.prev
+	}
 }
 
 describe('authorizeFileRecord', () => {
@@ -34,18 +55,18 @@ describe('authorizeFileRecord', () => {
 				authorId: 'client-claims-alice',
 				body: toRichText('hi'),
 			})
-			const result = authorizeFileRecord.comment!({
+			const result = authorizing(authorizeFileRecord.comment!)({
 				session: session('real-bob'),
 				type: 'create',
 				prev: null,
 				next,
-			}) as TLComment
-			expect(result.authorId).toBe('real-bob')
+			})
+			expect(result?.authorId).toBe('real-bob')
 		})
 
 		it('vetoes thread hard-deletes (deletion is soft)', () => {
 			expect(
-				authorizeFileRecord['comment-thread']!({
+				authorizing(authorizeFileRecord['comment-thread']!)({
 					session: session('real-bob'),
 					type: 'delete',
 					prev: thread,
@@ -56,7 +77,7 @@ describe('authorizeFileRecord', () => {
 	})
 
 	describe('shape', () => {
-		const authorize = authorizeFileRecord.shape!
+		const authorize = authorizing(authorizeFileRecord.shape!)
 
 		function makeNote(textLastEditedBy: string | null): TLNoteShape {
 			return {

--- a/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
+++ b/apps/dotcom/sync-worker/src/authorizeFileRecord.ts
@@ -42,13 +42,15 @@ const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({
 	type,
 	prev,
 	next,
+	allow,
+	deny,
 }) => {
-	if (type === 'delete') return prev
+	if (type === 'delete') return allow()
 	// On create there's no prior attribution; on update an unchanged attribution is always allowed.
 	const before = type === 'create' ? null : getNoteAttribution(prev)
 	const after = getNoteAttribution(next)
-	if (after !== before && after != null && after !== session.meta.userId) return null
-	return next
+	if (after !== before && after != null && after !== session.meta.userId) return deny()
+	return allow()
 }
 
 /**

--- a/packages/sync-collaboration/src/comment-authorizers.test.ts
+++ b/packages/sync-collaboration/src/comment-authorizers.test.ts
@@ -1,3 +1,5 @@
+import type { UnknownRecord } from '@tldraw/store'
+import type { TLRecordAuthorizer, TLRecordAuthorizerArgs } from '@tldraw/sync-core'
 import {
 	TLComment,
 	TLCommentReaction,
@@ -20,6 +22,32 @@ interface TestMeta {
 const authorizers = createCommentAuthorizers<TestMeta>({
 	getUserId: (session) => session.meta.userId,
 })
+
+/** The `allow`/`deny` helpers the room hands to every authorizer. */
+const helpers = {
+	allow: (record?: any) =>
+		record ? { allowed: true as const, record } : { allowed: true as const },
+	deny: () => ({ allowed: false as const }),
+}
+
+/** The write to authorize, without the helpers the room supplies. */
+type Write<Rec extends UnknownRecord> = Omit<
+	TLRecordAuthorizerArgs<Rec, TestMeta>,
+	'allow' | 'deny'
+>
+
+/**
+ * Call an authorizer the way the room does, and flatten its verdict to the record that would be
+ * stored, or `null` when denied — so each test reads as one write in, one outcome out.
+ */
+function authorizing<Rec extends UnknownRecord>(authorize: TLRecordAuthorizer<Rec, TestMeta>) {
+	return (write: Write<Rec>): Rec | null => {
+		const result = authorize({ ...write, ...helpers } as TLRecordAuthorizerArgs<Rec, TestMeta>)
+		if (!result.allowed) return null
+		// create: the stamped record, if the authorizer passed one; update/delete: allow/veto only
+		return result.record ?? write.next ?? write.prev
+	}
+}
 
 const pageId = 'page:test' as TLPageId
 const thread = createCommentThread({
@@ -48,13 +76,36 @@ describe('createCommentAuthorizers', () => {
 		const prev = createCommentThread({ pageId, anchor: { type: 'page' }, createdBy: 'real-bob' })
 		const next = { ...prev, resolved: { at: 1, by: 'real-bob' }, isDeleted: true }
 		expect(
-			counted['comment-thread']!({ session: session('real-bob'), type: 'update', prev, next })
+			authorizing(counted['comment-thread']!)({
+				session: session('real-bob'),
+				type: 'update',
+				prev,
+				next,
+			})
 		).toBe(next)
 		expect(calls).toBe(1)
 	})
 
-	describe('comment', () => {
+	// The rest of the suite flattens verdicts through `authorizing`; this pins the shape itself, so
+	// a rule that returned a bare record (or nothing) would be caught here as well as by the compiler.
+	it('returns a discriminated verdict, carrying the stamped record on create', () => {
 		const authorize = authorizers.comment!
+		const next = createComment({
+			threadId: thread.id,
+			pageId,
+			authorId: 'client-claims-alice',
+			body: toRichText('hi'),
+		})
+		expect(
+			authorize({ ...helpers, session: session('real-bob'), type: 'create', prev: null, next })
+		).toEqual({ allowed: true, record: { ...next, authorId: 'real-bob' } })
+		expect(
+			authorize({ ...helpers, session: session(null), type: 'create', prev: null, next })
+		).toEqual({ allowed: false })
+	})
+
+	describe('comment', () => {
+		const authorize = authorizing(authorizers.comment!)
 		const comment = (authorId: string) =>
 			createComment({ threadId: thread.id, pageId, authorId, body: toRichText('hi') })
 
@@ -160,7 +211,7 @@ describe('createCommentAuthorizers', () => {
 	})
 
 	describe('comment-thread', () => {
-		const authorize = authorizers['comment-thread']!
+		const authorize = authorizing(authorizers['comment-thread']!)
 		const makeThread = (createdBy: string) =>
 			createCommentThread({ pageId, anchor: { type: 'page' }, createdBy })
 
@@ -270,7 +321,7 @@ describe('createCommentAuthorizers', () => {
 	// guards cover forging (userId is stamped from the session) and tampering (owner-only update).
 	// Crucially there is no shared field, so one person's write can't reach another's reaction.
 	describe('comment-reaction', () => {
-		const authorize = authorizers['comment-reaction']!
+		const authorize = authorizing(authorizers['comment-reaction']!)
 		const makeReaction = (userId: string, emoji = '👍') =>
 			createCommentReaction({
 				commentId: createCommentId('c1'),

--- a/packages/sync-collaboration/src/comment-authorizers.ts
+++ b/packages/sync-collaboration/src/comment-authorizers.ts
@@ -1,5 +1,10 @@
 import type { UnknownRecord } from '@tldraw/store'
-import type { TLRecordAuthorizer, TLRecordAuthorizers } from '@tldraw/sync-core'
+import type {
+	TLRecordAuthorizer,
+	TLRecordAuthorizerArgs,
+	TLRecordAuthorizerResult,
+	TLRecordAuthorizers,
+} from '@tldraw/sync-core'
 import {
 	createCommentReactionId,
 	type TLComment,
@@ -67,8 +72,8 @@ export function createCommentAuthorizers<SessionMeta>(
 	/** A rule is an authorizer that receives the session's user id, resolved for it exactly once. */
 	type Rule<Rec extends UnknownRecord> = (
 		userId: string | null,
-		args: Parameters<TLRecordAuthorizer<Rec, SessionMeta>>[0]
-	) => Rec | null
+		args: TLRecordAuthorizerArgs<Rec, SessionMeta>
+	) => TLRecordAuthorizerResult<Rec>
 
 	/** Adapt a rule to the authorizer signature, resolving the session's user id exactly once. */
 	function withUserId<Rec extends UnknownRecord>(
@@ -85,17 +90,17 @@ export function createCommentAuthorizers<SessionMeta>(
 		field: keyof Rec & string,
 		{ ownerOnlyUpdate = false } = {}
 	): Rule<Rec> {
-		return (userId, { type, prev, next }) => {
+		return (userId, { type, prev, next, allow, deny }) => {
 			if (type === 'create') {
-				if (!userId) return null // no identity to attribute → reject
-				return { ...next, [field]: userId } as Rec
+				if (!userId) return deny() // no identity to attribute → reject
+				return allow({ ...next, [field]: userId } as Rec)
 			}
 			if (type === 'update') {
-				if (next[field] !== prev[field]) return null // attribution is immutable
-				if (ownerOnlyUpdate && userId !== prev[field]) return null // only the author edits
-				return next
+				if (next[field] !== prev[field]) return deny() // attribution is immutable
+				if (ownerOnlyUpdate && userId !== prev[field]) return deny() // only the author edits
+				return allow()
 			}
-			return prev
+			return allow()
 		}
 	}
 
@@ -111,16 +116,17 @@ export function createCommentAuthorizers<SessionMeta>(
 		base: Rule<Rec>
 	): Rule<Rec> {
 		return (userId, args) => {
-			if (args.type === 'delete') return null
+			const { deny } = args
+			if (args.type === 'delete') return deny()
 			const result = base(userId, args)
-			if (!result) return null
+			if (!result.allowed) return result
 			// A record can't be born deleted — that would smuggle a deletion past the update checks.
-			if (args.type === 'create' && args.next.isDeleted) return null
+			if (args.type === 'create' && args.next.isDeleted) return deny()
 			if (args.type === 'update') {
 				const { prev, next } = args
 				if (prev.isDeleted !== next.isDeleted) {
-					if (prev.isDeleted) return null // write-once: never cleared
-					if (userId !== ownerOf(prev)) return null // only the owner deletes
+					if (prev.isDeleted) return deny() // write-once: never cleared
+					if (userId !== ownerOf(prev)) return deny() // only the owner deletes
 				}
 			}
 			return result
@@ -133,18 +139,19 @@ export function createCommentAuthorizers<SessionMeta>(
 	 * session's own user.
 	 */
 	const authorizeThreadResolution: Rule<TLCommentThread> = (userId, args) => {
+		const { deny } = args
 		const result = authorizeAuthored<TLCommentThread>('createdBy')(userId, args)
-		if (!result) return null
+		if (!result.allowed) return result
 		if (args.type === 'create') {
 			// Delete + re-put could otherwise smuggle in a resolution forged in someone else's name.
 			const { next } = args
-			if (next.resolved && next.resolved.by !== userId) return null
+			if (next.resolved && next.resolved.by !== userId) return deny()
 		}
 		if (args.type === 'update') {
 			const { prev, next } = args
 			const changed =
 				prev.resolved?.at !== next.resolved?.at || prev.resolved?.by !== next.resolved?.by
-			if (changed && next.resolved && next.resolved.by !== userId) return null
+			if (changed && next.resolved && next.resolved.by !== userId) return deny()
 		}
 		return result
 	}
@@ -163,9 +170,9 @@ export function createCommentAuthorizers<SessionMeta>(
 	): Rule<Rec> {
 		return (userId, args) => {
 			if (args.type === 'update') {
-				const { prev, next } = args
+				const { prev, next, deny } = args
 				for (const field of fields) {
-					if (next[field] !== prev[field]) return null
+					if (next[field] !== prev[field]) return deny()
 				}
 			}
 			return base(userId, args)
@@ -194,28 +201,29 @@ export function createCommentAuthorizers<SessionMeta>(
 	 *   So the id and the fields it is derived from can never drift apart.
 	 */
 	const authorizeReaction: Rule<TLCommentReaction> = (userId, args) => {
+		const { allow, deny } = args
 		// Only the reactor may remove their own reaction. Cascades still sweep every reactor's
 		// records because server-initiated writes carry no session and so skip authorizers
 		// entirely — an open client delete was never what made the sweep work.
 		if (args.type === 'delete') {
-			return userId && userId === args.prev.userId ? args.prev : null
+			return userId && userId === args.prev.userId ? allow() : deny()
 		}
 		const result = authorizeReactionBase(userId, args)
-		if (!result) return null
+		if (!result.allowed) return result
 		if (args.type === 'create') {
 			// Unreachable: the base rule already rejected identity-less creates. Checked to narrow.
-			if (!userId) return null
+			if (!userId) return deny()
 			const { next } = args
 			if (next.id !== createCommentReactionId(next.commentId, userId, next.emoji)) {
-				return null
+				return deny()
 			}
 		}
 		if (args.type === 'update') {
 			const { prev, next } = args
-			if (next.commentId !== prev.commentId) return null
-			if (next.threadId !== prev.threadId) return null
-			if (next.pageId !== prev.pageId) return null
-			if (next.emoji !== prev.emoji) return null
+			if (next.commentId !== prev.commentId) return deny()
+			if (next.threadId !== prev.threadId) return deny()
+			if (next.pageId !== prev.pageId) return deny()
+			if (next.emoji !== prev.emoji) return deny()
 		}
 		return result
 	}

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -444,7 +444,12 @@ export interface TLPushRequest<R extends UnknownRecord> {
 }
 
 // @public
-export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: {
+export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: TLRecordAuthorizerArgs<Rec, SessionMeta>) => TLRecordAuthorizerResult<Rec>;
+
+// @public
+export type TLRecordAuthorizerArgs<Rec extends UnknownRecord, SessionMeta> = {
+    allow(record?: Rec): TLRecordAuthorizerResult<Rec>;
+    deny(): TLRecordAuthorizerResult<Rec>;
     session: {
         meta: SessionMeta;
         sessionId: string;
@@ -461,7 +466,15 @@ export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (args: 
     next: Rec;
     prev: Rec;
     type: 'update';
-})) => null | Rec;
+});
+
+// @public
+export type TLRecordAuthorizerResult<Rec extends UnknownRecord> = {
+    record?: Rec;
+    allowed: true;
+} | {
+    allowed: false;
+};
 
 // @public
 export type TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> = {

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -71,6 +71,8 @@ export {
 	type PresenceStore,
 	type RoomSnapshot,
 	type TLRecordAuthorizer,
+	type TLRecordAuthorizerArgs,
+	type TLRecordAuthorizerResult,
 	type TLRecordAuthorizers,
 	type TLRoomSocket,
 } from './lib/TLSyncRoom'

--- a/packages/sync-core/src/lib/TLSyncRoom.ts
+++ b/packages/sync-core/src/lib/TLSyncRoom.ts
@@ -122,6 +122,46 @@ export interface RoomSnapshot {
 }
 
 /**
+ * The verdict a {@link TLRecordAuthorizer} returns: allow the write (optionally rewriting the
+ * record on create) or deny it. Build one with the `allow` and `deny` helpers handed to the
+ * authorizer in {@link TLRecordAuthorizerArgs} rather than by hand.
+ *
+ * @public
+ */
+export type TLRecordAuthorizerResult<Rec extends UnknownRecord> =
+	| {
+			allowed: true
+			/**
+			 * The record to store, on **create** only. Omitted means "store the pushed record as-is";
+			 * on update and delete it is ignored (those are allow-vs-deny only).
+			 */
+			record?: Rec
+	  }
+	| { allowed: false }
+
+/**
+ * The argument a {@link TLRecordAuthorizer} is called with: the write being authorized, the session
+ * making it, and the `allow`/`deny` helpers for returning a verdict.
+ *
+ * @public
+ */
+export type TLRecordAuthorizerArgs<Rec extends UnknownRecord, SessionMeta> = {
+	/** The session performing the write, including its host-provided `meta` (e.g. the authenticated user id). */
+	session: { sessionId: string; meta: SessionMeta }
+	/**
+	 * Allow the write. On **create**, pass a record to store it instead of the pushed one — that's
+	 * where you stamp identity fields. On update and delete, call it with no argument.
+	 */
+	allow(record?: Rec): TLRecordAuthorizerResult<Rec>
+	/** Deny the write: it's skipped, and the client self-corrects. */
+	deny(): TLRecordAuthorizerResult<Rec>
+} & (
+	| { type: 'create'; prev: null; next: Rec }
+	| { type: 'update'; prev: Rec; next: Rec }
+	| { type: 'delete'; prev: Rec; next: null }
+)
+
+/**
  * Authorizes a single record write from a client: any per-record, per-session rule the host wants
  * to enforce server-side — veto writes the session isn't allowed to make, or rewrite the record on
  * create. The session's `meta` carries whatever the rule needs (identity, roles, …); for example,
@@ -132,37 +172,40 @@ export interface RoomSnapshot {
  *
  * `prev` and `next` are always at the **server's** schema version: client writes are migrated
  * before the authorizer runs, so guarding or stamping a field never requires knowing what older
- * clients call it. On create, the record you return is what gets stored (after validation) — no
+ * clients call it. On create, the record you allow is what gets stored (after validation) — no
  * migration runs afterwards, so stamped fields can't be clobbered.
  *
- * Return `null` to reject the write — it's skipped and the client self-corrects, exactly like the
- * `objectAccess` gate. Otherwise the write is allowed, and:
+ * Return `deny()` to reject the write — it's skipped and the client self-corrects, exactly like the
+ * `objectAccess` gate. Return `allow()` to let it through, and:
  *
- * - on **create**, the record you return is what gets stored, so stamp identity fields here (e.g.
- *   set `authorId` from `session.meta`);
- * - on **update** and **delete**, only allow-vs-reject is used (the returned record's contents are
- *   ignored), so use them to veto changes to immutable fields or unauthorized deletes — return
- *   `next`/`prev` to allow, `null` to reject.
+ * - on **create**, `allow(record)` stores `record` instead of the pushed one, so stamp identity
+ *   fields here (e.g. set `authorId` from `session.meta`); bare `allow()` stores the pushed record;
+ * - on **update** and **delete**, only allow-vs-deny is used (a record passed to `allow` is
+ *   ignored), so use them to veto changes to immutable fields or unauthorized deletes.
+ *
+ * @example
+ * ```ts
+ * const authorizeComment: TLRecordAuthorizer<TLComment, SessionMeta> = (args) => {
+ * 	const userId = args.session.meta.userId
+ * 	if (!userId) return args.deny()
+ * 	// stamp authorship on create, and keep it immutable afterwards
+ * 	if (args.type === 'create') return args.allow({ ...args.next, authorId: userId })
+ * 	return args.prev.authorId === userId ? args.allow() : args.deny()
+ * }
+ * ```
  *
  * ⚠︎ Runs synchronously inside the commit transaction, on the same path as every document edit — it
  * must be fast and do **no** I/O. `next`/`prev` are client-controlled records, so treat their
- * contents as untrusted; prefer returning `null` to reject over throwing, though a throw is
- * caught, logged, and treated as a rejection (fail closed) rather than crashing the push. For
- * expensive, async checks (e.g. resolving mentions against who can access a file), react after the
- * fact via `onCommittedChanges`.
+ * contents as untrusted; prefer returning `deny()` over throwing, though a throw is caught, logged,
+ * and treated as a denial (fail closed) rather than crashing the push — as is anything returned
+ * that isn't an explicit `allow()`. For expensive, async checks (e.g. resolving mentions against
+ * who can access a file), react after the fact via `onCommittedChanges`.
  *
  * @public
  */
 export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (
-	args: {
-		/** The session performing the write, including its host-provided `meta` (e.g. the authenticated user id). */
-		session: { sessionId: string; meta: SessionMeta }
-	} & (
-		| { type: 'create'; prev: null; next: Rec }
-		| { type: 'update'; prev: Rec; next: Rec }
-		| { type: 'delete'; prev: Rec; next: null }
-	)
-) => Rec | null
+	args: TLRecordAuthorizerArgs<Rec, SessionMeta>
+) => TLRecordAuthorizerResult<Rec>
 
 /**
  * A map from record `typeName` to a {@link TLRecordAuthorizer} for that record type. Only listed
@@ -180,6 +223,24 @@ export type TLRecordAuthorizer<Rec extends UnknownRecord, SessionMeta> = (
  */
 export type TLRecordAuthorizers<R extends UnknownRecord, SessionMeta> = {
 	[K in R['typeName']]?: TLRecordAuthorizer<Extract<R, { typeName: K }>, SessionMeta>
+}
+
+// Frozen because they're handed out to (untrusted) host authorizers on every write: a verdict
+// mutated in place would leak into the next one, and these decide whether a write commits.
+const ALLOWED = Object.freeze({ allowed: true } as const)
+const DENIED = Object.freeze({ allowed: false } as const)
+
+/**
+ * The `allow`/`deny` helpers handed to every authorizer. Shared and stateless, so authorizing a
+ * write allocates a verdict only when the authorizer rewrites the record.
+ */
+const authorizerHelpers = {
+	allow<Rec extends UnknownRecord>(record?: Rec): TLRecordAuthorizerResult<Rec> {
+		return record ? { allowed: true, record } : ALLOWED
+	},
+	deny(): TLRecordAuthorizerResult<never> {
+		return DENIED
+	},
 }
 
 /**
@@ -328,10 +389,13 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 		// write through.
 		return (args) => {
 			try {
-				return authorize(args)
+				// Anything that isn't an explicit allow is a denial: a JS host that returns nothing
+				// (or something malformed) must not commit the write.
+				const result = authorize(args)
+				return result?.allowed ? result : DENIED
 			} catch (e) {
 				this.log?.error?.('record authorizer threw; rejecting the write', e)
-				return null
+				return DENIED
 			}
 		}
 	}
@@ -1369,22 +1433,25 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 									const authorizePut = this.authorizerFor(record.typeName)
 									if (authorizePut) {
 										authorize = (prevRec, next) => {
+											const authorizedSession = { sessionId: session.sessionId, meta: session.meta }
 											const result = authorizePut(
 												prevRec
 													? {
-															session: { sessionId: session.sessionId, meta: session.meta },
+															...authorizerHelpers,
+															session: authorizedSession,
 															type: 'update',
 															prev: prevRec,
 															next,
 														}
 													: {
-															session: { sessionId: session.sessionId, meta: session.meta },
+															...authorizerHelpers,
+															session: authorizedSession,
 															type: 'create',
 															prev: null,
 															next,
 														}
 											)
-											if (!result) {
+											if (!result.allowed) {
 												this.log?.warn?.(
 													'authorizer vetoed put',
 													record.typeName,
@@ -1394,8 +1461,9 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 												)
 												return null
 											}
-											// create: store the stamped record; update: allow/veto only
-											return prevRec ? next : result
+											// create: store the record the authorizer allowed (stamped, if it passed
+											// one); update: allow/veto only
+											return prevRec ? next : (result.record ?? next)
 										}
 									}
 								}
@@ -1413,12 +1481,13 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								const authorize = authorizePatch
 									? (prev: R, next: R) => {
 											const result = authorizePatch({
+												...authorizerHelpers,
 												session: { sessionId: session.sessionId, meta: session.meta },
 												type: 'update',
 												prev,
 												next,
 											})
-											if (!result) {
+											if (!result.allowed) {
 												this.log?.warn?.(
 													'authorizer vetoed patch',
 													doc.typeName,
@@ -1426,8 +1495,9 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 													'session:',
 													session.sessionId
 												)
+												return null
 											}
-											return result
+											return next
 										}
 									: undefined
 								// Try to patch the document. If it fails, stop here.
@@ -1447,11 +1517,12 @@ export class TLSyncRoom<R extends UnknownRecord, SessionMeta> {
 								if (
 									authorizeRemove &&
 									!authorizeRemove({
+										...authorizerHelpers,
 										session: { sessionId: session.sessionId, meta: session.meta },
 										type: 'delete',
 										prev: doc,
 										next: null,
-									})
+									}).allowed
 								) {
 									this.log?.warn?.(
 										'authorizer vetoed delete',

--- a/packages/sync-core/src/test/objectStore.test.ts
+++ b/packages/sync-core/src/test/objectStore.test.ts
@@ -89,6 +89,8 @@ function makeRoom(
 				type: 'create' | 'update' | 'delete'
 				prev: any
 				next: any
+				allow(record?: any): any
+				deny(): any
 			}) => any
 		}
 		log?: any
@@ -399,21 +401,21 @@ describe('object store lane', () => {
 
 	describe('authorizeRecord', () => {
 		it('rejects a presence typeName key at construction', () => {
-			expect(() => makeRoom({ authorizeRecord: { presence: ({ next }: any) => next } })).toThrow(
-				/presence/
-			)
+			expect(() =>
+				makeRoom({ authorizeRecord: { presence: ({ allow }: any) => allow() } })
+			).toThrow(/presence/)
 		})
 
 		// A per-type authorizer like dotcom's: stamp the note's text from the session's user id on
 		// create, keep it immutable on update, allow deletes.
-		const authorizeNote = ({ session, type, prev, next }: any) => {
+		const authorizeNote = ({ session, type, prev, next, allow, deny }: any) => {
 			if (type === 'create') {
 				const userId = session.meta?.userId
-				if (!userId) return null
-				return { ...next, text: `by:${userId}` }
+				if (!userId) return deny()
+				return allow({ ...next, text: `by:${userId}` })
 			}
-			if (type === 'update') return next.text === prev.text ? next : null
-			return prev // delete allowed
+			if (type === 'update') return next.text === prev.text ? allow() : deny()
+			return allow() // delete allowed
 		}
 
 		function withNote(authorize: any, extra: any = {}) {
@@ -452,7 +454,7 @@ describe('object store lane', () => {
 			expect(storedNote(storage, note.id)?.text).toBe('by:user-alice')
 		})
 
-		it('rejects a create the authorizer denies (returns null)', () => {
+		it('rejects a create the authorizer denies', () => {
 			const { room, storage } = withNote(authorizeNote)
 			const socket = connectSession(room, 'anon', { meta: { userId: null } })
 
@@ -466,9 +468,9 @@ describe('object store lane', () => {
 
 		it('only runs for registered types — other records write through untouched', () => {
 			const seen: string[] = []
-			const { room, storage } = withNote(({ next }: any) => {
+			const { room, storage } = withNote(({ allow }: any) => {
 				seen.push('note')
-				return next
+				return allow()
 			})
 			connectSession(room, 'writer', { meta: { userId: 'u' } })
 
@@ -484,7 +486,8 @@ describe('object store lane', () => {
 			const { room, storage } = makeRoom({
 				objectTypes: ['note'],
 				authorizeRecord: {
-					doc: ({ type, next }: any) => (type === 'create' ? { ...next, title: 'stamped' } : next),
+					doc: ({ type, next, allow }: any) =>
+						type === 'create' ? allow({ ...next, title: 'stamped' }) : allow(),
 				},
 			})
 			connectSession(room, 'writer', { meta: { userId: 'u' } })
@@ -510,9 +513,7 @@ describe('object store lane', () => {
 		})
 
 		it('allows an update the authorizer permits (patch)', () => {
-			const { room, storage, note } = seededWithNote(({ type, prev, next }: any) =>
-				type === 'delete' ? prev : next
-			)
+			const { room, storage, note } = seededWithNote(({ allow }: any) => allow())
 			connectSession(room, 'alice', { meta: { userId: 'u' } })
 
 			push(room, 'alice', {
@@ -523,7 +524,7 @@ describe('object store lane', () => {
 		})
 
 		it('does not consult the authorizer for a no-op patch', () => {
-			const authorize = vi.fn(({ type, prev, next }: any) => (type === 'delete' ? prev : next))
+			const authorize = vi.fn(({ allow }: any) => allow())
 			const { room, note } = seededWithNote(authorize)
 			connectSession(room, 'alice', { meta: { userId: 'u' } })
 			authorize.mockClear()
@@ -536,8 +537,8 @@ describe('object store lane', () => {
 		})
 
 		it('vetoes a delete the authorizer rejects', () => {
-			const { room, storage, note } = seededWithNote(({ type, next }: any) =>
-				type === 'delete' ? null : next
+			const { room, storage, note } = seededWithNote(({ type, allow, deny }: any) =>
+				type === 'delete' ? deny() : allow()
 			)
 			const socket = connectSession(room, 'mallory', { meta: { userId: 'm' } })
 
@@ -600,16 +601,28 @@ describe('object store lane', () => {
 			expect(storedNote(storage, note.id)?.text).toBe('by:user-alice')
 		})
 
-		it('ignores the record returned by an update authorizer (allow/veto only)', () => {
-			const { room, storage, note } = seededWithNote(({ type, prev, next }: any) => {
-				if (type === 'update') return { ...next, text: 'stamped-on-update' }
-				return type === 'delete' ? prev : next
+		it('ignores the record an update authorizer allows (allow/veto only)', () => {
+			const { room, storage, note } = seededWithNote(({ type, next, allow }: any) => {
+				if (type === 'update') return allow({ ...next, text: 'stamped-on-update' })
+				return allow()
 			})
 			connectSession(room, 'alice', { meta: { userId: 'u' } })
 
 			push(room, 'alice', { [note.id]: [RecordOpType.Put, { ...note, text: 'edited' }] })
 
 			expect(storedNote(storage, note.id)?.text).toBe('edited')
+		})
+
+		// A JS host can still return nothing (a forgotten return, which TypeScript would catch), so
+		// the room treats anything that isn't an explicit allow as a denial rather than crashing.
+		it('rejects the write (fail closed) when the authorizer returns no verdict', () => {
+			const { room, storage } = withNote(() => undefined)
+			const socket = connectSession(room, 'alice', { meta: { userId: 'u' } })
+			const note = Note.create({ text: 'x' })
+
+			expect(() => push(room, 'alice', { [note.id]: [RecordOpType.Put, note] })).not.toThrow()
+			expect(lastPushResult(socket)).toMatchObject({ action: 'discard' })
+			expect(storedIds(storage)).toEqual([])
 		})
 
 		it('rejects the write (fail closed) when the authorizer throws, without crashing the push', () => {
@@ -627,9 +640,9 @@ describe('object store lane', () => {
 		it('passes the change type for create, update, and delete', () => {
 			const types: string[] = []
 			const note = Note.create({ text: 'x' })
-			const { room } = withNote(({ type, prev, next }: any) => {
+			const { room } = withNote(({ type, allow }: any) => {
 				types.push(type)
-				return type === 'delete' ? prev : next
+				return allow()
 			})
 			connectSession(room, 'alice', { meta: { userId: 'u' } })
 
@@ -645,7 +658,7 @@ describe('object store lane', () => {
 			const note = Note.create({ text: 'by:user-alice' })
 			const { room } = makeRoom({
 				objectTypes: ['note'],
-				authorizeRecord: { note: () => null },
+				authorizeRecord: { note: ({ deny }: any) => deny() },
 				log: { warn },
 			})
 			connectSession(room, 'mallory', { meta: { userId: 'user-mallory' } })

--- a/packages/sync-core/src/test/upgradeDowngrade.test.ts
+++ b/packages/sync-core/src/test/upgradeDowngrade.test.ts
@@ -1249,7 +1249,7 @@ describe('record authorizers see server-schema records', () => {
 		const seen: any[] = []
 		const t = makeInstance((args: any) => {
 			seen.push(structuredClone({ type: args.type, prev: args.prev, next: args.next }))
-			return args.next
+			return args.allow()
 		})
 		t.oldSocketPair.connect()
 		t.flush()
@@ -1266,7 +1266,7 @@ describe('record authorizers see server-schema records', () => {
 
 	it('a stamp applied on create survives — no migration runs after the authorizer', () => {
 		const t = makeInstance((args: any) =>
-			args.type === 'create' ? { ...args.next, birthdate: '2001-02-03' } : args.next
+			args.type === 'create' ? args.allow({ ...args.next, birthdate: '2001-02-03' }) : args.allow()
 		)
 		t.oldSocketPair.connect()
 		t.flush()
@@ -1285,7 +1285,7 @@ describe('record authorizers see server-schema records', () => {
 		const seen: any[] = []
 		const t = makeInstance((args: any) => {
 			seen.push(structuredClone({ type: args.type, prev: args.prev, next: args.next }))
-			return args.next
+			return args.allow()
 		})
 		t.oldSocketPair.connect()
 		t.newSocketPair.connect()
@@ -1311,7 +1311,7 @@ describe('record authorizers see server-schema records', () => {
 
 	it('vetoes based on the server-schema record', () => {
 		const t = makeInstance((args: any) =>
-			args.type === 'update' && args.next.name === 'forged' ? null : args.next
+			args.type === 'update' && args.next.name === 'forged' ? args.deny() : args.allow()
 		)
 		t.oldSocketPair.connect()
 		t.newSocketPair.connect()


### PR DESCRIPTION
Follow-up to a review note on #9471. `TLRecordAuthorizer` returned `Rec | null`, where `null` meant deny — compact, but the deny path was easy to fat-finger. A forgotten `return` also denied (safe, but silently), and nothing at the type level separated "I decided to reject this write" from "I fell off the end of the function". Since hosts write these rules themselves — they're the server-side gate on who may post, edit, or delete a comment — the sentinel was the wrong shape for the one place a mistake should be loud.

Authorizers now return a discriminated result, built with `allow`/`deny` helpers that the room passes in alongside the write. A missing return is a compile error, and `allow(record)` names the create-time stamp explicitly instead of overloading the return value. `createCommentAuthorizers` is still the intended path for comments, so most hosts won't touch this directly.

```ts
// before
const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({ type, prev, next, session }) => {
	if (type === 'delete') return prev
	if (forged) return null
	return next
}

// after
const authorizeShape: TLRecordAuthorizer<TLShape, SessionMeta> = ({ type, prev, next, session, allow, deny }) => {
	if (type === 'delete') return allow()
	if (forged) return deny()
	return allow()
}
```

`allow(record)` only means anything on create (where it's what gets stored); update and delete stay allow-vs-deny, as before.

Fail-closed behaviour is unchanged and slightly stronger. The room already caught a throwing authorizer and treated it as a denial; it now also treats anything that isn't an explicit allow as a denial. That matters because an untyped JS host can still return nothing, and under the new shape reading `.allowed` off `undefined` would otherwise throw inside the commit transaction — where the old `!result` check had degraded gracefully.

### Change type

- [x] `api`

### Test plan

Server-side authorization has no manual surface; it's covered by unit tests.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Record authorizers now return `allow()` or `deny()` instead of a record or `null`, so a missing return is caught at compile time.

### API changes

- Added `TLRecordAuthorizerResult` — `{ allowed: true, record? } | { allowed: false }`
- Added `TLRecordAuthorizerArgs` — the authorizer's argument, now including the `allow`/`deny` helpers
- Breaking! `TLRecordAuthorizer` returns `TLRecordAuthorizerResult<Rec>` instead of `Rec | null`

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +140 / -59 |
| Tests           | +124 / -39 |
| Automated files | +15 / -2   |
| Apps            | +5 / -3    |
