### PR TITLE
chore(dotcom): delete legacy durable object classes

### DIFF
--- a/apps/dotcom/sync-worker/src/undeleteFile.test.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.test.ts
@@ -28,20 +28,16 @@ function makeFile(overrides: Partial<TlaFile> = {}): TlaFile {
 // Stubs the chains undeleteFile uses:
 //   selectFrom('file').where().selectAll().executeTakeFirst()
 //   selectFrom('group').select().where().executeTakeFirst()
-//   selectFrom('group_user').select().where().execute()
-//   selectFrom('user').select().where().executeTakeFirst()
 //   updateTable('file').set().where().execute()
 //   insertInto(table).values().onConflict().execute()
 function makeFakeDb(
 	fileRow: TlaFile | undefined,
 	opts: {
-		groupMembers?: Array<{ userId: string }>
-		userRow?: { id: string } | undefined
 		// Use 'none' to simulate a missing group row; omit for a live (isDeleted: false) group.
 		groupRow?: { isDeleted: boolean } | 'none'
 	} = {}
 ) {
-	const { groupMembers = [], userRow, groupRow = { isDeleted: false } } = opts
+	const { groupRow = { isDeleted: false } } = opts
 	const resolvedGroupRow = groupRow === 'none' ? undefined : groupRow
 	const updates: Array<{ table: string; values: any }> = []
 	const inserts: Array<{ table: string; values: any }> = []
@@ -65,20 +61,6 @@ function makeFakeDb(
 				return {
 					select: () => ({
 						where: () => ({ executeTakeFirst: async () => resolvedGroupRow }),
-					}),
-				}
-			}
-			if (table === 'group_user') {
-				return {
-					select: () => ({
-						where: () => ({ execute: async () => groupMembers }),
-					}),
-				}
-			}
-			if (table === 'user') {
-				return {
-					select: () => ({
-						where: () => ({ executeTakeFirst: async () => userRow }),
 					}),
 				}
 			}
@@ -148,11 +130,7 @@ describe('undeleteFile', () => {
 
 	it('restores the group_file link for a group-owned file', async () => {
 		const file = makeFile({ ownerId: undefined, owningGroupId: 'group-9' })
-		const { db, inserts } = makeFakeDb(file, {
-			groupMembers: [{ userId: 'user-1' }, { userId: 'user-2' }],
-			userRow: undefined,
-			groupRow: { isDeleted: false },
-		})
+		const { db, inserts } = makeFakeDb(file, { groupRow: { isDeleted: false } })
 		const result = await undeleteFile(db, file.id)
 		expect(result.result).toBe('restored')
 		expect(inserts).toEqual([

--- a/apps/dotcom/sync-worker/src/undeleteFile.test.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.test.ts
@@ -128,7 +128,6 @@ describe('undeleteFile', () => {
 		expect(await undeleteFile(db, file.id)).toEqual({
 			result: 'restored',
 			file,
-			rebootUserIds: ['user-1'],
 		})
 		expect(getTransactionCount()).toBe(1)
 		expect(updates).toEqual([
@@ -187,51 +186,5 @@ describe('undeleteFile', () => {
 		expect(await undeleteFile(db, file.id)).toEqual({ result: 'group_deleted', file })
 		expect(updates).toEqual([])
 		expect(inserts).toEqual([])
-	})
-
-	describe('rebootUserIds', () => {
-		it('is just the owner for a legacy file with no group', async () => {
-			const file = makeFile({ ownerId: 'user-1', owningGroupId: undefined })
-			const { db } = makeFakeDb(file)
-			const result = await undeleteFile(db, file.id)
-			expect(result).toMatchObject({ rebootUserIds: ['user-1'] })
-		})
-
-		it('includes the owner for a home-workspace file (group id == user id)', async () => {
-			const file = makeFile({ ownerId: undefined, owningGroupId: 'user-1' })
-			const { db } = makeFakeDb(file, {
-				groupMembers: [],
-				userRow: { id: 'user-1' },
-			})
-			const result = await undeleteFile(db, file.id)
-			expect(result).toMatchObject({ rebootUserIds: ['user-1'] })
-		})
-
-		it('dedupes when the home-workspace owner also has a group_user row', async () => {
-			const file = makeFile({ ownerId: undefined, owningGroupId: 'user-1' })
-			const { db } = makeFakeDb(file, {
-				groupMembers: [{ userId: 'user-1' }],
-				userRow: { id: 'user-1' },
-			})
-			const result = await undeleteFile(db, file.id)
-			expect(result).toMatchObject({ rebootUserIds: ['user-1'] })
-			if (result.result === 'restored') {
-				expect(result.rebootUserIds).toHaveLength(1)
-			}
-		})
-
-		it('includes all members for a shared workspace and not the group id itself', async () => {
-			const file = makeFile({ ownerId: undefined, owningGroupId: 'group-9' })
-			const { db } = makeFakeDb(file, {
-				groupMembers: [{ userId: 'user-1' }, { userId: 'user-2' }],
-				userRow: undefined,
-			})
-			const result = await undeleteFile(db, file.id)
-			expect(result.result).toBe('restored')
-			if (result.result === 'restored') {
-				expect(result.rebootUserIds.sort()).toEqual(['user-1', 'user-2'])
-				expect(result.rebootUserIds).not.toContain('group-9')
-			}
-		})
 	})
 })

--- a/apps/dotcom/sync-worker/src/undeleteFile.ts
+++ b/apps/dotcom/sync-worker/src/undeleteFile.ts
@@ -5,12 +5,12 @@ export type UndeleteFileResult =
 	| { result: 'not_found' }
 	| { result: 'not_deleted'; file: TlaFile }
 	| { result: 'group_deleted'; file: TlaFile }
-	| { result: 'restored'; file: TlaFile; rebootUserIds: string[] }
+	| { result: 'restored'; file: TlaFile }
 
 // Restores a soft-deleted file: clears isDeleted, re-creates the owner's file_state (if the
-// file has an ownerId) and the owning group's group_file link (if owningGroupId). rebootUserIds
-// is a holdover from the legacy sync engine's hard-reboot contract; the current caller
-// (adminRoutes.ts) instead pokes the file effect processor's outbox after a successful restore.
+// file has an ownerId) and the owning group's group_file link (if owningGroupId). The caller
+// pokes the file effect processor's outbox after a successful restore; Zero replicates the
+// row changes to clients on its own.
 export async function undeleteFile(db: Kysely<DB>, fileId: string): Promise<UndeleteFileResult> {
 	return db.transaction().execute(async (tx) => {
 		const file = await tx.selectFrom('file').where('id', '=', fileId).selectAll().executeTakeFirst()
@@ -41,34 +41,14 @@ export async function undeleteFile(db: Kysely<DB>, fileId: string): Promise<Unde
 				.execute()
 		}
 
-		const rebootUserIds = new Set<string>()
-		if (file.ownerId) rebootUserIds.add(file.ownerId)
-
 		if (file.owningGroupId) {
 			await tx
 				.insertInto('group_file')
 				.values({ fileId, groupId: file.owningGroupId, createdAt: now, updatedAt: now })
 				.onConflict((oc) => oc.columns(['fileId', 'groupId']).doNothing())
 				.execute()
-
-			// Workspace members see the file in their sidebar.
-			const members = await tx
-				.selectFrom('group_user')
-				.select('userId')
-				.where('groupId', '=', file.owningGroupId)
-				.execute()
-			for (const member of members) rebootUserIds.add(member.userId)
-
-			// A home workspace's group id equals its owner's user id, and the owner may not have an
-			// explicit group_user row for it, so check for a matching user row too.
-			const ownerAsUser = await tx
-				.selectFrom('user')
-				.select('id')
-				.where('id', '=', file.owningGroupId)
-				.executeTakeFirst()
-			if (ownerAsUser) rebootUserIds.add(ownerAsUser.id)
 		}
 
-		return { result: 'restored', file, rebootUserIds: [...rebootUserIds] }
+		return { result: 'restored', file }
 	})
 }

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -67,6 +67,15 @@ deleted_classes = ["TLDrawDurableObject"]
 tag = "v11"
 new_sqlite_classes = ["TLFileEffectProcessor"]
 
+# v12 deletes the legacy sync engine's DO classes (their bindings were removed in the
+# previous deploy; delete-class must not share a deploy with binding removal). Their no-op
+# stub exports in worker.ts stay forever — staging/prod migration history references the
+# classes, so removing the exports breaks deploys (see #8124). NOT mirrored in the preview
+# list: preview workers deploy fresh and never created these classes (see below).
+[[migrations]]
+tag = "v12"
+deleted_classes = ["TLPostgresReplicator", "TLUserDurableObject", "TLStatsDurableObject"]
+
 # preview workers are fresh deploys, so CF rejects v10's delete-class for
 # TLDrawDurableObject (code 10074). skip v1 and v10 here; env-level migrations
 # fully replace the top-level list.

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -57,6 +57,15 @@ deleted_classes = ["TLDrawDurableObject"]
 tag = "v11"
 new_sqlite_classes = ["TLFileEffectProcessor"]
 
+# v12 deletes the legacy sync engine's DO classes (their bindings were removed in the
+# previous deploy; delete-class must not share a deploy with binding removal). Their no-op
+# stub exports in worker.ts stay forever — staging/prod migration history references the
+# classes, so removing the exports breaks deploys (see #8124). NOT mirrored in the preview
+# list: preview workers deploy fresh and never created these classes (see below).
+[[migrations]]
+tag = "v12"
+deleted_classes = ["TLPostgresReplicator", "TLUserDurableObject", "TLStatsDurableObject"]
+
 # preview workers are fresh deploys, so CF rejects v10's delete-class for
 # TLDrawDurableObject (code 10074). skip v1 and v10 here; env-level migrations
 # fully replace the top-level list.

--- a/packages/dotcom-shared/src/tlaSchema.ts
+++ b/packages/dotcom-shared/src/tlaSchema.ts
@@ -417,29 +417,6 @@ export type TlaCommentMentionPartial = Partial<TlaCommentMention> & {
 	userId: TlaCommentMention['userId']
 }
 
-export type TlaRow =
-	| TlaFile
-	| TlaFileState
-	| TlaFileVisitor
-	| TlaUser
-	| TlaGroup
-	| TlaGroupUser
-	| TlaGroupFile
-	| TlaComment
-	| TlaCommentThread
-	| TlaCommentRead
-	| TlaCommentMention
-export type TlaRowPartial =
-	| TlaFilePartial
-	| TlaFileStatePartial
-	| TlaUserPartial
-	| TlaGroupPartial
-	| TlaGroupUserPartial
-	| TlaGroupFilePartial
-	| TlaCommentPartial
-	| TlaCommentThreadPartial
-	| TlaCommentReadPartial
-	| TlaCommentMentionPartial
 export const immutableColumns = {
 	user: new Set<keyof TlaUser>(['email', 'createdAt', 'updatedAt', 'avatar']),
 	file: new Set<keyof TlaFile>([


### PR DESCRIPTION
Step 3 of the legacy sync engine removal (see the rollout guide in #9893). Stacked on #9894 — the diff shows only this step.

## What it does

- Adds the `v12` wrangler migration deleting the legacy DO classes (`TLPostgresReplicator`, `TLUserDurableObject`, `TLStatsDurableObject`) and purging their stored state. Top-level migrations list only — never the preview list, where fresh workers would reject a delete-class for classes they never created (CF error 10074). The no-op stub exports in worker.ts stay forever; staging/prod migration history references the classes and removing the exports breaks their deploys.
- Drops `rebootUserIds` from `UndeleteFileResult`: it served the legacy engine's hard-reboot contract, which #9894 removed (Zero replicates the restore on its own). Callers never read it.
- Drops the orphaned `TlaRow`/`TlaRowPartial` unions from dotcom-shared: their last consumers were the legacy protocol's row-update types, deleted in #9894.

## Rollout steps (in order)

1. #9894 live on production for at least one deploy cycle. The class deletion must not share a deploy with the binding removal, and each environment must apply them in that order — the main→staging→hotfix pipeline gives the ordering for free as long as this stays a separate, later deploy.
2. **This PR**: merge to main (→ staging). Check the staging deploy logs for migration errors — a wrong preview/top-level split would show as CF error 10074.
3. **This PR**: hotfix to production after staging deploys cleanly with v12 applied; app smoke test (sign in, create/share/delete a file).
4. Manual Postgres cleanup, only after this PR is live on ALL environments (runbook below).
5. One-time R2 cleanup, last: wipe and decommission the `user-do-snapshots` bucket in every env (`user-do-snapshots`, `user-do-snapshots-staging`, `user-do-snapshots-preview`). #9894 removed the binding and the per-user wipe in `performUserDeletion`, so no code path can delete these objects anymore — deleted users' data sits there until the bucket itself goes.

## Postgres cleanup runbook (manual, run per environment)

```sql
-- confirm the legacy slots are inactive (replicator DO is gone):
SELECT slot_name, active FROM pg_replication_slots WHERE slot_name LIKE 'tlpr_%';
-- drop them:
SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_name LIKE 'tlpr_%' AND NOT active;
-- verify only zero consumers remain, then drop the legacy publication:
SELECT * FROM pg_stat_replication;
DROP PUBLICATION IF EXISTS alltables;
-- drop legacy tables (as the next free zero-cache migration number so all envs converge):
DROP TABLE IF EXISTS public.user_mutation_number;
DROP TABLE IF EXISTS public.replicator_boot_id;
```

### Change type

- [x] `other`

### Test plan

1. Fresh preview worker for this PR deploys without migration errors (10074 would show here if the preview list were wrong)
2. Staging deploy applies v12 cleanly; app smoke test (sign in, create/share/delete a file)

- [x] Unit tests

### Release notes

- Internal: deleted the legacy sync engine's durable object classes on tldraw.com.
