### PR TITLE
fix(commenting): use narrow relative-time style for comment timestamps

### DIFF
--- a/packages/commenting/src/ui/format-time.test.ts
+++ b/packages/commenting/src/ui/format-time.test.ts
@@ -11,7 +11,7 @@ const TWO_HOURS = 2 * 60 * 60
 describe('formatRelativeTime', () => {
 	it('formats in English by default', () => {
 		expect(formatRelativeTime(agoIso(TWO_HOURS))).toBe(
-			new Intl.RelativeTimeFormat('en', { numeric: 'auto', style: 'short' }).format(-2, 'hour')
+			new Intl.RelativeTimeFormat('en', { numeric: 'auto', style: 'narrow' }).format(-2, 'hour')
 		)
 	})
 
@@ -20,7 +20,7 @@ describe('formatRelativeTime', () => {
 	it('formats in the given locale', () => {
 		const french = formatRelativeTime(agoIso(TWO_HOURS), 'fr')
 		expect(french).toBe(
-			new Intl.RelativeTimeFormat('fr', { numeric: 'auto', style: 'short' }).format(-2, 'hour')
+			new Intl.RelativeTimeFormat('fr', { numeric: 'auto', style: 'narrow' }).format(-2, 'hour')
 		)
 		expect(french).not.toBe(formatRelativeTime(agoIso(TWO_HOURS), 'en'))
 	})
@@ -34,7 +34,7 @@ describe('formatRelativeTime', () => {
 
 	it('reads under a minute as "now" in the given locale', () => {
 		expect(formatRelativeTime(agoIso(5), 'fr')).toBe(
-			new Intl.RelativeTimeFormat('fr', { numeric: 'auto', style: 'short' }).format(0, 'second')
+			new Intl.RelativeTimeFormat('fr', { numeric: 'auto', style: 'narrow' }).format(0, 'second')
 		)
 	})
 

--- a/packages/commenting/src/ui/format-time.ts
+++ b/packages/commenting/src/ui/format-time.ts
@@ -9,7 +9,7 @@ const DIVISIONS = [
 ] as const
 
 /**
- * Format an ISO datetime as short relative time ("2 hr. ago", "yesterday", "last wk.").
+ * Format an ISO datetime as compact relative time ("2h ago", "yesterday", "last wk.").
  * Locale-aware via Intl.RelativeTimeFormat.
  * @public
  */
@@ -17,7 +17,7 @@ export function formatRelativeTime(iso: string, locale = 'en'): string {
 	const then = new Date(iso).getTime()
 	if (Number.isNaN(then)) return ''
 
-	const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto', style: 'short' })
+	const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto', style: 'narrow' })
 	let duration = (then - Date.now()) / 1000
 	// Under a minute is just "now" — with second granularity the label visibly ticks while
 	// typing a reply (every keystroke re-renders the card).


### PR DESCRIPTION
In order to drop the stray period in comment timestamps — the short `Intl.RelativeTimeFormat` style renders English abbreviations with a trailing dot ("7 min. ago") — this switches the relative-time formatter to the `narrow` style, which reads "7m ago" / "2h ago".

Days and weeks are unabbreviated in the narrow style, so they stay "yesterday" / "last wk." (the latter keeps its period — narrow only affects the units it shortens).

Preview: https://pr-9864-preview-deploy.tldraw.com/

### Change type

- [x] `bugfix`

### Test plan

1. On the preview deploy, open a file and post a comment.
2. Wait a moment (or open an existing comment) and check the "… ago" timestamp on the card.
3. It reads "7m ago" / "2h ago" — no trailing period — rather than "7 min. ago".

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Use a more compact format for comment timestamps ("7m ago").

