### PR TITLE
fix(tldraw): shifted number-row zoom shortcuts on non-US keyboard layouts

### DIFF
--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -412,13 +412,17 @@ function matchesEvent(e: KeyboardEvent, parsed: ParsedKbd): boolean {
 	if (e.ctrlKey !== parsed.ctrl) return false
 	if (e.metaKey !== parsed.meta) return false
 
-	// Match number-row digits by physical position rather than the typed glyph: the digit keys sit
-	// in the same place on every Latin layout, but their shifted glyph varies (shift+2 is '@' on
-	// US, '"' on British PC and German), so glyph matching misses them. Returning here also stops a
-	// digit press from matching a symbol shortcut that shares its glyph — on German, shift+0 types
-	// '=', which must run zoom-to-100, not the '=' zoom-in shortcut it would otherwise alias to.
-	const digitCode = /^Digit([0-9])$/.exec(e.code)
-	if (digitCode) return parsed.key === digitCode[1]
+	// With shift held, match number-row digits by physical position rather than the typed glyph: the
+	// digit keys sit in the same place on every Latin layout, but their shifted glyph varies
+	// (shift+2 is '@' on US, '"' on British PC and German), so glyph matching misses them. Returning
+	// here also stops a digit press from matching a symbol shortcut that shares its glyph — on
+	// German, shift+0 types '=', which must run zoom-to-100, not the '=' zoom-in shortcut it would
+	// otherwise alias to. Unshifted presses keep glyph matching, because layouts put real symbol
+	// shortcuts on the number row: AZERTY types '-' on Digit6, and that must still zoom out.
+	if (e.shiftKey) {
+		const digitCode = /^Digit([0-9])$/.exec(e.code)
+		if (digitCode) return parsed.key === digitCode[1]
+	}
 
 	const eventKey = getEventKey(e)
 	if (eventKey === parsed.key) return true

--- a/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
+++ b/packages/tldraw/src/lib/ui/hooks/useKeyboardShortcuts.ts
@@ -412,6 +412,14 @@ function matchesEvent(e: KeyboardEvent, parsed: ParsedKbd): boolean {
 	if (e.ctrlKey !== parsed.ctrl) return false
 	if (e.metaKey !== parsed.meta) return false
 
+	// Match number-row digits by physical position rather than the typed glyph: the digit keys sit
+	// in the same place on every Latin layout, but their shifted glyph varies (shift+2 is '@' on
+	// US, '"' on British PC and German), so glyph matching misses them. Returning here also stops a
+	// digit press from matching a symbol shortcut that shares its glyph — on German, shift+0 types
+	// '=', which must run zoom-to-100, not the '=' zoom-in shortcut it would otherwise alias to.
+	const digitCode = /^Digit([0-9])$/.exec(e.code)
+	if (digitCode) return parsed.key === digitCode[1]
+
 	const eventKey = getEventKey(e)
 	if (eventKey === parsed.key) return true
 

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -264,3 +264,44 @@ describe('keyboard shortcuts with a held key', () => {
 		expect(editor.getCurrentPageShapeIds().has(id)).toBe(true)
 	})
 })
+
+// Regression tests for shift+<digit> shortcuts across keyboard layouts. The physical number-row
+// keys are the same everywhere, but the shifted glyph varies by layout: US shift+2 is '@', British
+// PC and German '"'. German is the sharp case — it has no dedicated '=' key, so shift+0 produces
+// '=', which used to alias to the '=' zoom-in shortcut instead of zoom-to-100. Matching keys off
+// the physical Digit<N> code, so these work regardless of layout and never cross-fire.
+describe('shifted number-row shortcuts across keyboard layouts', () => {
+	it.each([
+		['US / Apple British', '@'],
+		['British PC / German', '"'],
+		// On AZERTY the number row is shifted, so shift+Digit2 already types '2'.
+		['AZERTY', '2'],
+	])('fires zoom-to-selection on shift+2 for a %s layout glyph', async (_layout, key) => {
+		const { editor } = await setupFocusedEditor()
+		const id = createShapeId()
+		act(() => {
+			editor.createShape({ id, type: 'geo', x: 0, y: 0 })
+			editor.select(id)
+		})
+		const zoomToSelection = vi.spyOn(editor, 'zoomToSelection').mockImplementation(() => editor)
+
+		keydown(editor, { key, code: 'Digit2', shiftKey: true })
+
+		expect(zoomToSelection).toHaveBeenCalledTimes(1)
+	})
+
+	it.each([
+		['US / UK', ')'],
+		// German has no '=' key; it sits on shift+0, so this press must still mean zoom-to-100.
+		['German', '='],
+	])('zooms to 100%% (never zoom-in) on shift+0 for a %s layout glyph', async (_layout, key) => {
+		const { editor } = await setupFocusedEditor()
+		const resetZoom = vi.spyOn(editor, 'resetZoom').mockImplementation(() => editor)
+		const zoomIn = vi.spyOn(editor, 'zoomIn').mockImplementation(() => editor)
+
+		keydown(editor, { key, code: 'Digit0', shiftKey: true })
+
+		expect(resetZoom).toHaveBeenCalledTimes(1)
+		expect(zoomIn).not.toHaveBeenCalled()
+	})
+})

--- a/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
+++ b/packages/tldraw/src/test/ui/keyboardShortcuts.test.tsx
@@ -304,4 +304,13 @@ describe('shifted number-row shortcuts across keyboard layouts', () => {
 		expect(resetZoom).toHaveBeenCalledTimes(1)
 		expect(zoomIn).not.toHaveBeenCalled()
 	})
+
+	it('still fires zoom-out for an unshifted number-row symbol (AZERTY types - on Digit6)', async () => {
+		const { editor } = await setupFocusedEditor()
+		const zoomOut = vi.spyOn(editor, 'zoomOut').mockImplementation(() => editor)
+
+		keydown(editor, { key: '-', code: 'Digit6' })
+
+		expect(zoomOut).toHaveBeenCalledTimes(1)
+	})
 })


### PR DESCRIPTION
Shortcuts bound to `shift` + a number-row key (zoom to fit / selection / 100%) were matched by the *typed character*, which varies by keyboard layout. On layouts whose shifted number row differs from US QWERTY, this broke them:

- **`Shift+2` (zoom to selection) did nothing** on British PC / German, where the key types `"` rather than `@`.
- On **German**, `Shift+0` types `=` (German has no dedicated `=` key), which the matcher read as `Shift+=` → **zoomed in instead of resetting to 100%**, leaving no way back to 100%.

US and Apple British keep `@` on `Shift+2`, so they were unaffected — which is why this slipped through.

### Fix

Resolve a `Digit<N>` keypress to its digit via `event.code` and match only that digit's shortcut, ahead of glyph matching. The number-row physical positions are stable across Latin layouts (QWERTY/AZERTY/QWERTZ/Dvorak/Colemak), and the early return also stops a digit press from firing a *symbol* shortcut that happens to share its glyph (the German `Shift+0`=`=` → zoom-in aliasing). Letters still match by typed character, so Dvorak/Colemak remain unaffected.

Scope: this fixes the number row (0–9), which covers every reported symptom. The symbol row (`shift+=` zoom-in, `shift+-` zoom-out) has a related but separate layout fragility that this PR does not address.

Closes #9862

### Change type

- [x] `bugfix`

### Test plan

On a German (or British PC) OS keyboard layout:

1. Select a shape and press `Shift+2` → zooms to selection.
2. Zoom in, then press `Shift+0` → resets to 100% (previously zoomed in further on German).
3. Press `Shift+1` → zooms to fit.

- [x] Unit tests — `keyboardShortcuts.test.tsx` adds a layout matrix for `shift+2` and `shift+0`; both German cases fail without the fix.

### Release notes

- Fixed the zoom keyboard shortcuts (`shift+1` / `shift+2` / `shift+0`) not working on non-US keyboard layouts.
