### PR TITLE
fix(i18n): enable cleanup mode on the SDK strings upload

### DIFF
--- a/internal/scripts/i18n-upload-strings.ts
+++ b/internal/scripts/i18n-upload-strings.ts
@@ -232,14 +232,17 @@ async function i18nUploadStrings() {
 	// The SDK project has no automated ordering — uploading keeps its source
 	// strings current so a manual order can pick them up. It runs last so a
 	// problem here can't stop the dotcom half of the pipeline.
-	// TODO: turn cleanup mode on here too once a run has confirmed this upload
-	// matches the keys already in the project. It deletes keys missing from the
-	// uploaded file, so a filename or platform mismatch would drop translations.
+	// Cleanup mode deletes keys missing from the uploaded file, which is what
+	// keeps the project matching main.json. Both projects export with
+	// original_filenames, and i18n-download-strings.ts maps every file in a
+	// locale's folder to the same <locale>.json, so a stray file here doesn't
+	// show up as extra keys — it silently overwrites a locale's real strings
+	// depending on export order.
 	await uploadFile(lokaliseApi, {
 		projectId: tldrawProjectId,
 		filePath: path.resolve(__dirname, '../../assets/translations/main.json'),
 		filename: 'main.json',
-		cleanupMode: false,
+		cleanupMode: true,
 	})
 }
 


### PR DESCRIPTION
Follow-up to #9787, which added the SDK strings upload with cleanup mode deliberately off until a real run could confirm the upload lined up with the project.

⚠️ **Merging this deletes 207 keys from the SDK Lokalise project on the next push to main.** That's the point of the PR, but it isn't reversible — take a project snapshot in Lokalise first.

The SDK project holds 745 keys, and they split in two: 538 with filename `main.json` (exactly `assets/translations/main.json`) and 207 with filename `%LANG_ISO%.json` — which is the *dotcom* project's naming, not the SDK's. All 207 were created in the same second on 2026-05-05 09:48:39, and 170 of them are current dotcom keys (`335defdafe` = "Please try refreshing the page." among them). A dotcom locale file was uploaded into the SDK project by hand that morning; no code was involved, and nothing has added to it since. Cleanup mode deletes keys missing from the uploaded file, so turning it on prunes the strays and keeps the project matching `main.json` from here on.

What made this safe to flip is the first automated `main.json` upload, in [run 30554934769](https://github.com/tldraw/tldraw/actions/runs/30554934769):

```
main.json: 0 inserted, 0 updated, 538 skipped (538 total).
```

Every key in the file matched an existing key, which is exactly what #9787 was waiting to see — the filename and platform mask line up, so cleanup takes the 207 strays and nothing else. None of them are untranslated, so no pending order is affected either.

Worth knowing why this matters beyond tidiness. Both projects export with `original_filenames`, and `i18n-download-strings.ts` maps every file in a locale's folder to the same `<locale>.json`:

```
ar/ar.json     207 keys  ['0095a9fa74', ...]                 → assets/translations/ar.json
ar/main.json   494 keys  ['a11y.adjust-shape-styles', ...]   → assets/translations/ar.json
```

The second write wins, so a stray file in the project doesn't surface as extra keys — it silently replaces a locale's real strings. Today `main.json` happens to land second for all 49 locales, because the stored filename is `%LANG_ISO%.json` and `%` sorts ahead of `m`. The repo files are clean right now (I checked all 49 against a real export), but that's ordering luck, not a guarantee. Removing the stray file removes the collision.

### Test plan

The upload only runs from CI against live Lokalise, so I verified the change against a stubbed API: `main.json` is now sent with `cleanup_mode=true`, everything else about the run is unchanged.

After merging, the run log should still show `538 total` for `main.json`, and the SDK project's key count should drop from 745 to 538. If it shows anything other than 538, stop and restore the snapshot — that would mean the upload stopped matching the project.

### Change type

- [x] `other`

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +7 / -4    |
