### PR TITLE
fix(deploy): use zone routes instead of custom domains for preview workers

### DIFF
--- a/internal/scripts/deploy-analytics.ts
+++ b/internal/scripts/deploy-analytics.ts
@@ -82,7 +82,7 @@ async function deployAnalyticsWorker({ dryRun }: { dryRun: boolean }) {
 	if (previewId && !didUpdateAnalyticsWorker) {
 		await setWranglerPreviewConfig(workerDir, {
 			name: workerId,
-			customDomain: `${previewId}-consent.tldraw.xyz`,
+			routeHostname: `${previewId}-consent.tldraw.xyz`,
 		})
 		didUpdateAnalyticsWorker = true
 	}

--- a/internal/scripts/deploy-bemo.ts
+++ b/internal/scripts/deploy-bemo.ts
@@ -63,12 +63,12 @@ async function main() {
 		await deployBemoWorker({ dryRun: false })
 	})
 
-	// we set the domain in the wrangler.toml file since it's managed by cloudflare
+	// the deploy hostname comes from the env's route pattern in wrangler.toml
 	const routePattern = toml.parse(readFileSync(join(workerDir, 'wrangler.toml')).toString())?.env[
 		env.TLDRAW_ENV
 	]?.routes?.[0]?.pattern
 	if (!routePattern) {
-		throw new Error('Could not find the domain in wrangler.toml')
+		throw new Error('Could not find the route pattern in wrangler.toml')
 	}
 
 	// preview route patterns carry a path glob ("host/*"); the deployment URL wants just the host

--- a/internal/scripts/deploy-bemo.ts
+++ b/internal/scripts/deploy-bemo.ts
@@ -89,7 +89,7 @@ async function deployBemoWorker({ dryRun }: { dryRun: boolean }) {
 	if (previewId && !didUpdateBemoWorker) {
 		await setWranglerPreviewConfig(workerDir, {
 			name: workerId,
-			customDomain: `${previewId}-demo.tldraw.xyz`,
+			routeHostname: `${previewId}-demo.tldraw.xyz`,
 		})
 		didUpdateBemoWorker = true
 	}

--- a/internal/scripts/deploy-bemo.ts
+++ b/internal/scripts/deploy-bemo.ts
@@ -64,14 +64,15 @@ async function main() {
 	})
 
 	// we set the domain in the wrangler.toml file since it's managed by cloudflare
-	const domain = toml.parse(readFileSync(join(workerDir, 'wrangler.toml')).toString())?.env[
+	const routePattern = toml.parse(readFileSync(join(workerDir, 'wrangler.toml')).toString())?.env[
 		env.TLDRAW_ENV
 	]?.routes?.[0]?.pattern
-	if (!domain) {
+	if (!routePattern) {
 		throw new Error('Could not find the domain in wrangler.toml')
 	}
 
-	const deploymentUrl = `https://${domain}`
+	// preview route patterns carry a path glob ("host/*"); the deployment URL wants just the host
+	const deploymentUrl = `https://${routePattern.split('/')[0]}`
 
 	nicelog('Creating deployment for', deploymentUrl)
 	await createGithubDeployment(env, {

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -624,7 +624,7 @@ async function deployImageResizeWorker({ dryRun }: { dryRun: boolean }) {
 	if (previewId && !didUpdateImageResizeWorker) {
 		await setWranglerPreviewConfig(imageResize, {
 			name: workerId,
-			customDomain: `${previewId}-images.tldraw.xyz`,
+			routeHostname: `${previewId}-images.tldraw.xyz`,
 			serviceBinding: {
 				binding: 'SYNC_WORKER',
 				service: `${previewId}-tldraw-multiplayer`,

--- a/internal/scripts/lib/deploy.ts
+++ b/internal/scripts/lib/deploy.ts
@@ -173,13 +173,17 @@ export async function setWranglerPreviewConfig(
 	location: string,
 	{
 		name,
-		customDomain,
+		routeHostname,
 		serviceBinding,
-	}: { name: string; customDomain?: string; serviceBinding?: ServiceBinding },
+	}: { name: string; routeHostname?: string; serviceBinding?: ServiceBinding },
 	queueName?: string
 ) {
+	// A zone route instead of a custom domain: custom domains mint a dedicated
+	// certificate pack per hostname, while routes are covered by the zone's
+	// universal wildcard cert and the existing proxied *.tldraw.xyz DNS record.
+	const zoneName = routeHostname?.split('.').slice(-2).join('.')
 	const additionalProperties = `name = "${name}"
-${customDomain ? `routes = [ { pattern = "${customDomain}", custom_domain = true} ]` : ''}
+${routeHostname ? `routes = [ { pattern = "${routeHostname}/*", zone_name = "${zoneName}" } ]` : ''}
 ${serviceBinding ? `services = [ {binding = "${serviceBinding.binding}", service = "${serviceBinding.service}" } ]` : ''}`
 
 	const envPreviewSection = `\n[env.preview]\n${additionalProperties}\n`

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -111,6 +111,9 @@ async function getPreviewZoneId() {
 
 // Preview workers are reachable via zone routes ("pr-NNNN-<app>.tldraw.xyz/*").
 // Deleting a worker does not delete its routes, so prune them separately.
+// Only routes matching this exact preview shape may ever be deleted — anything
+// else on the zone (or anything a future refactor feeds in) must not qualify.
+const PREVIEW_ROUTE_PATTERN_REGEX = /^pr-\d+-[a-z0-9-]+\.tldraw\.xyz\/\*$/
 const _workerRouteIdCache = new Map<string, string>()
 async function listPreviewWorkerRoutes() {
 	const zoneId = await getPreviewZoneId()
@@ -125,7 +128,7 @@ async function listPreviewWorkerRoutes() {
 	if (!data.success) {
 		throw new Error('Failed to list worker routes ' + JSON.stringify(data))
 	}
-	const previewRoutes = data.result.filter((r) => CLOUDFLARE_WORKER_REGEX.test(r.pattern))
+	const previewRoutes = data.result.filter((r) => PREVIEW_ROUTE_PATTERN_REGEX.test(r.pattern))
 	for (const r of previewRoutes) {
 		_workerRouteIdCache.set(r.pattern, r.id)
 	}
@@ -133,6 +136,9 @@ async function listPreviewWorkerRoutes() {
 }
 
 async function deletePreviewWorkerRoute(pattern: string) {
+	if (!PREVIEW_ROUTE_PATTERN_REGEX.test(pattern)) {
+		throw new Error(`Refusing to delete non-preview route ${pattern}`)
+	}
 	const id = _workerRouteIdCache.get(pattern)
 	if (!id) {
 		nicelog(`Route ${pattern} did not exist, skipping`)

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -143,12 +143,17 @@ async function listPreviewWorkerRoutes() {
 }
 
 async function deletePreviewWorkerRoute(pattern: string) {
-	nicelog('Deleting worker route:', pattern)
 	const id = _workerRouteIdCache.get(pattern)
 	if (!id) {
-		throw new Error(`Route ${pattern} not found in cache`)
+		nicelog(`Route ${pattern} did not exist, skipping`)
+		return
 	}
+	nicelog('Deleting worker route:', pattern)
 	const res = await cloudflareZoneApi(`/workers/routes/${id}`, { method: 'DELETE' })
+	if (res.status === 404) {
+		nicelog(`Route ${pattern} did not exist, skipping`)
+		return
+	}
 	if (!res.ok) {
 		throw new Error(`Failed to delete worker route ${pattern}: ${res.status} ${res.statusText}`)
 	}

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -75,9 +75,17 @@ async function cloudflareZoneApi(endpoint: string, options: RequestInit = {}): P
 			`https://api.cloudflare.com/client/v4/zones?name=${CLOUDFLARE_ZONE_NAME}`,
 			{ headers: { Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}` } }
 		)
+		if (!res.ok) {
+			throw new Error(
+				`Failed to look up zone ${CLOUDFLARE_ZONE_NAME}: ${res.status} ${res.statusText}`
+			)
+		}
 		const data = (await res.json()) as { success: boolean; result: { id: string }[] }
 		if (!data.success || !data.result[0]) {
-			throw new Error(`Failed to look up zone ${CLOUDFLARE_ZONE_NAME}: ${JSON.stringify(data)}`)
+			// an empty result also happens when the token lacks zone-scoped "Zone: Read"
+			throw new Error(
+				`Failed to look up zone ${CLOUDFLARE_ZONE_NAME} (does CLOUDFLARE_API_TOKEN have "Zone: Read" and "Workers Routes: Edit" on the zone?): ${JSON.stringify(data)}`
+			)
 		}
 		_cloudflareZoneId = data.result[0].id
 	}
@@ -117,6 +125,9 @@ async function listPreviewWorkerDeployments() {
 const _workerRouteIdCache = new Map<string, string>()
 async function listPreviewWorkerRoutes() {
 	const res = await cloudflareZoneApi('/workers/routes')
+	if (!res.ok) {
+		throw new Error(`Failed to list worker routes: ${res.status} ${res.statusText}`)
+	}
 	const data = (await res.json()) as {
 		success: boolean
 		result: { id: string; pattern: string }[]
@@ -138,6 +149,9 @@ async function deletePreviewWorkerRoute(pattern: string) {
 		throw new Error(`Route ${pattern} not found in cache`)
 	}
 	const res = await cloudflareZoneApi(`/workers/routes/${id}`, { method: 'DELETE' })
+	if (!res.ok) {
+		throw new Error(`Failed to delete worker route ${pattern}: ${res.status} ${res.statusText}`)
+	}
 	const data = (await res.json()) as { success: boolean }
 	if (!data.success) {
 		throw new Error(`Failed to delete worker route ${pattern}: ${JSON.stringify(data)}`)

--- a/internal/scripts/prune-preview-deploys.ts
+++ b/internal/scripts/prune-preview-deploys.ts
@@ -67,6 +67,30 @@ async function cloudflareApi(endpoint: string, options: RequestInit = {}): Promi
 	})
 }
 
+const CLOUDFLARE_ZONE_NAME = 'tldraw.xyz'
+let _cloudflareZoneId: string | null = null
+async function cloudflareZoneApi(endpoint: string, options: RequestInit = {}): Promise<Response> {
+	if (!_cloudflareZoneId) {
+		const res = await fetch(
+			`https://api.cloudflare.com/client/v4/zones?name=${CLOUDFLARE_ZONE_NAME}`,
+			{ headers: { Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}` } }
+		)
+		const data = (await res.json()) as { success: boolean; result: { id: string }[] }
+		if (!data.success || !data.result[0]) {
+			throw new Error(`Failed to look up zone ${CLOUDFLARE_ZONE_NAME}: ${JSON.stringify(data)}`)
+		}
+		_cloudflareZoneId = data.result[0].id
+	}
+	const url = `https://api.cloudflare.com/client/v4/zones/${_cloudflareZoneId}${endpoint}`
+	return fetch(url, {
+		...options,
+		headers: {
+			Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
+			'Content-Type': 'application/json',
+		},
+	})
+}
+
 async function listPreviewWorkerDeployments() {
 	const res = await cloudflareApi('/workers/scripts')
 	const data = (await res.json()) as ListWorkersResult
@@ -86,6 +110,38 @@ async function listPreviewWorkerDeployments() {
 				return 0
 			})
 	)
+}
+
+// Preview workers are reachable via zone routes ("pr-NNNN-<app>.tldraw.xyz/*").
+// Deleting a worker does not delete its routes, so prune them separately.
+const _workerRouteIdCache = new Map<string, string>()
+async function listPreviewWorkerRoutes() {
+	const res = await cloudflareZoneApi('/workers/routes')
+	const data = (await res.json()) as {
+		success: boolean
+		result: { id: string; pattern: string }[]
+	}
+	if (!data.success) {
+		throw new Error('Failed to list worker routes ' + JSON.stringify(data))
+	}
+	const previewRoutes = data.result.filter((r) => CLOUDFLARE_WORKER_REGEX.test(r.pattern))
+	for (const r of previewRoutes) {
+		_workerRouteIdCache.set(r.pattern, r.id)
+	}
+	return previewRoutes.map((r) => r.pattern)
+}
+
+async function deletePreviewWorkerRoute(pattern: string) {
+	nicelog('Deleting worker route:', pattern)
+	const id = _workerRouteIdCache.get(pattern)
+	if (!id) {
+		throw new Error(`Route ${pattern} not found in cache`)
+	}
+	const res = await cloudflareZoneApi(`/workers/routes/${id}`, { method: 'DELETE' })
+	const data = (await res.json()) as { success: boolean }
+	if (!data.success) {
+		throw new Error(`Failed to delete worker route ${pattern}: ${JSON.stringify(data)}`)
+	}
 }
 
 async function deleteQueue(queueName: string) {
@@ -269,6 +325,8 @@ const deletionErrors: string[] = []
 async function main() {
 	nicelog('Getting queues information')
 	await processItems(listPreviewWorkerDeployments, deletePreviewWorkerDeployment)
+	nicelog('\nPruning preview worker routes')
+	await processItems(listPreviewWorkerRoutes, deletePreviewWorkerRoute)
 	nicelog('\nPruning Supabase preview databases')
 	await processItems(listPreviewDatabases, deletePreviewDatabase)
 	nicelog('\nPruning fly.io preview apps')


### PR DESCRIPTION
In order to stop leaking Cloudflare advanced certificate packs (many orphaned packs for closed PRs have accumulated, and ACM caps packs per zone), this PR switches preview workers (`pr-N-demo`, `pr-N-images`, `pr-N-consent`) from wrangler custom domains to plain zone routes.

Custom domains mint a dedicated certificate pack per hostname and Cloudflare never garbage-collects the pack when the worker is deleted — redeploys even mint duplicates. Zone routes need no per-hostname cert: preview hostnames are first-level subdomains, so the zone's universal `*.tldraw.xyz` cert covers TLS, and the existing proxied `*.tldraw.xyz` DNS record resolves them (worker routes intercept before the origin, so unmatched subdomains keep falling through to Vercel as today). No new DNS records or certs are created per preview.

Because zone routes are zone-level objects that survive `wrangler delete`, the nightly prune now also deletes routes matching `pr-N-*` for closed PRs. This needs the `CLOUDFLARE_API_TOKEN` used by the prune workflow to have zone-scoped `Zone: Read` and `Workers Routes: Edit` on `tldraw.xyz`.

Staging and production keep their custom domains — they're few and stable.

Migration notes:
- Currently-open PRs already have a custom domain attached to their preview hostname. Their first redeploy after this merges may conflict with the new route (wrangler runs non-interactively in CI). Day-of fix: bulk-delete the `pr-*` workers custom domains via the API; the next deploy then attaches the route.
- The many orphaned cert packs from closed PRs are being cleaned up separately with a one-off script.

### Change type

- [x] `other`

### Test plan

1. Verified the generated `[env.preview]` section locally: `routes = [ { pattern = "pr-9999-demo.tldraw.xyz/*", zone_name = "tldraw.xyz" } ]`.
2. Open a PR, confirm the preview deploy attaches a zone route (no new cert pack appears in the dashboard) and `pr-N-demo.tldraw.xyz` serves the preview.
3. After the PR closes, confirm the nightly prune deletes the route.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +68 / -6   |
