### PR TITLE
fix(tldraw): make useDirection work outside translation context

### DIFF
--- a/packages/tldraw/api-report.api.md
+++ b/packages/tldraw/api-report.api.md
@@ -6521,6 +6521,9 @@ export function useKeyboardShortcuts(): void;
 // @public (undocumented)
 export function useLocalStorageState<T = any>(key: string, defaultValue: T): readonly [T, (setter: ((value: T) => T) | T) => void];
 
+// @public
+export function useMaybeCurrentTranslation(): null | TLUiTranslation;
+
 // @public (undocumented)
 export function useMenuClipboardEvents(): {
     copy: (source: TLUiEventSource) => Promise<void>;

--- a/packages/tldraw/src/index.ts
+++ b/packages/tldraw/src/index.ts
@@ -811,6 +811,7 @@ export { RTL_LANGUAGES, type TLUiTranslation } from './lib/ui/hooks/useTranslati
 export {
 	useCurrentTranslation,
 	useDirection,
+	useMaybeCurrentTranslation,
 	useTranslation,
 	type TLUiTranslationContextType,
 	type TLUiTranslationProviderProps,

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.test.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.test.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
+import * as React from 'react'
 import { DEFAULT_TRANSLATION } from './defaultTranslation'
 import { TLUiTranslation } from './translations'
 import {

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.test.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { DEFAULT_TRANSLATION } from './defaultTranslation'
+import { TLUiTranslation } from './translations'
+import {
+	TranslationsContext,
+	useCurrentTranslation,
+	useDirection,
+	useMaybeCurrentTranslation,
+} from './useTranslation'
+
+// The repo-wide test setup mocks this module's `useCurrentTranslation` to always succeed, since
+// most tests don't care about translation context. Unmock it here so we can test its real
+// context-dependent behavior.
+vi.unmock('./useTranslation')
+
+const rtlTranslation: TLUiTranslation = {
+	locale: 'ar',
+	label: 'Arabic',
+	dir: 'rtl',
+	messages: DEFAULT_TRANSLATION,
+}
+
+function withTranslation(translation: TLUiTranslation) {
+	return ({ children }: { children: React.ReactNode }) => (
+		<TranslationsContext.Provider value={translation}>{children}</TranslationsContext.Provider>
+	)
+}
+
+describe('useCurrentTranslation', () => {
+	it('returns the current translation when inside a provider', () => {
+		const { result } = renderHook(() => useCurrentTranslation(), {
+			wrapper: withTranslation(rtlTranslation),
+		})
+		expect(result.current).toBe(rtlTranslation)
+	})
+
+	it('throws when used outside of a provider', () => {
+		expect(() => renderHook(() => useCurrentTranslation())).toThrow(
+			'useCurrentTranslation must be used inside of <TldrawUiContextProvider />'
+		)
+	})
+})
+
+describe('useMaybeCurrentTranslation', () => {
+	it('returns the current translation when inside a provider', () => {
+		const { result } = renderHook(() => useMaybeCurrentTranslation(), {
+			wrapper: withTranslation(rtlTranslation),
+		})
+		expect(result.current).toBe(rtlTranslation)
+	})
+
+	it('returns null when used outside of a provider, without throwing', () => {
+		const { result } = renderHook(() => useMaybeCurrentTranslation())
+		expect(result.current).toBeNull()
+	})
+})
+
+describe('useDirection', () => {
+	it('returns the direction from the current translation when inside a provider', () => {
+		const { result } = renderHook(() => useDirection(), {
+			wrapper: withTranslation(rtlTranslation),
+		})
+		expect(result.current).toBe('rtl')
+	})
+
+	it('falls back to "ltr" when used outside of a provider, without throwing', () => {
+		const { result } = renderHook(() => useDirection())
+		expect(result.current).toBe('ltr')
+	})
+})

--- a/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
+++ b/packages/tldraw/src/lib/ui/hooks/useTranslation/useTranslation.tsx
@@ -37,6 +37,16 @@ export function useCurrentTranslation() {
 }
 
 /**
+ * Like {@link useCurrentTranslation}, but returns `null` instead of throwing when used outside
+ * of a `<TldrawUiTranslationProvider />` / `<TldrawUiContextProvider />`.
+ *
+ * @public
+ */
+export function useMaybeCurrentTranslation() {
+	return React.useContext(TranslationsContext)
+}
+
+/**
  * Provides a translation context to the editor. Wrap this around components that use
  * `useTranslation` (such as `TldrawSelectionForeground`) when you don't want to use the
  * full `TldrawUiContextProvider`. Must be rendered inside an `AssetUrlsProvider`.
@@ -138,8 +148,8 @@ export function useTranslation() {
  * @public
  */
 export function useDirection() {
-	const translation = useCurrentTranslation()
-	return translation.dir
+	const translation = useMaybeCurrentTranslation()
+	return translation?.dir ?? 'ltr'
 }
 
 export function untranslated(string: string) {


### PR DESCRIPTION
In order to let UI primitives (dropdown menus, popovers, tooltips, selects, sliders, dialogs, menu items) render standalone outside the full tldraw UI context, this PR makes `useDirection()` tolerate a missing translation provider instead of throwing.

`useDirection()` called `useCurrentTranslation()`, which throws unless there's a `<TldrawUiTranslationProvider>` / `<TldrawUiContextProvider>` ancestor. Since nearly every UI primitive calls `useDirection()` for RTL support, none of them could be used outside that context. This adds `useMaybeCurrentTranslation()`, a non-throwing variant that returns `null` when there's no provider, and switches `useDirection()` to use it with an `'ltr'` fallback. `useCurrentTranslation()` itself is unchanged for call sites that genuinely require translations.

### Change type

- [x] `bugfix`

### Test plan

- [x] Unit tests

### Release notes

- Add `useMaybeCurrentTranslation()`, a non-throwing variant of `useCurrentTranslation()` that returns `null` outside of a translation provider.
- Fix `useDirection()` (and the UI primitives that depend on it) throwing when used outside of a `TldrawUiTranslationProvider` / `TldrawUiContextProvider`.

### API changes

- Added `useMaybeCurrentTranslation()`, which returns the current `TLUiTranslation` or `null` instead of throwing.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +13 / -2   |
| Tests           | +71 / -0   |
| Automated files | +3 / -0    |