### PR TITLE
fix(tldraw): display comma keyboard shortcuts

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -1,7 +1,6 @@
 /*!
- * The kbd-string splitter (`getKeys`) and the form-input filter pattern in `shouldSkipEvent`
- * (including its list of non-text INPUT types) are adapted from hotkeys-js, which this hook
- * previously depended on.
+ * The form-input filter pattern in `shouldSkipEvent` (including its list of non-text INPUT
+ * types) is adapted from hotkeys-js, which this hook previously depended on.
  *
  * MIT License: https://github.com/jaywcjlove/hotkeys-js/blob/master/LICENSE
  * Copyright (c) 2015-present, Kenny Wong
@@ -19,6 +18,7 @@ import {
 } from '@tldraw/editor'
 import { useEffect } from 'react'
 import { useActions } from '../context/actions'
+import { splitKbd } from '../kbd-utils'
 import { useReadonly } from './useReadonly'
 import { useTools } from './useTools'
 
@@ -354,7 +354,7 @@ const PHYSICAL_KEY_MAP: Record<string, string> = {
  */
 export function parseKbd(kbd: string): ParsedKbd[] {
 	const out: ParsedKbd[] = []
-	for (const shortcut of getKeys(kbd)) {
+	for (const shortcut of splitKbd(kbd)) {
 		const parsed = parseShortcut(shortcut)
 		if (parsed) out.push(parsed)
 	}
@@ -454,7 +454,7 @@ function shouldSkipEvent(e: KeyboardEvent): boolean {
  * @internal
  */
 export function getHotkeysStringFromKbd(kbd: string) {
-	return getKeys(kbd)
+	return splitKbd(kbd)
 		.map((kbd) => {
 			let str = ''
 
@@ -486,22 +486,4 @@ export function getHotkeysStringFromKbd(kbd: string) {
 			return str
 		})
 		.join(',')
-}
-
-// Split a kbd string on commas, treating an empty entry produced by "x,," as a literal
-// trailing comma on the previous entry. Verbatim port of the splitter from hotkeys-js
-// (MIT, see top-of-file attribution).
-function getKeys(key: string) {
-	if (typeof key !== 'string') key = ''
-	key = key.replace(/\s/g, '')
-	const keys = key.split(',')
-	let index = keys.lastIndexOf('')
-
-	for (; index >= 0; ) {
-		keys[index - 1] += ','
-		keys.splice(index, 1)
-		index = keys.lastIndexOf('')
-	}
-
-	return keys
 }

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -354,7 +354,7 @@ const PHYSICAL_KEY_MAP: Record<string, string> = {
  */
 export function parseKbd(kbd: string): ParsedKbd[] {
 	const out: ParsedKbd[] = []
-	for (const shortcut of splitKbd(kbd)) {
+	for (const shortcut of splitKbd(kbd.replace(/\s/g, ''))) {
 		const parsed = parseShortcut(shortcut)
 		if (parsed) out.push(parsed)
 	}
@@ -454,7 +454,7 @@ function shouldSkipEvent(e: KeyboardEvent): boolean {
  * @internal
  */
 export function getHotkeysStringFromKbd(kbd: string) {
-	return splitKbd(kbd)
+	return splitKbd(kbd.replace(/\s/g, ''))
 		.map((kbd) => {
 			let str = ''
 

--- a/packages/tldraw/src/lib/ui/kbd-utils.test.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.test.ts
@@ -1,0 +1,7 @@
+import { kbd } from './kbd-utils'
+
+describe('kbd', () => {
+	it('displays a comma key with modifiers', () => {
+		expect(kbd('shift+,,shift+alt+,')).toEqual([...kbd('shift+.').slice(0, -1), ','])
+	})
+})

--- a/packages/tldraw/src/lib/ui/kbd-utils.test.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.test.ts
@@ -4,4 +4,8 @@ describe('kbd', () => {
 	it('displays a comma key with modifiers', () => {
 		expect(kbd('shift+,,shift+alt+,')).toEqual([...kbd('shift+.').slice(0, -1), ','])
 	})
+
+	it('preserves spaces in atomic key labels', () => {
+		expect(kbd('[[Page Up]]')).toEqual(['Page Up'])
+	})
 })

--- a/packages/tldraw/src/lib/ui/kbd-utils.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.ts
@@ -1,5 +1,14 @@
 import { tlenv } from '@tldraw/editor'
 
+/*!
+ * `splitKbd` is adapted from hotkeys-js.
+ *
+ * MIT License: https://github.com/jaywcjlove/hotkeys-js/blob/master/LICENSE
+ * Copyright (c) 2015-present, Kenny Wong
+ * Copyright (c) 2011-2013 Thomas Fuchs (https://github.com/madrobby/keymaster)
+ * Source: https://github.com/jaywcjlove/hotkeys-js
+ */
+
 // N.B. We rework these Windows placeholders down below.
 const cmdKey = tlenv.isDarwin ? '⌘' : '__CTRL__'
 const ctrlKey = tlenv.isDarwin ? '⌃' : '__CTRL__'
@@ -7,11 +16,8 @@ const altKey = tlenv.isDarwin ? '⌥' : '__ALT__'
 
 /** @public */
 export function kbd(str: string) {
-	if (str === ',') return [',']
-
 	return (
-		str
-			.split(',')[0]
+		(splitKbd(str)[0] ?? '')
 			// If the string contains [[Tab]], we don't split these up
 			// as they're meant to be atomic.
 			.split(/(\[\[[^\]]+\]\])/g)
@@ -45,6 +51,24 @@ export function kbd(str: string) {
 			})
 			.flat()
 	)
+}
+
+// Split a kbd string on commas, treating an empty entry produced by "x,," as a literal
+// trailing comma on the previous entry.
+/** @internal */
+export function splitKbd(key: string) {
+	if (!key) return []
+	key = key.replace(/\s/g, '')
+	const keys = key.split(',')
+	let index = keys.lastIndexOf('')
+
+	for (; index >= 0; ) {
+		keys[index - 1] += ','
+		keys.splice(index, 1)
+		index = keys.lastIndexOf('')
+	}
+
+	return keys
 }
 
 /** @public */

--- a/packages/tldraw/src/lib/ui/kbd-utils.ts
+++ b/packages/tldraw/src/lib/ui/kbd-utils.ts
@@ -58,7 +58,6 @@ export function kbd(str: string) {
 /** @internal */
 export function splitKbd(key: string) {
 	if (!key) return []
-	key = key.replace(/\s/g, '')
 	const keys = key.split(',')
 	let index = keys.lastIndexOf('')
 


### PR DESCRIPTION
In order to show the complete counterclockwise rotation shortcut in tooltips, this PR makes shortcut formatting understand literal comma keys using the same comma-aware splitting as keyboard registration. Atomic labels such as `[[Page Up]]` continue to preserve their spaces.

### Change type

- [x] `bugfix`

### Test plan

1. Select multiple shapes.
2. Open the actions menu and hover over **Rotate counterclockwise**.
3. Confirm the tooltip shows Shift + comma.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix the counterclockwise rotation tooltip to show its comma key.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +32 / -27  |
| Tests     | +11 / -0   |