### PR TITLE
fix(dotcom): stamp comment createdAt in Postgres and tighten the reply gate

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -136,9 +136,8 @@ describe('categorizeCommentNotifications', () => {
 	})
 
 	it("does not resurface a thread's opening comment when I reply to it seconds later", () => {
-		// The original bug: A starts a thread, B replies right away, and A's opening comment came
-		// back to B as an "A replied" notification because a clock-skew tolerance readmitted any
-		// comment less than a minute older than B's join.
+		// A starts a thread, B replies right away: A's opening comment is context B already saw,
+		// not a reply to B, no matter how narrowly it predates B's join.
 		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(0) + 5_000 }] }
 		const opener = comment({ createdAt: at(0), thread, file: { ownerId: THIRD } })
 		expect(categorizeCommentNotifications([opener], ME)).toEqual([])

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.test.ts
@@ -12,11 +12,7 @@ const ME = 'user_me'
 const OTHER = 'user_other'
 const THIRD = 'user_third'
 
-/**
- * Event times, in minutes from an arbitrary epoch. The join gate tolerates a minute of clock skew
- * between authors, so tests that turn on it space their events well past that — timestamps a few
- * milliseconds apart would all land inside the tolerance and say nothing about the gate.
- */
+/** Event times, in minutes from an arbitrary epoch. */
 const at = (minutes: number) => 1_700_000_000_000 + minutes * 60_000
 
 /** A comment body: paragraphs of plain text, with optional `@`-mentions (by member id) interleaved. */
@@ -139,31 +135,28 @@ describe('categorizeCommentNotifications', () => {
 		expect(result[0].primaryReason).toBe('reply')
 	})
 
-	it('keeps a comment from just before my join, absorbing clock skew between authors', () => {
-		// createdAt is stamped by each author's own clock, so a reply that really did follow my
-		// join can carry an earlier timestamp than it. Inside the tolerance it still counts.
-		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
-		const tied = comment({
-			id: 'comment:tied',
-			createdAt: at(10),
-			thread,
-			file: { ownerId: THIRD },
-		})
-		const skewed = comment({
-			id: 'comment:skewed',
-			createdAt: at(10) - 30_000,
-			thread,
-			file: { ownerId: THIRD },
-		})
-		const result = categorizeCommentNotifications([tied, skewed], ME)
-		expect(result.map((n) => n.comment.id)).toEqual(['comment:tied', 'comment:skewed'])
-		expect(result.map((n) => n.primaryReason)).toEqual(['reply', 'reply'])
+	it("does not resurface a thread's opening comment when I reply to it seconds later", () => {
+		// The original bug: A starts a thread, B replies right away, and A's opening comment came
+		// back to B as an "A replied" notification because a clock-skew tolerance readmitted any
+		// comment less than a minute older than B's join.
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(0) + 5_000 }] }
+		const opener = comment({ createdAt: at(0), thread, file: { ownerId: THIRD } })
+		expect(categorizeCommentNotifications([opener], ME)).toEqual([])
 	})
 
-	it('drops a comment older than my join by more than the skew tolerance', () => {
+	it('drops a comment stamped at exactly my join time', () => {
+		// The gate is strict: same-instant means "not after me". Postgres stamps createdAt
+		// monotonically per thread (migration 046), so real replies can never tie with my join.
 		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
-		const stale = comment({ createdAt: at(10) - 90_000, thread, file: { ownerId: THIRD } })
-		expect(categorizeCommentNotifications([stale], ME)).toEqual([])
+		const tied = comment({ createdAt: at(10), thread, file: { ownerId: THIRD } })
+		expect(categorizeCommentNotifications([tied], ME)).toEqual([])
+	})
+
+	it('keeps a reply stamped just after my join', () => {
+		const thread = { createdBy: OTHER, comments: [{ authorId: ME, createdAt: at(10) }] }
+		const reply = comment({ createdAt: at(10) + 1, thread, file: { ownerId: THIRD } })
+		const result = categorizeCommentNotifications([reply], ME)
+		expect(result.map((n) => n.primaryReason)).toEqual(['reply'])
 	})
 
 	it("ignores others' comments in the thread relation when deriving my join time", () => {

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -76,10 +76,14 @@ export interface CommentNotification<
  * Stricter than the `comments` synced query, whose reply category has no timing condition (ZQL
  * can't compare `createdAt` across correlated rows): the reply reason only applies to comments
  * from strictly after the user joined the thread — earlier ones are context they saw when
- * joining, not notifications. The strict compare is exact because Postgres stamps `createdAt`
- * monotonically per thread on insert (migration 046), so all comments in a thread share one
- * clock and one total order. A comment with no reason left is dropped. Post-join replies stay in
- * the feed once responded to; read receipts, not membership, handle their unread state.
+ * joining, not notifications. The strict compare leans on Postgres stamping `createdAt`
+ * monotonically per thread on insert (migration 046): every new comment lands strictly after the
+ * thread's max, so it can never tie with or fall behind the reader's join and get dropped. Rows
+ * from before that migration keep their client stamps, so in an old thread a pre-migration reply
+ * whose author's clock ran behind the reader's can still read as history and drop — accepted:
+ * that regime only shrinks, and only ever covers comments that predate the migration. A comment
+ * with no reason left is dropped. Post-join replies stay in the feed once responded to; read
+ * receipts, not membership, handle their unread state.
  */
 export function categorizeCommentNotifications<T extends CommentNotificationInput>(
 	comments: readonly T[],

--- a/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
+++ b/apps/dotcom/client/src/tla/components/TlaSidebar/components/commentNotifications.ts
@@ -19,21 +19,6 @@ export type CommentNotificationReason = 'mention' | 'reply' | 'owned-board' | 'r
 const REASON_PRIORITY: CommentNotificationReason[] = ['mention', 'reply', 'owned-board', 'reaction']
 
 /**
- * How far a comment may predate the user's join time and still count as a reply.
- *
- * `createdAt` is stamped by the authoring client's clock (`createComment` in tlschema defaults to
- * `Date.now()`), so the join gate compares timestamps written by two different machines. A user
- * whose clock runs fast stamps their own join late, and a reply that genuinely followed it reads
- * as thread history — silently dropped, with nothing in the UI to hint at what's missing.
- *
- * The two failure directions aren't symmetric: too small a tolerance loses real notifications,
- * too large lets a few already-seen comments through. So this errs permissive, at a minute — well
- * past the drift of a roughly-synced clock, and short enough that it can't readmit a thread's
- * history, which is what the gate exists to keep out.
- */
-const JOIN_TIME_SKEW_TOLERANCE_MS = 60_000
-
-/**
  * The comment fields the notifications feed needs — a structural subset of the Zero row so this
  * is unit-testable without Zero types. Both feeds yield comment rows: `comments` carries other
  * people's comments that concern the caller, `reactions` the caller's own that were reacted to.
@@ -90,10 +75,11 @@ export interface CommentNotification<
  *
  * Stricter than the `comments` synced query, whose reply category has no timing condition (ZQL
  * can't compare `createdAt` across correlated rows): the reply reason only applies to comments
- * from after the user joined the thread (within {@link JOIN_TIME_SKEW_TOLERANCE_MS}) — earlier
- * ones are context they saw when joining, not notifications. A comment with no reason left is
- * dropped. Post-join replies stay in the feed once responded to; read receipts, not membership,
- * handle their unread state.
+ * from strictly after the user joined the thread — earlier ones are context they saw when
+ * joining, not notifications. The strict compare is exact because Postgres stamps `createdAt`
+ * monotonically per thread on insert (migration 046), so all comments in a thread share one
+ * clock and one total order. A comment with no reason left is dropped. Post-join replies stay in
+ * the feed once responded to; read receipts, not membership, handle their unread state.
  */
 export function categorizeCommentNotifications<T extends CommentNotificationInput>(
 	comments: readonly T[],
@@ -109,10 +95,7 @@ export function categorizeCommentNotifications<T extends CommentNotificationInpu
 
 		const reasons: CommentNotificationReason[] = []
 		if (extractMentionIds(comment.body).includes(userId)) reasons.push('mention')
-		// the two sides of this comparison come from different machines' clocks, hence the
-		// tolerance — see JOIN_TIME_SKEW_TOLERANCE_MS
-		const joinedAt = joinedThreadAt(comment.thread, userId)
-		if (comment.createdAt > joinedAt - JOIN_TIME_SKEW_TOLERANCE_MS) reasons.push('reply')
+		if (comment.createdAt > joinedThreadAt(comment.thread, userId)) reasons.push('reply')
 		if (comment.file?.ownerId === userId) reasons.push('owned-board')
 		if (reasons.length === 0) continue
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -1879,6 +1879,9 @@ export class TLFileDurableObject extends DurableObject {
 								.whereRef('comment_thread.lastChangedClock', '<', 'excluded.lastChangedClock')
 						)
 						.execute()
+				// "createdAt" is deliberately absent from the update set: Postgres stamps it on first
+				// insert (migration 046) and the stamp must survive at-least-once replays and edits.
+				// stamp_comment_created_at.test.ts exercises this conflict shape — keep them in sync.
 				const insertCommentRows = (rows: DB['comment'][]) =>
 					this.db
 						.insertInto('comment')
@@ -1892,6 +1895,9 @@ export class TLFileDurableObject extends DurableObject {
 									body: eb.ref('excluded.body'),
 									editedAt: eb.ref('excluded.editedAt'),
 									isDeleted: eb.ref('excluded.isDeleted'),
+									// excluded.* has been through the BEFORE INSERT stamp trigger, which
+									// lifts updatedAt to the (server) attempt stamp — so this can never
+									// regress updatedAt below the row's createdAt
 									updatedAt: eb.ref('excluded.updatedAt'),
 									meta: eb.ref('excluded.meta'),
 									lastChangedClock: eb.ref('excluded.lastChangedClock'),

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -168,6 +168,8 @@ export function commentRecordToRow(
 		authorAvatar: '',
 		// TLRichText's content is unknown[], not structurally a zero ReadonlyJSONValue
 		body: record.body as DB['comment']['body'],
+		// client-dated placeholder — a Postgres trigger re-stamps it with server arrival time on
+		// insert (migration 046), and the upsert's conflict branch never writes this column
 		createdAt: record.createdAt,
 		editedAt: record.editedAt,
 		isDeleted: record.isDeleted,

--- a/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
+++ b/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
@@ -27,25 +27,3 @@ CREATE TRIGGER "set_comment_created_at_trigger"
 BEFORE INSERT ON comment
 FOR EACH ROW
 EXECUTE FUNCTION set_comment_created_at();
-
--- Clamp pre-existing rows whose client stamp sits in the future (a wrong system clock). Left
--- alone, such a row would poison its thread: every new insert chains to future+n via the
--- GREATEST above, and future stamps pin the top of the createdAt-DESC bounded notifications
--- window. Order among clamped rows is preserved by fanning them out just below the migration
--- time; past-dated rows keep their stamps — rewriting history would change displayed times.
-WITH now_ms AS (
-  SELECT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT AS ms
-),
-clamped AS (
-  SELECT
-    "id",
-    (SELECT ms FROM now_ms)
-      - COUNT(*) OVER (PARTITION BY "threadId")
-      + ROW_NUMBER() OVER (PARTITION BY "threadId" ORDER BY "createdAt", "id") AS stamp
-  FROM comment
-  WHERE "createdAt" > (SELECT ms FROM now_ms)
-)
-UPDATE comment c
-SET "createdAt" = clamped.stamp, "updatedAt" = clamped.stamp
-FROM clamped
-WHERE c."id" = clamped."id";

--- a/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
+++ b/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
@@ -27,3 +27,25 @@ CREATE TRIGGER "set_comment_created_at_trigger"
 BEFORE INSERT ON comment
 FOR EACH ROW
 EXECUTE FUNCTION set_comment_created_at();
+
+-- Clamp pre-existing rows whose client stamp sits in the future (a wrong system clock). Left
+-- alone, such a row would poison its thread: every new insert chains to future+n via the
+-- GREATEST above, and future stamps pin the top of the createdAt-DESC bounded notifications
+-- window. Order among clamped rows is preserved by fanning them out just below the migration
+-- time; past-dated rows keep their stamps — rewriting history would change displayed times.
+WITH now_ms AS (
+  SELECT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT AS ms
+),
+clamped AS (
+  SELECT
+    "id",
+    (SELECT ms FROM now_ms)
+      - COUNT(*) OVER (PARTITION BY "threadId")
+      + ROW_NUMBER() OVER (PARTITION BY "threadId" ORDER BY "createdAt", "id") AS stamp
+  FROM comment
+  WHERE "createdAt" > (SELECT ms FROM now_ms)
+)
+UPDATE comment c
+SET "createdAt" = clamped.stamp, "updatedAt" = clamped.stamp
+FROM clamped
+WHERE c."id" = clamped."id";

--- a/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
+++ b/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
@@ -1,13 +1,8 @@
--- Stamp comment."createdAt" on the server. The notifications reply gate compares comment times
--- against the user's join time with a strict ">", which is only sound when every comment in a
--- thread is stamped by one clock — client clocks would make thread history and genuine replies
--- indistinguishable.
---
--- The stamp is monotonic per thread, not plain now(): the room's Durable Object drains several
--- comments in one transaction (where now() is frozen) and even clock_timestamp() can tie at the
--- column's millisecond resolution. Ties break the strict "after my join" compare, so each insert
--- takes at least predecessor + 1ms. Rows never insert concurrently for one thread — a thread
--- belongs to one file and one file is one Durable Object — so the SELECT MAX has no race.
+-- Stamp comment."createdAt" on the server: the notifications reply gate compares comment times
+-- with a strict ">", which needs one clock and one total order per thread. Monotonic (max + 1)
+-- rather than plain time because the Durable Object drains several comments in one transaction,
+-- where now() is frozen and clock_timestamp() ties at millisecond resolution. No race on the
+-- SELECT MAX: a thread belongs to one file, and one file is one Durable Object.
 --
 -- BEFORE INSERT only: the drain retries at-least-once via ON CONFLICT, whose update set does not
 -- include "createdAt", so the first successful insert's stamp is permanent.

--- a/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
+++ b/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
@@ -1,0 +1,30 @@
+-- Stamp comment."createdAt" on the server instead of trusting the authoring client's clock.
+-- Client stamps made the notifications reply gate compare timestamps from different machines:
+-- a user who replied to a thread within the gate's clock-skew tolerance got notified about the
+-- very comment they were replying to. With a single server clock the gate can compare strictly
+-- and drop the tolerance.
+--
+-- The stamp is monotonic per thread, not plain now(): the room's Durable Object drains several
+-- comments in one transaction (where now() is frozen) and even clock_timestamp() can tie at the
+-- column's millisecond resolution. Ties break the strict "after my join" compare, so each insert
+-- takes at least predecessor + 1ms. Rows never insert concurrently for one thread — a thread
+-- belongs to one file and one file is one Durable Object — so the SELECT MAX has no race.
+--
+-- BEFORE INSERT only: the drain retries at-least-once via ON CONFLICT, whose update set does not
+-- include "createdAt", so the first successful insert's stamp is permanent.
+CREATE OR REPLACE FUNCTION set_comment_created_at() RETURNS TRIGGER AS $$
+BEGIN
+  NEW."createdAt" := GREATEST(
+    (SELECT COALESCE(MAX("createdAt"), 0) + 1 FROM comment WHERE "threadId" = NEW."threadId"),
+    (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT
+  );
+  -- keep the derived sort key consistent with the re-stamped creation time
+  NEW."updatedAt" := GREATEST(NEW."updatedAt", NEW."createdAt");
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER "set_comment_created_at_trigger"
+BEFORE INSERT ON comment
+FOR EACH ROW
+EXECUTE FUNCTION set_comment_created_at();

--- a/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
+++ b/apps/dotcom/zero-cache/migrations/046_stamp_comment_created_at.sql
@@ -1,8 +1,7 @@
--- Stamp comment."createdAt" on the server instead of trusting the authoring client's clock.
--- Client stamps made the notifications reply gate compare timestamps from different machines:
--- a user who replied to a thread within the gate's clock-skew tolerance got notified about the
--- very comment they were replying to. With a single server clock the gate can compare strictly
--- and drop the tolerance.
+-- Stamp comment."createdAt" on the server. The notifications reply gate compares comment times
+-- against the user's join time with a strict ">", which is only sound when every comment in a
+-- thread is stamped by one clock — client clocks would make thread history and genuine replies
+-- indistinguishable.
 --
 -- The stamp is monotonic per thread, not plain now(): the room's Durable Object drains several
 -- comments in one transaction (where now() is frozen) and even clock_timestamp() can tie at the

--- a/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
+++ b/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
@@ -33,8 +33,8 @@ const MIGRATION_SQL = readFileSync(
 
 const schemaName = `tldraw_test_comment_${process.pid}`
 
-// Only the columns the trigger reads or writes, plus enough NOT NULLs to stay realistic. No
-// foreign keys: the trigger never touches the referenced tables.
+// Only the columns the trigger reads or writes plus the drain's clock guard column. No foreign
+// keys: the trigger never touches the referenced tables.
 const SCHEMA_SQL = `
 DROP TABLE IF EXISTS "${schemaName}"."comment" CASCADE;
 CREATE TABLE "${schemaName}"."comment" (
@@ -43,11 +43,19 @@ CREATE TABLE "${schemaName}"."comment" (
   "body" JSONB NOT NULL,
   "createdAt" BIGINT NOT NULL,
   "editedAt" BIGINT,
-  "updatedAt" BIGINT NOT NULL
+  "updatedAt" BIGINT NOT NULL,
+  "lastChangedClock" BIGINT NOT NULL
 );
 `
 
 const describeMaybe = CONNECTION_STRING ? describe : describe.skip
+if (!CONNECTION_STRING) {
+	// eslint-disable-next-line no-console
+	console.warn(
+		'stamp_comment_created_at.test.ts: skipping — the client notifications gate depends on this ' +
+			'trigger; set ZERO_CACHE_TEST_POSTGRES_URL to verify it against a real postgres.'
+	)
+}
 
 describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps)', () => {
 	// A single Client, not a Pool: inTestSchema's BEGIN/COMMIT must run on one connection.
@@ -106,19 +114,37 @@ describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps
 		return Number(res.rows[0].now)
 	}
 
-	async function insert(
-		rows: { id: string; threadId: string; createdAt: number; editedAt?: number | null }[]
+	// Mirrors the drain's upsert in TLFileDurableObject.ts (insertCommentRows): the conflict
+	// branch's exclusion of "createdAt" is what makes the trigger's stamp permanent across
+	// at-least-once replays and edits — keep the two in sync.
+	async function upsert(
+		rows: {
+			id: string
+			threadId: string
+			createdAt: number
+			editedAt?: number | null
+			body?: string
+			clock?: number
+		}[]
 	) {
 		const values = rows
 			.map(
 				(r) =>
-					`('${r.id}', '${r.threadId}', '{}', ${r.createdAt}, ${r.editedAt ?? 'NULL'}, ${
-						r.editedAt ?? r.createdAt
-					})`
+					`('${r.id}', '${r.threadId}', '${r.body ?? '{}'}', ${r.createdAt}, ${
+						r.editedAt ?? 'NULL'
+					}, ${r.editedAt ?? r.createdAt}, ${r.clock ?? 1})`
 			)
 			.join(', ')
 		await inTestSchema(
-			`INSERT INTO comment ("id", "threadId", "body", "createdAt", "editedAt", "updatedAt") VALUES ${values}`
+			`INSERT INTO comment ("id", "threadId", "body", "createdAt", "editedAt", "updatedAt", "lastChangedClock")
+			 VALUES ${values}
+			 ON CONFLICT ("id") DO UPDATE SET
+			   "threadId" = excluded."threadId",
+			   "body" = excluded."body",
+			   "editedAt" = excluded."editedAt",
+			   "updatedAt" = excluded."updatedAt",
+			   "lastChangedClock" = excluded."lastChangedClock"
+			 WHERE "comment"."lastChangedClock" < excluded."lastChangedClock"`
 		)
 	}
 
@@ -143,7 +169,7 @@ describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps
 
 	it('replaces the client stamp with server time and lifts updatedAt, whether the client clock is slow or fast', async () => {
 		const before = await serverNowMs()
-		await insert([
+		await upsert([
 			{ id: 'c-slow', threadId: 't1', createdAt: before - 3_600_000 },
 			{ id: 'c-fast', threadId: 't2', createdAt: before + 3_600_000, editedAt: 2_000 },
 		])
@@ -164,7 +190,7 @@ describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps
 		// can tie at millisecond resolution. Ties would break the notifications feed's strict
 		// "after my join" compare.
 		const before = await serverNowMs()
-		await insert([
+		await upsert([
 			{ id: 'c1', threadId: 't1', createdAt: 1_000 },
 			{ id: 'c2', threadId: 't1', createdAt: 1_000 },
 			{ id: 'c3', threadId: 't1', createdAt: 500 },
@@ -179,14 +205,51 @@ describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps
 		expect(rows.get('d1')!.createdAt).toBeLessThanOrEqual(after)
 	})
 
-	it('does not re-stamp on update', async () => {
-		// The drain retries at-least-once; its conflict branch updates body/editedAt/etc. but the
-		// trigger is BEFORE INSERT only, so the first insert's stamp is permanent.
-		await insert([{ id: 'c1', threadId: 't1', createdAt: 1_000 }])
+	it('keeps the first stamp through the drain-shaped conflict branch, and keeps updatedAt >= createdAt', async () => {
+		// The drain retries at-least-once, so a row can arrive again as a conflict on id — with an
+		// edit here, carrying a client-clock editedAt/updatedAt far behind the server stamp. The
+		// first stamp must hold. The conflict branch takes excluded."updatedAt" verbatim, which is
+		// safe only because the excluded tuple went through the BEFORE INSERT trigger and had its
+		// updatedAt lifted to the (server) attempt stamp — this asserts that coupling.
+		await upsert([{ id: 'c1', threadId: 't1', createdAt: 1_000, clock: 1 }])
 		const stamped = (await stamps()).get('c1')!.createdAt
-		await client.query(
-			`UPDATE "${schemaName}"."comment" SET "body" = '{"edited": true}', "editedAt" = 5 WHERE "id" = 'c1'`
-		)
-		expect((await stamps()).get('c1')!.createdAt).toBe(stamped)
+		await upsert([
+			{
+				id: 'c1',
+				threadId: 't1',
+				createdAt: 1_000,
+				editedAt: 2_000,
+				body: '{"edited": true}',
+				clock: 2,
+			},
+		])
+		const row = (await stamps()).get('c1')!
+		expect(row.createdAt).toBe(stamped)
+		expect(row.editedAt).toBe(2_000)
+		expect(row.updatedAt).toBeGreaterThanOrEqual(row.createdAt)
+	})
+
+	it('backfills future-dated legacy stamps to migration time, preserving thread order', async () => {
+		// Seed a pre-046 state: trigger absent, one thread holding a wildly future-dated row that
+		// would otherwise chain every later reply to future+n. Re-applying the migration must pull
+		// it back below real time without reordering the thread.
+		await client.query(SCHEMA_SQL)
+		const now = await serverNowMs()
+		await upsert([
+			{ id: 'c-past', threadId: 't1', createdAt: now - 3_600_000, clock: 1 },
+			{ id: 'c-future-1', threadId: 't1', createdAt: now + 3_600_000, clock: 2 },
+			{ id: 'c-future-2', threadId: 't1', createdAt: now + 7_200_000, clock: 3 },
+		])
+		await inTestSchema(MIGRATION_SQL)
+		const after = await serverNowMs()
+
+		const rows = await stamps()
+		expect(rows.get('c-past')!.createdAt).toBe(now - 3_600_000)
+		const f1 = rows.get('c-future-1')!
+		const f2 = rows.get('c-future-2')!
+		expect(f1.createdAt).toBeLessThan(f2.createdAt)
+		expect(f2.createdAt).toBeLessThanOrEqual(after)
+		expect(f1.createdAt).toBeGreaterThan(now - 3_600_000)
+		expect(f1.updatedAt).toBe(f1.createdAt)
 	})
 })

--- a/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
+++ b/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
@@ -228,28 +228,4 @@ describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps
 		expect(row.editedAt).toBe(2_000)
 		expect(row.updatedAt).toBeGreaterThanOrEqual(row.createdAt)
 	})
-
-	it('backfills future-dated legacy stamps to migration time, preserving thread order', async () => {
-		// Seed a pre-046 state: trigger absent, one thread holding a wildly future-dated row that
-		// would otherwise chain every later reply to future+n. Re-applying the migration must pull
-		// it back below real time without reordering the thread.
-		await client.query(SCHEMA_SQL)
-		const now = await serverNowMs()
-		await upsert([
-			{ id: 'c-past', threadId: 't1', createdAt: now - 3_600_000, clock: 1 },
-			{ id: 'c-future-1', threadId: 't1', createdAt: now + 3_600_000, clock: 2 },
-			{ id: 'c-future-2', threadId: 't1', createdAt: now + 7_200_000, clock: 3 },
-		])
-		await inTestSchema(MIGRATION_SQL)
-		const after = await serverNowMs()
-
-		const rows = await stamps()
-		expect(rows.get('c-past')!.createdAt).toBe(now - 3_600_000)
-		const f1 = rows.get('c-future-1')!
-		const f2 = rows.get('c-future-2')!
-		expect(f1.createdAt).toBeLessThan(f2.createdAt)
-		expect(f2.createdAt).toBeLessThanOrEqual(after)
-		expect(f1.createdAt).toBeGreaterThan(now - 3_600_000)
-		expect(f1.updatedAt).toBe(f1.createdAt)
-	})
 })

--- a/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
+++ b/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
@@ -114,9 +114,10 @@ describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps
 		return Number(res.rows[0].now)
 	}
 
-	// Mirrors the drain's upsert in TLFileDurableObject.ts (insertCommentRows): the conflict
-	// branch's exclusion of "createdAt" is what makes the trigger's stamp permanent across
-	// at-least-once replays and edits — keep the two in sync.
+	// Mirrors the shape of the drain's upsert in TLFileDurableObject.ts (insertCommentRows) over
+	// this table's column subset. The parts that matter — and must stay in sync with the drain —
+	// are the conflict branch excluding "createdAt" (what makes the trigger's stamp permanent
+	// across at-least-once replays and edits) and the lastChangedClock guard.
 	async function upsert(
 		rows: {
 			id: string

--- a/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
+++ b/apps/dotcom/zero-cache/stamp_comment_created_at.test.ts
@@ -1,0 +1,192 @@
+import { readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import pg from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+// Focused integration test for the `set_comment_created_at` trigger (migration 046), which
+// replaces the authoring client's `createdAt` with a server stamp that is monotonic per thread.
+// Client stamps let a thread's history read as post-join replies in the notifications feed; the
+// stamp must also be strictly increasing within a thread because the notifications reply gate
+// compares with a strict `>`, and the Durable Object drains several comments in one transaction
+// where `now()` is frozen and even `clock_timestamp()` can tie at millisecond resolution.
+//
+// This talks to a real postgres (the trigger is plpgsql, so fakes can't exercise it). It is
+// opt-in: set ZERO_CACHE_TEST_POSTGRES_URL (local dev stack:
+// postgres://user:password@localhost:6543/postgres) to run it. Without a connection string the
+// suite is skipped so CI stays green.
+//
+// Safety: same model as delete_file_states.test.ts — everything the test owns is
+// schema-qualified, and the statements that cannot be qualified (the shipped migration SQL run
+// verbatim, and the inserts whose trigger body resolves `comment` via search_path at execution
+// time) run inside a transaction with `SET LOCAL search_path`.
+
+const DIRNAME = dirname(fileURLToPath(import.meta.url))
+const CONNECTION_STRING = process.env.ZERO_CACHE_TEST_POSTGRES_URL
+
+// The real, shipped trigger. Loaded from the migration file so the test exercises exactly what
+// runs in production rather than a hand-copied duplicate.
+const MIGRATION_SQL = readFileSync(
+	join(DIRNAME, 'migrations', '046_stamp_comment_created_at.sql'),
+	'utf8'
+)
+
+const schemaName = `tldraw_test_comment_${process.pid}`
+
+// Only the columns the trigger reads or writes, plus enough NOT NULLs to stay realistic. No
+// foreign keys: the trigger never touches the referenced tables.
+const SCHEMA_SQL = `
+DROP TABLE IF EXISTS "${schemaName}"."comment" CASCADE;
+CREATE TABLE "${schemaName}"."comment" (
+  "id" VARCHAR PRIMARY KEY,
+  "threadId" VARCHAR NOT NULL,
+  "body" JSONB NOT NULL,
+  "createdAt" BIGINT NOT NULL,
+  "editedAt" BIGINT,
+  "updatedAt" BIGINT NOT NULL
+);
+`
+
+const describeMaybe = CONNECTION_STRING ? describe : describe.skip
+
+describeMaybe('set_comment_created_at trigger (server-stamped comment timestamps)', () => {
+	// A single Client, not a Pool: inTestSchema's BEGIN/COMMIT must run on one connection.
+	let client: pg.Client
+
+	// Runs statements inside one transaction with search_path pinned to the test schema, for SQL
+	// executed verbatim (the shipped migration) and statements whose trigger body resolves the
+	// unqualified `comment` at execution time.
+	async function inTestSchema(...statements: string[]) {
+		await client.query('BEGIN')
+		try {
+			await client.query(`SET LOCAL search_path TO "${schemaName}"`)
+			for (const sql of statements) {
+				await client.query(sql)
+			}
+			await client.query('COMMIT')
+		} catch (err) {
+			await client.query('ROLLBACK')
+			throw err
+		}
+	}
+
+	beforeAll(async () => {
+		client = new pg.Client({ connectionString: CONNECTION_STRING })
+		await client.connect()
+		await client.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+		await client.query(`CREATE SCHEMA "${schemaName}"`)
+		await client.query('BEGIN')
+		await client.query(`SET LOCAL search_path TO "${schemaName}"`)
+		const res = await client.query<{ schema: string }>('SELECT current_schema() AS schema')
+		await client.query('COMMIT')
+		if (res.rows[0]?.schema !== schemaName) {
+			throw new Error(
+				`SET LOCAL search_path did not hold within a transaction (current_schema() is ` +
+					`"${res.rows[0]?.schema}", expected "${schemaName}"). Refusing to run unqualified ` +
+					`DDL against this connection.`
+			)
+		}
+	})
+
+	afterAll(async () => {
+		if (!client) return
+		await client.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+		await client.end()
+	})
+
+	beforeEach(async () => {
+		await client.query(SCHEMA_SQL)
+		await inTestSchema(MIGRATION_SQL)
+	})
+
+	async function serverNowMs(): Promise<number> {
+		const res = await client.query<{ now: string }>(
+			`SELECT (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT AS now`
+		)
+		return Number(res.rows[0].now)
+	}
+
+	async function insert(
+		rows: { id: string; threadId: string; createdAt: number; editedAt?: number | null }[]
+	) {
+		const values = rows
+			.map(
+				(r) =>
+					`('${r.id}', '${r.threadId}', '{}', ${r.createdAt}, ${r.editedAt ?? 'NULL'}, ${
+						r.editedAt ?? r.createdAt
+					})`
+			)
+			.join(', ')
+		await inTestSchema(
+			`INSERT INTO comment ("id", "threadId", "body", "createdAt", "editedAt", "updatedAt") VALUES ${values}`
+		)
+	}
+
+	async function stamps() {
+		const res = await client.query<{
+			id: string
+			createdAt: string
+			editedAt: string | null
+			updatedAt: string
+		}>(`SELECT "id", "createdAt", "editedAt", "updatedAt" FROM "${schemaName}"."comment"`)
+		return new Map(
+			res.rows.map((r) => [
+				r.id,
+				{
+					createdAt: Number(r.createdAt),
+					editedAt: r.editedAt === null ? null : Number(r.editedAt),
+					updatedAt: Number(r.updatedAt),
+				},
+			])
+		)
+	}
+
+	it('replaces the client stamp with server time and lifts updatedAt, whether the client clock is slow or fast', async () => {
+		const before = await serverNowMs()
+		await insert([
+			{ id: 'c-slow', threadId: 't1', createdAt: before - 3_600_000 },
+			{ id: 'c-fast', threadId: 't2', createdAt: before + 3_600_000, editedAt: 2_000 },
+		])
+		const after = await serverNowMs()
+
+		const rows = await stamps()
+		for (const id of ['c-slow', 'c-fast']) {
+			const { createdAt, updatedAt } = rows.get(id)!
+			expect(createdAt).toBeGreaterThanOrEqual(before)
+			expect(createdAt).toBeLessThanOrEqual(after)
+			expect(updatedAt).toBe(createdAt)
+		}
+		expect(rows.get('c-fast')!.editedAt).toBe(2_000)
+	})
+
+	it('stamps a multi-row insert strictly increasing per thread, in statement order', async () => {
+		// The drain writes a batch in one statement, where now() is frozen and clock_timestamp()
+		// can tie at millisecond resolution. Ties would break the notifications feed's strict
+		// "after my join" compare.
+		const before = await serverNowMs()
+		await insert([
+			{ id: 'c1', threadId: 't1', createdAt: 1_000 },
+			{ id: 'c2', threadId: 't1', createdAt: 1_000 },
+			{ id: 'c3', threadId: 't1', createdAt: 500 },
+			{ id: 'd1', threadId: 't2', createdAt: 1_000 },
+		])
+		const after = await serverNowMs()
+		const rows = await stamps()
+		expect(rows.get('c1')!.createdAt).toBeLessThan(rows.get('c2')!.createdAt)
+		expect(rows.get('c2')!.createdAt).toBeLessThan(rows.get('c3')!.createdAt)
+		// each thread chains independently: t2's single row stamps at real time, not after t1's
+		expect(rows.get('d1')!.createdAt).toBeGreaterThanOrEqual(before)
+		expect(rows.get('d1')!.createdAt).toBeLessThanOrEqual(after)
+	})
+
+	it('does not re-stamp on update', async () => {
+		// The drain retries at-least-once; its conflict branch updates body/editedAt/etc. but the
+		// trigger is BEFORE INSERT only, so the first insert's stamp is permanent.
+		await insert([{ id: 'c1', threadId: 't1', createdAt: 1_000 }])
+		const stamped = (await stamps()).get('c1')!.createdAt
+		await client.query(
+			`UPDATE "${schemaName}"."comment" SET "body" = '{"edited": true}', "editedAt" = 5 WHERE "id" = 'c1'`
+		)
+		expect((await stamps()).get('c1')!.createdAt).toBe(stamped)
+	})
+})


### PR DESCRIPTION
In order to stop a quick reply from resurfacing thread history as a notification — user A starts a thread, user B replies within a minute, and B got an "A replied" notification about the very comment they were answering — this PR moves `comment.createdAt` stamping into Postgres and makes the notifications reply gate a strict compare.

The gate previously compared client-stamped timestamps from different machines, so it carried a 60s clock-skew tolerance — which readmitted up to a minute of thread history, making the bug 100% reproducible for any reply within a minute. Migration 046 adds a `BEFORE INSERT` trigger that stamps `createdAt` server-side, monotonic per thread (`GREATEST(thread max + 1, clock_timestamp())` — plain `now()` is transaction-frozen, and drain batches insert several comments in one transaction, so ties would break a strict compare). With one clock per thread the client gate drops the tolerance entirely.

Notes for review:

- No race on the per-thread `SELECT MAX`: a thread belongs to one file, and one file is one Durable Object, the table's only writer. The drain's `ON CONFLICT` branch never writes `createdAt`, so at-least-once replays can't re-stamp; the trigger test exercises the drain's actual conflict shape to pin that coupling.
- The conflict branch takes `excluded."updatedAt"` verbatim; that's safe because the excluded tuple has been through the stamp trigger, which lifts `updatedAt` to the attempt stamp — so `updatedAt >= createdAt` holds on every path (also asserted in the test).
- Rows from before the migration keep their client stamps, so in a pre-existing thread a pre-migration reply whose author's clock ran behind can still read as history and drop from the feed. Accepted: commenting only just shipped, the regime only covers comments predating the migration, and new replies always stamp past the thread max so they are never lost.
- Deploy-wise the migration only adds a function + trigger — no new published columns, so none of the view-syncer backfill hazards apply.
- The canvas thread UI still orders by the live record's client-stamped `createdAt` until a cold room load rebuilds records from Postgres; that divergence is the same pattern as the migration 040 author-detail stamps and was already true before this change.
- The trigger test talks to real Postgres and is opt-in via `ZERO_CACHE_TEST_POSTGRES_URL` (now with a loud skip warning), same as `delete_file_states.test.ts`. Getting a postgres service into CI for these is a possible follow-up.

### Change type

- [x] `bugfix`

### Test plan

1. As user A, start a comment thread on a shared file.
2. As user B, reply within a few seconds.
3. B's notifications should not show A's opening comment as a reply; A should be notified of B's reply.
4. As user A, reply again — B should now get a reply notification.

- [x] Unit tests

### Release notes

- Fix comment reply notifications so replying to a thread no longer surfaces the comments you were replying to as new notifications.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Tests   | +250 / -26 |
| Apps    | +42 / -23  |
