### PR TITLE
feat(sync): let a client choose its own sync rate

### DIFF
--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -58,6 +58,9 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLSocket
 }
 
 // @public
+export const COLLABORATIVE_SYNC_FPS = 30;
+
+// @public
 export const DEFAULT_INITIAL_SNAPSHOT: {
     documentClock: number;
     documents: ({
@@ -374,6 +377,9 @@ export interface SyncSqliteDatabase {
     };
 }
 
+// @public
+export const SOLO_SYNC_FPS = 1;
+
 // @internal
 export interface TLConnectRequest {
     // (undocumented)
@@ -660,6 +666,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
         presenceMode?: Signal<TLPresenceMode>;
         socket: TLPersistentClientSocket<any, any>;
         store: S;
+        syncFps?: number | Signal<number>;
     });
     close(): void;
     // @internal (undocumented)
@@ -672,6 +679,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
     readonly presenceState: Signal<null | R> | undefined;
     // @internal (undocumented)
     readonly socket: TLPersistentClientSocket<TLSocketClientSentEvent<R>, TLSocketServerSentEvent<R>>;
+    // @internal (undocumented)
+    readonly syncFps: number | Signal<number> | undefined;
     // @internal (undocumented)
     readonly store: S;
 }

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -54,6 +54,8 @@ export {
 	type TLSyncLog,
 } from './lib/TLSocketRoom'
 export {
+	COLLABORATIVE_SYNC_FPS,
+	SOLO_SYNC_FPS,
 	TLSyncClient,
 	TLSyncErrorCloseEventCode,
 	TLSyncErrorCloseEventReason,

--- a/packages/sync-core/src/lib/TLSyncClient.test.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.test.ts
@@ -21,6 +21,8 @@ import {
 	getTlsyncProtocolVersion,
 } from './protocol'
 import {
+	COLLABORATIVE_SYNC_FPS,
+	SOLO_SYNC_FPS,
 	TLPersistentClientSocket,
 	TLPresenceMode,
 	TLSocketStatusChangeEvent,
@@ -231,6 +233,7 @@ describe('TLSyncClient', () => {
 			socket: TLPersistentClientSocket<TestRecord>
 			presence: Atom<TestRecord | null>
 			presenceMode?: Atom<TLPresenceMode>
+			syncFps?: number | Atom<number>
 			onLoad(self: TLSyncClient<TestRecord, Store<TestRecord, any>>): void
 			onSyncError(reason: string): void
 			onCustomMessageReceived?(data: any): void
@@ -850,13 +853,32 @@ describe('TLSyncClient', () => {
 
 		it('[CP6] drops the network throttle from 30fps to 1fps in solo mode', () => {
 			client = createClient()
-			expect((client as any).fpsScheduler.targetFps).toBe(30)
+			expect((client as any).fpsScheduler.targetFps).toBe(COLLABORATIVE_SYNC_FPS)
 
 			presenceMode.set('solo')
-			expect((client as any).fpsScheduler.targetFps).toBe(1)
+			expect((client as any).fpsScheduler.targetFps).toBe(SOLO_SYNC_FPS)
 
 			presenceMode.set('full')
-			expect((client as any).fpsScheduler.targetFps).toBe(30)
+			expect((client as any).fpsScheduler.targetFps).toBe(COLLABORATIVE_SYNC_FPS)
+		})
+
+		it('[CP6] an explicit syncFps overrides the rate presence would have chosen', () => {
+			// The point of the option: a caller whose connection costs nothing says so directly,
+			// instead of claiming to have company in the room to get the faster rate as a side effect.
+			client = createClient({ syncFps: COLLABORATIVE_SYNC_FPS })
+			expect((client as any).fpsScheduler.targetFps).toBe(COLLABORATIVE_SYNC_FPS)
+
+			presenceMode.set('solo')
+			expect((client as any).fpsScheduler.targetFps).toBe(COLLABORATIVE_SYNC_FPS)
+		})
+
+		it('[CP6] follows syncFps when it is a signal', () => {
+			const syncFps = atom('syncFps', 10)
+			client = createClient({ syncFps })
+			expect((client as any).fpsScheduler.targetFps).toBe(10)
+
+			syncFps.set(COLLABORATIVE_SYNC_FPS)
+			expect((client as any).fpsScheduler.targetFps).toBe(COLLABORATIVE_SYNC_FPS)
 		})
 
 		it('[CP7] stops sending pushes when the store reports possible corruption', () => {

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -43,11 +43,24 @@ import {
  */
 export type SubscribingFn<T> = (cb: (val: T) => void) => () => void
 
-/** Network sync frame rate when in solo mode (no collaborators) @internal */
-const SOLO_MODE_FPS = 1
+/**
+ * The rate a sync client flushes changes to the server at when it is the only session in the room.
+ *
+ * Low on purpose: with nobody to send cursors to, the only thing worth spending requests on is the
+ * user's own document changes, and those coalesce. Pass `syncFps` to override it — a connection that
+ * costs nothing (a loopback socket to a host process on the same machine) has nothing to save by
+ * waiting, and every push it delays is work that exists only in this client until the next tick.
+ *
+ * @public
+ */
+export const SOLO_SYNC_FPS = 1
 
-/** Network sync frame rate when in collaborative mode (with collaborators) @internal */
-const COLLABORATIVE_MODE_FPS = 30
+/**
+ * The rate a sync client flushes changes to the server at when other sessions are present.
+ *
+ * @public
+ */
+export const COLLABORATIVE_SYNC_FPS = 30
 
 /**
  * WebSocket close code used by the server to signal a non-recoverable sync error.
@@ -212,9 +225,9 @@ export type TLPersistentClientSocketStatus = 'online' | 'offline' | 'error'
  * @public
  */
 export type TLPresenceMode =
-	/** No presence sharing - client operates independently */
+	/** No presence sharing — this client's cursor and selection stay local. */
 	| 'solo'
-	/** Full presence sharing - cursors and selections visible to others */
+	/** Full presence sharing — cursors and selections are visible to others. */
 	| 'full'
 /**
  * Interface for persistent WebSocket-like connections used by TLSyncClient.
@@ -412,6 +425,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	readonly presenceState: Signal<R | null> | undefined
 	/** @internal */
 	readonly presenceMode: Signal<TLPresenceMode> | undefined
+	/** @internal */
+	readonly syncFps: number | Signal<number> | undefined
 
 	// isOnline is true when we have an open socket connection and we have
 	// established a connection with the server room (i.e. we have received a 'connect' message)
@@ -468,6 +483,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	 *   - socket - WebSocket adapter for server communication
 	 *   - presence - Reactive signal containing current user's presence data
 	 *   - presenceMode - Optional signal controlling presence sharing (defaults to 'full')
+	 *   - syncFps - Optional rate to flush changes to the server at, overriding the default derived
+	 *     from presenceMode ({@link SOLO_SYNC_FPS} alone, {@link COLLABORATIVE_SYNC_FPS} otherwise)
 	 *   - onLoad - Callback fired when initial sync completes successfully
 	 *   - onSyncError - Callback fired when sync fails with error reason
 	 *   - onCustomMessageReceived - Optional handler for custom messages
@@ -481,6 +498,16 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		socket: TLPersistentClientSocket<any, any>
 		presence: Signal<R | null>
 		presenceMode?: Signal<TLPresenceMode>
+		/**
+		 * How often to flush pending changes to the server, in frames per second. Defaults to a rate
+		 * derived from `presenceMode`: {@link SOLO_SYNC_FPS} while this is the only session in the
+		 * room, {@link COLLABORATIVE_SYNC_FPS} once another joins.
+		 *
+		 * Set it when that default's premise — that a quiet connection is worth saving — does not
+		 * hold: a local transport where bandwidth is free, or an app whose durability depends on
+		 * changes reaching the server promptly rather than on the next tick.
+		 */
+		syncFps?: number | Signal<number>
 		onLoad(self: TLSyncClient<R, S>): void
 		onSyncError(reason: string): void
 		onCustomMessageReceived?: TLCustomMessageHandler
@@ -496,7 +523,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 
 		// Create a separate throttle instance for network sync operations
 		// This ensures sync operations have their own queue separate from UI operations
-		this.fpsScheduler = new FpsScheduler(COLLABORATIVE_MODE_FPS)
+		this.fpsScheduler = new FpsScheduler(COLLABORATIVE_SYNC_FPS)
 
 		// Initialize throttled methods after throttle instance is created
 		this.sendUnsentChanges = this.fpsScheduler.fpsThrottle(() => {
@@ -554,6 +581,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 
 		this.presenceState = config.presence
 		this.presenceMode = config.presenceMode
+		this.syncFps = config.syncFps
 
 		this.disposables.push(
 			// when local 'user' changes are made, send them to the server
@@ -627,13 +655,21 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			}, PING_INTERVAL * 2)
 		)
 
+		// The flush rate follows its inputs on its own, rather than as a side effect of pushing
+		// presence: a client with no presence signal at all still has a rate, and a caller that
+		// drives `syncFps` from a signal expects it to take effect when that signal changes.
+		this.disposables.push(
+			react('syncFps', () => {
+				if (this.didCancel?.()) return this.close()
+				this.fpsScheduler.updateTargetFps(this.getSyncFps())
+			})
+		)
+
 		if (this.presenceState) {
 			this.disposables.push(
 				react('pushPresence', () => {
 					if (this.didCancel?.()) return this.close()
-					const mode = this.presenceMode?.get()
-					this.fpsScheduler.updateTargetFps(this.getSyncFps())
-					if (mode !== 'full') return
+					if (this.presenceMode?.get() !== 'full') return
 					this.pushPresence(this.presenceState!.get())
 				})
 			)
@@ -872,9 +908,14 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		this.sendUnsentChanges()
 	}
 
-	/** Get the target FPS for network operations based on presence mode */
+	/**
+	 * The rate to flush changes to the server at: whatever the caller asked for, or else derived
+	 * from presence — slow while this is the only session in the room, full once another joins.
+	 */
 	private getSyncFps(): number {
-		return this.presenceMode?.get() === 'solo' ? SOLO_MODE_FPS : COLLABORATIVE_MODE_FPS
+		if (typeof this.syncFps === 'number') return this.syncFps
+		if (this.syncFps) return this.syncFps.get()
+		return this.presenceMode?.get() === 'solo' ? SOLO_SYNC_FPS : COLLABORATIVE_SYNC_FPS
 	}
 
 	/**

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Editor } from 'tldraw';
+import { Signal } from 'tldraw';
 import { TLAssetStore } from 'tldraw';
 import { TLObjectStoreAccess } from '@tldraw/sync-core';
 import { TLPersistentClientSocket } from '@tldraw/sync-core';
@@ -65,6 +66,7 @@ export interface UseSyncOptionsBase {
     onMount?(editor: Editor): void;
     // @internal
     roomId?: string;
+    syncFps?: number | Signal<number>;
     themes?: Partial<TLThemes>;
     // @internal (undocumented)
     trackAnalyticsEvent?(name: string, data: {

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -1,4 +1,4 @@
-import { atom, transact } from '@tldraw/state'
+import { atom, transact, type Signal } from '@tldraw/state'
 import {
 	ClientWebSocketAdapter,
 	TLCustomMessageHandler,
@@ -193,6 +193,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		getUserPresence: _getUserPresence,
 		onCustomMessageReceived: _onCustomMessageReceived,
 		themes,
+		syncFps,
 		...schemaOpts
 	} = opts
 
@@ -396,6 +397,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			onCustomMessageReceived,
 			presence,
 			presenceMode,
+			syncFps,
 		})
 
 		return () => {
@@ -416,6 +418,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		uri,
 		getUserPresence,
 		onCustomMessageReceived,
+		syncFps,
 	])
 
 	return useValue<RemoteTLStoreWithStatus>(
@@ -461,6 +464,23 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
  * @public
  */
 export interface UseSyncOptionsBase {
+	/**
+	 * How often to flush changes to the server, in frames per second.
+	 *
+	 * Defaults to a rate derived from the room: {@link @tldraw/sync-core#SOLO_SYNC_FPS} while this is
+	 * the only session present, {@link @tldraw/sync-core#COLLABORATIVE_SYNC_FPS} once another joins.
+	 * That default assumes a connection worth being frugal with. Set this when it isn't one — a local
+	 * transport where bandwidth is free — or when the app's durability depends on changes reaching
+	 * the server promptly rather than on the next tick.
+	 *
+	 * @example
+	 * ```ts
+	 * // a room served by a process on this machine: nothing to save by waiting
+	 * useSync({ connect, syncFps: COLLABORATIVE_SYNC_FPS })
+	 * ```
+	 */
+	syncFps?: number | Signal<number>
+
 	/**
 	 * Named theme definitions. When provided, custom color names are automatically
 	 * registered before the store is constructed so persisted data with those


### PR DESCRIPTION
`presenceMode` decides two unrelated things today.

Its documented job is whether this client publishes cursors and selections. Since #7657 it also selects the rate the client flushes changes to the server at — `SOLO_MODE_FPS` (1) alone, `COLLABORATIVE_MODE_FPS` (30) with company — because "nobody is here" is a decent proxy for "nobody needs my cursor 30 times a second".

That second meaning has no name of its own, and both directions of the coupling bite:

- An app that wants the faster rate has to claim it has company in the room to get it. That's asserting something false about the room to obtain a scheduler side effect.
- An app that picks `'solo'` for a presence/privacy reason silently accepts up to a second of lag on every change it makes, which nothing in the type or its docs mentions.

**So this names the rate.** `syncFps` — a number or a signal — overrides the derived default on `TLSyncClient` and passes through `useSync`. The two rates the default picks between are exported rather than internal, so a caller can ask for the collaborative rate without inventing a number. `presenceMode` keeps its own meaning, and `useSync` keeps computing it from the room: nothing about who is present becomes settable that wasn't before.

The scheduler now follows its inputs from a reaction of its own rather than from inside the presence push. Otherwise a `syncFps` signal would only take effect the next time presence happened to change.

### Where this comes from

tldraw desktop runs a sync room in its own main process; the editor connects to it over a loopback socket. The renderer's push is therefore not a network optimization — it is the only path an edit takes to durable storage. Solo throttling there leaves up to a second of the user's work living only in the renderer, and saves bandwidth on a connection that has none to save. Measured on the close path: the app's unsaved-changes prompt waited ~700ms for a scheduled push that had nothing to do but wait.

With this option, that call site says what is actually true:

```ts
useSync({ connect, syncFps: COLLABORATIVE_SYNC_FPS })
```

### Worth discussing separately

Should the solo throttle apply to **document** pushes at all, or only to presence? In any sync-backed app the server is the durability boundary, so 1fps means a solo user can hold up to a second of work in their tab alone — and the throttle only bites while they're actively drawing, which is exactly when that exposure matters most. Scoping it to presence would remove the need for this option in our case. It also raises write volume on dotcom, so I've left it as a question rather than a change.

### Also here

`TLPresenceMode`'s member docs are attached to the wrong members — `'full'` currently carries "No presence sharing - client operates independently" in the published types. Fixed in passing.

### Change type

- [x] `api`

### Test plan

- [x] Unit tests — two beside the existing `[CP6]` solo-throttle test: an explicit rate wins over the one presence would have chosen, and a rate signal is followed when it changes.
- [ ] I could not run the suite or `yarn build-api` where this was written; the `api-report.api.md` edits are by hand and want confirming by CI.

### Release notes

- `useSync` and `TLSyncClient` accept `syncFps` to set how often changes are flushed to the server, instead of that rate being decided entirely by `presenceMode`. The rates it defaults to are exported as `SOLO_SYNC_FPS` and `COLLABORATIVE_SYNC_FPS`.
