### PR TITLE
fix(commenting): give sidebar comment rows the standard inset hover

### DIFF
--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -876,6 +876,7 @@ button.tlui-cmt-reaction--active:hover {
 	font-size: 12px;
 }
 .tlui-cmt-list__item {
+	position: relative;
 	display: flex;
 	gap: 10px;
 	width: 100%;
@@ -890,18 +891,27 @@ button.tlui-cmt-reaction--active:hover {
 	color: inherit;
 	text-decoration: none;
 }
-.tlui-cmt-list__item:hover {
+/* The highlight is an inset, rounded wash like tldraw's buttons and menu items — not an
+   edge-to-edge band — so a comment row lights up the same way every other interactive row does. */
+.tlui-cmt-list__item::after {
+	content: '';
+	position: absolute;
+	inset: 4px;
+	border-radius: var(--tl-radius-2);
+	pointer-events: none;
+}
+.tlui-cmt-list__item:hover::after {
 	background: var(--tl-color-muted-2);
 }
 /* Selected sits a step above hover so the open thread's row stays distinguishable while
    pointing at other rows — but only a step: the muted-1 token (10%) reads too heavy here.
    These rows sit on the opaque sidebar panel, so a translucent tint composes safely. */
-.tlui-cmt-list__item--selected,
-.tlui-cmt-list__item--selected:hover {
+.tlui-cmt-list__item--selected::after,
+.tlui-cmt-list__item--selected:hover::after {
 	background: hsl(0, 0%, 0%, 5%);
 }
-.tl-theme__dark .tlui-cmt-list__item--selected,
-.tl-theme__dark .tlui-cmt-list__item--selected:hover {
+.tl-theme__dark .tlui-cmt-list__item--selected::after,
+.tl-theme__dark .tlui-cmt-list__item--selected:hover::after {
 	background: hsl(0, 0%, 100%, 5%);
 }
 /* resolved rows mute their content but keep the "Resolved" marker legible */


### PR DESCRIPTION
In order to fix the sidebar comment rows highlighting differently from the rest of tldraw (feedback from Steve), this gives them the standard hover.

The rows used an edge-to-edge `muted-2` background band on hover, where tldraw's buttons and menu items — including the context-menu item hover — use an **inset, rounded** wash. This draws the row's hover and selected states as an inset `::after` square with a rounded corner instead, so a comment row lights up the same way every other interactive row does. Pure CSS; the same `muted-2` / translucent selected tokens as before, only the shape changes.

Preview: https://pr-9866-preview-deploy.tldraw.com/

### Change type

- [x] `bugfix`

### Test plan

1. On the preview deploy, open a file and the comments sidebar (a doc with a few comments).
2. Hover a comment row: the highlight is an inset, rounded fill — not an edge-to-edge band — matching a context-menu item's hover.
3. Open a thread so its row is selected, then hover other rows: selected and hover both read as inset rounded washes.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Use tldraw's standard inset hover highlight for comment rows in the sidebar.
