### PR TITLE
feat(commenting): mobile-friendly composer and thread placement

### DIFF
--- a/apps/examples/src/examples/collaboration/commenting-mobile/CommentingMobileExample.tsx
+++ b/apps/examples/src/examples/collaboration/commenting-mobile/CommentingMobileExample.tsx
@@ -1,0 +1,82 @@
+import {
+	CanvasComments,
+	CommentAuthor,
+	CommentTool,
+	commentToolOverrides,
+	filterMentionMembers,
+	MentionMember,
+} from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useMemo } from 'react'
+import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldraw } from 'tldraw'
+import '@tldraw/commenting/commenting.css'
+import 'tldraw/tldraw.css'
+
+// A demo avatar image (inline SVG) so one author shows an image instead of a colored initial.
+const ADA_AVATAR =
+	'data:image/svg+xml,' +
+	encodeURIComponent(
+		`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 28 28"><rect width="28" height="28" fill="#0E9F6E"/><circle cx="14" cy="11" r="5" fill="#fff"/><ellipse cx="14" cy="24" rx="9" ry="7" fill="#fff"/></svg>`
+	)
+
+// The people who can be @-mentioned. A real app would pull this from its own roster; the composer
+// filters this list as you type after `@`. Ids match the author directory below.
+const MEMBERS: MentionMember[] = [
+	{ id: 'me', name: 'You', color: '#EC5E41', you: true },
+	{ id: 'ada', name: 'Ada Lovelace', color: '#0E9F6E', image: ADA_AVATAR },
+	{ id: 'grace', name: 'Grace Hopper', color: '#4465E9' },
+	{ id: 'alan', name: 'Alan Turing', color: '#9C1FBE' },
+]
+
+// A tiny local user directory so the flow shows names, colors, and images instead of ids. A real
+// app would resolve these from its own identity system.
+const AUTHORS: Record<string, CommentAuthor> = Object.fromEntries(MEMBERS.map((m) => [m.id, m]))
+const resolveAuthor = (id: string): CommentAuthor => AUTHORS[id] ?? { name: id }
+
+// Region comments are off by default (click-only). Configuring the tool with `enableRegions` lets
+// dragging the comment tool out create a comment anchored to a rectangular area.
+const COMMENT_TOOLS = [CommentTool.configure({ enableRegions: true })]
+
+export default function CommentingMobileExample() {
+	// Comments are stored as `comment-thread` and `comment` records in the editor's own store.
+	// Registering `commentSchemaRecords` on the schema is all it takes to persist and sync them
+	// alongside shapes — no separate backend, so the whole flow runs in-memory here.
+	const store = useMemo(
+		() => createTLStore({ schema: createTLSchema({ records: commentSchemaRecords }) }),
+		[]
+	)
+
+	// `CanvasComments` reads those records reactively and draws the pins, threads, and composer.
+	// Mounting it in front of the canvas is the entire UI layer.
+	const components = useMemo<TLComponents>(
+		() => ({
+			InFrontOfTheCanvas: () => (
+				<CanvasComments
+					currentUserId="me"
+					resolveAuthor={resolveAuthor}
+					getMentionSuggestions={(query) => filterMentionMembers(MEMBERS, query)}
+				/>
+			),
+		}),
+		[]
+	)
+
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				// `forceMobile` pins the mobile breakpoint on any screen size, so the mobile thread and
+				// composer placement is visible here on desktop. On a real device the same layout comes
+				// from the narrow viewport — the thread popover and composer position themselves against
+				// the visual viewport, riding up rather than hiding behind the software keyboard.
+				forceMobile
+				// Commenting is a licensed feature. Every feature is enabled in local development, but a
+				// deployed app needs a license key that includes commenting — swap in your own key here.
+				licenseKey={getLicenseKey()}
+				store={store}
+				tools={COMMENT_TOOLS}
+				overrides={[commentToolOverrides]}
+				components={components}
+			/>
+		</div>
+	)
+}

--- a/apps/examples/src/examples/collaboration/commenting-mobile/README.md
+++ b/apps/examples/src/examples/collaboration/commenting-mobile/README.md
@@ -1,0 +1,28 @@
+---
+title: Commenting on mobile
+component: ./CommentingMobileExample.tsx
+priority: 5
+keywords:
+  [
+    comments,
+    commenting,
+    mobile,
+    responsive,
+    breakpoint,
+    forcemobile,
+    thread,
+    composer,
+    placement,
+    keyboard,
+  ]
+---
+
+Commenting on a mobile layout: the thread popover and composer place themselves to stay on-screen above the keyboard.
+
+---
+
+The same commenting toolkit as the [Commenting](/commenting) example, with `forceMobile` on the editor so the mobile layout shows on any screen size.
+
+In mobile mode the thread popover and the new-comment composer position themselves relative to the pin and the visual viewport, rather than sitting at a fixed offset. They pick a side of the pin that keeps the whole panel on-screen, and ride up when the software keyboard shrinks the viewport instead of hiding behind it. Place a comment near an edge to see the placement adapt.
+
+Drop `forceMobile` and the layout switches on the viewport width, the way it does on a real device.

--- a/packages/commenting/src/canvas/mobile-placement.ts
+++ b/packages/commenting/src/canvas/mobile-placement.ts
@@ -1,0 +1,98 @@
+import { RefObject, useLayoutEffect, useState } from 'react'
+import { PORTRAIT_BREAKPOINT, useBreakpoint, useContainer } from 'tldraw'
+import { getVisibleViewport } from '../ui/visual-viewport'
+
+/**
+ * Mobile mode for the commenting surfaces — the same breakpoint gate as tldraw's mobile toolbar and
+ * style panel (which also honors `forceMobile` on `<Tldraw>`). The commenting layer can mount
+ * without tldraw's default UI (`hideUi`, custom UI), where the breakpoint provider is absent and
+ * `useBreakpoint` throws; fall back to desktop there, matching the pre-mobile rendering those hosts
+ * always had.
+ */
+export function useIsMobileCommenting(): boolean {
+	let breakpoint: number
+	try {
+		// The call is unconditional — the try only guards the provider's absence, not hook order.
+		// oxlint-disable-next-line react-hooks/rules-of-hooks
+		breakpoint = useBreakpoint()
+	} catch {
+		return false
+	}
+	return breakpoint < PORTRAIT_BREAKPOINT.TABLET_SM
+}
+
+const VIEWPORT_MARGIN = 8
+
+/**
+ * Keep a canvas-anchored panel — the pending composer or an open thread popover — within the
+ * visible viewport on mobile. The software keyboard shrinks the *visual* viewport while leaving the
+ * layout viewport (and CSS `dvh`) untouched, so a panel placed at a fixed offset from its pin can
+ * end up behind the keyboard. On mobile this clamps the panel's top-left into the visible box so it
+ * stays on-screen above the keyboard. Desktop is untouched: when `enabled` is false the base point
+ * is returned unchanged, tracking the camera exactly as before.
+ *
+ * `base` is the panel's desired top-left in container-relative viewport coordinates (what the call
+ * site would otherwise write straight into `left`/`top`).
+ */
+export function useMobilePlacement(
+	ref: RefObject<HTMLElement | null>,
+	base: { x: number; y: number },
+	enabled: boolean
+): { left: number; top: number } {
+	const container = useContainer()
+	const [placed, setPlaced] = useState<{ left: number; top: number }>(() => ({
+		left: base.x,
+		top: base.y,
+	}))
+
+	useLayoutEffect(() => {
+		if (!enabled) return
+		const el = ref.current
+		if (!el) return
+		const win = container.ownerDocument.defaultView ?? window
+
+		const update = () => {
+			// Panel coordinates are container-relative; the visual viewport is window-relative.
+			const cRect = container.getBoundingClientRect()
+			const vp = getVisibleViewport(win)
+			const top = vp.top - cRect.top + VIEWPORT_MARGIN
+			const bottom = vp.bottom - cRect.top - VIEWPORT_MARGIN
+			const left = vp.left - cRect.left + VIEWPORT_MARGIN
+			const right = vp.right - cRect.left - VIEWPORT_MARGIN
+
+			const w = el.offsetWidth
+			const h = el.offsetHeight
+
+			const nextLeft = Math.max(left, Math.min(base.x, right - w))
+			// The keyboard only ever covers space from the bottom, so it can pull the panel up (when its
+			// bottom would be hidden) but must never push it down below its natural spot. `base.y` is the
+			// floor: any spurious rise in `top` (e.g. iOS scrolling the page to reveal a focused input)
+			// is capped here, so a panel that already clears the keyboard doesn't move at all.
+			const nextTop = Math.min(base.y, Math.max(top, bottom - h))
+			setPlaced((prev) =>
+				prev.left === nextLeft && prev.top === nextTop ? prev : { left: nextLeft, top: nextTop }
+			)
+		}
+
+		update()
+		// Re-place when the panel grows (replies, edits), when the visual viewport changes (keyboard,
+		// pinch-zoom), or when the window resizes.
+		const ro = new ResizeObserver(update)
+		ro.observe(el)
+		const vv = win.visualViewport
+		vv?.addEventListener('resize', update)
+		vv?.addEventListener('scroll', update)
+		win.addEventListener('resize', update)
+		return () => {
+			ro.disconnect()
+			vv?.removeEventListener('resize', update)
+			vv?.removeEventListener('scroll', update)
+			win.removeEventListener('resize', update)
+		}
+	}, [container, ref, base.x, base.y, enabled])
+
+	// Desktop keeps its fixed placement, recomputed each render so it tracks the pin as the camera
+	// moves.
+	if (!enabled) return { left: base.x, top: base.y }
+	return placed
+}

--- a/packages/commenting/src/canvas/mobile-placement.ts
+++ b/packages/commenting/src/canvas/mobile-placement.ts
@@ -1,4 +1,4 @@
-import { RefObject, useLayoutEffect, useState } from 'react'
+import { RefObject, useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { PORTRAIT_BREAKPOINT, useBreakpoint, useContainer } from 'tldraw'
 import { getVisibleViewport } from '../ui/visual-viewport'
 
@@ -40,43 +40,60 @@ export function useMobilePlacement(
 	enabled: boolean
 ): { left: number; top: number } {
 	const container = useContainer()
+	// Destructured so the effects below depend on the two numbers rather than the object, which the
+	// call sites build fresh on every render.
+	const { x: baseX, y: baseY } = base
 	const [placed, setPlaced] = useState<{ left: number; top: number }>(() => ({
-		left: base.x,
-		top: base.y,
+		left: baseX,
+		top: baseY,
 	}))
+	// The camera moves `base` every frame while panning. Reading it from a ref keeps `update` stable
+	// across those frames, so the observers below are set up once per panel rather than being torn
+	// down and rebuilt each frame.
+	const baseRef = useRef({ x: baseX, y: baseY })
 
+	const update = useCallback(() => {
+		if (!enabled) return
+		const el = ref.current
+		if (!el) return
+		const win = container.ownerDocument.defaultView ?? window
+		const { x, y } = baseRef.current
+
+		// Panel coordinates are container-relative; the visual viewport is window-relative.
+		const cRect = container.getBoundingClientRect()
+		const vp = getVisibleViewport(win)
+		const top = vp.top - cRect.top + VIEWPORT_MARGIN
+		const bottom = vp.bottom - cRect.top - VIEWPORT_MARGIN
+		const left = vp.left - cRect.left + VIEWPORT_MARGIN
+		const right = vp.right - cRect.left - VIEWPORT_MARGIN
+
+		const w = el.offsetWidth
+		const h = el.offsetHeight
+
+		const nextLeft = Math.max(left, Math.min(x, right - w))
+		// The keyboard only ever covers space from the bottom, so it can pull the panel up (when its
+		// bottom would be hidden) but must never push it down below its natural spot. `y` is the
+		// floor: any spurious rise in `top` (e.g. iOS scrolling the page to reveal a focused input)
+		// is capped here, so a panel that already clears the keyboard doesn't move at all.
+		const nextTop = Math.min(y, Math.max(top, bottom - h))
+		setPlaced((prev) =>
+			prev.left === nextLeft && prev.top === nextTop ? prev : { left: nextLeft, top: nextTop }
+		)
+	}, [container, ref, enabled])
+
+	// Re-place as the camera moves the panel's base point.
+	useLayoutEffect(() => {
+		baseRef.current = { x: baseX, y: baseY }
+		update()
+	}, [baseX, baseY, update])
+
+	// Re-place when the panel grows (replies, edits), when the visual viewport changes (keyboard,
+	// pinch-zoom), or when the window resizes.
 	useLayoutEffect(() => {
 		if (!enabled) return
 		const el = ref.current
 		if (!el) return
 		const win = container.ownerDocument.defaultView ?? window
-
-		const update = () => {
-			// Panel coordinates are container-relative; the visual viewport is window-relative.
-			const cRect = container.getBoundingClientRect()
-			const vp = getVisibleViewport(win)
-			const top = vp.top - cRect.top + VIEWPORT_MARGIN
-			const bottom = vp.bottom - cRect.top - VIEWPORT_MARGIN
-			const left = vp.left - cRect.left + VIEWPORT_MARGIN
-			const right = vp.right - cRect.left - VIEWPORT_MARGIN
-
-			const w = el.offsetWidth
-			const h = el.offsetHeight
-
-			const nextLeft = Math.max(left, Math.min(base.x, right - w))
-			// The keyboard only ever covers space from the bottom, so it can pull the panel up (when its
-			// bottom would be hidden) but must never push it down below its natural spot. `base.y` is the
-			// floor: any spurious rise in `top` (e.g. iOS scrolling the page to reveal a focused input)
-			// is capped here, so a panel that already clears the keyboard doesn't move at all.
-			const nextTop = Math.min(base.y, Math.max(top, bottom - h))
-			setPlaced((prev) =>
-				prev.left === nextLeft && prev.top === nextTop ? prev : { left: nextLeft, top: nextTop }
-			)
-		}
-
-		update()
-		// Re-place when the panel grows (replies, edits), when the visual viewport changes (keyboard,
-		// pinch-zoom), or when the window resizes.
 		const ro = new ResizeObserver(update)
 		ro.observe(el)
 		const vv = win.visualViewport
@@ -89,10 +106,10 @@ export function useMobilePlacement(
 			vv?.removeEventListener('scroll', update)
 			win.removeEventListener('resize', update)
 		}
-	}, [container, ref, base.x, base.y, enabled])
+	}, [container, ref, enabled, update])
 
 	// Desktop keeps its fixed placement, recomputed each render so it tracks the pin as the camera
 	// moves.
-	if (!enabled) return { left: base.x, top: base.y }
+	if (!enabled) return { left: baseX, top: baseY }
 	return placed
 }

--- a/packages/commenting/src/canvas/pending-composer.tsx
+++ b/packages/commenting/src/canvas/pending-composer.tsx
@@ -23,6 +23,7 @@ import { commitCommentMutation, putRecordsInCommit } from './comment-mutations'
 import { UNKNOWN_COMMENT_AUTHOR } from './comment-render'
 import { PendingComment } from './comment-tool'
 import { type CommentingContext } from './context'
+import { useIsMobileCommenting, useMobilePlacement } from './mobile-placement'
 import { useCanComment, useCommentingOptions } from './options'
 import { pendingComment } from './state'
 
@@ -65,6 +66,10 @@ export function PendingComposer({
 		editor,
 		pending.point,
 	])
+	// On mobile the composer floats free of the pin so it can clear the software keyboard; desktop
+	// keeps it pinned to the point.
+	const isMobile = useIsMobileCommenting()
+	const placed = useMobilePlacement(ref, point, isMobile)
 
 	// Dismiss on a click anywhere outside the composer (capture-phase, ahead of stopPropagation).
 	useEffect(() => {
@@ -115,7 +120,7 @@ export function PendingComposer({
 				]
 					.filter(Boolean)
 					.join(' ')}
-				style={{ left: point.x, top: point.y }}
+				style={{ left: placed.left, top: placed.top }}
 				onPointerDown={stop}
 				onContextMenu={stop}
 				onKeyDown={(e) => {

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -390,9 +390,9 @@ export const ThreadPin = memo(function ThreadPin({
 			    the pin itself stays in the canvas-in-front layer, beneath the UI. */}
 				{open && (
 					<ThreadPopover
-						style={{
-							left: renderPoint.x + POPOVER_OFFSET.thread.x,
-							top: renderPoint.y + POPOVER_OFFSET.thread.y - THREAD_HEADER_BLOCK,
+						base={{
+							x: renderPoint.x + POPOVER_OFFSET.thread.x,
+							y: renderPoint.y + POPOVER_OFFSET.thread.y - THREAD_HEADER_BLOCK,
 						}}
 					>
 						<ThreadView editor={editor} thread={thread} {...props} />

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -176,9 +176,9 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 			)}
 			{open && (
 				<ThreadPopover
-					style={{
-						left: point.x + POPOVER_OFFSET.list.x,
-						top: point.y + POPOVER_OFFSET.list.y - liftForHeader,
+					base={{
+						x: point.x + POPOVER_OFFSET.list.x,
+						y: point.y + POPOVER_OFFSET.list.y - liftForHeader,
 					}}
 				>
 					<div className="tlui-cmt-stack-list">

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -1,13 +1,4 @@
-import {
-	memo,
-	ReactNode,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-	type CSSProperties,
-} from 'react'
+import { memo, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
 	createComment,
 	Editor,
@@ -50,6 +41,7 @@ import { CommentReactionPicker, CommentReactions } from './comment-reactions'
 import { UNKNOWN_AUTHOR, UNKNOWN_COMMENT_AUTHOR } from './comment-render'
 import { type CommentingContext } from './context'
 import { useThreadComments } from './hooks'
+import { useIsMobileCommenting, useMobilePlacement } from './mobile-placement'
 import { type CommentingComponents, useCanComment, useCommentingOptions } from './options'
 import { openThreadId } from './state'
 
@@ -155,9 +147,19 @@ export const POPOVER_OFFSET = {
 
 /** The open thread's popover container, portaled above the UI panels. A wheel over it passes
  *  through to the canvas (unless it scrolls its own content), like tldraw's panels. */
-export function ThreadPopover({ style, children }: { style: CSSProperties; children: ReactNode }) {
+export function ThreadPopover({
+	base,
+	children,
+}: {
+	base: { x: number; y: number }
+	children: ReactNode
+}) {
 	const ref = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(ref)
+	// On mobile the popover slides off its fixed offset to stay above the software keyboard and
+	// on-screen; desktop keeps the fixed offset (base returned unchanged).
+	const isMobile = useIsMobileCommenting()
+	const placed = useMobilePlacement(ref, base, isMobile)
 	return (
 		<EditorPortal>
 			{/* contextmenu also stops here: portals bubble React events to the canvas's context-menu
@@ -165,7 +167,7 @@ export function ThreadPopover({ style, children }: { style: CSSProperties; child
 			<div
 				ref={ref}
 				className="tlui-cmt-canvas-popover"
-				style={style}
+				style={{ left: placed.left, top: placed.top }}
 				onPointerDown={stop}
 				onContextMenu={stop}
 			>

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -236,6 +236,17 @@
 	pointer-events: none;
 }
 
+/* iOS Safari zooms the whole page in when a text input with a sub-16px font takes focus, and doesn't
+   zoom back out. Raising the font to 16px on touch devices suppresses that without disabling
+   pinch-zoom of the canvas (which a `maximum-scale` viewport lock would). Must come after both base
+   rules above: a media query adds no specificity, so it only wins the placeholder on source order. */
+@media (pointer: coarse) {
+	.tlui-cmt-input,
+	.tlui-cmt-input__placeholder {
+		font-size: 16px;
+	}
+}
+
 /* A bare up-arrow icon button (matching the placement composer): no fill by default, a grey square
    on hover, grey while there's nothing to send and dark once there is. */
 .tlui-cmt-send {

--- a/packages/commenting/src/ui/visual-viewport.test.ts
+++ b/packages/commenting/src/ui/visual-viewport.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { getVisibleViewport, isSoftKeyboardOpen, SOFT_KEYBOARD_MIN_INSET } from './visual-viewport'
+import { getVisibleViewport } from './visual-viewport'
 
 function makeWindow(
 	innerWidth: number,
@@ -32,38 +32,5 @@ describe('getVisibleViewport', () => {
 			bottom: 768,
 			right: 1024,
 		})
-	})
-})
-
-describe('isSoftKeyboardOpen', () => {
-	it('is true when the visible viewport is shorter than the layout viewport past the threshold', () => {
-		const win = makeWindow(390, 800, { offsetTop: 0, offsetLeft: 0, width: 390, height: 500 })
-		expect(isSoftKeyboardOpen(win)).toBe(true)
-	})
-
-	it('is false when nothing is covering the viewport', () => {
-		const win = makeWindow(390, 800, { offsetTop: 0, offsetLeft: 0, width: 390, height: 800 })
-		expect(isSoftKeyboardOpen(win)).toBe(false)
-	})
-
-	it('needs the inset to exceed the threshold, not just meet it', () => {
-		const atThreshold = makeWindow(390, 800, {
-			offsetTop: 0,
-			offsetLeft: 0,
-			width: 390,
-			height: 800 - SOFT_KEYBOARD_MIN_INSET,
-		})
-		const pastThreshold = makeWindow(390, 800, {
-			offsetTop: 0,
-			offsetLeft: 0,
-			width: 390,
-			height: 800 - SOFT_KEYBOARD_MIN_INSET - 1,
-		})
-		expect(isSoftKeyboardOpen(atThreshold)).toBe(false)
-		expect(isSoftKeyboardOpen(pastThreshold)).toBe(true)
-	})
-
-	it('treats a missing visualViewport as keyboard-down', () => {
-		expect(isSoftKeyboardOpen(makeWindow(390, 800))).toBe(false)
 	})
 })

--- a/packages/commenting/src/ui/visual-viewport.test.ts
+++ b/packages/commenting/src/ui/visual-viewport.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { getVisibleViewport, isSoftKeyboardOpen, SOFT_KEYBOARD_MIN_INSET } from './visual-viewport'
+
+function makeWindow(
+	innerWidth: number,
+	innerHeight: number,
+	vv?: { offsetTop: number; offsetLeft: number; width: number; height: number }
+): Window {
+	return { innerWidth, innerHeight, visualViewport: vv ?? null } as unknown as Window
+}
+
+describe('getVisibleViewport', () => {
+	it('reads the visual viewport, carrying its offset into the derived edges', () => {
+		const win = makeWindow(1024, 768, { offsetTop: 40, offsetLeft: 10, width: 900, height: 500 })
+		expect(getVisibleViewport(win)).toEqual({
+			top: 40,
+			left: 10,
+			width: 900,
+			height: 500,
+			bottom: 540,
+			right: 910,
+		})
+	})
+
+	it('falls back to the layout viewport when visualViewport is absent', () => {
+		const win = makeWindow(1024, 768)
+		expect(getVisibleViewport(win)).toEqual({
+			top: 0,
+			left: 0,
+			width: 1024,
+			height: 768,
+			bottom: 768,
+			right: 1024,
+		})
+	})
+})
+
+describe('isSoftKeyboardOpen', () => {
+	it('is true when the visible viewport is shorter than the layout viewport past the threshold', () => {
+		const win = makeWindow(390, 800, { offsetTop: 0, offsetLeft: 0, width: 390, height: 500 })
+		expect(isSoftKeyboardOpen(win)).toBe(true)
+	})
+
+	it('is false when nothing is covering the viewport', () => {
+		const win = makeWindow(390, 800, { offsetTop: 0, offsetLeft: 0, width: 390, height: 800 })
+		expect(isSoftKeyboardOpen(win)).toBe(false)
+	})
+
+	it('needs the inset to exceed the threshold, not just meet it', () => {
+		const atThreshold = makeWindow(390, 800, {
+			offsetTop: 0,
+			offsetLeft: 0,
+			width: 390,
+			height: 800 - SOFT_KEYBOARD_MIN_INSET,
+		})
+		const pastThreshold = makeWindow(390, 800, {
+			offsetTop: 0,
+			offsetLeft: 0,
+			width: 390,
+			height: 800 - SOFT_KEYBOARD_MIN_INSET - 1,
+		})
+		expect(isSoftKeyboardOpen(atThreshold)).toBe(false)
+		expect(isSoftKeyboardOpen(pastThreshold)).toBe(true)
+	})
+
+	it('treats a missing visualViewport as keyboard-down', () => {
+		expect(isSoftKeyboardOpen(makeWindow(390, 800))).toBe(false)
+	})
+})

--- a/packages/commenting/src/ui/visual-viewport.ts
+++ b/packages/commenting/src/ui/visual-viewport.ts
@@ -25,13 +25,3 @@ export function getVisibleViewport(win: Window): VisibleViewport {
 	const height = vv ? vv.height : win.innerHeight
 	return { top, left, width, height, bottom: top + height, right: left + width }
 }
-
-/** How much shorter than the layout viewport the visible viewport is — a keyboard is much taller
- *  than any browser UI chrome, so a gap past this reads as the keyboard being up rather than a URL
- *  bar. */
-export const SOFT_KEYBOARD_MIN_INSET = 100
-
-/** Whether the software keyboard is taking up meaningful vertical space right now. */
-export function isSoftKeyboardOpen(win: Window): boolean {
-	return win.innerHeight - getVisibleViewport(win).height > SOFT_KEYBOARD_MIN_INSET
-}

--- a/packages/commenting/src/ui/visual-viewport.ts
+++ b/packages/commenting/src/ui/visual-viewport.ts
@@ -1,0 +1,37 @@
+// The visual viewport is the region actually on screen. The software keyboard (and pinch-zoom)
+// shrink it while leaving the layout viewport — and CSS `dvh` — unchanged, most notably on iOS.
+// So placing a panel above the keyboard means measuring against `window.visualViewport`, not CSS.
+// These helpers are the single place the commenting layer reads it.
+
+/** The on-screen viewport region in window coordinates, falling back to the layout viewport where
+ *  `visualViewport` is unavailable. `top`/`left` carry the viewport's own offset — on iOS this is
+ *  non-zero while the keyboard is open, and dropping it misplaces anything measured against it. */
+export interface VisibleViewport {
+	top: number
+	left: number
+	width: number
+	height: number
+	bottom: number
+	right: number
+}
+
+/** Read the visible viewport once. Call it inside a `visualViewport` resize/scroll handler to keep
+ *  a measurement current as the keyboard opens and closes. */
+export function getVisibleViewport(win: Window): VisibleViewport {
+	const vv = win.visualViewport
+	const top = vv ? vv.offsetTop : 0
+	const left = vv ? vv.offsetLeft : 0
+	const width = vv ? vv.width : win.innerWidth
+	const height = vv ? vv.height : win.innerHeight
+	return { top, left, width, height, bottom: top + height, right: left + width }
+}
+
+/** How much shorter than the layout viewport the visible viewport is — a keyboard is much taller
+ *  than any browser UI chrome, so a gap past this reads as the keyboard being up rather than a URL
+ *  bar. */
+export const SOFT_KEYBOARD_MIN_INSET = 100
+
+/** Whether the software keyboard is taking up meaningful vertical space right now. */
+export function isSoftKeyboardOpen(win: Window): boolean {
+	return win.innerHeight - getVisibleViewport(win).height > SOFT_KEYBOARD_MIN_INSET
+}


### PR DESCRIPTION
In order to make commenting usable on mobile, this PR keeps the new-comment composer and the open thread/stack popover clear of the software keyboard, and stops iOS zooming the page when you focus the comment input.

On mobile these panels are placed at a fixed offset from their pin, so the software keyboard — which shrinks the visual viewport that CSS `dvh` can't see — can hide them. A new `useMobilePlacement` hook (gated on the mobile breakpoint) clamps a canvas-anchored panel into the visible viewport, moving it up only when its bottom would be covered and never below its natural spot, so an iOS scroll-into-view can't push it down. Desktop is untouched — the hook returns the panel's base point unchanged.

Separately, iOS Safari auto-zooms the whole page in when a sub-16px input takes focus (and doesn't zoom back out); the comment input is raised to 16px on coarse-pointer devices, which suppresses that without a `maximum-scale` viewport lock that would also kill canvas pinch-zoom.

Verified on the iOS and iPadOS simulators (iPhone 17 / iPad Air, iOS 26.5): placement above the keyboard, reply-focus holding position, no auto-zoom, correct card shadow, and a centered 16px placeholder.

**Preview:** https://pr-9823-preview-deploy.tldraw.com/

### Why a new viewport helper

The editor already exports `useViewportHeight`, but it wasn't reusable here: it's `@public` yet has zero call sites in the repo, and it returns only a scalar height (`vv.height + vv.offsetTop`). Keeping a panel on-screen needs the full visible *rectangle* — all four edges — to clamp horizontally and pick a side of the pin. So this PR adds `visual-viewport.ts` (`getVisibleViewport` → top/left/width/height/bottom/right, plus `isSoftKeyboardOpen`), the strictly-more-capable primitive the placement needs.

### New examples

- `commenting-mobile` — the commenting toolkit with `forceMobile`, so the mobile thread and composer placement is visible on any screen.

### Change type

- [x] `feature`

### Test plan

1. Open the **Commenting on mobile** example (or any commenting example with `forceMobile`) on a touch device or simulator.
2. Place a comment low on the canvas and focus the composer — it rides up above the keyboard, and the page doesn't zoom.
3. Open a thread and focus the reply — the popover stays put above the keyboard.

- [x] Unit tests

### Release notes

- The comment composer and thread popover now stay above the software keyboard on mobile, and focusing a comment input no longer zooms the page on iOS.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +172 / -19 |
| Tests           | +69 / -0   |
| Documentation   | +110 / -0  |
