### PR TITLE
chore(commenting): remove the dead movable region class

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -345,13 +345,6 @@
 	background: color-mix(in srgb, var(--tl-color-selected) 10%, transparent);
 }
 
-/* A movable region body (the 'body'/'both' move modes): draggable to translate the whole region.
-   Interactive, so it captures the interior while shown — the tradeoff of dragging the body. */
-.tlui-cmt-canvas-region--movable {
-	pointer-events: auto;
-	cursor: move;
-}
-
 /* Corner resize handles on a region box (three corners; the pin corner is the move handle). */
 .tlui-cmt-canvas-region-handle {
 	position: absolute;

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -145,8 +145,8 @@ export const ThreadPin = memo(function ThreadPin({
 			if (target.closest('.tlui-cmt-canvas-popover')) return
 			const marker = markerRef.current
 			if (marker && marker.contains(target)) return
-			// A press on a region's resize handle or movable body edits this thread — don't dismiss it.
-			if (target.closest('.tlui-cmt-canvas-region-handle, .tlui-cmt-canvas-region--movable')) return
+			// A press on a region's resize handle edits this thread — don't dismiss it.
+			if (target.closest('.tlui-cmt-canvas-region-handle')) return
 			// A click inside a menu/popover layered above us (the sidebar's filter or overflow
 			// dropdown, or the composer's mention picker — all portaled elsewhere) belongs to that
 			// layer; defer to its own dismissal instead of closing the thread out from under it.


### PR DESCRIPTION
In order to stop a reviewer from reasoning about a mode that no longer exists, this removes `.tlui-cmt-canvas-region--movable`.

The class is a leftover from a removed "movable region body" mode — the one where dragging a region's interior translated it. Regions now move by their pin and resize from their corner handles, and no component applies the class anywhere. So the CSS rule (`pointer-events: auto; cursor: move`) can never take effect, and the pin's click-away dismiss handler was guarding against an element that can't appear in the DOM. Nothing behaves differently after this; it just stops describing a mode we don't have.

Noticed while moving this code around in #9794, where it didn't belong — that PR was a pure move.

### Change type

- [x] `other`

### Test plan

1. Open a region comment thread on the canvas.
2. Drag a corner handle to resize it — the thread stays open.
3. Click on empty canvas — the thread dismisses.
4. Drag the region's interior — nothing happens (it never did).

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -9    |
