### PR TITLE
fix(commenting): make comment body text selectable

### DIFF
--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -84,6 +84,15 @@
 	overflow-wrap: anywhere;
 }
 
+/* A comment body is read-only but its text must stay selectable so it can be copied. tldraw's
+   container sets `user-select: none` on every descendant (`.tl-container *`) to keep canvas gestures
+   from selecting UI text, so the body and its rendered children have to opt back in. */
+.tlui-cmt-text,
+.tlui-cmt-text * {
+	-webkit-user-select: text;
+	user-select: text;
+}
+
 .tlui-cmt-edited {
 	font-style: italic;
 }


### PR DESCRIPTION
Comment bodies render read-only rich text but couldn't be selected — they inherited `user-select: none` from tldraw's container (`.tl-container *`, which disables selection so canvas gestures don't grab UI text). So there was no way to copy a comment's contents.

This opts the comment body and its rendered children back in with `user-select: text`, mirroring the shape of the global rule:

```css
.tlui-cmt-text,
.tlui-cmt-text * {
	-webkit-user-select: text;
	user-select: text;
}
```

Closes #9853

### How to test
Preview: https://pr-9856-preview-deploy.tldraw.com/

- Open a file with comments (sign in, add a comment on a shape or region).
- Click-drag across a comment's text in the thread or sidebar — it should now highlight and be copyable (Cmd/Ctrl+C).