### PR TITLE
fix(commenting): never render the open thread from a fade node

### DIFF
--- a/packages/commenting/src/canvas/comments-overlay.test.ts
+++ b/packages/commenting/src/canvas/comments-overlay.test.ts
@@ -18,7 +18,7 @@ describe('fadeNodeMarkerThreadId', () => {
 		expect(fadeNodeMarkerThreadId(node(['t1']), null, 't2')).toBe('t1')
 	})
 
-	it('never resolves to the open thread — the open slot renders it', () => {
+	it('returns null for the open thread — the open-thread render slot draws it', () => {
 		// Drawing it here too would mount its popover twice while the node fades out.
 		expect(fadeNodeMarkerThreadId(node(['t1']), null, 't1')).toBeNull()
 	})
@@ -28,16 +28,16 @@ describe('fadeNodeMarkerThreadId', () => {
 		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), 't1', 't2')).toBe('t1')
 	})
 
-	it('yields a stack whose owner is the open thread', () => {
+	it('returns null for a stack whose owner is the open thread', () => {
 		// Otherwise this node and the open slot would both draw the stack.
 		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), 't1', 't1')).toBeNull()
 	})
 
-	it('yields a stack whose owner is no longer a member', () => {
+	it('returns null for a stack whose owner is no longer a member', () => {
 		expect(fadeNodeMarkerThreadId(node(['t2', 't3']), 't1', null)).toBeNull()
 	})
 
-	it('yields a stack with no owner', () => {
+	it('returns null for a stack with no owner', () => {
 		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), null, null)).toBeNull()
 	})
 })

--- a/packages/commenting/src/canvas/comments-overlay.test.ts
+++ b/packages/commenting/src/canvas/comments-overlay.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { ClusterNode } from '../clustering/types'
+import { fadeNodeMarkerThreadId } from './comments-overlay'
+
+function node(ids: string[], x = 0, y = 0): ClusterNode {
+	const members = ids.slice().sort()
+	return {
+		id: members.length === 1 ? members[0] : `cluster:${members.length}:${members[0]}`,
+		centroid: { x, y },
+		count: members.length,
+		members,
+	}
+}
+
+describe('fadeNodeMarkerThreadId', () => {
+	it('resolves a count-1 node to its own thread', () => {
+		expect(fadeNodeMarkerThreadId(node(['t1']), null, null)).toBe('t1')
+		expect(fadeNodeMarkerThreadId(node(['t1']), null, 't2')).toBe('t1')
+	})
+
+	it('never resolves to the open thread — its dedicated slot renders it', () => {
+		// The open thread's node lingers as a stale/exiting fade entry during the open transition;
+		// rendering its pin here would mount a second popover stacked over the real one.
+		expect(fadeNodeMarkerThreadId(node(['t1']), null, 't1')).toBeNull()
+	})
+
+	it('resolves a coincident stack to its owner', () => {
+		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), 't1', null)).toBe('t1')
+		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), 't1', 't2')).toBe('t1')
+	})
+
+	it('yields a stack whose owner is the open thread', () => {
+		// Mid-transition the node's members still include the open thread, so the owner scan can
+		// land on it; without the guard both this node and the open slot would draw the stack.
+		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), 't1', 't1')).toBeNull()
+	})
+
+	it('yields a stack whose owner is no longer a member', () => {
+		// Post-detach the open thread has left the members list; the open slot owns the stack.
+		expect(fadeNodeMarkerThreadId(node(['t2', 't3']), 't1', null)).toBeNull()
+	})
+
+	it('yields a stack with no owner', () => {
+		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), null, null)).toBeNull()
+	})
+})

--- a/packages/commenting/src/canvas/comments-overlay.test.ts
+++ b/packages/commenting/src/canvas/comments-overlay.test.ts
@@ -18,9 +18,8 @@ describe('fadeNodeMarkerThreadId', () => {
 		expect(fadeNodeMarkerThreadId(node(['t1']), null, 't2')).toBe('t1')
 	})
 
-	it('never resolves to the open thread — its dedicated slot renders it', () => {
-		// The open thread's node lingers as a stale/exiting fade entry during the open transition;
-		// rendering its pin here would mount a second popover stacked over the real one.
+	it('never resolves to the open thread — the open slot renders it', () => {
+		// Drawing it here too would mount its popover twice while the node fades out.
 		expect(fadeNodeMarkerThreadId(node(['t1']), null, 't1')).toBeNull()
 	})
 
@@ -30,13 +29,11 @@ describe('fadeNodeMarkerThreadId', () => {
 	})
 
 	it('yields a stack whose owner is the open thread', () => {
-		// Mid-transition the node's members still include the open thread, so the owner scan can
-		// land on it; without the guard both this node and the open slot would draw the stack.
+		// Otherwise this node and the open slot would both draw the stack.
 		expect(fadeNodeMarkerThreadId(node(['t1', 't2']), 't1', 't1')).toBeNull()
 	})
 
 	it('yields a stack whose owner is no longer a member', () => {
-		// Post-detach the open thread has left the members list; the open slot owns the stack.
 		expect(fadeNodeMarkerThreadId(node(['t2', 't3']), 't1', null)).toBeNull()
 	})
 

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -41,9 +41,10 @@ import { ThreadStackPin } from './thread-stack'
 export type CanvasCommentsProps = CommentingContext
 
 /**
- * Which thread's pin a fade node should draw: its own thread for a single pin, `stackOwner` for a
- * coincident stack, null for neither. Never the open thread — the open slot below draws that one,
- * and drawing it here too (which the fade-out window would otherwise do) mounts its popover twice.
+ * Which thread's pin a fade node should draw: its own thread for a single pin, `stackOwner` (when
+ * still a member) for a coincident stack, null for neither. Never the open thread — the open-thread
+ * render slot draws that one, and drawing it here too (which the fade-out window would otherwise
+ * do) mounts its popover twice.
  * @internal
  */
 export function fadeNodeMarkerThreadId(

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -41,14 +41,9 @@ import { ThreadStackPin } from './thread-stack'
 export type CanvasCommentsProps = CommentingContext
 
 /**
- * The thread a fade node's marker resolves to, or null when the node draws no marker of its own.
- * `stackOwner` is the rendering owner when the node is a coincident stack (null otherwise).
- *
- * The open thread never resolves here — its dedicated slot renders it. During the open transition
- * its node lingers as a stale then exiting fade entry, and a pin rendered from it would mount a
- * second popover: portaled out of the fading wrapper, so stacked at full strength over the real
- * one (a doubled shadow) until the fade unmounts it.
- *
+ * Which thread's pin a fade node should draw: its own thread for a single pin, `stackOwner` for a
+ * coincident stack, null for neither. Never the open thread — the open slot below draws that one,
+ * and drawing it here too (which the fade-out window would otherwise do) mounts its popover twice.
  * @internal
  */
 export function fadeNodeMarkerThreadId(

--- a/packages/commenting/src/canvas/comments-overlay.tsx
+++ b/packages/commenting/src/canvas/comments-overlay.tsx
@@ -41,6 +41,27 @@ import { ThreadStackPin } from './thread-stack'
 export type CanvasCommentsProps = CommentingContext
 
 /**
+ * The thread a fade node's marker resolves to, or null when the node draws no marker of its own.
+ * `stackOwner` is the rendering owner when the node is a coincident stack (null otherwise).
+ *
+ * The open thread never resolves here — its dedicated slot renders it. During the open transition
+ * its node lingers as a stale then exiting fade entry, and a pin rendered from it would mount a
+ * second popover: portaled out of the fading wrapper, so stacked at full strength over the real
+ * one (a doubled shadow) until the fade unmounts it.
+ *
+ * @internal
+ */
+export function fadeNodeMarkerThreadId(
+	node: ClusterNode,
+	stackOwner: string | null,
+	openId: string | null
+): string | null {
+	const candidate =
+		node.count === 1 ? node.id : stackOwner && node.members.includes(stackOwner) ? stackOwner : null
+	return candidate === openId ? null : candidate
+}
+
+/**
  * A ready-to-use comments layer for a tldraw canvas: pins each thread at its anchor, opens a
  * thread popover (with a reply composer) on click, and shows a composer where the comment tool
  * placed a new thread. Reads/writes comment records straight from `editor.store`.
@@ -286,17 +307,16 @@ function CanvasCommentsLayer(props: CommentingContext) {
 							let content: ReactNode
 							const stackGroup = node.count > 1 ? stackGroupOf(node) : null
 							if (node.count === 1) {
-								const thread = threadsById.get(node.id)
+								const markerId = fadeNodeMarkerThreadId(node, null, openId)
+								const thread = markerId ? threadsById.get(markerId) : undefined
 								if (!thread) return null
 								content = renderThreadPin(thread)
 							} else if (stackGroup) {
 								// Routed through the stack's owner so the open/orphan/held slots stay deduped:
 								// when the owner is one of them, that slot draws the stack and this draws nothing.
-								const owner = stackGroup.find((id) => renderedThreadIds.has(id))
-								content =
-									owner && node.members.includes(owner)
-										? renderThreadPin(threadsById.get(owner)!)
-										: null
+								const owner = stackGroup.find((id) => renderedThreadIds.has(id)) ?? null
+								const markerId = fadeNodeMarkerThreadId(node, owner, openId)
+								content = markerId ? renderThreadPin(threadsById.get(markerId)!) : null
 							} else {
 								content = (
 									<ClusterBadge


### PR DESCRIPTION
This solves the strange shadow popping when opening a comment thread for the first time:

### Before

https://github.com/user-attachments/assets/af61fa1b-435b-4a30-98a5-c05cc5b2781e

### After

https://github.com/user-attachments/assets/b299ac64-aef9-4962-aef1-9634fdc3d84c

In order to stop the open thread's popover shadow from "popping" — briefly rendering twice as dark and then settling — the first time a comment is opened, this PR stops cluster fade nodes from rendering the open thread's pin. Opening a thread pulls its leaf out of the cluster input, so its old node lingers for the 150ms exit fade while the dedicated open-thread slot mounts its own pin. Both pins mounted the thread popover, and the duplicate portals out of the fading wrapper — so it sat at full opacity, perfectly stacked over the real one, until the fade timer unmounted it. Two identical `--tl-shadow-3`s summed reads as a heavier shadow that snaps back after ~150ms.

The fix routes fade-node markers through a small guard, `fadeNodeMarkerThreadId`, which resolves a node to its own thread (single pin) or its stack owner (coincident stack) but never to the open thread — the dedicated slot below owns that render. Subsequent opens were already clean (the pin renders via the orphan path after its first open/close), which is why the pop only showed on the first open per load.

### Change type

- [x] `bugfix`

### Test plan

1. Load a board with a comment pin, without zooming first.
2. Open the comment (pin click, hover preview click, or sidebar) and watch the panel shadow — it should not darken then lighten.
3. In devtools, `document.querySelectorAll('.tlui-cmt-canvas-popover')` should never exceed 1 during the open transition.

- [x] Unit tests

### Release notes

- Fixed the comment thread popover briefly rendering with a doubled shadow the first time a thread is opened.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +21 / -6   |
| Tests     | +43 / -0   |