### PR TITLE
feat(dotcom): add a filter menu and pin rows to notifications

### DIFF
--- a/apps/dotcom/client/public/tla/locales-compiled/en.json
+++ b/apps/dotcom/client/public/tla/locales-compiled/en.json
@@ -179,6 +179,12 @@
       "value": "Export as"
     }
   ],
+  "14b03eeeb5": [
+    {
+      "type": 0,
+      "value": "Notification options"
+    }
+  ],
   "181b90f889": [
     {
       "type": 0,
@@ -467,6 +473,12 @@
     {
       "type": 0,
       "value": "Page menu"
+    }
+  ],
+  "53770fd374": [
+    {
+      "type": 0,
+      "value": "Unread"
     }
   ],
   "542248f0ba": [
@@ -1234,6 +1246,12 @@
     {
       "type": 0,
       "value": " replied"
+    }
+  ],
+  "b1c94ca2fb": [
+    {
+      "type": 0,
+      "value": "All"
     }
   ],
   "b2326c3a34": [

--- a/apps/dotcom/client/public/tla/locales/en.json
+++ b/apps/dotcom/client/public/tla/locales/en.json
@@ -68,6 +68,9 @@
   "13ddd375ad": {
     "translation": "Export as"
   },
+  "14b03eeeb5": {
+    "translation": "Notification options"
+  },
   "181b90f889": {
     "translation": "Create file"
   },
@@ -193,6 +196,9 @@
   },
   "517bb809d9": {
     "translation": "Page menu"
+  },
+  "53770fd374": {
+    "translation": "Unread"
   },
   "542248f0ba": {
     "translation": "This file is now read-only"
@@ -500,6 +506,9 @@
   },
   "b03400e2db": {
     "translation": "<name>{author}</name> replied"
+  },
+  "b1c94ca2fb": {
+    "translation": "All"
   },
   "b2326c3a34": {
     "translation": "Regenerate"

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/TlaSidebarNotificationsPanel.tsx
@@ -7,12 +7,26 @@ import {
 	richTextToPlaintext,
 	summarizeReactions,
 } from '@tldraw/commenting'
-import { ReactNode, useCallback } from 'react'
+import { ReactNode, useCallback, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { createDeepLinkString, TLRichText, useValue } from 'tldraw'
+import {
+	createDeepLinkString,
+	TldrawUiButton,
+	TldrawUiDropdownMenuContent,
+	TldrawUiDropdownMenuRoot,
+	TldrawUiDropdownMenuTrigger,
+	TldrawUiMenuCheckboxItem,
+	TldrawUiMenuContextProvider,
+	TldrawUiMenuGroup,
+	TldrawUiMenuItem,
+	TLRichText,
+	useValue,
+} from 'tldraw'
 import { routes } from '../../../../routeDefs'
 import { useMaybeApp } from '../../../hooks/useAppState'
 import { defineMessages, F, useMsg } from '../../../utils/i18n'
+import { TLA_MENU_POSITION } from '../../tla-menu/tla-menu'
+import { TlaIcon } from '../../TlaIcon/TlaIcon'
 import {
 	buildReactionNotifications,
 	categorizeCommentNotifications,
@@ -24,11 +38,16 @@ import styles from './notifications.module.css'
 
 const messages = defineMessages({
 	title: { defaultMessage: 'Notifications' },
+	moreOptions: { defaultMessage: 'Notification options' },
+	close: { defaultMessage: 'Close' },
+	filterAll: { defaultMessage: 'All' },
+	filterUnread: { defaultMessage: 'Unread' },
 	markAllRead: { defaultMessage: 'Mark all as read' },
 	empty: { defaultMessage: 'You’re all caught up.' },
 	unknownAuthor: { defaultMessage: 'Someone' },
-	untitledFile: { defaultMessage: 'Untitled file' },
 })
+
+type NotificationFilter = 'all' | 'unread'
 
 /** Byline for a notification row, phrased by why it's there. `<name>` wraps the author's name. */
 function ReasonByline({
@@ -101,6 +120,63 @@ function ReasonByline({
 	}
 }
 
+/** Uses the dotcom sidebar's menu primitives (not the canvas comment menus), so it renders without an editor. */
+function NotificationsOverflowMenu({
+	filter,
+	onFilterChange,
+	onMarkAllRead,
+	hasUnread,
+}: {
+	filter: NotificationFilter
+	onFilterChange(filter: NotificationFilter): void
+	onMarkAllRead(): void
+	hasUnread: boolean
+}) {
+	const moreLbl = useMsg(messages.moreOptions)
+	const allLbl = useMsg(messages.filterAll)
+	const unreadLbl = useMsg(messages.filterUnread)
+	const markAllReadLbl = useMsg(messages.markAllRead)
+
+	return (
+		<TldrawUiDropdownMenuRoot id="notifications-overflow">
+			<TldrawUiMenuContextProvider type="menu" sourceId="menu">
+				<TldrawUiDropdownMenuTrigger>
+					<TldrawUiButton type="icon" title={moreLbl} className="tlui-cmt-header-btn">
+						<TlaIcon icon="dots-vertical-strong" />
+					</TldrawUiButton>
+				</TldrawUiDropdownMenuTrigger>
+				<TldrawUiDropdownMenuContent side="bottom" align="end" {...TLA_MENU_POSITION}>
+					<TldrawUiMenuGroup id="notifications-filter">
+						<TldrawUiMenuCheckboxItem
+							id="filter-all"
+							label={allLbl}
+							checked={filter === 'all'}
+							onSelect={() => onFilterChange('all')}
+							readonlyOk
+						/>
+						<TldrawUiMenuCheckboxItem
+							id="filter-unread"
+							label={unreadLbl}
+							checked={filter === 'unread'}
+							onSelect={() => onFilterChange('unread')}
+							readonlyOk
+						/>
+					</TldrawUiMenuGroup>
+					<TldrawUiMenuGroup id="notifications-actions">
+						<TldrawUiMenuItem
+							id="mark-all-read"
+							label={markAllReadLbl}
+							onSelect={onMarkAllRead}
+							disabled={!hasUnread}
+							readonlyOk
+						/>
+					</TldrawUiMenuGroup>
+				</TldrawUiDropdownMenuContent>
+			</TldrawUiMenuContextProvider>
+		</TldrawUiDropdownMenuRoot>
+	)
+}
+
 /**
  * Comments and reactions surfaced as notifications, merged from the `comments` and `reactions`
  * synced queries and sorted by timestamp. {@link categorizeCommentNotifications} and
@@ -131,19 +207,21 @@ function commentLink(fileId: string, shapeId: string | null | undefined, comment
 
 /**
  * Notifications popover contents. Reuses the comments sidebar's list shell (header, scroll, empty)
- * but renders each row document-first — the file title leads, with who-commented and the comment
- * preview as supporting detail — since a notification is about a document, not a person.
+ * but renders each row person-first — an author-coloured pin and a name-led byline (who, and why
+ * you're being notified), the comment preview and any reaction pills beneath, and an unread dot.
  */
 export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 	const app = useMaybeApp()
 	const { notifications, unreadCount } = useCommentNotifications()
+	const [filter, setFilter] = useState<NotificationFilter>('all')
 	const title = useMsg(messages.title)
-	const markAllReadLbl = useMsg(messages.markAllRead)
+	const closeLbl = useMsg(messages.close)
 	const empty = useMsg(messages.empty)
 	const unknownAuthor = useMsg(messages.unknownAuthor)
-	const untitledFile = useMsg(messages.untitledFile)
 
-	const items: CommentListItemProps[] = notifications.map((n) => {
+	const visible = filter === 'unread' ? notifications.filter((n) => n.unread) : notifications
+
+	const items: CommentListItemProps[] = visible.map((n) => {
 		const c = n.comment
 		return {
 			id: c.id,
@@ -164,15 +242,22 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 				app?.userId,
 				(id) => c.reactions?.find((r) => r.userId === id)?.userName || undefined
 			),
-			// the document the comment lives on — the headline of the notification row
-			page: c.file?.name || untitledFile,
 			// a real link target, so browser affordances (ctrl/cmd-click, middle-click) open a new tab
 			href: commentLink(c.fileId, c.thread?.shapeId, c.id),
 		}
 	})
 
-	// Row id → its notification, so the byline can be phrased per reason and reactor count.
-	const notificationById = new Map(notifications.map((n) => [n.comment.id, n]))
+	// Row id → its notification, for the byline's reason/reactors and the unread dot.
+	const notificationById = new Map(visible.map((n) => [n.comment.id, n]))
+
+	const markAllRead = useCallback(() => {
+		if (!app) return
+		// one batched mutation rather than one markRead per comment. A reaction entry carries its
+		// own unread state (a fresh reaction re-unreads a read comment), so this filters on the
+		// entry rather than on the comment's receipt — and repeats are fine, since the mutator
+		// dedupes the batch.
+		app.markCommentsRead(notifications.filter((n) => n.unread).map((n) => n.comment.id))
+	}, [app, notifications])
 
 	const handleSelect = useCallback(
 		(id: string, isNewTab: boolean) => {
@@ -191,23 +276,22 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 				items={items}
 				header={title}
 				headerAction={
-					<button
-						type="button"
-						className={styles.markAll}
-						onClick={() => {
-							if (!app) return
-							// one batched mutation rather than one markRead per comment. A reaction entry
-							// carries its own unread state (a fresh reaction re-unreads a read comment),
-							// so this filters on the entry rather than on the comment's receipt — and
-							// repeats are fine, since the mutator dedupes the batch.
-							app.markCommentsRead(
-								notifications.filter((n) => n.unread).map((n) => n.comment.id)
-							)
-						}}
-						disabled={unreadCount === 0}
-					>
-						{markAllReadLbl}
-					</button>
+					<div className="tlui-cmt-list__header-actions">
+						<NotificationsOverflowMenu
+							filter={filter}
+							onFilterChange={setFilter}
+							onMarkAllRead={markAllRead}
+							hasUnread={unreadCount > 0}
+						/>
+						<TldrawUiButton
+							type="icon"
+							title={closeLbl}
+							className="tlui-cmt-header-btn"
+							onClick={onClose}
+						>
+							<TlaIcon icon="close" style={{ width: 12, height: 12 }} />
+						</TldrawUiButton>
+					</div>
 				}
 				empty={empty}
 				renderItem={(item) => {
@@ -221,24 +305,29 @@ export function TlaSidebarNotificationsPanel({ onClose }: { onClose(): void }) {
 							// middle-click opens the tab natively without firing onClick; still mark it read
 							onAuxClick={(e) => e.button === 1 && handleSelect(item.id, true)}
 						>
+							<span
+								className={styles.pin}
+								style={{ backgroundColor: item.author.color }}
+								aria-hidden="true"
+							/>
 							<div className="tlui-cmt-list__item-body">
 								<div className={styles.head}>
-									<span className={styles.docTitle}>{item.page}</span>
+									<span className={styles.byline}>
+										<ReasonByline
+											reason={n?.primaryReason ?? 'owned-board'}
+											author={item.author.name}
+											reactors={summarizeForeignReactors(n?.comment.reactions, app?.userId)}
+											nameClassName={styles.author}
+										/>
+									</span>
 									<span className={styles.time}>{formatRelativeTime(item.date)}</span>
-								</div>
-								<div className={styles.byline}>
-									<ReasonByline
-										reason={n?.primaryReason ?? 'owned-board'}
-										author={item.author.name}
-										reactors={summarizeForeignReactors(n?.comment.reactions, app?.userId)}
-										nameClassName={styles.author}
-									/>
 								</div>
 								<div className={styles.preview}>{item.preview}</div>
 								{item.reactions && (
 									<Reactions reactions={item.reactions} canReact={false} enableHoverList={false} />
 								)}
 							</div>
+							{n?.unread && <span className={styles.unreadDot} aria-hidden="true" />}
 						</Link>
 					)
 				}}

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/notifications.module.css
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/notifications.module.css
@@ -7,64 +7,35 @@
 	max-height: 60vh;
 }
 
-/* A small text action in the list header, alongside the uppercase title. */
-.markAll {
-	border: none;
-	background: none;
-	margin: 0;
-	padding: 4px 6px;
-	border-radius: 6px;
-	cursor: pointer;
-	font: inherit;
-	font-size: 11px;
-	color: var(--tl-color-selected);
+/* The author-coloured comment pin leading each row — the SDK pin silhouette (.tlui-cmt-pin),
+   filled solid rather than holding an avatar. Colour set inline from the author's colour. */
+.pin {
+	align-self: flex-start;
+	margin-top: 2px;
+	flex-shrink: 0;
+	width: 16px;
+	height: 16px;
+	border-radius: 50% 50% 50% 0;
+	background: var(--tl-color-text-3);
 }
 
-.markAll:hover:not(:disabled) {
-	background: var(--tl-color-muted-2);
-}
-
-.markAll:disabled {
-	color: var(--tl-color-text-3);
-	cursor: not-allowed;
-}
-
-/* Row IA: document title leads, with the byline and comment preview as supporting detail. */
 .head {
 	display: flex;
 	align-items: baseline;
-	justify-content: space-between;
 	gap: 8px;
 }
 
-.docTitle {
-	font-size: 13px;
-	font-weight: 600;
-	color: var(--tl-color-text-1);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.time {
-	flex-shrink: 0;
-	font-size: 11px;
-	color: var(--tl-color-text-3);
-}
-
+/* The headline: the name-led reason it's a notification, wrapping so it stays fully readable. */
 .byline {
-	margin-top: 2px;
-	font-size: 12px;
+	flex: 0 1 auto;
+	min-width: 0;
+	font-size: 13px;
 	color: var(--tl-color-text-3);
-	overflow: hidden;
-	display: -webkit-box;
-	-webkit-line-clamp: 2;
-	-webkit-box-orient: vertical;
 }
 
 .author {
-	font-weight: 500;
-	color: var(--tl-color-text-2);
+	font-weight: 600;
+	color: var(--tl-color-text-1);
 	/* a single absurd display name must not eat the row: ellipsize each name span */
 	display: inline-block;
 	max-width: 9em;
@@ -72,6 +43,12 @@
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	vertical-align: bottom;
+}
+
+.time {
+	flex-shrink: 0;
+	font-size: 11px;
+	color: var(--tl-color-text-3);
 }
 
 .preview {
@@ -83,6 +60,17 @@
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 	word-break: break-word;
+}
+
+/* Unread marker on a row — the same blue as the sidebar bell's badge, pinned top-right. */
+.unreadDot {
+	align-self: flex-start;
+	margin-top: 5px;
+	flex-shrink: 0;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background-color: var(--tl-color-selected);
 }
 
 /* Small dot on the sidebar bell when there are unread notifications. */


### PR DESCRIPTION
## What

Reworks the notifications panel (the sidebar bell popover), on top of the reaction-notifications work:

- A **⋯ overflow menu** in the header with an **All / Unread** filter and **Mark all as read**, replacing the bare "Mark all as read" text button.
- A **✕ close** button.
- Each row now leads with an **author-coloured comment pin** and a **name-led byline** ("Jessica Edwards mentioned you" / "Steve reacted to your comment"), with an **unread dot** for anything unopened.

Keeps the existing reaction notifications, `<Link>` rows (new-tab / middle-click), and batched mark-read.

## Preview

https://pr-9822-preview-deploy.tldraw.com/

## How to test

1. Open the preview and sign in.
2. Get some comment notifications — a mention, reply, or reaction on one of your boards.
3. Open the notifications bell in the sidebar.
4. In the **⋯** menu, switch between **All** and **Unread**, and try **Mark all as read** (disabled when nothing's unread).
5. Close the panel with **✕**.

No API report changes.
