### PR TITLE
fix(editor): reconcile remotely reparented shapes after merge

### DIFF
--- a/packages/editor/src/lib/editor/Editor.ts
+++ b/packages/editor/src/lib/editor/Editor.ts
@@ -564,6 +564,13 @@ export class Editor extends EventEmitter<TLEventMap> {
 		const deletedShapeIds = new Set<TLShapeId>()
 		const invalidParents = new Set<TLShapeId>()
 		const createdShapes = new Set<TLShapeId>()
+		// Shapes that a remote merge moved or reparented under a shape parent. A reparent is
+		// semantically atomic (change parentId AND re-express the coordinates in the new parent's
+		// space) but syncs field-by-field, so a concurrent merge can keep a shape's parentId from
+		// one client and its x/y from another - leaving the coordinates in the wrong frame of
+		// reference and flinging the shape far away. We can't detect that from the record alone, so
+		// after the merge settles we re-run the same geometric drop check that a local drag uses.
+		const remotelyMovedShapeIds = new Set<TLShapeId>()
 		let invalidBindingTypes = new Set<TLBinding['type']>()
 
 		this.disposables.add(
@@ -572,6 +579,11 @@ export class Editor extends EventEmitter<TLEventMap> {
 				// and we want the next invocation of this handler to handle those separately
 				const deletedIds = deletedShapeIds.size ? new Set(deletedShapeIds) : null
 				deletedShapeIds.clear()
+
+				// captured and cleared up-front so the kickout's own reparenting (which re-enters this
+				// handler) doesn't reprocess these ids
+				const remotelyMovedIds = remotelyMovedShapeIds.size ? new Set(remotelyMovedShapeIds) : null
+				remotelyMovedShapeIds.clear()
 
 				if (deletedIds) {
 					const updates = compact(
@@ -619,6 +631,21 @@ export class Editor extends EventEmitter<TLEventMap> {
 					}
 				}
 
+				if (remotelyMovedIds) {
+					// Re-run the drop check for shapes a remote merge moved: any that no longer sit
+					// inside their (still-existing) parent are kicked out and reparented to the page,
+					// which recomputes their coordinates so parentId and transform agree again. This
+					// reuses the same geometry a local drag uses, so every client reaches the same
+					// result from the same synced state and they converge.
+					const idsToCheck = [...remotelyMovedIds].filter((id) => {
+						const shape = this.getShape(id)
+						return shape && isShapeId(shape.parentId) && this.getShape(shape.parentId)
+					})
+					if (idsToCheck.length) {
+						kickoutOccludedShapes(this, idsToCheck)
+					}
+				}
+
 				this.emit('update')
 			})
 		)
@@ -632,7 +659,7 @@ export class Editor extends EventEmitter<TLEventMap> {
 							invalidParents.add(shape.parentId)
 						}
 					},
-					afterChange: (shapeBefore, shapeAfter) => {
+					afterChange: (shapeBefore, shapeAfter, source) => {
 						for (const binding of this.getBindingsInvolvingShape(shapeAfter)) {
 							invalidBindingTypes.add(binding.type)
 							if (binding.fromId === shapeAfter.id) {
@@ -707,6 +734,22 @@ export class Editor extends EventEmitter<TLEventMap> {
 
 						if (shapeAfter.parentId !== shapeBefore.parentId && isShapeId(shapeAfter.parentId)) {
 							invalidParents.add(shapeAfter.parentId)
+						}
+
+						// A remote merge that changed this shape's parent or position under a shape
+						// parent may have left its coordinates in the wrong frame of reference. Flag it
+						// so the operation-complete handler can re-run the drop check once the merge has
+						// settled. Local (user) moves are already reconciled by the interaction that
+						// made them, so we only do this for remote changes.
+						if (
+							source === 'remote' &&
+							isShapeId(shapeAfter.parentId) &&
+							(shapeBefore.parentId !== shapeAfter.parentId ||
+								shapeBefore.x !== shapeAfter.x ||
+								shapeBefore.y !== shapeAfter.y ||
+								shapeBefore.rotation !== shapeAfter.rotation)
+						) {
+							remotelyMovedShapeIds.add(shapeAfter.id)
 						}
 					},
 					beforeDelete: (shape) => {

--- a/packages/sync-core/src/test/TLSyncClientReparentDesync.test.ts
+++ b/packages/sync-core/src/test/TLSyncClientReparentDesync.test.ts
@@ -1,0 +1,149 @@
+import { computed } from '@tldraw/state'
+import { BaseRecord, RecordId, Store, StoreSchema, createRecordType } from '@tldraw/store'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TLSyncClient } from '../lib/TLSyncClient'
+import { TestServer } from './TestServer'
+import { TestSocketPair } from './TestSocketPair'
+
+// Characterizes the root cause behind the reparent "offshot" bug (follow-up to the reverted #9581 /
+// issue #9567).
+//
+// A shape's `x/y` is relative to its `parentId`. A gulp (drop into a frame) is *semantically*
+// atomic: change parentId AND re-express the coordinates in the new parent's space, together. But
+// over the wire a record change is transmitted and merged field-by-field (see applyObjectDiff in
+// ../lib/diff.ts, and TLSyncRoom.patchDocument). So when two clients touch the same shape at once,
+// the merge can keep `parentId` from one client and `x` from the other — the coordinate ends up in
+// the wrong frame of reference, and the shape renders far away ("offshot").
+//
+// This is inherent to the sync layer's last-writer-wins-per-field merge: it converges every client
+// to the same record, but that record can be incoherent. Rather than change the wire protocol, we
+// restore coherence one level up, in the editor: after a remote merge the editor re-runs its drop
+// geometry and kicks any shape that no longer overlaps its parent back onto the page (see the
+// "reconciling remote reparents" tests in packages/tldraw/src/test/frames.test.ts). This test pins
+// the merge behavior that reconciliation is there to clean up.
+//
+// We model the smallest thing that has the bug: a `doc` with `parent` (a string, standing in for
+// parentId) and `x` (its parent-local coordinate). frame origin is 200 on the page, so:
+//   absolute page position = parent === 'frame' ? 200 + x : x
+
+interface TestDoc extends BaseRecord<'doc', RecordId<TestDoc>> {
+	parent: 'page' | 'frame'
+	x: number
+}
+const TestDocType = createRecordType<TestDoc>('doc', {
+	scope: 'document',
+	validator: { validate: (value) => value as TestDoc },
+})
+const testSchema = StoreSchema.create<TestDoc>({ doc: TestDocType })
+type R = TestDoc
+
+const FRAME_ORIGIN = 200
+function pagePosition(doc: TestDoc): number {
+	return doc.parent === 'frame' ? FRAME_ORIGIN + doc.x : doc.x
+}
+
+interface Client {
+	socketPair: TestSocketPair<R>
+	client: TLSyncClient<R>
+	store: Store<R>
+}
+
+const disposables: Array<() => void> = []
+afterEach(() => {
+	while (disposables.length) disposables.pop()!()
+})
+
+function makeServer(doc0: TestDoc) {
+	return new TestServer<R>(testSchema, {
+		documents: [{ state: doc0, lastChangedClock: 0 }],
+		clock: 0,
+		documentClock: 0,
+		schema: testSchema.serialize(),
+	})
+}
+
+function makeClient(server: TestServer<R>, id: string, doc0: TestDoc): Client {
+	const socketPair = new TestSocketPair<R>(id, server)
+	socketPair.connect()
+
+	const store = new Store<R>({ schema: testSchema, props: {} })
+	const client = new TLSyncClient<R>({
+		store,
+		socket: socketPair.clientSocket,
+		presence: computed('presence', () => null),
+		onLoad: () => {},
+		onSyncError: (reason) => {
+			throw new Error(`unexpected sync error: ${reason}`)
+		},
+	})
+	disposables.push(() => client.close())
+
+	// complete the connect handshake (hydrate doc0 from the server)
+	while (socketPair.getNeedsFlushing()) {
+		socketPair.flushClientSentEvents()
+		socketPair.flushServerSentEvents()
+	}
+	expect(store.get(doc0.id)).toEqual(doc0)
+
+	return { socketPair, client, store }
+}
+
+/** Pump both clients <-> server until nothing is left to deliver. */
+function flushAll(server: TestServer<R>, clients: Client[]) {
+	let guard = 0
+	const needsFlushing = () => clients.some((c) => c.socketPair.getNeedsFlushing())
+	while (needsFlushing()) {
+		for (const c of clients) c.socketPair.flushClientSentEvents()
+		server.flushDebouncingMessages()
+		for (const c of clients) c.socketPair.flushServerSentEvents()
+		if (guard++ > 200) throw new Error('flushAll did not settle')
+	}
+}
+
+describe('reparent coordinate desync (field-level merge characterization)', () => {
+	it('field-level merge keeps parentId from one client and x from the other', () => {
+		const docId = TestDocType.createId('shape')
+		// the shape starts on the page at page-x = 500
+		const doc0 = TestDocType.create({ id: docId, parent: 'page', x: 500 })
+
+		const server = makeServer(doc0)
+		const A = makeClient(server, 'clientA', doc0) // the "gulper"
+		const B = makeClient(server, 'clientB', doc0) // the "mover"
+
+		// Concurrently, before either has seen the other's change:
+		// A gulps the shape into the frame. It stays visually put: page-x 500 -> frame-local 300.
+		A.store.update(docId, (d) => ({ ...d, parent: 'frame', x: 500 - FRAME_ORIGIN }))
+		// B drags the shape along the page to page-x = 600. B never touches parent (stays 'page'),
+		// so B's push is an x-only patch.
+		B.store.update(docId, (d) => ({ ...d, x: 600 }))
+
+		// Deliver A's gulp to the server first, then B's move (staggered, as they would race).
+		A.socketPair.flushClientSentEvents()
+		server.flushDebouncingMessages()
+		B.socketPair.flushClientSentEvents()
+		flushAll(server, [A, B])
+
+		const finalA = A.store.get(docId)!
+		const finalB = B.store.get(docId)!
+		const serverDoc = server.storage.getSnapshot().documents.find((d) => d.state.id === docId)!
+			.state as TestDoc
+
+		// Everyone converges to the same record...
+		expect(finalA).toEqual(finalB)
+		expect(finalA).toEqual(serverDoc)
+
+		// ...but that record is an incoherent mix: parentId from A, x from B. Neither client's
+		// intended (parent, x) pair survived.
+		expect(serverDoc.parent).toBe('frame') // A's write won on parent
+		expect(serverDoc.x).toBe(600) // B's write won on x
+
+		expect(serverDoc).not.toEqual({ ...doc0, parent: 'frame', x: 300 }) // not A's intent
+		expect(serverDoc).not.toEqual({ ...doc0, parent: 'page', x: 600 }) // not B's intent
+
+		// The merged record is offshot: B meant page-x 600, but it renders at 200 + 600 = 800. In a
+		// real editor this is exactly the state the post-merge reconciliation detects and repairs
+		// (the shape no longer overlaps its frame, so it's kicked back onto the page).
+		expect(pagePosition(serverDoc)).toBe(FRAME_ORIGIN + 600)
+		expect(pagePosition(serverDoc)).not.toBe(600)
+	})
+})

--- a/packages/tldraw/src/test/frames.test.ts
+++ b/packages/tldraw/src/test/frames.test.ts
@@ -1707,6 +1707,52 @@ describe('When resizing a frame', () => {
 	})
 })
 
+describe('reconciling remote reparents', () => {
+	it('kicks a shape back to the page when a remote merge parents it to a frame it no longer overlaps', () => {
+		// A concurrent gulp + move can merge field-by-field into an incoherent record: parentId from
+		// the client that dropped the shape into the frame, x/y from the client that moved it on the
+		// page. The shape ends up parented to the frame while sitting far outside it ("offshot"). We
+		// simulate that merged record directly by swapping only the parent on a remote change.
+		const frameId = createShapeId('frame')
+		editor.createShape({ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+		const boxId = createShapeId('box')
+		editor.createShape({ id: boxId, type: 'geo', x: 500, y: 50, props: { w: 40, h: 20 } })
+		expect(editor.getShape(boxId)!.parentId).toBe(editor.getCurrentPageId())
+
+		editor.store.mergeRemoteChanges(() => {
+			editor.store.update(boxId, (r) => ({ ...r, parentId: frameId }))
+		})
+
+		// the shape is reconciled back onto the page, with parentId and transform agreeing again
+		expect(editor.getShape(boxId)!.parentId).toBe(editor.getCurrentPageId())
+		expect(editor.getShapePageBounds(boxId)).toMatchObject({ x: 500, y: 50, w: 40, h: 20 })
+	})
+
+	it('leaves a remotely moved shape alone when it still overlaps its frame parent', () => {
+		const frameId = createShapeId('frame')
+		editor.createShape({ id: frameId, type: 'frame', x: 0, y: 0, props: { w: 100, h: 100 } })
+
+		const boxId = createShapeId('box')
+		editor.createShape({
+			id: boxId,
+			type: 'geo',
+			parentId: frameId,
+			x: 10,
+			y: 10,
+			props: { w: 20, h: 20 },
+		})
+		expect(editor.getShape(boxId)!.parentId).toBe(frameId)
+
+		// a remote move that keeps the shape inside the frame must not trigger a kickout
+		editor.store.mergeRemoteChanges(() => {
+			editor.store.update(boxId, (r) => ({ ...r, x: 40, y: 40 }))
+		})
+
+		expect(editor.getShape(boxId)!.parentId).toBe(frameId)
+	})
+})
+
 it('avoids crash when dragging into descendant', () => {
 	const frame1id = dragCreateFrame({ down: [0, 0], move: [100, 100], up: [100, 100] })
 	const frame2id = dragCreateFrame({ down: [50, 50], move: [150, -50], up: [150, -50] })


### PR DESCRIPTION
In multiplayer, when one person drags a shape while another draws a frame over it, the shape can be flung far across the canvas instead of being gulped into the frame. A shape's `x/y` is stored relative to its `parentId`, but sync merges records field-by-field (last-writer-wins per field). So the two concurrent edits merge into an incoherent record: the frame `parentId` from the person who drew the frame, but the page-space `x/y` from the person who moved the shape. The shape ends up parented to a frame it no longer overlaps, rendered at the wrong offset ("offshot").

This is inherent to the merge and can't be detected from the record alone. Rather than change the wire protocol, we restore coherence one level up in the editor: after a remote merge settles, we re-run the existing drop geometry over the shapes the merge moved or reparented, and kick any that no longer overlap their parent back onto the page — recomputing their coordinates so `parentId` and transform agree again. Because it's derived purely from the synced geometry, it's deterministic and idempotent, so every client converges from the same state.

It's gated to remote changes only; local moves are already reconciled by the interaction that made them.

Relates to #9567 and the reverted #9581 (which tried to fix the same area by deleting shapes and introduced this offshot regression). This intentionally does **not** touch the undo-restore-missing-parent case from #9567 — it's scoped to the multiplayer reparent desync.

> Draft for now: the main goal is to get a preview deploy so we can test the real gulp-over-a-moving-shape race in a live multiplayer room.

### Change type

- [x] `bugfix`

### Test plan

1. Open the same multiplayer room in two clients, A and B.
2. In A, start dragging a shape (keep it moving).
3. In B, draw a frame over where that shape is.
4. The shape should end up either dropped into the frame or left on the page at a sensible position — never flung far across the canvas.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix shapes being flung across the canvas when one collaborator moves a shape while another reparents it (for example by drawing a frame over it) at the same time.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +44 / -1   |
| Tests     | +195 / -0  |

Made with [Cursor](https://cursor.com)