### PR TITLE
refactor(store): share filtered history squashing

### DIFF
--- a/packages/store/src/lib/RecordsDiff.ts
+++ b/packages/store/src/lib/RecordsDiff.ts
@@ -212,6 +212,35 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 	diffs: RecordsDiff<T>[],
 	fromIndex = 0
 ): void {
+	squashRecordDiffsMutableImpl(target, diffs, fromIndex)
+}
+
+/**
+ * Applies only records of a given type from an array of diffs to a target diff. Returns the net
+ * change in the number of entries in the target.
+ *
+ * @internal
+ */
+export function squashRecordDiffsMutableByType<
+	T extends UnknownRecord,
+	TypeName extends T['typeName'],
+>(
+	target: RecordsDiff<Extract<T, { typeName: TypeName }>>,
+	diffs: RecordsDiff<T>[],
+	typeName: TypeName
+): number {
+	return squashRecordDiffsMutableImpl(target, diffs, 0, typeName)
+}
+
+function squashRecordDiffsMutableImpl<T extends UnknownRecord>(
+	target: RecordsDiff<T>,
+	diffs: RecordsDiff<T>[],
+	fromIndex: number,
+	typeName?: T['typeName']
+): number {
+	let sizeChange = 0
+	const trackSize = typeName !== undefined
+
 	// This runs on every history interceptor call — e.g. once per input tick while
 	// resizing N shapes, with N entries in diff.updated — so the updated loop must not
 	// allocate per entry. We use for-in instead of Object.entries, mutate the target's
@@ -228,13 +257,17 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 		for (const _id in diff.added) {
 			const id = _id as IdOf<T>
 			const value = diff.added[id]
+			if (typeName !== undefined && value.typeName !== typeName) continue
 			if (targetHasRemoved && target.removed[id]) {
 				const original = target.removed[id]
 				delete target.removed[id]
+				if (trackSize) sizeChange--
 				if (original !== value) {
 					target.updated[id] = [original, value]
+					if (trackSize) sizeChange++
 				}
 			} else {
+				if (trackSize && !target.added[id]) sizeChange++
 				target.added[id] = value
 			}
 		}
@@ -245,35 +278,52 @@ export function squashRecordDiffsMutable<T extends UnknownRecord>(
 		for (const _id in diff.updated) {
 			const id = _id as IdOf<T>
 			const to = diff.updated[id][1]
+			if (typeName !== undefined && to.typeName !== typeName) continue
 			if (targetHasAdded && target.added[id]) {
 				target.added[id] = to
+				if (trackSize && target.updated[id]) sizeChange--
 				delete target.updated[id]
-				if (targetHasRemoved) delete target.removed[id]
+				if (targetHasRemoved) {
+					if (trackSize && target.removed[id]) sizeChange--
+					delete target.removed[id]
+				}
 				continue
 			}
 			const existing = target.updated[id]
 			if (existing) {
 				existing[1] = to
-				if (targetHasRemoved) delete target.removed[id]
+				if (targetHasRemoved) {
+					if (trackSize && target.removed[id]) sizeChange--
+					delete target.removed[id]
+				}
 				continue
 			}
 
 			// copy the tuple so the target owns it and can mutate it in place later
 			target.updated[id] = [diff.updated[id][0], to]
-			if (targetHasRemoved) delete target.removed[id]
+			if (trackSize) sizeChange++
+			if (targetHasRemoved) {
+				if (trackSize && target.removed[id]) sizeChange--
+				delete target.removed[id]
+			}
 		}
 
 		for (const _id in diff.removed) {
 			const id = _id as IdOf<T>
+			if (typeName !== undefined && diff.removed[id].typeName !== typeName) continue
 			// the same record was added in this diff sequence, just drop it
 			if (target.added[id]) {
 				delete target.added[id]
+				if (trackSize) sizeChange--
 			} else if (target.updated[id]) {
 				target.removed[id] = target.updated[id][0]
 				delete target.updated[id]
 			} else {
+				if (trackSize && !target.removed[id]) sizeChange++
 				target.removed[id] = diff.removed[id]
 			}
 		}
 	}
+
+	return sizeChange
 }

--- a/packages/store/src/lib/StoreQueries.test.ts
+++ b/packages/store/src/lib/StoreQueries.test.ts
@@ -211,6 +211,30 @@ describe('filtered history (QH)', () => {
 			},
 		])
 	})
+
+	it('[QH2] squashes matching records while ignoring interleaved record types', () => {
+		const authorHistory = store.query.filterHistory('author')
+		authorHistory.get()
+
+		const lastChangedEpoch = authorHistory.lastChangedEpoch
+		const newAuthor = Author.create({ name: 'Stanley Briggs' })
+		const updatedNewAuthor = { ...newAuthor, age: 38 }
+
+		store.put([newAuthor])
+		store.put([updatedNewAuthor, { ...books.lotr, title: 'The Fellowship of the Ring' }])
+		store.put([{ ...authors.davidMitchellFunny, age: 38 }])
+		store.remove([authors.davidMitchellFunny.id])
+		store.remove([authors.tolkein.id])
+		store.put([authors.tolkein])
+
+		expect(authorHistory.getDiffSince(lastChangedEpoch)).toEqual([
+			{
+				added: { [newAuthor.id]: updatedNewAuthor },
+				updated: {},
+				removed: { [authors.davidMitchellFunny.id]: authors.davidMitchellFunny },
+			},
+		])
+	})
 })
 
 describe('indexes (QI)', () => {

--- a/packages/store/src/lib/StoreQueries.ts
+++ b/packages/store/src/lib/StoreQueries.ts
@@ -12,7 +12,7 @@ import { AtomMap } from './AtomMap'
 import { IdOf, UnknownRecord } from './BaseRecord'
 import { executeQuery, objectMatchesQuery, QueryExpression } from './executeQuery'
 import { IncrementalSetConstructor } from './IncrementalSetConstructor'
-import { hasAnyKey, RecordsDiff } from './RecordsDiff'
+import { hasAnyKey, RecordsDiff, squashRecordDiffsMutableByType } from './RecordsDiff'
 import { diffSets } from './setUtils'
 import { CollectionDiff } from './Store'
 
@@ -197,62 +197,9 @@ export class StoreQueries<R extends UnknownRecord> {
 				if (diff === RESET_VALUE) return this.history.get()
 
 				const res = { added: {}, removed: {}, updated: {} } as RecordsDiff<S>
-				let numAdded = 0
-				let numRemoved = 0
-				let numUpdated = 0
+				const size = squashRecordDiffsMutableByType(res, diff, typeName)
 
-				for (const changes of diff) {
-					for (const added of objectMapValues(changes.added)) {
-						if (added.typeName === typeName) {
-							if (res.removed[added.id as IdOf<S>]) {
-								const original = res.removed[added.id as IdOf<S>]
-								delete res.removed[added.id as IdOf<S>]
-								numRemoved--
-								if (original !== added) {
-									res.updated[added.id as IdOf<S>] = [original, added as S]
-									numUpdated++
-								}
-							} else {
-								res.added[added.id as IdOf<S>] = added as S
-								numAdded++
-							}
-						}
-					}
-
-					for (const [from, to] of objectMapValues(changes.updated)) {
-						if (to.typeName === typeName) {
-							if (res.added[to.id as IdOf<S>]) {
-								res.added[to.id as IdOf<S>] = to as S
-							} else if (res.updated[to.id as IdOf<S>]) {
-								res.updated[to.id as IdOf<S>] = [res.updated[to.id as IdOf<S>][0], to as S]
-							} else {
-								res.updated[to.id as IdOf<S>] = [from as S, to as S]
-								numUpdated++
-							}
-						}
-					}
-
-					for (const removed of objectMapValues(changes.removed)) {
-						if (removed.typeName === typeName) {
-							if (res.added[removed.id as IdOf<S>]) {
-								// was added during this diff sequence, so just undo the add
-								delete res.added[removed.id as IdOf<S>]
-								numAdded--
-							} else if (res.updated[removed.id as IdOf<S>]) {
-								// remove oldest version
-								res.removed[removed.id as IdOf<S>] = res.updated[removed.id as IdOf<S>][0]
-								delete res.updated[removed.id as IdOf<S>]
-								numUpdated--
-								numRemoved++
-							} else {
-								res.removed[removed.id as IdOf<S>] = removed as S
-								numRemoved++
-							}
-						}
-					}
-				}
-
-				if (numAdded || numRemoved || numUpdated) {
+				if (size) {
 					return withDiff(this.history.get(), res)
 				} else {
 					return lastValue


### PR DESCRIPTION
In order to prevent filtered query history and general record diffs from developing different squashing semantics, this PR routes StoreQueries.filterHistory through the same allocation-conscious state-transition loop as squashRecordDiffsMutable. Type filtering and size accounting stay inside the loop, avoiding intermediate filtered diffs, per-record allocations, and final dictionary-size scans. Follow-up to #9689.

### Change type

- [x] `improvement`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +56 / -59  |
| Tests     | +24 / -0   |