### PR TITLE
fix(editor): don't crash on browsers without Intl.Segmenter

### DIFF
--- a/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
+++ b/packages/editor/src/lib/editor/managers/TextManager/TextManager.ts
@@ -1,5 +1,5 @@
 import { BoxModel, TLDefaultHorizontalAlignStyle } from '@tldraw/tlschema'
-import { objectMapKeys } from '@tldraw/utils'
+import { iterateGraphemes, objectMapKeys } from '@tldraw/utils'
 import type { Editor } from '../../Editor'
 import { EditorManager } from '../EditorManager'
 
@@ -93,10 +93,6 @@ export interface TLMeasureTextSpanOpts {
 }
 
 const spaceCharacterRegex = /\s/
-
-// Iterate by grapheme cluster (e.g. emoji sequences, flags, accented letters)
-// rather than by code point, so a single glyph is measured as one unit.
-const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
 
 const initialDefaultStyles = Object.freeze({
 	'overflow-wrap': 'break-word',
@@ -309,7 +305,7 @@ export class TextManager extends EditorManager {
 		for (const childNode of element.childNodes) {
 			if (childNode.nodeType !== Node.TEXT_NODE) continue
 
-			for (const { segment } of graphemeSegmenter.segment(childNode.textContent ?? '')) {
+			for (const segment of iterateGraphemes(childNode.textContent ?? '')) {
 				// place the range around the grapheme we're interested in
 				range.setStart(textNode, idx)
 				range.setEnd(textNode, idx + segment.length)

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -244,6 +244,9 @@ export function isNonNull<T>(value: T): value is typeof value extends null ? nev
 export function isNonNullish<T>(value: T): value is typeof value extends undefined ? never : typeof value extends null ? never : T;
 
 // @public
+export function iterateGraphemes(str: string): Generator<string, void, undefined>;
+
+// @public
 export type JsonArray = JsonValue[];
 
 // @public

--- a/packages/utils/api-report.api.md
+++ b/packages/utils/api-report.api.md
@@ -244,7 +244,7 @@ export function isNonNull<T>(value: T): value is typeof value extends null ? nev
 export function isNonNullish<T>(value: T): value is typeof value extends undefined ? never : typeof value extends null ? never : T;
 
 // @public
-export function iterateGraphemes(str: string): Generator<string, void, undefined>;
+export function iterateGraphemes(str: string): IterableIterator<string>;
 
 // @public
 export type JsonArray = JsonValue[];

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -91,7 +91,7 @@ export {
 	setInLocalStorage,
 	setInSessionStorage,
 } from './lib/storage'
-export { getFirstCharacter } from './lib/string'
+export { getFirstCharacter, iterateGraphemes } from './lib/string'
 export { stringEnum } from './lib/stringEnum'
 export { FpsScheduler, fpsThrottle, throttleToNextFrame } from './lib/throttle'
 export { Timers } from './lib/timers'

--- a/packages/utils/src/lib/string.test.ts
+++ b/packages/utils/src/lib/string.test.ts
@@ -1,4 +1,5 @@
-import { getFirstCharacter } from './string'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getFirstCharacter, iterateGraphemes } from './string'
 
 describe('getFirstCharacter', () => {
 	it('returns the first character of a plain string', () => {
@@ -19,5 +20,61 @@ describe('getFirstCharacter', () => {
 
 	it('handles a leading whitespace character', () => {
 		expect(getFirstCharacter(' hi')).toBe(' ')
+	})
+})
+
+describe('iterateGraphemes', () => {
+	it('yields each grapheme cluster in order', () => {
+		expect([...iterateGraphemes('a😀b')]).toEqual(['a', '😀', 'b'])
+	})
+
+	it('keeps a multi-code-point cluster whole', () => {
+		expect([...iterateGraphemes('👨‍👩‍👧!')]).toEqual(['👨‍👩‍👧', '!'])
+	})
+
+	it('yields nothing for an empty string', () => {
+		expect([...iterateGraphemes('')]).toEqual([])
+	})
+})
+
+// On browsers without `Intl.Segmenter` (e.g. Firefox before 125) the module must not throw and must
+// still iterate; it falls back to code-point iteration. The segmenter is probed lazily on first
+// use, so `Intl.Segmenter` has to be absent at call time — reset the module and remove the global
+// for the duration of each call.
+describe('grapheme iteration without Intl.Segmenter', () => {
+	afterEach(() => {
+		vi.resetModules()
+	})
+
+	async function withoutSegmenter<T>(fn: (mod: typeof import('./string')) => T): Promise<T> {
+		vi.resetModules()
+		// `Intl.Segmenter` is typed read-only; take a mutable view so we can remove and restore it.
+		const mutableIntl = Intl as { Segmenter?: typeof Intl.Segmenter }
+		const original = mutableIntl.Segmenter
+		delete mutableIntl.Segmenter
+		expect('Segmenter' in Intl).toBe(false)
+		try {
+			return fn(await import('./string'))
+		} finally {
+			mutableIntl.Segmenter = original
+		}
+	}
+
+	it('iterateGraphemes falls back to code-point iteration', async () => {
+		await withoutSegmenter(({ iterateGraphemes }) => {
+			expect([...iterateGraphemes('ab😀')]).toEqual(['a', 'b', '😀'])
+		})
+	})
+
+	it('getFirstCharacter keeps a surrogate pair whole', async () => {
+		await withoutSegmenter(({ getFirstCharacter }) => {
+			expect(getFirstCharacter('😀 hello')).toBe('😀')
+		})
+	})
+
+	it('getFirstCharacter splits a ZWJ cluster to its first code point rather than throwing', async () => {
+		await withoutSegmenter(({ getFirstCharacter }) => {
+			expect(getFirstCharacter('👨‍👩‍👧 family')).toBe('👨')
+		})
 	})
 })

--- a/packages/utils/src/lib/string.ts
+++ b/packages/utils/src/lib/string.ts
@@ -25,7 +25,7 @@ function getGraphemeSegmenter(): Intl.Segmenter | undefined {
  *
  * @public
  */
-export function* iterateGraphemes(str: string): Generator<string, void, undefined> {
+export function* iterateGraphemes(str: string): IterableIterator<string> {
 	const segmenter = getGraphemeSegmenter()
 	if (segmenter) {
 		for (const { segment } of segmenter.segment(str)) yield segment

--- a/packages/utils/src/lib/string.ts
+++ b/packages/utils/src/lib/string.ts
@@ -1,4 +1,38 @@
 let graphemeSegmenter: Intl.Segmenter | undefined
+let checkedForSegmenter = false
+
+/**
+ * Resolve a shared grapheme `Intl.Segmenter`, or `undefined` when the runtime has no
+ * `Intl.Segmenter`. `Intl.Segmenter` is unavailable on some older browsers (notably Firefox before
+ * 125), so feature-detect it once rather than constructing it eagerly, which would throw at module
+ * load and take down the whole app.
+ */
+function getGraphemeSegmenter(): Intl.Segmenter | undefined {
+	if (!checkedForSegmenter) {
+		checkedForSegmenter = true
+		if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+			graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+		}
+	}
+	return graphemeSegmenter
+}
+
+/**
+ * Iterate over the grapheme clusters of a string — user-perceived characters such as emoji
+ * sequences, flags, and accented letters — instead of UTF-16 code units. Uses `Intl.Segmenter`
+ * where available and falls back to iterating by code point on browsers that lack it, where a
+ * multi-code-point cluster is yielded as its component code points rather than as one segment.
+ *
+ * @public
+ */
+export function* iterateGraphemes(str: string): Generator<string, void, undefined> {
+	const segmenter = getGraphemeSegmenter()
+	if (segmenter) {
+		for (const { segment } of segmenter.segment(str)) yield segment
+	} else {
+		yield* str
+	}
+}
 
 /**
  * Get the first character of a string, treating a multi-code-unit character such as an emoji as a
@@ -17,8 +51,7 @@ let graphemeSegmenter: Intl.Segmenter | undefined
  */
 export function getFirstCharacter(str: string): string {
 	if (!str) return ''
-	graphemeSegmenter ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' })
-	for (const { segment } of graphemeSegmenter.segment(str)) {
+	for (const segment of iterateGraphemes(str)) {
 		return segment
 	}
 	return ''


### PR DESCRIPTION
In order to keep tldraw.com loading on older browsers, this fixes a crash on any browser without `Intl.Segmenter` — notably Firefox before 125, including the 115 ESR line that some users are stuck on because it's the last Firefox for their OS. `TextManager` constructed `new Intl.Segmenter(...)` at module top-level, so simply *importing* it threw `Intl.Segmenter is not a constructor` before the app could render — the user got a blank canvas rather than degraded text. `getFirstCharacter` had the same latent throw the first time it was called (e.g. rendering avatar initials).

Grapheme segmentation now lives in a shared `iterateGraphemes()` helper in `@tldraw/utils` that feature-detects `Intl.Segmenter` lazily (on first use, never at import) and falls back to iterating by code point when it's missing. Both `TextManager` and `getFirstCharacter` route through it, so there's a single source of truth. On browsers that lack the API the app now loads normally; the only degradation there is that multi-code-point clusters (ZWJ emoji like 👨‍👩‍👧, flags) are measured as their component code points instead of as one glyph.

Opening as a draft to verify on the preview deploy in a real Firefox 115 ESR before marking ready.

Closes #9895

### Preview & testing

Preview deploy: https://pr-9896-preview-deploy.tldraw.com/

### Change type

- [x] `bugfix`

### Test plan

1. In Firefox older than 125 (e.g. 115 ESR), open the preview URL. Before this change: a blank canvas with `Intl.Segmenter is not a constructor` in the console. After: the editor loads and text shapes render.
2. Add a text shape with plain text and with emoji, and confirm it renders and measures. On old Firefox, multi-code-point emoji (👨‍👩‍👧, flags) may be spaced slightly differently — that's the expected degradation.
3. On a modern browser, confirm there's no regression to text measurement/wrapping or to avatar initials (`getFirstCharacter`).

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix tldraw.com failing to load on older browsers that lack `Intl.Segmenter`, such as Firefox before 125.

### API changes

- Added `iterateGraphemes(str)` to `@tldraw/utils` — iterates a string's grapheme clusters, using `Intl.Segmenter` when available and falling back to code-point iteration when it isn't.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +38 / -9   |
| Tests           | +58 / -1   |
| Automated files | +3 / -0    |
