### PR TITLE
fix(commenting): keep the comment tool active while the composer is open

### DIFF
--- a/packages/commenting/src/canvas/comment-tool.test.ts
+++ b/packages/commenting/src/canvas/comment-tool.test.ts
@@ -13,6 +13,7 @@ import {
 } from 'tldraw'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { CommentTool } from './comment-tool'
+import { commentsSidebarOpen, pendingComment } from './state'
 
 /**
  * Pointer-driven tests for the comment tool's placement affordances. These need a real editor
@@ -90,11 +91,68 @@ describe('comment tool placement hints', () => {
 		driver.pointerMove(150, 125)
 		expect(editor.getHintingShapeIds()).toEqual([id])
 
-		// Releasing places the comment and hands back to select, which owns its own hover state.
-		driver.pointerDown(150, 125)
-		driver.pointerUp(150, 125)
-		expect(editor.isIn('select')).toBe(true)
+		// Select owns its own hover state, so the comment hint leaves with the tool.
+		editor.setCurrentTool('select')
 		expect(editor.getHintingShapeIds()).toEqual([])
+	})
+})
+
+describe('comment tool placement lifecycle', () => {
+	let driver: Driver
+
+	beforeEach(() => {
+		driver = makeEditor()
+	})
+
+	it('stays in the tool with the composer open after placing', () => {
+		editor.setCurrentTool('comment')
+		driver.pointerDown(400, 300)
+		driver.pointerUp(400, 300)
+		// Placement opens the composer but the interaction isn't over — the tool holds on until
+		// the comment is posted or dismissed, so the surrounding UI stays stable.
+		expect(editor.isIn('comment.idle')).toBe(true)
+		expect(pendingComment.get(editor)).toMatchObject({ anchor: { type: 'point' } })
+	})
+
+	it('re-places the composer on a second click', () => {
+		editor.setCurrentTool('comment')
+		driver.pointerDown(400, 300)
+		driver.pointerUp(400, 300)
+		driver.pointerDown(200, 200)
+		driver.pointerUp(200, 200)
+		expect(editor.isIn('comment.idle')).toBe(true)
+		expect(pendingComment.get(editor)).toMatchObject({ point: { x: 200, y: 200 } })
+	})
+
+	it('drops the pending composer when the tool exits', () => {
+		editor.setCurrentTool('comment')
+		driver.pointerDown(400, 300)
+		driver.pointerUp(400, 300)
+		expect(pendingComment.get(editor)).not.toBeNull()
+
+		// A direct tool switch (toolbar, shortcut) abandons the draft composer — it belongs to
+		// the tool. The text itself survives in the comment draft store.
+		editor.setCurrentTool('select')
+		expect(pendingComment.get(editor)).toBeNull()
+	})
+
+	it('closes the comments sidebar for the whole interaction', () => {
+		commentsSidebarOpen.set(editor, true)
+		editor.setCurrentTool('comment')
+		expect(commentsSidebarOpen.get(editor)).toBe(false)
+
+		// ...and placing doesn't reopen it: the tool (and the closed sidebar) hold through the
+		// composer. Reopening is the host's button, never a side effect of leaving the tool.
+		driver.pointerDown(400, 300)
+		driver.pointerUp(400, 300)
+		expect(editor.isIn('comment.idle')).toBe(true)
+		expect(commentsSidebarOpen.get(editor)).toBe(false)
+	})
+
+	it('escape leaves the tool for select', () => {
+		editor.setCurrentTool('comment')
+		editor.cancel()
+		expect(editor.isIn('select')).toBe(true)
 	})
 })
 
@@ -112,6 +170,16 @@ describe('comment tool placement hints with regions enabled', () => {
 		driver.pointerMove(180, 140)
 		expect(editor.isIn('comment.dragging')).toBe(true)
 		expect(editor.getHintingShapeIds()).toEqual([])
+	})
+
+	it('stays in the tool with the composer open after a region drag', () => {
+		const driver = makeEditor(CommentTool.configure({ enableRegions: true }))
+		editor.setCurrentTool('comment')
+		driver.pointerDown(100, 100)
+		driver.pointerMove(200, 180)
+		driver.pointerUp(200, 180)
+		expect(editor.isIn('comment.idle')).toBe(true)
+		expect(pendingComment.get(editor)).toMatchObject({ anchor: { type: 'region' } })
 	})
 })
 

--- a/packages/commenting/src/canvas/comment-tool.test.ts
+++ b/packages/commenting/src/canvas/comment-tool.test.ts
@@ -13,7 +13,7 @@ import {
 } from 'tldraw'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { CommentTool } from './comment-tool'
-import { commentsSidebarOpen, pendingComment } from './state'
+import { commentsSidebarOpen, pendingComment, regionDraft } from './state'
 
 /**
  * Pointer-driven tests for the comment tool's placement affordances. These need a real editor
@@ -111,7 +111,10 @@ describe('comment tool placement lifecycle', () => {
 		// Placement opens the composer but the interaction isn't over — the tool holds on until
 		// the comment is posted or dismissed, so the surrounding UI stays stable.
 		expect(editor.isIn('comment.idle')).toBe(true)
-		expect(pendingComment.get(editor)).toMatchObject({ anchor: { type: 'point' } })
+		expect(pendingComment.get(editor)).toEqual({
+			anchor: { type: 'point', x: 400, y: 300 },
+			point: { x: 400, y: 300 },
+		})
 	})
 
 	it('re-places the composer on a second click', () => {
@@ -121,7 +124,10 @@ describe('comment tool placement lifecycle', () => {
 		driver.pointerDown(200, 200)
 		driver.pointerUp(200, 200)
 		expect(editor.isIn('comment.idle')).toBe(true)
-		expect(pendingComment.get(editor)).toMatchObject({ point: { x: 200, y: 200 } })
+		expect(pendingComment.get(editor)).toEqual({
+			anchor: { type: 'point', x: 200, y: 200 },
+			point: { x: 200, y: 200 },
+		})
 	})
 
 	it('drops the pending composer when the tool exits', () => {
@@ -149,10 +155,13 @@ describe('comment tool placement lifecycle', () => {
 		expect(commentsSidebarOpen.get(editor)).toBe(false)
 	})
 
-	it('escape leaves the tool for select', () => {
+	it('escape leaves the tool for select and drops the draft', () => {
 		editor.setCurrentTool('comment')
+		driver.pointerDown(400, 300)
+		driver.pointerUp(400, 300)
 		editor.cancel()
 		expect(editor.isIn('select')).toBe(true)
+		expect(pendingComment.get(editor)).toBeNull()
 	})
 })
 
@@ -179,7 +188,35 @@ describe('comment tool placement hints with regions enabled', () => {
 		driver.pointerMove(200, 180)
 		driver.pointerUp(200, 180)
 		expect(editor.isIn('comment.idle')).toBe(true)
-		expect(pendingComment.get(editor)).toMatchObject({ anchor: { type: 'region' } })
+		expect(pendingComment.get(editor)).toEqual({
+			anchor: { type: 'region', x: 100, y: 100, w: 100, h: 80, pinX: 1, pinY: 1 },
+			point: { x: 200, y: 180 },
+		})
+	})
+
+	it('does not hint a shape under the pin corner of a placed region', () => {
+		const driver = makeEditor(CommentTool.configure({ enableRegions: true }))
+		makeShape(100, 100)
+		editor.setCurrentTool('comment')
+		// Release on top of the shape: a region anchors to its rectangle, so the outline that
+		// normally previews a shape anchor would be a lie here.
+		driver.pointerDown(50, 50)
+		driver.pointerMove(150, 125)
+		driver.pointerUp(150, 125)
+		expect(editor.isIn('comment.idle')).toBe(true)
+		expect(editor.getHintingShapeIds()).toEqual([])
+	})
+
+	it('drops the region draft when the tool exits mid-drag', () => {
+		const driver = makeEditor(CommentTool.configure({ enableRegions: true }))
+		editor.setCurrentTool('comment')
+		driver.pointerDown(100, 100)
+		driver.pointerMove(200, 180)
+		expect(regionDraft.get(editor)).not.toBeNull()
+
+		// A direct tool switch (shortcut, toolbar) mid-drag must not strand the drawn rectangle.
+		editor.setCurrentTool('select')
+		expect(regionDraft.get(editor)).toBeNull()
 	})
 })
 

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -100,11 +100,11 @@ export class CommentTool extends StateNode {
 
 	override onExit() {
 		// Drop the hover hint painted while pointing at shapes (see CommentIdle). The cursor resets
-		// when the next tool takes over. The draft composer belongs to the tool, so it leaves with
-		// it — posting and cancelling clear it themselves before switching, so this only catches
-		// direct tool switches (toolbar click, shortcut) while a draft is open.
+		// when the next tool takes over. The draft composer and region draft belong to the tool, so
+		// they leave with it; the draft's text survives in the comment draft store.
 		this.editor.setHintingShapes([])
 		pendingComment.set(this.editor, null)
+		regionDraft.set(this.editor, null)
 	}
 
 	// Escape leaves the tool, like the built-in tools (the editor dispatches `cancel` on Escape).
@@ -127,7 +127,14 @@ class CommentIdle extends StateNode {
 	override onEnter() {
 		// Back to hovering: restore the pin cursor (a prior placing state may have hidden it).
 		this.editor.setCursor({ type: 'comment', rotation: 0 })
-		updateAnchorHint(this.editor)
+		// With a region composer open, a shape outline under its pin corner would imply a shape
+		// anchor the region will never use — and it would stick, since moves over the composer
+		// never reach the canvas. Point placements keep the hint: it previews the next click.
+		if (pendingComment.get(this.editor)?.anchor.type === 'region') {
+			this.editor.setHintingShapes([])
+		} else {
+			updateAnchorHint(this.editor)
+		}
 	}
 
 	override onPointerMove() {
@@ -192,7 +199,7 @@ class CommentPointing extends StateNode {
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
 		// Stay in the tool while the composer is open — the interaction isn't over until the
 		// comment is posted or dismissed, and staying keeps the surrounding UI (style panel,
-		// sidebar) from churning mid-placement. The composer hands back to select on post.
+		// sidebar) from churning mid-placement.
 		this.parent.transition('idle')
 	}
 
@@ -204,9 +211,9 @@ class CommentPointing extends StateNode {
 		this.cancel()
 	}
 
-	// Abandon the follow composer if placement is interrupted (Escape, focus loss, etc.).
+	// Abandon the follow composer if placement is interrupted (Escape, focus loss, etc.). The
+	// tool's onExit drops the draft.
 	private cancel() {
-		pendingComment.set(this.editor, null)
 		this.editor.setCurrentTool('select')
 	}
 }
@@ -261,8 +268,8 @@ class CommentDragging extends StateNode {
 		)
 	}
 
+	// The tool's onExit drops the region draft.
 	private cancel() {
-		regionDraft.set(this.editor, null)
 		this.editor.setCurrentTool('select')
 	}
 }

--- a/packages/commenting/src/canvas/comment-tool.tsx
+++ b/packages/commenting/src/canvas/comment-tool.tsx
@@ -52,7 +52,9 @@ export function regionBetween(a: VecLike, b: VecLike): BoxModel {
  * The comment tool. Pressing down opens the comment composer at the pointer and it follows until
  * release — like placing a sticky note — settling on a point, or on a shape when released over one.
  * With region comments enabled, dragging past the threshold draws a region rectangle instead.
- * Placement only opens a composer; the records are created when the comment is posted.
+ * Placement only opens a composer; the records are created when the comment is posted. The tool
+ * stays active while the composer is open — posting returns to select, and clicking elsewhere
+ * re-places the composer.
  * @public
  */
 export class CommentTool extends StateNode {
@@ -98,8 +100,11 @@ export class CommentTool extends StateNode {
 
 	override onExit() {
 		// Drop the hover hint painted while pointing at shapes (see CommentIdle). The cursor resets
-		// when the next tool takes over.
+		// when the next tool takes over. The draft composer belongs to the tool, so it leaves with
+		// it — posting and cancelling clear it themselves before switching, so this only catches
+		// direct tool switches (toolbar click, shortcut) while a draft is open.
 		this.editor.setHintingShapes([])
+		pendingComment.set(this.editor, null)
 	}
 
 	// Escape leaves the tool, like the built-in tools (the editor dispatches `cancel` on Escape).
@@ -185,7 +190,10 @@ class CommentPointing extends StateNode {
 				)
 			: { type: 'point', x: point.x, y: point.y }
 		pendingComment.set(editor, { anchor, point: { x: point.x, y: point.y } })
-		editor.setCurrentTool('select')
+		// Stay in the tool while the composer is open — the interaction isn't over until the
+		// comment is posted or dismissed, and staying keeps the surrounding UI (style panel,
+		// sidebar) from churning mid-placement. The composer hands back to select on post.
+		this.parent.transition('idle')
 	}
 
 	override onCancel() {
@@ -233,7 +241,8 @@ class CommentDragging extends StateNode {
 			anchor: { type: 'region', ...region, pinX: pin.x, pinY: pin.y },
 			point: regionPinPoint(region, pin),
 		})
-		editor.setCurrentTool('select')
+		// Same as the point placement: the tool stays active while the composer is open.
+		this.parent.transition('idle')
 	}
 
 	override onCancel() {

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -68,11 +68,16 @@ function CanvasCommentsLayer(props: CommentingContext) {
 	const pending = usePendingComment()
 	const canComment = useCanComment(props.currentUserId)
 	// Nothing renders a pending comment when composing is blocked and there's no fallback slot, and
-	// the dismiss handlers live inside PendingComposer — so clear the atom rather than strand it.
+	// the dismiss handlers live inside PendingComposer — so clear the atom rather than strand it,
+	// and leave the tool too: it holds while a composer is open, so staying would turn every click
+	// into a silently swallowed placement.
 	const canRenderComposer = canComment || options.components.ComposerFallback != null
 	const showPendingComposer = pending != null && canRenderComposer
 	useEffect(() => {
-		if (pending && !showPendingComposer) pendingComment.set(editor, null)
+		if (pending && !showPendingComposer) {
+			pendingComment.set(editor, null)
+			if (editor.isIn('comment')) editor.setCurrentTool('select')
+		}
 	}, [editor, pending, showPendingComposer])
 	const openId = useValue('open thread id', () => openThreadId.get(editor), [editor])
 	// Matches the sidebar's `showResolved` filter. The open thread stays in — resolving from its own

--- a/packages/commenting/src/canvas/pending-composer.tsx
+++ b/packages/commenting/src/canvas/pending-composer.tsx
@@ -107,9 +107,10 @@ export function PendingComposer({
 		setText(EMPTY_COMMENT)
 		clearCommentDraft(NEW_COMMENT_DRAFT)
 		pendingComment.set(editor, null)
-		// Posting ends the placement interaction — the comment tool held on while the composer was
-		// open, so hand back to select now.
-		if (editor.isIn('comment')) editor.setCurrentTool('select')
+		// Posting ends the placement interaction — hand the comment tool back to select. Only from
+		// the settled idle state: Enter can land while a fresh press is mid-gesture (the composer
+		// trails the pointer), and switching tools under a held pointer would strand the gesture.
+		if (editor.isIn('comment.idle')) editor.setCurrentTool('select')
 		// The host's callback is its own operation, not part of the post's history scope. It runs
 		// last so a throwing host can't strand the composer holding a draft of a posted comment.
 		onPostComment?.(comment)

--- a/packages/commenting/src/canvas/pending-composer.tsx
+++ b/packages/commenting/src/canvas/pending-composer.tsx
@@ -107,6 +107,9 @@ export function PendingComposer({
 		setText(EMPTY_COMMENT)
 		clearCommentDraft(NEW_COMMENT_DRAFT)
 		pendingComment.set(editor, null)
+		// Posting ends the placement interaction — the comment tool held on while the composer was
+		// open, so hand back to select now.
+		if (editor.isIn('comment')) editor.setCurrentTool('select')
 		// The host's callback is its own operation, not part of the post's history scope. It runs
 		// last so a throwing host can't strand the composer holding a draft of a posted comment.
 		onPostComment?.(comment)


### PR DESCRIPTION
@mimecuvalo this felt like the right approach, but happy to change it.

In order to keep the right-hand panels stable while placing a comment (#9829), this PR makes the comment tool hold until the placement interaction actually ends. Placing used to switch to select on pointer up while the draft composer was still open, so the style panel materialized next to the composer mid-interaction; the sidebar had already closed on tool enter, making one interaction cycle through three panel states. Closes #9829.

The tool now stays active while the pending composer is open: posting hands back to select, Escape backs out to select, clicking elsewhere re-places the composer at the new point (the draft text survives via the draft store), and a direct tool switch abandons the composer. Since the style panel only shows in select or shape tools, it stays hidden for the whole placement, and the sidebar close now spans the whole interaction instead of just its first half. The sidebar auto-close on tool enter is kept deliberately — placing comments is canvas-focused.

Behavior deltas worth a conscious sign-off:

- There is no pointer-only dismiss anymore — a canvas tap re-places rather than dismisses, so on mobile the ways out of a draft are posting or switching tools.
- Double-clicking the canvas re-places the composer instead of falling into select's text-shape creation.
- When composing is blocked (no `currentUserId`, no `ComposerFallback`), placement now exits the tool instead of silently swallowing every click.
- A direct tool switch mid-region-drag now clears the drawn rectangle, and a placed region no longer paints a shape-anchor hint under its pin corner.

### Change type

- [x] `bugfix`

### Test plan

1. In the commenting sidebar example, open the sidebar, pick the comment tool, click the canvas: the style panel must not appear while the composer is open.
2. Click elsewhere on the canvas — the composer re-places and keeps its text; post — the tool returns to select.
3. With regions enabled, drag a region ending on a shape — no hint outline under the pin corner; press `v` mid-drag — no stranded rectangle.

- [x] Unit tests
- [ ] End to end tests

The post-to-select handoff in `PendingComposer.submit` has no direct unit test (the package has no component-render test setup); it's covered indirectly by the commenting a11y e2e suite.

### Release notes

- Fix the comment tool switching to select (and the style panel appearing) while the comment composer is still open. The tool now stays active until the comment is posted or dismissed.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +35 / -10  |
| Tests     | +109 / -4  |