### PR TITLE
chore(dotcom): alert on slow Zero query materializations

### DIFF
--- a/.github/workflows/zero-slow-queries.yml
+++ b/.github/workflows/zero-slow-queries.yml
@@ -1,0 +1,56 @@
+name: Zero slow query check
+
+# A Zero synced query that takes longer to materialize than the sync connection's auth token lives
+# invalidates that connection, so clients retry forever and never complete a first sync. Cost is set
+# by query shape against production-sized tables, so neither unit tests nor the PR preview deploy
+# (which runs against a fresh, empty database) can catch it. The view syncer logs it; this reads.
+
+on:
+  schedule:
+    # hourly, offset off the hour so it isn't competing with deploys
+    - cron: '20 * * * *'
+  workflow_dispatch:
+    inputs:
+      app:
+        description: 'Fly app to scan'
+        default: 'production-zero-vs'
+      last:
+        description: 'Window to scan (e.g. 30m, 2h)'
+        default: '1h'
+      threshold:
+        description: 'Alert threshold in ms'
+        default: '30000'
+
+permissions:
+  contents: read
+
+env:
+  CI: 1
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    name: 'Check for slow Zero queries'
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    environment: 'deploy-production'
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Run our setup
+        uses: ./.github/actions/setup
+
+      - name: Check slow query materializations
+        run: |
+          yarn tsx internal/scripts/dotcom/check-zero-slow-queries.ts \
+            --app "${{ inputs.app || 'production-zero-vs' }}" \
+            --last "${{ inputs.last || '1h' }}" \
+            --threshold "${{ inputs.threshold || '30000' }}"
+        env:
+          FLY_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          DISCORD_HEALTH_WEBHOOK_URL: ${{ secrets.DISCORD_HEALTH_WEBHOOK_URL }}

--- a/internal/scripts/dotcom/check-zero-slow-queries.ts
+++ b/internal/scripts/dotcom/check-zero-slow-queries.ts
@@ -1,0 +1,178 @@
+/**
+ * Alert on Zero synced queries that are slow enough to break syncing.
+ *
+ * A query that takes longer to materialize than the sync connection's auth token lives doesn't just
+ * feel slow — zero-cache reuses that token for the transform and push fetches behind the
+ * connection, so the token expires mid-hydration, the connection is invalidated, the client retries
+ * from scratch and never completes a first sync. That is what took tldraw.com down for every user
+ * on Zero: `queries.reactions` materialized in ~150s against production data while every other
+ * query stayed at ~250ms, and nothing surfaced it for hours. The view syncer had been logging it
+ * the whole time.
+ *
+ * Query cost here is set by how deep a query's file-access gate sits, not by how much data the
+ * feature has, so a query that is instant against a preview database can be pathological in
+ * production. Neither unit tests nor the PR preview deploy can catch that. This can.
+ *
+ * Usage:
+ *   yarn tsx internal/scripts/dotcom/check-zero-slow-queries.ts
+ *   yarn tsx internal/scripts/dotcom/check-zero-slow-queries.ts --app staging-zero-vs --last 2h
+ *   FLY_TOKEN=... yarn tsx internal/scripts/dotcom/check-zero-slow-queries.ts --threshold 10000
+ *
+ * Exits 1 when anything breaches the threshold, so CI marks the run red whether or not a Discord
+ * webhook is configured.
+ */
+import { parseDuration, queryFlyLogs } from '../fly-common'
+import { Discord } from '../lib/discord'
+import { nicelog } from '../lib/nicelog'
+
+/**
+ * Default alert threshold. Well clear of a healthy query (~250-300ms in production) and below
+ * Clerk's 60s session-token lifetime, which is the point at which slow stops meaning slow and
+ * starts meaning the connection dies. Lower this as headroom improves; don't raise it above the
+ * token lifetime.
+ */
+const DEFAULT_THRESHOLD_MS = 30_000
+const DEFAULT_APP = 'production-zero-vs'
+const DEFAULT_WINDOW = '1h'
+/** Fly caps a single response; slow-query lines are rare so this is generous. */
+const LOG_LIMIT = 5000
+
+interface SlowQuery {
+	queryName: string
+	table: string
+	durationMs: number
+	clientGroupID: string
+}
+
+function parseArgs(argv: string[]) {
+	const opts: Record<string, string> = {}
+	for (let i = 0; i < argv.length; i++) {
+		if (argv[i] === '--app' || argv[i] === '-a') opts.app = argv[++i]
+		else if (argv[i] === '--last' || argv[i] === '-l') opts.last = argv[++i]
+		else if (argv[i] === '--threshold' || argv[i] === '-t') opts.threshold = argv[++i]
+		else if (argv[i] === '--token') opts.token = argv[++i]
+		else if (argv[i] === '--help' || argv[i] === '-h') opts.help = 'true'
+	}
+	return opts
+}
+
+/**
+ * Pull `Slow query materialization <ms>` warnings. zero-cache logs these as JSON in `_msg`, with
+ * the query's identity alongside the message.
+ */
+export function parseSlowQueries(messages: string[], thresholdMs: number): SlowQuery[] {
+	const slow: SlowQuery[] = []
+	for (const raw of messages) {
+		let entry: any
+		try {
+			entry = JSON.parse(raw)
+		} catch {
+			continue
+		}
+		const message = String(entry?.message ?? '')
+		if (!message.startsWith('Slow query materialization')) continue
+		const durationMs = Number(message.split(' ').at(-1))
+		if (!Number.isFinite(durationMs) || durationMs < thresholdMs) continue
+		slow.push({
+			// an ad-hoc (non-synced) query has no name; report the table so it's still identifiable
+			queryName: entry?.queryName ?? '(unnamed)',
+			table: entry?.table ?? '(unknown)',
+			durationMs,
+			clientGroupID: entry?.clientGroupID ?? '(unknown)',
+		})
+	}
+	return slow
+}
+
+/** Worst-first summary, one line per distinct query. */
+export function summarize(slow: SlowQuery[]): string[] {
+	const byQuery = new Map<string, SlowQuery[]>()
+	for (const s of slow) {
+		const key = `${s.queryName} (${s.table})`
+		byQuery.set(key, [...(byQuery.get(key) ?? []), s])
+	}
+	return [...byQuery.entries()]
+		.map(([key, entries]) => {
+			const worst = Math.max(...entries.map((e) => e.durationMs))
+			const clients = new Set(entries.map((e) => e.clientGroupID)).size
+			return {
+				worst,
+				line: `**${key}** — ${entries.length} over threshold, worst ${(worst / 1000).toFixed(1)}s, ${clients} client group${clients === 1 ? '' : 's'}`,
+			}
+		})
+		.sort((a, b) => b.worst - a.worst)
+		.map((s) => s.line)
+}
+
+async function main() {
+	const opts = parseArgs(process.argv.slice(2))
+	if (opts.help) {
+		nicelog(
+			[
+				'Usage: yarn tsx internal/scripts/dotcom/check-zero-slow-queries.ts [options]',
+				'',
+				`  --app, -a        Fly app to scan (default: ${DEFAULT_APP})`,
+				`  --last, -l       Window to scan, e.g. 30m, 2h (default: ${DEFAULT_WINDOW})`,
+				`  --threshold, -t  Alert threshold in ms (default: ${DEFAULT_THRESHOLD_MS})`,
+				'  --token          Fly API token (falls back to FLY_TOKEN)',
+				'',
+				'Posts to DISCORD_HEALTH_WEBHOOK_URL when set. Exits 1 if anything breaches.',
+			].join('\n')
+		)
+		return
+	}
+
+	const app = opts.app ?? DEFAULT_APP
+	const thresholdMs = opts.threshold ? Number(opts.threshold) : DEFAULT_THRESHOLD_MS
+	const windowMs = parseDuration(opts.last ?? DEFAULT_WINDOW, 'ms')
+	const end = new Date()
+	const start = new Date(end.getTime() - windowMs)
+
+	const entries = await queryFlyLogs({
+		app,
+		start: start.toISOString(),
+		end: end.toISOString(),
+		filter: '"Slow query materialization"',
+		limit: LOG_LIMIT,
+		token: opts.token,
+	})
+	const slow = parseSlowQueries(
+		entries.map((e) => e._msg),
+		thresholdMs
+	)
+
+	const window = opts.last ?? DEFAULT_WINDOW
+	if (slow.length === 0) {
+		nicelog(`✅ ${app}: no query slower than ${thresholdMs}ms in the last ${window}`)
+		return
+	}
+
+	const summary = summarize(slow)
+	nicelog(`🚨 ${app}: ${slow.length} slow query materializations in the last ${window}`)
+	for (const line of summary) nicelog(`   ${line.replace(/\*\*/g, '')}`)
+
+	const webhookUrl = process.env.DISCORD_HEALTH_WEBHOOK_URL
+	if (webhookUrl) {
+		const discord = new Discord({ webhookUrl, shouldNotify: true, messagePrefix: '[ZERO]' })
+		await discord.message(
+			[
+				`${Discord.AT_TEAM_MENTION} **Slow Zero queries on \`${app}\`**`,
+				`${slow.length} materializations over ${thresholdMs}ms in the last ${window}:`,
+				...summary.map((l) => `• ${l}`),
+				'',
+				'A query slower than the auth token lifetime invalidates the sync connection, so clients',
+				'never finish a first sync. See `queries.reactions` in dotcom-shared for the last one.',
+			].join('\n'),
+			{ always: true }
+		)
+	} else {
+		nicelog('(DISCORD_HEALTH_WEBHOOK_URL not set — not posting)')
+	}
+
+	process.exit(1)
+}
+
+main().catch((err) => {
+	console.error(err)
+	process.exit(1)
+})

--- a/internal/scripts/fly-common.ts
+++ b/internal/scripts/fly-common.ts
@@ -24,6 +24,53 @@ export function getFlyToken(explicit?: string): string {
 	return token
 }
 
+const LOGS_BASE_URL = `https://api.fly.io/victorialogs/${FLY_ORG_SLUG}/select/logsql/query`
+
+/** One VictoriaLogs record: `_msg` is the raw log line, which for zero-cache is itself JSON. */
+export interface FlyLogEntry {
+	_time: string
+	_msg: string
+}
+
+/**
+ * Query an app's logs. `filter` is appended to the app filter as LogsQL, e.g. `'"Slow query"'`.
+ * Results come back newest-first-capped at `limit`, so a filter is what keeps a busy app's noise
+ * from crowding out what you're looking for.
+ */
+export async function queryFlyLogs(opts: {
+	app: string
+	start: string
+	end: string
+	filter?: string
+	limit?: number
+	token?: string
+}): Promise<FlyLogEntry[]> {
+	const query = opts.filter
+		? `fly.app.name: ${opts.app} AND ${opts.filter}`
+		: `fly.app.name: ${opts.app}`
+	const params = new URLSearchParams({ query, start: opts.start, end: opts.end })
+	if (opts.limit) params.set('limit', String(opts.limit))
+
+	const res = await fetch(`${LOGS_BASE_URL}?${params}`, {
+		headers: { Authorization: `FlyV1 ${getFlyToken(opts.token)}` },
+	})
+	if (!res.ok) {
+		throw new Error(`Fly logs query failed: HTTP ${res.status}: ${await res.text()}`)
+	}
+	const body = await res.text()
+	if (!body.trim()) return []
+	return body
+		.trim()
+		.split('\n')
+		.flatMap((line) => {
+			try {
+				return [JSON.parse(line) as FlyLogEntry]
+			} catch {
+				return []
+			}
+		})
+}
+
 export function parseDuration(s: string, unit: 'ms' | 's' = 's'): number {
 	const match = s.match(/^(\d+)(m|h|d)$/)
 	if (!match) {


### PR DESCRIPTION
In order to find out about a pathological Zero query from an alert rather than from the site being down, this checks the view syncer's `Slow query materialization` warnings hourly and posts to the health channel when one crosses a threshold.

`queries.reactions` took tldraw.com down for every user on Zero and it took hours of manual log digging to find, even though `production-zero-vs` had been logging the cause the entire time — ~150s materializations while every other query sat near 250ms. The reason a slow query is fatal rather than merely slow: zero-cache reuses the connection's auth token for its transform and push fetches, so a query that outlives the token invalidates the connection, and clients retry a first sync forever without completing one.

What makes this class of bug worth automating: cost is set by query shape against production-sized tables, so a query that is instant against a preview database can be pathological in production. Preview deploys run against a fresh Supabase branch with no `file_state` volume, so neither they nor unit tests can catch it — production logs are the only place the signal exists.

The 30s default threshold sits clear of a healthy query and below Clerk's 60s token lifetime, which is the point where slow stops meaning slow and starts meaning the connection dies. It exits non-zero on a breach, so the run goes red whether or not the Discord webhook is configured. Pointed at production as it stands today it reports `reactions (comment_reaction) — worst 221.1s, 5 client groups`.

`queryFlyLogs` is extracted into `fly-common.ts` rather than duplicating the fetch out of `fetch-fly-logs.ts`.

One gap worth naming: `internal/scripts` has no vitest config or test script, so `parseSlowQueries` and `summarize` have no unit tests — standing up a harness for that workspace felt out of scope here. They're exported and ready if we want to add one.

### Change type

- [x] `other`

### Test plan

1. `FLY_TOKEN=... yarn tsx internal/scripts/dotcom/check-zero-slow-queries.ts --last 3h` and confirm it reports the known slow query.
2. Run it with `--threshold 500000` and confirm it exits clean.
3. Trigger the workflow manually from the Actions tab.
