### PR TITLE
refactor(mentions): use the shared wheel pass-through hook for the @-picker

### DIFF
--- a/packages/commenting/src/canvas/thread-preview.tsx
+++ b/packages/commenting/src/canvas/thread-preview.tsx
@@ -5,7 +5,6 @@ import {
 	EditorAtom,
 	TLComment,
 	TLCommentThread,
-	usePassThroughMouseOverEvents,
 	usePassThroughWheelEvents,
 	useTranslation,
 	useValue,
@@ -191,12 +190,9 @@ export function ThreadPreview({
 
 	// The panel floats over the canvas and scrolls nothing of its own, so a wheel on it should zoom
 	// and pan the canvas underneath — like every other tldraw panel, and like the popover it
-	// previews. Without this the canvas would freeze wherever the preview happened to be. Hover
-	// passes through too: the panel portals to the container, outside the comments layer whose root
-	// does this for the pins, so it needs its own.
+	// previews. Without this the canvas would freeze wherever the preview happened to be.
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
-	usePassThroughMouseOverEvents(ref)
 
 	// Each thread's opening comment and its total comment count. `useComments` is oldest-first, so
 	// the first hit per thread is that thread's first comment. One pass over every comment beats a

--- a/packages/commenting/src/canvas/thread-preview.tsx
+++ b/packages/commenting/src/canvas/thread-preview.tsx
@@ -5,6 +5,7 @@ import {
 	EditorAtom,
 	TLComment,
 	TLCommentThread,
+	usePassThroughMouseOverEvents,
 	usePassThroughWheelEvents,
 	useTranslation,
 	useValue,
@@ -190,9 +191,12 @@ export function ThreadPreview({
 
 	// The panel floats over the canvas and scrolls nothing of its own, so a wheel on it should zoom
 	// and pan the canvas underneath — like every other tldraw panel, and like the popover it
-	// previews. Without this the canvas would freeze wherever the preview happened to be.
+	// previews. Without this the canvas would freeze wherever the preview happened to be. Hover
+	// passes through too: the panel portals to the container, outside the comments layer whose root
+	// does this for the pins, so it needs its own.
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
+	usePassThroughMouseOverEvents(ref)
 
 	// Each thread's opening comment and its total comment count. `useComments` is oldest-first, so
 	// the first hit per thread is that thread's first comment. One pass over every comment beats a

--- a/packages/mentions/api-report.api.md
+++ b/packages/mentions/api-report.api.md
@@ -5,12 +5,14 @@
 ```ts
 
 import { Editor } from 'tldraw';
+import { ForwardRefExoticComponent } from 'react';
 import { JsonObject } from 'tldraw';
 import { JSX } from 'react/jsx-runtime';
 import { MentionNodeAttrs } from '@tiptap/extension-mention';
 import { MentionOptions } from '@tiptap/extension-mention';
 import { Node as Node_2 } from '@tiptap/core';
 import { ReactNode } from 'react';
+import { RefAttributes } from 'react';
 import type { SuggestionOptions } from '@tiptap/suggestion';
 
 // @public
@@ -53,7 +55,7 @@ export interface MentionExtensionOptions {
 }
 
 // @public
-export function MentionList({ members, activeIndex, onSelect, emptyLabel, renderMember }: MentionListProps): JSX.Element;
+export const MentionList: ForwardRefExoticComponent<MentionListProps & RefAttributes<HTMLDivElement>>;
 
 // @public (undocumented)
 export interface MentionListProps {

--- a/packages/mentions/src/mention-list.tsx
+++ b/packages/mentions/src/mention-list.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, forwardRef } from 'react'
 import { useTranslation } from 'tldraw'
 import { Avatar } from './avatar'
 import { CommentAuthor } from './comment-author'
@@ -56,23 +56,20 @@ function DefaultMemberRow({ member }: { member: MentionMember }) {
  * placement, and drives this with the host-resolved `members` and the highlighted `activeIndex`.
  * @public @react
  */
-export function MentionList({
-	members,
-	activeIndex = 0,
-	onSelect,
-	emptyLabel,
-	renderMember,
-}: MentionListProps) {
+export const MentionList = forwardRef<HTMLDivElement, MentionListProps>(function MentionList(
+	{ members, activeIndex = 0, onSelect, emptyLabel, renderMember },
+	ref
+) {
 	const msg = useTranslation()
 	if (members.length === 0) {
 		return (
-			<div className="tlui-cmt-mention-list tlui-cmt-mention-list--empty">
+			<div ref={ref} className="tlui-cmt-mention-list tlui-cmt-mention-list--empty">
 				{emptyLabel ?? msg('comments.mention-no-matches')}
 			</div>
 		)
 	}
 	return (
-		<div className="tlui-cmt-mention-list" role="listbox">
+		<div ref={ref} className="tlui-cmt-mention-list" role="listbox">
 			{members.map((member, i) => {
 				const active = i === activeIndex
 				return (
@@ -100,4 +97,4 @@ export function MentionList({
 			})}
 		</div>
 	)
-}
+})

--- a/packages/mentions/src/mention-suggestion.tsx
+++ b/packages/mentions/src/mention-suggestion.tsx
@@ -3,13 +3,7 @@ import { ReactRenderer } from '@tiptap/react'
 import type { SuggestionKeyDownProps, SuggestionOptions } from '@tiptap/suggestion'
 import { assertExists } from '@tldraw/utils'
 import { type ReactNode, forwardRef, useImperativeHandle, useRef, useState } from 'react'
-import {
-	type Editor as TldrawEditor,
-	atom,
-	react,
-	usePassThroughMouseOverEvents,
-	usePassThroughWheelEvents,
-} from 'tldraw'
+import { type Editor as TldrawEditor, atom, react, usePassThroughWheelEvents } from 'tldraw'
 import { MentionList, MentionMember } from './mention-list'
 
 /** The handle the suggestion plugin drives — it forwards navigation keys into the popup. */
@@ -29,14 +23,13 @@ const MentionPopup = forwardRef<MentionPopupHandle, MentionPopupProps>(function 
 	ref
 ) {
 	const [activeIndex, setActiveIndex] = useState(0)
-	// Wheel and hover over the popup drive the canvas beneath it, so scrolling to pan or zoom (and
-	// hovering shapes) isn't swallowed by the roster — the same pass-through every tldraw panel gets.
-	// The wheel hook leaves the list alone while it scrolls its own overflow. The suggestion plugin
-	// builds the popup element imperatively, but the `ReactRenderer` portals this component into the
-	// composer's React tree, so tldraw's container and editor context reach these hooks.
+	// A wheel over the popup drives the canvas beneath it, so scrolling to pan or zoom isn't
+	// swallowed by the roster — the same pass-through every tldraw panel gets. The hook leaves the
+	// list alone while it scrolls its own overflow. The suggestion plugin builds the popup element
+	// imperatively, but the `ReactRenderer` portals this component into the composer's React tree,
+	// so tldraw's container and editor context reach the hook.
 	const listRef = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(listRef)
-	usePassThroughMouseOverEvents(listRef)
 	// A new query yields new items; reset the highlight to the top during render — not in an effect,
 	// which would leave a frame where `activeIndex` still points past a shrunk list and Enter selects
 	// its (now out-of-range, undefined) item, swallowing the key without inserting a mention.

--- a/packages/mentions/src/mention-suggestion.tsx
+++ b/packages/mentions/src/mention-suggestion.tsx
@@ -1,8 +1,14 @@
 import type { MentionNodeAttrs } from '@tiptap/extension-mention'
 import { ReactRenderer } from '@tiptap/react'
 import type { SuggestionKeyDownProps, SuggestionOptions } from '@tiptap/suggestion'
-import { type ReactNode, forwardRef, useImperativeHandle, useState } from 'react'
-import { type Editor as TldrawEditor, atom, react } from 'tldraw'
+import { type ReactNode, forwardRef, useImperativeHandle, useRef, useState } from 'react'
+import {
+	type Editor as TldrawEditor,
+	atom,
+	react,
+	usePassThroughMouseOverEvents,
+	usePassThroughWheelEvents,
+} from 'tldraw'
 import { MentionList, MentionMember } from './mention-list'
 
 /** The handle the suggestion plugin drives — it forwards navigation keys into the popup. */
@@ -22,6 +28,14 @@ const MentionPopup = forwardRef<MentionPopupHandle, MentionPopupProps>(function 
 	ref
 ) {
 	const [activeIndex, setActiveIndex] = useState(0)
+	// Wheel and hover over the popup drive the canvas beneath it, so scrolling to pan or zoom (and
+	// hovering shapes) isn't swallowed by the roster — the same pass-through every tldraw panel gets.
+	// The wheel hook leaves the list alone while it scrolls its own overflow. The suggestion plugin
+	// builds the popup element imperatively, but the `ReactRenderer` portals this component into the
+	// composer's React tree, so tldraw's container and editor context reach these hooks.
+	const listRef = useRef<HTMLDivElement>(null)
+	usePassThroughWheelEvents(listRef)
+	usePassThroughMouseOverEvents(listRef)
 	// A new query yields new items; reset the highlight to the top during render — not in an effect,
 	// which would leave a frame where `activeIndex` still points past a shrunk list and Enter selects
 	// its (now out-of-range, undefined) item, swallowing the key without inserting a mention.
@@ -59,6 +73,7 @@ const MentionPopup = forwardRef<MentionPopupHandle, MentionPopupProps>(function 
 
 	return (
 		<MentionList
+			ref={listRef}
 			members={items}
 			activeIndex={activeIndex}
 			onSelect={select}
@@ -121,7 +136,6 @@ export function createMentionSuggestion(
 			let renderer: ReactRenderer<MentionPopupHandle, MentionPopupProps> | null = null
 			let container: HTMLElement | null = null
 			let editorEl: HTMLElement | null = null
-			let canvasEl: Element | null = null
 			let stopCameraReaction: (() => void) | null = null
 			// The composer field's top-left in page space, plus the popup's screen width. Captured on a
 			// fresh read so camera moves can re-derive the popup's screen position from the page anchor
@@ -188,20 +202,6 @@ export function createMentionSuggestion(
 				mentionPickerOpen.set(false)
 			}
 
-			// Wheel/panning over the popup drives the canvas beneath it, so scrolling to pan or zoom
-			// isn't swallowed by the roster — the same passthrough the rest of the comments UI gets from
-			// `usePassThroughWheelEvents`. The list still scrolls itself when the roster overflows (we
-			// only redispatch when it can't). Done imperatively because the popup lives outside React.
-			const onWheel = (e: WheelEvent) => {
-				if ((e as any).isSpecialRedispatchedEvent || !canvasEl) return
-				const list = container?.querySelector('.tlui-cmt-mention-list')
-				if (list && list.scrollHeight > list.clientHeight) return
-				e.preventDefault()
-				const redispatched = new WheelEvent('wheel', e)
-				;(redispatched as any).isSpecialRedispatchedEvent = true
-				canvasEl.dispatchEvent(redispatched)
-			}
-
 			return {
 				onStart: (props) => {
 					renderer = new ReactRenderer(MentionPopup, {
@@ -224,8 +224,6 @@ export function createMentionSuggestion(
 					// (--tl-color-*); portaling to document.body would strip them and lose the panel.
 					const themed = editorEl.closest('.tl-container')
 					;(themed ?? document.body).appendChild(container)
-					canvasEl = themed?.querySelector('.tl-canvas') ?? null
-					container.addEventListener('wheel', onWheel, { passive: false })
 					place()
 					startFollowing()
 					mentionPickerOpen.set(true)
@@ -272,12 +270,10 @@ export function createMentionSuggestion(
 				onExit: () => {
 					stopFollowing()
 					if (editorEl) editorEl.removeEventListener('blur', hide)
-					if (container) container.removeEventListener('wheel', onWheel)
 					if (container) container.remove()
 					if (renderer) renderer.destroy()
 					renderer = null
 					container = null
-					canvasEl = null
 					mentionPickerOpen.set(false)
 				},
 			}

--- a/packages/mentions/src/mention-suggestion.tsx
+++ b/packages/mentions/src/mention-suggestion.tsx
@@ -1,6 +1,7 @@
 import type { MentionNodeAttrs } from '@tiptap/extension-mention'
 import { ReactRenderer } from '@tiptap/react'
 import type { SuggestionKeyDownProps, SuggestionOptions } from '@tiptap/suggestion'
+import { assertExists } from '@tldraw/utils'
 import { type ReactNode, forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import {
 	type Editor as TldrawEditor,
@@ -220,10 +221,13 @@ export function createMentionSuggestion(
 					container = document.createElement('div')
 					container.className = 'tlui-cmt-mention-popup'
 					container.appendChild(renderer.element)
-					// Mount inside the tldraw container so the popup inherits the theme variables
-					// (--tl-color-*); portaling to document.body would strip them and lose the panel.
-					const themed = editorEl.closest('.tl-container')
-					;(themed ?? document.body).appendChild(container)
+					// Mount inside the tldraw container: the popup inherits the theme variables
+					// (--tl-color-*) from it, and the pass-through hooks read it from context to find the
+					// canvas. Anywhere else there'd be no theme and nothing to pass a wheel to.
+					assertExists(
+						editorEl.closest('.tl-container'),
+						'the @-mention picker must be used inside <Tldraw>'
+					).appendChild(container)
 					place()
 					startFollowing()
 					mentionPickerOpen.set(true)

--- a/packages/mentions/src/mention-suggestion.tsx
+++ b/packages/mentions/src/mention-suggestion.tsx
@@ -1,7 +1,6 @@
 import type { MentionNodeAttrs } from '@tiptap/extension-mention'
 import { ReactRenderer } from '@tiptap/react'
 import type { SuggestionKeyDownProps, SuggestionOptions } from '@tiptap/suggestion'
-import { assertExists } from '@tldraw/utils'
 import { type ReactNode, forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { type Editor as TldrawEditor, atom, react, usePassThroughWheelEvents } from 'tldraw'
 import { MentionList, MentionMember } from './mention-list'
@@ -216,11 +215,9 @@ export function createMentionSuggestion(
 					container.appendChild(renderer.element)
 					// Mount inside the tldraw container: the popup inherits the theme variables
 					// (--tl-color-*) from it, and the pass-through hooks read it from context to find the
-					// canvas. Anywhere else there'd be no theme and nothing to pass a wheel to.
-					assertExists(
-						editorEl.closest('.tl-container'),
-						'the @-mention picker must be used inside <Tldraw>'
-					).appendChild(container)
+					// canvas. Outside one there's no theme and nothing to pass a wheel to, but the picker
+					// still works, so fall back to the body rather than taking the composer down with us.
+					;(editorEl.closest('.tl-container') ?? document.body).appendChild(container)
 					place()
 					startFollowing()
 					mentionPickerOpen.set(true)


### PR DESCRIPTION
In order to keep the canvas pannable under the @-mention picker without a second, weaker copy of the pass-through logic, this replaces the picker's hand-rolled `wheel` listener with `usePassThroughWheelEvents`.

The picker's popup element is built imperatively by the TipTap suggestion plugin, which is why it grew its own listener: hooks weren't obviously available. But the popup's *contents* are a React component, and the `ReactRenderer` mounts it with `createPortal` into the composer's tree — so tldraw's container and editor context reach it, the same way `useTranslation` already worked there. The hook hangs off the list root; `MentionList` forwards its ref for that.

Two behavior differences fall out of using the shared hook. It walks from the wheel target up through the ancestors checking computed `overflow` rather than spot-checking `.tlui-cmt-mention-list`'s `scrollHeight`, so an overflowing roster still scrolls itself and everything else pans the canvas. And it only passes through while the editor is focused, which is the gate every other comments panel already lives with.

One consequence worth naming: `usePassThroughWheelEvents` calls `useContainer()`, which throws outside `<Tldraw>`, so the picker is now explicitly tldraw-only. `createMentionSuggestion` used to fall back to appending the popup to `document.body` — but the popup never got the theme variables there either, so that path was already broken. It's now an `assertExists` that names the requirement instead.

An earlier revision of this PR also added `usePassThroughMouseOverEvents` here and to the thread preview panel. Testing in the browser showed that hook has never done anything — it redispatches a `mouseover` at the canvas, which listens for `pointerover` — so those calls are gone and #9810 removes the hook outright.

### Change type

- [x] `improvement`

### Test plan

1. Open a comment thread on the canvas and type `@` in the composer.
2. Scroll over the picker — the canvas should zoom/pan beneath it.
3. Narrow the roster until it overflows (a board with many members), then scroll over it — the list should scroll itself instead.

- [ ] Unit tests
- [ ] End to end tests

### API changes

- Changed `MentionList` to forward its root ref (`ForwardRefExoticComponent<MentionListProps & RefAttributes<HTMLDivElement>>`)

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +26 / -36  |
| Automated files | +3 / -1    |
