### PR TITLE
feat(dotcom): add transactional outbox for file side effects

### DIFF
--- a/apps/dotcom/client/src/pages/admin/SystemSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/SystemSection.tsx
@@ -5,18 +5,18 @@ import { StructuredDataDisplay } from './shared'
 import styles from './admin.module.css'
 
 export function SystemSection() {
-	const [replicatorData, setReplicatorData] = useState(null)
+	const [outboxData, setOutboxData] = useState(null)
 	const [error, setError] = useState(null as string | null)
 
 	useEffect(() => {
-		fetch('/api/app/admin/replicator')
+		fetch('/api/app/admin/outbox')
 			.then(async (res) => {
 				if (!res.ok) {
 					setError(res.statusText + ': ' + (await res.text()))
 					return
 				}
 				setError(null)
-				setReplicatorData(await res.json())
+				setOutboxData(await res.json())
 			})
 			.catch((e) => {
 				setError(e.message)
@@ -37,7 +37,7 @@ export function SystemSection() {
 			<section className={styles.adminSection}>
 				<h3 className={styles.sectionTitle}>System health</h3>
 				{error && <div className={styles.errorMessage}>{error}</div>}
-				{replicatorData && <StructuredDataDisplay data={replicatorData} />}
+				{outboxData && <StructuredDataDisplay data={outboxData} />}
 			</section>
 		</>
 	)

--- a/apps/dotcom/client/src/pages/admin/UsersSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/UsersSection.tsx
@@ -1,4 +1,4 @@
-import { TlaFile, ZStoreData } from '@tldraw/dotcom-shared'
+import { TlaFile, TlaUser } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetch } from 'tldraw'
 import { AdminButton } from './AdminButton'
@@ -6,17 +6,17 @@ import { StructuredDataDisplay } from './shared'
 import styles from './admin.module.css'
 
 // Helper component for user data summary. deletedFileCount comes from the dedicated endpoint —
-// the replicated store excludes the user's own deleted files, so it can't be derived from `data`.
+// `data.files` excludes the user's own deleted files, so it can't be derived from `data`.
 function UserDataSummary({
 	data,
 	deletedFileCount,
 }: {
-	data: ZStoreData
+	data: { user: TlaUser; memberships: unknown[]; files: TlaFile[] }
 	deletedFileCount: number
 }) {
 	const getUserInfo = () => {
-		const user = data.user[0]
-		const files = data.file || []
+		const user = data.user
+		const files = data.files || []
 		const activeFiles = files.filter((f: TlaFile) => !f.isDeleted)
 
 		return {
@@ -146,7 +146,6 @@ export function UsersSection() {
 	const [data, setData] = useState<any>(null)
 	const [deletedFiles, setDeletedFiles] = useState<DeletedFileRow[]>([])
 	const [error, setError] = useState(null as string | null)
-	const [isRebooting, setIsRebooting] = useState(false)
 	const [successMessage, setSuccessMessage] = useState(null as string | null)
 	const inputRef = useRef<HTMLInputElement>(null)
 
@@ -184,31 +183,6 @@ export function UsersSection() {
 		await loadDeletedFiles()
 	}, [loadDeletedFiles])
 
-	const doReboot = useCallback(async () => {
-		const q = inputRef.current?.value?.trim() ?? ''
-		if (!q) {
-			setError('Please enter an email or ID')
-			return
-		}
-
-		setIsRebooting(true)
-		setError(null)
-		try {
-			const res = await fetch(`/api/app/admin/user/reboot?${new URLSearchParams({ q })}`, {
-				method: 'POST',
-			})
-			if (!res.ok) {
-				setError(res.statusText + ': ' + (await res.text()))
-				return
-			}
-			setError(null)
-			loadData()
-			setSuccessMessage('User rebooted successfully')
-		} finally {
-			setIsRebooting(false)
-		}
-	}, [loadData])
-
 	// Clear success message after 3 seconds
 	useEffect(() => {
 		if (successMessage) {
@@ -223,8 +197,8 @@ export function UsersSection() {
 			<section className={styles.adminSection}>
 				<h2 className={styles.sectionTitle}>User management</h2>
 				<p>
-					Look up a user by email or ID to inspect their data, force a reboot, restore deleted
-					files, or delete the account.
+					Look up a user by email or ID to inspect their data, restore deleted files, or delete the
+					account.
 				</p>
 				<div className={styles.searchContainer}>
 					<input
@@ -261,21 +235,8 @@ export function UsersSection() {
 						>
 							Copy data
 						</AdminButton>
-						<AdminButton
-							variant="secondary"
-							disabled={isRebooting}
-							onClick={doReboot}
-							isLoading={isRebooting}
-							className={styles.userActionButton}
-						>
-							Force reboot
-						</AdminButton>
 					</div>
-					<DeletedFilesTable
-						files={deletedFiles}
-						userId={data.user[0]?.id}
-						onUndeleted={loadData}
-					/>
+					<DeletedFilesTable files={deletedFiles} userId={data.user?.id} onUndeleted={loadData} />
 					<StructuredDataDisplay data={data} />
 				</section>
 			)}

--- a/apps/dotcom/process-compose.yaml
+++ b/apps/dotcom/process-compose.yaml
@@ -2,7 +2,8 @@
 
 version: '0.5'
 
-# Readiness = TCP connect (a portable node one-liner; wrangler's `/` 404s, so http_get won't do).
+# Readiness = TCP connect (a portable node one-liner; wrangler's `/` 404s, so http_get won't do),
+# except sync-worker, which probes a real route (see its probe comment).
 
 processes:
   # postgres + pgbouncer — the two containers (wal2json / logical replication)
@@ -63,9 +64,14 @@ processes:
     depends_on:
       zero-cache:
         condition: process_healthy
+    # Probing /app/outbox-status (not a bare TCP connect) also wakes the outbox processor DO —
+    # local workerd doesn't fire persisted alarms for an uninstantiated DO, so without this a
+    # restarted stack wouldn't drain trigger-only writes until the first mutation.
     readiness_probe:
-      exec:
-        command: node -e "require('net').connect(8787,'127.0.0.1').on('connect',function(){this.end();process.exit(0)}).on('error',()=>process.exit(1))"
+      http_get:
+        host: 127.0.0.1
+        port: 8787
+        path: /app/outbox-status
       initial_delay_seconds: 3
       period_seconds: 2
       failure_threshold: 60

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -17,7 +17,7 @@
 		"test": "yarn run -T vitest --passWithNoTests",
 		"clean": "rm -rf .wrangler/state .wrangler/state-*",
 		"test-coverage": "yarn run -T vitest run --coverage --passWithNoTests",
-		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 1600000",
+		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 1650000",
 		"reset-db": "./reset-db.sh",
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"
 	},

--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -17,7 +17,7 @@
 		"test": "yarn run -T vitest --passWithNoTests",
 		"clean": "rm -rf .wrangler/state .wrangler/state-*",
 		"test-coverage": "yarn run -T vitest run --coverage --passWithNoTests",
-		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 1650000",
+		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 1800000",
 		"reset-db": "./reset-db.sh",
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"
 	},

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -2591,10 +2591,12 @@ export class TLFileDurableObject extends DurableObject {
 
 		this._fileRecordCache = null
 
-		// prevent new connections while we clean everything up
+		// prevent new connections while we clean everything up. Fall back to the argument for the
+		// slug (an app file's slug is its id): a never-initialized room has no documentInfo, and
+		// delete must stay terminal for any DO state instead of tripping the asserting getter.
 		this.setDocumentInfo({
 			version: CURRENT_DOCUMENT_INFO_VERSION,
-			slug: this.documentInfo.slug,
+			slug: this._documentInfo?.slug ?? id,
 			isApp: true,
 			deleted: true,
 		})

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -21,11 +21,12 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	constructor(ctx: DurableObjectState, env: Environment) {
 		super(ctx, env)
 		this.sentry = createSentry(ctx, env)
-		// Bootstrap the sweep so a never-poked DO still drains trigger-only rows (e.g. the
-		// workspace-delete cascade on an otherwise idle env) instead of sitting forever.
+		// Keep the sweep chain alive across restarts/evictions: if the persisted alarm is
+		// missing or past-due (a past-due alarm can't be trusted to fire), re-arm it. Note this
+		// runs only once something instantiates the DO — the first poke() ever is what starts
+		// the chain; until then, outbox rows wait.
 		ctx.blockConcurrencyWhile(async () => {
 			const scheduled = await ctx.storage.getAlarm()
-			// A past-due persisted alarm can't be trusted to fire; re-arm it too.
 			if (scheduled === null || scheduled <= Date.now()) {
 				await ctx.storage.setAlarm(Date.now() + SWEEP_INTERVAL_MS)
 			}

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -1,0 +1,146 @@
+import { TlaEffectOutbox } from '@tldraw/dotcom-shared'
+import { createSentry } from '@tldraw/worker-shared'
+import { DurableObject } from 'cloudflare:workers'
+import { sql } from 'kysely'
+import { FileEffectDeps, processFileEffect } from './fileEffects'
+import { MAX_ATTEMPTS, drainOutbox } from './outboxDrain'
+import { createPostgresConnectionPool } from './postgres'
+import { Environment } from './types'
+import { getRoomDurableObject } from './utils/durableObjects'
+import { publishSnapshot, unpublishSnapshot } from './utils/publishSnapshots'
+
+const SWEEP_INTERVAL_MS = 30_000
+
+// Singleton DO that drains effect_outbox. Poked by the Zero push endpoint and
+// admin routes after file writes; the alarm sweep catches PG-trigger writes
+// (workspace-delete cascade) and lost pokes.
+export class TLFileEffectProcessor extends DurableObject<Environment> {
+	private drainPromise: Promise<void> | null = null
+	private sentry
+
+	constructor(ctx: DurableObjectState, env: Environment) {
+		super(ctx, env)
+		this.sentry = createSentry(ctx, env)
+	}
+
+	// same pattern as TLPostgresReplicator.ts:110-121
+	// eslint-disable-next-line tldraw/prefer-class-methods
+	private captureException = (exception: unknown, extras?: Record<string, unknown>) => {
+		// eslint-disable-next-line @typescript-eslint/no-deprecated
+		this.sentry?.withScope((scope) => {
+			if (extras) scope.setExtras(extras)
+			// eslint-disable-next-line @typescript-eslint/no-deprecated
+			this.sentry?.captureException(exception) as any
+		})
+		if (!this.sentry) {
+			console.error(`[TLFileEffectProcessor]: `, exception)
+		}
+	}
+
+	async poke() {
+		const scheduled = await this.ctx.storage.getAlarm()
+		const now = Date.now()
+		if (scheduled === null || scheduled > now) {
+			await this.ctx.storage.setAlarm(now)
+		}
+	}
+
+	async drainNow() {
+		await this.drain()
+	}
+
+	override async alarm() {
+		try {
+			await this.drain()
+		} catch (e) {
+			// row-level failures are handled inside the drain; this catches drain-level
+			// crashes like an unreachable database
+			this.captureException(e)
+		} finally {
+			await this.ctx.storage.setAlarm(Date.now() + SWEEP_INTERVAL_MS)
+		}
+	}
+
+	private drain() {
+		// Coalesce: one drain in flight; a poke during a drain lands on the next alarm.
+		if (!this.drainPromise) {
+			this.drainPromise = this._drain().finally(() => {
+				this.drainPromise = null
+			})
+		}
+		return this.drainPromise
+	}
+
+	private async _drain() {
+		const db = createPostgresConnectionPool(this.env, 'TLFileEffectProcessor')
+		const fileDeps: FileEffectDeps = {
+			getCurrentFile: (fileId) =>
+				db.selectFrom('file').selectAll().where('id', '=', fileId).executeTakeFirst(),
+			notifyInsert: (file) => getRoomDurableObject(this.env, file.id).appFileRecordCreated(file),
+			notifyUpdate: (file) => getRoomDurableObject(this.env, file.id).appFileRecordDidUpdate(file),
+			notifyDelete: (fileRow) =>
+				getRoomDurableObject(this.env, fileRow.id).appFileRecordDidDelete(fileRow),
+			publish: (file) => publishSnapshot(this.env, file),
+			unpublish: (file) => unpublishSnapshot(this.env, file),
+		}
+		// One handler per source table. Future effect sources (e.g. notifications)
+		// register here alongside their trigger.
+		const handlers: Record<string, (row: TlaEffectOutbox) => Promise<void>> = {
+			file: (row) => processFileEffect(fileDeps, row),
+		}
+		try {
+			await drainOutbox({
+				getBatch: () =>
+					db
+						.selectFrom('effect_outbox')
+						.selectAll()
+						.where('attempts', '<', MAX_ATTEMPTS)
+						.orderBy('id')
+						.limit(50)
+						.execute(),
+				deleteRow: async (id) => {
+					await db.deleteFrom('effect_outbox').where('id', '=', id).execute()
+				},
+				bumpAttempts: async (id) => {
+					await db
+						.updateTable('effect_outbox')
+						.set((eb) => ({ attempts: eb('attempts', '+', 1) }))
+						.where('id', '=', id)
+						.execute()
+				},
+				deleteParkedRowsOlderThan: async (days) => {
+					await db
+						.deleteFrom('effect_outbox')
+						.where('attempts', '>=', MAX_ATTEMPTS)
+						.where('createdAt', '<', sql<Date>`now() - (${days} || ' days')::interval`)
+						.execute()
+				},
+				process: async (row) => {
+					const handler = handlers[row.tableName]
+					if (!handler) {
+						// trigger + handler ship together; this only catches mistakes
+						this.captureException(new Error('effect_outbox row for unhandled table, dropping'), {
+							tableName: row.tableName,
+							outboxId: row.id,
+						})
+						return
+					}
+					await handler(row)
+				},
+				onError: (error, row) => {
+					// only report at the parking threshold to avoid a Sentry event per retry
+					if (row.attempts + 1 >= MAX_ATTEMPTS) {
+						this.captureException(error, {
+							tableName: row.tableName,
+							entityId: row.entityId,
+							command: row.command,
+							outboxId: row.id,
+						})
+					}
+				},
+			})
+		} finally {
+			await db.destroy()
+		}
+	}
+}

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -3,7 +3,7 @@ import { createSentry } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
 import { sql } from 'kysely'
 import { FileEffectDeps, processFileEffect } from './fileEffects'
-import { MAX_ATTEMPTS, drainOutbox } from './outboxDrain'
+import { EFFECT_TIMEOUT_MS, MAX_ATTEMPTS, computeNextAlarm, drainOutbox } from './outboxDrain'
 import { createPostgresConnectionPool } from './postgres'
 import { Environment } from './types'
 import { getRoomDurableObject } from './utils/durableObjects'
@@ -77,16 +77,13 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 			// crashes like an unreachable database
 			this.captureException(e)
 		} finally {
-			// Don't clobber a sooner FUTURE alarm: a poke that arrived mid-drain set an immediate
-			// alarm, and unconditionally pushing it to now+30s would swallow that poke. But a
-			// PAST-due alarm can't be trusted to fire (stale persisted state, see poke()) — treat
-			// it as absent so the sweep chain can never starve.
-			const now = Date.now()
-			const nextSweep = now + SWEEP_INTERVAL_MS
+			// Re-arm the sweep without swallowing a mid-drain poke. A poke that arrived during the
+			// drain set alarm(now) and is past-due by the time we get here; computeNextAlarm honors
+			// it with a ~1s delay rather than pushing it out to the next full sweep, while still
+			// never trusting a past-due alarm to fire on its own. null => leave it as-is.
 			const scheduled = await this.ctx.storage.getAlarm()
-			if (scheduled === null || scheduled <= now || scheduled > nextSweep) {
-				await this.ctx.storage.setAlarm(nextSweep)
-			}
+			const next = computeNextAlarm(scheduled, Date.now(), SWEEP_INTERVAL_MS)
+			if (next !== null) await this.ctx.storage.setAlarm(next)
 		}
 	}
 
@@ -136,19 +133,34 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 				deleteRow: async (id) => {
 					await db.deleteFrom('effect_outbox').where('id', '=', id).execute()
 				},
-				bumpAttempts: async (id, attempts) => {
+				bumpAttempts: async (row) => {
 					// Exponential backoff from the row's current attempt count, capped at 5 minutes.
-					// The 30s base keeps the first retry at or after the effect timeout, so a
-					// timed-out RPC (which keeps running — it can't be cancelled) usually finishes
-					// before its retry starts instead of overlapping it.
-					const backoffSeconds = Math.min(2 ** attempts * 30, 300)
+					// The base IS the effect timeout, so the first retry can't land before a
+					// timed-out RPC's window closes (the RPC keeps running — it can't be cancelled),
+					// avoiding an overlapping retry.
+					const backoffSeconds = Math.min(2 ** row.attempts * (EFFECT_TIMEOUT_MS / 1000), 300)
+					const backoff = sql<Date>`now() + (${backoffSeconds} || ' seconds')::interval`
+					// (a) Back off the failed row itself and bump its attempt count.
 					await db
 						.updateTable('effect_outbox')
 						.set((eb) => ({
 							attempts: eb('attempts', '+', 1),
-							nextRetryAt: sql<Date>`now() + (${backoffSeconds} || ' seconds')::interval`,
+							nextRetryAt: backoff,
 						}))
-						.where('id', '=', id)
+						.where('id', '=', row.id)
+						.execute()
+					// (b) Defer the failed row's later same-entity siblings so per-entity ordering
+					// holds across drains: they must not run while this row is backing off. Do NOT
+					// touch their attempts (they haven't been tried), and never shrink an existing
+					// later nextRetryAt (GREATEST keeps the furthest-out schedule).
+					await db
+						.updateTable('effect_outbox')
+						.set({
+							nextRetryAt: sql<Date>`GREATEST("nextRetryAt", ${backoff})`,
+						})
+						.where('tableName', '=', row.tableName)
+						.where('entityId', '=', row.entityId)
+						.where('id', '>', row.id)
 						.execute()
 				},
 				deleteParkedRowsOlderThan: async (days) => {

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -137,9 +137,11 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 					await db.deleteFrom('effect_outbox').where('id', '=', id).execute()
 				},
 				bumpAttempts: async (id, attempts) => {
-					// Exponential backoff from the row's current attempt count, capped at 5 minutes,
-					// so rapid pokes can't burn through all attempts in a burst.
-					const backoffSeconds = Math.min(2 ** attempts * 5, 300)
+					// Exponential backoff from the row's current attempt count, capped at 5 minutes.
+					// The 30s base keeps the first retry at or after the effect timeout, so a
+					// timed-out RPC (which keeps running — it can't be cancelled) usually finishes
+					// before its retry starts instead of overlapping it.
+					const backoffSeconds = Math.min(2 ** attempts * 30, 300)
 					await db
 						.updateTable('effect_outbox')
 						.set((eb) => ({

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -24,7 +24,9 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 		// Bootstrap the sweep so a never-poked DO still drains trigger-only rows (e.g. the
 		// workspace-delete cascade on an otherwise idle env) instead of sitting forever.
 		ctx.blockConcurrencyWhile(async () => {
-			if ((await ctx.storage.getAlarm()) === null) {
+			const scheduled = await ctx.storage.getAlarm()
+			// A past-due persisted alarm may never fire (see poke()); re-arm it too.
+			if (scheduled === null || scheduled <= Date.now()) {
 				await ctx.storage.setAlarm(Date.now() + SWEEP_INTERVAL_MS)
 			}
 		})
@@ -45,11 +47,11 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	}
 
 	async poke() {
-		const scheduled = await this.ctx.storage.getAlarm()
-		const now = Date.now()
-		if (scheduled === null || scheduled > now) {
-			await this.ctx.storage.setAlarm(now)
-		}
+		// Always (re)arm. Skipping when an alarm is already due (scheduled <= now) assumes the
+		// runtime will fire it momentarily — but a stale past-due alarm the runtime dropped
+		// (observed in local dev after restarts) then starves the queue forever, with every
+		// poke no-oping against it. Re-setting an imminent alarm is a harmless storage write.
+		await this.ctx.storage.setAlarm(Date.now())
 	}
 
 	async drainNow() {
@@ -75,12 +77,14 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 			// crashes like an unreachable database
 			this.captureException(e)
 		} finally {
-			// Don't clobber a sooner alarm: a poke that arrived mid-drain set an immediate alarm,
-			// and unconditionally pushing it to now+30s would swallow that poke. Only schedule the
-			// next sweep if nothing sooner is already pending.
-			const nextSweep = Date.now() + SWEEP_INTERVAL_MS
+			// Don't clobber a sooner FUTURE alarm: a poke that arrived mid-drain set an immediate
+			// alarm, and unconditionally pushing it to now+30s would swallow that poke. But a
+			// PAST-due alarm can't be trusted to fire (stale persisted state, see poke()) — treat
+			// it as absent so the sweep chain can never starve.
+			const now = Date.now()
+			const nextSweep = now + SWEEP_INTERVAL_MS
 			const scheduled = await this.ctx.storage.getAlarm()
-			if (scheduled === null || scheduled > nextSweep) {
+			if (scheduled === null || scheduled <= now || scheduled > nextSweep) {
 				await this.ctx.storage.setAlarm(nextSweep)
 			}
 		}

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -25,14 +25,13 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 		// workspace-delete cascade on an otherwise idle env) instead of sitting forever.
 		ctx.blockConcurrencyWhile(async () => {
 			const scheduled = await ctx.storage.getAlarm()
-			// A past-due persisted alarm may never fire (see poke()); re-arm it too.
+			// A past-due persisted alarm can't be trusted to fire; re-arm it too.
 			if (scheduled === null || scheduled <= Date.now()) {
 				await ctx.storage.setAlarm(Date.now() + SWEEP_INTERVAL_MS)
 			}
 		})
 	}
 
-	// same pattern as TLPostgresReplicator.ts:110-121
 	// eslint-disable-next-line tldraw/prefer-class-methods
 	private captureException = (exception: unknown, extras?: Record<string, unknown>) => {
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
@@ -47,10 +46,9 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	}
 
 	async poke() {
-		// Always (re)arm. Skipping when an alarm is already due (scheduled <= now) assumes the
-		// runtime will fire it momentarily — but a stale past-due alarm the runtime dropped
-		// (observed in local dev after restarts) then starves the queue forever, with every
-		// poke no-oping against it. Re-setting an imminent alarm is a harmless storage write.
+		// Always (re)arm: a past-due persisted alarm can't be trusted to fire (the runtime can
+		// drop one, e.g. across restarts), and re-setting an imminent alarm is a harmless
+		// storage write.
 		await this.ctx.storage.setAlarm(Date.now())
 	}
 
@@ -62,10 +60,9 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 			// crashes like an unreachable database
 			this.captureException(e)
 		} finally {
-			// Re-arm the sweep without swallowing a mid-drain poke. A poke that arrived during the
-			// drain set alarm(now) and is past-due by the time we get here; computeNextAlarm honors
-			// it with a ~1s delay rather than pushing it out to the next full sweep, while still
-			// never trusting a past-due alarm to fire on its own. null => leave it as-is.
+			// Re-arm the sweep without swallowing a mid-drain poke: a poke that arrived during
+			// the drain set alarm(now), which is past-due by now; computeNextAlarm re-arms it at
+			// ~1s (a past-due alarm can't be trusted to fire on its own). null => leave as-is.
 			const scheduled = await this.ctx.storage.getAlarm()
 			const next = computeNextAlarm(scheduled, Date.now(), SWEEP_INTERVAL_MS)
 			if (next !== null) await this.ctx.storage.setAlarm(next)
@@ -73,7 +70,8 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	}
 
 	private drain() {
-		// Coalesce: one drain in flight; a poke during a drain lands on the next alarm.
+		// Coalesce: one drain in flight; a poke during a drain lands on the ~1s follow-up alarm
+		// computeNextAlarm arms after this drain finishes.
 		if (!this.drainPromise) {
 			const promise = this._drain().finally(() => {
 				// Identity guard: only clear the latch if it's still ours.

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -5,7 +5,8 @@ import { sql } from 'kysely'
 import { FileEffectDeps, processFileEffect } from './fileEffects'
 import { EFFECT_TIMEOUT_MS, MAX_ATTEMPTS, computeNextAlarm, drainOutbox } from './outboxDrain'
 import { createPostgresConnectionPool } from './postgres'
-import { Environment } from './types'
+import { Analytics, Environment } from './types'
+import { EventData, writeDataPoint } from './utils/analytics'
 import { getRoomDurableObject } from './utils/durableObjects'
 import { publishSnapshot, unpublishSnapshot } from './utils/publishSnapshots'
 
@@ -17,10 +18,12 @@ const SWEEP_INTERVAL_MS = 30_000
 export class TLFileEffectProcessor extends DurableObject<Environment> {
 	private drainPromise: Promise<void> | null = null
 	private sentry
+	private measure: Analytics | undefined
 
 	constructor(ctx: DurableObjectState, env: Environment) {
 		super(ctx, env)
 		this.sentry = createSentry(ctx, env)
+		this.measure = env.MEASURE
 		// Keep the sweep chain alive across restarts/evictions: if the persisted alarm is
 		// missing or past-due (a past-due alarm can't be trusted to fire), re-arm it. Note this
 		// runs only once something instantiates the DO — the first poke() ever is what starts
@@ -44,6 +47,11 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 		if (!this.sentry) {
 			console.error(`[TLFileEffectProcessor]: `, exception)
 		}
+	}
+
+	// eslint-disable-next-line tldraw/prefer-class-methods
+	private writeEvent = (name: string, eventData: EventData) => {
+		writeDataPoint(this.sentry, this.measure, this.env, name, eventData)
 	}
 
 	async poke() {
@@ -84,6 +92,9 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	}
 
 	private async _drain() {
+		const drainStart = Date.now()
+		let processed = 0
+		let failed = 0
 		const db = createPostgresConnectionPool(this.env, 'TLFileEffectProcessor')
 		const fileDeps: FileEffectDeps = {
 			getCurrentFile: (fileId) =>
@@ -115,8 +126,10 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 						.execute(),
 				deleteRow: async (id) => {
 					await db.deleteFrom('effect_outbox').where('id', '=', id).execute()
+					processed++
 				},
 				bumpAttempts: async (row) => {
+					failed++
 					// Exponential backoff from the row's current attempt count, capped at 5 minutes.
 					// The base IS the effect timeout, so the first retry can't land before a
 					// timed-out RPC's window closes (the RPC keeps running — it can't be cancelled),
@@ -164,10 +177,18 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 						return
 					}
 					await handler(row)
+					// End-to-end effect latency: time from the row landing in the outbox (its
+					// transaction commit) to the effect completing. This is the user-facing number —
+					// how long after a file change the room notification / publish actually lands.
+					this.writeEvent('outbox_effect', {
+						blobs: [row.tableName, row.command],
+						doubles: [Date.now() - new Date(row.createdAt).getTime()],
+					})
 				},
 				onError: (error, row) => {
 					// only report at the parking threshold to avoid a Sentry event per retry
 					if (row.attempts + 1 >= MAX_ATTEMPTS) {
+						this.writeEvent('outbox_parked', { blobs: [row.tableName, row.command] })
 						this.captureException(error, {
 							tableName: row.tableName,
 							entityId: row.entityId,
@@ -179,6 +200,10 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 			})
 		} finally {
 			await db.destroy()
+			// Per-drain summary: throughput (processed/failed) and how long the drain took.
+			// Drains coalesce, so this is low-volume; the sweep also emits an empty summary every
+			// ~30s, which doubles as a liveness heartbeat for the processor.
+			this.writeEvent('outbox_drain', { doubles: [processed, failed, Date.now() - drainStart] })
 		}
 	}
 }

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -21,6 +21,13 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	constructor(ctx: DurableObjectState, env: Environment) {
 		super(ctx, env)
 		this.sentry = createSentry(ctx, env)
+		// Bootstrap the sweep so a never-poked DO still drains trigger-only rows (e.g. the
+		// workspace-delete cascade on an otherwise idle env) instead of sitting forever.
+		ctx.blockConcurrencyWhile(async () => {
+			if ((await ctx.storage.getAlarm()) === null) {
+				await ctx.storage.setAlarm(Date.now() + SWEEP_INTERVAL_MS)
+			}
+		})
 	}
 
 	// same pattern as TLPostgresReplicator.ts:110-121
@@ -68,7 +75,14 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 			// crashes like an unreachable database
 			this.captureException(e)
 		} finally {
-			await this.ctx.storage.setAlarm(Date.now() + SWEEP_INTERVAL_MS)
+			// Don't clobber a sooner alarm: a poke that arrived mid-drain set an immediate alarm,
+			// and unconditionally pushing it to now+30s would swallow that poke. Only schedule the
+			// next sweep if nothing sooner is already pending.
+			const nextSweep = Date.now() + SWEEP_INTERVAL_MS
+			const scheduled = await this.ctx.storage.getAlarm()
+			if (scheduled === null || scheduled > nextSweep) {
+				await this.ctx.storage.setAlarm(nextSweep)
+			}
 		}
 	}
 
@@ -109,16 +123,25 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 						.selectFrom('effect_outbox')
 						.selectAll()
 						.where('attempts', '<', MAX_ATTEMPTS)
+						.where((eb) =>
+							eb.or([eb('nextRetryAt', 'is', null), eb('nextRetryAt', '<=', sql<Date>`now()`)])
+						)
 						.orderBy('id')
 						.limit(50)
 						.execute(),
 				deleteRow: async (id) => {
 					await db.deleteFrom('effect_outbox').where('id', '=', id).execute()
 				},
-				bumpAttempts: async (id) => {
+				bumpAttempts: async (id, attempts) => {
+					// Exponential backoff from the row's current attempt count, capped at 5 minutes,
+					// so rapid pokes can't burn through all attempts in a burst.
+					const backoffSeconds = Math.min(2 ** attempts * 5, 300)
 					await db
 						.updateTable('effect_outbox')
-						.set((eb) => ({ attempts: eb('attempts', '+', 1) }))
+						.set((eb) => ({
+							attempts: eb('attempts', '+', 1),
+							nextRetryAt: sql<Date>`now() + (${backoffSeconds} || ' seconds')::interval`,
+						}))
 						.where('id', '=', id)
 						.execute()
 				},

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -54,21 +54,6 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 		await this.ctx.storage.setAlarm(Date.now())
 	}
 
-	async drainNow() {
-		// A drain already in flight may have fetched its batch before rows this call needs to see
-		// were committed, so wait for it, then always run one more drain for read-your-writes
-		// semantics. Can't just call drain() afterwards: if its `finally` hasn't cleared
-		// drainPromise yet by the time we resume, drain() would coalesce into the very promise we
-		// just awaited instead of starting a fresh one. Start the new cycle unconditionally and
-		// only ever clear the latch if it's still pointing at this call's own promise.
-		if (this.drainPromise) await this.drainPromise
-		const promise = this._drain().finally(() => {
-			if (this.drainPromise === promise) this.drainPromise = null
-		})
-		this.drainPromise = promise
-		await promise
-	}
-
 	override async alarm() {
 		try {
 			await this.drain()
@@ -91,8 +76,7 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 		// Coalesce: one drain in flight; a poke during a drain lands on the next alarm.
 		if (!this.drainPromise) {
 			const promise = this._drain().finally(() => {
-				// Same identity guard as drainNow(): only clear the latch if it's still ours, so
-				// this doesn't clobber a newer drainPromise set by an interleaved drainNow() call.
+				// Identity guard: only clear the latch if it's still ours.
 				if (this.drainPromise === promise) this.drainPromise = null
 			})
 			this.drainPromise = promise

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -46,7 +46,18 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	}
 
 	async drainNow() {
-		await this.drain()
+		// A drain already in flight may have fetched its batch before rows this call needs to see
+		// were committed, so wait for it, then always run one more drain for read-your-writes
+		// semantics. Can't just call drain() afterwards: if its `finally` hasn't cleared
+		// drainPromise yet by the time we resume, drain() would coalesce into the very promise we
+		// just awaited instead of starting a fresh one. Start the new cycle unconditionally and
+		// only ever clear the latch if it's still pointing at this call's own promise.
+		if (this.drainPromise) await this.drainPromise
+		const promise = this._drain().finally(() => {
+			if (this.drainPromise === promise) this.drainPromise = null
+		})
+		this.drainPromise = promise
+		await promise
 	}
 
 	override async alarm() {

--- a/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
+++ b/apps/dotcom/sync-worker/src/TLFileEffectProcessor.ts
@@ -75,9 +75,12 @@ export class TLFileEffectProcessor extends DurableObject<Environment> {
 	private drain() {
 		// Coalesce: one drain in flight; a poke during a drain lands on the next alarm.
 		if (!this.drainPromise) {
-			this.drainPromise = this._drain().finally(() => {
-				this.drainPromise = null
+			const promise = this._drain().finally(() => {
+				// Same identity guard as drainNow(): only clear the latch if it's still ours, so
+				// this doesn't clobber a newer drainPromise set by an interleaved drainNow() call.
+				if (this.drainPromise === promise) this.drainPromise = null
 			})
+			this.drainPromise = promise
 		}
 		return this.drainPromise
 	}

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -60,9 +60,10 @@ export const adminRoutes = createRouter<Environment>()
 				.where('group_user.userId', '=', userRow.id)
 				.select(['group.id', 'group.name', 'group.isDeleted', 'group_user.role'])
 				.execute()
-			const fileRows = await db
+			const files = await db
 				.selectFrom('file')
 				.leftJoin('group_file', 'group_file.fileId', 'file.id')
+				.where('file.isDeleted', '=', false)
 				.where((eb) =>
 					eb.or([
 						eb('file.ownerId', '=', userRow.id),
@@ -73,12 +74,14 @@ export const adminRoutes = createRouter<Environment>()
 						),
 					])
 				)
+				// distinctOn dedupes before the limit is applied, so a file matching both the owner
+				// clause and multiple group memberships (join fanout) still only counts once against
+				// the 500 cap.
+				.distinctOn('file.id')
+				.orderBy('file.id')
 				.selectAll('file')
 				.limit(500)
 				.execute()
-			// The left join over group_file can duplicate a file row (owner match + membership in
-			// multiple groups); dedupe by id.
-			const files = [...new Map(fileRows.map((f) => [f.id, f])).values()]
 			return json({ user: userRow, memberships, files })
 		} finally {
 			await db.destroy()
@@ -587,7 +590,9 @@ async function hardDeleteAppFile({
 		// do soft delete first if not done already; the outbox trigger records it
 		await pg.updateTable('file').set('isDeleted', true).where('id', '=', file.id).execute()
 	}
-	// drain the outbox so the room DO closes sessions and cleans R2 before the row vanishes
+	// Drain the outbox so the soft-delete row's effects (session kicks) land before the row is
+	// hard deleted below. R2/room cleanup rides the delete-row effect produced by the DELETE
+	// FROM file below, delivered via the post-delete poke() at the end of this function.
 	await getFileEffectProcessor(env).drainNow()
 	// clean up assets eagerly
 	const assets = await pg.selectFrom('asset').where('fileId', '=', file.id).selectAll().execute()

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -13,6 +13,7 @@ import { createRouter } from '@tldraw/worker-shared'
 import { StatusError, json } from 'itty-router'
 import PQueue from 'p-queue'
 import { getUploadObjectName } from './assetAssociation'
+import { MAX_ATTEMPTS } from './outboxDrain'
 import { createPostgresConnectionPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
 import { getFileSnapshot, returnFileSnapshot } from './routes/tla/getFileSnapshot'
@@ -59,7 +60,7 @@ export const adminRoutes = createRouter<Environment>()
 				.where('group_user.userId', '=', userRow.id)
 				.select(['group.id', 'group.name', 'group.isDeleted', 'group_user.role'])
 				.execute()
-			const files = await db
+			const fileRows = await db
 				.selectFrom('file')
 				.leftJoin('group_file', 'group_file.fileId', 'file.id')
 				.where((eb) =>
@@ -75,6 +76,9 @@ export const adminRoutes = createRouter<Environment>()
 				.selectAll('file')
 				.limit(500)
 				.execute()
+			// The left join over group_file can duplicate a file row (owner match + membership in
+			// multiple groups); dedupe by id.
+			const files = [...new Map(fileRows.map((f) => [f.id, f])).values()]
 			return json({ user: userRow, memberships, files })
 		} finally {
 			await db.destroy()
@@ -86,9 +90,9 @@ export const adminRoutes = createRouter<Environment>()
 			const stats = await db
 				.selectFrom('effect_outbox')
 				.select((eb) => [
-					eb.fn.countAll<number>().filterWhere('attempts', '<', 10).as('pending'),
-					eb.fn.countAll<number>().filterWhere('attempts', '>=', 10).as('parked'),
-					eb.fn.min('createdAt').filterWhere('attempts', '<', 10).as('oldestPending'),
+					eb.fn.countAll<number>().filterWhere('attempts', '<', MAX_ATTEMPTS).as('pending'),
+					eb.fn.countAll<number>().filterWhere('attempts', '>=', MAX_ATTEMPTS).as('parked'),
+					eb.fn.min('createdAt').filterWhere('attempts', '<', MAX_ATTEMPTS).as('oldestPending'),
 				])
 				.executeTakeFirstOrThrow()
 			return json({
@@ -170,6 +174,9 @@ export const adminRoutes = createRouter<Environment>()
 				status: 409,
 			})
 		}
+		// Nudge the outbox so the restore's effects (room DO reopen, etc.) land promptly instead
+		// of waiting for the 30s alarm sweep. poke() is cheap: it just schedules an alarm.
+		await getFileEffectProcessor(env).poke()
 		// Hard-reboot every affected user so the restored rows replicate to their session (the
 		// isDeleted false-flip case flagged in dotcom-shared mutators.ts). Best-effort: the
 		// writes already committed, so a reboot failure must not surface as a 500 (a retry would
@@ -603,6 +610,9 @@ async function hardDeleteAppFile({
 	}
 	// hard delete file (this will trigger a cascade delete of all remaining related records & R2 objects)
 	await pg.deleteFrom('file').where('id', '=', file.id).execute()
+	// Nudge the outbox so the delete's effects land promptly instead of waiting for the 30s
+	// alarm sweep. poke() is cheap: it just schedules an alarm.
+	await getFileEffectProcessor(env).poke()
 	return new Response('Deleted', { status: 200 })
 }
 

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -18,7 +18,11 @@ import { getR2KeyForRoom } from './r2'
 import { getFileSnapshot, returnFileSnapshot } from './routes/tla/getFileSnapshot'
 import { type Environment } from './types'
 import { undeleteFile } from './undeleteFile'
-import { getReplicator, getRoomDurableObject, getUserDurableObject } from './utils/durableObjects'
+import {
+	getFileEffectProcessor,
+	getRoomDurableObject,
+	getUserDurableObject,
+} from './utils/durableObjects'
 import { FEATURE_FLAG_KEYS, getFeatureFlagsAdmin, setFeatureFlag } from './utils/featureFlags'
 import { getClerkClient, requireAdminAccess, requireAuth } from './utils/tla/getAuth'
 
@@ -47,24 +51,58 @@ export const adminRoutes = createRouter<Environment>()
 			return new Response('Missing query param', { status: 400 })
 		}
 		const userRow = await requireUser(env, q)
-
-		const user = getUserDurableObject(env, userRow.id)
-		return json(await user.admin_getData(userRow.id))
-	})
-	.get('/app/admin/replicator', async (res, env) => {
-		const replicator = getReplicator(env)
-		const diagnostics = await replicator.getDiagnostics()
-		return json(diagnostics)
-	})
-	.post('/app/admin/user/reboot', async (res, env) => {
-		const q = res.query['q']
-		if (typeof q !== 'string') {
-			return new Response('Missing query param', { status: 400 })
+		const db = createPostgresConnectionPool(env, '/app/admin/user')
+		try {
+			const memberships = await db
+				.selectFrom('group_user')
+				.innerJoin('group', 'group.id', 'group_user.groupId')
+				.where('group_user.userId', '=', userRow.id)
+				.select(['group.id', 'group.name', 'group.isDeleted', 'group_user.role'])
+				.execute()
+			const files = await db
+				.selectFrom('file')
+				.leftJoin('group_file', 'group_file.fileId', 'file.id')
+				.where((eb) =>
+					eb.or([
+						eb('file.ownerId', '=', userRow.id),
+						eb(
+							'group_file.groupId',
+							'in',
+							memberships.length ? memberships.map((m) => m.id) : ['']
+						),
+					])
+				)
+				.selectAll('file')
+				.limit(500)
+				.execute()
+			return json({ user: userRow, memberships, files })
+		} finally {
+			await db.destroy()
 		}
-		const userRow = await requireUser(env, q)
-		const user = getUserDurableObject(env, userRow.id)
-		await user.admin_forceHardReboot(userRow.id)
-		return new Response('Rebooted', { status: 200 })
+	})
+	.get('/app/admin/outbox', async (res, env) => {
+		const db = createPostgresConnectionPool(env, '/app/admin/outbox')
+		try {
+			const stats = await db
+				.selectFrom('effect_outbox')
+				.select((eb) => [
+					eb.fn.countAll<number>().filterWhere('attempts', '<', 10).as('pending'),
+					eb.fn.countAll<number>().filterWhere('attempts', '>=', 10).as('parked'),
+					eb.fn.min('createdAt').filterWhere('attempts', '<', 10).as('oldestPending'),
+				])
+				.executeTakeFirstOrThrow()
+			return json({
+				outbox: {
+					pending: Number(stats.pending),
+					parked: Number(stats.parked),
+					oldestPendingAgeSeconds: stats.oldestPending
+						? Math.round((Date.now() - new Date(stats.oldestPending).getTime()) / 1000)
+						: null,
+				},
+			})
+		} finally {
+			await db.destroy()
+		}
 	})
 	.get('/app/admin/feature-flags', getFeatureFlagsAdmin)
 	.post('/app/admin/feature-flags', async (req, env) => {
@@ -539,12 +577,11 @@ async function hardDeleteAppFile({
 	file: TlaFile
 }) {
 	if (!file.isDeleted) {
-		// do soft delete first if not done already
+		// do soft delete first if not done already; the outbox trigger records it
 		await pg.updateTable('file').set('isDeleted', true).where('id', '=', file.id).execute()
-		// allow a little time for the delete to propagate
-		// don't think this is really needed, but just in case
-		await sleep(1000)
 	}
+	// drain the outbox so the room DO closes sessions and cleans R2 before the row vanishes
+	await getFileEffectProcessor(env).drainNow()
 	// clean up assets eagerly
 	const assets = await pg.selectFrom('asset').where('fileId', '=', file.id).selectAll().execute()
 	for (const asset of assets) {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -594,20 +594,12 @@ async function hardDeleteAppFile({
 		// do soft delete first if not done already; the outbox trigger records it
 		await pg.updateTable('file').set('isDeleted', true).where('id', '=', file.id).execute()
 	}
-	// Drain the outbox so the soft-delete row's effects (session kicks) land before the row is
-	// hard deleted below. R2/room cleanup rides the delete-row effect produced by the DELETE
-	// FROM file below, delivered via the post-delete poke() at the end of this function.
-	// Bounded: drainNow() drains the WHOLE outbox, so under a backlog it can hang for minutes.
-	// Race it against a ~10s cap and proceed either way. This is safe because the post-DELETE
-	// outbox row re-runs the full cleanup (appFileRecordDidDelete) via poke/sweep within ~30s;
-	// the inline drain is only a best-effort kick of sessions before the row disappears, not a
-	// correctness requirement.
-	await Promise.race([
-		getFileEffectProcessor(env)
-			.drainNow()
-			.catch(() => {}),
-		sleep(10_000),
-	])
+	// No inline drain here: the DELETE FROM file below writes a terminal delete-row effect that
+	// kicks sessions and cleans up R2/room state via the post-delete poke() (sweep backstop
+	// ~30s), and the soft-delete row's effect is staleness-guarded so it skips harmlessly if it
+	// runs after the row is gone. Draining inline would also run once per file when
+	// performUserDeletion loops over a user's files, stacking whole-outbox drains on the
+	// singleton processor.
 	// clean up assets eagerly
 	const assets = await pg.selectFrom('asset').where('fileId', '=', file.id).selectAll().execute()
 	for (const asset of assets) {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -179,7 +179,11 @@ export const adminRoutes = createRouter<Environment>()
 		}
 		// Nudge the outbox so the restore's effects (room DO reopen, etc.) land promptly instead
 		// of waiting for the 30s alarm sweep. poke() is cheap: it just schedules an alarm.
-		await getFileEffectProcessor(env).poke()
+		// Best-effort nudge: the sweep backstops it, so a poke failure must not fail the request
+		// (the restore already committed; a retry would just 400 with 'File is not deleted').
+		await getFileEffectProcessor(env)
+			.poke()
+			.catch(() => {})
 		// Hard-reboot every affected user so the restored rows replicate to their session (the
 		// isDeleted false-flip case flagged in dotcom-shared mutators.ts). Best-effort: the
 		// writes already committed, so a reboot failure must not surface as a 500 (a retry would
@@ -593,7 +597,17 @@ async function hardDeleteAppFile({
 	// Drain the outbox so the soft-delete row's effects (session kicks) land before the row is
 	// hard deleted below. R2/room cleanup rides the delete-row effect produced by the DELETE
 	// FROM file below, delivered via the post-delete poke() at the end of this function.
-	await getFileEffectProcessor(env).drainNow()
+	// Bounded: drainNow() drains the WHOLE outbox, so under a backlog it can hang for minutes.
+	// Race it against a ~10s cap and proceed either way. This is safe because the post-DELETE
+	// outbox row re-runs the full cleanup (appFileRecordDidDelete) via poke/sweep within ~30s;
+	// the inline drain is only a best-effort kick of sessions before the row disappears, not a
+	// correctness requirement.
+	await Promise.race([
+		getFileEffectProcessor(env)
+			.drainNow()
+			.catch(() => {}),
+		sleep(10_000),
+	])
 	// clean up assets eagerly
 	const assets = await pg.selectFrom('asset').where('fileId', '=', file.id).selectAll().execute()
 	for (const asset of assets) {
@@ -616,8 +630,11 @@ async function hardDeleteAppFile({
 	// hard delete file (this will trigger a cascade delete of all remaining related records & R2 objects)
 	await pg.deleteFrom('file').where('id', '=', file.id).execute()
 	// Nudge the outbox so the delete's effects land promptly instead of waiting for the 30s
-	// alarm sweep. poke() is cheap: it just schedules an alarm.
-	await getFileEffectProcessor(env).poke()
+	// alarm sweep. poke() is cheap: it just schedules an alarm. Best-effort nudge: the sweep
+	// backstops it, so a poke failure must not fail the request after the delete committed.
+	await getFileEffectProcessor(env)
+		.poke()
+		.catch(() => {})
 	return new Response('Deleted', { status: 200 })
 }
 

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -177,10 +177,9 @@ export const adminRoutes = createRouter<Environment>()
 				status: 409,
 			})
 		}
-		// Nudge the outbox so the restore's effects (room DO reopen, etc.) land promptly instead
-		// of waiting for the 30s alarm sweep. poke() is cheap: it just schedules an alarm.
-		// Best-effort nudge: the sweep backstops it, so a poke failure must not fail the request
-		// (the restore already committed; a retry would just 400 with 'File is not deleted').
+		// Best-effort nudge so the restore's effects land promptly; the sweep backstops it, so a
+		// poke failure must not fail the request (the restore already committed; a retry would
+		// just 400 with 'File is not deleted').
 		await getFileEffectProcessor(env)
 			.poke()
 			.catch(() => {})
@@ -594,12 +593,10 @@ async function hardDeleteAppFile({
 		// do soft delete first if not done already; the outbox trigger records it
 		await pg.updateTable('file').set('isDeleted', true).where('id', '=', file.id).execute()
 	}
-	// No inline drain here: the DELETE FROM file below writes a terminal delete-row effect that
-	// kicks sessions and cleans up R2/room state via the post-delete poke() (sweep backstop
-	// ~30s), and the soft-delete row's effect is staleness-guarded so it skips harmlessly if it
-	// runs after the row is gone. Draining inline would also run once per file when
-	// performUserDeletion loops over a user's files, stacking whole-outbox drains on the
-	// singleton processor.
+	// Session kicks and R2/room cleanup ride the terminal delete-row effect written by the
+	// DELETE FROM file below, delivered via the post-delete poke() (sweep backstop ~30s); the
+	// soft-delete row's effect is staleness-guarded, so it skips harmlessly if it runs after
+	// the row is gone.
 	// clean up assets eagerly
 	const assets = await pg.selectFrom('asset').where('fileId', '=', file.id).selectAll().execute()
 	for (const asset of assets) {

--- a/apps/dotcom/sync-worker/src/fileEffects.test.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.test.ts
@@ -1,6 +1,6 @@
-import { TlaFile } from '@tldraw/dotcom-shared'
+import { TlaEffectOutbox, TlaFile } from '@tldraw/dotcom-shared'
 import { describe, expect, it } from 'vitest'
-import { getPublishTransition } from './fileEffects'
+import { FileEffectDeps, getPublishTransition, processFileEffect } from './fileEffects'
 
 function file(partial: Partial<TlaFile>): TlaFile {
 	return {
@@ -91,5 +91,115 @@ describe('getPublishTransition', () => {
 				prevPayload: file({}),
 			})
 		).toBe(null)
+	})
+})
+
+function effectRow(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
+	return {
+		id: 1,
+		tableName: 'file',
+		entityId: 'f1',
+		command: 'update',
+		payload: file({}),
+		prevPayload: null,
+		attempts: 0,
+		createdAt: new Date(0),
+		...partial,
+	}
+}
+
+function makeFileDeps(current: Record<string, TlaFile | undefined>): FileEffectDeps & {
+	calls: string[]
+} {
+	const calls: string[] = []
+	return {
+		calls,
+		getCurrentFile: async (fileId) => current[fileId],
+		notifyInsert: async (f) => {
+			calls.push(`insert:${f.id}`)
+		},
+		notifyUpdate: async (f) => {
+			calls.push(`update:${f.id}`)
+		},
+		notifyDelete: async (f) => {
+			calls.push(`delete:${f.id}`)
+		},
+		publish: async (f) => {
+			calls.push(`publish:${f.id}`)
+		},
+		unpublish: async (f) => {
+			calls.push(`unpublish:${f.id}`)
+		},
+	}
+}
+
+describe('processFileEffect', () => {
+	it('skips insert/update effects when the file no longer exists (staleness guard)', async () => {
+		const deps = makeFileDeps({})
+		await processFileEffect(deps, effectRow({ command: 'insert' }))
+		await processFileEffect(deps, effectRow({ command: 'update' }))
+		expect(deps.calls).toEqual([])
+	})
+
+	it('delete command uses the outbox payload, not current state', async () => {
+		const deps = makeFileDeps({})
+		await processFileEffect(deps, effectRow({ command: 'delete', payload: file({ id: 'f1' }) }))
+		expect(deps.calls).toEqual(['delete:f1'])
+	})
+
+	it('notifies with the freshly-read row, not the outbox payload', async () => {
+		const current = file({ id: 'f1', name: 'newest' })
+		const deps = makeFileDeps({ f1: current })
+		await processFileEffect(
+			deps,
+			effectRow({
+				command: 'update',
+				payload: file({ id: 'f1', name: 'stale' }),
+				prevPayload: file({ id: 'f1' }),
+			})
+		)
+		expect(deps.calls).toEqual(['update:f1'])
+	})
+
+	it('publishes only when current state still matches the transition', async () => {
+		const published = file({ id: 'f1', published: true, lastPublished: 100 })
+		const deps = makeFileDeps({ f1: published })
+		await processFileEffect(
+			deps,
+			effectRow({
+				command: 'update',
+				payload: published,
+				prevPayload: file({ id: 'f1', published: false, lastPublished: 0 }),
+			})
+		)
+		expect(deps.calls).toEqual(['update:f1', 'publish:f1'])
+	})
+
+	it('skips a stale publish superseded by a newer publish (flapping collapses)', async () => {
+		const current = file({ id: 'f1', published: true, lastPublished: 500 })
+		const deps = makeFileDeps({ f1: current })
+		await processFileEffect(
+			deps,
+			effectRow({
+				command: 'update',
+				payload: file({ id: 'f1', published: true, lastPublished: 100 }),
+				prevPayload: file({ id: 'f1', published: false, lastPublished: 0 }),
+			})
+		)
+		expect(deps.calls).toEqual(['update:f1'])
+	})
+
+	it('skips a stale unpublish when the file is currently published', async () => {
+		const current = file({ id: 'f1', published: true, lastPublished: 500 })
+		const deps = makeFileDeps({ f1: current })
+		await processFileEffect(
+			deps,
+			effectRow({
+				command: 'update',
+				payload: file({ id: 'f1', published: false, lastPublished: 100 }),
+				prevPayload: file({ id: 'f1', published: true, lastPublished: 100 }),
+			})
+		)
+		expect(deps.calls).toEqual(['update:f1'])
 	})
 })

--- a/apps/dotcom/sync-worker/src/fileEffects.test.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.test.ts
@@ -104,6 +104,7 @@ function effectRow(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
 		prevPayload: null,
 		attempts: 0,
 		createdAt: new Date(0),
+		nextRetryAt: null,
 		...partial,
 	}
 }

--- a/apps/dotcom/sync-worker/src/fileEffects.test.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.test.ts
@@ -1,0 +1,95 @@
+import { TlaFile } from '@tldraw/dotcom-shared'
+import { describe, expect, it } from 'vitest'
+import { getPublishTransition } from './fileEffects'
+
+function file(partial: Partial<TlaFile>): TlaFile {
+	return {
+		id: 'f1',
+		name: 'file',
+		ownerId: 'u1',
+		ownerName: '',
+		ownerAvatar: '',
+		thumbnail: '',
+		shared: true,
+		sharedLinkType: 'edit',
+		published: false,
+		lastPublished: 0,
+		publishedSlug: 'slug-1',
+		createdAt: 0,
+		updatedAt: 0,
+		isEmpty: false,
+		isDeleted: false,
+		createSource: null,
+		owningGroupId: null,
+		...partial,
+	}
+}
+
+describe('getPublishTransition', () => {
+	it('returns null for inserts and deletes', () => {
+		expect(
+			getPublishTransition({
+				command: 'insert',
+				payload: file({ published: true }),
+				prevPayload: null,
+			})
+		).toBe(null)
+		expect(
+			getPublishTransition({
+				command: 'delete',
+				payload: file({ published: true }),
+				prevPayload: null,
+			})
+		).toBe(null)
+	})
+
+	it('returns publish when file becomes published', () => {
+		expect(
+			getPublishTransition({
+				command: 'update',
+				payload: file({ published: true, lastPublished: 100 }),
+				prevPayload: file({ published: false, lastPublished: 0 }),
+			})
+		).toBe('publish')
+	})
+
+	it('returns publish when file is republished with newer timestamp', () => {
+		expect(
+			getPublishTransition({
+				command: 'update',
+				payload: file({ published: true, lastPublished: 200 }),
+				prevPayload: file({ published: true, lastPublished: 100 }),
+			})
+		).toBe('publish')
+	})
+
+	it('returns null when file remains published with same timestamp', () => {
+		expect(
+			getPublishTransition({
+				command: 'update',
+				payload: file({ published: true, lastPublished: 100 }),
+				prevPayload: file({ published: true, lastPublished: 100 }),
+			})
+		).toBe(null)
+	})
+
+	it('returns unpublish when file becomes unpublished', () => {
+		expect(
+			getPublishTransition({
+				command: 'update',
+				payload: file({ published: false, lastPublished: 100 }),
+				prevPayload: file({ published: true, lastPublished: 100 }),
+			})
+		).toBe('unpublish')
+	})
+
+	it('returns null for a plain update with no publication change', () => {
+		expect(
+			getPublishTransition({
+				command: 'update',
+				payload: file({ name: 'renamed' }),
+				prevPayload: file({}),
+			})
+		).toBe(null)
+	})
+})

--- a/apps/dotcom/sync-worker/src/fileEffects.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.ts
@@ -32,6 +32,7 @@ export interface FileEffectDeps {
 }
 
 export async function processFileEffect(deps: FileEffectDeps, genericRow: TlaEffectOutbox) {
+	// Invariant: caller must route only tableName === 'file' rows here.
 	const row = genericRow as FileEffectRow
 	if (row.command === 'delete') {
 		// Terminal: appFileRecordDidDelete is self-guarded, no staleness check needed.

--- a/apps/dotcom/sync-worker/src/fileEffects.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.ts
@@ -21,3 +21,39 @@ export function getPublishTransition(
 	}
 	return null
 }
+
+export interface FileEffectDeps {
+	getCurrentFile(fileId: string): Promise<TlaFile | undefined>
+	notifyInsert(file: TlaFile): Promise<void> // room DO appFileRecordCreated
+	notifyUpdate(file: TlaFile): Promise<void> // room DO appFileRecordDidUpdate (fresh row)
+	notifyDelete(fileRow: TlaFile): Promise<void> // room DO appFileRecordDidDelete (outbox payload)
+	publish(file: TlaFile): Promise<void>
+	unpublish(file: TlaFile): Promise<void>
+}
+
+export async function processFileEffect(deps: FileEffectDeps, genericRow: TlaEffectOutbox) {
+	const row = genericRow as FileEffectRow
+	if (row.command === 'delete') {
+		// Terminal: appFileRecordDidDelete is self-guarded, no staleness check needed.
+		await deps.notifyDelete(row.payload)
+		return
+	}
+	// Staleness guard: act on present truth, treat the row as a wake-up signal.
+	const current = await deps.getCurrentFile(row.entityId)
+	if (!current) return // hard-deleted since; a delete row follows or already ran
+	if (row.command === 'insert') {
+		await deps.notifyInsert(current)
+		return
+	}
+	await deps.notifyUpdate(current)
+	const transition = getPublishTransition(row)
+	if (
+		transition === 'publish' &&
+		current.published &&
+		current.lastPublished === row.payload.lastPublished
+	) {
+		await deps.publish(current)
+	} else if (transition === 'unpublish' && !current.published) {
+		await deps.unpublish(current)
+	}
+}

--- a/apps/dotcom/sync-worker/src/fileEffects.ts
+++ b/apps/dotcom/sync-worker/src/fileEffects.ts
@@ -1,0 +1,23 @@
+import { TlaEffectOutbox, TlaFile } from '@tldraw/dotcom-shared'
+
+// An effect_outbox row whose tableName is 'file'.
+export interface FileEffectRow extends TlaEffectOutbox {
+	payload: TlaFile
+	prevPayload: TlaFile | null
+}
+
+// Port of the publish/unpublish transition logic from replicator/ChangeCollator.ts getEffects().
+export function getPublishTransition(
+	row: Pick<FileEffectRow, 'command' | 'payload' | 'prevPayload'>
+): 'publish' | 'unpublish' | null {
+	if (row.command !== 'update' || !row.prevPayload) return null
+	const file = row.payload
+	const previous = row.prevPayload
+	if (file.published && (!previous.published || file.lastPublished !== previous.lastPublished)) {
+		return 'publish'
+	}
+	if (!file.published && previous.published) {
+		return 'unpublish'
+	}
+	return null
+}

--- a/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
+++ b/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
@@ -1,5 +1,6 @@
 import { createRouter, notFound } from '@tldraw/worker-shared'
 import { sql } from 'kysely'
+import { MAX_ATTEMPTS } from './outboxDrain'
 import { createPostgresConnectionPool } from './postgres'
 import { isDebugLogging, type Environment } from './types'
 import { getClerkClient } from './utils/tla/getAuth'
@@ -173,7 +174,7 @@ export const healthCheckRoutes = createRouter<Environment>()
 				const thresholdSeconds = 300
 				const result = await sql<{ age_seconds: string | null }>`
 					SELECT EXTRACT(EPOCH FROM (now() - min("createdAt"))) AS age_seconds
-					FROM effect_outbox WHERE attempts < 10
+					FROM effect_outbox WHERE attempts < ${sql.raw(String(MAX_ATTEMPTS))}
 				`.execute(db)
 				const age = result.rows[0]?.age_seconds ? parseFloat(result.rows[0].age_seconds) : 0
 				if (age > thresholdSeconds) {

--- a/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
+++ b/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
@@ -172,17 +172,25 @@ export const healthCheckRoutes = createRouter<Environment>()
 			// outbox-lag
 			try {
 				const thresholdSeconds = 300
-				const result = await sql<{ age_seconds: string | null }>`
-					SELECT EXTRACT(EPOCH FROM (now() - min("createdAt"))) AS age_seconds
-					FROM effect_outbox WHERE attempts < ${sql.raw(String(MAX_ATTEMPTS))}
+				const result = await sql<{ age_seconds: string | null; parked: string }>`
+					SELECT
+						EXTRACT(EPOCH FROM (now() - min("createdAt") FILTER (WHERE attempts < ${sql.raw(String(MAX_ATTEMPTS))}))) AS age_seconds,
+						count(*) FILTER (WHERE attempts >= ${sql.raw(String(MAX_ATTEMPTS))}) AS parked
+					FROM effect_outbox
 				`.execute(db)
-				const age = result.rows[0]?.age_seconds ? parseFloat(result.rows[0].age_seconds) : 0
+				const row = result.rows[0]
+				const age = row?.age_seconds ? parseFloat(row.age_seconds) : 0
+				const parked = row?.parked ? parseInt(row.parked, 10) : 0
 				if (age > thresholdSeconds) {
 					failures.push(
 						`outbox-lag: oldest pending effect ${Math.round(age)}s > ${thresholdSeconds}s`
 					)
-				} else {
-					okDetails.push(`outbox: ${Math.round(age)}s`)
+				}
+				if (parked > 0) {
+					failures.push(`outbox-parked: ${parked} rows parked`)
+				}
+				if (age <= thresholdSeconds && parked === 0) {
+					okDetails.push(`outbox: ${Math.round(age)}s, 0 parked`)
 				}
 			} catch (_e) {
 				failures.push('outbox-lag: query failed')

--- a/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
+++ b/apps/dotcom/sync-worker/src/healthCheckRoutes.ts
@@ -2,7 +2,6 @@ import { createRouter, notFound } from '@tldraw/worker-shared'
 import { sql } from 'kysely'
 import { createPostgresConnectionPool } from './postgres'
 import { isDebugLogging, type Environment } from './types'
-import { getStatsDurableObjct } from './utils/durableObjects'
 import { getClerkClient } from './utils/tla/getAuth'
 
 function isAuthorized(req: Request, env: Environment) {
@@ -15,26 +14,6 @@ export const healthCheckRoutes = createRouter<Environment>()
 	.all('/health-check/*', (req, env) => {
 		if (isDebugLogging(env) || isAuthorized(req, env)) return undefined
 		return new Response('Unauthorized', { status: 401 })
-	})
-	.get('/health-check/replicator', async (_, env) => {
-		const stats = getStatsDurableObjct(env)
-		const unusualRetries = await stats.unusualNumberOfReplicatorBootRetries()
-		if (unusualRetries) {
-			return new Response('High ammount of replicator boot retries', { status: 500 })
-		}
-		const isGettingUpdates = await stats.isReplicatorGettingUpdates()
-		if (!isGettingUpdates) {
-			return new Response('Replicator is not getting postgres updates', { status: 500 })
-		}
-		return new Response('ok', { status: 200 })
-	})
-	.get('/health-check/user-durable-objects', async (_, env) => {
-		const stats = getStatsDurableObjct(env)
-		const abortsOverThreshold = await stats.unusualNumberOfUserDOAborts()
-		if (abortsOverThreshold) {
-			return new Response('High ammount of user durable object aborts', { status: 500 })
-		}
-		return new Response('ok', { status: 200 })
 	})
 	.get('/health-check/clerk', async (_, env) => {
 		const clerk = getClerkClient(env)
@@ -92,8 +71,8 @@ export const healthCheckRoutes = createRouter<Environment>()
 		}
 	})
 	// Combined postgres health check: db size, changelog size, WAL retention, replication slots, and
-	// tlpr replicator status. Grouped into a single endpoint because updown.io charges per check
-	// invocation. Failures include the sub-check name so alerts remain distinguishable.
+	// outbox lag. Grouped into a single endpoint because updown.io charges per check invocation.
+	// Failures include the sub-check name so alerts remain distinguishable.
 	.get('/health-check/postgres', async (_, env) => {
 		const db = createPostgresConnectionPool(env, '/health-check/postgres')
 		const failures: string[] = []
@@ -172,7 +151,7 @@ export const healthCheckRoutes = createRouter<Environment>()
 				}>`
 					SELECT slot_name, active, wal_status
 					FROM pg_replication_slots
-					WHERE slot_name LIKE 'zero_%' OR slot_name LIKE 'tlpr_%'
+					WHERE slot_name LIKE 'zero_%'
 				`.execute(db)
 				const unhealthy = result.rows.filter(
 					(row) => row.wal_status === 'lost' || row.wal_status === 'unreserved'
@@ -189,31 +168,23 @@ export const healthCheckRoutes = createRouter<Environment>()
 				failures.push('replication-slots: query failed')
 			}
 
-			// tlpr-replicator
+			// outbox-lag
 			try {
-				const result = await sql<{
-					slot_name: string
-					active: boolean
-					wal_status: string | null
-				}>`
-					SELECT slot_name, active, wal_status
-					FROM pg_replication_slots
-					WHERE slot_name LIKE 'tlpr_%'
+				const thresholdSeconds = 300
+				const result = await sql<{ age_seconds: string | null }>`
+					SELECT EXTRACT(EPOCH FROM (now() - min("createdAt"))) AS age_seconds
+					FROM effect_outbox WHERE attempts < 10
 				`.execute(db)
-				if (result.rows.length === 0) {
-					failures.push('tlpr-replicator: no slot found')
+				const age = result.rows[0]?.age_seconds ? parseFloat(result.rows[0].age_seconds) : 0
+				if (age > thresholdSeconds) {
+					failures.push(
+						`outbox-lag: oldest pending effect ${Math.round(age)}s > ${thresholdSeconds}s`
+					)
 				} else {
-					const slot = result.rows[0]
-					if (!slot.active) {
-						failures.push(`tlpr-replicator: ${slot.slot_name} not active`)
-					} else if (slot.wal_status === 'lost' || slot.wal_status === 'unreserved') {
-						failures.push(`tlpr-replicator: ${slot.slot_name} wal_status=${slot.wal_status}`)
-					} else {
-						okDetails.push('tlpr: active')
-					}
+					okDetails.push(`outbox: ${Math.round(age)}s`)
 				}
 			} catch (_e) {
-				failures.push('tlpr-replicator: query failed')
+				failures.push('outbox-lag: query failed')
 			}
 
 			if (failures.length > 0) {

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -74,4 +74,38 @@ describe('drainOutbox', () => {
 		await drainOutbox(deps)
 		expect(deps.calls).toEqual(['bump:1', 'process:2', 'deleteRow:2'])
 	})
+
+	it('stops instead of spinning when the same failing batch keeps coming back', async () => {
+		const rows = [row({ id: 1, entityId: 'f1' }), row({ id: 2, entityId: 'f2' })]
+		const deps = makeDeps([])
+		let getBatchCalls = 0
+		deps.getBatch = async () => {
+			getBatchCalls++
+			return rows
+		}
+		deps.process = async () => {
+			throw new Error('always fails')
+		}
+		await drainOutbox(deps)
+		// Each row bumped exactly once, then the loop breaks instead of refetching forever.
+		expect(deps.calls).toEqual(['bump:1', 'bump:2'])
+		expect(getBatchCalls).toBe(1)
+	})
+
+	it('bumps a failing entity at most once per drain even if later batches resurface it', async () => {
+		const batch1 = [row({ id: 1, entityId: 'bad' }), row({ id: 2, entityId: 'good' })]
+		// Simulates the failing row still being in range (attempts < MAX_ATTEMPTS) and reappearing
+		// in the next getBatch call alongside a new healthy row.
+		const batch2 = [row({ id: 1, entityId: 'bad' }), row({ id: 3, entityId: 'good2' })]
+		const batches = [batch1, batch2, []]
+		const deps = makeDeps([])
+		deps.getBatch = async () => batches.shift() ?? []
+		deps.process = async (r) => {
+			if (r.entityId === 'bad') throw new Error('always fails')
+			deps.calls.push(`process:${r.id}`)
+		}
+		await drainOutbox(deps)
+		expect(deps.calls).toEqual(['bump:1', 'process:2', 'deleteRow:2', 'process:3', 'deleteRow:3'])
+		expect(deps.calls.filter((c) => c === 'bump:1')).toHaveLength(1)
+	})
 })

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -12,15 +12,24 @@ function row(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
 		prevPayload: null,
 		attempts: 0,
 		createdAt: new Date(0),
+		nextRetryAt: null,
 		...partial,
 	}
 }
 
-function makeDeps(rows: TlaEffectOutbox[]): OutboxDeps & { calls: string[] } {
+interface TestDeps extends OutboxDeps {
+	calls: string[]
+	bumped: Array<{ id: number; attempts: number }>
+}
+
+function makeDeps(rows: TlaEffectOutbox[], timeoutMs = 30_000): TestDeps {
 	const calls: string[] = []
+	const bumped: Array<{ id: number; attempts: number }> = []
 	let batch = rows
 	return {
 		calls,
+		bumped,
+		timeoutMs,
 		getBatch: async () => {
 			const b = batch
 			batch = []
@@ -29,8 +38,9 @@ function makeDeps(rows: TlaEffectOutbox[]): OutboxDeps & { calls: string[] } {
 		deleteRow: async (id) => {
 			calls.push(`deleteRow:${id}`)
 		},
-		bumpAttempts: async (id) => {
+		bumpAttempts: async (id, attempts) => {
 			calls.push(`bump:${id}`)
+			bumped.push({ id, attempts })
 		},
 		deleteParkedRowsOlderThan: async () => {},
 		process: async (r) => {
@@ -58,7 +68,13 @@ describe('drainOutbox', () => {
 			deps.calls.push(`process:${r.id}`)
 		}
 		await drainOutbox(deps)
-		expect(deps.calls).toEqual(['bump:1', 'process:3', 'deleteRow:3'])
+		// f1 and f2 are separate entities processed concurrently, so ordering across them
+		// is not guaranteed; assert on membership instead.
+		expect(deps.calls).toContain('bump:1')
+		expect(deps.calls).toContain('process:3')
+		expect(deps.calls).toContain('deleteRow:3')
+		expect(deps.calls).not.toContain('process:2')
+		expect(deps.calls).not.toContain('bump:2')
 		expect(deps.onError).toHaveBeenCalledTimes(1)
 	})
 
@@ -72,7 +88,9 @@ describe('drainOutbox', () => {
 			deps.calls.push(`process:${r.id}`)
 		}
 		await drainOutbox(deps)
-		expect(deps.calls).toEqual(['bump:1', 'process:2', 'deleteRow:2'])
+		expect(deps.calls).toContain('bump:1')
+		expect(deps.calls).toContain('process:2')
+		expect(deps.calls).toContain('deleteRow:2')
 	})
 
 	it('stops instead of spinning when the same failing batch keeps coming back', async () => {
@@ -87,8 +105,9 @@ describe('drainOutbox', () => {
 			throw new Error('always fails')
 		}
 		await drainOutbox(deps)
-		// Each row bumped exactly once, then the loop breaks instead of refetching forever.
-		expect(deps.calls).toEqual(['bump:1', 'bump:2'])
+		// Each entity bumped exactly once, then the loop breaks instead of refetching forever.
+		expect(deps.calls.filter((c) => c === 'bump:1')).toHaveLength(1)
+		expect(deps.calls.filter((c) => c === 'bump:2')).toHaveLength(1)
 		expect(getBatchCalls).toBe(1)
 	})
 
@@ -105,7 +124,86 @@ describe('drainOutbox', () => {
 			deps.calls.push(`process:${r.id}`)
 		}
 		await drainOutbox(deps)
-		expect(deps.calls).toEqual(['bump:1', 'process:2', 'deleteRow:2', 'process:3', 'deleteRow:3'])
+		expect(deps.calls).toContain('process:2')
+		expect(deps.calls).toContain('deleteRow:2')
+		expect(deps.calls).toContain('process:3')
+		expect(deps.calls).toContain('deleteRow:3')
 		expect(deps.calls.filter((c) => c === 'bump:1')).toHaveLength(1)
+	})
+
+	it('processes independent entities concurrently: a hung entity does not block another', async () => {
+		// entity "slow" row never resolves; entity "fast" must still complete because groups
+		// run concurrently and the per-effect timeout unsticks the slow group.
+		const deps = makeDeps(
+			[row({ id: 1, entityId: 'slow' }), row({ id: 2, entityId: 'fast' })],
+			5 // short injected timeout so the hung row fails fast
+		)
+		deps.process = (r) => {
+			deps.calls.push(`process:${r.id}`)
+			if (r.entityId === 'slow') return new Promise<void>(() => {}) // never resolves
+			return Promise.resolve()
+		}
+		await drainOutbox(deps)
+		// fast entity completed
+		expect(deps.calls).toContain('process:2')
+		expect(deps.calls).toContain('deleteRow:2')
+		// slow entity timed out => failure path
+		expect(deps.calls).toContain('bump:1')
+		expect(deps.onError).toHaveBeenCalledTimes(1)
+	})
+
+	it('processes rows within a single entity strictly sequentially even under concurrency', async () => {
+		const order: string[] = []
+		const deps = makeDeps([
+			row({ id: 1, entityId: 'e' }),
+			row({ id: 2, entityId: 'e' }),
+			row({ id: 3, entityId: 'e' }),
+		])
+		deps.process = async (r) => {
+			order.push(`start:${r.id}`)
+			await new Promise((res) => setTimeout(res, 1))
+			order.push(`end:${r.id}`)
+		}
+		await drainOutbox(deps)
+		// each row fully completes (start then end) before the next starts
+		expect(order).toEqual(['start:1', 'end:1', 'start:2', 'end:2', 'start:3', 'end:3'])
+	})
+
+	it('a per-effect timeout counts as a failure: bumps and reports onError with a timeout error', async () => {
+		const deps = makeDeps([row({ id: 1 })], 5)
+		deps.process = () => new Promise<void>(() => {}) // never resolves
+		await drainOutbox(deps)
+		expect(deps.calls).toContain('bump:1')
+		expect(deps.calls).not.toContain('deleteRow:1')
+		expect(deps.onError).toHaveBeenCalledTimes(1)
+		const err = (deps.onError as any).mock.calls[0][0]
+		expect(String(err)).toMatch(/timed out/i)
+	})
+
+	it('late resolution after a timeout does not double-delete or double-bump', async () => {
+		let resolveLate!: () => void
+		const deps = makeDeps([row({ id: 1 })], 5)
+		deps.process = () =>
+			new Promise<void>((res) => {
+				resolveLate = res
+			})
+		await drainOutbox(deps)
+		// timeout already recorded a failure
+		expect(deps.calls.filter((c) => c === 'bump:1')).toHaveLength(1)
+		expect(deps.calls).not.toContain('deleteRow:1')
+		// now the underlying RPC finally resolves; must not trigger a delete
+		resolveLate()
+		await new Promise((r) => setTimeout(r, 10))
+		expect(deps.calls).not.toContain('deleteRow:1')
+		expect(deps.calls.filter((c) => c === 'bump:1')).toHaveLength(1)
+	})
+
+	it('passes the row current attempts to bumpAttempts so backoff can be scheduled', async () => {
+		const deps = makeDeps([row({ id: 7, attempts: 3 })])
+		deps.process = async () => {
+			throw new Error('fail')
+		}
+		await drainOutbox(deps)
+		expect(deps.bumped).toEqual([{ id: 7, attempts: 3 }])
 	})
 })

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -1,6 +1,6 @@
 import { TlaEffectOutbox } from '@tldraw/dotcom-shared'
 import { describe, expect, it, vi } from 'vitest'
-import { OutboxDeps, drainOutbox } from './outboxDrain'
+import { OutboxDeps, computeNextAlarm, drainOutbox } from './outboxDrain'
 
 function row(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
 	return {
@@ -38,9 +38,9 @@ function makeDeps(rows: TlaEffectOutbox[], timeoutMs = 30_000): TestDeps {
 		deleteRow: async (id) => {
 			calls.push(`deleteRow:${id}`)
 		},
-		bumpAttempts: async (id, attempts) => {
-			calls.push(`bump:${id}`)
-			bumped.push({ id, attempts })
+		bumpAttempts: async (r) => {
+			calls.push(`bump:${r.id}`)
+			bumped.push({ id: r.id, attempts: r.attempts })
 		},
 		deleteParkedRowsOlderThan: async () => {},
 		process: async (r) => {
@@ -205,5 +205,49 @@ describe('drainOutbox', () => {
 		}
 		await drainOutbox(deps)
 		expect(deps.bumped).toEqual([{ id: 7, attempts: 3 }])
+	})
+
+	it('passes the FULL failed row to bumpAttempts so the impl can defer later siblings', async () => {
+		// bumpAttempts is the only hook the DO has to defer the failed row's later same-entity
+		// siblings (set their nextRetryAt) and preserve per-entity ordering across drains, so it
+		// must receive the whole row (tableName + entityId + id), not just id/attempts.
+		const failed = row({ id: 5, tableName: 'file', entityId: 'f1', attempts: 2 })
+		let received: TlaEffectOutbox | undefined
+		const deps = makeDeps([failed, row({ id: 6, tableName: 'file', entityId: 'f1' })])
+		deps.bumpAttempts = async (r) => {
+			received = r
+		}
+		deps.process = async () => {
+			throw new Error('fail')
+		}
+		await drainOutbox(deps)
+		expect(received).toEqual(failed)
+		// the later sibling (id 6) is NOT processed this drain — the DO's sibling deferral keeps it
+		// out of the next drain too, but here we only assert the in-drain skip.
+		expect(deps.calls).not.toContain('process:6')
+	})
+})
+
+describe('computeNextAlarm', () => {
+	const SWEEP = 30_000
+	const now = 1_000_000
+
+	it('arms the next sweep when no alarm is persisted', () => {
+		expect(computeNextAlarm(null, now, SWEEP)).toBe(now + SWEEP)
+	})
+
+	it('arms the next sweep when the persisted alarm is further out than the next sweep', () => {
+		expect(computeNextAlarm(now + SWEEP + 5_000, now, SWEEP)).toBe(now + SWEEP)
+	})
+
+	it('honors a mid-drain poke (past-due alarm) by arming now+1s, not the full sweep', () => {
+		// a poke during the drain set alarm(now); it is past-due in the finally and can't be
+		// trusted to fire on its own, so re-arm with a small delay instead of swallowing it.
+		expect(computeNextAlarm(now, now, SWEEP)).toBe(now + 1_000)
+		expect(computeNextAlarm(now - 5_000, now, SWEEP)).toBe(now + 1_000)
+	})
+
+	it('leaves a sooner future alarm (imminent poke) untouched', () => {
+		expect(computeNextAlarm(now + 1_000, now, SWEEP)).toBe(null)
 	})
 })

--- a/apps/dotcom/sync-worker/src/outboxDrain.test.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.test.ts
@@ -1,0 +1,77 @@
+import { TlaEffectOutbox } from '@tldraw/dotcom-shared'
+import { describe, expect, it, vi } from 'vitest'
+import { OutboxDeps, drainOutbox } from './outboxDrain'
+
+function row(partial: Partial<TlaEffectOutbox>): TlaEffectOutbox {
+	return {
+		id: 1,
+		tableName: 'file',
+		entityId: 'f1',
+		command: 'update',
+		payload: {},
+		prevPayload: null,
+		attempts: 0,
+		createdAt: new Date(0),
+		...partial,
+	}
+}
+
+function makeDeps(rows: TlaEffectOutbox[]): OutboxDeps & { calls: string[] } {
+	const calls: string[] = []
+	let batch = rows
+	return {
+		calls,
+		getBatch: async () => {
+			const b = batch
+			batch = []
+			return b
+		},
+		deleteRow: async (id) => {
+			calls.push(`deleteRow:${id}`)
+		},
+		bumpAttempts: async (id) => {
+			calls.push(`bump:${id}`)
+		},
+		deleteParkedRowsOlderThan: async () => {},
+		process: async (r) => {
+			calls.push(`process:${r.id}`)
+		},
+		onError: vi.fn(),
+	}
+}
+
+describe('drainOutbox', () => {
+	it('processes rows in id order and deletes them', async () => {
+		const deps = makeDeps([row({ id: 1 }), row({ id: 2 })])
+		await drainOutbox(deps)
+		expect(deps.calls).toEqual(['process:1', 'deleteRow:1', 'process:2', 'deleteRow:2'])
+	})
+
+	it('on failure bumps attempts and skips later rows for the same entity only', async () => {
+		const deps = makeDeps([
+			row({ id: 1, entityId: 'f1' }),
+			row({ id: 2, entityId: 'f1' }),
+			row({ id: 3, entityId: 'f2' }),
+		])
+		deps.process = async (r) => {
+			if (r.entityId === 'f1') throw new Error('room DO unavailable')
+			deps.calls.push(`process:${r.id}`)
+		}
+		await drainOutbox(deps)
+		expect(deps.calls).toEqual(['bump:1', 'process:3', 'deleteRow:3'])
+		expect(deps.onError).toHaveBeenCalledTimes(1)
+	})
+
+	it('same entityId in different tables does not cross-skip', async () => {
+		const deps = makeDeps([
+			row({ id: 1, tableName: 'file', entityId: 'x' }),
+			row({ id: 2, tableName: 'comment', entityId: 'x' }),
+		])
+		deps.process = async (r) => {
+			if (r.tableName === 'file') throw new Error('boom')
+			deps.calls.push(`process:${r.id}`)
+		}
+		await drainOutbox(deps)
+		expect(deps.calls).toEqual(['bump:1', 'process:2', 'deleteRow:2'])
+	})
+})

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -13,14 +13,18 @@ export interface OutboxDeps {
 }
 
 export async function drainOutbox(deps: OutboxDeps) {
+	// Hoisted above the batch loop: an entity that fails must be skipped for the rest of this
+	// drain call, not just the rest of its batch, so a stuck entity can't burn all its attempts
+	// (and reach the parking threshold) in a single drain while other entities keep it looping.
+	const failedEntities = new Set<string>()
+	const entityKey = (row: TlaEffectOutbox) => `${row.tableName}:${row.entityId}`
 	while (true) {
 		const rows = await deps.getBatch()
 		if (rows.length === 0) break
-		// A failing entity's later rows must not run out of order; other entities continue.
-		const failedEntities = new Set<string>()
-		const entityKey = (row: TlaEffectOutbox) => `${row.tableName}:${row.entityId}`
+		let processedAny = false
 		for (const row of rows) {
 			if (failedEntities.has(entityKey(row))) continue
+			processedAny = true
 			try {
 				await deps.process(row)
 				await deps.deleteRow(row.id)
@@ -30,9 +34,9 @@ export async function drainOutbox(deps: OutboxDeps) {
 				deps.onError(error, row)
 			}
 		}
-		// If every row in the batch failed we'd spin on the same batch; stop and let the
-		// alarm retry after backoff.
-		if (failedEntities.size > 0 && rows.every((r) => failedEntities.has(entityKey(r)))) break
+		// If every row in the batch was already-failed or failed just now, we'd spin refetching
+		// the same rows; stop and let the alarm retry after backoff.
+		if (!processedAny || rows.every((r) => failedEntities.has(entityKey(r)))) break
 	}
 	await deps.deleteParkedRowsOlderThan(PARKED_ROW_TTL_DAYS)
 }

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -2,38 +2,109 @@ import { TlaEffectOutbox } from '@tldraw/dotcom-shared'
 
 export const MAX_ATTEMPTS = 10
 export const PARKED_ROW_TTL_DAYS = 7
+// Groups (one per entity) processed at once. A slow publish/cold-boot only stalls its own
+// group; other entities keep draining. Small so a burst can't fan out to unbounded RPCs.
+export const MAX_CONCURRENT_ENTITIES = 5
+// Per-effect ceiling. The underlying room-DO RPC can't be cancelled, but the drain stops
+// waiting on it and moves on; a timed-out effect is treated as a failure and retried later.
+export const EFFECT_TIMEOUT_MS = 30_000
 
 export interface OutboxDeps {
-	getBatch(): Promise<TlaEffectOutbox[]> // WHERE attempts < MAX_ATTEMPTS ORDER BY id LIMIT 50
+	getBatch(): Promise<TlaEffectOutbox[]> // WHERE attempts < MAX_ATTEMPTS AND ("nextRetryAt" IS NULL OR "nextRetryAt" <= now()) ORDER BY id LIMIT 50
 	deleteRow(id: number): Promise<void>
-	bumpAttempts(id: number): Promise<void>
+	// attempts is the row's CURRENT attempt count, so backoff scheduling can be derived from it.
+	bumpAttempts(id: number, attempts: number): Promise<void>
 	deleteParkedRowsOlderThan(days: number): Promise<void>
 	process(row: TlaEffectOutbox): Promise<void> // dispatches by tableName (wired in the DO)
 	onError(error: unknown, row: TlaEffectOutbox): void
+	// Overridable so tests don't wait the full timeout in real time.
+	timeoutMs?: number
 }
+
+class EffectTimeoutError extends Error {
+	constructor(row: TlaEffectOutbox, ms: number) {
+		super(`effect for ${row.tableName}:${row.entityId} (outbox ${row.id}) timed out after ${ms}ms`)
+		this.name = 'EffectTimeoutError'
+	}
+}
+
+// Races process(row) against a timeout. Resolves true on success, false on failure/timeout.
+// A late resolution of the underlying promise after a timeout is swallowed so it can't
+// double-act; only the first settlement of the race drives delete/bump.
+async function processWithTimeout(deps: OutboxDeps, row: TlaEffectOutbox): Promise<boolean> {
+	const ms = deps.timeoutMs ?? EFFECT_TIMEOUT_MS
+	let timer: ReturnType<typeof setTimeout> | undefined
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new EffectTimeoutError(row, ms)), ms)
+	})
+	// Swallow a late rejection from the losing branch so it doesn't become an unhandled rejection.
+	const work = deps.process(row)
+	work.catch(() => {})
+	try {
+		await Promise.race([work, timeout])
+		await deps.deleteRow(row.id)
+		return true
+	} catch (error) {
+		await deps.bumpAttempts(row.id, row.attempts)
+		deps.onError(error, row)
+		return false
+	} finally {
+		if (timer) clearTimeout(timer)
+	}
+}
+
+// Runs tasks with a bounded concurrency, preserving nothing about order (callers that need
+// ordering enforce it inside a single task).
+async function runWithConcurrency(tasks: Array<() => Promise<void>>, limit: number) {
+	let next = 0
+	async function worker() {
+		while (next < tasks.length) {
+			const task = tasks[next++]
+			await task()
+		}
+	}
+	const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker())
+	await Promise.all(workers)
+}
+
+const entityKey = (row: TlaEffectOutbox) => `${row.tableName}:${row.entityId}`
 
 export async function drainOutbox(deps: OutboxDeps) {
 	// Hoisted above the batch loop: an entity that fails must be skipped for the rest of this
 	// drain call, not just the rest of its batch, so a stuck entity can't burn all its attempts
 	// (and reach the parking threshold) in a single drain while other entities keep it looping.
 	const failedEntities = new Set<string>()
-	const entityKey = (row: TlaEffectOutbox) => `${row.tableName}:${row.entityId}`
+
 	while (true) {
 		const rows = await deps.getBatch()
 		if (rows.length === 0) break
-		let processedAny = false
+
+		// Group rows by entity, preserving id order within each group. Different entities have
+		// no ordering constraint between them, so their groups run concurrently.
+		const groups = new Map<string, TlaEffectOutbox[]>()
 		for (const row of rows) {
-			if (failedEntities.has(entityKey(row))) continue
-			processedAny = true
-			try {
-				await deps.process(row)
-				await deps.deleteRow(row.id)
-			} catch (error) {
-				failedEntities.add(entityKey(row))
-				await deps.bumpAttempts(row.id)
-				deps.onError(error, row)
-			}
+			const key = entityKey(row)
+			if (failedEntities.has(key)) continue
+			let group = groups.get(key)
+			if (!group) groups.set(key, (group = []))
+			group.push(row)
 		}
+
+		let processedAny = false
+		const tasks = Array.from(groups.entries()).map(([key, group]) => async () => {
+			for (const row of group) {
+				processedAny = true
+				const ok = await processWithTimeout(deps, row)
+				if (!ok) {
+					// A failed entity skips its remaining rows this drain and, via failedEntities,
+					// any rows that resurface in later batches.
+					failedEntities.add(key)
+					return
+				}
+			}
+		})
+		await runWithConcurrency(tasks, MAX_CONCURRENT_ENTITIES)
+
 		// If every row in the batch was already-failed or failed just now, we'd spin refetching
 		// the same rows; stop and let the alarm retry after backoff.
 		if (!processedAny || rows.every((r) => failedEntities.has(entityKey(r)))) break

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -12,13 +12,34 @@ export const EFFECT_TIMEOUT_MS = 30_000
 export interface OutboxDeps {
 	getBatch(): Promise<TlaEffectOutbox[]> // WHERE attempts < MAX_ATTEMPTS AND ("nextRetryAt" IS NULL OR "nextRetryAt" <= now()) ORDER BY id LIMIT 50
 	deleteRow(id: number): Promise<void>
-	// attempts is the row's CURRENT attempt count, so backoff scheduling can be derived from it.
-	bumpAttempts(id: number, attempts: number): Promise<void>
+	// Called with the FAILED row (its `attempts` is the current count, so backoff can be derived).
+	// The implementation must both back off the failed row AND defer its later same-entity
+	// siblings (see the drainOutbox comment) so per-entity ordering holds across drains, not just
+	// within one.
+	bumpAttempts(row: TlaEffectOutbox): Promise<void>
 	deleteParkedRowsOlderThan(days: number): Promise<void>
 	process(row: TlaEffectOutbox): Promise<void> // dispatches by tableName (wired in the DO)
 	onError(error: unknown, row: TlaEffectOutbox): void
 	// Overridable so tests don't wait the full timeout in real time.
 	timeoutMs?: number
+}
+
+// Decides what to (re)arm the sweep alarm to after a drain finishes, given the currently
+// persisted alarm. Returns null to mean "leave the persisted alarm unchanged".
+//  - scheduled === null || scheduled > nextSweep: nothing sooner is pending → arm the next sweep.
+//  - scheduled <= now: a poke that arrived MID-drain set alarm(now) and is now past-due; a
+//    past-due alarm can't be trusted to fire on its own, so honor the poke by arming now+1s
+//    (a small delay, still never trusting the stale past-due alarm).
+//  - otherwise (future, sooner than nextSweep): a legit imminent poke → leave it.
+export function computeNextAlarm(
+	scheduled: number | null,
+	now: number,
+	sweepIntervalMs: number
+): number | null {
+	const nextSweep = now + sweepIntervalMs
+	if (scheduled === null || scheduled > nextSweep) return nextSweep
+	if (scheduled <= now) return now + 1_000
+	return null
 }
 
 class EffectTimeoutError extends Error {
@@ -50,7 +71,7 @@ async function processWithTimeout(deps: OutboxDeps, row: TlaEffectOutbox): Promi
 		await deps.deleteRow(row.id)
 		return true
 	} catch (error) {
-		await deps.bumpAttempts(row.id, row.attempts)
+		await deps.bumpAttempts(row)
 		deps.onError(error, row)
 		return false
 	} finally {
@@ -75,9 +96,20 @@ async function runWithConcurrency(tasks: Array<() => Promise<void>>, limit: numb
 const entityKey = (row: TlaEffectOutbox) => `${row.tableName}:${row.entityId}`
 
 export async function drainOutbox(deps: OutboxDeps) {
-	// Hoisted above the batch loop: an entity that fails must be skipped for the rest of this
-	// drain call, not just the rest of its batch, so a stuck entity can't burn all its attempts
-	// (and reach the parking threshold) in a single drain while other entities keep it looping.
+	// Per-entity ordering is strict WITHIN and ACROSS drains:
+	//  - within a drain: each entity is one sequential group; a failure stops its group and (via
+	//    failedEntities below) skips any of its rows that resurface in later batches.
+	//  - across drains: when a row fails, bumpAttempts also defers its later same-entity siblings
+	//    (sets their nextRetryAt) so they can't run in a subsequent drain while the failed row is
+	//    still backing off. The failed row itself always retries no later than its siblings.
+	// Exception at the parking boundary: once a row parks (attempts >= MAX_ATTEMPTS) getBatch stops
+	// returning it, so it no longer defers its siblings and they run. Liveness deliberately wins
+	// over strict ordering here — parking is already a Sentry-reported data-loss event.
+	//
+	// failedEntities is hoisted above the batch loop so one failure skips the entity for the rest
+	// of THIS drain call (not just the rest of its batch): it caps a stuck entity at one attempt
+	// per drain, so a single drain can't burn all its attempts to the parking threshold. It does
+	// not by itself provide cross-drain ordering — the sibling deferral in bumpAttempts does that.
 	const failedEntities = new Set<string>()
 
 	while (true) {

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -1,0 +1,38 @@
+import { TlaEffectOutbox } from '@tldraw/dotcom-shared'
+
+export const MAX_ATTEMPTS = 10
+export const PARKED_ROW_TTL_DAYS = 7
+
+export interface OutboxDeps {
+	getBatch(): Promise<TlaEffectOutbox[]> // WHERE attempts < MAX_ATTEMPTS ORDER BY id LIMIT 50
+	deleteRow(id: number): Promise<void>
+	bumpAttempts(id: number): Promise<void>
+	deleteParkedRowsOlderThan(days: number): Promise<void>
+	process(row: TlaEffectOutbox): Promise<void> // dispatches by tableName (wired in the DO)
+	onError(error: unknown, row: TlaEffectOutbox): void
+}
+
+export async function drainOutbox(deps: OutboxDeps) {
+	while (true) {
+		const rows = await deps.getBatch()
+		if (rows.length === 0) break
+		// A failing entity's later rows must not run out of order; other entities continue.
+		const failedEntities = new Set<string>()
+		const entityKey = (row: TlaEffectOutbox) => `${row.tableName}:${row.entityId}`
+		for (const row of rows) {
+			if (failedEntities.has(entityKey(row))) continue
+			try {
+				await deps.process(row)
+				await deps.deleteRow(row.id)
+			} catch (error) {
+				failedEntities.add(entityKey(row))
+				await deps.bumpAttempts(row.id)
+				deps.onError(error, row)
+			}
+		}
+		// If every row in the batch failed we'd spin on the same batch; stop and let the
+		// alarm retry after backoff.
+		if (failedEntities.size > 0 && rows.every((r) => failedEntities.has(entityKey(r)))) break
+	}
+	await deps.deleteParkedRowsOlderThan(PARKED_ROW_TTL_DAYS)
+}

--- a/apps/dotcom/sync-worker/src/outboxDrain.ts
+++ b/apps/dotcom/sync-worker/src/outboxDrain.ts
@@ -37,11 +37,16 @@ async function processWithTimeout(deps: OutboxDeps, row: TlaEffectOutbox): Promi
 	const timeout = new Promise<never>((_, reject) => {
 		timer = setTimeout(() => reject(new EffectTimeoutError(row, ms)), ms)
 	})
-	// Swallow a late rejection from the losing branch so it doesn't become an unhandled rejection.
+	// Swallow late rejections from BOTH branches: only the race's first settlement drives
+	// delete/bump. Without this, a timeout firing while deleteRow is still awaited (or a late
+	// work rejection) becomes an unhandled rejection.
+	timeout.catch(() => {})
 	const work = deps.process(row)
 	work.catch(() => {})
 	try {
 		await Promise.race([work, timeout])
+		// Stop the clock before the follow-up await so a slow deleteRow can't trip the timeout.
+		if (timer) clearTimeout(timer)
 		await deps.deleteRow(row.id)
 		return true
 	} catch (error) {

--- a/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getPublishedFile.ts
@@ -38,13 +38,14 @@ export async function getPublishedRoomSnapshot(
 	env: Environment,
 	roomId: string
 ): Promise<RoomSnapshot | undefined> {
-	// Re-resolve the published slug on every read so the published gate holds at serve time, not just
-	// when the board was first resolved. A board un-published between resolution and this read must
-	// stop resolving even though its R2 snapshot lingers until the replicator deletes it (the DB
-	// `published` flag flips immediately; the R2 cleanup lags behind it).
+	// Re-resolve the published slug on every read so the published gate holds at serve time, not
+	// just when the board was first resolved. A board un-published between resolution and this
+	// read must stop resolving even though its R2 snapshot lingers until the outbox's unpublish
+	// effect deletes it (the DB `published` flag flips immediately; R2 cleanup lags behind it).
+	// Undefined (not a throw) so unknown/unpublished slugs surface as a 404, not a 500.
 	const file = await getPublishedFileInfo(env, roomId)
-	if (!file) throw Error('not found')
-	if (!file.published) throw Error('not published')
+	if (!file) return undefined
+	if (!file.published) return undefined
 
 	return (await env.ROOM_SNAPSHOTS.get(
 		getR2KeyForRoom({ slug: `${file.id}/${roomId}`, isApp: true })

--- a/apps/dotcom/sync-worker/src/routes/tla/initUser.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/initUser.ts
@@ -30,6 +30,12 @@ export async function initUser(req: IRequest, env: Environment): Promise<Respons
 		const clerkUser = await clerk.users.getUser(id)
 		if (!clerkUser) return new Response('Clerk user not found', { status: 404 })
 
+		// A Clerk user can lack an email (e.g. some SSO/social flows); reading [0].emailAddress
+		// on such a user throws and permanently 500s user boot. Fail cleanly with a 400 instead.
+		const email =
+			clerkUser.primaryEmailAddress?.emailAddress ?? clerkUser.emailAddresses[0]?.emailAddress
+		if (!email) return new Response('Clerk user has no email address', { status: 400 })
+
 		await db.transaction().execute(async (tx) => {
 			const now = Date.now()
 			await tx
@@ -37,7 +43,7 @@ export async function initUser(req: IRequest, env: Environment): Promise<Respons
 				.values({
 					id,
 					name: clerkUser.fullName ?? '',
-					email: clerkUser.emailAddresses[0].emailAddress,
+					email,
 					avatar: clerkUser.imageUrl,
 					color: '___INIT___',
 					exportFormat: 'png',

--- a/apps/dotcom/sync-worker/src/routes/tla/initUser.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/initUser.ts
@@ -5,13 +5,11 @@ import { Environment } from '../../types'
 import { isRateLimited } from '../../utils/rateLimit'
 import { getClerkClient } from '../../utils/tla/getAuth'
 
-// Ensures the user row + home workspace exist before Zero can query. Idempotent:
-// concurrent calls race safely via the in-transaction re-check.
+// Ensures the user row + home workspace exist before Zero can query. Idempotent: concurrent
+// first-sign-ins race safely because all three inserts no-op on conflict, so the loser of the
+// race falls through to the same 200 as the winner instead of hitting a unique violation.
 export async function initUser(req: IRequest, env: Environment): Promise<Response> {
 	const id = req.params.userId
-	if (await isRateLimited(env, id)) {
-		return new Response('Rate limited', { status: 429 })
-	}
 	const db = createPostgresConnectionPool(env, '/app/init')
 	try {
 		const existing = await db
@@ -21,16 +19,18 @@ export async function initUser(req: IRequest, env: Environment): Promise<Respons
 			.executeTakeFirst()
 		if (existing) return new Response('ok', { status: 200 })
 
+		// Only the creation path is rate-limited: existing users hit the cheap SELECT above on
+		// every sign-in and shouldn't burn rate-limit budget or risk a 429 boot-hang.
+		if (await isRateLimited(env, id)) {
+			return new Response('Rate limited', { status: 429 })
+		}
+
 		// auth is checked in the main worker, so the clerk user definitely exists
 		const clerk = getClerkClient(env)
 		const clerkUser = await clerk.users.getUser(id)
 		if (!clerkUser) return new Response('Clerk user not found', { status: 404 })
 
 		await db.transaction().execute(async (tx) => {
-			// check that user wasn't added by another request in between the auth check and here
-			if (await tx.selectFrom('user').where('id', '=', id).select('id').executeTakeFirst()) {
-				return
-			}
 			const now = Date.now()
 			await tx
 				.insertInto('user')
@@ -49,6 +49,7 @@ export async function initUser(req: IRequest, env: Environment): Promise<Respons
 					// No feature flags on new users; the column is retained for future flags.
 					flags: '',
 				})
+				.onConflict((oc) => oc.doNothing())
 				.execute()
 			await tx
 				.insertInto('group')
@@ -61,6 +62,7 @@ export async function initUser(req: IRequest, env: Environment): Promise<Respons
 					isDeleted: false,
 					inviteSecret: null,
 				})
+				.onConflict((oc) => oc.doNothing())
 				.execute()
 			await tx
 				.insertInto('group_user')
@@ -74,6 +76,7 @@ export async function initUser(req: IRequest, env: Environment): Promise<Respons
 					userName: clerkUser.fullName ?? '',
 					userColor: '',
 				})
+				.onConflict((oc) => oc.doNothing())
 				.execute()
 		})
 		return new Response('ok', { status: 200 })

--- a/apps/dotcom/sync-worker/src/routes/tla/initUser.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/initUser.ts
@@ -1,0 +1,83 @@
+import { IndexKey } from '@tldraw/utils'
+import { IRequest } from 'itty-router'
+import { createPostgresConnectionPool } from '../../postgres'
+import { Environment } from '../../types'
+import { isRateLimited } from '../../utils/rateLimit'
+import { getClerkClient } from '../../utils/tla/getAuth'
+
+// Ensures the user row + home workspace exist before Zero can query. Idempotent:
+// concurrent calls race safely via the in-transaction re-check.
+export async function initUser(req: IRequest, env: Environment): Promise<Response> {
+	const id = req.params.userId
+	if (await isRateLimited(env, id)) {
+		return new Response('Rate limited', { status: 429 })
+	}
+	const db = createPostgresConnectionPool(env, '/app/init')
+	try {
+		const existing = await db
+			.selectFrom('user')
+			.where('id', '=', id)
+			.select('id')
+			.executeTakeFirst()
+		if (existing) return new Response('ok', { status: 200 })
+
+		// auth is checked in the main worker, so the clerk user definitely exists
+		const clerk = getClerkClient(env)
+		const clerkUser = await clerk.users.getUser(id)
+		if (!clerkUser) return new Response('Clerk user not found', { status: 404 })
+
+		await db.transaction().execute(async (tx) => {
+			// check that user wasn't added by another request in between the auth check and here
+			if (await tx.selectFrom('user').where('id', '=', id).select('id').executeTakeFirst()) {
+				return
+			}
+			const now = Date.now()
+			await tx
+				.insertInto('user')
+				.values({
+					id,
+					name: clerkUser.fullName ?? '',
+					email: clerkUser.emailAddresses[0].emailAddress,
+					avatar: clerkUser.imageUrl,
+					color: '___INIT___',
+					exportFormat: 'png',
+					exportTheme: 'light',
+					exportBackground: true,
+					exportPadding: true,
+					createdAt: now,
+					updatedAt: now,
+					// No feature flags on new users; the column is retained for future flags.
+					flags: '',
+				})
+				.execute()
+			await tx
+				.insertInto('group')
+				.values({
+					id,
+					// The home/private workspace defaults to "My workspace" and is renameable.
+					name: 'My workspace',
+					createdAt: now,
+					updatedAt: now,
+					isDeleted: false,
+					inviteSecret: null,
+				})
+				.execute()
+			await tx
+				.insertInto('group_user')
+				.values({
+					userId: id,
+					groupId: id,
+					createdAt: now,
+					updatedAt: now,
+					role: 'owner',
+					index: 'a1' as IndexKey,
+					userName: clerkUser.fullName ?? '',
+					userColor: '',
+				})
+				.execute()
+		})
+		return new Response('ok', { status: 200 })
+	} finally {
+		await db.destroy()
+	}
+}

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -3,6 +3,7 @@
 import { Queue } from '@cloudflare/workers-types'
 import { RoomSnapshot } from '@tldraw/sync-core'
 import type { TLFileDurableObject } from './TLFileDurableObject'
+import type { TLFileEffectProcessor } from './TLFileEffectProcessor'
 import type { TLLoggerDurableObject } from './TLLoggerDurableObject'
 import type { TLPostgresReplicator } from './TLPostgresReplicator'
 import { TLStatsDurableObject } from './TLStatsDurableObject'
@@ -31,6 +32,7 @@ export interface Environment {
 	TLDR_DOC: DurableObjectNamespace<TLFileDurableObject>
 	TL_PG_REPLICATOR: DurableObjectNamespace<TLPostgresReplicator>
 	TL_USER: DurableObjectNamespace<TLUserDurableObject>
+	TL_FILE_EFFECTS: DurableObjectNamespace<TLFileEffectProcessor>
 	TL_LOGGER: DurableObjectNamespace<TLLoggerDurableObject>
 	TL_STATS: DurableObjectNamespace<TLStatsDurableObject>
 

--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -1,5 +1,6 @@
 import { ROOM_PREFIX } from '@tldraw/dotcom-shared'
 import { TLFileDurableObject } from '../TLFileDurableObject'
+import type { TLFileEffectProcessor } from '../TLFileEffectProcessor'
 import { TLLoggerDurableObject } from '../TLLoggerDurableObject'
 import type { TLPostgresReplicator } from '../TLPostgresReplicator'
 import { TLStatsDurableObject } from '../TLStatsDurableObject'
@@ -14,6 +15,12 @@ export function getReplicator(env: Environment) {
 
 export function getUserDurableObject(env: Environment, userId: string) {
 	return env.TL_USER.get(env.TL_USER.idFromName(userId)) as any as TLUserDurableObject
+}
+
+export function getFileEffectProcessor(env: Environment) {
+	return env.TL_FILE_EFFECTS.get(env.TL_FILE_EFFECTS.idFromName('0'), {
+		locationHint: 'weur',
+	}) as any as TLFileEffectProcessor
 }
 
 export function getLogger(env: Environment) {

--- a/apps/dotcom/sync-worker/src/utils/publishSnapshots.ts
+++ b/apps/dotcom/sync-worker/src/utils/publishSnapshots.ts
@@ -1,0 +1,38 @@
+import { TlaFile } from '@tldraw/dotcom-shared'
+import { getR2KeyForRoom } from '../r2'
+import { Environment } from '../types'
+import { getRoomDurableObject } from './durableObjects'
+
+// Moved from TLPostgresReplicator. Errors propagate so the outbox consumer can retry.
+export async function publishSnapshot(env: Environment, file: TlaFile) {
+	// make sure the room's snapshot is up to date
+	await getRoomDurableObject(env, file.id).awaitPersist()
+	// and that it exists
+	const snapshot = await env.ROOMS.get(getR2KeyForRoom({ slug: file.id, isApp: true }))
+
+	if (!snapshot) {
+		throw new Error(`Snapshot not found for file ${file.id}`)
+	}
+	const blob = await snapshot.blob()
+
+	// Create a new slug for the published room
+	await env.SNAPSHOT_SLUG_TO_PARENT_SLUG.put(file.publishedSlug, file.id)
+
+	// Bang the snapshot into the database
+	await env.ROOM_SNAPSHOTS.put(
+		getR2KeyForRoom({ slug: `${file.id}/${file.publishedSlug}`, isApp: true }),
+		blob
+	)
+	const currentTime = new Date().toISOString()
+	await env.ROOM_SNAPSHOTS.put(
+		getR2KeyForRoom({ slug: `${file.id}/${file.publishedSlug}|${currentTime}`, isApp: true }),
+		blob
+	)
+}
+
+export async function unpublishSnapshot(env: Environment, file: TlaFile) {
+	await env.SNAPSHOT_SLUG_TO_PARENT_SLUG.delete(file.publishedSlug)
+	await env.ROOM_SNAPSHOTS.delete(
+		getR2KeyForRoom({ slug: `${file.id}/${file.publishedSlug}`, isApp: true })
+	)
+}

--- a/apps/dotcom/sync-worker/src/utils/publishSnapshots.ts
+++ b/apps/dotcom/sync-worker/src/utils/publishSnapshots.ts
@@ -3,7 +3,7 @@ import { getR2KeyForRoom } from '../r2'
 import { Environment } from '../types'
 import { getRoomDurableObject } from './durableObjects'
 
-// Moved from TLPostgresReplicator. Errors propagate so the outbox consumer can retry.
+// Errors propagate so the outbox consumer can retry.
 export async function publishSnapshot(env: Environment, file: TlaFile) {
 	// make sure the room's snapshot is up to date
 	await getRoomDurableObject(env, file.id).awaitPersist()

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -148,6 +148,14 @@ const router = createRouter<Environment>()
 		await getReplicator(env).ping()
 		return new Response('ok')
 	})
+	// Dev/preview only. Wakes the outbox processor: local workerd doesn't fire persisted alarms
+	// for an uninstantiated DO, so without this a restarted dev stack drains nothing until the
+	// first mutation. The dev stack's readiness probe hits this route.
+	.get('/app/outbox-status', async (_, env) => {
+		if (!isDebugLogging(env)) return notFound()
+		await getFileEffectProcessor(env).poke()
+		return new Response('ok')
+	})
 	.get('/app/file/:roomId', (req, env) => {
 		if (req.headers.get('upgrade')?.toLowerCase() === 'websocket') {
 			return forwardRoomRequest(req, env)

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -208,7 +208,7 @@ const router = createRouter<Environment>()
 	})
 	.all('/health-check/*', healthCheckRoutes.fetch)
 	.all('/app/admin/*', adminRoutes.fetch)
-	.post('/app/zero/mutate', async (req, env) => {
+	.post('/app/zero/mutate', async (req, env, ctx) => {
 		const auth = await getAuth(req, env)
 		if (!auth) {
 			return Response.json({ error: 'Unauthorized' }, { status: 401 })
@@ -218,8 +218,13 @@ const router = createRouter<Environment>()
 			'debug'
 		)
 		const result = await processor.process(createMutators(auth.userId), req)
-		// wake the outbox consumer; poke only schedules an immediate alarm so this is fast
-		await getFileEffectProcessor(env).poke()
+		// Wake the outbox consumer without blocking the response: a poke failure must not 500 a
+		// mutation that already committed, and the singleton DO shouldn't sit on the hot path.
+		ctx.waitUntil(
+			getFileEffectProcessor(env)
+				.poke()
+				.catch((e) => console.error('outbox poke failed', e))
+		)
 		return json(result)
 	})
 	.post('/app/zero/query', async (req, env) => {

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -48,6 +48,7 @@ import { getInviteInfo } from './routes/tla/getInviteInfo'
 import { getOgImage } from './routes/tla/getOgImage'
 import { getPublishedFile } from './routes/tla/getPublishedFile'
 import { getThumbnailSnapshot } from './routes/tla/getThumbnailSnapshot'
+import { initUser } from './routes/tla/initUser'
 import { handleOgImageRenderMessage } from './routes/tla/ogImageQueue'
 import { sharedBoardScreenshotMcp } from './routes/tla/sharedBoardScreenshotMcp'
 import { upload } from './routes/tla/uploads'
@@ -140,8 +141,7 @@ const router = createRouter<Environment>()
 		// Ensure user exists in DB before Zero can query
 		const auth = await requireAuth(req, env)
 		if (req.params.userId !== auth.userId) return notFound()
-		const stub = getUserDurableObject(env, auth.userId)
-		return stub.fetch(req)
+		return initUser(req, env)
 	})
 	.post('/app/tldr', createFiles)
 	.get('/app/replicator-status', async (_, env) => {

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -53,11 +53,17 @@ import { sharedBoardScreenshotMcp } from './routes/tla/sharedBoardScreenshotMcp'
 import { upload } from './routes/tla/uploads'
 import { testRoutes } from './testRoutes'
 import { Environment, OgImageRenderQueueMessage, QueueMessage, isDebugLogging } from './types'
-import { getLogger, getReplicator, getUserDurableObject } from './utils/durableObjects'
+import {
+	getFileEffectProcessor,
+	getLogger,
+	getReplicator,
+	getUserDurableObject,
+} from './utils/durableObjects'
 import { getFeatureFlags } from './utils/featureFlags'
 import { getAuth, requireAuth } from './utils/tla/getAuth'
 import { getRole } from './utils/tla/getRole'
 export { TLFileDurableObject } from './TLFileDurableObject'
+export { TLFileEffectProcessor } from './TLFileEffectProcessor'
 export { TLLoggerDurableObject } from './TLLoggerDurableObject'
 export { TLPostgresReplicator } from './TLPostgresReplicator'
 export { TLStatsDurableObject } from './TLStatsDurableObject'
@@ -212,6 +218,8 @@ const router = createRouter<Environment>()
 			'debug'
 		)
 		const result = await processor.process(createMutators(auth.userId), req)
+		// wake the outbox consumer; poke only schedules an immediate alarm so this is fast
+		await getFileEffectProcessor(env).poke()
 		return json(result)
 	})
 	.post('/app/zero/query', async (req, env) => {

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -53,6 +53,10 @@ new_sqlite_classes = ["TLFileDurableObject"]
 tag = "v10"
 deleted_classes = ["TLDrawDurableObject"]
 
+[[migrations]]
+tag = "v11"
+new_sqlite_classes = ["TLFileEffectProcessor"]
+
 # preview workers are fresh deploys, so CF rejects v10's delete-class for
 # TLDrawDurableObject (code 10074). skip v1 and v10 here; env-level migrations
 # fully replace the top-level list.
@@ -88,6 +92,10 @@ deleted_classes = ["TLAppDurableObject"]
 [[env.preview.migrations]]
 tag = "v9"
 new_sqlite_classes = ["TLFileDurableObject"]
+
+[[env.preview.migrations]]
+tag = "v11"
+new_sqlite_classes = ["TLFileEffectProcessor"]
 
 [[analytics_engine_datasets]]
 binding = "MEASURE"
@@ -172,6 +180,7 @@ bindings = [
 	{ name = "TLDR_DOC", class_name = "TLFileDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
 	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_FILE_EFFECTS", class_name = "TLFileEffectProcessor" },
 	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 	{ name = "TL_STATS", class_name = "TLStatsDurableObject" },
 ]
@@ -181,6 +190,7 @@ bindings = [
 	{ name = "TLDR_DOC", class_name = "TLFileDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
 	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_FILE_EFFECTS", class_name = "TLFileEffectProcessor" },
 	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 	{ name = "TL_STATS", class_name = "TLStatsDurableObject" },
 ]
@@ -190,6 +200,7 @@ bindings = [
 	{ name = "TLDR_DOC", class_name = "TLFileDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
 	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_FILE_EFFECTS", class_name = "TLFileEffectProcessor" },
 	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 	{ name = "TL_STATS", class_name = "TLStatsDurableObject" },
 ]
@@ -199,6 +210,7 @@ bindings = [
 	{ name = "TLDR_DOC", class_name = "TLFileDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
 	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_FILE_EFFECTS", class_name = "TLFileEffectProcessor" },
 	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 	{ name = "TL_STATS", class_name = "TLStatsDurableObject" },
 ]
@@ -208,6 +220,7 @@ bindings = [
 	{ name = "TLDR_DOC", class_name = "TLFileDurableObject" },
 	{ name = "TL_PG_REPLICATOR", class_name = "TLPostgresReplicator" },
 	{ name = "TL_USER", class_name = "TLUserDurableObject" },
+	{ name = "TL_FILE_EFFECTS", class_name = "TLFileEffectProcessor" },
 	{ name = "TL_LOGGER", class_name = "TLLoggerDurableObject" },
 	{ name = "TL_STATS", class_name = "TLStatsDurableObject" },
 ]

--- a/apps/dotcom/zero-cache/effect_outbox.test.ts
+++ b/apps/dotcom/zero-cache/effect_outbox.test.ts
@@ -1,0 +1,232 @@
+import { readdirSync, readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import pg from 'pg'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+
+// Focused integration test for the effect_outbox trigger (migrations 047, 048), the
+// generic transactional outbox that TLFileEffectProcessor (sync-worker) drains. The
+// design-critical case is #5 below: cleanup_deleted_group_trigger (023_groups.sql)
+// soft-deletes group-owned files from inside a plpgsql trigger when a group is
+// deleted, and file_effect_outbox_after_change must still fire for that UPDATE —
+// a trigger-on-trigger cascade that only a real Postgres can exercise.
+//
+// This talks to a real postgres (the triggers are plpgsql, so fakes can't exercise
+// them). It is opt-in: set ZERO_CACHE_TEST_POSTGRES_URL (local dev stack:
+// postgres://user:password@localhost:6543/postgres) to run it. Without a connection
+// string the suite is skipped so CI stays green.
+//
+// Isolation differs from stamp_comment_created_at.test.ts / delete_file_states.test.ts:
+// those pin `search_path` to a throwaway schema because their migration SQL uses
+// unqualified table names. 047/048 hardcode `public.` (CREATE TABLE public.effect_outbox,
+// CREATE TRIGGER ... ON public.file), so search_path can't redirect them — running them
+// verbatim always targets the connection's `public` schema. Since ZERO_CACHE_TEST_POSTGRES_URL
+// points at a real local dev stack whose `public` schema holds real dev data, this suite
+// instead creates a throwaway database with CREATE DATABASE, and drops it in afterAll.
+//
+// Owning a whole database also means the REAL migration chain (000 → 048) can run
+// verbatim, exactly like migrate.ts applies it. Every trigger involved — the outbox
+// trigger, the group-delete cascade, the updatedAt bumper (005), the owner-details
+// denormalizers — is the shipped one, not a test copy, so a behavior change in any
+// migration is caught here.
+const CONNECTION_STRING = process.env.ZERO_CACHE_TEST_POSTGRES_URL
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), 'migrations')
+
+// The full, shipped migration chain in filename order — the same ordering migrate.ts
+// uses (readdirSync().sort()).
+const MIGRATION_FILES = readdirSync(MIGRATIONS_DIR)
+	.filter((f) => f.endsWith('.sql'))
+	.sort()
+
+const dbName = `tldraw_test_outbox_${process.pid}`
+
+const describeMaybe = CONNECTION_STRING ? describe : describe.skip
+if (!CONNECTION_STRING) {
+	// eslint-disable-next-line no-console
+	console.warn(
+		'effect_outbox.test.ts: skipping — TLFileEffectProcessor depends on this trigger; set ' +
+			'ZERO_CACHE_TEST_POSTGRES_URL to verify it against a real postgres.'
+	)
+}
+
+describeMaybe('effect_outbox trigger (file changes + group-delete cascade)', () => {
+	// One client on the admin connection (for CREATE/DROP DATABASE, which cannot run
+	// inside a transaction) and one on the throwaway database (where the migration
+	// chain and all DML run un-namespaced, matching production).
+	let adminClient: pg.Client
+	let client: pg.Client
+
+	beforeAll(async () => {
+		adminClient = new pg.Client({ connectionString: CONNECTION_STRING })
+		await adminClient.connect()
+		await adminClient.query(`DROP DATABASE IF EXISTS "${dbName}"`)
+		await adminClient.query(`CREATE DATABASE "${dbName}"`)
+
+		const url = new URL(CONNECTION_STRING!)
+		url.pathname = `/${dbName}`
+		client = new pg.Client({ connectionString: url.toString() })
+		await client.connect()
+
+		// Apply the real migration chain, in order, verbatim.
+		for (const filename of MIGRATION_FILES) {
+			const sql = readFileSync(join(MIGRATIONS_DIR, filename), 'utf8')
+			try {
+				await client.query(sql)
+			} catch (err) {
+				throw new Error(`Migration ${filename} failed: ${(err as Error).message}`)
+			}
+		}
+	})
+
+	afterAll(async () => {
+		if (client) await client.end()
+		if (adminClient) {
+			await adminClient.query(`DROP DATABASE IF EXISTS "${dbName}"`)
+			await adminClient.end()
+		}
+	})
+
+	beforeEach(async () => {
+		// TRUNCATE fires no row-level triggers, so resetting state writes no outbox rows.
+		// CASCADE clears referencing tables (file_state, group_file, group_user, ...).
+		await client.query(`TRUNCATE "user", "file", "group", effect_outbox CASCADE`)
+	})
+
+	async function seedUser(id: string) {
+		await client.query(
+			`INSERT INTO "user" ("id", "name", "email", "avatar", "color", "exportFormat", "exportTheme",
+			   "exportBackground", "exportPadding", "createdAt", "updatedAt", "flags")
+			 VALUES ($1, $1, $1, '', '', 'png', 'auto', false, false, 0, 0, '')`,
+			[id]
+		)
+	}
+
+	async function seedFile(
+		id: string,
+		overrides: { ownerId?: string | null; owningGroupId?: string | null } = {}
+	) {
+		const ownerId = overrides.ownerId !== undefined ? overrides.ownerId : 'u1'
+		const owningGroupId = overrides.owningGroupId !== undefined ? overrides.owningGroupId : null
+		await client.query(
+			`INSERT INTO "file" ("id", "name", "ownerId", "owningGroupId", "thumbnail", "shared",
+			   "sharedLinkType", "published", "lastPublished", "publishedSlug", "createdAt",
+			   "updatedAt", "isEmpty")
+			 VALUES ($1, $1, $2, $3, '', false, 'view', false, 0, $1, 0, 0, false)`,
+			[id, ownerId, owningGroupId]
+		)
+	}
+
+	interface OutboxRow {
+		tableName: string
+		entityId: string
+		command: string
+		payload: any
+		prevPayload: any
+		attempts: number
+		nextRetryAt: string | null
+	}
+
+	async function outboxRows(entityId: string): Promise<OutboxRow[]> {
+		const res = await client.query<OutboxRow>(
+			`SELECT "tableName", "entityId", command, payload, "prevPayload", attempts, "nextRetryAt"
+			 FROM effect_outbox WHERE "entityId" = $1 ORDER BY id`,
+			[entityId]
+		)
+		return res.rows
+	}
+
+	it('file INSERT produces one outbox row with the new row as payload and no prevPayload', async () => {
+		await seedUser('u1')
+		await seedFile('f1')
+
+		const rows = await outboxRows('f1')
+		expect(rows).toHaveLength(1)
+		expect(rows[0].tableName).toBe('file')
+		expect(rows[0].command).toBe('insert')
+		expect(rows[0].payload.id).toBe('f1')
+		expect(rows[0].prevPayload).toBeNull()
+	})
+
+	it('a no-op update (bumping only updatedAt) produces no new outbox row', async () => {
+		await seedUser('u1')
+		await seedFile('f1')
+
+		// This is the room-persist path: sync-worker bumps updatedAt every few seconds
+		// per active room. The 005 trigger rewrites updatedAt to now() on any distinct
+		// update, so only updatedAt differs between OLD and NEW — the outbox filter
+		// must treat that as a no-op.
+		await client.query(`UPDATE "file" SET "updatedAt" = 12345 WHERE "id" = 'f1'`)
+
+		const rows = await outboxRows('f1')
+		// only the insert row from seedFile
+		expect(rows).toHaveLength(1)
+		expect(rows[0].command).toBe('insert')
+	})
+
+	it('an effect-relevant update (publish) produces an update row carrying the full OLD row as prevPayload', async () => {
+		await seedUser('u1')
+		await seedFile('f1')
+
+		await client.query(
+			`UPDATE "file" SET "published" = true, "lastPublished" = 999 WHERE "id" = 'f1'`
+		)
+
+		const rows = await outboxRows('f1')
+		expect(rows).toHaveLength(2)
+		const updateRow = rows[1]
+		expect(updateRow.command).toBe('update')
+		expect(updateRow.payload.published).toBe(true)
+		expect(updateRow.payload.lastPublished).toBe(999)
+		// prevPayload is the full OLD row: changed columns show their old values,
+		// unchanged columns are present and equal
+		expect(updateRow.prevPayload.published).toBe(false)
+		expect(updateRow.prevPayload.lastPublished).toBe(0)
+		expect(updateRow.prevPayload.id).toBe('f1')
+		expect(updateRow.prevPayload.name).toBe('f1')
+		expect(updateRow.prevPayload.ownerId).toBe('u1')
+	})
+
+	it('file DELETE produces a delete row with the OLD row as payload and no prevPayload', async () => {
+		await seedUser('u1')
+		await seedFile('f1')
+
+		await client.query(`DELETE FROM "file" WHERE "id" = 'f1'`)
+
+		const rows = await outboxRows('f1')
+		expect(rows).toHaveLength(2)
+		const deleteRow = rows[1]
+		expect(deleteRow.command).toBe('delete')
+		expect(deleteRow.payload.id).toBe('f1')
+		expect(deleteRow.prevPayload).toBeNull()
+	})
+
+	it('deleting a group cascades to a soft-delete update on its files, and the outbox trigger fires for it', async () => {
+		await seedUser('u1')
+		await client.query(`INSERT INTO "group" ("id", "name") VALUES ('g1', 'g1')`)
+		await seedFile('fGroup', { ownerId: null, owningGroupId: 'g1' })
+
+		// The real cleanup_deleted_group_trigger (023_groups.sql) fires inside this
+		// UPDATE and soft-deletes fGroup, which in turn must fire
+		// file_effect_outbox_after_change for that nested UPDATE.
+		await client.query(`UPDATE "group" SET "isDeleted" = true WHERE "id" = 'g1'`)
+
+		const rows = await outboxRows('fGroup')
+		expect(rows).toHaveLength(2)
+		const cascadeRow = rows[1]
+		expect(cascadeRow.tableName).toBe('file')
+		expect(cascadeRow.command).toBe('update')
+		expect(cascadeRow.payload.isDeleted).toBe(true)
+		expect(cascadeRow.prevPayload.isDeleted).toBe(false)
+	})
+
+	it('new rows start with attempts = 0 and nextRetryAt IS NULL (048 applied)', async () => {
+		await seedUser('u1')
+		await seedFile('f1')
+
+		const rows = await outboxRows('f1')
+		expect(rows).toHaveLength(1)
+		expect(rows[0].attempts).toBe(0)
+		expect(rows[0].nextRetryAt).toBeNull()
+	})
+})

--- a/apps/dotcom/zero-cache/migrations/047_effect_outbox.sql
+++ b/apps/dotcom/zero-cache/migrations/047_effect_outbox.sql
@@ -1,0 +1,53 @@
+-- Generic transactional outbox for server-side effects. Rows are written by
+-- row-level triggers on source tables (only "file" today) so every write path is
+-- captured, including the cleanup_deleted_group_trigger cascade. Drained by
+-- TLFileEffectProcessor in sync-worker, which dispatches on "tableName".
+-- Future effect sources (e.g. notifications) add a trigger + a consumer handler.
+-- NOT added to the zero_data publication: server-only table.
+
+CREATE TABLE public.effect_outbox (
+	id            BIGSERIAL PRIMARY KEY,
+	"tableName"   VARCHAR NOT NULL,  -- source table
+	"entityId"    VARCHAR NOT NULL,  -- source row id
+	command       VARCHAR NOT NULL,  -- 'insert' | 'update' | 'delete'
+	payload       JSONB NOT NULL,    -- NEW row (OLD for delete)
+	"prevPayload" JSONB,             -- full OLD row, updates only
+	attempts      INT NOT NULL DEFAULT 0,
+	"createdAt"   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION file_effect_outbox_fn() RETURNS trigger AS $$
+BEGIN
+	IF TG_OP = 'INSERT' THEN
+		INSERT INTO public.effect_outbox ("tableName", "entityId", command, payload)
+		VALUES ('file', NEW.id, 'insert', to_jsonb(NEW));
+		RETURN NEW;
+	ELSIF TG_OP = 'UPDATE' THEN
+		-- Skip no-op updates: room persists bump "updatedAt" every few seconds per active
+		-- room; only effect-relevant columns should produce outbox rows.
+		IF NEW.name IS NOT DISTINCT FROM OLD.name
+			AND NEW.shared IS NOT DISTINCT FROM OLD.shared
+			AND NEW."sharedLinkType" IS NOT DISTINCT FROM OLD."sharedLinkType"
+			AND NEW.published IS NOT DISTINCT FROM OLD.published
+			AND NEW."lastPublished" IS NOT DISTINCT FROM OLD."lastPublished"
+			AND NEW."publishedSlug" IS NOT DISTINCT FROM OLD."publishedSlug"
+			AND NEW."isDeleted" IS NOT DISTINCT FROM OLD."isDeleted"
+			AND NEW."ownerId" IS NOT DISTINCT FROM OLD."ownerId"
+			AND NEW."owningGroupId" IS NOT DISTINCT FROM OLD."owningGroupId"
+		THEN
+			RETURN NEW;
+		END IF;
+		INSERT INTO public.effect_outbox ("tableName", "entityId", command, payload, "prevPayload")
+		VALUES ('file', NEW.id, 'update', to_jsonb(NEW), to_jsonb(OLD));
+		RETURN NEW;
+	ELSE
+		INSERT INTO public.effect_outbox ("tableName", "entityId", command, payload)
+		VALUES ('file', OLD.id, 'delete', to_jsonb(OLD));
+		RETURN OLD;
+	END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER file_effect_outbox_after_change
+AFTER INSERT OR UPDATE OR DELETE ON public.file
+FOR EACH ROW EXECUTE FUNCTION file_effect_outbox_fn();

--- a/apps/dotcom/zero-cache/migrations/048_effect_outbox_retry_at.sql
+++ b/apps/dotcom/zero-cache/migrations/048_effect_outbox_retry_at.sql
@@ -1,0 +1,4 @@
+-- Timed retry backoff for effect_outbox. A failed row schedules its next
+-- eligible retry so rapid pokes can't burn all attempts in a burst; the drain
+-- filter skips rows until "nextRetryAt" passes and the 30s alarm sweep retries.
+ALTER TABLE public.effect_outbox ADD COLUMN "nextRetryAt" TIMESTAMPTZ;

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -472,6 +472,17 @@ export interface TlaAsset {
 	userId: string | null
 }
 
+export interface TlaEffectOutbox {
+	id: number
+	tableName: string
+	entityId: string
+	command: 'insert' | 'update' | 'delete'
+	payload: unknown
+	prevPayload: unknown | null
+	attempts: number
+	createdAt: Date
+}
+
 /**
  * The welcome-template pointer (see migration 035). Worker-side config only — not a Zero
  * table (absent from `createSchema` below), so it never replicates to clients.
@@ -521,6 +532,7 @@ export interface DB {
 	comment_read: TlaCommentRead
 	comment_mention: TlaCommentMention
 	comment_reaction: TlaCommentReaction & CommentReactionPersistenceColumns
+	effect_outbox: TlaEffectOutbox
 }
 
 export const schema = createSchema({

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -481,6 +481,7 @@ export interface TlaEffectOutbox {
 	prevPayload: unknown | null
 	attempts: number
 	createdAt: Date
+	nextRetryAt: Date | null
 }
 
 /**


### PR DESCRIPTION
Adds a transactional outbox that takes over the legacy sync engine's remaining side effects, running in parallel with that engine. This is the first of two PRs; deleting the engine itself (TLPostgresReplicator, TLUserDurableObject) comes in a follow-up gated on staging verification.

## Background

Before Zero, tldraw.com synced app data (files, workspaces, preferences) through a custom engine: `TLPostgresReplicator` tailed the database's logical replication stream and fanned changes out to per-user durable objects (`TLUserDurableObject`), which pushed them to clients over websockets. Zero now handles all of that sync, so the engine's only remaining jobs are its side effects: server-side reactions to `file` row changes that no client ever performs. This PR moves those side effects to a transactional outbox so the engine can be deleted.

## The side effects being moved

Every one of these is triggered by a change to a `file` row in Postgres:

1. **Notify the file's live room.** Each file's multiplayer session runs in a durable object (`TLFileDurableObject`). When the file row changes, that room must react: sync a rename into the document, kick or downgrade connected guests when sharing is turned off or restricted, and — on delete — close every session and clean up the room's stored data (R2 snapshots, edit history).
2. **Publish / unpublish.** Publishing copies the room's current snapshot to the published-snapshots bucket and registers the public slug; unpublishing tears that down. Triggered by `published`/`lastPublished` transitions on the file row.
3. **User creation on first sign-in** (not file-triggered, but also lived in the legacy engine): create the `user` row and home workspace. This moves to a plain worker route.

Why a database trigger rather than hooking the mutation endpoint: not all file changes go through our code. Deleting a workspace fires a Postgres trigger that soft-deletes its member files entirely inside the database — an outbox row written by a trigger in the same transaction is the only mechanism that catches every write path, loss-free.

Everything else the replicator did (subscription graphs, per-user fan-out, mutation acks) existed only to serve the pre-Zero sync protocol and disappears with the engine in the follow-up PR.

## How it works

- Migration 047 adds a generic `effect_outbox` table and a row-level trigger on `file`, so every file change — including the workspace-delete cascade that soft-deletes files inside Postgres — records an effect row in the same transaction. No-op updates (e.g. `updatedAt` bumps from room persists) are filtered in the trigger.
- A new singleton `TLFileEffectProcessor` durable object drains the table in id order: room DO lifecycle notifications (`appFileRecordCreated/DidUpdate/DidDelete`) and publish/unpublish snapshot management (moved verbatim from the replicator into `utils/publishSnapshots.ts`). The Zero mutate endpoint pokes it (fire-and-forget via `waitUntil`); a 30s alarm sweep catches trigger-only writes and lost pokes.
- Before executing an effect the consumer re-reads the current file row and acts on present truth, so rapid publish/unpublish flapping converges and stale effects are skipped. Failed effects retry with at most one attempt per drain, park after 10 attempts (reported to Sentry), and are cleaned up after 7 days.
- `POST /app/:userId/init` becomes a plain worker route (same transaction as the user DO's init, minus the DO).
- Admin: `/app/admin/user` is now backed by Postgres directly, `/app/admin/outbox` replaces `/app/admin/replicator` with outbox stats, the force-reboot route is gone, and `hard_delete_file` awaits an outbox drain instead of `sleep(1000)`.
- Health checks: the legacy `/health-check/replicator` and `/health-check/user-durable-objects` routes are removed and `/health-check/postgres` gains an `outbox-lag` sub-check. `/health-check/zero-replicator` (which monitors Zero's replication connection) is untouched.

Parallel-run with the legacy engine is safe: both replay the same ordered sequence of file changes and all effects are idempotent. The outbox table is not in the `zero_data` publication and is filtered out of the legacy replicator's wal2json table list.

Deploy notes:
- updown.io monitors for the two deleted health-check endpoints should be removed when this deploys.
- May conflict trivially with #9676 in `worker.ts`.

### Change type

- [x] `improvement`

### Test plan

Verified manually against the local dev stack (temporary dev-gated logging on the drain pipeline):

1. ✅ Init route: fresh signup creates user + home workspace; repeat calls no-op (idempotent under the onConflict guard)
2. ✅ File create: trigger row → poke → drain → `appFileRecordCreated`, end to end in ~40ms
3. ✅ No-op filter: drawing (room persists bumping `updatedAt`) produces zero outbox rows
4. ✅ Live-session effects with a guest tab: rename propagates, share downgrade/unshare kicks the guest
5. ✅ Publish/unpublish: snapshots created and removed, published link follows; rapid publish/unpublish flapping converges to the last action via the staleness guard
6. ✅ Workspace delete cascade: `cleanup_deleted_group_trigger`'s in-Postgres soft-deletes produced one outbox batch with every member file, drained in 51ms (the write path no worker code observes — the reason for the trigger-based outbox)
7. ✅ Alarm-only path: a direct psql `UPDATE file SET "isDeleted" = true` (no poke) drained by the 30s sweep
8. ✅ Retry/backoff: a synthetic poison row climbed the exponential ladder (30s base, 5min cap) and stayed invisible to drains between retries
9. ✅ Backlog recovery: 10 accumulated rows drained in one cycle after the past-due-alarm fix (found via this testing; see the alarm commit)
10. ✅ Admin: user lookup, outbox stats endpoint, undelete; hard-delete drains before the row cascade
11. ✅ At rest: `effect_outbox` returns to 0 rows; `/health-check/postgres` reports `outbox: 0s, 0 parked`

Remaining for staging: repeat 2, 4-6 on real infrastructure and watch the `outbox-lag`/parked sub-checks for a few days before the follow-up removal PR.

- [x] Unit tests

### Release notes

- Internal: moved file side effects (room notifications, publish/unpublish) to a transactional outbox on tldraw.com.

## Rollout guide (whole removal, 4 steps)

This PR is step 1 of removing the legacy sync engine. Each step deploys via the normal pipeline: merge to `main` → staging (migrations run automatically before zero-cache + sync-worker), then `dotcom-hotfix-please` → production.

1. **This PR.** Merge to main, run the verification checklist on staging (signup, rename/share with a guest, publish/unpublish incl. rapid flapping, file delete, workspace delete, admin panel, `effect_outbox` empty at rest). Hotfix to production. Remove the updown.io monitors for `/health-check/replicator` and `/health-check/user-durable-objects` at deploy time. The legacy engine keeps running in parallel — double notifications are idempotent by design.
2. **Engine deletion PR.** Hold until this PR has been on production for a few days with a quiet `outbox-lag` sub-check and no new Sentry noise from `TLFileEffectProcessor`. Its PR description carries its own merge/hotfix gates.
3. **`deleted_classes` (v12) PR.** A tiny wrangler-only follow-up. Must reach each environment only after that environment ran the deletion PR (the main→staging→hotfix flow gives this ordering for free as long as it stays a separate, later PR). Never added to the preview migration list (CF error 10074 on fresh preview workers).
4. **Postgres cleanup (manual runbook, in the deletion PR's description).** Drop the `tlpr_*` replication slots, the `alltables` publication, and the `user_mutation_number` / `replicator_boot_id` tables — only after step 3 is live everywhere.


