### PR TITLE
fix(editor): re-attach wheel pass-through when the ref's element changes

### DIFF
--- a/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
+++ b/packages/editor/src/lib/hooks/usePassThroughWheelEvents.ts
@@ -1,7 +1,8 @@
-import { RefObject, useEffect } from 'react'
+import { RefObject, useEffect, useRef } from 'react'
 import { preventDefault } from '../utils/dom'
 import { useContainer } from './useContainer'
 import { useMaybeEditor } from './useEditor'
+import { useEvent } from './useEvent'
 
 function isScrollableOverflow(overflow: string) {
 	return overflow === 'auto' || overflow === 'scroll' || overflow === 'overlay'
@@ -51,33 +52,49 @@ export function usePassThroughWheelEvents(ref: RefObject<HTMLElement | null>) {
 	const container = useContainer()
 	const editor = useMaybeEditor()
 
-	useEffect(() => {
-		function onWheel(e: WheelEvent) {
-			// Only pass through wheel events if the editor is focused
-			if (!editor?.getInstanceState().isFocused) return
+	const onWheel = useEvent((e: WheelEvent) => {
+		// Only pass through wheel events if the editor is focused
+		if (!editor?.getInstanceState().isFocused) return
 
-			if ((e as any).isSpecialRedispatchedEvent) return
+		if ((e as any).isSpecialRedispatchedEvent) return
 
-			// If the wheel is over a scrollable element, let it scroll instead of redispatching.
-			const elm = ref.current
-			if (elm && hasScrollableElement(e.target, elm)) {
-				return
-			}
-
-			preventDefault(e)
-			const cvs = container.querySelector('.tl-canvas')
-			if (!cvs) return
-			const newEvent = new WheelEvent('wheel', e as any)
-			;(newEvent as any).isSpecialRedispatchedEvent = true
-			cvs.dispatchEvent(newEvent)
-		}
-
+		// If the wheel is over a scrollable element, let it scroll instead of redispatching.
 		const elm = ref.current
-		if (!elm) return
-
-		elm.addEventListener('wheel', onWheel, { passive: false })
-		return () => {
-			elm.removeEventListener('wheel', onWheel)
+		if (elm && hasScrollableElement(e.target, elm)) {
+			return
 		}
-	}, [container, editor, ref])
+
+		preventDefault(e)
+		const cvs = container.querySelector('.tl-canvas')
+		if (!cvs) return
+		const newEvent = new WheelEvent('wheel', e as any)
+		;(newEvent as any).isSpecialRedispatchedEvent = true
+		cvs.dispatchEvent(newEvent)
+	})
+
+	// The element the listener is currently on, which isn't necessarily `ref.current`: a `RefObject`
+	// gives no notification when its element changes.
+	const attached = useRef<HTMLElement | null>(null)
+
+	// Deliberately no dependency array — this re-checks the ref after every render of the component
+	// that owns it, and re-attaches when the element has been swapped. A component that keeps the
+	// hook mounted while unmounting and remounting the element it points at (a comment pin culled
+	// while its anchor is off screen, say) would otherwise leave the listener on the discarded node
+	// and silently lose pass-through once the element comes back.
+	useEffect(() => {
+		const elm = ref.current
+		if (elm === attached.current) return
+		attached.current?.removeEventListener('wheel', onWheel)
+		attached.current = elm
+		elm?.addEventListener('wheel', onWheel, { passive: false })
+	})
+
+	// Teardown is its own effect so the re-attach check above can skip returning a cleanup that
+	// would tear the listener down and rebuild it on every render.
+	useEffect(() => {
+		return () => {
+			attached.current?.removeEventListener('wheel', onWheel)
+			attached.current = null
+		}
+	}, [onWheel])
 }

--- a/packages/editor/src/lib/test/usePassThroughWheelEvents.test.tsx
+++ b/packages/editor/src/lib/test/usePassThroughWheelEvents.test.tsx
@@ -1,0 +1,77 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { useRef, useState } from 'react'
+import { createTLStore } from '../config/createTLStore'
+import { usePassThroughWheelEvents } from '../hooks/usePassThroughWheelEvents'
+import { TL_CONTAINER_CLASS, TldrawEditor } from '../TldrawEditor'
+
+let setVisible: (visible: boolean) => void
+let rerender: () => void
+
+/**
+ * The shape a comment pin has: the hook's owner stays mounted while the element the ref points at
+ * is culled and later remounted (the pin returns null when its anchor leaves the viewport).
+ */
+function Culled() {
+	const ref = useRef<HTMLButtonElement>(null)
+	usePassThroughWheelEvents(ref)
+	const [visible, _setVisible] = useState(true)
+	const [, setTick] = useState(0)
+	setVisible = _setVisible
+	rerender = () => setTick((t) => t + 1)
+	if (!visible) return null
+	return <button ref={ref} data-testid="marker" />
+}
+
+describe('usePassThroughWheelEvents', () => {
+	async function renderEditor() {
+		const store = createTLStore({ shapeUtils: [], bindingUtils: [] })
+		await act(async () => {
+			render(<TldrawEditor store={store} components={{ InFrontOfTheCanvas: Culled }} />)
+		})
+		return document.querySelector(`.${TL_CONTAINER_CLASS}`)!
+	}
+
+	function wheelOverMarker(container: Element) {
+		const canvas = container.querySelector('.tl-canvas')!
+		const received: Event[] = []
+		canvas.addEventListener('wheel', (e) => received.push(e))
+		const marker = container.querySelector('[data-testid="marker"]')!
+		marker.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 10 }))
+		return received
+	}
+
+	it('redispatches wheel events over the element to the canvas', async () => {
+		const container = await renderEditor()
+		expect(wheelOverMarker(container)).toHaveLength(1)
+	})
+
+	// The regression: the owner stays mounted across the cull, so an effect keyed on its deps never
+	// re-runs and the listener is left on the discarded element.
+	it('still redispatches after the element unmounts and remounts', async () => {
+		const container = await renderEditor()
+		await act(async () => setVisible(false))
+		await act(async () => setVisible(true))
+		expect(wheelOverMarker(container)).toHaveLength(1)
+	})
+
+	// The re-attach check runs on every render, so it has to be a no-op when the element hasn't
+	// changed — otherwise each render stacks another listener and one wheel redispatches many.
+	it('does not stack listeners across renders that leave the element in place', async () => {
+		const container = await renderEditor()
+		for (let i = 0; i < 3; i++) {
+			await act(async () => rerender())
+		}
+		expect(wheelOverMarker(container)).toHaveLength(1)
+	})
+
+	it('stops redispatching once the owner unmounts', async () => {
+		const container = await renderEditor()
+		const marker = container.querySelector('[data-testid="marker"]')!
+		const canvas = container.querySelector('.tl-canvas')!
+		const received: Event[] = []
+		canvas.addEventListener('wheel', (e) => received.push(e))
+		await act(async () => cleanup())
+		marker.dispatchEvent(new WheelEvent('wheel', { bubbles: true, cancelable: true, deltaY: 10 }))
+		expect(received).toHaveLength(0)
+	})
+})


### PR DESCRIPTION
Wheeling over a comment pin should zoom the canvas underneath it, not do nothing. It does at first — then some pins go dead, and which ones seems arbitrary. The dead ones turn out to be exactly the pins that have scrolled off-screen and come back.

`usePassThroughWheelEvents` read `ref.current` once, inside an effect keyed on `[container, editor, ref]`. A `RefObject` gives no notification when its element changes, and those deps are stable for a pin's lifetime, so the effect ran exactly once per mount.

That's fine for the panels the hook was written for, which render their element unconditionally. A comment pin doesn't: `ThreadPin` calls the hook, then culls itself with `if (!point) return null` when its anchor leaves the viewport. The component stays mounted the whole time — the overlay keeps rendering it under a stable key — while the `<button>` the ref points at unmounts and later remounts. The effect never re-ran, so the listener stayed on the discarded node and the new one never got one. `ClusterBadge` and `ThreadStackPin` cull the same way and lose it the same way.

Fixing this in the hook rather than in the three call sites keeps the API unchanged and covers any other consumer that culls its element. The handler moves to `useEvent` so it has a stable identity, and attaching becomes a deliberately dep-array-free effect that compares `ref.current` against the node it last attached to, re-attaching only when they differ. Teardown is a separate effect so the per-render check doesn't tear the listener down and rebuild it on every render.

Relates to #9880, which fixes a different symptom of the same pin-culls-itself design (a press that unmounts mid-gesture strands its pointer capture). No overlapping files.

### Change type

- [x] `bugfix`

### Test plan

1. `yarn dev`, open `/commenting`.
2. Add a couple of comment pins.
3. Pan or zoom until a pin leaves the viewport, then bring it back.
4. Wheel over that pin — the canvas zooms. Before this change the pin swallowed the wheel and nothing happened, while pins that never left the viewport still worked.

- [x] Unit tests

### Release notes

- Fix comment pins swallowing wheel events after scrolling off-screen and back, instead of passing them through to the canvas.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +39 / -22  |
| Tests     | +77 / -0   |
