### PR TITLE
fix(dotcom): root the reactions query at comment, not comment_reaction

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -5,7 +5,6 @@ import {
 	categorizeCommentNotifications,
 	CommentNotificationInput,
 	mergeNotifications,
-	ReactionNotificationInput,
 	summarizeForeignReactors,
 } from './commentNotifications'
 
@@ -274,8 +273,8 @@ describe('categorizeCommentNotifications', () => {
 })
 
 describe('buildReactionNotifications', () => {
-	/** My own comment, as the related comment carried on a reaction row — full `reactions` set
-	 *  included, since that's what the entry now derives its timestamp and pills from. */
+	/** One row of the reactions feed: my own comment, carrying the full `reactions` set the entry
+	 *  derives its timestamp and pills from. */
 	function mine(overrides: Partial<CommentNotificationInput> = {}): CommentNotificationInput {
 		return comment({
 			authorId: ME,
@@ -286,25 +285,15 @@ describe('buildReactionNotifications', () => {
 		})
 	}
 
-	function reactionRow(
-		overrides: Partial<ReactionNotificationInput> = {}
-	): ReactionNotificationInput {
-		return {
-			commentId: 'comment:1',
-			userId: OTHER,
-			userName: 'Other',
-			emoji: '👍',
-			createdAt: at(10),
-			comment: mine(),
-			...overrides,
-		}
-	}
-
-	it('dedupes multiple rows on the same comment into one entry', () => {
+	it('makes one entry per comment, however many people reacted', () => {
 		const result = buildReactionNotifications(
 			[
-				reactionRow({ userId: OTHER, createdAt: at(10) }),
-				reactionRow({ userId: THIRD, createdAt: at(20) }),
+				mine({
+					reactions: [
+						{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) },
+						{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
+					],
+				}),
 			],
 			ME
 		)
@@ -313,43 +302,35 @@ describe('buildReactionNotifications', () => {
 		expect(result[0].primaryReason).toBe('reaction')
 	})
 
-	it('groups rows on two different comments into two entries', () => {
+	it('makes two entries for two reacted-to comments', () => {
 		const result = buildReactionNotifications(
-			[
-				reactionRow({ commentId: 'comment:1', comment: mine({ id: 'comment:1' }) }),
-				reactionRow({ commentId: 'comment:2', comment: mine({ id: 'comment:2' }) }),
-			],
+			[mine({ id: 'comment:1' }), mine({ id: 'comment:2' })],
 			ME
 		)
 		expect(result.map((n) => n.comment.id).sort()).toEqual(['comment:1', 'comment:2'])
 	})
 
-	it("carries the related comment's full reactions set unmodified, not just the feed rows", () => {
-		// three foreign reactions on the comment, but only one made it into the top-N feed window
+	it("carries the comment's full reactions set unmodified, own reaction included", () => {
 		const fullReactions = [
 			{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(5) },
 			{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
 			{ userId: ME, userName: 'Me', emoji: '🔥', createdAt: at(15) },
 		]
-		const result = buildReactionNotifications(
-			[reactionRow({ createdAt: at(5), comment: mine({ reactions: fullReactions }) })],
-			ME
-		)
+		const result = buildReactionNotifications([mine({ reactions: fullReactions })], ME)
 		expect(result).toHaveLength(1)
 		expect(result[0].comment.reactions).toBe(fullReactions)
 	})
 
-	it('timestamps the entry by the newest foreign reaction on the comment, not the feed row', () => {
+	it('timestamps the entry by the newest foreign reaction, ignoring my own and the comment date', () => {
 		const result = buildReactionNotifications(
 			[
-				reactionRow({
-					createdAt: at(10),
-					comment: mine({
-						reactions: [
-							{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) },
-							{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
-						],
-					}),
+				mine({
+					createdAt: at(0),
+					reactions: [
+						{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(10) },
+						{ userId: THIRD, userName: 'Third', emoji: '🎉', createdAt: at(20) },
+						{ userId: ME, userName: 'Me', emoji: '🔥', createdAt: at(30) },
+					],
 				}),
 			],
 			ME
@@ -359,13 +340,7 @@ describe('buildReactionNotifications', () => {
 
 	it('drops the entry when the comment has no foreign reaction left', () => {
 		const result = buildReactionNotifications(
-			[
-				reactionRow({
-					comment: mine({
-						reactions: [{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(10) }],
-					}),
-				}),
-			],
+			[mine({ reactions: [{ userId: ME, userName: 'Me', emoji: '👍', createdAt: at(10) }] })],
 			ME
 		)
 		expect(result).toEqual([])
@@ -374,12 +349,7 @@ describe('buildReactionNotifications', () => {
 	it('is unread until my read receipt is newer than the newest foreign reaction', () => {
 		const withReadAt = (readAt: number | undefined) =>
 			buildReactionNotifications(
-				[
-					reactionRow({
-						createdAt: at(10),
-						comment: mine({ read: readAt === undefined ? undefined : { readAt } }),
-					}),
-				],
+				[mine({ read: readAt === undefined ? undefined : { readAt } })],
 				ME
 			)[0].unread
 		expect(withReadAt(undefined)).toBe(true)
@@ -390,27 +360,18 @@ describe('buildReactionNotifications', () => {
 		expect(withReadAt(at(15))).toBe(false)
 	})
 
-	it('drops rows whose comment outraced its sync', () => {
-		const result = buildReactionNotifications([reactionRow({ comment: null })], ME)
-		expect(result).toEqual([])
-	})
-
-	it('drops my own reaction rows as a belt against a self row slipping through', () => {
-		const result = buildReactionNotifications([reactionRow({ userId: ME, userName: 'Me' })], ME)
+	it("drops someone else's comment as a belt against a foreign row slipping through", () => {
+		const result = buildReactionNotifications([mine({ authorId: OTHER })], ME)
 		expect(result).toEqual([])
 	})
 
 	it('sorts reaction entries among comment entries by their reaction time', () => {
 		const reacted = buildReactionNotifications(
 			[
-				reactionRow({
-					commentId: 'comment:reacted',
-					createdAt: at(20),
-					comment: mine({
-						id: 'comment:reacted',
-						createdAt: at(0),
-						reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(20) }],
-					}),
+				mine({
+					id: 'comment:reacted',
+					createdAt: at(0),
+					reactions: [{ userId: OTHER, userName: 'Other', emoji: '👍', createdAt: at(20) }],
 				}),
 			],
 			ME

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -35,8 +35,8 @@ const JOIN_TIME_SKEW_TOLERANCE_MS = 60_000
 
 /**
  * The comment fields the notifications feed needs — a structural subset of the Zero row so this
- * is unit-testable without Zero types. A `T` is either a comments-feed row, or a reactions-feed
- * row's related comment.
+ * is unit-testable without Zero types. Both feeds yield comment rows: `comments` carries other
+ * people's comments that concern the caller, `reactions` the caller's own that were reacted to.
  */
 export interface CommentNotificationInput {
 	id: string
@@ -169,19 +169,6 @@ export function summarizeForeignReactors(
 	return { names, others: ordered.length - names.length, total: ordered.length }
 }
 
-/** One row of the reactions feed: a foreign reaction joined to the reacted-to comment. Only
- *  `commentId`/`userId`/`emoji`/`createdAt` matter here (dedupe key and ordering); the byline and
- *  pills read the comment's own unbounded `reactions` set instead. */
-export interface ReactionNotificationInput {
-	commentId: string
-	userId: string
-	userName?: string
-	emoji: string
-	createdAt: number
-	/** Absent only if the row outraced its comment's sync; such rows are dropped. */
-	comment?: CommentNotificationInput | null
-}
-
 /** Newest `createdAt` among `reactions` from someone other than `userId`; `undefined` if none. */
 export function latestForeignReactionAt(
 	reactions: CommentNotificationInput['reactions'],
@@ -195,26 +182,24 @@ export function latestForeignReactionAt(
 }
 
 /**
- * Groups the reactions feed into one {@link CommentNotification} per reacted-to comment. Feed
- * rows only decide which comments appear (deduped by `commentId`); the entry's `comment` rides
- * along as-is, its unbounded `reactions` set feeding the byline and pills. Dated and marked
- * unread by the newest foreign reaction in that set (strict >: same-instant receipt = read).
+ * Turns the reactions feed — the caller's own comments that someone else has reacted to — into one
+ * {@link CommentNotification} per comment. Each entry is dated and marked unread by the newest
+ * foreign reaction in the comment's own unbounded `reactions` set, which also feeds the byline and
+ * pills (strict >: a receipt from the same instant counts as read).
+ *
+ * The feed rows are comments rather than reactions because the query is rooted at `comment`; see
+ * `queries.reactions` for why that rooting is load-bearing.
  */
 export function buildReactionNotifications(
-	reactions: readonly ReactionNotificationInput[],
+	comments: readonly CommentNotificationInput[],
 	userId: string | undefined | null
 ): CommentNotification<CommentNotificationInput>[] {
 	if (!userId) return []
 
-	const comments = new Map<string, CommentNotificationInput>()
-	for (const row of reactions) {
-		// server already filters both; cheap belt against a dangling or self row slipping through
-		if (!row.comment || row.userId === userId) continue
-		comments.set(row.commentId, row.comment)
-	}
-
 	const notifications: CommentNotification<CommentNotificationInput>[] = []
-	for (const comment of comments.values()) {
+	for (const comment of comments) {
+		// server already filters to the caller's own comments; cheap belt against a foreign row
+		if (comment.authorId !== userId) continue
 		const timestamp = latestForeignReactionAt(comment.reactions, userId)
 		if (timestamp === undefined) continue
 		notifications.push({

--- a/packages/dotcom-shared/src/queries.test.ts
+++ b/packages/dotcom-shared/src/queries.test.ts
@@ -11,13 +11,15 @@ const ctx: ZeroContext = { userId: 'user_test' }
  * that decides what one of these queries costs.
  *
  * The file-access gate (`file` and its `states`/`groupFiles` relations) is the expensive part of
- * every feed query: `file`, `file_state` and `group_file` each hold hundreds of thousands of rows,
- * against a `comment_reaction` table of ~50. At depth 1 the fileId correlation is pushed into those
- * relations and the gate touches only the handful of files the query concerns. Deeper, it isn't,
- * and the query traverses them wholesale — `reactions` rooted at `comment_reaction` put the gate at
- * depth 2 and took ~150s to materialize in production, outrunning the sync connection's 60s auth
- * token so that no client could complete a first sync. Neither unit tests nor the PR preview deploy
- * can catch that: previews run against a fresh database with no file_state volume.
+ * every feed query: `file`, `file_state` and `group_file` each hold hundreds of thousands of rows.
+ * At depth 1 the fileId correlation is pushed into those relations and the gate touches only the
+ * handful of files the query concerns. Deeper, it isn't, and the query traverses them wholesale —
+ * `reactions` rooted at `comment_reaction` put the gate at depth 2 and took ~150s to materialize
+ * in production (while `comment_reaction` held ~50 rows), outrunning the sync connection's 60s
+ * auth token so that no client could complete a first sync. Neither unit tests nor the PR preview
+ * deploy can catch that: previews run against a fresh database with no file_state volume.
+ *
+ * Scans only the root `where` tree; gates inside `related` branches aren't measured.
  */
 export function accessGateDepth(ast: any, table: string): number {
 	// the deepest occurrence, not the shallowest: one cheap path to `file` doesn't redeem a second

--- a/packages/dotcom-shared/src/queries.test.ts
+++ b/packages/dotcom-shared/src/queries.test.ts
@@ -1,0 +1,70 @@
+import { createBuilder } from '@rocicorp/zero'
+import { describe, expect, it } from 'vitest'
+import { queries, ZeroContext } from './queries'
+import { schema } from './tlaSchema'
+
+const zql = createBuilder(schema)
+const ctx: ZeroContext = { userId: 'user_test' }
+
+/**
+ * How many correlated-subquery hops it takes to reach `table` from the query root — the property
+ * that decides what one of these queries costs.
+ *
+ * The file-access gate (`file` and its `states`/`groupFiles` relations) is the expensive part of
+ * every feed query: `file`, `file_state` and `group_file` each hold hundreds of thousands of rows,
+ * against a `comment_reaction` table of ~50. At depth 1 the fileId correlation is pushed into those
+ * relations and the gate touches only the handful of files the query concerns. Deeper, it isn't,
+ * and the query traverses them wholesale — `reactions` rooted at `comment_reaction` put the gate at
+ * depth 2 and took ~150s to materialize in production, outrunning the sync connection's 60s auth
+ * token so that no client could complete a first sync. Neither unit tests nor the PR preview deploy
+ * can catch that: previews run against a fresh database with no file_state volume.
+ */
+export function accessGateDepth(ast: any, table: string): number {
+	// the deepest occurrence, not the shallowest: one cheap path to `file` doesn't redeem a second
+	// path that reaches it two hops down
+	let deepest = 0
+	const visit = (condition: any, depth: number) => {
+		if (!condition || typeof condition !== 'object') return
+		if (condition.type === 'correlatedSubquery' && condition.related?.subquery) {
+			const subquery = condition.related.subquery
+			if (subquery.table === table) deepest = Math.max(deepest, depth + 1)
+			visit(subquery.where, depth + 1)
+		}
+		for (const nested of condition.conditions ?? []) visit(nested, depth)
+	}
+	visit(ast.where, 0)
+	return deepest
+}
+
+function astOf(name: keyof typeof queries, args: object = {}) {
+	const query = (queries as any)[name].fn({ ctx, args })
+	return JSON.parse(JSON.stringify(query.ast ?? query))
+}
+
+describe('feed query shape', () => {
+	// Not a style preference: this is the regression guard for the outage described on
+	// accessGateDepth. A query that reaches `file` more than one hop from its root is the shape
+	// that took production down, however small the table it is rooted at.
+	it.each([
+		['comments', {}],
+		['reactions', {}],
+		['fileComments', { fileId: 'file:1' }],
+	])('keeps the file access gate one hop from the root: %s', (name, args) => {
+		const ast = astOf(name as keyof typeof queries, args)
+		expect(accessGateDepth(ast, 'file')).toBe(1)
+	})
+
+	it('roots the reactions feed at comment, not comment_reaction', () => {
+		expect(astOf('reactions').table).toBe('comment')
+	})
+
+	// proves the guard above can actually fail: reaching `file` through an intermediate subquery,
+	// the way the pre-fix `reactions` query reached it through `comment`, measures one hop deeper
+	it('measures a gate behind an intermediate subquery as depth 2', () => {
+		const gateBehindThread = zql.comment
+			.where('authorId', '=', ctx.userId)
+			.whereExists('thread', (t) => t.whereExists('file', (f) => f.where('isDeleted', '=', false)))
+		const ast = JSON.parse(JSON.stringify((gateBehindThread as any).ast ?? gateBehindThread))
+		expect(accessGateDepth(ast, 'file')).toBe(2)
+	})
+})

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -17,10 +17,9 @@ const defineQueries = defineQueriesWithType<TlaSchema>()
 /** Upper bound on the comments notifications feed, so the synced set stays finite as files accrue. */
 const RECENT_COMMENTS_LIMIT = 50
 
-/** Bound on the reactions feed, counted in reaction rows; the byline's "and N others" absorbs
- *  undercounts, but a comment with 200+ recent reactions can push every other comment's rows out
- *  of the window entirely, not just shrink a byline. */
-export const RECENT_REACTIONS_LIMIT = 200
+/** Bound on the reactions feed, counted in reacted-to comments — one row per comment of the
+ *  caller's that someone else has reacted to, however many reactions it carries. */
+export const REACTED_COMMENTS_LIMIT = 200
 
 /**
  * Upper bound on the per-file @-mention roster of past viewers, so a heavily-viewed public board
@@ -157,46 +156,60 @@ export const queries = defineQueries({
 	),
 
 	/**
-	 * Reactions to the user's comments, for the notifications feed. Rooted at comment_reaction and
-	 * ordered by reaction time, not comment time, so a fresh reaction on an old comment still syncs.
-	 * Access gates mirror the comments query; grouping into per-comment entries is client-side.
+	 * The caller's own comments that someone else has reacted to, for the notifications feed's
+	 * "reacted to your comment" entries. Access gates mirror the comments query; grouping and
+	 * ordering by reaction time are client-side (see `buildReactionNotifications`).
+	 *
+	 * Rooted at `comment`, *not* at `comment_reaction`, so the file-access gate sits one level from
+	 * the root exactly as it does in {@link comments}. Rooting at the reaction put that gate behind
+	 * a second correlated subquery, and the fileId correlation then stopped being pushed down into
+	 * `file`'s `states`/`groupFiles` relations: the query traversed those tables — hundreds of
+	 * thousands of rows — rather than the handful of files it actually concerned. It materialized in
+	 * ~150s against production data while `comment_reaction` held ~50 rows, which outran the sync
+	 * connection's 60s auth token and left every client unable to finish a first sync. The cost of
+	 * one of these queries is set by how deep the file gate sits, not by how much comment data
+	 * exists, so keep it at depth 1.
+	 *
+	 * Bounded to {@link REACTED_COMMENTS_LIMIT} by comment recency rather than reaction recency, so
+	 * a reaction on a comment older than the window doesn't surface. The window counts only the
+	 * caller's own reacted-to comments, so it's far slacker than the reaction-counted bound it
+	 * replaced.
 	 */
 	reactions: defineQuery(({ ctx }) =>
-		zql.comment_reaction
-			.where('userId', '!=', ctx.userId)
-			.whereExists('comment', (c) =>
-				c
-					.where('authorId', '=', ctx.userId)
-					.where('isDeleted', '=', false)
-					.whereExists('thread', (t) => t.where('isDeleted', '=', false))
-					.whereExists('file', (f) =>
-						f.where(({ and, cmp, or, exists }) =>
-							and(
-								cmp('isDeleted', '=', false),
-								or(
-									cmp('ownerId', '=', ctx.userId),
-									exists('states', (s) => s.where('userId', '=', ctx.userId)),
-									exists('groupFiles', (gf) =>
-										gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
-									)
+		zql.comment
+			.where('authorId', '=', ctx.userId)
+			// soft-deleted comments and comments of soft-deleted threads stay in Postgres but must
+			// never surface as notifications, same as in `comments`
+			.where('isDeleted', '=', false)
+			.whereExists('thread', (t) => t.where('isDeleted', '=', false))
+			.whereExists('file', (f) => f.where('isDeleted', '=', false))
+			// somebody else reacted — the entry's whole reason for existing. Without this the feed
+			// would sync every comment the user has ever written
+			.whereExists('reactions', (r) => r.where('userId', '!=', ctx.userId))
+			// having authored a comment doesn't outlive access to the board it's on
+			.where(({ or, exists }) =>
+				or(
+					exists('file', (f) => f.where('ownerId', '=', ctx.userId)),
+					exists('file', (f) =>
+						f.where(({ or, exists }) =>
+							or(
+								exists('states', (s) => s.where('userId', '=', ctx.userId)),
+								exists('groupFiles', (gf) =>
+									gf.whereExists('groupMembers', (gm) => gm.where('userId', '=', ctx.userId))
 								)
 							)
 						)
 					)
+				)
 			)
-			// the reacted-to comment, with what the notification row renders
-			.related('comment', (c) =>
-				c
-					.one()
-					.related('file', (f) => f.one())
-					.related('thread', (t) => t.one())
-					.related('read', (r) => r.where('userId', '=', ctx.userId).one())
-					// every reaction incl. the caller's own: pills need exact counts and the own-reaction
-					// highlight, which the window-capped feed rows can't provide
-					.related('reactions')
-			)
+			.related('file', (file) => file.one())
+			.related('thread', (thread) => thread.one())
+			.related('read', (read) => read.where('userId', '=', ctx.userId).one())
+			// every reaction incl. the caller's own: pills need exact counts and the own-reaction
+			// highlight
+			.related('reactions')
 			.orderBy('createdAt', 'desc')
-			.limit(RECENT_REACTIONS_LIMIT)
+			.limit(REACTED_COMMENTS_LIMIT)
 	),
 
 	/**

--- a/packages/dotcom-shared/src/queries.ts
+++ b/packages/dotcom-shared/src/queries.ts
@@ -157,8 +157,10 @@ export const queries = defineQueries({
 
 	/**
 	 * The caller's own comments that someone else has reacted to, for the notifications feed's
-	 * "reacted to your comment" entries. Access gates mirror the comments query; grouping and
-	 * ordering by reaction time are client-side (see `buildReactionNotifications`).
+	 * "reacted to your comment" entries. Uses the same access building blocks as {@link comments}
+	 * (owner, file state, group membership). Ordering by reaction time is client-side:
+	 * `buildReactionNotifications` stamps each entry with its newest foreign reaction and
+	 * `mergeNotifications` sorts on it.
 	 *
 	 * Rooted at `comment`, *not* at `comment_reaction`, so the file-access gate sits one level from
 	 * the root exactly as it does in {@link comments}. Rooting at the reaction put that gate behind
@@ -184,7 +186,7 @@ export const queries = defineQueries({
 			.whereExists('thread', (t) => t.where('isDeleted', '=', false))
 			.whereExists('file', (f) => f.where('isDeleted', '=', false))
 			// somebody else reacted — the entry's whole reason for existing. Without this the feed
-			// would sync every comment the user has ever written
+			// would sync the caller's most recent comments whether or not anyone reacted
 			.whereExists('reactions', (r) => r.where('userId', '!=', ctx.userId))
 			// having authored a comment doesn't outlive access to the board it's on
 			.where(({ or, exists }) =>

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -373,15 +373,6 @@ const commentThreadRelationships = relationships(comment_thread, ({ one, many })
 	}),
 }))
 
-const commentReactionRelationships = relationships(comment_reaction, ({ one }) => ({
-	// the reacted-to comment, for the reactions query's authorship gate and feed row
-	comment: one({
-		sourceField: ['commentId'],
-		destField: ['id'],
-		destSchema: comment,
-	}),
-}))
-
 export type TlaFilePartial = Partial<TlaFile> & {
 	id: TlaFile['id']
 }
@@ -556,7 +547,6 @@ export const schema = createSchema({
 		groupFileRelationships,
 		commentRelationships,
 		commentThreadRelationships,
-		commentReactionRelationships,
 	],
 })
 


### PR DESCRIPTION
In order to get tldraw.com loading again for everyone on Zero, this roots the reactions notifications query at `comment` instead of `comment_reaction`.

Rooted at the reaction, the file-access gate sat behind a second correlated subquery (reaction → comment → file). The fileId correlation then stopped being pushed into `file`'s `states`/`groupFiles` relations, so the query traversed those tables — `file_state` and `group_file` hold ~750k rows each — rather than the handful of files it actually concerned. It materialized in ~150s (worst 221s) against production data while `comment_reaction` held 49 rows. That outran the sync connection's 60-second Clerk token, so zero-cache's transform fetch 401'd mid-hydration, the connection was invalidated, and clients retried a first sync forever without ever completing one.

The control is the `comments` query: identical access gate, same tables, `.related('reactions')` too, but rooted at `comment` so the gate is one hop from the root. It materializes in ~162ms. What a query costs here is set by how deep its gate sits, not by how much data the feature has — which is also why nothing caught this before production: preview deploys run against a fresh Supabase branch with no `file_state` volume.

`queries.test.ts` pins that down, asserting the gate stays one hop from the root for all three feed queries, with a control case that builds a deeper gate and proves the assertion can actually fail.

Two behaviour changes worth a reviewer's judgement:

- The window is comment-recency rather than reaction-recency, so a reaction on a comment older than the 200 most recent reacted-to comments won't surface. Slacker than the bound it replaces, but not identical to it.
- Feed rows are comments rather than reactions, so a comment with 50 reactions is one row instead of 50.

### Change type

- [x] `bugfix`

### Test plan

1. React to someone else's comment on tldraw.com and confirm it appears in their notifications panel, with the right byline and reaction pills.
2. Mark it read, then react again, and confirm the entry goes back to unread.
3. Confirm a first sync completes for a user with commenting enabled.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix tldraw.com failing to load for users with commenting enabled.
