### PR TITLE
fix(dotcom): schedule the Zero auth refresh from the token's own expiry

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -273,14 +273,21 @@ export class TldrawApp {
 				})
 			}, msUntilTokenRefresh(token))
 		}
+		// Reschedule on every outcome — a rejected getToken() or a throwing connect() must not kill
+		// the refresh chain, so scheduling happens before connect and in the reject path.
 		const refreshToken = () =>
-			getToken().then((token) => {
-				if (token) {
-					z.connection.connect({ auth: token })
-				}
-				scheduleRefresh(token)
-				return !!token
-			})
+			getToken()
+				.catch((err) => {
+					scheduleRefresh(undefined)
+					throw err
+				})
+				.then((token) => {
+					scheduleRefresh(token)
+					if (token) {
+						z.connection.connect({ auth: token })
+					}
+					return !!token
+				})
 		scheduleRefresh(initialToken)
 		this.disposables.push(() => clearTimeout(refreshTimeout))
 		// A hidden tab's timers are throttled to about once a minute, so a token that lives 60s

--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -104,6 +104,49 @@ export function getFileRecencyDate(
 	return getFileVisitDate(state) ?? file?.createdAt ?? 0
 }
 
+/** Milliseconds until a JWT's `exp`, or null if it can't be read. */
+function msUntilExpiry(token: string | undefined, now = Date.now()): number | null {
+	if (!token) return null
+	try {
+		const [, payload] = token.split('.')
+		if (!payload) return null
+		// base64url, which atob doesn't accept
+		const claims = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/')))
+		if (typeof claims?.exp !== 'number') return null
+		return claims.exp * 1000 - now
+	} catch {
+		// a token we can't parse is still a usable token; fall back to the fixed cadence
+		return null
+	}
+}
+
+/** Fallback cadence for a token whose expiry we can't read. Under Clerk's 60s default this is
+ *  already too slow for a hidden tab — see {@link msUntilTokenRefresh}. */
+const FALLBACK_TOKEN_REFRESH_MS = 50_000
+/** Never busy-loop on a token that is expired or nearly so. */
+const MIN_TOKEN_REFRESH_MS = 5_000
+
+/**
+ * When to refresh the auth token, derived from the token's own expiry rather than a fixed cadence.
+ *
+ * This matters more than a normal token refresh because Zero hands the token to zero-cache, which
+ * reuses it for the transform and push fetches behind the connection. An expired token there
+ * doesn't fail one request, it invalidates the whole connection — which is what produced a steady
+ * ~2k `TransformFailed` and ~600 connection invalidations per hour in production.
+ *
+ * Refreshing at half the remaining life means a tick that runs late still has a whole half-life of
+ * slack. Reading the deadline off the token also means raising the session-token lifetime in the
+ * Clerk dashboard takes effect here with no code change — which is the part that actually fixes
+ * this. Browsers throttle timers in hidden tabs to roughly once a minute, so against Clerk's 60s
+ * default the token expires under a backgrounded tab no matter what cadence we ask for; no
+ * client-side schedule can beat that, only a longer-lived token can.
+ */
+export function msUntilTokenRefresh(token: string | undefined, now = Date.now()): number {
+	const remaining = msUntilExpiry(token, now)
+	if (remaining === null) return FALLBACK_TOKEN_REFRESH_MS
+	return Math.max(MIN_TOKEN_REFRESH_MS, remaining / 2)
+}
+
 export class TldrawApp {
 	config = {
 		maxNumberOfFiles: MAX_NUMBER_OF_FILES,
@@ -218,23 +261,41 @@ export class TldrawApp {
 			kvStore: window.navigator.webdriver ? 'mem' : 'idb',
 		})
 		this.z = z
+		// Refresh the token ahead of its own expiry and reschedule from whatever we get back, so the
+		// cadence follows the session-token lifetime rather than a hardcoded guess at it. In Zero
+		// 0.26+ this sends an updateAuth message without reconnecting.
+		let refreshTimeout: ReturnType<typeof setTimeout> | undefined
+		const scheduleRefresh = (token: string | undefined) => {
+			clearTimeout(refreshTimeout)
+			refreshTimeout = setTimeout(() => {
+				refreshToken().catch((err) => {
+					console.error('Failed to proactively refresh auth token:', err)
+				})
+			}, msUntilTokenRefresh(token))
+		}
 		const refreshToken = () =>
 			getToken().then((token) => {
 				if (token) {
 					z.connection.connect({ auth: token })
-					return true
 				}
-				return false
+				scheduleRefresh(token)
+				return !!token
 			})
-		// Proactively refresh auth token before Clerk's 60s expiry.
-		// In Zero 0.26+, this sends an updateAuth message without reconnecting.
-		const TOKEN_REFRESH_INTERVAL = 50_000
-		const refreshInterval = setInterval(() => {
+		scheduleRefresh(initialToken)
+		this.disposables.push(() => clearTimeout(refreshTimeout))
+		// A hidden tab's timers are throttled to about once a minute, so a token that lives 60s
+		// expires under it however early we schedule. Refresh on the way back rather than leaving the
+		// user to interact with a connection whose token went stale while they were away.
+		const onVisibilityChange = () => {
+			if (document.visibilityState !== 'visible') return
 			refreshToken().catch((err) => {
-				console.error('Failed to proactively refresh auth token:', err)
+				console.error('Failed to refresh auth token on focus:', err)
 			})
-		}, TOKEN_REFRESH_INTERVAL)
-		this.disposables.push(() => clearInterval(refreshInterval))
+		}
+		document.addEventListener('visibilitychange', onVisibilityChange)
+		this.disposables.push(() =>
+			document.removeEventListener('visibilitychange', onVisibilityChange)
+		)
 		// Set up token refresh on auth errors with backoff
 		let authRetryCount = 0
 		const MAX_AUTH_RETRIES = 5

--- a/apps/dotcom/client/src/tla/app/msUntilTokenRefresh.test.ts
+++ b/apps/dotcom/client/src/tla/app/msUntilTokenRefresh.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { msUntilTokenRefresh } from './TldrawApp'
+
+const NOW = 1_700_000_000_000
+
+/** A JWT whose payload carries `exp`, base64url-encoded the way Clerk emits it. */
+function tokenExpiringIn(seconds: number, now = NOW): string {
+	const payload = JSON.stringify({ exp: Math.floor(now / 1000) + seconds })
+	const encoded = btoa(payload).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+	return `header.${encoded}.signature`
+}
+
+describe('msUntilTokenRefresh', () => {
+	it('refreshes at half the remaining lifetime', () => {
+		expect(msUntilTokenRefresh(tokenExpiringIn(60), NOW)).toBe(30_000)
+		// the case that actually fixes the 401 storm: a longer-lived token stretches the cadence
+		// past the ~1/minute timer budget a hidden tab gets
+		expect(msUntilTokenRefresh(tokenExpiringIn(600), NOW)).toBe(300_000)
+	})
+
+	it('falls back to a fixed cadence for a token it cannot read', () => {
+		expect(msUntilTokenRefresh(undefined, NOW)).toBe(50_000)
+		expect(msUntilTokenRefresh('not-a-jwt', NOW)).toBe(50_000)
+		expect(msUntilTokenRefresh('header.!!!not-base64!!!.signature', NOW)).toBe(50_000)
+		// parseable, but no exp claim to schedule from
+		expect(msUntilTokenRefresh(`header.${btoa('{"sub":"user_1"}')}.signature`, NOW)).toBe(50_000)
+	})
+
+	it('never busy-loops on an expired or nearly-expired token', () => {
+		expect(msUntilTokenRefresh(tokenExpiringIn(4), NOW)).toBe(5_000)
+		expect(msUntilTokenRefresh(tokenExpiringIn(0), NOW)).toBe(5_000)
+		expect(msUntilTokenRefresh(tokenExpiringIn(-3600), NOW)).toBe(5_000)
+	})
+})


### PR DESCRIPTION
In order to stop Zero connections being torn down by an auth token that expired underneath them, this schedules the refresh from the token's own `exp` rather than a fixed interval, and refreshes when a backgrounded tab comes back.

Production runs a steady ~2,000 `TransformFailed` and ~600 `Connection auth validation failed; invalidating connection` an hour, flat across the day and unrelated to deploys. Zero hands its token to zero-cache, which reuses it for the transform and push fetches behind the connection, so an expired token there doesn't fail a single request — it invalidates the connection and the client reconnects from scratch.

The cause is a 50s `setInterval` against a 60-second Clerk token. Browsers throttle timers in hidden tabs to roughly once a minute, so a backgrounded tab's refresh lands at or after expiry on every cycle.

It's worth being clear that this doesn't fix the storm on its own, and can't: no client-side cadence beats a ~1/minute throttle budget against a 60-second token. What it does is make the cadence follow the token, so **raising the session-token lifetime in the Clerk dashboard** — the actual lever, and a dashboard change rather than a code one — takes effect here with nothing further to ship. At a 5-minute lifetime the client refreshes at 2.5 minutes, comfortably inside the throttle budget.

### Change type

- [x] `bugfix`

### Test plan

1. Sign in to tldraw.com, leave the tab in the background for several minutes, come back, and confirm the board is still live rather than reconnecting.
2. After raising the Clerk session-token lifetime, watch `production-zero-vs` logs and confirm `Connection auth validation failed` drops off.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix tldraw.com connections being dropped after a tab has been in the background.
