### PR TITLE
chore(commenting): trim verbose code comments

### DIFF
--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -16,25 +16,14 @@ import { JsonObject } from '@tldraw/utils'
 
 /**
  * Conversions between the room's comment records and their Postgres rows. Postgres is the sole
- * durable store for comment records: the columns collectively carry every record field, so the
- * Durable Object can rebuild the records losslessly on cold start (`rowTo*Record`), and the
- * Zero-visible subset serves app-level queries. `lastChangedClock` preserves each record's sync
- * clock across reloads and guards upserts against no-op replays. Timestamps and clocks are read
- * through Number() as defense against driver/config drift: `postgres.ts` installs a global
- * int8-to-number type parser today, so pg already returns bigints as numbers, but nothing else
- * enforces that stays true.
+ * durable store, so the columns carry every record field and the DO can rebuild records losslessly
+ * on cold start. Timestamps and clocks go through Number() in case the global int8-to-number parser
+ * in `postgres.ts` ever goes away.
  */
 
 /**
- * True when `error` is Postgres rejecting a comment upsert because its author's user row no
- * longer exists: foreign key violation (code 23503) on `comment_author_id_fkey`. Deleting a user
- * cascades their comment rows away in Postgres (`ON DELETE CASCADE`), so hitting this means a
- * warm room still holds comment records for a since-deleted author. The caller mirrors the
- * cascade into the room by pruning those records instead of retrying the upsert forever.
- *
- * The error shape (`code`/`constraint`) is what node-postgres surfaces on `DatabaseError` and
- * kysely rethrows unchanged; both fields must match so unrelated FK failures keep the normal
- * at-least-once retry behavior.
+ * The author's user row is gone — deleting a user cascades their comment rows away, so a warm room
+ * is still holding records for a deleted author. Retrying can't succeed; the caller prunes.
  */
 export function isCommentAuthorFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
@@ -43,12 +32,8 @@ export function isCommentAuthorFkViolation(error: unknown): boolean {
 }
 
 /**
- * True when `error` is Postgres rejecting a thread upsert because its file row doesn't exist
- * (code 23503 on `comment_thread_file_id_fkey`). Either the file was deleted while a warm room
- * still held its threads, or a forged client pushed comment records into a room whose slug was
- * never a `file` row. Neither can ever succeed on retry, so the caller prunes the record rather
- * than leaving the outbox entry to fail on every drain forever. Same error-shape contract as
- * {@link isCommentAuthorFkViolation}.
+ * The thread's file row doesn't exist: the file was deleted, or a client pushed comments into a
+ * room whose slug was never a `file` row. Neither can succeed on retry, so the caller prunes.
  */
 export function isCommentThreadFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
@@ -56,12 +41,7 @@ export function isCommentThreadFkViolation(error: unknown): boolean {
 	return code === '23503' && constraint === 'comment_thread_file_id_fkey'
 }
 
-/**
- * True when `error` is Postgres rejecting a comment upsert because its file row doesn't exist
- * (code 23503 on `comment_file_id_fkey`). The file is gone — deleting it cascades every comment
- * row away — so retrying can never succeed and the caller prunes. Same error-shape contract as
- * {@link isCommentAuthorFkViolation}.
- */
+/** The comment's file row is gone, cascading every comment row with it. The caller prunes. */
 export function isCommentFileFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
 	const { code, constraint } = error as { code?: unknown; constraint?: unknown }
@@ -69,21 +49,10 @@ export function isCommentFileFkViolation(error: unknown): boolean {
 }
 
 /**
- * True when `error` is Postgres rejecting a comment upsert because the thread it points at doesn't
- * exist (code 23503 on `comment_thread_id_fkey`).
- *
- * Unlike the other FK matchers this one is **not** on its own sufficient to prune. Threads are
- * upserted before comments in the same drain, so this fires in two very different situations:
- *
- * - the thread genuinely doesn't exist (its create was vetoed by the authorizer, or a forged
- *   client referenced a thread id that never was) — permanent, prune;
- * - the thread exists in the room but its own upsert failed *this drain* for a transient reason
- *   (a timeout, a serialization failure). Its outbox entry is still queued and will retry, so the
- *   comment must wait for it — pruning here would destroy a live comment moments before its
- *   parent lands.
- *
- * The caller tells them apart by looking the comment's `threadId` up in the room's lane: absent
- * means permanent. See the prune predicate in `drainCommentOutbox`.
+ * The comment's thread row doesn't exist. Unlike the other FK matchers this is NOT on its own
+ * sufficient to prune: threads upsert before comments in the same drain, so a thread whose own
+ * upsert just failed transiently also fails its comments' FK, and it's still queued to retry.
+ * The caller only prunes when the threadId is also absent from the room's lane.
  */
 export function isCommentThreadIdFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
@@ -92,12 +61,8 @@ export function isCommentThreadIdFkViolation(error: unknown): boolean {
 }
 
 /**
- * True when `error` is Postgres rejecting a `comment_mention` insert on either of its foreign
- * keys (code 23503): the mentioned user's row no longer exists (deleted account, or a client
- * supplied an id that never was a user), or the comment itself was deleted between its upsert
- * and the mention write (e.g. a version restore's fileId-wide wipe). In both cases the mention
- * row is genuinely unwanted — retrying can't help — so the caller skips the row instead of
- * failing the drain. Same error-shape contract as {@link isCommentAuthorFkViolation}.
+ * A `comment_mention` insert hit either of its foreign keys: the mentioned user is gone, or the
+ * comment was deleted between its upsert and the mention write. The caller skips the row.
  */
 export function isCommentMentionFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
@@ -110,11 +75,8 @@ export function isCommentMentionFkViolation(error: unknown): boolean {
 }
 
 /**
- * True when `error` is Postgres rejecting a reaction upsert on one of its foreign keys (code
- * 23503): the comment, thread, or reacting user's row is gone. Deleting any of them cascades the
- * reaction rows away, so hitting this means a warm room still holds a reaction for something
- * Postgres has already removed. Retrying can never succeed, so the caller prunes the record
- * instead — the same contract as {@link isCommentAuthorFkViolation}.
+ * A reaction's comment, thread, or user row is gone, cascading the reaction rows with it. The
+ * caller prunes.
  */
 export function isCommentReactionFkViolation(error: unknown): boolean {
 	if (typeof error !== 'object' || error === null) return false
@@ -134,11 +96,9 @@ export interface CommentMentionReconcile {
 }
 
 /**
- * The desired end state of the `comment_mention` table for a drain's successfully upserted
- * comment rows: for each comment, the user ids its body currently `@`-mentions (deduped by
- * {@link extractMentionIds}). The caller reconciles Postgres to this — delete rows not in the
- * set, insert the rest with ON CONFLICT DO NOTHING — so the write is idempotent: an
- * at-least-once replay deletes nothing and inserts nothing, producing no WAL churn for Zero.
+ * The desired end state of `comment_mention` for a drain's upserted comments. The caller
+ * reconciles Postgres to this (delete rows not in the set, insert the rest with ON CONFLICT DO
+ * NOTHING), so an at-least-once replay is a no-op rather than WAL churn for Zero.
  */
 export function planMentionReconciles(commentRows: DB['comment'][]): CommentMentionReconcile[] {
 	return commentRows.map((row) => ({
@@ -229,8 +189,8 @@ export function rowToThreadRecord(row: DB['comment_thread']): TLCommentThread {
 		isDeleted: row.isDeleted,
 		meta: (row.meta ?? {}) as JsonObject,
 	}
-	// The fields above are raw casts from the row; validate the finished record so a corrupt
-	// Postgres row fails the room open loudly instead of seeding an invalid record into the room.
+	// The fields above are raw casts, so validate: a corrupt row should fail the room open rather
+	// than seed an invalid record.
 	return commentThreadRecordConfig.validator.validate(record) as TLCommentThread
 }
 
@@ -247,8 +207,8 @@ export function rowToCommentRecord(row: DB['comment']): TLComment {
 		isDeleted: row.isDeleted,
 		meta: (row.meta ?? {}) as JsonObject,
 	}
-	// The fields above are raw casts from the row; validate the finished record so a corrupt
-	// Postgres row fails the room open loudly instead of seeding an invalid record into the room.
+	// The fields above are raw casts, so validate: a corrupt row should fail the room open rather
+	// than seed an invalid record.
 	return commentRecordConfig.validator.validate(record) as TLComment
 }
 
@@ -264,7 +224,7 @@ export function rowToReactionRecord(row: DB['comment_reaction']): TLCommentReact
 		createdAt: Number(row.createdAt),
 		meta: (row.meta ?? {}) as JsonObject,
 	}
-	// See rowToCommentRecord: validate the finished record so a corrupt row fails loudly.
+	// See rowToCommentRecord.
 	return commentReactionRecordConfig.validator.validate(record) as TLCommentReaction
 }
 
@@ -297,31 +257,20 @@ export function rowsToSnapshotDocuments(
 export interface CommentLoadResult {
 	documents: RoomSnapshot['documents']
 	/**
-	 * The highest `lastChangedClock` across ALL of the file's comment rows, including the
-	 * soft-deleted ones whose records were dropped from `documents`. Merge clamping must use this
-	 * rather than the merged documents' own clocks: a dropped row can hold the file's highest
-	 * clock, and seeding the room's clock below it would let future edits emit clocks the drain's
-	 * lastChangedClock guard rejects.
+	 * The highest `lastChangedClock` across ALL of the file's comment rows, including soft-deleted
+	 * ones dropped from `documents` — a dropped row can hold the file's highest clock, and seeding
+	 * the room below it would make future edits emit clocks the drain's guard rejects.
 	 */
 	clockFloor: number
 }
 
 /**
- * Build the room-seedable comment documents from a file's Postgres rows. Soft-deleted threads
- * (`isDeleted` — see TLCommentThread.isDeleted) and their comments are dropped, as are
- * soft-deleted comments of live threads: their rows stay in Postgres for recovery and Zero-side
- * filtering, but they never re-enter a room.
+ * Build the room-seedable comment documents from a file's Postgres rows. Soft-deleted records stay
+ * in Postgres for recovery and Zero-side filtering but never re-enter a room.
  *
- * A live thread whose comment rows are all soft-deleted is dropped too. It's the durable
- * backstop for the drain's emptied-thread prune: the thread's own isDeleted stamp rides a
- * comment_outbox entry in DO SQLite between drains, so losing that storage in the window leaves
- * the thread live in Postgres with nothing left to ever stamp it — this filter keeps it out of
- * rooms regardless. A thread with no comment rows at all is kept: it's a brand-new thread whose
- * first comment hasn't drained, not an emptied one.
- *
- * Reactions seed only when their comment does. A soft-deleted comment's reaction rows persist
- * (the comment row still exists, so no cascade fired) — this filter is what keeps them out of
- * rooms, mirroring the drain's orphan-reaction lane prune.
+ * A live thread whose comments are all soft-deleted is dropped too — the durable backstop for the
+ * drain's emptied-thread prune, whose isDeleted stamp rides an outbox entry in DO SQLite. A thread
+ * with no comment rows at all is kept: that's a new thread whose first comment hasn't drained.
  */
 export function liveCommentDocuments(
 	threadRows: DB['comment_thread'][],
@@ -360,10 +309,8 @@ export interface CommentOutboxEntry {
 }
 
 /**
- * The pure output of `planCommentDrain`: Postgres writes grouped by table and operation. The
- * delete buckets carry lane-absent ids, and "delete" means stamping the row's `isDeleted` —
- * the drain never hard-deletes comment-lane rows (the only hard deletes are Postgres-side
- * cascades: user-account deletion, file deletion, version restore).
+ * Postgres writes grouped by table and operation. The delete buckets carry lane-absent ids, and
+ * "delete" means stamping `isDeleted` — the drain never hard-deletes comment-lane rows.
  */
 export interface CommentDrainPlan {
 	threadUpserts: DB['comment_thread'][]
@@ -372,22 +319,14 @@ export interface CommentDrainPlan {
 	threadDeletes: string[]
 	commentDeletes: string[]
 	reactionDeletes: string[]
-	/**
-	 * Ids that are none of the comment record types. The outbox should only ever contain those, so
-	 * an unknown id means a bug or a corrupted outbox row; it is reported here instead of being
-	 * misfiled into an upsert/delete bucket, and the caller decides how to surface it.
-	 */
+	/** Ids of no known comment record type — a bug or a corrupted outbox row. */
 	unknownIds: string[]
 }
 
 /**
- * The pure planning half of the comment outbox drain (see drainCommentOutbox in
- * TLFileDurableObject). The outbox stores only ids; whether an id is an upsert or a delete is
- * decided by its presence in the object `lane` at plan time, so multiple entries for one record
- * coalesce into a single write (deduped by recordId, keeping first-occurrence order) and a
- * create-then-prune nets out to a delete bucket entry. Only ids present in `entries` are considered — the
- * caller bounds the entries to its drain's high-water mark, and lane records outside that set
- * belong to a later drain.
+ * The pure planning half of the comment outbox drain (see drainCommentOutbox). The outbox stores
+ * only ids; upsert-vs-delete is decided by presence in the object `lane` at plan time, so multiple
+ * entries for one record coalesce into a single write and a create-then-prune nets out to a delete.
  */
 export function planCommentDrain(
 	entries: CommentOutboxEntry[],
@@ -438,11 +377,8 @@ export function planCommentDrain(
 }
 
 /**
- * Which outbox entries a finished drain may delete. Entries whose recordId is in `failedIds`
- * are kept queued so the next drain retries them; everything else (including entries for pruned
- * or unknown ids, where retrying can't help) is cleared. When nothing failed, `clearAll` is the
- * fast path: the caller can bulk-clear everything up to its drain bound instead of deleting
- * per-seq.
+ * Which outbox entries a finished drain may delete. `failedIds` stay queued for the next drain;
+ * everything else clears. `clearAll` is the fast path when nothing failed.
  */
 export function outboxEntriesToClear(
 	entries: CommentOutboxEntry[],
@@ -458,18 +394,12 @@ export function outboxEntriesToClear(
 }
 
 /**
- * Given the `threadId`s of comment records that were just pruned and a view of the records that
- * remain (read AFTER the pruned comments were deleted), return the threadIds that no longer have
- * any comments referencing them. The callers (the author-FK prune and the soft-delete prune in
- * drainCommentOutbox) delete those threads in the same transaction: an emptied thread never
- * renders (clients hide threads with no comments), and no client may delete a thread it didn't
- * create — the ordinary "delete the last comment" path relies on this server-side prune.
+ * Of the just-pruned comments' threads, which no longer have any comments. Callers delete those
+ * threads in the same transaction: an emptied thread never renders, and no client may delete a
+ * thread it didn't create, so the ordinary "delete the last comment" path needs this prune.
  *
- * The view must be transaction-time (e.g. the prune transaction's own read surface), not an
- * earlier lane snapshot: a reply committed between the snapshot and the transaction must keep its
- * thread alive. The scan iterates `keys()` (an id-only scan; comment ids are typeName-prefixed so
- * non-comment records are skipped without being read) and `get`s only comment records, stopping
- * early once every candidate thread has been kept alive.
+ * `remaining` must be transaction-time, not an earlier lane snapshot — a reply committed in
+ * between has to keep its thread alive.
  */
 export function findEmptiedCommentThreads(
 	candidateThreadIds: ReadonlySet<string>,
@@ -486,16 +416,8 @@ export function findEmptiedCommentThreads(
 }
 
 /**
- * Given the ids of comments that were just pruned and a view of the records that remain, return the
- * ids of reaction records whose `commentId` points at one of those pruned comments. The caller (see
- * the author-FK prune in drainCommentOutbox) deletes those reactions from the room in the same
- * transaction: `comment_reaction.commentId` is `ON DELETE CASCADE`, so Postgres already dropped the
- * rows when the comment row went — this only catches the warm room's SQLite up, so orphan reactions
- * don't linger pointing at a comment that no longer exists.
- *
- * Like {@link findEmptiedCommentThreads}, the scan iterates `keys()` (an id-only scan; reaction ids
- * are typeName-prefixed so non-reaction records are skipped without being read) and `get`s only
- * reaction records.
+ * Reactions pointing at just-pruned comments. Postgres already cascaded these rows away, so this
+ * only catches the warm room's SQLite up.
  */
 export function findOrphanedReactions(
 	prunedCommentIds: ReadonlySet<string>,
@@ -513,25 +435,13 @@ export function findOrphanedReactions(
 
 /**
  * Merge rehydrated comment documents into a room snapshot, clamping the snapshot's clocks up to
- * the load's `clockFloor` (the highest clock across all of the file's comment rows — including
- * soft-deleted ones that contributed no document). Comments push to Postgres per-commit while
- * the document snapshot persists on a throttle, so after a storage loss the comment clocks can
- * be ahead of the snapshot's — seeding the room clock below them would make future edits emit
- * clocks the drain's lastChangedClock guard rejects, silently dropping those edits from
- * Postgres.
+ * the load's `clockFloor`. Comments push to Postgres per-commit while the snapshot persists on a
+ * throttle, so after a storage loss the comment clocks can be ahead — seeding the room below them
+ * would make future edits emit clocks the drain's guard silently rejects.
  *
- * `SQLiteSyncStorage` seeds its clock from `snapshot.documentClock ?? snapshot.clock ?? 0`, so we
- * clamp based on that effective value (setting `documentClock` when only a higher legacy `clock`
- * was present would lower the seed, not raise it) and keep `clock` \>= `documentClock` when both
- * are set.
- *
- * When the clamp fires, the room is claiming a clock higher than anything the stale snapshot
- * actually has history for — the delete/tombstone history between the snapshot's old clock and
- * `maxClock` lived only in the DO's SQLite storage that we just lost, so it's genuinely gone, not
- * merely unsynced. We raise `tombstoneHistoryStartsAtClock` to match so `wipeAll` fires for any
- * client reconnecting with `sinceClock` short of `maxClock`: that forces a full resync instead of
- * a partial incremental diff, which would otherwise let clients silently keep documents the
- * server can no longer account for.
+ * The clamp works off `documentClock ?? clock ?? 0`, matching how `SQLiteSyncStorage` seeds.
+ * `tombstoneHistoryStartsAtClock` rises with it: the tombstone history for that range lived only
+ * in the lost SQLite, so reconnecting clients must full-resync rather than take a partial diff.
  */
 export function mergeCommentDocumentsIntoSnapshot(
 	snapshot: RoomSnapshot,

--- a/apps/examples/src/examples/collaboration/comment-drawing-reactions/drawing-reactions.tsx
+++ b/apps/examples/src/examples/collaboration/comment-drawing-reactions/drawing-reactions.tsx
@@ -24,8 +24,6 @@ import { Editor, TldrawOptions, TLUiOverrides, Tldraw, useEditor, useValue } fro
  * See `CommentDrawingReactionsExample.tsx` for the wiring.
  */
 
-// ── Tokens ───────────────────────────────────────────────────────────────────────────────────
-
 /** The image format a drawn reaction is exported as. */
 export type DrawingReactionFormat = 'svg' | 'png'
 
@@ -43,8 +41,6 @@ const TOKEN_PREFIXES = ['data:image/svg+xml,', 'data:image/svg+xml;', 'data:imag
 export function isDrawingReactionToken(token: string): boolean {
 	return TOKEN_PREFIXES.some((prefix) => token.startsWith(prefix))
 }
-
-// ── Renderer ─────────────────────────────────────────────────────────────────────────────────
 
 /**
  * Sized in `em` so a drawn reaction matches whatever font size its host sets — the pill in the
@@ -79,8 +75,6 @@ export function renderDrawingReaction(token: string): ReactNode {
 export function DrawingReactionContent({ token }: { token: string }) {
 	return <>{renderDrawingReaction(token)}</>
 }
-
-// ── Export ───────────────────────────────────────────────────────────────────────────────────
 
 export interface DrawingReactionExportOptions {
 	/**
@@ -157,8 +151,6 @@ export async function exportDrawingReactionToken(
 	}
 	return token
 }
-
-// ── Palette ──────────────────────────────────────────────────────────────────────────────────
 
 /**
  * Keyboard shortcuts stay mounted when `hideUi` is set, so hiding the toolbar isn't enough on its
@@ -441,8 +433,6 @@ function EraserIcon() {
 		</svg>
 	)
 }
-
-// ── Styles ───────────────────────────────────────────────────────────────────────────────────
 
 const STYLE_ELEMENT_ID = 'tlui-cmt-drawing-palette-styles'
 

--- a/packages/commenting/src/canvas/anchor-lifecycle.ts
+++ b/packages/commenting/src/canvas/anchor-lifecycle.ts
@@ -8,10 +8,8 @@ type ShapeAnchor = Extract<TLCommentAnchor, { type: 'shape' }>
 
 /**
  * Threads converted to point anchors because their shape was deleted, kept so the anchor can be
- * restored if the shape comes back (page move re-create, undo of the delete). Owned by the
- * editor, not the registration closure: the registering effect can re-run (a prop identity
- * change, a remount), and an undo can arrive arbitrarily long after the delete — the memory has
- * to outlive any one registration.
+ * restored if the shape comes back. Owned by the editor, not the registration closure: the
+ * registering effect can re-run, and an undo can arrive long after the delete.
  */
 const convertedByShapeCache = new WeakCache<
 	Editor,
@@ -29,35 +27,26 @@ function isAnchoredToShape(
 /**
  * Keep shape-anchored threads alive across their shape's lifecycle:
  *
- * - When the shape is deleted, the thread converts to a `point` anchor at the spot its pin last
- *   occupied, so the conversation outlives the shape instead of becoming invisible (a missing
- *   shape has no bounds, which hides the pin).
+ * - When the shape is deleted, the thread converts to a `point` anchor where its pin last sat, so
+ *   the conversation outlives the shape instead of becoming invisible.
  * - When the shape moves to another page, the thread follows: its `pageId` and each comment's
- *   denormalized `pageId` update to the shape's new page, and the anchor keeps riding the shape.
- * - When a deleted shape comes back (a page move re-creates it with its id preserved; undoing a
- *   delete restores it), the thread re-attaches — unless its pin was manually moved in the
- *   meantime, in which case the manual placement wins.
+ *   denormalized `pageId` update, and the anchor keeps riding the shape.
+ * - When a deleted shape comes back, the thread re-attaches — unless its pin was manually moved in
+ *   the meantime, in which case the manual placement wins.
  *
  * A page move is `deleteShapes` + re-create with preserved ids inside one `editor.run`, but each
- * store write is its own operation — so at no single moment does "this shape is being moved"
- * exist as an observable event. The handlers therefore cooperate across operations:
- * `beforeDelete` snapshots where each affected pin sits (every record is still in the store at
- * that point, so page bounds resolve even for children of a deleted frame); the
- * operation-complete pass converts threads whose shape is really gone, remembering the original
- * anchor; `afterCreate` notes a reappeared shape id, and the operation-complete pass restores
- * the anchor once the store has settled (creation order within an operation is arbitrary, so a
- * fresh shape may not resolve an ancestor page mid-operation). Undo/redo of a move
- * replays as a `parentId` update (remove + add of one id squash to an update in the history
- * diff), so an `afterChange` handler re-homes threads on cross-page reparents — including
- * threads anchored to descendants, which move with their parent without change events of their
- * own.
+ * store write is its own operation, so "this shape is being moved" is never observable as a single
+ * event. The handlers therefore cooperate across operations: `beforeDelete` snapshots where each
+ * affected pin sits, the operation-complete pass converts threads whose shape is really gone, and
+ * `afterCreate` plus that same pass restore the anchor once the store has settled. Undo/redo of a
+ * move replays as a `parentId` update, so `afterChange` re-homes threads on cross-page reparents —
+ * including threads anchored to descendants, which move without change events of their own.
  *
- * Remote changes are ignored: the client that performed the operation runs this same
- * maintenance and syncs the resulting thread updates. Writes honour the
- * {@link CommentingOptions.history} option, so the consumer decides whether they're undoable.
+ * Remote changes are ignored: the client that performed the operation runs this same maintenance
+ * and syncs the result. Writes honour the {@link CommentingOptions.history} option.
  *
- * Registered by `CanvasComments` on mount; parts-built consumers can call this directly.
- * Returns a cleanup function that unregisters all handlers.
+ * Registered by `CanvasComments` on mount; parts-built consumers can call this directly. Returns a
+ * cleanup function that unregisters all handlers.
  *
  * @public
  */
@@ -85,10 +74,8 @@ export function registerCommentAnchorLifecycle(editor: Editor): () => void {
 					snapshot = new Map()
 					pendingByShape.set(shape.id, snapshot)
 				}
-				// Snapshot where the pin is drawn, not just the anchor point: imprecise shape pins
-				// render inset toward the shape's centre, and the converted point pin renders at
-				// its point exactly — without the inset the pin would jump on deletion. The inset
-				// is screen-fixed, so bake it in at the current zoom.
+				// Snapshot where the pin is drawn, not just the anchor point: imprecise shape pins render inset
+				// toward the shape's centre, so without baking the inset in at the current zoom the pin would jump.
 				let point = anchorPagePoint(editor, thread.anchor)
 				const inset = impreciseShapePinInset(editor, thread.anchor)
 				if (point && inset) {
@@ -100,10 +87,9 @@ export function registerCommentAnchorLifecycle(editor: Editor): () => void {
 		}
 	)
 
-	// Shape ids from `convertedByShape` re-created during the current operation. Restores are
-	// settled at operation complete rather than in `afterCreate` itself: creation order within an
-	// operation is arbitrary, so a shape can appear before its parent and not resolve an ancestor
-	// page yet — and the conversion memory must outlive any such partial state.
+	// Shape ids from `convertedByShape` re-created during the current operation. Settled at operation
+	// complete rather than in `afterCreate`: creation order within an operation is arbitrary, so a shape
+	// can appear before its parent and not resolve an ancestor page yet.
 	const returnedShapeIds = new Set<TLShapeId>()
 
 	const disposeOperationComplete = editor.sideEffects.registerOperationCompleteHandler((source) => {

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -44,13 +44,11 @@ export interface ClusterModelState {
 /**
  * The clustering state machine behind the comments layer.
  *
- * The core invariant: the only thing that re-flows clustering doc-wide is zoom. Every rebuild
- * (add / move / delete / open / pop-out) is computed immediately as `latestModel` — the MST
- * stays correct — but the on-screen partition is `renderedModel`, and it only ever changes via
- * (a) the cursor walking on zoom, (b) adoption of the pending rebuild on zoom-out, or
- * (c) LOCAL detach patches: a leaf that left the input (deleted, opened, popped out) is
- * detached from its own badge in place — count and centroid update for that badge alone,
- * and nothing else on the canvas moves.
+ * The core invariant: the only thing that re-flows clustering doc-wide is zoom. Every rebuild is
+ * computed immediately as `latestModel`, but the on-screen partition is `renderedModel`, which only
+ * changes via (a) the cursor walking on zoom, (b) adoption of the pending rebuild on zoom-out, or
+ * (c) LOCAL detach patches, where a leaf that left the input is detached from its own badge in
+ * place and nothing else on the canvas moves.
  *
  * Threads the displayed partition can't represent are returned separately (`orphanThreads`,
  * `heldThreads`) for the layer to draw as ordinary pins.
@@ -103,10 +101,8 @@ export function useClusterModel(
 		setRenderedModel(latestModel)
 		clusterModel = latestModel
 	}
-	// adoptOnRebuild is set by the rejoin reaction below, outside React's render cycle, paired
-	// with clearing heldThreadIds. Only trust it once that pairing is actually visible here
-	// (heldThreadIds confirmed empty) — an unrelated re-render can land in the gap between the
-	// ref being set and the state update it was paired with being applied.
+	// adoptOnRebuild is set outside React's render cycle, paired with clearing heldThreadIds. Only trust
+	// it once that pairing is visible here, or an unrelated re-render can land in the gap.
 	const rejoinPending = heldThreadIds.size === 0 && adoptOnRebuild.current
 	if (renderedModel !== latestModel && rejoinPending) {
 		adoptOnRebuild.current = false
@@ -129,11 +125,9 @@ export function useClusterModel(
 		for (const id of newlyMovedIds) next.add(id)
 		setHeldThreadIds(next)
 	}
-	// Local partition maintenance — the only non-zoom visual change, and it is local by
-	// construction: any displayed leaf that has left the cluster input (deleted, thread opened,
-	// popped out above) is detached from its badge in place. The corrected rebuild is already
-	// sitting in latestModel awaiting the next zoom-out. When the rendered model IS the latest
-	// model (the common render) the leaf sets are identical by construction, so skip the scan.
+	// Local partition maintenance — the only non-zoom visual change. Any displayed leaf that has left the
+	// cluster input is detached from its badge in place; the corrected rebuild already sits in latestModel
+	// awaiting the next zoom-out. When the two models match, the leaf sets are identical, so skip the scan.
 	if (clusterModel !== latestModel) {
 		const latestLeafIds = new Set(latestModel.table.leaves.map((leaf) => leaf.id))
 		const removedLeafIds: string[] = []
@@ -175,10 +169,9 @@ export function useClusterModel(
 			setRenderedModel(latestModel)
 		})
 	}, [clusterModel, latestModel, editor])
-	// Threads in the current input that the displayed partition doesn't show anywhere (new
-	// comments, reopened threads, undone deletions): render as plain pins until the next
-	// zoom-out folds them in. Membership is judged against the *displayed* partition (with
-	// detaches applied), not the rendered table, so a detached-then-restored leaf reappears.
+	// Threads the displayed partition doesn't show anywhere (new comments, reopened threads, undone
+	// deletions) render as plain pins until the next zoom-out folds them in. Judged against the
+	// displayed partition, so a detached-then-restored leaf reappears.
 	const partitionVersion = clusterModel.runtime.version
 	const orphanThreads = useMemo(() => {
 		if (clusterModel === latestModel) return []
@@ -195,11 +188,9 @@ export function useClusterModel(
 		() => threads.filter((thread) => heldThreadIds.has(thread.id) && thread.id !== openId),
 		[threads, heldThreadIds, openId]
 	)
-	// Subscribe to the runtime's partition version, not the raw zoom: onCamera runs on every zoom
-	// tick (O(1) threshold checks) but the version only moves when the partition actually changes
-	// — so this component only re-renders on cluster changes, not on every camera frame. The memo
-	// below keys on a fresh inline read of the version rather than the subscribed value, because
-	// render-time detaches (above) bump it after the subscription's computed already evaluated.
+	// Subscribe to the runtime's partition version, not the raw zoom, so this only re-renders on cluster
+	// changes rather than every camera frame. The memo below re-reads the version inline because
+	// render-time detaches bump it after the subscription's computed already evaluated.
 	useValue(
 		'comment cluster version',
 		() => {
@@ -302,11 +293,9 @@ export function revealThreadPin(
 
 /**
  * Zoom to just past the zoom at which a cluster first unclusters, centered on its centroid. The
- * event that created a visible cluster is the event that splits it, and (by the table's sort +
- * monotone thresholds) it has the smallest zSplit of everything applied inside it — so its zSplit
- * is exactly the first split within those comments. The animated zoom-in then drives the runtime
- * cursor like any manual zoom, so the badge splits (and can be drilled into further) with no extra
- * bookkeeping. A no-op for a node with no split event.
+ * event that created a visible cluster is the event that splits it, and has the smallest zSplit of
+ * everything applied inside it — so its zSplit is exactly the first split within those comments.
+ * The animated zoom drives the runtime cursor like any manual zoom. A no-op with no split event.
  */
 export function zoomToClusterSplit(
 	editor: Editor,

--- a/packages/commenting/src/canvas/comment-mutations.ts
+++ b/packages/commenting/src/canvas/comment-mutations.ts
@@ -16,14 +16,11 @@ import { openThreadId } from './state'
 /**
  * Every write to a comment record, and the undo/redo policy governing them.
  *
- * This file layers bottom-up: {@link commitCommentMutation} resolves the history mode,
+ * The file layers bottom-up: {@link commitCommentMutation} resolves the history mode,
  * {@link putCommentRecords} and {@link removeCommentRecords} are the typed writes that run under
- * it, and the verbs below are those writes plus the one rule each carries — a timestamp to stamp, a
- * shape to put the `resolved` field in, or the soft-delete protocol. The built-in thread view calls
- * exactly these verbs, so a UI of your own behaves the same as the one in the box.
- *
- * Every verb takes the record it acts on, but treats it as the identity of what to change rather
- * than as the value to write back — see {@link readLatest}.
+ * it, and the verbs below are those writes plus the one rule each carries. Every verb takes the
+ * record it acts on as the identity of what to change, not the value to write back — see
+ * {@link readLatest}.
  *
  * Posting carries no such rule, so it isn't a verb here: build the records with
  * `createCommentThread`/`createComment` and write them with {@link putCommentRecords}.
@@ -82,10 +79,9 @@ export function commitCommentMutation<T>(
 /**
  * Write records without opening a commit, for call sites that already sit inside one.
  *
- * `editor.run`'s history option isn't additive — a nested run overwrites the enclosing mode for its
- * own scope — so a {@link putCommentRecords} call inside a commit would discard the mode its caller
- * chose. A pin drag committed as `drag` under `dragHistory: 'record'` would land back on
- * `history: 'ignore'` and quietly stop being undoable. Inside a commit, write with this.
+ * `editor.run`'s history option isn't additive — a nested run overwrites the enclosing mode — so
+ * {@link putCommentRecords} inside a commit would discard the mode its caller chose, quietly
+ * making a `drag` write non-undoable.
  *
  * @internal
  */
@@ -102,13 +98,11 @@ export function removeRecordsInCommit(
 }
 
 /**
- * Write comment records to the store, under the configured
- * {@link CommentingOptions.history} behavior — so a record you write lands on the undo stack (or
- * doesn't) exactly like one the built-in UI writes. Defaults to `'ignore'`.
+ * Write comment records to the store, under the configured {@link CommentingOptions.history}
+ * behavior. Defaults to `'ignore'`.
  *
- * Use it to seed or import threads, and to save an edit. To delete, prefer
- * {@link deleteComment} and {@link deleteThread} over {@link removeCommentRecords}: comments are
- * soft-deleted, and a synced server rejects the hard delete.
+ * Use it to seed or import threads, and to save an edit. To delete, prefer {@link deleteComment}
+ * and {@link deleteThread}: comments are soft-deleted, and a synced server rejects the hard delete.
  *
  * @public
  */
@@ -120,12 +114,10 @@ export function putCommentRecords(editor: Editor, records: TLCommentRecord[]): v
  * Remove comment records from the store by id, under the configured
  * {@link CommentingOptions.history} behavior.
  *
- * This is a hard delete, which is rarely what you want for a comment or a thread: the built-in UI
- * soft-deletes them ({@link deleteComment}, {@link deleteThread}) so the server can prune the
- * records — including reactions, which belong to whoever left them rather than to the deleter. A
- * server that enforces per-record permissions will veto a hard delete outright. Reach for this on
- * a local, unsynced comment store, or to drop a reaction (which is a hard delete — see
- * {@link toggleCommentReaction}).
+ * This is a hard delete, which is rarely what you want: the built-in UI soft-deletes
+ * ({@link deleteComment}, {@link deleteThread}) so the server can prune the records, and a server
+ * enforcing per-record permissions vetoes a hard delete outright. Reach for this on a local,
+ * unsynced store, or to drop a reaction (see {@link toggleCommentReaction}).
  *
  * @public
  */
@@ -139,18 +131,13 @@ export function removeCommentRecords(
 /**
  * The record as the store currently holds it, or `undefined` if it isn't there any more.
  *
- * A verb is handed a record, but that record is a snapshot of whenever its caller got hold of one,
- * and a comment record moves underneath it. A thread's `anchor` and `pageId` are rewritten without
- * anyone touching the thread: deleting a pinned shape converts the anchor to a point, reparenting
- * one rehomes the thread to another page, a pin drag re-anchors it. Writing the caller's snapshot
- * back would put those fields as they were and sync the revert out to everyone.
- *
- * `put` is also an upsert, so a record a remote delete has already removed would come back — with
- * `isDeleted: false` on an edit or a resolve. That's the multiplayer surprise the schema warns
- * about (see `TLComment`), reached by a route the history option doesn't cover.
+ * A verb is handed a record, but that record is a snapshot and comment records move underneath it:
+ * deleting a pinned shape converts the anchor to a point, reparenting rehomes the thread, a drag
+ * re-anchors it. Writing the caller's snapshot back would revert those fields for everyone. `put`
+ * is also an upsert, so a record a remote delete already removed would come back.
  *
  * So a verb reads what it's changing rather than trusting what it was given, and a record that's
- * gone is a no-op: whatever the change was, there's nothing left for it to apply to.
+ * gone is a no-op.
  */
 function readLatest<T extends TLComment | TLCommentThread>(
 	editor: Editor,
@@ -162,15 +149,12 @@ function readLatest<T extends TLComment | TLCommentThread>(
 }
 
 /**
- * Replace a comment's body and stamp it as edited, which is what renders the "(edited)" marker on
- * its byline.
+ * Replace a comment's body and stamp it as edited, which renders the "(edited)" marker on its
+ * byline. Editing is the author's to do, and a server enforcing per-record permissions rejects
+ * anyone else's.
  *
- * Editing is the author's to do. The built-in UI only offers it on your own comments, and a server
- * that enforces per-record permissions rejects anyone else's edit.
- *
- * The `comment` you pass says which comment to edit; the body lands on the version the store
- * currently holds, so a copy you've held on to can't revert a change made since it, and can't
- * re-create a comment that's already been removed — editing one of those does nothing.
+ * The body lands on the version the store currently holds, so a stale copy can't revert a later
+ * change or re-create a removed comment — editing one of those does nothing.
  *
  * @example
  * ```ts
@@ -191,8 +175,8 @@ export function editComment(editor: Editor, comment: TLComment, body: TLRichText
  * Mark a thread resolved, stamping who resolved it and when. Resolved threads keep their pin (a
  * checked one) and are hidden from the sidebar until its "show resolved" filter is on.
  *
- * Only the resolution is written: the rest of the thread is read fresh, so resolving with a stale
- * copy in hand won't drag a pin back to where it used to be. A no-op on a thread that's gone.
+ * Only the resolution is written — the rest of the thread is read fresh, so a stale copy can't drag
+ * a pin back. A no-op on a thread that's gone.
  *
  * @public
  */
@@ -221,21 +205,15 @@ export function reopenThread(editor: Editor, thread: TLCommentThread): void {
 /**
  * Delete a comment.
  *
- * This is a soft delete: it sets the record's `isDeleted` flag rather than removing it, and the
- * server prunes the comment and its reactions once the flag is persisted. That way no client ever
- * removes records it doesn't own — a reaction belongs to whoever left it — and a server enforcing
- * per-record permissions has a write it can check rather than a deletion it can only refuse.
- * Deleting is the author's to do; the built-in UI only offers it on your own comments.
+ * This is a soft delete: it sets `isDeleted` rather than removing the record, and the server prunes
+ * the comment and its reactions once the flag is persisted — so no client removes records it
+ * doesn't own, and a server enforcing per-record permissions has a write it can check.
  *
- * The write is never undoable, whatever {@link CommentingOptions.history} says: the flag is
- * write-once server-side, so an undo clearing it would be vetoed and rebased rather than bring the
- * comment back.
+ * Never undoable, whatever {@link CommentingOptions.history} says: the flag is write-once
+ * server-side, so an undo clearing it would be vetoed rather than bring the comment back.
  *
- * Deleting a thread's last comment leaves the thread with no surface — an empty thread renders
- * nothing — and closes it if it's open. The thread record is left for the server to prune, since
- * the deleter may not be its creator.
- *
- * A comment that's already deleted, or already pruned, is a no-op.
+ * Deleting a thread's last comment closes it and leaves the thread record for the server to prune,
+ * since the deleter may not be its creator. An already-deleted comment is a no-op.
  *
  * @public
  */
@@ -244,10 +222,8 @@ export function deleteComment(editor: Editor, comment: TLComment): void {
 		editor,
 		() => {
 			const current = readLatest(editor, comment)
-			// Deleting twice — a double activation, a handler firing on a copy taken before the first
-			// delete — is nothing to do rather than something to redo. The check below counts the
-			// comment being deleted among the live ones, so it only reads as "the last one" while
-			// this delete is the one taking it away.
+			// Deleting twice is nothing to do rather than something to redo. The check below counts this
+			// comment among the live ones, so it only reads as "the last one" while this delete takes it away.
 			if (!current || current.isDeleted) return
 			const isLastInThread =
 				getLiveComments(editor).filter((c) => c.threadId === current.threadId).length <= 1
@@ -263,12 +239,10 @@ export function deleteComment(editor: Editor, comment: TLComment): void {
 /**
  * Delete a thread and, with it, the whole conversation.
  *
- * A soft delete on the same model as {@link deleteComment}: the flag goes on the thread record and
- * the server prunes the thread, its comments, and their reactions once it's persisted. Deleting a
- * thread is its creator's to do — a server enforcing per-record permissions vetoes anyone else —
- * and the write is never undoable.
- *
- * Closes the thread if it's the open one. A thread that's already pruned is a no-op.
+ * A soft delete on the same model as {@link deleteComment}: the server prunes the thread, its
+ * comments, and their reactions once the flag is persisted. Deleting a thread is its creator's to
+ * do, and the write is never undoable. Closes the thread if it's the open one; a pruned thread is
+ * a no-op.
  *
  * @public
  */

--- a/packages/commenting/src/canvas/comment-reactions.tsx
+++ b/packages/commenting/src/canvas/comment-reactions.tsx
@@ -41,8 +41,8 @@ export function useCommentReactions(
 
 /**
  * The reaction fields {@link summarizeReactions} needs — a structural subset of
- * {@link tldraw#TLCommentReaction}, so tallies can also be built from reaction rows synced outside
- * the editor store (e.g. an app-level reactions table backing a notifications feed).
+ * {@link tldraw#TLCommentReaction}, so tallies can also be built from rows synced outside the
+ * editor store.
  *
  * @public
  */
@@ -53,11 +53,10 @@ export interface ReactionSummaryInput {
 }
 
 /**
- * Tally a comment's reactions into an entry per emoji, ordered by when that emoji was first used
- * so the row stays stable as later reactions arrive. `active` marks the emoji the current user
- * reacted with (the pills render those highlighted), and `reactors` lists who reacted with it, in
- * reaction order, for the hover list. `resolveName` names each reactor; an id it can't name falls
- * back to a generic "Someone", never the raw user id.
+ * Tally a comment's reactions into an entry per emoji, ordered by when that emoji was first used so
+ * the row stays stable as later reactions arrive. `active` marks the current user's emoji and
+ * `reactors` lists who reacted, in reaction order. `resolveName` names each reactor; an id it can't
+ * name falls back to a generic "Someone", never the raw user id.
  *
  * @public
  */
@@ -102,14 +101,12 @@ export function summarizeReactions(
 /**
  * Toggle one user's reaction with a given emoji on a comment.
  *
- * Each reaction is its own record keyed by (comment, user, emoji), so this only ever touches that
- * one user's own records — two people reacting at once never conflict. Behaviour depends on the
- * `allowMultipleReactions` option:
+ * Each reaction is its own record keyed by (comment, user, emoji), so this only touches that user's
+ * own records and two people reacting at once never conflict. Behaviour depends on
+ * `allowMultipleReactions`:
  *
- * - **multiple** (default): the emoji toggles independently — add it if absent, remove it if
- *   present, leaving the user's other reactions alone.
- * - **single**: picking a new emoji first removes the user's existing reaction(s) on the comment,
- *   then adds this one (a replace); picking the one they already have removes it.
+ * - **multiple** (default): the emoji toggles independently, leaving other reactions alone.
+ * - **single**: a new emoji replaces the user's existing reaction; the same one removes it.
  *
  * @public
  */
@@ -165,9 +162,8 @@ export interface CommentReactionsProps {
 }
 
 /**
- * Adapts the `ReactionContent` component override (if any) into a `renderReaction` function for the
- * presentational reaction components. Returns undefined when no override is set, so they fall back
- * to the default (the token string, drawn by the OS emoji font).
+ * Adapts the `ReactionContent` override into a `renderReaction` function for the presentational
+ * components. Undefined when no override is set, so they fall back to drawing the token string.
  */
 function useReactionRenderer(): RenderReaction | undefined {
 	const { components } = useCommentingOptions()
@@ -223,9 +219,8 @@ export interface CommentReactionPickerProps {
 }
 
 /**
- * The add-reaction button for one comment. Belongs with the comment card's hover actions (under
- * the ⋯ button) rather than in the reaction row, so opening it doesn't chase the row as reactions
- * are added.
+ * The add-reaction button for one comment. Belongs with the comment card's hover actions rather
+ * than in the reaction row, so opening it doesn't chase the row as reactions are added.
  * @public @react
  */
 export function CommentReactionPicker({

--- a/packages/commenting/src/canvas/comment-store.ts
+++ b/packages/commenting/src/canvas/comment-store.ts
@@ -3,15 +3,13 @@ import { Editor, TLComment, TLCommentReaction, TLCommentThread, TLRecord } from 
 /**
  * Typed reads of comment records on the editor store.
  *
- * Comment threads and comments live on the editor's local store so the canvas can render them
- * reactively, but they are opt-in records that aren't part of the `TLRecord` union (they ride the
- * sync server's object-store lane on the wire — see `TLCommentThread`). `editor.store` is therefore
- * statically typed `Store<TLRecord>` and doesn't know about them, so every access has to reinterpret
- * the type. These helpers own that reinterpretation — an `unknown` hop to exactly the type the store
- * expects, so the rest of each call stays checked — behind one boundary, and keep call sites typed.
+ * Comment records live on the editor's local store so the canvas can render them reactively, but
+ * they're opt-in and aren't part of the `TLRecord` union — so `editor.store` is statically typed
+ * `Store<TLRecord>` and every access has to reinterpret the type. These helpers own that
+ * reinterpretation behind one boundary and keep call sites typed.
  *
- * Writes do the same reinterpretation, but they also answer to the undo/redo policy, so they live
- * with the rest of the write path in `comment-mutations.ts`.
+ * Writes do the same, but also answer to the undo/redo policy, so they live in
+ * `comment-mutations.ts`.
  */
 
 /**
@@ -36,9 +34,8 @@ export function getCommentRecord(editor: Editor, id: string): TLCommentRecord | 
 }
 
 /**
- * Every comment thread in the store, **including soft-deleted ones** and ones left empty by their
- * last comment's delete — records that are still present but awaiting the server's prune, and that
- * nothing renders. For the set the UI shows, use {@link getLiveCommentThreads}.
+ * Every comment thread in the store, **including soft-deleted and emptied ones** awaiting the
+ * server's prune, which nothing renders. For the set the UI shows, use {@link getLiveCommentThreads}.
  *
  * Non-reactive; wrap in `useValue`, or use `useCommentThreads`, to react.
  * @public
@@ -62,8 +59,7 @@ export function getComments(editor: Editor): TLComment[] {
 
 /**
  * The comments that should render: not soft-deleted. A deleted record lingers in the store until
- * the server prunes it, so this — not {@link getComments} — is what a count or a list of your own
- * should be built from.
+ * the server prunes it, so build counts and lists from this rather than {@link getComments}.
  *
  * Non-reactive; the reactive equivalent is `useComments` (which also sorts oldest first).
  * @public
@@ -73,10 +69,9 @@ export function getLiveComments(editor: Editor): TLComment[] {
 }
 
 /**
- * The comment threads that should render (pins, sidebar): live — not soft-deleted — and still
- * holding at least one live comment. A soft-deleted thread or comment is awaiting the server's
- * prune, as is a thread emptied by its last comment's delete; until the prune lands, the emptied
- * thread record lingers with no surface.
+ * The comment threads that should render (pins, sidebar): not soft-deleted, and still holding at
+ * least one live comment. A thread emptied by its last comment's delete lingers with no surface
+ * until the server's prune lands.
  *
  * Non-reactive; the reactive equivalent is `useCommentThreads`.
  * @public

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -125,7 +125,6 @@ class CommentIdle extends StateNode {
 		updateAnchorHint(this.editor)
 	}
 
-	// Hint the shape a click would attach to.
 	override onPointerMove() {
 		updateAnchorHint(this.editor)
 	}
@@ -186,7 +185,6 @@ class CommentPointing extends StateNode {
 				)
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
-		// Hand back to select; the open composer is now the focus.
 		editor.setCurrentTool('select')
 	}
 

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -49,11 +49,10 @@ export function regionBetween(a: VecLike, b: VecLike): BoxModel {
 }
 
 /**
- * The comment tool. Pressing down opens the comment composer immediately at the pointer, and it
- * follows the pointer until release — like placing a sticky note — settling on a point, or on a
- * shape when released over one. (With region comments enabled, dragging past the threshold instead
- * draws a region rectangle.) Placement only opens a composer (via `pendingComment`); the records
- * are created when the comment is posted.
+ * The comment tool. Pressing down opens the comment composer at the pointer and it follows until
+ * release — like placing a sticky note — settling on a point, or on a shape when released over one.
+ * With region comments enabled, dragging past the threshold draws a region rectangle instead.
+ * Placement only opens a composer; the records are created when the comment is posted.
  * @public
  */
 export class CommentTool extends StateNode {
@@ -210,10 +209,9 @@ class CommentDragging extends StateNode {
 	static override id = 'dragging'
 
 	override onEnter() {
-		// A region drag supersedes the point-follow composer opened in `pointing`. Show a crosshair
-		// again — the composer no longer stands in for the pointer, so a hidden cursor would leave
-		// the drag with no pointer at all. Drop the placement hint too: a region anchors to its
-		// rectangle, so a single-shape outline under the dashed box would be stale.
+		// A region drag supersedes the point-follow composer opened in `pointing`. Show a crosshair again,
+		// since the composer no longer stands in for the pointer, and drop the placement hint — a region
+		// anchors to its rectangle, so a single-shape outline would be stale.
 		pendingComment.set(this.editor, null)
 		this.editor.setHintingShapes([])
 		this.editor.setCursor({ type: 'cross', rotation: 0 })

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -226,6 +226,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		return node.members.every((id) => group.includes(id)) ? group : null
 	}
 
+	// Which threads are on screen this render. A stack renders once, owned by its first on-screen
+	// member — members arrive by different paths, so ownership can't be decided per-path.
 	const renderedThreadIds = new Set<string>()
 	if (options.enableClustering) {
 		for (const { node } of fadeNodes) {

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -46,20 +46,17 @@ export type CanvasCommentsProps = CommentingContext
  * thread popover (with a reply composer) on click, and shows a composer where the comment tool
  * placed a new thread. Reads/writes comment records straight from `editor.store`.
  *
- * It's meant as the batteries-included default — every visible piece is a lever (the `CommentBody`
- * and `PinContent` slots on `CommentTool.configure({ components })`), and the pieces it composes
- * (`CommentPin`, `CommentThread`, `CommentComposer`, the hooks, the tool) are all exported, so a
- * consumer can rebuild this from parts instead.
- *
- * The host wiring — who the viewer is, how ids become names, read status, mentions — is the
- * {@link CommentingContext}, which `CanvasCommentsSidebar` takes too, so a host mounting both can
- * build it once and spread it into each.
+ * It's the batteries-included default: every visible piece is a slot on
+ * `CommentTool.configure({ components })`, and the pieces it composes (`CommentPin`,
+ * `CommentThread`, `CommentComposer`, the hooks, the tool) are all exported, so a consumer can
+ * rebuild it from parts instead. The host wiring is the {@link CommentingContext}, which
+ * `CanvasCommentsSidebar` takes too.
  *
  * @public @react
  */
 export function CanvasComments(props: CanvasCommentsProps) {
-	// Gate the whole layer on the license before doing any work. The inner component holds all the
-	// other hooks, so mounting/unmounting it as the license resolves keeps hook order stable here.
+	// The inner component holds every other hook, so mounting it as the license resolves keeps hook
+	// order stable here.
 	const commentingEnabled = useCommentingEnabled()
 	if (!commentingEnabled) return null
 	return <CanvasCommentsLayer {...props} />
@@ -71,18 +68,16 @@ function CanvasCommentsLayer(props: CommentingContext) {
 	const allThreads = useCommentThreads(editor)
 	const pending = usePendingComment()
 	const canComment = useCanComment(props.currentUserId)
-	// With composing blocked and no fallback slot there's nothing to render for a pending comment —
-	// and the dismiss handlers (Escape, click-away) live inside PendingComposer, which would never
-	// mount. Clear the atom instead of stranding it (a stale pending would pop a composer at the
-	// old click point if `canComment` later flips true).
+	// Nothing renders a pending comment when composing is blocked and there's no fallback slot, and
+	// the dismiss handlers live inside PendingComposer — so clear the atom rather than strand it.
 	const canRenderComposer = canComment || options.components.ComposerFallback != null
 	const showPendingComposer = pending != null && canRenderComposer
 	useEffect(() => {
 		if (pending && !showPendingComposer) pendingComment.set(editor, null)
 	}, [editor, pending, showPendingComposer])
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
-	// Hide resolved threads' pins by default, matching the sidebar's `showResolved` filter. The open
-	// thread stays in — resolving from its own popover shouldn't make the pin vanish under it.
+	// Matches the sidebar's `showResolved` filter. The open thread stays in — resolving from its own
+	// popover shouldn't make the pin vanish under it.
 	const showResolved = useValue('show resolved', () => sidebarFilters.get(editor).showResolved, [
 		editor,
 	])
@@ -102,9 +97,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		() => new Map<string, TLCommentThread>(threads.map((thread) => [thread.id, thread])),
 		[threads]
 	)
-	// Zooming separates near pins, but pins with the *same* anchor point (several imprecise
-	// comments on one shape) coincide at every zoom — those render as one count-badge stack that
-	// opens the threads as a list. Keyed on page-space anchors, so camera moves never recompute this.
+	// Pins with the *same* anchor point coincide at every zoom, so they render as one count-badge
+	// stack. Keyed on page-space anchors, so camera moves never recompute this.
 	const pinStacks = useValue('comment pin stacks', () => computePinStacks(editor, threads), [
 		editor,
 		threads,
@@ -123,12 +117,9 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		}
 	}, [editor])
 
-	// Clear a stale open-stack key. `openStackId` is a stack's coincident point key, and only the
-	// stack's own (mounted) handlers clear it — so collapsing the stack to a single pin unmounts the
-	// `ThreadStackPin` and strands the key. A dangling `openStackId` is not harmless: `useMarkerPreview`
-	// treats any non-null value as "a stack is open" and suppresses every hover preview until it's
-	// cleared. Keep it while any live stack still sits at that key (so losing a member — even the
-	// oldest — keeps the list open under the survivors), and clear it once none does.
+	// Clear a stale open-stack key: only the stack's own mounted handlers clear it, so collapsing to
+	// a single pin strands it — and `useMarkerPreview` reads any non-null value as "a stack is open"
+	// and suppresses every hover preview. Kept while any live stack still sits at that key.
 	useEffect(() => {
 		const key = openStackId.get(editor)
 		if (!key) return
@@ -157,10 +148,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		[editor]
 	)
 
-	// Serve a pending reveal request: open the thread, zooming to the first cluster split that
-	// reveals its pin when it's currently folded into a badge. A reveal is an explicit ask to see
-	// the thread, so it also unhides pins — the popover opens on the on-canvas layer, which stays
-	// invisible while hidden.
+	// Serve a pending reveal request, zooming to the first cluster split that reveals the pin if it's
+	// folded into a badge. Also unhides pins: the popover opens on the layer that hiding withholds.
 	useEffect(() => {
 		if (!requestedRevealThread) return
 		revealThreadRequest.set(editor, null)
@@ -169,10 +158,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		openThreadId.set(editor, requestedRevealThread.id)
 	}, [requestedRevealThread, clusterModel.table, clusterZoomBounds, editor, options])
 
-	// Picking a thread out of a cluster's hover preview. Setting `openThreadId` alone would work —
-	// the thread leaves the cluster input and renders its own pin — but it would cut straight there
-	// from wherever the badge was. Zoom in on it first, the same move (and duration) the badge's
-	// own click makes, so the thread arrives instead of appearing.
+	// Picking a thread out of a cluster's hover preview. `openThreadId` alone would work, but would
+	// cut straight there from the badge — zoom in first, the same move the badge's own click makes.
 	const revealClusteredThread = useCallback(
 		(thread: TLCommentThread) => {
 			revealThreadPin(
@@ -188,8 +175,7 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		[clusterModel.table, clusterZoomBounds, editor, options]
 	)
 
-	// Clicking a badge zooms past the zoom at which that cluster first unclusters, centered on its
-	// centroid — see `zoomToClusterSplit`.
+	// Clicking a badge zooms past the point where that cluster unclusters — see `zoomToClusterSplit`.
 	const expandCluster = useCallback(
 		(node: ClusterNode) => {
 			zoomToClusterSplit(editor, clusterModel.table, clusterZoomBounds, node)
@@ -197,9 +183,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		[clusterModel.table, clusterZoomBounds, editor]
 	)
 
-	// Escape collapses the open thread. Capture-phase + stopPropagation so it runs ahead of the
-	// editor (which would otherwise cancel the current tool or clear the selection). If a comment is
-	// being edited, let its own Escape handler exit edit mode first, keeping the thread open.
+	// Escape collapses the open thread. Capture-phase so it runs ahead of the editor, which would
+	// otherwise cancel the tool or clear the selection.
 	useEffect(() => {
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== 'Escape' || openThreadId.get(editor) === null) return
@@ -215,8 +200,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		return () => document.removeEventListener('keydown', onKeyDown, true)
 	}, [editor])
 
-	// Shift+C toggles comment-pin visibility on the canvas. Skipped while typing so it never fires
-	// from inside a composer. Physical `KeyC` (layout-independent) with shift only.
+	// Shift+C toggles pin visibility. Physical `KeyC` so it's layout-independent, and skipped while
+	// typing so it never fires from inside a composer.
 	useEffect(() => {
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.code !== 'KeyC' || !e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return
@@ -229,19 +214,12 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		return () => document.removeEventListener('keydown', onKeyDown, true)
 	}, [editor])
 
-	// Hidden: the whole canvas layer (pins, open popover, pending composer) is withheld. The signal
-	// is read above so this component stays mounted and its shortcut/Escape effects keep running.
+	// The signal is read above so this stays mounted and its shortcut/Escape effects keep running.
 	if (hidden) return null
 
-	// Which threads are on screen this render, across every path below. A stack renders exactly
-	// once, owned by its first member that is actually on screen — members can arrive by different
-	// paths (a leaf via clustering while its open sibling renders via the open slot), so ownership
-	// can't be decided per-path.
-	// A cluster node that is exactly one coincident stack — every member shares a single pin-stack
-	// group, with no distinct-position comment mixed in. Such a node is a stack standing on its own
-	// (its neighbours have already split off as the view zoomed in), so it renders as the immediate
-	// cascading count-badge list rather than a zoom-to-split cluster badge. Returns the stack's full
-	// group — which can include an open or orphan member the node's own leaves omit — or null.
+	// The node's pin-stack group when every member shares one — a stack standing on its own, which
+	// renders as a cascading count-badge list rather than a zoom-to-split cluster badge. The group
+	// can include an open or orphan member the node's own leaves omit.
 	const stackGroupOf = (node: ClusterNode): readonly string[] | null => {
 		const group = pinStacks.get(node.members[0])
 		if (!group) return null
@@ -252,8 +230,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 	if (options.enableClustering) {
 		for (const { node } of fadeNodes) {
 			if (node.count === 1) renderedThreadIds.add(node.id)
-			// A pure-stack node owns its members here (they aren't count-1 leaves), so register them so
-			// the owner logic can pick one — mirroring how count-1 leaves are added above.
+			// A pure-stack node's members aren't count-1 leaves, so register them here for the owner
+			// logic to pick from.
 			else if (stackGroupOf(node)) for (const id of node.members) renderedThreadIds.add(id)
 		}
 		for (const thread of orphanThreads) renderedThreadIds.add(thread.id)
@@ -278,16 +256,15 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		return <ThreadPin editor={editor} thread={thread} {...props} />
 	}
 
-	// Rendered through the editor's portal rather than into the slot this component is mounted in:
-	// the pins sit below the collaborator cursors and the popovers above the UI panels, and no
-	// single canvas layer spans both. `EditorPortal` also fixes where the layer lands among the
-	// container's children, so it stays behind the UI's skip link in the tab order.
+	// Portalled rather than rendered into this component's slot: pins sit below the collaborator
+	// cursors and popovers above the UI panels, and no single canvas layer spans both. The portal
+	// also fixes where the layer lands among the container's children, keeping it behind the UI's
+	// skip link in the tab order.
 	return (
 		<EditorPortal>
-			{/* Wheel pass-through is deliberately NOT on this root: it lives on each interactive
-			    element instead. The root spans the whole canvas, so any pin past its bottom/right
-			    edge inflates the root's scrollHeight — which the wheel hook's is-this-scrollable
-			    guard reads as scrollable, silently disabling pass-through. */}
+			{/* Wheel pass-through lives on each interactive element, not this root: the root spans the
+			    whole canvas, so a pin past its bottom/right edge inflates scrollHeight and the wheel
+			    hook's is-this-scrollable guard silently disables pass-through. */}
 			<div className="tlui-cmt-canvas-layer">
 				{options.enableClustering ? (
 					<>
@@ -299,10 +276,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 								if (!thread) return null
 								content = renderThreadPin(thread)
 							} else if (stackGroup) {
-								// A coincident stack standing alone: draw the cascading count-badge list now
-								// instead of a zoom-to-split cluster badge. Route it through the stack's owner so
-								// the open/orphan/held slots stay deduped — when the owner is one of them, that
-								// slot draws the stack and this node draws nothing.
+								// Routed through the stack's owner so the open/orphan/held slots stay deduped:
+								// when the owner is one of them, that slot draws the stack and this draws nothing.
 								const owner = stackGroup.find((id) => renderedThreadIds.has(id))
 								content =
 									owner && node.members.includes(owner)
@@ -335,10 +310,8 @@ function CanvasCommentsLayer(props: CommentingContext) {
 						))}
 					</>
 				) : (
-					// Clustering off: every thread renders as its own live pin (each returns null when it's
-					// not on the current page or its anchor is missing). The open thread is excluded here and
-					// rendered once below, mirroring how the clustering path keeps it out of the cluster leaves —
-					// otherwise it would mount a second, stacked pin.
+					// Clustering off: every thread renders its own pin. The open thread is excluded and
+					// rendered once below, or it would mount a second, stacked pin.
 					threads
 						.filter((thread) => thread.id !== openId)
 						.map((thread) => <Fragment key={thread.id}>{renderThreadPin(thread)}</Fragment>)

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -106,8 +106,6 @@ function CanvasCommentsLayer(props: CommentingContext) {
 	const openThread = openId ? threadsById.get(openId) : null
 	const hidden = useValue('comments hidden', () => commentsHidden.get(editor), [editor])
 
-	// Reset the transient UI state (open thread, open stack, half-placed comment, unserved reveal)
-	// when this unmounts.
 	useEffect(() => {
 		return () => {
 			openThreadId.set(editor, null)
@@ -175,7 +173,6 @@ function CanvasCommentsLayer(props: CommentingContext) {
 		[clusterModel.table, clusterZoomBounds, editor, options]
 	)
 
-	// Clicking a badge zooms past the point where that cluster unclusters — see `zoomToClusterSplit`.
 	const expandCluster = useCallback(
 		(node: ClusterNode) => {
 			zoomToClusterSplit(editor, clusterModel.table, clusterZoomBounds, node)

--- a/packages/commenting/src/canvas/options.ts
+++ b/packages/commenting/src/canvas/options.ts
@@ -94,7 +94,7 @@ export interface CommentingComponents {
  * @public
  */
 export interface CommentingOptions {
-	// ── History / undo ───────────────────────────────────────────────────────────────────────
+	// History / undo
 	/**
 	 * How comment mutations interact with the editor undo stack. Defaults to `'ignore'` — comments
 	 * are deliberately not undoable (see `TLComment`). `'record'` is a multiplayer footgun: undoing
@@ -107,7 +107,7 @@ export interface CommentingOptions {
 	 */
 	readonly dragHistory: TLHistoryBatchOptions['history'] | undefined
 
-	// ── Feature toggles ──────────────────────────────────────────────────────────────────────
+	// Feature toggles
 	/** Fold nearby pins into count badges as the camera zooms out. */
 	readonly enableClustering: boolean
 	/**
@@ -131,7 +131,7 @@ export interface CommentingOptions {
 	 */
 	readonly enableRegions: boolean
 
-	// ── Permissions ──────────────────────────────────────────────────────────────────────────
+	// Permissions
 	/**
 	 * Whether the viewer may participate in commenting: composing, editing, deleting, resolving, and
 	 * moving pins. When false, {@link CommentingComponents.ComposerFallback} renders in the
@@ -146,7 +146,7 @@ export interface CommentingOptions {
 		| ((ctx: { editor: Editor; currentUserId: string | null }) => boolean)
 		| undefined
 
-	// ── Anchoring ────────────────────────────────────────────────────────────────────────────
+	// Anchoring
 	/** Normalized (0–1) spot within a shape where imprecise shape pins sit. Default top-right. */
 	readonly impreciseShapeAnchor: { readonly x: number; readonly y: number }
 	/**
@@ -156,7 +156,7 @@ export interface CommentingOptions {
 	 */
 	shouldBePrecise(editor: Editor, context: ShapeCommentPrecisionContext): boolean
 
-	// ── Components ────────────────────────────────────────────────────────────────────────────
+	// Components
 	/** Component overrides. See {@link CommentingComponents}. */
 	readonly components: CommentingComponents
 }

--- a/packages/commenting/src/canvas/options.ts
+++ b/packages/commenting/src/canvas/options.ts
@@ -41,47 +41,40 @@ export interface CommentingComponents {
 	ThreadPreview?: ComponentType<{ comment: TLComment }>
 	/**
 	 * A whole sidebar row. Replaces the default `<CommentListItem>`, which is exported — so a row
-	 * that only adds something (an unread dot, an assignee, a status chip) can spread these props
-	 * into it rather than start over. Receives the summarized row along with the thread record
-	 * behind it, so host state kept in `thread.meta` is available. Use `ThreadPreview` instead when
-	 * only the preview text is changing.
+	 * that only adds an unread dot or a status chip can spread these props into it. Use
+	 * `ThreadPreview` instead when only the preview text is changing.
 	 */
 	ThreadRow?: ComponentType<CommentListItemRenderProps & { thread: TLCommentThread }>
 	/**
-	 * Extra controls in an open thread's header, rendered ahead of the built-in resolve and dismiss
-	 * buttons. This is where host verbs go — assign a thread, link it to a ticket, mark it as a
-	 * to-do. The built-in actions stay put; this adds alongside them rather than replacing them.
-	 *
-	 * Note the header already offers "copy link" whenever the host supplies `getThreadHref` on the
-	 * commenting context, so a link affordance doesn't need this slot.
+	 * Extra controls in an open thread's header, added ahead of the built-in resolve and dismiss
+	 * buttons rather than replacing them. "Copy link" is already built in whenever the host supplies
+	 * `getThreadHref`.
 	 */
 	ThreadActions?: ComponentType<{ thread: TLCommentThread; comments: TLComment[] }>
 	/**
 	 * A reaction's visual, given its token. The default renders the token string for the OS emoji
-	 * font to draw (so the token is the emoji glyph). Override this to render your own palette —
-	 * return an `<img>` for custom emoji, an SVG, or anything. The token is whatever your picker
-	 * emits and is what gets stored/synced; this only controls how it's drawn.
+	 * font. Override to draw a custom palette — an `<img>`, an SVG, anything. The token is what gets
+	 * stored and synced; this only controls how it's drawn.
 	 */
 	ReactionContent?: ComponentType<{ token: string }>
 	/**
-	 * What the add-reaction button opens: the thing that produces a reaction token. Replaces the
-	 * default `<EmojiPicker>` grid. Pairs with `ReactionContent` (which draws whatever tokens this
-	 * emits) and with `isAllowedReaction` (which has to accept them).
+	 * What the add-reaction button opens. Replaces the default `<EmojiPicker>` grid. Pairs with
+	 * `ReactionContent` (which draws the tokens this emits) and `isAllowedReaction` (which must
+	 * accept them).
 	 */
 	ReactionPalette?: ComponentType<EmojiPickerProps>
 	/**
-	 * The hover affordance naming who reacted with an emoji. It receives the reactors and the pill
-	 * (as `children`) and returns the whole thing — so it owns the tooltip, its box, size, shape, and
-	 * position. Replaces the default (`DefaultReactionTooltip`). For a simple wording change, translate
-	 * the `comments.reacted-*` strings instead; reach for this to change the structure — a different
-	 * box, avatars, a banner anywhere on screen.
+	 * The hover affordance naming who reacted with an emoji. Receives the reactors and the pill (as
+	 * `children`) and owns the whole thing — box, size, shape, position. For a wording change,
+	 * translate the `comments.reacted-*` strings instead.
 	 */
 	ReactionTooltip?: ComponentType<ReactionTooltipProps>
-	/** Shown where a composer would sit when the viewer can't compose (see
-	 *  {@link CommentingOptions.canComment} — a signed-out viewer, a viewer role, a host that
-	 *  turns commenting off). `context` says which surface is rendering it: the bottom of an open
-	 *  thread popover (`'thread'`) or the placement popover the comment tool opens (`'pending'`).
-	 *  Unset, those surfaces render nothing. */
+	/**
+	 * Shown where a composer would sit when the viewer can't compose (see
+	 * {@link CommentingOptions.canComment}). `context` is the surface rendering it: an open thread
+	 * popover (`'thread'`) or the comment tool's placement popover (`'pending'`). Unset, those
+	 * surfaces render nothing.
+	 */
 	ComposerFallback?: ComponentType<{ context: 'pending' | 'thread' }>
 }
 
@@ -103,11 +96,9 @@ export interface CommentingComponents {
 export interface CommentingOptions {
 	// ── History / undo ───────────────────────────────────────────────────────────────────────
 	/**
-	 * How comment mutations (post, reply, edit, resolve, delete) interact with the editor undo
-	 * stack. Defaults to `'ignore'` — comments are deliberately not undoable (see `TLComment`).
-	 * `'record'` is a multiplayer footgun: undoing a delete resurrects a thread a collaborator
-	 * already removed, and undoing a resolve/edit reverts their newer state. Safe only single-player
-	 * or on a non-synced local comment store.
+	 * How comment mutations interact with the editor undo stack. Defaults to `'ignore'` — comments
+	 * are deliberately not undoable (see `TLComment`). `'record'` is a multiplayer footgun: undoing
+	 * a delete resurrects a thread a collaborator already removed. Safe only single-player.
 	 */
 	readonly history: TLHistoryBatchOptions['history']
 	/**
@@ -127,35 +118,29 @@ export interface CommentingOptions {
 	 */
 	readonly allowMultipleReactions: boolean
 	/**
-	 * Whether a token may be added as a reaction. Defaults to {@link isAllowedReactionEmoji} against
-	 * the built-in emoji palette, which is what keeps a scripted client from writing junk `emoji`
-	 * values the picker would never offer. Override it alongside a custom `ReactionPalette` so the
-	 * tokens that palette emits get through. Removals aren't checked — a reaction carrying an
-	 * off-palette token must still be clearable.
+	 * Whether a token may be added as a reaction. Defaults to {@link isAllowedReactionEmoji}, which
+	 * keeps a scripted client from writing junk values the picker would never offer. Override
+	 * alongside a custom `ReactionPalette`. Removals aren't checked — an off-palette reaction must
+	 * still be clearable.
 	 */
 	isAllowedReaction(token: string): boolean
 	/**
 	 * Whether dragging the comment tool out creates a region anchor — a comment attached to a
-	 * rectangular area of the page, drawn as a dashed box with the thread's pin on the corner the
-	 * drag released on. Off by default: comments attach to points and shapes only, and a drag just
-	 * trails the composer. A region reveals its box while the pointer is inside it, moves by its
-	 * pin, and resizes from its corners.
+	 * rectangular area, drawn as a dashed box with the pin on the corner the drag released on. Off
+	 * by default, where comments attach to points and shapes only and a drag trails the composer.
 	 */
 	readonly enableRegions: boolean
 
 	// ── Permissions ──────────────────────────────────────────────────────────────────────────
 	/**
-	 * Whether the viewer may participate in commenting: composing new threads and replies, editing
-	 * and deleting comments, resolving threads, and moving pins or regions. Composers render when
-	 * it returns true; when it returns false, the {@link CommentingComponents.ComposerFallback}
-	 * slot renders in their place (or nothing, if that slot is unset) and the action affordances
-	 * are hidden. Unset, participation is allowed exactly when `currentUserId` is set.
+	 * Whether the viewer may participate in commenting: composing, editing, deleting, resolving, and
+	 * moving pins. When false, {@link CommentingComponents.ComposerFallback} renders in the
+	 * composer's place and action affordances are hidden. Unset, participation is allowed exactly
+	 * when `currentUserId` is set.
 	 *
-	 * Called during render via {@link useCanComment}, so reactive reads (signals) are tracked.
-	 * The comment tool itself stays registered and selectable — hosts that want its toolbar button
-	 * to do something else (e.g. open a sign-in dialog) can override the tool item's `onSelect`.
-	 * Note posting still requires a `currentUserId` to author the records, so a callback that
-	 * returns true for a signed-out viewer yields a composer whose send button stays disabled.
+	 * Called during render via {@link useCanComment}, so signal reads are tracked. Posting still
+	 * needs a `currentUserId`, so returning true for a signed-out viewer yields a composer whose
+	 * send button stays disabled.
 	 */
 	readonly canComment:
 		| ((ctx: { editor: Editor; currentUserId: string | null }) => boolean)
@@ -165,12 +150,9 @@ export interface CommentingOptions {
 	/** Normalized (0–1) spot within a shape where imprecise shape pins sit. Default top-right. */
 	readonly impreciseShapeAnchor: { readonly x: number; readonly y: number }
 	/**
-	 * Whether a comment landing on a shape anchors precisely — pinned to the exact clicked spot
-	 * within the shape — or imprecisely — pinned to the shape as a whole, rendered at
-	 * `impreciseShapeAnchor`. Called wherever a shape anchor is created (placing with the comment
-	 * tool, dropping a dragged pin onto a shape). Always precise by default. Return `false` for
-	 * shape-level anchoring, or decide from the context — the Alt key's state, or the shape itself,
-	 * e.g. precise only on notes. Governs new placements only; existing anchors render as stored.
+	 * Whether a comment landing on a shape pins to the exact clicked spot, or to the shape as a
+	 * whole (rendered at `impreciseShapeAnchor`). Always precise by default; return `false`, or
+	 * decide from the context. Governs new placements only — existing anchors render as stored.
 	 */
 	shouldBePrecise(editor: Editor, context: ShapeCommentPrecisionContext): boolean
 
@@ -223,11 +205,9 @@ export function useCommentingOptions(): CommentingOptions {
 
 /**
  * Whether the viewer may participate in commenting, per {@link CommentingOptions.canComment}
- * (defaulting to `currentUserId != null` when unset). Where this is false, composers give way to
- * the {@link CommentingComponents.ComposerFallback} slot and action affordances are hidden.
+ * (defaulting to `currentUserId != null` when unset).
  *
- * This is a plain, untracked read — a `canComment` callback that reads signals is not observed.
- * In React, use {@link useCanComment} instead.
+ * This is a plain, untracked read — in React, use {@link useCanComment} instead.
  *
  * @public
  */

--- a/packages/commenting/src/canvas/state.ts
+++ b/packages/commenting/src/canvas/state.ts
@@ -3,20 +3,19 @@ import type { PendingComment } from './comment-tool'
 import { DEFAULT_SIDEBAR_FILTERS, type SidebarFilters } from './sidebar-filters'
 
 /**
- * Transient commenting UI state, scoped per editor via {@link EditorAtom}. Editor-scoping (rather
- * than module-global atoms) keeps two editors on one page — or an editor and a second instance —
- * from sharing open-thread, visibility, and filter state. Reachable from both React (`useEditor()`)
- * and the comment tool (`this.editor`).
+ * Transient commenting UI state, scoped per editor via {@link EditorAtom} so two editors on one
+ * page don't share open-thread, visibility, and filter state. Reachable from both React
+ * (`useEditor()`) and the comment tool (`this.editor`).
  */
 
 /** The id of the one open thread (only one popover is open at a time), or null when all closed.
  * @public */
 export const openThreadId = new EditorAtom<string | null>('openThreadId', () => null)
 
-/** The coincident-pin stack whose thread list is showing (keyed by its oldest member's thread
- * id), or null. Editor state rather than component state: the stack pin remounts when its owning
- * render path changes (e.g. a member thread opens), and the open list must survive that.
- * @internal */
+/** The coincident-pin stack whose thread list is showing (keyed by its oldest member's thread id),
+ *  or null. Editor state rather than component state: the stack pin remounts when its owning render
+ *  path changes, and the open list must survive that.
+ *  @internal */
 export const openStackId = new EditorAtom<string | null>('openStackId', () => null)
 
 /** The comment currently being placed (composer open, not yet posted), or null.
@@ -32,13 +31,12 @@ export const pendingComment = new EditorAtom<PendingComment | null>('pendingComm
 export const revealThreadRequest = new EditorAtom<string | null>('revealThreadRequest', () => null)
 
 /**
- * Open a thread and bring it into view, given a thread id or the id of any comment in it. Use it
- * to jump to a thread from outside the canvas — a notification, a deep link, your own list.
+ * Open a thread and bring it into view, given a thread id or the id of any comment in it. Use it to
+ * jump to a thread from outside the canvas — a notification, a deep link, your own list.
  *
- * The request is served by `CanvasComments`, so it works before the records have arrived: the
- * layer waits for them to sync in, switches pages if it needs to, unhides pins, zooms in far
- * enough to split the thread out of any cluster it's folded into, and then opens it. That also
- * means nothing happens if `CanvasComments` isn't mounted.
+ * The request is served by `CanvasComments`, so it works before the records have arrived: the layer
+ * waits for them, switches pages, unhides pins, and zooms far enough to split the thread out of any
+ * cluster. That also means nothing happens if `CanvasComments` isn't mounted.
  *
  * To open a thread you already hold and skip the wait, see {@link focusThread}.
  *
@@ -55,12 +53,10 @@ export function revealThread(editor: Editor, threadOrCommentId: string): void {
 
 /**
  * The id passed to the most recent {@link revealThread} call that `CanvasComments` hasn't served
- * yet, or null when there's nothing outstanding. A request also clears when `CanvasComments`
- * unmounts, since nothing is left to serve it.
+ * yet, or null. A request also clears when `CanvasComments` unmounts.
  *
- * This is a plain, untracked read. In React, use {@link useRevealThreadPending} — but reach for
- * this one inside a timer or callback that needs the value as of *now* rather than as of the
- * render it closed over.
+ * This is a plain, untracked read — in React, use {@link useRevealThreadPending}, unless you need
+ * the value as of *now* rather than as of the render you closed over.
  *
  * @public
  */
@@ -71,11 +67,9 @@ export function getRevealThreadPending(editor: Editor): string | null {
 /**
  * Reactive React hook for {@link getRevealThreadPending}.
  *
- * Use it to notice a reveal that never lands — most often a deep link to a comment that has since
- * been deleted. Give it a grace period before you act: a request also sits here while its records
- * are still syncing in, which is the normal case on a cold load. Re-check with
- * {@link getRevealThreadPending} when the grace period elapses, since the request can clear inside
- * it without this hook's value having caught up yet.
+ * Use it to notice a reveal that never lands — usually a deep link to a deleted comment. Give it a
+ * grace period first, since a request also sits here while its records sync in, and re-check with
+ * {@link getRevealThreadPending} when it elapses.
  *
  * @public
  */
@@ -96,10 +90,8 @@ export const regionDraft = new EditorAtom<BoxModel | null>('regionDraft', () => 
 export const commentsHidden = new EditorAtom<boolean>('commentsHidden', () => false)
 
 /**
- * Whether the comments sidebar (the thread list) is open. Driven by an explicit control — a button
- * next to Share on dotcom — rather than by which tool is active, so browsing threads is separate
- * from placing them. The comment tool additionally closes it on enter, keeping placement
- * canvas-focused.
+ * Whether the comments sidebar (the thread list) is open. Driven by an explicit control rather than
+ * by which tool is active, so browsing threads is separate from placing them.
  * @public
  */
 export const commentsSidebarOpen = new EditorAtom<boolean>('commentsSidebarOpen', () => false)

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -45,9 +45,8 @@ import {
 import { POPOVER_OFFSET, ThreadPopover, ThreadView } from './thread-view'
 
 /** The opened popover has a header row the hover preview lacks, so it opens this much higher — the
- *  first comment then lands where the preview's sat. Measured: the expanded first comment sits ~42px
- *  below the panel top (the 40px header, no gap) vs the preview's 4px (its panel padding).
- *  Re-measure if the header height or the preview panel padding changes. */
+ *  first comment then lands where the preview's sat. Re-measure if the header height or the preview
+ *  panel padding changes. */
 const THREAD_HEADER_BLOCK = 36
 
 /**
@@ -55,9 +54,8 @@ const THREAD_HEADER_BLOCK = 36
  * preview, and — for a region anchor — the dashed box and its resize handles. Dragging the marker
  * re-anchors the thread.
  *
- * Memoized: thread records are identity-stable while unchanged, so a pin skips re-rendering when
- * the layer re-renders for reasons that don't concern it. Camera tracking still works — the pin
- * subscribes to its own viewport position via signals, not via props.
+ * Memoized so a pin skips re-rendering when the layer re-renders for unrelated reasons; camera
+ * tracking still works, since the pin subscribes to its own viewport position via signals.
  */
 export const ThreadPin = memo(function ThreadPin({
 	editor,
@@ -135,10 +133,9 @@ export const ThreadPin = memo(function ThreadPin({
 		}
 	}, [editor])
 
-	// Clicking outside the open popover (and off its own pin) closes the thread — mirrors the
-	// pending composer's dismiss. Capture phase + a class check rather than stopPropagation, since the
-	// popover portals elsewhere in the DOM. The pin marker is excluded so its own click-to-toggle
-	// handles it instead of this closing then the toggle reopening.
+	// Clicking outside the open popover closes the thread. Capture phase + a class check rather than
+	// stopPropagation, since the popover portals elsewhere in the DOM. The marker is excluded so its own
+	// click-to-toggle handles it instead of this closing and the toggle reopening.
 	useEffect(() => {
 		if (!open) return
 		const onPointerDown = (e: PointerEvent) => {
@@ -176,10 +173,8 @@ export const ThreadPin = memo(function ThreadPin({
 			const point = inset
 				? { x: viewportPoint.x + inset.x, y: viewportPoint.y + inset.y }
 				: viewportPoint
-			// Off-screen pins (plus a pre-mount margin) unmount rather than re-rendering on every
-			// camera frame — the same cull the cluster badges apply. A region thread stays mounted
-			// while any part of its box is on screen: the box and its pointer-reveal affordance
-			// render from this component even when the pin corner itself is off-screen.
+			// Off-screen pins (plus a pre-mount margin) unmount rather than re-render every camera frame. A
+			// region thread stays mounted while any part of its box is on screen, since the box renders here too.
 			if (!exemptFromCull) {
 				const visible =
 					thread.anchor.type === 'region'
@@ -205,10 +200,8 @@ export const ThreadPin = memo(function ThreadPin({
 		thread.resolved ? 'comments.pin-label-resolved' : 'comments.pin-label'
 	).replace('{name}', threadAuthor?.name ?? UNKNOWN_AUTHOR)
 
-	// Drag the marker to move the thread: its position is overridden locally while dragging, then
-	// re-anchored on drop. A point/shape thread re-anchors to whatever it's dropped on (a shape, else
-	// a point); a region thread translates, keeping its size. A pointer that barely moves is a click —
-	// toggle the popover.
+	// Drag the marker to move the thread: position is overridden locally while dragging, then re-anchored
+	// on drop. A region translates keeping its size; a barely-moved pointer is a click.
 	const isRegion = thread.anchor.type === 'region'
 	// The marker is a button (so it's keyboard-reachable), so the drag handlers are typed to it.
 	const startDrag = (e: ReactPointerEvent<HTMLButtonElement>) => {

--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -78,7 +78,6 @@ export const ThreadPin = memo(function ThreadPin({
 	])
 	// While dragging the marker, its page point overrides the anchor's; committed on drop.
 	const [dragPagePoint, setDragPagePoint] = useState<{ x: number; y: number } | null>(null)
-	// The live bounds while a corner handle is resizing the region, else null.
 	const [resizeBounds, setResizeBounds] = useState<BoxModel | null>(null)
 	// Hovering the marker previews the thread's opening comment, on the delay every marker uses.
 	const { previewShown, previewHandlers } = useMarkerPreview(editor, `pin:${thread.id}`)
@@ -189,7 +188,6 @@ export const ThreadPin = memo(function ThreadPin({
 	if (!point) return null
 
 	const PinContent = options.components.PinContent
-	// The `PinContent` component slot overrides the built-in author-avatar default.
 	const threadAuthor = resolveAuthor(thread.createdBy)
 	const pinContent = PinContent ? (
 		<PinContent thread={thread} comments={comments} />

--- a/packages/commenting/src/canvas/thread-preview.tsx
+++ b/packages/commenting/src/canvas/thread-preview.tsx
@@ -19,26 +19,21 @@ import { POPOVER_OFFSET, toCardProps, useResolveName } from './thread-view'
 
 /**
  * Hover previews for every canvas marker — a single pin, a coincident stack, or a cluster badge.
- * Hovering shows the thread(s) behind the marker as cards; the marker's own click keeps whatever
- * it already did (open the thread, open the stack list, zoom to the cluster's split).
+ * Hovering shows the thread(s) behind the marker as cards; the marker's own click is unchanged.
  *
- * The panel is live, not a passive tooltip: the pointer can travel right into it and hover each
- * card, and clicking one opens that thread — the same affordance the stack list gives its cards.
- * Two pieces make that work. The close delay survives the trip across the gap, and the panel
- * carries an invisible bridge over that gap (see `.tlui-cmt-canvas-preview::before`) so the
- * journey never crosses dead space and retracts the panel mid-move.
+ * The panel is live, not a passive tooltip: the pointer can travel into it and click a card to open
+ * that thread. Two pieces make that work — the close delay survives the trip across the gap, and
+ * the panel carries an invisible bridge over it (see `.tlui-cmt-canvas-preview::before`).
  *
- * Opening a thread from a card needs nothing more than setting `openThreadId`, including for a
- * thread currently folded inside a cluster badge: `collectClusterLeaves` skips the open thread, so
- * it drops out of its badge and renders its own pin and popover.
+ * Opening a thread from a card needs nothing more than setting `openThreadId`, even for one folded
+ * inside a badge: `collectClusterLeaves` skips the open thread, so it drops out and renders itself.
  */
 
 /** How long the pointer must rest on a marker before its preview appears. */
 const PREVIEW_OPEN_DELAY_MS = 180
 /**
- * Grace period after the pointer leaves the marker *or* the panel. Long enough to cross the gap
- * between them by hand — the bridge element covers that gap geometrically, and this covers the
- * moment of transit between the two elements' enter/leave events.
+ * Grace period after the pointer leaves the marker *or* the panel — long enough to cross the gap
+ * between them, which the bridge element covers geometrically.
  */
 const PREVIEW_CLOSE_DELAY_MS = 220
 /** Cards shown before the panel falls back to a "+N more" line. */
@@ -53,9 +48,8 @@ export interface ThreadPreviewCard {
 /**
  * The cards a marker's preview will show, and how many threads it will summarise as "+N more".
  *
- * A thread can exist before its opening comment does — a collaborator's, mid-sync — and has nothing
- * to preview until it arrives. Those are dropped here rather than rendered as blank cards, and they
- * don't count toward the overflow tally either, so "+2 more" always means two readable threads.
+ * A thread can exist before its opening comment does — a collaborator's, mid-sync. Those are
+ * dropped rather than rendered blank, and don't count toward the overflow tally.
  */
 export function selectPreviewCards(
 	threads: readonly TLCommentThread[],
@@ -81,17 +75,15 @@ export type ThreadPreviewVariant = 'thread' | 'list'
 
 /**
  * Which marker's preview is showing, or null. One atom for the whole layer, so previews are
- * mutually exclusive by construction: the close delay means an outgoing marker's timer can still
- * be pending when the next marker opens, and per-component state would briefly show both.
+ * mutually exclusive: the close delay can leave an outgoing marker's timer pending when the next
+ * opens, and per-component state would briefly show both.
  */
 const hoveredMarkerId = new EditorAtom<string | null>('commentHoveredMarkerId', () => null)
 
 /**
  * Hover state for one marker. Returns whether its preview should render, plus the pointer handlers
- * to spread onto the marker element.
- *
- * `markerId` must be stable and unique per marker across the layer — prefix by kind, since a stack
- * is keyed by its oldest member's thread id and would otherwise collide with that thread's own pin.
+ * to spread onto the marker element. `markerId` must be stable and unique per marker across the
+ * layer — prefix by kind, or a stack collides with its oldest member's own pin.
  */
 export function useMarkerPreview(editor: Editor, markerId: string) {
 	const openTimer = useRef(0)
@@ -154,9 +146,8 @@ export function useMarkerPreview(editor: Editor, markerId: string) {
 }
 
 /**
- * The hover panel: each thread's opening comment as a read-only card, capped with a "+N more"
- * line. Mounted only while hovering, so the store subscription it needs to find those comments
- * costs nothing at rest.
+ * The hover panel: each thread's opening comment as a read-only card, capped with a "+N more" line.
+ * Mounted only while hovering, so its store subscription costs nothing at rest.
  */
 export function ThreadPreview({
 	editor,

--- a/packages/commenting/src/canvas/thread-stack.tsx
+++ b/packages/commenting/src/canvas/thread-stack.tsx
@@ -26,9 +26,8 @@ import {
 
 /**
  * The pin for threads whose anchors resolve to the same page point — pins zooming can never
- * separate, so instead of stacked markers they share one count badge. Clicking it opens a
- * popover listing each thread as a card; clicking a card expands that thread in place (via the
- * single open-thread state, so expanding one collapses another).
+ * separate, so they share one count badge. Clicking it lists each thread as a card; clicking a card
+ * expands that thread in place, via the single open-thread state.
  */
 export const ThreadStackPin = memo(function ThreadStackPin({
 	editor,
@@ -47,12 +46,9 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 	// Hovering the badge previews its threads; clicking still opens them as the interactive list.
 	// The preview is what makes the badge legible before you commit to opening it.
 	const { previewShown, previewHandlers } = useMarkerPreview(editor, `stack:${threads[0].id}`)
-	// The list stays open while a member thread is expanded, and on its own after the member
-	// collapses — so Escape steps back: expanded thread → card list → closed. Held in editor
-	// state (not component state) because this pin remounts as its owning render path changes.
-	// Keyed by the coincident page point, not a member id, so the open state survives losing a
-	// member (including the oldest): the survivors keep the same key. Falls back to a thread id
-	// only when the anchor can't resolve (off page), where the list isn't shown anyway.
+	// The list stays open while a member thread is expanded, so Escape steps back: expanded thread ->
+	// card list -> closed. Held in editor state because this pin remounts as its owning render path
+	// changes, and keyed by the coincident page point so the open state survives losing a member.
 	const stackId = useValue(
 		'stack id',
 		() => {
@@ -74,12 +70,9 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 		() => {
 			const first = threads[0]
 			if (first.pageId !== editor.getCurrentPageId()) return null
-			// The badge hangs off its anchor point bottom-left (transform: translate(0, -100%)),
-			// like a pin — and it applies the same imprecise-shape inset the pins it stands in for
-			// would (see ThreadPin): the stack's members share one anchor point, so they share one
-			// inset, and skipping it would snap the marker from tucked inside the shape to the raw
-			// corner the moment a second imprecise comment turns a pin into a stack. The cluster
-			// badge matches by drawing at the centroid of the pins as rendered.
+			// The badge hangs off its anchor point bottom-left like a pin, and applies the same imprecise-shape
+			// inset the pins it stands in for would (see ThreadPin) — otherwise the marker would snap from tucked
+			// inside the shape to the raw corner the moment a second comment turns a pin into a stack.
 			const pagePoint = anchorPagePoint(editor, first.anchor)
 			if (!pagePoint) return null
 			const viewportPoint = editor.pageToViewport(pagePoint)
@@ -136,12 +129,9 @@ export const ThreadStackPin = memo(function ThreadStackPin({
 		}
 	}
 
-	// The expanded thread gains a "Comment" header that pushes its first comment down from where the
-	// hover preview showed it. When that thread is the list's first, lift the whole list by the
-	// header block so its "You" holds position across hover -> open: the single thread's
-	// THREAD_HEADER_BLOCK (36) plus the 8px margin above the expanded entry, less the 2px top the
-	// preview card sits its "You" down by. Only the first entry — lifting the list can't also hold a
-	// lower thread's neighbours in place.
+	// The expanded thread gains a header that pushes its first comment down from where the hover preview
+	// showed it. When that thread is the list's first, lift the whole list so its "You" holds position
+	// across hover -> open. Only the first entry — lifting can't also hold a lower thread's neighbours.
 	const liftForHeader = threads[0]?.id === openId ? 42 : 0
 
 	return (

--- a/packages/commenting/src/canvas/thread-state.ts
+++ b/packages/commenting/src/canvas/thread-state.ts
@@ -102,13 +102,11 @@ export function regionPinPoint(region: BoxModel, corner: VecLike = REGION_PIN_CO
 }
 
 /**
- * Where a thread's pin sits on the page, for each anchor kind. Null hides the pin. For imprecise
- * shape anchors the pin uses the editor's {@link CommentingOptions.impreciseShapeAnchor} (a
- * normalized 0–1 spot, top-right by default) rather than the stored `x`/`y`.
+ * Where a thread's pin sits on the page, for each anchor kind. Null hides the pin. Imprecise shape
+ * anchors use {@link CommentingOptions.impreciseShapeAnchor} rather than the stored `x`/`y`.
  *
- * A shape anchor's `x`/`y` are normalized within the shape's own bounds and resolved through the
- * shape's page transform, so the pin rides every part of that transform — rotating the shape
- * carries the pin around with it instead of leaving it behind in the bounding box.
+ * A shape anchor's `x`/`y` are normalized within the shape's bounds and resolved through its page
+ * transform, so the pin rides rotation instead of being left behind in the bounding box.
  * @public
  */
 export function anchorPagePoint(
@@ -138,15 +136,12 @@ export function anchorPagePoint(
 /**
  * The shape a comment placed at a page point should anchor to, or undefined for empty canvas.
  *
- * Uses the editor's hit-test margin, the same slack select and hover use. Without it, shapes whose
- * geometry is an open path — arrows, lines, draw strokes — are unhittable in practice: their
- * geometry reports a positive distance for every point off the stroke, so a zero margin only
- * matches a pixel-perfect click right on the line.
+ * Uses the editor's hit-test margin, the same slack select and hover use — without it, open-path
+ * shapes (arrows, lines, draw strokes) are unhittable in practice.
  *
- * `hitFrameInside` lets a click inside a frame's body anchor to the frame — without it a frame is
- * hit only on its edge/label (the select-tool convention), so the frame's interior would fall
- * through to a bare point. A child shape under the pointer still wins (children sort above the
- * frame), so only a frame's empty interior anchors the frame.
+ * `hitFrameInside` lets a click inside a frame's body anchor to the frame, which it otherwise
+ * wouldn't (the select-tool convention hits only the edge/label). A child shape under the pointer
+ * still wins, so only a frame's empty interior anchors the frame.
  *
  * @internal
  */
@@ -160,11 +155,9 @@ export function commentTargetShapeAt(editor: Editor, page: VecLike): TLShape | u
 
 /**
  * A shape anchor for a page point. `x`/`y` are the point's normalized (0–1) offset within the
- * shape's own bounds — taken in the shape's own space, so a pin placed on a rotated shape records
- * the spot it was dropped on rather than a spot in the bounding box. Remembered either way: when
- * `precise` the pin sits at exactly `x`/`y`; otherwise it sits at the consumer's imprecise default
- * (top-right out of the box). Placement gestures get `precise` from the `shouldBePrecise`
- * commenting option (always precise, by default).
+ * shape's own bounds, taken in the shape's own space, so a pin on a rotated shape records the spot
+ * it was dropped on. Remembered either way: when `precise` the pin sits at exactly `x`/`y`,
+ * otherwise at the consumer's imprecise default.
  * @public
  */
 export function shapeAnchorAt(
@@ -209,10 +202,9 @@ const THREAD_UI_EXTENT_PX = POPOVER_OFFSET.thread.x + 300
 
 /**
  * How far right of a centered-on pin the true viewport center should sit, in screen px. While the
- * comments sidebar covers the viewport's right edge, centering a pin dead-center puts the thread
- * popover that opens on it under the sidebar — so centering aims the pin at the middle of the
- * uncovered area instead, nudged further left if the thread UI would still reach the sidebar, but
- * never past the viewport's left edge. Zero when the sidebar is closed or not on screen.
+ * comments sidebar covers the viewport's right edge, dead-centering a pin would put its thread
+ * popover under the sidebar — so centering aims at the middle of the uncovered area instead, never
+ * past the viewport's left edge. Zero when the sidebar is closed or not on screen.
  * @internal
  */
 export function commentCenterScreenOffset(editor: Editor): number {

--- a/packages/commenting/src/canvas/thread-view.tsx
+++ b/packages/commenting/src/canvas/thread-view.tsx
@@ -67,10 +67,9 @@ export function useResolveName(resolveAuthor: CommentingContext['resolveAuthor']
 const LINK_COPIED_MS = 2000
 
 /**
- * What a thread's `getThreadHref` should put on the clipboard. Hosts hand back an href, which is
- * allowed to be relative (`/file/abc?comment=…`) — that works as a link target but is meaningless
- * once it's pasted into a chat window, so it's resolved against the current document first. An href
- * the URL parser can't make sense of is copied as-is rather than dropped.
+ * What a thread's `getThreadHref` should put on the clipboard. Hosts may hand back a relative href,
+ * which is meaningless once pasted elsewhere, so it's resolved against the current document first.
+ * An href the URL parser can't make sense of is copied as-is rather than dropped.
  *
  * @internal
  */
@@ -84,9 +83,7 @@ export function absoluteThreadLink(href: string, base = window.location.href): s
 
 /**
  * Copy a thread's link, with a flag that stays set briefly afterwards so the control can confirm.
- * The flag only sets once the write actually resolves — a clipboard the browser withholds
- * (an insecure context, a denied permission) leaves the label alone rather than claiming a copy
- * that didn't happen.
+ * Only set once the write resolves, so a withheld clipboard doesn't claim a copy that didn't happen.
  */
 function useCopyLink(href: string | undefined) {
 	const [copied, setCopied] = useState(false)
@@ -128,9 +125,8 @@ export function toCardProps(
 	}
 }
 
-/** A pin is this square (mirrors `--tlui-cmt-pin-size`). Needed because the two marker kinds are
- *  different sizes *and* anchor at different points, and lining their previews up means
- *  correcting for that. Keep in sync with the stylesheet. */
+/** A pin is this square (mirrors `--tlui-cmt-pin-size`). The two marker kinds differ in size *and*
+ *  anchor point, so lining their previews up means correcting for both. Keep in sync with the CSS. */
 const PIN_SIZE = 28
 
 /** A cluster/stack badge is this square (`--tlui-cmt-marker-size`) — pin-sized, so the marker
@@ -145,16 +141,12 @@ const CARD_TOP_Y = -28
 const PREVIEW_GAP = 6
 
 /**
- * Where a marker's popover sits relative to the marker's anchor point.
+ * Where a marker's popover sits relative to the marker's anchor point. The hover preview uses the
+ * same origins, so moving a popover here moves its preview with it.
  *
- * The hover preview places itself at these same origins, so the two views of a thread differ only
- * by the header the popover has — which its own stylesheet then compensates for. Moving a popover
- * here moves its preview with it.
- *
- * Both marker kinds hang off their point the same way (`translate(0, -100%)`): the anchor is the
- * visual's bottom-left corner. They differ only in size, so each offset clears its own width plus
- * the shared gap, and re-bases the shared card-top measure from its bottom anchor to its middle —
- * keeping the two previews' top cards on the same line.
+ * Both marker kinds hang off their point the same way (`translate(0, -100%)`), differing only in
+ * size — so each offset clears its own width plus the shared gap, and re-bases the shared card-top
+ * measure from its bottom anchor to its middle.
  */
 export const POPOVER_OFFSET = {
 	thread: { x: PIN_SIZE + PREVIEW_GAP, y: CARD_TOP_Y - PIN_SIZE / 2 },
@@ -185,14 +177,11 @@ export function ThreadPopover({ style, children }: { style: CSSProperties; child
 
 /**
  * One thread's interactive view: its comments, the reply composer, edit-in-place on your own
- * comments, and the resolve/delete actions. Reads and writes comment records via the editor's
- * store; read receipts are reported for every unread comment while mounted, so only mount it
- * where the thread is actually being shown.
+ * comments, and the resolve/delete actions. Read receipts are reported for every unread comment
+ * while mounted, so only mount it where the thread is actually being shown.
  *
- * Memoized: the popover position rides the pin's per-frame render point, so the pin re-renders
- * on every camera frame while a thread is open. Thread and comment records are identity-stable
- * while unchanged and the context callbacks are the host's stable references, so memoization
- * keeps camera frames to moving the thin popover wrapper instead of re-running this whole body.
+ * Memoized because the popover position rides the pin's per-frame render point, so the pin
+ * re-renders on every camera frame while a thread is open.
  */
 export const ThreadView = memo(function ThreadView({
 	editor,
@@ -213,9 +202,8 @@ export const ThreadView = memo(function ThreadView({
 	const comments = useThreadComments(editor, thread.id)
 	const msg = useTranslation()
 	const resolveName = useResolveName(resolveAuthor)
-	// Card props rebuild only when the comments (or how they render) actually change — not on
-	// every render of the view, each of which would otherwise re-allocate a date string and body
-	// element per comment.
+	// Rebuilt only when the comments change, not on every render — each of which would otherwise
+	// re-allocate a date string and body element per comment.
 	const cards = useMemo(
 		() =>
 			comments.map((c) =>
@@ -224,9 +212,8 @@ export const ThreadView = memo(function ThreadView({
 		[comments, currentUserId, resolveAuthor, options.components, resolveName]
 	)
 	const me = currentUserId ? resolveAuthor(currentUserId) : undefined
-	// Composing, editing, deleting, and resolving are all commenting writes: gated on the viewer's
-	// permission. Where it's withheld the composer gives way to the ComposerFallback slot (a
-	// sign-in prompt, say) and the action affordances are hidden.
+	// Composing, editing, deleting, and resolving are all gated on the viewer's permission. Where it's
+	// withheld the composer gives way to the ComposerFallback slot and the affordances are hidden.
 	const canComment = useCanComment(currentUserId)
 	const ComposerFallback = options.components.ComposerFallback
 	// An unsent reply survives closing the thread (saved on every change, keyed by thread id) —
@@ -238,15 +225,12 @@ export const ThreadView = memo(function ThreadView({
 	const [editText, setEditText] = useState<TLRichText>(EMPTY_COMMENT)
 	const canReply = canComment && !thread.resolved
 	const container = useContainer()
-	// Where focus goes when the edit composer closes, resolved at that moment rather than held as an
-	// element: the card (and its edit button with it) unmounts while the composer stands in its
-	// place, so the node captured on the way in is gone by the way out.
+	// Resolved when the composer closes rather than held as an element: the card unmounts while the
+	// composer stands in its place, so the node captured on the way in is gone by the way out.
 	const editReturnFocus = useRef<(() => HTMLElement | null) | null>(null)
 
-	// Tab from the canvas drops the caret in the reply box. Clicking a pin opens the thread but
-	// leaves focus on the editor container, so the first Tab would otherwise walk the app's own UI
-	// instead of the panel the click just opened. Capture phase, ahead of the editor's own handling.
-	// Fires once per open thread, so Tab inside the thread stays plain tab-through.
+	// Tab from the canvas drops the caret in the reply box: a pin click leaves focus on the editor
+	// container, so the first Tab would otherwise walk the app's UI. Capture phase, once per open thread.
 	const [focusReply, setFocusReply] = useState(false)
 	const tabTaken = useRef(false)
 	const swallowTabUp = useRef(false)
@@ -262,9 +246,8 @@ export const ThreadView = memo(function ThreadView({
 		const onKeyDown = (e: KeyboardEvent) => {
 			if (e.key !== 'Tab' || e.shiftKey || e.metaKey || e.ctrlKey || e.altKey) return
 			if (e.defaultPrevented || tabTaken.current) return
-			// Focus rests on the container (or nothing at all) after a pin click. Anywhere else means
-			// it's already somewhere deliberate — the thread's own controls, the sidebar, a panel —
-			// and Tab belongs to whatever holds it.
+			// Focus rests on the container (or nothing) after a pin click. Anywhere else is deliberate, and
+			// Tab belongs to whatever holds it.
 			if (e.target !== container && e.target !== doc.body) return
 			tabTaken.current = true
 			swallowTabUp.current = true
@@ -272,9 +255,8 @@ export const ThreadView = memo(function ThreadView({
 			e.preventDefault()
 			e.stopPropagation()
 		}
-		// The select tool navigates shapes on Tab's *keyup*, and the composer isn't focused until the
-		// next frame — so a quick tap with shapes selected would both focus the reply and step the
-		// selection. Swallow the release of the press we took, and only that one.
+		// The select tool navigates shapes on Tab's *keyup*, so a quick tap would both focus the reply and
+		// step the selection. Swallow the release of the press we took, and only that one.
 		const onKeyUp = (e: KeyboardEvent) => {
 			if (e.key !== 'Tab' || !swallowTabUp.current) return
 			swallowTabUp.current = false
@@ -289,12 +271,9 @@ export const ThreadView = memo(function ThreadView({
 		}
 	}, [canReply, container])
 
-	// Leaving the edit composer — Escape, or a save — unmounts it while it holds focus, and the
-	// browser drops focus on the editor container. That's outside the thread, so a Tab from there
-	// walks the app's UI instead of carrying on from where the edit left off (the thread's one
-	// Tab-into-the-reply-box has usually been spent by then). Hand focus back to whatever opened the
-	// composer instead: the card's edit button, or the reply box when the edit came from arrow-up.
-	// The card's actions row reveals itself on `:focus-within`, so the button focus is visible.
+	// Leaving the edit composer unmounts it while it holds focus, dropping focus to the editor
+	// container — outside the thread, so a Tab from there walks the app's UI. Hand focus back to
+	// whatever opened the composer instead.
 	useEffect(() => {
 		if (editingId !== null) return
 		const resolve = editReturnFocus.current
@@ -303,9 +282,7 @@ export const ThreadView = memo(function ThreadView({
 		resolve?.()?.focus()
 	}, [editingId])
 
-	// Every unread comment on display gets reported read — including replies that arrive while
-	// the view stays mounted, since the effect re-runs as `comments` changes. Reported as one
-	// batch so the host can record the receipts in a single write. The host's receipt write flips
+	// Reported as one batch so the host can record the receipts in a single write. The write flips
 	// isCommentUnread to false, so re-runs find nothing to report.
 	useEffect(() => {
 		if (!isCommentUnread || !onCommentsRead) return
@@ -343,19 +320,14 @@ export const ThreadView = memo(function ThreadView({
 	}
 
 	const ThreadActions = options.components.ThreadActions
-	// The host's URL for this thread, when it supplies one. Its presence is what puts "copy link" in
-	// the header menu — a host that has per-thread URLs shouldn't have to rebuild the thread view to
-	// offer the one affordance every commenting product has.
+	// The host's URL for this thread. Its presence is what puts "copy link" in the header menu.
 	const threadHref = getThreadHref?.(thread.id)
 	const [linkCopied, copyThreadLink] = useCopyLink(threadHref)
 	const canDeleteThread = canComment && currentUserId != null && currentUserId === thread.createdBy
 
 	const startEdit = (comment: TLComment, { fromMoreMenu = false } = {}) => {
-		// The ⋯ menu's button is the thing to come back to when Edit opened the composer — looked up
-		// again on the way out, since the menu item that was clicked (and the card) unmount while the
-		// composer stands in their place. Otherwise come back to whatever held focus: arrow-up-to-edit
-		// comes straight from the reply box, which stays put. The document body and the editor
-		// container are where focus falls when nothing holds it, so neither is somewhere to return to.
+		// Edit from the ⋯ menu comes back to that button, looked up again on the way out since the card
+		// unmounts. Otherwise return to whatever held focus, ignoring the body and the editor container.
 		const active = container.ownerDocument.activeElement
 		editReturnFocus.current = fromMoreMenu
 			? () => container.querySelector<HTMLElement>(`[data-cmt-more-for="${comment.id}"]`)

--- a/packages/commenting/src/clustering/replay.test.ts
+++ b/packages/commenting/src/clustering/replay.test.ts
@@ -51,7 +51,6 @@ function eventShapes(events: RawMergeEvent[]) {
 	return events.map(eventShape)
 }
 
-// --- Reference oracle -------------------------------------------------------
 // Direct transcription of contract clause 4 (CLUSTERING-STEPS.md step 2): at
 // each of the n−1 steps, evaluate every unfired MST edge's zEff against the
 // CURRENT clusters and fire the highest, tie-broken by the edge's normalized
@@ -181,8 +180,6 @@ function referenceReplay(
 	return events
 }
 
-// --- Shared invariant assertions --------------------------------------------
-
 function expectNonIncreasingZ(events: RawMergeEvent[]) {
 	for (let i = 1; i < events.length; i++) {
 		expect(events[i].z).toBeLessThanOrEqual(events[i - 1].z)
@@ -259,8 +256,6 @@ function expectCentroids(events: RawMergeEvent[], leaves: readonly LeafInput[]) 
 		expect(ev.result.centroid.y).toBeCloseTo(sy / ev.result.count, 8)
 	}
 }
-
-// --- Fixtures ----------------------------------------------------------------
 
 describe('cappedReplay fixtures', () => {
 	it('exports the pinned D_FLOOR constant', () => {
@@ -408,8 +403,6 @@ describe('cappedReplay fixtures', () => {
 		expect(events[1].result.id).toBe('cluster:3:a')
 	})
 })
-
-// --- Properties against the reference oracle ---------------------------------
 
 describe('cappedReplay vs reference simulator', () => {
 	const OPTION_SETS = [

--- a/packages/commenting/src/clustering/runtime.test.ts
+++ b/packages/commenting/src/clustering/runtime.test.ts
@@ -5,8 +5,6 @@ import { createClusterRuntime } from './runtime'
 import { contract, finalize } from './schedule'
 import { ClusterNode, ClusterTable, LeafInput, MergeEvent } from './types'
 
-// --- Synthetic builders --------------------------------------------------------
-
 function node(ids: string[], x = 0, y = 0): ClusterNode {
 	const members = ids.slice().sort()
 	return {
@@ -78,8 +76,6 @@ function microTraceTable(): ClusterTable {
 		leaves: [A, B, C, D],
 	}
 }
-
-// --- Fixtures -------------------------------------------------------------------
 
 describe('createClusterRuntime micro-trace (CLUSTERING.md §8.5)', () => {
 	it('walks the exact documented trace', () => {
@@ -238,8 +234,6 @@ describe('createClusterRuntime edge cases', () => {
 		expect(JSON.parse(JSON.stringify(table))).toEqual(snapshot)
 	})
 })
-
-// --- Property tests against real pipeline tables --------------------------------
 
 function leaf(id: string, x: number, y: number): LeafInput {
 	return { id, point: { x, y } }

--- a/packages/commenting/src/clustering/runtime.ts
+++ b/packages/commenting/src/clustering/runtime.ts
@@ -16,26 +16,21 @@ export interface ClusterRuntime {
 	/** Reset state from scratch for the given zoom (cold start / after rebuild). Clears detaches. */
 	seed(zoom: number): void
 	/**
-	 * Reset state for the given zoom, carrying hysteresis state over from a previous partition
-	 * (the visible map of the model being replaced). Threshold-forced events ignore history:
-	 * zoom \<= zMerge is always merged, zoom \>= zSplit always split. An event inside its band
-	 * keeps its previous state: merged iff its members were merged together in `previous`; a band
-	 * event that was unmerged (or has no history, e.g. introduced by the rebuild) stays unmerged —
-	 * inside the cursor but suppressed — until a zoom-out crosses its own zMerge, exactly like any
-	 * other pending merge. Carryover is exact: no group changes state because of the swap alone.
-	 * Clears detaches.
+	 * Reset state for the given zoom, carrying hysteresis state over from a previous partition.
+	 * Threshold-forced events ignore history: zoom \<= zMerge is always merged, zoom \>= zSplit always
+	 * split. An event inside its band keeps its previous state; one that was unmerged (or has no
+	 * history) stays suppressed inside the cursor until a zoom-out crosses its own zMerge. Carryover is
+	 * exact — no group changes state because of the swap alone. Clears detaches.
 	 */
 	seedFrom(zoom: number, previous: ReadonlyMap<string, ClusterNode>): void
 	/** Advance/retreat the cursor for a camera change. No-op if zoom sits inside all bands. */
 	onCamera(zoom: number): void
 	/**
 	 * Remove one leaf from the displayed partition without touching the event table. Local by
-	 * construction: only the nodes containing the leaf change — a badge shrinks in place (count
-	 * and centroid recomputed from its remaining members), a pair collapses to its surviving
-	 * leaf, and the leaf on its own disappears. Everything else is untouched, so a deletion,
-	 * pop-out, or thread-open never re-flows the rest of the document. The table's thresholds
-	 * around the detached leaf go stale; the caller is expected to hold a corrected rebuild and
-	 * adopt it (with seedFrom) at the next zoom-out. Unknown or already-detached ids are no-ops.
+	 * construction: only the nodes containing the leaf change, so a deletion, pop-out, or thread-open
+	 * never re-flows the rest of the document. The table's thresholds around the detached leaf go
+	 * stale; the caller is expected to adopt a corrected rebuild (with seedFrom) at the next zoom-out.
+	 * Unknown or already-detached ids are no-ops.
 	 */
 	detachLeaf(leafId: string): void
 	/**
@@ -62,10 +57,9 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 	// time in getVisible().
 	private visible = new Map<string, ClusterNode>()
 	private seeded = false
-	// Indices (< k) of band events held unmerged by seedFrom carryover. The single cursor can
-	// only express "merged up to here", but a carried-over partition can be "merged except these"
-	// — the exceptions live here. Self-draining: an entry leaves via onCamera when the zoom
-	// crosses its own zMerge (merges) or its zSplit (the split walk retreats past it).
+	// Indices (< k) of band events held unmerged by seedFrom carryover. The single cursor can only
+	// express "merged up to here", but a carried-over partition can be "merged except these". Self-
+	// draining: an entry leaves via onCamera when the zoom crosses its zMerge or its zSplit.
 	private suppressed = new Set<number>()
 	// Leaves removed from the displayed partition (deleted / popped out / opened). Patches map
 	// each structural node containing a detached leaf to its displayed replacement (or null to
@@ -127,10 +121,8 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 		for (let i = 0; i < k; i++) {
 			const event = events[i]
 			if (zoom > event.zMerge && !wasMergedTogether(event.result.members, ownerByMember)) {
-				// In its band and previously unmerged: keep it unmerged, as an exception inside
-				// the cursor. Dependency-safe: an applied event can never consume a suppressed
-				// result — merged members imply merged (subset) children, and threshold-forced
-				// events force their children too (zMerge is non-increasing down the table).
+				// In its band and previously unmerged: keep it unmerged, as an exception inside the cursor.
+				// Dependency-safe, since an applied event can never consume a suppressed result.
 				this.suppressed.add(i)
 			} else {
 				applyEvent(this.visible, event)
@@ -147,18 +139,11 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 		}
 
 		let changed = false
-		// Heal suppressed events at their own merge threshold BEFORE the merge walk: a zoom-out
-		// past zMerge merges a held-out band event exactly as if it had still been ahead of the
-		// cursor. Healing must precede the walk because a single zoom jump can cross both a
-		// suppressed event and an event that consumes its result; applying the consumer first
-		// would leave the unapplied producer's children in `visible` (its delete is a no-op) and
-		// then re-add the producer on top, double-counting those leaves. Threshold monotonicity
-		// guarantees a suppressed producer's zMerge is >= its consumer's, so anything the walk
-		// needs has already healed. Set iteration is insertion order (ascending index), so a
-		// healed event's suppressed children (larger zMerge, smaller index) heal before it.
-		// Iterated live (no snapshot copy): this runs on every zoom tick while carryover
-		// suppressions exist, and deleting only the entry currently being visited is safe —
-		// Set iteration still yields every remaining entry, in insertion order.
+		// Heal suppressed events at their own merge threshold BEFORE the merge walk, so a zoom-out past
+		// zMerge merges a held-out band event as if it had still been ahead of the cursor. Healing must come
+		// first: one zoom jump can cross both a suppressed event and an event consuming its result, and
+		// applying the consumer first would double-count the producer's leaves. Iterated live — deleting only
+		// the entry being visited is safe, and Set iteration still yields the rest in insertion order.
 		if (this.suppressed.size > 0) {
 			for (const i of this.suppressed) {
 				if (zoom <= this.table.events[i].zMerge) {
@@ -227,10 +212,9 @@ class ClusterRuntimeImpl implements ClusterRuntime {
 		return this.leafById
 	}
 
-	/** Recompute the patch map from the detached set. A node is patched iff it contains a
-	 *  detached member; the patch drops those members and recomputes count/centroid, collapsing
-	 *  to the surviving leaf node at count 1 and to nothing at count 0. Patched nodes keep their
-	 *  structural id, so cursor events keep addressing them. */
+	/** Recompute the patch map from the detached set. A node is patched iff it contains a detached
+	 *  member; the patch drops those members and recomputes count/centroid, collapsing to the surviving
+	 *  leaf at count 1 and to nothing at count 0. Patched nodes keep their structural id. */
 	private rebuildPatches() {
 		this.patched.clear()
 		const leafById = this.getLeafById()

--- a/packages/commenting/src/clustering/schedule.test.ts
+++ b/packages/commenting/src/clustering/schedule.test.ts
@@ -7,7 +7,6 @@ import { cappedReplay } from './replay'
 import { contract, finalize } from './schedule'
 import { ClusterNode, ContractedEvent, LeafInput, MergeEvent, RawMergeEvent } from './types'
 
-// --- Synthetic builders -------------------------------------------------------
 // `contract` is specified over plain RawMergeEvent[] input precisely so it can
 // be tested with hand-built events, without running the replay.
 
@@ -54,8 +53,6 @@ const E = node(['e'])
 const F = node(['f'])
 const X = node(['x'])
 const Y = node(['y'])
-
-// --- contract: fixtures -------------------------------------------------------
 
 describe('contract fixtures', () => {
 	it('returns [] for empty input', () => {
@@ -210,8 +207,6 @@ describe('contract validation and purity', () => {
 	})
 })
 
-// --- finalize: fixtures --------------------------------------------------------
-
 const FIN_OPTS = { Tc: 40, Tu: 60, minZoom: 0.1, maxZoom: 8, maxSplitZoom: 1e9 } // r = 1.5
 
 function contracted(zMerge: number, children: ClusterNode[], result: ClusterNode): ContractedEvent {
@@ -322,7 +317,6 @@ describe('finalize fixtures', () => {
 	})
 })
 
-// --- Composed pipeline properties ---------------------------------------------
 // finalize(contract(cappedReplay(mstEdges(leaves)))) must satisfy every table
 // invariant of CLUSTERING.md §7.6.
 

--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -66,12 +66,10 @@ export function CommentComposer({
 	renderMentionSuggestion,
 }: CommentComposerProps) {
 	const interactive = !!onChange || !!onSubmit
-	// The canvas editor the composer lives in, if any — lets the mention popup track the camera. Null
-	// when the composer is used outside a tldraw editor (e.g. an isolated demo).
+	// Lets the mention popup track the camera. Null outside a tldraw editor.
 	const tlEditor = useMaybeEditor()
 
-	// Callbacks are read through refs so the editor instance doesn't need to be recreated when they
-	// change identity between renders.
+	// Read through refs so the editor isn't recreated when callback identity changes.
 	const onChangeRef = useRef(onChange)
 	onChangeRef.current = onChange
 	const onSubmitRef = useRef(onSubmit)
@@ -94,17 +92,16 @@ export function CommentComposer({
 	const inputWrapRef = useRef<HTMLDivElement>(null)
 	const mirrorRef = useRef<HTMLDivElement>(null)
 
-	// Measure whether the content still fits on one line beside the send button. The mirror is a
-	// hidden, nowrap clone of the editor's rendered content, so marks and mention chips measure at
-	// their true width. A small dead zone between the expand and collapse thresholds keeps the
-	// layout from flapping while typing at the boundary.
+	// Measure whether the content still fits on one line beside the send button, against a hidden
+	// nowrap clone so marks and mention chips measure at their true width. The gap between the
+	// expand and collapse thresholds is a dead zone, so the layout can't flap at the boundary.
 	const remeasure = () => {
 		const wrap = inputWrapRef.current
 		const mirror = mirrorRef.current
 		const editor = editorRef.current
 		if (!wrap || !mirror || !editor) return
-		// Empty always fits — and measuring before TipTap's DOM has laid out reads zero widths,
-		// which would flash the expanded layout for a frame on mount.
+		// Empty always fits — and measuring before TipTap has laid out reads zero widths, flashing
+		// the expanded layout for a frame on mount.
 		if (editor.isEmpty) {
 			if (expandedRef.current) setExpanded(false)
 			return
@@ -123,11 +120,8 @@ export function CommentComposer({
 		if (!send || !input) return
 		mirror.innerHTML = input.innerHTML
 		const textWidth = mirror.offsetWidth
-		// The single-line space the input has beside the send button: the wrap's *content* box
-		// (clientWidth minus its own horizontal padding — the text wraps there, not at clientWidth),
-		// less the button plus the field's 6px gap when already expanded (the wrap then spans the
-		// full field). Without subtracting the padding, a padded wrap wraps to a second line ~padding
-		// px before expansion fires, so the input grows a line and then snaps to the expanded layout.
+		// Measured against the wrap's *content* box: text wraps at clientWidth minus padding, so
+		// without subtracting it the input grows a line before expansion fires and then snaps.
 		const wrapStyle = getComputedStyle(wrap)
 		const wrapPadX = parseFloat(wrapStyle.paddingLeft) + parseFloat(wrapStyle.paddingRight)
 		const collapsedAvailable =
@@ -141,34 +135,22 @@ export function CommentComposer({
 	const remeasureRef = useRef(remeasure)
 	remeasureRef.current = remeasure
 
-	// The editor instance, reachable from `handleKeyDown` (which is created before `useEditor`
-	// returns). Updated on every render so the ref never points at a stale editor.
+	// Reachable from `handleKeyDown`, which is created before `useEditor` returns.
 	const editorRef = useRef<ReturnType<typeof useEditor>>(null)
 
-	// Set while we replay Enter through the keymaps for a Shift+Enter newline: `commands.enter()`
-	// re-dispatches Enter through `handleKeyDown`, and without this guard our own handler would catch
-	// that synthetic Enter and submit instead.
+	// `commands.enter()` re-dispatches through `handleKeyDown`; without this guard our own handler
+	// would catch the synthetic Enter and submit.
 	const replayingEnter = useRef(false)
 
-	// Enter and Cmd/Ctrl+Enter submit the comment; Shift+Enter inserts a new line for the occasional
-	// multi-line comment. This is handled through `editorProps.handleKeyDown` (below) rather than a
-	// keyboard-shortcut extension: ProseMirror runs `handleKeyDown` before every keymap plugin, so it
-	// can tell Shift+Enter apart from Enter — an `Enter` keymap binding also fires on Shift/Cmd+Enter
-	// and would otherwise swallow the newline.
-
-	// The suggestion plugin is built once (the editor is recreated only on `interactive`) and runs
-	// outside React, so it must read the mention callbacks through refs — like onChange/onSubmit —
-	// or it queries the roster present at mount forever, never seeing a member who loads or joins
-	// later. Whether mentions (and a custom picker row) are wired at all is fixed at mount; only the
-	// callbacks themselves are live.
+	// The suggestion plugin is built once and runs outside React, so it reads the mention callbacks
+	// through refs — otherwise it queries the roster present at mount forever, never seeing a member
+	// who joins later. Whether mentions are wired at all is fixed at mount; the callbacks are live.
 	const mentionsEnabled = !!getMentionSuggestions
 	const hasCustomRow = !!renderMentionSuggestion
 	const extensions = useMemo(() => {
 		const list = [...commentTipTapExtensions]
-		// Always register the mention node so an existing body that contains a mention keeps it on
-		// edit (an unregistered node would be stripped by ProseMirror when the content loads). The `@`
-		// picker itself only turns on when the host provides a resolver; otherwise the node is present
-		// but its trigger is disabled.
+		// The mention node is always registered, or ProseMirror strips existing mentions when an
+		// edited body loads. Only the `@` trigger is gated on the host providing a resolver.
 		if (mentionsEnabled) {
 			const resolveSuggestions = (query: string) => getMentionSuggestionsRef.current?.(query) ?? []
 			const renderRow = hasCustomRow
@@ -193,9 +175,8 @@ export function CommentComposer({
 			extensions,
 			content: (value ?? EMPTY_COMMENT) as JSONContent,
 			editable: interactive,
-			// tldraw's default extensions add their own TextDirection extension (so it can be
-			// overridden), so disable TipTap's core one to avoid a duplicate-extension warning —
-			// mirrors RichTextArea's setup.
+			// tldraw ships its own TextDirection extension, so TipTap's core one would warn about a
+			// duplicate. Mirrors RichTextArea's setup.
 			enableCoreExtensions: { textDirection: false },
 			textDirection: 'auto',
 			editorProps: {
@@ -210,8 +191,8 @@ export function CommentComposer({
 				handleKeyDown: (_view, event) => {
 					// Let the keymaps handle the synthetic Enter we replay for a Shift+Enter newline.
 					if (replayingEnter.current) return false
-					// Up in an empty composer hands off to the host (edit the comment above). With
-					// content, Up stays cursor movement; with the mention picker open, it navigates it.
+					// Up in an empty composer hands off to the host. With content it stays cursor
+					// movement, and with the picker open it navigates the roster.
 					if (event.key === 'ArrowUp' && !event.isComposing) {
 						if (
 							onArrowUpWhenEmptyRef.current &&
@@ -226,12 +207,10 @@ export function CommentComposer({
 					if (event.key !== 'Enter' || event.isComposing) return false
 					// While the @-mention picker is open, Enter selects the highlighted member — defer.
 					if (isMentionPickerOpen()) return false
-					// Shift+Enter inserts a new line. Replay a plain Enter through the keymaps (guarded so
-					// we don't re-enter and submit) to reuse the editor's list-aware Enter handling — a new
-					// list item in a list, a new paragraph otherwise. tldraw doesn't do soft breaks.
+					// Shift+Enter inserts a new line by replaying a plain Enter through the keymaps, reusing
+					// the editor's list-aware handling. tldraw doesn't do soft breaks.
 					if (event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey) {
-						// An empty field has nothing to break onto — swallow the keypress so it doesn't
-						// open the comment with a stray leading blank line.
+						// An empty field would open the comment with a stray leading blank line.
 						if (editorRef.current?.isEmpty) return true
 						replayingEnter.current = true
 						try {
@@ -248,8 +227,7 @@ export function CommentComposer({
 			},
 			onUpdate: ({ editor }) => {
 				setIsEmpty(editor.isEmpty)
-				// Same-value state sets don't re-render, so measure here — the editor's DOM is
-				// already updated when onUpdate fires.
+				// Same-value state sets don't re-render, and the DOM is already updated here.
 				remeasureRef.current()
 				onChangeRef.current?.(editor.getJSON() as TLRichText)
 			},

--- a/packages/editor/src/lib/components/EditorPortal.tsx
+++ b/packages/editor/src/lib/components/EditorPortal.tsx
@@ -36,25 +36,22 @@ export interface EditorPortalProps {
  *
  * Use this for anything anchored to canvas coordinates that also has to draw over the UI — a
  * popover on a shape, a comment thread, an annotation panel. The `OnTheCanvas` and
- * `InFrontOfTheCanvas` component slots are fixed layers, and each is its own stacking context, so
- * content mounted there can't paint above whatever outranks its layer, no matter what z-index it
- * asks for. Mount your component in whichever slot suits your data flow, wrap the part that needs
- * its own layer in this, and give that part a z-index.
+ * `InFrontOfTheCanvas` slots are fixed layers, each its own stacking context, so content mounted
+ * there can't paint above whatever outranks its layer whatever z-index it asks for. Mount in
+ * whichever slot suits your data flow, wrap the part that needs its own layer in this, and give
+ * that part a z-index.
  *
- * Which z-index depends on what you're drawing over. This package's own layers stop at 250
- * (`--tl-layer-canvas-in-front`); everything above that belongs to whatever renders the UI. In
- * `tldraw`, that's `--tl-layer-panels` (300, the toolbar and style panel) and `--tl-layer-menus`
- * (400) — defined by `tldraw`'s stylesheet rather than this package's, so reach for those variables
- * only if you're building on `tldraw` and not the bare editor.
+ * This package's own layers stop at 250 (`--tl-layer-canvas-in-front`); above that belongs to
+ * whatever renders the UI. In `tldraw` that's `--tl-layer-panels` (300) and `--tl-layer-menus`
+ * (400), defined by `tldraw`'s stylesheet rather than this one.
  *
- * Positioning still resolves against the editor's container, the same as the canvas layers, so a
- * `position: absolute` child uses ordinary container coordinates.
+ * Positioning still resolves against the editor's container, so a `position: absolute` child uses
+ * ordinary container coordinates.
  *
- * Prefer this over `createPortal(children, useContainer())`. A portal picks its DOM position from
- * the commit that mounts it, so portaling straight into the container lands the node ahead of the
- * container's own shallower children — ahead of the UI, and ahead of the "skip to main content"
- * link that only works while nothing precedes it. The host this renders into is a real element in
- * the editor's tree, placed last, so ordering is fixed rather than dependent on mount timing.
+ * Prefer this over `createPortal(children, useContainer())`, which picks its DOM position from the
+ * commit that mounts it — landing the node ahead of the UI and of the "skip to main content" link
+ * that only works while nothing precedes it. This host is a real element placed last, so ordering
+ * is fixed rather than dependent on mount timing.
  *
  * @example
  * ```tsx

--- a/packages/mentions/src/mention-suggestion.tsx
+++ b/packages/mentions/src/mention-suggestion.tsx
@@ -22,11 +22,9 @@ const MentionPopup = forwardRef<MentionPopupHandle, MentionPopupProps>(function 
 	ref
 ) {
 	const [activeIndex, setActiveIndex] = useState(0)
-	// A wheel over the popup drives the canvas beneath it, so scrolling to pan or zoom isn't
-	// swallowed by the roster — the same pass-through every tldraw panel gets. The hook leaves the
-	// list alone while it scrolls its own overflow. The suggestion plugin builds the popup element
-	// imperatively, but the `ReactRenderer` portals this component into the composer's React tree,
-	// so tldraw's container and editor context reach the hook.
+	// A wheel over the popup drives the canvas beneath it, the same pass-through every tldraw panel gets;
+	// the hook leaves the list alone while it scrolls its own overflow. The suggestion plugin builds the
+	// popup imperatively, but `ReactRenderer` portals this into the composer's tree, so context reaches it.
 	const listRef = useRef<HTMLDivElement>(null)
 	usePassThroughWheelEvents(listRef)
 	// A new query yields new items; reset the highlight to the top during render — not in an effect,
@@ -84,10 +82,9 @@ export function filterMentionMembers(members: MentionMember[], query: string): M
 	return members.filter((m) => m.name.toLowerCase().includes(q)).slice(0, MAX_SUGGESTIONS)
 }
 
-// A reactive flag for whether the @-picker is showing. Deliberately NOT tldraw's open-menu registry:
-// registering there mounts MenuClickCapture, which covers the canvas with a click-capture overlay to
-// make it inert while a menu is open. But the picker is an inline autocomplete, not a modal — the
-// canvas must stay pannable/zoomable beneath it — so we track "open" ourselves instead.
+// Deliberately NOT tldraw's open-menu registry: registering there mounts MenuClickCapture, which
+// makes the canvas inert. The picker is an inline autocomplete, not a modal — the canvas must stay
+// pannable beneath it — so track "open" ourselves.
 const mentionPickerOpen = atom('isMentionPickerOpen', false)
 
 /**
@@ -112,10 +109,8 @@ export interface MentionSuggestionOptions {
 
 /**
  * Build the TipTap `suggestion` config for the \@-picker. `getSuggestions(query)` is the host's
- * resolver — it returns the members matching the query (sync or async); the SDK owns neither the
- * roster nor the filtering. The plugin runs outside React, so `render` mounts `MentionPopup` via a
- * `ReactRenderer`, forwards navigation keys through the popup's imperative handle, and lets it call
- * `command` to insert.
+ * resolver — the SDK owns neither the roster nor the filtering. The plugin runs outside React, so
+ * `render` mounts `MentionPopup` via a `ReactRenderer` and forwards navigation keys to it.
  * @public
  */
 export function createMentionSuggestion(
@@ -154,20 +149,17 @@ export function createMentionSuggestion(
 				applyScreen(rect.left, rect.bottom, rect.width)
 			}
 
-			// Re-derive the popup's screen position from the remembered page anchor — pure camera math,
-			// always current. Reading the field's DOM rect here instead would lag by a frame: the canvas
-			// composer re-positions itself on a React commit (a `useValue(pageToViewport(...))`), which
-			// lands after a camera reaction runs, so the rect is still last frame's during a pan.
+			// Re-derived from the remembered page anchor — pure camera math, always current. Reading the field's
+			// DOM rect would lag a frame: the composer re-positions on a React commit, after the camera reaction.
 			const reposition = () => {
 				if (!anchorPage || !options.editor) return
 				const s = options.editor.pageToScreen(anchorPage)
 				applyScreen(s.x, s.y, popupWidth)
 			}
 
-			// The popup is `position: fixed`, but its anchor — a canvas composer — rides the camera:
-			// panning or zooming moves the composer with no scroll/resize event to hook. Re-anchor when
-			// the camera actually changes (via a tldraw reaction) rather than polling every frame, plus
-			// on window scroll/resize for the off-canvas case (which re-read the field directly).
+			// The popup is `position: fixed`, but a canvas composer rides the camera, which moves it with no
+			// scroll/resize event to hook. Re-anchor from a tldraw reaction rather than polling every frame,
+			// plus on window scroll/resize for the off-canvas case.
 			const startFollowing = () => {
 				window.addEventListener('scroll', place, true)
 				window.addEventListener('resize', place)
@@ -186,10 +178,8 @@ export function createMentionSuggestion(
 				anchorPage = null
 			}
 
-			// Dismiss the roster — on Escape, or when the composer loses focus — by hiding it and
-			// clearing the open flag, so isMentionPickerOpen() stays accurate and the thread's own
-			// Escape/outside-click dismissal can take over. The TipTap suggestion stays active, so typing
-			// re-shows the roster via onUpdate.
+			// Dismiss the roster on Escape or blur, clearing the open flag so isMentionPickerOpen() stays
+			// accurate and the thread's own dismissal can take over. Typing re-shows it via onUpdate.
 			const hide = () => {
 				if (container) container.style.display = 'none'
 				mentionPickerOpen.set(false)
@@ -213,10 +203,8 @@ export function createMentionSuggestion(
 					container = document.createElement('div')
 					container.className = 'tlui-cmt-mention-popup'
 					container.appendChild(renderer.element)
-					// Mount inside the tldraw container: the popup inherits the theme variables
-					// (--tl-color-*) from it, and the pass-through hooks read it from context to find the
-					// canvas. Outside one there's no theme and nothing to pass a wheel to, but the picker
-					// still works, so fall back to the body rather than taking the composer down with us.
+					// Mounted inside the tldraw container so the popup inherits the theme variables and the pass-through
+					// hooks can find the canvas. Outside one, fall back to the body — the picker still works.
 					;(editorEl.closest('.tl-container') ?? document.body).appendChild(container)
 					place()
 					startFollowing()
@@ -235,10 +223,8 @@ export function createMentionSuggestion(
 					place()
 				},
 				onKeyDown: (props) => {
-					// Once the roster is hidden (a prior Escape), the TipTap suggestion is still active but
-					// this handler goes inert — every key passes through to the composer/thread (so a second
-					// Escape closes them, and Arrow/Enter don't select from an invisible list). Typing
-					// re-shows the roster via onUpdate.
+					// Once the roster is hidden, the suggestion stays active but this handler goes inert — keys pass
+					// through so a second Escape closes the composer. Typing re-shows the roster via onUpdate.
 					if (!isMentionPickerOpen()) return false
 					if (props.event.key === 'Escape') {
 						// Dismiss only the roster: hide it and stop the key so the composer/thread beneath

--- a/packages/sync-collaboration/src/comment-authorizers.ts
+++ b/packages/sync-collaboration/src/comment-authorizers.ts
@@ -14,42 +14,33 @@ import {
  */
 export interface CommentAuthorizerOptions<SessionMeta> {
 	/**
-	 * Resolve the authenticated user id for a session from its host-provided `meta`. Return
-	 * `null` for anonymous sessions — they can't create comments or threads, and can't perform
-	 * any owner-only action. Called exactly once per authorized write.
+	 * Resolve the authenticated user id for a session from its host-provided `meta`. Return `null`
+	 * for anonymous sessions — they can't create records or perform any owner-only action.
 	 */
 	getUserId(session: { sessionId: string; isReadonly: boolean; meta: SessionMeta }): string | null
 
 	/**
-	 * Whether a session may write comment records at all — checked before the per-type rules on
-	 * every create, update, and delete. Defaults to `({ isReadonly }) => !isReadonly`: comment
-	 * writes follow canvas access, so read-only viewers can read threads but not post, edit,
-	 * resolve, or react. Override to decouple the lanes — `() => true` allows commenting on a
-	 * read-only canvas (comment-only setups) — or to enforce custom criteria from the session.
+	 * Whether a session may write comment records at all — checked before the per-type rules.
+	 * Defaults to `({ isReadonly }) => !isReadonly`, so read-only viewers can read threads but not
+	 * post. Override to decouple the lanes: `() => true` allows commenting on a read-only canvas.
 	 */
 	canComment?(session: { sessionId: string; isReadonly: boolean; meta: SessionMeta }): boolean
 }
 
 /**
  * Server-side write authorization for comment records, for use with a sync server's
- * `authorizeRecord` option (see `TLSocketRoom` in `@tldraw/sync-core`). Forces comment and
- * thread authorship from the session's identity so nothing can be posted, resolved, or deleted
- * in someone else's name:
+ * `authorizeRecord` option (see `TLSocketRoom` in `@tldraw/sync-core`). Forces authorship from the
+ * session's identity so nothing can be posted, resolved, or deleted in someone else's name:
  *
- * - `comment`: `authorId` is stamped from the session on create (anonymous creates are
- *   rejected) and immutable afterwards; only the author may update. `threadId` and `createdAt`
- *   are immutable too — a comment can't be re-parented or back-dated after the fact.
- * - `comment-thread`: `createdBy` and `createdAt` are stamped/fixed on create. Anyone with access
- *   may resolve/reopen, but a non-null `resolved.by` must be the session's own user.
- * - `comment-reaction`: `userId` is stamped on create and immutable; a create must land at the
- *   canonical id for its (comment, user, emoji) triple, everything identity-bearing is immutable
- *   on update, and only the reactor may delete their own reaction.
- * - Deletion is soft for comments and threads: a write-once `isDeleted` flag that only the
- *   record's owner may set, never cleared, never set at create. Client hard-deletes are always
- *   rejected — record removals are server-side only.
- * - `canComment` gates every create, update, and delete above, before the per-type rules run.
- *   By default it mirrors the session's canvas access (`!isReadonly`), so read-only viewers can
- *   read threads but not write to them; override it to decouple commenting from canvas access.
+ * - `comment`: `authorId` is stamped on create (anonymous creates rejected) and immutable after;
+ *   only the author may update. `threadId` and `createdAt` are immutable too.
+ * - `comment-thread`: `createdBy` and `createdAt` are fixed on create. Anyone with access may
+ *   resolve/reopen, but a non-null `resolved.by` must be the session's own user.
+ * - `comment-reaction`: `userId` is stamped and immutable, a create must land at the canonical id
+ *   for its (comment, user, emoji) triple, and only the reactor may delete their own.
+ * - Deletion is soft for comments and threads: a write-once, owner-only `isDeleted` flag. Client
+ *   hard-deletes are always rejected — record removals are server-side only.
+ * - `canComment` gates every write before the per-type rules, defaulting to `!isReadonly`.
  *
  * Comment records ride alongside your document records, so widen the room's record union to
  * include them, then spread the result into the authorizer map alongside your own entries:
@@ -118,11 +109,9 @@ export function createCommentAuthorizers<SessionMeta>(
 	}
 
 	/**
-	 * Police a soft-deleted record type on top of `base`: deletion is a write-once `isDeleted`
-	 * flag — set exactly once, never cleared, only by the record's owner (`ownerOf`), never on
-	 * create — and clients never hard-delete these records at all. Record removals are
-	 * server-initiated only (server-side deletes don't run authorizers), so once the server
-	 * prunes a flagged record there is no un-delete.
+	 * Police a soft-deleted record type on top of `base`: `isDeleted` is write-once, owner-only
+	 * (`ownerOf`), never set at create, and clients never hard-delete these records. Removals are
+	 * server-initiated only, so once the server prunes a flagged record there is no un-delete.
 	 */
 	function authorizeSoftDeleted<Rec extends UnknownRecord & { isDeleted: boolean }>(
 		ownerOf: (rec: Rec) => string,
@@ -147,8 +136,7 @@ export function createCommentAuthorizers<SessionMeta>(
 
 	/**
 	 * Threads stay editable by anyone with access (resolve/reopen), but resolution is itself an
-	 * attribution: a non-null `resolved.by`, set at create or changed by update, must be the
-	 * session's own user.
+	 * attribution: a non-null `resolved.by` must be the session's own user.
 	 */
 	const authorizeThreadResolution: Rule<TLCommentThread> = (userId, args) => {
 		const result = authorizeAuthored<TLCommentThread>('createdBy')(userId, args)
@@ -168,12 +156,9 @@ export function createCommentAuthorizers<SessionMeta>(
 	}
 
 	/**
-	 * Reject an update that changes any of `fields`. Used for the structural fields an update must
-	 * never touch: a comment's parent thread and its creation time. `threadId` is what ties a
-	 * comment to its conversation (and, downstream, to a file), so letting an author re-parent an
-	 * existing comment would move it between threads — and, where threads span files, between
-	 * files. `createdAt` orders threads and bounds the notification feed, so a mutable one lets a
-	 * comment be re-sorted after the fact.
+	 * Reject an update that changes any of `fields` — the structural ones an update must never touch.
+	 * A mutable `threadId` would let an author re-parent a comment between conversations (and, where
+	 * threads span files, between files); a mutable `createdAt` would let it be re-sorted after the fact.
 	 */
 	function immutableFields<Rec extends UnknownRecord>(
 		fields: readonly (keyof Rec & string)[],
@@ -195,21 +180,15 @@ export function createCommentAuthorizers<SessionMeta>(
 	})
 
 	/**
-	 * A reaction's id is derived from its (comment, user, emoji) triple (see
-	 * `createCommentReactionId`), which is what makes reaction identity structural. The base rule
-	 * already stamps `userId` from the session and lets only the owner change a reaction — but the
-	 * id, the comment it points at, and the emoji are all client-supplied, so this wrapper adds two
-	 * things:
+	 * A reaction's id is derived from its (comment, user, emoji) triple. The base rule already stamps
+	 * `userId` and lets only the owner change a reaction, but the id, comment, and emoji are all
+	 * client-supplied, so this adds:
 	 *
-	 * - On **create**, the id must be the canonical id for `commentId` + the session's user +
-	 *   `next.emoji`. Without this a forged client could create a record at another user's id slot
-	 *   (locking them out of that reaction), or push a mismatched id that lands two records on one
-	 *   (comment, user, emoji) — an invariant any persistence layer keyed on the triple relies on.
+	 * - On **create**, the id must be canonical for `commentId` + the session's user + `next.emoji`.
+	 *   Otherwise a forged client could squat another user's id slot, or land two records on one triple.
 	 *
-	 * - On **update**, everything identity-bearing is immutable: `commentId`, `threadId`, `pageId`,
-	 *   and `emoji` all feed the id (directly or by denormalization), so a re-react is a
-	 *   create/delete, not an update. The only thing an update may touch is `createdAt`/`meta`.
-	 *   So the id and the fields it is derived from can never drift apart.
+	 * - On **update**, everything feeding the id is immutable, so a re-react is a create/delete rather
+	 *   than an update and the id can never drift from its fields.
 	 */
 	const authorizeReaction: Rule<TLCommentReaction> = (userId, args) => {
 		// Only the reactor may remove their own reaction. Cascades still sweep every reactor's
@@ -256,14 +235,9 @@ export function createCommentAuthorizers<SessionMeta>(
 				immutableFields<TLCommentThread>(['createdAt'], authorizeThreadResolution)
 			)
 		),
-		// A reaction is one user's own record, so the standard attribution rules mostly cover it:
-		// `userId` is stamped from the session and only the reactor can change their reaction, and
-		// the wrapper's id check ties the record to its (comment, user, emoji) slot — so no one can
-		// forge or hijack another user's reaction. Deletion, though, is deliberately open: anyone
-		// with access to the room may hard-delete any reaction. Reactions have no soft-delete /
-		// `isDeleted` flag (unlike comments) on purpose — a reaction is a toggle, so removing one is
-		// a plain record delete, and a host cascading a comment or thread deletion must sweep every
-		// reactor's records, not just the caller's own.
+		// Deletion is deliberately open: anyone with room access may hard-delete any reaction. Reactions
+		// have no soft-delete flag on purpose — a reaction is a toggle, and a host cascading a comment or
+		// thread deletion must sweep every reactor's records, not just the caller's own.
 		'comment-reaction': withUserId(authorizeReaction),
 	}
 }

--- a/packages/tlschema/src/records/TLComment.ts
+++ b/packages/tlschema/src/records/TLComment.ts
@@ -11,11 +11,10 @@ import { TLShapeId } from './TLShape'
  * Where a comment thread is anchored on the canvas. Modeled as a discriminated union so new
  * anchor kinds can be added without breaking existing threads:
  *
- * - `shape` — pinned to a shape. `x`/`y` are normalized (0–1) within the shape's own bounds and
- *   resolved through the shape's page transform, so the pin keeps its spot as the shape moves,
- *   resizes, and rotates. `isPrecise` mirrors arrow bindings: when
- *   true the pin sits at exactly `x`/`y`; when false (the default) it sits at a consumer-defined
- *   spot (top-right out of the box), and `x`/`y` are the remembered precise position
+ * - `shape` — pinned to a shape. `x`/`y` are normalized (0–1) within the shape's bounds, so the pin
+ *   keeps its spot as the shape moves, resizes, and rotates. `isPrecise` mirrors arrow bindings:
+ *   when false (the default) the pin sits at a consumer-defined spot instead, top-right out of the
+ *   box, and `x`/`y` are the remembered precise position
  * - `point` — pinned to a fixed point on the page, in page coordinates
  * - `region` — pinned to a rectangular area of the page, in page coordinates
  * - `page` — a page-level thread with no spatial anchor
@@ -59,20 +58,15 @@ export interface TLCommentThread extends BaseRecord<'comment-thread', TLCommentT
 	pageId: TLPageId
 	/** Where the thread is anchored on that page. */
 	anchor: TLCommentAnchor
-	/**
-	 * Who started the thread. Client-supplied for now; the sync server should stamp/verify this
-	 * from the session's authenticated identity once record-level authorization lands (the same
-	 * model presence already uses for self-ownership).
-	 */
+	/** Who started the thread. Client-supplied; sync servers are expected to stamp/verify it. */
 	createdBy: string
 	createdAt: number
 	/** Resolution state: when and by whom the thread was resolved, or null while open. */
 	resolved: { at: number; by: string } | null
 	/**
-	 * Whether the thread is soft-deleted. Clients delete a thread by setting this flag and
-	 * leaving the record (and its comments) in place, hidden from rendering. Sync servers are
-	 * expected to enforce the flag as write-once and creator-only, reject hard deletes from
-	 * clients, and drop flagged threads from future room loads.
+	 * Whether the thread is soft-deleted. Clients set the flag and leave the record in place. Sync
+	 * servers are expected to enforce it as write-once and creator-only, reject client hard
+	 * deletes, and drop flagged threads from future room loads.
 	 */
 	isDeleted: boolean
 	meta: JsonObject
@@ -103,12 +97,7 @@ export interface TLComment extends BaseRecord<'comment', TLCommentId> {
 	editedAt: number | null
 	/** Rich text body. Use `toRichText(...)` for plaintext input. */
 	body: TLRichText
-	/**
-	 * Whether the comment is soft-deleted. Same model as `TLCommentThread.isDeleted` — clients
-	 * delete a comment by setting this flag and leaving the record in place, hidden from
-	 * rendering. Sync servers are expected to enforce the flag as write-once and author-only,
-	 * reject hard deletes from clients, and drop flagged comments from future room loads.
-	 */
+	/** Whether the comment is soft-deleted. Same model as `TLCommentThread.isDeleted`. */
 	isDeleted: boolean
 	meta: JsonObject
 }
@@ -119,16 +108,11 @@ export type TLCommentId = RecordId<TLComment>
 /**
  * One person's emoji reaction to one comment.
  *
- * A reaction is its own record rather than a field on the comment, for the same reason read
- * receipts are their own row: it's one person's data about someone else's comment. Comment records
- * are owner-only for updates, so a reaction could never be written onto them; and holding
- * everyone's reactions in one shared field would mean each write carried the whole set, so two
- * people reacting at once would race to overwrite each other. A record per person keeps every
- * write to its own record, which is what lets concurrent reactions coexist.
+ * A reaction is its own record rather than a field on the comment: comment records are owner-only
+ * for updates, and a shared field would make concurrent reactions race to overwrite each other.
  *
- * A user holds at most one record per (comment, emoji) pair — so one user can react with several
- * different emoji to the same comment. That's enforced by the id: see `createCommentReactionId`.
- * Restricting a user to a single reaction overall is a client-side policy layered on top (see the
+ * A user holds at most one record per (comment, emoji) pair, enforced by the derived id — see
+ * `createCommentReactionId`. Limiting a user to one reaction overall is client-side policy (the
  * commenting package's `reactionMode`), not a property of this record.
  *
  * @public
@@ -189,11 +173,9 @@ const commentAnchorValidator: T.Validator<TLCommentAnchor> = T.union('type', {
 })
 
 /**
- * Guard migrations for the comment record types. Each sequence is retroactive and starts with an
- * identity migration that has no `down`: a sync server whose schema registers the comment types
- * cannot down-migrate records for a session whose schema predates them, so such sessions are
- * rejected with CLIENT_TOO_OLD (prompting a refresh) instead of being sent record types their
- * store cannot represent.
+ * Guard migrations for the comment record types. Each sequence starts with an identity migration
+ * that has no `down`, so a session whose schema predates the comment types is rejected with
+ * CLIENT_TOO_OLD instead of being sent records its store can't represent.
  */
 function createCommentGuardMigrations(
 	typeName: 'comment' | 'comment-thread' | 'comment-reaction',
@@ -337,16 +319,10 @@ export function createCommentId(id?: string): TLCommentId {
 
 /**
  * The id of one user's reaction to one comment, derived from the (comment, user, emoji) triple
- * rather than random. This is what makes reaction identity structural: the same triple always
- * addresses the same record, so re-picking an emoji toggles that one record and two tabs converge
- * instead of racing to create duplicates. A user can hold one record per emoji on a comment
- * (multiple reactions); enforcing "at most one reaction total" is a client concern layered on top,
- * not a property of the id. The sync authorizer leans on this derivation, so it must be injective.
- *
- * `emoji` here is the reaction's token — the emoji glyph for the default palette, or whatever
- * opaque string a consumer's palette uses. All three parts are URI-encoded before joining, so a
- * `:` in any of them can't shift the boundary and collapse two different triples onto one id. The
- * id is only ever recomputed for comparison, never parsed back, so the encoding needs no inverse.
+ * rather than random, so the same triple always addresses the same record and two tabs converge
+ * instead of racing to create duplicates. The sync authorizer leans on this, so it must be
+ * injective: all three parts are URI-encoded before joining, so a `:` in any of them can't shift
+ * the boundary and collapse two triples onto one id.
  *
  * @public
  */
@@ -362,9 +338,8 @@ export function createCommentReactionId(
 }
 
 /**
- * Type guard for `TLCommentThreadId`. Note `isCommentId` does not accept these: the prefixes
- * are `comment-thread:` vs `comment:`, and the character after `comment` differs (`-` vs `:`),
- * so the two never overlap.
+ * Type guard for `TLCommentThreadId`. `isCommentId` rejects these — `comment-thread:` and
+ * `comment:` differ in the character after `comment`, so the prefixes never overlap.
  *
  * @public
  */
@@ -373,8 +348,7 @@ export function isCommentThreadId(id: string): id is TLCommentThreadId {
 }
 
 /**
- * Type guard for `TLCommentId`. See `isCommentThreadId` for why `comment-thread:...` ids are
- * correctly rejected here.
+ * Type guard for `TLCommentId`. See `isCommentThreadId`.
  *
  * @public
  */
@@ -383,8 +357,7 @@ export function isCommentId(id: string): id is TLCommentId {
 }
 
 /**
- * Type guard for `TLCommentReactionId`. As with `isCommentThreadId`, the `comment-reaction:`
- * prefix never overlaps `comment:` — the character after `comment` differs (`-` vs `:`).
+ * Type guard for `TLCommentReactionId`. See `isCommentThreadId`.
  *
  * @public
  */


### PR DESCRIPTION
In order to make the commenting code readable again, this trims back the explanatory comments added in #9471 and #9782. A lot of them had grown into multi-paragraph essays — the worst were long enough that a reviewer would skip past them to get at the code, which is the opposite of what a comment is for. Several were added proactively alongside small changes and explained things the code already said.

Each surviving comment is cut down to the non-obvious reason it exists. Public API docs keep their `@public`/`@internal` tags and `@example` blocks, and the genuinely subtle invariants are still stated — just once, and tersely. Some representative cuts:

- `commentRows.ts` had six near-identical 8-line docs on the FK matchers, each opening "True when `error` is Postgres rejecting…" and then restating the signature. They're one or two lines now.
- `comment-composer.tsx` carried a free-floating 5-line comment about Enter handling that repeated, almost verbatim, the comment sitting on `handleKeyDown` itself. Deleted.
- `anchor-lifecycle.ts`'s 35-line header, `comment-authorizers.ts`'s 17-line reaction-id rationale, and `runtime.ts`'s 12-line suppressed-event proof are all shorter without losing the rule each was there to state.

A second pass then dropped comments outright rather than shortening them:

- **Section-divider banners** (`// ── Tokens ─────…`, `// --- Fixtures ----…`) — 21 of them, and the style appears nowhere else in the repo. Removed from the example and test files. In `CommentingOptions` the labels are doing navigational work on a long public interface, so those keep the label and lose the rule.
- **Six comments that restated the declaration below them** — e.g. `// The live bounds while a corner handle is resizing the region, else null.` above `const [resizeBounds] = useState<BoxModel | null>(null)`, and a four-line effect that clears four atoms sitting under a comment listing the same four atoms.

Deliberately *not* dropped: the clustering tests' short comments. They look like narration but annotate the zoom values and expected transitions that make a bare `rt.onCamera(3.5)` legible, so they're load-bearing.

**This is comments-only.** No code changed — verified mechanically: every added and removed line in the diff is a comment line.

Scope note: this covers the code that was *new* in those PRs. The comments those PRs added to pre-existing files — `TLFileDurableObject.ts` (~335 comment lines, including a 32-line concurrency proof above the version-restore path), `TLSocketRoom.ts` (~248), `TLSyncRoom.ts` (~226) — are untouched here and would make a sensible follow-up.

Heads up on conflicts: #9823, #9815, #9812, #9807, and #9806 all target `commenting-followups` and touch some of the same files. They change code where this changes comment text, so nothing competes, but whichever lands second will need a small manual resolution in the overlapping blocks.

### Change type

- [x] `other`

### Test plan

Nothing to test manually — no behavior changes. Checks run on the branch:

- `yarn typecheck`, `yarn lint-current`, `yarn api-check` all pass
- `yarn oxfmt --check` clean on all changed files
- Tests pass in every touched package: commenting (319), tlschema (502), sync-collaboration (45), mentions (5), sync-worker `commentRows` (71), editor `EditorPortal` (3)

### Code changes

| Section       | LOC change  |
| ------------- | ----------- |
| Core code     | +446 / -739 |
| Tests         | +0 / -19    |
| Documentation | +0 / -10    |
| Apps          | +53 / -143  |
