### PR TITLE
fix(dotcom): give each zero-cache machine a distinct OTel instance id

### DIFF
--- a/apps/dotcom/zero-cache/start.sh
+++ b/apps/dotcom/zero-cache/start.sh
@@ -4,5 +4,35 @@ set -e
 # Substitute FLY_MACHINE_ID into nginx config (only this var, preserve nginx $vars)
 envsubst '${FLY_MACHINE_ID}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
 
+# Give every machine a distinct OTel instance identity.
+#
+# Grafana Cloud's OTLP ingestion only promotes a fixed set of resource
+# attributes to Prometheus labels: service.name, service.namespace,
+# deployment.environment and service.instance.id. host.name is not among them —
+# it lands in target_info instead — so OTEL_NODE_RESOURCE_DETECTORS="...,host,..."
+# is not enough to tell two machines apart in a metric query.
+#
+# Without a distinct instance label every machine writes to the *same* series.
+# Prometheus then sees one series being overwritten by several independent
+# cumulative counters, reads each downward jump as a counter reset, and rate()
+# adds up every apparent increase. The result is a rate inflated by orders of
+# magnitude that climbs steadily since the last deploy and drops to zero when
+# the machines restart together. Ratios and histogram quantiles survive it
+# (the inflation is common-mode and cancels); every absolute counter rate does
+# not.
+#
+# This must be set here rather than in the fly.toml [env] block, because
+# FLY_MACHINE_ID only exists at runtime. supervisord passes its own environment
+# through to child programs, so exporting before exec is enough for zero-cache
+# to pick it up.
+if [ -n "$FLY_MACHINE_ID" ]; then
+	if [ -n "$OTEL_RESOURCE_ATTRIBUTES" ]; then
+		OTEL_RESOURCE_ATTRIBUTES="$OTEL_RESOURCE_ATTRIBUTES,service.instance.id=$FLY_MACHINE_ID"
+	else
+		OTEL_RESOURCE_ATTRIBUTES="service.instance.id=$FLY_MACHINE_ID"
+	fi
+	export OTEL_RESOURCE_ATTRIBUTES
+fi
+
 # Start supervisord which manages both nginx and zero-cache
 exec supervisord -c /etc/supervisord.conf


### PR DESCRIPTION
In order to get trustworthy counter rates out of the zero-cache Grafana dashboards, this PR gives every Fly machine a distinct OTel identity by appending `service.instance.id=$FLY_MACHINE_ID` to `OTEL_RESOURCE_ATTRIBUTES` in the container entrypoint.

Grafana Cloud's OTLP ingestion only promotes a fixed set of resource attributes to Prometheus labels, and `host.name` (which the `host` resource detector provides) is not one of them. Without a promoted per-machine attribute, all view-syncer machines write to the same series; Prometheus reads the interleaved cumulative counters as constant counter resets, and `rate()` inflates by orders of magnitude, climbing steadily between deploys. `service.instance.id` is in the promoted set, so this makes each machine its own series and the counter math correct.

This has to happen in `start.sh` rather than the fly.toml `[env]` block because `FLY_MACHINE_ID` only exists at runtime. supervisord passes its environment through to `zero-cache`, so exporting before `exec supervisord` is sufficient.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy to staging and confirm each zero-vs/zero-rm machine reports its own `instance` label in Grafana.
2. Confirm `rate()` on a zero-cache counter no longer shows the sawtooth inflation between deploys.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +30 / -0   |
