### PR TITLE
feat(editor): grant evaluation licenses all features

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -1202,6 +1202,31 @@ describe('getEnabledFeatures', () => {
 		}
 	)
 
+	it('enables every feature for an evaluation license regardless of flags', () => {
+		const result = getDefaultLicenseResult({
+			isEvaluationLicense: true,
+			isCollaborationEnabled: false,
+			isCommentingEnabled: false,
+		})
+		expect(getEnabledFeatures(result, 'licensed', false)).toEqual({
+			collaboration: true,
+			commenting: true,
+		})
+	})
+
+	it('disables all features for an expired evaluation license', () => {
+		const result = getDefaultLicenseResult({
+			isEvaluationLicense: true,
+			isEvaluationLicenseExpired: true,
+			isCollaborationEnabled: false,
+			isCommentingEnabled: false,
+		})
+		expect(getEnabledFeatures(result, 'expired', false)).toEqual({
+			collaboration: false,
+			commenting: false,
+		})
+	})
+
 	it('disables all features when the license is not parseable', () => {
 		expect(
 			getEnabledFeatures(

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -566,6 +566,13 @@ export function getEnabledFeatures(
 		return { ...NO_FEATURES }
 	}
 
+	// Evaluation licenses get every feature so prospects can trial the whole product without us
+	// having to mint per-feature evaluation keys. Expired evaluation licenses are already excluded
+	// above: they resolve to the 'expired' state.
+	if (result.isEvaluationLicense) {
+		return { ...ALL_FEATURES }
+	}
+
 	return {
 		collaboration: result.isCollaborationEnabled,
 		commenting: result.isCommentingEnabled,


### PR DESCRIPTION
In order to hand a prospect a single evaluation key that unlocks everything they might want to try, this makes evaluation licenses grant all licensable features regardless of the per-feature flags encoded in the key. Today an evaluation key still has to carry `FEAT_COLLABORATION` / `FEAT_COMMENTING` explicitly, so evaluating a newly gated feature means minting and re-sending a new key.

The check sits in `getEnabledFeatures`, after the license-validity gate, so it doesn't loosen anything else: an expired evaluation license resolves to the `expired` state and still gets no features, and non-evaluation licenses continue to be read flag by flag.

Based on #9782 — this targets `commenting-followups`.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests

### Release notes

- Evaluation licenses now unlock all licensable features.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +7 / -0    |
| Tests     | +25 / -0   |
