### PR TITLE
perf: low-priority follow-ups from the commenting performance review

### DIFF
--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -128,14 +128,18 @@ export function useClusterModel(
 	// Local partition maintenance — the only non-zoom visual change, and it is local by
 	// construction: any displayed leaf that has left the cluster input (deleted, thread opened,
 	// popped out above) is detached from its badge in place. The corrected rebuild is already
-	// sitting in latestModel awaiting the next zoom-out.
-	{
+	// sitting in latestModel awaiting the next zoom-out. When the rendered model IS the latest
+	// model (the common render) the leaf sets are identical by construction, so skip the scan.
+	if (clusterModel !== latestModel) {
 		const latestLeafIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
+		let removedLeafIds: string[] | null = null
 		for (const leaf of clusterModel.table.leaves) {
 			if (!latestLeafIds.has(leaf.id)) {
-				clusterModel.runtime.detachLeaf(leaf.id)
+				;(removedLeafIds ??= []).push(leaf.id)
 			}
 		}
+		// Batched: one patch rebuild and one version bump for the whole set.
+		if (removedLeafIds) clusterModel.runtime.detachLeaves(removedLeafIds)
 	}
 	// Moved pins rejoin clustering on the next zoom-out motion: clear the set (so the rebuild
 	// includes them again) and adopt that rebuild immediately instead of deferring it. Zooming in

--- a/packages/commenting/src/clustering/replay.ts
+++ b/packages/commenting/src/clustering/replay.ts
@@ -253,11 +253,29 @@ interface HeapEntry {
 
 class EdgeMaxHeap {
 	private readonly items: HeapEntry[] = []
+	// Per-edge normalized (lo, hi) id pair for the z tie-break, precomputed once so comparisons
+	// allocate nothing. With coincident anchors every edge prices to the same z (+Infinity), so
+	// the tie-break runs on nearly every comparison of a rebuild — allocating the pair there
+	// churned millions of short-lived tuples.
+	private readonly loIds: string[]
+	private readonly hiIds: string[]
 
-	constructor(
-		private readonly edges: readonly MstEdge[],
-		private readonly leaves: readonly LeafInput[]
-	) {}
+	constructor(edges: readonly MstEdge[], leaves: readonly LeafInput[]) {
+		const n = edges.length
+		this.loIds = new Array(n)
+		this.hiIds = new Array(n)
+		for (let i = 0; i < n; i++) {
+			const aId = leaves[edges[i].a].id
+			const bId = leaves[edges[i].b].id
+			if (aId < bId) {
+				this.loIds[i] = aId
+				this.hiIds[i] = bId
+			} else {
+				this.loIds[i] = bId
+				this.hiIds[i] = aId
+			}
+		}
+	}
 
 	peek(): HeapEntry | undefined {
 		return this.items[0]
@@ -282,7 +300,11 @@ class EdgeMaxHeap {
 	higherPriority(a: HeapEntry, b: HeapEntry): boolean {
 		if (a.z > b.z) return true
 		if (a.z < b.z) return false
-		return edgeIdPairLess(this.edges[a.edgeIndex], this.edges[b.edgeIndex], this.leaves)
+		// Tie-break on the normalized leaf-id pair, ascending.
+		const aLo = this.loIds[a.edgeIndex]
+		const bLo = this.loIds[b.edgeIndex]
+		if (aLo !== bLo) return aLo < bLo
+		return this.hiIds[a.edgeIndex] < this.hiIds[b.edgeIndex]
 	}
 
 	private siftUp(index: number) {
@@ -310,17 +332,4 @@ class EdgeMaxHeap {
 			index = best
 		}
 	}
-}
-
-function edgeIdPairLess(a: MstEdge, b: MstEdge, leaves: readonly LeafInput[]): boolean {
-	const [aLo, aHi] = normalizedEdgeIds(a, leaves)
-	const [bLo, bHi] = normalizedEdgeIds(b, leaves)
-	if (aLo !== bLo) return aLo < bLo
-	return aHi < bHi
-}
-
-function normalizedEdgeIds(edge: MstEdge, leaves: readonly LeafInput[]): [string, string] {
-	const aId = leaves[edge.a].id
-	const bId = leaves[edge.b].id
-	return aId < bId ? [aId, bId] : [bId, aId]
 }

--- a/packages/commenting/src/clustering/runtime.test.ts
+++ b/packages/commenting/src/clustering/runtime.test.ts
@@ -793,6 +793,56 @@ describe('createClusterRuntime detachLeaf (local partition edits)', () => {
 		expect(rt.getVisible().get(P.id)).toEqual(P)
 	})
 
+	it('detachLeaves batches a whole set into one version bump', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4) // P = a+b+c visible, d separate
+		const versionBefore = rt.version
+		rt.detachLeaves(['a', 'b'])
+		expect(rt.version).toBe(versionBefore + 1)
+		expect(rt.getDetachedCount()).toBe(2)
+		// P = {a,b,c} minus a,b → the leaf node c, keyed by its own id
+		expect(rt.getVisible().get('c')).toEqual(C)
+		expect(rt.getVisible().has(P.id)).toBe(false)
+		expect(visibleIds(rt)).toEqual(['c', 'd'])
+	})
+
+	it('detachLeaves matches the equivalent one-at-a-time detaches', () => {
+		const makeDetached = (detach: (rt: ReturnType<typeof createClusterRuntime>) => void) => {
+			const rt = createClusterRuntime(microTraceTable())
+			rt.seed(4)
+			detach(rt)
+			return rt
+		}
+		const batched = makeDetached((rt) => rt.detachLeaves(['a', 'd']))
+		const oneByOne = makeDetached((rt) => {
+			rt.detachLeaf('a')
+			rt.detachLeaf('d')
+		})
+		expect(visibleIds(batched)).toEqual(visibleIds(oneByOne))
+		for (const id of visibleIds(batched)) {
+			expect(batched.getVisible().get(id)).toEqual(oneByOne.getVisible().get(id))
+		}
+	})
+
+	it('detachLeaves skips unknown and already-detached ids, and no-ops on an empty batch', () => {
+		const table = microTraceTable()
+		const rt = createClusterRuntime(table)
+		rt.seed(4)
+		rt.detachLeaf('a')
+		const version = rt.version
+		const visible = rt.getVisible()
+		rt.detachLeaves([])
+		rt.detachLeaves(['a', 'nonexistent'])
+		expect(rt.version).toBe(version)
+		expect(rt.getDetachedCount()).toBe(1)
+		expect(rt.getVisible()).toBe(visible)
+		// a mixed batch still applies the new id in a single bump
+		rt.detachLeaves(['a', 'b', 'nonexistent'])
+		expect(rt.version).toBe(version + 1)
+		expect(rt.getDetachedCount()).toBe(2)
+	})
+
 	it('getVisible returns a stable reference until the partition changes', () => {
 		const table = microTraceTable()
 		const rt = createClusterRuntime(table)

--- a/packages/commenting/src/clustering/runtime.ts
+++ b/packages/commenting/src/clustering/runtime.ts
@@ -150,8 +150,11 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 		// guarantees a suppressed producer's zMerge is >= its consumer's, so anything the walk
 		// needs has already healed. Set iteration is insertion order (ascending index), so a
 		// healed event's suppressed children (larger zMerge, smaller index) heal before it.
+		// Iterated live (no snapshot copy): this runs on every zoom tick while carryover
+		// suppressions exist, and deleting only the entry currently being visited is safe —
+		// Set iteration still yields every remaining entry, in insertion order.
 		if (this.suppressed.size > 0) {
-			for (const i of [...this.suppressed]) {
+			for (const i of this.suppressed) {
 				if (zoom <= this.table.events[i].zMerge) {
 					this.suppressed.delete(i)
 					applyEvent(this.visible, this.table.events[i])

--- a/packages/commenting/src/clustering/runtime.ts
+++ b/packages/commenting/src/clustering/runtime.ts
@@ -38,6 +38,12 @@ export interface ClusterRuntime {
 	 * adopt it (with seedFrom) at the next zoom-out. Unknown or already-detached ids are no-ops.
 	 */
 	detachLeaf(leafId: string): void
+	/**
+	 * Batch form of {@link ClusterRuntime.detachLeaf}: detach every given leaf with a single
+	 * patch rebuild and a single version bump. Ids that are unknown or already detached are
+	 * skipped; if nothing new detaches, nothing changes.
+	 */
+	detachLeaves(leafIds: Iterable<string>): void
 	/** The displayed partition: cluster id → node, with detaches applied. Do not mutate. */
 	getVisible(): ReadonlyMap<string, ClusterNode>
 }
@@ -179,9 +185,19 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 	}
 
 	detachLeaf(leafId: string): void {
-		if (this.detached.has(leafId)) return
-		if (!this.getLeafById().has(leafId)) return
-		this.detached.add(leafId)
+		this.detachLeaves([leafId])
+	}
+
+	detachLeaves(leafIds: Iterable<string>): void {
+		const leafById = this.getLeafById()
+		let changed = false
+		for (const leafId of leafIds) {
+			if (this.detached.has(leafId)) continue
+			if (!leafById.has(leafId)) continue
+			this.detached.add(leafId)
+			changed = true
+		}
+		if (!changed) return
 		this.rebuildPatches()
 		this.version++
 	}

--- a/packages/editor/src/lib/components/LiveCollaborators.tsx
+++ b/packages/editor/src/lib/components/LiveCollaborators.tsx
@@ -1,4 +1,4 @@
-import { track, useQuickReactor } from '@tldraw/state-react'
+import { track, useQuickReactor, useValue } from '@tldraw/state-react'
 import { TLInstancePresence } from '@tldraw/tlschema'
 import { useLayoutEffect, useRef } from 'react'
 import { useEditorComponents } from '../hooks/EditorComponentsContext'
@@ -15,8 +15,11 @@ import { getHtmlLayerTransform } from '../utils/getHtmlLayerTransform'
  * (CollaboratorHintOverlayUtil), not this layer's.
  *
  * Cursors are DOM rather than canvas-drawn so their chrome styles and composes like the rest of
- * the UI; per-cursor positioning writes `transform` directly (see `useTransform`), so pointer- and
- * camera-frequency updates never re-render more than the moved cursor.
+ * the UI. Re-render traffic is kept narrow: per-cursor positioning writes `transform` directly
+ * (see `useTransform`), so a pointer move re-renders only the moved cursor; the camera transform
+ * is written imperatively below, so a pure pan re-renders only cursors whose viewport visibility
+ * flips (an equality-gated boolean per cursor); a zoom change re-renders every visible cursor,
+ * because each one rescales by `1/zoom`.
  *
  * @public @react
  */
@@ -76,15 +79,26 @@ const Collaborator = track(function Collaborator({
 	const editor = useEditor()
 	const { CollaboratorCursor } = useEditorComponents()
 
-	const zoomLevel = editor.getZoomLevel()
-	const viewportPageBounds = editor.getViewportPageBounds()
 	const { userId, chatMessage, userName, cursor, color } = latestPresence
+
+	// The viewport read lives inside this equality-gated computed rather than the tracked render:
+	// pans move the viewport every frame, but this component only needs to know when the cursor
+	// crosses the edge, so it subscribes to the boolean and re-renders only when it flips.
+	const cursorInViewport = useValue(
+		'cursor in viewport',
+		() =>
+			!!cursor && isCursorInViewport(cursor, editor.getViewportPageBounds(), editor.getZoomLevel()),
+		[editor, cursor]
+	)
+	// The zoom read is tracked directly: the cursor scales by 1/zoom, so zoom changes must
+	// re-render it. Pure pans leave the zoom value unchanged, so they never invalidate this.
+	const zoomLevel = editor.getZoomLevel()
 
 	if (!cursor) return null
 
 	// Off-viewport collaborators show as the canvas-drawn hint arrows
 	// (CollaboratorHintOverlayUtil), which shares this predicate — only the cursor itself is DOM.
-	if (!isCursorInViewport(cursor, viewportPageBounds, zoomLevel)) return null
+	if (!cursorInViewport) return null
 	if (!CollaboratorCursor) return null
 	return (
 		<CollaboratorCursor

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.test.ts
@@ -143,6 +143,24 @@ describe(CollaboratorsManager, () => {
 		expect(manager.getVisibleCollaborators()).toHaveLength(1)
 	})
 
+	it('keeps array identity when a presence update leaves the derived lists unchanged', () => {
+		const peerHere = createPresence(createUserId('peer-here'))
+		const peerElsewhere = createPresence(createUserId('peer-elsewhere'))
+		peerElsewhere.currentPageId = PageRecordType.createId('other-page')
+		const { editor } = createEditor([peerHere, peerElsewhere])
+		const manager = new CollaboratorsManager(editor)
+
+		const onPage = manager.getCollaboratorsOnCurrentPage()
+		const visibleOnPage = manager.getVisibleCollaboratorsOnCurrentPage()
+		expect(onPage).toEqual([peerHere])
+
+		// The off-page peer sends a presence update: the current-page lists are unaffected, so
+		// they keep the exact same array identity and don't invalidate downstream subscribers.
+		editor.store.put([{ ...peerElsewhere, chatMessage: 'hello from another page' }])
+		expect(manager.getCollaboratorsOnCurrentPage()).toBe(onPage)
+		expect(manager.getVisibleCollaboratorsOnCurrentPage()).toBe(visibleOnPage)
+	})
+
 	it('shows newly-joined collaborators that have not recorded any activity yet', () => {
 		// A peer who has joined but not moved their pointer broadcasts the default
 		// `lastActivityTimestamp` of 0. They should still be treated as active so

--- a/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
+++ b/packages/editor/src/lib/editor/managers/CollaboratorsManager/CollaboratorsManager.ts
@@ -1,6 +1,6 @@
 import { EMPTY_ARRAY, atom, computed } from '@tldraw/state'
 import type { TLInstancePresence } from '@tldraw/tlschema'
-import { maxBy } from '@tldraw/utils'
+import { areArraysShallowEqual, maxBy } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
 
 /**
@@ -41,11 +41,16 @@ export class CollaboratorsManager {
 		}))
 	}
 
+	// These queries all derive fresh arrays with map/filter, so they compare results with
+	// shallow (element-identity) equality: a presence update that leaves a derived list's
+	// elements unchanged — e.g. a peer moving on another page — keeps the previous array's
+	// identity and doesn't invalidate downstream subscribers such as the cursor layer.
+
 	/**
 	 * Returns a list of presence records for all peer collaborators.
 	 * This will return the latest presence record for each connected user.
 	 */
-	@computed
+	@computed({ isEqual: areArraysShallowEqual })
 	getCollaborators(): TLInstancePresence[] {
 		const allPresenceRecords = this._getCollaboratorsQuery().get()
 		if (!allPresenceRecords.length) return EMPTY_ARRAY
@@ -63,7 +68,7 @@ export class CollaboratorsManager {
 	 * Returns a list of presence records for all peer collaborators on the current page.
 	 * This will return the latest presence record for each connected user.
 	 */
-	@computed
+	@computed({ isEqual: areArraysShallowEqual })
 	getCollaboratorsOnCurrentPage(): TLInstancePresence[] {
 		const currentPageId = this.editor.getCurrentPageId()
 		return this.getCollaborators().filter((c) => c.currentPageId === currentPageId)
@@ -76,7 +81,7 @@ export class CollaboratorsManager {
 	 * highlighted users. Re-evaluates on the visibility clock, so callers don't need to
 	 * drive their own activity timer.
 	 */
-	@computed
+	@computed({ isEqual: areArraysShallowEqual })
 	getVisibleCollaborators(): TLInstancePresence[] {
 		const { editor } = this
 		const { collaboratorInactiveTimeoutMs, collaboratorIdleTimeoutMs } = editor.options
@@ -121,7 +126,7 @@ export class CollaboratorsManager {
 	 * Returns a list of presence records for peer collaborators who should currently be
 	 * shown in the UI, filtered to those on the current page.
 	 */
-	@computed
+	@computed({ isEqual: areArraysShallowEqual })
 	getVisibleCollaboratorsOnCurrentPage(): TLInstancePresence[] {
 		const currentPageId = this.editor.getCurrentPageId()
 		return this.getVisibleCollaborators().filter((c) => c.currentPageId === currentPageId)


### PR DESCRIPTION
A performance review of the commenting work (#9471) surfaced findings in three tiers; this PR is the low-priority tier (critical: #9806, medium: #9805). These are small allocation and re-render reductions on paths that are hot but cheap enough that they only matter at scale.

- Cluster runtime: leaf detachment is batched (`detachLeaves`) so bulk deletions do one patch rebuild and one version bump instead of one per leaf, the detach bookkeeping scan is skipped on the common render where the rendered model is already the latest model, and `onCamera` no longer copies the suppressed-event set on every zoom tick.
- Cluster replay: the heap tie-break precomputes its normalized edge-id pairs once per edge instead of allocating two tuples per comparison — degenerate inputs (many coincident anchors) previously caused millions of short-lived allocations per rebuild.
- Collaborator cursors (editor): the `CollaboratorsManager` list computeds now use shallow equality so presence updates that leave a derived list unchanged (for example a peer moving on another page) no longer invalidate the cursor layer, and each cursor's viewport-visibility check is an equality-gated boolean so pure pans only re-render a cursor when it crosses the viewport edge. The layer comment previously claimed this behavior; now the code matches it.

### Change type

- [x] `improvement`

### Test plan

1. In a multiplayer room, pan and zoom while collaborators move their cursors — cursors track and rescale as before, and appear or disappear at the viewport edge.
2. With clustered comment pins, bulk-delete several comments — badges update in one step.

- [x] Unit tests
