### PR TITLE
refactor(dotcom): remove polyfill-only zero shims left behind by commenting

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaFileShareMenu/Tabs/TlaPublishTab.tsx
@@ -21,13 +21,6 @@ import {
 import { TlaButton } from '../../TlaButton/TlaButton'
 import { TlaShareMenuCopyButton } from '../file-share-menu-primitives'
 
-// add errors to zero-polyfill toasts
-// const messages = defineMessages({
-// 	publishChangesError: { defaultMessage: 'Could not publish changes' },
-// 	publishFileError: { defaultMessage: 'Could not publish file' },
-// 	deleteError: { defaultMessage: 'Could not delete' },
-// })
-
 export function TlaPublishTab({ file }: { file: TlaFile }) {
 	const { fileSlug } = useParams()
 	const editor = useEditor()

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -13,6 +13,7 @@ import {
 	ZRowUpdate,
 	ZServerSentPacket,
 	ZStoreData,
+	isZTable,
 } from '@tldraw/dotcom-shared'
 import { react, transact } from '@tldraw/state'
 import {
@@ -653,6 +654,10 @@ export class UserDataSyncer {
 			this.broadcast({ type: 'update', update })
 		}
 		for (const [table, diff] of objectMapEntries(changes)) {
+			// The accumulator spans every schema table, but this store and its wire protocol only
+			// carry the legacy tables. Nothing accumulates outside `file` today; skip rather than
+			// send rows legacy clients can't hold.
+			if (!isZTable(table)) continue
 			for (const newRow of diff?.added ?? []) {
 				apply({ event: 'insert', row: newRow, table })
 			}

--- a/apps/dotcom/sync-worker/src/zero/ServerCrud.ts
+++ b/apps/dotcom/sync-worker/src/zero/ServerCrud.ts
@@ -1,13 +1,5 @@
 import type { SchemaValue, TableMutator, TableSchema } from '@rocicorp/zero'
-import {
-	DB,
-	TlaFile,
-	TlaRow,
-	TlaRowPartial,
-	TlaSchema,
-	ZErrorCode,
-	ZTable,
-} from '@tldraw/dotcom-shared'
+import { DB, TlaFile, TlaRow, TlaRowPartial, TlaSchema, ZErrorCode } from '@tldraw/dotcom-shared'
 import { assert, omit } from '@tldraw/utils'
 import {
 	CompiledQuery,
@@ -23,8 +15,11 @@ import { QueryResultRow } from 'pg'
 import { ZMutationError } from './ZMutationError'
 const quote = (s: string) => '"' + s.replace(/"/g, '""') + '"'
 
+// Keyed by every schema table so the generic CRUD below can index it, but only pre-initialized
+// keys ever accumulate (callers seed `file.added` and nothing else), and only ZTable tables can
+// cross the legacy user-DO pipe — see UserDataSyncer.incorporateUnsyncedChanges.
 export type ChangeAccumulator = {
-	[table in ZTable]?: {
+	[table in keyof DB]?: {
 		added?: TlaRow[]
 		updated?: TlaRow[]
 		removed?: TlaRowPartial[]

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -1,14 +1,8 @@
 import { stringEnum } from '@tldraw/utils'
 import type { SerializedSchema, SerializedStore, TLRecord } from 'tldraw'
 import {
-	TlaComment,
-	TlaCommentMention,
-	TlaCommentReaction,
-	TlaCommentRead,
-	TlaCommentThread,
 	TlaFile,
 	TlaFileState,
-	TlaFileVisitor,
 	TlaGroup,
 	TlaGroupFile,
 	TlaGroupUser,
@@ -174,25 +168,6 @@ export interface ZStoreData {
 	group: TlaGroup[]
 	group_user: TlaGroupUser[]
 	group_file: TlaGroupFile[]
-	// Optional: comments are served via the proper-Zero synced query, not the legacy polyfill store,
-	// so the polyfill never populates this. Present only so the CRUD types (generic over all schema
-	// tables) compile.
-	comment?: TlaComment[]
-	// Same as comment: never populated by the legacy polyfill store, present only for the
-	// generic CRUD types.
-	comment_thread?: TlaCommentThread[]
-	// Same as comment: never populated by the legacy polyfill store, present only for the
-	// generic CRUD types.
-	comment_read?: TlaCommentRead[]
-	// Same as comment: never populated by the legacy polyfill store, present only for the
-	// generic CRUD types.
-	comment_mention?: TlaCommentMention[]
-	// Same as comment: never populated by the legacy polyfill store, present only for the
-	// generic CRUD types.
-	comment_reaction?: TlaCommentReaction[]
-	// Same as comment: the viewer roster is served via the proper-Zero synced query (fileVisitors),
-	// never populated by the legacy polyfill store; present only for the generic CRUD types.
-	file_visitor?: TlaFileVisitor[]
 	lsn: string
 }
 
@@ -210,19 +185,13 @@ export interface ZRowDeleteOrUpdate {
 	event: 'update' | 'delete'
 }
 
-export type ZTable =
-	| 'file'
-	| 'file_state'
-	| 'file_visitor'
-	| 'user'
-	| 'group'
-	| 'group_user'
-	| 'group_file'
-	| 'comment'
-	| 'comment_thread'
-	| 'comment_read'
-	| 'comment_mention'
-	| 'comment_reaction'
+export const Z_TABLES = ['file', 'file_state', 'user', 'group', 'group_user', 'group_file'] as const
+export type ZTable = (typeof Z_TABLES)[number]
+
+/** Whether a schema table is part of the legacy user-DO sync protocol. */
+export function isZTable(table: string): table is ZTable {
+	return (Z_TABLES as readonly string[]).includes(table)
+}
 
 export type ZEvent = 'insert' | 'update' | 'delete'
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -209,9 +209,8 @@ export const ZErrorCode = stringEnum(
 )
 export type ZErrorCode = keyof typeof ZErrorCode
 
-// increment this to force clients to reload
-// e.g. if we make backwards-incompatible changes to the schema
-export const Z_PROTOCOL_VERSION = 3
+// The minimum legacy-protocol version /app/:userId/connect still accepts; only pre-polyfill-removal
+// bundles send it. Raise (or delete with the legacy path) to force those clients to reload.
 export const MIN_Z_PROTOCOL_VERSION = 3
 
 export type ZServerSentPacket =


### PR DESCRIPTION
In order to finish the cleanup started in #9564, this PR removes the type shims the commenting PR (#9471) had to add so the zero polyfill would compile against the comment tables. With the polyfill gone their only consumer (the polyfill's generic `ClientCRUD`) no longer exists, and the legacy user-DO protocol never carried comment rows at runtime.

The shims were load-bearing for typechecking in one place: `ServerCRUD` runs mutators for every schema table and indexes its `ChangeAccumulator` by table name, which forced `ZTable` (the legacy wire-protocol type) to list the comment tables, which in turn forced `ZStoreData` to carry optional comment fields. This PR rekeys `ChangeAccumulator` by the real DB table union — honest, since only `file.added` ever accumulates — and skips non-legacy tables at the single point where accumulator diffs become legacy `ZRowUpdate`s. Runtime no-op; the legacy protocol types no longer claim comment support that never existed.

Also removes `Z_PROTOCOL_VERSION` (only the deleted polyfill ever sent it; the server-side `MIN_Z_PROTOCOL_VERSION` gate for old bundles stays) and a stale commented-out polyfill-toast TODO in `TlaPublishTab`.

The remaining legacy surface (`UserDataSyncer`, `OptimisticAppStore`, `ZTable`, `/connect`, the forced-on zero flags) intentionally stays until pre-#9564 bundles age out.

### Change type

- [x] `other`

### Test plan

- [x] Unit tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -41   |
| Apps      | +10 / -17  |