### PR TITLE
feat(dotcom): reaction notifications in the notifications panel

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -1588,6 +1588,36 @@
       "value": "Terms of service"
     }
   ],
+  "e65b2dcb6f": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "a"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "b"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " reacted to your comment"
+    }
+  ],
   "e81c4e4f2b": [
     {
       "type": 0,
@@ -1696,6 +1726,70 @@
     {
       "type": 0,
       "value": "Delete"
+    }
+  ],
+  "f476ba8646": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "a"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": ", "
+    },
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "b"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " other"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " others"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " reacted to your comment"
     }
   ],
   "f4f70727dc": [

--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -549,6 +549,22 @@
       "value": "My workspace"
     }
   ],
+  "5bffeebf03": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " reacted to your comment"
+    }
+  ],
   "5d04a002ea": [
     {
       "type": 0,
@@ -589,6 +605,35 @@
     {
       "type": 0,
       "value": "Later"
+    }
+  ],
+  "61fb03fd7b": [
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 0,
+              "value": "Someone reacted to your comment"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " people reacted to your comment"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
     }
   ],
   "625fd29749": [
@@ -1373,6 +1418,56 @@
     {
       "type": 0,
       "value": "Learn more about publishing."
+    }
+  ],
+  "d0e3556476": [
+    {
+      "children": [
+        {
+          "type": 1,
+          "value": "author"
+        }
+      ],
+      "type": 8,
+      "value": "name"
+    },
+    {
+      "type": 0,
+      "value": " and "
+    },
+    {
+      "offset": 0,
+      "options": {
+        "one": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " other"
+            }
+          ]
+        },
+        "other": {
+          "value": [
+            {
+              "type": 7
+            },
+            {
+              "type": 0,
+              "value": " others"
+            }
+          ]
+        }
+      },
+      "pluralType": "cardinal",
+      "type": 6,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": " reacted to your comment"
     }
   ],
   "d3d2e61733": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -621,6 +621,9 @@
   "e404559826": {
     "translation": "Terms of service"
   },
+  "e65b2dcb6f": {
+    "translation": "<name>{a}</name> and <name>{b}</name> reacted to your comment"
+  },
   "e81c4e4f2b": {
     "translation": "or"
   },
@@ -668,6 +671,9 @@
   },
   "f2a6c498fb": {
     "translation": "Delete"
+  },
+  "f476ba8646": {
+    "translation": "<name>{a}</name>, <name>{b}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
   },
   "f4f70727dc": {
     "translation": "Settings"

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -227,6 +227,9 @@
   "5bff3c9c88": {
     "translation": "My workspace"
   },
+  "5bffeebf03": {
+    "translation": "<name>{author}</name> reacted to your comment"
+  },
   "5d04a002ea": {
     "translation": "Unable to connect"
   },
@@ -247,6 +250,9 @@
   },
   "61057a0c84": {
     "translation": "Later"
+  },
+  "61fb03fd7b": {
+    "translation": "{count, plural, one {Someone reacted to your comment} other {# people reacted to your comment}}"
   },
   "625fd29749": {
     "translation": "Older"
@@ -566,6 +572,9 @@
   },
   "cea291e45e": {
     "translation": "Learn more about publishing."
+  },
+  "d0e3556476": {
+    "translation": "<name>{author}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
   },
   "d3d2e61733": {
     "translation": "Close"

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -128,6 +128,8 @@ export class TldrawApp {
 	 * keep it off the wire entirely, not just hide the UI that reads it.
 	 */
 	private readonly comments$: Signal<QueryResultType<typeof queries.comments>> | null
+	/** Null when commenting is disabled for this user, like {@link comments$}. */
+	private readonly reactions$: Signal<QueryResultType<typeof queries.reactions>> | null
 
 	/** Whether this user gets the commenting UI — see {@link shouldEnableCommenting}. */
 	readonly isCommentingEnabled: boolean
@@ -268,6 +270,9 @@ export class TldrawApp {
 		this.comments$ = this.isCommentingEnabled
 			? this.signalizeQuery('comments signal', this.commentsQuery())
 			: null
+		this.reactions$ = this.isCommentingEnabled
+			? this.signalizeQuery('reactions signal', this.reactionsQuery())
+			: null
 	}
 
 	private userQuery() {
@@ -286,12 +291,25 @@ export class TldrawApp {
 		return queries.comments()
 	}
 
+	private reactionsQuery() {
+		return queries.reactions()
+	}
+
 	/**
 	 * Recent comments across the user's files, for the notifications feed (bounded, cross-file).
 	 * Empty when commenting is disabled for this user — the query isn't subscribed at all.
 	 */
 	getComments(): QueryResultType<typeof queries.comments> {
 		return this.comments$?.get() ?? []
+	}
+
+	/**
+	 * Recent reactions to the user's comments across their files, for the notifications feed
+	 * (bounded, cross-file). Empty when commenting is disabled for this user — the query isn't
+	 * subscribed at all.
+	 */
+	getReactions(): QueryResultType<typeof queries.reactions> {
+		return this.reactions$?.get() ?? []
 	}
 
 	/**

--- a/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/CommentsOnCanvas.tsx
@@ -16,6 +16,7 @@ import { useTldrawAppUiEvents } from '../../utils/app-ui-events'
 import { defineMessages, F, useMsg } from '../../utils/i18n'
 import { TlaSignInDialog } from '../dialogs/TlaSignInDialog'
 import { TlaCtaButton } from '../TlaCtaButton/TlaCtaButton'
+import { latestForeignReactionAt } from '../TlaSidebar/components/commentNotifications'
 
 type FileComments = QueryResultType<typeof queries.fileComments>
 type FileVisitors = QueryResultType<typeof queries.fileVisitors>
@@ -92,13 +93,20 @@ export function CommentsOnCanvas({ fileId }: { fileId: string }) {
 		return authors
 	}, [fileComments])
 
-	// Ids of unread comments: others' comments with no read receipt in Zero. Zero comment row ids
-	// are TLComment record ids verbatim (see commentRecordToRow in the sync-worker), so these map
-	// straight onto store records. Own comments never get a receipt and never count as unread.
+	// Ids of unread comments: others' comments with no read receipt, plus own comments whose
+	// newest foreign reaction postdates the receipt — so opening the thread writes/advances the
+	// receipt and clears the "reacted to your comment" notification. Zero comment row ids are
+	// TLComment record ids verbatim, so these map straight onto store records.
 	const unreadCommentIds = useMemo(() => {
 		const ids = new Set<string>()
 		for (const c of fileComments) {
-			if (c.authorId !== currentUserId && !c.read) ids.add(c.id)
+			if (c.authorId !== currentUserId) {
+				if (!c.read) ids.add(c.id)
+			} else {
+				const latestForeign = latestForeignReactionAt(c.reactions, currentUserId)
+				if (latestForeign !== undefined && latestForeign > (c.read?.readAt ?? -Infinity))
+					ids.add(c.id)
+			}
 		}
 		return ids
 	}, [fileComments, currentUserId])

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -38,7 +38,7 @@ function ReasonByline({
 	reason: CommentNotificationReason
 	author: string
 	/** Who reacted, for the `reaction` phrasing — see {@link summarizeForeignReactors}. */
-	reactors: { name: string | undefined; others: number; total: number }
+	reactors: { names: string[]; others: number; total: number }
 	nameClassName: string
 }) {
 	const name = (chunks: ReactNode) => <span className={nameClassName}>{chunks}</span>
@@ -54,42 +54,59 @@ function ReasonByline({
 					values={{ author, name }}
 				/>
 			)
-		case 'reaction':
-			// Reaction rows carry no display name, so the face is best-effort — resolved from
-			// comment authors in the feed and workspace members. Nobody resolvable → anonymous count.
-			if (reactors.name === undefined) {
+		case 'reaction': {
+			const { names, others, total } = reactors
+			const [a, b] = names
+			if (names.length === 0) {
 				return (
 					<F
 						defaultMessage="{count, plural, one {Someone reacted to your comment} other {# people reacted to your comment}}"
-						values={{ count: reactors.total }}
+						values={{ count: total }}
 					/>
 				)
 			}
-			if (reactors.others === 0) {
+			if (names.length === 1 && others === 0) {
 				return (
 					<F
 						defaultMessage="<name>{author}</name> reacted to your comment"
-						values={{ author: reactors.name, name }}
+						values={{ author: a, name }}
+					/>
+				)
+			}
+			if (names.length === 2 && others === 0) {
+				return (
+					<F
+						defaultMessage="<name>{a}</name> and <name>{b}</name> reacted to your comment"
+						values={{ a, b, name }}
+					/>
+				)
+			}
+			if (names.length === 1) {
+				return (
+					<F
+						defaultMessage="<name>{author}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
+						values={{ author: a, count: others, name }}
 					/>
 				)
 			}
 			return (
 				<F
-					defaultMessage="<name>{author}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
-					values={{ author: reactors.name, count: reactors.others, name }}
+					defaultMessage="<name>{a}</name>, <name>{b}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
+					values={{ a, b, count: others, name }}
 				/>
 			)
+		}
 	}
 }
 
 /**
- * Comments surfaced as notifications. The `comments` synced query already filters to the three
- * categories that concern the user server-side — comments on boards they own, replies in threads
- * they're a part of, and `@`-mentions of them — so out-of-category comments never reach the
- * client; {@link categorizeCommentNotifications} tags each synced comment with why it's there,
- * newest first, and drops reply-only thread history from before the user joined. Also returns
- * the caller's unread count over that set (a notification is unread when it has no read
- * receipt). Shared by the trigger button (for its badge) and the panel (for its list).
+ * Comments surfaced as notifications. The `comments` synced query already filters to four
+ * categories server-side — comments on boards they own, replies in threads they're part of,
+ * `@`-mentions of them, and reactions on their comments — so out-of-category entries never
+ * reach the client; {@link categorizeCommentNotifications} tags each with why it's there,
+ * newest first, and drops reply-only history from before the user joined. Unread: comment
+ * entries when no read receipt, reaction entries when the newest foreign reaction postdates
+ * the caller's read receipt. Shared by trigger button (badge) and panel (list).
  */
 export function useCommentNotifications() {
 	const app = useMaybeApp()
@@ -120,27 +137,6 @@ function commentLink(fileId: string, shapeId: string | null | undefined, comment
 export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 	const app = useMaybeApp()
 	const { notifications, unreadCount } = useCommentNotifications()
-	// Reactor id → display name, from the identity the app already syncs: workspace member rows
-	// and comment authors in the feed (authors win — comments carry the fresher denormalization
-	// for someone who just wrote). A reactor outside both (e.g. a shared-link guest who never
-	// commented) stays unresolved and the byline falls back to an anonymous count.
-	const resolveReactorName = useValue(
-		'reactor names',
-		() => {
-			const names = new Map<string, string>()
-			if (!app) return (id: string) => names.get(id)
-			for (const membership of app.getWorkspaceMemberships()) {
-				for (const member of membership.groupMembers ?? []) {
-					if (member.userName) names.set(member.userId, member.userName)
-				}
-			}
-			for (const c of app.getComments()) {
-				if (c.authorName) names.set(c.authorId, c.authorName)
-			}
-			return (id: string) => names.get(id)
-		},
-		[app]
-	)
 	const title = useMsg(messages.title)
 	const markAllReadLbl = useMsg(messages.markAllRead)
 	const empty = useMsg(messages.empty)
@@ -163,7 +159,11 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 			date: new Date(n.timestamp).toISOString(),
 			// inert pills: no toggling from the panel, emoji + count with the user's own
 			// reactions highlighted
-			reactions: summarizeReactions(c.reactions ?? [], app?.userId, resolveReactorName),
+			reactions: summarizeReactions(
+				c.reactions ?? [],
+				app?.userId,
+				(id) => c.reactions?.find((r) => r.userId === id)?.userName || undefined
+			),
 			// the document the comment lives on — the headline of the notification row
 			page: c.file?.name || untitledFile,
 			// a real link target, so browser affordances (ctrl/cmd-click, middle-click) open a new tab
@@ -226,11 +226,7 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 									<ReasonByline
 										reason={n?.primaryReason ?? 'owned-board'}
 										author={item.author.name}
-										reactors={summarizeForeignReactors(
-											n?.comment.reactions,
-											app?.userId,
-											resolveReactorName
-										)}
+										reactors={summarizeForeignReactors(n?.comment.reactions, app?.userId)}
 										nameClassName={styles.author}
 									/>
 								</div>

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -17,6 +17,7 @@ import {
 	buildReactionNotifications,
 	categorizeCommentNotifications,
 	CommentNotificationReason,
+	mergeNotifications,
 	summarizeForeignReactors,
 } from './commentNotifications'
 import styles from './notifications.module.css'
@@ -112,9 +113,7 @@ export function useCommentNotifications() {
 		() => {
 			const comments = categorizeCommentNotifications(app?.getComments() ?? [], app?.userId)
 			const reactionEntries = buildReactionNotifications(app?.getReactions() ?? [], app?.userId)
-			const notifications = [...comments, ...reactionEntries].sort(
-				(a, b) => b.timestamp - a.timestamp
-			)
+			const notifications = mergeNotifications(comments, reactionEntries)
 			const unreadCount = notifications.filter((n) => n.unread).length
 			return { notifications, unreadCount }
 		},

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -3,7 +3,9 @@ import {
 	CommentsList,
 	formatRelativeTime,
 	isOpenInNewTabClick,
+	Reactions,
 	richTextToPlaintext,
+	summarizeReactions,
 } from '@tldraw/commenting'
 import { ReactNode, useCallback } from 'react'
 import { Link } from 'react-router-dom'
@@ -11,7 +13,11 @@ import { createDeepLinkString, TLRichText, useValue } from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { defineMessages, F, useMsg } from '../../../utils/i18n'
-import { categorizeCommentNotifications, CommentNotificationReason } from './commentNotifications'
+import {
+	categorizeCommentNotifications,
+	CommentNotificationReason,
+	summarizeForeignReactors,
+} from './commentNotifications'
 import styles from './notifications.module.css'
 
 const messages = defineMessages({
@@ -26,10 +32,13 @@ const messages = defineMessages({
 function ReasonByline({
 	reason,
 	author,
+	reactors,
 	nameClassName,
 }: {
 	reason: CommentNotificationReason
 	author: string
+	/** Who reacted, for the `reaction` phrasing — see {@link summarizeForeignReactors}. */
+	reactors: { name: string | undefined; others: number; total: number }
 	nameClassName: string
 }) {
 	const name = (chunks: ReactNode) => <span className={nameClassName}>{chunks}</span>
@@ -43,6 +52,31 @@ function ReasonByline({
 				<F
 					defaultMessage="<name>{author}</name> commented on your board"
 					values={{ author, name }}
+				/>
+			)
+		case 'reaction':
+			// Reaction rows carry no display name, so the face is best-effort — resolved from
+			// comment authors in the feed and workspace members. Nobody resolvable → anonymous count.
+			if (reactors.name === undefined) {
+				return (
+					<F
+						defaultMessage="{count, plural, one {Someone reacted to your comment} other {# people reacted to your comment}}"
+						values={{ count: reactors.total }}
+					/>
+				)
+			}
+			if (reactors.others === 0) {
+				return (
+					<F
+						defaultMessage="<name>{author}</name> reacted to your comment"
+						values={{ author: reactors.name, name }}
+					/>
+				)
+			}
+			return (
+				<F
+					defaultMessage="<name>{author}</name> and {count, plural, one {# other} other {# others}} reacted to your comment"
+					values={{ author: reactors.name, count: reactors.others, name }}
 				/>
 			)
 	}
@@ -63,7 +97,7 @@ export function useCommentNotifications() {
 		'comment notifications',
 		() => {
 			const notifications = categorizeCommentNotifications(app?.getComments() ?? [], app?.userId)
-			const unreadCount = notifications.filter((n) => !n.comment.read).length
+			const unreadCount = notifications.filter((n) => n.unread).length
 			return { notifications, unreadCount }
 		},
 		[app]
@@ -86,36 +120,65 @@ function commentLink(fileId: string, shapeId: string | null | undefined, comment
 export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 	const app = useMaybeApp()
 	const { notifications, unreadCount } = useCommentNotifications()
+	// Reactor id → display name, from the identity the app already syncs: workspace member rows
+	// and comment authors in the feed (authors win — comments carry the fresher denormalization
+	// for someone who just wrote). A reactor outside both (e.g. a shared-link guest who never
+	// commented) stays unresolved and the byline falls back to an anonymous count.
+	const resolveReactorName = useValue(
+		'reactor names',
+		() => {
+			const names = new Map<string, string>()
+			if (!app) return (id: string) => names.get(id)
+			for (const membership of app.getWorkspaceMemberships()) {
+				for (const member of membership.groupMembers ?? []) {
+					if (member.userName) names.set(member.userId, member.userName)
+				}
+			}
+			for (const c of app.getComments()) {
+				if (c.authorName) names.set(c.authorId, c.authorName)
+			}
+			return (id: string) => names.get(id)
+		},
+		[app]
+	)
 	const title = useMsg(messages.title)
 	const markAllReadLbl = useMsg(messages.markAllRead)
 	const empty = useMsg(messages.empty)
 	const unknownAuthor = useMsg(messages.unknownAuthor)
 	const untitledFile = useMsg(messages.untitledFile)
 
-	const items: CommentListItemProps[] = notifications.map(({ comment: c }) => ({
-		id: c.id,
-		author: {
-			// never fall back to the raw id: an opaque uuid as a byline reads as a bug, and the rest
-			// of the commenting UI says "Someone" for an unresolvable author
-			name: c.authorName || unknownAuthor,
-			color: c.authorColor || undefined,
-		},
-		preview: richTextToPlaintext(c.body as TLRichText),
-		date: new Date(c.createdAt).toISOString(),
-		// the document the comment lives on — the headline of the notification row
-		page: c.file?.name || untitledFile,
-		// a real link target, so browser affordances (ctrl/cmd-click, middle-click) open a new tab
-		href: commentLink(c.fileId, c.thread?.shapeId, c.id),
-	}))
+	const items: CommentListItemProps[] = notifications.map((n) => {
+		const c = n.comment
+		return {
+			id: c.id,
+			author: {
+				// never fall back to the raw id: an opaque uuid as a byline reads as a bug, and the rest
+				// of the commenting UI says "Someone" for an unresolvable author
+				name: c.authorName || unknownAuthor,
+				color: c.authorColor || undefined,
+			},
+			preview: richTextToPlaintext(c.body as TLRichText),
+			// the notified-about event: a reaction entry dates from its newest foreign reaction,
+			// not from the (older) comment it decorates
+			date: new Date(n.timestamp).toISOString(),
+			// inert pills: no toggling from the panel, emoji + count with the user's own
+			// reactions highlighted
+			reactions: summarizeReactions(c.reactions ?? [], app?.userId, resolveReactorName),
+			// the document the comment lives on — the headline of the notification row
+			page: c.file?.name || untitledFile,
+			// a real link target, so browser affordances (ctrl/cmd-click, middle-click) open a new tab
+			href: commentLink(c.fileId, c.thread?.shapeId, c.id),
+		}
+	})
 
-	// Row id → why it's a notification, so the byline can be phrased per reason.
-	const reasonById = new Map(notifications.map((n) => [n.comment.id, n.primaryReason]))
+	// Row id → its notification, so the byline can be phrased per reason and reactor count.
+	const notificationById = new Map(notifications.map((n) => [n.comment.id, n]))
 
 	const handleSelect = useCallback(
 		(id: string, isNewTab: boolean) => {
 			const n = notifications.find((n) => n.comment.id === id)
 			if (!n) return
-			if (!n.comment.read) app?.markCommentRead(n.comment.id)
+			if (n.unread) app?.markCommentRead(n.comment.id)
 			// keep the popover open when opening in a new tab, so more can be opened
 			if (!isNewTab) onClose()
 		},
@@ -133,8 +196,8 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 						className={styles.markAll}
 						onClick={() => {
 							if (!app) return
-							for (const { comment: c } of notifications) {
-								if (!c.read) app.markCommentRead(c.id)
+							for (const n of notifications) {
+								if (n.unread) app.markCommentRead(n.comment.id)
 							}
 						}}
 						disabled={unreadCount === 0}
@@ -143,31 +206,42 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 					</button>
 				}
 				empty={empty}
-				renderItem={(item) => (
-					<Link
-						key={item.id}
-						to={item.href!}
-						className="tlui-cmt-list__item"
-						onClick={(e) => handleSelect(item.id, isOpenInNewTabClick(e))}
-						// middle-click opens the tab natively without firing onClick; still mark it read
-						onAuxClick={(e) => e.button === 1 && handleSelect(item.id, true)}
-					>
-						<div className="tlui-cmt-list__item-body">
-							<div className={styles.head}>
-								<span className={styles.docTitle}>{item.page}</span>
-								<span className={styles.time}>{formatRelativeTime(item.date)}</span>
+				renderItem={(item) => {
+					const n = notificationById.get(item.id)
+					return (
+						<Link
+							key={item.id}
+							to={item.href!}
+							className="tlui-cmt-list__item"
+							onClick={(e) => handleSelect(item.id, isOpenInNewTabClick(e))}
+							// middle-click opens the tab natively without firing onClick; still mark it read
+							onAuxClick={(e) => e.button === 1 && handleSelect(item.id, true)}
+						>
+							<div className="tlui-cmt-list__item-body">
+								<div className={styles.head}>
+									<span className={styles.docTitle}>{item.page}</span>
+									<span className={styles.time}>{formatRelativeTime(item.date)}</span>
+								</div>
+								<div className={styles.byline}>
+									<ReasonByline
+										reason={n?.primaryReason ?? 'owned-board'}
+										author={item.author.name}
+										reactors={summarizeForeignReactors(
+											n?.comment.reactions,
+											app?.userId,
+											resolveReactorName
+										)}
+										nameClassName={styles.author}
+									/>
+								</div>
+								<div className={styles.preview}>{item.preview}</div>
+								{item.reactions && (
+									<Reactions reactions={item.reactions} canReact={false} enableHoverList={false} />
+								)}
 							</div>
-							<div className={styles.byline}>
-								<ReasonByline
-									reason={reasonById.get(item.id) ?? 'owned-board'}
-									author={item.author.name}
-									nameClassName={styles.author}
-								/>
-							</div>
-							<div className={styles.preview}>{item.preview}</div>
-						</div>
-					</Link>
-				)}
+						</Link>
+					)
+				}}
 			/>
 		</div>
 	)

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -14,6 +14,7 @@ import { routes } from '../../../../routeDefs'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { defineMessages, F, useMsg } from '../../../utils/i18n'
 import {
+	buildReactionNotifications,
 	categorizeCommentNotifications,
 	CommentNotificationReason,
 	summarizeForeignReactors,
@@ -100,20 +101,20 @@ function ReasonByline({
 }
 
 /**
- * Comments surfaced as notifications. The `comments` synced query already filters to four
- * categories server-side — comments on boards they own, replies in threads they're part of,
- * `@`-mentions of them, and reactions on their comments — so out-of-category entries never
- * reach the client; {@link categorizeCommentNotifications} tags each with why it's there,
- * newest first, and drops reply-only history from before the user joined. Unread: comment
- * entries when no read receipt, reaction entries when the newest foreign reaction postdates
- * the caller's read receipt. Shared by trigger button (badge) and panel (list).
+ * Comments and reactions surfaced as notifications, merged from the `comments` and `reactions`
+ * synced queries and sorted by timestamp. {@link categorizeCommentNotifications} and
+ * {@link buildReactionNotifications} do the per-feed shaping. Shared by trigger button and panel.
  */
 export function useCommentNotifications() {
 	const app = useMaybeApp()
 	return useValue(
 		'comment notifications',
 		() => {
-			const notifications = categorizeCommentNotifications(app?.getComments() ?? [], app?.userId)
+			const comments = categorizeCommentNotifications(app?.getComments() ?? [], app?.userId)
+			const reactionEntries = buildReactionNotifications(app?.getReactions() ?? [], app?.userId)
+			const notifications = [...comments, ...reactionEntries].sort(
+				(a, b) => b.timestamp - a.timestamp
+			)
 			const unreadCount = notifications.filter((n) => n.unread).length
 			return { notifications, unreadCount }
 		},

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -1,8 +1,10 @@
 import { TLRichText } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 import {
+	buildReactionNotifications,
 	categorizeCommentNotifications,
 	CommentNotificationInput,
+	ReactionNotificationInput,
 	summarizeForeignReactors,
 } from './commentNotifications'
 
@@ -37,6 +39,7 @@ function comment(overrides: Partial<CommentNotificationInput> = {}): CommentNoti
 	return {
 		id: 'comment:1',
 		authorId: OTHER,
+		fileId: 'file:1',
 		threadId: 'comment-thread:1',
 		createdAt: at(0),
 		body: body('hello'),
@@ -269,70 +272,76 @@ describe('categorizeCommentNotifications', () => {
 	})
 })
 
-describe('reaction notifications', () => {
-	/** My own comment, with reactions. */
-	function mine(overrides: Partial<CommentNotificationInput> = {}): CommentNotificationInput {
+describe('buildReactionNotifications', () => {
+	/** My own comment, as the reacted-to comment carried on a reaction row. */
+	function mine(
+		overrides: Partial<CommentNotificationInput> = {}
+	): CommentNotificationInput & { id: string } {
 		return comment({
 			authorId: ME,
 			thread: { createdBy: ME },
 			file: { ownerId: THIRD },
 			...overrides,
-		})
+		}) as CommentNotificationInput & { id: string }
 	}
 
-	it("labels my comment with someone else's reaction as reaction", () => {
-		const result = categorizeCommentNotifications(
-			[mine({ reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) }] })],
+	function reactionRow(
+		overrides: Partial<ReactionNotificationInput> = {}
+	): ReactionNotificationInput {
+		return {
+			commentId: 'comment:1',
+			userId: OTHER,
+			userName: 'Other',
+			emoji: '👍',
+			createdAt: at(10),
+			comment: mine(),
+			...overrides,
+		}
+	}
+
+	it('groups multiple rows on the same comment into one entry', () => {
+		const result = buildReactionNotifications(
+			[
+				reactionRow({ userId: OTHER, createdAt: at(10) }),
+				reactionRow({ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) }),
+			],
 			ME
 		)
 		expect(result).toHaveLength(1)
+		expect(result[0].comment.reactions).toHaveLength(2)
 		expect(result[0].reasons).toEqual(['reaction'])
 		expect(result[0].primaryReason).toBe('reaction')
 	})
 
-	it('drops my comment with no reactions, or with only my own', () => {
-		expect(categorizeCommentNotifications([mine()], ME)).toEqual([])
-		expect(
-			categorizeCommentNotifications(
-				[mine({ reactions: [{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(10) }] })],
-				ME
-			)
-		).toEqual([])
-	})
-
-	it("never labels others' comments as reaction, whatever their reactions", () => {
-		const theirs = comment({
-			file: { ownerId: ME },
-			reactions: [{ userId: THIRD, userName: 'Third', emoji: '👍', createdAt: at(10) }],
-		})
-		const result = categorizeCommentNotifications([theirs], ME)
-		expect(result[0].reasons).toEqual(['owned-board'])
-	})
-
-	it('timestamps the entry by the newest foreign reaction, ignoring my own later one', () => {
-		const result = categorizeCommentNotifications(
+	it('groups rows on two different comments into two entries', () => {
+		const result = buildReactionNotifications(
 			[
-				mine({
-					createdAt: at(0),
-					reactions: [
-						{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) },
-						{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
-						{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(30) },
-					],
-				}),
+				reactionRow({ commentId: 'comment:1', comment: mine({ id: 'comment:1' }) }),
+				reactionRow({ commentId: 'comment:2', comment: mine({ id: 'comment:2' }) }),
+			],
+			ME
+		)
+		expect(result.map((n) => n.comment.id).sort()).toEqual(['comment:1', 'comment:2'])
+	})
+
+	it('timestamps the entry by the newest reaction in the group', () => {
+		const result = buildReactionNotifications(
+			[
+				reactionRow({ createdAt: at(10) }),
+				reactionRow({ userId: THIRD, userName: 'Third', createdAt: at(20) }),
 			],
 			ME
 		)
 		expect(result[0].timestamp).toBe(at(20))
 	})
 
-	it('is unread until my read receipt is newer than the newest foreign reaction', () => {
+	it('is unread until my read receipt is newer than the newest reaction', () => {
 		const withReadAt = (readAt: number | undefined) =>
-			categorizeCommentNotifications(
+			buildReactionNotifications(
 				[
-					mine({
-						read: readAt === undefined ? undefined : { readAt },
-						reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) }],
+					reactionRow({
+						createdAt: at(10),
+						comment: mine({ read: readAt === undefined ? undefined : { readAt } }),
 					}),
 				],
 				ME
@@ -345,14 +354,32 @@ describe('reaction notifications', () => {
 		expect(withReadAt(at(15))).toBe(false)
 	})
 
+	it('drops rows whose comment outraced its sync', () => {
+		const result = buildReactionNotifications([reactionRow({ comment: null })], ME)
+		expect(result).toEqual([])
+	})
+
+	it('drops my own reaction rows as a belt against a self row slipping through', () => {
+		const result = buildReactionNotifications([reactionRow({ userId: ME, userName: 'Me' })], ME)
+		expect(result).toEqual([])
+	})
+
 	it('sorts reaction entries among comment entries by their reaction time', () => {
-		const reacted = mine({
-			id: 'comment:reacted',
-			createdAt: at(0),
-			reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(20) }],
-		})
-		const replied = comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })
-		const result = categorizeCommentNotifications([replied, reacted], ME)
+		const reacted = buildReactionNotifications(
+			[
+				reactionRow({
+					commentId: 'comment:reacted',
+					createdAt: at(20),
+					comment: mine({ id: 'comment:reacted', createdAt: at(0) }),
+				}),
+			],
+			ME
+		)
+		const replied = categorizeCommentNotifications(
+			[comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })],
+			ME
+		)
+		const result = [...replied, ...reacted].sort((a, b) => b.timestamp - a.timestamp)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:reacted', 'comment:replied'])
 	})
 })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -4,6 +4,7 @@ import {
 	buildReactionNotifications,
 	categorizeCommentNotifications,
 	CommentNotificationInput,
+	mergeNotifications,
 	ReactionNotificationInput,
 	summarizeForeignReactors,
 } from './commentNotifications'
@@ -273,16 +274,16 @@ describe('categorizeCommentNotifications', () => {
 })
 
 describe('buildReactionNotifications', () => {
-	/** My own comment, as the reacted-to comment carried on a reaction row. */
-	function mine(
-		overrides: Partial<CommentNotificationInput> = {}
-	): CommentNotificationInput & { id: string } {
+	/** My own comment, as the related comment carried on a reaction row — full `reactions` set
+	 *  included, since that's what the entry now derives its timestamp and pills from. */
+	function mine(overrides: Partial<CommentNotificationInput> = {}): CommentNotificationInput {
 		return comment({
 			authorId: ME,
 			thread: { createdBy: ME },
 			file: { ownerId: THIRD },
+			reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) }],
 			...overrides,
-		}) as CommentNotificationInput & { id: string }
+		})
 	}
 
 	function reactionRow(
@@ -299,16 +300,15 @@ describe('buildReactionNotifications', () => {
 		}
 	}
 
-	it('groups multiple rows on the same comment into one entry', () => {
+	it('dedupes multiple rows on the same comment into one entry', () => {
 		const result = buildReactionNotifications(
 			[
 				reactionRow({ userId: OTHER, createdAt: at(10) }),
-				reactionRow({ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) }),
+				reactionRow({ userId: THIRD, createdAt: at(20) }),
 			],
 			ME
 		)
 		expect(result).toHaveLength(1)
-		expect(result[0].comment.reactions).toHaveLength(2)
 		expect(result[0].reasons).toEqual(['reaction'])
 		expect(result[0].primaryReason).toBe('reaction')
 	})
@@ -324,18 +324,54 @@ describe('buildReactionNotifications', () => {
 		expect(result.map((n) => n.comment.id).sort()).toEqual(['comment:1', 'comment:2'])
 	})
 
-	it('timestamps the entry by the newest reaction in the group', () => {
+	it("carries the related comment's full reactions set unmodified, not just the feed rows", () => {
+		// three foreign reactions on the comment, but only one made it into the top-N feed window
+		const fullReactions = [
+			{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(5) },
+			{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
+			{ userId: ME, userName: 'Me', emoji: '🔥', createdAt: at(15) },
+		]
+		const result = buildReactionNotifications(
+			[reactionRow({ createdAt: at(5), comment: mine({ reactions: fullReactions }) })],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(result[0].comment.reactions).toBe(fullReactions)
+	})
+
+	it('timestamps the entry by the newest foreign reaction on the comment, not the feed row', () => {
 		const result = buildReactionNotifications(
 			[
-				reactionRow({ createdAt: at(10) }),
-				reactionRow({ userId: THIRD, userName: 'Third', createdAt: at(20) }),
+				reactionRow({
+					createdAt: at(10),
+					comment: mine({
+						reactions: [
+							{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) },
+							{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
+						],
+					}),
+				}),
 			],
 			ME
 		)
 		expect(result[0].timestamp).toBe(at(20))
 	})
 
-	it('is unread until my read receipt is newer than the newest reaction', () => {
+	it('drops the entry when the comment has no foreign reaction left', () => {
+		const result = buildReactionNotifications(
+			[
+				reactionRow({
+					comment: mine({
+						reactions: [{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(10) }],
+					}),
+				}),
+			],
+			ME
+		)
+		expect(result).toEqual([])
+	})
+
+	it('is unread until my read receipt is newer than the newest foreign reaction', () => {
 		const withReadAt = (readAt: number | undefined) =>
 			buildReactionNotifications(
 				[
@@ -370,7 +406,11 @@ describe('buildReactionNotifications', () => {
 				reactionRow({
 					commentId: 'comment:reacted',
 					createdAt: at(20),
-					comment: mine({ id: 'comment:reacted', createdAt: at(0) }),
+					comment: mine({
+						id: 'comment:reacted',
+						createdAt: at(0),
+						reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(20) }],
+					}),
 				}),
 			],
 			ME
@@ -379,8 +419,31 @@ describe('buildReactionNotifications', () => {
 			[comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })],
 			ME
 		)
-		const result = [...replied, ...reacted].sort((a, b) => b.timestamp - a.timestamp)
+		const result = mergeNotifications(replied, reacted)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:reacted', 'comment:replied'])
+	})
+})
+
+describe('mergeNotifications', () => {
+	it('merges multiple feeds newest first', () => {
+		const a = categorizeCommentNotifications(
+			[
+				comment({ id: 'comment:a1', createdAt: at(0), file: { ownerId: ME } }),
+				comment({ id: 'comment:a2', createdAt: at(20), file: { ownerId: ME } }),
+			],
+			ME
+		)
+		const b = categorizeCommentNotifications(
+			[comment({ id: 'comment:b1', createdAt: at(10), file: { ownerId: ME } })],
+			ME
+		)
+		const result = mergeNotifications(a, b)
+		expect(result.map((n) => n.comment.id)).toEqual(['comment:a2', 'comment:b1', 'comment:a1'])
+	})
+
+	it('handles no feeds and empty feeds', () => {
+		expect(mergeNotifications()).toEqual([])
+		expect(mergeNotifications([], [])).toEqual([])
 	})
 })
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -340,6 +340,8 @@ describe('reaction notifications', () => {
 		expect(withReadAt(undefined)).toBe(true)
 		// a stale receipt (read before this reaction landed) leaves the entry unread
 		expect(withReadAt(at(5))).toBe(true)
+		// the watermark comparison is strict: a receipt from the same instant counts as read
+		expect(withReadAt(at(10))).toBe(false)
 		expect(withReadAt(at(15))).toBe(false)
 	})
 
@@ -368,6 +370,17 @@ describe('summarizeForeignReactors', () => {
 			names: [],
 			others: 0,
 			total: 0,
+		})
+	})
+
+	it('drops names missing at runtime but still counts the reactor', () => {
+		// rows synced before a view-syncer picks up the userName column arrive without it,
+		// defeating the type — never render "undefined reacted to your comment"
+		const ghost = { userId: 'ghost', emoji: '👍', createdAt: 3 } as unknown as ReturnType<typeof r>
+		expect(summarizeForeignReactors([r('bo', 'Bo', 1), ghost], 'me')).toEqual({
+			names: ['Bo'],
+			others: 1,
+			total: 2,
 		})
 	})
 

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -1,6 +1,10 @@
 import { TLRichText } from 'tldraw'
 import { describe, expect, it } from 'vitest'
-import { categorizeCommentNotifications, CommentNotificationInput } from './commentNotifications'
+import {
+	categorizeCommentNotifications,
+	CommentNotificationInput,
+	summarizeForeignReactors,
+} from './commentNotifications'
 
 const ME = 'user_me'
 const OTHER = 'user_other'
@@ -252,5 +256,158 @@ describe('categorizeCommentNotifications', () => {
 		const newer = comment({ id: 'comment:new', createdAt: at(10), file: { ownerId: ME } })
 		const result = categorizeCommentNotifications([older, newer], ME)
 		expect(result.map((n) => n.comment.id)).toEqual(['comment:new', 'comment:old'])
+	})
+
+	it('marks a comment notification unread until it has a read receipt', () => {
+		const unread = categorizeCommentNotifications([comment({ file: { ownerId: ME } })], ME)
+		expect(unread[0].unread).toBe(true)
+		const read = categorizeCommentNotifications(
+			[comment({ file: { ownerId: ME }, read: { readAt: at(1) } })],
+			ME
+		)
+		expect(read[0].unread).toBe(false)
+	})
+})
+
+describe('reaction notifications', () => {
+	/** My own comment, with reactions. */
+	function mine(overrides: Partial<CommentNotificationInput> = {}): CommentNotificationInput {
+		return comment({
+			authorId: ME,
+			thread: { createdBy: ME },
+			file: { ownerId: THIRD },
+			...overrides,
+		})
+	}
+
+	it("labels my comment with someone else's reaction as reaction", () => {
+		const result = categorizeCommentNotifications(
+			[mine({ reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(10) }] })],
+			ME
+		)
+		expect(result).toHaveLength(1)
+		expect(result[0].reasons).toEqual(['reaction'])
+		expect(result[0].primaryReason).toBe('reaction')
+	})
+
+	it('drops my comment with no reactions, or with only my own', () => {
+		expect(categorizeCommentNotifications([mine()], ME)).toEqual([])
+		expect(
+			categorizeCommentNotifications(
+				[mine({ reactions: [{ userId: ME, emoji: '👍', createdAt: at(10) }] })],
+				ME
+			)
+		).toEqual([])
+	})
+
+	it("never labels others' comments as reaction, whatever their reactions", () => {
+		const theirs = comment({
+			file: { ownerId: ME },
+			reactions: [{ userId: THIRD, emoji: '👍', createdAt: at(10) }],
+		})
+		const result = categorizeCommentNotifications([theirs], ME)
+		expect(result[0].reasons).toEqual(['owned-board'])
+	})
+
+	it('timestamps the entry by the newest foreign reaction, ignoring my own later one', () => {
+		const result = categorizeCommentNotifications(
+			[
+				mine({
+					createdAt: at(0),
+					reactions: [
+						{ userId: OTHER, emoji: '👍', createdAt: at(10) },
+						{ userId: THIRD, emoji: '🎉', createdAt: at(20) },
+						{ userId: ME, emoji: '👍', createdAt: at(30) },
+					],
+				}),
+			],
+			ME
+		)
+		expect(result[0].timestamp).toBe(at(20))
+	})
+
+	it('is unread until my read receipt is newer than the newest foreign reaction', () => {
+		const withReadAt = (readAt: number | undefined) =>
+			categorizeCommentNotifications(
+				[
+					mine({
+						read: readAt === undefined ? undefined : { readAt },
+						reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(10) }],
+					}),
+				],
+				ME
+			)[0].unread
+		expect(withReadAt(undefined)).toBe(true)
+		// a stale receipt (read before this reaction landed) leaves the entry unread
+		expect(withReadAt(at(5))).toBe(true)
+		expect(withReadAt(at(15))).toBe(false)
+	})
+
+	it('sorts reaction entries among comment entries by their reaction time', () => {
+		const reacted = mine({
+			id: 'comment:reacted',
+			createdAt: at(0),
+			reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(20) }],
+		})
+		const replied = comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })
+		const result = categorizeCommentNotifications([replied, reacted], ME)
+		expect(result.map((n) => n.comment.id)).toEqual(['comment:reacted', 'comment:replied'])
+	})
+})
+
+describe('summarizeForeignReactors', () => {
+	const names = new Map([
+		[OTHER, 'Olive'],
+		[THIRD, 'Théo'],
+	])
+	const resolve = (id: string) => names.get(id)
+
+	it('names the newest resolvable reactor and counts the rest', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: THIRD, emoji: '👍', createdAt: at(0) },
+				{ userId: OTHER, emoji: '🎉', createdAt: at(10) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: 'Olive', others: 1, total: 2 })
+	})
+
+	it('counts a reactor once however many emoji they used, and skips my own reactions', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: OTHER, emoji: '👍', createdAt: at(0) },
+				{ userId: OTHER, emoji: '🎉', createdAt: at(10) },
+				{ userId: ME, emoji: '👍', createdAt: at(20) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: 'Olive', others: 0, total: 1 })
+	})
+
+	it('falls back to an older reactor when the newest has no resolvable name', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: THIRD, emoji: '👍', createdAt: at(0) },
+				{ userId: 'user_stranger', emoji: '🎉', createdAt: at(10) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: 'Théo', others: 1, total: 2 })
+	})
+
+	it('gives no name when nobody resolves', () => {
+		const result = summarizeForeignReactors(
+			[
+				{ userId: 'user_a', emoji: '👍', createdAt: at(0) },
+				{ userId: 'user_b', emoji: '🎉', createdAt: at(10) },
+			],
+			ME,
+			resolve
+		)
+		expect(result).toEqual({ name: undefined, others: 2, total: 2 })
 	})
 })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -282,7 +282,7 @@ describe('reaction notifications', () => {
 
 	it("labels my comment with someone else's reaction as reaction", () => {
 		const result = categorizeCommentNotifications(
-			[mine({ reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(10) }] })],
+			[mine({ reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) }] })],
 			ME
 		)
 		expect(result).toHaveLength(1)
@@ -294,7 +294,7 @@ describe('reaction notifications', () => {
 		expect(categorizeCommentNotifications([mine()], ME)).toEqual([])
 		expect(
 			categorizeCommentNotifications(
-				[mine({ reactions: [{ userId: ME, emoji: '👍', createdAt: at(10) }] })],
+				[mine({ reactions: [{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(10) }] })],
 				ME
 			)
 		).toEqual([])
@@ -303,7 +303,7 @@ describe('reaction notifications', () => {
 	it("never labels others' comments as reaction, whatever their reactions", () => {
 		const theirs = comment({
 			file: { ownerId: ME },
-			reactions: [{ userId: THIRD, emoji: '👍', createdAt: at(10) }],
+			reactions: [{ userId: THIRD, userName: 'Third', emoji: '👍', createdAt: at(10) }],
 		})
 		const result = categorizeCommentNotifications([theirs], ME)
 		expect(result[0].reasons).toEqual(['owned-board'])
@@ -315,9 +315,9 @@ describe('reaction notifications', () => {
 				mine({
 					createdAt: at(0),
 					reactions: [
-						{ userId: OTHER, emoji: '👍', createdAt: at(10) },
-						{ userId: THIRD, emoji: '🎉', createdAt: at(20) },
-						{ userId: ME, emoji: '👍', createdAt: at(30) },
+						{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) },
+						{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
+						{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(30) },
 					],
 				}),
 			],
@@ -332,7 +332,7 @@ describe('reaction notifications', () => {
 				[
 					mine({
 						read: readAt === undefined ? undefined : { readAt },
-						reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(10) }],
+						reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) }],
 					}),
 				],
 				ME
@@ -347,7 +347,7 @@ describe('reaction notifications', () => {
 		const reacted = mine({
 			id: 'comment:reacted',
 			createdAt: at(0),
-			reactions: [{ userId: OTHER, emoji: '👍', createdAt: at(20) }],
+			reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(20) }],
 		})
 		const replied = comment({ id: 'comment:replied', createdAt: at(10), file: { ownerId: ME } })
 		const result = categorizeCommentNotifications([replied, reacted], ME)
@@ -356,58 +356,57 @@ describe('reaction notifications', () => {
 })
 
 describe('summarizeForeignReactors', () => {
-	const names = new Map([
-		[OTHER, 'Olive'],
-		[THIRD, 'Théo'],
-	])
-	const resolve = (id: string) => names.get(id)
-
-	it('names the newest resolvable reactor and counts the rest', () => {
-		const result = summarizeForeignReactors(
-			[
-				{ userId: THIRD, emoji: '👍', createdAt: at(0) },
-				{ userId: OTHER, emoji: '🎉', createdAt: at(10) },
-			],
-			ME,
-			resolve
-		)
-		expect(result).toEqual({ name: 'Olive', others: 1, total: 2 })
+	const r = (userId: string, userName: string, createdAt: number, emoji = '👍') => ({
+		userId,
+		userName,
+		emoji,
+		createdAt,
 	})
 
-	it('counts a reactor once however many emoji they used, and skips my own reactions', () => {
-		const result = summarizeForeignReactors(
-			[
-				{ userId: OTHER, emoji: '👍', createdAt: at(0) },
-				{ userId: OTHER, emoji: '🎉', createdAt: at(10) },
-				{ userId: ME, emoji: '👍', createdAt: at(20) },
-			],
-			ME,
-			resolve
-		)
-		expect(result).toEqual({ name: 'Olive', others: 0, total: 1 })
+	it('returns no names for no foreign reactions', () => {
+		expect(summarizeForeignReactors([r('me', 'Me', 1)], 'me')).toEqual({
+			names: [],
+			others: 0,
+			total: 0,
+		})
 	})
 
-	it('falls back to an older reactor when the newest has no resolvable name', () => {
-		const result = summarizeForeignReactors(
-			[
-				{ userId: THIRD, emoji: '👍', createdAt: at(0) },
-				{ userId: 'user_stranger', emoji: '🎉', createdAt: at(10) },
-			],
-			ME,
-			resolve
-		)
-		expect(result).toEqual({ name: 'Théo', others: 1, total: 2 })
+	it('names a single reactor', () => {
+		expect(summarizeForeignReactors([r('bo', 'Bo', 1)], 'me')).toEqual({
+			names: ['Bo'],
+			others: 0,
+			total: 1,
+		})
 	})
 
-	it('gives no name when nobody resolves', () => {
-		const result = summarizeForeignReactors(
-			[
-				{ userId: 'user_a', emoji: '👍', createdAt: at(0) },
-				{ userId: 'user_b', emoji: '🎉', createdAt: at(10) },
-			],
-			ME,
-			resolve
-		)
-		expect(result).toEqual({ name: undefined, others: 2, total: 2 })
+	it('caps at two names, newest reaction first, counting the rest as others', () => {
+		const reactions = [r('bo', 'Bo', 1), r('ada', 'Ada', 3), r('cy', 'Cy', 2)]
+		expect(summarizeForeignReactors(reactions, 'me')).toEqual({
+			names: ['Ada', 'Cy'],
+			others: 1,
+			total: 3,
+		})
+	})
+
+	it('counts one person with several emoji once, dated by their newest reaction', () => {
+		const reactions = [r('bo', 'Bo', 1, '👍'), r('ada', 'Ada', 2), r('bo', 'Bo', 3, '🔥')]
+		expect(summarizeForeignReactors(reactions, 'me')).toEqual({
+			names: ['Bo', 'Ada'],
+			others: 0,
+			total: 2,
+		})
+	})
+
+	it('skips empty names but still counts them', () => {
+		const reactions = [r('ghost', '', 3), r('bo', 'Bo', 1)]
+		expect(summarizeForeignReactors(reactions, 'me')).toEqual({
+			names: ['Bo'],
+			others: 1,
+			total: 2,
+		})
+	})
+
+	it('handles undefined reactions', () => {
+		expect(summarizeForeignReactors(undefined, 'me')).toEqual({ names: [], others: 0, total: 0 })
 	})
 })

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -57,8 +57,11 @@ export interface CommentNotificationInput {
 		comments?: readonly { authorId: string; createdAt: number }[] | null
 	} | null
 	/** Every reaction to the comment, the caller's own included. Categorization only reads who and
-	 *  when; `emoji` rides along for the row's reaction pills. */
-	reactions?: readonly { userId: string; emoji: string; createdAt: number }[] | null
+	 *  when; `emoji` rides along for the row's reaction pills; `userName` is denormalized from the
+	 *  `reactions` table (task 2 migration 045). */
+	reactions?:
+		| readonly { userId: string; userName: string; emoji: string; createdAt: number }[]
+		| null
 }
 
 /** A comment in the notifications feed, tagged with why it's there. */
@@ -147,31 +150,29 @@ function joinedThreadAt(thread: CommentNotificationInput['thread'], userId: stri
 }
 
 /**
- * The reactor summary a "reacted to your comment" byline is phrased from: the newest reactor with
- * a resolvable display name (the byline's face), how many other distinct people reacted beyond
- * them, and the distinct total for when no name resolves at all. `resolveName` covers whatever
- * identity sources the caller has (comment authors in the feed, workspace members) — reaction rows
- * themselves carry no name.
+ * The reactor summary a "reacted to your comment" byline is phrased from: up to two distinct
+ * reactor names (newest reaction first, blank names skipped — e.g. rows from before the 045
+ * backfill), how many distinct people react beyond the named ones, and the distinct total for
+ * when no name is available at all.
  */
 export function summarizeForeignReactors(
 	reactions: CommentNotificationInput['reactions'],
-	userId: string | undefined | null,
-	resolveName: (userId: string) => string | undefined
-): { name: string | undefined; others: number; total: number } {
+	userId: string | undefined | null
+): { names: string[]; others: number; total: number } {
 	// distinct foreign reactors, newest reaction first
-	const newestById = new Map<string, number>()
+	const byId = new Map<string, { name: string; newest: number }>()
 	for (const r of reactions ?? []) {
 		if (r.userId === userId) continue
-		const newest = newestById.get(r.userId)
-		if (newest === undefined || r.createdAt > newest) newestById.set(r.userId, r.createdAt)
+		const seen = byId.get(r.userId)
+		if (!seen || r.createdAt > seen.newest)
+			byId.set(r.userId, { name: r.userName, newest: r.createdAt })
 	}
-	const ordered = [...newestById.entries()].sort(([, a], [, b]) => b - a).map(([id]) => id)
-	const name = ordered.map(resolveName).find((n) => n !== undefined)
-	return {
-		name,
-		others: name === undefined ? ordered.length : ordered.length - 1,
-		total: ordered.length,
-	}
+	const ordered = [...byId.values()].sort((a, b) => b.newest - a.newest)
+	const names = ordered
+		.map((e) => e.name)
+		.filter((n) => n !== '')
+		.slice(0, 2)
+	return { names, others: ordered.length - names.length, total: ordered.length }
 }
 
 /**

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -34,9 +34,9 @@ const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned
 const JOIN_TIME_SKEW_TOLERANCE_MS = 60_000
 
 /**
- * The comment fields the notifications feed needs, from either synced query's related comment —
- * a structural subset of the Zero row so this is unit-testable without Zero types. `read` is the
- * caller's read receipt: a related row when present, absent (falsy) when unread.
+ * The comment fields the notifications feed needs — a structural subset of the Zero row so this
+ * is unit-testable without Zero types. A `T` is either a comments-feed row, or a reactions-feed
+ * row's related comment.
  */
 export interface CommentNotificationInput {
 	id: string
@@ -63,7 +63,7 @@ export interface CommentNotificationInput {
 	 *  when; `emoji` rides along for the row's reaction pills; `userName` is the reactor's display
 	 *  name, denormalized from `user.name` onto reaction rows by Postgres triggers. */
 	reactions?:
-		| readonly { userId: string; userName: string; emoji: string; createdAt: number }[]
+		| readonly { userId: string; userName?: string; emoji: string; createdAt: number }[]
 		| null
 }
 
@@ -144,16 +144,16 @@ function joinedThreadAt(thread: CommentNotificationInput['thread'], userId: stri
 
 /**
  * The reactor summary a "reacted to your comment" byline is phrased from: up to two distinct
- * reactor names (newest reaction first, blank names skipped — e.g. rows from before the 045
- * backfill), how many distinct people react beyond the named ones, and the distinct total for
- * when no name is available at all.
+ * reactor names (newest reaction first, blank or missing names skipped but still counted), how
+ * many distinct people react beyond the named ones, and the distinct total for when no name is
+ * available at all.
  */
 export function summarizeForeignReactors(
 	reactions: CommentNotificationInput['reactions'],
 	userId: string | undefined | null
 ): { names: string[]; others: number; total: number } {
 	// distinct foreign reactors, newest reaction first
-	const byId = new Map<string, { name: string; newest: number }>()
+	const byId = new Map<string, { name?: string; newest: number }>()
 	for (const r of reactions ?? []) {
 		if (r.userId === userId) continue
 		const seen = byId.get(r.userId)
@@ -169,45 +169,56 @@ export function summarizeForeignReactors(
 	return { names, others: ordered.length - names.length, total: ordered.length }
 }
 
-/** One row of the reactions feed: a foreign reaction joined to the reacted-to comment. */
+/** One row of the reactions feed: a foreign reaction joined to the reacted-to comment. Only
+ *  `commentId`/`userId`/`emoji`/`createdAt` matter here (dedupe key and ordering); the byline and
+ *  pills read the comment's own unbounded `reactions` set instead. */
 export interface ReactionNotificationInput {
 	commentId: string
 	userId: string
-	userName: string
+	userName?: string
 	emoji: string
 	createdAt: number
 	/** Absent only if the row outraced its comment's sync; such rows are dropped. */
-	comment?: (CommentNotificationInput & { id: string }) | null
+	comment?: CommentNotificationInput | null
 }
 
-/** Groups the reactions feed into one {@link CommentNotification} per comment, dated and marked
- *  unread by the newest reaction in the group (strict >: same-instant receipt counts as read). */
+/** Newest `createdAt` among `reactions` from someone other than `userId`; `undefined` if none. */
+function latestForeignReactionAt(
+	reactions: CommentNotificationInput['reactions'],
+	userId: string
+): number | undefined {
+	let latest: number | undefined
+	for (const r of reactions ?? []) {
+		if (r.userId !== userId && (latest === undefined || r.createdAt > latest)) latest = r.createdAt
+	}
+	return latest
+}
+
+/**
+ * Groups the reactions feed into one {@link CommentNotification} per reacted-to comment. Feed
+ * rows only decide which comments appear (deduped by `commentId`); the entry's `comment` rides
+ * along as-is, its unbounded `reactions` set feeding the byline and pills. Dated and marked
+ * unread by the newest foreign reaction in that set (strict >: same-instant receipt = read).
+ */
 export function buildReactionNotifications(
 	reactions: readonly ReactionNotificationInput[],
 	userId: string | undefined | null
-): CommentNotification<CommentNotificationInput & { id: string }>[] {
+): CommentNotification<CommentNotificationInput>[] {
 	if (!userId) return []
 
-	const groups = new Map<
-		string,
-		{ comment: CommentNotificationInput & { id: string }; rows: ReactionNotificationInput[] }
-	>()
+	const comments = new Map<string, CommentNotificationInput>()
 	for (const row of reactions) {
 		// server already filters both; cheap belt against a dangling or self row slipping through
 		if (!row.comment || row.userId === userId) continue
-		const group = groups.get(row.commentId)
-		if (group) {
-			group.rows.push(row)
-		} else {
-			groups.set(row.commentId, { comment: row.comment, rows: [row] })
-		}
+		comments.set(row.commentId, row.comment)
 	}
 
-	const notifications: CommentNotification<CommentNotificationInput & { id: string }>[] = []
-	for (const { comment, rows } of groups.values()) {
-		const timestamp = Math.max(...rows.map((r) => r.createdAt))
+	const notifications: CommentNotification<CommentNotificationInput>[] = []
+	for (const comment of comments.values()) {
+		const timestamp = latestForeignReactionAt(comment.reactions, userId)
+		if (timestamp === undefined) continue
 		notifications.push({
-			comment: { ...comment, reactions: rows },
+			comment,
 			reasons: ['reaction'],
 			primaryReason: 'reaction',
 			timestamp,
@@ -216,4 +227,11 @@ export function buildReactionNotifications(
 	}
 
 	return notifications
+}
+
+/** Merges both feeds' entries newest-first; the panel and its tests share this. */
+export function mergeNotifications<T extends CommentNotificationInput>(
+	...feeds: readonly CommentNotification<T>[][]
+): CommentNotification<T>[] {
+	return feeds.flat().sort((a, b) => b.timestamp - a.timestamp)
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -7,14 +7,16 @@ import { extractMentionIds } from '@tldraw/dotcom-shared'
  * - `reply` — the comment is in a thread the user is a part of (started, or has commented in),
  *   posted after they joined it
  * - `owned-board` — the comment is on a file the user owns
+ * - `reaction` — the user's own comment, reacted to by someone else. The only reason about the
+ *   user's own comments, so it never combines with the others
  *
  * A single comment can match more than one; {@link CommentNotification.primaryReason} picks the one
  * shown to the user, in the order mention \> reply \> owned-board (most-to-least specific).
  */
-export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board'
+export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board' | 'reaction'
 
 /** Priority order for {@link CommentNotification.primaryReason}: most specific first. */
-const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board']
+const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board', 'reaction']
 
 /**
  * How far a comment may predate the user's join time and still count as a reply.
@@ -45,13 +47,18 @@ export interface CommentNotificationInput {
 	// Comment body, as rich text JSON. Typed `unknown` so the real Zero row (whose `body` is a wide
 	// `ReadonlyJSONValue`) still satisfies this constraint; extractMentionIds accepts unknown.
 	body: unknown
-	read?: unknown
+	/** The caller's read receipt — a related row when present, absent (falsy) when unread. Its
+	 *  `readAt` dates the receipt, which is what lets a reaction newer than it re-unread the entry. */
+	read?: { readAt?: number | null } | null
 	file?: { ownerId?: string | null } | null
 	thread?: {
 		createdBy?: string | null
 		/** The caller's own comments in the thread (the query syncs no one else's). */
 		comments?: readonly { authorId: string; createdAt: number }[] | null
 	} | null
+	/** Every reaction to the comment, the caller's own included. Categorization only reads who and
+	 *  when; `emoji` rides along for the row's reaction pills. */
+	reactions?: readonly { userId: string; emoji: string; createdAt: number }[] | null
 }
 
 /** A comment in the notifications feed, tagged with why it's there. */
@@ -63,6 +70,13 @@ export interface CommentNotification<
 	reasons: CommentNotificationReason[]
 	/** The single reason to surface, per {@link REASON_PRIORITY}. */
 	primaryReason: CommentNotificationReason
+	/** When the notified-about event happened: the newest foreign reaction for a `reaction` entry,
+	 *  the comment's creation otherwise. Orders the feed and dates the row. */
+	timestamp: number
+	/** Whether the entry needs the user's attention. A comment entry is unread until it has a read
+	 *  receipt; a reaction entry is unread while the newest foreign reaction postdates the receipt —
+	 *  so fresh reactions re-unread a comment the user had already read. */
+	unread: boolean
 }
 
 /**
@@ -83,8 +97,19 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 
 	const notifications: CommentNotification<T>[] = []
 	for (const comment of comments) {
-		// A notification is always about someone else's comment, never your own.
-		if (comment.authorId === userId) continue
+		// The user's own comment only notifies about what others did to it: their reactions.
+		if (comment.authorId === userId) {
+			const latestForeign = latestForeignReactionAt(comment.reactions, userId)
+			if (latestForeign === undefined) continue
+			notifications.push({
+				comment,
+				reasons: ['reaction'],
+				primaryReason: 'reaction',
+				timestamp: latestForeign,
+				unread: latestForeign > (comment.read?.readAt ?? -Infinity),
+			})
+			continue
+		}
 
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
@@ -96,10 +121,16 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 		if (reasons.length === 0) continue
 
 		const primaryReason = REASON_PRIORITY.find((r) => reasons.includes(r))!
-		notifications.push({ comment, reasons, primaryReason })
+		notifications.push({
+			comment,
+			reasons,
+			primaryReason,
+			timestamp: comment.createdAt,
+			unread: !comment.read,
+		})
 	}
 
-	return notifications.sort((a, b) => b.comment.createdAt - a.comment.createdAt)
+	return notifications.sort((a, b) => b.timestamp - a.timestamp)
 }
 
 /**
@@ -113,4 +144,47 @@ function joinedThreadAt(thread: CommentNotificationInput['thread'], userId: stri
 		if (c.authorId === userId && c.createdAt < joinedAt) joinedAt = c.createdAt
 	}
 	return joinedAt
+}
+
+/**
+ * The reactor summary a "reacted to your comment" byline is phrased from: the newest reactor with
+ * a resolvable display name (the byline's face), how many other distinct people reacted beyond
+ * them, and the distinct total for when no name resolves at all. `resolveName` covers whatever
+ * identity sources the caller has (comment authors in the feed, workspace members) — reaction rows
+ * themselves carry no name.
+ */
+export function summarizeForeignReactors(
+	reactions: CommentNotificationInput['reactions'],
+	userId: string | undefined | null,
+	resolveName: (userId: string) => string | undefined
+): { name: string | undefined; others: number; total: number } {
+	// distinct foreign reactors, newest reaction first
+	const newestById = new Map<string, number>()
+	for (const r of reactions ?? []) {
+		if (r.userId === userId) continue
+		const newest = newestById.get(r.userId)
+		if (newest === undefined || r.createdAt > newest) newestById.set(r.userId, r.createdAt)
+	}
+	const ordered = [...newestById.entries()].sort(([, a], [, b]) => b - a).map(([id]) => id)
+	const name = ordered.map(resolveName).find((n) => n !== undefined)
+	return {
+		name,
+		others: name === undefined ? ordered.length : ordered.length - 1,
+		total: ordered.length,
+	}
+}
+
+/**
+ * When someone else last reacted to the comment, or undefined if no one has — the user's own
+ * reactions don't notify them.
+ */
+function latestForeignReactionAt(
+	reactions: CommentNotificationInput['reactions'],
+	userId: string
+): number | undefined {
+	let latest: number | undefined
+	for (const r of reactions ?? []) {
+		if (r.userId !== userId && (latest === undefined || r.createdAt > latest)) latest = r.createdAt
+	}
+	return latest
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -183,7 +183,7 @@ export interface ReactionNotificationInput {
 }
 
 /** Newest `createdAt` among `reactions` from someone other than `userId`; `undefined` if none. */
-function latestForeignReactionAt(
+export function latestForeignReactionAt(
 	reactions: CommentNotificationInput['reactions'],
 	userId: string
 ): number | undefined {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -34,14 +34,16 @@ const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned
 const JOIN_TIME_SKEW_TOLERANCE_MS = 60_000
 
 /**
- * The comment fields {@link categorizeCommentNotifications} needs. A structural subset of the
- * `app.getComments()` row (with its `file`/`thread`/`read` relationships) so the categorization
- * can be unit-tested without Zero types. `read` is the caller's read receipt — a related row
- * when present, absent (falsy) when unread.
+ * The comment fields the notifications feed needs, from either synced query's related comment —
+ * a structural subset of the Zero row so this is unit-testable without Zero types. `read` is the
+ * caller's read receipt: a related row when present, absent (falsy) when unread.
  */
 export interface CommentNotificationInput {
 	id: string
 	authorId: string
+	authorName?: string | null
+	authorColor?: string | null
+	fileId: string
 	threadId: string
 	createdAt: number
 	// Comment body, as rich text JSON. Typed `unknown` so the real Zero row (whose `body` is a wide
@@ -50,9 +52,10 @@ export interface CommentNotificationInput {
 	/** The caller's read receipt — a related row when present, absent (falsy) when unread. Its
 	 *  `readAt` dates the receipt, which is what lets a reaction newer than it re-unread the entry. */
 	read?: { readAt?: number | null } | null
-	file?: { ownerId?: string | null } | null
+	file?: { ownerId?: string | null; name?: string | null } | null
 	thread?: {
 		createdBy?: string | null
+		shapeId?: string | null
 		/** The caller's own comments in the thread (the query syncs no one else's). */
 		comments?: readonly { authorId: string; createdAt: number }[] | null
 	} | null
@@ -100,19 +103,9 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 
 	const notifications: CommentNotification<T>[] = []
 	for (const comment of comments) {
-		// The user's own comment only notifies about what others did to it: their reactions.
-		if (comment.authorId === userId) {
-			const latestForeign = latestForeignReactionAt(comment.reactions, userId)
-			if (latestForeign === undefined) continue
-			notifications.push({
-				comment,
-				reasons: ['reaction'],
-				primaryReason: 'reaction',
-				timestamp: latestForeign,
-				unread: latestForeign > (comment.read?.readAt ?? -Infinity),
-			})
-			continue
-		}
+		// A notification is always about someone else's comment; reactions to the user's own
+		// comments come from the separate reactions feed (see buildReactionNotifications).
+		if (comment.authorId === userId) continue
 
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
@@ -176,17 +169,51 @@ export function summarizeForeignReactors(
 	return { names, others: ordered.length - names.length, total: ordered.length }
 }
 
-/**
- * When someone else last reacted to the comment, or undefined if no one has — the user's own
- * reactions don't notify them.
- */
-function latestForeignReactionAt(
-	reactions: CommentNotificationInput['reactions'],
+/** One row of the reactions feed: a foreign reaction joined to the reacted-to comment. */
+export interface ReactionNotificationInput {
+	commentId: string
 	userId: string
-): number | undefined {
-	let latest: number | undefined
-	for (const r of reactions ?? []) {
-		if (r.userId !== userId && (latest === undefined || r.createdAt > latest)) latest = r.createdAt
+	userName: string
+	emoji: string
+	createdAt: number
+	/** Absent only if the row outraced its comment's sync; such rows are dropped. */
+	comment?: (CommentNotificationInput & { id: string }) | null
+}
+
+/** Groups the reactions feed into one {@link CommentNotification} per comment, dated and marked
+ *  unread by the newest reaction in the group (strict >: same-instant receipt counts as read). */
+export function buildReactionNotifications(
+	reactions: readonly ReactionNotificationInput[],
+	userId: string | undefined | null
+): CommentNotification<CommentNotificationInput & { id: string }>[] {
+	if (!userId) return []
+
+	const groups = new Map<
+		string,
+		{ comment: CommentNotificationInput & { id: string }; rows: ReactionNotificationInput[] }
+	>()
+	for (const row of reactions) {
+		// server already filters both; cheap belt against a dangling or self row slipping through
+		if (!row.comment || row.userId === userId) continue
+		const group = groups.get(row.commentId)
+		if (group) {
+			group.rows.push(row)
+		} else {
+			groups.set(row.commentId, { comment: row.comment, rows: [row] })
+		}
 	}
-	return latest
+
+	const notifications: CommentNotification<CommentNotificationInput & { id: string }>[] = []
+	for (const { comment, rows } of groups.values()) {
+		const timestamp = Math.max(...rows.map((r) => r.createdAt))
+		notifications.push({
+			comment: { ...comment, reactions: rows },
+			reasons: ['reaction'],
+			primaryReason: 'reaction',
+			timestamp,
+			unread: timestamp > (comment.read?.readAt ?? -Infinity),
+		})
+	}
+
+	return notifications
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -57,8 +57,8 @@ export interface CommentNotificationInput {
 		comments?: readonly { authorId: string; createdAt: number }[] | null
 	} | null
 	/** Every reaction to the comment, the caller's own included. Categorization only reads who and
-	 *  when; `emoji` rides along for the row's reaction pills; `userName` is denormalized from the
-	 *  `reactions` table (task 2 migration 045). */
+	 *  when; `emoji` rides along for the row's reaction pills; `userName` is the reactor's display
+	 *  name, denormalized from `user.name` onto reaction rows by Postgres triggers. */
 	reactions?:
 		| readonly { userId: string; userName: string; emoji: string; createdAt: number }[]
 		| null
@@ -168,9 +168,10 @@ export function summarizeForeignReactors(
 			byId.set(r.userId, { name: r.userName, newest: r.createdAt })
 	}
 	const ordered = [...byId.values()].sort((a, b) => b.newest - a.newest)
+	// typeof guard: rows synced before a view-syncer picks up the userName column arrive without it
 	const names = ordered
 		.map((e) => e.name)
-		.filter((n) => n !== '')
+		.filter((n): n is string => typeof n === 'string' && n !== '')
 		.slice(0, 2)
 	return { names, others: ordered.length - names.length, total: ordered.length }
 }

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/notifications.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/notifications.module.css
@@ -56,11 +56,22 @@
 	margin-top: 2px;
 	font-size: 12px;
 	color: var(--tl-color-text-3);
+	overflow: hidden;
+	display: -webkit-box;
+	-webkit-line-clamp: 2;
+	-webkit-box-orient: vertical;
 }
 
 .author {
 	font-weight: 500;
 	color: var(--tl-color-text-2);
+	/* a single absurd display name must not eat the row: ellipsize each name span */
+	display: inline-block;
+	max-width: 9em;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	vertical-align: bottom;
 }
 
 .preview {

--- a/apps/dotcom/sync-worker/src/commentRows.test.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.test.ts
@@ -440,6 +440,22 @@ describe('round-trip: record -> row -> rowTo*Record', () => {
 		const row = reactionRecordToRow(reaction, 'file1', 45)
 		expect(rowToReactionRecord(row)).toEqual(reaction)
 	})
+
+	it('clamps a future-dated reaction createdAt to server time', () => {
+		const thread = makeThread()
+		const reaction = createCommentReaction({
+			commentId: createCommentId('c1'),
+			threadId: thread.id,
+			pageId,
+			userId: 'user1',
+			emoji: '👍',
+			now: Date.now() + 60 * 60 * 1000,
+		})
+		const before = Date.now()
+		const row = reactionRecordToRow(reaction, 'file1', 45)
+		expect(row.createdAt).toBeGreaterThanOrEqual(before)
+		expect(row.createdAt).toBeLessThanOrEqual(Date.now())
+	})
 })
 
 describe('rehydration validation', () => {

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -183,7 +183,9 @@ export function reactionRecordToRow(
 		// stamped by Postgres (set_comment_reaction_user_name_trigger); value here is ignored
 		userName: '',
 		emoji: record.emoji,
-		createdAt: record.createdAt,
+		// client-dated; clamp so it can't outrun the server-clamped comment_read.readAt watermark,
+		// which would make a "reacted to your comment" notification impossible to mark read
+		createdAt: Math.min(record.createdAt, Date.now()),
 		meta: record.meta,
 		lastChangedClock,
 	}

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -180,6 +180,8 @@ export function reactionRecordToRow(
 		threadId: record.threadId,
 		pageId: record.pageId,
 		userId: record.userId,
+		// stamped by Postgres (set_comment_reaction_user_name_trigger); value here is ignored
+		userName: '',
 		emoji: record.emoji,
 		createdAt: record.createdAt,
 		meta: record.meta,

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -1,0 +1,47 @@
+-- Denormalize the reacting user's display name onto reaction rows, like comment.authorName:
+-- joining "user" from the notifications query would expose private user fields to file readers.
+
+ALTER TABLE comment_reaction ADD COLUMN "userName" VARCHAR DEFAULT '' NOT NULL;
+
+-- Stamp the name on insert — the Durable Object only knows userId.
+CREATE OR REPLACE FUNCTION set_comment_reaction_user_name() RETURNS TRIGGER AS $$
+DECLARE
+  user_name VARCHAR;
+BEGIN
+  SELECT u."name" INTO user_name
+  FROM public."user" u
+  WHERE u."id" = NEW."userId";
+  -- a missing user row keeps the default, so the insert still fails its user FK check
+  IF FOUND THEN
+    NEW."userName" := user_name;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "set_comment_reaction_user_name_trigger"
+BEFORE INSERT OR UPDATE OF "userId" ON comment_reaction
+FOR EACH ROW
+EXECUTE FUNCTION set_comment_reaction_user_name();
+
+-- Propagate user renames to their existing reactions.
+CREATE OR REPLACE FUNCTION update_comment_reaction_user_name() RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE comment_reaction
+  SET "userName" = NEW."name"
+  WHERE "userId" = NEW."id";
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "update_comment_reaction_user_name_trigger"
+AFTER UPDATE OF "name" ON public."user"
+FOR EACH ROW
+WHEN (OLD."name" IS DISTINCT FROM NEW."name")
+EXECUTE FUNCTION update_comment_reaction_user_name();
+
+-- Backfill rows that predate the column.
+UPDATE comment_reaction cr
+SET "userName" = u."name"
+FROM public."user" u
+WHERE u."id" = cr."userId";

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -45,3 +45,8 @@ UPDATE comment_reaction cr
 SET "userName" = u."name"
 FROM public."user" u
 WHERE u."id" = cr."userId";
+
+-- Top-N scans for the app-level feeds: the comments and reactions queries order by createdAt
+-- desc with a limit; without these, every query hydration scans and sorts the whole table.
+CREATE INDEX comment_created_at_idx ON comment("createdAt" DESC);
+CREATE INDEX comment_reaction_created_at_idx ON comment_reaction("createdAt" DESC);

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -45,10 +45,3 @@ UPDATE comment_reaction cr
 SET "userName" = u."name"
 FROM public."user" u
 WHERE u."id" = cr."userId";
-
--- Reaction rows are client-dated; a future-dated row would outrun the server-clamped
--- comment_read.readAt watermark and its notification could never be marked read. Clamp
--- existing rows; the Durable Object drain clamps new ones the same way.
-UPDATE comment_reaction
-SET "createdAt" = (extract(epoch from now()) * 1000)::bigint
-WHERE "createdAt" > (extract(epoch from now()) * 1000)::bigint;

--- a/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
+++ b/apps/dotcom/zero-cache/migrations/045_add_comment_reaction_user_name.sql
@@ -45,3 +45,10 @@ UPDATE comment_reaction cr
 SET "userName" = u."name"
 FROM public."user" u
 WHERE u."id" = cr."userId";
+
+-- Reaction rows are client-dated; a future-dated row would outrun the server-clamped
+-- comment_read.readAt watermark and its notification could never be marked read. Clamp
+-- existing rows; the Durable Object drain clamps new ones the same way.
+UPDATE comment_reaction
+SET "createdAt" = (extract(epoch from now()) * 1000)::bigint
+WHERE "createdAt" > (extract(epoch from now()) * 1000)::bigint;

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -200,6 +200,7 @@ export interface CommentListItemProps {
     id: string;
     page?: string;
     preview: ReactNode;
+    reactions?: ReactionSummary[];
     // (undocumented)
     resolved?: boolean;
     selected?: boolean;
@@ -517,6 +518,16 @@ export interface ReactionSummary {
     reactors: ReactionReactor[];
 }
 
+// @public
+export interface ReactionSummaryInput {
+    // (undocumented)
+    createdAt: number;
+    // (undocumented)
+    emoji: string;
+    // (undocumented)
+    userId: string;
+}
+
 // @public (undocumented)
 export interface ReactionTooltipProps {
     children: ReactNode;
@@ -594,7 +605,7 @@ export interface SidebarRow {
 export function sortSidebarRows(rows: readonly SidebarRow[]): readonly SidebarRow[];
 
 // @public
-export function summarizeReactions(reactions: TLCommentReaction[], currentUserId?: null | string, resolveName?: (userId: string) => string | undefined): ReactionSummary[];
+export function summarizeReactions(reactions: readonly ReactionSummaryInput[], currentUserId?: null | string, resolveName?: (userId: string) => string | undefined): ReactionSummary[];
 
 // @public
 export type TLCommentRecord = TLComment | TLCommentReaction | TLCommentThread;

--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -187,7 +187,7 @@ export interface CommentingOptions {
 }
 
 // @public
-export function CommentListItem({ id, author, preview, date, resolved, page, count, selected, href, resolvedLabel, onSelect }: CommentListItemRenderProps): JSX.Element;
+export function CommentListItem({ id, author, preview, date, resolved, page, count, selected, reactions, href, resolvedLabel, onSelect }: CommentListItemRenderProps): JSX.Element;
 
 // @public (undocumented)
 export interface CommentListItemProps {

--- a/packages/commenting/src/canvas/comment-reactions.test.ts
+++ b/packages/commenting/src/canvas/comment-reactions.test.ts
@@ -87,6 +87,28 @@ describe('summarizeReactions', () => {
 	})
 })
 
+describe('summarizeReactions input', () => {
+	// the notifications panel tallies rows synced from the app database, which carry only the
+	// fields the tally needs — full TLCommentReaction records must not be required
+	it('accepts minimal rows with only userId, emoji, and createdAt', () => {
+		const rows = [
+			{ userId: 'user1', emoji: '👍', createdAt: 100 },
+			{ userId: 'user2', emoji: '👍', createdAt: 200 },
+		]
+		expect(summarizeReactions(rows, 'user1')).toEqual([
+			{
+				emoji: '👍',
+				count: 2,
+				active: true,
+				reactors: [
+					{ name: 'Someone', you: true },
+					{ name: 'Someone', you: false },
+				],
+			},
+		])
+	})
+})
+
 describe('createCommentReactionId', () => {
 	// the id is what makes reaction identity structural: re-picking the same emoji addresses the
 	// same record (toggle off), while a different emoji is its own record (independent)

--- a/packages/commenting/src/canvas/comment-reactions.tsx
+++ b/packages/commenting/src/canvas/comment-reactions.tsx
@@ -40,6 +40,19 @@ export function useCommentReactions(
 }
 
 /**
+ * The reaction fields {@link summarizeReactions} needs — a structural subset of
+ * {@link tldraw#TLCommentReaction}, so tallies can also be built from reaction rows synced outside
+ * the editor store (e.g. an app-level reactions table backing a notifications feed).
+ *
+ * @public
+ */
+export interface ReactionSummaryInput {
+	userId: string
+	emoji: string
+	createdAt: number
+}
+
+/**
  * Tally a comment's reactions into an entry per emoji, ordered by when that emoji was first used
  * so the row stays stable as later reactions arrive. `active` marks the emoji the current user
  * reacted with (the pills render those highlighted), and `reactors` lists who reacted with it, in
@@ -49,7 +62,7 @@ export function useCommentReactions(
  * @public
  */
 export function summarizeReactions(
-	reactions: TLCommentReaction[],
+	reactions: readonly ReactionSummaryInput[],
 	currentUserId?: string | null,
 	resolveName?: (userId: string) => string | undefined
 ): ReactionSummary[] {

--- a/packages/commenting/src/canvas/comment-reactions.tsx
+++ b/packages/commenting/src/canvas/comment-reactions.tsx
@@ -160,7 +160,7 @@ export interface CommentReactionsProps {
 	/** The reacting user. Null/omitted gives a read-only row (signed out): counts show, but the
 	 *  pills don't toggle. */
 	currentUserId?: string | null
-	/** Names a reactor id for the hover list. Ids it can't name fall back to the id. */
+	/** Names a reactor id for the hover list. Ids it can't name fall back to a generic "Someone". */
 	resolveName?(userId: string): string | undefined
 }
 

--- a/packages/commenting/src/canvas/comment-reactions.tsx
+++ b/packages/commenting/src/canvas/comment-reactions.tsx
@@ -57,7 +57,7 @@ export interface ReactionSummaryInput {
  * so the row stays stable as later reactions arrive. `active` marks the emoji the current user
  * reacted with (the pills render those highlighted), and `reactors` lists who reacted with it, in
  * reaction order, for the hover list. `resolveName` names each reactor; an id it can't name falls
- * back to the id itself.
+ * back to a generic "Someone", never the raw user id.
  *
  * @public
  */

--- a/packages/commenting/src/index.ts
+++ b/packages/commenting/src/index.ts
@@ -75,6 +75,7 @@ export {
 	type CommentReactionPickerProps,
 	CommentReactions,
 	type CommentReactionsProps,
+	type ReactionSummaryInput,
 	summarizeReactions,
 	toggleCommentReaction,
 	useCommentReactions,

--- a/packages/commenting/src/ui/comments-list.tsx
+++ b/packages/commenting/src/ui/comments-list.tsx
@@ -3,6 +3,7 @@ import { Fragment, MouseEvent, ReactNode } from 'react'
 import { useTranslation } from 'tldraw'
 import { Byline } from './byline'
 import { CheckIcon } from './icons'
+import { Reactions, type ReactionSummary } from './reactions'
 import { replyCountLabel } from './reply-count'
 
 /** @public */
@@ -20,6 +21,9 @@ export interface CommentListItemProps {
 	count?: number
 	/** Whether this thread is the open one. */
 	selected?: boolean
+	/** Tallied reactions for the row (a thread's, or a single comment's when the row is one
+	 *  comment), shown as inert pills under the preview. Omit to hide. */
+	reactions?: ReactionSummary[]
 	/**
 	 * Link target for the item. When set, the row renders as an anchor so browser affordances
 	 * (ctrl/cmd-click, middle-click) open it in a new tab; a plain click still calls `onSelect`.
@@ -116,6 +120,7 @@ export function CommentListItem({
 	page,
 	count,
 	selected,
+	reactions,
 	href,
 	resolvedLabel = 'Resolved',
 	onSelect,
@@ -142,6 +147,7 @@ export function CommentListItem({
 			<div className="tlui-cmt-list__item-body">
 				<Byline author={author} date={date} />
 				<div className="tlui-cmt-list__item-preview">{preview}</div>
+				{reactions && <Reactions reactions={reactions} canReact={false} enableHoverList={false} />}
 				{(resolved || page !== undefined || replies) && (
 					<div className="tlui-cmt-list__item-meta">
 						{resolved && (

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -412,12 +412,17 @@
 	font-size: 10px;
 	font-weight: 400;
 	color: var(--tl-color-text-1);
+}
+
+/* An inert pill renders as a span (e.g. in a notification row); only the button variant is
+   clickable, so only it gets the pointer cursor and hover shade. */
+button.tlui-cmt-reaction {
 	cursor: pointer;
 }
 
 /* Hover deepens the grey — no border to tint now. Mixing toward the text colour is theme-aware:
    it darkens the fill in light mode and lightens it in dark, tracking the pill's own contrast. */
-.tlui-cmt-reaction:hover {
+button.tlui-cmt-reaction:hover {
 	background: var(--tl-color-muted-1);
 }
 
@@ -427,7 +432,7 @@
 	background: color-mix(in srgb, var(--tl-color-selected) 28%, var(--tl-color-panel));
 }
 
-.tlui-cmt-reaction--active:hover {
+button.tlui-cmt-reaction--active:hover {
 	background: color-mix(in srgb, var(--tl-color-selected) 38%, var(--tl-color-panel));
 }
 

--- a/packages/commenting/src/ui/reaction.tsx
+++ b/packages/commenting/src/ui/reaction.tsx
@@ -46,19 +46,20 @@ export function Reaction({
 	ReactionTooltip = DefaultReactionTooltip,
 	onClick,
 }: ReactionProps) {
+	// An inert pill (no handler) is plain content, not a control — rendering it as a span keeps it
+	// valid inside an anchor row (e.g. a notification list item) and out of the tab order.
+	const Tag = onClick ? 'button' : 'span'
 	const pill = (
-		<button
+		<Tag
 			className={active ? 'tlui-cmt-reaction tlui-cmt-reaction--active' : 'tlui-cmt-reaction'}
-			type="button"
+			{...(onClick ? { type: 'button' as const, 'aria-pressed': active, onClick } : undefined)}
 			// The emoji alone announces as its unicode name ("thumbs up"); pairing it with the count
 			// is what makes the pill's state legible to a screen reader.
 			aria-label={`${emoji} ${count}`}
-			aria-pressed={active}
-			onClick={onClick}
 		>
 			<span className="tlui-cmt-reaction__emoji">{renderReaction(emoji)}</span>
 			<span className="tlui-cmt-reaction__count">{count}</span>
-		</button>
+		</Tag>
 	)
 
 	// A bare pill when hovering is suppressed, or when there's no one to name.

--- a/packages/commenting/src/ui/reaction.tsx
+++ b/packages/commenting/src/ui/reaction.tsx
@@ -52,9 +52,12 @@ export function Reaction({
 	const pill = (
 		<Tag
 			className={active ? 'tlui-cmt-reaction tlui-cmt-reaction--active' : 'tlui-cmt-reaction'}
-			{...(onClick ? { type: 'button' as const, 'aria-pressed': active, onClick } : undefined)}
+			{...(onClick
+				? { type: 'button' as const, 'aria-pressed': active, onClick }
+				: { role: 'img' as const })}
 			// The emoji alone announces as its unicode name ("thumbs up"); pairing it with the count
-			// is what makes the pill's state legible to a screen reader.
+			// is what makes the pill's state legible to a screen reader. The inert span needs the
+			// img role for the label to be announced at all.
 			aria-label={`${emoji} ${count}`}
 		>
 			<span className="tlui-cmt-reaction__emoji">{renderReaction(emoji)}</span>

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -49,8 +49,8 @@ export const queries = defineQueries({
 	),
 
 	/**
-	 * Recent comments that concern the current user, for the app-level notifications feed. A
-	 * comment qualifies when it isn't the user's own and matches at least one of three categories:
+	 * Recent comments that concern the current user, for the app-level notifications feed. Someone
+	 * else's comment qualifies when it matches at least one of three categories:
 	 *
 	 * - it's on a file the user owns
 	 * - it's in a thread the user is a part of (started, or has commented in) and on a file they
@@ -61,6 +61,10 @@ export const queries = defineQueries({
 	 *   workspace they're a member of. Ownership carries its own access evidence; replies and
 	 *   mentions need an explicit current-access gate because historical thread participation can
 	 *   outlive access to the file.
+	 *
+	 * The user's own comment qualifies only when someone else has reacted to it (a "reacted to
+	 * your comment" entry), on a file the user can still access — owns, has a file_state for, or
+	 * reaches through a workspace.
 	 *
 	 * Filtering here (server-side) rather than on the client is what keeps out-of-category
 	 * comments off the wire entirely. One gate stays client-side: `categorizeCommentNotifications`
@@ -74,7 +78,6 @@ export const queries = defineQueries({
 	 */
 	comments: defineQuery(({ ctx }) =>
 		zql.comment
-			.where('authorId', '!=', ctx.userId)
 			// soft-deleted comments and comments of soft-deleted threads stay in Postgres (see
 			// TLComment.isDeleted) but must never surface as notifications
 			.where('isDeleted', '=', false)
@@ -82,42 +85,66 @@ export const queries = defineQueries({
 			// same for soft-deleted boards: their comment rows persist, but a notification would
 			// navigate to a file the user can no longer open
 			.whereExists('file', (f) => f.where('isDeleted', '=', false))
-			.where(({ and, or, exists }) =>
+			.where(({ and, or, cmp, exists }) =>
 				or(
-					// on a board the user owns
-					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
-					// a reply: in a thread the user started or has commented in, on a file they
-					// can still access
+					// someone else's comment, in one of the three categories that concern the user
 					and(
-						exists('thread', (t) =>
-							t.where(({ cmp, or, exists }) =>
-								or(
-									cmp('createdBy', '=', ctx.userId),
-									// live comments only: soft-deleted rows persist, and deleting your
-									// last comment in a thread must end the reply subscription with it
-									exists('comments', (c) =>
-										c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
+						cmp('authorId', '!=', ctx.userId),
+						or(
+							// on a board the user owns
+							exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
+							// a reply: in a thread the user started or has commented in, on a file they
+							// can still access
+							and(
+								exists('thread', (t) =>
+									t.where(({ cmp, or, exists }) =>
+										or(
+											cmp('createdBy', '=', ctx.userId),
+											// live comments only: soft-deleted rows persist, and deleting your
+											// last comment in a thread must end the reply subscription with it
+											exists('comments', (c) =>
+												c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
+											)
+										)
+									)
+								),
+								exists('file', (f) =>
+									f.where(({ or, exists }) =>
+										or(
+											exists('states', (s) => s.where('userId', '=', ctx.userId)),
+											exists('groupFiles', (gf) =>
+												gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+											)
+										)
 									)
 								)
-							)
-						),
-						exists('file', (f) =>
-							f.where(({ or, exists }) =>
-								or(
-									exists('states', (s) => s.where('userId', '=', ctx.userId)),
-									exists('groupFiles', (gf) =>
-										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+							),
+							// @-mentions the user, on a file they can access (opened it, or workspace member)
+							and(
+								exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
+								exists('file', (f) =>
+									f.where(({ or, exists }) =>
+										or(
+											exists('states', (s) => s.where('userId', '=', ctx.userId)),
+											exists('groupFiles', (gf) =>
+												gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+											)
+										)
 									)
 								)
 							)
 						)
 					),
-					// @-mentions the user, on a file they can access (opened it, or workspace member)
+					// the user's own comment, once someone else reacts to it — a "reacted to your
+					// comment" entry. Gated on current file access like replies and mentions, with
+					// ownership as its own evidence
 					and(
-						exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
+						cmp('authorId', '=', ctx.userId),
+						exists('reactions', (r) => r.where('userId', '!=', ctx.userId)),
 						exists('file', (f) =>
-							f.where(({ or, exists }) =>
+							f.where(({ cmp, or, exists }) =>
 								or(
+									cmp('ownerId', '=', ctx.userId),
 									exists('states', (s) => s.where('userId', '=', ctx.userId)),
 									exists('groupFiles', (gf) =>
 										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
@@ -142,6 +169,9 @@ export const queries = defineQueries({
 			// the caller's read receipt (at most one row: PK is (userId, commentId) and we filter
 			// on userId); absent (for others' comments) = unread
 			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
+			// every reaction to the comment, for the inert reaction pills on notification rows. A
+			// comment's reactions are naturally few, so the set syncs unbounded
+			.related('reactions')
 			.orderBy('createdAt', 'desc')
 			.limit(RECENT_COMMENTS_LIMIT)
 	),

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -17,7 +17,9 @@ const defineQueries = defineQueriesWithType<TlaSchema>()
 /** Upper bound on the comments notifications feed, so the synced set stays finite as files accrue. */
 const RECENT_COMMENTS_LIMIT = 50
 
-/** Bound on the reactions feed, counted in reaction rows; the byline's "and N others" absorbs undercounts. */
+/** Bound on the reactions feed, counted in reaction rows; the byline's "and N others" absorbs
+ *  undercounts, but a comment with 200+ recent reactions can push every other comment's rows out
+ *  of the window entirely, not just shrink a byline. */
 export const RECENT_REACTIONS_LIMIT = 200
 
 /**
@@ -189,6 +191,9 @@ export const queries = defineQueries({
 					.related('file', (f) => f.one())
 					.related('thread', (t) => t.one())
 					.related('read', (r) => r.where('userId', '=', ctx.userId).one())
+					// every reaction incl. the caller's own: pills need exact counts and the own-reaction
+					// highlight, which the window-capped feed rows can't provide
+					.related('reactions')
 			)
 			.orderBy('createdAt', 'desc')
 			.limit(RECENT_REACTIONS_LIMIT)

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -17,6 +17,9 @@ const defineQueries = defineQueriesWithType<TlaSchema>()
 /** Upper bound on the comments notifications feed, so the synced set stays finite as files accrue. */
 const RECENT_COMMENTS_LIMIT = 50
 
+/** Bound on the reactions feed, counted in reaction rows; the byline's "and N others" absorbs undercounts. */
+export const RECENT_REACTIONS_LIMIT = 200
+
 /**
  * Upper bound on the per-file @-mention roster of past viewers, so a heavily-viewed public board
  * doesn't stream an unbounded set to every collaborator. The composer's autocomplete only ever
@@ -62,9 +65,7 @@ export const queries = defineQueries({
 	 *   mentions need an explicit current-access gate because historical thread participation can
 	 *   outlive access to the file.
 	 *
-	 * The user's own comment qualifies only when someone else has reacted to it (a "reacted to
-	 * your comment" entry), on a file the user can still access — owns, has a file_state for, or
-	 * reaches through a workspace.
+	 * "Reacted to your comment" entries come from the separate {@link reactions} query, not here.
 	 *
 	 * Filtering here (server-side) rather than on the client is what keeps out-of-category
 	 * comments off the wire entirely. One gate stays client-side: `categorizeCommentNotifications`
@@ -78,6 +79,7 @@ export const queries = defineQueries({
 	 */
 	comments: defineQuery(({ ctx }) =>
 		zql.comment
+			.where('authorId', '!=', ctx.userId)
 			// soft-deleted comments and comments of soft-deleted threads stay in Postgres (see
 			// TLComment.isDeleted) but must never surface as notifications
 			.where('isDeleted', '=', false)
@@ -85,66 +87,42 @@ export const queries = defineQueries({
 			// same for soft-deleted boards: their comment rows persist, but a notification would
 			// navigate to a file the user can no longer open
 			.whereExists('file', (f) => f.where('isDeleted', '=', false))
-			.where(({ and, or, cmp, exists }) =>
+			.where(({ and, or, exists }) =>
 				or(
-					// someone else's comment, in one of the three categories that concern the user
+					// on a board the user owns
+					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
+					// a reply: in a thread the user started or has commented in, on a file they
+					// can still access
 					and(
-						cmp('authorId', '!=', ctx.userId),
-						or(
-							// on a board the user owns
-							exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
-							// a reply: in a thread the user started or has commented in, on a file they
-							// can still access
-							and(
-								exists('thread', (t) =>
-									t.where(({ cmp, or, exists }) =>
-										or(
-											cmp('createdBy', '=', ctx.userId),
-											// live comments only: soft-deleted rows persist, and deleting your
-											// last comment in a thread must end the reply subscription with it
-											exists('comments', (c) =>
-												c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
-											)
-										)
-									)
-								),
-								exists('file', (f) =>
-									f.where(({ or, exists }) =>
-										or(
-											exists('states', (s) => s.where('userId', '=', ctx.userId)),
-											exists('groupFiles', (gf) =>
-												gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
-											)
-										)
+						exists('thread', (t) =>
+							t.where(({ cmp, or, exists }) =>
+								or(
+									cmp('createdBy', '=', ctx.userId),
+									// live comments only: soft-deleted rows persist, and deleting your
+									// last comment in a thread must end the reply subscription with it
+									exists('comments', (c) =>
+										c.where('authorId', '=', ctx.userId).where('isDeleted', '=', false)
 									)
 								)
-							),
-							// @-mentions the user, on a file they can access (opened it, or workspace member)
-							and(
-								exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
-								exists('file', (f) =>
-									f.where(({ or, exists }) =>
-										or(
-											exists('states', (s) => s.where('userId', '=', ctx.userId)),
-											exists('groupFiles', (gf) =>
-												gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
-											)
-										)
+							)
+						),
+						exists('file', (f) =>
+							f.where(({ or, exists }) =>
+								or(
+									exists('states', (s) => s.where('userId', '=', ctx.userId)),
+									exists('groupFiles', (gf) =>
+										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
 									)
 								)
 							)
 						)
 					),
-					// the user's own comment, once someone else reacts to it — a "reacted to your
-					// comment" entry. Gated on current file access like replies and mentions, with
-					// ownership as its own evidence
+					// @-mentions the user, on a file they can access (opened it, or workspace member)
 					and(
-						cmp('authorId', '=', ctx.userId),
-						exists('reactions', (r) => r.where('userId', '!=', ctx.userId)),
+						exists('mentions', (m) => m.where('userId', '=', ctx.userId)),
 						exists('file', (f) =>
-							f.where(({ cmp, or, exists }) =>
+							f.where(({ or, exists }) =>
 								or(
-									cmp('ownerId', '=', ctx.userId),
 									exists('states', (s) => s.where('userId', '=', ctx.userId)),
 									exists('groupFiles', (gf) =>
 										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
@@ -174,6 +152,46 @@ export const queries = defineQueries({
 			.related('reactions')
 			.orderBy('createdAt', 'desc')
 			.limit(RECENT_COMMENTS_LIMIT)
+	),
+
+	/**
+	 * Reactions to the user's comments, for the notifications feed. Rooted at comment_reaction and
+	 * ordered by reaction time, not comment time, so a fresh reaction on an old comment still syncs.
+	 * Access gates mirror the comments query; grouping into per-comment entries is client-side.
+	 */
+	reactions: defineQuery(({ ctx }) =>
+		zql.comment_reaction
+			.where('userId', '!=', ctx.userId)
+			.whereExists('comment', (c) =>
+				c
+					.where('authorId', '=', ctx.userId)
+					.where('isDeleted', '=', false)
+					.whereExists('thread', (t) => t.where('isDeleted', '=', false))
+					.whereExists('file', (f) =>
+						f.where(({ and, cmp, or, exists }) =>
+							and(
+								cmp('isDeleted', '=', false),
+								or(
+									cmp('ownerId', '=', ctx.userId),
+									exists('states', (s) => s.where('userId', '=', ctx.userId)),
+									exists('groupFiles', (gf) =>
+										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
+									)
+								)
+							)
+						)
+					)
+			)
+			// the reacted-to comment, with what the notification row renders
+			.related('comment', (c) =>
+				c
+					.one()
+					.related('file', (f) => f.one())
+					.related('thread', (t) => t.one())
+					.related('read', (r) => r.where('userId', '=', ctx.userId).one())
+			)
+			.orderBy('createdAt', 'desc')
+			.limit(RECENT_REACTIONS_LIMIT)
 	),
 
 	/**

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -216,6 +216,9 @@ export const queries = defineQueries({
 				file.whereExists('states', (s) => s.where('userId', '=', ctx.userId))
 			)
 			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
+			// so the canvas can flag own comments with fresh foreign reactions as unread, and its
+			// thread-view auto-mark-read can clear the reaction notification on view
+			.related('reactions')
 	),
 
 	/**

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -373,6 +373,15 @@ const commentThreadRelationships = relationships(comment_thread, ({ one, many })
 	}),
 }))
 
+const commentReactionRelationships = relationships(comment_reaction, ({ one }) => ({
+	// the reacted-to comment, for the reactions query's authorship gate and feed row
+	comment: one({
+		sourceField: ['commentId'],
+		destField: ['id'],
+		destSchema: comment,
+	}),
+}))
+
 export type TlaFilePartial = Partial<TlaFile> & {
 	id: TlaFile['id']
 }
@@ -547,6 +556,7 @@ export const schema = createSchema({
 		groupFileRelationships,
 		commentRelationships,
 		commentThreadRelationships,
+		commentReactionRelationships,
 	],
 })
 

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -212,8 +212,8 @@ export const comment_mention = table('comment_mention')
 // One row per (comment, reacting user, emoji) — a user may react with several emoji. Written by
 // the file's Durable Object from the room's comment-reaction records, like comment/comment_thread.
 // The in-document reaction UI reads reactions over the sync object-lane, not from here; this table
-// mirrors comment_mention so a future app-level query (e.g. "reacted to your comment") can reach
-// reactions server-side without a schema change. Nothing consumes it yet.
+// feeds the app-level `comments` query: its "reacted to your comment" category and the reaction
+// pills on notification rows.
 export const comment_reaction = table('comment_reaction')
 	.columns({
 		id: string(),

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -212,8 +212,8 @@ export const comment_mention = table('comment_mention')
 // One row per (comment, reacting user, emoji) — a user may react with several emoji. Written by
 // the file's Durable Object from the room's comment-reaction records, like comment/comment_thread.
 // The in-document reaction UI reads reactions over the sync object-lane, not from here; this table
-// feeds the app-level `comments` query: its "reacted to your comment" category and the reaction
-// pills on notification rows.
+// feeds the app-level `reactions` query (the notifications feed's "reacted to your comment"
+// category) and the reaction pills on notification rows.
 export const comment_reaction = table('comment_reaction')
 	.columns({
 		id: string(),

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -222,6 +222,8 @@ export const comment_reaction = table('comment_reaction')
 		threadId: string(),
 		pageId: string(),
 		userId: string(),
+		// denormalized user display name, stamped and kept fresh by Postgres triggers (045)
+		userName: string(),
 		emoji: string(),
 		createdAt: number(),
 	})


### PR DESCRIPTION
In order to let people know someone appreciated their comment without pinging them for every 👍, this PR surfaces reactions to your own comments in the notifications panel — grouped into one entry per comment, sorted by the newest reaction, and re-unread when a new reaction arrives after you've read it.

Design decisions:

- **One entry per comment, no expansion.** Reactions are lower-signal than replies, so they aggregate: the byline names up to two reactors (newest first) then "and N others", with inert reaction pills under the preview (pills read the comment's full reaction set, so counts match the canvas and your own reaction highlights). Name spans ellipsize and the byline clamps to two lines, so one long display name can't grow the row.
- **Reactor names are denormalized onto `comment_reaction` rows** (migration 045, same trigger pattern as `comment.authorName`) rather than resolved client-side from whoever happens to be in the feed — a lurker who only reacts still gets named, and nothing joins the private `user` table.
- **Read state reuses `comment_read.readAt` as a watermark**: a reaction entry is unread while its newest foreign reaction postdates the receipt. Your own comments have no read row otherwise, so there's no collision with comment-read semantics and no new table.
- **Reaction timestamps are clamped at the Durable Object drain.** `createdAt` is client-authored while `readAt` is server-clamped, so an unclamped future-dated reaction could outrun every read receipt and leave its notification permanently unclearable. `Math.min(createdAt, Date.now())` at the drain restores the invariant that both sides of the watermark comparison are bounded by server time.
- **The reactions feed is its own synced query, rooted at `comment_reaction`** and ordered by reaction time (`RECENT_REACTIONS_LIMIT = 200` rows, grouped per comment client-side). A comment-rooted feed capped by comment recency would silently miss a fresh reaction on an old comment; a separate root fixes that and keeps reactions from competing with comment notifications for slots. Soft-delete and file-access gates mirror the comments query, and `createdAt` indexes back both feeds' top-N scans.

⚠️ **Merge order:** contains the same migration as #9795. Merge only after #9795 is deployed and view-syncer replicas have the column — both zero-cache (schema declares `userName`) and sync-worker (drain writes it) depend on the column existing.

Supersedes #9785.

### Change type

- [x] `feature`

### Test plan

1. As user B, react to a comment authored by user A.
2. As user A: notification bell badges; entry reads "B reacted to your comment" with the emoji pill, dated by the reaction.
3. Click the entry: navigates to the comment, marks the entry read.
4. As user B, add another reaction: the entry re-unreads and bubbles to the top.
5. More reactors: byline shows two newest names, then "and N others"; an absurdly long name truncates with an ellipsis instead of wrapping the row.
6. Delete the comment: the entry and its unread count disappear.

- [x] Unit tests

### API changes

`packages/commenting`: added `ReactionSummaryInput` (structural input for `summarizeReactions`, which now accepts `readonly ReactionSummaryInput[]` instead of `TLCommentReaction[]` — non-breaking widening); `CommentListItemProps.reactions` for inert pills on list rows; `Reaction` renders as a `span` when no `onClick` is passed.

### Release notes

- Show reactions to your comments in the tldraw.com notifications panel.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +105 / -14 |
| Tests           | +298 / -1  |
| Automated files | +216 / -1  |
| Apps            | +342 / -66 |
