### PR TITLE
chore(dotcom): raise the sync worker bundle size limit to 1.8mb

### DIFF
--- a/apps/dotcom/sync-worker/package.json
+++ b/apps/dotcom/sync-worker/package.json
@@ -17,7 +17,7 @@
 		"test": "yarn run -T vitest --passWithNoTests",
 		"clean": "rm -rf .wrangler/state .wrangler/state-*",
 		"test-coverage": "yarn run -T vitest run --coverage --passWithNoTests",
-		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 1600000",
+		"check-bundle-size": "yarn run -T tsx ../../../internal/scripts/check-worker-bundle.ts --entry src/worker.ts --size-limit-bytes 1800000",
 		"reset-db": "./reset-db.sh",
 		"lint": "yarn run -T tsx ../../../internal/scripts/lint.ts"
 	},


### PR DESCRIPTION
In order to land anything in the sync worker again, this raises its bundle size limit from 1.6mb to 1.8mb.

The limit has not moved in a while and main now bundles to **1,596,735 bytes — 3,265 bytes of headroom, 99.8% of the budget**. That is small enough that the check fails on the next change to touch this worker whatever its size; it caught a feature adding 12kb, but a 4kb one would have done it too.

### Where the 1.6mb goes

Measured from the esbuild metafile the check already writes:

| | | |
| --- | --- | --- |
| Third-party dependencies | 1,055,280 | 66% |
| The worker's own source | 366,203 | 23% |
| tldraw workspace packages | 183,329 | 11% |

Two things stand out, and neither is code anyone wrote recently:

- **`src/welcome/defaultWelcomeSnapshot.ts` is 177,203 bytes — 11% of the whole bundle**, larger than any single dependency and larger than every tldraw workspace package put together. It is the welcome board's document snapshot, compiled in as source rather than fetched.
- **`protobufjs` is 79,892 bytes (5%)** and is reached only through `pg-logical-replication`'s decoder plugin — no worker code imports it. `zod` (60,343, 3.7%) arrives the same way through `@pierre/storage`.

Database access is the largest theme overall: kysely plus the three Postgres clients is ~258kb, 16%.

### Why raise it rather than reduce

Both of the reductions above are worth doing and neither is small or obviously safe. Moving the welcome snapshot out of the bundle is a ~177kb win on its own, roughly fifteen times what any recent feature has added. Doing that work under time pressure, because an unrelated PR is blocked, is how it gets done badly. Raising the ceiling separates the two so the reductions can be judged on their own.

The new number is a guardrail against unnoticed growth, not a target.

### Change type

- [x] `other`

### Test plan

1. `yarn workspace @tldraw/dotcom-worker check-bundle-size` passes on main (1,596,735 < 1,800,000).

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +1 / -1    |
