### PR TITLE
fix: prune orphaned preview certificate packs and drop deletion grace period

### DIFF
--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -155,11 +155,15 @@ async function getCertZoneId() {
 	return _certZoneId
 }
 
-const _certPackCache = new Map<string, string>()
+// `status=all` also returns packs that are already gone (`deleted` /
+// `pending_deletion`); a host can therefore appear on several packs. Skip the
+// dead ones and keep every live pack id per host — caching just the last-seen
+// id would let a dead pack shadow a live one, which would then never be pruned.
+const _certPackCache = new Map<string, string[]>()
 const CERT_PACKS_PER_PAGE = 50
+const CERT_PACK_GONE_STATUSES = new Set(['deleted', 'pending_deletion'])
 async function listPreviewCertPacks() {
 	const zoneId = await getCertZoneId()
-	const hosts: string[] = []
 	for (let page = 1; ; page++) {
 		const res = await cloudflareV4Api(
 			`/zones/${zoneId}/ssl/certificate_packs?status=all&per_page=${CERT_PACKS_PER_PAGE}&page=${page}`
@@ -169,39 +173,45 @@ async function listPreviewCertPacks() {
 		}
 		const data = (await res.json()) as {
 			success: boolean
-			result: { id: string; type: string; hosts: string[] }[]
+			result: { id: string; type: string; status: string; hosts: string[] }[]
 		}
 		if (!data.success) {
 			throw new Error('Failed to list certificate packs ' + JSON.stringify(data))
 		}
 		for (const pack of data.result) {
 			if (pack.type !== 'advanced') continue
+			if (CERT_PACK_GONE_STATUSES.has(pack.status)) continue
 			const prHost = pack.hosts.find((h) => CERT_PACK_HOST_REGEX.test(h))
 			if (!prHost) continue
-			_certPackCache.set(prHost, pack.id)
-			hosts.push(prHost)
+			const ids = _certPackCache.get(prHost) ?? []
+			ids.push(pack.id)
+			_certPackCache.set(prHost, ids)
 		}
 		if (data.result.length < CERT_PACKS_PER_PAGE) break
 	}
-	return hosts
+	return [..._certPackCache.keys()]
 }
 
 async function deletePreviewCertPack(host: string) {
-	const packId = _certPackCache.get(host)
-	if (!packId) {
+	const packIds = _certPackCache.get(host)
+	if (!packIds?.length) {
 		throw new Error(`Certificate pack for ${host} not found in cache`)
 	}
-	nicelog('Deleting certificate pack:', packId, 'for', host)
 	const zoneId = await getCertZoneId()
-	const res = await cloudflareV4Api(`/zones/${zoneId}/ssl/certificate_packs/${packId}`, {
-		method: 'DELETE',
-	})
-	if (!res.ok) {
-		throw new Error(`Failed to delete certificate pack ${packId}: ${res.status} ${res.statusText}`)
-	}
-	const data = (await res.json()) as { success: boolean }
-	if (!data.success) {
-		throw new Error(`Failed to delete certificate pack ${packId}: ${JSON.stringify(data)}`)
+	for (const packId of packIds) {
+		nicelog('Deleting certificate pack:', packId, 'for', host)
+		const res = await cloudflareV4Api(`/zones/${zoneId}/ssl/certificate_packs/${packId}`, {
+			method: 'DELETE',
+		})
+		if (!res.ok) {
+			throw new Error(
+				`Failed to delete certificate pack ${packId}: ${res.status} ${res.statusText}`
+			)
+		}
+		const data = (await res.json()) as { success: boolean }
+		if (!data.success) {
+			throw new Error(`Failed to delete certificate pack ${packId}: ${JSON.stringify(data)}`)
+		}
 	}
 }
 

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -156,12 +156,13 @@ async function getCertZoneId() {
 }
 
 const _certPackCache = new Map<string, string>()
+const CERT_PACKS_PER_PAGE = 50
 async function listPreviewCertPacks() {
 	const zoneId = await getCertZoneId()
 	const hosts: string[] = []
 	for (let page = 1; ; page++) {
 		const res = await cloudflareV4Api(
-			`/zones/${zoneId}/ssl/certificate_packs?status=all&per_page=100&page=${page}`
+			`/zones/${zoneId}/ssl/certificate_packs?status=all&per_page=${CERT_PACKS_PER_PAGE}&page=${page}`
 		)
 		if (!res.ok) {
 			throw new Error(`Failed to list certificate packs: ${res.status} ${res.statusText}`)
@@ -169,7 +170,6 @@ async function listPreviewCertPacks() {
 		const data = (await res.json()) as {
 			success: boolean
 			result: { id: string; type: string; hosts: string[] }[]
-			result_info?: { total_pages?: number }
 		}
 		if (!data.success) {
 			throw new Error('Failed to list certificate packs ' + JSON.stringify(data))
@@ -181,7 +181,7 @@ async function listPreviewCertPacks() {
 			_certPackCache.set(prHost, pack.id)
 			hosts.push(prHost)
 		}
-		if (page >= (data.result_info?.total_pages ?? 1)) break
+		if (data.result.length < CERT_PACKS_PER_PAGE) break
 	}
 	return hosts
 }

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -142,6 +142,11 @@ let _certZoneId: string | undefined
 async function getCertZoneId() {
 	if (_certZoneId) return _certZoneId
 	const res = await cloudflareV4Api(`/zones?name=${CLOUDFLARE_CERT_ZONE}`)
+	if (!res.ok) {
+		throw new Error(
+			`Failed to look up zone ${CLOUDFLARE_CERT_ZONE}: ${res.status} ${res.statusText}`
+		)
+	}
 	const data = (await res.json()) as { success: boolean; result: { id: string }[] }
 	if (!data.success || !data.result.length) {
 		throw new Error(`Failed to find zone ${CLOUDFLARE_CERT_ZONE}: ${JSON.stringify(data)}`)
@@ -158,6 +163,9 @@ async function listPreviewCertPacks() {
 		const res = await cloudflareV4Api(
 			`/zones/${zoneId}/ssl/certificate_packs?status=all&per_page=100&page=${page}`
 		)
+		if (!res.ok) {
+			throw new Error(`Failed to list certificate packs: ${res.status} ${res.statusText}`)
+		}
 		const data = (await res.json()) as {
 			success: boolean
 			result: { id: string; type: string; hosts: string[] }[]
@@ -181,16 +189,18 @@ async function listPreviewCertPacks() {
 async function deletePreviewCertPack(host: string) {
 	const packId = _certPackCache.get(host)
 	if (!packId) {
-		nicelog(`Certificate pack for ${host} not found in cache`)
-		return
+		throw new Error(`Certificate pack for ${host} not found in cache`)
 	}
 	nicelog('Deleting certificate pack:', packId, 'for', host)
 	const zoneId = await getCertZoneId()
 	const res = await cloudflareV4Api(`/zones/${zoneId}/ssl/certificate_packs/${packId}`, {
 		method: 'DELETE',
 	})
+	if (!res.ok) {
+		throw new Error(`Failed to delete certificate pack ${packId}: ${res.status} ${res.statusText}`)
+	}
 	const data = (await res.json()) as { success: boolean }
-	if (!res.ok || !data.success) {
+	if (!data.success) {
 		throw new Error(`Failed to delete certificate pack ${packId}: ${JSON.stringify(data)}`)
 	}
 }
@@ -331,7 +341,7 @@ const dotcomAssetsCache: R2BucketRef = {
 const deletionErrors: string[] = []
 
 async function main() {
-	nicelog('Getting queues information')
+	nicelog('Pruning preview worker deployments')
 	await processItems(listPreviewWorkerDeployments, deletePreviewWorkerDeployment)
 	nicelog('\nPruning preview certificate packs')
 	await processItems(listPreviewCertPacks, deletePreviewCertPack)

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -26,7 +26,7 @@ interface ListWorkersResult {
 }
 
 const _isPrClosedCache = new Map<number, boolean>()
-async function isPrClosedForAWhile(prNumber: number) {
+async function isPrClosed(prNumber: number) {
 	if (_isPrClosedCache.has(prNumber)) {
 		return _isPrClosedCache.get(prNumber)!
 	}
@@ -45,10 +45,7 @@ async function isPrClosedForAWhile(prNumber: number) {
 		}
 		throw err
 	}
-	const timeout = 1000 * 60 * 60 * 24 * 2 // two days
-	const result =
-		prResult.data.state === 'closed' &&
-		Date.now() - new Date(prResult.data.closed_at!).getTime() > timeout
+	const result = prResult.data.state === 'closed'
 	_isPrClosedCache.set(prNumber, result)
 	return result
 }
@@ -56,8 +53,8 @@ async function isPrClosedForAWhile(prNumber: number) {
 const CLOUDFLARE_WORKER_REGEX = /^pr-(\d+)-/
 const CLOUDFLARE_SYNC_WORKER_REGEX = /^pr-\d+-tldraw-multiplayer$/
 
-async function cloudflareApi(endpoint: string, options: RequestInit = {}): Promise<Response> {
-	const url = `https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}${endpoint}`
+async function cloudflareV4Api(endpoint: string, options: RequestInit = {}): Promise<Response> {
+	const url = `https://api.cloudflare.com/client/v4${endpoint}`
 	return fetch(url, {
 		...options,
 		headers: {
@@ -65,6 +62,10 @@ async function cloudflareApi(endpoint: string, options: RequestInit = {}): Promi
 			'Content-Type': 'application/json',
 		},
 	})
+}
+
+async function cloudflareApi(endpoint: string, options: RequestInit = {}): Promise<Response> {
+	return cloudflareV4Api(`/accounts/${env.CLOUDFLARE_ACCOUNT_ID}${endpoint}`, options)
 }
 
 async function listPreviewWorkerDeployments() {
@@ -128,6 +129,69 @@ async function deletePreviewWorkerDeployment(id: string) {
 		}
 	} else {
 		await deletePreviewWorker(id)
+	}
+}
+
+// Deleting a worker with a custom domain leaves its edge certificate behind
+// (https://github.com/cloudflare/workers-sdk/issues/5139), so prune per-PR
+// advanced cert packs on the preview zone separately.
+const CLOUDFLARE_CERT_ZONE = 'tldraw.xyz'
+const CERT_PACK_HOST_REGEX = /^pr-\d+-/
+
+let _certZoneId: string | undefined
+async function getCertZoneId() {
+	if (_certZoneId) return _certZoneId
+	const res = await cloudflareV4Api(`/zones?name=${CLOUDFLARE_CERT_ZONE}`)
+	const data = (await res.json()) as { success: boolean; result: { id: string }[] }
+	if (!data.success || !data.result.length) {
+		throw new Error(`Failed to find zone ${CLOUDFLARE_CERT_ZONE}: ${JSON.stringify(data)}`)
+	}
+	_certZoneId = data.result[0].id
+	return _certZoneId
+}
+
+const _certPackCache = new Map<string, string>()
+async function listPreviewCertPacks() {
+	const zoneId = await getCertZoneId()
+	const hosts: string[] = []
+	for (let page = 1; ; page++) {
+		const res = await cloudflareV4Api(
+			`/zones/${zoneId}/ssl/certificate_packs?status=all&per_page=100&page=${page}`
+		)
+		const data = (await res.json()) as {
+			success: boolean
+			result: { id: string; type: string; hosts: string[] }[]
+			result_info?: { total_pages?: number }
+		}
+		if (!data.success) {
+			throw new Error('Failed to list certificate packs ' + JSON.stringify(data))
+		}
+		for (const pack of data.result) {
+			if (pack.type !== 'advanced') continue
+			const prHost = pack.hosts.find((h) => CERT_PACK_HOST_REGEX.test(h))
+			if (!prHost) continue
+			_certPackCache.set(prHost, pack.id)
+			hosts.push(prHost)
+		}
+		if (page >= (data.result_info?.total_pages ?? 1)) break
+	}
+	return hosts
+}
+
+async function deletePreviewCertPack(host: string) {
+	const packId = _certPackCache.get(host)
+	if (!packId) {
+		nicelog(`Certificate pack for ${host} not found in cache`)
+		return
+	}
+	nicelog('Deleting certificate pack:', packId, 'for', host)
+	const zoneId = await getCertZoneId()
+	const res = await cloudflareV4Api(`/zones/${zoneId}/ssl/certificate_packs/${packId}`, {
+		method: 'DELETE',
+	})
+	const data = (await res.json()) as { success: boolean }
+	if (!res.ok || !data.success) {
+		throw new Error(`Failed to delete certificate pack ${packId}: ${JSON.stringify(data)}`)
 	}
 }
 
@@ -269,6 +333,8 @@ const deletionErrors: string[] = []
 async function main() {
 	nicelog('Getting queues information')
 	await processItems(listPreviewWorkerDeployments, deletePreviewWorkerDeployment)
+	nicelog('\nPruning preview certificate packs')
+	await processItems(listPreviewCertPacks, deletePreviewCertPack)
 	nicelog('\nPruning Supabase preview databases')
 	await processItems(listPreviewDatabases, deletePreviewDatabase)
 	nicelog('\nPruning fly.io preview apps')
@@ -301,7 +367,7 @@ async function processItems(
 			nicelog(`Skipping ${item} because it doesn't match the regex`)
 			continue
 		}
-		if (await isPrClosedForAWhile(number)) {
+		if (await isPrClosed(number)) {
 			nicelog(`Deleting ${item} because PR is closed`)
 			try {
 				await deleteFn(item)


### PR DESCRIPTION
In order to stop orphaned SSL certificates from piling up on the tldraw.xyz zone, this PR makes the nightly prune script delete the per-PR advanced certificate packs (`pr-N-images/consent/demo.tldraw.xyz`). Deleting a worker with a custom domain removes the domain but leaves its edge certificate behind (cloudflare/workers-sdk#5139), so until now these could only be cleaned up by hand.

It also removes the 2-day grace period after a PR closes: preview infra is now pruned on the first nightly run after close.

Deploy note: the `CLOUDFLARE_API_TOKEN` secret in the `deploy-staging` environment needs `Zone: Read` and `SSL and Certificates: Write` on the tldraw.xyz zone. If it lacks them, the new step fails loudly rather than skipping.

I'm not sure what permissions we have on these tokens, I'd merge, manually run the prune script and then we'll see.

### Change type

- [x] `other`

### Test plan

1. Trigger the "Prune preview deploys" workflow via `workflow_dispatch` and check the "Pruning preview certificate packs" step in the logs.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +85 / -9   |