### PR TITLE
fix(tldraw): line up the people menu rows

### DIFF
--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -2163,9 +2163,12 @@ tldraw? probably.
 }
 
 /* The color swatch and name line up with the ones on the user's own row above,
-   where the swatch sits inside a standard 12px-padded icon button. */
+   where the swatch sits inside a standard 12px-padded icon button. No padding on
+   the trailing edge: the follow button brings its own, and the row above only
+   spends that gap once. */
 .tlui-people-menu__item__button {
-	padding: 0 12px;
+	padding-inline-start: 12px;
+	padding-inline-end: 0px;
 	overflow: hidden;
 }
 

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -2157,8 +2157,10 @@ tldraw? probably.
 	margin-bottom: 0;
 }
 
+/* The color swatch and name line up with the ones on the user's own row above,
+   where the swatch sits inside a standard 12px-padded icon button. */
 .tlui-people-menu__item__button {
-	padding: 0 11px;
+	padding: 0 12px;
 	overflow: hidden;
 }
 
@@ -2168,7 +2170,7 @@ tldraw? probably.
 	align-items: auto;
 	justify-content: flex-start;
 	flex-grow: 2;
-	gap: 11px;
+	gap: 12px;
 }
 
 .tlui-people-menu__name {

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -2182,7 +2182,9 @@ tldraw? probably.
 	position: absolute;
 	top: 0px;
 	inset-inline-end: 0px;
-	max-width: 40px;
+	/* The button is out of flow, so it opts out of the negative margins that
+	   .tlui-row applies to its children. */
+	margin: 0px;
 	flex-shrink: 0;
 }
 

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -2104,7 +2104,9 @@ tldraw? probably.
 	align-items: center;
 }
 
-.tlui-people-menu__user__color {
+/* The buttons at either end of a row hold their size; the name absorbs the slack. */
+.tlui-people-menu__user__color,
+.tlui-people-menu__user__edit {
 	flex-shrink: 0;
 }
 
@@ -2149,8 +2151,11 @@ tldraw? probably.
 	padding: 0px;
 }
 
+/* Same container as .tlui-people-menu__user above, so the two kinds of row
+   share their insets. */
 .tlui-people-menu__item {
-	position: relative;
+	display: flex;
+	align-items: center;
 }
 
 .tlui-people-menu__item:last-of-type .tlui-button__menu {
@@ -2180,19 +2185,10 @@ tldraw? probably.
 	text-overflow: ellipsis;
 }
 
+/* The button keeps its space whether or not it's showing, so the name doesn't
+   re-truncate as the pointer moves on and off the row. */
 .tlui-people-menu__item__follow {
-	position: absolute;
-	top: 0px;
-	inset-inline-end: 0px;
-	/* The button is out of flow, so it opts out of the negative margins that
-	   .tlui-row applies to its children. */
-	margin: 0px;
 	flex-shrink: 0;
-}
-
-.tlui-people-menu__item[data-follow='true'],
-.tlui-people-menu__item:has(.tlui-button:focus-visible) {
-	padding-inline-end: 36px;
 }
 
 .tlui-people-menu__item[data-follow='true'] .tlui-people-menu__item__follow,
@@ -2205,9 +2201,6 @@ tldraw? probably.
 		opacity: 0;
 	}
 
-	.tlui-people-menu__item:hover {
-		padding-right: 36px;
-	}
 	.tlui-people-menu__item:hover .tlui-people-menu__item__follow {
 		opacity: 1;
 	}

--- a/packages/tldraw/src/lib/ui.css
+++ b/packages/tldraw/src/lib/ui.css
@@ -2104,7 +2104,6 @@ tldraw? probably.
 	align-items: center;
 }
 
-/* The buttons at either end of a row hold their size; the name absorbs the slack. */
 .tlui-people-menu__user__color,
 .tlui-people-menu__user__edit {
 	flex-shrink: 0;
@@ -2151,8 +2150,6 @@ tldraw? probably.
 	padding: 0px;
 }
 
-/* Same container as .tlui-people-menu__user above, so the two kinds of row
-   share their insets. */
 .tlui-people-menu__item {
 	display: flex;
 	align-items: center;
@@ -2162,10 +2159,6 @@ tldraw? probably.
 	margin-bottom: 0;
 }
 
-/* The color swatch and name line up with the ones on the user's own row above,
-   where the swatch sits inside a standard 12px-padded icon button. No padding on
-   the trailing edge: the follow button brings its own, and the row above only
-   spends that gap once. */
 .tlui-people-menu__item__button {
 	padding-inline-start: 12px;
 	padding-inline-end: 0px;
@@ -2188,8 +2181,6 @@ tldraw? probably.
 	text-overflow: ellipsis;
 }
 
-/* The button keeps its space whether or not it's showing, so the name doesn't
-   re-truncate as the pointer moves on and off the row. */
 .tlui-people-menu__item__follow {
 	flex-shrink: 0;
 }

--- a/packages/tldraw/src/lib/ui/components/SharePanel/DefaultPeopleMenuItem.tsx
+++ b/packages/tldraw/src/lib/ui/components/SharePanel/DefaultPeopleMenuItem.tsx
@@ -4,7 +4,6 @@ import { useUiEvents } from '../../context/events'
 import { useTranslation } from '../../hooks/useTranslation/useTranslation'
 import { TldrawUiButton } from '../primitives/Button/TldrawUiButton'
 import { TldrawUiButtonIcon } from '../primitives/Button/TldrawUiButtonIcon'
-import { TldrawUiRow } from '../primitives/layout'
 import { TldrawUiIcon } from '../primitives/TldrawUiIcon'
 
 /** @public */
@@ -38,7 +37,7 @@ export const DefaultPeopleMenuItem = track(function DefaultPeopleMenuItem({
 	if (!presence) return null
 
 	return (
-		<TldrawUiRow
+		<div
 			className="tlui-people-menu__item"
 			data-follow={youAreFollowingThem || theyAreFollowingYou}
 		>
@@ -70,6 +69,6 @@ export const DefaultPeopleMenuItem = track(function DefaultPeopleMenuItem({
 					icon={theyAreFollowingYou ? 'leading' : youAreFollowingThem ? 'following' : 'follow'}
 				/>
 			</TldrawUiButton>
-		</TldrawUiRow>
+		</div>
 	)
 })


### PR DESCRIPTION
In the people menu, a collaborator row doesn't line up with your own row directly above it. The follow (eye) icon sits closer to the panel's right edge than the edit icon does, and the color swatch and name sit slightly further left than yours. Every row should share the same insets.

The two kinds of row were built differently. Your own row is a plain flex container whose buttons are ordinary in-flow children — `.tlui-people-menu__user__edit` has no CSS of its own at all, so it lands on the stock `.tlui-button` geometry. A collaborator row was a `TldrawUiRow` with the follow button absolutely positioned on top of it, and that divergence is where the misalignment came from:

- `.tlui-row > * { margin-left: -2px; margin-right: -2px }` applied to the follow button, and on an out-of-flow box that margin doesn't collapse against a sibling — it just shifted the button 2px past the row's right edge.
- A `max-width: 40px` clamped a button whose natural width is 42px (18px icon + 12px padding each side), so with `box-sizing: border-box` the icon overflowed its own padding by another 1px.
- `.tlui-people-menu__item__button` used `padding: 0 11px` and an `11px` gap where your own row gets 12px from the standard icon button padding.

So this makes the collaborator row use the same container as your own: a plain flex `div`, with the follow button in flow. That deletes the absolute positioning, the `.tlui-row` negative margins, and the `padding-inline-end: 36px` the row used to add on hover to make space for the overlaid button.

One thing that only showed up once the button was in flow: the name lives *inside* the row-spanning button, so its trailing padding and the follow button's leading padding stacked into a 24px gap where your own row — whose name is a bare div butting against the edit button — spends 12px. The row-spanning button no longer pads its trailing edge.

Measured at the wrapper's edges, against your own row:

| | before | after | your own row |
| --- | --- | --- | --- |
| color swatch → left edge | 11px | **12px** | 12px |
| swatch → name | 11px | **12px** | 12px |
| name → trailing icon | 18px | **12px** | 12px |
| trailing icon → right edge | 9px | **12px** | 12px |
| name width | 169px / 135px | **136px** | 136px |

Two behavior changes fall out of going in-flow, both improvements:

- The name column used to be 169px at rest and 135px once the icon appeared, so a long name re-truncated as the pointer moved on and off the row. It's now a constant 136px — the same width as the old hovered state, and identical to your own row.
- On touch the button is always visible, but the row only got its hover padding when `data-follow` was set, so the icon overlapped the end of the name by 16px. In flow it can't.

`flex-shrink: 0` now covers the trailing icon buttons on both rows — `__user__edit` previously had none, so it could have collapsed toward its 40px `min-width` under pressure.

### Change type

- [x] `bugfix`

### Test plan

1. Open a tldraw.com file with at least one other person in the room.
2. Open the people menu from the face pile.
3. The color swatch, name, and trailing icon on a collaborator row should line up with the swatch, name, and edit icon on your own row above.
4. Hover a collaborator row: the eye icon fades in without the name shifting.
5. Tab into the menu: the eye icon on the focused row should appear.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the people menu rows not lining up: the follow icon sat too close to the right edge, and collaborator names sat slightly left of your own.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -19   |

