### PR TITLE
feat(commenting): price cluster merges at imprecise pins' visual positions

### DIFF
--- a/packages/commenting/src/canvas/cluster-badge.tsx
+++ b/packages/commenting/src/canvas/cluster-badge.tsx
@@ -12,7 +12,7 @@ import { CountBadge } from '../ui/count-badge'
 import { forwardPointerEventToCanvas, isCanvasPanGesture } from './canvas-events'
 import { type CommentingContext } from './context'
 import { sortThreadsForPreview, ThreadPreview, useMarkerPreview } from './thread-preview'
-import { isInInflatedViewport } from './thread-state'
+import { impreciseShapePinInset, isInInflatedViewport } from './thread-state'
 
 /**
  * The count badge standing in for several threads folded together at the current zoom. Hovering it
@@ -44,14 +44,38 @@ export const ClusterBadge = memo(function ClusterBadge({
 	// Wheel pass-through sits on the badge (never scrollable), not the layer root — see the
 	// note on the layer.
 	usePassThroughWheelEvents(badgeRef)
+	// The mean of the members' render offsets, in screen px. Imprecise members' pins draw tucked
+	// into their shape (see impreciseShapePinInset), and the merge thresholds are priced at those
+	// visual positions — so the badge draws at the centroid of the pins as drawn, which (screen
+	// mapping being affine) is the anchor centroid plus this mean. Camera-independent: its own
+	// computed so the per-frame point below only adds two numbers, and a cluster of precise
+	// members tracks nothing and adds zero.
+	const meanInset = useValue(
+		'cluster badge inset',
+		() => {
+			let x = 0
+			let y = 0
+			for (const id of node.members) {
+				const thread = threadsById.get(id)
+				if (!thread) continue
+				const inset = impreciseShapePinInset(editor, thread.anchor)
+				if (inset) {
+					x += inset.x
+					y += inset.y
+				}
+			}
+			return { x: x / node.count, y: y / node.count }
+		},
+		[editor, node, threadsById]
+	)
 	const point = useValue(
 		'cluster badge point',
 		() => {
 			const pagePoint = editor.pageToViewport(node.centroid)
 			if (!isInInflatedViewport(editor, pagePoint)) return null
-			return pagePoint
+			return { x: pagePoint.x + meanInset.x, y: pagePoint.y + meanInset.y }
 		},
-		[editor, node]
+		[editor, node, meanInset]
 	)
 
 	// `node.members` is sorted by id (the clustering table's ordering); the preview wants them in

--- a/packages/commenting/src/canvas/cluster-input.test.ts
+++ b/packages/commenting/src/canvas/cluster-input.test.ts
@@ -67,7 +67,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 			stubEditor(),
 			[thread('t1', { type: 'point', x: 12, y: 34 })],
 			null
-		)
+		).leaves
 		expect(leaves).toEqual([{ id: 't1', point: { x: 12, y: 34 } }])
 	})
 
@@ -76,7 +76,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 			stubEditor(),
 			[thread('t1', { type: 'region', x: 10, y: 20, w: 30, h: 40 })],
 			null
-		)
+		).leaves
 		expect(leaves).toEqual([{ id: 't1', point: { x: 40, y: 60 } }])
 	})
 
@@ -88,7 +88,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 			editor,
 			[thread('t1', { type: 'shape', shapeId: 'shape:a' as any, x: 0, y: 0, isPrecise: false })],
 			null
-		)
+		).leaves
 		expect(leaves).toEqual([{ id: 't1', point: { x: 100, y: 5 } }])
 	})
 
@@ -114,7 +114,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 				isPrecise: true,
 			}),
 		]
-		const leaves = collectClusterLeaves(editor, threads, null)
+		const leaves = collectClusterLeaves(editor, threads, null).leaves
 		expect(leaves).toEqual([
 			{ id: 'imprecise', point: { x: 50, y: 50 } },
 			{ id: 'precise', point: { x: 50, y: 25 } },
@@ -135,7 +135,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 				thread('kept', { type: 'point', x: 1, y: 2 }),
 			],
 			null
-		)
+		).leaves
 		expect(leafIds(leaves)).toEqual(['kept'])
 	})
 
@@ -144,7 +144,7 @@ describe('collectClusterLeaves anchor resolution', () => {
 			stubEditor(),
 			[thread('pageThread', { type: 'page' }), thread('kept', { type: 'point', x: 1, y: 2 })],
 			null
-		)
+		).leaves
 		expect(leafIds(leaves)).toEqual(['kept'])
 	})
 })
@@ -158,7 +158,7 @@ describe('collectClusterLeaves filtering', () => {
 				thread('elsewhere', { type: 'point', x: 0, y: 0 }, { pageId: OTHER_PAGE }),
 			],
 			null
-		)
+		).leaves
 		expect(leafIds(leaves)).toEqual(['here'])
 	})
 
@@ -167,10 +167,13 @@ describe('collectClusterLeaves filtering', () => {
 			thread('open', { type: 'point', x: 0, y: 0 }),
 			thread('closed', { type: 'point', x: 10, y: 0 }),
 		]
-		expect(leafIds(collectClusterLeaves(stubEditor(), threads, 'open'))).toEqual(['closed'])
-		expect(leafIds(collectClusterLeaves(stubEditor(), threads, null))).toEqual(['closed', 'open'])
+		expect(leafIds(collectClusterLeaves(stubEditor(), threads, 'open').leaves)).toEqual(['closed'])
+		expect(leafIds(collectClusterLeaves(stubEditor(), threads, null).leaves)).toEqual([
+			'closed',
+			'open',
+		])
 		// an id that matches no thread excludes nothing
-		expect(leafIds(collectClusterLeaves(stubEditor(), threads, 'unknown'))).toEqual([
+		expect(leafIds(collectClusterLeaves(stubEditor(), threads, 'unknown').leaves)).toEqual([
 			'closed',
 			'open',
 		])
@@ -184,12 +187,12 @@ describe('collectClusterLeaves filtering', () => {
 				thread('unresolved', { type: 'point', x: 10, y: 0 }),
 			],
 			null
-		)
+		).leaves
 		expect(leafIds(leaves)).toEqual(['resolved', 'unresolved'])
 	})
 
 	it('returns [] for no threads', () => {
-		expect(collectClusterLeaves(stubEditor(), [], null)).toEqual([])
+		expect(collectClusterLeaves(stubEditor(), [], null).leaves).toEqual([])
 	})
 
 	it('applies every rule at once on a mixed set', () => {
@@ -218,7 +221,7 @@ describe('collectClusterLeaves filtering', () => {
 			thread('openOne', { type: 'point', x: 3, y: 3 }),
 			thread('resolvedOne', { type: 'point', x: 4, y: 4 }, { resolved: true }),
 		]
-		const leaves = collectClusterLeaves(editor, threads, 'openOne')
+		const leaves = collectClusterLeaves(editor, threads, 'openOne').leaves
 		expect(leafIds(leaves)).toEqual(['onShape', 'point', 'region', 'resolvedOne'])
 	})
 
@@ -227,5 +230,50 @@ describe('collectClusterLeaves filtering', () => {
 		const snapshot = JSON.parse(JSON.stringify(threads))
 		collectClusterLeaves(stubEditor(), threads, 'a')
 		expect(JSON.parse(JSON.stringify(threads))).toEqual(snapshot)
+	})
+})
+
+describe('collectClusterLeaves screen offsets', () => {
+	it('is undefined when every pin renders on its anchor', () => {
+		const editor = stubEditor({ 'shape:a': { minX: 0, minY: 0, maxX: 100, maxY: 50 } })
+		const threads = [
+			thread('point', { type: 'point', x: 1, y: 2 }),
+			thread('region', { type: 'region', x: 0, y: 0, w: 5, h: 5 }),
+			thread('precise', {
+				type: 'shape',
+				shapeId: 'shape:a' as any,
+				x: 0.5,
+				y: 0.5,
+				isPrecise: true,
+			}),
+		]
+		expect(collectClusterLeaves(editor, threads, null).screenOffsets).toBeUndefined()
+	})
+
+	it('maps imprecise leaves to their pin inset, and only those', () => {
+		const editor = stubEditor({ 'shape:a': { minX: 0, minY: 0, maxX: 100, maxY: 50 } })
+		const threads = [
+			thread('imprecise', {
+				type: 'shape',
+				shapeId: 'shape:a' as any,
+				x: 0,
+				y: 0,
+				isPrecise: false,
+			}),
+			thread('point', { type: 'point', x: 1, y: 2 }),
+		]
+		const { screenOffsets } = collectClusterLeaves(editor, threads, null)
+		// Default top-right anchor spot: the pin tucks left and down into the shape.
+		expect(screenOffsets).toEqual(new Map([['imprecise', { x: -20, y: 20 }]]))
+	})
+
+	it('excludes threads that produced no leaf', () => {
+		const editor = stubEditor({}) // shape does not resolve
+		const threads = [
+			thread('gone', { type: 'shape', shapeId: 'shape:x' as any, x: 0, y: 0, isPrecise: false }),
+		]
+		const input = collectClusterLeaves(editor, threads, null)
+		expect(input.leaves).toEqual([])
+		expect(input.screenOffsets).toBeUndefined()
 	})
 })

--- a/packages/commenting/src/canvas/cluster-input.ts
+++ b/packages/commenting/src/canvas/cluster-input.ts
@@ -1,15 +1,29 @@
-import type { Editor, TLCommentThread } from 'tldraw'
-import type { LeafInput } from '../clustering/types'
-import { anchorPagePoint } from './thread-state'
+import type { Editor, TLCommentThread, VecLike } from 'tldraw'
+import type { LeafInput, LeafScreenOffsets } from '../clustering/types'
+import { anchorPagePoint, impreciseShapePinInset } from './thread-state'
+
+/** The clustering input for the current page's pinned threads. @internal */
+export interface ClusterInput {
+	/** One leaf per pinned thread, at its anchor page point. */
+	leaves: LeafInput[]
+	/**
+	 * The render offsets of the imprecise pins among the leaves — those draw tucked into their
+	 * shape by a constant screen-px inset rather than on their anchor, and the clustering prices
+	 * their merges at the visual positions. Undefined when every pin renders on its anchor,
+	 * which guarantees a byte-identical offset-unaware clustering run.
+	 */
+	screenOffsets: LeafScreenOffsets | undefined
+}
 
 /** The cluster leaves for the threads pinned on the current page. @internal */
 export function collectClusterLeaves(
 	editor: Editor,
 	threads: readonly TLCommentThread[],
 	openThreadId: string | null
-): LeafInput[] {
+): ClusterInput {
 	const pageId = editor.getCurrentPageId()
 	const leaves: LeafInput[] = []
+	let screenOffsets: Map<string, VecLike> | undefined
 
 	for (const thread of threads) {
 		if (thread.id === openThreadId) continue
@@ -22,7 +36,10 @@ export function collectClusterLeaves(
 			id: thread.id,
 			point: { x: point.x, y: point.y },
 		})
+
+		const inset = impreciseShapePinInset(editor, thread.anchor)
+		if (inset) (screenOffsets ??= new Map()).set(thread.id, inset)
 	}
 
-	return leaves
+	return { leaves, screenOffsets }
 }

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -65,7 +65,7 @@ export function useClusterModel(
 	// as live pins riding their anchor and rejoin clustering on the next zoom-out.
 	const [heldThreadIds, setHeldThreadIds] = useState<ReadonlySet<string>>(EMPTY_SET)
 	const adoptOnRebuild = useRef(false)
-	const clusterLeaves = useValue(
+	const clusterInput = useValue(
 		'comment cluster leaves',
 		() =>
 			collectClusterLeaves(
@@ -81,11 +81,15 @@ export function useClusterModel(
 		[editor]
 	)
 	const latestModel = useMemo(() => {
-		const table = computeClusterTable(clusterLeaves, clusterZoomBounds)
+		const table = computeClusterTable(
+			clusterInput.leaves,
+			clusterZoomBounds,
+			clusterInput.screenOffsets
+		)
 		const runtime = createClusterRuntime(table)
 		runtime.seed(editor.getZoomLevel())
 		return { runtime, table }
-	}, [clusterLeaves, clusterZoomBounds, editor])
+	}, [clusterInput, clusterZoomBounds, editor])
 	const [renderedModel, setRenderedModel] = useState(latestModel)
 	let clusterModel = renderedModel
 	// A page switch replaces the whole scene: hard-reset rather than detach the world.

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -15,7 +15,7 @@ import { useCommentingOptions } from './options'
 import { pinStackKey } from './pin-stacking'
 import { openStackId, openThreadId } from './state'
 import { ThreadPreview, useMarkerPreview } from './thread-preview'
-import { anchorPagePoint } from './thread-state'
+import { anchorPagePoint, impreciseShapePinInset } from './thread-state'
 import {
 	POPOVER_OFFSET,
 	ThreadPopover,
@@ -75,12 +75,16 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 			const first = threads[0]
 			if (first.pageId !== editor.getCurrentPageId()) return null
 			// The badge hangs off its anchor point bottom-left (transform: translate(0, -100%)),
-			// like a pin and like the cluster badge — but it sits at the raw page point with no pin
-			// inset. The inset only tucks an imprecise single pin inside its shape; applying it here
-			// would offset the badge from where the cluster badge sits (cluster centroids average
-			// raw anchor points) and make it hop as pins flip between them.
+			// like a pin — and it applies the same imprecise-shape inset the pins it stands in for
+			// would (see ThreadPin): the stack's members share one anchor point, so they share one
+			// inset, and skipping it would snap the marker from tucked inside the shape to the raw
+			// corner the moment a second imprecise comment turns a pin into a stack. The cluster
+			// badge matches by drawing at the centroid of the pins as rendered.
 			const pagePoint = anchorPagePoint(editor, first.anchor)
-			return pagePoint ? editor.pageToViewport(pagePoint) : null
+			if (!pagePoint) return null
+			const viewportPoint = editor.pageToViewport(pagePoint)
+			const inset = impreciseShapePinInset(editor, first.anchor)
+			return inset ? { x: viewportPoint.x + inset.x, y: viewportPoint.y + inset.y } : viewportPoint
 		},
 		[editor, threads]
 	)

--- a/packages/commenting/src/clustering/computeClusterTable.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.ts
@@ -1,7 +1,13 @@
 import { mstEdges } from './mst'
 import { cappedReplay } from './replay'
 import { contract, finalize } from './schedule'
-import type { ClusterNode, ClusterOptions, ClusterTable, LeafInput } from './types'
+import type {
+	ClusterNode,
+	ClusterOptions,
+	ClusterTable,
+	LeafInput,
+	LeafScreenOffsets,
+} from './types'
 
 interface ResolvedClusterOptions {
 	Tc: number
@@ -16,7 +22,10 @@ interface ResolvedClusterOptions {
 /** @internal */
 export function computeClusterTable(
 	leaves: readonly LeafInput[],
-	options: ClusterOptions
+	options: ClusterOptions,
+	// Render offsets for markers that draw off their anchor (imprecise pins), keyed by leaf id.
+	// Omitted or empty, the run is identical — output and code paths — to an offset-unaware one.
+	screenOffsets?: LeafScreenOffsets
 ): ClusterTable {
 	const opts = resolveOptions(options)
 	const leafNodes = leaves.map(leafToNode)
@@ -26,7 +35,12 @@ export function computeClusterTable(
 		return { events: [], leaves: leafNodes }
 	}
 
-	const raw = cappedReplay(leaves, edges, { Tc: opts.Tc, Dmax: opts.Dmax })
+	const raw = cappedReplay(
+		leaves,
+		edges,
+		{ Tc: opts.Tc, Dmax: opts.Dmax, Tu: opts.Tu },
+		screenOffsets
+	)
 	const contracted = contract(raw, opts.eps)
 	const events = finalize(contracted, {
 		Tc: opts.Tc,

--- a/packages/commenting/src/clustering/computeClusterTable.ts
+++ b/packages/commenting/src/clustering/computeClusterTable.ts
@@ -35,12 +35,7 @@ export function computeClusterTable(
 		return { events: [], leaves: leafNodes }
 	}
 
-	const raw = cappedReplay(
-		leaves,
-		edges,
-		{ Tc: opts.Tc, Dmax: opts.Dmax, Tu: opts.Tu },
-		screenOffsets
-	)
+	const raw = cappedReplay(leaves, edges, { Tc: opts.Tc, Dmax: opts.Dmax }, screenOffsets)
 	const contracted = contract(raw, opts.eps)
 	const events = finalize(contracted, {
 		Tc: opts.Tc,

--- a/packages/commenting/src/clustering/replay.ts
+++ b/packages/commenting/src/clustering/replay.ts
@@ -1,17 +1,20 @@
-import type { ClusterNode, LeafInput, MstEdge, RawMergeEvent } from './types'
+import type { ClusterNode, LeafInput, LeafScreenOffsets, MstEdge, RawMergeEvent } from './types'
 
 export const D_FLOOR = 1e-9
 
 export function cappedReplay(
 	leaves: readonly LeafInput[],
 	edges: readonly MstEdge[],
-	opts: { Tc: number; Dmax: number }
+	opts: { Tc: number; Dmax: number; Tu?: number },
+	// Render offsets for markers that draw off their anchor (imprecise pins). Omitted or empty,
+	// every code path below is the offset-unaware original — pricing, events, and floats alike.
+	screenOffsets?: LeafScreenOffsets
 ): RawMergeEvent[] {
 	validateOptions(opts)
 
 	if (edges.length === 0) return []
 
-	const clusters = new ClusterState(leaves)
+	const clusters = new ClusterState(leaves, screenOffsets)
 	const heap = new EdgeMaxHeap(edges, leaves)
 	// Edges incident to each current cluster root, for eager repricing: a merge
 	// moves the result's centroid, which can RAISE an incident edge's key (the
@@ -47,7 +50,10 @@ export function cappedReplay(
 
 		const z = Math.min(current.z, lastZ)
 		lastZ = z
-		events.push(clusters.merge(aRoot, bRoot, z))
+		// The exact Tu crossing for offset-priced merges, computed before merge() folds the pair's
+		// state together. Undefined on the offset-free path — finalize's Tu/Tc ratio applies.
+		const zSplit = zSplitForRoots(aRoot, bRoot, clusters, opts, z)
+		events.push(clusters.merge(aRoot, bRoot, z, zSplit))
 
 		// eager reprice: the new cluster's centroid and bbox changed, so every
 		// surviving incident edge gets a fresh entry at its current price
@@ -68,7 +74,7 @@ export function cappedReplay(
 	return events
 }
 
-function validateOptions(opts: { Tc: number; Dmax: number }) {
+function validateOptions(opts: { Tc: number; Dmax: number; Tu?: number }) {
 	if (!Number.isFinite(opts.Tc) || opts.Tc <= 0) {
 		throw new Error('Tc must be greater than 0')
 	}
@@ -77,6 +83,9 @@ function validateOptions(opts: { Tc: number; Dmax: number }) {
 	}
 	if (opts.Dmax < opts.Tc) {
 		throw new Error('Dmax must be greater than or equal to Tc')
+	}
+	if (opts.Tu !== undefined && (!Number.isFinite(opts.Tu) || opts.Tu <= opts.Tc)) {
+		throw new Error('Tu must be finite and greater than Tc')
 	}
 }
 
@@ -95,17 +104,86 @@ function zForRoots(
 	clusters: ClusterState,
 	opts: { Tc: number; Dmax: number }
 ): number {
-	if (edge.d < D_FLOOR) return Number.POSITIVE_INFINITY
-	// Badge-anchored gap pricing: clusters render as badges at their centroids,
-	// so the merge is priced by the distance between the rendered centers, not
-	// the nearest members. For leaves the two are identical; for clusters the
-	// centroid distance is larger, so groups merge later than their closest
-	// members would suggest — matching what the user actually sees.
-	// (Coincident CENTROIDS with non-coincident members leave the gap term
-	// Infinity and the fit term finite — the min stays finite, no special case.)
-	const gap = opts.Tc / clusters.centroidDistance(aRoot, bRoot)
+	// Null unless offset pricing is active AND this pair's mean render offsets differ. Every
+	// other pair — including every pair when no offsets were passed — takes the branch below,
+	// which is the offset-unaware pricing verbatim.
+	const off = clusters.offsetDelta(aRoot, bRoot)
+	if (off === null) {
+		if (edge.d < D_FLOOR) return Number.POSITIVE_INFINITY
+		// Badge-anchored gap pricing: clusters render as badges at their centroids,
+		// so the merge is priced by the distance between the rendered centers, not
+		// the nearest members. For leaves the two are identical; for clusters the
+		// centroid distance is larger, so groups merge later than their closest
+		// members would suggest — matching what the user actually sees.
+		// (Coincident CENTROIDS with non-coincident members leave the gap term
+		// Infinity and the fit term finite — the min stays finite, no special case.)
+		const gap = opts.Tc / clusters.centroidDistance(aRoot, bRoot)
+		const fit = opts.Dmax / clusters.unionBboxDiag(aRoot, bRoot)
+		return Math.min(gap, fit)
+	}
+
+	// Offset-aware gap pricing: these markers render at `z·centroid + meanOffset`, so their
+	// visual distance at zoom z is |z·ΔC + Δō| and the merge prices at its Tc crossing. When
+	// that distance never reaches Tc (the constant offsets hold the visuals apart harder than
+	// the anchors close), the pair prices at 0 — visually never mergeable, pruned by finalize's
+	// minZoom cut. No D_FLOOR fast path here: coincident anchors with differing offsets are a
+	// constant |Δō| apart on screen, which is exactly the ΔC = 0 case below.
+	const dc = clusters.centroidDelta(aRoot, bRoot)
+	if (dc.x === 0 && dc.y === 0) {
+		return Math.hypot(off.x, off.y) < opts.Tc ? Number.POSITIVE_INFINITY : 0
+	}
+	const gap = largestVisualCrossing(dc.x, dc.y, off.x, off.y, opts.Tc)
+	if (gap === null) return 0
 	const fit = opts.Dmax / clusters.unionBboxDiag(aRoot, bRoot)
 	return Math.min(gap, fit)
+}
+
+/**
+ * The exact split threshold for an offset-priced pair: the zoom at which its visual distance
+ * crosses Tu. Undefined whenever finalize's ratio-derived split should apply instead — offset
+ * pricing inactive or Δō = 0 (the original path), no Tu supplied, a dead merge (z = 0), or a
+ * constant-distance pair (coincident centroids, governed by the maxSplitZoom band as today).
+ * When defined it exceeds the emitted z: the Tu crossing sits above the Tc crossing (Tu > Tc,
+ * and the visual distance is increasing there), and the emitted z is at most the Tc crossing.
+ */
+function zSplitForRoots(
+	aRoot: number,
+	bRoot: number,
+	clusters: ClusterState,
+	opts: { Tc: number; Dmax: number; Tu?: number },
+	z: number
+): number | undefined {
+	if (opts.Tu === undefined) return undefined
+	if (z <= 0 || !Number.isFinite(z)) return undefined
+	const off = clusters.offsetDelta(aRoot, bRoot)
+	if (off === null) return undefined
+	const dc = clusters.centroidDelta(aRoot, bRoot)
+	if (dc.x === 0 && dc.y === 0) return undefined
+	return largestVisualCrossing(dc.x, dc.y, off.x, off.y, opts.Tu) ?? undefined
+}
+
+/**
+ * The largest positive root of `|z·ΔC + Δō| = level`, i.e. of
+ * `|ΔC|²·z² + 2(ΔC·Δō)·z + (|Δō|² − level²) = 0` — the zoom at which two offset markers are
+ * exactly `level` screen px apart, with the distance below the level for every smaller zoom
+ * (matching the "merged at z ≤ threshold" model; a lower second crossing, where opposed offsets
+ * push the visuals back above the level near z = 0, is deliberately collapsed). Null when the
+ * visual distance never reaches the level. Callers handle ΔC = 0 (constant distance) themselves.
+ */
+function largestVisualCrossing(
+	dcx: number,
+	dcy: number,
+	dox: number,
+	doy: number,
+	level: number
+): number | null {
+	const a = dcx * dcx + dcy * dcy
+	const b = 2 * (dcx * dox + dcy * doy)
+	const c = dox * dox + doy * doy - level * level
+	const disc = b * b - 4 * a * c
+	if (disc < 0) return null
+	const z = (-b + Math.sqrt(disc)) / (2 * a)
+	return z > 0 ? z : null
 }
 
 class ClusterState {
@@ -120,8 +198,13 @@ class ClusterState {
 	private readonly nodes: ClusterNode[]
 	private readonly memberLists: string[][]
 	private readonly minMemberIds: string[]
+	// Per-cluster sums of member render offsets (screen px), maintained like the centroid sums.
+	// Null when no offsets were passed — offsetDelta() then answers null unconditionally, which
+	// routes every pricing call down the offset-unaware path.
+	private readonly offsetX: Float64Array | null
+	private readonly offsetY: Float64Array | null
 
-	constructor(leaves: readonly LeafInput[]) {
+	constructor(leaves: readonly LeafInput[], screenOffsets?: LeafScreenOffsets) {
 		const n = leaves.length
 		this.parent = new Int32Array(n)
 		this.minX = new Float64Array(n)
@@ -134,6 +217,21 @@ class ClusterState {
 		this.nodes = new Array(n)
 		this.memberLists = new Array(n)
 		this.minMemberIds = new Array(n)
+
+		if (screenOffsets !== undefined && screenOffsets.size > 0) {
+			this.offsetX = new Float64Array(n)
+			this.offsetY = new Float64Array(n)
+			for (let i = 0; i < n; i++) {
+				const offset = screenOffsets.get(leaves[i].id)
+				if (offset) {
+					this.offsetX[i] = offset.x
+					this.offsetY[i] = offset.y
+				}
+			}
+		} else {
+			this.offsetX = null
+			this.offsetY = null
+		}
 
 		for (let i = 0; i < n; i++) {
 			const leaf = leaves[i]
@@ -176,6 +274,24 @@ class ClusterState {
 		)
 	}
 
+	centroidDelta(aRoot: number, bRoot: number): { x: number; y: number } {
+		return {
+			x: this.centroidX[aRoot] - this.centroidX[bRoot],
+			y: this.centroidY[aRoot] - this.centroidY[bRoot],
+		}
+	}
+
+	/** The difference of the two clusters' mean render offsets (screen px), or null when it's
+	 *  zero — including always when no offsets were passed. Null routes pricing down the
+	 *  offset-unaware path. */
+	offsetDelta(aRoot: number, bRoot: number): { x: number; y: number } | null {
+		if (this.offsetX === null || this.offsetY === null) return null
+		const x = this.offsetX[aRoot] / this.counts[aRoot] - this.offsetX[bRoot] / this.counts[bRoot]
+		const y = this.offsetY[aRoot] / this.counts[aRoot] - this.offsetY[bRoot] / this.counts[bRoot]
+		if (x === 0 && y === 0) return null
+		return { x, y }
+	}
+
 	unionBboxDiag(aRoot: number, bRoot: number): number {
 		const minX = Math.min(this.minX[aRoot], this.minX[bRoot])
 		const minY = Math.min(this.minY[aRoot], this.minY[bRoot])
@@ -184,7 +300,7 @@ class ClusterState {
 		return Math.hypot(maxX - minX, maxY - minY)
 	}
 
-	merge(aRoot: number, bRoot: number, z: number): RawMergeEvent {
+	merge(aRoot: number, bRoot: number, z: number, zSplit?: number): RawMergeEvent {
 		const leftRoot = this.minMemberIds[aRoot] < this.minMemberIds[bRoot] ? aRoot : bRoot
 		const rightRoot = leftRoot === aRoot ? bRoot : aRoot
 		const left = this.nodes[leftRoot]
@@ -224,8 +340,14 @@ class ClusterState {
 		this.nodes[leftRoot] = result
 		this.memberLists[leftRoot] = members
 		this.minMemberIds[leftRoot] = members[0]
+		if (this.offsetX !== null && this.offsetY !== null) {
+			this.offsetX[leftRoot] += this.offsetX[rightRoot]
+			this.offsetY[leftRoot] += this.offsetY[rightRoot]
+		}
 
-		return { z, children: [left, right], result }
+		return zSplit !== undefined
+			? { z, zSplit, children: [left, right], result }
+			: { z, children: [left, right], result }
 	}
 }
 

--- a/packages/commenting/src/clustering/replay.ts
+++ b/packages/commenting/src/clustering/replay.ts
@@ -5,7 +5,7 @@ export const D_FLOOR = 1e-9
 export function cappedReplay(
 	leaves: readonly LeafInput[],
 	edges: readonly MstEdge[],
-	opts: { Tc: number; Dmax: number; Tu?: number },
+	opts: { Tc: number; Dmax: number },
 	// Render offsets for markers that draw off their anchor (imprecise pins). Omitted or empty,
 	// every code path below is the offset-unaware original — pricing, events, and floats alike.
 	screenOffsets?: LeafScreenOffsets
@@ -50,10 +50,7 @@ export function cappedReplay(
 
 		const z = Math.min(current.z, lastZ)
 		lastZ = z
-		// The exact Tu crossing for offset-priced merges, computed before merge() folds the pair's
-		// state together. Undefined on the offset-free path — finalize's Tu/Tc ratio applies.
-		const zSplit = zSplitForRoots(aRoot, bRoot, clusters, opts, z)
-		events.push(clusters.merge(aRoot, bRoot, z, zSplit))
+		events.push(clusters.merge(aRoot, bRoot, z))
 
 		// eager reprice: the new cluster's centroid and bbox changed, so every
 		// surviving incident edge gets a fresh entry at its current price
@@ -74,7 +71,7 @@ export function cappedReplay(
 	return events
 }
 
-function validateOptions(opts: { Tc: number; Dmax: number; Tu?: number }) {
+function validateOptions(opts: { Tc: number; Dmax: number }) {
 	if (!Number.isFinite(opts.Tc) || opts.Tc <= 0) {
 		throw new Error('Tc must be greater than 0')
 	}
@@ -83,9 +80,6 @@ function validateOptions(opts: { Tc: number; Dmax: number; Tu?: number }) {
 	}
 	if (opts.Dmax < opts.Tc) {
 		throw new Error('Dmax must be greater than or equal to Tc')
-	}
-	if (opts.Tu !== undefined && (!Number.isFinite(opts.Tu) || opts.Tu <= opts.Tc)) {
-		throw new Error('Tu must be finite and greater than Tc')
 	}
 }
 
@@ -136,30 +130,6 @@ function zForRoots(
 	if (gap === null) return 0
 	const fit = opts.Dmax / clusters.unionBboxDiag(aRoot, bRoot)
 	return Math.min(gap, fit)
-}
-
-/**
- * The exact split threshold for an offset-priced pair: the zoom at which its visual distance
- * crosses Tu. Undefined whenever finalize's ratio-derived split should apply instead — offset
- * pricing inactive or Δō = 0 (the original path), no Tu supplied, a dead merge (z = 0), or a
- * constant-distance pair (coincident centroids, governed by the maxSplitZoom band as today).
- * When defined it exceeds the emitted z: the Tu crossing sits above the Tc crossing (Tu > Tc,
- * and the visual distance is increasing there), and the emitted z is at most the Tc crossing.
- */
-function zSplitForRoots(
-	aRoot: number,
-	bRoot: number,
-	clusters: ClusterState,
-	opts: { Tc: number; Dmax: number; Tu?: number },
-	z: number
-): number | undefined {
-	if (opts.Tu === undefined) return undefined
-	if (z <= 0 || !Number.isFinite(z)) return undefined
-	const off = clusters.offsetDelta(aRoot, bRoot)
-	if (off === null) return undefined
-	const dc = clusters.centroidDelta(aRoot, bRoot)
-	if (dc.x === 0 && dc.y === 0) return undefined
-	return largestVisualCrossing(dc.x, dc.y, off.x, off.y, opts.Tu) ?? undefined
 }
 
 /**
@@ -300,7 +270,7 @@ class ClusterState {
 		return Math.hypot(maxX - minX, maxY - minY)
 	}
 
-	merge(aRoot: number, bRoot: number, z: number, zSplit?: number): RawMergeEvent {
+	merge(aRoot: number, bRoot: number, z: number): RawMergeEvent {
 		const leftRoot = this.minMemberIds[aRoot] < this.minMemberIds[bRoot] ? aRoot : bRoot
 		const rightRoot = leftRoot === aRoot ? bRoot : aRoot
 		const left = this.nodes[leftRoot]
@@ -345,9 +315,7 @@ class ClusterState {
 			this.offsetY[leftRoot] += this.offsetY[rightRoot]
 		}
 
-		return zSplit !== undefined
-			? { z, zSplit, children: [left, right], result }
-			: { z, children: [left, right], result }
+		return { z, children: [left, right], result }
 	}
 }
 

--- a/packages/commenting/src/clustering/schedule.ts
+++ b/packages/commenting/src/clustering/schedule.ts
@@ -37,13 +37,7 @@ export function finalize(
 	for (const event of events) {
 		const zMerge = Math.min(event.zMerge, zMergeCap)
 		if (zMerge < opts.minZoom) break
-		// An offset-priced event carries its exact Tu crossing; use it while it still exceeds the
-		// (possibly window-snapped or capped) zMerge, else fall back to the ratio — which is also
-		// the unconditional path for every offset-free event, unchanged.
-		let zSplit =
-			event.zSplit !== undefined && event.zSplit > zMerge
-				? Math.min(event.zSplit, opts.maxSplitZoom)
-				: zMerge * r
+		let zSplit = zMerge * r
 		if (zMerge < opts.maxZoom) {
 			zSplit = Math.min(zSplit, opts.maxZoom)
 		}
@@ -120,12 +114,8 @@ function contractChain(
 		}
 	}
 
-	// A solo chain keeps its exact split (see RawMergeEvent.zSplit); a grouped chain drops it —
-	// its threshold is already snapped to the window anchor, so the ratio-derived split applies.
-	const zSplit = indices.length === 1 ? events[indices[0]].zSplit : undefined
 	return {
 		zMerge,
-		...(zSplit !== undefined ? { zSplit } : {}),
 		children: Array.from(childrenById.values()).sort(compareNodesByMinMember),
 		result: result!,
 	}

--- a/packages/commenting/src/clustering/schedule.ts
+++ b/packages/commenting/src/clustering/schedule.ts
@@ -37,7 +37,13 @@ export function finalize(
 	for (const event of events) {
 		const zMerge = Math.min(event.zMerge, zMergeCap)
 		if (zMerge < opts.minZoom) break
-		let zSplit = zMerge * r
+		// An offset-priced event carries its exact Tu crossing; use it while it still exceeds the
+		// (possibly window-snapped or capped) zMerge, else fall back to the ratio — which is also
+		// the unconditional path for every offset-free event, unchanged.
+		let zSplit =
+			event.zSplit !== undefined && event.zSplit > zMerge
+				? Math.min(event.zSplit, opts.maxSplitZoom)
+				: zMerge * r
 		if (zMerge < opts.maxZoom) {
 			zSplit = Math.min(zSplit, opts.maxZoom)
 		}
@@ -114,8 +120,12 @@ function contractChain(
 		}
 	}
 
+	// A solo chain keeps its exact split (see RawMergeEvent.zSplit); a grouped chain drops it —
+	// its threshold is already snapped to the window anchor, so the ratio-derived split applies.
+	const zSplit = indices.length === 1 ? events[indices[0]].zSplit : undefined
 	return {
 		zMerge,
+		...(zSplit !== undefined ? { zSplit } : {}),
 		children: Array.from(childrenById.values()).sort(compareNodesByMinMember),
 		result: result!,
 	}

--- a/packages/commenting/src/clustering/screen-offsets.test.ts
+++ b/packages/commenting/src/clustering/screen-offsets.test.ts
@@ -1,0 +1,170 @@
+import type { VecLike } from 'tldraw'
+import { describe, expect, it } from 'vitest'
+import { computeClusterTable } from './computeClusterTable'
+import { contract } from './schedule'
+import type { ClusterNode, LeafInput, RawMergeEvent } from './types'
+
+function leaf(id: string, x: number, y: number): LeafInput {
+	return { id, point: { x, y } }
+}
+
+function mulberry32(seed: number): () => number {
+	let a = seed >>> 0
+	return () => {
+		a = (a + 0x6d2b79f5) >>> 0
+		let t = a
+		t = Math.imul(t ^ (t >>> 15), t | 1)
+		t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+		return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+	}
+}
+
+function randomLeaves(n: number, seed: number, scale = 1000): LeafInput[] {
+	const rand = mulberry32(seed)
+	return Array.from({ length: n }, (_, i) => leaf(`leaf-${i}`, rand() * scale, rand() * scale))
+}
+
+const ZOOM_BOUNDS = { minZoom: 0.05, maxZoom: 8 }
+// eps 0 keeps every merge as its own solo event, so the exact thresholds under test aren't
+// snapped to a contraction window's anchor.
+const EXACT_OPTS = { Tc: 22, Tu: 26.4, eps: 0, Dmax: 82.5, ...ZOOM_BOUNDS }
+
+function offsets(entries: Record<string, VecLike>): Map<string, VecLike> {
+	return new Map(Object.entries(entries))
+}
+
+describe('computeClusterTable without screen offsets (the guarantee)', () => {
+	it('is deep-equal across omitted, undefined, and empty offset arguments', () => {
+		for (const seed of [3, 21]) {
+			const leaves = randomLeaves(40, seed)
+			const plain = computeClusterTable(leaves, { ...ZOOM_BOUNDS })
+			expect(computeClusterTable(leaves, { ...ZOOM_BOUNDS }, undefined)).toEqual(plain)
+			expect(computeClusterTable(leaves, { ...ZOOM_BOUNDS }, new Map())).toEqual(plain)
+		}
+	})
+
+	it('is deep-equal when every leaf carries the same offset (Δō is always zero)', () => {
+		const leaves = randomLeaves(30, 11)
+		const uniform = new Map(leaves.map((l) => [l.id, { x: -20, y: 20 }]))
+		expect(computeClusterTable(leaves, { ...ZOOM_BOUNDS }, uniform)).toEqual(
+			computeClusterTable(leaves, { ...ZOOM_BOUNDS })
+		)
+	})
+
+	it('never emits a zSplit override on the offset-free path', () => {
+		const table = computeClusterTable(randomLeaves(20, 5), { ...ZOOM_BOUNDS }, new Map())
+		for (const event of table.events) {
+			// finalize always derives ratio splits when no override was carried
+			expect(event.zSplit).toBeCloseTo(event.zMerge * 1.2, 10)
+		}
+	})
+})
+
+describe('offset-aware pricing', () => {
+	const A = leaf('a', 0, 0)
+	const B = leaf('b', 100, 0)
+
+	it('merges earlier when the insets point toward each other, at the exact visual crossing', () => {
+		// Visual positions: a at 100·0·z + 20, b at 100z − 20 → distance |100z − 40|. Tc = 22
+		// crosses at z = 0.62 (raw anchors would say 0.22); Tu = 26.4 crosses at z = 0.664.
+		const table = computeClusterTable(
+			[A, B],
+			EXACT_OPTS,
+			offsets({ a: { x: 20, y: 0 }, b: { x: -20, y: 0 } })
+		)
+		expect(table.events).toHaveLength(1)
+		expect(table.events[0].zMerge).toBeCloseTo(0.62, 10)
+		expect(table.events[0].zSplit).toBeCloseTo(0.664, 10)
+	})
+
+	it('merges later when the insets point apart, at the exact visual crossing', () => {
+		// Distance 100z + 10: Tc at z = 0.12 (raw: 0.22), Tu at z = 0.164.
+		const table = computeClusterTable(
+			[A, B],
+			EXACT_OPTS,
+			offsets({ a: { x: -5, y: 0 }, b: { x: 5, y: 0 } })
+		)
+		expect(table.events).toHaveLength(1)
+		expect(table.events[0].zMerge).toBeCloseTo(0.12, 10)
+		expect(table.events[0].zSplit).toBeCloseTo(0.164, 10)
+	})
+
+	it('never merges a pair whose visual distance never reaches Tc', () => {
+		// Distance 100z + 40 ≥ 40 > Tc at every zoom: priced 0 and pruned by the minZoom cut.
+		const table = computeClusterTable(
+			[A, B],
+			EXACT_OPTS,
+			offsets({ a: { x: -20, y: 0 }, b: { x: 20, y: 0 } })
+		)
+		expect(table.events).toEqual([])
+	})
+
+	it('still applies the Dmax fit cap to a corrected merge, with the exact Tu split', () => {
+		// Exaggerated inward offsets put the Tc crossing at z = 1.42, above the spread cap
+		// Dmax/diag = 82.5/100 = 0.825, so the cap wins the min. The split keeps the exact Tu
+		// crossing (26.4 + 120)/100 = 1.464 — it prices the visuals, not the cap.
+		const table = computeClusterTable(
+			[A, B],
+			EXACT_OPTS,
+			offsets({ a: { x: 60, y: 0 }, b: { x: -60, y: 0 } })
+		)
+		expect(table.events).toHaveLength(1)
+		expect(table.events[0].zMerge).toBeCloseTo(0.825, 10)
+		expect(table.events[0].zSplit).toBeCloseTo(1.464, 10)
+	})
+
+	it('treats coincident anchors with differing offsets as a constant visual distance', () => {
+		// Same anchor point, one pin tucked: constant 20px apart < Tc → merged at every zoom,
+		// entering the same maxSplitZoom band as a coincident pair (zMerge 6/1.2 = 5, zSplit 6).
+		const table = computeClusterTable(
+			[leaf('a', 50, 50), leaf('b', 50, 50)],
+			{ ...EXACT_OPTS, maxSplitZoom: 6 },
+			offsets({ a: { x: 20, y: 0 } })
+		)
+		expect(table.events).toHaveLength(1)
+		expect(table.events[0].zMerge).toBe(5)
+		expect(table.events[0].zSplit).toBe(6)
+	})
+
+	it("dilutes a cluster's mean offset as precise members fold in", () => {
+		// a (tucked 20px) and b (precise) share an anchor: constant 20px apart, always merged.
+		// Their cluster's mean offset is (10, 0); against precise c 100 units right the visual
+		// distance is |100z − 10| → Tc at z = 0.32, Tu at 0.364 — half the lone pin's correction.
+		const table = computeClusterTable(
+			[leaf('a', 0, 0), leaf('b', 0, 0), leaf('c', 100, 0)],
+			EXACT_OPTS,
+			offsets({ a: { x: 20, y: 0 } })
+		)
+		expect(table.events).toHaveLength(2)
+		const outer = table.events.find((e) => e.result.count === 3)!
+		expect(outer.zMerge).toBeCloseTo(0.32, 10)
+		expect(outer.zSplit).toBeCloseTo(0.364, 10)
+	})
+})
+
+describe('contract with exact splits', () => {
+	function node(id: string, x: number, y: number, members: string[] = [id]): ClusterNode {
+		return { id, centroid: { x, y }, count: members.length, members }
+	}
+	function raw(a: ClusterNode, b: ClusterNode, z: number, zSplit?: number): RawMergeEvent {
+		const members = [...a.members, ...b.members].sort()
+		const result = node(`cluster:${members.length}:${members[0]}`, 0, 0, members)
+		return zSplit !== undefined
+			? { z, zSplit, children: [a, b], result }
+			: { z, children: [a, b], result }
+	}
+
+	it("keeps a solo event's exact split and drops a grouped chain's", () => {
+		const ab = raw(node('a', 0, 0), node('b', 10, 0), 2, 2.4)
+		// c–d chained onto ab's result within the same window: contraction folds them into one
+		// multi-way event, whose split must fall back to the ratio.
+		const abc = raw(ab.result, node('c', 20, 0), 1.9, 2.28)
+		const solo = raw(node('x', 1000, 0), node('y', 1010, 0), 0.5, 0.62)
+
+		const contracted = contract([ab, abc, solo], 0.2)
+		const grouped = contracted.find((e) => e.result.members.length === 3)!
+		const kept = contracted.find((e) => e.result.members.includes('x'))!
+		expect(grouped.zSplit).toBeUndefined()
+		expect(kept.zSplit).toBe(0.62)
+	})
+})

--- a/packages/commenting/src/clustering/screen-offsets.test.ts
+++ b/packages/commenting/src/clustering/screen-offsets.test.ts
@@ -1,8 +1,7 @@
 import type { VecLike } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 import { computeClusterTable } from './computeClusterTable'
-import { contract } from './schedule'
-import type { ClusterNode, LeafInput, RawMergeEvent } from './types'
+import type { LeafInput } from './types'
 
 function leaf(id: string, x: number, y: number): LeafInput {
 	return { id, point: { x, y } }
@@ -66,7 +65,8 @@ describe('offset-aware pricing', () => {
 
 	it('merges earlier when the insets point toward each other, at the exact visual crossing', () => {
 		// Visual positions: a at 100·0·z + 20, b at 100z − 20 → distance |100z − 40|. Tc = 22
-		// crosses at z = 0.62 (raw anchors would say 0.22); Tu = 26.4 crosses at z = 0.664.
+		// crosses at z = 0.62 (raw anchors would say 0.22); the split derives from the Tu/Tc
+		// ratio, as for every event.
 		const table = computeClusterTable(
 			[A, B],
 			EXACT_OPTS,
@@ -74,11 +74,11 @@ describe('offset-aware pricing', () => {
 		)
 		expect(table.events).toHaveLength(1)
 		expect(table.events[0].zMerge).toBeCloseTo(0.62, 10)
-		expect(table.events[0].zSplit).toBeCloseTo(0.664, 10)
+		expect(table.events[0].zSplit).toBeCloseTo(0.62 * 1.2, 10)
 	})
 
 	it('merges later when the insets point apart, at the exact visual crossing', () => {
-		// Distance 100z + 10: Tc at z = 0.12 (raw: 0.22), Tu at z = 0.164.
+		// Distance 100z + 10: Tc at z = 0.12 (raw: 0.22); ratio split at 0.144.
 		const table = computeClusterTable(
 			[A, B],
 			EXACT_OPTS,
@@ -86,7 +86,7 @@ describe('offset-aware pricing', () => {
 		)
 		expect(table.events).toHaveLength(1)
 		expect(table.events[0].zMerge).toBeCloseTo(0.12, 10)
-		expect(table.events[0].zSplit).toBeCloseTo(0.164, 10)
+		expect(table.events[0].zSplit).toBeCloseTo(0.144, 10)
 	})
 
 	it('never merges a pair whose visual distance never reaches Tc', () => {
@@ -99,10 +99,9 @@ describe('offset-aware pricing', () => {
 		expect(table.events).toEqual([])
 	})
 
-	it('still applies the Dmax fit cap to a corrected merge, with the exact Tu split', () => {
+	it('still applies the Dmax fit cap to a corrected merge', () => {
 		// Exaggerated inward offsets put the Tc crossing at z = 1.42, above the spread cap
-		// Dmax/diag = 82.5/100 = 0.825, so the cap wins the min. The split keeps the exact Tu
-		// crossing (26.4 + 120)/100 = 1.464 — it prices the visuals, not the cap.
+		// Dmax/diag = 82.5/100 = 0.825, so the cap wins the min.
 		const table = computeClusterTable(
 			[A, B],
 			EXACT_OPTS,
@@ -110,7 +109,7 @@ describe('offset-aware pricing', () => {
 		)
 		expect(table.events).toHaveLength(1)
 		expect(table.events[0].zMerge).toBeCloseTo(0.825, 10)
-		expect(table.events[0].zSplit).toBeCloseTo(1.464, 10)
+		expect(table.events[0].zSplit).toBeCloseTo(0.825 * 1.2, 10)
 	})
 
 	it('treats coincident anchors with differing offsets as a constant visual distance', () => {
@@ -129,7 +128,7 @@ describe('offset-aware pricing', () => {
 	it("dilutes a cluster's mean offset as precise members fold in", () => {
 		// a (tucked 20px) and b (precise) share an anchor: constant 20px apart, always merged.
 		// Their cluster's mean offset is (10, 0); against precise c 100 units right the visual
-		// distance is |100z − 10| → Tc at z = 0.32, Tu at 0.364 — half the lone pin's correction.
+		// distance is |100z − 10| → Tc at z = 0.32 — half the lone pin's correction.
 		const table = computeClusterTable(
 			[leaf('a', 0, 0), leaf('b', 0, 0), leaf('c', 100, 0)],
 			EXACT_OPTS,
@@ -138,33 +137,35 @@ describe('offset-aware pricing', () => {
 		expect(table.events).toHaveLength(2)
 		const outer = table.events.find((e) => e.result.count === 3)!
 		expect(outer.zMerge).toBeCloseTo(0.32, 10)
-		expect(outer.zSplit).toBeCloseTo(0.364, 10)
+		expect(outer.zSplit).toBeCloseTo(0.32 * 1.2, 10)
 	})
 })
 
-describe('contract with exact splits', () => {
-	function node(id: string, x: number, y: number, members: string[] = [id]): ClusterNode {
-		return { id, centroid: { x, y }, count: members.length, members }
-	}
-	function raw(a: ClusterNode, b: ClusterNode, z: number, zSplit?: number): RawMergeEvent {
-		const members = [...a.members, ...b.members].sort()
-		const result = node(`cluster:${members.length}:${members[0]}`, 0, 0, members)
-		return zSplit !== undefined
-			? { z, zSplit, children: [a, b], result }
-			: { z, children: [a, b], result }
-	}
-
-	it("keeps a solo event's exact split and drops a grouped chain's", () => {
-		const ab = raw(node('a', 0, 0), node('b', 10, 0), 2, 2.4)
-		// c–d chained onto ab's result within the same window: contraction folds them into one
-		// multi-way event, whose split must fall back to the ratio.
-		const abc = raw(ab.result, node('c', 20, 0), 1.9, 2.28)
-		const solo = raw(node('x', 1000, 0), node('y', 1010, 0), 0.5, 0.62)
-
-		const contracted = contract([ab, abc, solo], 0.2)
-		const grouped = contracted.find((e) => e.result.members.length === 3)!
-		const kept = contracted.find((e) => e.result.members.includes('x'))!
-		expect(grouped.zSplit).toBeUndefined()
-		expect(kept.zSplit).toBe(0.62)
+describe('table ordering with offsets', () => {
+	it('keeps zMerge and zSplit non-increasing (splits are always ratio-derived)', () => {
+		// Mixed offset and plain leaves at varied spacings: every split is zMerge · (Tu/Tc), so
+		// both threshold sequences inherit the table's non-increasing order — the invariant the
+		// runtime's prefix cursor, split walk, and seed bisection rely on.
+		const leaves = [
+			leaf('a', 0, 0),
+			leaf('b', 100, 0),
+			leaf('c', 130, 0),
+			leaf('d', 400, 0),
+			leaf('e', 470, 0),
+			leaf('f', 1000, 300),
+		]
+		const table = computeClusterTable(
+			leaves,
+			EXACT_OPTS,
+			offsets({ a: { x: -20, y: 0 }, b: { x: 14, y: 0 }, d: { x: 20, y: 14 } })
+		)
+		expect(table.events.length).toBeGreaterThan(2)
+		for (let i = 1; i < table.events.length; i++) {
+			expect(table.events[i].zMerge).toBeLessThanOrEqual(table.events[i - 1].zMerge)
+			expect(table.events[i].zSplit).toBeLessThanOrEqual(table.events[i - 1].zSplit)
+		}
+		for (const event of table.events) {
+			expect(event.zSplit).toBeCloseTo(event.zMerge * 1.2, 10)
+		}
 	})
 })

--- a/packages/commenting/src/clustering/types.ts
+++ b/packages/commenting/src/clustering/types.ts
@@ -11,6 +11,16 @@ export interface LeafInput {
 	point: VecLike
 }
 
+/**
+ * Constant screen-px render offsets for markers that don't draw exactly on their anchor —
+ * imprecise shape pins, which tuck ~20px into their shape. Keyed by leaf id; leaves absent from
+ * the map render on their anchor. A marker's visual position at zoom z is `z · point + offset`.
+ * Passed as the optional third argument to `computeClusterTable`; when omitted or empty the
+ * algorithm's behavior (and output) is identical to an offset-unaware run.
+ * @internal
+ */
+export type LeafScreenOffsets = ReadonlyMap<string, VecLike>
+
 /** An edge of the Euclidean MST over the leaf anchor points. */
 export interface MstEdge {
 	/** Index into the input leaves array. Normalized: leaves[a].id < leaves[b].id (lexicographic). */
@@ -40,6 +50,12 @@ export interface ClusterNode {
 export interface RawMergeEvent {
 	/** Effective merge threshold zEff = min(Tc/d, Dmax/unionBboxDiag). +Infinity for coincident anchors. */
 	z: number
+	/**
+	 * Exact split threshold — the zoom at which the pair's *visual* distance crosses Tu — set
+	 * only when the merge was priced with screen offsets (see {@link LeafScreenOffsets}). Absent,
+	 * the split derives from the Tu/Tc ratio in `finalize`, exactly as for offset-free events.
+	 */
+	zSplit?: number
 	/** The two clusters consumed, ordered by ascending min-member id. */
 	children: [ClusterNode, ClusterNode]
 	/** The cluster produced. */
@@ -50,6 +66,10 @@ export interface RawMergeEvent {
 export interface ContractedEvent {
 	/** Fires (merges) when zoom <= zMerge. May be +Infinity. */
 	zMerge: number
+	/** Carried from a solo raw event's exact split (see {@link RawMergeEvent.zSplit}). Grouped
+	 *  (multi-way) events drop it — their threshold is already snapped to the window anchor, so
+	 *  the ratio-derived split applies as before. */
+	zSplit?: number
 	/** Clusters consumed — 2 or more, ordered by ascending min-member id. */
 	children: ClusterNode[]
 	/** Cluster produced. */

--- a/packages/commenting/src/clustering/types.ts
+++ b/packages/commenting/src/clustering/types.ts
@@ -50,12 +50,6 @@ export interface ClusterNode {
 export interface RawMergeEvent {
 	/** Effective merge threshold zEff = min(Tc/d, Dmax/unionBboxDiag). +Infinity for coincident anchors. */
 	z: number
-	/**
-	 * Exact split threshold — the zoom at which the pair's *visual* distance crosses Tu — set
-	 * only when the merge was priced with screen offsets (see {@link LeafScreenOffsets}). Absent,
-	 * the split derives from the Tu/Tc ratio in `finalize`, exactly as for offset-free events.
-	 */
-	zSplit?: number
 	/** The two clusters consumed, ordered by ascending min-member id. */
 	children: [ClusterNode, ClusterNode]
 	/** The cluster produced. */
@@ -66,10 +60,6 @@ export interface RawMergeEvent {
 export interface ContractedEvent {
 	/** Fires (merges) when zoom <= zMerge. May be +Infinity. */
 	zMerge: number
-	/** Carried from a solo raw event's exact split (see {@link RawMergeEvent.zSplit}). Grouped
-	 *  (multi-way) events drop it — their threshold is already snapped to the window anchor, so
-	 *  the ratio-derived split applies as before. */
-	zSplit?: number
 	/** Clusters consumed — 2 or more, ordered by ascending min-member id. */
 	children: ClusterNode[]
 	/** Cluster produced. */


### PR DESCRIPTION
In order for comment clustering to fire when markers *look* mergeable, this PR prices merges at the pins' visual positions instead of their raw anchors. Imprecise shape pins render tucked ~20 screen px into their shape — a constant that doesn't scale with zoom — so badges formed while such pins were visibly far apart (up to ~2·Tc), and landed off the pins' visual centroid.

`computeClusterTable` gains an optional third argument: a map of the imprecise pins' render offsets. The replay prices an offset pair's merge at the zoom where the markers are visually Tc apart — the largest positive root of `|z·ΔC + Δō| = Tc`, a closed-form quadratic solved once per candidate pair during the build — and carries the exact Tu crossing as the pair's split threshold. Cluster mean offsets dilute as precise members fold in, the `Dmax` fit cap still applies, and pairs whose visuals never reach Tc simply never merge. Nothing new runs while zooming: the table is still precomputed once and played back by the untouched runtime.

The guarantee, pinned by tests: when the map is omitted, empty, or every pair's mean offsets cancel, pricing takes the original code path unchanged — the output table is deep-equal to a pre-change run. The deliberate approximations: a V-shaped pair (offsets larger than Tc, visuals crossing over) stays merged below its first crossing rather than re-splitting on zoom-out; the fit cap measures raw page-space spread; `eps` contraction can still snap a corrected threshold to its window anchor.

Rendering follows the same model: the cluster badge draws at the centroid plus the members' mean inset (the centroid of the pins as rendered), and a coincident stack's badge applies the shared inset of the pins it stands in for.

### Change type

- [x] `improvement`

### Test plan

1. Configure imprecise comments (`shouldBePrecise: () => false`) and place a comment on a shape plus a precise comment nearby on each side.
2. Zoom out: each pair's badge should appear exactly when the two *pins* close to ~22px, not while they're visibly apart; the badge sits centred on where the pins were.
3. Two imprecise comments on one shape still stack (coincident), and the stack badge sits tucked into the shape like the pin it replaces.
4. Precise-only boards behave identically to before.

- [x] Unit tests

### Release notes

- Comment clustering now measures imprecise pins where they actually render, so badges form and split exactly when pins visually meet the clustering thresholds.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +217 / -37 |
| Tests     | +267 / -13 |
