### PR TITLE
chore(editor): deprecate useViewportHeight

### DIFF
--- a/packages/editor/api-report.api.md
+++ b/packages/editor/api-report.api.md
@@ -5213,7 +5213,7 @@ export function useTransform(ref: React.RefObject<HTMLElement | null | SVGElemen
 // @public
 export function useUniqueSafeId(suffix?: string): SafeId;
 
-// @public (undocumented)
+// @public @deprecated
 export function useViewportHeight(): number;
 
 // @internal (undocumented)

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -325,7 +325,6 @@ export {
 export { useTransform } from './lib/hooks/useTransform'
 export { isCursorInViewport } from './lib/utils/collaborators'
 export { useTLSchemaFromUtils, useTLStore } from './lib/hooks/useTLStore'
-// Deprecated, but still exported so existing callers keep working until it's removed.
 // oxlint-disable-next-line typescript/no-deprecated
 export { useViewportHeight } from './lib/hooks/useViewportHeight'
 export {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -325,6 +325,8 @@ export {
 export { useTransform } from './lib/hooks/useTransform'
 export { isCursorInViewport } from './lib/utils/collaborators'
 export { useTLSchemaFromUtils, useTLStore } from './lib/hooks/useTLStore'
+// Deprecated, but still exported so existing callers keep working until it's removed.
+// oxlint-disable-next-line typescript/no-deprecated
 export { useViewportHeight } from './lib/hooks/useViewportHeight'
 export {
 	LicenseManager,

--- a/packages/editor/src/lib/hooks/useViewportHeight.ts
+++ b/packages/editor/src/lib/hooks/useViewportHeight.ts
@@ -12,16 +12,11 @@ import { useMaybeEditor } from './useEditor'
  * while using the virtual keyboard.
  */
 /**
- * The height of the visible viewport, including the visual viewport's own offset — so it tracks a
- * mobile software keyboard, which shrinks the visual viewport while leaving the layout viewport
- * (and CSS `dvh`) alone.
+ * The height of the visible viewport, including the visual viewport's own offset.
  *
- * @deprecated Read `window.visualViewport` directly instead. This returns a single scalar — the
- * visible viewport's bottom edge — where keeping UI clear of the software keyboard generally needs
- * the whole visible rectangle: the left and right edges to keep a panel on screen horizontally, and
- * `offsetTop` on its own to find the visible top. It has had no callers since the contextual
- * toolbar it was written for was cut before v3.14 shipped. This will be removed in a future
- * release.
+ * @deprecated Read `window.visualViewport` directly: this flattens the visible rectangle to a
+ * single scalar, and keeping UI clear of the software keyboard usually needs the other edges too.
+ * Unused since v3.14; will be removed in a future release.
  *
  * @public
  */

--- a/packages/editor/src/lib/hooks/useViewportHeight.ts
+++ b/packages/editor/src/lib/hooks/useViewportHeight.ts
@@ -11,7 +11,20 @@ import { useMaybeEditor } from './useEditor'
  * N.B. On iOS, you have to take into account the offsetTop as well so that you get an accurate position
  * while using the virtual keyboard.
  */
-/** @public */
+/**
+ * The height of the visible viewport, including the visual viewport's own offset — so it tracks a
+ * mobile software keyboard, which shrinks the visual viewport while leaving the layout viewport
+ * (and CSS `dvh`) alone.
+ *
+ * @deprecated Read `window.visualViewport` directly instead. This returns a single scalar — the
+ * visible viewport's bottom edge — where keeping UI clear of the software keyboard generally needs
+ * the whole visible rectangle: the left and right edges to keep a panel on screen horizontally, and
+ * `offsetTop` on its own to find the visible top. It has had no callers since the contextual
+ * toolbar it was written for was cut before v3.14 shipped. This will be removed in a future
+ * release.
+ *
+ * @public
+ */
 export function useViewportHeight(): number {
 	const editor = useMaybeEditor()
 	const win = editor?.getContainerWindow() ?? window


### PR DESCRIPTION
In order to stop pointing people at a hook that no longer earns its place in the public API, this deprecates `useViewportHeight`.

It was written for the rich-text contextual toolbar — on mobile that toolbar pinned itself to `viewportHeight - menuHeight - 16` so the iOS software keyboard couldn't swallow it, which is why the hook adds `visualViewport.offsetTop` rather than reading `innerHeight`. Its only caller was `useContextualToolbarPosition`, and that file was deleted in the run-up to #4895 ("remove contextual toolbar example, hook"); the contextual toolbar survived as an example that does its own positioning. The `@public` export line had already landed and stayed behind, so the hook has shipped with zero callers since v3.14 — about seventeen months.

It's being flagged now rather than quietly left alone because it came up while looking at keeping the commenting surfaces clear of the software keyboard (#9821, #9823), where it looked like the obvious thing to reuse. It isn't quite: the scalar it returns is only the visible viewport's *bottom* edge, and keeping a panel on screen generally needs the whole visible rectangle — the side edges to clamp horizontally, and `offsetTop` on its own to find the visible top.

Deprecated rather than removed, since it's `@public` and removing it is a breaking change. Note there's also live, unrelated `visualViewport` handling in `TldrawUiInput` that takes a different approach entirely (`scrollIntoView` on viewport change) — worth knowing about before anyone reaches for a shared helper here.

### Change type

- [x] `api`

### API changes

- Deprecated `useViewportHeight()`. Read `window.visualViewport` directly instead.

### Test plan

Not manually testable — a doc comment change with no behavior change. `yarn api-check` covers the report update.

### Release notes

- Deprecate `useViewportHeight`. Read `window.visualViewport` directly instead.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +14 / -1   |
| Automated files | +1 / -1    |
