### PR TITLE
fix(docs): correct commenting example link in commenting-mobile README

### DIFF
--- a/apps/examples/src/examples/collaboration/commenting-mobile/README.md
+++ b/apps/examples/src/examples/collaboration/commenting-mobile/README.md
@@ -21,7 +21,7 @@ Commenting on a mobile layout: the thread popover and composer place themselves 
 
 ---
 
-The same commenting toolkit as the [Commenting](/commenting) example, with `forceMobile` on the editor so the mobile layout shows on any screen size.
+The same commenting toolkit as the [Commenting](/examples/commenting) example, with `forceMobile` on the editor so the mobile layout shows on any screen size.
 
 In mobile mode the thread popover and the new-comment composer position themselves relative to the pin and the visual viewport, rather than sitting at a fixed offset. They pick a side of the pin that keeps the whole panel on-screen, and ride up when the software keyboard shrinks the viewport instead of hiding behind it. Place a comment near an edge to see the placement adapt.
 


### PR DESCRIPTION
The docs build is failing its broken-link check on the commenting-mobile example README, which links to the sibling commenting example as `/commenting`. Example articles are published at `/examples/<folder-name>` (see `getArticlePath` in `apps/docs/scripts/lib/generateSection.ts`), so the correct path is `/examples/commenting`.

### Change type

- [x] `bugfix`

### Test plan

1. Run `yarn check-links` in `apps/docs` (needs the content DB from `yarn refresh-everything`) and confirm no broken links are reported.
