### PR TITLE
chore(tldraw): remove unused wheel pass-through from the actions menu

### DIFF
--- a/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
+++ b/packages/tldraw/src/lib/ui/components/ActionsMenu/DefaultActionsMenu.tsx
@@ -1,5 +1,5 @@
-import { useEditor, usePassThroughWheelEvents, useValue } from '@tldraw/editor'
-import { ReactNode, memo, useRef } from 'react'
+import { useEditor, useValue } from '@tldraw/editor'
+import { ReactNode, memo } from 'react'
 import { PORTRAIT_BREAKPOINT } from '../../constants'
 import { useBreakpoint } from '../../context/breakpoints'
 import { useReadonly } from '../../hooks/useReadonly'
@@ -28,9 +28,6 @@ export const DefaultActionsMenu = memo(function DefaultActionsMenu({
 	const breakpoint = useBreakpoint()
 	const isReadonlyMode = useReadonly()
 	const { orientation } = useTldrawUiOrientation()
-
-	const ref = useRef<HTMLDivElement>(null)
-	usePassThroughWheelEvents(ref)
 
 	const editor = useEditor()
 	const isInAcceptableReadonlyState = useValue(
@@ -71,7 +68,6 @@ export const DefaultActionsMenu = memo(function DefaultActionsMenu({
 				sideOffset={6}
 			>
 				<TldrawUiToolbar
-					ref={ref}
 					label={msg('actions-menu.title')}
 					className="tlui-actions-menu"
 					data-testid="actions-menu.content"


### PR DESCRIPTION
`DefaultActionsMenu` called `usePassThroughWheelEvents` and attached the ref to a toolbar inside `TldrawUiPopoverContent`. That never worked. The popover only mounts its content while open, and its open state lives in a descendant (`TldrawUiPopover` → `useMenuIsOpen`), so the element appears and disappears without the menu component around it re-rendering. The hook reads `ref.current` when the component calling it renders, so at mount the ref was null and the effect bailed, and nothing re-rendered the menu afterwards to give it a second look.

This PR originally repaired that by moving the element into its own component. Measuring the rest of the UI first changed the conclusion: **no popover in the default UI passes wheel events through.** Counting wheel events that reach `.tl-canvas` with a menu open:

| open menu | passed through |
| --------- | -------------- |
| actions menu | 0 |
| toolbar overflow | 0 |
| main menu | 0 |
| page menu | 0 |
| zoom menu | 0 |

Against the persistent panels, which all work: toolbar 1, menu zone 1, style panel 1, navigation panel 1.

That's a coherent line, not an oversight. Persistent chrome permanently covers the canvas, so a wheel over it has to reach the canvas or those regions become dead zones. A popover is transient, you dismiss it in a second, and it may want to scroll its own content. Every other `usePassThroughWheelEvents` call site in the UI attaches to a persistent panel; the actions menu was the only one arranged otherwise, and it was the only one that silently broke.

So this drops the call instead of repairing it, which makes the actions menu consistent with every other popover.

No user-visible change: the actions menu already doesn't pass wheel through. It does remove one edge. The hook's attach effect has no dependency array, so it re-runs on every render of the calling component — meaning any re-render of the menu *while it is open* (breakpoint, orientation, readonly, or the current tool becoming `hand`/`zoom`) attaches the listener after the fact and gives the actions menu pass-through no other menu has. Deleting the call makes it deterministic.

Left open deliberately: *should* popovers pass wheel through? If we ever say yes, it belongs in `TldrawUiPopoverContent` and `TldrawUiDropdownMenuContent`, which own their content elements and mount with them, so all five menus behave alike with no ref-timing subtlety. That would need the hook's `isScrollable` bailout tested against an overflowing menu (a long main menu, a long page list) so wheel still scrolls the menu rather than zooming the canvas. It's a deliberate default-behavior change for every consumer's custom popovers, so it shouldn't ride along in a bugfix.

Related: #9882, which fixes a different failure in the same hook — an element that unmounts and remounts while its owner stays mounted. It's in this branch's base and does not rescue this case, since the owner here never re-renders at all.

### Change type

- [x] `other` (cleanup)

### Test plan

Verified in the examples app, before and after, by counting wheel events reaching `.tl-canvas`:

1. `yarn dev`, click the canvas to focus the editor.
2. Ctrl+wheel over the toolbar — the zoom readout in the bottom-left changes. Control case.
3. Open the actions menu and ctrl+wheel over the grid of icons — the readout does not move, on `main` and on this branch alike.

Use ctrl+wheel and watch the zoom readout rather than a plain wheel: a plain wheel pans, which is invisible on an empty canvas. Note also that the `⋮` sits in the top-left menu zone at desktop widths, and that `<nav>` has its own working pass-through — wheeling a few pixels off the popover and onto the bar behind it zooms fine.

- [x] Unit tests (existing UI suite, 58 passing; no new tests — this asserts the absence of behavior)

### Release notes

- None. No user-visible change.
