### PR TITLE
fix(commenting): keep comment surfaces inside the visible viewport

### DIFF
--- a/packages/commenting/src/canvas/canvas.css
+++ b/packages/commenting/src/canvas/canvas.css
@@ -403,11 +403,33 @@
 	transform: none;
 }
 
-/* The open thread's popover — portaled to the menus layer (above the UI), positioned at the pin. */
+/* The open thread's popover — portaled to the menus layer (above the UI), positioned at the pin.
+   `useViewportFit` supplies a `max-height` inline when the pin's spot leaves less room than the
+   panel wants (a phone screen, or a software keyboard covering the lower half). The flex column
+   hands that bound to the thread or stack inside, whose list then scrolls; `align-items` keeps
+   children at their own width rather than stretching them to the popover's. No `overflow: hidden`
+   here or on the thread, deliberately: the thread's action pill floats above the panel's top edge
+   and would be clipped by it, and the list is the only child that can outgrow the cap. */
 .tlui-cmt-canvas-popover {
 	position: absolute;
 	z-index: var(--tl-layer-menus);
 	pointer-events: auto;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+}
+/* A flex item won't shrink below its content unless told to, which is what the cap needs it to do. */
+.tlui-cmt-canvas-popover > * {
+	min-height: 0;
+}
+/* The part that scrolls: a thread's comments, or a stack's cards. Everything the thread panel
+   keeps outside its list — the header pill, the reply composer — stays put while they scroll,
+   the same split the comments sidebar uses. */
+.tlui-cmt-canvas-popover .tlui-cmt-thread__list,
+.tlui-cmt-canvas-popover .tlui-cmt-stack-list {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
 }
 
 /* The placement composer — a distinct floating view (portaled to the menus layer, below the click

--- a/packages/commenting/src/canvas/pending-composer.tsx
+++ b/packages/commenting/src/canvas/pending-composer.tsx
@@ -25,6 +25,7 @@ import { PendingComment } from './comment-tool'
 import { type CommentingContext } from './context'
 import { useCanComment, useCommentingOptions } from './options'
 import { pendingComment } from './state'
+import { useViewportFit } from './viewport-fit'
 
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
 
@@ -65,6 +66,10 @@ export function PendingComposer({
 		editor,
 		pending.point,
 	])
+	// Slide back on screen when the click point leaves no room for the composer — off the edge of a
+	// phone screen, or under the software keyboard the autofocus below raises. No `maxHeight`: the
+	// field grows with the draft and has nothing to scroll, so capping it would only clip the text.
+	const fit = useViewportFit(ref, point.x, point.y)
 
 	// Dismiss on a click anywhere outside the composer (capture-phase, ahead of stopPropagation).
 	useEffect(() => {
@@ -115,7 +120,7 @@ export function PendingComposer({
 				]
 					.filter(Boolean)
 					.join(' ')}
-				style={{ left: point.x, top: point.y }}
+				style={{ left: fit.left, top: fit.top }}
 				onPointerDown={stop}
 				onContextMenu={stop}
 				onKeyDown={(e) => {

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -399,10 +399,8 @@ export const ThreadPin = memo(function ThreadPin({
 			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
 				{open && (
 					<ThreadPopover
-						style={{
-							left: renderPoint.x + POPOVER_OFFSET.thread.x,
-							top: renderPoint.y + POPOVER_OFFSET.thread.y - THREAD_HEADER_BLOCK,
-						}}
+						left={renderPoint.x + POPOVER_OFFSET.thread.x}
+						top={renderPoint.y + POPOVER_OFFSET.thread.y - THREAD_HEADER_BLOCK}
 					>
 						<ThreadView editor={editor} thread={thread} {...props} />
 					</ThreadPopover>

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -186,10 +186,8 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 			)}
 			{open && (
 				<ThreadPopover
-					style={{
-						left: point.x + POPOVER_OFFSET.list.x,
-						top: point.y + POPOVER_OFFSET.list.y - liftForHeader,
-					}}
+					left={point.x + POPOVER_OFFSET.list.x}
+					top={point.y + POPOVER_OFFSET.list.y - liftForHeader}
 				>
 					<div className="tlui-cmt-stack-list">
 						{threads.map((thread) =>

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -1,13 +1,4 @@
-import {
-	memo,
-	ReactNode,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	type CSSProperties,
-} from 'react'
+import { memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
 	createComment,
 	Editor,
@@ -52,6 +43,7 @@ import { type CommentingContext } from './context'
 import { useThreadComments } from './hooks'
 import { type CommentingComponents, useCanComment, useCommentingOptions } from './options'
 import { openThreadId } from './state'
+import { useViewportFit } from './viewport-fit'
 
 const stop = (e: { stopPropagation(): void }) => e.stopPropagation()
 
@@ -162,10 +154,23 @@ export const POPOVER_OFFSET = {
 } as const
 
 /** The open thread's popover container, portaled above the UI panels. A wheel over it passes
- *  through to the canvas (unless it scrolls its own content), like tldraw's panels. */
-export function ThreadPopover({ style, children }: { style: CSSProperties; children: ReactNode }) {
+ *  through to the canvas (unless it scrolls its own content), like tldraw's panels.
+ *
+ *  `left`/`top` are where the popover wants to sit relative to its marker; {@link useViewportFit}
+ *  slides it back on screen and caps its height when that spot runs past the visible viewport —
+ *  off the edge of a phone screen, or under the software keyboard. */
+export function ThreadPopover({
+	left,
+	top,
+	children,
+}: {
+	left: number
+	top: number
+	children: ReactNode
+}) {
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
+	const fit = useViewportFit(ref, left, top)
 	return (
 		<EditorPortal>
 			{/* contextmenu also stops here: portals bubble React events to the canvas's context-menu
@@ -173,7 +178,7 @@ export function ThreadPopover({ style, children }: { style: CSSProperties; child
 			<div
 				ref={ref}
 				className="tlui-cmt-canvas-popover"
-				style={style}
+				style={fit}
 				onPointerDown={stop}
 				onContextMenu={stop}
 			>

--- a/packages/commenting/src/canvas/viewport-fit.test.ts
+++ b/packages/commenting/src/canvas/viewport-fit.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { fitInViewport } from './viewport-fit'
+
+/**
+ * A 300×400 surface in a 360×640 container flush with the top of the window — a phone, roughly.
+ * `shiftX`/`shiftY` are zero: the popover surfaces have no CSS transform, so their painted box is
+ * the box they're positioned at. The composer's case is covered separately below.
+ */
+const PHONE = {
+	width: 300,
+	height: 400,
+	shiftX: 0,
+	shiftY: 0,
+	containerTop: 0,
+	containerWidth: 360,
+}
+
+/** No keyboard: the visual viewport's bottom edge is the full window height. */
+const NO_KEYBOARD = 640
+
+/** A keyboard covering the lower 300px of that 640px window. */
+const KEYBOARD_UP = 340
+
+describe('fitInViewport', () => {
+	it('leaves a surface that already fits exactly where it was asked for', () => {
+		expect(fitInViewport(PHONE, NO_KEYBOARD, 30, 100)).toMatchObject({ left: 30, top: 100 })
+	})
+
+	it('slides a surface up off the bottom edge rather than letting it hang past it', () => {
+		// Asked for 400, which would end at 800 — 160px past the window.
+		expect(fitInViewport(PHONE, NO_KEYBOARD, 30, 400).top).toBe(640 - 8 - 400)
+	})
+
+	it('slides a surface in off the right edge', () => {
+		// Asked for 200, which would end at 500 in a 360-wide container.
+		expect(fitInViewport(PHONE, NO_KEYBOARD, 200, 100).left).toBe(360 - 300 - 8)
+	})
+
+	it('keeps a surface off the near edges too', () => {
+		expect(fitInViewport(PHONE, NO_KEYBOARD, -50, -50)).toMatchObject({ left: 8, top: 8 })
+	})
+
+	it('rides above the software keyboard', () => {
+		// The same anchor that needed no adjustment with the keyboard down now has to move: only
+		// 340px of window is visible, and the surface is 400 tall, so it caps and pins to the top.
+		const fit = fitInViewport(PHONE, KEYBOARD_UP, 30, 100)
+		expect(fit.maxHeight).toBe(340 - 8 - 8)
+		expect(fit.top).toBe(8)
+		expect(fit.top + fit.maxHeight).toBeLessThanOrEqual(KEYBOARD_UP)
+	})
+
+	it('caps to the visible height, not the window height, so a long thread scrolls', () => {
+		expect(fitInViewport(PHONE, NO_KEYBOARD, 30, 100).maxHeight).toBe(640 - 8 - 8)
+		expect(fitInViewport(PHONE, KEYBOARD_UP, 30, 100).maxHeight).toBe(340 - 8 - 8)
+	})
+
+	it('places a capped surface by the height it will have, not the height it wants', () => {
+		// 400 tall but capped to 200 by a 216px-tall visible strip: it should sit at the top of
+		// that strip, not be pushed up as though it were still 400 tall.
+		const fit = fitInViewport(PHONE, 216, 30, 100)
+		expect(fit.maxHeight).toBe(200)
+		expect(fit.top).toBe(8)
+	})
+
+	it('never caps below a usable minimum, however little room is left', () => {
+		expect(fitInViewport(PHONE, 0, 30, 100).maxHeight).toBe(120)
+	})
+
+	it('lets a surface too wide for its container overflow the far edge, not the near one', () => {
+		// The leading edge stays reachable — a panel clamped off the left is unusable.
+		const wide = { ...PHONE, width: 500 }
+		expect(fitInViewport(wide, NO_KEYBOARD, 30, 100).left).toBe(8)
+	})
+
+	// The placement composer hangs its draft pin on the click point with a CSS transform, so it
+	// paints 4px left of and 32px above the spot it is positioned at. It's the painted box that has
+	// to stay on screen, and `left`/`top` still have to come back in positioned-box terms.
+	const COMPOSER = { ...PHONE, height: 42, shiftX: -4, shiftY: -32 }
+
+	it('corrects for a painted box the CSS transform moved off the positioned one', () => {
+		const fit = fitInViewport(COMPOSER, KEYBOARD_UP, 200, 400)
+		// The painted box lands exactly on the margin, on both axes.
+		expect(fit.top + COMPOSER.shiftY + COMPOSER.height).toBe(KEYBOARD_UP - 8)
+		expect(fit.left + COMPOSER.shiftX + COMPOSER.width).toBe(360 - 8)
+	})
+
+	it('leaves a transformed surface alone where its painted box already fits', () => {
+		expect(fitInViewport(COMPOSER, KEYBOARD_UP, 30, 200)).toMatchObject({ left: 30, top: 200 })
+	})
+})

--- a/packages/commenting/src/canvas/viewport-fit.ts
+++ b/packages/commenting/src/canvas/viewport-fit.ts
@@ -1,0 +1,125 @@
+import { useLayoutEffect, useState, type RefObject } from 'react'
+import { clamp, useContainer, useViewportHeight } from 'tldraw'
+
+/** How close a floating comment surface may come to the edge of the visible viewport. */
+const VIEWPORT_MARGIN = 8
+
+/** Never cap a surface below this, however little room is left: a sliver is no more usable than an
+ *  overflowing panel, and it keeps the height a sane number in the degenerate cases (a container
+ *  scrolled off screen entirely, a keyboard covering all of a very short window). */
+const MIN_HEIGHT = 120
+
+/** What a surface's placement depends on besides the anchor: measured in the DOM, then held still
+ *  so that moving the camera is arithmetic rather than a layout read. */
+interface Metrics {
+	width: number
+	height: number
+	/** Where the painted box sits relative to the positioned one — see `measure` below. */
+	shiftX: number
+	shiftY: number
+	containerTop: number
+	containerWidth: number
+}
+
+function sameMetrics(a: Metrics, b: Metrics) {
+	return (
+		a.width === b.width &&
+		a.height === b.height &&
+		a.shiftX === b.shiftX &&
+		a.shiftY === b.shiftY &&
+		a.containerTop === b.containerTop &&
+		a.containerWidth === b.containerWidth
+	)
+}
+
+/**
+ * Keep a floating comment surface — an open thread, a coincident stack, the placement composer —
+ * inside the part of the screen the reader can actually see.
+ *
+ * These surfaces are placed at their pin, which on a phone puts them off the bottom or the right
+ * of the screen often enough, and under the software keyboard almost always. The keyboard is the
+ * hard half: it doesn't shrink the layout viewport, so neither `dvh` nor `window.innerHeight` can
+ * see it. {@link useViewportHeight} can — it tracks `visualViewport`, whose bottom edge rises with
+ * the keyboard — and that one number is the whole basis for this hook.
+ *
+ * Given the bottom edge the rest is arithmetic: slide the surface back inside the visible box, and
+ * cap its height so a long thread scrolls its comment list (see `canvas.css`) rather than running
+ * off the screen. Both are no-ops wherever the surface already fits, which is why there's no
+ * mobile/desktop split here — desktop placement is unchanged because desktop has the room, and a
+ * cramped desktop window gets the same treatment a phone does.
+ *
+ * @param ref - The surface being placed.
+ * @param left - Where it wants to sit, in container coordinates.
+ * @param top - Where it wants to sit, in container coordinates.
+ * @returns `left` and `top` to position it at, and a `maxHeight` for surfaces that can scroll.
+ */
+export function useViewportFit(ref: RefObject<HTMLElement | null>, left: number, top: number) {
+	const container = useContainer()
+	const viewportBottom = useViewportHeight()
+	const [metrics, setMetrics] = useState<Metrics | null>(null)
+
+	useLayoutEffect(() => {
+		const el = ref.current
+		if (!el) return
+
+		const measure = () => {
+			const containerRect = container.getBoundingClientRect()
+			const rect = el.getBoundingClientRect()
+			const next: Metrics = {
+				width: rect.width,
+				height: rect.height,
+				// A surface can hang off its anchor with a CSS transform (the composer does, to put
+				// its draft pin on the click point), so the box that has to stay on screen isn't
+				// the one `left`/`top` position. Measure the gap between the two and correct by it.
+				// `offsetLeft`/`offsetTop` are relative to `.tl-container`, which is the offset
+				// parent: the editor's portal host is `display: contents`.
+				shiftX: rect.left - containerRect.left - el.offsetLeft,
+				shiftY: rect.top - containerRect.top - el.offsetTop,
+				containerTop: containerRect.top,
+				containerWidth: containerRect.width,
+			}
+			setMetrics((prev) => (prev && sameMetrics(prev, next) ? prev : next))
+		}
+
+		measure()
+		// Re-measure when the surface grows (a reply lands, a draft wraps onto a second line) or
+		// when the editor is resized. Keyboard and pinch-zoom changes arrive via
+		// `useViewportHeight` instead, which re-runs the render-time maths below.
+		const observer = new ResizeObserver(measure)
+		observer.observe(el)
+		observer.observe(container)
+		return () => observer.disconnect()
+	}, [ref, container])
+
+	// Pure arithmetic on measurements already taken, so panning the camera — which moves
+	// `left`/`top` every frame — costs no DOM reads and re-runs no effects.
+	if (!metrics) return { left, top, maxHeight: undefined }
+	return fitInViewport(metrics, viewportBottom, left, top)
+}
+
+/**
+ * The placement maths behind {@link useViewportFit}, split out so it can be exercised without a
+ * layout engine.
+ *
+ * @internal
+ */
+export function fitInViewport(metrics: Metrics, viewportBottom: number, left: number, top: number) {
+	// The viewport bound is in client coordinates; these surfaces are positioned in the container's.
+	const bottom = viewportBottom - metrics.containerTop - VIEWPORT_MARGIN
+	const maxHeight = Math.max(MIN_HEIGHT, bottom - VIEWPORT_MARGIN)
+	// How tall the surface will be once the cap applies — the height that has to stay on screen.
+	const height = Math.min(metrics.height, maxHeight)
+	// Clamping in painted-box terms, then handing back a positioned-box `left`/`top`: hence the
+	// shift on both ends. `clamp` lets the minimum win when the two cross, which is what a surface
+	// wider or taller than the space it has should do — overflow off the far edge, not the near one,
+	// so its leading edge stays reachable.
+	return {
+		left: clamp(
+			left,
+			VIEWPORT_MARGIN - metrics.shiftX,
+			metrics.containerWidth - metrics.width - VIEWPORT_MARGIN - metrics.shiftX
+		),
+		top: clamp(top, VIEWPORT_MARGIN - metrics.shiftY, bottom - height - metrics.shiftY),
+		maxHeight,
+	}
+}

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -17,9 +17,15 @@ import {
 	useRef,
 	useState,
 } from 'react'
-import { isEqual, TLRichText, useMaybeEditor } from 'tldraw'
+import { isEqual, tlenv, TLRichText, useMaybeEditor } from 'tldraw'
 import { commentTipTapExtensions, EMPTY_COMMENT, isCommentEmpty } from './comment-extensions'
 import { SendButton } from './send-button'
+
+/** How far a touch may travel and still count as a tap rather than a drag or a scroll. */
+const TAP_SLOP = 10
+
+/** A gap this big between the layout and visual viewports means a software keyboard is up. */
+const KEYBOARD_MIN_HEIGHT = 100
 
 /** @public */
 export interface CommentComposerProps {
@@ -280,6 +286,45 @@ export function CommentComposer({
 		const raf = requestAnimationFrame(() => editor.commands.focus('end'))
 		return () => cancelAnimationFrame(raf)
 	}, [autoFocus, editor])
+
+	// iOS raises the software keyboard only on a focus *transition* inside a user gesture. The
+	// deferred autofocus above focuses the input outside one, so the keyboard stays down — and a
+	// tap on the already-focused input is then a no-op, no transition and no keyboard, leaving
+	// nowhere to type. Re-run the transition inside the tap itself: a synchronous blur + refocus
+	// within `touchend` reads as user-initiated and brings the keyboard up.
+	//
+	// Tightly gated, because the blur/refocus also discards the tap's caret placement: iOS only
+	// (elsewhere focus raises the keyboard on its own), stationary taps only (a selection-handle
+	// drag or a scroll ending over the input must not blur it), and only while the keyboard is
+	// actually down — an ordinary editing tap keeps its caret. That last one reads the gap between
+	// the layout and visual viewports, the same signal `useViewportFit` places surfaces by.
+	useEffect(() => {
+		const wrap = inputWrapRef.current
+		if (!wrap || !editor || !tlenv.isIos) return
+		let start: { x: number; y: number } | null = null
+		const onTouchStart = (e: TouchEvent) => {
+			const touch = e.touches[0]
+			start = touch ? { x: touch.clientX, y: touch.clientY } : null
+		}
+		const onTouchEnd = (e: TouchEvent) => {
+			const dom = editor.view?.dom
+			if (!dom || dom.ownerDocument.activeElement !== dom) return
+			const touch = e.changedTouches[0]
+			if (!start || !touch) return
+			if (Math.hypot(touch.clientX - start.x, touch.clientY - start.y) > TAP_SLOP) return
+			const win = dom.ownerDocument.defaultView ?? window
+			const vv = win.visualViewport
+			if (vv && win.innerHeight - vv.height > KEYBOARD_MIN_HEIGHT) return
+			dom.blur()
+			editor.commands.focus()
+		}
+		wrap.addEventListener('touchstart', onTouchStart)
+		wrap.addEventListener('touchend', onTouchEnd)
+		return () => {
+			wrap.removeEventListener('touchstart', onTouchStart)
+			wrap.removeEventListener('touchend', onTouchEnd)
+		}
+	}, [editor])
 
 	// The whole field behaves like the text input: clicking its empty area (the padding, or the
 	// space beside/below a short line) focuses the editor rather than only the text glyphs being


### PR DESCRIPTION
In order to make commenting usable on a phone — where thread popovers and the placement composer opened off the bottom or right of the screen, and almost always behind the software keyboard — this teaches all three floating comment surfaces to stay inside the part of the screen you can actually see.

This is a rework of #9765, which targets the same problem (and did the legwork of finding it). The difference is framing. That PR treats this as a *placement* problem: a mobile-mode gate, five candidate positions tried in turn around the pin, a stationary draft-pin marker, and a collapse-into-pin animation on send. This treats it as a *bounds* problem. `useViewportHeight` already returns `visualViewport.height + offsetTop` — the keyboard-aware bottom edge of the visible viewport — and once you have that edge, the whole thing is a clamp and a height cap.

The consequence worth reviewing is that **there is no mobile gate**. Clamping is a no-op wherever a surface already fits, so desktop placement is unchanged not because it's excluded but because desktop has the room — and a short or cramped desktop window now gets the same fix. That removes the need for `useIsMobileCommenting`, a hook in #9765 that called `useBreakpoint()` inside a `try/catch` so the commenting layer could still mount in hosts without tldraw's default UI. No breakpoint dependency, no provider requirement, no fallback path.

The height cap is what lets a long thread scroll: `.tlui-cmt-canvas-popover` becomes a flex column that hands its bound to the thread inside, whose comment list scrolls between a pinned header and a pinned reply composer — the same split the comments sidebar uses.

### Decisions worth a second opinion

- **Dropped the draft-pin marker and the collapse-into-pin animation.** These carried the messiest code in #9765 — direct DOM style mutation racing React's render, a `data-collapsing` flag to freeze the placement hook mid-animation, a timer, and a double-submit guard. Clamping keeps the composer as close to the tap point as the room allows, and the composer's leading element is already a draft pin. Straightforward to add back on top if we want the flourish.
- **Dropped the `padding: 16px; margin: -16px` scrollport hack.** #9765 added it so the hover-action pills wouldn't grow a horizontal scrollbar once the list became a scroll container. I measured `scrollWidth === clientWidth` with the list capped and scrolling, and the hover actions render inline inside the card — so there was nothing to suppress.
- **The composer gets no `maxHeight`.** Its field grows with the draft and has nothing to scroll, so a cap would only clip text.
- **`useViewportFit` measures the painted box, not the positioned one.** The composer hangs off its click point with a CSS transform, so the two differ. Rather than duplicate the transform as a JS constant (`ATTACHED_OFFSET` in #9765, which had to be re-derived when the pin size changed), the hook measures the gap and corrects for it generically.
- **Kept the iOS keyboard fix from #9765** (second commit), in its final tightly-gated form. It's orthogonal to placement, but without it the deferred autofocus leaves the keyboard down and taps on the already-focused input are no-ops — you can't type at all.

Relates to #9735. Based on `commenting-followups` (#9782).

### Change type

- [x] `improvement`

### Test plan

Verified in the examples app by shrinking `visualViewport` to simulate the keyboard:

1. Place a comment near the bottom of the screen, then simulate the keyboard: the composer rides up to sit just above it, and slides back down when it closes.
2. Open a thread near the right edge: it slides in to stay fully on screen.
3. Open a long thread with the keyboard up: the panel caps to the visible strip and its comment list scrolls, while the header and reply composer stay pinned.
4. On desktop, confirm popover and composer placement is byte-identical to before — a thread popover with room around it should still land at exactly its legacy offset.

- [x] Unit tests

### Release notes

- Keep comment threads and the comment composer on screen and above the software keyboard, and let long threads scroll.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +222 / -24 |
| Tests     | +90 / -0   |
