### PR TITLE
fix(commenting): pop clustered pins out of their badge when a drag first moves them

### DIFF
--- a/packages/commenting/src/canvas/cluster-model.test.ts
+++ b/packages/commenting/src/canvas/cluster-model.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { createClusterRuntime } from '../clustering/runtime'
+import type { ClusterNode, ClusterTable, LeafInput } from '../clustering/types'
+import type { ClusterInput } from './cluster-input'
+import { anyFoldedLeafMoved, type ClusterModel } from './cluster-model'
+
+function node(ids: string[], x = 0, y = 0): ClusterNode {
+	const members = ids.slice().sort()
+	return {
+		id: members.length === 1 ? members[0] : `cluster:${members.length}:${members[0]}`,
+		centroid: { x, y },
+		count: members.length,
+		members,
+	}
+}
+
+/** t1 and t2 fold into one badge below zoom 1; t3 sits far away and never merges. */
+const TABLE: ClusterTable = {
+	leaves: [node(['t1'], 0, 0), node(['t2'], 10, 0), node(['t3'], 5000, 0)],
+	events: [
+		{
+			zMerge: 1,
+			zSplit: 2,
+			children: [node(['t1']), node(['t2'])],
+			result: node(['t1', 't2'], 5, 0),
+		},
+	],
+}
+
+/** The rendered partition at `zoom`: below 1 the badge is up, above 2 every pin stands alone. */
+function rendered(zoom: number): ClusterModel {
+	const runtime = createClusterRuntime(TABLE)
+	runtime.seed(zoom)
+	return { runtime, table: TABLE }
+}
+
+const leaf = (id: string, x: number, y: number): LeafInput => ({ id, point: { x, y } })
+const input = (leaves: LeafInput[]): ClusterInput => ({ leaves, screenOffsets: undefined })
+
+const AT_REST = [leaf('t1', 0, 0), leaf('t2', 10, 0), leaf('t3', 5000, 0)]
+
+describe('anyFoldedLeafMoved', () => {
+	it('breaks the freeze when a leaf folded into a badge moves', () => {
+		const model = rendered(0.5)
+		expect([...model.runtime.getVisible().keys()].sort()).toEqual(['cluster:2:t1', 't3'])
+		const next = input([leaf('t1', 40, 0), leaf('t2', 10, 0), leaf('t3', 5000, 0)])
+		expect(anyFoldedLeafMoved(input(AT_REST), next, model)).toBe(true)
+	})
+
+	it('holds the freeze when a visible leaf moves — its pin already rides its anchor', () => {
+		const next = input([leaf('t1', 0, 0), leaf('t2', 10, 0), leaf('t3', 5040, 0)])
+		expect(anyFoldedLeafMoved(input(AT_REST), next, rendered(0.5))).toBe(false)
+		// and with the badge split, the same move of a former badge member is visible too
+		const split = input([leaf('t1', 40, 0), leaf('t2', 10, 0), leaf('t3', 5000, 0)])
+		expect(anyFoldedLeafMoved(input(AT_REST), split, rendered(3))).toBe(false)
+	})
+
+	it('holds the freeze when an orphan moves — it is not in the rendered partition to pop out of', () => {
+		// t4 was added since the last adopted rebuild: it is in the input but not in the rendered
+		// table, so it renders as a plain live pin and no pop-out can ever hold it. Counting it as
+		// folded would rebuild on every pointermove for the rest of the drag.
+		const atRest = [...AT_REST, leaf('t4', 20, 0)]
+		const next = input([...AT_REST, leaf('t4', 60, 0)])
+		expect(anyFoldedLeafMoved(input(atRest), next, rendered(0.5))).toBe(false)
+	})
+
+	it('holds the freeze when a detached leaf moves — it left the badge already', () => {
+		const model = rendered(0.5)
+		model.runtime.detachLeaves(['t1'])
+		expect(
+			anyFoldedLeafMoved(input(AT_REST), input([leaf('t1', 40, 0), ...AT_REST.slice(1)]), model)
+		).toBe(false)
+	})
+
+	it('holds the freeze when nothing moved', () => {
+		expect(anyFoldedLeafMoved(input(AT_REST), input([...AT_REST]), rendered(0.5))).toBe(false)
+	})
+
+	it('holds the freeze with no rendered model yet', () => {
+		const next = input([leaf('t1', 40, 0), leaf('t2', 10, 0), leaf('t3', 5000, 0)])
+		expect(anyFoldedLeafMoved(input(AT_REST), next, null)).toBe(false)
+	})
+
+	it('holds the freeze on mismatched inputs rather than reading past the end', () => {
+		const next = input([leaf('t1', 40, 0), leaf('t2', 10, 0)])
+		expect(anyFoldedLeafMoved(input(AT_REST), next, rendered(0.5))).toBe(false)
+	})
+})

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -88,12 +88,16 @@ export function useClusterModel(
 	// reply, a reaction, a resolve — anything that touches comment records without moving a pin —
 	// returns the previous input and rebuilds nothing.
 	//
-	// Mid-drag the gate widens to ignore positions too, and that costs something real: it freezes
-	// `latestModel`, which is where `findMovedClusteredLeafIds` reads live positions from, so a pin
-	// folded into a badge stops popping out to ride its anchor and corrects on release instead. The
-	// per-frame rebuild it buys back was paid by every drag on the board, comment-anchored or not.
-	// An added or deleted thread changes the id set, so it still rebuilds promptly.
+	// Mid-drag the gate widens to ignore positions too — except a folded leaf's. A visible pin
+	// rides its anchor live, so its move can wait for release; a pin folded into a badge can't
+	// (the badge position is baked into the model), so the first move of a folded leaf passes
+	// through: a rebuild at drag start, whose pop-out (below) holds the pin out of clustering as a
+	// live pin (one more rebuild, as the held pin leaves the input) — after which the input is
+	// static again and the gate re-freezes for the rest of the drag. The per-frame rebuild the
+	// freeze buys back was paid by every drag on the board, comment-anchored or not. An added or
+	// deleted thread changes the id set, so it still rebuilds promptly.
 	const clusterInputRef = useRef<ClusterInput>({ leaves: [], screenOffsets: undefined })
+	const renderedModelRef = useRef<ClusterModel | null>(null)
 	const clusterInput = useValue(
 		'comment cluster leaves',
 		() => {
@@ -103,7 +107,13 @@ export function useClusterModel(
 				openThreadId.get(editor)
 			)
 			const prev = clusterInputRef.current
-			if (isShapeDragInProgress(editor) && clusterInputIdsEqual(prev, next)) return prev
+			if (
+				isShapeDragInProgress(editor) &&
+				clusterInputIdsEqual(prev, next) &&
+				!anyFoldedLeafMoved(prev, next, renderedModelRef.current)
+			) {
+				return prev
+			}
 			if (clusterInputEqual(prev, next)) return prev
 			clusterInputRef.current = next
 			return next
@@ -153,6 +163,9 @@ export function useClusterModel(
 		// survive to force-adopt a later, unrelated rebuild.
 		adoptOnRebuild.current = false
 	}
+	// The displayed partition, for the input gate above: it runs between renders (one per
+	// pointermove), and folded-vs-visible is a property of what's on screen right now.
+	renderedModelRef.current = clusterModel
 	// Pop-out detection: a leaf folded inside a badge can't follow its anchor (the badge position
 	// is baked into the model), so when its live position drifts from the baked one, hold it out.
 	// It renders as a live pin riding the anchor; the detach loop below shrinks its badge locally.
@@ -250,6 +263,31 @@ export function useClusterModel(
 		orphanThreads,
 		heldThreads,
 	}
+}
+
+/**
+ * Whether a position-only input change (ids already known equal, same order) moved a leaf that is
+ * folded inside a badge of the rendered partition. Visible leaves ride their anchors live, so only
+ * a folded move needs to break the mid-drag input freeze — it's the one the badge can't follow.
+ * With no rendered model yet there's nothing folded, so nothing needs the rebuild.
+ * @internal
+ */
+export function anyFoldedLeafMoved(
+	prev: ClusterInput,
+	next: ClusterInput,
+	rendered: ClusterModel | null
+): boolean {
+	if (!rendered) return false
+	const visible = rendered.runtime.getVisible()
+	for (let i = 0; i < next.leaves.length; i++) {
+		if (visible.has(next.leaves[i].id)) continue
+		const a = prev.leaves[i].point
+		const b = next.leaves[i].point
+		if (Math.abs(a.x - b.x) > MOVED_LEAF_EPSILON || Math.abs(a.y - b.y) > MOVED_LEAF_EPSILON) {
+			return true
+		}
+	}
+	return false
 }
 
 /**

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -262,6 +262,12 @@ export function useClusterModel(
 /**
  * Whether a position-only input change (ids equal, same order) moved a leaf folded inside a badge
  * of the rendered partition — the one move the mid-drag freeze must let through.
+ *
+ * Folded means a member of a displayed badge, not merely "absent from the displayed partition":
+ * the input also carries orphans (threads the rendered partition has never seen) and detached
+ * leaves, which already ride their anchors as plain pins. Neither is in the rendered table, so the
+ * pop-out below can never hold one — counting them here would break the freeze on every
+ * pointermove for the rest of the drag.
  * @internal
  */
 export function anyFoldedLeafMoved(
@@ -270,9 +276,16 @@ export function anyFoldedLeafMoved(
 	rendered: ClusterModel | null
 ): boolean {
 	if (!rendered) return false
-	const visible = rendered.runtime.getVisible()
+	if (prev.leaves.length !== next.leaves.length) return false
+	const folded = new Set<string>()
+	for (const node of rendered.runtime.getVisible().values()) {
+		if (node.count < 2) continue
+		for (const member of node.members) folded.add(member)
+	}
+	// No badges on screen, so nothing can be folded — the common case, and the cheap way out of it.
+	if (folded.size === 0) return false
 	for (let i = 0; i < next.leaves.length; i++) {
-		if (visible.has(next.leaves[i].id)) continue
+		if (!folded.has(next.leaves[i].id)) continue
 		const a = prev.leaves[i].point
 		const b = next.leaves[i].point
 		if (Math.abs(a.x - b.x) > MOVED_LEAF_EPSILON || Math.abs(a.y - b.y) > MOVED_LEAF_EPSILON) {

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -88,14 +88,9 @@ export function useClusterModel(
 	// reply, a reaction, a resolve — anything that touches comment records without moving a pin —
 	// returns the previous input and rebuilds nothing.
 	//
-	// Mid-drag the gate widens to ignore positions too — except a folded leaf's. A visible pin
-	// rides its anchor live, so its move can wait for release; a pin folded into a badge can't
-	// (the badge position is baked into the model), so the first move of a folded leaf passes
-	// through: a rebuild at drag start, whose pop-out (below) holds the pin out of clustering as a
-	// live pin (one more rebuild, as the held pin leaves the input) — after which the input is
-	// static again and the gate re-freezes for the rest of the drag. The per-frame rebuild the
-	// freeze buys back was paid by every drag on the board, comment-anchored or not. An added or
-	// deleted thread changes the id set, so it still rebuilds promptly.
+	// Mid-drag the gate ignores positions too — except a folded leaf's, which a badge can't
+	// follow. Its first move passes through, the pop-out below holds the pin out as a live pin,
+	// and the input is static again for the rest of the drag.
 	const clusterInputRef = useRef<ClusterInput>({ leaves: [], screenOffsets: undefined })
 	const renderedModelRef = useRef<ClusterModel | null>(null)
 	const clusterInput = useValue(
@@ -163,8 +158,7 @@ export function useClusterModel(
 		// survive to force-adopt a later, unrelated rebuild.
 		adoptOnRebuild.current = false
 	}
-	// The displayed partition, for the input gate above: it runs between renders (one per
-	// pointermove), and folded-vs-visible is a property of what's on screen right now.
+	// For the input gate above: folded-vs-visible is judged against what's on screen.
 	renderedModelRef.current = clusterModel
 	// Pop-out detection: a leaf folded inside a badge can't follow its anchor (the badge position
 	// is baked into the model), so when its live position drifts from the baked one, hold it out.
@@ -266,10 +260,8 @@ export function useClusterModel(
 }
 
 /**
- * Whether a position-only input change (ids already known equal, same order) moved a leaf that is
- * folded inside a badge of the rendered partition. Visible leaves ride their anchors live, so only
- * a folded move needs to break the mid-drag input freeze — it's the one the badge can't follow.
- * With no rendered model yet there's nothing folded, so nothing needs the rebuild.
+ * Whether a position-only input change (ids equal, same order) moved a leaf folded inside a badge
+ * of the rendered partition — the one move the mid-drag freeze must let through.
  * @internal
  */
 export function anyFoldedLeafMoved(


### PR DESCRIPTION
In order to keep a comment visibly attached to its shape while the shape is dragged, this PR makes a pin that is folded into a cluster badge pop out of the badge on the drag's first movement instead of lagging invisibly until pointer-up.

The mid-drag input freeze from #9782 deliberately ignored position changes to avoid an O(N²) cluster rebuild on every pointermove of every drag — at the cost of freezing pop-out detection too, so a clustered pin only corrected on release. The freeze now yields in exactly one case: a position change to a *folded* leaf (one not visible as its own node in the rendered partition). That admits one rebuild at drag start, the existing pop-out path holds the pin out of clustering as a live pin riding its anchor (a second rebuild as it leaves the input), and the gate re-freezes for the rest of the drag. Release triggers no rebuild; the moved pin rejoins clustering on the next zoom-out via the existing rejoin path, now at its final position. Visible pins already track their anchors live, so their moves stay deferred exactly as before, and drags of uncommented shapes still never rebuild.

### Change type

- [x] `bugfix`

### Test plan

1. Place two comments close enough to fold into a cluster badge, one anchored to a shape
2. Drag the shape: the pin should leave the badge on the first movement and ride the shape live, the badge shrinking immediately
3. Release, then zoom out: the moved pin should fold into whatever cluster is now nearby
4. Drag a shape with an unclustered comment: pin rides live, no clustering churn (unchanged)

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix comments clustered into a badge lagging behind their shape while the shape is dragged

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +44 / -6   |