### PR TITLE
[wip] feat(dotcom): show comment reactions in the notifications panel

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -549,6 +549,22 @@
       "value": "My workspace"
     }
   ],
+  "5bffeebf03": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " reacted to your comment"
+    }
+  ],
   "5d04a002ea": [
     {
       "type": 0,
@@ -589,6 +605,35 @@
     {
       "type": 0,
       "value": "Later"
+    }
+  ],
+  "61fb03fd7b": [
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Someone reacted to your comment"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " people reacted to your comment"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
     }
   ],
   "625fd29749": [
@@ -1373,6 +1418,56 @@
     {
       "type": 0,
       "value": "Learn more about publishing."
+    }
+  ],
+  "d0e3556476": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " other"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " others"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " reacted to your comment"
     }
   ],
   "d3d2e61733": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -227,6 +227,9 @@
   "5bff3c9c88": {
     "translation": "My workspace"
   },
+  "5bffeebf03": {
+    "translation": "<name>{author}</name> reacted to your comment"
+  },
   "5d04a002ea": {
     "translation": "Unable to connect"
   },
@@ -247,6 +250,9 @@
   },
   "61057a0c84": {
     "translation": "Later"
+  },
+  "61fb03fd7b": {
+    "translation": "{count, plural, one {Someone reacted to your comment} other {# people reacted to your comment}}"
   },
   "625fd29749": {
     "translation": "Older"
@@ -566,6 +572,9 @@
   },
   "cea291e45e": {
     "translation": "Learn more about publishing."
+  },
+  "d0e3556476": {
+    "translation": "<name>{author}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
   },
   "d3d2e61733": {
     "translation": "Close"

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -3,7 +3,9 @@ import {
 	CommentsList,
 	formatRelativeTime,
 	isOpenInNewTabClick,
+	Reactions,
 	richTextToPlaintext,
+	summarizeReactions,
 } from '@tldraw/commenting'
 import { ReactNode, useCallback } from 'react'
 import { Link } from 'react-router-dom'
@@ -11,7 +13,11 @@ import { createDeepLinkString, TLRichText, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { defineMessages, F, useMsg } from '../../../utils/i18n'
-import { categorizeCommentNotifications, CommentNotificationReason } from './commentNotifications'
+import {
+	categorizeCommentNotifications,
+	CommentNotificationReason,
+	summarizeForeignReactors,
+} from './commentNotifications'
 import styles from './notifications.module.css'
 
 const messages = defineMessages({
@@ -26,10 +32,13 @@ const messages = defineMessages({
 function ReasonByline({
 	reason,
 	author,
+	reactors,
 	nameClassName,
 }: {
 	reason: CommentNotificationReason
 	author: string
+	/** Who reacted, for the `reaction` phrasing — see {@link summarizeForeignReactors}. */
+	reactors: { name: string | undefined; others: number; total: number }
 	nameClassName: string
 }) {
 	const name = (chunks: ReactNode) => <span className={nameClassName}>{chunks}</span>
@@ -43,6 +52,31 @@ function ReasonByline({
 				<F
 					defaultMessage="<name>{author}</name> commented on your board"
 					values={{ author, name }}
+				/>
+			)
+		case 'reaction':
+			// Reaction rows carry no display name, so the face is best-effort — resolved from
+			// comment authors in the feed and workspace members. Nobody resolvable → anonymous count.
+			if (reactors.name === undefined) {
+				return (
+					<F
+						defaultMessage="{count, plural, one {Someone reacted to your comment} other {# people reacted to your comment}}"
+						values={{ count: reactors.total }}
+					/>
+				)
+			}
+			if (reactors.others === 0) {
+				return (
+					<F
+						defaultMessage="<name>{author}</name> reacted to your comment"
+						values={{ author: reactors.name, name }}
+					/>
+				)
+			}
+			return (
+				<F
+					defaultMessage="<name>{author}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
+					values={{ author: reactors.name, count: reactors.others, name }}
 				/>
 			)
 	}
@@ -63,7 +97,7 @@ export function useCommentNotifications() {
 		'comment notifications',
 		() => {
 			const notifications = categorizeCommentNotifications(app?.getComments() ?? [], app?.userId)
-			const unreadCount = notifications.filter((n) => !n.comment.read).length
+			const unreadCount = notifications.filter((n) => n.unread).length
 			return { notifications, unreadCount }
 		},
 		[app]
@@ -86,36 +120,65 @@ function commentLink(fileId: string, shapeId: string | null | undefined, comment
 export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 	const app = useMaybeApp()
 	const { notifications, unreadCount } = useCommentNotifications()
+	// Reactor id → display name, from the identity the app already syncs: workspace member rows
+	// and comment authors in the feed (authors win — comments carry the fresher denormalization
+	// for someone who just wrote). A reactor outside both (e.g. a shared-link guest who never
+	// commented) stays unresolved and the byline falls back to an anonymous count.
+	const resolveReactorName = useValue(
+		'reactor names',
+		() => {
+			const names = new Map<string, string>()
+			if (!app) return (id: string) => names.get(id)
+			for (const membership of app.getWorkspaceMemberships()) {
+				for (const member of membership.groupMembers ?? []) {
+					if (member.userName) names.set(member.userId, member.userName)
+				}
+			}
+			for (const c of app.getComments()) {
+				if (c.authorName) names.set(c.authorId, c.authorName)
+			}
+			return (id: string) => names.get(id)
+		},
+		[app]
+	)
 	const title = useMsg(messages.title)
 	const markAllReadLbl = useMsg(messages.markAllRead)
 	const empty = useMsg(messages.empty)
 	const unknownAuthor = useMsg(messages.unknownAuthor)
 	const untitledFile = useMsg(messages.untitledFile)
 
-	const items: CommentListItemProps[] = notifications.map(({ comment: c }) => ({
-		id: c.id,
-		author: {
-			// never fall back to the raw id: an opaque uuid as a byline reads as a bug, and the rest
-			// of the commenting UI says "Someone" for an unresolvable author
-			name: c.authorName || unknownAuthor,
-			color: c.authorColor || undefined,
-		},
-		preview: richTextToPlaintext(c.body as TLRichText),
-		date: new Date(c.createdAt).toISOString(),
-		// the document the comment lives on — the headline of the notification row
-		page: c.file?.name || untitledFile,
-		// a real link target, so browser affordances (ctrl/cmd-click, middle-click) open a new tab
-		href: commentLink(c.fileId, c.thread?.shapeId, c.id),
-	}))
+	const items: CommentListItemProps[] = notifications.map((n) => {
+		const c = n.comment
+		return {
+			id: c.id,
+			author: {
+				// never fall back to the raw id: an opaque uuid as a byline reads as a bug, and the rest
+				// of the commenting UI says "Someone" for an unresolvable author
+				name: c.authorName || unknownAuthor,
+				color: c.authorColor || undefined,
+			},
+			preview: richTextToPlaintext(c.body as TLRichText),
+			// the notified-about event: a reaction entry dates from its newest foreign reaction,
+			// not from the (older) comment it decorates
+			date: new Date(n.timestamp).toISOString(),
+			// inert pills: no toggling from the panel, emoji + count with the user's own
+			// reactions highlighted
+			reactions: summarizeReactions(c.reactions ?? [], app?.userId, resolveReactorName),
+			// the document the comment lives on — the headline of the notification row
+			page: c.file?.name || untitledFile,
+			// a real link target, so browser affordances (ctrl/cmd-click, middle-click) open a new tab
+			href: commentLink(c.fileId, c.thread?.shapeId, c.id),
+		}
+	})
 
-	// Row id → why it's a notification, so the byline can be phrased per reason.
-	const reasonById = new Map(notifications.map((n) => [n.comment.id, n.primaryReason]))
+	// Row id → its notification, so the byline can be phrased per reason and reactor count.
+	const notificationById = new Map(notifications.map((n) => [n.comment.id, n]))
 
 	const handleSelect = useCallback(
 		(id: string, isNewTab: boolean) => {
 			const n = notifications.find((n) => n.comment.id === id)
 			if (!n) return
-			if (!n.comment.read) app?.markCommentRead(n.comment.id)
+			if (n.unread) app?.markCommentRead(n.comment.id)
 			// keep the popover open when opening in a new tab, so more can be opened
 			if (!isNewTab) onClose()
 		},
@@ -133,8 +196,8 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 						className={styles.markAll}
 						onClick={() => {
 							if (!app) return
-							for (const { comment: c } of notifications) {
-								if (!c.read) app.markCommentRead(c.id)
+							for (const n of notifications) {
+								if (n.unread) app.markCommentRead(n.comment.id)
 							}
 						}}
 						disabled={unreadCount === 0}
@@ -143,31 +206,42 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 					</button>
 				}
 				empty={empty}
-				renderItem={(item) => (
-					<Link
-						key={item.id}
-						to={item.href!}
-						className="tlui-cmt-list__item"
-						onClick={(e) => handleSelect(item.id, isOpenInNewTabClick(e))}
-						// middle-click opens the tab natively without firing onClick; still mark it read
-						onAuxClick={(e) => e.button === 1 && handleSelect(item.id, true)}
-					>
-						<div className="tlui-cmt-list__item-body">
-							<div className={styles.head}>
-								<span className={styles.docTitle}>{item.page}</span>
-								<span className={styles.time}>{formatRelativeTime(item.date)}</span>
+				renderItem={(item) => {
+					const n = notificationById.get(item.id)
+					return (
+						<Link
+							key={item.id}
+							to={item.href!}
+							className="tlui-cmt-list__item"
+							onClick={(e) => handleSelect(item.id, isOpenInNewTabClick(e))}
+							// middle-click opens the tab natively without firing onClick; still mark it read
+							onAuxClick={(e) => e.button === 1 && handleSelect(item.id, true)}
+						>
+							<div className="tlui-cmt-list__item-body">
+								<div className={styles.head}>
+									<span className={styles.docTitle}>{item.page}</span>
+									<span className={styles.time}>{formatRelativeTime(item.date)}</span>
+								</div>
+								<div className={styles.byline}>
+									<ReasonByline
+										reason={n?.primaryReason ?? 'owned-board'}
+										author={item.author.name}
+										reactors={summarizeForeignReactors(
+											n?.comment.reactions,
+											app?.userId,
+											resolveReactorName
+										)}
+										nameClassName={styles.author}
+									/>
+								</div>
+								<div className={styles.preview}>{item.preview}</div>
+								{item.reactions && (
+									<Reactions reactions={item.reactions} canReact={false} enableHoverList={false} />
+								)}
 							</div>
-							<div className={styles.byline}>
-								<ReasonByline
-									reason={reasonById.get(item.id) ?? 'owned-board'}
-									author={item.author.name}
-									nameClassName={styles.author}
-								/>
-							</div>
-							<div className={styles.preview}>{item.preview}</div>
-						</div>
-					</Link>
-				)}
+						</Link>
+					)
+				}}
 			/>
 		</div>
 	)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -1,6 +1,10 @@
 import { TLRichText } from 'tldraw'
 import { describe, expect, it } from 'vitest'
-import { categorizeCommentNotifications, CommentNotificationInput } from './commentNotifications'
+import {
+	categorizeCommentNotifications,
+	CommentNotificationInput,
+	summarizeForeignReactors,
+} from './commentNotifications'
 
 const ME = 'user_me'
 const OTHER = 'user_other'
@@ -252,5 +256,158 @@ describe('categorizeCommentNotifications', () => {
 		const newer = comment({ id: 'comment:new', createdAt: at(10), file: { ownerId: ME } })
 		const result = categorizeCommentNotifications([older, newer], ME)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:new', 'comment:old'])
+	})
+
+	it('marks a comment notification unread until it has a read receipt', () => {
+		const unread = categorizeCommentNotifications([comment({ file: { ownerId: ME } })], ME)
+		expect(unread[0].unread).toBe(true)
+		const read = categorizeCommentNotifications(
+			[comment({ file: { ownerId: ME }, read: { readAt: at(1) } })],
+			ME
+		)
+		expect(read[0].unread).toBe(false)
+	})
+})
+
+describe('reaction notifications', () => {
+	/** My own comment, with reactions. */
+	function mine(overrides: Partial<CommentNotificationInput> = {}): CommentNotificationInput {
+		return comment({
+			authorId: ME,
+			thread: { createdBy: ME },
+			file: { ownerId: THIRD },
+			...overrides,
+		})
+	}
+
+	it("labels my comment with someone else's reaction as reaction", () => {
+		const result = categorizeCommentNotifications(
+			[mine({ reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(10) }] })],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(result[0].reasons).toEqual(['reaction'])
+		expect(result[0].primaryReason).toBe('reaction')
+	})
+
+	it('drops my comment with no reactions, or with only my own', () => {
+		expect(categorizeCommentNotifications([mine()], ME)).toEqual([])
+		expect(
+			categorizeCommentNotifications(
+				[mine({ reactions: [{ userId: ME, emoji: '👍', createdAt: at(10) }] })],
+				ME
+			)
+		).toEqual([])
+	})
+
+	it("never labels others' comments as reaction, whatever their reactions", () => {
+		const theirs = comment({
+			file: { ownerId: ME },
+			reactions: [{ userId: THIRD, emoji: '👍', createdAt: at(10) }],
+		})
+		const result = categorizeCommentNotifications([theirs], ME)
+		expect(result[0].reasons).toEqual(['owned-board'])
+	})
+
+	it('timestamps the entry by the newest foreign reaction, ignoring my own later one', () => {
+		const result = categorizeCommentNotifications(
+			[
+				mine({
+					createdAt: at(0),
+					reactions: [
+						{ userId: OTHER, emoji: '👍', createdAt: at(10) },
+						{ userId: THIRD, emoji: '🎉', createdAt: at(20) },
+						{ userId: ME, emoji: '👍', createdAt: at(30) },
+					],
+				}),
+			],
+			ME
+		)
+		expect(result[0].timestamp).toBe(at(20))
+	})
+
+	it('is unread until my read receipt is newer than the newest foreign reaction', () => {
+		const withReadAt = (readAt: number | undefined) =>
+			categorizeCommentNotifications(
+				[
+					mine({
+						read: readAt === undefined ? undefined : { readAt },
+						reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(10) }],
+					}),
+				],
+				ME
+			)[0].unread
+		expect(withReadAt(undefined)).toBe(true)
+		// a stale receipt (read before this reaction landed) leaves the entry unread
+		expect(withReadAt(at(5))).toBe(true)
+		expect(withReadAt(at(15))).toBe(false)
+	})
+
+	it('sorts reaction entries among comment entries by their reaction time', () => {
+		const reacted = mine({
+			id: 'comment:reacted',
+			createdAt: at(0),
+			reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(20) }],
+		})
+		const replied = comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })
+		const result = categorizeCommentNotifications([replied, reacted], ME)
+		expect(result.map((n) => n.comment.id)).toEqual(['comment:reacted', 'comment:replied'])
+	})
+})
+
+describe('summarizeForeignReactors', () => {
+	const names = new Map([
+		[OTHER, 'Olive'],
+		[THIRD, 'Théo'],
+	])
+	const resolve = (id: string) => names.get(id)
+
+	it('names the newest resolvable reactor and counts the rest', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: THIRD, emoji: '👍', createdAt: at(0) },
+				{ userId: OTHER, emoji: '🎉', createdAt: at(10) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: 'Olive', others: 1, total: 2 })
+	})
+
+	it('counts a reactor once however many emoji they used, and skips my own reactions', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: OTHER, emoji: '👍', createdAt: at(0) },
+				{ userId: OTHER, emoji: '🎉', createdAt: at(10) },
+				{ userId: ME, emoji: '👍', createdAt: at(20) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: 'Olive', others: 0, total: 1 })
+	})
+
+	it('falls back to an older reactor when the newest has no resolvable name', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: THIRD, emoji: '👍', createdAt: at(0) },
+				{ userId: 'user_stranger', emoji: '🎉', createdAt: at(10) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: 'Théo', others: 1, total: 2 })
+	})
+
+	it('gives no name when nobody resolves', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: 'user_a', emoji: '👍', createdAt: at(0) },
+				{ userId: 'user_b', emoji: '🎉', createdAt: at(10) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: undefined, others: 2, total: 2 })
 	})
 })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -7,14 +7,16 @@ import { extractMentionIds } from '@tldraw/dotcom-shared'
  * - `reply` — the comment is in a thread the user is a part of (started, or has commented in),
  *   posted after they joined it
  * - `owned-board` — the comment is on a file the user owns
+ * - `reaction` — the user's own comment, reacted to by someone else. The only reason about the
+ *   user's own comments, so it never combines with the others
  *
  * A single comment can match more than one; {@link CommentNotification.primaryReason} picks the one
  * shown to the user, in the order mention \> reply \> owned-board (most-to-least specific).
  */
-export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board'
+export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board' | 'reaction'
 
 /** Priority order for {@link CommentNotification.primaryReason}: most specific first. */
-const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board']
+const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board', 'reaction']
 
 /**
  * How far a comment may predate the user's join time and still count as a reply.
@@ -45,13 +47,18 @@ export interface CommentNotificationInput {
 	// Comment body, as rich text JSON. Typed `unknown` so the real Zero row (whose `body` is a wide
 	// `ReadonlyJSONValue`) still satisfies this constraint; extractMentionIds accepts unknown.
 	body: unknown
-	read?: unknown
+	/** The caller's read receipt — a related row when present, absent (falsy) when unread. Its
+	 *  `readAt` dates the receipt, which is what lets a reaction newer than it re-unread the entry. */
+	read?: { readAt?: number | null } | null
 	file?: { ownerId?: string | null } | null
 	thread?: {
 		createdBy?: string | null
 		/** The caller's own comments in the thread (the query syncs no one else's). */
 		comments?: readonly { authorId: string; createdAt: number }[] | null
 	} | null
+	/** Every reaction to the comment, the caller's own included. Categorization only reads who and
+	 *  when; `emoji` rides along for the row's reaction pills. */
+	reactions?: readonly { userId: string; emoji: string; createdAt: number }[] | null
 }
 
 /** A comment in the notifications feed, tagged with why it's there. */
@@ -63,6 +70,13 @@ export interface CommentNotification<
 	reasons: CommentNotificationReason[]
 	/** The single reason to surface, per {@link REASON_PRIORITY}. */
 	primaryReason: CommentNotificationReason
+	/** When the notified-about event happened: the newest foreign reaction for a `reaction` entry,
+	 *  the comment's creation otherwise. Orders the feed and dates the row. */
+	timestamp: number
+	/** Whether the entry needs the user's attention. A comment entry is unread until it has a read
+	 *  receipt; a reaction entry is unread while the newest foreign reaction postdates the receipt —
+	 *  so fresh reactions re-unread a comment the user had already read. */
+	unread: boolean
 }
 
 /**
@@ -83,8 +97,19 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 
 	const notifications: CommentNotification<T>[] = []
 	for (const comment of comments) {
-		// A notification is always about someone else's comment, never your own.
-		if (comment.authorId === userId) continue
+		// The user's own comment only notifies about what others did to it: their reactions.
+		if (comment.authorId === userId) {
+			const latestForeign = latestForeignReactionAt(comment.reactions, userId)
+			if (latestForeign === undefined) continue
+			notifications.push({
+				comment,
+				reasons: ['reaction'],
+				primaryReason: 'reaction',
+				timestamp: latestForeign,
+				unread: latestForeign > (comment.read?.readAt ?? -Infinity),
+			})
+			continue
+		}
 
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
@@ -96,10 +121,16 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 		if (reasons.length === 0) continue
 
 		const primaryReason = REASON_PRIORITY.find((r) => reasons.includes(r))!
-		notifications.push({ comment, reasons, primaryReason })
+		notifications.push({
+			comment,
+			reasons,
+			primaryReason,
+			timestamp: comment.createdAt,
+			unread: !comment.read,
+		})
 	}
 
-	return notifications.sort((a, b) => b.comment.createdAt - a.comment.createdAt)
+	return notifications.sort((a, b) => b.timestamp - a.timestamp)
 }
 
 /**
@@ -113,4 +144,47 @@ function joinedThreadAt(thread: CommentNotificationInput['thread'], userId: stri
 		if (c.authorId === userId && c.createdAt < joinedAt) joinedAt = c.createdAt
 	}
 	return joinedAt
+}
+
+/**
+ * The reactor summary a "reacted to your comment" byline is phrased from: the newest reactor with
+ * a resolvable display name (the byline's face), how many other distinct people reacted beyond
+ * them, and the distinct total for when no name resolves at all. `resolveName` covers whatever
+ * identity sources the caller has (comment authors in the feed, workspace members) — reaction rows
+ * themselves carry no name.
+ */
+export function summarizeForeignReactors(
+	reactions: CommentNotificationInput['reactions'],
+	userId: string | undefined | null,
+	resolveName: (userId: string) => string | undefined
+): { name: string | undefined; others: number; total: number } {
+	// distinct foreign reactors, newest reaction first
+	const newestById = new Map<string, number>()
+	for (const r of reactions ?? []) {
+		if (r.userId === userId) continue
+		const newest = newestById.get(r.userId)
+		if (newest === undefined || r.createdAt > newest) newestById.set(r.userId, r.createdAt)
+	}
+	const ordered = [...newestById.entries()].sort(([, a], [, b]) => b - a).map(([id]) => id)
+	const name = ordered.map(resolveName).find((n) => n !== undefined)
+	return {
+		name,
+		others: name === undefined ? ordered.length : ordered.length - 1,
+		total: ordered.length,
+	}
+}
+
+/**
+ * When someone else last reacted to the comment, or undefined if no one has — the user's own
+ * reactions don't notify them.
+ */
+function latestForeignReactionAt(
+	reactions: CommentNotificationInput['reactions'],
+	userId: string
+): number | undefined {
+	let latest: number | undefined
+	for (const r of reactions ?? []) {
+		if (r.userId !== userId && (latest === undefined || r.createdAt > latest)) latest = r.createdAt
+	}
+	return latest
 }

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -190,6 +190,7 @@ export interface CommentListItemProps {
     id: string;
     page?: string;
     preview: ReactNode;
+    reactions?: ReactionSummary[];
     // (undocumented)
     resolved?: boolean;
     selected?: boolean;
@@ -501,6 +502,16 @@ export interface ReactionSummary {
     reactors: ReactionReactor[];
 }
 
+// @public
+export interface ReactionSummaryInput {
+    // (undocumented)
+    createdAt: number;
+    // (undocumented)
+    emoji: string;
+    // (undocumented)
+    userId: string;
+}
+
 // @public (undocumented)
 export interface ReactionTooltipProps {
     children: ReactNode;
@@ -568,7 +579,7 @@ export interface SidebarFilters {
 export const sidebarFilters: EditorAtom<SidebarFilters>;
 
 // @public
-export function summarizeReactions(reactions: TLCommentReaction[], currentUserId?: null | string, resolveName?: (userId: string) => string | undefined): ReactionSummary[];
+export function summarizeReactions(reactions: readonly ReactionSummaryInput[], currentUserId?: null | string, resolveName?: (userId: string) => string | undefined): ReactionSummary[];
 
 // @public
 export type TLCommentRecord = TLComment | TLCommentReaction | TLCommentThread;

--- a/packages/commenting/src/canvas/comment-reactions.test.ts
+++ b/packages/commenting/src/canvas/comment-reactions.test.ts
@@ -87,6 +87,28 @@ describe('summarizeReactions', () => {
 	})
 })
 
+describe('summarizeReactions input', () => {
+	// the notifications panel tallies rows synced from the app database, which carry only the
+	// fields the tally needs — full TLCommentReaction records must not be required
+	it('accepts minimal rows with only userId, emoji, and createdAt', () => {
+		const rows = [
+			{ userId: 'user1', emoji: '👍', createdAt: 100 },
+			{ userId: 'user2', emoji: '👍', createdAt: 200 },
+		]
+		expect(summarizeReactions(rows, 'user1')).toEqual([
+			{
+				emoji: '👍',
+				count: 2,
+				active: true,
+				reactors: [
+					{ name: 'Someone', you: true },
+					{ name: 'Someone', you: false },
+				],
+			},
+		])
+	})
+})
+
 describe('createCommentReactionId', () => {
 	// the id is what makes reaction identity structural: re-picking the same emoji addresses the
 	// same record (toggle off), while a different emoji is its own record (independent)

--- a/packages/commenting/src/canvas/comment-reactions.tsx
+++ b/packages/commenting/src/canvas/comment-reactions.tsx
@@ -40,6 +40,19 @@ export function useCommentReactions(
 }
 
 /**
+ * The reaction fields {@link summarizeReactions} needs — a structural subset of
+ * {@link tldraw#TLCommentReaction}, so tallies can also be built from reaction rows synced outside
+ * the editor store (e.g. an app-level reactions table backing a notifications feed).
+ *
+ * @public
+ */
+export interface ReactionSummaryInput {
+	userId: string
+	emoji: string
+	createdAt: number
+}
+
+/**
  * Tally a comment's reactions into an entry per emoji, ordered by when that emoji was first used
  * so the row stays stable as later reactions arrive. `active` marks the emoji the current user
  * reacted with (the pills render those highlighted), and `reactors` lists who reacted with it, in
@@ -49,7 +62,7 @@ export function useCommentReactions(
  * @public
  */
 export function summarizeReactions(
-	reactions: TLCommentReaction[],
+	reactions: readonly ReactionSummaryInput[],
 	currentUserId?: string | null,
 	resolveName?: (userId: string) => string | undefined
 ): ReactionSummary[] {

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -73,6 +73,7 @@ export {
 	type CommentReactionPickerProps,
 	CommentReactions,
 	type CommentReactionsProps,
+	type ReactionSummaryInput,
 	summarizeReactions,
 	toggleCommentReaction,
 	useCommentReactions,

--- a/packages/commenting/src/ui/comments-list.tsx
+++ b/packages/commenting/src/ui/comments-list.tsx
@@ -2,6 +2,7 @@ import { Avatar, type CommentAuthor } from '@tldraw/mentions'
 import { MouseEvent, ReactNode } from 'react'
 import { useTranslation } from 'tldraw'
 import { Byline } from './byline'
+import { Reactions, type ReactionSummary } from './reactions'
 import { replyCountLabel } from './reply-count'
 
 /** @public */
@@ -19,6 +20,9 @@ export interface CommentListItemProps {
 	count?: number
 	/** Whether this thread is the open one. */
 	selected?: boolean
+	/** Tallied reactions for the row (a thread's, or a single comment's when the row is one
+	 *  comment), shown as inert pills under the preview. Omit to hide. */
+	reactions?: ReactionSummary[]
 	/**
 	 * Link target for the item. When set, the row renders as an anchor so browser affordances
 	 * (ctrl/cmd-click, middle-click) open it in a new tab; a plain click still calls `onSelect`.
@@ -97,6 +101,7 @@ function CommentListItem({
 	page,
 	count,
 	selected,
+	reactions,
 	href,
 	resolvedLabel = 'Resolved',
 	onSelect,
@@ -123,6 +128,7 @@ function CommentListItem({
 			<div className="tlui-cmt-list__item-body">
 				<Byline author={author} date={date} />
 				<div className="tlui-cmt-list__item-preview">{preview}</div>
+				{reactions && <Reactions reactions={reactions} canReact={false} enableHoverList={false} />}
 				{(resolved || page !== undefined || replies) && (
 					<div className="tlui-cmt-list__item-meta">
 						{resolved && (

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -414,12 +414,17 @@
 	font-size: 10px;
 	font-weight: 400;
 	color: var(--tl-color-text-1);
+}
+
+/* An inert pill renders as a span (e.g. in a notification row); only the button variant is
+   clickable, so only it gets the pointer cursor and hover shade. */
+button.tlui-cmt-reaction {
 	cursor: pointer;
 }
 
 /* Hover deepens the grey — no border to tint now. Mixing toward the text colour is theme-aware:
    it darkens the fill in light mode and lightens it in dark, tracking the pill's own contrast. */
-.tlui-cmt-reaction:hover {
+button.tlui-cmt-reaction:hover {
 	background: var(--tl-color-muted-1);
 }
 
@@ -429,7 +434,7 @@
 	background: color-mix(in srgb, var(--tl-color-selected) 28%, var(--tl-color-panel));
 }
 
-.tlui-cmt-reaction--active:hover {
+button.tlui-cmt-reaction--active:hover {
 	background: color-mix(in srgb, var(--tl-color-selected) 38%, var(--tl-color-panel));
 }
 

--- a/packages/commenting/src/ui/reaction.tsx
+++ b/packages/commenting/src/ui/reaction.tsx
@@ -46,19 +46,20 @@ export function Reaction({
 	ReactionTooltip = DefaultReactionTooltip,
 	onClick,
 }: ReactionProps) {
+	// An inert pill (no handler) is plain content, not a control — rendering it as a span keeps it
+	// valid inside an anchor row (e.g. a notification list item) and out of the tab order.
+	const Tag = onClick ? 'button' : 'span'
 	const pill = (
-		<button
+		<Tag
 			className={active ? 'tlui-cmt-reaction tlui-cmt-reaction--active' : 'tlui-cmt-reaction'}
-			type="button"
+			{...(onClick ? { type: 'button' as const, 'aria-pressed': active, onClick } : undefined)}
 			// The emoji alone announces as its unicode name ("thumbs up"); pairing it with the count
 			// is what makes the pill's state legible to a screen reader.
 			aria-label={`${emoji} ${count}`}
-			aria-pressed={active}
-			onClick={onClick}
 		>
 			<span className="tlui-cmt-reaction__emoji">{renderReaction(emoji)}</span>
 			<span className="tlui-cmt-reaction__count">{count}</span>
-		</button>
+		</Tag>
 	)
 
 	// A bare pill when hovering is suppressed, or when there's no one to name.

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -49,8 +49,8 @@ export const queries = defineQueries({
 	),
 
 	/**
-	 * Recent comments that concern the current user, for the app-level notifications feed. A
-	 * comment qualifies when it isn't the user's own and matches at least one of three categories:
+	 * Recent comments that concern the current user, for the app-level notifications feed. Someone
+	 * else's comment qualifies when it matches at least one of three categories:
 	 *
 	 * - it's on a file the user owns
 	 * - it's in a thread the user is a part of (started, or has commented in) and on a file they
@@ -61,6 +61,10 @@ export const queries = defineQueries({
 	 *   workspace they're a member of. Ownership carries its own access evidence; replies and
 	 *   mentions need an explicit current-access gate because historical thread participation can
 	 *   outlive access to the file.
+	 *
+	 * The user's own comment qualifies only when someone else has reacted to it (a "reacted to
+	 * your comment" entry), on a file the user can still access — owns, has a file_state for, or
+	 * reaches through a workspace.
 	 *
 	 * Filtering here (server-side) rather than on the client is what keeps out-of-category
 	 * comments off the wire entirely. One gate stays client-side: `categorizeCommentNotifications`
@@ -74,7 +78,6 @@ export const queries = defineQueries({
 	 */
 	comments: defineQuery(({ ctx }) =>
 		zql.comment
-			.where('authorId', '!=', ctx.userId)
 			// soft-deleted comments and comments of soft-deleted threads stay in Postgres (see
 			// TLComment.isDeleted) but must never surface as notifications
 			.where('isDeleted', '=', false)
@@ -82,42 +85,66 @@ export const queries = defineQueries({
 			// same for soft-deleted boards: their comment rows persist, but a notification would
 			// navigate to a file the user can no longer open
 			.whereExists('file', (f) => f.where('isDeleted', '=', false))
-			.where(({ and, or, exists }) =>
+			.where(({ and, or, cmp, exists }) =>
 				or(
-					// on a board the user owns
-					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
-					// a reply: in a thread the user started or has commented in, on a file they
-					// can still access
+					// someone else's comment, in one of the three categories that concern the user
 					and(
-						exists('thread', (t) =>
-							t.where(({ cmp, or, exists }) =>
-								or(
-									cmp('createdBy', '=', ctx.userId),
-									// live comments only: soft-deleted rows persist, and deleting your
-									// last comment in a thread must end the reply subscription with it
-									exists('comments', (c) =>
-										c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
+						cmp('authorId', '!=', ctx.userId),
+						or(
+							// on a board the user owns
+							exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
+							// a reply: in a thread the user started or has commented in, on a file they
+							// can still access
+							and(
+								exists('thread', (t) =>
+									t.where(({ cmp, or, exists }) =>
+										or(
+											cmp('createdBy', '=', ctx.userId),
+											// live comments only: soft-deleted rows persist, and deleting your
+											// last comment in a thread must end the reply subscription with it
+											exists('comments', (c) =>
+												c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
+											)
+										)
+									)
+								),
+								exists('file', (f) =>
+									f.where(({ or, exists }) =>
+										or(
+											exists('states', (s) => s.where('userId', '=', ctx.userId)),
+											exists('groupFiles', (gf) =>
+												gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+											)
+										)
 									)
 								)
-							)
-						),
-						exists('file', (f) =>
-							f.where(({ or, exists }) =>
-								or(
-									exists('states', (s) => s.where('userId', '=', ctx.userId)),
-									exists('groupFiles', (gf) =>
-										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+							),
+							// @-mentions the user, on a file they can access (opened it, or workspace member)
+							and(
+								exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
+								exists('file', (f) =>
+									f.where(({ or, exists }) =>
+										or(
+											exists('states', (s) => s.where('userId', '=', ctx.userId)),
+											exists('groupFiles', (gf) =>
+												gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+											)
+										)
 									)
 								)
 							)
 						)
 					),
-					// @-mentions the user, on a file they can access (opened it, or workspace member)
+					// the user's own comment, once someone else reacts to it — a "reacted to your
+					// comment" entry. Gated on current file access like replies and mentions, with
+					// ownership as its own evidence
 					and(
-						exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
+						cmp('authorId', '=', ctx.userId),
+						exists('reactions', (r) => r.where('userId', '!=', ctx.userId)),
 						exists('file', (f) =>
-							f.where(({ or, exists }) =>
+							f.where(({ cmp, or, exists }) =>
 								or(
+									cmp('ownerId', '=', ctx.userId),
 									exists('states', (s) => s.where('userId', '=', ctx.userId)),
 									exists('groupFiles', (gf) =>
 										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
@@ -142,6 +169,9 @@ export const queries = defineQueries({
 			// the caller's read receipt (at most one row: PK is (userId, commentId) and we filter
 			// on userId); absent (for others' comments) = unread
 			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
+			// every reaction to the comment, for the inert reaction pills on notification rows. A
+			// comment's reactions are naturally few, so the set syncs unbounded
+			.related('reactions')
 			.orderBy('createdAt', 'desc')
 			.limit(RECENT_COMMENTS_LIMIT)
 	),

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -212,8 +212,8 @@ export const comment_mention = table('comment_mention')
 // One row per (comment, reacting user, emoji) — a user may react with several emoji. Written by
 // the file's Durable Object from the room's comment-reaction records, like comment/comment_thread.
 // The in-document reaction UI reads reactions over the sync object-lane, not from here; this table
-// mirrors comment_mention so a future app-level query (e.g. "reacted to your comment") can reach
-// reactions server-side without a schema change. Nothing consumes it yet.
+// feeds the app-level `comments` query: its "reacted to your comment" category and the reaction
+// pills on notification rows.
 export const comment_reaction = table('comment_reaction')
 	.columns({
 		id: string(),


### PR DESCRIPTION
Not ready yet — the synced query shape is still under discussion, the UI is not final, and the feature hasn’t been fully tested with a second account.

In order to let people know when their comments get reactions — today a reaction is invisible unless you happen to reopen the thread — this PR surfaces reactions in the app-level notifications panel, in two ways:

- Every notification row now shows the comment's reactions as read-only emoji + count pills (your own highlighted).
- A new notification category: "X reacted to your comment", aggregated per comment, timestamped by the newest foreign reaction. It goes unread again when a new reaction lands after you've read it, using the existing `comment_read.readAt` receipt — no schema or mutator changes.

This is the first consumer of the `comment_reaction` Zero table (written by the file DO since #9471, unread until now). The `comments` synced query is restructured into `or(someone else's comment AND <the existing three categories>, your own comment AND has foreign reactions AND you can still access the file)`.

Reactor names in the byline are best-effort: reaction rows carry no display name, so names resolve from comment authors in the feed and workspace member rows ("Olive reacted…", "Olive and 2 others reacted…"), falling back to anonymous counts ("3 people reacted…") for e.g. shared-link guests who never commented.

Known limitation, deliberately unresolved while the query shape is discussed: the feed's 50-row window is ordered by `comment.createdAt`, so a reaction landing on a comment older than the window never surfaces as a notification. Fixing that properly means a reaction-recency-ordered query (base table `comment_reaction`).

### Change type

- [x] `feature`

### Test plan

1. As user B, react to a comment authored by user A.
2. As user A, open the notifications bell: a "B reacted to your comment" entry appears with reaction pills, dated by the reaction.
3. Click it — it marks read; react again as B and it becomes unread again.
4. Reactions on other notification rows (mentions, replies, owned-board) show as pills.

- [x] Unit tests

### API changes

- Added `CommentListItemProps.reactions` — optional tallied reactions rendered as inert pills on a list row.
- Added `ReactionSummaryInput` and widened `summarizeReactions` to accept it (a structural subset of `TLCommentReaction`), so tallies can be built from app-level reaction rows. Non-breaking.
- `Reaction` renders a `<span>` instead of a `<button>` when it has no `onClick`, so inert pills are valid inside anchor rows.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +93 / -37  |
| Tests           | +180 / -1  |
| Automated files | +116 / -1  |
| Apps            | +201 / -53 |

### Release notes

- Comment reactions now show in the tldraw.com notifications panel, including "reacted to your comment" notifications.
