### PR TITLE
feat(examples): add keyboard math input example

### DIFF
--- a/apps/examples/package.json
+++ b/apps/examples/package.json
@@ -61,6 +61,7 @@
 		"axe-core": "^4.10.3",
 		"classnames": "^2.5.1",
 		"d3-geo": "^3.1.1",
+		"katex": "^0.18.1",
 		"lazyrepo": "0.0.0-alpha.27",
 		"lodash": "^4.17.21",
 		"mermaid": "11.15.0",
@@ -78,6 +79,7 @@
 	},
 	"devDependencies": {
 		"@types/d3-geo": "^3.1.0",
+		"@types/katex": "^0.16.8",
 		"@types/lodash": "^4.17.14",
 		"@types/react": "^19.2.7",
 		"@types/react-dom": "^19.2.3",

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/KeyboardMathInputExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/KeyboardMathInputExample.tsx
@@ -1,0 +1,119 @@
+import 'katex/dist/katex.min.css'
+import {
+	DefaultToolbar,
+	DefaultToolbarContent,
+	TLComponents,
+	TLUiOverrides,
+	Tldraw,
+	TldrawUiMenuItem,
+	createShapeId,
+	toRichText,
+	useIsToolSelected,
+	useTools,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import { MathShapeUtil } from './MathShapeUtil'
+import { MathTool } from './MathTool'
+import './keyboard-math-input.css'
+
+// There's a guide at the bottom of this file!
+
+const customShapeUtils = [MathShapeUtil]
+const customTools = [MathTool]
+
+// [1]
+const uiOverrides: TLUiOverrides = {
+	tools(editor, tools) {
+		tools.math = {
+			id: 'math',
+			icon: 'tool-math',
+			label: 'Math',
+			kbd: 'm',
+			onSelect: () => editor.setCurrentTool('math'),
+		}
+		return tools
+	},
+}
+
+function Toolbar() {
+	const tools = useTools()
+	const isMathSelected = useIsToolSelected(tools.math)
+	return (
+		<DefaultToolbar>
+			<TldrawUiMenuItem {...tools.math} isSelected={isMathSelected} />
+			<DefaultToolbarContent />
+		</DefaultToolbar>
+	)
+}
+
+const components: TLComponents = { Toolbar }
+
+// [2]
+const MATH_ICON =
+	'data:image/svg+xml;utf8,' +
+	encodeURIComponent(
+		'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30"><text x="15" y="21" font-family="Georgia, serif" font-style="italic" font-size="17" text-anchor="middle">&#8730;x</text></svg>'
+	)
+
+export default function KeyboardMathInputExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={customShapeUtils}
+				tools={customTools}
+				overrides={uiOverrides}
+				components={components}
+				assetUrls={{ icons: { 'tool-math': MATH_ICON } }}
+				onMount={(editor) => {
+					if (editor.getCurrentPageShapes().length > 0) return
+					const examples = [
+						'x = (-b +- sqrt(b^2 - 4ac))/(2a)',
+						'e^(i pi) + 1 = 0',
+						'int_0^inf e^(-x^2) dx = sqrt(pi)/2',
+					]
+					const ids = examples.map((text, i) => {
+						const id = createShapeId(`example-${i}`)
+						editor.createShape({ id, type: 'math', x: 160, y: 120 + i * 120, props: { text } })
+						return id
+					})
+					editor.createShape({
+						type: 'text',
+						x: 560,
+						y: 150,
+						props: {
+							richText: toRichText(
+								'Pick the √x tool (or press M), then click the canvas\nand just type: 1/2, sqrt(2), x^2, pi\nDouble-click any equation to edit it. Enter when done.'
+							),
+						},
+					})
+					// [3]
+					editor.timers.setTimeout(() => {
+						editor.stackShapes(ids, 'vertical', 32)
+						editor.zoomToFit({ animation: { duration: 0 } })
+					}, 100)
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+Math equations as a first-class canvas shape. The shape stores keyboard
+shorthand, translates it to LaTeX (see shorthand.ts), and renders it with
+KaTeX. While editing, a text input with a live preview appears (see
+MathShapeUtil.tsx and MathInput.tsx). This file wires up the tool and toolbar.
+
+[1]
+Register the math tool with the UI: the overrides object adds it to the
+toolbar schema with a keyboard shortcut, and the custom Toolbar component
+places its button ahead of the default content.
+
+[2]
+tldraw renders toolbar icons as CSS masks, so any SVG works and the fill
+color is irrelevant. An inline data URL avoids shipping an asset file.
+
+[3]
+The math shape sizes itself to its rendered content, so the seeded shapes
+only have real heights after their first render. Wait a beat, then stack
+them with an even gap and frame the result.
+*/

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/MathInput.tsx
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/MathInput.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react'
+import { useEditor } from 'tldraw'
+
+// A plain text input for math shorthand, shown in place of the rendered
+// equation while the shape is being edited. A floating bubble above the shape
+// previews the rendered equation live as you type (see MathShapeUtil.tsx).
+export function MathInput({
+	text,
+	onChange,
+	onDone,
+}: {
+	text: string
+	onChange(text: string): void
+	onDone(): void
+}) {
+	const editor = useEditor()
+	const ref = useRef<HTMLInputElement>(null)
+
+	useEffect(() => {
+		ref.current?.focus()
+		ref.current?.select()
+	}, [])
+
+	return (
+		<input
+			ref={ref}
+			className="math-input"
+			value={text}
+			spellCheck={false}
+			placeholder="1/2 + sqrt(2) or x^2"
+			onChange={(e) => onChange(e.currentTarget.value)}
+			onKeyDown={(e) => {
+				if (e.key === 'Enter' || e.key === 'Escape') {
+					e.preventDefault()
+					onDone()
+				}
+			}}
+			// Pointer events on the input must not reach the canvas, or tldraw
+			// would select and drag the shape instead of placing the caret
+			onPointerDown={editor.markEventAsHandled}
+			onTouchStart={editor.markEventAsHandled}
+		/>
+	)
+}

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/MathShapeUtil.tsx
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/MathShapeUtil.tsx
@@ -1,0 +1,191 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import katex from 'katex'
+import { useEffect, useMemo, useRef } from 'react'
+import { HTMLContainer, RecordProps, Rectangle2d, ShapeUtil, T, TLShape, useValue } from 'tldraw'
+import { MathInput } from './MathInput'
+import { translateToLatex } from './shorthand'
+
+// There's a guide at the bottom of this file!
+
+const MATH_SHAPE_TYPE = 'math'
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[MATH_SHAPE_TYPE]: {
+			w: number
+			h: number
+			text: string
+		}
+	}
+}
+
+export type IMathShape = TLShape<typeof MATH_SHAPE_TYPE>
+
+const MIN_W = 40
+const MIN_H = 36
+
+// [1]
+function Rendered({ text }: { text: string }) {
+	const html = useMemo(() => {
+		if (!text.trim()) return ''
+		return katex.renderToString(translateToLatex(text), {
+			throwOnError: false,
+			displayMode: true,
+		})
+	}, [text])
+	if (!html) return null
+	return <div className="math-rendered" dangerouslySetInnerHTML={{ __html: html }} />
+}
+
+export class MathShapeUtil extends ShapeUtil<IMathShape> {
+	static override type = MATH_SHAPE_TYPE
+	static override props: RecordProps<IMathShape> = {
+		w: T.number,
+		h: T.number,
+		text: T.string,
+	}
+
+	getDefaultProps(): IMathShape['props'] {
+		return { w: MIN_W, h: MIN_H, text: '' }
+	}
+
+	// [2]
+	override canEdit() {
+		return true
+	}
+
+	// [3]
+	override canResize() {
+		return false
+	}
+
+	// [4]
+	override onEditEnd(shape: IMathShape) {
+		if (!shape.props.text.trim()) {
+			this.editor.deleteShape(shape.id)
+		}
+	}
+
+	getGeometry(shape: IMathShape) {
+		return new Rectangle2d({
+			width: shape.props.w,
+			height: shape.props.h,
+			isFilled: true,
+		})
+	}
+
+	component(shape: IMathShape) {
+		const isEditing = useValue('isEditing', () => this.editor.getEditingShapeId() === shape.id, [
+			shape.id,
+		])
+		const ref = useRef<HTMLDivElement>(null)
+
+		// [5]
+		useEffect(() => {
+			const el = ref.current
+			if (!el) return
+			const measure = () => {
+				const w = Math.max(MIN_W, Math.ceil(el.offsetWidth))
+				const h = Math.max(MIN_H, Math.ceil(el.offsetHeight))
+				const current = this.editor.getShape<IMathShape>(shape.id)
+				if (!current) return
+				if (Math.abs(w - current.props.w) > 1 || Math.abs(h - current.props.h) > 1) {
+					this.editor.updateShape<IMathShape>({
+						id: shape.id,
+						type: MATH_SHAPE_TYPE,
+						props: { w, h },
+					})
+				}
+			}
+			const observer = new ResizeObserver(measure)
+			observer.observe(el)
+			measure()
+			return () => observer.disconnect()
+		}, [shape.id])
+
+		return (
+			<HTMLContainer>
+				<div
+					ref={ref}
+					className={`math-text ${isEditing ? 'math-text-editing' : ''}`}
+					// [6]
+					style={{ pointerEvents: isEditing ? 'all' : 'none' }}
+				>
+					{isEditing ? (
+						<>
+							{shape.props.text.trim() !== '' && (
+								// [7]
+								<div className="math-preview">
+									<Rendered text={shape.props.text} />
+								</div>
+							)}
+							<MathInput
+								text={shape.props.text}
+								onChange={(text) =>
+									this.editor.updateShape<IMathShape>({
+										id: shape.id,
+										type: MATH_SHAPE_TYPE,
+										props: { text },
+									})
+								}
+								onDone={() => this.editor.setEditingShape(null)}
+							/>
+						</>
+					) : (
+						<Rendered text={shape.props.text} />
+					)}
+				</div>
+			</HTMLContainer>
+		)
+	}
+
+	getIndicatorPath(shape: IMathShape) {
+		const p = new Path2D()
+		p.rect(0, 0, shape.props.w, shape.props.h)
+		return p
+	}
+}
+
+/*
+A text-like custom shape for math. It stores the shorthand exactly as typed,
+translates it to LaTeX (see shorthand.ts), and renders it with KaTeX. Storing
+the source rather than the LaTeX means re-editing shows what you typed.
+
+[1]
+Display: translate the shorthand and render it with KaTeX. `throwOnError:
+false` means partially-typed input still renders instead of throwing. KaTeX
+escapes its input, so the innerHTML here is safe as long as the `trust`
+option stays off (it is off by default).
+
+[2]
+Only shapes with `canEdit` can enter the editor's editing state (double-click,
+or select + Enter). Like tldraw's own text shape, editing swaps the rendered
+equation for a plain text input showing the shorthand source; the math
+renders again when the edit ends (see MathInput.tsx).
+
+[3]
+The shape hugs its content, so manual resizing is disabled: `w` and `h` are
+derived from measurement, not set by the user.
+
+[4]
+Like tldraw's own text shape, finishing an edit with nothing typed deletes the
+shape rather than leaving an invisible empty one behind.
+
+[5]
+Auto-size: a ResizeObserver measures the rendered content and writes the size
+back into the shape's props, so the geometry and selection indicator always
+fit the equation. offsetWidth/offsetHeight ignore CSS transforms, so the
+measurement is independent of the camera zoom.
+
+[6]
+The shape's HTML container has pointer-events: none, and the property
+inherits. Interactive content inside a shape must opt back in with
+pointer-events: all. We only do so while editing, so clicking the rendered
+equation still selects the shape normally.
+
+[7]
+Live preview: while editing, the rendered equation floats in a bubble above
+the shape, updating on every keystroke. It's absolutely positioned, so it
+doesn't affect the measured size of the shape, and styled as a card so it
+reads as UI rather than a second copy of the text.
+*/

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/MathTool.ts
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/MathTool.ts
@@ -1,0 +1,28 @@
+import { StateNode, createShapeId } from 'tldraw'
+import { IMathShape } from './MathShapeUtil'
+
+// Click anywhere on the canvas to drop a math shape and start typing straight
+// away: the tool creates the shape, then hands off to the select tool with the
+// shape in the editing state so the math field focuses immediately.
+export class MathTool extends StateNode {
+	static override id = 'math'
+
+	override onEnter() {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onPointerDown() {
+		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
+		const id = createShapeId()
+		this.editor.createShape<IMathShape>({
+			id,
+			type: 'math',
+			x: currentPagePoint.x,
+			y: currentPagePoint.y - 18,
+			props: { text: '' },
+		})
+		this.editor.setCurrentTool('select')
+		this.editor.select(id)
+		this.editor.setEditingShape(id)
+	}
+}

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/README.md
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/README.md
@@ -1,0 +1,28 @@
+---
+title: Keyboard math input
+component: ./KeyboardMathInputExample.tsx
+category: shapes/tools
+priority: 3
+keywords:
+  [
+    custom shape,
+    shapeutil,
+    katex,
+    math,
+    latex,
+    equation,
+    shorthand,
+    editing state,
+    custom tool,
+    toolbar,
+    auto-size,
+  ]
+---
+
+Type math equations with a plain keyboard, using a custom shape rendered with KaTeX.
+
+---
+
+This example adds a math equation shape that behaves like a text shape. Pick the math tool from the toolbar (or press M), click the canvas, and type shorthand: `1/2` becomes a fraction, `sqrt(2)` a radical, `x^2` a superscript, `pi` the symbol, and so on. A preview bubble above the shape renders the equation live as you type. Press Enter or Escape (or click away) and the equation renders in place of what you typed. Double-click any equation to edit its shorthand again.
+
+The shape stores the shorthand exactly as typed. A small translator (`shorthand.ts`) rewrites it into LaTeX, which is rendered with [KaTeX](https://katex.org). Raw LaTeX commands pass through the translator untouched, so `\frac{a}{b}` works too.

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/keyboard-math-input.css
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/keyboard-math-input.css
@@ -1,0 +1,61 @@
+/* Text-like math shape: no chrome, hugs its content. */
+.math-text {
+	position: relative;
+	width: max-content;
+	min-width: 40px;
+	min-height: 36px;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: flex-start;
+	gap: 6px;
+	padding: 4px 6px;
+	color: var(--color-text, #1d1d1d);
+}
+
+.math-text-editing {
+	outline: 1.5px dashed var(--color-selection-stroke, #3b73f6);
+	outline-offset: 2px;
+	border-radius: 4px;
+}
+
+.math-rendered {
+	font-size: 24px;
+	white-space: nowrap;
+	align-self: center;
+}
+
+/* Live preview bubble floating above the shape while editing. Absolutely
+   positioned so it doesn't affect the shape's measured size. */
+.math-preview {
+	position: absolute;
+	bottom: 100%;
+	left: 0;
+	margin-bottom: 10px;
+	padding: 8px 14px;
+	background: var(--color-panel, #fff);
+	border-radius: 8px;
+	box-shadow:
+		0 1px 2px rgba(0, 0, 0, 0.12),
+		0 4px 12px rgba(0, 0, 0, 0.12);
+	pointer-events: none;
+}
+
+/* KaTeX display mode adds vertical margins; keep the shape tight. */
+.math-rendered .katex-display {
+	margin: 0;
+}
+
+.math-input {
+	pointer-events: all;
+	min-width: 260px;
+	border: none;
+	outline: none;
+	background: transparent;
+	font:
+		16px/1.5 ui-monospace,
+		'SF Mono',
+		Menlo,
+		monospace;
+	color: inherit;
+}

--- a/apps/examples/src/examples/shapes/tools/keyboard-math-input/shorthand.ts
+++ b/apps/examples/src/examples/shapes/tools/keyboard-math-input/shorthand.ts
@@ -1,0 +1,48 @@
+// Translates keyboard-friendly shorthand into LaTeX for KaTeX to render.
+// It's a small chain of regex rewrites, applied in order:
+//
+//   1/2                  → \frac{1}{2}
+//   sqrt(2)              → \sqrt{2}
+//   x^10, e^(i pi)       → x^{10}, e^{i \pi}
+//   pi, theta, inf       → \pi, \theta, \infty
+//   +-, ->, <=, >=, !=   → \pm, \to, \le, \ge, \ne
+//
+// Anything it doesn't recognize (including raw LaTeX commands) passes
+// through untouched, so power users can still type \frac{a}{b} directly.
+
+// A fraction operand: a number/word, optionally followed by one brace or
+// paren group so \sqrt{2} and sin(x) stay whole, or a bare parenthesized
+// group with no nested parens.
+const OPERAND = /(?:\\?[A-Za-z0-9.]+(?:\{[^{}]*\}|\([^()]*\))?|\([^()]*\))/
+const FRACTION = new RegExp(`(${OPERAND.source})\\s*/\\s*(${OPERAND.source})`, 'g')
+
+// Letter-based boundaries rather than \b, so names still match when touching
+// an underscore or caret (int_0, x^inf), but not inside words (point, using)
+const NAMED =
+	/(?<![\\A-Za-z])(alpha|beta|gamma|delta|epsilon|theta|lambda|mu|sigma|phi|omega|pi|infty|inf|int|sum|prod|lim|sin|cos|tan|log|ln)(?![A-Za-z])/g
+
+function stripParens(s: string) {
+	return s.startsWith('(') && s.endsWith(')') ? s.slice(1, -1) : s
+}
+
+export function translateToLatex(text: string): string {
+	return (
+		text
+			// Two-character operators first, before anything eats their pieces
+			.replace(/\+-/g, '\\pm ')
+			.replace(/->/g, '\\to ')
+			.replace(/<=/g, '\\le ')
+			.replace(/>=/g, '\\ge ')
+			.replace(/!=/g, '\\ne ')
+			// sqrt(...) → \sqrt{...}
+			.replace(/sqrt\(([^()]*)\)/g, '\\sqrt{$1}')
+			// Superscripts and subscripts: brace parenthesized or multi-character
+			// arguments so KaTeX applies the script to the whole thing
+			.replace(/([\^_])\(([^()]*)\)/g, '$1{$2}')
+			.replace(/([\^_])([A-Za-z0-9]{2,})/g, '$1{$2}')
+			// a/b → \frac{a}{b}
+			.replace(FRACTION, (_m, a, b) => `\\frac{${stripParens(a)}}{${stripParens(b)}}`)
+			// Named symbols and functions, unless already escaped
+			.replace(NAMED, (m) => `\\${m === 'inf' ? 'infty' : m}`)
+	)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13099,6 +13099,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/katex@npm:^0.16.8":
+  version: 0.16.8
+  resolution: "@types/katex@npm:0.16.8"
+  checksum: 10/4bf5d83d2430bc04c183765c5916c21180a75cb0181172a0aac7350943507679ceb79bfd13e394cf7c101b7417564d14c0c660baa93b16f2f42baef22a99435c
+  languageName: node
+  linkType: hard
+
 "@types/linkify-it@npm:^5":
   version: 5.0.0
   resolution: "@types/linkify-it@npm:5.0.0"
@@ -20051,6 +20058,7 @@ __metadata:
     "@tldraw/state": "workspace:*"
     "@tldraw/sync": "workspace:*"
     "@types/d3-geo": "npm:^3.1.0"
+    "@types/katex": "npm:^0.16.8"
     "@types/lodash": "npm:^4.17.14"
     "@types/react": "npm:^19.2.7"
     "@types/react-dom": "npm:^19.2.3"
@@ -20072,6 +20080,7 @@ __metadata:
     d3-geo: "npm:^3.1.1"
     dotenv: "npm:^16.4.7"
     expect-webdriverio: "npm:^5.6.8"
+    katex: "npm:^0.18.1"
     lazyrepo: "npm:0.0.0-alpha.27"
     lodash: "npm:^4.17.21"
     mermaid: "npm:11.15.0"
@@ -23429,6 +23438,17 @@ __metadata:
   bin:
     katex: cli.js
   checksum: 10/e0286b45d9e0c8443cf0381205619ecbab3919ea5fb6616408f46f0cb471ce2222e83f46aef52cdaacdcbfd4485e00fcfbcf36bd85a8a9a81e22b45827c27ced
+  languageName: node
+  linkType: hard
+
+"katex@npm:^0.18.1":
+  version: 0.18.1
+  resolution: "katex@npm:0.18.1"
+  dependencies:
+    commander: "npm:^8.3.0"
+  bin:
+    katex: cli.js
+  checksum: 10/57c8832760a3466e84bd3d01f409fb3149c0450f156de24ddd447a414b309a286980a4a3cfcd41c8f7179ea3c49bd5a04d3c7ffb6ea14a68aa965a9f5dcf061d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds an example to use KaTeX to allow for keyboard input -> Latex style text rendered on the canvas