### PR TITLE
fix(commenting): restyle the canvas comment UI

### DIFF
--- a/apps/examples/e2e/tests/test-commenting-a11y.spec.ts
+++ b/apps/examples/e2e/tests/test-commenting-a11y.spec.ts
@@ -143,14 +143,15 @@ test.describe('commenting a11y', () => {
 		const reply = page.locator('.tlui-cmt-canvas-popover [contenteditable="true"].tlui-cmt-input')
 		await expect(reply).toBeFocused()
 
-		// Edit from the card's own button: escaping should land back on it, not on the editor
-		// container, where Tab would walk the app's UI instead of the thread's own controls.
-		const editButton = page.locator('.tlui-cmt-canvas-popover [data-cmt-edit-for]')
-		await editButton.click()
+		// Edit from the ⋯ menu: escaping should land back on the ⋯ button that opened it, not on the
+		// editor container, where Tab would walk the app's UI instead of the thread's own controls.
+		const moreButton = page.locator('.tlui-cmt-canvas-popover [data-cmt-more-for]')
+		await moreButton.click()
+		await page.locator('.tlui-cmt-menu-item', { hasText: 'Edit' }).click()
 		await expect(page.locator('.tlui-cmt-editing [contenteditable="true"]')).toBeFocused()
 		await page.keyboard.press('Escape')
 		await expect(page.locator('.tlui-cmt-canvas-popover')).toBeVisible()
-		await expect(editButton).toBeFocused()
+		await expect(moreButton).toBeFocused()
 
 		// Arrow-up-to-edit comes from the reply box, so that's where escaping returns.
 		await reply.focus()

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -193,12 +193,11 @@ export interface CommentListItemProps {
 }
 
 // @public
-export function CommentPin({ children, resolved, open, color }: CommentPinProps): JSX.Element;
+export function CommentPin({ children, resolved, open }: CommentPinProps): JSX.Element;
 
 // @public (undocumented)
 export interface CommentPinProps {
     children?: ReactNode;
-    color?: string;
     open?: boolean;
     // (undocumented)
     resolved?: boolean;

--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -123,13 +123,6 @@
 	display: flex;
 	flex-direction: column;
 	gap: 10px;
-	max-height: 420px;
-	overflow-y: auto;
-	/* A scroll container clips at its own box — including the cards' shadows (setting one overflow
-	   axis makes both non-visible). Pad the clip box outward and pull the list back into place so
-	   the shadows have room to paint. */
-	padding: 16px;
-	margin: -16px;
 }
 
 /* The expanded thread is the only entry with pills floating above its panel — its header actions,
@@ -149,7 +142,7 @@
 	background: var(--tl-color-panel);
 	border-radius: 12px;
 	box-shadow: var(--tl-shadow-3);
-	padding: 10px 14px;
+	padding: 2px 12px 10px;
 	cursor: pointer;
 	text-align: left;
 	display: block;
@@ -172,16 +165,15 @@
 }
 
 /* The wrapper is the card's surface — inside it the comment is plain content, mirroring how the
-   thread panel flattens its own cards. The avatar centers against the short two-line block so a
-   collapsed entry doesn't read as top-heavy. Stacked above the action overlay so the body's links
-   stay clickable. */
+   thread panel flattens its own cards. Stacked above the action overlay so the body's links stay
+   clickable. */
 .tlui-cmt-stack-list__card .tlui-cmt-card {
 	position: relative;
 	width: 100%;
+	gap: 0;
 	padding: 0;
 	background: transparent;
 	border: none;
-	align-items: center;
 }
 
 /* The hover preview, shown for any marker — a pin, a coincident stack, or a cluster badge. Live,
@@ -241,16 +233,18 @@
 	box-sizing: border-box;
 	width: 300px;
 	gap: var(--tlui-cmt-thread-gap);
-	padding: var(--tlui-cmt-thread-padding);
+	/* Top/bottom only — the card pads its own sides now (12px), matching the expanded thread. A
+	   little extra below so the (often truncated) last line doesn't sit against the rounded edge. */
+	padding: 4px 0 8px;
 	background: var(--tl-color-panel);
 	border-radius: var(--tl-radius-4);
 	box-shadow: var(--tl-shadow-3);
 }
 
-/* Previewing a stack or cluster: one card per thread, matching the card list a click opens.
-   Its first card sits flush with the popover's top, so no shift is needed. */
+/* Previewing a stack or cluster: one card per thread, matching the card list a click opens. */
 .tlui-cmt-canvas-preview__panel--list {
 	gap: 8px;
+	padding: 4px 0 8px;
 }
 
 /* Matches the stack list's card surface, so a preview and the list it previews read as the same
@@ -261,7 +255,9 @@
 	background: var(--tl-color-panel);
 	border-radius: 12px;
 	box-shadow: var(--tl-shadow-3);
-	padding: 10px 14px;
+	/* A 2px nudge above the byline's centring — a boxed card reads a touch better with it than the
+	   single preview's flat card, which pads 0 vertically and leans on the panel + byline. */
+	padding: 2px 12px 10px;
 }
 
 .tlui-cmt-preview-card--selectable {
@@ -282,11 +278,8 @@
    so its var() was already substituted there and the white is baked into what we inherit. Instead
    lay a ring of the new surface over the old one — first shadow in the list paints on top. */
 .tlui-cmt-stack-list__card:hover,
-.pseudo-hover.tlui-cmt-stack-list__card,
 .tlui-cmt-preview-card--selectable:hover,
-.pseudo-hover.tlui-cmt-preview-card--selectable,
-.tlui-cmt-canvas-preview__panel--thread.tlui-cmt-canvas-preview__panel--selectable:hover,
-.pseudo-hover.tlui-cmt-canvas-preview__panel--thread {
+.tlui-cmt-canvas-preview__panel--thread.tlui-cmt-canvas-preview__panel--selectable:hover {
 	--tlui-cmt-preview-hover-surface: color-mix(
 		in srgb,
 		var(--tl-color-low) 50%,
@@ -301,10 +294,10 @@
 
 .tlui-cmt-preview-card .tlui-cmt-card {
 	width: 100%;
+	gap: 0;
 	padding: 0;
 	background: transparent;
 	border: none;
-	align-items: center;
 }
 
 /* A preview is a glance, not a list — past a few cards it says how many were left out rather than
@@ -403,6 +396,10 @@
 .tlui-cmt-canvas-pin__marker:hover .tlui-cmt-marker:not(.tlui-cmt-marker--open) {
 	box-shadow: var(--tlui-cmt-marker-shadow-hover);
 }
+/* The comment pin doesn't scale on hover — only the shadow lifts (badges still scale). */
+.tlui-cmt-canvas-pin__marker:hover .tlui-cmt-pin {
+	transform: none;
+}
 
 /* The open thread's popover — portaled to the menus layer (above the UI), positioned at the pin. */
 .tlui-cmt-canvas-popover {
@@ -412,8 +409,8 @@
 }
 
 /* The placement composer — a distinct floating view (portaled to the menus layer, below the click
-   point): a pencil "draft" avatar beside a pill field that is itself the surface (no wrapping
-   panel). Scoped here so the in-thread reply composer keeps its own squarer look. */
+   point): a draft avatar pin beside a pill field that is itself the surface (no wrapping panel).
+   Scoped here so the in-thread reply composer keeps its own squarer look. */
 .tlui-cmt-canvas-composer {
 	position: absolute;
 	z-index: var(--tl-layer-menus);
@@ -422,9 +419,6 @@
 	   into the row, so its bottom-left corner is 4px right of and 4px + a pin below the composer's
 	   top-left corner. */
 	transform: translate(-4px, calc(-4px - var(--tlui-cmt-pin-size)));
-	/* The rich-text editor has no intrinsic width (unlike the old <input>), so give the floating
-	   placement composer a definite width or it collapses to nothing. */
-	width: 280px;
 }
 
 /* A region placement centres the draft avatar on the region's pin corner — the pin it becomes
@@ -449,27 +443,96 @@
 	border-radius: var(--tl-radius-4);
 	box-shadow: var(--tl-shadow-3);
 }
-.tlui-cmt-canvas-composer .tlui-cmt-composer__field {
-	background: var(--tl-color-panel);
-	border-color: transparent;
-	border-radius: var(--tl-radius-4);
-	box-shadow: var(--tl-shadow-3);
-	/* The pin is anchored by its bottom corner at the click point and can't move; raise the
-	   taller field onto the shorter pin's centre instead. */
-	margin-top: -3px;
+.tlui-cmt-canvas-composer .tlui-cmt-composer {
+	gap: 6px;
 }
-/* The draft avatar: panel-white (no author tint while you're still editing), sharing the
-   composer's lift so the pencil and its field match. Not interactive — it drops the pin's
-   pointer cursor and hover affordances (scale + shadow bump). */
-.tlui-cmt-canvas-composer .tlui-cmt-pin {
+/* The card: a fixed 300×42 surface whose uniform 3px padding derives the 294×36 focusable input. */
+.tlui-cmt-canvas-composer .tlui-cmt-composer__field {
+	position: relative;
+	flex: none;
+	width: 300px;
+	min-height: 42px;
+	padding: 3px;
+	border: none;
 	background: var(--tl-color-panel);
-	color: var(--tl-color-text-1);
-	box-shadow: var(--tl-shadow-3);
+	border-radius: var(--tl-radius-3);
+	box-shadow: var(--tl-shadow-2);
+	/* The pin is anchored by its bottom corner at the click point and can't move; raise the taller
+	   card onto the shorter pin's centre instead. */
+	margin-top: -6px;
+}
+/* Focused (the placement composer autofocuses on mount): a selection-blue ring inset 3px from the
+   card edge, so the card frames a bordered input rather than the border sitting on the card edge. */
+.tlui-cmt-canvas-composer .tlui-cmt-composer__field:focus-within::before {
+	content: '';
+	position: absolute;
+	inset: 3px;
+	border: 1px solid var(--tl-color-selected);
+	border-radius: var(--tl-radius-2);
+	pointer-events: none;
+}
+/* The text sits 12px in from the focus ring rather than against it. The placeholder is absolutely
+   positioned (it ignores the wrap's padding), so it carries the same offset itself. */
+.tlui-cmt-canvas-composer .tlui-cmt-composer__input-wrap {
+	padding: 4.5px 12px;
+}
+.tlui-cmt-canvas-composer .tlui-cmt-composer__field--expanded .tlui-cmt-composer__input-wrap {
+	/* The base expanded rule re-pads the right edge for the squarer composer's geometry; here the
+	   12px is already symmetric. */
+	padding-right: 12px;
+}
+.tlui-cmt-canvas-composer .tlui-cmt-input__placeholder {
+	left: 12px;
+}
+/* The draft avatar previews the pin it becomes — a white 28px pin holding the author's 22px avatar
+   circle — sharing the composer's lift. Not interactive: it drops the pin's pointer cursor and
+   hover affordances (scale + shadow bump), but keeps a 40×40 hit area (the ::after below). */
+.tlui-cmt-canvas-composer .tlui-cmt-pin {
+	position: relative;
+	box-shadow: var(--tl-shadow-2);
 	cursor: default;
+}
+.tlui-cmt-canvas-composer .tlui-cmt-pin::after {
+	content: '';
+	position: absolute;
+	inset: -6px;
 }
 .tlui-cmt-canvas-composer .tlui-cmt-pin:hover {
 	transform: none;
-	box-shadow: var(--tl-shadow-3);
+	box-shadow: var(--tl-shadow-2);
+}
+/* The placement composer's send button — a bare arrow, no pill: grey while empty, black once
+   there's something to send. A 28px square centred in the 36px input height, so its hover wash
+   clears the focus ring rather than butting against it; the ::after keeps a 40×40 hit area. */
+.tlui-cmt-canvas-composer .tlui-cmt-send {
+	position: relative;
+	width: 28px;
+	height: 28px;
+	margin-right: 4px;
+	background: transparent;
+	border-radius: var(--tl-radius-2);
+	color: var(--tl-color-text-3);
+}
+.tlui-cmt-canvas-composer .tlui-cmt-send::after {
+	content: '';
+	position: absolute;
+	inset: -6px;
+}
+.tlui-cmt-canvas-composer .tlui-cmt-send:not(:disabled) {
+	color: var(--tl-color-text-1);
+}
+/* Hover and press wash grey behind the bare arrow (the same treatment as the thread actions),
+   overriding the base button's blue fill. */
+.tlui-cmt-canvas-composer .tlui-cmt-send:hover:not(:disabled) {
+	background: var(--tl-color-muted-2);
+}
+.tlui-cmt-canvas-composer .tlui-cmt-send:active:not(:disabled) {
+	background: var(--tl-color-muted-1);
+}
+/* In the expanded (multi-line) layout the send drops to the bottom-right corner; give it the same
+   4px gap from the focus ring on the bottom that it already keeps on the right. */
+.tlui-cmt-canvas-composer .tlui-cmt-composer__field--expanded .tlui-cmt-send {
+	margin-bottom: 4px;
 }
 
 /* The comments list panel — a right-side surface shown while the comments sidebar is open. Below

--- a/packages/commenting/src/canvas/comments-overflow-menu.tsx
+++ b/packages/commenting/src/canvas/comments-overflow-menu.tsx
@@ -35,6 +35,7 @@ export function CommentsOverflowMenu() {
 				side="bottom"
 				align="end"
 				alignOffset={0}
+				sideOffset={4}
 			>
 				<TldrawUiDropdownMenuGroup>
 					<TldrawUiDropdownMenuItem>

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,4 +1,4 @@
-import { isMentionPickerOpen } from '@tldraw/mentions'
+import { Avatar, isMentionPickerOpen } from '@tldraw/mentions'
 import {
 	Fragment,
 	memo,
@@ -17,7 +17,6 @@ import {
 	createComment,
 	createCommentThread,
 	Editor,
-	getFirstCharacter,
 	react,
 	TLCommentThread,
 	TLRichText,
@@ -65,6 +64,7 @@ import {
 	pendingComment,
 	regionDraft,
 	revealThreadRequest,
+	sidebarFilters,
 	toggleCommentsHidden,
 	usePendingComment,
 } from './state'
@@ -106,7 +106,6 @@ function forwardPointerEventToCanvas(container: HTMLElement, e: ReactPointerEven
 	cvs.dispatchEvent(newEvent)
 }
 
-const initialOf = (name: string): string => (getFirstCharacter(name.trim()) || '?').toUpperCase()
 const CLUSTER_FADE_MS = 150
 /** Duration of the click-a-badge zoom-to-split animation. */
 const CLUSTER_EXPAND_ZOOM_MS = 450
@@ -117,26 +116,11 @@ const CLUSTER_SPLIT_ZOOM_FACTOR = 1.05
  *  just off-screen is already mounted when a pan brings it in. */
 const CLUSTER_CULL_MARGIN_PX = 120
 
-/** The leading element for the placement composer — the comment pin's shape, but a pencil
- *  instead of an initial, marking an unsent draft. */
-const draftAvatar = (
-	<CommentPin>
-		<svg
-			viewBox="0 0 24 24"
-			width="15"
-			height="15"
-			fill="none"
-			stroke="currentColor"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
-			aria-hidden="true"
-		>
-			<path d="M12 20h9" />
-			<path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
-		</svg>
-	</CommentPin>
-)
+/** The opened popover has a header row the hover preview lacks, so it opens this much higher — the
+ *  first comment then lands where the preview's sat. Measured: the expanded first comment sits ~42px
+ *  below the panel top (the 40px header, no gap) vs the preview's 4px (its panel padding).
+ *  Re-measure if the header height or the preview panel padding changes. */
+const THREAD_HEADER_BLOCK = 36
 
 /**
  * A ready-to-use comments layer for a tldraw canvas: pins each thread at its anchor, opens a
@@ -205,7 +189,7 @@ function CanvasCommentsLayer(props: CommentingContext) {
 	// canvas, so any pin past its bottom/right edge inflates the root's scrollHeight — which the
 	// wheel hook's is-this-scrollable guard reads as scrollable, silently disabling pass-through.
 	usePassThroughMouseOverEvents(layerRef)
-	const threads = useCommentThreads(editor)
+	const allThreads = useCommentThreads(editor)
 	const pending = usePendingComment()
 	const canComment = useCanComment(props.currentUserId)
 	// With composing blocked and no fallback slot there's nothing to render for a pending comment —
@@ -218,6 +202,15 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		if (pending && !showPendingComposer) pendingComment.set(editor, null)
 	}, [editor, pending, showPendingComposer])
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
+	// Hide resolved threads' pins by default, matching the sidebar's `showResolved` filter. The open
+	// thread stays in — resolving from its own popover shouldn't make the pin vanish under it.
+	const showResolved = useValue('show resolved', () => sidebarFilters.get(editor).showResolved, [
+		editor,
+	])
+	const threads = useMemo(
+		() => allThreads.filter((t) => showResolved || t.resolved == null || t.id === openId),
+		[allThreads, showResolved, openId]
+	)
 	useEffect(() => registerCommentAnchorLifecycle(editor), [editor])
 	// Threads held out of clustering because their anchor moved while folded inside a badge
 	// (drag, nudge, align, undo, a collaborator — detected by position, not gesture). They render
@@ -1185,12 +1178,12 @@ const ThreadPin = memo(function ThreadPin({
 	if (!point) return null
 
 	const PinContent = options.components.PinContent
-	// The `PinContent` component slot overrides the built-in author-initial default.
+	// The `PinContent` component slot overrides the built-in author-avatar default.
 	const threadAuthor = resolveAuthor(thread.createdBy)
 	const pinContent = PinContent ? (
 		<PinContent thread={thread} comments={comments} />
 	) : (
-		initialOf(threadAuthor?.name ?? UNKNOWN_AUTHOR)
+		<Avatar author={threadAuthor ?? UNKNOWN_COMMENT_AUTHOR} />
 	)
 	const pinLabel = msg(
 		thread.resolved ? 'comments.pin-label-resolved' : 'comments.pin-label'
@@ -1382,7 +1375,7 @@ const ThreadPin = memo(function ThreadPin({
 					onFocus={previewHandlers.onPointerEnter}
 					onBlur={previewHandlers.onPointerLeave}
 				>
-					<CommentPin resolved={thread.resolved != null} open={open} color={threadAuthor?.color}>
+					<CommentPin resolved={thread.resolved != null} open={open}>
 						{pinContent}
 					</CommentPin>
 				</button>
@@ -1393,7 +1386,7 @@ const ThreadPin = memo(function ThreadPin({
 						container={container}
 						style={{
 							left: renderPoint.x + POPOVER_OFFSET.thread.x,
-							top: renderPoint.y + POPOVER_OFFSET.thread.y,
+							top: renderPoint.y + POPOVER_OFFSET.thread.y - THREAD_HEADER_BLOCK,
 						}}
 					>
 						<ThreadView editor={editor} thread={thread} {...props} />
@@ -1431,6 +1424,12 @@ function PendingComposer({
 	const ComposerFallback = useCommentingOptions().components.ComposerFallback
 	const canComment = useCanComment(currentUserId)
 	const me = currentUserId ? resolveAuthor(currentUserId) : undefined
+	// The leading pin previews the pin this draft becomes: a white pin holding the author's avatar.
+	const draftAvatar = (
+		<CommentPin>
+			<Avatar author={me ?? UNKNOWN_COMMENT_AUTHOR} />
+		</CommentPin>
+	)
 	// Click-away keeps the draft (saved on every change) and the next placement composer
 	// restores it — the flip side of dismissing without a discard warning.
 	const [text, setText] = useState<TLRichText>(

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -133,6 +133,14 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 		}
 	}
 
+	// The expanded thread gains a "Comment" header that pushes its first comment down from where the
+	// hover preview showed it. When that thread is the list's first, lift the whole list by the
+	// header block so its "You" holds position across hover -> open: the single thread's
+	// THREAD_HEADER_BLOCK (36) plus the 8px margin above the expanded entry, less the 2px top the
+	// preview card sits its "You" down by. Only the first entry — lifting the list can't also hold a
+	// lower thread's neighbours in place.
+	const liftForHeader = threads[0]?.id === openId ? 42 : 0
+
 	return (
 		<>
 			<div className="tlui-cmt-canvas-pin" style={{ left: point.x, top: point.y }}>
@@ -177,7 +185,10 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 			{open && (
 				<ThreadPopover
 					container={container}
-					style={{ left: point.x + POPOVER_OFFSET.list.x, top: point.y + POPOVER_OFFSET.list.y }}
+					style={{
+						left: point.x + POPOVER_OFFSET.list.x,
+						top: point.y + POPOVER_OFFSET.list.y - liftForHeader,
+					}}
 				>
 					<div className="tlui-cmt-stack-list">
 						{threads.map((thread) =>

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -75,8 +75,9 @@ export function toCardProps(
  *  correcting for that. Keep in sync with the stylesheet. */
 const PIN_SIZE = 28
 
-/** A coincident stack's / cluster's card list, whose first card sits flush with the popover top. */
-const LIST_OFFSET = { x: 36, y: -28 } as const
+/** A coincident stack's / cluster's card list, whose first card sits flush with the popover top.
+ *  x = half the 34px badge (it's centred on its point) + the same 6px gap the pin's preview uses. */
+const LIST_OFFSET = { x: 23, y: -28 } as const
 
 /**
  * Where a marker's popover sits relative to the marker's anchor point.
@@ -98,7 +99,7 @@ export const POPOVER_OFFSET = {
 	 * pin's middle — where a badge measures from — with `- PIN_SIZE / 2`. The opened popover shares
 	 * the offset and opens from there.
 	 */
-	thread: { x: 48, y: LIST_OFFSET.y - PIN_SIZE / 2 },
+	thread: { x: PIN_SIZE + 6, y: LIST_OFFSET.y - PIN_SIZE / 2 },
 	list: LIST_OFFSET,
 } as const
 
@@ -290,15 +291,15 @@ export function ThreadView({
 		})
 	}
 
-	const startEdit = (comment: TLComment, { fromEditButton = false } = {}) => {
-		// The edit button is the thing to come back to when it opened the composer — looked up again
-		// on the way out, since this one is about to unmount with its card. Otherwise come back to
-		// whatever held focus: arrow-up-to-edit comes straight from the reply box, which stays put.
-		// The document body and the editor container are where focus falls when nothing holds it, so
-		// neither is somewhere to return anyone to.
+	const startEdit = (comment: TLComment, { fromMoreMenu = false } = {}) => {
+		// The ⋯ menu's button is the thing to come back to when Edit opened the composer — looked up
+		// again on the way out, since the menu item that was clicked (and the card) unmount while the
+		// composer stands in their place. Otherwise come back to whatever held focus: arrow-up-to-edit
+		// comes straight from the reply box, which stays put. The document body and the editor
+		// container are where focus falls when nothing holds it, so neither is somewhere to return to.
 		const active = container.ownerDocument.activeElement
-		editReturnFocus.current = fromEditButton
-			? () => container.querySelector<HTMLElement>(`[data-cmt-edit-for="${comment.id}"]`)
+		editReturnFocus.current = fromMoreMenu
+			? () => container.querySelector<HTMLElement>(`[data-cmt-more-for="${comment.id}"]`)
 			: active instanceof HTMLElement && active !== container && active !== document.body
 				? () => (active.isConnected ? active : null)
 				: null
@@ -380,52 +381,52 @@ export function ThreadView({
 				actions={
 					canComment && (
 						<>
-							{comment.authorId === currentUserId && (
-								<>
-									<TooltipButton
-										tooltip={msg('comments.edit')}
-										className="tlui-cmt-thread__action"
-										data-cmt-edit-for={comment.id}
-										onClick={() => startEdit(comment, { fromEditButton: true })}
-									>
-										<svg
-											width="15"
-											height="15"
-											viewBox="0 0 15 15"
-											fill="none"
-											xmlns="http://www.w3.org/2000/svg"
-										>
-											<path
-												d="M12.1464 1.14645C12.3417 0.951184 12.6583 0.951184 12.8535 1.14645L14.8535 3.14645C15.0488 3.34171 15.0488 3.65829 14.8535 3.85355L10.9109 7.79618C10.8349 7.87218 10.7471 7.93543 10.651 7.9835L6.72359 9.94721C6.53109 10.0435 6.29861 10.0057 6.14643 9.85355C5.99425 9.70137 5.95652 9.46889 6.05277 9.27639L8.01648 5.34897C8.06455 5.25283 8.1278 5.16507 8.2038 5.08907L12.1464 1.14645ZM12.5 2.20711L8.91091 5.79618L7.87266 7.87267L8.12731 8.12732L10.2038 7.08907L13.7929 3.5L12.5 2.20711ZM9.99998 2L8.99998 3H4.9C4.47171 3 4.18056 3.00039 3.95552 3.01877C3.73631 3.03668 3.62421 3.06915 3.54601 3.10899C3.35785 3.20487 3.20487 3.35785 3.10899 3.54601C3.06915 3.62421 3.03669 3.73631 3.01878 3.95552C3.00039 4.18056 3 4.47171 3 4.9V11.1C3 11.5283 3.00039 11.8194 3.01878 12.0445C3.03669 12.2637 3.06915 12.3758 3.10899 12.454C3.20487 12.6422 3.35785 12.7951 3.54601 12.891C3.62421 12.9309 3.73631 12.9633 3.95552 12.9812C4.18056 12.9996 4.47171 13 4.9 13H11.1C11.5283 13 11.8194 12.9996 12.0445 12.9812C12.2637 12.9633 12.3758 12.9309 12.454 12.891C12.6422 12.7951 12.7951 12.6422 12.891 12.454C12.9309 12.3758 12.9633 12.2637 12.9812 12.0445C12.9996 11.8194 13 11.5283 13 11.1V6.99998L14 5.99998V11.1V11.1207C14 11.5231 14 11.8553 13.9779 12.1259C13.9549 12.407 13.9057 12.6653 13.782 12.908C13.5903 13.2843 13.2843 13.5903 12.908 13.782C12.6653 13.9057 12.407 13.9549 12.1259 13.9779C11.8553 14 11.5231 14 11.1207 14H11.1H4.9H4.87934C4.47686 14 4.14468 14 3.87409 13.9779C3.59304 13.9549 3.33469 13.9057 3.09202 13.782C2.7157 13.5903 2.40973 13.2843 2.21799 12.908C2.09434 12.6653 2.04506 12.407 2.0221 12.1259C1.99999 11.8553 1.99999 11.5231 2 11.1207V11.1206V11.1V4.9V4.87935V4.87932V4.87931C1.99999 4.47685 1.99999 4.14468 2.0221 3.87409C2.04506 3.59304 2.09434 3.33469 2.21799 3.09202C2.40973 2.71569 2.7157 2.40973 3.09202 2.21799C3.33469 2.09434 3.59304 2.04506 3.87409 2.0221C4.14468 1.99999 4.47685 1.99999 4.87932 2H4.87935H4.9H9.99998Z"
-												fill="currentColor"
-												fillRule="evenodd"
-												clipRule="evenodd"
-											/>
-										</svg>
-									</TooltipButton>
-									<TooltipButton
-										tooltip={msg('action.delete')}
-										className="tlui-cmt-thread__action tlui-cmt-thread__action--danger"
-										onClick={() => deleteComment(comment)}
-									>
-										<svg
-											width="15"
-											height="15"
-											viewBox="0 0 15 15"
-											fill="none"
-											xmlns="http://www.w3.org/2000/svg"
-										>
-											<path
-												d="M5.5 1C5.22386 1 5 1.22386 5 1.5C5 1.77614 5.22386 2 5.5 2H9.5C9.77614 2 10 1.77614 10 1.5C10 1.22386 9.77614 1 9.5 1H5.5ZM3 3.5C3 3.22386 3.22386 3 3.5 3H5H10H11.5C11.7761 3 12 3.22386 12 3.5C12 3.77614 11.7761 4 11.5 4H11V12C11 12.5523 10.5523 13 10 13H5C4.44772 13 4 12.5523 4 12V4L3.5 4C3.22386 4 3 3.77614 3 3.5ZM5 4H10V12H5V4Z"
-												fill="currentColor"
-												fillRule="evenodd"
-												clipRule="evenodd"
-											/>
-										</svg>
-									</TooltipButton>
-								</>
-							)}
 							<CommentReactionPicker comment={comment} currentUserId={currentUserId} />
+							{comment.authorId === currentUserId && (
+								<TldrawUiDropdownMenuRoot id={`comment-actions-${comment.id}`}>
+									<TldrawUiDropdownMenuTrigger>
+										<TooltipButton
+											tooltip={msg('comments.more-options')}
+											className="tlui-cmt-thread__action"
+											data-cmt-more-for={comment.id}
+										>
+											<TldrawUiIcon
+												icon="dots-vertical"
+												label={msg('comments.more-options')}
+												small
+											/>
+										</TooltipButton>
+									</TldrawUiDropdownMenuTrigger>
+									<TldrawUiDropdownMenuContent
+										className="tlui-cmt-menu"
+										side="bottom"
+										align="start"
+										alignOffset={0}
+										sideOffset={4}
+									>
+										<TldrawUiDropdownMenuGroup>
+											<TldrawUiDropdownMenuItem>
+												<button
+													type="button"
+													className="tlui-cmt-menu-item"
+													onClick={() => startEdit(comment, { fromMoreMenu: true })}
+												>
+													<span>{msg('comments.edit')}</span>
+												</button>
+											</TldrawUiDropdownMenuItem>
+											<TldrawUiDropdownMenuItem>
+												<button
+													type="button"
+													className="tlui-cmt-menu-item tlui-cmt-menu-item--danger"
+													onClick={() => deleteComment(comment)}
+												>
+													<span>{msg('action.delete')}</span>
+												</button>
+											</TldrawUiDropdownMenuItem>
+										</TldrawUiDropdownMenuGroup>
+									</TldrawUiDropdownMenuContent>
+								</TldrawUiDropdownMenuRoot>
+							)}
 						</>
 					)
 				}
@@ -437,19 +438,6 @@ export function ThreadView({
 	// resolve stamps into `resolved.by`.
 	const headerActions = (
 		<>
-			{canComment && currentUserId && (
-				<TooltipButton
-					tooltip={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
-					className="tlui-cmt-thread__action"
-					onClick={toggleResolve}
-				>
-					<TldrawUiIcon
-						icon="check"
-						label={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
-						small
-					/>
-				</TooltipButton>
-			)}
 			{/* Deleting a thread is creator-only (server-enforced), and it's the menu's only item. */}
 			{canComment && currentUserId && currentUserId === thread.createdBy && (
 				<TldrawUiDropdownMenuRoot id={`comment-thread-actions-${thread.id}`}>
@@ -464,8 +452,9 @@ export function ThreadView({
 					<TldrawUiDropdownMenuContent
 						className="tlui-cmt-menu"
 						side="bottom"
-						align="end"
+						align="start"
 						alignOffset={0}
+						sideOffset={4}
 					>
 						<TldrawUiDropdownMenuGroup>
 							<TldrawUiDropdownMenuItem>
@@ -481,11 +470,32 @@ export function ThreadView({
 					</TldrawUiDropdownMenuContent>
 				</TldrawUiDropdownMenuRoot>
 			)}
+			{canComment && currentUserId && (
+				<TooltipButton
+					tooltip={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
+					className="tlui-cmt-thread__action"
+					onClick={toggleResolve}
+				>
+					<TldrawUiIcon
+						icon="check"
+						label={msg(thread.resolved ? 'comments.reopen' : 'comments.resolve')}
+						small
+					/>
+				</TooltipButton>
+			)}
+			<TooltipButton
+				tooltip={msg('comments.dismiss')}
+				className="tlui-cmt-thread__action"
+				onClick={() => openThreadId.set(editor, null)}
+			>
+				<TldrawUiIcon icon="cross-2" label={msg('comments.dismiss')} small />
+			</TooltipButton>
 		</>
 	)
 
 	return (
 		<CommentThread
+			header={msg('comments.thread-title')}
 			headerActions={headerActions}
 			renderComment={renderComment}
 			comments={comments.map((c) => toCardProps(c, props, options.components, resolveName))}

--- a/packages/commenting/src/ui/byline.tsx
+++ b/packages/commenting/src/ui/byline.tsx
@@ -1,4 +1,4 @@
-import { type CommentAuthor } from '@tldraw/mentions'
+import { Avatar, type CommentAuthor } from '@tldraw/mentions'
 import { formatRelativeTime } from './format-time'
 
 /** @public */
@@ -14,6 +14,7 @@ export interface BylineProps {
 export function Byline({ author, date, edited }: BylineProps) {
 	return (
 		<div className="tlui-cmt-head">
+			<Avatar author={author} />
 			<span className="tlui-cmt-author">{author.name}</span>
 			<span className="tlui-cmt-time">
 				{formatRelativeTime(date)}

--- a/packages/commenting/src/ui/comment-card.tsx
+++ b/packages/commenting/src/ui/comment-card.tsx
@@ -1,4 +1,4 @@
-import { Avatar, type CommentAuthor } from '@tldraw/mentions'
+import { type CommentAuthor } from '@tldraw/mentions'
 import { ReactNode } from 'react'
 import { Byline } from './byline'
 
@@ -31,9 +31,8 @@ export function CommentCard({
 }: CommentCardProps) {
 	return (
 		<div className={you ? 'tlui-cmt-card tlui-cmt-card--you' : 'tlui-cmt-card'}>
-			<Avatar author={author} />
+			<Byline author={author} date={date} edited={edited} />
 			<div className="tlui-cmt-body">
-				<Byline author={author} date={date} edited={edited} />
 				{body}
 				{footer}
 			</div>

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -123,9 +123,15 @@ export function CommentComposer({
 		if (!send || !input) return
 		mirror.innerHTML = input.innerHTML
 		const textWidth = mirror.offsetWidth
-		// The single-line space the input has beside the send button: when already expanded the
-		// wrap spans the full field, so subtract the button (plus the field's 6px gap) back out.
-		const collapsedAvailable = wrap.clientWidth - (expandedRef.current ? send.offsetWidth + 6 : 0)
+		// The single-line space the input has beside the send button: the wrap's *content* box
+		// (clientWidth minus its own horizontal padding — the text wraps there, not at clientWidth),
+		// less the button plus the field's 6px gap when already expanded (the wrap then spans the
+		// full field). Without subtracting the padding, a padded wrap wraps to a second line ~padding
+		// px before expansion fires, so the input grows a line and then snaps to the expanded layout.
+		const wrapStyle = getComputedStyle(wrap)
+		const wrapPadX = parseFloat(wrapStyle.paddingLeft) + parseFloat(wrapStyle.paddingRight)
+		const collapsedAvailable =
+			wrap.clientWidth - wrapPadX - (expandedRef.current ? send.offsetWidth + 6 : 0)
 		if (!expandedRef.current && textWidth > collapsedAvailable - 8) {
 			setExpanded(true)
 		} else if (expandedRef.current && textWidth < collapsedAvailable - 24) {

--- a/packages/commenting/src/ui/comment-pin.tsx
+++ b/packages/commenting/src/ui/comment-pin.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from 'react'
+import { ReactNode } from 'react'
 
 /** @public */
 export interface CommentPinProps {
@@ -8,9 +8,6 @@ export interface CommentPinProps {
 	resolved?: boolean
 	/** The pin's thread is open — shows the active/selected indicator state. */
 	open?: boolean
-	/** Background color (any CSS color). Falls back to the default pin tint.
-	 *  Ignored while resolved — resolved pins are always grey. */
-	color?: string
 }
 
 /* An inline check, not a text glyph — the '✓' character sits off-baseline and varies by font. */
@@ -33,24 +30,16 @@ const resolvedCheck = (
 /** A canvas comment marker: shows its `children` (or a check when resolved). Purely
  * presentational — it reflects open/resolved state via CSS; wrap it to make it clickable.
  * @public @react */
-export function CommentPin({ children, resolved, open, color }: CommentPinProps) {
+export function CommentPin({ children, resolved, open }: CommentPinProps) {
 	const className = [
-		// `tlui-cmt-marker` carries the resting shadow, the hover lift, and the open ring — the same
-		// treatment a count badge wears, so the two markers behave alike.
+		// `tlui-cmt-marker` carries the resting shadow and the hover lift — the same treatment a
+		// count badge wears, so the two markers behave alike.
 		'tlui-cmt-marker',
 		'tlui-cmt-pin',
 		resolved && 'tlui-cmt-pin--resolved',
 		open && 'tlui-cmt-marker--open',
-		open && 'tlui-cmt-pin--open',
 	]
 		.filter(Boolean)
 		.join(' ')
-	// A custom property rather than backgroundColor, so the open ring follows the tint too.
-	const style =
-		color && !resolved ? ({ '--tlui-cmt-pin-color': color } as CSSProperties) : undefined
-	return (
-		<div className={className} style={style}>
-			{resolved ? resolvedCheck : children}
-		</div>
-	)
+	return <div className={className}>{resolved ? resolvedCheck : children}</div>
 }

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -3,6 +3,7 @@
 .tlui-cmt-card {
 	position: relative;
 	display: flex;
+	flex-direction: column;
 	gap: 8px;
 	padding: 8px;
 	width: 260px;
@@ -11,17 +12,19 @@
 	border-radius: var(--tl-radius-3);
 }
 
+/* The avatar lives in the byline row (see Byline), so the body text below indents to line up with
+   the name — the avatar's width plus the head's gap. */
+.tlui-cmt-body {
+	padding-left: calc(28px + 6px);
+}
+
 /* hover-revealed controls (edit, react…) stacked at the card's top-right */
 .tlui-cmt-card__actions {
 	position: absolute;
 	top: 6px;
 	right: 6px;
 	display: flex;
-	gap: 2px;
-	padding: 2px;
-	background: var(--tl-color-panel);
-	border-radius: var(--tl-radius-3);
-	box-shadow: var(--tlui-cmt-pill-shadow);
+	gap: 0;
 	opacity: 0;
 }
 .tlui-cmt-card:hover .tlui-cmt-card__actions,
@@ -44,7 +47,7 @@
 }
 
 .tlui-cmt-author {
-	font-weight: 600;
+	font-weight: 500;
 	font-size: 12px;
 	color: var(--tl-color-text-1);
 	/* a long name ellipsizes rather than pushing the time out or running under the actions */
@@ -55,14 +58,24 @@
 }
 
 .tlui-cmt-time {
-	font-size: 10px;
+	font-size: 12px;
 	color: var(--tl-color-text-3);
 	flex-shrink: 0;
 	white-space: nowrap;
 }
 
+/* In the hover preview a long comment truncates with an ellipsis rather than growing the card —
+   ~7 lines (≈120px at this line height). Preview only. */
+.tlui-cmt-canvas-preview--thread .tlui-cmt-text {
+	display: -webkit-box;
+	-webkit-box-orient: vertical;
+	-webkit-line-clamp: 7;
+	line-clamp: 7;
+	overflow: hidden;
+}
+
 .tlui-cmt-text {
-	margin: 3px 0 0;
+	margin: 0 0 6px;
 	font-size: 12px;
 	line-height: 1.4;
 	color: var(--tl-color-text-1);
@@ -136,7 +149,7 @@
 	padding: 3px 3px 3px 8px;
 	background: var(--tl-color-muted-0);
 	border: 1px solid var(--tl-color-divider);
-	border-radius: var(--tl-radius-3);
+	border-radius: var(--tl-radius-2);
 	/* The whole field reads as the text input — clicking its empty area focuses the editor
 	   (see CommentComposer). The send button restores its own pointer cursor. */
 	cursor: text;
@@ -144,12 +157,15 @@
 
 .tlui-cmt-composer__field:focus-within {
 	border-color: var(--tl-color-selected);
+	background: var(--tl-color-panel);
 }
 
 /* Expanded: the content no longer fits on one line beside the send button, so the input takes
    the full width and the send button drops to its own row, right-aligned. */
 .tlui-cmt-composer__field--expanded {
 	flex-wrap: wrap;
+	/* No vertical gap between the input and the send-button row it wraps onto. */
+	row-gap: 0;
 }
 .tlui-cmt-composer__field--expanded .tlui-cmt-composer__input-wrap {
 	flex-basis: 100%;
@@ -192,11 +208,6 @@
 	color: var(--tl-color-text-1);
 	outline: none;
 	min-height: 17px;
-	/* Long pastes scroll inside a compact box instead of growing the composer to fill the
-	   screen — ~9 lines, capped further on short viewports. Overflow scrolls (see the wheel
-	   handler in CommentComposer, which keeps a wheel here from panning the canvas). */
-	max-height: min(160px, 40vh);
-	overflow-y: auto;
 	white-space: pre-wrap;
 	word-break: break-word;
 }
@@ -227,32 +238,34 @@
 	pointer-events: none;
 }
 
-/* An up-arrow icon button, sized to sit inside the composer field's 3px inset (the field is
-   ~29px tall there). Centre it on the input's line rather than bottom-aligning (a leftover from
-   the old text "Send" button, which sat at the field's bottom as it grew to multiple lines). */
+/* A bare up-arrow icon button (matching the placement composer): no fill by default, a grey square
+   on hover, grey while there's nothing to send and dark once there is. */
 .tlui-cmt-send {
 	flex-shrink: 0;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 23px;
-	height: 23px;
+	width: 28px;
+	height: 28px;
 	border: 0;
-	border-radius: 50%;
-	background: var(--tl-color-selected);
-	color: #fff;
+	border-radius: var(--tl-radius-2);
+	background: transparent;
+	color: var(--tl-color-text-3);
 	cursor: pointer;
 	align-self: center;
 }
 
-.tlui-cmt-send:hover:not(:disabled),
-.pseudo-hover .tlui-cmt-send:not(:disabled) {
-	background: color-mix(in srgb, var(--tl-color-selected) 88%, black);
+.tlui-cmt-send:not(:disabled) {
+	color: var(--tl-color-text-1);
+}
+
+.tlui-cmt-send:hover:not(:disabled) {
+	background: var(--tl-color-muted-2);
 }
 
 .tlui-cmt-send:active:not(:disabled),
 .pseudo-active .tlui-cmt-send:not(:disabled) {
-	background: color-mix(in srgb, var(--tl-color-selected) 78%, black);
+	background: var(--tl-color-muted-1);
 }
 
 .tlui-cmt-send:focus-visible,
@@ -261,17 +274,15 @@
 	outline-offset: 2px;
 }
 
-/* Disabled reads as grey, not a washed-out blue — "can't send yet" rather than "send, dimmed". */
 .tlui-cmt-send:disabled {
-	background: var(--tl-color-muted-1);
+	background: transparent;
 	color: var(--tl-color-text-3);
 	cursor: not-allowed;
 }
 
 /* The shared marker treatment. To the pointer a comment pin and a count badge are the same
-   object — a token sitting on the canvas — so they rest, lift, and ring identically. Only the tint
-   differs, which each marker supplies via `--tlui-cmt-marker-tint`; everything else lives here so
-   the two can't drift apart. */
+   object — a token sitting on the canvas — so they rest and lift identically; everything shared
+   lives here so the two can't drift apart. */
 .tlui-cmt-marker {
 	box-shadow: var(--tlui-cmt-marker-shadow);
 	cursor: pointer;
@@ -280,44 +291,53 @@
 		box-shadow var(--tlui-cmt-marker-transition);
 }
 
-.tlui-cmt-marker:hover,
-.pseudo-hover .tlui-cmt-marker {
+.tlui-cmt-marker:hover {
 	transform: scale(var(--tlui-cmt-marker-hover-scale));
 }
 
 /* The hover shadow is for closed markers only — an open one keeps its selection ring, which this
    box-shadow would otherwise override (the hover selector outranks the --open rule). */
-.tlui-cmt-marker:not(.tlui-cmt-marker--open):hover,
-.pseudo-hover .tlui-cmt-marker:not(.tlui-cmt-marker--open) {
+.tlui-cmt-marker:not(.tlui-cmt-marker--open):hover {
 	box-shadow: var(--tlui-cmt-marker-shadow-hover);
 }
 
-/* open: the thread (or a stack's list) is showing — a selection ring marks the active marker, in
-   that marker's own tint. */
-.tlui-cmt-marker--open {
-	box-shadow:
-		0 0 0 2px var(--tl-color-panel),
-		0 0 0 4px var(--tlui-cmt-marker-tint),
-		var(--tlui-cmt-marker-shadow);
+/* Count badges don't react to hover — no scale, no shadow lift. Only pins do. */
+.tlui-cmt-count-badge:hover {
+	transform: none;
+	box-shadow: var(--tlui-cmt-marker-shadow);
 }
 
-/* pin — a canvas marker tinted with the comment author's color (via the `color` prop →
-   `--tlui-cmt-pin-color`) so a thread is identifiable at a glance. The composer's draft avatar
-   overrides to panel-white while you're still editing (see canvas.css). */
+/* Pins don't scale on hover — only the shadow lifts. */
+.tlui-cmt-pin:hover {
+	transform: none;
+}
+
+/* open: the thread (or a stack's list) is showing — the active marker just keeps its lift shadow,
+   no selection ring. */
+.tlui-cmt-marker--open {
+	box-shadow: var(--tlui-cmt-marker-shadow);
+}
+
+/* pin — a canvas marker: a white teardrop holding the author's avatar circle, so a thread is
+   identifiable at a glance. */
 .tlui-cmt-pin {
-	--tlui-cmt-marker-tint: var(--tlui-cmt-pin-color, var(--tl-color-selected));
 	/* A pin is smaller than the count badge, which keeps the marker-size default. */
 	--tlui-cmt-marker-size: var(--tlui-cmt-pin-size);
 	width: var(--tlui-cmt-marker-size);
 	height: var(--tlui-cmt-marker-size);
-	border-radius: 50% 50% 50% 3px;
-	background: var(--tlui-cmt-pin-color, var(--tl-color-selected));
+	border-radius: 50% 50% 50% 0;
+	background: var(--tl-color-panel);
 	color: #fff;
 	display: flex;
 	align-items: center;
 	justify-content: center;
 	font-size: 14px;
 	font-weight: 600;
+}
+/* The pin holds the author's 22px avatar circle, centred in its 28px face. */
+.tlui-cmt-pin .tlui-cmt-avatar {
+	width: 22px;
+	height: 22px;
 }
 
 /* resolved: a solid, muted grey (the default --tl-color-muted-1 is 10% black, so it goes
@@ -331,10 +351,8 @@
 	color: hsl(0, 0%, 72%);
 }
 
-/* count badge — the same marker as a pin, keeping its own colour as the tint so the ring matches
-   the face, exactly as the pin's does. */
+/* count badge — the same marker as a pin. */
 .tlui-cmt-count-badge {
-	--tlui-cmt-marker-tint: var(--tl-color-text-1);
 	width: var(--tlui-cmt-marker-size);
 	height: var(--tlui-cmt-marker-size);
 	border-radius: 50%;
@@ -352,7 +370,6 @@
 .tlui-cmt-thread {
 	display: flex;
 	flex-direction: column;
-	gap: 8px;
 	width: 300px;
 }
 
@@ -389,37 +406,37 @@
 .tlui-cmt-reaction {
 	display: inline-flex;
 	align-items: center;
-	gap: 5px;
-	padding: 3px 9px;
-	border-radius: 999px;
-	border: 1px solid var(--tl-color-divider);
-	background: var(--tl-color-panel);
+	gap: 4px;
+	padding: 2px 6px;
+	border: none;
+	border-radius: var(--tl-radius-1);
+	background: var(--tl-color-muted-2);
 	font: inherit;
-	font-size: 12px;
+	font-size: 10px;
+	font-weight: 400;
 	color: var(--tl-color-text-1);
 	cursor: pointer;
 }
 
-.tlui-cmt-reaction:hover,
-.pseudo-hover .tlui-cmt-reaction {
-	border-color: var(--tl-color-selected);
+/* Hover deepens the grey — no border to tint now. Mixing toward the text colour is theme-aware:
+   it darkens the fill in light mode and lightens it in dark, tracking the pill's own contrast. */
+.tlui-cmt-reaction:hover {
+	background: var(--tl-color-muted-1);
 }
 
-/* your own reactions read as filled-in: a deeper wash of the selection colour than the hover
-   state, so "I reacted with this" is distinguishable from "my pointer is over this" */
+/* a reaction you're part of fills with the selection colour, so "I reacted with this" stands out
+   from the grey pills of reactions you haven't joined. */
 .tlui-cmt-reaction--active {
-	border-color: var(--tl-color-selected);
 	background: color-mix(in srgb, var(--tl-color-selected) 28%, var(--tl-color-panel));
 }
 
-.tlui-cmt-reaction--active:hover,
-.pseudo-hover .tlui-cmt-reaction--active {
+.tlui-cmt-reaction--active:hover {
 	background: color-mix(in srgb, var(--tl-color-selected) 38%, var(--tl-color-panel));
 }
 
-/* the emoji carries the pill; the count stays at the pill's base size beside it */
+/* the emoji sits at the same 10px as the count beside it */
 .tlui-cmt-reaction__emoji {
-	font-size: 15px;
+	font-size: 10px;
 	line-height: 1;
 }
 
@@ -430,25 +447,25 @@
 
 .tlui-cmt-reaction--active .tlui-cmt-reaction__count {
 	color: var(--tl-color-text-1);
-	font-weight: 600;
 }
 
 /* emoji picker */
 .tlui-cmt-emoji-picker {
 	display: grid;
-	grid-template-columns: repeat(5, 1fr);
-	gap: 2px;
+	grid-template-columns: repeat(5, 40px);
+	gap: 0;
 	padding: 4px;
 }
 
 .tlui-cmt-emoji-picker__item {
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 34px;
-	height: 34px;
+	width: 40px;
+	height: 40px;
+	padding: 0;
 	border: none;
-	border-radius: var(--tl-radius-2);
 	background: none;
 	font: inherit;
 	font-size: 21px;
@@ -456,12 +473,23 @@
 	cursor: pointer;
 }
 
-.tlui-cmt-emoji-picker__item:hover,
-.pseudo-hover .tlui-cmt-emoji-picker__item {
+/* Inset wash behind the glyph — the 40px hit cells tile edge-to-edge, the squares sit 4px apart,
+   like the thread action buttons. Sits under the emoji so an opaque selected fill can't hide it. */
+.tlui-cmt-emoji-picker__item::after {
+	content: '';
+	position: absolute;
+	inset: 2px;
+	z-index: -1;
+	border-radius: var(--tl-radius-2);
+}
+.tlui-cmt-emoji-picker__item:hover {
+	z-index: 1;
+}
+.tlui-cmt-emoji-picker__item:hover::after {
 	background: var(--tl-color-muted-2);
 }
 
-.tlui-cmt-emoji-picker__item--active {
+.tlui-cmt-emoji-picker__item--active::after {
 	background: color-mix(in srgb, var(--tl-color-selected) 28%, var(--tl-color-panel));
 }
 
@@ -508,8 +536,8 @@
 	--tlui-cmt-marker-shadow-hover: var(--tlui-cmt-marker-shadow);
 	--tlui-cmt-marker-hover-scale: 1.08;
 	--tlui-cmt-marker-transition: 0.08s ease;
-	--tlui-cmt-thread-padding: 8px;
-	--tlui-cmt-thread-gap: 6px;
+	--tlui-cmt-thread-padding: 12px;
+	--tlui-cmt-thread-gap: 0px;
 	--tlui-cmt-thread-action-size: 26px;
 	/* A floating pill's edge — its hairline ring is the only thing separating it from the panel it
 	   overlaps, so the ring is a theme token rather than a literal black: a near-black hairline
@@ -522,9 +550,7 @@
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	gap: var(--tlui-cmt-thread-gap);
 	width: 300px;
-	padding: var(--tlui-cmt-thread-padding);
 	background: var(--tl-color-panel);
 	border-radius: var(--tl-radius-4);
 	box-shadow: var(--tl-shadow-3);
@@ -556,38 +582,36 @@
 .tlui-cmt-thread__header:has(.tlui-cmt-thread__title) {
 	position: static;
 	align-items: center;
-	padding: 2px 2px 2px 4px;
+	padding: 0;
 	background: none;
 	border-radius: 0;
 	box-shadow: none;
 }
-/* …and with a header occupying that corner, the first comment's actions stay inside their card
-   rather than floating up into it. */
-.tlui-cmt-thread:has(.tlui-cmt-thread__title)
-	.tlui-cmt-thread__list
-	> :first-child
-	.tlui-cmt-card__actions {
-	top: 3px;
-}
 .tlui-cmt-thread__title {
+	padding: 10px 12px;
 	font-size: 12px;
-	font-weight: 600;
+	line-height: 20px;
+	font-weight: 500;
 	color: var(--tl-color-text-1);
 }
 .tlui-cmt-thread__actions {
 	display: flex;
-	gap: 2px;
+	gap: 0;
 	/* Right-align the actions whether or not the header has a title (it currently has none, so
 	   space-between alone would leave them at the left). */
 	margin-left: auto;
 }
+/* Follows tldraw's toolbar buttons (.tlui-button), used by both the header and card actions: the
+   button is the 40px hit target that tiles with its neighbours; its 32px ::after is the visual
+   square carrying the hover wash, so the hit area (not the ::after) is what's clickable and it
+   never reaches past its row. */
 .tlui-cmt-thread__action {
 	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: var(--tlui-cmt-thread-action-size);
-	height: var(--tlui-cmt-thread-action-size);
+	width: 40px;
+	height: 40px;
 	padding: 0;
 	border: none;
 	border-radius: 6px;
@@ -597,33 +621,31 @@
 	line-height: 1;
 	cursor: pointer;
 }
-/* Enlarge the click/tap target past the compact 26px visual — the button reads small but is
-   comfortable to hit. A transparent ::after, so nothing changes visually.
-
-   Sideways it stops at half the row's 2px gap, so neighbouring targets tile instead of overlapping.
-   Overlapping would be worse than no expansion at all: the targets are siblings with no z-index, so
-   the later one paints — and hits — on top, and a 6px reach across a 2px gap would put delete's
-   invisible target over the right edge of edit's *visible* button. The row's outer edges have no
-   neighbour to steal from, so they expand fully. */
+/* Overlap each button 4px into the previous so the 32px visual squares sit 4px apart, not 8px.
+   Left-only, so the last button's hit area still stops at its row's right edge. */
+.tlui-cmt-thread__action + .tlui-cmt-thread__action {
+	margin-left: -4px;
+}
 .tlui-cmt-thread__action::after {
 	content: '';
 	position: absolute;
-	inset: -6px -1px;
-}
-.tlui-cmt-thread__action:first-child::after {
-	left: -6px;
-}
-.tlui-cmt-thread__action:last-child::after {
-	right: -6px;
+	inset: 4px;
+	border-radius: var(--tl-radius-2);
 }
 .tlui-cmt-thread__action:hover {
-	background: var(--tl-color-muted-2);
 	color: var(--tl-color-text-1);
+	/* Raise the hovered button above its overlapping neighbours so its 40px hit area wins the
+	   overlap zone — the same z-index flip tldraw's own toolbar buttons use. */
+	z-index: 1;
+}
+.tlui-cmt-thread__action:hover::after {
+	background: var(--tl-color-muted-2);
 }
 .tlui-cmt-thread__action--danger:hover {
 	color: var(--tl-color-danger);
 }
 .tlui-cmt-thread__resolved {
+	margin: 4px 12px;
 	padding: 6px 10px;
 	border-radius: 8px;
 	background: var(--tl-color-muted-2);
@@ -635,6 +657,11 @@
 	flex-direction: column;
 	gap: var(--tlui-cmt-thread-gap);
 }
+/* When nothing follows the list (a resolved thread has no composer or footer) the last comment
+   would sit against the panel's rounded bottom — restore the trailing inset the composer supplies. */
+.tlui-cmt-thread__list:last-child {
+	padding-bottom: 12px;
+}
 /* The footer slot sits where the composer would — its content (e.g. a sign-in prompt) sits at
    the thread's trailing edge, like the composer's send button. */
 .tlui-cmt-thread__footer {
@@ -645,15 +672,16 @@
 /* Inside a thread, author identity is a small colour dot, no initial — the letter doesn't fit
    at this size. */
 .tlui-cmt-thread .tlui-cmt-avatar,
-.tlui-cmt-canvas-preview--thread .tlui-cmt-avatar {
-	width: 14px;
-	height: 14px;
+.tlui-cmt-canvas-preview--thread .tlui-cmt-avatar,
+.tlui-cmt-canvas-preview--list .tlui-cmt-avatar,
+.tlui-cmt-stack-list .tlui-cmt-avatar {
+	width: 12px;
+	height: 12px;
 	font-size: 0;
-	margin-top: 2px;
 }
 
 .tlui-cmt-thread .tlui-cmt-composer {
-	padding: 4px 0 0;
+	padding: 12px;
 }
 .tlui-cmt-thread .tlui-cmt-composer .tlui-cmt-avatar {
 	display: none;
@@ -666,10 +694,23 @@
 	font-size: 0;
 	margin-top: 2px;
 }
+/* The sidebar row already leads with its own avatar (the flex row's first column); the byline's
+   avatar — added for the canvas thread views — would double it, so hide the byline's inside a row. */
+.tlui-cmt-list .tlui-cmt-head .tlui-cmt-avatar {
+	display: none;
+}
 
 /* The dot treatment is for colour-only identity — an image avatar stays full size. */
 .tlui-cmt-thread .tlui-cmt-avatar--image,
 .tlui-cmt-canvas-preview--thread .tlui-cmt-avatar--image,
+.tlui-cmt-canvas-preview--list .tlui-cmt-avatar--image,
+.tlui-cmt-stack-list .tlui-cmt-avatar--image {
+	/* Match the 12px colour dot's width so the body's calc(12px + 6px) indent still lines up under
+	   the byline name when the author has an image rather than a dot. */
+	width: 12px;
+	height: 12px;
+	margin-top: 0;
+}
 .tlui-cmt-list .tlui-cmt-avatar--image {
 	width: 24px;
 	height: 24px;
@@ -682,22 +723,39 @@
 .tlui-cmt-thread .tlui-cmt-card,
 .tlui-cmt-canvas-preview--thread .tlui-cmt-card {
 	width: 100%;
-	padding: 6px 0 6px 4px;
+	gap: 0;
+	padding: 0 12px;
 	background: transparent;
 	border: none;
+}
+/* The avatar is a 12px dot, so the body lines up 12px + the head's 6px gap in from the row. */
+.tlui-cmt-thread .tlui-cmt-body,
+.tlui-cmt-canvas-preview--thread .tlui-cmt-body,
+.tlui-cmt-canvas-preview--list .tlui-cmt-body,
+.tlui-cmt-stack-list .tlui-cmt-body {
+	padding-left: calc(12px + 6px);
 }
 /* Inside a panel the actions float as their own pill — the same pill the thread header is, in the
    same corner (which is why the header hides while the first comment is hovered). It sits just
    above the card's top edge rather than on the byline. */
-.tlui-cmt-thread .tlui-cmt-card .tlui-cmt-card__actions,
-.tlui-cmt-canvas-preview--thread .tlui-cmt-card .tlui-cmt-card__actions {
-	top: -2px;
-	right: 2px;
+/* Line the card actions up with the header actions: flush to the full-width card's right edge (the
+   panel edge, matching the header ✕) and flush on the 40px byline row, so the 40px buttons fill it. */
+.tlui-cmt-thread .tlui-cmt-card .tlui-cmt-card__actions {
+	top: 0;
+	right: 0;
 }
-/* The pill overlays the byline's corner, so reserve its footprint — the byline can never run
-   underneath it, even mid-hover. Derived from the action size so it can't drift:
-   n buttons + (n−1) 2px gaps + the pill's 2px padding either side + its 2px right inset. One
-   button (react) on others' comments, three (edit, delete, react) on your own. */
+/* The byline row is 40px: on the opened thread it fits the action pills (react/edit/delete) that
+   float in its corner without the text running underneath; previews and collapsed cards carry the
+   same height so every comment row reads identically, solo or in a stack. */
+.tlui-cmt-thread .tlui-cmt-card .tlui-cmt-head,
+.tlui-cmt-canvas-preview--thread .tlui-cmt-card .tlui-cmt-head,
+.tlui-cmt-canvas-preview--list .tlui-cmt-card .tlui-cmt-head,
+.tlui-cmt-stack-list .tlui-cmt-card .tlui-cmt-head {
+	min-height: 40px;
+}
+/* Only the opened thread's comments actually carry the pills, so only they reserve room for them.
+   Derived from the action size so it can't drift: n buttons + (n−1) 2px gaps + the pill's 2px
+   padding either side + its 2px right inset. One button (react) on others' comments. */
 .tlui-cmt-thread .tlui-cmt-card .tlui-cmt-head {
 	padding-right: calc(var(--tlui-cmt-thread-action-size) + 6px);
 }
@@ -768,26 +826,35 @@
 
 /* The commenting dropdowns' surface — a little air between the items and the menu edge. */
 .tlui-cmt-menu {
+	min-width: 100px;
 	padding: 4px;
 }
 
 /* a menu row with a label and a right-aligned shortcut hint (overflow menu) */
 .tlui-cmt-menu-item {
+	position: relative;
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 24px;
 	width: 100%;
-	padding: 6px 8px;
+	min-height: 40px;
+	padding: 0 10px;
 	border: none;
-	border-radius: 6px;
 	background: transparent;
 	font: inherit;
 	font-size: 12px;
 	color: var(--tl-color-text-1);
 	cursor: pointer;
 }
-.tlui-cmt-menu-item:hover {
+/* 36px visual inset within the 40px row — the hover wash the action and emoji buttons use. */
+.tlui-cmt-menu-item::after {
+	content: '';
+	position: absolute;
+	inset: 2px;
+	border-radius: var(--tl-radius-2);
+}
+.tlui-cmt-menu-item:hover::after {
 	background: var(--tl-color-muted-2);
 }
 /* Destructive menu entries (delete) — the same danger colour as tldraw's danger buttons. */

--- a/packages/commenting/src/ui/format-time.ts
+++ b/packages/commenting/src/ui/format-time.ts
@@ -9,7 +9,7 @@ const DIVISIONS = [
 ] as const
 
 /**
- * Format an ISO datetime as relative time ("2 hours ago", "yesterday", "last week").
+ * Format an ISO datetime as short relative time ("2 hr. ago", "yesterday", "last wk.").
  * Locale-aware via Intl.RelativeTimeFormat.
  * @public
  */
@@ -17,7 +17,7 @@ export function formatRelativeTime(iso: string, locale = 'en'): string {
 	const then = new Date(iso).getTime()
 	if (Number.isNaN(then)) return ''
 
-	const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' })
+	const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto', style: 'short' })
 	let duration = (then - Date.now()) / 1000
 	// Under a minute is just "now" — with second granularity the label visibly ticks while
 	// typing a reply (every keystroke re-renders the card).

--- a/packages/commenting/src/ui/reaction-picker.tsx
+++ b/packages/commenting/src/ui/reaction-picker.tsx
@@ -82,8 +82,8 @@ export function ReactionPicker({
 					<SmileyIcon />
 				</TooltipButton>
 			</TldrawUiDropdownMenuTrigger>
-			{/* right-aligned under the trigger, so the grid hangs down the card's right edge */}
-			<TldrawUiDropdownMenuContent side="bottom" align="end" alignOffset={0}>
+			{/* left-aligned under the trigger, so the grid opens rightward off the card's edge */}
+			<TldrawUiDropdownMenuContent side="bottom" align="start" alignOffset={0} sideOffset={4}>
 				<Palette
 					emoji={emoji}
 					selected={selected}


### PR DESCRIPTION
Restyle of the canvas commenting UI, aligning the thread / stack / cluster previews and refreshing the composer, cards, reactions, markers, and dropdowns. Part of the `commenting` feature branch (base: `commenting`).

## What changed

- **Composer** — restyled the placement + reply composer field (radius, shadow, and focus ring from tokens), an author-colour dot in place of the avatar, and a bare-icon send button with a 40px hit area.
- **Comment cards & byline** — the avatar now sits inside the byline row as a 12px colour dot; action and emoji buttons share the tldraw 40px-hit / inset-wash / z-index-on-hover pattern.
- **Previews** — the single-pin preview, the cluster hover preview, and the collapsed stack cards share one comment layout (12px inset, 40px byline, `gap: 0`, dot avatar, matching padding). The cluster preview sits 6px off its badge like the pin preview, and the stack lifts to hold the first thread's "You" in place from hover → open.
- **Reactions** — grey pill (`--tl-color-muted-1`, 4px radius, borderless, 10px emoji + count); your own reaction is a deeper grey.
- **Markers** — removed the open-marker selection ring and the count badge's hover (scale + shadow lift). Pins keep their hover.
- **Dropdowns** — 40px rows with a 36px inset hover wash, `sideOffset: 4`, `min-width: 100px`.
- **Behaviour** — resolved threads' pins are hidden on the canvas by default, matching the sidebar's `showResolved` filter (the open thread stays visible so resolving from its popover doesn't drop the pin).

### API changes

- Removed the `color` prop from `CommentPinProps` (`CommentPin`). It only tinted the now-removed open-state selection ring — it never set the pin's background despite its doc — so it was inert. The internal `--tlui-cmt-pin-color` / `--tlui-cmt-marker-tint` custom properties went with it.

## How to test

Preview deploy: https://pr-9776-preview-deploy.tldraw.com/

1. Open the commenting example (`yarn dev` → Commenting), or the dotcom preview with a signed-in user and a file open.
2. Place a comment (`c`, then click the canvas) — check the composer field, send button, and avatar dot.
3. Make a few coincident comments (a stack) and/or zoom out until they cluster (the "N" badge). Hover the badge (preview cards), then click it and expand the top thread — the "You" rows should hold position across hover → open.
4. Open a thread and add reactions — check the grey pills and the deeper grey of your own.
5. Resolve a thread — its pin should vanish from the canvas; toggle "show resolved" in the sidebar filter to bring it back.
