### PR TITLE
fix(commenting): align region comment pin with its draft position

### DIFF
--- a/packages/commenting/src/canvas/thread-pin.tsx
+++ b/packages/commenting/src/canvas/thread-pin.tsx
@@ -305,9 +305,10 @@ export const ThreadPin = memo(function ThreadPin({
 	const livePinPage = resizeBounds ? regionPinPoint(resizeBounds, pinCorner) : dragPagePoint
 	const renderPointBase = livePinPage ? editor.pageToViewport(livePinPage) : point
 	// A region's pin centres on its corner — overlapping the box — rather than hanging off it.
-	// The marker anchors bottom-left, so step half its 34px size left and down (screen px).
+	// The marker anchors bottom-left, so step half its 28px size (--tlui-cmt-pin-size) left and
+	// down (screen px), matching the draft composer's --region centring on the same corner.
 	const renderPoint = isRegion
-		? { x: renderPointBase.x - 17, y: renderPointBase.y + 17 }
+		? { x: renderPointBase.x - 14, y: renderPointBase.y + 14 }
 		: renderPointBase
 
 	// A region's live box bounds, by priority: a corner resize, else a pin-drag translation (the pin


### PR DESCRIPTION
Fixes the region comment pin jumping down-and-left when a draft is posted (closes #9852).

## The bug
Dragging out a region comment shows a draft pin (the composer's leading avatar) centred on the region's pin corner. On posting, the committed thread pin landed a few pixels down and to the left, so the pin visibly shifted as the thread was created.

## Cause
`ThreadPin` centres the region marker on its corner by stepping half the marker's size left and down. That step was hard-coded to `17` (half of 34px), but the marker is `28px` (`--tlui-cmt-pin-size` — the pin was resized 34→28 and this spot wasn't updated). The draft composer centres correctly off the CSS var, so only the committed pin drifted. Stepping `14` (half of 28) makes them coincide.

## Alternative considered
The sturdier fix is to drop the JS half-size and centre the region marker via CSS `translate(-50%, -50%)`, sourcing the size from `--tlui-cmt-pin-size` alone — no magic number to drift. I kept this minimal because `renderPoint` also positions the thread popover and hover preview, so re-basing those offsets wants a visual check. Happy to take the CSS route instead if preferred.

## How to test
Preview deploy: https://pr-9855-preview-deploy.tldraw.com/

Enable region comments (via `CommentTool.configure`). Drag out a region comment and watch the pin corner as you post — the pin should stay put rather than hopping down-and-left.