### PR TITLE
refactor(editor): add EditorPortal for canvas-anchored content

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -1,7 +1,8 @@
-/* The comments layer is portaled into the editor container. Pins live in the canvas-in-front layer
-   (beneath the UI panels at z-index 300), so the toolbar and style panel draw over them; the open
-   thread's popover portals up to the menus layer separately (`.tlui-cmt-canvas-popover`) so it isn't
-   clipped. Click-through except on its own children. */
+/* The comments layer renders through `EditorPortal`, so its pieces can pick their own layer rather
+   than the one the component is mounted in. Pins live in the canvas-in-front layer (beneath the UI
+   panels at z-index 300), so the toolbar and style panel draw over them; the open thread's popover
+   goes to the menus layer instead (`.tlui-cmt-canvas-popover`) so it isn't clipped. Click-through
+   except on its own children. */
 .tlui-cmt-canvas-layer {
 	position: absolute;
 	inset: 0;

--- a/packages/commenting/src/canvas/cluster-badge.tsx
+++ b/packages/commenting/src/canvas/cluster-badge.tsx
@@ -100,7 +100,6 @@ export const ClusterBadge = memo(function ClusterBadge({
 				<ThreadPreview
 					editor={editor}
 					threads={previewThreads}
-					container={container}
 					variant="list"
 					point={point}
 					onSelectThread={onSelectThread}

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -1,18 +1,8 @@
 import { isMentionPickerOpen } from '@tldraw/mentions'
+import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react'
 import {
-	Fragment,
-	ReactNode,
-	useCallback,
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-	useState,
-} from 'react'
-import { createPortal } from 'react-dom'
-import {
+	EditorPortal,
 	TLCommentThread,
-	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
 	useValue,
@@ -81,42 +71,9 @@ export function CanvasComments(props: CanvasCommentsProps) {
 	return <CanvasCommentsLayer {...props} />
 }
 
-/**
- * A mount point appended to the end of the editor container, for a portal that has to come last
- * among the container's children.
- *
- * `createPortal(…, container)` doesn't get to say where its node lands: React places a portal
- * during the same commit that mounts it, and a portal nested this deep in the tree is placed
- * before the container's own, shallower children — so the layer ends up ahead of the UI and its
- * "move focus to canvas" skip link. That link only works if nothing precedes it, and the pins are
- * real buttons, so a single comment would take the first tab stop and leave no keyboard route to
- * the canvas. A layout effect runs after the whole commit instead, by which point the container's
- * children are all in place and appending is guaranteed to land at the end.
- *
- * Null until the effect has run, so the first render has nothing to portal into.
- */
-function useTrailingPortalHost(container: HTMLElement) {
-	const [host, setHost] = useState<HTMLDivElement | null>(null)
-	useLayoutEffect(() => {
-		const elm = container.ownerDocument.createElement('div')
-		// The host is a position in the DOM, not a box — what it holds is positioned against the
-		// container, the same as it was when it hung off the container directly.
-		elm.style.display = 'contents'
-		container.appendChild(elm)
-		setHost(elm)
-		return () => {
-			elm.remove()
-			setHost(null)
-		}
-	}, [container])
-	return host
-}
-
 function CanvasCommentsLayer(props: CommentingContext) {
 	const editor = useEditor()
 	const options = useCommentingOptions()
-	const container = useContainer()
-	const portalHost = useTrailingPortalHost(container)
 	const layerRef = useRef<HTMLDivElement>(null)
 	// Over the pins and cluster badges, hover passes through to the canvas beneath (these events
 	// bubble up from the pointer-interactive markers to this layer root). Wheel pass-through is
@@ -334,79 +291,80 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		return <ThreadPin editor={editor} thread={thread} {...props} />
 	}
 
-	// Render into the container (above the panels' stacking context) so the pins and popovers
-	// live in the UI layer rather than being clipped by the canvas layer — but at the end of it,
-	// behind the editor's own children in the tab order. See `useTrailingPortalHost`.
-	if (!portalHost) return null
-	return createPortal(
-		<div ref={layerRef} className="tlui-cmt-canvas-layer">
-			{options.enableClustering ? (
-				<>
-					{fadeNodes.map(({ node, phase }) => {
-						let content: ReactNode
-						const stackGroup = node.count > 1 ? stackGroupOf(node) : null
-						if (node.count === 1) {
-							const thread = threadsById.get(node.id)
-							if (!thread) return null
-							content = renderThreadPin(thread)
-						} else if (stackGroup) {
-							// A coincident stack standing alone: draw the cascading count-badge list now
-							// instead of a zoom-to-split cluster badge. Route it through the stack's owner so
-							// the open/orphan/held slots stay deduped — when the owner is one of them, that
-							// slot draws the stack and this node draws nothing.
-							const owner = stackGroup.find((id) => renderedThreadIds.has(id))
-							content =
-								owner && node.members.includes(owner)
-									? renderThreadPin(threadsById.get(owner)!)
-									: null
-						} else {
-							content = (
-								<ClusterBadge
-									editor={editor}
-									node={node}
-									onExpand={expandCluster}
-									onSelectThread={revealClusteredThread}
-									threadsById={threadsById}
-									currentUserId={props.currentUserId}
-									resolveAuthor={props.resolveAuthor}
-								/>
+	// Rendered through the editor's portal rather than into the slot this component is mounted in:
+	// the pins sit below the collaborator cursors and the popovers above the UI panels, and no
+	// single canvas layer spans both. `EditorPortal` also fixes where the layer lands among the
+	// container's children, so it stays behind the UI's skip link in the tab order.
+	return (
+		<EditorPortal>
+			<div ref={layerRef} className="tlui-cmt-canvas-layer">
+				{options.enableClustering ? (
+					<>
+						{fadeNodes.map(({ node, phase }) => {
+							let content: ReactNode
+							const stackGroup = node.count > 1 ? stackGroupOf(node) : null
+							if (node.count === 1) {
+								const thread = threadsById.get(node.id)
+								if (!thread) return null
+								content = renderThreadPin(thread)
+							} else if (stackGroup) {
+								// A coincident stack standing alone: draw the cascading count-badge list now
+								// instead of a zoom-to-split cluster badge. Route it through the stack's owner so
+								// the open/orphan/held slots stay deduped — when the owner is one of them, that
+								// slot draws the stack and this node draws nothing.
+								const owner = stackGroup.find((id) => renderedThreadIds.has(id))
+								content =
+									owner && node.members.includes(owner)
+										? renderThreadPin(threadsById.get(owner)!)
+										: null
+							} else {
+								content = (
+									<ClusterBadge
+										editor={editor}
+										node={node}
+										onExpand={expandCluster}
+										onSelectThread={revealClusteredThread}
+										threadsById={threadsById}
+										currentUserId={props.currentUserId}
+										resolveAuthor={props.resolveAuthor}
+									/>
+								)
+							}
+							return (
+								<div key={`cluster-fade:${node.id}`} className={clusterFadeClassName(phase)}>
+									{content}
+								</div>
 							)
-						}
-						return (
-							<div key={`cluster-fade:${node.id}`} className={clusterFadeClassName(phase)}>
-								{content}
-							</div>
-						)
-					})}
-					{orphanThreads.map((thread) => (
-						<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
-					))}
-					{heldThreads.map((thread) => (
-						<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
-					))}
-				</>
-			) : (
-				// Clustering off: every thread renders as its own live pin (each returns null when it's
-				// not on the current page or its anchor is missing). The open thread is excluded here and
-				// rendered once below, mirroring how the clustering path keeps it out of the cluster leaves —
-				// otherwise it would mount a second, stacked pin.
-				threads
-					.filter((thread) => thread.id !== openId)
-					.map((thread) => <Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>)
-			)}
-			{openThread && (
-				<Fragment key={`open:${openThread.id}`}>{renderThreadPin(openThread)}</Fragment>
-			)}
-			<RegionDraftBox editor={editor} />
-			{/* Keep the region visible while composing — the drag draft is gone by now, and no thread
-			    exists yet, so the pending anchor is what shows the area under the open composer. */}
-			{pending?.anchor.type === 'region' && showPendingComposer && (
-				<RegionBox editor={editor} box={pending.anchor} />
-			)}
-			{pending && showPendingComposer && (
-				<PendingComposer editor={editor} pending={pending} {...props} />
-			)}
-		</div>,
-		portalHost
+						})}
+						{orphanThreads.map((thread) => (
+							<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
+						))}
+						{heldThreads.map((thread) => (
+							<Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>
+						))}
+					</>
+				) : (
+					// Clustering off: every thread renders as its own live pin (each returns null when it's
+					// not on the current page or its anchor is missing). The open thread is excluded here and
+					// rendered once below, mirroring how the clustering path keeps it out of the cluster leaves —
+					// otherwise it would mount a second, stacked pin.
+					threads
+						.filter((thread) => thread.id !== openId)
+						.map((thread) => <Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>)
+				)}
+				{openThread && (
+					<Fragment key={`open:${openThread.id}`}>{renderThreadPin(openThread)}</Fragment>
+				)}
+				<RegionDraftBox editor={editor} />
+				{/* Keep the region visible while composing — the drag draft is gone by now, and no thread
+				    exists yet, so the pending anchor is what shows the area under the open composer. */}
+				{pending?.anchor.type === 'region' && showPendingComposer && (
+					<RegionBox editor={editor} box={pending.anchor} />
+				)}
+				{pending && showPendingComposer && (
+					<PendingComposer editor={editor} pending={pending} {...props} />
+				)}
+			</div>
+		</EditorPortal>
 	)
 }

--- a/packages/commenting/src/canvas/comments-sidebar.tsx
+++ b/packages/commenting/src/canvas/comments-sidebar.tsx
@@ -1,9 +1,8 @@
 import { ReactNode, useCallback, useRef } from 'react'
-import { createPortal } from 'react-dom'
 import {
+	EditorPortal,
 	TLComment,
 	TLCommentThread,
-	useContainer,
 	useEditor,
 	usePassThroughMouseOverEvents,
 	useTranslation,
@@ -52,7 +51,6 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 	const resolveName = useCallback((id: string) => resolveAuthor(id)?.name, [resolveAuthor])
 	const editor = useEditor()
 	const options = useCommentingOptions()
-	const container = useContainer()
 	const commentingEnabled = useCommentingEnabled()
 	const msg = useTranslation()
 	const threads = useCommentThreads(editor)
@@ -161,7 +159,7 @@ export function CanvasCommentsSidebar(props: CanvasCommentsSidebarProps) {
 		: undefined
 
 	return (
-		<SidebarPanel container={container}>
+		<SidebarPanel>
 			<CommentsList
 				items={items}
 				header={header ?? msg('comments.title')}
@@ -216,13 +214,14 @@ export function sortSidebarRows(rows: readonly SidebarRow[]): readonly SidebarRo
 /** The sidebar surface, portaled into the container. It scrolls its own list, so — unlike tldraw's
  *  wheel-transparent panels — a wheel over it doesn't pan the canvas. Hover still passes through so
  *  shapes beneath it stay interactive. */
-function SidebarPanel({ container, children }: { container: HTMLElement; children: ReactNode }) {
+function SidebarPanel({ children }: { children: ReactNode }) {
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughMouseOverEvents(ref)
-	return createPortal(
-		<div ref={ref} className="tlui-cmt-canvas-sidebar" onContextMenu={(e) => e.stopPropagation()}>
-			{children}
-		</div>,
-		container
+	return (
+		<EditorPortal>
+			<div ref={ref} className="tlui-cmt-canvas-sidebar" onContextMenu={(e) => e.stopPropagation()}>
+				{children}
+			</div>
+		</EditorPortal>
 	)
 }

--- a/packages/commenting/src/canvas/pending-composer.tsx
+++ b/packages/commenting/src/canvas/pending-composer.tsx
@@ -1,12 +1,11 @@
 import { Avatar, isMentionPickerOpen } from '@tldraw/mentions'
 import { useEffect, useRef, useState } from 'react'
-import { createPortal } from 'react-dom'
 import {
 	createComment,
 	createCommentThread,
 	Editor,
+	EditorPortal,
 	TLRichText,
-	useContainer,
 	usePassThroughMouseOverEvents,
 	usePassThroughWheelEvents,
 	useTranslation,
@@ -60,7 +59,6 @@ export function PendingComposer({
 	)
 	const ref = useRef<HTMLDivElement>(null)
 	const msg = useTranslation()
-	const container = useContainer()
 	// Over this floating panel, scroll and hover reach the canvas (except where it scrolls itself).
 	usePassThroughWheelEvents(ref)
 	usePassThroughMouseOverEvents(ref)
@@ -108,45 +106,46 @@ export function PendingComposer({
 		pendingComment.set(editor, null)
 	}
 
-	return createPortal(
-		<div
-			ref={ref}
-			className={[
-				'tlui-cmt-canvas-composer',
-				pending.anchor.type === 'region' && 'tlui-cmt-canvas-composer--region',
-				!canComment && 'tlui-cmt-canvas-composer--fallback',
-			]
-				.filter(Boolean)
-				.join(' ')}
-			style={{ left: point.x, top: point.y }}
-			onPointerDown={stop}
-			onContextMenu={stop}
-			onKeyDown={(e) => {
-				if (e.key === 'Escape' && !isMentionPickerOpen()) pendingComment.set(editor, null)
-			}}
-		>
-			{canComment ? (
-				<CommentComposer
-					author={me ?? UNKNOWN_COMMENT_AUTHOR}
-					placeholder={msg('comments.add-placeholder')}
-					sendLabel={msg('comments.send')}
-					value={text}
-					onChange={(value) => {
-						setText(value)
-						saveCommentDraft(NEW_COMMENT_DRAFT, value)
-					}}
-					onSubmit={submit}
-					// No user, no author for the record — dead send button.
-					disabled={isCommentEmpty(text) || !currentUserId}
-					getMentionSuggestions={getMentionSuggestions}
-					renderMentionSuggestion={renderMentionSuggestion}
-					autoFocus
-					leading={draftAvatar}
-				/>
-			) : (
-				ComposerFallback && <ComposerFallback context="pending" />
-			)}
-		</div>,
-		container
+	return (
+		<EditorPortal>
+			<div
+				ref={ref}
+				className={[
+					'tlui-cmt-canvas-composer',
+					pending.anchor.type === 'region' && 'tlui-cmt-canvas-composer--region',
+					!canComment && 'tlui-cmt-canvas-composer--fallback',
+				]
+					.filter(Boolean)
+					.join(' ')}
+				style={{ left: point.x, top: point.y }}
+				onPointerDown={stop}
+				onContextMenu={stop}
+				onKeyDown={(e) => {
+					if (e.key === 'Escape' && !isMentionPickerOpen()) pendingComment.set(editor, null)
+				}}
+			>
+				{canComment ? (
+					<CommentComposer
+						author={me ?? UNKNOWN_COMMENT_AUTHOR}
+						placeholder={msg('comments.add-placeholder')}
+						sendLabel={msg('comments.send')}
+						value={text}
+						onChange={(value) => {
+							setText(value)
+							saveCommentDraft(NEW_COMMENT_DRAFT, value)
+						}}
+						onSubmit={submit}
+						// No user, no author for the record — dead send button.
+						disabled={isCommentEmpty(text) || !currentUserId}
+						getMentionSuggestions={getMentionSuggestions}
+						renderMentionSuggestion={renderMentionSuggestion}
+						autoFocus
+						leading={draftAvatar}
+					/>
+				) : (
+					ComposerFallback && <ComposerFallback context="pending" />
+				)}
+			</div>
+		</EditorPortal>
 	)
 }

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -380,7 +380,6 @@ export const ThreadPin = memo(function ThreadPin({
 			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
 				{open && (
 					<ThreadPopover
-						container={container}
 						style={{
 							left: renderPoint.x + POPOVER_OFFSET.thread.x,
 							top: renderPoint.y + POPOVER_OFFSET.thread.y - THREAD_HEADER_BLOCK,
@@ -395,7 +394,6 @@ export const ThreadPin = memo(function ThreadPin({
 					<ThreadPreview
 						editor={editor}
 						threads={previewThreads}
-						container={container}
 						variant="thread"
 						point={renderPoint}
 						onSelectThread={() => openThreadId.set(editor, thread.id)}

--- a/packages/commenting/src/canvas/thread-preview.tsx
+++ b/packages/commenting/src/canvas/thread-preview.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useRef, type CSSProperties } from 'react'
-import { createPortal } from 'react-dom'
 import {
 	Editor,
 	EditorAtom,
+	EditorPortal,
 	TLComment,
 	TLCommentThread,
 	usePassThroughWheelEvents,
@@ -161,7 +161,6 @@ export function useMarkerPreview(editor: Editor, markerId: string) {
 export function ThreadPreview({
 	editor,
 	threads,
-	container,
 	variant,
 	point,
 	onSelectThread,
@@ -172,7 +171,6 @@ export function ThreadPreview({
 	editor: Editor
 	/** The marker's threads, in the order they should read (oldest first). */
 	threads: readonly TLCommentThread[]
-	container: HTMLElement
 	/** What the marker's click opens, which this panel imitates. */
 	variant: ThreadPreviewVariant
 	/** The marker's anchor point in viewport space — the same origin its popover is placed from. */
@@ -231,68 +229,69 @@ export function ThreadPreview({
 		.filter(Boolean)
 		.join(' ')
 
-	return createPortal(
-		// The root is the hover region — it carries the bridge back to the marker — while the panel
-		// inside it is the visible surface. Keeping them apart is what lets the surface light up on
-		// its own hover without the bridge (which reaches back over the marker) lighting it up too.
-		<div
-			ref={ref}
-			className={`tlui-cmt-canvas-preview tlui-cmt-canvas-preview--${variant}`}
-			style={
-				{
-					left: point.x + offset.x,
-					top: point.y + offset.y,
-					// The stylesheet sizes the hover bridge against this, so the gap it spans follows
-					// the offset rather than being restated as a second magic number.
-					'--tlui-cmt-preview-offset': `${offset.x}px`,
-				} as CSSProperties
-			}
-			onPointerEnter={onPointerEnter}
-			onPointerLeave={onPointerLeave}
-			// The panel sits over the canvas; a press on it is not a canvas press.
-			onPointerDown={(e) => e.stopPropagation()}
-		>
-			<div className={panelClass}>
-				{cards.map(({ thread, first }) => {
-					// The preview shows only the opening comment, so its reply count is what tells the
-					// reader the thread continues past what they see.
-					const replies = replyCountLabel(msg, (countByThread.get(thread.id) ?? 1) - 1)
-					return (
-						<div
-							key={thread.id}
-							className={
-								isThread
-									? undefined
-									: onSelectThread
-										? 'tlui-cmt-preview-card tlui-cmt-preview-card--selectable'
-										: 'tlui-cmt-preview-card'
-							}
-							onClick={
-								onSelectThread
-									? (e) => {
-											e.stopPropagation()
-											onSelectThread(thread)
-										}
-									: undefined
-							}
-						>
-							<CommentCard
-								{...toCardProps(first, props, options.components, resolveName)}
-								footer={
-									replies ? <span className="tlui-cmt-card__replies">{replies}</span> : undefined
+	return (
+		<EditorPortal>
+			{/* The root is the hover region — it carries the bridge back to the marker — while the panel
+		    inside it is the visible surface. Keeping them apart is what lets the surface light up on
+		    its own hover without the bridge (which reaches back over the marker) lighting it up too. */}
+			<div
+				ref={ref}
+				className={`tlui-cmt-canvas-preview tlui-cmt-canvas-preview--${variant}`}
+				style={
+					{
+						left: point.x + offset.x,
+						top: point.y + offset.y,
+						// The stylesheet sizes the hover bridge against this, so the gap it spans follows
+						// the offset rather than being restated as a second magic number.
+						'--tlui-cmt-preview-offset': `${offset.x}px`,
+					} as CSSProperties
+				}
+				onPointerEnter={onPointerEnter}
+				onPointerLeave={onPointerLeave}
+				// The panel sits over the canvas; a press on it is not a canvas press.
+				onPointerDown={(e) => e.stopPropagation()}
+			>
+				<div className={panelClass}>
+					{cards.map(({ thread, first }) => {
+						// The preview shows only the opening comment, so its reply count is what tells the
+						// reader the thread continues past what they see.
+						const replies = replyCountLabel(msg, (countByThread.get(thread.id) ?? 1) - 1)
+						return (
+							<div
+								key={thread.id}
+								className={
+									isThread
+										? undefined
+										: onSelectThread
+											? 'tlui-cmt-preview-card tlui-cmt-preview-card--selectable'
+											: 'tlui-cmt-preview-card'
 								}
-							/>
+								onClick={
+									onSelectThread
+										? (e) => {
+												e.stopPropagation()
+												onSelectThread(thread)
+											}
+										: undefined
+								}
+							>
+								<CommentCard
+									{...toCardProps(first, props, options.components, resolveName)}
+									footer={
+										replies ? <span className="tlui-cmt-card__replies">{replies}</span> : undefined
+									}
+								/>
+							</div>
+						)
+					})}
+					{overflow > 0 && (
+						<div className="tlui-cmt-preview-more">
+							{msg('comments.preview-more').replace('{count}', String(overflow))}
 						</div>
-					)
-				})}
-				{overflow > 0 && (
-					<div className="tlui-cmt-preview-more">
-						{msg('comments.preview-more').replace('{count}', String(overflow))}
-					</div>
-				)}
+					)}
+				</div>
 			</div>
-		</div>,
-		container
+		</EditorPortal>
 	)
 }
 

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -2,7 +2,6 @@ import { type MouseEvent as ReactMouseEvent, memo, useEffect, useRef } from 'rea
 import {
 	Editor,
 	TLCommentThread,
-	useContainer,
 	usePassThroughWheelEvents,
 	useTranslation,
 	useValue,
@@ -40,7 +39,6 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 	/** The stack's threads, oldest first. All resolve to the same anchor point. */
 	threads: readonly TLCommentThread[]
 }) {
-	const container = useContainer()
 	const msg = useTranslation()
 	const badgeRef = useRef<HTMLButtonElement>(null)
 	// The badge takes pointer events (to open on click), so wheel input over it would otherwise be
@@ -167,7 +165,6 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 				<ThreadPreview
 					editor={editor}
 					threads={threads}
-					container={container}
 					// Lines the preview up with the stack list itself, so opening it leaves the cards
 					// exactly where the preview had them.
 					variant="list"
@@ -185,7 +182,6 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 			)}
 			{open && (
 				<ThreadPopover
-					container={container}
 					style={{
 						left: point.x + POPOVER_OFFSET.list.x,
 						top: point.y + POPOVER_OFFSET.list.y - liftForHeader,

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -1,8 +1,8 @@
 import { ReactNode, useCallback, useEffect, useRef, useState, type CSSProperties } from 'react'
-import { createPortal } from 'react-dom'
 import {
 	createComment,
 	Editor,
+	EditorPortal,
 	TLComment,
 	TLCommentThread,
 	TLRichText,
@@ -155,31 +155,24 @@ export const POPOVER_OFFSET = {
 
 /** The open thread's popover container, portaled above the UI panels. Over it, wheel and hover
  *  events pass through to the canvas (unless it scrolls its own content), like tldraw's panels. */
-export function ThreadPopover({
-	container,
-	style,
-	children,
-}: {
-	container: HTMLElement
-	style: CSSProperties
-	children: ReactNode
-}) {
+export function ThreadPopover({ style, children }: { style: CSSProperties; children: ReactNode }) {
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
 	usePassThroughMouseOverEvents(ref)
-	return createPortal(
-		// contextmenu also stops here: portals bubble React events to the canvas's context-menu
-		// trigger (the layer mounts inside it), which would open the canvas menu over this panel.
-		<div
-			ref={ref}
-			className="tlui-cmt-canvas-popover"
-			style={style}
-			onPointerDown={stop}
-			onContextMenu={stop}
-		>
-			{children}
-		</div>,
-		container
+	return (
+		<EditorPortal>
+			{/* contextmenu also stops here: portals bubble React events to the canvas's context-menu
+			    trigger (the layer mounts inside it), which would open the canvas menu over this panel. */}
+			<div
+				ref={ref}
+				className="tlui-cmt-canvas-popover"
+				style={style}
+				onPointerDown={stop}
+				onContextMenu={stop}
+			>
+				{children}
+			</div>
+		</EditorPortal>
 	)
 }
 

--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -32,6 +32,7 @@ import * as React_2 from 'react';
 import { default as React_3 } from 'react';
 import { ReactElement } from 'react';
 import { ReactNode } from 'react';
+import { ReactPortal } from 'react';
 import { RecordProps } from '@tldraw/tlschema';
 import { RecordsDiff } from '@tldraw/store';
 import { RefAttributes } from 'react';
@@ -1724,6 +1725,15 @@ export abstract class EditorManager {
     // (undocumented)
     protected readonly editor: Editor;
     protected register(dispose: () => void): () => void;
+}
+
+// @public
+export function EditorPortal({ children }: EditorPortalProps): ReactPortal | null;
+
+// @public (undocumented)
+export interface EditorPortalProps {
+    // (undocumented)
+    children: ReactNode;
 }
 
 // @public (undocumented)
@@ -5067,6 +5077,9 @@ export function useEditor(): Editor;
 
 // @public (undocumented)
 export function useEditorComponents(): Required<TLEditorComponents>;
+
+// @public
+export function useEditorPortalHost(): HTMLElement | null;
 
 // @internal
 export function useEvent<Args extends Array<unknown>, Result>(handler: (...args: Args) => Result): (...args: Args) => Result;

--- a/packages/editor/editor.css
+++ b/packages/editor/editor.css
@@ -295,6 +295,12 @@
 	outline: 1px solid var(--tl-color-low);
 }
 
+/* The host for <EditorPortal>, last among the container's children. It's a position in the DOM
+   rather than a box: `display: contents` keeps what it holds positioned against the container. */
+.tl-portal-host {
+	display: contents;
+}
+
 input,
 *[contenteditable],
 *[contenteditable] * {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -35,6 +35,11 @@ export {
 export { DefaultSpinner } from './lib/components/default-components/DefaultSpinner'
 export { DefaultSvgDefs } from './lib/components/default-components/DefaultSvgDefs'
 export {
+	EditorPortal,
+	useEditorPortalHost,
+	type EditorPortalProps,
+} from './lib/components/EditorPortal'
+export {
 	ErrorBoundary,
 	OptionalErrorBoundary,
 	type TLErrorBoundaryProps,

--- a/packages/editor/src/lib/TldrawEditor.tsx
+++ b/packages/editor/src/lib/TldrawEditor.tsx
@@ -24,6 +24,7 @@ import React, {
 } from 'react'
 import { version } from '../version'
 import { DefaultErrorFallback } from './components/default-components/DefaultErrorFallback'
+import { EditorPortalProvider } from './components/EditorPortal'
 import { OptionalErrorBoundary } from './components/ErrorBoundary'
 import { createTLCurrentUser, TLCurrentUser } from './config/createTLCurrentUser'
 import { TLStoreBaseOptions } from './config/createTLStore'
@@ -304,6 +305,7 @@ export const TldrawEditor = memo(function TldrawEditor({
 	registerFontsFromThemes(resolvedThemes)
 
 	const [container, setContainer] = useState<HTMLElement | null>(null)
+	const [portalHost, setPortalHost] = useState<HTMLElement | null>(null)
 	const user = useMemo(() => _user ?? createTLCurrentUser(), [_user])
 
 	const ErrorFallback =
@@ -352,24 +354,30 @@ export const TldrawEditor = memo(function TldrawEditor({
 				{container && (
 					<LicenseProvider licenseKey={rest.licenseKey}>
 						<ContainerProvider container={container}>
-							<EditorComponentsProvider overrides={components}>
-								{store ? (
-									store instanceof Store ? (
-										// Store is ready to go, whether externally synced or not
-										<TldrawEditorWithReadyStore {...withDefaults} store={store} user={user} />
+							<EditorPortalProvider host={portalHost}>
+								<EditorComponentsProvider overrides={components}>
+									{store ? (
+										store instanceof Store ? (
+											// Store is ready to go, whether externally synced or not
+											<TldrawEditorWithReadyStore {...withDefaults} store={store} user={user} />
+										) : (
+											// Store is a synced store, so handle syncing stages internally
+											<TldrawEditorWithLoadingStore {...withDefaults} store={store} user={user} />
+										)
 									) : (
-										// Store is a synced store, so handle syncing stages internally
-										<TldrawEditorWithLoadingStore {...withDefaults} store={store} user={user} />
-									)
-								) : (
-									// We have no store (it's undefined) so create one and possibly sync it
-									<TldrawEditorWithOwnStore {...withDefaults} store={store} user={user} />
-								)}
-							</EditorComponentsProvider>
+										// We have no store (it's undefined) so create one and possibly sync it
+										<TldrawEditorWithOwnStore {...withDefaults} store={store} user={user} />
+									)}
+								</EditorComponentsProvider>
+							</EditorPortalProvider>
 						</ContainerProvider>
 					</LicenseProvider>
 				)}
 			</OptionalErrorBoundary>
+			{/* The host for <EditorPortal>, last among the container's children so that anything
+			    portaled through it lands after the canvas and the UI — behind the UI's "skip to main
+			    content" link in the tab order, which only works while nothing precedes it. */}
+			<div className="tl-portal-host" ref={setPortalHost} />
 		</div>
 	)
 })

--- a/packages/editor/src/lib/components/EditorPortal.tsx
+++ b/packages/editor/src/lib/components/EditorPortal.tsx
@@ -1,0 +1,80 @@
+import { ReactNode, createContext, useContext } from 'react'
+import { createPortal } from 'react-dom'
+
+const EditorPortalContext = createContext<HTMLElement | null>(null)
+
+/** @internal */
+export function EditorPortalProvider({
+	host,
+	children,
+}: {
+	host: HTMLElement | null
+	children: ReactNode
+}) {
+	return <EditorPortalContext.Provider value={host}>{children}</EditorPortalContext.Provider>
+}
+
+/**
+ * The DOM node that {@link EditorPortal} renders into: an empty `display: contents` element the
+ * editor renders last among its container's children, after the canvas and after the UI.
+ *
+ * Null until the container has mounted, so prefer {@link EditorPortal}, which handles that for you.
+ *
+ * @public
+ */
+export function useEditorPortalHost(): HTMLElement | null {
+	return useContext(EditorPortalContext)
+}
+
+/** @public */
+export interface EditorPortalProps {
+	children: ReactNode
+}
+
+/**
+ * Renders its children into the end of the editor's container, escaping the canvas layer.
+ *
+ * Use this for anything anchored to canvas coordinates that also has to draw over the UI — a
+ * popover on a shape, a comment thread, an annotation panel. The `OnTheCanvas` and
+ * `InFrontOfTheCanvas` component slots are fixed layers, and each is its own stacking context, so
+ * content mounted there can't paint above whatever outranks its layer, no matter what z-index it
+ * asks for. Mount your component in whichever slot suits your data flow, wrap the part that needs
+ * its own layer in this, and give that part a z-index.
+ *
+ * Which z-index depends on what you're drawing over. This package's own layers stop at 250
+ * (`--tl-layer-canvas-in-front`); everything above that belongs to whatever renders the UI. In
+ * `tldraw`, that's `--tl-layer-panels` (300, the toolbar and style panel) and `--tl-layer-menus`
+ * (400) — defined by `tldraw`'s stylesheet rather than this package's, so reach for those variables
+ * only if you're building on `tldraw` and not the bare editor.
+ *
+ * Positioning still resolves against the editor's container, the same as the canvas layers, so a
+ * `position: absolute` child uses ordinary container coordinates.
+ *
+ * Prefer this over `createPortal(children, useContainer())`. A portal picks its DOM position from
+ * the commit that mounts it, so portaling straight into the container lands the node ahead of the
+ * container's own shallower children — ahead of the UI, and ahead of the "skip to main content"
+ * link that only works while nothing precedes it. The host this renders into is a real element in
+ * the editor's tree, placed last, so ordering is fixed rather than dependent on mount timing.
+ *
+ * @example
+ * ```tsx
+ * // 400 clears tldraw's menus layer; the bare editor's own layers stop at 250.
+ * function ShapeAnnotation({ point }: { point: VecLike }) {
+ * 	return (
+ * 		<EditorPortal>
+ * 			<div style={{ position: 'absolute', left: point.x, top: point.y, zIndex: 400 }}>
+ * 				Above the UI
+ * 			</div>
+ * 		</EditorPortal>
+ * 	)
+ * }
+ * ```
+ *
+ * @public
+ * @react
+ */
+export function EditorPortal({ children }: EditorPortalProps) {
+	const host = useEditorPortalHost()
+	if (!host) return null
+	return createPortal(children, host)
+}

--- a/packages/editor/src/lib/test/EditorPortal.test.tsx
+++ b/packages/editor/src/lib/test/EditorPortal.test.tsx
@@ -1,0 +1,48 @@
+import { act, render, screen } from '@testing-library/react'
+import { EditorPortal } from '../components/EditorPortal'
+import { createTLStore } from '../config/createTLStore'
+import { TL_CONTAINER_CLASS, TldrawEditor } from '../TldrawEditor'
+
+/** Mounted in a canvas slot — the deep-in-the-tree case the portal exists for. */
+function Portaled() {
+	return (
+		<EditorPortal>
+			<div data-testid="portaled" />
+		</EditorPortal>
+	)
+}
+
+describe('EditorPortal', () => {
+	async function renderEditor() {
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} components={{ InFrontOfTheCanvas: Portaled }} />)
+		})
+		return document.querySelector(`.${TL_CONTAINER_CLASS}`)!
+	}
+
+	it('renders its children into the editor container', async () => {
+		const container = await renderEditor()
+		expect(container.contains(screen.getByTestId('portaled'))).toBe(true)
+	})
+
+	it('renders into a host that comes after everything the editor renders', async () => {
+		const container = await renderEditor()
+		const host = container.querySelector('.tl-portal-host')!
+		expect(host.contains(screen.getByTestId('portaled'))).toBe(true)
+		// Last of the container's rendered children. Managers append their own nodes after this one
+		// (the text measurement element, say) but those are `tabIndex = -1` and out of the tab order.
+		const rendered = [...container.children].filter((el) => !el.matches('.tl-text-measure'))
+		expect(rendered.at(-1)).toBe(host)
+	})
+
+	// The tab order guarantee: mounted in a canvas slot, the portaled content still lands after
+	// everything the editor renders itself — including (in tldraw) the UI's skip link, which only
+	// works while nothing precedes it. Portaling straight into the container lands it ahead of them.
+	it('places its children after the rest of the editor in document order', async () => {
+		await renderEditor()
+		const portaled = screen.getByTestId('portaled')
+		const canvas = screen.getByTestId('canvas')
+		expect(canvas.compareDocumentPosition(portaled) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+	})
+})

--- a/packages/tldraw/src/test/ui/EditorPortal.test.tsx
+++ b/packages/tldraw/src/test/ui/EditorPortal.test.tsx
@@ -1,0 +1,35 @@
+import { EditorPortal } from '@tldraw/editor'
+import { Tldraw } from '../../lib/Tldraw'
+import { renderTldrawComponent } from '../testutils/renderTldrawComponent'
+
+/**
+ * The reason `EditorPortal` exists rather than `createPortal(children, useContainer())`: a portal
+ * takes its DOM position from the commit that mounts it, so portaling into the container from a
+ * canvas slot lands the node ahead of the UI — and ahead of the skip link, which is only a keyboard
+ * route to the canvas while nothing precedes it.
+ */
+describe('EditorPortal in a full editor', () => {
+	it('renders after the UI and its skip link', async () => {
+		const rendered = await renderTldrawComponent(
+			<Tldraw
+				components={{
+					InFrontOfTheCanvas: () => (
+						<EditorPortal>
+							<button data-testid="portaled-button">A pin, say</button>
+						</EditorPortal>
+					),
+				}}
+			/>,
+			{ waitForPatterns: false }
+		)
+
+		const portaled = await rendered.findByTestId('portaled-button')
+		const skipLink = document.querySelector('.tl-skip-to-main-content')!
+		const ui = document.querySelector('.tlui-layout')!
+
+		expect(
+			skipLink.compareDocumentPosition(portaled) & Node.DOCUMENT_POSITION_FOLLOWING
+		).toBeTruthy()
+		expect(ui.compareDocumentPosition(portaled) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+	})
+})


### PR DESCRIPTION
Exploratory — opening as a draft to see whether we want this shape at all.

Reviewing the commenting work in #9471, the `createPortal` usage stood out and the question was whether a better entry point into the editor would remove the need for it. Digging in: the portals themselves are load-bearing. `CanvasComments` is mounted in `InFrontOfTheCanvas`, but its pins have to sit *below* the collaborator cursors (~240) and its popovers *above* the UI panels (400), and no single slot spans that range — `.tl-canvas__in-front` is z-index 250 and its own stacking context, `.tlui-layout` is a `contain: strict` grid at 300. Splitting the layer across several slots would mean lifting its shared open/hover/cluster/drag state across three mount points, and any third party building a similar overlay hits the same wall. Portaling into the container is also what the SDK already does everywhere else — every Radix menu passes `container={useContainer()}`.

What doesn't hold up is `useTrailingPortalHost`: commenting creates a `display: contents` div in a layout effect and appends it to the container, because a portal takes its DOM position from the commit that mounts it and would otherwise land *ahead* of the UI — putting a comment pin in front of the "skip to main content" link, which is only a keyboard route to the canvas while nothing precedes it. That's a package outside the editor re-deriving an implicit ordering contract of the editor's own a11y layer, and paying an extra render on mount to do it.

So in order to keep that contract in one place, this PR renders the mount point in the editor instead — an empty `.tl-portal-host` element rendered last among the container's children, given `display: contents` by the editor's stylesheet — and exposes it as `EditorPortal`. Commenting's five portals (layer, popover, hover preview, placement composer, sidebar) go through it and `useTrailingPortalHost` goes away. Ordering is now fixed by JSX position rather than by mount timing, and it's reusable by anything else that's canvas-anchored but drawn over the UI.

```tsx
// before, in @tldraw/commenting
const portalHost = useTrailingPortalHost(useContainer()) // 30 lines of layout effect
if (!portalHost) return null
return createPortal(<div className="tlui-cmt-canvas-layer">…</div>, portalHost)

// after
return (
	<EditorPortal>
		<div className="tlui-cmt-canvas-layer">…</div>
	</EditorPortal>
)
```

Deliberately *not* done here, but worth deciding on:

- **One host, not named layers.** The host is `display: contents`, so children resolve z-index against the container and the existing `--tl-layer-*` vars keep doing the layering. Named hosts (`overlay` / `menus`) would only matter if we wanted DOM order to carry meaning too.
- **`useEditorPortalHost` is exported** for the raw node, so a Radix `container` prop can target it. The SDK's own menus still pass `useContainer()`; moving them over would give menus the same ordering guarantee, but they mount on open so they land last anyway — didn't seem worth the churn in this PR.
- **Naming.** `EditorPortal` / `useEditorPortalHost` / `.tl-portal-host` are first drafts.
- The alternative fix — making the skip link immune to DOM order so nothing needs to be placed after it — would remove the constraint rather than encode it. Happy to go that way instead if it's preferred.

Verified in the examples app (`/commenting`, `/commenting-sidebar`): one `.tl-portal-host`, last of the container's rendered children, comment layer inside it and after `.tlui-layout`, pin after the skip link, and the skip link still the first tab stop.

### Change type

- [x] `api`

### Test plan

1. Open the commenting example, place a comment, and open its thread — the popover should draw over the toolbar and style panel, and the pin should sit under collaborator cursors.
2. Hover a pin for its preview, drag a pin, and open the sidebar example — all four surfaces are portaled.
3. Tab into the editor with a comment on the canvas: the first stop should still be "skip to main content", not the pin.

- [x] Unit tests

### Release notes

- Add `EditorPortal`, for rendering canvas-anchored content that needs to draw over the editor's UI.

### API changes

- Added `EditorPortal` and `useEditorPortalHost` to `@tldraw/editor`.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +321 / -280 |
| Tests           | +83 / -0    |
| Automated files | +13 / -0    |

Based on `commenting-followups`. Relates to #9471.


