### PR TITLE
feat(dotcom): add comment_reaction userName column

### DIFF
--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -1,0 +1,47 @@
+-- Denormalize the reacting user's display name onto reaction rows, like comment.authorName:
+-- joining "user" from the notifications query would expose private user fields to file readers.
+
+ALTER TABLE comment_reaction ADD COLUMN "userName" VARCHAR DEFAULT '' NOT NULL;
+
+-- Stamp the name on insert — the Durable Object only knows userId.
+CREATE OR REPLACE FUNCTION set_comment_reaction_user_name() RETURNS TRIGGER AS $$
+DECLARE
+  user_name VARCHAR;
+BEGIN
+  SELECT u."name" INTO user_name
+  FROM public."user" u
+  WHERE u."id" = NEW."userId";
+  -- a missing user row keeps the default, so the insert still fails its user FK check
+  IF FOUND THEN
+    NEW."userName" := user_name;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "set_comment_reaction_user_name_trigger"
+BEFORE INSERT OR UPDATE OF "userId" ON comment_reaction
+FOR EACH ROW
+EXECUTE FUNCTION set_comment_reaction_user_name();
+
+-- Propagate user renames to their existing reactions.
+CREATE OR REPLACE FUNCTION update_comment_reaction_user_name() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE comment_reaction
+  SET "userName" = NEW."name"
+  WHERE "userId" = NEW."id";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_comment_reaction_user_name_trigger"
+AFTER UPDATE OF "name" ON public."user"
+FOR EACH ROW
+WHEN (OLD."name" IS DISTINCT FROM NEW."name")
+EXECUTE FUNCTION update_comment_reaction_user_name();
+
+-- Backfill rows that predate the column.
+UPDATE comment_reaction cr
+SET "userName" = u."name"
+FROM public."user" u
+WHERE u."id" = cr."userId";

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -45,3 +45,8 @@ UPDATE comment_reaction cr
 SET "userName" = u."name"
 FROM public."user" u
 WHERE u."id" = cr."userId";
+
+-- Top-N scans for the app-level feeds: the comments and reactions queries order by createdAt
+-- desc with a limit; without these, every query hydration scans and sorts the whole table.
+CREATE INDEX comment_created_at_idx ON comment("createdAt" DESC);
+CREATE INDEX comment_reaction_created_at_idx ON comment_reaction("createdAt" DESC);

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -45,10 +45,3 @@ UPDATE comment_reaction cr
 SET "userName" = u."name"
 FROM public."user" u
 WHERE u."id" = cr."userId";
-
--- Reaction rows are client-dated; a future-dated row would outrun the server-clamped
--- comment_read.readAt watermark and its notification could never be marked read. Clamp
--- existing rows; the Durable Object drain clamps new ones the same way.
-UPDATE comment_reaction
-SET "createdAt" = (extract(epoch from now()) * 1000)::bigint
-WHERE "createdAt" > (extract(epoch from now()) * 1000)::bigint;

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -45,3 +45,10 @@ UPDATE comment_reaction cr
 SET "userName" = u."name"
 FROM public."user" u
 WHERE u."id" = cr."userId";
+
+-- Reaction rows are client-dated; a future-dated row would outrun the server-clamped
+-- comment_read.readAt watermark and its notification could never be marked read. Clamp
+-- existing rows; the Durable Object drain clamps new ones the same way.
+UPDATE comment_reaction
+SET "createdAt" = (extract(epoch from now()) * 1000)::bigint
+WHERE "createdAt" > (extract(epoch from now()) * 1000)::bigint;


### PR DESCRIPTION
In order to show who reacted in the upcoming reaction-notifications feature without joining the private `user` table, this PR denormalizes the reacting user's display name onto `comment_reaction` rows — the same pattern as `comment.authorName` from migration 040: a `BEFORE INSERT` stamp trigger, a user-rename fan-out trigger, and an in-migration backfill. It also adds `createdAt` indexes on `comment` and `comment_reaction` so the app-level feed queries (`orderBy createdAt desc limit N`) hydrate from an index instead of a full scan + sort.

This is deliberately a migration-only PR: a newly replicated column must reach zero-cache view-syncer replicas before any code declares or queries it (the 037 lesson). Nothing reads the column yet. The feature PR that consumes it (#9797) follows and must merge only after this is deployed.

### Change type

- [x] `feature`

### Test plan

- SQL mirrors the proven 040 trigger pair; nothing consumes the column yet, so behavior is unchanged.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +52 / -0   |
