### PR TITLE
fix(commenting): anchor and size cluster badges like pins, retune clustering thresholds

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -39,8 +39,10 @@
 	font: inherit;
 }
 
+/* Anchored by its bottom-left corner like a pin, so the badge sits up-and-right of the cluster's
+   centroid — the same visual-to-anchor relationship a single comment pin has. */
 .tlui-cmt-canvas-cluster {
-	transform: translate(-50%, -50%);
+	transform: translate(0, -100%);
 	pointer-events: auto;
 	cursor: pointer;
 }
@@ -103,7 +105,8 @@
    (`pointer-events: none`) so its box doesn't shadow the canvas — without this the badge renders
    but can't be hovered or clicked, like the cluster badge's own `pointer-events: auto`. */
 .tlui-cmt-canvas-stack-badge {
-	transform: translate(-50%, -50%);
+	/* Bottom-left anchored like the pins it stands in for, and like the cluster badge. */
+	transform: translate(0, -100%);
 	width: max-content;
 	pointer-events: auto;
 	cursor: pointer;
@@ -216,9 +219,9 @@
 	--tlui-cmt-preview-bridge: calc(var(--tlui-cmt-preview-offset) - var(--tlui-cmt-pin-size));
 }
 
-/* A badge is centred on its anchor, so only half of it does. */
+/* A badge is anchored at its bottom-left corner like a pin, so its full width does too. */
 .tlui-cmt-canvas-preview--list {
-	--tlui-cmt-preview-bridge: calc(var(--tlui-cmt-preview-offset) - var(--tlui-cmt-marker-size) / 2);
+	--tlui-cmt-preview-bridge: calc(var(--tlui-cmt-preview-offset) - var(--tlui-cmt-marker-size));
 }
 
 .tlui-cmt-canvas-preview__panel {

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -76,10 +76,11 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 		() => {
 			const first = threads[0]
 			if (first.pageId !== editor.getCurrentPageId()) return null
-			// The badge is centered on its anchor point (transform: translate(-50%, -50%)), like the
-			// cluster badge — so it sits at the raw page point with no pin inset. The inset only
-			// compensates for the single pin's bottom-left anchoring; applying it here would offset
-			// the badge from where the cluster badge sits and make it hop as pins flip between them.
+			// The badge hangs off its anchor point bottom-left (transform: translate(0, -100%)),
+			// like a pin and like the cluster badge — but it sits at the raw page point with no pin
+			// inset. The inset only tucks an imprecise single pin inside its shape; applying it here
+			// would offset the badge from where the cluster badge sits (cluster centroids average
+			// raw anchor points) and make it hop as pins flip between them.
 			const pagePoint = anchorPagePoint(editor, first.anchor)
 			return pagePoint ? editor.pageToViewport(pagePoint) : null
 		},

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -75,9 +75,16 @@ export function toCardProps(
  *  correcting for that. Keep in sync with the stylesheet. */
 const PIN_SIZE = 28
 
-/** A coincident stack's / cluster's card list, whose first card sits flush with the popover top.
- *  x = half the 34px badge (it's centred on its point) + the same 6px gap the pin's preview uses. */
-const LIST_OFFSET = { x: 23, y: -28 } as const
+/** A cluster/stack badge is this square (`--tlui-cmt-marker-size`) — pin-sized, so the marker
+ *  kinds read as one family. Keep in sync with the stylesheet. */
+const MARKER_SIZE = PIN_SIZE
+
+/** Where a popover's top card sits vertically, measured from the marker visual's middle. */
+const CARD_TOP_Y = -28
+
+/** The horizontal gap between a marker visual's right edge and its popover/preview panel. The
+ *  preview's hover bridge spans exactly this (see `--tlui-cmt-preview-bridge`). */
+const PREVIEW_GAP = 6
 
 /**
  * Where a marker's popover sits relative to the marker's anchor point.
@@ -86,21 +93,14 @@ const LIST_OFFSET = { x: 23, y: -28 } as const
  * by the header the popover has — which its own stylesheet then compensates for. Moving a popover
  * here moves its preview with it.
  *
- * The two marker kinds don't anchor alike, which the vertical offsets have to correct for. A
- * badge is centred on its point (`translate(-50%, -50%)`), so `LIST_OFFSET.y` is measured from its
- * middle. A pin hangs off its point (`translate(0, -100%)`), so its point is the pin's *bottom*.
- * Measuring a raw offset from there would drop the pin's preview half a pin below a badge's; the
- * terms below re-base it so the two previews' top cards land on the same line.
+ * Both marker kinds hang off their point the same way (`translate(0, -100%)`): the anchor is the
+ * visual's bottom-left corner. They differ only in size, so each offset clears its own width plus
+ * the shared gap, and re-bases the shared card-top measure from its bottom anchor to its middle —
+ * keeping the two previews' top cards on the same line.
  */
 export const POPOVER_OFFSET = {
-	/**
-	 * A single pin's thread popover. Its preview should read level with a cluster/stack preview's
-	 * top card, so start from the list offset and re-base it from the pin's bottom anchor to the
-	 * pin's middle — where a badge measures from — with `- PIN_SIZE / 2`. The opened popover shares
-	 * the offset and opens from there.
-	 */
-	thread: { x: PIN_SIZE + 6, y: LIST_OFFSET.y - PIN_SIZE / 2 },
-	list: LIST_OFFSET,
+	thread: { x: PIN_SIZE + PREVIEW_GAP, y: CARD_TOP_Y - PIN_SIZE / 2 },
+	list: { x: MARKER_SIZE + PREVIEW_GAP, y: CARD_TOP_Y - MARKER_SIZE / 2 },
 } as const
 
 /** The open thread's popover container, portaled above the UI panels. Over it, wheel and hover

--- a/packages/commenting/src/clustering/computeClusterTable.test.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.test.ts
@@ -86,27 +86,27 @@ describe('computeClusterTable composition', () => {
 		}
 	})
 
-	it('resolves all defaults from an empty option set (Tc 40, Tu 60, eps 0.12, Dmax 120)', () => {
+	it('resolves all defaults from an empty option set (Tc 25, Tu 30, eps 0.35, Dmax 93.75)', () => {
 		const leaves = randomLeaves(30, 7)
 		const table = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
 		const expected = manualPipeline(leaves, {
-			Tc: 40,
-			Tu: 60,
-			eps: 0.12,
-			Dmax: 120,
+			Tc: 25,
+			Tu: 30,
+			eps: 0.35,
+			Dmax: 93.75,
 			...ZOOM_BOUNDS,
 		})
 		expect(tableShapes(table)).toEqual(expected.map(eventShape))
 	})
 
-	it('derives Tu and Dmax from a caller-supplied Tc (Tu = 1.5·Tc, Dmax = 3·Tc)', () => {
+	it('derives Tu and Dmax from a caller-supplied Tc (Tu = 1.2·Tc, Dmax = 3.75·Tc)', () => {
 		const leaves = randomLeaves(30, 13)
 		const table = computeClusterTable(leaves, { Tc: 50, ...ZOOM_BOUNDS })
 		const expected = manualPipeline(leaves, {
 			Tc: 50,
-			Tu: 75,
-			eps: 0.12,
-			Dmax: 150,
+			Tu: 60,
+			eps: 0.35,
+			Dmax: 187.5,
 			...ZOOM_BOUNDS,
 		})
 		expect(tableShapes(table)).toEqual(expected.map(eventShape))
@@ -114,11 +114,12 @@ describe('computeClusterTable composition', () => {
 
 	it('caps coincident pairs at the default maxSplitZoom of 6 (600%)', () => {
 		// Two threads at the same point: raw merge zoom is Infinity (never split), but the
-		// default cap schedules them to merge at 4 and split at 6 like any ultra-tight pair.
+		// default cap schedules them to merge at 5 (maxSplitZoom / (Tu/Tc) = 6 / 1.2) and split
+		// at 6 like any ultra-tight pair.
 		const leaves = [leaf('a', 50, 50), leaf('b', 50, 50)]
 		const table = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
 		expect(table.events).toHaveLength(1)
-		expect(table.events[0].zMerge).toBe(4)
+		expect(table.events[0].zMerge).toBe(5)
 		expect(table.events[0].zSplit).toBe(6)
 	})
 
@@ -126,10 +127,10 @@ describe('computeClusterTable composition', () => {
 		const leaves = randomLeaves(30, 29)
 		const table = computeClusterTable(leaves, { Tu: 100, eps: 0, ...ZOOM_BOUNDS })
 		const expected = manualPipeline(leaves, {
-			Tc: 40,
+			Tc: 25,
 			Tu: 100,
 			eps: 0,
-			Dmax: 120,
+			Dmax: 93.75,
 			...ZOOM_BOUNDS,
 		})
 		expect(tableShapes(table)).toEqual(expected.map(eventShape))
@@ -193,9 +194,9 @@ describe('computeClusterTable validation', () => {
 		expect(() => computeClusterTable(leaves, { Tc: 0, ...ZOOM_BOUNDS })).toThrow()
 		expect(() => computeClusterTable(leaves, { Tc: -5, ...ZOOM_BOUNDS })).toThrow()
 		expect(() => computeClusterTable(leaves, { Tc: 40, Tu: 40, ...ZOOM_BOUNDS })).toThrow()
-		expect(() => computeClusterTable(leaves, { Tu: 30, ...ZOOM_BOUNDS })).toThrow() // < default Tc 40
+		expect(() => computeClusterTable(leaves, { Tu: 20, ...ZOOM_BOUNDS })).toThrow() // < default Tc 25
 		expect(() => computeClusterTable(leaves, { eps: -0.01, ...ZOOM_BOUNDS })).toThrow()
-		expect(() => computeClusterTable(leaves, { Dmax: 30, ...ZOOM_BOUNDS })).toThrow() // < default Tc 40
+		expect(() => computeClusterTable(leaves, { Dmax: 20, ...ZOOM_BOUNDS })).toThrow() // < default Tc 25
 		expect(() => computeClusterTable(leaves, { Tc: 50, Dmax: 40, ...ZOOM_BOUNDS })).toThrow()
 		expect(() => computeClusterTable(leaves, { minZoom: 0, maxZoom: 8 })).toThrow()
 		expect(() => computeClusterTable(leaves, { minZoom: 8, maxZoom: 8 })).toThrow()
@@ -226,8 +227,8 @@ describe('computeClusterTable end-to-end scenarios', () => {
 		const leaves = Array.from({ length: 8 }, (_, i) => leaf(`p${i + 1}`, i * 10, 0))
 		const table = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
 
-		// events (centroid pricing): four pair births at zMerge 4 (zSplit 6), two
-		// quads at zMerge 2 (zSplit 3), the bridge at zMerge 1 (zSplit 1.5)
+		// events (centroid pricing): four pair births at zMerge 2.5 (zSplit 3), two
+		// quads at zMerge 1.25 (zSplit 1.5), the bridge at zMerge 0.625 (zSplit 0.75)
 		const seedAt = (zoom: number) => {
 			const rt = createClusterRuntime(table)
 			rt.seed(zoom)
@@ -235,12 +236,12 @@ describe('computeClusterTable end-to-end scenarios', () => {
 		}
 		// zoom 8: above every band midpoint → 8 separate pins
 		expect(seedAt(8)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'])
-		// zoom 3: below the pair midpoints (√24 ≈ 4.9), above the quad midpoint (√6 ≈ 2.45)
-		expect(seedAt(3)).toEqual(['cluster:2:p1', 'cluster:2:p3', 'cluster:2:p5', 'cluster:2:p7'])
-		// zoom 2: quads merged, above the bridge midpoint (√1.5 ≈ 1.22)
-		expect(seedAt(2)).toEqual(['cluster:4:p1', 'cluster:4:p5'])
-		// zoom 1: below everything → one badge of 8
-		expect(seedAt(1)).toEqual(['cluster:8:p1'])
+		// zoom 2: below the pair midpoints (√7.5 ≈ 2.74), above the quad midpoint (√1.875 ≈ 1.37)
+		expect(seedAt(2)).toEqual(['cluster:2:p1', 'cluster:2:p3', 'cluster:2:p5', 'cluster:2:p7'])
+		// zoom 1: quads merged, above the bridge midpoint (√0.469 ≈ 0.68)
+		expect(seedAt(1)).toEqual(['cluster:4:p1', 'cluster:4:p5'])
+		// zoom 0.5: below everything → one badge of 8
+		expect(seedAt(0.5)).toEqual(['cluster:8:p1'])
 	})
 
 	it('keeps far-apart groups exactly independent at eps = 0 (bridge pruned by minZoom)', () => {

--- a/packages/commenting/src/clustering/computeClusterTable.test.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.test.ts
@@ -86,14 +86,14 @@ describe('computeClusterTable composition', () => {
 		}
 	})
 
-	it('resolves all defaults from an empty option set (Tc 25, Tu 30, eps 0.35, Dmax 93.75)', () => {
+	it('resolves all defaults from an empty option set (Tc 22, Tu 26.4, eps 0.7, Dmax 82.5)', () => {
 		const leaves = randomLeaves(30, 7)
 		const table = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
 		const expected = manualPipeline(leaves, {
-			Tc: 25,
-			Tu: 30,
-			eps: 0.35,
-			Dmax: 93.75,
+			Tc: 22,
+			Tu: 26.4,
+			eps: 0.7,
+			Dmax: 82.5,
 			...ZOOM_BOUNDS,
 		})
 		expect(tableShapes(table)).toEqual(expected.map(eventShape))
@@ -105,7 +105,7 @@ describe('computeClusterTable composition', () => {
 		const expected = manualPipeline(leaves, {
 			Tc: 50,
 			Tu: 60,
-			eps: 0.35,
+			eps: 0.7,
 			Dmax: 187.5,
 			...ZOOM_BOUNDS,
 		})
@@ -127,10 +127,10 @@ describe('computeClusterTable composition', () => {
 		const leaves = randomLeaves(30, 29)
 		const table = computeClusterTable(leaves, { Tu: 100, eps: 0, ...ZOOM_BOUNDS })
 		const expected = manualPipeline(leaves, {
-			Tc: 25,
+			Tc: 22,
 			Tu: 100,
 			eps: 0,
-			Dmax: 93.75,
+			Dmax: 82.5,
 			...ZOOM_BOUNDS,
 		})
 		expect(tableShapes(table)).toEqual(expected.map(eventShape))
@@ -194,9 +194,9 @@ describe('computeClusterTable validation', () => {
 		expect(() => computeClusterTable(leaves, { Tc: 0, ...ZOOM_BOUNDS })).toThrow()
 		expect(() => computeClusterTable(leaves, { Tc: -5, ...ZOOM_BOUNDS })).toThrow()
 		expect(() => computeClusterTable(leaves, { Tc: 40, Tu: 40, ...ZOOM_BOUNDS })).toThrow()
-		expect(() => computeClusterTable(leaves, { Tu: 20, ...ZOOM_BOUNDS })).toThrow() // < default Tc 25
+		expect(() => computeClusterTable(leaves, { Tu: 20, ...ZOOM_BOUNDS })).toThrow() // < default Tc 22
 		expect(() => computeClusterTable(leaves, { eps: -0.01, ...ZOOM_BOUNDS })).toThrow()
-		expect(() => computeClusterTable(leaves, { Dmax: 20, ...ZOOM_BOUNDS })).toThrow() // < default Tc 25
+		expect(() => computeClusterTable(leaves, { Dmax: 20, ...ZOOM_BOUNDS })).toThrow() // < default Tc 22
 		expect(() => computeClusterTable(leaves, { Tc: 50, Dmax: 40, ...ZOOM_BOUNDS })).toThrow()
 		expect(() => computeClusterTable(leaves, { minZoom: 0, maxZoom: 8 })).toThrow()
 		expect(() => computeClusterTable(leaves, { minZoom: 8, maxZoom: 8 })).toThrow()
@@ -227,8 +227,8 @@ describe('computeClusterTable end-to-end scenarios', () => {
 		const leaves = Array.from({ length: 8 }, (_, i) => leaf(`p${i + 1}`, i * 10, 0))
 		const table = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
 
-		// events (centroid pricing): four pair births at zMerge 2.5 (zSplit 3), two
-		// quads at zMerge 1.25 (zSplit 1.5), the bridge at zMerge 0.625 (zSplit 0.75)
+		// events (centroid pricing): four pair births at zMerge 2.2 (zSplit 2.64), two
+		// quads at zMerge 1.1 (zSplit 1.32), the bridge at zMerge 0.55 (zSplit 0.66)
 		const seedAt = (zoom: number) => {
 			const rt = createClusterRuntime(table)
 			rt.seed(zoom)
@@ -236,9 +236,9 @@ describe('computeClusterTable end-to-end scenarios', () => {
 		}
 		// zoom 8: above every band midpoint → 8 separate pins
 		expect(seedAt(8)).toEqual(['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8'])
-		// zoom 2: below the pair midpoints (√7.5 ≈ 2.74), above the quad midpoint (√1.875 ≈ 1.37)
+		// zoom 2: below the pair midpoints (√5.81 ≈ 2.41), above the quad midpoint (√1.45 ≈ 1.2)
 		expect(seedAt(2)).toEqual(['cluster:2:p1', 'cluster:2:p3', 'cluster:2:p5', 'cluster:2:p7'])
-		// zoom 1: quads merged, above the bridge midpoint (√0.469 ≈ 0.68)
+		// zoom 1: quads merged, above the bridge midpoint (√0.363 ≈ 0.6)
 		expect(seedAt(1)).toEqual(['cluster:4:p1', 'cluster:4:p5'])
 		// zoom 0.5: below everything → one badge of 8
 		expect(seedAt(0.5)).toEqual(['cluster:8:p1'])

--- a/packages/commenting/src/clustering/computeClusterTable.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.ts
@@ -40,9 +40,9 @@ export function computeClusterTable(
 }
 
 function resolveOptions(options: ClusterOptions): ResolvedClusterOptions {
-	const Tc = options.Tc ?? 25
+	const Tc = options.Tc ?? 22
 	const Tu = options.Tu ?? 1.2 * Tc
-	const eps = options.eps ?? 0.35
+	const eps = options.eps ?? 0.7
 	const Dmax = options.Dmax ?? 3.75 * Tc
 	const maxSplitZoom = options.maxSplitZoom ?? 6
 	const { minZoom, maxZoom } = options

--- a/packages/commenting/src/clustering/computeClusterTable.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.ts
@@ -40,10 +40,10 @@ export function computeClusterTable(
 }
 
 function resolveOptions(options: ClusterOptions): ResolvedClusterOptions {
-	const Tc = options.Tc ?? 40
-	const Tu = options.Tu ?? 1.5 * Tc
-	const eps = options.eps ?? 0.12
-	const Dmax = options.Dmax ?? 3 * Tc
+	const Tc = options.Tc ?? 25
+	const Tu = options.Tu ?? 1.2 * Tc
+	const eps = options.eps ?? 0.35
+	const Dmax = options.Dmax ?? 3.75 * Tc
 	const maxSplitZoom = options.maxSplitZoom ?? 6
 	const { minZoom, maxZoom } = options
 

--- a/packages/commenting/src/clustering/types.ts
+++ b/packages/commenting/src/clustering/types.ts
@@ -81,13 +81,13 @@ export interface ClusterTable {
 
 /** @internal */
 export interface ClusterOptions {
-	/** Cluster (merge) distance, screen px. Default 40. */
+	/** Cluster (merge) distance, screen px. Default 22. */
 	Tc?: number
-	/** Uncluster (split) distance, screen px. Must be \> Tc. Default 1.5 · Tc. */
+	/** Uncluster (split) distance, screen px. Must be \> Tc. Default 1.2 · Tc. */
 	Tu?: number
-	/** Contraction window ratio. Default 0.12. */
+	/** Contraction window ratio. Default 0.7. */
 	eps?: number
-	/** Max cluster screen extent at birth, screen px. Must be \>= Tc. Default 3 · Tc. */
+	/** Max cluster screen extent at birth, screen px. Must be \>= Tc. Default 3.75 · Tc. */
 	Dmax?: number
 	/** Camera zoom bounds — pass the editor's camera constraints. Required. */
 	minZoom: number

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -321,7 +321,6 @@
 /* pin — a canvas marker: a white teardrop holding the author's avatar circle, so a thread is
    identifiable at a glance. */
 .tlui-cmt-pin {
-	/* A pin is smaller than the count badge, which keeps the marker-size default. */
 	--tlui-cmt-marker-size: var(--tlui-cmt-pin-size);
 	width: var(--tlui-cmt-marker-size);
 	height: var(--tlui-cmt-marker-size);
@@ -522,13 +521,15 @@
    the pixel the panel would. Deriving the preview's offset from these means the two can't drift —
    retune the padding or the header here and the preview follows. */
 .tl-container {
-	/* A cluster badge and a stack badge are this square. The hover preview measures its bridge
-	   against it, so the bridge stops at the marker's edge instead of covering it. */
-	--tlui-cmt-marker-size: 34px;
-	/* A pin is smaller than a badge (a cluster reads fine a touch bigger). Everything that has to
-	   line up against a pin — its preview's bridge, the draft composer's offsets, `PIN_SIZE` in
-	   thread-view.tsx — derives from this, so the pin's size stays one number. */
+	/* Everything that has to line up against a pin — its preview's bridge, the draft composer's
+	   offsets, `PIN_SIZE` in thread-view.tsx — derives from this, so the pin's size stays one
+	   number. */
 	--tlui-cmt-pin-size: 28px;
+	/* A cluster badge and a stack badge are this square — the same size as a pin, so the marker
+	   kinds read as one family. The hover preview measures its bridge against it, so the bridge
+	   stops at the marker's edge instead of covering it. Mirrored by `MARKER_SIZE` in
+	   thread-view.tsx. */
+	--tlui-cmt-marker-size: var(--tlui-cmt-pin-size);
 	/* How a marker sits, lifts, and rings. Shared so a pin and a badge respond identically.
 	   shadow-3's depth without its `inset 1px panel-contrast` edge — that inset reads as a white
 	   border on a coloured pin (it's invisible on the panel-white menus shadow-3 is meant for). */


### PR DESCRIPTION
In order for the canvas comment markers to read as one family, this PR makes the cluster and stack badges sit relative to their anchor point exactly the way a single pin does — bottom-left corner on the point, at the pin's 28px size — and retunes the default clustering thresholds around the smaller markers.

Builds on #9776 (now merged into `commenting`); the popover/preview offsets and the hover bridge are re-derived from shared terms (`MARKER_SIZE`, `CARD_TOP_Y`, `PREVIEW_GAP`) on top of that restyle so the two marker kinds can't drift apart again.

The threshold retune (`Tc` 40→25, `Tu` 1.5→1.2·Tc, `eps` 0.12→0.35, `Dmax` 3→3.75·Tc): with markers now 28px, clusters form later (markers must get closer before folding), split back apart sooner, and tolerate slightly larger spreads. The hand-derived expectations in `computeClusterTable.test.ts` are recomputed for the new constants.

### Change type

- [x] `improvement`

### Test plan

1. Open the commenting example (`yarn dev` → Commenting) or dotcom with a few comments placed.
2. Check a single pin, a coincident stack badge, and a cluster badge all sit up-and-right of their anchor point, at the same size.
3. Hover each marker kind — the preview should sit 6px off the marker's right edge with no flicker crossing the gap, and no dead strip over the badge.
4. Zoom out/in over a group of comments — clusters now form a touch later and split a touch sooner than before.

- [x] Unit tests

### Release notes

- Comment cluster and stack badges now anchor and size like comment pins, and clustering thresholds are retuned for the smaller markers.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +36 / -31  |
| Tests     | +28 / -27  |

