### PR TITLE
fix(i18n): wait for the Lokalise upload before ordering translations

### DIFF
--- a/.github/workflows/i18n-upload-strings.yml
+++ b/.github/workflows/i18n-upload-strings.yml
@@ -27,5 +27,6 @@ jobs:
         env:
           LOKALISE_API_TOKEN: ${{ secrets.LOKALISE_API_TOKEN }}
           LOKALISE_PROJECT_ID: ${{ secrets.LOKALISE_PROJECT_ID }}
+          LOKALISE_TLDRAW_PROJECT_ID: ${{ secrets.LOKALISE_TLDRAW_PROJECT_ID }}
           LOKALISE_TEAM_ID: ${{ secrets.LOKALISE_TEAM_ID }}
           LOKALISE_CARD_ID: ${{ secrets.LOKALISE_CARD_ID }}

--- a/internal/scripts/i18n-upload-strings.ts
+++ b/internal/scripts/i18n-upload-strings.ts
@@ -14,7 +14,7 @@ import { LokaliseApi, QueuedProcess } from '@lokalise/node-api'
 
 const UPLOAD_POLL_INTERVAL_MS = 2000
 const UPLOAD_MAX_POLLS = 120
-/** Keys/languages per page when listing. Lokalise caps this at 500. */
+/** Items per page when listing keys and languages, within Lokalise's per-endpoint maximums. */
 const PAGE_LIMIT = 500
 /** Anything pricier than this wants a human to look at it first. */
 const MAX_ORDER_TOTAL = 10
@@ -96,6 +96,10 @@ async function uploadFile(
 		detect_icu_plurals: true,
 		cleanup_mode: cleanupMode,
 	})
+
+	if (!uploadResult.process_id) {
+		throw new Error(`Upload did not return a process_id: ${JSON.stringify(uploadResult, null, 2)}`)
+	}
 
 	const queuedProcess = await waitForUpload(lokaliseApi, projectId, uploadResult.process_id)
 	console.log(`Uploaded ${filename} successfully!`)

--- a/internal/scripts/i18n-upload-strings.ts
+++ b/internal/scripts/i18n-upload-strings.ts
@@ -1,44 +1,153 @@
 import fs from 'fs'
 import path from 'path'
-import { LokaliseApi } from '@lokalise/node-api'
+import { LokaliseApi, QueuedProcess } from '@lokalise/node-api'
 
-async function i18nUploadStrings() {
-	const projectId = process.env.LOKALISE_PROJECT_ID!
-	const teamId = process.env.LOKALISE_TEAM_ID!
-	const cardId = process.env.LOKALISE_CARD_ID!
-	const filePath = path.resolve(__dirname, '../../apps/dotcom/client/public/tla/locales/en.json')
-	const file = fs.readFileSync(filePath, 'utf8')
-	console.log('Uploading files...')
+// Pushes the English source strings to Lokalise and orders machine translations
+// for anything still untranslated (see i18n-download-strings.ts for the other
+// half of the pipeline).
+//
+// Two Lokalise projects are in play:
+//   - the dotcom project (LOKALISE_PROJECT_ID), source apps/dotcom/client/public/tla/locales/en.json
+//   - the tldraw SDK project (LOKALISE_TLDRAW_PROJECT_ID), source assets/translations/main.json
+// Only the dotcom project orders translations automatically; SDK orders are
+// still placed by hand.
 
-	const lokaliseApi = new LokaliseApi({ apiKey: process.env.LOKALISE_API_TOKEN })
-	const uploadResult = await lokaliseApi.files().upload(projectId, {
-		data: Buffer.from(file).toString('base64'),
-		filename: 'en.json',
-		lang_iso: 'en',
-		detect_icu_plurals: true,
-		cleanup_mode: true,
-	})
-	if (uploadResult.status === 'queued') {
-		console.log('Uploaded files successfully!')
-	} else {
-		console.error('Failed to upload files:', uploadResult)
-		process.exit(1)
+const UPLOAD_POLL_INTERVAL_MS = 2000
+const UPLOAD_MAX_POLLS = 120
+/** Keys/languages per page when listing. Lokalise caps this at 500. */
+const PAGE_LIMIT = 500
+/** Anything pricier than this wants a human to look at it first. */
+const MAX_ORDER_TOTAL = 10
+
+function formatError(error: unknown) {
+	if (error instanceof Error) {
+		return error.stack ?? error.message
 	}
 
-	const targetLanguageIsos = (await lokaliseApi.languages().list({ project_id: projectId })).items
-		.map((item) => item.lang_iso)
-		.filter((lang) => lang !== 'en')
-	const allProjectUntranslatedKeys = (
-		await lokaliseApi.keys().list({
+	try {
+		return JSON.stringify(error, null, 2)
+	} catch {
+		return String(error)
+	}
+}
+
+function sleep(ms: number) {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function getEnv(name: string) {
+	const value = process.env[name]
+	if (!value) throw new Error(`Missing required env var: ${name}`)
+	return value
+}
+
+/**
+ * Lokalise's file upload is asynchronous: it returns a queued process and
+ * creates the keys in the background. Poll until it's done — otherwise anything
+ * we ask about the project next still describes the state from before the
+ * upload, and freshly added strings look like they don't exist.
+ */
+async function waitForUpload(lokaliseApi: LokaliseApi, projectId: string, processId: string) {
+	for (let i = 0; i < UPLOAD_MAX_POLLS; i++) {
+		const queuedProcess = await lokaliseApi
+			.queuedProcesses()
+			.get(processId, { project_id: projectId })
+
+		if (queuedProcess.status === 'finished') return queuedProcess
+		if (queuedProcess.status === 'failed' || queuedProcess.status === 'cancelled') {
+			throw new Error(
+				`Upload ${queuedProcess.status}: ${queuedProcess.message || 'No message'}\n${JSON.stringify(queuedProcess, null, 2)}`
+			)
+		}
+
+		await sleep(UPLOAD_POLL_INTERVAL_MS)
+	}
+
+	throw new Error(`Upload timed out after ${UPLOAD_MAX_POLLS} polls for project ${projectId}`)
+}
+
+function logUploadResult(queuedProcess: QueuedProcess) {
+	const files = queuedProcess.details?.files ?? []
+	if (!files.length) {
+		console.log('  Upload finished, but Lokalise reported no file details.')
+		return
+	}
+	for (const file of files) {
+		console.log(
+			`  ${file.name_original ?? 'file'}: ${file.key_count_inserted ?? 0} inserted, ` +
+				`${file.key_count_updated ?? 0} updated, ${file.key_count_skipped ?? 0} skipped ` +
+				`(${file.key_count_total ?? 0} total).`
+		)
+	}
+}
+
+async function uploadFile(
+	lokaliseApi: LokaliseApi,
+	options: { projectId: string; filePath: string; filename: string; cleanupMode: boolean }
+) {
+	const { projectId, filePath, filename, cleanupMode } = options
+	const file = fs.readFileSync(filePath, 'utf8')
+	console.log(`Uploading ${filename}...`)
+
+	const uploadResult = await lokaliseApi.files().upload(projectId, {
+		data: Buffer.from(file).toString('base64'),
+		filename,
+		lang_iso: 'en',
+		detect_icu_plurals: true,
+		cleanup_mode: cleanupMode,
+	})
+
+	const queuedProcess = await waitForUpload(lokaliseApi, projectId, uploadResult.process_id)
+	console.log(`Uploaded ${filename} successfully!`)
+	logUploadResult(queuedProcess)
+}
+
+/** Every target language in the project, English excluded. Paginated: there are 50+ of them. */
+async function listTargetLanguageIsos(lokaliseApi: LokaliseApi, projectId: string) {
+	const isos: string[] = []
+	for (let page = 1; ; page++) {
+		const result = await lokaliseApi
+			.languages()
+			.list({ project_id: projectId, limit: PAGE_LIMIT, page })
+		isos.push(...result.items.map((item) => item.lang_iso))
+		if (result.items.length < PAGE_LIMIT) break
+	}
+	return isos.filter((lang) => lang !== 'en')
+}
+
+/** Every key with at least one missing translation. Paginated: a big batch would otherwise truncate. */
+async function listUntranslatedKeyIds(lokaliseApi: LokaliseApi, projectId: string) {
+	const keyIds: number[] = []
+	let cursor: string | undefined
+	do {
+		const result = await lokaliseApi.keys().list({
 			project_id: projectId,
 			filter_untranslated: 1,
+			pagination: 'cursor',
+			limit: PAGE_LIMIT,
+			...(cursor ? { cursor } : {}),
 		})
-	).items.map((item) => item.key_id)
+		keyIds.push(...result.items.map((item) => item.key_id))
+		cursor = result.hasNextCursor() ? (result.nextCursor ?? undefined) : undefined
+	} while (cursor)
+	return keyIds
+}
+
+async function orderDotcomTranslations(lokaliseApi: LokaliseApi, projectId: string) {
+	const teamId = getEnv('LOKALISE_TEAM_ID')
+	const cardId = getEnv('LOKALISE_CARD_ID')
+
+	const targetLanguageIsos = await listTargetLanguageIsos(lokaliseApi, projectId)
+	const allProjectUntranslatedKeys = await listUntranslatedKeyIds(lokaliseApi, projectId)
 
 	if (!allProjectUntranslatedKeys.length) {
 		console.log('No new strings to translate.')
 		return
 	}
+
+	console.log(
+		`Found ${allProjectUntranslatedKeys.length} untranslated key(s) across ${targetLanguageIsos.length} language(s).`
+	)
 
 	const orderDetails = {
 		project_id: projectId,
@@ -63,17 +172,35 @@ async function i18nUploadStrings() {
 		}
 	)
 
+	// Lokalise won't accept an order that prices out at 0, so there's nothing to
+	// place here. Log enough to diagnose it: the usual cause is that the keys are
+	// untranslated but not billable (already covered by translation memory, or
+	// sitting in an open order from a previous run).
 	if (placeTranslationOrderDryRun.total === 0) {
-		console.log(`There are strings to translate but Lokalise can't do the order b/c it's 0. UGH.`)
+		console.log(
+			`There are strings to translate but the dry run priced them at 0, so Lokalise won't take the order.`
+		)
+		console.log(
+			`  Untranslated keys (${allProjectUntranslatedKeys.length}): ${allProjectUntranslatedKeys.join(', ')}`
+		)
+		console.log(
+			`  Target languages (${targetLanguageIsos.length}): ${targetLanguageIsos.join(', ')}`
+		)
+		console.log(`  Dry run response: ${JSON.stringify(placeTranslationOrderDryRun, null, 2)}`)
+		console.log('Place the order manually in Lokalise if these strings need translating.')
 		return
 	}
 
-	if (placeTranslationOrderDryRun.total > 10) {
-		console.error('Cost of translations is exceeding expectations. Place a manual order.')
+	if (placeTranslationOrderDryRun.total > MAX_ORDER_TOTAL) {
+		console.error(
+			`Cost of translations (${placeTranslationOrderDryRun.total}) is exceeding expectations (${MAX_ORDER_TOTAL}). Place a manual order.`
+		)
 		process.exit(1)
 	}
 
-	console.log('Placing actual order for new strings...')
+	console.log(
+		`Placing actual order for new strings (total: ${placeTranslationOrderDryRun.total})...`
+	)
 	await lokaliseApi.orders().create(
 		{
 			...orderDetails,
@@ -85,7 +212,35 @@ async function i18nUploadStrings() {
 	console.log('Finished placing order for new strings.')
 }
 
-i18nUploadStrings().catch((e) => {
-	console.error(e)
+async function i18nUploadStrings() {
+	const lokaliseApi = new LokaliseApi({ apiKey: getEnv('LOKALISE_API_TOKEN') })
+	const dotcomProjectId = getEnv('LOKALISE_PROJECT_ID')
+	const tldrawProjectId = getEnv('LOKALISE_TLDRAW_PROJECT_ID')
+
+	await uploadFile(lokaliseApi, {
+		projectId: dotcomProjectId,
+		filePath: path.resolve(__dirname, '../../apps/dotcom/client/public/tla/locales/en.json'),
+		filename: 'en.json',
+		cleanupMode: true,
+	})
+	await orderDotcomTranslations(lokaliseApi, dotcomProjectId)
+
+	// The SDK project has no automated ordering — uploading keeps its source
+	// strings current so a manual order can pick them up. It runs last so a
+	// problem here can't stop the dotcom half of the pipeline.
+	// TODO: turn cleanup mode on here too once a run has confirmed this upload
+	// matches the keys already in the project. It deletes keys missing from the
+	// uploaded file, so a filename or platform mismatch would drop translations.
+	await uploadFile(lokaliseApi, {
+		projectId: tldrawProjectId,
+		filePath: path.resolve(__dirname, '../../assets/translations/main.json'),
+		filename: 'main.json',
+		cleanupMode: false,
+	})
+}
+
+i18nUploadStrings().catch((error) => {
+	console.error('Failed to upload i18n strings:')
+	console.error(formatError(error))
 	process.exit(1)
 })


### PR DESCRIPTION
In order to get new dotcom strings actually translated, this PR makes the upload script wait for Lokalise to finish ingesting them before it asks what needs translating.

The commenting PR (#9471) added 13 English strings, but [its i18n upload run](https://github.com/tldraw/tldraw/actions/runs/30537751242/job/90855019639) reported "No new strings to translate" and placed no order. Lokalise's file upload is asynchronous — it returns a queued process and creates the keys in the background — and the script treated a `queued` status as done, then listed untranslated keys 0.54s later. It was reading the project as it was *before* the upload. Earlier runs only appeared to work because they picked up leftovers from previous pushes; once those got translated, every run reported nothing to do.

So the upload now polls the queued process to completion the way `i18n-download-strings.ts` already polls its async export, and logs Lokalise's inserted/updated/skipped counts so a run says plainly whether new strings landed.

Three other things surfaced while tracing that, all in the same script:

- **Both list calls read only their first page.** `en.json` is already at 229 keys, so a large batch of new strings would have been silently truncated at 100. The untranslated keys now page through by cursor, and the language list pages too.
- **SDK strings were never uploaded at all.** `assets/translations/main.json` belongs to the tldraw Lokalise project, which the download script reads from but nothing ever wrote to — #9471's 43 new SDK strings never reached Lokalise. It's uploaded now, last, so a problem in this new path can't stop the dotcom half. Cleanup mode is deliberately off for it: it deletes keys missing from the uploaded file, so it should stay off until a real run confirms this upload matches the keys already in that project. Ordering there stays manual.
- **A zero-priced dry run said only "UGH".** That branch fired on Jul 24 and Jul 28 and told us nothing; it now logs the keys, languages, and dry run response.

I couldn't verify the `main.json` filename against the real project without the API token, so the first run's log line is worth an eyeball — that's what the cleanup-mode TODO hinges on.

### Test plan

This only runs from CI against a live Lokalise account, so I exercised it locally against a stubbed API instead. Confirmed: the script waits through a `running` process status before listing keys; cursor pagination issues a second request with the returned cursor and collects keys across both pages; and the happy, zero-total, nothing-untranslated, over-budget, and upload-failed paths each log and exit as intended.

After merging, the next push to main should find #9471's 13 keys untranslated and order them — and if the dry run prices at 0 again, the log will now say why.

### Change type

- [x] `other`

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +187 / -27 |
