### PR TITLE
[HOTFIX] feat(dotcom): render board thumbnails ahead of the first share

### DIFF
--- a/apps/dotcom/browser-run-thumbnails.md
+++ b/apps/dotcom/browser-run-thumbnails.md
@@ -10,39 +10,217 @@ tldraw.com can capture PNG thumbnails of public boards by taking a Cloudflare Br
 - an MCP server at `POST /api/app/mcp` exposing two tools: `get_board_info` lists a board's pages (name, 0-based index, and whether each has content), and `get_shared_board_screenshot` returns a content-fit PNG of a single page. Each screenshot renders exactly one page, so an agent lists pages first and then requests the ones it wants; and
 - a board OG image endpoint, `GET /api/app/social-preview/:prefix/:slug/image`, built for high-traffic paths (link unfurls, crawlers): it serves only from the R2 cache and delegates rendering to a queue consumer, so a request never waits on Browser Run. It lives under the `social-preview` route family alongside the crawler HTML that references it.
 
-Rendering runs through the Browser Rendering `/screenshot` Quick Action, invoked from the worker via the `BROWSER` binding's `quickAction` method (`env.BROWSER.quickAction('screenshot', …)`). Chrome runs in Cloudflare's Browser Rendering fleet, not in the worker isolate. The pipeline never hands the browser a user-provided URL: the worker resolves the board, verifies it is publicly viewable (a published board, or a file shared via link), mints a short-lived signed render job, and the screenshot only ever targets the internal render page with that token. The MCP surface exposes page metadata (names, counts) and page screenshots only: no document structure, shape listing, arbitrary selectors, arbitrary URLs, or access to files that are not publicly shared.
+Rendering runs through the Browser Rendering `/screenshot` Quick Action, invoked from the worker via the `BROWSER` binding's `quickAction` method (`env.BROWSER.quickAction('screenshot', …)`). Chrome runs in Cloudflare's Browser Rendering fleet, not in the worker isolate. The pipeline never hands the browser a user-provided URL: the worker resolves the board, mints a short-lived signed render job, and the screenshot only ever targets the internal render page with that token. **Rendering is not gated on public viewability — serving is.** A thumbnail is generated for every board, private ones included, so that an owner-facing surface has one to show; the OG image route re-applies the public gate on every request. See "Rendering every board" below for what that means for the render token. The MCP surface exposes page metadata (names, counts) and page screenshots only: no document structure, shape listing, arbitrary selectors, arbitrary URLs, or access to files that are not publicly shared.
 
 ## Architecture
 
 1. A client calls `get_shared_board_screenshot` with a board id — the `:slug` of a published board (`https://www.tldraw.com/p/:slug`) or of an anonymously-shared file (`https://www.tldraw.com/f/:slug`) — a 0-based `page` ordinal (default 0), and an optional theme (default light). It usually calls `get_board_info` first to discover the board's pages.
-2. The sync worker resolves the id as a shared file first and as a published-board slug second, so callers never need to know which kind of board they hold. Shared files resolve the id directly as the `file.id` (`getSharedFileInfo`) and must pass the same anonymous-view gate the live file room enforces: the file exists, is not deleted, and is `shared` via link (`isFileAnonymouslyViewable`). `sharedLinkType` (`view` vs `edit`) is irrelevant to viewing; test-slug files are refused because they require admin auth the anonymous tool never has. Published boards resolve through the `file` row (`getPublishedFileInfo`) and must be published. Unknown, unpublished, or private boards fail without spending any Browser Rendering capacity.
+2. The sync worker resolves the id as a shared file first and as a published-board slug second, so callers never need to know which kind of board they hold. Shared files resolve the id directly as the `file.id` (`getSharedFileInfo`) and must pass the same anonymous-view gate the live file room enforces: the file exists, is not deleted, and is `shared` via link (`isFileAnonymouslyViewable`). `sharedLinkType` (`view` vs `edit`) is irrelevant to viewing; test-slug files are refused because they require admin auth the anonymous tool never has. Published boards resolve through the `file` row (`getPublishedFileInfo`) and must be published. Unknown, unpublished, or private boards fail without spending any Browser Rendering capacity. This is the `access: 'public'` gate; the render path uses a weaker one — see "Rendering every board".
 3. The worker builds a per-page R2 cache key from board identity, a content version, the fixed 1200x630 output size, theme, and the page ordinal (`mcp/{kind}/{slug}/{version}/1200x630/{theme}/page-{n}.png`), with the page name in object metadata. The version is the file's `lastPublished` for published boards and the persisted room snapshot's R2 etag for shared files, so republishing or editing rotates every page's key. A cache hit in the `THUMBNAILS` bucket returns immediately — without even loading the board snapshot, since the ordinal alone keys the object and the page name rides in its metadata.
-4. On a miss, the worker loads the board's room snapshot to resolve the ordinal to a real page (its `TLPageId` and name) and to validate the range, then mints an HMAC-signed render token (`renderTokens.ts`) carrying the board identity, that `pageId`, and render parameters with a 5 minute expiry. Page enumeration is capped at `MAX_THUMBNAIL_PAGES` (40), so `pageCount` and the addressable ordinals stop there on very large boards. The snapshot route re-checks that `pageId` still exists at render time: a page deleted inside the token's window fails the render rather than returning a different page's image under the original page's name.
-5. The worker calls the Browser Rendering `/screenshot` Quick Action through `env.BROWSER.quickAction`, targeting `{MCP_SCREENSHOT_RENDER_ORIGIN}/__thumbnail-render?token=...`. The render page (`apps/dotcom/client/src/pages/thumbnail-render.tsx`) exchanges the token for snapshot data at `GET /api/app/thumbnail-render/snapshot`, which verifies the signature and expiry before returning records, schema, and render params. Published boards read a frozen R2 snapshot; shared files read the live persisted room snapshot from R2 (`env.ROOMS`) and re-check the share gate here, not just when the token was minted, so a board un-shared during the token's 5 minute window stops resolving. The page selects the requested `pageId`, content-fits it with margins once fonts and image assets have settled, exports it with `editor.toImage`, and then displays that PNG as a full-viewport `<img>` and sets `data-thumbnail-ready` — so the screenshot captures the exact export rather than the live editor canvas. Any failure (bad token, snapshot load, export, image decode) sets `data-thumbnail-error` instead. The Quick Action waits for _either_ terminal marker and captures `body[data-thumbnail-ready="true"]`, which only exists on the success path — so a failed render returns as soon as it errors rather than holding Browser Run capacity for the whole timeout. The render and settle budgets (`THUMBNAIL_RENDER_TIMEOUT_MS` 45s, `THUMBNAIL_SETTLE_TIMEOUT_MS` 10s) live in `@tldraw/dotcom-shared` so the worker's deadline and the page's can't drift.
+4. On a miss, the worker loads the board's room snapshot to resolve the ordinal to a real page (its `TLPageId` and name) and to validate the range, then mints an HMAC-signed render token (`renderTokens.ts`) carrying the board identity, that `pageId`, and render parameters, expiring in `THUMBNAIL_RENDER_TOKEN_TTL_MS` (60s). Page enumeration is capped at `MAX_THUMBNAIL_PAGES` (40), so `pageCount` and the addressable ordinals stop there on very large boards. The snapshot route re-checks that `pageId` still exists at render time: a page deleted inside the token's window fails the render rather than returning a different page's image under the original page's name.
+5. The worker calls the Browser Rendering `/screenshot` Quick Action through `env.BROWSER.quickAction`, targeting `{MCP_SCREENSHOT_RENDER_ORIGIN}/__thumbnail-render?token=...`. The render page (`apps/dotcom/client/src/pages/thumbnail-render.tsx`) exchanges the token for snapshot data at `GET /api/app/thumbnail-render/snapshot`, which verifies the signature and expiry before returning records, schema, and render params. Published boards read a frozen R2 snapshot; shared files read the live persisted room snapshot from R2 (`env.ROOMS`) and re-check their gate here, not just when the token was minted, so a board deleted during the token's window stops resolving. The page selects the requested `pageId`, content-fits it with margins once fonts and image assets have settled, exports it with `editor.toImage`, and then displays that PNG as a full-viewport `<img>` and sets `data-thumbnail-ready` — so the screenshot captures the exact export rather than the live editor canvas. Any failure (bad token, snapshot load, export, image decode) sets `data-thumbnail-error` instead. The Quick Action waits for _either_ terminal marker and captures `body[data-thumbnail-ready="true"]`, which only exists on the success path — so a failed render returns as soon as it errors rather than holding Browser Run capacity for the whole timeout. The render and settle budgets (`THUMBNAIL_RENDER_TIMEOUT_MS` 45s, `THUMBNAIL_SETTLE_TIMEOUT_MS` 10s) live in `@tldraw/dotcom-shared` so the worker's deadline and the page's can't drift.
 6. The screenshot response body is the PNG bytes. The worker writes them to the page's cache key in R2 (for future hits) and returns two MCP content items: a text item with the page name, followed by the image.
 
 ### OG images (queue-backed async rendering)
 
-`GET /api/app/social-preview/:prefix/:slug/image` (`:prefix` is `p` for published boards or `f` for shared files) serves a 1200x630 light-theme, content-fit PNG for use in `og:image` tags. The crawler HTML that references it is the existing worker route `/app/social-preview/:prefix/:slug` (`getSocialPreview`, which Vercel routes crawler user-agents to), which puts the board name in the title and bounces human visitors back to the board. It only emits the board `og:image` (and `summary_large_image`) when the board resolves through the same gate the image route applies; for private, deleted, or unpublished boards it keeps the static site-wide preview image, because crawlers that don't follow `og:image` redirects (notably X) would otherwise render a broken card. The request path never invokes Browser Run:
+`GET /api/app/social-preview/:prefix/:slug/image` (`:prefix` is `p` for published boards or `f` for shared files) serves a 1200x630 light-theme, content-fit PNG for use in `og:image` tags. The crawler HTML that references it is the existing worker route `/app/social-preview/:prefix/:slug` (`getSocialPreview`, which Vercel routes crawler user-agents to), which puts the board name in the title and bounces human visitors back to the board. It only emits the board `og:image` (and `summary_large_image`) when the board resolves through the same gate the image route applies; for private, deleted, or unpublished boards it names the static site-wide preview image directly, since pointing at a board image route that has nothing to serve would only cost the crawler a redirect to reach the same file. The request path never invokes Browser Run:
 
-1. The board is resolved through the same gates as the MCP tool. Private, deleted, unpublished, or unknown boards redirect (302) to the default tldraw OG image.
-2. If the cached image in R2 matches the board's current content version - or is younger than one hour, which caps one board's Browser Run spend at roughly one render per hour no matter how often it changes or is crawled - it is served as a hit with `max-age=3600`.
-3. Otherwise the worker enqueues an `og-image-render` job on the existing sync-worker queue (guarded by a per-board rate limit and a two-minute pending marker in R2 that dedupes concurrent enqueues) and serves the previous image marked stale with `max-age=300`, or the default-image redirect with `max-age=60` if the board has never been rendered. Scrapers pick up the fresh render on their next visit. The route is registered with `.all`, because crawlers probe with HEAD before (or instead of) GET: a HEAD gets the same cache/redirect headers from an R2 `head`, but never reads the body and never enqueues, so a probe can't spend Browser Run.
-4. The queue consumer (`ogImageQueue.ts`, dispatched from the worker's `queue()` handler) re-resolves the board at render time: a board un-shared while queued is dropped and its cached OG image deleted, and the version is re-read so bursts of enqueues coalesce into one capture of the newest content. It checks the shared global Browser Rendering rate limit (the same `global` limiter key the MCP tool uses, so both surfaces draw from one cap), loads the snapshot to pick the first page that _has content_ (so a board with an empty first page still unfurls with a meaningful image), mints a render token with `camera: 'content'` and that `pageId`, screenshots it through the same `env.BROWSER.quickAction` path as the MCP tool, and writes the PNG to the cache key the route reads. If the snapshot can't be read it fails there and then rather than paying for a capture that would fail on the render page for the same reason. Genuine transient failures retry up to three times with backoff, then drop. When global capacity is busy the job is instead re-enqueued as a fresh message on its own budget (so backpressure never consumes the failure-retry budget), with exponential backoff capped at two minutes and a maximum of 12 requeues — after that the chain gives up so its own capacity checks stop crowding the shared limiter, and the next crawler hit re-enqueues once capacity recovers.
+The route is a **pure read** — two questions and nothing else:
+
+1. **Is the board publicly viewable?** Resolved through the same gate as the MCP tool: published, or shared via link. Private, deleted, unpublished, or unknown boards get the default tldraw OG image (see the fallback below). This is checked on every request, which is what keeps an unshared board's image unreachable even though the image itself is never deleted.
+2. **Does a thumbnail exist?** If so it is served, whatever its state, with `max-age=300` and the object's etag. That is the only thing the version affects — a mismatch is logged as `stale` and served anyway, because an old picture of the board beats the generic tldraw logo, and there is no "too stale to serve". Otherwise, the default-image fallback with `max-age=60`.
+
+**The lifetime is chosen from the share gate, not from cost or freshness.** R2 reads are a rounding error next to rendering, and unfurl platforms cache a card their own side for days whatever we send, so neither pushes the number around. What the lifetime does decide is how long an image can be served without the gate in step 1 being consulted — and since nothing deletes a board's image when it stops being public, that gate is the only thing keeping an unshared board's thumbnail off the internet. So it is minutes rather than the hour it used to be, `stale-while-revalidate` is absent (it would extend serving a day past expiry, the same objection the default-image redirect already answers), and an `etag` with `if-none-match` support makes the resulting revalidations cheap: a cache that still holds the current bytes gets a 304, and every one of those re-runs the gate.
+
+The route is registered with `.all`, because crawlers probe with HEAD before (or instead of) GET: a HEAD gets the same cache headers from an R2 `head` but never reads the body.
+
+**It has no rate limiting, and it enqueues a render in exactly one case.** It used to do both generally. The general enqueue was pointless in the way that matters: unfurl platforms resolve a URL's card once and reuse it for every repost, so the crawler that triggered the render has already cached the default by the time the render lands — a viral link can be fetched once and shown thousands of times, and none of those views come back here. The render was real work whose result nobody fetched. Making the image exist _before_ the board is ever shared is the job of the publish and edit triggers below, not of the request that discovers it missing. With that gone, the per-board limit and the one-hour minimum refresh age that bounded it went too, along with `getOgImageAge`.
+
+What remains is a **repair for published boards with no image at all** (`repairMissingPublishedImage`), and it exists because the two kinds are not symmetric in how many triggers they have. A shared file re-asks on every persist that advances its document clock, so an ask lost to a queue failure or to a pending marker left behind by an earlier one is made good by the next edit. A published board has exactly one trigger — the publish effect — and its snapshot is frozen, so nothing ever edits it into asking again: one lost ask leaves that board's card generic until somebody republishes. The repair fires only on a total miss (never on a stale image), only for `published`, and on HEAD as well as GET since some crawlers only ever probe. It does not contradict the paragraph above — it is not trying to serve the request that triggers it, it is being the thing that asks when nothing else will.
+
+Because it is the one render ask an unauthenticated request can cause, it is bounded twice. The pending marker dedupes it while a job is alive, and a **repair cooldown** (`OG_REPAIR_COOLDOWN_MS`, 1 hour) bounds it after one dies: when a crawler-triggered job burns its whole retry budget, the give-up arms a per-board cooldown that the repair consults before enqueueing. Without it, the give-up clearing the pending marker would let the next crawl re-arm a full retry chain immediately — a published board that deterministically fails to render (a huge board that times out, say) would cost a chain of captures every ~4 minutes for as long as anything an attacker controls fetched its URL. With it, such a board costs one chain per hour. Only the crawler-reason give-up arms the cooldown, and only the repair consults it, so a publish-triggered render that fails transiently still gets one immediate repair on the next crawl, and a genuine republish renders straight away regardless. The publish trigger also _clears_ the cooldown, because an in-place republish reuses the slug: the cooldown is evidence about the snapshot that failed to render, and it must not outlive that snapshot and suppress the new one's repair. A republished board that still cannot render simply re-arms it on the next crawler give-up.
+
+3. The queue consumer (`ogImageQueue.ts`, dispatched from the worker's `queue()` handler) re-resolves the board at render time under `access: 'render'`: a board deleted or unpublished while queued is dropped without rendering, an unshared one still renders (see "Rendering every board"), and the version is re-read so bursts of enqueues coalesce into one capture of the newest content. It loads the snapshot to pick the first page that _has content_ (so a board with an empty first page still unfurls with a meaningful image), mints a render token with `camera: 'content'` and that `pageId`, screenshots it through the same `env.BROWSER.quickAction` path as the MCP tool, and writes the PNG to the cache key the route reads. If the snapshot can't be read it fails there and then rather than paying for a capture that would fail on the render page for the same reason. Genuine transient failures retry up to three times with backoff, then drop. There is no capacity check: thumbnail rendering is uncapped (see "Request limits").
+
+#### Default-image fallback
+
+A board with no usable cached image is sent to the site-wide default (`/social-og.png`, 1200x630, the size the `og:image:width`/`height` meta advertises) with a **302**. The worker does not proxy those bytes: the default is a static asset on the client origin and already cached at the edge, so serving it here would put worker egress in front of every unfurl of an unrendered board. The redirect carries `cache-control: public, max-age=60` with no `s-maxage` and no `stale-while-revalidate`, so nothing pins it under a board's permanent image URL once the real render arrives. Telemetry records it as `not_rendered_yet`.
+
+**The cost is a generic card, not a broken one.** The crawler follows the redirect and gets a valid image — the tldraw logo rather than the board — and then caches that card for days. So what matters is not how the empty case renders but how often it is reached, which is what the publish and edit triggers are for. What remains exposed is a board shared within the debounce window of its first edit, or one dormant since before this shipped.
+
+### Keeping the thumbnail current
+
+Nothing renders on crawler demand any more, so a board's thumbnail has to exist before its first share. Two triggers make that happen, both enqueueing onto the same queue and consumer, and both subject to the same re-resolve and version check at render time. Every queue message carries a `reason` (`publish`, `edit`) that rides through to telemetry; `crawler` survives in the union only as the fallback for messages enqueued before the field existed.
+
+- **Publish.** The `publish` effect in `TLPostgresReplicator` enqueues a render right after `publishSnapshot` writes the frozen R2 snapshot, so a published board's image is being made before its link is pasted anywhere. `unpublish` deletes the cached image and pending marker instead — the one replicator effect that touches a thumbnail. **Unsharing has no effect of its own**: every board renders whether shared or not, and the share gate is applied at serve time, so there is nothing derived from a board's public state to tear down when it goes private.
+- **On edit.** `TLFileDurableObject.persistToDatabase` schedules a render on a persist that actually advanced the document clock. The only states that skip are `legacy` and `deleted` (see "Rendering every board"); shared and private boards both render. There is no sampling and no staleness window — a persist means the board's saved content genuinely differs from what the cached thumbnail shows, which is exactly when a re-render is warranted.
+
+  **The ask is debounced, not throttled.** Each persist pushes the render deadline out by `OG_RENDER_DEBOUNCE_MS` (60s), so a board renders once its editing _settles_ rather than on a cadence while it is still being drawn on — which is what a thumbnail is for. `OG_RENDER_MAX_WAIT_MS` (5 minutes), measured from the first persist since the last render, stops a board that is never left alone from never rendering. The arithmetic lives in `utils/ogRenderDebounce.ts` so it is testable without standing up a durable object; the object supplies the clock and the alarm.
+
+  **The durable alarm is the deadline**, not an approximation of it. Every persist re-arms it, so the two can never disagree and an eviction loses only the in-memory copy: the alarm still fires at exactly the time the debouncer chose, and the board renders once, when it should.
+
+  This replaced a cheaper scheme where the deadline moved in memory and the alarm was left where it was, re-arming itself on each fire. That wrote storage about once per debounce window instead of once per persist, but it meant the alarm was only a _lower bound_ on the deadline — so an evicted object woke early, rendered, and then rendered again when editing actually settled. The cost moved rather than grew: an alarm write per persist (7.5/min for a continuously edited board), against far fewer alarm **invocations**, since the alarm no longer fires mid-session purely to push itself further out. Ten minutes of unbroken editing goes from ~20 wake-ups to 2 — the two renders themselves. `ogRenderDebounce.test.ts` pins both halves.
+
+  `pendingSince`, the max-wait anchor, is still in memory only. Losing it to an eviction restarts the five minute window, which can delay a render but never duplicate one.
+
+- **The debounce is the rate control; the pending marker is not.** `OG_PENDING_MARKER_TTL_MS` (5 minutes) reads like a render interval but isn't one — the consumer deletes the marker as soon as a render lands, so on a healthy board it never lives out its TTL. It is a single-flight that stops a second ask being queued while one is in flight, plus a crash ceiling. The TTL is sized above a job's worst-case retry chain (three captures at the full 45s timeout plus 30s and 60s of backoff, ~3.75 minutes) so the marker cannot lapse while its job is still alive — a lapse would let a second job for the same board overlap the first and clobber its render token record. A test pins that inequality. To change how often a board renders, change the debounce.
+
+  **The marker drops asks rather than deferring them,** which matters because nothing upstream retries one. The debouncer resets the moment it fires and neither caller reads the enqueue result, so an ask turned away is simply gone. A capture takes seconds, so an edit landing during one hits this: without help, the board would keep a thumbnail of its before-the-last-edits state until something happened to ask again.
+
+  Two things cover it. A **retry** needs nothing — every delivery re-resolves before capturing, so a later attempt picks up the newest content by itself. A **completed render** re-resolves afterwards and enqueues a follow-up if the version moved under it (`enqueueFollowUpIfBoardMoved`). A job that gives up permanently clears the marker rather than letting it lapse, so the next ask is acted on immediately.
+
+  Follow-ups deliberately **do not chain**: a board edited without pause is stale at the end of every capture, so chaining would render it continuously — the exact cost the debounce exists to avoid. The ceiling is one extra render per triggered render. The residue is narrow and known: if editing stops such that the final debounce fire lands inside a follow-up's capture window, that last ask is swallowed and nothing re-asks, so the board keeps a nearly-settled thumbnail until its next edit.
+
+#### Why a debounce and not a throttle
+
+This started as a 30s leading-and-trailing throttle. Measurement killed it. Production runs **~555 persists/min across ~359 boards active in a 10 minute window** — a mean gap between a given board's persists of roughly **39 seconds**, which is _longer_ than the 30s window. A throttle whose window is shorter than the gap between events suppresses almost nothing: its leading edge fired on nearly every persist, so render volume tracked persist volume rather than the interval it was nominally set to.
+
+The debounce is a better fit in shape as well as cost. Cost, for a board edited without pause (verified in `utils/ogRenderDebounce.test.ts`):
+
+| Mechanism                        | Renders per 10-minute editing session | Isolated burst |
+| -------------------------------- | ------------------------------------- | -------------- |
+| None                             | 76                                    | 1              |
+| 30s throttle                     | ~20                                   | 1–2            |
+| 1/min rate limit                 | 10                                    | 1              |
+| **60s debounce + 5min max wait** | **2**                                 | **1**          |
+
+Note the right-hand column: on a bursty board — which the 39s mean gap says is the common case — every mechanism costs the same one render. The debounce is not a saving there; it is a saving on the heavy tail of sustained editing, and it renders the _finished_ burst rather than its first stroke.
+
+Sizing what remains: Browser Run allows 60 new browser instances per minute per account. With a debounce, spend scales with **editing sessions**, not persists and not wall-clock windows, so the quantity to forecast is distinct shared boards starting an editing session per minute. Both inputs — the link-shared fraction `f` and the session shape — now ride on `persist_success` (`blob3` and `index1`), so they are Analytics Engine questions rather than database ones. See "Open questions", and "What it costs" for what the answer is worth in dollars.
 
 ### Request limits
 
-- Per IP: ~2 calls per minute each for `get_board_info` (`ip-info:`) and `get_shared_board_screenshot` (`ip-shot:`), on separate keys of `MCP_SCREENSHOT_RATE_LIMITER`. They are separate because `get_board_info` spends no Browser Run, and sharing one budget would let the usual "list once, then screenshot pages" flow burn its allowance on the free call.
-- Per board: ~2 Browser Run captures per minute, applied only on cache misses. The OG route applies the same limit to its own key (`og-board:`) to bound queue enqueues per board.
-- Global: ~6 Browser Run captures per minute across all callers (`MCP_SCREENSHOT_BROWSER_RATE_LIMITER`), shared by the MCP tool and the OG queue consumer via the single `global` key.
+Thumbnail rendering has **no global cap**, deliberately. It is our own derived artifact, triggered by things that already happened (a publish, an edit persisting) rather than by anything a caller can drive, so a global rate limiter there would only ever mean "serve a stale thumbnail to save a render we intend to do anyway". The queue consumer performs no capacity check at all.
 
-The Cloudflare rate limit bindings are declared in `wrangler.toml` for every environment. When a binding is absent (local dev, tests) the route falls back to an isolate-local guard with the same limits.
+What bounds it instead is per-board: the render debounce in front of the edit trigger (`OG_RENDER_DEBOUNCE_MS`, with `OG_RENDER_MAX_WAIT_MS` as its ceiling). That is a freshness rule rather than a budget — it does not know or care what the rest of the system is spending — so total thumbnail spend scales with the number of boards being edited at once. See "Keeping the thumbnail current" for how it is sized against Browser Run's account limits, which are now the real ceiling.
+
+Worth being explicit that **no per-board mechanism can cap total spend**, because total is `active boards × per-board rate`. Cloudflare's rate limit binding cannot close that gap either: limits are applied per Cloudflare location, so a single global key gives `limit × locations`, not `limit`. (The same caveat applies to the MCP global cap below — `MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT = 20` is really 20/min per colo. It bounds a rogue caller, which is its job, but it is not an account-wide spend ceiling.) The levers that actually bound the total are Browser Run's own account limits and raising them.
+
+The limits below are therefore the **only** rate limiting in the pipeline, and they exist for the **MCP endpoint** specifically — the one Browser Run-spending surface an outside caller can drive directly, where a rogue or looping agent is the threat being bounded. They are applied in `sharedBoardScreenshotMcp.ts` (with the fallback budgets in `config.ts`), not in the shared render core, so a new surface built on those helpers cannot pick one up by accident:
+
+- Per IP: ~10 `get_shared_board_screenshot` calls per minute (`ip-shot:` on `MCP_SCREENSHOT_RATE_LIMITER`).
+- Per board: ~2 Browser Run captures per minute (`board:` on `MCP_SERVER_BOARD_RATE_LIMITER`), applied only on cache misses.
+- Global: ~20 Browser Run captures per minute across all MCP callers (`MCP_SERVER_BROWSER_RATE_LIMITER`, key `global`).
+
+Per-board is deliberately far tighter than per-IP: a caller gets 10 captures a minute, but no single board may absorb more than 2 of them. Because captures are counted only on cache misses, this does not bound the usual "screenshot several pages of one board" flow — a repeated capture of the same page is a cache hit.
+
+That gap is only expressible because each budget has **its own binding**. A binding carries a single `limit` applied per key, so two budgets wanting different numbers cannot share one however distinct their keys are. Per-IP and per-board shared `MCP_SCREENSHOT_RATE_LIMITER` while both were 2, which made them look separable when they were not; per-board moved to `MCP_SERVER_BOARD_RATE_LIMITER` (`namespace_id` 1013–1016) when they diverged.
+
+The `MCP_SERVER_` prefix on two of the three is deliberate. Neither budget is about screenshots as such — they bound Browser Run spending by the MCP endpoint, and the cluster tools land on the same allowance, so a name tied to one tool is wrong the moment a second tool spends it.
+
+Only the global cap is built to last, though. Authentication on the MCP server replaces **both** caller-scoped budgets with a single per-user limiter: once anonymous access is blocked, the logged-in user is the thing to limit, and neither the IP nor the board is. So the two are treated differently only because of where they are in their lives. The per-IP binding keeps `MCP_SCREENSHOT_RATE_LIMITER` because it is deployed and counting, and renaming live state on its way out buys nothing. The per-board binding has never been deployed — it is introduced on this branch — so it costs nothing to ship under the better name for however long it lives.
+
+Two things to know when changing any of these. The numbers live in **two places that must move together** — the constants in `sharedBoardScreenshotMcp.ts` are only the isolate-local fallback for local dev and tests, and every deployed environment is governed by the Cloudflare binding in `wrangler.toml`, so editing one alone changes nothing where it matters. Unit tests run with no bindings at all, so they pin the fallback constants and can never catch a wrong or shared binding; `wrangler.toml` is the only place to check that. And `period` in those bindings [must be either 10 or 60 seconds](https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/) — that restriction is on the window, not on `limit`, which is an unconstrained integer. All of these use `period = 60`.
+
+Only the calls that actually spend Browser Run are limited. `get_board_info` is not: it resolves a board and reads its snapshot, which is the same work the ordinary board routes already do for anyone. It previously held its own per-IP budget (`ip-info:`), kept separate from the screenshot one so the usual "list once, then screenshot pages" flow could not burn its allowance on the free call; that budget is now simply absent. The OG image route's per-board limit (`og-board:`) is gone too, along with the route's enqueue — see "OG images (queue-backed async rendering)" above.
+
+The Cloudflare rate limit bindings are declared in `wrangler.toml` for every environment. When a binding is absent (local dev, tests) the route falls back to an isolate-local guard with the same limits. Changing the global cap means moving the `MCP_SERVER_BROWSER_RATE_LIMITER` bindings in `wrangler.toml` (one per environment) and the isolate-local fallback constant `MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT` in `config.ts` together.
+
+The thing to watch instead of a cap is Browser Rendering's own account limits: a render can hold a session for the full 45s `THUMBNAIL_RENDER_TIMEOUT_MS`, so sustained edit volume is bounded in practice by concurrent-session and new-session-per-minute limits rather than by anything in this worker. Browser Rendering bills by browser duration, so thumbnail spend now scales with editing activity. `fetch-screenshot-metrics.ts` (below) is how that gets watched.
+
+### What it costs
+
+Quick Actions bill [**duration only**](https://developers.cloudflare.com/browser-run/pricing/) — $0.09 per browser hour beyond the 10 hours a month Workers Paid includes. The per-concurrent-browser charge applies to Browser Sessions, which this pipeline does not use, so concurrency is a limit here rather than a line item. A capture that fails on a `waitForTimeout` is not charged at all, which means telemetry's wall-clock `double3` is an upper bound on the bill rather than the bill.
+
+**What it costs today, measured.** The Browser Run dashboard (Compute > Browser Run) for July 2026: **15.22 browser hours across 8.75k Quick Action requests**, all of them `Screenshot` against `www.tldraw.com/__thumbnail-render`, no Browser Sessions at all. Volume was near zero until about July 20 and has run at **~1,000 captures and 1.6–2.6 browser hours a day** since — call it **0.7 renders/min**, against a **$0.47** bill for the month and a **$4–6/month** run rate if that holds. This is the pre-branch pipeline: the edit trigger is not deployed, so what is being measured is publish- and crawler-driven rendering only.
+
+**Those hours are all thumbnails.** Browser Run reports one account-wide figure that both surfaces land in, but the buckets separate them: `dotcom-mcp-data-preview` holds **0 objects**, and the production `dotcom-mcp-data` bucket does not exist yet. Since every MCP capture writes exactly one object and its key carries the board's content version, an empty bucket is an unused surface — so the whole 8.75k is the OG pipeline, and the MCP tool's share of the bill is currently zero. That also makes the object count the standing way to split the two later: MCP captures over the last 30 days are just the object count in that bucket, since the lifecycle rule expires them on exactly that schedule.
+
+The useful number that falls out of it is the **mean capture: 6.3 seconds** (15.22h / 8.75k). That is what the forecast below is priced at, rather than an assumption, and it is worth re-deriving the same way whenever these figures move — two dashboard numbers divided by each other.
+
+At that 6.3 seconds, one render is **~$0.00016 of browser time** and **~$0.000018 of everything else**: three R2 class A writes (the pending marker, the render token record, the PNG — deletes are free), roughly seven class B reads across resolve, cache check, snapshot load and token check, three queue operations, and a couple of worker requests. So ~$160 per million renders against ~$18 for the machinery around them, and the only quantity worth forecasting is the render count.
+
+**Renders scale with editing sessions, and the session shape is now measured.** [PR 9708](https://github.com/tldraw/tldraw/pull/9708) put `index1` (the durable object id) on every file DO event in production, which is exactly what open question 2 needs: `persist_success` rows carry a per-board key, so a board's persists can be bucketed by time and the runs between them counted. Replaying the debounce's own rules over a 30 minute production window (`blob1 = 'persist_success'`, `blob2 = 'production-tldraw-multiplayer'`, grouping by `index1`, splitting a board's persists wherever the gap exceeds `OG_RENDER_DEBOUNCE_MS`, and adding one render per `OG_RENDER_MAX_WAIT_MS` a run survives):
+
+| Quantity                                    | Measured                                  |
+| ------------------------------------------- | ----------------------------------------- |
+| Boards persisting in the window             | 553                                       |
+| Persists                                    | 521/min (independently confirms the ~555) |
+| Editing time                                | 69.5 board-minutes per minute             |
+| **Renders — sessions settling**             | **34–51/min**                             |
+| **Renders — `OG_RENDER_MAX_WAIT_MS` fires** | **0.3–4/min**                             |
+| **Total**                                   | **~37–51/min, ~54,000–74,000/day**        |
+| Browser hours/month                         | 2,800–3,900                               |
+| **Browser Run $/month**                     | **$250–350**                              |
+
+The range is sampling, not uncertainty about the mechanism: Analytics Engine thins high-volume indexes, and a thinned timeline splits runs that were really continuous, so the raw count is an upper bound. The low end divides each board's gaps by its own `_sample_interval` before applying the 30 second rule. Both ends assume nothing — they are the branch's constants applied to production timings. **Call it $250–350/month and plan against ~$300.**
+
+Two things fall out of the measurement that the model got wrong:
+
+- **Renders per persist is 0.07–0.10.** The debounce suppresses about 90% of persists, which is the claim in "Why a debounce and not a throttle", now with a number on it.
+- **Editing is far more fragmented than assumed.** The median session spans **8–12 seconds** and the p90 spans 86–216 seconds; in a 10 minute window, 105 of 251 persisting boards persisted exactly once. Sessions are short bursts, not the multi-minute stretches the estimate assumed, which is why the render count is close to one per board-editing-visit.
+
+One caveat on the figure: `persist_success` on `main` carries no `sharedState`, so these counts include `legacy` and `deleted` rooms that the trigger skips. The measurement is an over-count by that fraction, and this branch's `blob3` is what nets it out.
+
+#### The two constants only work as a pair
+
+The same replay run over six hours (3,507 boards) against a grid of both constants, in renders/min and Browser Run $/month:
+
+| Debounce ↓ / max wait → | 5 min           | 10 min      | 15 min      | off         |
+| ----------------------- | --------------- | ----------- | ----------- | ----------- |
+| 30s                     | 35.7 · $240     | 32.1 · $216 | 31.3 · $211 | 30.5 · $205 |
+| **60s (current)**       | **32.3 · $218** | 26.7 · $180 | 25.1 · $169 | 23.3 · $157 |
+| 120s                    | 32.0 · $215     | 24.4 · $164 | 22.0 · $148 | 19.0 · $128 |
+
+Read along the first column: at a 5 minute max wait, quadrupling the debounce from 30s to 120s saves almost nothing (35.7 → 32.0). The reason is mechanical — merging two bursts into one longer session pushes that session past `OG_RENDER_MAX_WAIT_MS`, so a settle render is traded for a max-wait render, and `OG_RENDER_MAX_WAIT_MS` puts a floor under what the debounce alone can achieve. The savings live on the diagonal: 60s with a 10 minute max wait is ~25% fewer renders, 120s with 15 minutes is ~38% fewer.
+
+The debounce is at 60s and the max wait stays at 5 minutes, which buys roughly 10%. That is a deliberate choice rather than the cheapest point on the grid: a board edited without pause keeps a five minute old thumbnail rather than a ten minute old one, and the cheaper cells are available whenever spend matters more than that.
+
+**Raising the account limit is still worth doing, and the grid is why.** Browser Run allows 60 new browsers/min. The mean is ~32 renders/min at the current constants, but the limit applies per minute and the distribution has a tail: p99 is ~47/min and the busiest minute observed reached 71–75/min — most likely a wave of rooms persisting together after a deploy or an eviction, which is exactly the shape that breaches a per-minute limit. `enqueueFollowUpIfBoardMoved` adds up to a tenth on top of all of it. So the debounce change moves the mean but barely touches the peak, and the peak is what the limit sees. Past the limit the spend stops growing and the failure rate starts — a rejected render retries three times holding its pending marker, so overload amplifies rather than backs off. **Ask for the increase before the deploy**, and watch renders/min against 60 from the first hour.
+
+**Render page egress is plausibly larger than the browser time, and is not Cloudflare's.** Every capture is a cold browser loading `/__thumbnail-render` from the client origin: the lazy route chunk, the editor bundle, fonts, and whatever image assets the board contains. At a nominal 2 MB transferred that is ~2 TB and a few hundred dollars per million renders — so at the measured ~60,000 renders/day it is ~3.6 TB and **~$540 a month, more than the browser time itself**, and on a different bill. The transferred size of one render is worth measuring before trusting the magnitude, and it is the one cost that can be cut without touching thumbnail freshness.
+
+Two smaller lines, both fixed rather than per-render:
+
+- **~$24/month of durable object alarm writes.** `scheduleOgRender` calls `setAlarm` on every persist and [each `setAlarm` is one row written](https://developers.cloudflare.com/durable-objects/platform/pricing/#sqlite-storage-backend) — ~24M rows/month at $1.00/M. This is the cost the alarm-is-the-deadline design deliberately took on, and it is paid whether or not a render results. See "Keeping the thumbnail current" for what it buys.
+- **R2 storage is a rounding error.** The `og/…` keys carry no version, so it is one object per board: the production `thumbnails` bucket currently holds **4.71k objects in 404 MB** (~86 KB a thumbnail, plus the zero-byte markers and token records), which is well under a cent a month. Growth is bounded by board count rather than by render volume, so rendering every board on every edit does not move this line. The `mcp/…` keys do accumulate, which is what their expiration rule is for.
+
+The MCP surface prices separately, since it is driven by callers rather than by editing: at the full `MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT` of 20 captures/min it is ~$135/month, and because Cloudflare rate limits apply per location that is per colo. It bounds a rogue agent, which is its job; it does not bound spend.
+
+If this needs to come down, in order of leverage: shrink what the render page loads, which is the largest line and costs no freshness at all; then raise `OG_RENDER_MAX_WAIT_MS` alongside the debounce, since the grid above says neither constant does much alone; then cap the render rate outright with the dedicated queue described in "Follow-up work". Prioritising by `sharedState` — a longer debounce for private boards than for shared ones — is the option that goes below the floor of one render per board-editing-visit without capping anything, and the durable object already knows which is which at trigger time.
 
 ### Telemetry and monitoring
 
-All three surfaces write `mcp_shared_board_screenshot` events with the same blob layout, so one dashboard covers everything; the source blob distinguishes `mcp` (the tool), `og` (the OG image route), and `queue` (the async consumer). Events record hashed board slug, cache hit/stale/miss, render duration (wall-clock around the browser session), output dimensions, failure reason, rate-limit decisions, and a hashed IP. Two dimensions are deliberately kept low-cardinality: the failure reason is always a bounded reason code (`invalid_input`, `not_found`, `board_empty`, `no_pages`, `page_out_of_range`, `rate_limited_ip`/`board`/`global`, `rate_limited_global_exhausted`, `board_not_viewable`, `not_rendered_yet`, `browser_failed`, `browser_timeout`, `empty_render`, `not_configured`, `render_error`), never raw `error.message` text; and the hashed IP is written only on failed or rate-limited events (where it's useful for abuse analysis) — successful events carry `ip:none`, so the per-client IP dimension never lands on the common success path. Column layout in the Analytics Engine dataset (`MEASURE`): `blob1` event name, `blob2` worker name, `blob3` source, `blob4` cache status, `blob5` failure reason, `blob6` rate-limit decision, `blob7` hashed IP (or `none`), `double1`/`double2` output width/height, `double3` render duration ms, `double4` browser ms used, `double5` rate-limit allowed (1/0), `index1` hashed board slug. (The `quickAction` screenshot response includes an `X-Browser-Ms-Used` header, but the worker does not currently read it — telemetry uses wall-clock render duration in `double3` as the spend proxy and writes `double4` as -1. Wiring the header into `double4` is a possible follow-up.)
+All three surfaces write `mcp_shared_board_screenshot` events with the same blob layout, so one dashboard covers everything; the source blob distinguishes `mcp` (the tool), `og` (the OG image route), and `queue` (the async consumer). Events record cache hit/stale/miss, render duration (wall-clock around the browser session), output dimensions, failure reason, rate-limit decisions, a hashed IP, and the trigger that asked for the render. They carry **no board identity at all** — no index, no slug, no hash, no derived id (see below). Two dimensions are deliberately kept low-cardinality: the failure reason is always a bounded reason code (`invalid_input`, `not_found`, `board_empty`, `no_pages`, `page_out_of_range`, `rate_limited_ip`/`board`/`global`, `board_not_viewable`, `not_rendered_yet`, `browser_failed`, `browser_timeout`, `empty_render`, `not_configured`, `render_error`), never raw `error.message` text; and the hashed IP is written only on failed or rate-limited events (where it's useful for abuse analysis) — successful events carry `ip:none`, so the per-client IP dimension never lands on the common success path. Column layout in the Analytics Engine dataset (`MEASURE`): `blob1` event name, `blob2` worker name, `blob3` source, `blob4` cache status, `blob5` failure reason, `blob6` rate-limit decision, `blob7` hashed IP (or `none`), `blob8` render trigger (`crawler`, `publish`, `edit`, or `none` on the surfaces that have no trigger), `double1`/`double2` output width/height, `double3` render duration ms, `double4` browser ms used, `double5` rate-limit allowed (1/0), and no `index1`. (The `quickAction` screenshot response includes an `X-Browser-Ms-Used` header, but the worker does not currently read it — telemetry uses wall-clock render duration in `double3` as the spend proxy and writes `double4` as -1. Wiring the header into `double4` is a possible follow-up.)
+
+One event outside that dataset matters for sizing: `persist_success` (same `MEASURE` dataset, written by `TLFileDurableObject.logEvent`). It fires on exactly the event that triggers a thumbnail render, so it carries what sizing that render needs: `index1` the **durable object id**, `blob3` the board's `sharedState` (`shared`, `private`, `unknown` for an app file whose record hasn't loaded, `legacy` for a non-app room, `deleted` for a deleted file), and `double1` the retry attempt count. It is written by `getBoardRenderState`, the same method that gates the render, so a board the trigger skips can never be counted as one it renders.
+
+The index is stamped centrally in `writeEvent` for every file DO event, not per call site. Analytics Engine samples by index, so a board that persists rarely keeps data points instead of being sampled away inside the volume of a busy one, and since it has no `uniq()`/`count(distinct)`, distinct boards means `GROUP BY index1` and counting the returned rows.
+
+It is the durable object id rather than the board slug on purpose: `idFromName` is one-way, and for an app file the slug _is_ the authority of `tldraw.com/f/<id>`, so writing it to an account-readable dataset exported to Grafana would put working capabilities in telemetry. Resolving in the useful direction still works from a slug you already hold, via `env.TLDR_DOC.idFromName('/r/' + slug)`.
+
+Only `persist_success` carries that index. The screenshot events deliberately carry none (see "No board identifier leaves this pipeline"), so the two datasets cannot be joined and renders-per-persist is two aggregate counts divided by each other rather than a per-board number.
+
+The one-way-ness is also why `sharedState` has to be recorded at write time rather than recovered later: the dataset cannot be joined back to a file row. Postgres could not answer it anyway — it knows which files are shared, not which are being edited. See "Open questions".
 
 Bounded reason codes say _that_ a board stopped rendering, never _why_, and every one of these surfaces deliberately swallows its own errors (the OG route falls back to the default image, the snapshot route 404s, the MCP tools return a tool error, the queue retries or drops). So each swallow point also reports the underlying error to Sentry through `reportThumbnailError` (`thumbnailShared.ts`), tagged `thumbnail_surface` with a closed set of values: `og_route`, `og_queue`, `thumbnail_snapshot`, `mcp_board_info`, `mcp_screenshot`. Reporting rides on the handler's `waitUntil` and is itself failure-proof — a missing Sentry env var must never turn a degraded-but-fine response into a 500.
+
+#### No board identifier leaves this pipeline
+
+**No board identity is written anywhere** — not to telemetry, not to a log line, not to a Sentry event. Not the slug, not a hash of it, not a derived durable object id. For a link-shared file the slug _is_ the file id, and `tldraw.com/f/<id>` is the capability to view a board somebody chose to share by link rather than publish; a one-way derivation avoids handing that out, but it is still a per-board dimension in an account-readable dataset, so the simplest guarantee is to record none.
+
+Three routes out, and the third was the sharp one:
+
+- **Telemetry** writes no `index1`. It briefly carried the board's durable object id so renders could be joined to the `persist_success` events that caused them; that join is gone deliberately, and with it the ability to say which board is failing from the dataset alone. These datapoints answer aggregate spend and failure-rate questions.
+- **Sentry extras** carried raw `slug`/`boardId` at six call sites, then briefly a derived id. They now carry neither — only `kind`, `prefix`, `page`, `theme`, `attempts` and the like.
+- **The request object** is no longer handed to `createSentry` at all. It passes one straight to Toucan with `allowedSearchParams: /(.*)/`, which records the full URL and every query parameter — and on these routes the URL is the sensitive part. `/app/social-preview/f/<id>/image` carries a link-shared file's id in its path, and `/api/app/thumbnail-render/snapshot?token=…` carries a signed render token, which is a live capability to read that board's entire snapshot until it expires. `reportThumbnailError` now takes only the method and user agent from the request; the `thumbnail_surface` tag already says which endpoint it was.
+
+`TLFileDurableObject`'s render log had the same issue and now logs only the enqueue result — no slug and no derived id.
+
+#### Reading a Browser Run failure
+
+`422 Unprocessable Entity` is the status to expect from a failed capture, and on its own it says almost nothing. Cloudflare answers 422 for [every "the page did not cooperate" outcome](https://developers.cloudflare.com/browser-run/faq/): a page that crashed, a render that exhausted the container's memory, and any of the [Quick Action timers](https://developers.cloudflare.com/browser-run/reference/timeouts/) expiring. Our own render page marking `data-thumbnail-error` arrives as one too, because the capture selector (`body[data-thumbnail-ready="true"]`) exists only on the success path — that is the design working, and it is indistinguishable by status from the cases that aren't.
+
+What separates them is the response body, so `renderThumbnailScreenshot` reads it and throws a `BrowserRenderError` carrying the status, Cloudflare's own message (its `errors[].message`, truncated), the wall-clock duration, and the timeout budget. Two things follow:
+
+- **`classifyScreenshotFailure` splits 422 into `browser_timeout` and `browser_failed`** from that body, falling back to "did the call spend essentially the whole budget" when the body names no timer. It used to classify on `error.message` alone, which for a Browser Run failure never contains the word "timeout" — so every timeout was filed as `browser_failed` and the dashboard's timeout rate was structurally always zero.
+- **The specifics reach Sentry as event context, not as the message.** Sentry groups on the message, so it stays exactly `Browser Rendering screenshot failed (<status>)` and the varying parts ride on `browser_render_status`, `browser_render_detail`, `browser_render_duration_ms`, `browser_render_timeout_ms`, and `browser_render_reason`. Putting the detail in the message would shatter one recurring issue into a stream of new ones.
+
+The queue consumer reports **once per job, on the delivery that gives up**, rather than once per delivery. A board that fails deterministically fails all `OG_MAX_RENDER_ATTEMPTS` times, so per-delivery reporting filed three events for one problem. A failure that recovers on retry now reports nothing, which is correct — the render landed.
+
+Telemetry goes the other way on purpose: **one datapoint per delivery, and a failed capture records its duration in `double3` like a successful one.** The split is that telemetry counts spend and Sentry counts problems — three deliveries are three lots of Browser Run and one problem. This used to write nothing at all on the retried deliveries and `-1` for the duration on the final one, so a failing board's spend was invisible on a path that has no cap and is watched only by this dataset. A delivery that bails before the capture (an unreadable or empty snapshot) still records `-1`, because it genuinely spent nothing.
+
+If timeouts turn out to dominate, the knob Cloudflare points at is `actionTimeout` (default none, max 5 minutes), which bounds the capture itself rather than the page load; it is not currently set in `getThumbnailScreenshotRequestBody`.
 
 `internal/scripts/fetch-screenshot-metrics.ts` queries the Analytics Engine SQL API and reports request volume, failure rate, timeout rate, cache hit rate, rate-limit blocks, and Browser Run render time per source (wall-clock `double3`, summed over rows that actually rendered — `double4` billed ms is not currently recorded, always -1):
 
@@ -77,12 +255,106 @@ The sync worker needs:
 - `MCP_SCREENSHOT_ENABLED` - kill switch for the MCP server (`POST /app/mcp`), set to `"true"` in `wrangler.toml` for dev, staging, and production. The worker reads it per request, so setting it to anything else takes the endpoint down (it 404s, including the `initialize` handshake) without a rebuild or a code deploy — flip it in the Cloudflare dashboard under the worker's variables, and it applies to the next request. The next deploy overwrites the dashboard value from `wrangler.toml`, so follow an emergency flip with a config change. An unset var counts as enabled, so preview deploys (which don't set it) behave as they always have. Only the MCP server is gated: OG image rendering has its own path and keeps running.
 - `MCP_SCREENSHOT_TOKEN_SECRET` (deploy var, GitHub secret) - HMAC secret for render tokens. Local dev uses the placeholder in `[env.dev.vars]`.
 - `MCP_SCREENSHOT_RENDER_ORIGIN` - set in `wrangler.toml` for dev (`http://localhost:3000`), staging, and production. Preview deploys have no `wrangler.toml` entry, so `deploy-dotcom.ts` injects the preview's own client origin (`https://${previewId}-preview-deploy.tldraw.com`) as a deploy var.
-- `THUMBNAILS` R2 bucket binding - `thumbnails-preview` in dev/preview/staging and `thumbnails` in production.
+- `THUMBNAILS` R2 bucket binding - board thumbnails / OG images (`og/…` keys) and their pending markers. `thumbnails-preview` in dev/preview/staging, `thumbnails` in production.
+- `MCP_DATA_BUCKET` binding - R2 bucket for MCP tool output; today that is screenshots (`mcp/…` keys). `dotcom-mcp-data-preview` in dev/preview/staging, `dotcom-mcp-data` in production.
 
-One-time ops setup before the first deploy of this feature:
+### Why two buckets
 
-1. Create the R2 buckets: `wrangler r2 bucket create thumbnails-preview` and `wrangler r2 bucket create thumbnails`.
-2. Enable Browser Rendering on the Cloudflare account (the `BROWSER` binding needs it) and add the `MCP_SCREENSHOT_TOKEN_SECRET` GitHub secret. Until the secret exists the deploy passes an empty string and the MCP tool returns a configuration error instead of failing the deploy.
+Both key spaces used to live in `thumbnails`, separated only by prefix. They are now separate buckets for two reasons:
+
+- **Domain.** `MCP_DATA_BUCKET` is where the MCP surface puts what it produces, and that won't stay limited to board thumbnails. Keying the bucket to the tool rather than to the artifact means the next MCP output type lands somewhere that already fits, instead of accreting inside a bucket named for something it isn't.
+- **Retention.** The two caches want opposite lifetimes:
+  - **`og/…`** keys (`og/{kind}/{slug}/{theme}.png`) carry no version, so each render overwrites the same object in place and a board costs exactly one object for as long as it exists. Nothing accumulates and nothing deletes one, and the current thumbnail must outlive any lifecycle window — so `THUMBNAILS` gets **no expiration rule**.
+
+    That is also why the key holds nothing but the board and the theme — in particular **not the output dimensions**. This key is the image's sole address, so anything in the path that can change re-addresses every board's image at once and strands the old objects permanently, since there is no lifecycle rule to sweep them. A size change is a replacement rather than a second object, so it belongs in the object's metadata, which overwrites in place. The trade is that a size change serves old-sized images as fresh hits until each board next renders, because the stored `version` tracks board content, not render parameters.
+
+  - **`mcp/…`** keys include the board's content version (`mcp/{kind}/{slug}/{version}/{w}x{h}/{theme}/page-{n}.png`), so every edit strands the previous object and the set grows without bound. A pure regenerable cache, so `MCP_DATA_BUCKET` gets an **expiration rule**.
+
+A prefix-scoped lifecycle rule on a single bucket would also work (`wrangler r2 bucket lifecycle add` takes a prefix positionally), and has the nice property of ageing out the existing backlog in place. It was rejected because a future rule added without a prefix, or with a typo'd one, would silently delete every board's live thumbnail, and R2 expiration has no undo. Separate buckets make that mistake impossible.
+
+#### Nothing deletes a rendered image
+
+Whether an image is deleted when a board stops being publicly viewable depends on which key it is, and the two are **not symmetric**:
+
+- **`og/shared_file/{fileId}/…` is kept.** Its key is the file id, which never changes, so it stays useful for as long as the board exists — an owner-facing surface behind auth wants it, and switching the link back on makes it an immediate cache hit rather than a cold render. Unsharing clears only the pending marker.
+- **`og/published/{publishedSlug}/…` is deleted on unpublish.** It depicts a published _snapshot_, and unpublishing destroys the thing it was a picture of. Its key is the published slug rather than the file, so leaving it would strand an object that a regenerated publish link could make permanently unreadable — nothing would ever read or overwrite it again. `deleteOgImage` is scoped by the board passed in, so unpublishing cannot touch the same board's file-keyed image.
+
+The queue consumer applies the same rule when it drops a job for a board that no longer resolves.
+
+The argument for keeping the file-keyed half: an unshared board's thumbnail does depict content that is no longer public, but the image is not public because it exists — it is public because a route serves it, and the only route that does re-checks the share gate on every request (`resolveThumbnailBoard` in `getOgImage`). An unshared board's image is already unreachable while it sits in R2.
+
+Keeping it means an owner-facing surface behind authz — a workspace or project view showing every board's thumbnail — can use the image a board already has, instead of it having been thrown away the moment the board went private. The `og/…` keys carry no version, so retaining them costs one object per board and does not accumulate.
+
+`deleteOgImageCache` is therefore now `clearOgImagePendingMarker`, which drops only the `.pending` marker. That part is still load-bearing: a marker left behind would dedupe away the next legitimate enqueue after a reshare, or after the render that failed.
+
+**Hard deletion is where both halves go.** `TLFileDurableObject.appFileRecordDidDelete` — the same cleanup that removes the room snapshot, the edit history and the published history — deletes the file-keyed image, the published-slug image, both render token records, and the pending and repair-cooldown markers. Neither reason for keeping an image survives here: there is no board left to reshare, and no snapshot left to depict. It matters more than tidiness reads, because these keys carry no version, so each board owns exactly one object in a bucket that has **no lifecycle rule and must never get one** — an image left behind by a deleted board is an object nothing will ever read, overwrite, or sweep. MCP screenshots need no equivalent: their keys carry a content version and their bucket expires them.
+
+### Rendering every board
+
+Thumbnails are generated for **every** board, not only publicly viewable ones, so an owner-facing surface (a workspace or project view, behind auth) always has a current image to show. Sharing is a condition of _serving_, not of _rendering_.
+
+That is expressed as an explicit access level, `ThumbnailBoardAccess`, required at every call site of `resolveThumbnailBoard` and `loadBoardSnapshot` rather than defaulted — a default would be wrong for half of them, and silence is the wrong way to choose a gate:
+
+- **`access: 'public'`** — every anonymous-facing surface: the OG image route, the crawler HTML (`getSocialPreview`), both MCP tools. A published board must be published; a shared file must currently be shared via link (`isFileAnonymouslyViewable`). This is the only thing keeping a private board's thumbnail off the public internet, and it is re-applied per request rather than inferred from what is in R2 — necessarily, since nothing deletes an image when a board stops being public.
+- **`access: 'render'`** — the queue consumer and the render page's snapshot route. Requires only that the board exists, is not deleted, is not a test file (`isFileRenderable`), and has persisted content.
+
+Three gates moved together, and all three had to: the durable object's edit trigger (which skipped anything not `shared`/`unknown`), the consumer's `resolveThumbnailBoard`, and `getThumbnailSnapshot`'s read. Relaxing fewer would have produced enqueues that were dropped downstream, or captures whose render page 404'd.
+
+The durable object now skips only two states, and neither is about privacy: `legacy` (not an app file, so no board identity to render) and `deleted` (nothing worth depicting). `shared`, `private` and `unknown` all render.
+
+**What this costs.** `GET /api/app/thumbnail-render/snapshot` previously refused anything not publicly viewable, so a leaked or forged render token exposed nothing that was not already public. It now serves a **private** board's full document — every shape. That makes the token load-bearing in a way it was not before, so two things guard it.
+
+`THUMBNAIL_RENDER_TOKEN_TTL_MS` is **60 seconds**, down from five minutes. Sized against what the token is actually for: the render page fetches the snapshot in its loader, seconds after navigation, and nothing touches the token afterwards — settle, `toImage` and capture all run without it. So the window has to cover browser start plus navigation plus bundle load, not the whole render. The thing that would break a short TTL is not a slow render but Browser Run _queueing_ before the browser starts (new instances are limited to 1/second); at current volume that is three orders of magnitude away.
+
+**A signature alone is no longer sufficient.** Every mint also records the token's hash in R2, and the route requires the record to be present (`recordMintedRenderToken` / `isMintedRenderToken`). A leaked `MCP_SCREENSHOT_TOKEN_SECRET` therefore stops being catastrophic: an attacker can forge signatures for any board, but without write access to our bucket the forgeries have no record and are refused before the board is read. The secret becomes one of two required factors rather than the sole authority over every private board's contents.
+
+Three details of that worth knowing:
+
+- **Only `render` jobs are recorded.** The access level rides inside the signed token: the MCP tool mints `public`, the OG pipeline mints `render`. A `public` job renders a board anyone could already fetch, so a forged token for one grants nothing and a record would buy no security. Skipping it is also what keeps the two surfaces out of each other's way — see below.
+- **Keyed per board** (`render-tokens/{kind}/{slug}`), not per token, so each render overwrites its board's record and the space is bounded by board count — exactly like the `.pending` marker. Nothing accumulates, so there is no lifecycle rule to add, and none must ever be added to this bucket.
+
+  A board's newest mint therefore invalidates any older in-flight token for it, which is intended: a fresher render supersedes one already running, and the OG pipeline is single-flighted per board by the `.pending` marker anyway.
+
+  **This is why the MCP tool must not mint `render` jobs.** It has no pending marker, and its per-board limiter deliberately allows two cache-missing captures a minute, so two captures of different pages of one board would share a record key and invalidate each other — as would an edit-triggered render landing during a capture. The loser fails its snapshot fetch with a 403, which surfaces as a generic `browser_failed`, indistinguishable from a real browser crash. Authenticating the MCP endpoints would invite exactly this change, since it would let them screenshot private boards; namespace the record key by surface first.
+
+- **Records are not deleted after a capture.** Expiry lives in the signed `exp` and is checked before the record is ever consulted, so a leftover record cannot extend a token's life. Deleting would tighten the window from `exp` to the render's duration — worth nothing against an attacker who cannot get a record written at all, and it would cost a `finally` and a third state to reason about.
+- **A hash, in `customMetadata`.** The bucket never holds a usable credential, and checking one is a `head` rather than a `get`.
+
+When `THUMBNAILS` is unbound (local dev, tests) the check is skipped, which degrades to signature-only verification — the level this replaces, not a hole beneath it. Every deployed environment binds it.
+
+Still worth doing when the authenticated retrieval endpoint lands: serving the render page as inline `html` with the records embedded would remove this public route altogether.
+
+Cost in Browser Run terms is not the constraint. The sizing here assumed ~30% of edited boards are link-shared, so rendering all of them is roughly 3.3x the previous volume — about 3 renders/min against measured production traffic of ~1/min and an account limit of 60/min.
+
+### One-time ops setup
+
+Before the first deploy of this feature:
+
+1. Create the R2 buckets:
+
+   ```bash
+   wrangler r2 bucket create thumbnails-preview
+   wrangler r2 bucket create thumbnails
+   wrangler r2 bucket create dotcom-mcp-data-preview
+   wrangler r2 bucket create dotcom-mcp-data
+   ```
+
+2. Add the expiration rule to the MCP data buckets only (30 days is a starting point — these are a regenerable cache, so the only cost of expiring one is a re-render the next time an agent asks for that exact board version):
+
+   ```bash
+   wrangler r2 bucket lifecycle add dotcom-mcp-data-preview expire-screenshots --expire-days 30 -y
+   wrangler r2 bucket lifecycle add dotcom-mcp-data expire-screenshots --expire-days 30 -y
+   ```
+
+   Verify with `wrangler r2 bucket lifecycle list dotcom-mcp-data`. Do **not** add an equivalent rule to `thumbnails`.
+
+3. Enable Browser Rendering on the Cloudflare account (the `BROWSER` binding needs it) and add the `MCP_SCREENSHOT_TOKEN_SECRET` GitHub secret. Until the secret exists the deploy passes an empty string and the MCP tool returns a configuration error instead of failing the deploy.
+
+Migration note: MCP screenshots previously lived under `mcp/…` in the `thumbnails` bucket, where nothing ever deleted them. Those objects are now orphaned — the tool reads and writes the new bucket, and the version in the key means nothing will ever hit them again. Clear them out with a one-off prefix-scoped rule (`wrangler r2 bucket lifecycle add thumbnails expire-legacy-mcp mcp/ --expire-days 1 -y`, removed once the prefix is empty) or by deleting the `mcp/` folder from the dashboard.
+
+Second migration note: the OG key dropped its `{w}x{h}` segment, so anything already written as `og/{kind}/{slug}/1200x630/{theme}.png` is orphaned too. Bounded and small — one object per board ever rendered before this deploy, and each board rewrites at its new key on the next publish or edit — but nothing will read or overwrite the old ones, and this bucket has no lifecycle rule to sweep them. A prefix rule cannot match a middle segment, so clear them by listing and deleting the `og/` keys containing `/1200x630/`, or leave them and accept a fixed one-off cost. Do **not** reach for a lifecycle rule on `thumbnails` to do it.
+
+Third migration note: the MCP buckets were originally named `mcp-screenshots-preview` / `mcp-screenshots`, after the one artifact they held rather than the surface that writes them. R2 has no rename, so the names above are fresh buckets. Nothing needs copying — the preview bucket was created but never written to, and the production one was never created — so the old preview bucket can simply be deleted (`wrangler r2 bucket delete mcp-screenshots-preview`) once this config is deployed.
 
 ## Local development
 
@@ -160,6 +432,10 @@ The screenshot layer lives in the dotcom sync worker rather than the interactive
 
 ## Remaining follow-up work
 
+- **Move thumbnail rendering onto its own queue and cap it with `max_concurrency`.** This is the only mechanism in this stack that bounds total render rate: per-board rules cannot (total is `boards × rate`), and Cloudflare's rate limit bindings apply per location. Because the consumer captures one screenshot at a time, the arithmetic is exact — at the measured 6.3s capture, `renders/min ≈ 9.6 × max_concurrency`, so 4 is ~38/min and 5 is ~48/min. Its real merit is the failure mode: a capped consumer defers, where an over-limit Browser Run call fails and retries three times, so a cap converts overload into queue depth rather than amplification.
+
+  Two prerequisites, which are why this is a follow-up rather than a config line. **The queue has to be split first** — `tldraw-multiplayer-queue` also carries `asset-upload`, and `max_concurrency` is a per-consumer setting, so capping the shared queue would throttle uploads too. And **`OG_PENDING_MARKER_TTL_MS` has to be re-derived from the cap**: it is sized against a job's retry chain (~3.75 minutes) on the assumption that queue latency is negligible, which is true only while nothing throttles. Once depth can build, a message can wait longer than its marker lives, the marker lapses, the next edit enqueues a second job for the same board, and the two clobber each other's per-board render token record — adding load exactly when the queue is already behind. Either refresh the marker when the job starts or derive its TTL from the cap.
+
 - Schedule `fetch-screenshot-metrics.ts --check` somewhere (cron CI job or an external monitor) and point a dashboard at the SQL queries above; the script and queries exist, the scheduling is an ops decision.
 - Shared files render the last persisted room snapshot from R2, which can lag in-memory edits by the persist debounce. If near-real-time accuracy is ever required, add a `getCurrentSnapshot` RPC on `TLFileDurableObject` (modeled on `onDownloadTldr`) instead of reading R2.
 - Keep private (unshared) files, board metadata, document structure, current-viewport screenshots, and selected-shape screenshots out of the MCP scope.
@@ -178,8 +454,14 @@ flowchart TB
         QC["Queue consumer<br/>og-image-render (async refresh)"]
     end
 
+    subgraph warm ["Refresh triggers (ahead of the first crawler)"]
+        PUB["publish effect<br/>(TLPostgresReplicator)"]
+        SPEC["persist on edit<br/>(TLFileDurableObject,<br/>debounced 60s, 5min max wait)"]
+    end
+
     SP -->|og:image references| OGR
-    OGR -->|stale / missing → enqueue| QC
+    PUB -->|reason: publish| QC
+    SPEC -->|reason: edit| QC
 
     BI --> GATE["Resolve board + share gate<br/>(published or link-shared only)"]
     MCP --> GATE
@@ -187,7 +469,7 @@ flowchart TB
 
     GATE --> SNAP2["Load room snapshot<br/>(enumerate pages; board-info returns here)"]
     SNAP2 -->|name, page list| BI
-    SNAP2 --> TOKEN["Mint HMAC render token<br/>(board identity, pageId, 5 min expiry)"]
+    SNAP2 --> TOKEN["Mint HMAC render token<br/>(board identity, pageId, 60s expiry)"]
     TOKEN --> BR["env.BROWSER.quickAction<br/>(navigate → wait data-thumbnail-ready → PNG)"]
 
     BR --> PAGE["/__thumbnail-render (client render page)"]
@@ -196,7 +478,7 @@ flowchart TB
     EXPORT -->|screenshot captures the img| BR
 
     BR -->|PNG bytes| WORKER["Worker writes R2 + returns image"]
-    WORKER --> R2[("THUMBNAILS R2 bucket<br/>mcp/…/page-n.png and og/… keys")]
+    WORKER --> R2[("THUMBNAILS bucket (og/… keys)<br/>MCP_DATA_BUCKET (mcp/… keys,<br/>expiring)")]
     WORKER -->|image in hand| MCP
     R2 -->|serve cached| OGR
     R2 -->|serve cached| MCP
@@ -212,4 +494,148 @@ The MCP/OG rework and the Browser Rendering binding migration described above ar
 
 Not doing:
 
+- The render token's explicit viewport (`x`/`y`/`z`, used when `camera` is omitted) stays, even though every surface mints `camera: 'content'` and nothing exercises it in production. It was briefly removed as unreachable and put back. The token payload is short-lived and has no stored state, so dropping it costs nothing to undo _on the worker side_ — but the render page ships with the client and the worker deploys separately, so bringing it back would mean landing the client's handling first and waiting for that deploy before the worker could send one. Keeping it holds that door open for the price of three ignored fields.
 - `useThumbnailPageSize` stays in `thumbnail-render.tsx`. It is load-bearing for the production render page, not dev-only: the render page displays the export as a full-viewport `<img>` and Browser Run takes a viewport screenshot of it, and the dotcom client has no global `body { margin: 0 }` reset (only `#root { width/height: 100% }` in `index.html`), so without the hook's `margin: 0` the browser's default 8px body margin would offset the image and the screenshot would show a white border and clip the bottom-right of every thumbnail.
+
+## Real thumbnails on first share
+
+Status: phases 2 and 3 are implemented and on; phase 1 is not shipping and phase 4 is still conditional. The mechanics of what shipped are documented above — "Default-image fallback" under the OG images section, "Keeping the thumbnail current" for the publish and edit triggers, and "Request limits" for why the render path is uncapped. This section keeps the rationale and the outstanding work.
+
+### Problem
+
+The first crawler to unfurl a board hits a cold OG-image cache and is sent to the generic tldraw image, and platforms cache that unfurl card on their side for days. So the first share of a board shows the logo rather than the board, and stays wrong long after the render lands seconds later.
+
+The card itself is valid — the crawler follows the redirect and gets a real image — so there is nothing to fix in how the miss is served. The only lever is how often a crawler finds nothing, which means making the thumbnail exist first.
+
+### Strategy
+
+Make the thumbnail exist before the first crawler arrives. No synchronous rendering on crawler paths; the pending marker and the queue stay load-bearing as dedupe.
+
+| Phase                       | Covers                                                | Cost                                                           | Status                |
+| --------------------------- | ----------------------------------------------------- | -------------------------------------------------------------- | --------------------- |
+| 2. Publish hook             | explicit publish/republish, always fresh              | negligible                                                     | done                  |
+| 3. Render on every persist  | the create → draw → share flow and revived old boards | ~1 render per editing session, +1 per 5min of unbroken editing | done                  |
+| 4. Hop-1 warming (optional) | immediate shares, never-edited-again boards           | negligible                                                     | published boards only |
+
+Phase 1 was a fallback that served the default image's bytes from the worker as a `200` rather than redirecting to them. It is not shipping: it existed to protect crawlers that do not follow an `og:image` redirect, and it bought a generic card either way. Phase 4 is what covers the case it aimed at — a board shared within the debounce window of its first edit.
+
+`getOgImage`'s stale-serve behaviour is the residual backstop: a board whose thumbnail is out of date still gets its own picture, on a short TTL, rather than the site-wide default. The general on-miss enqueue that used to sit alongside it is gone; what survives is phase 4 narrowed to the one case that needs it, a published board with no image at all, since that is the only kind with no second trigger to fall back on (see "OG images (queue-backed async rendering)").
+
+### Beyond OG images
+
+This isn't just a crawler fix. The result is a board thumbnail that's reliably current in R2 — kept fresh by publish and edit triggers rather than rendered synchronously per request — for every shared board, not only the ones a crawler happens to hit. That's the same primitive other surfaces need: board previews in a folder or workspace view, for instance, which today would otherwise need their own render-on-demand path or ship without a real thumbnail. Those surfaces can just read the cached image.
+
+### Phase 0 — measure (still worth doing, no longer a gate)
+
+Pull two numbers from existing telemetry (`mcp_shared_board_screenshot` dataset via `internal/scripts/fetch-screenshot-metrics.ts`; `room_empty`/persist log events):
+
+- daily unique boards with contentful edit sessions
+- daily unique boards receiving og-image fetches
+
+This was originally the gate on turning edit-triggered rendering on, because it sized the sampling percentage and the raised global cap. Neither exists now: rendering is uncapped and runs for every board. The numbers are still the ones to watch, but as observation rather than a precondition — they say what thumbnail rendering actually costs per day and whether Browser Rendering's account-level session limits are anywhere near being the binding constraint.
+
+### Full path, from first edit to first-share cache hit
+
+```mermaid
+flowchart TB
+    EDIT["t=0 — a change lands<br/>in TLFileDurableObject"]
+    EDIT --> PERSIST["t≤8s — persist tick advances the<br/>document clock (persistToDatabase)"]
+    PERSIST --> DEBOUNCE{"scheduleOgRender<br/>(push deadline out 60s —<br/>THE rate control)"}
+
+    DEBOUNCE -->|"more edits arrive first"| WAIT["alarm fires, sees a newer<br/>deadline, re-arms (no render)"]
+    WAIT --> DEBOUNCE
+    DEBOUNCE -->|"editing settled, or<br/>5min max wait hit"| GATE{"requestOgRenderForEdit<br/>(share gate; fire-and-forget,<br/>never blocks persistence)"}
+
+    GATE -->|"file record not shared"| SKIP["skip"]
+    GATE -->|"shared or unknown"| MARK{"pending marker<br/>already set?"}
+
+    MARK -->|"yes"| DEDUPE["already_pending — no message<br/>(single-flight, not a rate limit)"]
+    MARK -->|"no"| ENQ["write marker + enqueue<br/>reason: edit"]
+
+    ENQ --> QUEUE[("queue")]
+
+    QUEUE --> CONSUMER["consumer delivery"]
+    CONSUMER -->|"board no longer viewable"| DROPV["drop + delete cached image"]
+    CONSUMER -->|"cached version already current"| ACK["ack without rendering<br/>((board, version) idempotency)"]
+    CONSUMER -->|"otherwise"| RENDER["re-resolve → render CURRENT content<br/>(no capacity check)"]
+
+    RENDER --> R2[("THUMBNAILS R2<br/>og/… key, version + createdAt")]
+    R2 --> SHARE["first share: crawler og:image<br/>fetch is a cache hit"]
+```
+
+There are two constants to tune, both in `config.ts`, and the measurement in "What it costs" says they only work as a pair. `OG_RENDER_DEBOUNCE_MS` (60 seconds) sets how long a board must go quiet before its thumbnail is rendered — lower it for fresher thumbnails after short bursts, raise it to absorb more of a session into one render. `OG_RENDER_MAX_WAIT_MS` (5 minutes) caps how long a continuously edited board can go stale. Raising either one alone barely moves total spend, because a longer debounce merges bursts into sessions that then run into the max wait, trading a settle render for a max-wait one; raising both together is what actually reduces renders. `OG_PENDING_MARKER_TTL_MS` is not a dial: it is a single-flight guard and a crash ceiling, cleared as soon as a render lands.
+
+### Phase 4 (conditional) — hop-1 warming
+
+- `getBoardOgImageUrl` in `getSocialPreview.ts` already resolves the board; add: if no fresh cached image (one R2 `head` plus version compare, extracted from `getOgImage`'s check), `ctx.waitUntil(enqueueOgImageRender(env, board, { reason: 'crawler' }))`. Thread `ctx` into the route. This is the one thing that would put `crawler` back in use as a live reason.
+- Ship only if phase-3 telemetry shows first-fetch misses are still meaningful (dormant never-edited boards, mostly — the delay that immediate sharers used to beat is gone).
+
+### Explicitly not doing
+
+- Synchronous wait in `getOgImage` — the queue's ~5s default batch linger means a short wait mostly misses, and the phases above remove the need. Revisit only with data showing otherwise.
+- An `isEmpty`-based trigger — the `file.isEmpty` column is vestigial (written `true` at creation, never flipped by client or server), so there is no replicator-visible first-content transition.
+- A DO-owned render single-flight — the advisory pending marker plus the consumer's version check is the accepted model and stays adequate at these volumes.
+- A cap on thumbnail rendering — see "Request limits". Capping our own derived artifact only buys staler thumbnails; the caps belong on the MCP endpoint, which is the surface an outside caller can actually drive.
+
+### Metrics to watch
+
+- og-route cache hit rate (should be high — every shared, edited board should already have an image). This is now an aggregate only: with no `index1` on these events there is no per-board breakdown and no "first fetch per board".
+- `not_rendered_yet` rate (should fall to near-zero for edited boards; every one of these is a crawler sent to the default image rather than the board)
+- renders/day by `reason`, and total Browser Run minutes — the real spend signal, since the only bound is per-board and nothing caps the total
+- ratio of renders to `persist_success` events: the debounce's whole claim is that this stays well below 1, and it is the number that would show the max wait being hit more often than expected. Note this is now **two aggregate counts divided by each other**, not a per-board join — the screenshot events carry no index. A handful of pathological boards and a uniformly high ratio look the same from here
+- queue depth, especially through the first days after deploy, when every actively edited board renders for the first time
+
+### Open questions
+
+**These gate the deploy.** The sizing rests on two numbers, and the plausible range spans the account limit, so they want answering before this ships rather than after. Both are answered by telemetry on `persist_success` — in particular by no query against the production database. Question 2 is now answered from production data (see "What it costs"); question 1 still needs this branch's `blob3` deployed, and matters less than it did, since rendering no longer depends on a board being shared.
+
+Deliberately not a Postgres question. Postgres knows which files are `shared`, but not which are being _edited_, and the only way to approximate that there is a predicate on `file.updatedAt` — a sequential scan of a hot table to answer a capacity-planning question. `persist_success` fires on exactly the event that triggers a render, so it can carry both facts itself.
+
+1. **What fraction of actively edited boards are link-shared (`f`)?** This is the multiplier on every render estimate here; the current constants assume `f ≈ 30%`. `sharedState` (`blob3`) records it at persist time, from the same `_fileRecordCache.shared` the render trigger gates on, so it is persist-weighted — which is the weighting render cost actually has, unlike a per-file count.
+
+   ```sql
+   -- f = shared / (shared + private). Check the other rows before trusting it: `legacy` (non-app
+   -- rooms) and `deleted` never render and are correctly outside the ratio; a large `unknown` means
+   -- file records often aren't loaded at persist time and the ratio stands on a thin denominator.
+   SELECT blob3 AS shared_state, SUM(_sample_interval) AS persists
+   FROM MEASURE
+   WHERE blob1 = 'persist_success'
+     AND blob2 = 'production-tldraw-multiplayer'
+     AND timestamp > NOW() - INTERVAL '1' HOUR
+   GROUP BY shared_state
+   ```
+
+   For the board-weighted figure instead — distinct shared boards rather than persists — group by `index1` with `blob3 = 'shared'` and count the returned rows.
+
+   ```sql
+   -- Persists per board, keyed on the durable object id (one-way, so it identifies a board without
+   -- being usable as a board URL). No uniq()/count(distinct) exists in Analytics Engine, so GROUP BY
+   -- and count the rows. This is also the input to question 2.
+   SELECT index1 AS durable_object_id, SUM(_sample_interval) AS persists
+   FROM MEASURE
+   WHERE blob1 = 'persist_success'
+     AND blob2 = 'production-tldraw-multiplayer'
+     AND blob3 = 'shared'
+     AND timestamp > NOW() - INTERVAL '1' HOUR
+   GROUP BY durable_object_id
+   ```
+
+2. **How many editing sessions start per minute? — answered.** [PR 9708](https://github.com/tldraw/tldraw/pull/9708) shipped `index1` on file DO events to production, so this no longer waits on deploying this branch. Replaying the debounce over a 30 minute production window gives **~37–51 renders/min** (the spread is Analytics Engine sampling, which splits runs that were really continuous). See "What it costs" for the method, the resulting $250–350/month, and the two consequences: production would sit at 70–95% of Browser Run's 60/min account limit on day one, and `OG_RENDER_MAX_WAIT_MS` is not the cost dial — it fires for under a tenth of renders, because the median editing session spans about ten seconds.
+
+   The query is raw rows rather than an aggregate, since sessions are a property of the sequence:
+
+   ```sql
+   -- Then group by index1 in the client, sort each board's timestamps, and count runs separated by
+   -- more than OG_RENDER_DEBOUNCE_MS, adding floor(run length / OG_RENDER_MAX_WAIT_MS) per run.
+   -- Divide each board's gaps by its own _sample_interval for the low end of the range.
+   SELECT index1, timestamp, _sample_interval
+   FROM MEASURE
+   WHERE blob1 = 'persist_success'
+     AND blob2 = 'production-tldraw-multiplayer'
+     AND timestamp > NOW() - INTERVAL '30' MINUTE
+   LIMIT 100000
+   ```
+
+   Worth re-running before the deploy rather than trusting the number here: it is one window on one afternoon, and it includes `legacy` and `deleted` rooms that never render, which this branch's `blob3` would net out.
+
+3. Browser Run's account limits (120 concurrent browsers, 1 new browser/second) are the real ceiling now that nothing in this worker caps renders. New-browsers-per-minute is the binding one, not concurrency: even at 217 renders/min with ~8s renders that is only ~29 concurrent against a limit of 120. Worth confirming whether `quickAction` bills against those or against the separate REST quota, and watching the Browser Run dashboard's Runs tab through rollout — the failure mode is a render error and three retries (so, amplification rather than backpressure), not a clean 429.

--- a/apps/dotcom/client/src/pages/thumbnail-render.tsx
+++ b/apps/dotcom/client/src/pages/thumbnail-render.tsx
@@ -136,6 +136,9 @@ function ThumbnailRenderPage({
 					if (renderParams.pageId && editor.getPage(renderParams.pageId as TLPageId)) {
 						editor.setCurrentPage(renderParams.pageId as TLPageId)
 					}
+					// `content` is what every surface asks for today; an explicit viewport is still honoured
+					// (see ThumbnailRenderParams) so the worker can start sending one without waiting on a
+					// separate client deploy to teach this page how to handle it.
 					if (renderParams.camera === 'content') {
 						fitContentCamera(editor, width, height)
 					} else {

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -77,12 +77,14 @@ import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
 import { getPublishedRoomSnapshot } from './routes/tla/getPublishedFile'
+import { deleteBoardThumbnails, enqueueOgImageRender } from './routes/tla/ogImageQueue'
 import { generateSnapshotChunks } from './snapshotUtils'
 import { Analytics, DBLoadResult, Environment, TLServerEvent } from './types'
 import { EventData, writeDataPoint } from './utils/analytics'
 import { createPierreClient, isSlugInPierreRollout } from './utils/createPierreClient'
 import { createSupabaseClient } from './utils/createSupabaseClient'
 import { getRoomDurableObject } from './utils/durableObjects'
+import { OgRenderDebouncer } from './utils/ogRenderDebounce'
 import { reconstructSnapshotFromPierre } from './utils/pierreSnapshot'
 import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
@@ -1001,6 +1003,45 @@ export class TLFileDurableObject extends DurableObject {
 		this.persistToDatabase()
 	}, PERSIST_INTERVAL_MS)
 
+	// Whether a persist on this board costs a thumbnail render, and why. The single source of truth for
+	// both the gate in `requestOgRenderForEdit` and the `sharedState` blob on `persist_success`, so the
+	// telemetry cannot report a state that differs from the one the decision was made on.
+	//
+	// `deleted` is its own state rather than folded into `private` or `unknown`: it never renders, so
+	// counting its persists as either would corrupt the shared fraction this exists to measure.
+	//
+	// Both delete lanes count. A hard delete arrives as `appFileRecordDidDelete` and flips
+	// `documentInfo.deleted`; a soft delete (trash) arrives as an ordinary record update and only
+	// flips `isDeleted` on the cached row, leaving `documentInfo.deleted` false. The connection path
+	// already treats the two as one, and so does this.
+	private getBoardRenderState(): 'shared' | 'private' | 'unknown' | 'legacy' | 'deleted' {
+		if (!this.documentInfo.isApp) return 'legacy'
+		if (this.documentInfo.deleted || this._fileRecordCache?.isDeleted) return 'deleted'
+		const shared = this._fileRecordCache?.shared
+		if (shared === undefined) return 'unknown'
+		return shared ? 'shared' : 'private'
+	}
+
+	// Decides when this board's thumbnail is due (see OgRenderDebouncer). This object contributes the
+	// clock and the durable alarm, and the alarm below IS the deadline rather than an approximation of
+	// one: every persist re-arms it, so an eviction loses the in-memory copy and nothing else.
+	private ogRenderDebouncer = new OgRenderDebouncer()
+
+	private scheduleOgRender() {
+		this.ctx.storage
+			.setAlarm(this.ogRenderDebouncer.onPersist(Date.now()))
+			.catch((e) => this.reportError(e))
+	}
+
+	override async alarm() {
+		const result = this.ogRenderDebouncer.onAlarm(Date.now())
+		if (!result.render) {
+			await this.ctx.storage.setAlarm(result.reArmAt)
+			return
+		}
+		await this.requestOgRenderForEdit()
+	}
+
 	/**
 	 * Indexes every data point on this object's durable object id, so any event can be grouped by
 	 * room. The id is the one Cloudflare keys its own telemetry on — `$workers.durableObjectId` in
@@ -1025,7 +1066,14 @@ export class TLFileDurableObject extends DurableObject {
 	logEvent(event: TLServerEvent) {
 		switch (event.type) {
 			case 'persist_success': {
-				this.writeEvent(event.type, { doubles: [event.attempts] })
+				// This event fires on exactly what triggers a thumbnail render, so it carries what sizing
+				// that spend needs. `writeEvent` already indexes it on the durable object id, which makes
+				// distinct boards countable; `sharedState` is the other half, and has to be recorded here
+				// because the id is one-way and cannot be joined back to a file row.
+				this.writeEvent(event.type, {
+					blobs: [event.sharedState],
+					doubles: [event.attempts],
+				})
 				break
 			}
 			case 'room': {
@@ -1539,8 +1587,18 @@ export class TLFileDurableObject extends DurableObject {
 
 						await this.persistToPierre(storage, snapshot)
 
-						this.logEvent({ type: 'persist_success', attempts: attempt })
+						this.logEvent({
+							type: 'persist_success',
+							attempts: attempt,
+							sharedState: this.getBoardRenderState(),
+						})
 						this._lastPersistedClock = snapshot.documentClock
+						// The board's content just changed, so its thumbnail is out of date. Push the render
+						// deadline out rather than rendering now: the useful thumbnail is of the settled
+						// board, and a persist mid-session says more edits are probably coming. Costs one
+						// alarm write per persist, not awaited here (see scheduleOgRender), so a slow or
+						// failed write cannot hold up a persist.
+						this.scheduleOgRender()
 						// Store the clock in DO storage so we can compare against SQLite on next load.
 						if (this.persistenceBad) {
 							this.broadcastPersistenceEvent({ type: 'persistence_good' })
@@ -1574,6 +1632,39 @@ export class TLFileDurableObject extends DurableObject {
 				this.logEvent({ type: 'room', name: 'fail_persist' })
 				this.reportError(e)
 			})
+	}
+
+	/**
+	 * Asks for this board's thumbnail to be re-rendered, because the content it depicts just changed.
+	 *
+	 * Called from `alarm()` when the debounce expires, so it runs once editing has settled or the max
+	 * wait is up. That debounce is the render rate control; there is no sampling or staleness gate on
+	 * top, because a persist means the saved content genuinely differs from what the cached thumbnail
+	 * shows. Downstream, the pending marker single-flights the ask and the consumer re-checks
+	 * `(board, version)` before spending a Browser Run slot — neither is a rate control either.
+	 */
+	private async requestOgRenderForEdit() {
+		try {
+			// Two states skip, and neither is about privacy: a legacy room is not an app file and has no
+			// board identity to render, and a deleted one has nothing worth depicting. `shared`, `private`
+			// and `unknown` all proceed — every board gets a thumbnail, so that an owner-facing surface has
+			// one to show. Sharing is a condition of *serving*, re-applied by the OG route per request.
+			const state = this.getBoardRenderState()
+			if (state === 'legacy' || state === 'deleted') return
+
+			const slug = this.documentInfo.slug
+			const result = await enqueueOgImageRender(
+				this.env,
+				{ kind: 'shared_file', slug },
+				{ reason: 'edit' }
+			)
+			// No board identifier: for a shared file the slug is a capability, and a derived id is still a
+			// board identity in a log sink. The result alone is what this line is for.
+			this.log.debug('og render for edit', result)
+		} catch (e) {
+			// Reported, not thrown: this runs off the persist path and must never affect it.
+			this.reportError(e)
+		}
 	}
 
 	private async _uploadSnapshotToR2(snapshot: RoomSnapshot, key: string) {
@@ -2634,6 +2725,16 @@ export class TLFileDurableObject extends DurableObject {
 
 			// remove main file
 			await this.env.ROOMS.delete(r2Key)
+
+			// The board's thumbnails go with it. Both keys, because they are kept for different reasons
+			// and neither reason survives a hard delete: the file-keyed image is deliberately *not*
+			// deleted when a board is unshared (it stays useful behind auth, and resharing makes it an
+			// immediate hit), and the published-slug one only goes when the board is unpublished. Nothing
+			// else would ever remove either — `og/…` keys carry no version, so each board owns exactly one
+			// object, in a bucket with no lifecycle rule to sweep it. The render token record is dropped
+			// for the same reason. MCP screenshots need no equivalent: their keys carry a content version
+			// and their bucket has an expiration rule.
+			await deleteBoardThumbnails(this.env, { fileId: id, publishedSlug })
 
 			// finally clear storage so we don't keep the data around
 			this.ctx.storage.deleteAll()

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -27,6 +27,7 @@ import {
 	parseTopicSubscriptionTree,
 	serializeSubscriptions,
 } from './replicator/Subscription'
+import { deleteOgImage, enqueuePublishThumbnailRender } from './routes/tla/ogImageQueue'
 import {
 	Analytics,
 	Environment,
@@ -873,6 +874,20 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				getR2KeyForRoom({ slug: `${file.id}/${file.publishedSlug}|${currentTime}`, isApp: true }),
 				blob
 			)
+
+			// The published snapshot is now the content an unfurl would show, so render its OG image
+			// straight away rather than leaving the first crawler to find a cold cache. Publishing is an
+			// explicit, low-volume act, so this costs about one render per publish.
+			//
+			// Reported rather than swallowed, and the no-op results are reported too, because this is the
+			// *only* trigger a published board has. A published snapshot is frozen, so nothing edits it
+			// into needing another render: an ask lost here — thrown, or turned away as `already_pending`
+			// by a marker some earlier failure left behind — leaves that board's card generic until it is
+			// republished. `getOgImage` repairs it on the next fetch (see the `published` on-miss enqueue
+			// there); this line is how we find out it happened.
+			await enqueuePublishThumbnailRender(this.env, file.publishedSlug, (error) =>
+				this.captureException(error, { publishThumbnailEnqueue: true })
+			)
 		} catch (e) {
 			this.log.debug('Error publishing snapshot', e)
 		}
@@ -884,6 +899,9 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			await this.env.ROOM_SNAPSHOTS.delete(
 				getR2KeyForRoom({ slug: `${file.id}/${file.publishedSlug}`, isApp: true })
 			)
+			// The published thumbnail goes with the published snapshot it depicts. Scoped to
+			// `kind: 'published'`, so the board's own file-keyed image is untouched. See deleteOgImage.
+			await deleteOgImage(this.env, { kind: 'published', slug: file.publishedSlug })
 		} catch (e) {
 			this.log.debug('Error unpublishing snapshot', e)
 		}

--- a/apps/dotcom/sync-worker/src/config.ts
+++ b/apps/dotcom/sync-worker/src/config.ts
@@ -1,8 +1,150 @@
+// Tuning constants for the sync worker, gathered here so the dials live in one place.
+//
+// Several of these come out to 60 seconds. That is coincidence, not coupling: each one is derived
+// from its own constraint (production persist timings, capture p90, Cloudflare's fixed rate limit
+// period), and each can move without the others. The one genuine interdependency in this file is
+// OG_PENDING_MARKER_TTL_MS against the retry chain (OG_MAX_RENDER_ATTEMPTS, OG_RETRY_DELAY_SECONDS
+// and the capture timeout), and a test in ogImageQueue.test.ts pins that inequality.
+
 /**
  * How often we the document to R2?
  * 8 seconds.
  */
 export const PERSIST_INTERVAL_MS = 8_000
+
+/**
+ * How long a board must go without persisting before its thumbnail is rendered. 60 seconds.
+ *
+ * A debounce, not a throttle or an interval: each persist pushes the render further out, so a board
+ * renders once its editing *settles*, which is the state a thumbnail is meant to show. Note that a
+ * fixed window would be the wrong shape here whatever its length — production's mean gap between one
+ * board's persists is ~39s, so a window shorter than that suppresses almost nothing and a longer one
+ * costs thumbnail freshness. See "Why a debounce and not a throttle" in
+ * apps/dotcom/browser-run-thumbnails.md for the measurements and the cost table.
+ *
+ * 60s rather than 30s because replaying both values over six hours of production `persist_success`
+ * timings costs ~35.7 renders/min at 30s against ~32.3 at 60s. Note how small that is: raising this
+ * alone cannot save much, because a merged session then runs long enough to hit
+ * `OG_RENDER_MAX_WAIT_MS` and trades a settle render for a max-wait one. The two constants have to
+ * move together to matter — see "What it costs" in the doc for the grid.
+ */
+export const OG_RENDER_DEBOUNCE_MS = 60_000
+
+/**
+ * Ceiling on how long a continuously edited board can go without its thumbnail being refreshed.
+ * 5 minutes.
+ *
+ * Bounds the one failure mode of a pure debounce: a board that never stops being edited would
+ * otherwise never render, since every persist pushes the deadline out again. Measured from the first
+ * persist after a render.
+ *
+ * Raising it does not affect the far more common short-burst board, which costs one render either way.
+ *
+ * Measured against six hours of production persists, this is now the constant that governs total
+ * spend, and it governs it jointly with `OG_RENDER_DEBOUNCE_MS`: at a 60s debounce, taking this from
+ * 5 to 10 minutes goes from ~32.3 to ~26.7 renders/min, while leaving it at 5 minutes makes the
+ * debounce itself nearly inert. Left at 5 minutes deliberately — a board edited without pause holds a
+ * five minute old thumbnail rather than a ten minute old one — but this is the first dial to turn if
+ * spend needs to come down.
+ */
+export const OG_RENDER_MAX_WAIT_MS = 5 * 60_000
+
+/**
+ * Suppresses a duplicate OG render enqueue while one is queued or in flight. A single-flight, not a
+ * rate limit: the consumer clears it as soon as a render lands, so on a healthy board it never
+ * reaches this TTL, which exists only so a consumer dying cannot wedge a board permanently. To
+ * change how often a board renders, change OG_RENDER_DEBOUNCE_MS.
+ *
+ * Must outlive a job's worst-case retry chain — every capture running to its timeout plus every
+ * backoff delay — or the marker lapses while the job is still alive, a fresh ask enqueues a second
+ * job for the same board, and the two clobber each other's per-board render token record
+ * (renderTokens.ts is keyed on the single-flight this marker provides). A test in
+ * ogImageQueue.test.ts pins the inequality against OG_MAX_RENDER_ATTEMPTS, OG_RETRY_DELAY_SECONDS
+ * and THUMBNAIL_RENDER_TIMEOUT_MS.
+ */
+export const OG_PENDING_MARKER_TTL_MS = 5 * 60_000
+
+/**
+ * Retries are bounded by max_retries in wrangler.toml too; this lower cap keeps thumbnail jobs from
+ * burning Browser Run capacity on a persistently failing board.
+ */
+export const OG_MAX_RENDER_ATTEMPTS = 3
+export const OG_RETRY_DELAY_SECONDS = 30
+
+/**
+ * How long the OG route's published-board repair (`repairMissingPublishedImage` in getOgImage.ts)
+ * stays quiet after a crawler-triggered render job for that board has burnt its whole retry budget.
+ * 1 hour.
+ *
+ * The repair is the one render ask an unauthenticated request can cause, and without this it re-arms
+ * as soon as the failed job clears its pending marker: a published board that deterministically fails
+ * to render — a huge board that times out, say — would burn a full retry chain of Browser Run every
+ * ~4 minutes for as long as anything crawls its URL. With it, such a board costs one chain per hour.
+ *
+ * Only the *crawler-reason* give-up arms it, so a publish-triggered render that fails transiently
+ * still gets one immediate repair on the next crawl — the case the repair exists for — and the
+ * cooldown only meters the attempts after that one has also failed. The publish trigger clears it,
+ * because an in-place republish reuses the slug: the cooldown is evidence about the snapshot that
+ * failed, and it must not outlive that snapshot and block the new one's repair.
+ */
+export const OG_REPAIR_COOLDOWN_MS = 60 * 60_000
+
+/**
+ * Cache lifetimes the OG image route hands to callers, in seconds because they land in
+ * `cache-control` headers.
+ *
+ * Short, and deliberately not chosen for cost or freshness. Neither is the binding constraint:
+ * R2 reads are a rounding error next to rendering, and unfurl platforms cache a card their own side
+ * for days whatever we say. What the lifetime actually decides is how long an image can be served
+ * without the share gate being consulted — nothing deletes a board's image when it stops being
+ * public, so the route re-checking the gate per request is the only thing keeping an unshared
+ * board's thumbnail off the internet. Every second of cache lifetime is a second that check does not
+ * happen, so these are minutes, and revalidation is made cheap with an etag instead.
+ */
+export const OG_FRESH_IMAGE_MAX_AGE_SECONDS = 5 * 60
+export const OG_STALE_IMAGE_MAX_AGE_SECONDS = 5 * 60
+export const OG_FALLBACK_MAX_AGE_SECONDS = 60
+
+/**
+ * How long a minted render token stays valid.
+ *
+ * Sized against what a capture needs rather than generously, because this token is what stands between
+ * an HMAC signature and a *private* board's full document: thumbnails are rendered for every board, not
+ * only public ones. Measured renders run 4s at p50 and 12-17s at p90, so 60s is several times p90.
+ *
+ * Queue linger and retry backoff do not eat into it — a token is minted immediately before the
+ * `quickAction` call, not at enqueue. A render slower than this fails and retries with a fresh token.
+ */
+export const THUMBNAIL_RENDER_TOKEN_TTL_MS = 60_000
+
+/**
+ * MCP rate limits: the only rate limiting anywhere in the thumbnail pipeline, applied in
+ * sharedBoardScreenshotMcp.ts. The MCP endpoint is the one Browser Run-spending surface an outside
+ * caller can drive directly, so a rogue or looping agent is the threat being bounded, and only the
+ * calls that actually spend Browser Run are limited — `get_board_info` does the same work the
+ * ordinary board routes do for anyone. The global limit is applied per Cloudflare location, so it
+ * bounds a caller rather than the account. See "Request limits" in browser-run-thumbnails.md.
+ *
+ * These constants are only the isolate-local fallback for local dev and tests. Deployed environments
+ * are governed by the Cloudflare rate limit bindings in wrangler.toml, so changing a number here
+ * alone changes nothing in production. Each budget has its own binding, and the pairs must move
+ * together:
+ *
+ *   MCP_PER_IP_RATE_LIMIT              ->  MCP_SCREENSHOT_RATE_LIMITER      (limit = 10)
+ *   MCP_PER_BOARD_RATE_LIMIT           ->  MCP_SERVER_BOARD_RATE_LIMITER    (limit = 2)
+ *   MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT  ->  MCP_SERVER_BROWSER_RATE_LIMITER  (limit = 20)
+ *
+ * Per-board is far below per-IP on purpose: a caller gets 10 captures a minute, but no single board
+ * may absorb more than 2 of them. Cache misses only, so this does not bound the usual "screenshot
+ * several pages of one board" flow — a repeated capture of the same page is a cache hit.
+ *
+ * The window matches the period configured on the Cloudflare bindings, which only support 60s (or
+ * 10s) periods — this is the one number here that is Cloudflare's rather than ours.
+ */
+export const MCP_PER_IP_RATE_LIMIT = 10
+export const MCP_PER_BOARD_RATE_LIMIT = 2
+export const MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT = 20
+export const MCP_RATE_LIMIT_WINDOW_MS = 60_000
 
 /**
  * The URL of the PostHog instance to use.

--- a/apps/dotcom/sync-worker/src/replicator/ChangeCollator.test.ts
+++ b/apps/dotcom/sync-worker/src/replicator/ChangeCollator.test.ts
@@ -219,6 +219,52 @@ describe('ChangeCollator', () => {
 			})
 		})
 
+		// Unsharing has no side effect of its own. A thumbnail is rendered for every board, shared or
+		// not, and the OG route re-checks the share gate on every request — so there is nothing derived
+		// from the board's public state to clean up when it goes private.
+		it('should add no effect of its own when a file stops being shared via link', () => {
+			const previous = {
+				id: 'doc1',
+				ownerId: 'alice',
+				shared: true,
+			}
+
+			const change = createMockFileChangeV2('doc1', 'alice', 'update', {
+				shared: false,
+				previous,
+			})
+
+			const result = getEffects(change)
+
+			expect(result!.map((effect) => effect.type)).toEqual(['notify_file_durable_object'])
+		})
+
+		// Unpublishing still does have one, because the published image depicts a snapshot that no
+		// longer exists and is keyed on a slug that may never be read again.
+		it('should return only the unpublish effect when a file loses both publish and share', () => {
+			const previous = {
+				id: 'doc1',
+				ownerId: 'alice',
+				published: true,
+				lastPublished: 100,
+				shared: true,
+			}
+
+			const change = createMockFileChangeV2('doc1', 'alice', 'update', {
+				published: false,
+				lastPublished: 100,
+				shared: false,
+				previous,
+			})
+
+			const result = getEffects(change)
+
+			expect(result!.map((effect) => effect.type)).toEqual([
+				'notify_file_durable_object',
+				'unpublish',
+			])
+		})
+
 		it('should handle edge case where previous is undefined for non-update commands', () => {
 			const change = createMockFileChangeV2('doc1', 'alice', 'insert', {
 				published: true,

--- a/apps/dotcom/sync-worker/src/routes/getSocialPreview.ts
+++ b/apps/dotcom/sync-worker/src/routes/getSocialPreview.ts
@@ -66,12 +66,9 @@ export async function getSocialPreview(request: IRequest, env: Environment): Pro
 
 // Shared files (`/f/`) and published boards (`/p/`) get a live board thumbnail as their preview
 // image. We only emit the thumbnail URL when the board actually resolves to a public, renderable
-// board — the same gate the image route itself applies (resolveThumbnailBoard). For private, deleted,
-// or unpublished boards the image route only ever 302s to the default OG image, and crawlers that
-// don't follow og:image redirects (notably X/Twitter) would then show a broken card. Returning null
-// for those boards keeps the static, directly-fetchable site-wide preview image instead. A board
-// that is public but not yet rendered still resolves here; the route serves the default and enqueues
-// the render on the first crawler hit.
+// board — the same gate the image route itself applies (resolveThumbnailBoard). For everything else
+// that route has no picture of its own to serve and redirects to the site-wide default, so pointing
+// at it would cost a crawler an extra hop to reach the image this file can name directly.
 async function getBoardOgImageUrl(
 	request: IRequest,
 	env: Environment,
@@ -80,7 +77,7 @@ async function getBoardOgImageUrl(
 ): Promise<string | null> {
 	const kind = ogBoardKindForPrefix(prefix)
 	if (!kind) return null
-	const resolved = await resolveThumbnailBoard(env, kind, slug)
+	const resolved = await resolveThumbnailBoard(env, kind, slug, { access: 'public' })
 	if (!resolved.ok) return null
 	return `${getPublicOrigin(request, env)}/api/app/social-preview/${prefix}/${encodeURIComponent(slug)}/image`
 }

--- a/apps/dotcom/sync-worker/src/routes/tla/getOgImage.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getOgImage.test.ts
@@ -1,15 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OG_REPAIR_COOLDOWN_MS } from '../../config'
 import { getOgImage } from './getOgImage'
 import { getPublishedFileInfo } from './getPublishedFile'
 import { getSharedFileInfo } from './getSharedFile'
 import { getOgImageCacheKey } from './ogImageQueue'
 import {
+	failureBlobsOf,
+	indexesOf,
 	makeFakeQueue,
 	makeFakeRoomsBucket,
 	makeFakeThumbnailsBucket,
 	makeScreenshotTestEnv as makeEnv,
 } from './screenshotTestHelpers'
-import { resetRateLimitFallbackForTests } from './thumbnailRender'
 
 vi.mock('./getPublishedFile', () => ({
 	getPublishedFileInfo: vi.fn(),
@@ -22,45 +24,135 @@ vi.mock('./getSharedFile', async (importOriginal) => ({
 
 afterEach(() => {
 	vi.useRealTimers()
-	vi.unstubAllGlobals()
 	vi.clearAllMocks()
-	resetRateLimitFallbackForTests()
 })
 
-function makeRequest(prefix: string, slug: string, method = 'GET') {
+function makeRequest(prefix: string, slug: string, method = 'GET', headers?: HeadersInit) {
 	return Object.assign(
-		new Request(`https://sync.tldraw.xyz/app/social-preview/${prefix}/${slug}/image`, { method }),
+		new Request(`https://sync.tldraw.xyz/app/social-preview/${prefix}/${slug}/image`, {
+			method,
+			headers,
+		}),
 		{ params: { prefix, slug } }
 	) as any
 }
 
 describe('getOgImage', () => {
-	it('enqueues a render and redirects to the default OG image on a cold cache', async () => {
+	// A board with no image of its own is sent to the site-wide default rather than having the worker
+	// proxy those bytes: it is a static asset on the client origin, already cached at the edge.
+	it('redirects to the default image on a cold cache', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',
 			published: true,
 			lastPublished: 1751234567890,
 		})
-		const fetch = vi.fn()
-		vi.stubGlobal('fetch', fetch)
 		const bucket = makeFakeThumbnailsBucket()
 		const queue = makeFakeQueue()
 		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: queue })
 
 		const response = await getOgImage(makeRequest('p', 'published-board'), env)
 
-		// The request never waits on Browser Run; the render happens in the queue consumer.
-		expect(fetch).not.toHaveBeenCalled()
 		expect(response.status).toBe(302)
 		expect(response.headers.get('location')).toBe('https://www.tldraw.com/social-og.png')
-		expect(queue.send).toHaveBeenCalledExactlyOnceWith({
+		expect(failureBlobsOf(env)).toEqual(['failure:not_rendered_yet'])
+	})
+
+	// The asymmetry this repair exists for: a published snapshot is frozen and its publish effect is
+	// the only thing that ever asks for a render, so an ask lost to a queue failure or a stale pending
+	// marker would leave a generic card until somebody republished.
+	it('asks for a render when a published board has no image at all', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		const queue = makeFakeQueue()
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: queue })
+
+		await getOgImage(makeRequest('p', 'published-board'), env)
+
+		expect(queue.send).toHaveBeenCalledTimes(1)
+		expect(queue.send).toHaveBeenCalledWith({
 			type: 'og-image-render',
 			kind: 'published',
 			slug: 'published-board',
+			reason: 'crawler',
 		})
 	})
 
-	it('serves fresh cache hits without enqueueing', async () => {
+	// The repair is the one render ask an unauthenticated request can cause, so once a repair job has
+	// failed its whole retry budget, crawler traffic must not be able to re-arm another chain until the
+	// cooldown lapses — otherwise a board that cannot render is a Browser Run spend lever for whoever
+	// fetches its URL.
+	it('does not re-ask while a failed repair has the board on cooldown', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		const bucket = makeFakeThumbnailsBucket()
+		await bucket.put(
+			getOgImageCacheKey({ kind: 'published', slug: 'failing-board' }).replace(
+				/\.png$/,
+				'.repair-cooldown'
+			),
+			new Uint8Array().buffer,
+			{ customMetadata: { expiresAt: String(Date.now() + OG_REPAIR_COOLDOWN_MS) } }
+		)
+		const queue = makeFakeQueue()
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: queue })
+
+		await getOgImage(makeRequest('p', 'failing-board'), env)
+		expect(queue.send).not.toHaveBeenCalled()
+
+		// Once the cooldown lapses, the repair asks again.
+		vi.setSystemTime(Date.parse('2026-01-01T00:00:00Z') + OG_REPAIR_COOLDOWN_MS + 1000)
+		await getOgImage(makeRequest('p', 'failing-board'), env)
+		expect(queue.send).toHaveBeenCalledTimes(1)
+	})
+
+	// A shared file gets no such repair, and the reason is that it does not need one: every persist
+	// that advances its document clock re-asks, so a lost ask is made good by the next edit. Rendering
+	// from here would be work whose result nobody comes back for — unfurl platforms resolve a card once
+	// and reuse it for every repost.
+	it('does not ask for a render when a shared file has no image yet', async () => {
+		vi.mocked(getSharedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			shared: true,
+			sharedLinkType: 'view',
+			isDeleted: false,
+		} as any)
+		const queue = makeFakeQueue()
+		const env = makeEnv({
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+			ROOMS: makeFakeRoomsBucket('room-etag-1'),
+			QUEUE: queue,
+		})
+
+		await getOgImage(makeRequest('f', 'file-1'), env)
+
+		expect(queue.send).not.toHaveBeenCalled()
+	})
+
+	// The redirect sits on a board's own permanent OG image URL, so nothing between here and the
+	// crawler may pin it: a shared cache holding this redirect would outlive the render it stands in
+	// for, and keep sending crawlers to the default long after the board has a picture.
+	it('redirects with a short client-only TTL', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: makeFakeQueue() })
+
+		const response = await getOgImage(makeRequest('p', 'board'), env)
+
+		expect(response.headers.get('cache-control')).toBe('public, max-age=60')
+	})
+
+	it('serves an image whose version matches as a fresh hit', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',
 			published: true,
@@ -84,7 +176,122 @@ describe('getOgImage', () => {
 		expect(queue.send).not.toHaveBeenCalled()
 	})
 
-	it('keeps serving a stale-but-recent image as a hit so one board cannot burn render capacity', async () => {
+	// The lifetime is short and revalidation is cheap on purpose. Nothing deletes a board's image when
+	// it stops being public, so this route re-checking the share gate is the only thing keeping an
+	// unshared board's thumbnail off the internet — and a cache serving without asking is that check not
+	// happening. `stale-while-revalidate` is absent for the same reason: it would extend serving a day
+	// past expiry.
+	it('serves a fresh hit with a short lifetime and an etag, and no stale-while-revalidate', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		const bucket = makeFakeThumbnailsBucket()
+		await bucket.put(
+			getOgImageCacheKey({ kind: 'published', slug: 'cached-board' }),
+			new Uint8Array([1, 2, 3]).buffer,
+			{ customMetadata: { version: '1', createdAt: String(Date.now()) } }
+		)
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+
+		const response = await getOgImage(makeRequest('p', 'cached-board'), env)
+
+		expect(response.headers.get('cache-control')).toBe('public, max-age=300')
+		expect(response.headers.get('etag')).toBe('"etag-1"')
+	})
+
+	it('answers a conditional request whose etag still matches with a 304 and no body', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		const bucket = makeFakeThumbnailsBucket()
+		await bucket.put(
+			getOgImageCacheKey({ kind: 'published', slug: 'cached-board' }),
+			new Uint8Array([1, 2, 3]).buffer,
+			{ customMetadata: { version: '1', createdAt: String(Date.now()) } }
+		)
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+
+		const response = await getOgImage(
+			makeRequest('p', 'cached-board', 'GET', { 'if-none-match': '"etag-1"' }),
+			env
+		)
+
+		expect(response.status).toBe(304)
+		expect(await response.text()).toBe('')
+		// The headers still refresh what the caller holds, so the next revalidation is a whole lifetime
+		// away rather than immediate.
+		expect(response.headers.get('cache-control')).toBe('public, max-age=300')
+		expect(response.headers.get('etag')).toBe('"etag-1"')
+		expect(response.headers.get('x-tldraw-og-cache')).toBe('hit')
+	})
+
+	// The bytes are read lazily on a conditional request, so a render landing since the caller cached
+	// has to be noticed and served rather than answered with a 304 for content that has moved.
+	it('serves the new bytes when a conditional request holds a superseded etag', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 2,
+		})
+		const bucket = makeFakeThumbnailsBucket()
+		const key = getOgImageCacheKey({ kind: 'published', slug: 'cached-board' })
+		await bucket.put(key, new Uint8Array([1, 2, 3]).buffer, {
+			customMetadata: { version: '1', createdAt: String(Date.now()) },
+		})
+		await bucket.put(key, new Uint8Array([4, 5, 6]).buffer, {
+			customMetadata: { version: '2', createdAt: String(Date.now()) },
+		})
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+
+		const response = await getOgImage(
+			makeRequest('p', 'cached-board', 'GET', { 'if-none-match': '"etag-1"' }),
+			env
+		)
+
+		expect(response.status).toBe(200)
+		expect(await response.arrayBuffer()).toEqual(new Uint8Array([4, 5, 6]).buffer)
+		expect(response.headers.get('etag')).toBe('"etag-2"')
+		expect(response.headers.get('x-tldraw-og-cache')).toBe('hit')
+	})
+
+	// The share gate runs before the etag is ever looked at, so holding a valid etag for a board that
+	// has since been unshared buys nothing. This is what the short lifetime is protecting.
+	it('sends a conditional request for a board that is no longer shared to the default image', async () => {
+		vi.mocked(getSharedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			shared: false,
+			sharedLinkType: 'view',
+			isDeleted: false,
+		} as any)
+		const bucket = makeFakeThumbnailsBucket()
+		await bucket.put(
+			getOgImageCacheKey({ kind: 'shared_file', slug: 'file-1' }),
+			new Uint8Array([1, 2, 3]).buffer,
+			{ customMetadata: { version: 'room-etag-1', createdAt: String(Date.now()) } }
+		)
+		const env = makeEnv({
+			THUMBNAILS: bucket,
+			ROOMS: makeFakeRoomsBucket('room-etag-1'),
+			QUEUE: makeFakeQueue(),
+		})
+
+		const response = await getOgImage(
+			makeRequest('f', 'file-1', 'GET', { 'if-none-match': '"etag-1"' }),
+			env
+		)
+
+		expect(response.status).toBe(302)
+		expect(response.headers.get('location')).toBe('https://www.tldraw.com/social-og.png')
+	})
+
+	// There is no "too stale to serve". An old picture of this board beats the generic tldraw logo, so a
+	// version mismatch only shortens the cache lifetime — it never withholds the image or asks for a
+	// render, and the image's age is not consulted at all.
+	it('serves a version-mismatched image as stale with a short TTL, however old it is', async () => {
 		vi.useFakeTimers()
 		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
@@ -101,24 +308,21 @@ describe('getOgImage', () => {
 		const queue = makeFakeQueue()
 		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: queue })
 
-		vi.setSystemTime(new Date('2026-01-01T00:30:00Z'))
-		const staleButYoung = await getOgImage(makeRequest('p', 'cached-board'), env)
-		expect(staleButYoung.headers.get('x-tldraw-og-cache')).toBe('hit')
+		// Minutes old and a year old behave identically: both serve the bytes as stale.
+		for (const now of ['2026-01-01T00:30:00Z', '2027-01-01T00:00:00Z']) {
+			vi.setSystemTime(new Date(now))
+			const stale = await getOgImage(makeRequest('p', 'cached-board'), env)
+			expect(stale.status).toBe(200)
+			expect(stale.headers.get('x-tldraw-og-cache')).toBe('stale')
+			expect(stale.headers.get('cache-control')).toBe('public, max-age=300')
+			expect(await stale.arrayBuffer()).toEqual(new Uint8Array([1, 2, 3]).buffer)
+		}
 		expect(queue.send).not.toHaveBeenCalled()
-
-		vi.setSystemTime(new Date('2026-01-01T01:01:00Z'))
-		const stale = await getOgImage(makeRequest('p', 'cached-board'), env)
-		expect(stale.status).toBe(200)
-		expect(stale.headers.get('x-tldraw-og-cache')).toBe('stale')
-		expect(await stale.arrayBuffer()).toEqual(new Uint8Array([1, 2, 3]).buffer)
-		expect(queue.send).toHaveBeenCalledExactlyOnceWith({
-			type: 'og-image-render',
-			kind: 'published',
-			slug: 'cached-board',
-		})
 	})
 
-	it('enqueues renders for shared files behind the share gate', async () => {
+	// The route's whole gate: viewable (published, or shared via link) and an image exists. A shared
+	// file with no image yet passes the first and fails the second, so it gets the default.
+	it('serves a shared file that passes its gate but has no image yet', async () => {
 		vi.mocked(getSharedFileInfo).mockResolvedValue({
 			id: 'shared-file',
 			shared: true,
@@ -134,14 +338,37 @@ describe('getOgImage', () => {
 		const response = await getOgImage(makeRequest('f', 'shared-file'), env)
 
 		expect(response.status).toBe(302)
-		expect(queue.send).toHaveBeenCalledExactlyOnceWith({
-			type: 'og-image-render',
-			kind: 'shared_file',
-			slug: 'shared-file',
-		})
+		expect(queue.send).not.toHaveBeenCalled()
 	})
 
-	it('answers HEAD probes with cache headers but no body and no render enqueue', async () => {
+	// An unshared board's thumbnail stays in R2 for owner-facing surfaces behind authz, so the gate is
+	// the only thing keeping it off the public internet. It has to be checked on every request rather
+	// than relied on having deleted the object at unshare time.
+	it('refuses a board that has an image but no longer passes its gate', async () => {
+		vi.mocked(getSharedFileInfo).mockResolvedValue({
+			id: 'unshared-file',
+			shared: false,
+			isDeleted: false,
+		})
+		const bucket = makeFakeThumbnailsBucket()
+		await bucket.put(
+			getOgImageCacheKey({ kind: 'shared_file', slug: 'unshared-file' }),
+			new Uint8Array([1, 2, 3]).buffer,
+			{ customMetadata: { version: 'etag-1', createdAt: String(Date.now()) } }
+		)
+		const env = makeEnv({ ROOMS: makeFakeRoomsBucket('etag-1'), THUMBNAILS: bucket })
+
+		const response = await getOgImage(makeRequest('f', 'unshared-file'), env)
+
+		expect(response.status).toBe(302)
+		expect(response.headers.get('location')).toBe('https://www.tldraw.com/social-og.png')
+		// Still there, just unreachable from here.
+		expect(
+			bucket.store.has(getOgImageCacheKey({ kind: 'shared_file', slug: 'unshared-file' }))
+		).toBe(true)
+	})
+
+	it('answers HEAD probes with the same cache headers as a GET, but no body', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',
 			published: true,
@@ -162,12 +389,12 @@ describe('getOgImage', () => {
 		expect(response.status).toBe(200)
 		expect(response.headers.get('content-type')).toBe('image/png')
 		expect(response.headers.get('x-tldraw-og-cache')).toBe('hit')
-		// ...but no body is read, and no Browser Run is spent.
+		// ...but the R2 body is never read.
 		expect((await response.arrayBuffer()).byteLength).toBe(0)
 		expect(queue.send).not.toHaveBeenCalled()
 	})
 
-	it('does not enqueue a render for a HEAD probe on a cold cache', async () => {
+	it('answers a HEAD probe on a cold cache with the same redirect a GET would get', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',
 			published: true,
@@ -180,17 +407,17 @@ describe('getOgImage', () => {
 
 		expect(response.status).toBe(302)
 		expect(response.headers.get('location')).toBe('https://www.tldraw.com/social-og.png')
-		expect(queue.send).not.toHaveBeenCalled()
+		// Including the repair ask: some crawlers only ever probe with HEAD, and a published board with
+		// no image has nothing else that will ask for one.
+		expect(queue.send).toHaveBeenCalledTimes(1)
 	})
 
-	it('redirects private or unknown boards to the default tldraw OG image without enqueueing', async () => {
+	it('sends private or unknown boards to the default tldraw OG image', async () => {
 		vi.mocked(getSharedFileInfo).mockResolvedValue({
 			id: 'private-file',
 			shared: false,
 			isDeleted: false,
 		})
-		const fetch = vi.fn()
-		vi.stubGlobal('fetch', fetch)
 		const queue = makeFakeQueue()
 
 		const response = await getOgImage(
@@ -200,7 +427,38 @@ describe('getOgImage', () => {
 
 		expect(response.status).toBe(302)
 		expect(response.headers.get('location')).toBe('https://www.tldraw.com/social-og.png')
-		expect(fetch).not.toHaveBeenCalled()
 		expect(queue.send).not.toHaveBeenCalled()
+	})
+
+	// These datapoints carry no board identity at all — no index, no slug, no hash, no derived id.
+	// The dataset answers aggregate spend and failure questions, and a board that resolves must be
+	// indistinguishable from one that doesn't, or the dimension is back by another name.
+	it('writes no board identity on any datapoint, resolved or not', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getSharedFileInfo).mockResolvedValue({
+			id: 'private-file',
+			shared: false,
+			isDeleted: false,
+		})
+		const env = makeEnv({
+			ROOMS: makeFakeRoomsBucket('etag-1'),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+			QUEUE: makeFakeQueue(),
+		})
+
+		// A board that resolves, and one that fails its gate (which returns before writing anything).
+		await getOgImage(makeRequest('p', 'published-slug'), env)
+		await getOgImage(makeRequest('f', 'private-file'), env)
+
+		expect(indexesOf(env)).toEqual([undefined])
+		// Nothing board-shaped anywhere in the blobs either.
+		const written = JSON.stringify((env.MEASURE as any).writeDataPoint.mock.calls)
+		expect(written).not.toContain('published-slug')
+		expect(written).not.toContain('file-1')
+		expect(written).not.toContain('private-file')
 	})
 })

--- a/apps/dotcom/sync-worker/src/routes/tla/getOgImage.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getOgImage.ts
@@ -1,32 +1,32 @@
 import { IRequest } from 'itty-router'
+import {
+	OG_FALLBACK_MAX_AGE_SECONDS,
+	OG_FRESH_IMAGE_MAX_AGE_SECONDS,
+	OG_STALE_IMAGE_MAX_AGE_SECONDS,
+} from '../../config'
 import { Environment, ThumbnailBoardKind } from '../../types'
 import { getPublicOrigin } from '../../utils/getPublicOrigin'
-import { enqueueOgImageRender, getOgImageCacheKey } from './ogImageQueue'
+import { enqueueOgImageRender, getOgImageCacheKey, isOgImageRepairOnCooldown } from './ogImageQueue'
 import {
 	ResolvedThumbnailBoard,
-	isRateLimited,
 	resolveThumbnailBoard,
 	writeScreenshotTelemetry,
 } from './thumbnailRender'
-import { reportThumbnailError, sha256 } from './thumbnailShared'
+import { reportThumbnailError } from './thumbnailShared'
 
-// OG images are served entirely from the R2 cache; rendering happens asynchronously through the
-// og-image queue consumer (ogImageQueue.ts). A request never waits on Browser Run: it gets the
-// cached image (fresh or stale, while a refresh job runs in the background) or a redirect to the
-// default tldraw OG image until the first render lands. This is what makes the endpoint safe on
-// high-traffic paths like link unfurls.
-
-// A stale-but-recent image is still served as fresh without enqueueing a refresh, so one board
-// cannot spend Browser Run capacity more than about once an hour no matter how often it changes
-// or is crawled.
-const OG_IMAGE_MIN_REFRESH_AGE_MS = 60 * 60_000
-const OG_IMAGE_BOARD_RATE_LIMIT = 2
+// Almost a pure read. Two questions and nothing else: is this board publicly viewable (published, or
+// shared via link), and does a thumbnail for it exist? Both yes, serve it. Anything else, redirect to
+// the site-wide default. No rendering inline, no rate limiting, no waiting.
+//
+// Making the thumbnail exist before the board is ever shared is the job of the publish and edit
+// triggers (TLPostgresReplicator, TLFileDurableObject), not of the request that finds it missing:
+// unfurl platforms cache a URL's card on first resolve, so a render triggered from here lands after
+// the crawler has already taken the default away. Rendering inline is worse still — captures run
+// 4-17s, past any crawler's patience. See browser-run-thumbnails.md.
+//
+// The one exception is `repairMissingPublishedImage` below, which asks for a render when a *published*
+// board has no image at all — the single case where no other trigger will ever ask again.
 const DEFAULT_OG_IMAGE_PATH = '/social-og.png'
-const FRESH_IMAGE_MAX_AGE_SECONDS = 60 * 60
-// Stale images and redirects use short TTLs so scrapers and browsers come back for the fresh
-// render soon after the queued job completes.
-const STALE_IMAGE_MAX_AGE_SECONDS = 5 * 60
-const REDIRECT_MAX_AGE_SECONDS = 60
 
 export async function getOgImage(
 	request: IRequest,
@@ -34,10 +34,10 @@ export async function getOgImage(
 	ctx?: ExecutionContext
 ): Promise<Response> {
 	// Crawlers probe this URL with HEAD before (or instead of) GET, so the route is registered with
-	// .all and HEAD must still return the cache/redirect headers. But a HEAD must not spend Browser
-	// Run: only a real GET reads the R2 body and enqueues a render. Any non-GET method is treated
-	// like a probe (headers only, no enqueue).
+	// .all and HEAD must still return the same cache headers a GET would. Only a real GET reads the
+	// R2 body; any other method is treated as a probe and answers headers only.
 	const wantsBody = request.method === 'GET'
+	const imageUrl = `${getPublicOrigin(request, env)}${DEFAULT_OG_IMAGE_PATH}`
 	const board = await resolveOgBoard(request, env).catch((error) => {
 		// Resolution reads Postgres and R2, so a throw here is infrastructure failing, not a board
 		// that isn't public — but both produce the same default-image redirect. Report it, or an
@@ -47,64 +47,57 @@ export async function getOgImage(
 			env,
 			request,
 			surface: 'og_route',
-			extras: { prefix: request.params.prefix, slug: request.params.slug },
+			// The route prefix only. No board identifier reaches an error report: for a link-shared file
+			// the slug is the file id, which is the capability to view the board.
+			extras: { prefix: request.params.prefix },
 		})
 		return null
 	})
-	if (!board) return redirectToDefaultOgImage(request, env)
+	if (!board) return redirectToDefaultOgImage(imageUrl)
 
-	const boardHash = await sha256(board.slug)
 	const cacheKey = getOgImageCacheKey(board)
-	const cached = wantsBody
-		? await env.THUMBNAILS?.get(cacheKey)
-		: await env.THUMBNAILS?.head(cacheKey)
-	const now = Date.now()
-	if (cached && shouldServeCachedOgImage(cached, board.version, now)) {
-		writeScreenshotTelemetry(env, { source: 'og', boardHash, cacheStatus: 'hit' })
-		return imageResponse(wantsBody ? await (cached as R2ObjectBody).arrayBuffer() : null, {
-			cacheStatus: 'hit',
-			maxAgeSeconds: FRESH_IMAGE_MAX_AGE_SECONDS,
-			version: cached.customMetadata?.version,
-		})
-	}
-
-	// Stale or never rendered: a GET kicks off (at most) one background render, then returns the best
-	// response we have right now. HEAD probes skip the enqueue so they never spend Browser Run. The
-	// per-board limit guards the queue against being flooded on a single board's behalf; enqueue
-	// failures degrade to the fallback response rather than a 500.
-	if (
-		wantsBody &&
-		!(await isRateLimited(env.MCP_SCREENSHOT_RATE_LIMITER, `og-board:${board.kind}:${board.slug}`, {
-			fallbackLimit: OG_IMAGE_BOARD_RATE_LIMIT,
-		}))
-	) {
-		await enqueueOgImageRender(env, board).catch(() => {})
-	}
+	// A conditional request needs metadata only: if the etag still matches, the answer is a 304 and the
+	// bytes are never read. A HEAD probe needs metadata only for the same reason.
+	const ifNoneMatch = request.headers.get('if-none-match')
+	let cached =
+		wantsBody && !ifNoneMatch
+			? await env.THUMBNAILS?.get(cacheKey)
+			: await env.THUMBNAILS?.head(cacheKey)
 
 	if (cached) {
-		writeScreenshotTelemetry(env, { source: 'og', boardHash, cacheStatus: 'stale' })
-		return imageResponse(wantsBody ? await (cached as R2ObjectBody).arrayBuffer() : null, {
-			cacheStatus: 'stale',
-			maxAgeSeconds: STALE_IMAGE_MAX_AGE_SECONDS,
-			version: cached.customMetadata?.version,
-		})
+		// The caller already holds these bytes. This is the path the short max-age is designed to make
+		// common: a cache revalidates for the price of a 304, and every revalidation re-runs the share
+		// gate above, so an unshared board stops being served within minutes rather than within a day.
+		if (ifNoneMatch && etagMatches(ifNoneMatch, cached.etag)) {
+			writeScreenshotTelemetry(env, { source: 'og', cacheStatus: cacheStatusOf(cached, board) })
+			return notModifiedResponse(cacheParamsOf(cached, board))
+		}
+
+		// A conditional GET whose etag no longer matches: the board has re-rendered since it was cached,
+		// so the bytes are needed after all. Every header below is derived from this second read, so a
+		// render landing between the two cannot make them describe bytes we did not send.
+		if (wantsBody && !('body' in cached)) {
+			cached = await env.THUMBNAILS?.get(cacheKey)
+			if (!cached) return redirectToDefaultOgImage(imageUrl)
+		}
+
+		writeScreenshotTelemetry(env, { source: 'og', cacheStatus: cacheStatusOf(cached, board) })
+		return imageResponse(
+			wantsBody ? await (cached as R2ObjectBody).arrayBuffer() : null,
+			cacheParamsOf(cached, board)
+		)
 	}
 
+	// Never rendered, so the board has nothing of its own to show and the request is sent to the
+	// site-wide default instead. The short max-age is what lets the real image take over as soon as a
+	// publish or an edit lands it.
 	writeScreenshotTelemetry(env, {
 		source: 'og',
-		boardHash,
 		cacheStatus: 'miss',
 		failureReason: 'not_rendered_yet',
 	})
-	return redirectToDefaultOgImage(request, env)
-}
-
-function shouldServeCachedOgImage(cached: R2Object, version: string | number, now: number) {
-	const cachedVersion = cached.customMetadata?.version
-	if (cachedVersion === String(version)) return true
-
-	const createdAt = Number(cached.customMetadata?.createdAt ?? cached.uploaded?.getTime() ?? 0)
-	return Number.isFinite(createdAt) && now - createdAt < OG_IMAGE_MIN_REFRESH_AGE_MS
+	await repairMissingPublishedImage(board, env, ctx)
+	return redirectToDefaultOgImage(imageUrl)
 }
 
 async function resolveOgBoard(
@@ -114,7 +107,9 @@ async function resolveOgBoard(
 	const kind = parseOgKind(request.params.prefix)
 	const slug = parseSlug(request.params.slug)
 	if (!kind || !slug) return null
-	const resolved = await resolveThumbnailBoard(env, kind, slug)
+	// 'public' is load-bearing here: since a thumbnail exists for every board and is never deleted, this
+	// gate is the only thing keeping a private board's off the public internet.
+	const resolved = await resolveThumbnailBoard(env, kind, slug, { access: 'public' })
 	return resolved.ok ? resolved.board : null
 }
 
@@ -128,34 +123,114 @@ function parseSlug(value: unknown) {
 	return typeof value === 'string' && value.length > 0 && !value.includes('/') ? value : null
 }
 
-function imageResponse(
-	body: ArrayBuffer | null,
-	{
-		cacheStatus,
-		maxAgeSeconds,
-		version,
-	}: {
-		cacheStatus: 'hit' | 'stale'
-		maxAgeSeconds: number
-		version?: string
-	}
+/**
+ * The one case where this route asks for a render, and it is a repair rather than a refresh.
+ *
+ * The two kinds are not symmetric in how many triggers they have. A shared file re-asks on every
+ * persist that advances its document clock, so an ask lost to a queue failure or a stale pending
+ * marker is made good by the next edit. A published board has exactly one trigger — the publish
+ * effect in `TLPostgresReplicator` — and its snapshot is frozen, so nothing ever edits it into
+ * asking again. One lost ask there means a generic card until somebody republishes.
+ *
+ * So this fires only for `published`, and only on a total miss: no image at all, not a stale one.
+ * The pending marker dedupes it while a job is alive, and the repair cooldown bounds it after one
+ * dies: this is the only render ask an unauthenticated request can cause, so once a crawler-triggered
+ * job has burnt its whole retry budget, a board that cannot render costs one retry chain per
+ * OG_REPAIR_COOLDOWN_MS rather than one per marker-clear — traffic an outside caller controls must
+ * not be able to re-arm it faster than that.
+ *
+ * This does not undo the reasoning that removed the general on-miss enqueue. That enqueue was
+ * pointless because the crawler which triggered it has already cached the default by the time the
+ * render lands, and unfurl platforms resolve a card once — both still true. The point here is not to
+ * serve *this* request; it is that without it, nothing else will ever ask.
+ */
+async function repairMissingPublishedImage(
+	board: ResolvedThumbnailBoard,
+	env: Environment,
+	ctx: ExecutionContext | undefined
 ) {
+	if (board.kind !== 'published') return
+	if (await isOgImageRepairOnCooldown(env, board)) return
+	const enqueued = enqueueOgImageRender(env, board, { reason: 'crawler' }).catch((error) => {
+		reportThumbnailError(error, {
+			ctx,
+			env,
+			surface: 'og_route',
+			extras: { kind: board.kind, repair: true },
+		})
+	})
+	// Off the response path in production; awaited only when there is no execution context to hand it
+	// to, which is tests.
+	if (ctx) ctx.waitUntil(enqueued)
+	else await enqueued
+}
+
+// Whether the image still depicts the board's current content decides the cache lifetime and nothing
+// else — both are served. There is no "too stale to serve": an old picture of this board beats the
+// generic tldraw logo, so a mismatch only asks callers back sooner.
+function cacheStatusOf(cached: R2Object, board: ResolvedThumbnailBoard) {
+	return cached.customMetadata?.version === String(board.version) ? 'hit' : 'stale'
+}
+
+function cacheParamsOf(cached: R2Object, board: ResolvedThumbnailBoard): CacheParams {
+	const cacheStatus = cacheStatusOf(cached, board)
+	return {
+		cacheStatus,
+		maxAgeSeconds:
+			cacheStatus === 'hit' ? OG_FRESH_IMAGE_MAX_AGE_SECONDS : OG_STALE_IMAGE_MAX_AGE_SECONDS,
+		etag: cached.httpEtag,
+		version: cached.customMetadata?.version,
+	}
+}
+
+interface CacheParams {
+	cacheStatus: 'hit' | 'stale'
+	maxAgeSeconds: number
+	etag?: string
+	version?: string
+}
+
+// `if-none-match` is a list, each entry optionally weak-prefixed and quoted; R2's `etag` is the bare
+// value, so both sides are normalised before comparing.
+function etagMatches(ifNoneMatch: string, etag: string) {
+	return ifNoneMatch
+		.split(',')
+		.map((candidate) => candidate.trim().replace(/^W\//, '').replace(/^"|"$/g, ''))
+		.some((candidate) => candidate === '*' || candidate === etag)
+}
+
+function cacheHeaders({ cacheStatus, maxAgeSeconds, etag, version }: CacheParams) {
+	return {
+		// No `stale-while-revalidate`: it would let a cache keep serving for a day past expiry, which is
+		// a day of serving without the share gate — the same reason the default-image redirect carries
+		// none. See OG_FRESH_IMAGE_MAX_AGE_SECONDS in config.ts.
+		'cache-control': `public, max-age=${maxAgeSeconds}`,
+		'x-tldraw-og-cache': cacheStatus,
+		...(etag ? { etag } : null),
+		...(version ? { 'x-tldraw-og-version': version } : null),
+	}
+}
+
+function imageResponse(body: ArrayBuffer | null, params: CacheParams) {
 	return new Response(body, {
-		headers: {
-			'content-type': 'image/png',
-			'cache-control': `public, max-age=${maxAgeSeconds}, stale-while-revalidate=86400`,
-			'x-tldraw-og-cache': cacheStatus,
-			...(version ? { 'x-tldraw-og-version': version } : null),
-		},
+		headers: { 'content-type': 'image/png', ...cacheHeaders(params) },
 	})
 }
 
-function redirectToDefaultOgImage(request: IRequest, env: Environment) {
+// A 304 carries no body, and its headers refresh what the caller already holds.
+function notModifiedResponse(params: CacheParams) {
+	return new Response(null, { status: 304, headers: cacheHeaders(params) })
+}
+
+// Sends a request with no board image of its own to the site-wide default. The worker never serves
+// those bytes itself: the default is a static asset on the client origin, already cached at the edge,
+// and proxying it would put worker egress in front of every unfurl of an unrendered board.
+function redirectToDefaultOgImage(imageUrl: string) {
 	return new Response(null, {
 		status: 302,
 		headers: {
-			location: `${getPublicOrigin(request, env)}${DEFAULT_OG_IMAGE_PATH}`,
-			'cache-control': `public, max-age=${REDIRECT_MAX_AGE_SECONDS}`,
+			location: imageUrl,
+			'cache-control': `public, max-age=${OG_FALLBACK_MAX_AGE_SECONDS}`,
 		},
 	})
 }

--- a/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.test.ts
@@ -1,9 +1,34 @@
 import { describe, expect, it } from 'vitest'
-import { SharedFileInfo, isFileAnonymouslyViewable } from './getSharedFile'
+import { SharedFileInfo, isFileAnonymouslyViewable, isFileRenderable } from './getSharedFile'
 
 function makeFile(overrides: Partial<SharedFileInfo> = {}): SharedFileInfo {
 	return { id: 'file-abc', shared: true, isDeleted: false, ...overrides }
 }
+
+// The two gates, and the one difference between them: sharing. Rendering happens for every board so
+// an owner-facing surface has a thumbnail; serving to an anonymous caller does not.
+describe('isFileRenderable', () => {
+	it('allows a private file — privacy gates serving, not rendering', () => {
+		expect(isFileRenderable(makeFile({ shared: false }))).toBe(true)
+		expect(isFileAnonymouslyViewable(makeFile({ shared: false }))).toBe(false)
+	})
+
+	it('refuses a missing file', () => {
+		expect(isFileRenderable(null)).toBe(false)
+	})
+
+	// A deleted board has nothing worth depicting, shared or not.
+	it('refuses a deleted file', () => {
+		expect(isFileRenderable(makeFile({ isDeleted: true }))).toBe(false)
+		expect(isFileRenderable(makeFile({ isDeleted: true, shared: false }))).toBe(false)
+	})
+
+	// Reading a test file needs admin auth, so it has no business being pulled through the render page
+	// even though nothing would serve the result anonymously.
+	it('refuses a test file', () => {
+		expect(isFileRenderable(makeFile({ id: 'test_abc' }))).toBe(false)
+	})
+})
 
 describe('isFileAnonymouslyViewable', () => {
 	it('allows a shared, non-deleted, non-test file', () => {

--- a/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.ts
@@ -1,7 +1,7 @@
 import { RoomSnapshot } from '@tldraw/sync-core'
 import { createPostgresConnectionPool } from '../../postgres'
 import { getR2KeyForRoom } from '../../r2'
-import { Environment } from '../../types'
+import { Environment, ThumbnailBoardAccess } from '../../types'
 import { isTestFile } from '../../utils/tla/isTestFile'
 
 export interface SharedFileInfo {
@@ -32,24 +32,49 @@ export async function getSharedFileInfo(
 }
 
 /**
- * Whether a file may be screenshotted by the anonymous, image-only MCP tool. This mirrors the
- * anonymous read gate enforced by the file room itself (`TLFileDurableObject.onRequest`): the file
- * must exist, not be deleted, and be shared via link. `sharedLinkType` (`view` vs `edit`) is
- * irrelevant to viewing. Test-slug files require admin auth to read, which the anonymous tool never
- * has, so they are refused outright.
+ * Whether a file is worth rendering a thumbnail of at all: it exists, is not deleted, and is not a test
+ * file (reading one requires admin auth, so it has no business going through the render page). Says
+ * nothing about who may *see* that thumbnail — every board gets one, private ones included, and serving
+ * is gated separately.
  */
-export function isFileAnonymouslyViewable(file: SharedFileInfo | null): file is SharedFileInfo {
-	return !!file && !file.isDeleted && file.shared === true && !isTestFile(file.id)
+export function isFileRenderable(file: SharedFileInfo | null): file is SharedFileInfo {
+	return !!file && !file.isDeleted && !isTestFile(file.id)
 }
 
-// Read the live room snapshot for an anonymously-shared file from R2. Re-checks the share gate so a
-// board that was un-shared after a render token was minted is not served during the token's window.
+/**
+ * Whether a file may be served to an anonymous caller — the MCP tool, the OG image route, the
+ * crawler HTML. Renderable, plus actually shared via link. This mirrors the anonymous read gate
+ * enforced by the file room itself (`TLFileDurableObject.onRequest`). `sharedLinkType` (`view` vs
+ * `edit`) is irrelevant to viewing.
+ */
+export function isFileAnonymouslyViewable(file: SharedFileInfo | null): file is SharedFileInfo {
+	return isFileRenderable(file) && file.shared === true
+}
+
+/**
+ * Applies the gate an access level asks for. The mapping lives here, once, so that resolving a board
+ * and reading its snapshot cannot end up applying different gates to the same access level — which
+ * would mean a board resolving publicly and then being read under the weaker one.
+ */
+export function isFileViewableFor(
+	file: SharedFileInfo | null,
+	access: ThumbnailBoardAccess
+): file is SharedFileInfo {
+	return access === 'public' ? isFileAnonymouslyViewable(file) : isFileRenderable(file)
+}
+
+// Read the live room snapshot for an app file from R2. Re-checks the caller's gate rather than
+// trusting whatever check happened earlier: a `public` read of a board un-shared since a render
+// token was minted must stop resolving inside that token's window.
 export async function getSharedFileRoomSnapshot(
 	env: Environment,
-	slug: string
+	slug: string,
+	{ access }: { access: ThumbnailBoardAccess }
 ): Promise<RoomSnapshot | undefined> {
 	const file = await getSharedFileInfo(env, slug)
-	if (!isFileAnonymouslyViewable(file)) throw Error('not shared')
+	if (!isFileViewableFor(file, access)) {
+		throw Error(access === 'public' ? 'not shared' : 'not renderable')
+	}
 
 	return (await env.ROOMS.get(getR2KeyForRoom({ slug, isApp: true })).then((r) => r?.json())) as
 		| RoomSnapshot

--- a/apps/dotcom/sync-worker/src/routes/tla/getThumbnailSnapshot.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getThumbnailSnapshot.test.ts
@@ -1,13 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { THUMBNAIL_RENDER_TOKEN_TTL_MS } from '../../config'
 import { Environment } from '../../types'
 import {
-	THUMBNAIL_RENDER_TOKEN_TTL_MS,
 	ThumbnailRenderJob,
 	mintThumbnailRenderToken,
+	recordMintedRenderToken,
 } from '../../utils/renderTokens'
 import { getPublishedRoomSnapshot } from './getPublishedFile'
 import { getSharedFileRoomSnapshot } from './getSharedFile'
 import { getThumbnailSnapshot } from './getThumbnailSnapshot'
+import { makeFakeThumbnailsBucket } from './screenshotTestHelpers'
 
 vi.mock('./getPublishedFile', () => ({
 	getPublishedRoomSnapshot: vi.fn(),
@@ -29,9 +31,11 @@ function makeJob(overrides: Partial<ThumbnailRenderJob> = {}): ThumbnailRenderJo
 		kind: 'published',
 		slug: 'my-board',
 		version: 1751234567890,
-		x: 10,
-		y: 20,
-		z: 0.5,
+		access: 'render',
+		camera: 'content',
+		x: 0,
+		y: 0,
+		z: 1,
 		width: 1200,
 		height: 630,
 		theme: 'dark',
@@ -63,9 +67,12 @@ describe('getThumbnailSnapshot', () => {
 			records: [{ id: 'shape:1', typeName: 'shape' }],
 			schema: { schemaVersion: 2, sequences: {} },
 			renderParams: {
-				x: 10,
-				y: 20,
-				z: 0.5,
+				camera: 'content',
+				// Echoed even though `content` makes the render page ignore them, so a job that omits
+				// `camera` has a viewport to fall back on without a second shape of response.
+				x: 0,
+				y: 0,
+				z: 1,
 				width: 1200,
 				height: 630,
 				theme: 'dark',
@@ -182,17 +189,119 @@ describe('getThumbnailSnapshot', () => {
 		)
 
 		expect(response.status).toBe(200)
-		expect(vi.mocked(getSharedFileRoomSnapshot)).toHaveBeenCalledWith(env, 'file-abc')
+		expect(vi.mocked(getSharedFileRoomSnapshot)).toHaveBeenCalledWith(env, 'file-abc', {
+			access: 'render',
+		})
 		expect(vi.mocked(getPublishedRoomSnapshot)).not.toHaveBeenCalled()
 	})
 
-	it('returns 404 when a shared file is un-shared during the token window', async () => {
-		vi.mocked(getSharedFileRoomSnapshot).mockRejectedValue(Error('not shared'))
+	// The gate comes from the signed job, not from this route. An MCP token is minted `public`, so it
+	// reads under the anonymous gate and stays confined to what the MCP tool could resolve — a board
+	// that went private after minting is refused, where a thumbnail render's `render` token is not.
+	it('reads under the access level the token was minted with', async () => {
+		vi.mocked(getSharedFileRoomSnapshot).mockResolvedValue({
+			documents: [{ state: { id: 'shape:1', typeName: 'shape' }, lastChangedClock: 0 }],
+			schema: { schemaVersion: 2, sequences: {} },
+			clock: 0,
+		} as any)
+
+		await getThumbnailSnapshot(
+			makeRequest(
+				await mintToken({
+					kind: 'shared_file',
+					slug: 'file-abc',
+					version: 'etag-1',
+					access: 'public',
+				})
+			),
+			env
+		)
+
+		expect(vi.mocked(getSharedFileRoomSnapshot)).toHaveBeenCalledWith(env, 'file-abc', {
+			access: 'public',
+		})
+	})
+
+	// Deleted, not un-shared: this route reads with `access: 'render'`, so a private board resolves and
+	// its content is served to the render page. What refuses is a board that is deleted or unknown,
+	// which `isFileRenderable` rejects.
+	it('returns 404 when the board is deleted during the token window', async () => {
+		vi.mocked(getSharedFileRoomSnapshot).mockRejectedValue(Error('not renderable'))
 		const response = await getThumbnailSnapshot(
 			makeRequest(await mintToken({ kind: 'shared_file', slug: 'file-abc', version: 'etag-1' })),
 			env
 		)
 		expect(response.status).toBe(404)
+	})
+})
+
+// The route is the place this actually protects something: it serves any board's full document now
+// that thumbnails render for every board, so a valid signature must not be sufficient on its own.
+describe('getThumbnailSnapshot render token records', () => {
+	function makeEnvWithBucket() {
+		return {
+			MCP_SCREENSHOT_TOKEN_SECRET: 'test-secret',
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		} as unknown as Environment
+	}
+
+	function snapshotOfOneShape() {
+		return {
+			documents: [{ state: { id: 'shape:1', typeName: 'shape' }, lastChangedClock: 0 }],
+			schema: { schemaVersion: 2, sequences: {} },
+			clock: 0,
+		} as any
+	}
+
+	it('serves a token that was recorded at mint time', async () => {
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(snapshotOfOneShape())
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob()
+		const token = await mintThumbnailRenderToken(envWithBucket, job)
+		await recordMintedRenderToken(envWithBucket, job, token)
+
+		const response = await getThumbnailSnapshot(makeRequest(token), envWithBucket)
+
+		expect(response.status).toBe(200)
+	})
+
+	// The case a leaked MCP_SCREENSHOT_TOKEN_SECRET produces: signatures that verify, for any board,
+	// minted by someone who cannot write to our bucket. Refused, and with the same 403 a bad signature
+	// gets — which check failed is not the caller's business.
+	it('refuses a validly signed token with no record, without reading the board', async () => {
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(snapshotOfOneShape())
+		const envWithBucket = makeEnvWithBucket()
+		const forged = await mintThumbnailRenderToken(envWithBucket, makeJob())
+
+		const response = await getThumbnailSnapshot(makeRequest(forged), envWithBucket)
+
+		expect(response.status).toBe(403)
+		expect(await response.json()).toEqual({
+			error: true,
+			message: 'Invalid or expired render token',
+		})
+		// Refused before the board is touched, so a forged token cannot even cause a snapshot read.
+		expect(vi.mocked(getPublishedRoomSnapshot)).not.toHaveBeenCalled()
+	})
+
+	// A capture that crosses a rolling deploy: minted by the previous worker version, which had no
+	// `access` field and wrote no records, then presented to this one. It reads as `public`, so it is
+	// served rather than 403ing on a record that was never going to exist.
+	it('serves a pre-deploy token that has no access field and no record', async () => {
+		vi.mocked(getSharedFileRoomSnapshot).mockResolvedValue(snapshotOfOneShape())
+		const envWithBucket = makeEnvWithBucket()
+		const token = await mintThumbnailRenderToken(
+			envWithBucket,
+			makeJob({ kind: 'shared_file', slug: 'file-abc', version: 'etag-1', access: undefined })
+		)
+
+		const response = await getThumbnailSnapshot(makeRequest(token), envWithBucket)
+
+		expect(response.status).toBe(200)
+		// And under the gate that worker version applied, not the wider one.
+		expect(vi.mocked(getSharedFileRoomSnapshot)).toHaveBeenCalledWith(envWithBucket, 'file-abc', {
+			access: 'public',
+		})
 	})
 })
 

--- a/apps/dotcom/sync-worker/src/routes/tla/getThumbnailSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getThumbnailSnapshot.ts
@@ -2,7 +2,11 @@ import { ThumbnailSnapshotResponseBody } from '@tldraw/dotcom-shared'
 import { TLRecord } from '@tldraw/tlschema'
 import { IRequest } from 'itty-router'
 import { Environment } from '../../types'
-import { verifyThumbnailRenderToken } from '../../utils/renderTokens'
+import {
+	isMintedRenderToken,
+	renderJobAccess,
+	verifyThumbnailRenderToken,
+} from '../../utils/renderTokens'
 import { getPublishedRoomSnapshot } from './getPublishedFile'
 import { getSharedFileRoomSnapshot } from './getSharedFile'
 import { reportThumbnailError } from './thumbnailShared'
@@ -25,12 +29,21 @@ export async function getThumbnailSnapshot(
 		return json({ error: true, message: 'Invalid or expired render token' }, 403)
 	}
 
-	// Shared files re-check their share status here (not just when the token was minted), so that a
-	// board un-shared during a token's 5 minute window stops resolving.
+	// A valid signature only proves the holder of the secret made this, and a `render` token reads a
+	// private board's full document. So one must also be recorded as ours (see isMintedRenderToken).
+	// Answers the same 403 as a bad signature: which check failed is not the caller's business.
+	if (!(await isMintedRenderToken(env, job, token))) {
+		return json({ error: true, message: 'Invalid or expired render token' }, 403)
+	}
+
+	// Read under the gate the job was signed with, not a fixed one, so an MCP token stays confined to
+	// what the MCP tool could resolve — including a board that has gone private since it was minted.
+	// Shared files re-check here rather than trusting the mint, so a board deleted inside the token's
+	// window (THUMBNAIL_RENDER_TOKEN_TTL_MS) stops resolving either way.
 	const snapshot = await (
 		job.kind === 'published'
 			? getPublishedRoomSnapshot(env, job.slug)
-			: getSharedFileRoomSnapshot(env, job.slug)
+			: getSharedFileRoomSnapshot(env, job.slug, { access: renderJobAccess(job) })
 	).catch((error) => {
 		// A load failure and a genuinely missing board both answer 404 here, which the render page
 		// turns into an error state and the capture surfaces as a generic render failure. Report the
@@ -40,7 +53,7 @@ export async function getThumbnailSnapshot(
 			env,
 			request,
 			surface: 'thumbnail_snapshot',
-			extras: { kind: job.kind, slug: job.slug },
+			extras: { kind: job.kind },
 		})
 		return undefined
 	})

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.test.ts
@@ -1,25 +1,38 @@
+import { THUMBNAIL_RENDER_TIMEOUT_MS } from '@tldraw/dotcom-shared'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+	OG_MAX_RENDER_ATTEMPTS,
+	OG_PENDING_MARKER_TTL_MS,
+	OG_REPAIR_COOLDOWN_MS,
+	OG_RETRY_DELAY_SECONDS,
+} from '../../config'
 import { OgImageRenderQueueMessage } from '../../types'
 import { verifyThumbnailRenderToken } from '../../utils/renderTokens'
 import { getPublishedFileInfo, getPublishedRoomSnapshot } from './getPublishedFile'
 import { getSharedFileInfo, getSharedFileRoomSnapshot } from './getSharedFile'
 import {
+	clearOgImagePendingMarker,
+	deleteBoardThumbnails,
+	deleteOgImage,
 	enqueueOgImageRender,
+	enqueuePublishThumbnailRender,
 	getOgImageCacheKey,
 	handleOgImageRenderMessage,
-	MAX_RATE_LIMIT_REQUEUES,
+	isOgImageRepairOnCooldown,
 } from './ogImageQueue'
 import {
+	blobsWithPrefix,
 	failureBlobsOf,
 	makeBrowserBinding,
+	makeFakeQueue,
 	makeFakeRoomsBucket,
 	makeFakeThumbnailsBucket,
 	makeScreenshotTestEnv as makeEnv,
 	makeSnapshot,
+	renderDurationsOf,
 	screenshotOf,
 	tokenFromScreenshot,
 } from './screenshotTestHelpers'
-import { resetRateLimitFallbackForTests } from './thumbnailRender'
 
 vi.mock('./getPublishedFile', () => ({
 	getPublishedFileInfo: vi.fn(),
@@ -33,9 +46,9 @@ vi.mock('./getSharedFile', async (importOriginal) => ({
 }))
 
 afterEach(() => {
+	vi.useRealTimers()
 	vi.unstubAllGlobals()
 	vi.clearAllMocks()
-	resetRateLimitFallbackForTests()
 })
 
 function makeMessage(
@@ -61,8 +74,9 @@ describe('enqueueOgImageRender', () => {
 		const bucket = makeFakeThumbnailsBucket()
 		const env = makeEnv({ THUMBNAILS: bucket })
 
-		const first = await enqueueOgImageRender(env, { kind: 'published', slug: 'board' })
-		const second = await enqueueOgImageRender(env, { kind: 'published', slug: 'board' })
+		const board = { kind: 'published', slug: 'board' } as const
+		const first = await enqueueOgImageRender(env, board, { reason: 'publish' })
+		const second = await enqueueOgImageRender(env, board, { reason: 'publish' })
 
 		expect(first).toBe('enqueued')
 		expect(second).toBe('already_pending')
@@ -70,14 +84,316 @@ describe('enqueueOgImageRender', () => {
 			type: 'og-image-render',
 			kind: 'published',
 			slug: 'board',
+			reason: 'publish',
 		})
 	})
 
 	it('reports unavailable when the thumbnails bucket is not configured', async () => {
 		const env = makeEnv({ THUMBNAILS: undefined })
-		expect(await enqueueOgImageRender(env, { kind: 'published', slug: 'board' })).toBe(
-			'unavailable'
+		expect(
+			await enqueueOgImageRender(env, { kind: 'published', slug: 'board' }, { reason: 'publish' })
+		).toBe('unavailable')
+	})
+
+	it('tags the message with the trigger that asked for the render', async () => {
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+
+		await enqueueOgImageRender(env, { kind: 'published', slug: 'board' }, { reason: 'publish' })
+
+		expect((env as any).QUEUE.send).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ reason: 'publish' })
 		)
+	})
+
+	// With no rate limiter left, the marker is the only thing keeping an 8-second persist cadence from
+	// becoming an 8-second render cadence, so its TTL is load-bearing rather than incidental.
+	it('suppresses duplicate enqueues for the marker TTL, then allows one through', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket })
+
+		const board = { kind: 'shared_file', slug: 'board' } as const
+		expect(await enqueueOgImageRender(env, board, { reason: 'edit' })).toBe('enqueued')
+
+		const enqueuedAt = Date.parse('2026-01-01T00:00:00Z')
+		const marker = [...bucket.store.entries()].find(([key]) => key.endsWith('.pending'))!
+		expect(Number(marker[1].customMetadata!.expiresAt)).toBe(enqueuedAt + OG_PENDING_MARKER_TTL_MS)
+
+		// Every persist inside the window asks again and is deduped away.
+		vi.setSystemTime(enqueuedAt + OG_PENDING_MARKER_TTL_MS - 1000)
+		expect(await enqueueOgImageRender(env, board, { reason: 'edit' })).toBe('already_pending')
+
+		// Once it lapses, the next edit gets a fresh render.
+		vi.setSystemTime(enqueuedAt + OG_PENDING_MARKER_TTL_MS + 1000)
+		expect(await enqueueOgImageRender(env, board, { reason: 'edit' })).toBe('enqueued')
+	})
+
+	// The marker must outlive a job's worst-case retry chain: every capture running to its full
+	// timeout, plus every backoff delay between deliveries. If it lapsed while a job was still alive,
+	// a fresh ask would enqueue a second job for the same board, the two captures could overlap, and
+	// each would clobber the other's per-board render token record (renderTokens.ts) — 403ing the
+	// loser's snapshot read mid-capture. The record's per-board key is safe only because this marker
+	// single-flights renders per board.
+	it('has a marker TTL longer than the worst-case retry chain', () => {
+		const backoffMs = Array.from(
+			{ length: OG_MAX_RENDER_ATTEMPTS - 1 },
+			(_, i) => OG_RETRY_DELAY_SECONDS * (i + 1) * 1000
+		).reduce((a, b) => a + b, 0)
+		const worstCaseChainMs = OG_MAX_RENDER_ATTEMPTS * THUMBNAIL_RENDER_TIMEOUT_MS + backoffMs
+
+		expect(OG_PENDING_MARKER_TTL_MS).toBeGreaterThan(worstCaseChainMs)
+	})
+})
+
+describe('enqueueOgImageRender for an edit', () => {
+	const board = { kind: 'shared_file', slug: 'board' } as const
+
+	// Unconditional by design: a persist means the saved content genuinely differs from what the
+	// cached thumbnail shows, so there is no sampling or staleness window to satisfy first. The share
+	// gate lives in TLFileDurableObject.requestOgRenderForEdit, which decides before calling this.
+	it('enqueues on every edit, with no sampling or staleness gate', async () => {
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+
+		expect(await enqueueOgImageRender(env, board, { reason: 'edit' })).toBe('enqueued')
+		expect((env as any).QUEUE.send).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ kind: 'shared_file', slug: 'board', reason: 'edit' })
+		)
+	})
+
+	// A freshly rendered thumbnail is no reason to skip: the board changed again, so the cached image
+	// is stale regardless of its age. The consumer's version check is what avoids redundant renders.
+	it('enqueues even when the cached image was rendered moments ago', async () => {
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket })
+		await bucket.put(getOgImageCacheKey(board), new Uint8Array([1]).buffer, {
+			customMetadata: { version: 'v1', createdAt: String(Date.now()) },
+		})
+
+		expect(await enqueueOgImageRender(env, board, { reason: 'edit' })).toBe('enqueued')
+	})
+})
+
+// The two keys are not symmetric on purpose, and this is the pair that pins it.
+describe('deleteOgImage vs clearOgImagePendingMarker', () => {
+	it("deletes a published board's image, since the snapshot it depicts is gone", async () => {
+		const board = { kind: 'published', slug: 'published-slug' } as const
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket })
+		await enqueueOgImageRender(env, board, { reason: 'publish' })
+		await bucket.put(getOgImageCacheKey(board), new Uint8Array([1]).buffer)
+		// A cooldown left by an earlier failed repair goes with it: an unpublish-then-republish is a new
+		// snapshot, and its repair must not inherit the old one's failure.
+		await bucket.put(
+			getOgImageCacheKey(board).replace(/\.png$/, '.repair-cooldown'),
+			new Uint8Array().buffer
+		)
+
+		await deleteOgImage(env, board)
+
+		expect([...bucket.store.keys()]).toEqual([])
+	})
+
+	// Unpublishing must not reach the file-keyed image. That one is the board's own thumbnail, and it
+	// is what makes a later reshare an immediate cache hit.
+	it('leaves the file-keyed image alone when a published board is unpublished', async () => {
+		const published = { kind: 'published', slug: 'published-slug' } as const
+		const file = { kind: 'shared_file', slug: 'file-1' } as const
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket })
+		await bucket.put(getOgImageCacheKey(published), new Uint8Array([1]).buffer)
+		await bucket.put(getOgImageCacheKey(file), new Uint8Array([2]).buffer)
+
+		await deleteOgImage(env, published)
+
+		expect([...bucket.store.keys()]).toEqual([getOgImageCacheKey(file)])
+	})
+})
+
+describe('clearOgImagePendingMarker', () => {
+	// The rendered image is deliberately kept when a board stops being public. It is unreachable
+	// either way — the OG route re-checks the share gate on every request — and keeping it means an
+	// owner-facing surface behind authz can use the thumbnail a board already has, instead of it
+	// having been thrown away the moment the board went private.
+	it('clears the pending marker so a reshare can render again, and keeps the image', async () => {
+		const board = { kind: 'shared_file', slug: 'board' } as const
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket })
+		await enqueueOgImageRender(env, board, { reason: 'edit' })
+		await bucket.put(getOgImageCacheKey(board), new Uint8Array([1]).buffer)
+
+		await clearOgImagePendingMarker(env, board)
+
+		expect([...bucket.store.keys()]).toEqual([getOgImageCacheKey(board)])
+		// With the marker gone, the next enqueue is not deduped away.
+		expect(await enqueueOgImageRender(env, board, { reason: 'edit' })).toBe('enqueued')
+	})
+})
+
+// The publish effect is the only trigger a published board has: its snapshot is frozen, so nothing
+// edits it into asking again. An ask lost here therefore leaves that board's card generic until
+// somebody republishes, and none of the ways it can be lost throw loudly enough to notice.
+describe('enqueuePublishThumbnailRender', () => {
+	it('enqueues the published board and reports nothing when it takes effect', async () => {
+		const queue = makeFakeQueue()
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: queue })
+		const reportProblem = vi.fn()
+
+		await enqueuePublishThumbnailRender(env, 'published-slug', reportProblem)
+
+		expect(queue.send).toHaveBeenCalledWith({
+			type: 'og-image-render',
+			kind: 'published',
+			slug: 'published-slug',
+			reason: 'publish',
+		})
+		expect(reportProblem).not.toHaveBeenCalled()
+	})
+
+	// The quiet one. A marker left behind by an earlier failed job turns the ask away with a value, not
+	// an exception, so this is the case that would go unnoticed without the report.
+	it('reports the ask being turned away by a pending marker', async () => {
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+		const board = { kind: 'published', slug: 'published-slug' } as const
+		await enqueueOgImageRender(env, board, { reason: 'publish' })
+		const reportProblem = vi.fn()
+
+		await enqueuePublishThumbnailRender(env, 'published-slug', reportProblem)
+
+		expect(reportProblem).toHaveBeenCalledTimes(1)
+		expect((reportProblem.mock.calls[0][0] as Error).message).toContain('already_pending')
+	})
+
+	it('reports an unconfigured queue rather than passing for success', async () => {
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: undefined })
+		const reportProblem = vi.fn()
+
+		await enqueuePublishThumbnailRender(env, 'published-slug', reportProblem)
+
+		expect((reportProblem.mock.calls[0][0] as Error).message).toContain('unavailable')
+	})
+
+	// An in-place republish reuses the slug, so a repair cooldown armed against the previous
+	// snapshot's failure would otherwise outlive the snapshot it was evidence about — and if the
+	// republished render then failed transiently, the crawler repair that failure relies on would be
+	// suppressed for the rest of the old cooldown.
+	it('clears a leftover repair cooldown, giving the new snapshot its own repair backstop', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const board = { kind: 'published', slug: 'published-slug' } as const
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(async () => {
+				throw new Error('browser session failed')
+			}),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		// The previous snapshot's crawler repair gave up, arming the cooldown.
+		await handleOgImageRenderMessage(env, makeMessage({ ...board, reason: 'crawler' }, 3))
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(true)
+
+		await enqueuePublishThumbnailRender(env, 'published-slug', vi.fn())
+
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(false)
+	})
+
+	// Publishing must survive its thumbnail ask failing: the snapshot is already written, and this is
+	// the last thing the effect does.
+	it('reports a throw without rethrowing it into the publish handler', async () => {
+		const queue = makeFakeQueue()
+		queue.send.mockRejectedValue(new Error('queue is down'))
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: queue })
+		const reportProblem = vi.fn()
+
+		await expect(
+			enqueuePublishThumbnailRender(env, 'published-slug', reportProblem)
+		).resolves.toBeUndefined()
+		expect((reportProblem.mock.calls[0][0] as Error).message).toBe('queue is down')
+	})
+})
+
+// Hard deletion is the one place both image keys go. Everywhere else keeps one of them: unsharing
+// keeps the file-keyed image (a reshare should be an immediate hit), and unpublishing only takes the
+// published one. Neither reason survives the board ceasing to exist — and since `og/…` keys carry no
+// version and THUMBNAILS has no lifecycle rule, whatever is left behind is an object nothing will
+// ever read, overwrite or sweep.
+describe('deleteBoardThumbnails', () => {
+	const renderTokenKey = (kind: string, slug: string) => `render-tokens/${kind}/${slug}`
+
+	async function seedBoard(bucket: ReturnType<typeof makeFakeThumbnailsBucket>, env: any) {
+		const file = { kind: 'shared_file', slug: 'file-1' } as const
+		const published = { kind: 'published', slug: 'published-slug' } as const
+		for (const board of [file, published]) {
+			// An enqueue writes the pending marker, so the fixture covers image, marker and token record.
+			await enqueueOgImageRender(env, board, { reason: 'publish' })
+			await bucket.put(getOgImageCacheKey(board), new Uint8Array([1]).buffer)
+			await bucket.put(renderTokenKey(board.kind, board.slug), new Uint8Array().buffer)
+		}
+	}
+
+	it('removes both images, both markers and both render token records', async () => {
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+		await seedBoard(bucket, env)
+
+		await deleteBoardThumbnails(env, { fileId: 'file-1', publishedSlug: 'published-slug' })
+
+		expect([...bucket.store.keys()]).toEqual([])
+	})
+
+	it('touches nothing belonging to another board', async () => {
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+		await seedBoard(bucket, env)
+		const other = { kind: 'shared_file', slug: 'file-2' } as const
+		await bucket.put(getOgImageCacheKey(other), new Uint8Array([2]).buffer)
+		await bucket.put(renderTokenKey(other.kind, other.slug), new Uint8Array().buffer)
+
+		await deleteBoardThumbnails(env, { fileId: 'file-1', publishedSlug: 'published-slug' })
+
+		expect([...bucket.store.keys()].sort()).toEqual(
+			[getOgImageCacheKey(other), renderTokenKey(other.kind, other.slug)].sort()
+		)
+	})
+
+	// An empty published slug would address `og/published//light.png`, which is not this board's key
+	// and may well be somebody else's neighbourhood.
+	it('skips the published half when the file has no published slug', async () => {
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+		await seedBoard(bucket, env)
+
+		await deleteBoardThumbnails(env, { fileId: 'file-1', publishedSlug: null })
+
+		expect([...bucket.store.keys()].sort()).toEqual(
+			[
+				getOgImageCacheKey({ kind: 'published', slug: 'published-slug' }),
+				getOgImageCacheKey({ kind: 'published', slug: 'published-slug' }).replace(
+					/\.png$/,
+					'.pending'
+				),
+				renderTokenKey('published', 'published-slug'),
+			].sort()
+		)
+	})
+
+	// It runs inside the teardown that also removes the room snapshot and the histories, so a failure
+	// to tidy up must not abort what follows it.
+	it('resolves even when the bucket refuses a delete', async () => {
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket, QUEUE: makeFakeQueue() })
+		await seedBoard(bucket, env)
+		vi.spyOn(bucket, 'delete').mockRejectedValue(new Error('R2 is down'))
+
+		await expect(
+			deleteBoardThumbnails(env, { fileId: 'file-1', publishedSlug: 'published-slug' })
+		).resolves.toBeUndefined()
 	})
 })
 
@@ -104,6 +420,9 @@ describe('handleOgImageRenderMessage', () => {
 			camera: 'content',
 			width: 1200,
 			height: 630,
+			// The consumer renders every board, private ones included, so its tokens read under the weaker
+			// gate — and are the only ones a minted-token record is kept for.
+			access: 'render',
 		})
 		// the worker writes the rendered image to the cache key itself, stamping the version
 		expect(
@@ -187,53 +506,55 @@ describe('handleOgImageRenderMessage', () => {
 		expect(firstAttempt.retry).toHaveBeenCalledExactlyOnceWith({ delaySeconds: 30 })
 		expect(firstAttempt.ack).not.toHaveBeenCalled()
 
-		// The final delivery, so the job drops and writes its reason code instead of only retrying.
+		// The final delivery, so the job drops rather than retrying again.
 		vi.mocked(getPublishedRoomSnapshot).mockRejectedValueOnce(new Error('connection terminated'))
 		const finalAttempt = makeMessage({ kind: 'published', slug: 'board' }, 3)
 		await handleOgImageRenderMessage(env, finalAttempt)
 		expect(screenshotOf(env)).not.toHaveBeenCalled()
 		expect(finalAttempt.ack).toHaveBeenCalledTimes(1)
-		expect(failureBlobsOf(env)).toEqual(['failure:snapshot_read_error'])
+		// One row per delivery, not per job: the dataset is the spend ledger, so a retried failure is
+		// two events, not one. Neither of these spent Browser Run, but a retried *render* would spend
+		// it twice, and only per-delivery rows can show that.
+		expect(failureBlobsOf(env)).toEqual([
+			'failure:snapshot_read_error',
+			'failure:snapshot_read_error',
+		])
 	})
 
-	// A board un-shared between the resolve and the snapshot read looks like any other read failure
-	// from the catch, so this delivery retries rather than dropping. That costs one delivery, not one
-	// render: the retry re-resolves at the top of the handler, finds the board no longer viewable, and
-	// drops it there — neither pass spends any Browser Run.
-	it('retries a board that goes private mid-render, then drops it when the retry re-resolves', async () => {
+	// A read failure mid-render is transient as far as this handler can tell, so the delivery retries.
+	// The retry re-resolves and renders, because a board going private is not a reason to skip it.
+	it('retries a read failure, then renders on the retry even if the board went private', async () => {
 		vi.mocked(getSharedFileInfo).mockResolvedValue({
 			id: 'shared-file',
 			shared: true,
 			isDeleted: false,
 		})
-		vi.mocked(getSharedFileRoomSnapshot).mockRejectedValueOnce(new Error('not shared'))
+		vi.mocked(getSharedFileRoomSnapshot).mockRejectedValueOnce(new Error('postgres is down'))
 		const bucket = makeFakeThumbnailsBucket()
 		const cacheKey = getOgImageCacheKey({ kind: 'shared_file', slug: 'shared-file' })
-		bucket.store.set(cacheKey, { body: new ArrayBuffer(1), uploaded: new Date(0) })
 		const env = makeEnv({ ROOMS: makeFakeRoomsBucket('etag-1'), THUMBNAILS: bucket })
 
-		// The first delivery, which has two retries left.
 		const first = makeMessage({ kind: 'shared_file', slug: 'shared-file' }, 1)
 		await handleOgImageRenderMessage(env, first)
 
 		expect(first.retry).toHaveBeenCalledExactlyOnceWith({ delaySeconds: 30 })
 		expect(screenshotOf(env)).not.toHaveBeenCalled()
 
-		// By the time the retry lands, the board is un-shared, so the resolve gate ends it.
+		// The board is private by the time the retry lands. It renders anyway — privacy gates serving,
+		// not rendering, so an owner-facing surface has a current thumbnail to show.
 		vi.mocked(getSharedFileInfo).mockResolvedValue({
 			id: 'shared-file',
 			shared: false,
 			isDeleted: false,
 		})
+		vi.mocked(getSharedFileRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
 		const retry = makeMessage({ kind: 'shared_file', slug: 'shared-file' }, 2)
 		await handleOgImageRenderMessage(env, retry)
 
-		expect(retry.retry).not.toHaveBeenCalled()
+		expect(screenshotOf(env)).toHaveBeenCalledTimes(1)
 		expect(retry.ack).toHaveBeenCalledTimes(1)
-		expect(screenshotOf(env)).not.toHaveBeenCalled()
-		// The cached image is dropped too, so no-longer-public content does not linger in the cache.
-		expect(bucket.store.has(cacheKey)).toBe(false)
-		expect(failureBlobsOf(env)).toEqual(['failure:board_not_viewable'])
+		expect(bucket.store.has(cacheKey)).toBe(true)
+		expect(failureBlobsOf(env)).toEqual(['failure:snapshot_read_error', 'failure:none'])
 	})
 
 	it('renders shared files and keys their version on the room etag', async () => {
@@ -284,24 +605,32 @@ describe('handleOgImageRenderMessage', () => {
 		expect(message.ack).toHaveBeenCalledTimes(1)
 	})
 
-	it('drops the job and deletes the cached image when the board is no longer viewable', async () => {
+	// Deletion is terminal in a way privacy is not: no number of retries brings the board back, and a
+	// deleted board has nothing worth depicting. The job is acked without spending Browser Run, and the
+	// image it already had is kept, since only an unpublish deletes one.
+	it('drops the job without rendering when the board is deleted, keeping its image', async () => {
 		vi.mocked(getSharedFileInfo).mockResolvedValue({
-			id: 'unshared-file',
+			id: 'deleted-file',
 			shared: false,
-			isDeleted: false,
+			isDeleted: true,
 		})
+		const board = { kind: 'shared_file', slug: 'deleted-file' } as const
 		const bucket = makeFakeThumbnailsBucket()
-		const cacheKey = getOgImageCacheKey({ kind: 'shared_file', slug: 'unshared-file' })
+		const cacheKey = getOgImageCacheKey(board)
 		await bucket.put(cacheKey, new Uint8Array([9]).buffer, {
 			customMetadata: { version: 'old', createdAt: String(Date.now()) },
 		})
+		// A marker from the enqueue that raced the delete; it must not outlive the dropped job, or the
+		// next enqueue is deduped away against a render that never happened.
+		await enqueueOgImageRender(makeEnv({ THUMBNAILS: bucket }), board, { reason: 'edit' })
 		const env = makeEnv({ ROOMS: makeFakeRoomsBucket(), THUMBNAILS: bucket })
-		const message = makeMessage({ kind: 'shared_file', slug: 'unshared-file' })
+		const message = makeMessage(board)
 
 		await handleOgImageRenderMessage(env, message)
 
 		expect(screenshotOf(env)).not.toHaveBeenCalled()
-		expect(bucket.store.has(cacheKey)).toBe(false)
+		expect(bucket.store.has(cacheKey)).toBe(true)
+		expect([...bucket.store.keys()]).toEqual([cacheKey])
 		expect(message.ack).toHaveBeenCalledTimes(1)
 		expect(message.retry).not.toHaveBeenCalled()
 	})
@@ -333,107 +662,338 @@ describe('handleOgImageRenderMessage', () => {
 		expect(finalAttempt.ack).toHaveBeenCalledTimes(1)
 	})
 
-	it('re-enqueues a fresh job when global capacity is busy instead of spending a failure retry', async () => {
-		vi.mocked(getPublishedFileInfo).mockResolvedValue({
-			id: 'file-1',
-			published: true,
-			lastPublished: 1,
-		})
-		const queue = { send: vi.fn(async () => undefined) }
-		const env = makeEnv({
-			THUMBNAILS: makeFakeThumbnailsBucket(),
-			QUEUE: queue,
-			// A busy global limiter: every check reports the request blocked.
-			MCP_SCREENSHOT_BROWSER_RATE_LIMITER: { limit: vi.fn(async () => ({ success: false })) },
-		})
+	// A capture takes seconds. An edit landing during one asks for a render, is turned away by this
+	// job's pending marker, and that ask is *dropped* — the debouncer has already reset and neither
+	// caller reads the result. Without this check the board would sit on a thumbnail of its
+	// before-the-last-edits state until something happened to ask again.
+	it('re-asks when the board changed while it was capturing', async () => {
+		vi.mocked(getPublishedFileInfo)
+			// resolved at the top of the delivery, and rendered
+			.mockResolvedValueOnce({ id: 'file-1', published: true, lastPublished: 1 })
+			// the board moved under the capture
+			.mockResolvedValueOnce({ id: 'file-1', published: true, lastPublished: 2 })
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const queue = makeFakeQueue()
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: queue })
 
-		// Even on the final delivery, backpressure must re-enqueue rather than drop: the render never
-		// happened, so it should not count against the render-failure budget. The requeue carries an
-		// incremented rate-limit counter so the backoff chain is bounded.
-		const message = makeMessage({ kind: 'published', slug: 'board' }, 3)
-		await handleOgImageRenderMessage(env, message)
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }))
 
-		expect(screenshotOf(env)).not.toHaveBeenCalled()
-		expect(message.retry).not.toHaveBeenCalled()
-		expect(message.ack).toHaveBeenCalledTimes(1)
 		expect(queue.send).toHaveBeenCalledExactlyOnceWith(
-			{ type: 'og-image-render', kind: 'published', slug: 'board', rateLimitRequeues: 1 },
-			{ delaySeconds: 30 }
+			expect.objectContaining({ kind: 'published', slug: 'board', followUp: true })
 		)
 	})
 
-	it('backs off exponentially as rate-limit requeues accumulate', async () => {
+	it('does not re-ask when the board held still', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',
 			published: true,
 			lastPublished: 1,
 		})
-		const queue = { send: vi.fn(async () => undefined) }
-		const env = makeEnv({
-			THUMBNAILS: makeFakeThumbnailsBucket(),
-			QUEUE: queue,
-			MCP_SCREENSHOT_BROWSER_RATE_LIMITER: { limit: vi.fn(async () => ({ success: false })) },
-		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const queue = makeFakeQueue()
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: queue })
 
-		// Already re-enqueued twice: this delivery is requeue #3, so the delay is min(30 * 2^2, 120).
-		const message = makeMessage({ kind: 'published', slug: 'board', rateLimitRequeues: 2 })
-		await handleOgImageRenderMessage(env, message)
-
-		expect(queue.send).toHaveBeenCalledExactlyOnceWith(
-			{ type: 'og-image-render', kind: 'published', slug: 'board', rateLimitRequeues: 3 },
-			{ delaySeconds: 120 }
-		)
-	})
-
-	it('stops requeueing once the rate-limit backoff budget is exhausted', async () => {
-		vi.mocked(getPublishedFileInfo).mockResolvedValue({
-			id: 'file-1',
-			published: true,
-			lastPublished: 1,
-		})
-		const queue = { send: vi.fn(async () => undefined) }
-		const env = makeEnv({
-			THUMBNAILS: makeFakeThumbnailsBucket(),
-			QUEUE: queue,
-			MCP_SCREENSHOT_BROWSER_RATE_LIMITER: { limit: vi.fn(async () => ({ success: false })) },
-		})
-
-		// At the cap already: this delivery would be one requeue past the limit, so it gives up rather
-		// than looping forever and keeping the shared limiter saturated.
-		const message = makeMessage({
-			kind: 'published',
-			slug: 'board',
-			rateLimitRequeues: MAX_RATE_LIMIT_REQUEUES,
-		})
-		await handleOgImageRenderMessage(env, message)
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }))
 
 		expect(queue.send).not.toHaveBeenCalled()
-		expect(message.retry).not.toHaveBeenCalled()
-		expect(message.ack).toHaveBeenCalledTimes(1)
 	})
 
-	it('refreshes the pending marker on requeue so concurrent crawler hits coalesce', async () => {
+	// The ceiling on the above. A board edited without pause is stale at the end of every capture, so a
+	// chaining follow-up would render it continuously — exactly the cost the debounce upstream exists to
+	// avoid. One extra render per triggered render, never two.
+	it('never chains: a follow-up does not enqueue another', async () => {
+		vi.mocked(getPublishedFileInfo)
+			.mockResolvedValueOnce({ id: 'file-1', published: true, lastPublished: 1 })
+			.mockResolvedValueOnce({ id: 'file-1', published: true, lastPublished: 2 })
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const queue = makeFakeQueue()
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket(), QUEUE: queue })
+
+		await handleOgImageRenderMessage(
+			env,
+			makeMessage({ kind: 'published', slug: 'board', followUp: true })
+		)
+
+		expect(queue.send).not.toHaveBeenCalled()
+	})
+
+	// Once a job gives up, nothing is in flight and the marker has nothing left to single-flight.
+	// Leaving it to lapse would turn away the next ask for the rest of its TTL, which bites hardest
+	// here: this board has no image at all.
+	it('clears the pending marker when a job gives up, but keeps it between retries', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',
 			published: true,
 			lastPublished: 1,
 		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const board = { kind: 'published', slug: 'board' } as const
 		const bucket = makeFakeThumbnailsBucket()
-		const queue = { send: vi.fn(async () => undefined) }
 		const env = makeEnv({
+			BROWSER: makeBrowserBinding(async () => {
+				throw new Error('browser session failed')
+			}),
 			THUMBNAILS: bucket,
-			QUEUE: queue,
-			MCP_SCREENSHOT_BROWSER_RATE_LIMITER: { limit: vi.fn(async () => ({ success: false })) },
+		})
+		const markerKey = getOgImageCacheKey(board).replace(/\.png$/, '.pending')
+
+		await enqueueOgImageRender(env, board, { reason: 'publish' })
+		expect(bucket.store.has(markerKey)).toBe(true)
+
+		await handleOgImageRenderMessage(env, makeMessage(board, 1))
+		expect(bucket.store.has(markerKey)).toBe(true)
+
+		await handleOgImageRenderMessage(env, makeMessage(board, 3))
+		expect(bucket.store.has(markerKey)).toBe(false)
+	})
+
+	// The give-up clears the pending marker so a genuine republish is not turned away — but for the
+	// crawler-triggered repair, "acted on immediately" is the attack: with the marker gone, the next
+	// unauthenticated request would re-arm a whole retry chain of Browser Run on a board that just
+	// proved it cannot render. The cooldown is what stands in for the marker on that one path, and
+	// only that path: a publish-triggered failure must not arm it, or the repair loses the immediate
+	// first attempt it exists to provide.
+	it('arms the repair cooldown when a crawler-triggered job gives up, and only then', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const board = { kind: 'published', slug: 'board' } as const
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(async () => {
+				throw new Error('browser session failed')
+			}),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
 		})
 
-		const message = makeMessage({ kind: 'published', slug: 'board' })
+		// A retry is not a give-up, and a publish-triggered give-up arms nothing.
+		await handleOgImageRenderMessage(env, makeMessage({ ...board, reason: 'crawler' }, 1))
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(false)
+		await handleOgImageRenderMessage(env, makeMessage({ ...board, reason: 'publish' }, 3))
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(false)
+
+		// The crawler-triggered give-up is the one that does.
+		await handleOgImageRenderMessage(env, makeMessage({ ...board, reason: 'crawler' }, 3))
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(true)
+	})
+
+	it('lets the repair cooldown lapse after OG_REPAIR_COOLDOWN_MS', async () => {
+		vi.useFakeTimers()
+		vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const board = { kind: 'published', slug: 'board' } as const
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(async () => {
+				throw new Error('browser session failed')
+			}),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ ...board, reason: 'crawler' }, 3))
+		const armedAt = Date.parse('2026-01-01T00:00:00Z')
+
+		vi.setSystemTime(armedAt + OG_REPAIR_COOLDOWN_MS - 1000)
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(true)
+
+		vi.setSystemTime(armedAt + OG_REPAIR_COOLDOWN_MS + 1000)
+		expect(await isOgImageRepairOnCooldown(env, board)).toBe(false)
+	})
+
+	// A board that fails deterministically fails every attempt, so reporting each delivery filed three
+	// events for one problem. The delivery that gives up is the one worth seeing, and it is already the
+	// only one that reaches telemetry. Tests pass no ExecutionContext, so reporting logs instead.
+	it('reports a failing render once per job rather than once per delivery', async () => {
+		const reported = vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(async () => {
+				throw new Error('browser session failed')
+			}),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }, 1))
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }, 2))
+		expect(reported).not.toHaveBeenCalled()
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }, 3))
+		expect(reported).toHaveBeenCalledTimes(1)
+		// No board identity in the report at all — not the slug, not a derived id. For a link-shared
+		// file the slug is the file id, and tldraw.com/f/<id> is the capability to view the board.
+		const context = reported.mock.calls[0]![1]
+		expect(context).toEqual({ kind: 'published', attempts: 3 })
+		expect(JSON.stringify(context)).not.toContain('board')
+	})
+
+	// Browser Run answers 422 for a crashed page, an out-of-memory render and every one of its timers
+	// alike, so the reason code has to come from the response body. Classify on the status alone and
+	// every timeout files as `browser_failed`, leaving the dashboard's timeout rate structurally zero.
+	it('classifies a Browser Run timeout from the response body, not the status', async () => {
+		const reported = vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(
+				async () =>
+					new Response(
+						JSON.stringify({
+							success: false,
+							errors: [{ code: 500, message: 'Navigation timeout of 45000 ms exceeded' }],
+						}),
+						{ status: 422 }
+					)
+			),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }, 3))
+
+		expect(failureBlobsOf(env)).toEqual(['failure:browser_timeout'])
+		// The unbounded original goes to Sentry, where the cardinality that keeps it out of the blob
+		// doesn't matter and it is the only thing that says what actually went wrong.
+		expect(reported.mock.calls[0]![1]).toMatchObject({
+			browser_render_status: 422,
+			browser_render_detail: 'Navigation timeout of 45000 ms exceeded',
+		})
+	})
+
+	// The same 422 with a different cause: the render page marked data-thumbnail-error, so the
+	// success-only capture selector was absent and the call came back early.
+	it('classifies an early 422 as a render failure', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(
+				async () =>
+					new Response('Element not found: body[data-thumbnail-ready="true"]', { status: 422 })
+			),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }, 3))
+
+		expect(failureBlobsOf(env)).toEqual(['failure:browser_failed'])
+	})
+
+	// A failed capture created a browser and held it, sometimes for the whole 45s timeout. Recording -1
+	// there would understate what an uncapped render path costs, which is the one number the "no global
+	// cap" design leans on watching.
+	it('records the Browser Run time a failed render spent, and none where it spent none', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {})
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({
+			BROWSER: makeBrowserBinding(async () => new Response('boom', { status: 422 })),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }, 3))
+		expect(renderDurationsOf(env)[0]).toBeGreaterThanOrEqual(0)
+
+		// An empty board never reaches the capture, so it keeps the "spent nothing" sentinel.
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(null as any)
+		const emptyBoardEnv = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		await handleOgImageRenderMessage(
+			emptyBoardEnv,
+			makeMessage({ kind: 'published', slug: 'board' }, 3)
+		)
+		expect(failureBlobsOf(emptyBoardEnv)).toEqual(['failure:board_empty'])
+		expect(renderDurationsOf(emptyBoardEnv)).toEqual([-1])
+	})
+
+	// Thumbnail rendering is uncapped: the MCP endpoint's limiters exist to bound what an outside
+	// caller can spend, and this consumer is not caller-driven. A saturated MCP limiter must not stop a
+	// board's own thumbnail refreshing.
+	it('renders even when the MCP rate limiters are saturated, and never consults them', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const queue = { send: vi.fn(async () => undefined) }
+		const browserLimiter = { limit: vi.fn(async () => ({ success: false })) }
+		const env = makeEnv({
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+			QUEUE: queue,
+			MCP_SERVER_BROWSER_RATE_LIMITER: browserLimiter,
+		})
+
+		const message = makeMessage({ kind: 'published', slug: 'board', reason: 'edit' })
 		await handleOgImageRenderMessage(env, message)
 
-		// The requeue wrote a fresh pending marker, so a concurrent crawler enqueue dedupes onto this
-		// chain instead of spawning a second one.
-		queue.send.mockClear()
-		const result = await enqueueOgImageRender(env, { kind: 'published', slug: 'board' })
-		expect(result).toBe('already_pending')
+		expect(browserLimiter.limit).not.toHaveBeenCalled()
+		expect(screenshotOf(env)).toHaveBeenCalledTimes(1)
+		expect(message.ack).toHaveBeenCalledTimes(1)
+		expect(message.retry).not.toHaveBeenCalled()
+		// No requeue chain: there is no backpressure signal left to requeue for.
 		expect(queue.send).not.toHaveBeenCalled()
+		expect(failureBlobsOf(env)).toEqual(['failure:none'])
+	})
+
+	it('records the trigger that asked for a completed render', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+
+		await handleOgImageRenderMessage(
+			env,
+			makeMessage({ kind: 'published', slug: 'board', reason: 'publish' })
+		)
+
+		expect(blobsWithPrefix(env, 'reason:')).toEqual(['reason:publish'])
+	})
+
+	// A burst of edits enqueues once and renders once: the marker collapses the enqueues, and for any
+	// that slip past it the version check acks without spending Browser Run.
+	it('acks without rendering when the cache already matches the version', async () => {
+		vi.mocked(getPublishedFileInfo).mockResolvedValue({
+			id: 'file-1',
+			published: true,
+			lastPublished: 1,
+		})
+		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const bucket = makeFakeThumbnailsBucket()
+		const env = makeEnv({ THUMBNAILS: bucket })
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'published', slug: 'board' }))
+		expect(screenshotOf(env)).toHaveBeenCalledTimes(1)
+
+		// A second delivery for the same unchanged content renders nothing.
+		const duplicate = makeMessage({ kind: 'published', slug: 'board', reason: 'edit' })
+		await handleOgImageRenderMessage(env, duplicate)
+		expect(screenshotOf(env)).toHaveBeenCalledTimes(1)
+		expect(duplicate.ack).toHaveBeenCalledTimes(1)
 	})
 })

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
@@ -1,65 +1,114 @@
 import { DEFAULT_THUMBNAIL_HEIGHT, DEFAULT_THUMBNAIL_WIDTH } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { Environment, OgImageRenderQueueMessage, ThumbnailBoardKind } from '../../types'
+import {
+	OG_MAX_RENDER_ATTEMPTS,
+	OG_PENDING_MARKER_TTL_MS,
+	OG_REPAIR_COOLDOWN_MS,
+	OG_RETRY_DELAY_SECONDS,
+} from '../../config'
+import {
+	Environment,
+	OgImageRenderQueueMessage,
+	OgImageRenderReason,
+	ThumbnailBoardRef,
+} from '../../types'
+import { deleteRenderTokenRecord } from '../../utils/renderTokens'
 import {
 	ResolvedThumbnailBoard,
 	captureThumbnailScreenshot,
 	enumerateBoardPages,
-	isGlobalBrowserRunRateLimited,
 	loadBoardSnapshot,
 	putThumbnailPng,
 	resolveThumbnailBoard,
 	writeScreenshotTelemetry,
 } from './thumbnailRender'
-import { classifyScreenshotFailure, reportThumbnailError, sha256 } from './thumbnailShared'
+import {
+	browserRunDurationOf,
+	classifyScreenshotFailure,
+	reportThumbnailError,
+} from './thumbnailShared'
 
-// Queue-backed async OG image generation. The GET og-image route never blocks a request on
-// Browser Run: it serves whatever is cached (fresh or stale) or redirects to the default OG image,
-// and enqueues a render job here. This consumer performs the capture out of band and refreshes the
-// R2 cache the route reads. The synchronous MCP tool does not use this path: it must return the
-// image in-band, so it captures inline and caches under its own `mcp/` keys.
-
-// A pending marker suppresses duplicate enqueues while a render is queued or in flight. It is
-// advisory only: it expires on its own so a crashed consumer cannot wedge a board permanently.
-const PENDING_MARKER_TTL_MS = 2 * 60_000
-// Retries are also bounded by max_retries in wrangler.toml; this lower cap keeps OG jobs from
-// burning Browser Run capacity on a persistently failing board. It counts genuine render failures
-// only — global-capacity backpressure re-enqueues a fresh message instead (see requeueForRateLimit),
-// so a busy period never exhausts a board's failure budget.
-const MAX_RENDER_ATTEMPTS = 3
-const RETRY_DELAY_SECONDS = 30
-
-// Rate-limit backpressure gets its own bounded retry budget, kept separate from the render-failure
-// budget above. Each rate-limited delivery still spends one slot of the shared global Browser Run
-// limiter just to learn it can't render, so an unbounded requeue chain would let the OG queue's own
-// capacity checks keep the limiter saturated and starve every render surface (OG and MCP alike). Cap
-// the chain and back off so that check rate stays low; after the cap we give up and let the next
-// crawler hit re-enqueue once capacity has recovered (the OG route serves stale/default meanwhile).
-export const MAX_RATE_LIMIT_REQUEUES = 12
-const MAX_REQUEUE_DELAY_SECONDS = 120
+// Queue-backed async board thumbnail generation. Renders are asked for by the things that change a
+// board's content — publishing (TLPostgresReplicator) and editing (TLFileDurableObject) — and this
+// consumer performs the capture out of band, refreshing the R2 cache the GET og-image route reads.
+// That route only ever reads; the MCP tool must return its image in-band, so it captures inline into
+// its own bucket. Neither goes through here.
+//
+// This path has no cap of any kind, by design. What bounds it is the render debounce upstream in
+// TLFileDurableObject, which is per-board, so total spend scales with how many boards are edited at
+// once. See "Request limits" in browser-run-thumbnails.md for why, and why the only rate limiting in
+// the pipeline lives on the MCP endpoint instead (sharedBoardScreenshotMcp.ts).
 
 // OG images render a single page as the unfurl preview. Pick the first page (in board order) that
 // has content, so a board whose first page is empty still gets a meaningful image; fall back to the
-// first page when none have content (the render degrades to a blank, as it did before).
+// first page when none have content, which renders as a blank.
 function pickOgImagePageId(snapshot: RoomSnapshot): string | undefined {
 	const pages = enumerateBoardPages(snapshot)
 	if (pages.length === 0) return undefined
 	return (pages.find((page) => page.hasContent) ?? pages[0]).id
 }
 
-export function getOgImageCacheKey(board: Pick<ResolvedThumbnailBoard, 'kind' | 'slug'>) {
-	return `og/${board.kind}/${board.slug}/${DEFAULT_THUMBNAIL_WIDTH}x${DEFAULT_THUMBNAIL_HEIGHT}/light.png`
+/**
+ * A board's one OG image. The key carries only what can address two objects at once: the board, and
+ * the theme, which a dark-mode card would need.
+ *
+ * Keep it that way, and keep the output dimensions out in particular. This key is the image's sole
+ * address, in a bucket with no expiration rule, so any segment that can change re-addresses every
+ * board's image at once and strands the old objects permanently — unreachable, un-overwritable, one per
+ * board. A size change is a replacement rather than a second object, so it belongs in the object's
+ * metadata, which overwrites in place.
+ *
+ * The trade: a size change serves old-sized images as fresh hits until each board next renders, since
+ * the stored `version` tracks board content rather than render parameters.
+ */
+export function getOgImageCacheKey(board: ThumbnailBoardRef) {
+	return `og/${board.kind}/${board.slug}/light.png`
 }
 
 export type EnqueueOgImageResult = 'enqueued' | 'already_pending' | 'unavailable'
 
-function getOgImagePendingKey(board: { kind: ThumbnailBoardKind; slug: string }) {
+// The single-flight marker. Its TTL and the retry constants live together in config.ts, where the
+// comment on OG_PENDING_MARKER_TTL_MS explains the inequality that binds them.
+function getOgImagePendingKey(board: ThumbnailBoardRef) {
 	return getOgImageCacheKey(board).replace(/\.png$/, '.pending')
+}
+
+// Armed when a crawler-triggered job gives up, consulted only by the OG route's published-board
+// repair (see OG_REPAIR_COOLDOWN_MS in config.ts). Deliberately not consulted by enqueueOgImageRender
+// itself: a republish is a genuine new snapshot and must render regardless of how the last attempt
+// went, so only the one ask an outside caller can cause is metered. For the same reason the publish
+// trigger *clears* it: the cooldown is evidence about the snapshot that failed, and a republish
+// replaces that snapshot, so the new one gets its own repair backstop — and re-arms the cooldown
+// itself if it turns out to fail too.
+function getOgImageRepairCooldownKey(board: ThumbnailBoardRef) {
+	return getOgImageCacheKey(board).replace(/\.png$/, '.repair-cooldown')
+}
+
+export async function isOgImageRepairOnCooldown(
+	env: Environment,
+	board: ThumbnailBoardRef
+): Promise<boolean> {
+	if (!env.THUMBNAILS) return false
+	// Fail open on a read error: the enqueue this gates needs the same bucket for its pending marker,
+	// so if R2 is genuinely down the ask fails and reports there rather than being silently skipped.
+	const existing = await env.THUMBNAILS.head(getOgImageRepairCooldownKey(board)).catch(() => null)
+	if (!existing) return false
+	const expiresAt = Number(existing.customMetadata?.expiresAt)
+	return Number.isFinite(expiresAt) && expiresAt > Date.now()
 }
 
 export async function enqueueOgImageRender(
 	env: Environment,
-	board: { kind: ThumbnailBoardKind; slug: string }
+	board: ThumbnailBoardRef,
+	{
+		reason,
+		followUp,
+	}: {
+		// Required rather than defaulted: every trigger knows why it is asking, and a default would put
+		// whichever one forgot to say into some other trigger's telemetry bucket.
+		reason: OgImageRenderReason
+		followUp?: boolean
+	}
 ): Promise<EnqueueOgImageResult> {
 	if (!env.THUMBNAILS || !env.QUEUE) return 'unavailable'
 
@@ -73,44 +122,135 @@ export async function enqueueOgImageRender(
 	}
 
 	await env.THUMBNAILS.put(pendingKey, new Uint8Array(), {
-		customMetadata: { expiresAt: String(Date.now() + PENDING_MARKER_TTL_MS) },
+		customMetadata: {
+			expiresAt: String(Date.now() + OG_PENDING_MARKER_TTL_MS),
+		},
 	})
 
 	const message: OgImageRenderQueueMessage = {
 		type: 'og-image-render',
 		kind: board.kind,
 		slug: board.slug,
+		reason,
+		...(followUp ? { followUp } : null),
 	}
 	await env.QUEUE.send(message)
 	return 'enqueued'
 }
 
-// Queue consumer. Re-resolves the board at render time rather than trusting the enqueued state:
-// the share gate is re-checked (a board un-shared while queued is dropped without rendering, and
-// its cached OG image is deleted) and the version is re-read so the render always captures the
-// newest content, coalescing bursts of enqueues for a fast-changing board into one capture.
+// The two keys are not symmetric when a board stops being publicly viewable, and the difference is
+// what the next two functions are for. `og/shared_file/{fileId}/…` is keyed on the file id, so it
+// stays useful for as long as the board exists and unsharing keeps it: an unshared board's image is
+// already unreachable, since the only route that serves one re-checks the gate per request.
+// `og/published/{publishedSlug}/…` depicts a published snapshot, so unpublishing destroys what it was
+// a picture of — and its key is the published slug, so leaving it would strand an object that a
+// regenerated publish link could make permanently unreadable. See "Nothing deletes a rendered image"
+// in browser-run-thumbnails.md.
+
+// Clears only the pending render marker, keeping the image. Called when a render job is dropped: a
+// marker left behind would suppress the next legitimate enqueue until it expired.
+export async function clearOgImagePendingMarker(
+	env: Environment,
+	board: ThumbnailBoardRef
+): Promise<void> {
+	if (!env.THUMBNAILS) return
+	await env.THUMBNAILS.delete(getOgImagePendingKey(board)).catch(() => {})
+}
+
+// Deletes the image as well as the marker and the repair cooldown. Only for `published` boards
+// losing their publication. Scoped by the `board` passed in, so calling it with `kind: 'published'`
+// cannot touch the file-keyed image of the same board.
+export async function deleteOgImage(env: Environment, board: ThumbnailBoardRef): Promise<void> {
+	if (!env.THUMBNAILS) return
+	await Promise.all([
+		env.THUMBNAILS.delete(getOgImageCacheKey(board)).catch(() => {}),
+		env.THUMBNAILS.delete(getOgImagePendingKey(board)).catch(() => {}),
+		env.THUMBNAILS.delete(getOgImageRepairCooldownKey(board)).catch(() => {}),
+	])
+}
+
+/**
+ * Everything this pipeline stores for one board, removed when the file is hard deleted
+ * (`TLFileDurableObject.appFileRecordDidDelete`, alongside the room snapshot and the histories).
+ *
+ * Both kinds go, because each is normally kept for a reason about a board that still exists: the
+ * file-keyed image survives *unsharing* deliberately, and the published-slug image only goes on
+ * *unpublish*. A hard delete leaves nothing to reshare and no snapshot to depict.
+ *
+ * The stakes are orphans rather than tidiness. `og/…` keys carry no version, so a board owns exactly
+ * one object, and `THUMBNAILS` has no lifecycle rule and must never be given one — so anything left
+ * behind here is an object nothing will ever read, overwrite or sweep. MCP screenshots need no
+ * equivalent: their keys carry a content version and their bucket expires them.
+ *
+ * Best effort throughout, because it runs inside a teardown that must complete regardless.
+ */
+export async function deleteBoardThumbnails(
+	env: Environment,
+	{ fileId, publishedSlug }: { fileId: string; publishedSlug?: string | null }
+): Promise<void> {
+	const boards: ThumbnailBoardRef[] = [{ kind: 'shared_file', slug: fileId }]
+	// A file with no published slug never had a published key to delete, and deriving one from an empty
+	// slug would address `og/published//light.png` — some other board's neighbourhood, not this one's.
+	if (publishedSlug) boards.push({ kind: 'published', slug: publishedSlug })
+	await Promise.all(
+		boards.flatMap((board) => [deleteOgImage(env, board), deleteRenderTokenRecord(env, board)])
+	)
+}
+
+/**
+ * The publish effect's ask, and the reporting that goes with it.
+ *
+ * This is the *only* trigger a published board has. Its snapshot is frozen, so nothing edits it into
+ * asking again, where a shared file re-asks on every persist that advances its document clock. So an
+ * ask lost here — thrown, or turned away as `already_pending` by a marker an earlier failure left
+ * behind, or `unavailable` — leaves that board's card generic until it is republished, and none of
+ * those are exceptional enough to notice by themselves. `getOgImage` repairs the outcome on the next
+ * fetch; `reportProblem` is how the cause becomes visible.
+ */
+export async function enqueuePublishThumbnailRender(
+	env: Environment,
+	publishedSlug: string,
+	reportProblem: (error: unknown) => void
+): Promise<void> {
+	const board: ThumbnailBoardRef = { kind: 'published', slug: publishedSlug }
+	// An in-place republish reuses the slug, so a cooldown armed against the previous snapshot's
+	// failure would otherwise outlive the snapshot it was evidence about and block the new one's
+	// repair. Cleared unconditionally and first: even if the enqueue below fails, the next crawl's
+	// repair is exactly the backstop that failure needs.
+	await env.THUMBNAILS?.delete(getOgImageRepairCooldownKey(board)).catch(() => {})
+	try {
+		const result = await enqueueOgImageRender(env, board, { reason: 'publish' })
+		if (result !== 'enqueued') {
+			reportProblem(new Error(`Publish thumbnail enqueue did not take effect: ${result}`))
+		}
+	} catch (error) {
+		reportProblem(error)
+	}
+}
+
+// Queue consumer. Re-resolves the board at render time rather than trusting the enqueued state: a
+// board deleted or unpublished while queued is dropped without rendering, and the version is re-read
+// so the render captures the newest content, coalescing a burst of enqueues into one capture.
 export async function handleOgImageRenderMessage(
 	env: Environment,
 	message: Message<OgImageRenderQueueMessage>,
 	ctx?: ExecutionContext
 ): Promise<void> {
 	const { kind, slug } = message.body
-	const boardHash = await sha256(slug)
-	const cacheKey = getOgImageCacheKey({ kind, slug })
-	const clearPending = async () => {
-		await env.THUMBNAILS?.delete(getOgImagePendingKey({ kind, slug })).catch(() => {})
-	}
-	// The board went private, was deleted, was unpublished, or has no persisted content. Terminal,
-	// not transient: drop the cached image so no-longer-public content does not linger in the OG
-	// cache, and ack rather than retry, since no number of retries will make the board public again.
-	// Reached from the resolve below — a board that goes private after that point fails its snapshot
-	// read instead, and the retry lands back here on the next delivery.
+	const boardRef: ThumbnailBoardRef = { kind, slug }
+	// A message already in the queue may carry no reason; see OgImageRenderQueueMessage.
+	const reason = message.body.reason ?? 'crawler'
+	const cacheKey = getOgImageCacheKey(boardRef)
+	// The board was deleted, was unpublished, or has no persisted content. Terminal, not transient: ack
+	// rather than retry, since no number of retries brings the board back. Applies the same delete/keep
+	// asymmetry as the effects above.
 	const dropNoLongerViewable = async () => {
-		await env.THUMBNAILS?.delete(cacheKey).catch(() => {})
-		await clearPending()
+		await (kind === 'published'
+			? deleteOgImage(env, boardRef)
+			: clearOgImagePendingMarker(env, boardRef))
 		writeScreenshotTelemetry(env, {
 			source: 'queue',
-			boardHash,
+			reason,
 			cacheStatus: 'miss',
 			failureReason: 'board_not_viewable',
 		})
@@ -118,7 +258,9 @@ export async function handleOgImageRenderMessage(
 	}
 
 	try {
-		const resolved = await resolveThumbnailBoard(env, kind, slug)
+		// 'render' rather than 'public': every board gets a thumbnail, private ones included. The OG
+		// route re-applies the public gate when it serves.
+		const resolved = await resolveThumbnailBoard(env, kind, slug, { access: 'render' })
 		if (!resolved.ok) {
 			await dropNoLongerViewable()
 			return
@@ -128,8 +270,8 @@ export async function handleOgImageRenderMessage(
 		// Another consumer (or an earlier retry) may already have rendered this version.
 		const cached = await env.THUMBNAILS?.head(cacheKey)
 		if (cached?.customMetadata?.version === String(board.version)) {
-			await clearPending()
-			writeScreenshotTelemetry(env, { source: 'queue', boardHash, cacheStatus: 'hit' })
+			await clearOgImagePendingMarker(env, boardRef)
+			writeScreenshotTelemetry(env, { source: 'queue', reason, cacheStatus: 'hit' })
 			message.ack()
 			return
 		}
@@ -138,27 +280,20 @@ export async function handleOgImageRenderMessage(
 			throw new Error('THUMBNAILS bucket is not configured')
 		}
 
-		// Shares the global Browser Run budget with the synchronous surfaces, so the MCP tool and this
-		// consumer draw from one cap rather than two independent buckets. When capacity is busy, requeue
-		// rather than drop: the request path has already returned, so latency is free here.
-		if (await isGlobalBrowserRunRateLimited(env)) {
-			await requeueForRateLimit(env, message, boardHash)
-			return
-		}
+		// No capacity check, by design (see the top of this file). The version check above is what stops
+		// redundant work: everything past this point is a board whose cached thumbnail genuinely no
+		// longer matches its content.
 
-		// Target the first page that has content so a board whose first page is empty still gets a
-		// meaningful unfurl image (the render page otherwise exports whichever page the snapshot opens
-		// to, typically the first).
-		const snapshot = await loadBoardSnapshot(env, board)
+		// Loaded to target the first page that has content, so a board whose first page is empty still
+		// gets a meaningful unfurl image.
+		const snapshot = await loadBoardSnapshot(env, board, { access: 'render' })
 		if (!snapshot) {
-			// The board has no persisted content. The render page loads the snapshot from the same
-			// sources through the same functions (getThumbnailSnapshot ->
-			// get{Published,SharedFile}RoomSnapshot), so it would 404, mark its error state, and come
-			// back as a render failure — after spending a Browser Run slot to discover what we already
-			// know. Fail now instead. retryOrDrop still backs off and retries, in case content lands
-			// shortly after the enqueue. A read that *fails* throws rather than landing here; the catch
-			// below reports it and retries the same way, so that path spends no Browser Run either.
-			retryOrDrop(env, message, boardHash, 'board_empty')
+			// No persisted content. The render page reads the snapshot through the same functions, so it
+			// would 404 and come back as a render failure — after spending a Browser Run slot to learn
+			// what we already know. Retry from here instead, in case content lands shortly after the
+			// enqueue. A read that *fails* throws rather than landing here, and the catch below retries it
+			// the same way, so neither path spends Browser Run.
+			await retryOrDrop(env, message, { reason, failureReason: 'board_empty', board: boardRef })
 			return
 		}
 
@@ -171,108 +306,139 @@ export async function handleOgImageRenderMessage(
 			height: DEFAULT_THUMBNAIL_HEIGHT,
 		})
 		await putThumbnailPng(env.THUMBNAILS, cacheKey, render.base64, board.version)
-		await clearPending()
+		await clearOgImagePendingMarker(env, boardRef)
+		await enqueueFollowUpIfBoardMoved(env, message, board, reason, ctx)
 
 		writeScreenshotTelemetry(env, {
 			source: 'queue',
-			boardHash,
+			reason,
 			cacheStatus: 'miss',
 			browserRunDurationMs: render.durationMs,
-			browserMsUsed: null,
 		})
 		message.ack()
 	} catch (error) {
-		// Bounded reason code only — raw error.message would blow up the failure blob's cardinality.
-		// Sentry gets the unbounded original, since the reason code alone can't explain why a board
-		// burned through its retries.
+		// Reported once per job, on the delivery that gives up, rather than once per delivery: a board
+		// that fails deterministically fails all OG_MAX_RENDER_ATTEMPTS times, and one problem should not
+		// file three events. A failure that recovers on retry reports nothing, which is correct — the
+		// render landed. Sentry gets the unbounded original; telemetry below gets a bounded reason code,
+		// since raw error.message would blow up that dimension's cardinality.
+		if (message.attempts >= OG_MAX_RENDER_ATTEMPTS) {
+			reportThumbnailError(error, {
+				ctx,
+				env,
+				surface: 'og_queue',
+				extras: { kind, attempts: message.attempts },
+			})
+		}
+		// A board deleted between the resolve above and the snapshot read is retried rather than dropped,
+		// because from here it looks like any other read failure. That costs one extra delivery, not one
+		// extra render: the retry re-resolves at the top and drops before spending any Browser Run.
+		await retryOrDrop(env, message, {
+			reason,
+			failureReason: classifyScreenshotFailure(error),
+			browserRunDurationMs: browserRunDurationOf(error),
+			board: boardRef,
+		})
+	}
+}
+
+/**
+ * A capture takes seconds, and the board can change during one. An edit or publish landing in that
+ * window asks for a render, finds the pending marker this job set, and is turned away — the ask is
+ * *dropped*, not deferred, and nothing upstream retries it: the debouncer has already reset and
+ * neither caller reads the result. So the render we just wrote would be the last word, showing a
+ * board as it was before its final edits, until something happened to ask again.
+ *
+ * Re-resolving here is what closes that. A retry needs no such check, since every delivery re-resolves
+ * before capturing and so picks up the newest content by itself.
+ *
+ * Deliberately never chained. A board edited without pause would otherwise find itself stale on every
+ * follow-up and render continuously, which is the exact cost the debounce upstream exists to avoid.
+ * One extra render per triggered render is the ceiling.
+ *
+ * Best effort: the image is already written and the marker already cleared, so a failure here loses a
+ * refresh, not the render. It must not turn a completed job into a retry.
+ */
+async function enqueueFollowUpIfBoardMoved(
+	env: Environment,
+	message: Message<OgImageRenderQueueMessage>,
+	rendered: ResolvedThumbnailBoard,
+	reason: OgImageRenderReason,
+	ctx?: ExecutionContext
+) {
+	if (message.body.followUp) return
+	try {
+		const resolved = await resolveThumbnailBoard(env, rendered.kind, rendered.slug, {
+			access: 'render',
+		})
+		if (!resolved.ok) return
+		if (String(resolved.board.version) === String(rendered.version)) return
+		await enqueueOgImageRender(env, rendered, { reason, followUp: true })
+	} catch (error) {
 		reportThumbnailError(error, {
 			ctx,
 			env,
 			surface: 'og_queue',
-			extras: { kind, slug, attempts: message.attempts },
+			extras: { kind: rendered.kind, followUpCheck: true },
 		})
-		// A board that went private between the resolve above and the snapshot read is retried rather
-		// than dropped here, because a plain read failure looks the same from this catch. That costs
-		// one extra delivery, not one extra render: the retry re-resolves at the top of the handler,
-		// finds the board no longer viewable, and drops it before spending any Browser Run.
-		retryOrDrop(env, message, boardHash, classifyScreenshotFailure(error))
 	}
 }
 
-function retryOrDrop(
+async function retryOrDrop(
 	env: Environment,
 	message: Message<OgImageRenderQueueMessage>,
-	boardHash: string,
-	failureReason: string
-) {
-	// attempts counts this delivery, so attempts >= MAX means this was the final try. Only genuine
-	// render failures reach here (global-capacity backpressure re-enqueues instead), so attempts is a
-	// true failure count. The pending marker is left in place either way; it expires on its own and
-	// then requests re-enqueue.
-	if (message.attempts < MAX_RENDER_ATTEMPTS) {
-		message.retry({ delaySeconds: RETRY_DELAY_SECONDS * message.attempts })
-		return
+	{
+		reason,
+		failureReason,
+		browserRunDurationMs,
+		board,
+	}: {
+		/**
+		 * Passed in already resolved rather than read off the message here, so a delivery that fails is
+		 * attributed to the same trigger as one that succeeds. Reading `message.body.reason` directly
+		 * would bucket a legacy message with no reason as `none` on this path and `crawler` on the
+		 * others, splitting one job's deliveries across two values.
+		 */
+		reason: OgImageRenderReason
+		failureReason: string
+		browserRunDurationMs?: number
+		board: ThumbnailBoardRef
 	}
-	writeScreenshotTelemetry(env, { source: 'queue', boardHash, cacheStatus: 'miss', failureReason })
-	message.ack()
-}
-
-// Global Browser Run capacity is busy. Re-enqueue this job (on its own bounded rate-limit budget, so
-// backpressure never counts against the failure-retry budget in retryOrDrop) and ack this delivery.
-// The render still hasn't happened, so no Browser Run capacity was spent on a screenshot; the
-// consumer's version check coalesces the eventual retry with any newer enqueues, so a fast-changing
-// board still captures only its latest content.
-//
-// Two things keep this from turning into the runaway it used to be: the requeue counter bounds the
-// chain (an un-counted `message.body` reset the attempt count and looped forever), and the pending
-// marker is refreshed each time so concurrent crawler hits coalesce onto this one chain instead of
-// spawning a fresh parallel chain every time the marker's TTL lapsed.
-async function requeueForRateLimit(
-	env: Environment,
-	message: Message<OgImageRenderQueueMessage>,
-	boardHash: string
 ) {
-	const requeues = (message.body.rateLimitRequeues ?? 0) + 1
-
+	// One datapoint per delivery, the opposite of the Sentry report above, because this dataset is the
+	// spend ledger for an uncapped render path: every delivery that reaches the capture creates a
+	// browser and can hold it for the full THUMBNAIL_RENDER_TIMEOUT_MS, last attempt or not. Telemetry
+	// counts spend, Sentry counts problems — three deliveries are three lots of spend, one problem.
 	writeScreenshotTelemetry(env, {
 		source: 'queue',
-		boardHash,
+		reason,
 		cacheStatus: 'miss',
-		rateLimitAllowed: false,
-		failureReason:
-			requeues > MAX_RATE_LIMIT_REQUEUES ? 'rate_limited_global_exhausted' : 'rate_limited_global',
+		failureReason,
+		// Present only when the capture itself failed. A delivery that bailed earlier (an unreadable or
+		// empty snapshot) spent no Browser Run and correctly records none.
+		browserRunDurationMs,
 	})
-
-	if (requeues > MAX_RATE_LIMIT_REQUEUES) {
-		// Sustained global backpressure. Stop looping so this chain's capacity checks can't keep the
-		// shared limiter saturated; the pending marker is left to expire and the next crawler hit
-		// re-enqueues once capacity has recovered.
-		message.ack()
+	// attempts counts this delivery, so attempts >= MAX means this was the final try.
+	if (message.attempts < OG_MAX_RENDER_ATTEMPTS) {
+		// Marker kept: a retry is still this job in flight, and the next delivery re-resolves anyway, so
+		// an ask turned away meanwhile costs nothing — it would have rendered the same content.
+		message.retry({ delaySeconds: OG_RETRY_DELAY_SECONDS * message.attempts })
 		return
 	}
-
-	// Exponential backoff (capped) cuts how often a waiting job re-checks the shared limiter, so the OG
-	// queue's own checks stop crowding out real renders.
-	const delaySeconds = Math.min(
-		RETRY_DELAY_SECONDS * 2 ** (requeues - 1),
-		MAX_REQUEUE_DELAY_SECONDS
-	)
-	await refreshOgImagePendingMarker(env, message.body, delaySeconds)
-	await env.QUEUE.send({ ...message.body, rateLimitRequeues: requeues }, { delaySeconds })
+	// Given up, so nothing is in flight and the marker has nothing left to single-flight. Clearing it
+	// rather than letting it lapse means the next ask is acted on immediately instead of being turned
+	// away for the rest of the TTL — which matters most here, since this board has no image at all.
+	await clearOgImagePendingMarker(env, board)
+	// But when the ask that failed was itself the OG route's crawler-triggered repair, "immediately"
+	// is the problem rather than the point: with the marker gone, the next unauthenticated request
+	// would re-arm the whole retry chain, letting traffic an outside caller controls spend Browser Run
+	// on a board that just proved it cannot render. Arm the repair cooldown instead — publish- and
+	// edit-triggered asks don't consult it, so a genuine republish still renders straight away. Best
+	// effort: a cooldown that fails to write costs extra renders, not the ack.
+	if (board.kind === 'published' && reason === 'crawler') {
+		await env.THUMBNAILS?.put(getOgImageRepairCooldownKey(board), new Uint8Array(), {
+			customMetadata: { expiresAt: String(Date.now() + OG_REPAIR_COOLDOWN_MS) },
+		}).catch(() => {})
+	}
 	message.ack()
-}
-
-// Extends the pending marker so it outlives the scheduled redelivery. While a rate-limited job backs
-// off, its marker must keep suppressing duplicate enqueues (enqueueOgImageRender), or each TTL lapse
-// would let another parallel requeue chain spawn.
-async function refreshOgImagePendingMarker(
-	env: Environment,
-	board: { kind: ThumbnailBoardKind; slug: string },
-	delaySeconds: number
-) {
-	if (!env.THUMBNAILS) return
-	const expiresAt = Date.now() + delaySeconds * 1000 + PENDING_MARKER_TTL_MS
-	await env.THUMBNAILS.put(getOgImagePendingKey(board), new Uint8Array(), {
-		customMetadata: { expiresAt: String(expiresAt) },
-	}).catch(() => {})
 }

--- a/apps/dotcom/sync-worker/src/routes/tla/screenshotTestHelpers.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/screenshotTestHelpers.ts
@@ -2,9 +2,9 @@ import { vi } from 'vitest'
 import { Environment } from '../../types'
 
 // Shared fakes for the Browser Run thumbnail / OG image tests (thumbnailRender,
-// sharedBoardScreenshotMcp, ogImageQueue, getOgImage). These were copy-pasted across those files;
-// keep them here so the R2/browser/queue fakes, snapshot builder, and token helpers stay in one
-// place.
+// sharedBoardScreenshotMcp, ogImageQueue, getOgImage). The R2/browser/queue fakes, snapshot builder
+// and token helpers belong here rather than in any one test file, so that all four exercise the same
+// stand-ins.
 
 // Builds a room snapshot with the given pages and per-page shape counts. Shapes are parented
 // directly to their page, which is what enumerateBoardPages checks for "has content".
@@ -28,14 +28,20 @@ export function makeSnapshot(
 	return { documents, schema: { schemaVersion: 2, sequences: {} } } as any
 }
 
-// In-memory stand-in for the THUMBNAILS R2 bucket. Exposes `store` so tests can inspect or seed
+// In-memory stand-in for an R2 bucket (THUMBNAILS or MCP_DATA_BUCKET, which have the same shape).
+// Exposes `store` so tests can inspect or seed
 // entries directly. Covers get/head/put/delete; entries carry the customMetadata and upload time
 // the routes read.
 export function makeFakeThumbnailsBucket() {
 	const store = new Map<
 		string,
-		{ body: ArrayBuffer; customMetadata?: Record<string, string>; uploaded: Date }
+		{ body: ArrayBuffer; customMetadata?: Record<string, string>; uploaded: Date; etag: string }
 	>()
+	// R2 exposes an object's etag twice: `etag` bare and `httpEtag` quoted for the header. The OG route
+	// compares against the first and sends the second, so the fake has to carry both. The value only
+	// has to change when the bytes do, which a counter gives without hashing anything.
+	let version = 0
+	const etagOf = (value: { etag: string }) => ({ etag: value.etag, httpEtag: `"${value.etag}"` })
 	return {
 		store,
 		async get(key: string) {
@@ -44,13 +50,15 @@ export function makeFakeThumbnailsBucket() {
 			return {
 				customMetadata: value.customMetadata,
 				uploaded: value.uploaded,
+				...etagOf(value),
+				body: value.body,
 				arrayBuffer: async () => value.body,
 			}
 		},
 		async head(key: string) {
 			const value = store.get(key)
 			if (!value) return null
-			return { customMetadata: value.customMetadata, uploaded: value.uploaded }
+			return { customMetadata: value.customMetadata, uploaded: value.uploaded, ...etagOf(value) }
 		},
 		async put(
 			key: string,
@@ -61,6 +69,7 @@ export function makeFakeThumbnailsBucket() {
 				body,
 				customMetadata: options?.customMetadata,
 				uploaded: new Date(Date.now()),
+				etag: `etag-${++version}`,
 			})
 		},
 		async delete(key: string) {
@@ -99,6 +108,9 @@ export function makeScreenshotTestEnv(overrides: Partial<Record<string, unknown>
 		MCP_SCREENSHOT_TOKEN_SECRET: 'test-secret',
 		MEASURE: { writeDataPoint: vi.fn() },
 		QUEUE: makeFakeQueue(),
+		// Nothing in the thumbnail pipeline derives a board id, and this exists to keep it that way: if
+		// something starts, a legible `do(<name>)` shows up in an assertion rather than an opaque hash.
+		TLDR_DOC: { idFromName: (name: string) => ({ toString: () => `do(${name})` }) },
 		...overrides,
 	} as unknown as Environment
 }
@@ -122,6 +134,23 @@ export function failureBlobsOf(env: Environment) {
 
 export function ipBlobsOf(env: Environment) {
 	return blobsWithPrefix(env, 'ip:')
+}
+
+// The Browser Run duration (double3) of every datapoint written. -1 is the sentinel for "no browser
+// was spent", which is what separates a failure that never reached the capture from one that created
+// a browser and held it — a distinction the spend ledger would otherwise lose on every failed render.
+export function renderDurationsOf(env: Environment): number[] {
+	return (env.MEASURE as any).writeDataPoint.mock.calls.map(
+		(call: any[]) => (call[0].doubles as number[])[2]
+	)
+}
+
+// The index (index1) of every datapoint written. Always `undefined`, since the dataset carries no
+// board identity — this exists to pin that, not to read a value out.
+export function indexesOf(env: Environment): (string | undefined)[] {
+	return (env.MEASURE as any).writeDataPoint.mock.calls.map(
+		(call: any[]) => (call[0].indexes as [string] | undefined)?.[0]
+	)
 }
 
 // quickAction is called as quickAction('screenshot', body); the render URL rides in body (arg 1).

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
@@ -18,9 +18,9 @@ import {
 	isMcpScreenshotEnabled,
 	parseBoardInfoInput,
 	parseSharedBoardScreenshotInput,
+	resetRateLimitFallbackForTests,
 	sharedBoardScreenshotMcp,
 } from './sharedBoardScreenshotMcp'
-import { resetRateLimitFallbackForTests } from './thumbnailRender'
 
 vi.mock('./getPublishedFile', () => ({
 	getPublishedFileInfo: vi.fn(),
@@ -160,7 +160,7 @@ describe('MCP_SCREENSHOT_ENABLED', () => {
 		vi.mocked(getPublishedRoomSnapshot).mockResolvedValue(makeSnapshot(THREE_PAGES))
 		const env = makeEnv({
 			MCP_SCREENSHOT_ENABLED: 'false',
-			THUMBNAILS: makeFakeThumbnailsBucket(),
+			MCP_DATA_BUCKET: makeFakeThumbnailsBucket(),
 		})
 
 		const response = await sharedBoardScreenshotMcp(
@@ -312,7 +312,7 @@ describe('get_shared_board_screenshot', () => {
 	it('screenshots the first page by default and caches it', async () => {
 		mockPublishedBoard()
 		const bucket = makeFakeThumbnailsBucket()
-		const env = makeEnv({ THUMBNAILS: bucket })
+		const env = makeEnv({ MCP_DATA_BUCKET: bucket })
 
 		const result = await resultOf(
 			await sharedBoardScreenshotMcp(
@@ -334,6 +334,9 @@ describe('get_shared_board_screenshot', () => {
 			slug: 'abc',
 			camera: 'content',
 			pageId: 'page:a',
+			// This tool only ever resolves boards anyone could fetch, so it mints the anonymous gate. That
+			// is what keeps it out of the render-token records, and so out of the OG pipeline's way.
+			access: 'public',
 		})
 		// cached under the page-0 key
 		expect([...bucket.store.keys()]).toEqual([
@@ -343,7 +346,7 @@ describe('get_shared_board_screenshot', () => {
 
 	it('screenshots the requested page ordinal', async () => {
 		mockPublishedBoard()
-		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		const env = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
 
 		const result = await resultOf(
 			await sharedBoardScreenshotMcp(
@@ -359,7 +362,7 @@ describe('get_shared_board_screenshot', () => {
 
 	it('waits on either terminal selector and captures a success-only element so failed renders fail fast', async () => {
 		mockPublishedBoard()
-		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		const env = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
 
 		await sharedBoardScreenshotMcp(
 			makeToolCall('203.0.113.18', 'get_shared_board_screenshot', { boardId: 'abc' }),
@@ -388,7 +391,7 @@ describe('get_shared_board_screenshot', () => {
 	it('serves a cached page without screenshotting again', async () => {
 		mockPublishedBoard()
 		const bucket = makeFakeThumbnailsBucket()
-		const env = makeEnv({ THUMBNAILS: bucket })
+		const env = makeEnv({ MCP_DATA_BUCKET: bucket })
 
 		await sharedBoardScreenshotMcp(
 			makeToolCall('203.0.113.12', 'get_shared_board_screenshot', { boardId: 'abc' }),
@@ -410,7 +413,7 @@ describe('get_shared_board_screenshot', () => {
 
 	it('errors when the page ordinal is out of range, without screenshotting', async () => {
 		mockPublishedBoard()
-		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		const env = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
 
 		const result = await resultOf(
 			await sharedBoardScreenshotMcp(
@@ -426,7 +429,10 @@ describe('get_shared_board_screenshot', () => {
 	it('errors for a private (unshared) file without screenshotting', async () => {
 		vi.mocked(getSharedFileInfo).mockResolvedValue({ id: 'p', shared: false, isDeleted: false })
 		vi.mocked(getPublishedFileInfo).mockResolvedValue(null)
-		const env = makeEnv({ ROOMS: makeFakeRoomsBucket(), THUMBNAILS: makeFakeThumbnailsBucket() })
+		const env = makeEnv({
+			ROOMS: makeFakeRoomsBucket(),
+			MCP_DATA_BUCKET: makeFakeThumbnailsBucket(),
+		})
 
 		const result = await resultOf(
 			await sharedBoardScreenshotMcp(
@@ -443,7 +449,7 @@ describe('get_shared_board_screenshot', () => {
 		vi.mocked(getSharedFileInfo).mockResolvedValue({ id: 'e', shared: true, isDeleted: false })
 		const env = makeEnv({
 			ROOMS: makeFakeRoomsBucket(null),
-			THUMBNAILS: makeFakeThumbnailsBucket(),
+			MCP_DATA_BUCKET: makeFakeThumbnailsBucket(),
 		})
 
 		const result = await resultOf(
@@ -468,7 +474,7 @@ describe('get_shared_board_screenshot', () => {
 		)
 		const env = makeEnv({
 			ROOMS: makeFakeRoomsBucket(),
-			THUMBNAILS: makeFakeThumbnailsBucket(),
+			MCP_DATA_BUCKET: makeFakeThumbnailsBucket(),
 		})
 
 		const result = await resultOf(
@@ -495,7 +501,7 @@ describe('get_shared_board_screenshot', () => {
 		vi.mocked(getSharedFileRoomSnapshot).mockRejectedValueOnce(new Error('not shared'))
 		const env = makeEnv({
 			ROOMS: makeFakeRoomsBucket(),
-			THUMBNAILS: makeFakeThumbnailsBucket(),
+			MCP_DATA_BUCKET: makeFakeThumbnailsBucket(),
 		})
 
 		const result = await resultOf(
@@ -515,7 +521,7 @@ describe('get_shared_board_screenshot', () => {
 	it('surfaces a render failure when the screenshot call fails', async () => {
 		mockPublishedBoard()
 		const env = makeEnv({
-			THUMBNAILS: makeFakeThumbnailsBucket(),
+			MCP_DATA_BUCKET: makeFakeThumbnailsBucket(),
 			BROWSER: makeBrowserBinding(async () => new Response('nope', { status: 500 })),
 		})
 
@@ -536,16 +542,16 @@ describe('get_shared_board_screenshot', () => {
 
 	// The cache write happens after the render, so a failure there means we are holding a PNG that
 	// already cost Browser Run capacity and a slot of the caller's rate-limit budget. Returning it is
-	// the only sensible outcome — the cache is an optimization, and the image is exactly what was
-	// asked for. This used to sit in the render's try block, so an R2 outage turned every successful
-	// screenshot into a tool error.
+	// the only sensible outcome — the cache is an optimization, and the image is exactly what was asked
+	// for. Note what this pins: the write must stay outside the render's try block, or an R2 outage
+	// turns every successful screenshot into a tool error.
 	it('returns the screenshot even when the cache write fails', async () => {
 		mockPublishedBoard()
 		const bucket = makeFakeThumbnailsBucket()
 		bucket.put = async () => {
 			throw new Error('R2 PUT failed: internal-bucket.example')
 		}
-		const env = makeEnv({ THUMBNAILS: bucket })
+		const env = makeEnv({ MCP_DATA_BUCKET: bucket })
 
 		const result = await resultOf(
 			await sharedBoardScreenshotMcp(
@@ -563,26 +569,78 @@ describe('get_shared_board_screenshot', () => {
 		expect(failureBlobsOf(env)).toEqual(['failure:none'])
 	})
 
-	it('enforces the per-IP rate limit', async () => {
+	// Pins the configured per-IP budget, not merely that some limit eventually fires. Each call uses a
+	// distinct board so the per-board limiter can never be what trips, and the run stops one call past
+	// the budget so it stays below the global cap — otherwise a passing test could not say which of the
+	// three limits it had actually exercised.
+	const PER_IP_RATE_LIMIT = 10
+	it(`allows ${PER_IP_RATE_LIMIT} screenshots per IP per minute, then rate limits`, async () => {
 		mockPublishedBoard()
-		const env = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		const env = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
 
-		let lastResult: any
-		for (let i = 0; i < 21; i++) {
-			lastResult = await resultOf(
-				await sharedBoardScreenshotMcp(
-					makeToolCall('203.0.113.20', 'get_shared_board_screenshot', { boardId: `board-${i}` }),
-					env
+		const results = []
+		for (let i = 0; i <= PER_IP_RATE_LIMIT; i++) {
+			results.push(
+				await resultOf(
+					await sharedBoardScreenshotMcp(
+						makeToolCall('203.0.113.20', 'get_shared_board_screenshot', { boardId: `board-${i}` }),
+						env
+					)
 				)
 			)
 		}
-		expect(lastResult.isError).toBe(true)
-		expect(lastResult.content[0].text).toContain('Rate limited')
+
+		expect(results.slice(0, PER_IP_RATE_LIMIT).map((r) => r.isError)).toEqual(
+			Array(PER_IP_RATE_LIMIT).fill(undefined)
+		)
+		const blocked = results[PER_IP_RATE_LIMIT]
+		expect(blocked.isError).toBe(true)
+		// The per-IP message specifically, so this can't pass on the global cap firing instead.
+		expect(blocked.content[0].text).toContain('per minute per IP')
+		expect(failureBlobsOf(env)).toContain('failure:rate_limited_ip')
+	})
+
+	// Per-board is deliberately far tighter than per-IP: this blocks on the third capture of one board
+	// while the same IP still has plenty of budget left.
+	//
+	// Note what this can and cannot check. Tests run with no rate limit bindings, so both budgets take
+	// the isolate-local fallback and only the key and the fallback limit matter here — the part that
+	// makes different numbers possible in a *deployment* is per-board having its own Cloudflare binding
+	// (MCP_SERVER_BOARD_RATE_LIMITER), and no unit test can see that. wrangler.toml is the only
+	// place that goes wrong, and the only place to check it.
+	const PER_BOARD_RATE_LIMIT = 2
+	it(`allows ${PER_BOARD_RATE_LIMIT} captures per board per minute, well inside the per-IP budget`, async () => {
+		mockPublishedBoard()
+		const env = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
+
+		// Distinct pages of one board, so every call is a cache miss on the same board key.
+		const results = []
+		for (let page = 0; page <= PER_BOARD_RATE_LIMIT; page++) {
+			results.push(
+				await resultOf(
+					await sharedBoardScreenshotMcp(
+						makeToolCall('203.0.113.21', 'get_shared_board_screenshot', { boardId: 'abc', page }),
+						env
+					)
+				)
+			)
+		}
+
+		expect(results.slice(0, PER_BOARD_RATE_LIMIT).map((r) => r.isError)).toEqual(
+			Array(PER_BOARD_RATE_LIMIT).fill(undefined)
+		)
+		const blocked = results[PER_BOARD_RATE_LIMIT]
+		expect(blocked.isError).toBe(true)
+		expect(blocked.content[0].text).toContain('This board is being screenshotted too frequently')
+		expect(failureBlobsOf(env)).toContain('failure:rate_limited_board')
+		// Only 3 calls in, so neither the per-IP (10) nor the global (20) budget can be what fired.
+		expect(failureBlobsOf(env)).not.toContain('failure:rate_limited_ip')
+		expect(failureBlobsOf(env)).not.toContain('failure:rate_limited_global')
 	})
 
 	it('records the hashed ip only on failures, not on successful screenshots', async () => {
 		mockPublishedBoard()
-		const successEnv = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		const successEnv = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
 		await sharedBoardScreenshotMcp(
 			makeToolCall('203.0.113.30', 'get_shared_board_screenshot', { boardId: 'abc' }),
 			successEnv
@@ -591,7 +649,7 @@ describe('get_shared_board_screenshot', () => {
 
 		vi.mocked(getSharedFileInfo).mockResolvedValue(null)
 		vi.mocked(getPublishedFileInfo).mockResolvedValue(null)
-		const failEnv = makeEnv({ THUMBNAILS: makeFakeThumbnailsBucket() })
+		const failEnv = makeEnv({ MCP_DATA_BUCKET: makeFakeThumbnailsBucket() })
 		await sharedBoardScreenshotMcp(
 			makeToolCall('203.0.113.31', 'get_shared_board_screenshot', { boardId: 'missing' }),
 			failEnv

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
@@ -1,25 +1,30 @@
 import { DEFAULT_THUMBNAIL_HEIGHT, DEFAULT_THUMBNAIL_WIDTH } from '@tldraw/dotcom-shared'
 import { IRequest } from 'itty-router'
+import {
+	MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT,
+	MCP_PER_BOARD_RATE_LIMIT,
+	MCP_PER_IP_RATE_LIMIT,
+	MCP_RATE_LIMIT_WINDOW_MS,
+} from '../../config'
 import { Environment } from '../../types'
 import { arrayBufferToBase64 } from '../../utils/base64'
+import { sha256 } from '../../utils/hash'
 import { getDocumentNameFromSnapshot } from '../getDocumentNameFromSnapshot'
 import {
 	ResolveThumbnailBoardResult,
 	ResolvedThumbnailBoard,
 	captureThumbnailScreenshot,
 	enumerateBoardPages,
-	isGlobalBrowserRunRateLimited,
-	isRateLimited,
 	loadBoardSnapshot,
 	putThumbnailPng,
 	resolveThumbnailBoard,
 	writeScreenshotTelemetry,
 } from './thumbnailRender'
 import {
+	browserRunDurationOf,
 	classifyScreenshotFailure,
 	describeThumbnailFailure,
 	reportThumbnailError,
-	sha256,
 } from './thumbnailShared'
 
 // The MCP protocol surface over the shared render-and-cache core in thumbnailRender.ts: JSON-RPC
@@ -30,12 +35,50 @@ const SCREENSHOT_TOOL_NAME = 'get_shared_board_screenshot'
 const BOARD_INFO_TOOL_NAME = 'get_board_info'
 const MCP_PROTOCOL_VERSION = '2024-11-05'
 
-// Per-IP and per-board limits protect the endpoint and individual boards; the global limit in
-// thumbnailRender.ts caps total Browser Rendering spend across all callers. The Cloudflare bindings
-// in wrangler.toml enforce these in deployments; the isolate-local fallback only covers local dev
-// and tests.
-const PER_IP_RATE_LIMIT = 2
-const PER_BOARD_RATE_LIMIT = 2
+// The MCP rate limit budgets themselves live in config.ts (MCP_PER_IP_RATE_LIMIT and friends), with
+// the comment that maps each isolate-local fallback to its deployed Cloudflare binding. They are
+// applied here rather than in the shared render core so a new surface built on those helpers cannot
+// pick one up by accident.
+const GLOBAL_BROWSER_RATE_LIMIT_KEY = 'global'
+const RATE_LIMIT_FALLBACK = new Map<string, { count: number; resetAt: number }>()
+
+async function isGlobalBrowserRunRateLimited(env: Environment): Promise<boolean> {
+	return isRateLimited(env.MCP_SERVER_BROWSER_RATE_LIMITER, GLOBAL_BROWSER_RATE_LIMIT_KEY, {
+		fallbackLimit: MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT,
+	})
+}
+
+async function isRateLimited(
+	limiter: RateLimit | undefined,
+	key: string,
+	{ fallbackLimit }: { fallbackLimit: number }
+): Promise<boolean> {
+	// The mcp- prefix is load-bearing: it is what the deployed Cloudflare rate limit bindings have
+	// counted against, so changing it resets every configured bucket.
+	const rateLimitKey = `mcp-shared-board-screenshot:${key}`
+	if (limiter) {
+		const { success } = await limiter.limit({ key: rateLimitKey })
+		return !success
+	}
+
+	// Isolate-local fallback for local dev and tests; deployments configure the Cloudflare rate
+	// limit bindings in wrangler.toml.
+	const now = Date.now()
+	const existing = RATE_LIMIT_FALLBACK.get(rateLimitKey)
+	if (!existing || existing.resetAt <= now) {
+		RATE_LIMIT_FALLBACK.set(rateLimitKey, { count: 1, resetAt: now + MCP_RATE_LIMIT_WINDOW_MS })
+		return false
+	}
+	existing.count++
+	return existing.count > fallbackLimit
+}
+
+// The isolate-local fallback map is module state that persists across a test file's cases. Tests that
+// exercise the MCP tools must reset it between cases, or accumulated counts (especially on the shared
+// `global` key) would trip the low limits and rate-limit later cases' happy paths.
+export function resetRateLimitFallbackForTests() {
+	RATE_LIMIT_FALLBACK.clear()
+}
 
 type JsonRpcId = string | number | null
 
@@ -186,9 +229,9 @@ export async function resolveSharedBoardById(
 	env: Environment,
 	boardId: string
 ): Promise<ResolveThumbnailBoardResult> {
-	const shared = await resolveThumbnailBoard(env, 'shared_file', boardId)
+	const shared = await resolveThumbnailBoard(env, 'shared_file', boardId, { access: 'public' })
 	if (shared.ok || shared.reason === 'board_empty') return shared
-	return resolveThumbnailBoard(env, 'published', boardId)
+	return resolveThumbnailBoard(env, 'published', boardId, { access: 'public' })
 }
 
 // One R2 cache key per page. The ordinal keys the object directly; the version and theme are in the
@@ -207,7 +250,6 @@ async function callBoardInfoTool(
 	env: Environment,
 	ctx?: ExecutionContext
 ) {
-	const clientIp = getClientIp(request)
 	let input: { boardId: string }
 	try {
 		input = parseBoardInfoInput(argumentsValue)
@@ -215,19 +257,7 @@ async function callBoardInfoTool(
 		return toolError(error instanceof Error ? error.message : String(error))
 	}
 
-	// get_board_info spends no Browser Run, so it gets its own per-IP budget rather than sharing the
-	// screenshot one — otherwise the usual "list once, then screenshot pages" flow would exhaust the
-	// per-IP limit on the very first (free) call.
-	if (
-		await isRateLimited(env.MCP_SCREENSHOT_RATE_LIMITER, `ip-info:${clientIp ?? 'unknown'}`, {
-			fallbackLimit: PER_IP_RATE_LIMIT,
-		})
-	) {
-		return toolError(
-			`Rate limited. Requests are limited to about ${PER_IP_RATE_LIMIT} per minute per IP.`
-		)
-	}
-
+	// Not rate limited: the limiters here bound Browser Run, and this call spends none.
 	try {
 		const resolved = await resolveSharedBoardById(env, input.boardId)
 		if (!resolved.ok) {
@@ -238,7 +268,7 @@ async function callBoardInfoTool(
 			)
 		}
 
-		const snapshot = await loadBoardSnapshot(env, resolved.board)
+		const snapshot = await loadBoardSnapshot(env, resolved.board, { access: 'public' })
 		if (!snapshot) {
 			return toolError('This board has no saved content yet.')
 		}
@@ -257,7 +287,6 @@ async function callBoardInfoTool(
 			env,
 			request,
 			surface: 'mcp_board_info',
-			extras: { boardId: input.boardId },
 		})
 		return toolError(
 			`Could not read board info: ${describeThumbnailFailure(classifyScreenshotFailure(error))}.`
@@ -280,7 +309,6 @@ async function callSharedBoardScreenshotTool(
 		// Telemetry gets a bounded reason code; the caller gets the specific validation message.
 		writeScreenshotTelemetry(env, {
 			source: 'mcp',
-			boardHash: 'unresolved',
 			ipHash,
 			cacheStatus: 'miss',
 			failureReason: 'invalid_input',
@@ -288,26 +316,25 @@ async function callSharedBoardScreenshotTool(
 		return toolError(error instanceof Error ? error.message : String(error))
 	}
 
-	const boardHash = await sha256(input.boardId)
 	const telemetry = (data: {
 		cacheStatus: 'hit' | 'miss'
 		browserRunDurationMs?: number
 		failureReason?: string
 		rateLimitAllowed?: boolean
 	}) => {
-		writeScreenshotTelemetry(env, { source: 'mcp', boardHash, ipHash, ...data })
+		writeScreenshotTelemetry(env, { source: 'mcp', ipHash, ...data })
 	}
 
-	// Screenshots have their own per-IP budget (separate from get_board_info), sized to the ~2/min
-	// Browser Run cap: this is the throttle that actually bounds Browser Run spend per client.
+	// Checked before the cache, unlike the two below: this is the per-client ceiling on calls, not on
+	// captures, so a caller looping over cache hits is still bounded.
 	if (
 		await isRateLimited(env.MCP_SCREENSHOT_RATE_LIMITER, `ip-shot:${clientIp ?? 'unknown'}`, {
-			fallbackLimit: PER_IP_RATE_LIMIT,
+			fallbackLimit: MCP_PER_IP_RATE_LIMIT,
 		})
 	) {
 		telemetry({ cacheStatus: 'miss', rateLimitAllowed: false, failureReason: 'rate_limited_ip' })
 		return toolError(
-			`Rate limited. Shared board screenshots are limited to about ${PER_IP_RATE_LIMIT} requests per minute per IP.`
+			`Rate limited. Shared board screenshots are limited to about ${MCP_PER_IP_RATE_LIMIT} requests per minute per IP.`
 		)
 	}
 
@@ -324,14 +351,14 @@ async function callSharedBoardScreenshotTool(
 			)
 		}
 		const board = resolved.board
-		if (!env.THUMBNAILS) {
-			throw new Error('THUMBNAILS bucket is not configured')
+		if (!env.MCP_DATA_BUCKET) {
+			throw new Error('MCP_DATA_BUCKET bucket is not configured')
 		}
 
 		// The cache key is derived from the requested ordinal alone, so a cache hit skips loading the
 		// board snapshot entirely; the page name rides in the cached object's metadata.
 		const cacheKey = getThumbnailPageCacheKey(board, input.theme, input.page)
-		const cached = await env.THUMBNAILS.get(cacheKey)
+		const cached = await env.MCP_DATA_BUCKET.get(cacheKey)
 		if (cached) {
 			telemetry({ cacheStatus: 'hit' })
 			return toolPageResult(
@@ -342,7 +369,7 @@ async function callSharedBoardScreenshotTool(
 
 		// Cache miss: load the snapshot to resolve the ordinal to a real page (id + name) and validate
 		// the range.
-		const snapshot = await loadBoardSnapshot(env, board)
+		const snapshot = await loadBoardSnapshot(env, board, { access: 'public' })
 		if (!snapshot) {
 			telemetry({ cacheStatus: 'miss', failureReason: 'board_empty' })
 			return toolError('This board has no saved content to screenshot yet.')
@@ -363,8 +390,8 @@ async function callSharedBoardScreenshotTool(
 		// Only cache misses spend Browser Rendering capacity, so the per-board and global guards sit
 		// here rather than at the top of the tool call.
 		if (
-			await isRateLimited(env.MCP_SCREENSHOT_RATE_LIMITER, `board:${input.boardId}`, {
-				fallbackLimit: PER_BOARD_RATE_LIMIT,
+			await isRateLimited(env.MCP_SERVER_BOARD_RATE_LIMITER, `board:${input.boardId}`, {
+				fallbackLimit: MCP_PER_BOARD_RATE_LIMIT,
 			})
 		) {
 			telemetry({
@@ -390,14 +417,13 @@ async function callSharedBoardScreenshotTool(
 			height: DEFAULT_THUMBNAIL_HEIGHT,
 		})
 
-		// The render is already paid for in Browser Run capacity and the PNG in hand is exactly what the
-		// caller asked for, so a failed cache write must not throw it away — that would turn a working
-		// screenshot into a tool error and burn the caller's rate-limit budget for nothing. Report it
-		// instead: the caller can't act on it, but a cache that stops absorbing writes means every
-		// subsequent call re-renders, which we do need to see. The page name is URI-encoded into the
-		// object metadata (R2 custom metadata is not reliably unicode-safe).
+		// The render is already paid for and the PNG in hand is what the caller asked for, so a failed
+		// cache write must not throw it away — that would turn a working screenshot into a tool error and
+		// burn the caller's rate-limit budget for nothing. Reported rather than raised: the caller can't
+		// act on it, but a cache that stops absorbing writes means every call re-renders. The page name is
+		// URI-encoded because R2 custom metadata is not reliably unicode-safe.
 		try {
-			await putThumbnailPng(env.THUMBNAILS, cacheKey, render.base64, board.version, {
+			await putThumbnailPng(env.MCP_DATA_BUCKET, cacheKey, render.base64, board.version, {
 				pageName: encodeURIComponent(targetPage.name),
 			})
 		} catch (error) {
@@ -406,27 +432,31 @@ async function callSharedBoardScreenshotTool(
 				env,
 				request,
 				surface: 'mcp_screenshot_cache_write',
-				extras: { boardId: input.boardId, page: input.page, theme: input.theme },
+				extras: { page: input.page, theme: input.theme },
 			})
 		}
 
 		telemetry({ cacheStatus: 'miss', browserRunDurationMs: render.durationMs })
 		return toolPageResult(targetPage.name, render.base64)
 	} catch (error) {
-		// One bounded reason code drives both the telemetry blob (so unbounded error strings never
-		// inflate that dimension's cardinality) and the caller's message (so internal Postgres/R2
-		// detail never reaches this anonymous, unauthenticated endpoint). Sentry gets the unbounded
-		// original: this is the surface that actually spends Browser Run, so a Quick Action failing or
-		// the render page erroring out is the thing we most need the stack for.
+		// One bounded reason code drives both the telemetry blob (so unbounded error strings never inflate
+		// that dimension) and the caller's message (so internal Postgres/R2 detail never reaches this
+		// anonymous endpoint). Sentry gets the unbounded original.
 		reportThumbnailError(error, {
 			ctx,
 			env,
 			request,
 			surface: 'mcp_screenshot',
-			extras: { boardId: input.boardId, page: input.page, theme: input.theme },
+			extras: { page: input.page, theme: input.theme },
 		})
 		const failureReason = classifyScreenshotFailure(error)
-		telemetry({ cacheStatus: 'miss', failureReason })
+		// A capture that failed still held a browser, so its duration belongs on the datapoint the same
+		// as a successful one's. Undefined when the failure came before the capture and spent nothing.
+		telemetry({
+			cacheStatus: 'miss',
+			failureReason,
+			browserRunDurationMs: browserRunDurationOf(error),
+		})
 		return toolError(`Screenshot failed: ${describeThumbnailFailure(failureReason)}.`)
 	}
 }

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
@@ -7,91 +7,102 @@ import {
 	getThumbnailScreenshotRequestBody,
 } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
+import { THUMBNAIL_RENDER_TOKEN_TTL_MS } from '../../config'
 import { getR2KeyForRoom } from '../../r2'
-import { Environment, ThumbnailBoardKind } from '../../types'
+import {
+	Environment,
+	OgImageRenderReason,
+	ThumbnailBoardAccess,
+	ThumbnailBoardKind,
+	ThumbnailBoardRef,
+} from '../../types'
 import { writeDataPoint } from '../../utils/analytics'
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../../utils/base64'
 import {
-	THUMBNAIL_RENDER_TOKEN_TTL_MS,
 	ThumbnailRenderJob,
 	mintThumbnailRenderToken,
+	recordMintedRenderToken,
 } from '../../utils/renderTokens'
 import { getPublishedFileInfo, getPublishedRoomSnapshot } from './getPublishedFile'
-import {
-	getSharedFileInfo,
-	getSharedFileRoomSnapshot,
-	isFileAnonymouslyViewable,
-} from './getSharedFile'
-import { BoardSnapshotReadError } from './thumbnailShared'
+import { getSharedFileInfo, getSharedFileRoomSnapshot, isFileViewableFor } from './getSharedFile'
+import { BoardSnapshotReadError, BrowserRenderError } from './thumbnailShared'
 
 // The render-and-cache core shared by every Browser Run screenshot surface: the MCP screenshot
 // tool (sharedBoardScreenshotMcp.ts), the OG image route (getOgImage.ts), and the OG render queue
 // consumer (ogImageQueue.ts). Owns board resolution, snapshot loading, page enumeration, the
-// Browser Rendering invocation, rate limiting, and the shared telemetry writer. The surfaces own
-// their own protocol handling, cache keys, and retry/backoff policies.
+// Browser Rendering invocation, and the shared telemetry writer. The surfaces own their own protocol
+// handling, cache keys, and retry/backoff policies.
+//
+// Owns no rate limiting: the pipeline's only limiters live in sharedBoardScreenshotMcp.ts, so a new
+// surface built on these helpers cannot pick one up by accident.
 
-// The single limiter key every Browser Run-spending surface (the MCP tool and the OG queue
-// consumer) checks via isGlobalBrowserRunRateLimited, so they draw from one shared global cap
-// instead of separate per-key buckets.
-const GLOBAL_BROWSER_RATE_LIMIT_KEY = 'global'
-const GLOBAL_BROWSER_RUN_RATE_LIMIT = 6
-const RATE_LIMIT_WINDOW_MS = 60_000
-const RATE_LIMIT_FALLBACK = new Map<string, { count: number; resetAt: number }>()
-
-// A publicly viewable board a screenshot surface has resolved. The version rotates when the
-// rendered content changes (lastPublished for published boards, the persisted room snapshot's R2
-// etag for shared files), so it can key the thumbnail caches.
-export interface ResolvedThumbnailBoard {
-	kind: ThumbnailBoardKind
-	slug: string
+// A board a screenshot surface has resolved. Whether it is *publicly viewable* depends on the access
+// the caller asked for — see ThumbnailBoardAccess. The version rotates when the rendered content
+// changes (lastPublished for published boards, the persisted room snapshot's R2 etag for shared
+// files), so it can key the thumbnail caches.
+export interface ResolvedThumbnailBoard extends ThumbnailBoardRef {
 	version: string | number
+	/**
+	 * The gate this board was resolved under, carried so a render cannot be minted under a weaker one
+	 * than the resolution used. `captureThumbnailScreenshot` signs it into the job, and the snapshot
+	 * route reads the board back under it.
+	 */
+	access: ThumbnailBoardAccess
 }
 
 export type ResolveThumbnailBoardResult =
 	| { ok: true; board: ResolvedThumbnailBoard }
 	| { ok: false; reason: 'not_found' | 'board_empty' }
 
-// Resolves a board slug of a known kind, applying the public-view gates every screenshot surface
-// shares: published boards must be published, shared files must currently be shared via link and
-// have persisted content. `board_empty` means the board passed its gate but has no persisted room
-// content; `not_found` covers unknown, private, deleted, and unpublished boards alike.
+/**
+ * Resolves a board slug of a known kind, applying the gate the caller asked for (see
+ * `ThumbnailBoardAccess`). `access: 'public'` is the only thing standing between a private board and
+ * the public internet, and it is re-applied per request rather than inferred from what is in R2 —
+ * necessarily, since nothing deletes a thumbnail when a board stops being public.
+ *
+ * `board_empty` means the board passed its gate but has no persisted room content; `not_found` covers
+ * everything the gate refused.
+ */
 export async function resolveThumbnailBoard(
 	env: Environment,
 	kind: ThumbnailBoardKind,
-	slug: string
+	slug: string,
+	{ access }: { access: ThumbnailBoardAccess }
 ): Promise<ResolveThumbnailBoardResult> {
 	if (kind === 'published') {
+		// A published board's whole identity is its published slug, so there is no weaker gate to
+		// apply: an unpublished board has no published snapshot to render in the first place.
 		const file = await getPublishedFileInfo(env, slug)
 		if (!file?.published) return { ok: false, reason: 'not_found' }
-		return { ok: true, board: { kind, slug, version: file.lastPublished } }
+		return { ok: true, board: { kind, slug, version: file.lastPublished, access } }
 	}
 
 	const file = await getSharedFileInfo(env, slug)
-	if (!isFileAnonymouslyViewable(file)) return { ok: false, reason: 'not_found' }
+	if (!isFileViewableFor(file, access)) return { ok: false, reason: 'not_found' }
 
 	// The persisted room's R2 etag rotates when the board content changes, so it keys the
 	// thumbnail cache without a separate content-version field.
 	const persisted = await env.ROOMS.head(getR2KeyForRoom({ slug, isApp: true }))
 	if (!persisted) return { ok: false, reason: 'board_empty' }
 
-	return { ok: true, board: { kind, slug, version: persisted.etag } }
+	return { ok: true, board: { kind, slug, version: persisted.etag, access } }
 }
 
-// Reads a resolved board's snapshot, distinguishing the two outcomes callers need to tell apart.
-// `null` means one thing only: the board has no persisted room content, an empty board. Anything
-// the readers throw — Postgres, R2, a malformed payload, or the publish/share gate they re-check as
-// they read — is wrapped as a BoardSnapshotReadError so telemetry can name it. Collapsing both into
-// null, as this used to, filed database outages under "empty board" and left the real cause with no
-// trace anywhere.
+// Reads a resolved board's snapshot, keeping the two outcomes callers must tell apart distinct.
+// `null` means one thing only: an empty board, with no persisted room content. Anything the readers
+// throw — Postgres, R2, a malformed payload, or the gate they re-check as they read — is wrapped as a
+// BoardSnapshotReadError, so a database outage reaches telemetry under its own reason code instead of
+// as an empty board.
 export async function loadBoardSnapshot(
 	env: Environment,
-	board: { kind: ThumbnailBoardKind; slug: string }
+	board: ThumbnailBoardRef,
+	{ access }: { access: ThumbnailBoardAccess }
 ): Promise<RoomSnapshot | null> {
 	try {
 		const snapshot =
 			board.kind === 'published'
 				? await getPublishedRoomSnapshot(env, board.slug)
-				: await getSharedFileRoomSnapshot(env, board.slug)
+				: await getSharedFileRoomSnapshot(env, board.slug, { access })
 		return snapshot ?? null
 	} catch (error) {
 		// Keep the original message in the wrapper's own text as well as its `cause`, so the Sentry
@@ -175,8 +186,13 @@ export async function captureThumbnailScreenshot(
 		kind: board.kind,
 		slug: board.slug,
 		version: board.version,
+		// Taken from the resolution rather than the caller, so a surface cannot ask for a board under
+		// one gate and render it under another.
+		access: board.access,
 		camera: 'content',
 		...(pageId ? { pageId } : null),
+		// Ignored while `camera` is 'content', which is what every surface mints; carried because the
+		// job type keeps the explicit-viewport path available (see ThumbnailRenderJob).
 		x: 0,
 		y: 0,
 		z: 1,
@@ -186,34 +202,63 @@ export async function captureThumbnailScreenshot(
 		exp: Date.now() + THUMBNAIL_RENDER_TOKEN_TTL_MS,
 	}
 	const token = await mintThumbnailRenderToken(env, job)
+	// Record it as ours before the browser can present it, so the snapshot route can tell a token we
+	// minted from one merely signed with our secret. Awaited, not fired off: the render is about to
+	// depend on this having landed. A no-op for `public` jobs — see recordMintedRenderToken.
+	await recordMintedRenderToken(env, job, token)
 	return renderThumbnailScreenshot(env, buildThumbnailRenderUrl(getRenderOrigin(env), token), {
 		width,
 		height,
 	})
 }
 
-// The thumbnail pixels come from editor.toImage on the render page: the page exports the target page
-// itself and displays it as a full-viewport image, and the Browser Rendering `/screenshot` Quick
-// Action (called straight through the BROWSER binding, no puppeteer, no API token) captures exactly
-// that. Chrome runs in Cloudflare's fleet, not in this isolate. A render that fails marks an error
-// state instead of the ready one, so the Quick Action returns quickly and surfaces as a render
-// failure (see THUMBNAIL_SETTLED_SELECTOR / THUMBNAIL_CAPTURE_SELECTOR in @tldraw/dotcom-shared)
-// rather than burning the timeout.
+// The pixels come from editor.toImage on the render page, which displays its own export as a
+// full-viewport image for the Quick Action to capture. A failed render marks an error state rather
+// than the ready one, so it returns as a failure immediately instead of burning the timeout (see
+// THUMBNAIL_SETTLED_SELECTOR / THUMBNAIL_CAPTURE_SELECTOR in @tldraw/dotcom-shared).
 async function renderThumbnailScreenshot(
 	env: Environment,
 	renderUrl: string,
 	{ width, height }: { width: number; height: number }
 ): Promise<{ base64: string; durationMs: number }> {
+	// Built once and handed to whichever transport runs, so the wait strategy, capture target and
+	// timeout cannot drift between Browser Run and its development stand-in.
+	const requestBody = getThumbnailScreenshotRequestBody({
+		renderUrl,
+		width,
+		height,
+		timeoutMs: THUMBNAIL_RENDER_TIMEOUT_MS,
+	})
+
 	// Local dev has no route to Browser Run, so it points this at a screenshot service instead (the
 	// client's dev server, which can drive Playwright). Selected on the var being set rather than on
 	// an environment name, so only an environment that configures one can take this path.
-	if (env.LOCAL_SCREENSHOT_SERVICE_URL) {
-		return renderViaLocalScreenshotService(env.LOCAL_SCREENSHOT_SERVICE_URL, renderUrl, {
-			width,
-			height,
-		})
-	}
+	const { response, durationMs } = env.LOCAL_SCREENSHOT_SERVICE_URL
+		? await callLocalScreenshotService(env.LOCAL_SCREENSHOT_SERVICE_URL, requestBody)
+		: await callBrowserRun(env, requestBody)
 
+	const buffer = await response.arrayBuffer()
+	if (buffer.byteLength === 0) {
+		throw new Error('Render produced an empty screenshot')
+	}
+	return { base64: arrayBufferToBase64(buffer), durationMs }
+}
+
+type ThumbnailScreenshotRequestBody = ReturnType<typeof getThumbnailScreenshotRequestBody>
+
+// A capture that came back OK, and how long it took. Each transport times its own call and throws
+// its own kind of failure — only Browser Run's carries the status, body detail and timeout budget
+// that BrowserRenderError exists to hold — so what reaches the shared decode above is always a
+// response worth reading.
+interface TimedCapture {
+	response: Response
+	durationMs: number
+}
+
+async function callBrowserRun(
+	env: Environment,
+	requestBody: ThumbnailScreenshotRequestBody
+): Promise<TimedCapture> {
 	if (!env.BROWSER) {
 		throw new Error(
 			'Browser Rendering is not configured. Set the BROWSER binding (local dev needs Cloudflare credentials).'
@@ -223,49 +268,73 @@ async function renderThumbnailScreenshot(
 	const startedAt = Date.now()
 	// Browser Rendering `/screenshot` Quick Action, invoked straight through the binding (no
 	// puppeteer, no API token). Requires compatibility_date >= 2026-03-24 for `quickAction`.
-	const response = await env.BROWSER.quickAction(
-		'screenshot',
-		getThumbnailScreenshotRequestBody({
-			renderUrl,
-			width,
-			height,
-			timeoutMs: THUMBNAIL_RENDER_TIMEOUT_MS,
-		})
-	)
+	const response = await env.BROWSER.quickAction('screenshot', requestBody)
 	const durationMs = Date.now() - startedAt
 
 	if (!response.ok) {
-		throw new Error(`Browser Rendering screenshot failed (${response.status})`)
+		throw new BrowserRenderError({
+			status: response.status,
+			detail: await readBrowserErrorDetail(response),
+			durationMs,
+			timeoutMs: THUMBNAIL_RENDER_TIMEOUT_MS,
+		})
 	}
-	const buffer = await response.arrayBuffer()
-	if (buffer.byteLength === 0) {
-		throw new Error('Render produced an empty screenshot')
-	}
-	return { base64: arrayBufferToBase64(buffer), durationMs }
+	return { response, durationMs }
 }
 
-// Development stand-in for the Browser Rendering call above. It is sent the very same request body,
-// so the wait strategy, capture target, and timeout cannot drift between the two, and it returns the
-// same PNG bytes — everything either side of this call is the production path. The browser is a
-// local Playwright one though, not Browser Run, so a render that works here is not evidence that it
-// works in production.
-async function renderViaLocalScreenshotService(
+// How much of Cloudflare's error body to keep. It is a short JSON object in practice; the cap is
+// there so a proxy's HTML error page can't put a document into a Sentry event.
+const MAX_BROWSER_ERROR_DETAIL_LENGTH = 500
+
+// Reads why Browser Run refused, which the status cannot say on its own (see BrowserRenderError).
+// Failure-proof by construction: this runs on a path that is already failing, so a body that won't
+// read or won't parse must degrade to "no detail" rather than replace the status we do have with a
+// second error.
+async function readBrowserErrorDetail(response: Response): Promise<string | undefined> {
+	try {
+		const text = (await response.text()).trim()
+		if (!text) return undefined
+		return truncate(extractBrowserErrorMessages(text) ?? text)
+	} catch {
+		return undefined
+	}
+}
+
+// Cloudflare's error body is `{"success":false,"errors":[{"code":…,"message":"…"}]}`, and the
+// messages are the whole readable part. Anything else — a proxy's HTML, a plain string, a shape we
+// don't recognise — falls back to the raw text.
+function extractBrowserErrorMessages(text: string): string | undefined {
+	try {
+		const body = JSON.parse(text)
+		if (!Array.isArray(body?.errors)) return undefined
+		const messages = body.errors
+			.map((error: unknown) => (error as { message?: unknown } | null)?.message)
+			.filter((message: unknown): message is string => typeof message === 'string' && !!message)
+		return messages.length > 0 ? messages.join('; ') : undefined
+	} catch {
+		return undefined
+	}
+}
+
+function truncate(text: string) {
+	return text.length > MAX_BROWSER_ERROR_DETAIL_LENGTH
+		? `${text.slice(0, MAX_BROWSER_ERROR_DETAIL_LENGTH)}…`
+		: text
+}
+
+// Development stand-in for the Browser Rendering call above. Sent the same request body, and its
+// response decoded by the same code, so everything either side of the call is the production path.
+// The browser is a local Playwright one though, not Browser Run, so a render that works here is not
+// evidence that it works in production.
+async function callLocalScreenshotService(
 	serviceUrl: string,
-	renderUrl: string,
-	{ width, height }: { width: number; height: number }
-): Promise<{ base64: string; durationMs: number }> {
+	requestBody: ThumbnailScreenshotRequestBody
+): Promise<TimedCapture> {
 	const startedAt = Date.now()
 	const response = await fetch(serviceUrl, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify(
-			getThumbnailScreenshotRequestBody({
-				renderUrl,
-				width,
-				height,
-				timeoutMs: THUMBNAIL_RENDER_TIMEOUT_MS,
-			})
-		),
+		body: JSON.stringify(requestBody),
 	})
 	const durationMs = Date.now() - startedAt
 
@@ -282,11 +351,7 @@ async function renderViaLocalScreenshotService(
 			`Local screenshot service returned ${contentType || 'no content type'}, expected image/png. Is the client dev server running with the thumbnail screenshot plugin?`
 		)
 	}
-	const buffer = await response.arrayBuffer()
-	if (buffer.byteLength === 0) {
-		throw new Error('Render produced an empty screenshot')
-	}
-	return { base64: arrayBufferToBase64(buffer), durationMs }
+	return { response, durationMs }
 }
 
 // Writes one rendered PNG to a thumbnail cache, stamping the content version (so a stale version
@@ -308,72 +373,36 @@ export async function putThumbnailPng(
 	})
 }
 
-// The shared cap on total Browser Run spend. Every surface that spends Browser Run (the MCP
-// screenshot tool and the OG queue consumer) checks this, and all of them pass the same limiter key,
-// so they draw from one global bucket instead of separate per-surface budgets.
-export async function isGlobalBrowserRunRateLimited(env: Environment): Promise<boolean> {
-	return isRateLimited(env.MCP_SCREENSHOT_BROWSER_RATE_LIMITER, GLOBAL_BROWSER_RATE_LIMIT_KEY, {
-		fallbackLimit: GLOBAL_BROWSER_RUN_RATE_LIMIT,
-	})
-}
-
-export async function isRateLimited(
-	limiter: RateLimit | undefined,
-	key: string,
-	{ fallbackLimit }: { fallbackLimit: number }
-): Promise<boolean> {
-	// The mcp- prefix predates the OG surfaces sharing this limiter; it's kept (not renamed) so the
-	// deployed Cloudflare rate limit bindings and their configured buckets stay continuous.
-	const rateLimitKey = `mcp-shared-board-screenshot:${key}`
-	if (limiter) {
-		const { success } = await limiter.limit({ key: rateLimitKey })
-		return !success
-	}
-
-	// Isolate-local fallback for local dev and tests; deployments configure the Cloudflare rate
-	// limit bindings in wrangler.toml.
-	const now = Date.now()
-	const existing = RATE_LIMIT_FALLBACK.get(rateLimitKey)
-	if (!existing || existing.resetAt <= now) {
-		RATE_LIMIT_FALLBACK.set(rateLimitKey, {
-			count: 1,
-			resetAt: now + RATE_LIMIT_WINDOW_MS,
-		})
-		return false
-	}
-	existing.count++
-	return existing.count > fallbackLimit
-}
-
-// The isolate-local fallback map is module state that persists across a test file's cases. Tests
-// that exercise rendering must reset it between cases, or accumulated counts (especially on the
-// shared `global` key) would trip the low limits and rate-limit later cases' happy paths.
-export function resetRateLimitFallbackForTests() {
-	RATE_LIMIT_FALLBACK.clear()
-}
-
-// One datapoint writer for every screenshot surface, so they share a dataset and blob/doubles
-// layout and one dashboard covers them all; the source blob distinguishes mcp (the tool), og (the
-// GET route), and queue (the OG render consumer). The dataset name's mcp_ prefix predates the OG
-// surfaces; renaming it would split the dashboard's history, so it stays.
+// One datapoint writer for every screenshot surface, so they share a dataset and blob layout and one
+// dashboard covers them all; the source blob distinguishes mcp (the tool), og (the GET route) and
+// queue (the render consumer). The dataset name covers all three despite its mcp_ prefix, and must
+// keep doing so: renaming it would split the dashboard's history.
+//
+// Carries **no board identity**: no index, no slug, no hash, no derived id. Not an omission — these
+// datapoints answer aggregate spend and failure-rate questions, and the cost of that choice is a
+// dataset that cannot say which board is failing. See "No board identifier leaves this pipeline" in
+// browser-run-thumbnails.md.
 export function writeScreenshotTelemetry(
 	env: Environment,
 	data: {
 		source: 'mcp' | 'og' | 'queue'
-		boardHash: string
+		/**
+		 * Which trigger asked for this render — what attributes spend to publishing or editing. Only
+		 * meaningful on queue datapoints; the request paths have no trigger and record `none`.
+		 */
+		reason?: OgImageRenderReason
 		cacheStatus: 'hit' | 'stale' | 'miss'
 		/** Hashed client IP, for surfaces that have one. Recorded only on failures — see below. */
 		ipHash?: string
 		browserRunDurationMs?: number
-		browserMsUsed?: number | null
 		failureReason?: string
 		rateLimitAllowed?: boolean
 	}
 ) {
 	const rateLimitAllowed = data.rateLimitAllowed ?? true
-	// Record the hashed IP only on failed or rate-limited events, where it's useful for abuse
-	// analysis. Successful calls are the common case, and a per-IP blob there is one distinct
-	// dimension value per client on every request — a large cardinality cost for no query benefit.
+	// Only on failed or rate-limited events, where it's useful for abuse analysis. On the common
+	// success path a per-IP blob is one distinct dimension value per client, per request — a large
+	// cardinality cost for no query benefit.
 	const isFailure = data.failureReason !== undefined || !rateLimitAllowed
 	writeDataPoint(undefined, env.MEASURE, env, 'mcp_shared_board_screenshot', {
 		blobs: [
@@ -382,13 +411,18 @@ export function writeScreenshotTelemetry(
 			`failure:${data.failureReason ?? 'none'}`,
 			`rate_limit:${rateLimitAllowed ? 'allowed' : 'blocked'}`,
 			`ip:${isFailure && data.ipHash ? data.ipHash : 'none'}`,
+			// Appended rather than slotted in beside `source`, so the existing blob positions (and the
+			// dashboard panels reading them) don't shift.
+			`reason:${data.reason ?? 'none'}`,
 		],
-		indexes: [data.boardHash],
 		doubles: [
 			DEFAULT_THUMBNAIL_WIDTH,
 			DEFAULT_THUMBNAIL_HEIGHT,
 			data.browserRunDurationMs ?? -1,
-			data.browserMsUsed ?? -1,
+			// Billed browser ms, which the BROWSER binding does not surface, so it is always the sentinel.
+			// The slot stays occupied to hold the doubles positions after it — and the dashboard panels
+			// reading them — in place; double3 above is the spend proxy.
+			-1,
 			rateLimitAllowed ? 1 : 0,
 		],
 	})

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailShared.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailShared.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Environment } from '../../types'
+import {
+	BoardSnapshotReadError,
+	BrowserRenderError,
+	classifyScreenshotFailure,
+	reportThumbnailError,
+} from './thumbnailShared'
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+function makeBrowserRenderError(
+	overrides: Partial<ConstructorParameters<typeof BrowserRenderError>[0]> = {}
+) {
+	return new BrowserRenderError({
+		status: 422,
+		detail: undefined,
+		durationMs: 1_000,
+		timeoutMs: 45_000,
+		...overrides,
+	})
+}
+
+describe('BrowserRenderError', () => {
+	// Sentry groups on the message, so the detail has to stay off it: a body that names the board or
+	// the failing asset would turn one recurring issue into a new one per distinct string.
+	it('keeps the status-only message that Sentry groups on', () => {
+		const error = makeBrowserRenderError({ detail: 'Navigation timeout of 45000 ms exceeded' })
+		expect(error.message).toBe('Browser Rendering screenshot failed (422)')
+	})
+})
+
+describe('classifyScreenshotFailure', () => {
+	// 422 is Cloudflare's answer to a crashed page, an out-of-memory render, and every one of its
+	// timers expiring alike, so the status can't split them and the response body has to.
+	it('reads the timer out of the response body', () => {
+		const error = makeBrowserRenderError({
+			detail: 'Navigation timeout of 45000 ms exceeded',
+			durationMs: 900,
+		})
+		expect(classifyScreenshotFailure(error)).toBe('browser_timeout')
+	})
+
+	// The other half of the same 422: our own render page marked data-thumbnail-error, the capture
+	// selector (success-only) was therefore absent, and the call came back long before the budget.
+	it('classifies an early failure with no timer named as a render failure', () => {
+		const error = makeBrowserRenderError({
+			detail: 'Element with selector "body[data-thumbnail-ready=\\"true\\"]" not found',
+			durationMs: 3_000,
+		})
+		expect(classifyScreenshotFailure(error)).toBe('browser_failed')
+	})
+
+	// Fallback for a body that says nothing useful: a call that spent essentially the whole budget
+	// waited a timer out, whatever it was called.
+	it('falls back to the elapsed budget when the body names no timer', () => {
+		expect(classifyScreenshotFailure(makeBrowserRenderError({ durationMs: 44_000 }))).toBe(
+			'browser_timeout'
+		)
+		expect(classifyScreenshotFailure(makeBrowserRenderError({ durationMs: 5_000 }))).toBe(
+			'browser_failed'
+		)
+	})
+
+	it('still distinguishes a snapshot read failure from a render failure', () => {
+		expect(classifyScreenshotFailure(new BoardSnapshotReadError('postgres is down'))).toBe(
+			'snapshot_read_error'
+		)
+	})
+
+	it('keeps classifying the untyped errors the surfaces still throw', () => {
+		expect(classifyScreenshotFailure(new Error('Browser Rendering is not configured.'))).toBe(
+			'not_configured'
+		)
+		expect(classifyScreenshotFailure(new Error('Render produced an empty screenshot'))).toBe(
+			'empty_render'
+		)
+		expect(classifyScreenshotFailure(new Error('something else entirely'))).toBe('render_error')
+	})
+})
+
+describe('reportThumbnailError', () => {
+	// Without this the report says only "Browser Rendering screenshot failed (422)", which is equally
+	// true of a crashed page, an OOM render and a timeout — the whole point of reporting is to know
+	// which. Tests get no ExecutionContext, so reporting takes its console fallback.
+	it('reports the cause Cloudflare gave alongside the caller-supplied extras', () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const error = makeBrowserRenderError({
+			detail: 'Navigation timeout of 45000 ms exceeded',
+			durationMs: 45_100,
+		})
+
+		reportThumbnailError(error, {
+			ctx: undefined,
+			env: {} as Environment,
+			surface: 'og_queue',
+			extras: { kind: 'published' },
+		})
+
+		expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+			'[thumbnails:og_queue]',
+			{
+				kind: 'published',
+				browser_render_status: 422,
+				browser_render_detail: 'Navigation timeout of 45000 ms exceeded',
+				browser_render_duration_ms: 45_100,
+				browser_render_timeout_ms: 45_000,
+				browser_render_reason: 'browser_timeout',
+			},
+			error
+		)
+	})
+
+	// An empty body is itself a fact worth seeing, so it is recorded rather than omitted.
+	it('records the absence of a response body', () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+		reportThumbnailError(makeBrowserRenderError(), {
+			ctx: undefined,
+			env: {} as Environment,
+			surface: 'mcp_screenshot',
+		})
+
+		expect(consoleError.mock.calls[0]![1]).toMatchObject({
+			browser_render_detail: '(no response body)',
+		})
+	})
+
+	// The request is used for its method and user agent and nothing else. It is deliberately never
+	// handed to createSentry, which passes one to Toucan with `allowedSearchParams: /(.*)/` — that
+	// would record the full URL and every query parameter, and on these routes the URL is the
+	// sensitive part: a link-shared file's id sits in the OG route's path, and a signed render token
+	// (a live capability to read the board's whole snapshot) sits in the snapshot route's query.
+	it('takes no URL or query parameter from the request', () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const request = new Request(
+			'https://sync.tldraw.xyz/api/app/thumbnail-render/snapshot?token=super-secret-render-token',
+			{ headers: { 'user-agent': 'Twitterbot/1.0' } }
+		)
+
+		reportThumbnailError(new Error('nope'), {
+			ctx: undefined,
+			env: {} as Environment,
+			request,
+			surface: 'thumbnail_snapshot',
+			extras: { kind: 'shared_file' },
+		})
+
+		const context = consoleError.mock.calls[0]![1]
+		expect(context).toEqual({
+			kind: 'shared_file',
+			request_method: 'GET',
+			request_user_agent: 'Twitterbot/1.0',
+		})
+		const serialised = JSON.stringify(context)
+		expect(serialised).not.toContain('super-secret-render-token')
+		expect(serialised).not.toContain('thumbnail-render')
+		expect(serialised).not.toContain('sync.tldraw.xyz')
+	})
+
+	it('leaves errors that are not render failures alone', () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+		const error = new BoardSnapshotReadError('postgres is down')
+
+		reportThumbnailError(error, {
+			ctx: undefined,
+			env: {} as Environment,
+			surface: 'og_queue',
+			extras: { kind: 'shared_file' },
+		})
+
+		expect(consoleError).toHaveBeenCalledExactlyOnceWith(
+			'[thumbnails:og_queue]',
+			{ kind: 'shared_file' },
+			error
+		)
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailShared.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailShared.ts
@@ -6,9 +6,8 @@ import { Environment } from '../../types'
 // the OG route, and the OG queue consumer). This module imports nothing from those files so it can
 // be depended on from any of them without creating an import cycle.
 
-// A board's snapshot could not be read: Postgres, R2, or a malformed payload. Distinct from a
-// render failure so telemetry can tell "the database is down" apart from "Chrome fell over" — the
-// two have entirely different causes and fixes, and previously landed on the same reason code.
+// A board's snapshot could not be read: Postgres, R2, or a malformed payload. Distinct from a render
+// failure so telemetry can tell "the database is down" apart from "Chrome fell over".
 export class BoardSnapshotReadError extends Error {
 	constructor(message: string, options?: { cause?: unknown }) {
 		super(message, options)
@@ -16,33 +15,76 @@ export class BoardSnapshotReadError extends Error {
 	}
 }
 
-// Hex SHA-256 of a string. Used to hash IPs and board slugs before they reach telemetry, so raw
-// identifiers are never written to the analytics dataset.
-export async function sha256(value: string) {
-	const bytes = new TextEncoder().encode(value)
-	const digest = await crypto.subtle.digest('SHA-256', bytes)
-	return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+// A Browser Run `/screenshot` call that came back non-OK. The status alone says almost nothing:
+// Cloudflare answers 422 for every "the page did not cooperate" outcome — a crashed page, an
+// out-of-memory render, any Quick Action timer expiring — and our own render page marking
+// `data-thumbnail-error` lands there too, because the capture selector only exists on the success
+// path. What separates them is the response body and how much of the timeout budget the call spent,
+// so both are carried here rather than in the message.
+//
+// `message` stays exactly `Browser Rendering screenshot failed (<status>)`. Sentry groups on it, so a
+// varying detail string there would shatter one recurring issue into a stream of new ones;
+// `reportThumbnailError` lifts these fields into the event's context instead.
+export class BrowserRenderError extends Error {
+	readonly status: number
+	readonly detail: string | undefined
+	readonly durationMs: number
+	readonly timeoutMs: number
+
+	constructor(options: {
+		status: number
+		detail: string | undefined
+		durationMs: number
+		timeoutMs: number
+	}) {
+		super(`Browser Rendering screenshot failed (${options.status})`)
+		this.name = 'BrowserRenderError'
+		this.status = options.status
+		this.detail = options.detail
+		this.durationMs = options.durationMs
+		this.timeoutMs = options.timeoutMs
+	}
 }
 
-// Maps an arbitrary render error to a bounded set of reason codes for the `failure` telemetry
-// blob. Raw `error.message` strings (Postgres/R2/network/browser errors) are unbounded and would
-// blow up that dimension's cardinality, so they must never be written to the dataset directly.
-// Keep this a small, stable vocabulary. The typed case is matched first and by type: a failed
-// snapshot read is not a render that failed, and filing it under a render reason code sends whoever
-// reads the dashboard looking at the wrong subsystem.
+// Maps an arbitrary render error to a bounded set of reason codes for the `failure` telemetry blob.
+// Raw `error.message` strings are unbounded and must never reach that dimension, so keep this a
+// small, stable vocabulary. The typed cases are matched first and by type: a failed snapshot read is
+// not a render that failed, and filing it as one sends a dashboard reader to the wrong subsystem.
 //
-// A board un-shared or unpublished between a surface resolving it and reading its snapshot lands in
-// `snapshot_read_error` along with everything else the readers throw. That race is a few
-// milliseconds wide, so separating it out is not worth a dedicated error type threaded through
-// every reporting path.
+// A board deleted or unpublished between a surface resolving it and reading its snapshot lands in
+// `snapshot_read_error` with everything else the readers throw. That race is a few milliseconds wide,
+// so separating it out isn't worth a dedicated error type threaded through every reporting path.
 export function classifyScreenshotFailure(error: unknown): string {
 	if (error instanceof BoardSnapshotReadError) return 'snapshot_read_error'
+	if (error instanceof BrowserRenderError) return classifyBrowserRenderFailure(error)
 	const message = error instanceof Error ? error.message : String(error)
 	if (/not configured/i.test(message)) return 'not_configured'
 	if (/timeout|timed out/i.test(message)) return 'browser_timeout'
 	if (/empty screenshot/i.test(message)) return 'empty_render'
 	if (/Browser Rendering screenshot failed/i.test(message)) return 'browser_failed'
 	return 'render_error'
+}
+
+// Splits a Browser Run failure into `browser_timeout` and `browser_failed`, which the status cannot
+// do (see BrowserRenderError). Reads the response body, which usually names the timer, and falls back
+// to how much of the budget the call spent: one that used essentially the whole timeout waited a timer
+// out, one that returned early failed for another reason. Note the message is no use here — a Browser
+// Run failure's never contains the word "timeout", so matching on it reports a timeout rate of zero.
+const BROWSER_TIMEOUT_DURATION_FRACTION = 0.9
+function classifyBrowserRenderFailure(error: BrowserRenderError): string {
+	if (/timeout|timed out|timed-out/i.test(error.detail ?? '')) return 'browser_timeout'
+	if (error.durationMs >= error.timeoutMs * BROWSER_TIMEOUT_DURATION_FRACTION) {
+		return 'browser_timeout'
+	}
+	return 'browser_failed'
+}
+
+// The Browser Run time a failed capture still spent: a render that throws has already created a
+// browser and held it, often for the whole timeout, and that is real spend on a path whose only
+// safeguard is watching what it costs. Undefined for failures that never reached the capture (an
+// unreadable snapshot, an empty board), which spent nothing.
+export function browserRunDurationOf(error: unknown): number | undefined {
+	return error instanceof BrowserRenderError ? error.durationMs : undefined
 }
 
 // Caller-facing explanation for a classified failure, as a clause to follow a tool's own prefix.
@@ -76,15 +118,14 @@ export type ThumbnailErrorSurface =
 	// call is re-spending Browser Run.
 	| 'mcp_screenshot_cache_write'
 
-// Every thumbnail/OG surface deliberately swallows its own errors: the OG route falls back to the
-// default image, the render page's snapshot route 404s, the MCP tools return a tool error, and the
-// queue consumer retries or drops. That is right for callers, but it means the only trace a real
-// failure leaves is a bounded telemetry reason code, which says a board stopped rendering and
-// nothing about why. Report the underlying error here so these paths stay diagnosable.
+// Every thumbnail/OG surface swallows its own errors — the OG route falls back to the default image,
+// the snapshot route 404s, the MCP tools return a tool error, the queue retries or drops. Right for
+// callers, but it leaves a bounded telemetry reason code as the only trace, which says a board stopped
+// rendering and nothing about why. Reporting here is what keeps these paths diagnosable.
 //
-// `ctx` supplies the waitUntil that lets the report outlive the response — route handlers get one
-// from the router, the queue consumer from the worker entrypoint. Without one (unit tests) we log
-// instead, since createSentry throws when SENTRY_DSN and friends are unset.
+// `ctx` supplies the waitUntil that lets the report outlive the response — route handlers get one from
+// the router, the queue consumer from the worker entrypoint. Without one (unit tests) we log instead,
+// since createSentry throws when SENTRY_DSN and friends are unset.
 export function reportThumbnailError(
 	error: unknown,
 	{
@@ -102,15 +143,25 @@ export function reportThumbnailError(
 	}
 ) {
 	try {
-		const sentry = ctx ? createSentry(ctx, env, request) : null
+		const context = {
+			...extras,
+			...safeRequestContext(request),
+			...browserRenderContextOf(error),
+		}
+		// `request` is deliberately NOT handed to createSentry, which passes one straight to Toucan with
+		// `allowedSearchParams: /(.*)/` — recording the full URL and every query parameter. On these
+		// routes the URL is the sensitive part: `/app/social-preview/f/<id>/image` carries a link-shared
+		// file's id, and the render-snapshot route carries a signed token that can read the board's whole
+		// contents until it expires. safeRequestContext takes what is useful instead.
+		const sentry = ctx ? createSentry(ctx, env) : null
 		if (!sentry) {
-			console.error(`[thumbnails:${surface}]`, extras ?? {}, error)
+			console.error(`[thumbnails:${surface}]`, context, error)
 			return
 		}
 		// eslint-disable-next-line @typescript-eslint/no-deprecated
 		sentry.withScope((scope) => {
 			scope.setTag('thumbnail_surface', surface)
-			if (extras) scope.setExtras(extras)
+			scope.setExtras(context)
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			sentry.captureException(error)
 		})
@@ -118,5 +169,33 @@ export function reportThumbnailError(
 		// Reporting runs inside handlers whose whole point is to swallow failure, so it must never be
 		// the thing that throws: a missing Sentry env var would otherwise turn a degraded-but-fine
 		// response into a 500.
+	}
+}
+
+// The parts of a request worth attaching that carry no board identity. The URL is excluded (see the
+// call site); the user agent is kept because on the OG route it names the crawler that tripped over
+// the board, and the method because a HEAD probe and a GET behave differently there. Not the client
+// IP — telemetry records a hash of that, on failures only, which is where it earns its keep.
+function safeRequestContext(request: Request | undefined): Record<string, unknown> | null {
+	if (!request) return null
+	return {
+		request_method: request.method,
+		request_user_agent: request.headers.get('user-agent') ?? 'none',
+	}
+}
+
+// The fields BrowserRenderError keeps out of its message, lifted into the event context so they don't
+// file a new Sentry issue per distinct detail string. Without them an event says only "Browser
+// Rendering screenshot failed (422)", which is true of a crash, an OOM render and a timeout alike.
+function browserRenderContextOf(error: unknown): Record<string, unknown> | null {
+	if (!(error instanceof BrowserRenderError)) return null
+	return {
+		browser_render_status: error.status,
+		// Cloudflare's own explanation of the failure, verbatim (truncated at the throw site). Absent
+		// when the response carried no body, which is itself worth being able to see.
+		browser_render_detail: error.detail ?? '(no response body)',
+		browser_render_duration_ms: error.durationMs,
+		browser_render_timeout_ms: error.timeoutMs,
+		browser_render_reason: classifyScreenshotFailure(error),
 	}
 }

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -87,19 +87,33 @@ export interface Environment {
 	PIERRE_KEY: string | undefined
 
 	RATE_LIMITER: RateLimit
-	// Rate limit bindings for the Browser Run-backed MCP screenshot tool, declared in
-	// wrangler.toml. MCP_SCREENSHOT_RATE_LIMITER guards per-IP and per-board request rates;
-	// MCP_SCREENSHOT_BROWSER_RATE_LIMITER caps total Browser Run invocations across all callers.
-	// The route falls back to an isolate-local guard when the bindings are absent (local dev,
-	// tests).
+	// Rate limit bindings for the Browser Run-backed MCP screenshot tool, declared in wrangler.toml.
+	// All three bound what an agent calling the public MCP endpoint can spend; board thumbnail
+	// rendering is subject to none of them. Separate bindings because a binding carries one `limit`
+	// applied per key, so budgets with different numbers cannot share one. The route falls back to an
+	// isolate-local guard when they are absent (local dev, tests).
+	/** Per-IP `get_shared_board_screenshot` calls. */
 	MCP_SCREENSHOT_RATE_LIMITER: RateLimit | undefined
-	MCP_SCREENSHOT_BROWSER_RATE_LIMITER: RateLimit | undefined
+	/** Per-board Browser Run captures, applied only on cache misses. */
+	MCP_SERVER_BOARD_RATE_LIMITER: RateLimit | undefined
+	/** Total Browser Run invocations made by the tool, on one shared key. */
+	MCP_SERVER_BROWSER_RATE_LIMITER: RateLimit | undefined
 
 	QUEUE: Queue<QueueMessage>
 
-	// R2 cache for generated thumbnails, keyed on board identity, published version, and theme.
+	// R2 cache for board OG images (`og/…` keys), their pending-render markers and render token
+	// records. None of those keys carry a version, so a board costs one object per key however often it
+	// re-renders, nothing accumulates, and the bucket must have NO expiration rule — the current
+	// thumbnail has to outlive any lifecycle window.
 	// Optional so tests and unconfigured environments degrade to cacheless rendering.
 	THUMBNAILS: R2Bucket | undefined
+
+	// R2 storage for MCP tool output (`mcp/…` keys, screenshots today). Its own bucket rather than a
+	// prefix inside THUMBNAILS because these keys include the board's content version, so the set grows
+	// without bound and needs the expiration rule that would be actively wrong on THUMBNAILS. See "Why
+	// two buckets" in browser-run-thumbnails.md.
+	// Optional on the same terms as THUMBNAILS.
+	MCP_DATA_BUCKET: R2Bucket | undefined
 
 	// Cloudflare Browser Rendering binding. The worker takes thumbnails by calling the binding's
 	// `quickAction` Quick Actions method (e.g. `screenshot`) directly — no @cloudflare/puppeteer and
@@ -178,6 +192,18 @@ export type TLServerEvent =
 	| {
 			type: 'persist_success'
 			attempts: number
+			/**
+			 * Whether this board is link-shared. The shared fraction of *actively edited* boards is what
+			 * sizes thumbnail spend, and nothing else can answer it: Postgres knows which files are shared
+			 * but not which are being edited, and this event's index is one-way, so the dataset cannot be
+			 * joined back to a file row.
+			 *
+			 * `unknown` is an app file whose record has not loaded yet; `legacy` a non-app room, which has
+			 * no shareable board identity; `deleted` an app file whose record has been deleted. All three
+			 * stay distinct from `private` so the denominator is honest, and all are computed by
+			 * `getBoardRenderState`, which is also what gates the render.
+			 */
+			sharedState: 'shared' | 'private' | 'unknown' | 'legacy' | 'deleted'
 	  }
 
 export type TLPostgresReplicatorRebootSource =
@@ -239,6 +265,33 @@ export interface AssetUploadQueueMessage {
  */
 export type ThumbnailBoardKind = 'published' | 'shared_file'
 
+/**
+ * Which board, in which namespace. Everything that keys, enqueues, or cleans up a thumbnail takes
+ * this and nothing more — the pair is what a cache key is built from, so a function that took only a
+ * slug could silently address the wrong board's image.
+ */
+export interface ThumbnailBoardRef {
+	kind: ThumbnailBoardKind
+	slug: string
+}
+
+/**
+ * How much of a board a caller is entitled to. `public` is the anonymous gate: the board must be
+ * shared via link. `render` is for generating a thumbnail we will store but not necessarily serve
+ * publicly, so it only requires that the board exists and has content.
+ *
+ * Required at every call site rather than defaulted: a default would be wrong for half of them, and
+ * silence is the wrong way to pick a gate. It also rides inside the signed render job, so the gate a
+ * board was resolved under is the same one the snapshot route applies when it is read.
+ */
+export type ThumbnailBoardAccess = 'public' | 'render'
+
+// What prompted a board thumbnail render. Purely telemetry — every trigger is treated identically by
+// the consumer — so renders can be attributed to the thing that asked for them. `publish` and `edit`
+// are the two producers; `crawler` is reachable only as the fallback for a queued message that
+// carries no reason of its own.
+export type OgImageRenderReason = 'crawler' | 'publish' | 'edit'
+
 // Asks the queue consumer to render a board's OG image through Browser Run and refresh the R2
 // cache read by GET /app/social-preview/:prefix/:slug/image. Board state (share gate, content
 // version) is deliberately not carried in the message; the consumer re-resolves it at render time.
@@ -246,12 +299,14 @@ export interface OgImageRenderQueueMessage {
 	type: 'og-image-render'
 	kind: ThumbnailBoardKind
 	slug: string
-	// How many times this job has been re-enqueued because the shared global Browser Run cap was busy
-	// (see requeueForRateLimit). Bounds the rate-limit backoff loop: each rate-limited delivery still
-	// spends one slot of the shared limiter just to discover it can't render, so an unbounded requeue
-	// chain would let the OG queue's own capacity checks saturate the limiter and starve every render
-	// surface. Absent on the initial enqueue.
-	rateLimitRequeues?: number
+	// Optional only because a message may already be in the queue without one; every producer sets it.
+	reason?: OgImageRenderReason
+	/**
+	 * Set on a job the consumer enqueued for itself, having found the board changed while it was
+	 * capturing. A follow-up never spawns another: a board edited without pause would otherwise render
+	 * continuously instead of at the debounce's cadence.
+	 */
+	followUp?: boolean
 }
 
 export type QueueMessage = AssetUploadQueueMessage | OgImageRenderQueueMessage

--- a/apps/dotcom/sync-worker/src/utils/hash.ts
+++ b/apps/dotcom/sync-worker/src/utils/hash.ts
@@ -1,0 +1,14 @@
+// Hex SHA-256 of a string, for the two places that need a hash to be one-way rather than fast: the
+// render token records (utils/renderTokens.ts) hash a token before storing it, and the MCP tool
+// (routes/tla/) hashes client IPs before they reach telemetry.
+//
+// Not `getHashForString` and friends from @tldraw/utils, which are a 32-bit FNV-1a variant and wrong
+// for both. A 32-bit digest of an IPv4 address is a lookup table rather than a one-way function, and
+// one guarding a token is collision-searchable by anyone holding the signing secret — which is the
+// exact attacker the token record exists to stop.
+//
+// Under utils/ because both callers' layers need it and a utils module must not import a route.
+export async function sha256(value: string) {
+	const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value))
+	return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, '0')).join('')
+}

--- a/apps/dotcom/sync-worker/src/utils/ogRenderDebounce.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/ogRenderDebounce.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { OgRenderDebouncer } from './ogRenderDebounce'
+
+const DEBOUNCE = 30_000
+const MAX_WAIT = 300_000
+const PERSIST = 8_000
+
+function makeDebouncer() {
+	return new OgRenderDebouncer({ debounceMs: DEBOUNCE, maxWaitMs: MAX_WAIT })
+}
+
+/**
+ * Drives a debouncer through a run of persists at a fixed cadence, servicing alarms the way
+ * TLFileDurableObject does, and reports what it cost.
+ *
+ * `renders` is the number of Browser Run captures the run would have paid for; `alarmWrites` is the
+ * number of times durable storage was touched, and `alarmFires` the number of alarm invocations —
+ * the two halves of the cost, which the durable-deadline design trades against each other.
+ */
+function simulate({ persistEveryMs, forMs }: { persistEveryMs: number; forMs: number }) {
+	const debouncer = makeDebouncer()
+	const renderTimes: number[] = []
+	let alarmWrites = 0
+	let alarmFires = 0
+	let alarmAt: number | null = null
+	let persists = 0
+
+	const serviceAlarmsUntil = (now: number) => {
+		while (alarmAt !== null && alarmAt <= now) {
+			const firedAt = alarmAt
+			alarmAt = null
+			alarmFires++
+			const result = debouncer.onAlarm(firedAt)
+			if (result.render) {
+				renderTimes.push(firedAt)
+			} else {
+				alarmAt = result.reArmAt
+				alarmWrites++
+			}
+		}
+	}
+
+	for (let t = 0; t <= forMs; t += persistEveryMs) {
+		serviceAlarmsUntil(t)
+		persists++
+		// The object arms the alarm on every persist, so the durable copy never lags the deadline.
+		alarmAt = debouncer.onPersist(t)
+		alarmWrites++
+	}
+	// Let the board settle, so the trailing render lands.
+	serviceAlarmsUntil(forMs + MAX_WAIT + DEBOUNCE)
+
+	return { renderTimes, renders: renderTimes.length, alarmWrites, alarmFires, persists }
+}
+
+describe('OgRenderDebouncer', () => {
+	it('does not render while edits keep arriving', () => {
+		const debouncer = makeDebouncer()
+
+		debouncer.onPersist(0)
+		// An alarm set for t=30s fires, but another persist has moved the deadline to t=38s.
+		debouncer.onPersist(8_000)
+
+		expect(debouncer.onAlarm(30_000)).toEqual({ render: false, reArmAt: 38_000 })
+	})
+
+	it('renders once editing settles for the debounce window', () => {
+		const debouncer = makeDebouncer()
+
+		debouncer.onPersist(0)
+
+		expect(debouncer.onAlarm(30_000)).toEqual({ render: true })
+	})
+
+	// The defining behaviour: an isolated burst of editing renders AFTER the burst, so the thumbnail is
+	// of the finished board rather than of its first stroke.
+	it('renders after the last edit of a burst, not the first', () => {
+		const debouncer = makeDebouncer()
+
+		expect(debouncer.onPersist(0)).toBe(30_000)
+		debouncer.onPersist(8_000)
+		debouncer.onPersist(16_000)
+		// Deadline is now 16s + 30s, not 0s + 30s.
+		expect(debouncer.onAlarm(30_000)).toEqual({ render: false, reArmAt: 46_000 })
+		expect(debouncer.onAlarm(46_000)).toEqual({ render: true })
+	})
+
+	// Pure debounce would never render a board that is never left alone.
+	it('renders under sustained editing when the max wait expires', () => {
+		// Seven minutes of unbroken editing, against a five minute max wait.
+		const { renderTimes } = simulate({ persistEveryMs: PERSIST, forMs: 7 * 60_000 })
+
+		// One render forced by the max wait at t=5min, then one 30s after the last edit at t=416s.
+		expect(renderTimes).toEqual([MAX_WAIT, 446_000])
+	})
+
+	// The max wait is measured from the first persist of a session, not from each persist, or a board
+	// edited without pause would push it out forever alongside the debounce.
+	it('measures the max wait from the first persist since the last render', () => {
+		const debouncer = makeDebouncer()
+
+		debouncer.onPersist(0)
+		for (let t = PERSIST; t < MAX_WAIT; t += PERSIST) {
+			debouncer.onPersist(t)
+		}
+
+		// Capped at the max wait rather than the last persist + debounce.
+		expect(debouncer.onAlarm(MAX_WAIT - 1)).toEqual({ render: false, reArmAt: MAX_WAIT })
+		expect(debouncer.onAlarm(MAX_WAIT)).toEqual({ render: true })
+	})
+
+	// An evicted object loses the deadline but not the alarm — and because the alarm always carries
+	// the real deadline, an alarm with nothing in memory means the deadline genuinely arrived.
+	it('renders when an alarm arrives with no deadline in memory', () => {
+		const debouncer = makeDebouncer()
+
+		expect(debouncer.onAlarm(123_456)).toEqual({ render: true })
+	})
+
+	// The point of arming the alarm on every persist. Because the alarm carries the deadline itself
+	// rather than a lower bound on it, a revived object renders once, at the right time — leave the
+	// alarm behind the deadline and it renders early and then again when editing settles.
+	it('costs no extra render when the object is evicted mid-session', () => {
+		const live = makeDebouncer()
+		let alarmAt = live.onPersist(0)
+		for (let t = PERSIST; t <= 40_000; t += PERSIST) {
+			alarmAt = live.onPersist(t)
+		}
+		// Last persist at t=40s, so the deadline — and the alarm — sit at t=70s.
+		expect(alarmAt).toBe(70_000)
+
+		// Evicted: every field is gone, only the durable alarm survives.
+		const revived = makeDebouncer()
+
+		// It fires at the deadline the live object chose, and renders exactly once.
+		expect(revived.onAlarm(alarmAt)).toEqual({ render: true })
+		// Nothing is left over to fire a second time.
+		expect(revived.onAlarm(alarmAt + DEBOUNCE)).toEqual({ render: true })
+	})
+
+	it('starts a fresh cycle after a render', () => {
+		const debouncer = makeDebouncer()
+
+		debouncer.onPersist(0)
+		debouncer.onAlarm(30_000)
+
+		// A later persist schedules again rather than being swallowed by stale state. A returned alarm
+		// time (rather than null) is itself the proof the cycle reset: null means one is outstanding.
+		expect(debouncer.onPersist(100_000)).toBe(130_000)
+	})
+
+	// The cost claim the design rests on. Ten minutes of unbroken editing is 76 persists, which a 30s
+	// throttle would turn into roughly 20 renders (two per window). The debounce pays only for max-wait
+	// expiries plus one trailing render.
+	it('costs far less than a throttle for a long editing session', () => {
+		const { renders, persists } = simulate({ persistEveryMs: PERSIST, forMs: 10 * 60_000 })
+
+		expect(persists).toBe(76)
+		expect(renders).toBe(2)
+	})
+
+	// The common case in production, where the measured mean gap between a board's persists (~39s) is
+	// longer than the debounce window: a board is edited in a short burst and then left alone. Every
+	// mechanism costs one render here — which is why the debounce is not a saving on bursty boards,
+	// only on sustained ones. It still renders the *finished* burst rather than its first stroke.
+	it('costs exactly one render for an isolated burst', () => {
+		const { renderTimes } = simulate({ persistEveryMs: PERSIST, forMs: 24_000 })
+
+		// Last edit at t=24s, render 30s later.
+		expect(renderTimes).toEqual([54_000])
+	})
+
+	// The cost of a durable deadline, stated rather than hidden: one alarm write per persist. What it
+	// buys back is alarm invocations — the alarm never fires mid-session just to push itself out, so a
+	// sustained session wakes the object twice rather than ~20 times.
+	it('writes one alarm per persist, and wakes the object only to render', () => {
+		const { alarmWrites, alarmFires, persists, renders } = simulate({
+			persistEveryMs: PERSIST,
+			forMs: 10 * 60_000,
+		})
+
+		expect(alarmWrites).toBe(persists)
+		expect(alarmFires).toBe(renders)
+		expect(alarmFires).toBe(2)
+	})
+})

--- a/apps/dotcom/sync-worker/src/utils/ogRenderDebounce.ts
+++ b/apps/dotcom/sync-worker/src/utils/ogRenderDebounce.ts
@@ -1,0 +1,57 @@
+import { OG_RENDER_DEBOUNCE_MS, OG_RENDER_MAX_WAIT_MS } from '../config'
+
+/**
+ * The scheduling decision behind edit-triggered thumbnail rendering, kept separate from
+ * `TLFileDurableObject` so it can be tested without standing one up. The object owns the clock and the
+ * durable alarm; this owns only the arithmetic of when a render is due. A debounce with a max wait —
+ * see `OG_RENDER_DEBOUNCE_MS` for why that shape.
+ *
+ * `onPersist` always returns the deadline, and the caller always arms the alarm with it, so **the
+ * durable alarm and the deadline can never disagree**. That invariant is what makes the deadline
+ * survive eviction: the in-memory fields are lost and the alarm still fires at exactly the right time.
+ * The cost is one alarm write per persist; leaving the alarm behind the deadline instead would wake an
+ * evicted object early, render, then render again when the session actually settled.
+ */
+export class OgRenderDebouncer {
+	private readonly debounceMs: number
+	private readonly maxWaitMs: number
+
+	private targetAt: number | null = null
+	private pendingSince: number | null = null
+
+	constructor(opts: { debounceMs?: number; maxWaitMs?: number } = {}) {
+		this.debounceMs = opts.debounceMs ?? OG_RENDER_DEBOUNCE_MS
+		this.maxWaitMs = opts.maxWaitMs ?? OG_RENDER_MAX_WAIT_MS
+	}
+
+	/**
+	 * Records a persist that advanced the document clock. Returns the time the alarm must be set to —
+	 * always, because the alarm is the durable copy of this deadline and may never lag behind it.
+	 */
+	onPersist(now: number): number {
+		// Measured from the first persist since the last render, so the max wait bounds a whole editing
+		// session rather than resetting with every keystroke. Lost on eviction, which restarts the
+		// window and can therefore only *delay* a render, never duplicate one.
+		if (this.pendingSince === null) this.pendingSince = now
+		this.targetAt = Math.min(now + this.debounceMs, this.pendingSince + this.maxWaitMs)
+		return this.targetAt
+	}
+
+	/**
+	 * Handles the alarm firing. Since the alarm always carries the current deadline, a fire normally
+	 * means the deadline arrived — including after an eviction, where the alarm is the only thing left
+	 * that knows it.
+	 *
+	 * The re-arm branch guards the one case where it hasn't: a persist landing between the alarm firing
+	 * and this handler running has already moved the deadline, and this must not render underneath it.
+	 */
+	onAlarm(now: number): { render: true } | { render: false; reArmAt: number } {
+		const target = this.targetAt
+		if (target !== null && now < target) {
+			return { render: false, reArmAt: target }
+		}
+		this.targetAt = null
+		this.pendingSince = null
+		return { render: true }
+	}
+}

--- a/apps/dotcom/sync-worker/src/utils/renderTokens.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/renderTokens.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
+import { THUMBNAIL_RENDER_TOKEN_TTL_MS } from '../config'
+import { makeFakeThumbnailsBucket } from '../routes/tla/screenshotTestHelpers'
 import { Environment } from '../types'
 import {
-	THUMBNAIL_RENDER_TOKEN_TTL_MS,
 	ThumbnailRenderJob,
+	isMintedRenderToken,
 	mintThumbnailRenderToken,
+	recordMintedRenderToken,
 	verifyThumbnailRenderToken,
 } from './renderTokens'
 
@@ -15,9 +18,11 @@ function makeJob(overrides: Partial<ThumbnailRenderJob> = {}): ThumbnailRenderJo
 		kind: 'published',
 		slug: 'my-board',
 		version: 1751234567890,
-		x: 10,
-		y: 20,
-		z: 0.5,
+		access: 'render',
+		camera: 'content',
+		x: 0,
+		y: 0,
+		z: 1,
 		width: 1200,
 		height: 630,
 		theme: 'light',
@@ -39,12 +44,6 @@ describe('thumbnail render tokens', () => {
 		expect(await verifyThumbnailRenderToken(env, token)).toEqual(job)
 	})
 
-	it('round-trips a content-fit camera job', async () => {
-		const job = makeJob({ camera: 'content' })
-		const token = await mintThumbnailRenderToken(env, job)
-		expect(await verifyThumbnailRenderToken(env, token)).toEqual(job)
-	})
-
 	it('rejects tokens with an unknown kind', async () => {
 		const token = await mintThumbnailRenderToken(env, makeJob({ kind: 'bogus' as any }))
 		expect(await verifyThumbnailRenderToken(env, token)).toBeNull()
@@ -55,8 +54,30 @@ describe('thumbnail render tokens', () => {
 		expect(await verifyThumbnailRenderToken(env, token)).toBeNull()
 	})
 
+	// The access level decides which gate the snapshot route reads under, so an unrecognised one must
+	// not fall through to a default — it is refused outright.
+	it('rejects tokens with an unknown access level', async () => {
+		const token = await mintThumbnailRenderToken(env, makeJob({ access: 'admin' as any }))
+		expect(await verifyThumbnailRenderToken(env, token)).toBeNull()
+	})
+
+	it('round-trips the access level it was minted with', async () => {
+		const job = makeJob({ access: 'public' })
+		const token = await mintThumbnailRenderToken(env, job)
+		expect(await verifyThumbnailRenderToken(env, token)).toEqual(job)
+	})
+
+	// An absent camera is valid and means "use the explicit x/y/z viewport". No surface mints one
+	// today — they all ask for `content` — but the path is kept available, so the verifier has to
+	// accept it or the worker could not start sending one without a client deploy first.
+	it('accepts a token with no camera mode, carrying its viewport through', async () => {
+		const job = makeJob({ camera: undefined, x: 120, y: -40, z: 0.75 })
+		const token = await mintThumbnailRenderToken(env, job)
+		expect(await verifyThumbnailRenderToken(env, token)).toEqual(job)
+	})
+
 	it('round-trips a single-page (pageId) job', async () => {
-		const job = makeJob({ camera: 'content', pageId: 'page:abc123' })
+		const job = makeJob({ pageId: 'page:abc123' })
 		const token = await mintThumbnailRenderToken(env, job)
 		expect(await verifyThumbnailRenderToken(env, token)).toEqual(job)
 	})
@@ -101,5 +122,136 @@ describe('thumbnail render tokens', () => {
 		)
 		const token = await mintThumbnailRenderToken(env, makeJob())
 		expect(await verifyThumbnailRenderToken(emptyEnv, token)).toBeNull()
+	})
+})
+
+// A signature only proves someone holds the secret. The record proves *we* minted the token, which is
+// what keeps a leaked MCP_SCREENSHOT_TOKEN_SECRET from being enough to read a private board.
+describe('render token records', () => {
+	function makeEnvWithBucket() {
+		return {
+			MCP_SCREENSHOT_TOKEN_SECRET: 'test-secret',
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		} as unknown as Environment
+	}
+
+	it('accepts a token it recorded', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob()
+		const token = await mintThumbnailRenderToken(envWithBucket, job)
+
+		await recordMintedRenderToken(envWithBucket, job, token)
+
+		expect(await isMintedRenderToken(envWithBucket, job, token)).toBe(true)
+	})
+
+	// The whole point: a perfectly valid signature is refused when we never minted it. This is the
+	// case a compromised secret produces.
+	it('refuses a validly signed token that was never recorded', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob()
+		const forged = await mintThumbnailRenderToken(envWithBucket, job)
+
+		// The signature verifies...
+		expect(await verifyThumbnailRenderToken(envWithBucket, forged)).toEqual(job)
+		// ...and it is still refused, because no record of it exists.
+		expect(await isMintedRenderToken(envWithBucket, job, forged)).toBe(false)
+	})
+
+	// Records are keyed per board, so one board's record cannot vouch for another's token.
+	it('refuses a token recorded against a different board', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const mine = makeJob({ slug: 'my-board' })
+		const other = makeJob({ slug: 'someone-elses-board' })
+		const otherToken = await mintThumbnailRenderToken(envWithBucket, other)
+		await recordMintedRenderToken(envWithBucket, other, otherToken)
+
+		expect(await isMintedRenderToken(envWithBucket, mine, otherToken)).toBe(false)
+	})
+
+	// Per board, not per token: a board's newest render replaces the record, so an older in-flight
+	// token for the same board stops working. Only the OG pipeline is recorded, and it is single-flighted
+	// per board by the pending marker, so this is the intended "fresher render wins" rather than two
+	// unrelated captures colliding.
+	it('replaces a board record on the next mint', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob()
+		const first = await mintThumbnailRenderToken(envWithBucket, job)
+		await recordMintedRenderToken(envWithBucket, job, first)
+
+		const second = await mintThumbnailRenderToken(envWithBucket, { ...job, exp: job.exp + 1 })
+		await recordMintedRenderToken(envWithBucket, job, second)
+
+		expect(await isMintedRenderToken(envWithBucket, job, second)).toBe(true)
+		expect(await isMintedRenderToken(envWithBucket, job, first)).toBe(false)
+	})
+
+	// A `public` job renders a board anyone could fetch anyway, so the record buys no security and is
+	// skipped. Keeping the MCP tool out of the record entirely is what stops it sharing a key space
+	// with the OG pipeline.
+	it('does not record a public job, and accepts it with no record', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob({ access: 'public' })
+		const token = await mintThumbnailRenderToken(envWithBucket, job)
+
+		await recordMintedRenderToken(envWithBucket, job, token)
+
+		expect([...(envWithBucket.THUMBNAILS as any).store.keys()]).toEqual([])
+		expect(await isMintedRenderToken(envWithBucket, job, token)).toBe(true)
+	})
+
+	// The guarantee the two surfaces rest on: an MCP capture cannot invalidate a thumbnail render of the
+	// same board, because it writes nothing. Were it to share the key, the render's token would stop
+	// verifying mid-flight and the capture would 403.
+	it('leaves a render record intact when a public job is minted for the same board', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const render = makeJob({ access: 'render' })
+		const renderToken = await mintThumbnailRenderToken(envWithBucket, render)
+		await recordMintedRenderToken(envWithBucket, render, renderToken)
+
+		const capture = makeJob({ access: 'public', pageId: 'page:two' })
+		await recordMintedRenderToken(
+			envWithBucket,
+			capture,
+			await mintThumbnailRenderToken(envWithBucket, capture)
+		)
+
+		expect(await isMintedRenderToken(envWithBucket, render, renderToken)).toBe(true)
+	})
+
+	// A token still in flight from a worker version minted before the field existed. Those were served
+	// under the public gate and never recorded, so reading them as `public` is what keeps captures
+	// crossing a rolling deploy from 403ing on a record that was never going to be there.
+	it('treats a job with no access as public, accepting it with no record', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob({ access: undefined })
+		const token = await mintThumbnailRenderToken(envWithBucket, job)
+
+		expect(await isMintedRenderToken(envWithBucket, job, token)).toBe(true)
+
+		await recordMintedRenderToken(envWithBucket, job, token)
+		expect([...(envWithBucket.THUMBNAILS as any).store.keys()]).toEqual([])
+	})
+
+	// Local dev and tests run without the bucket, where the check leaves signature-only verification
+	// rather than refusing every render.
+	it('falls back to trusting the signature when no bucket is configured', async () => {
+		const job = makeJob()
+		const token = await mintThumbnailRenderToken(env, job)
+
+		expect(await isMintedRenderToken(env, job, token)).toBe(true)
+	})
+
+	// The bucket must never hold something usable as a credential.
+	it('stores a hash, never the token', async () => {
+		const envWithBucket = makeEnvWithBucket()
+		const job = makeJob()
+		const token = await mintThumbnailRenderToken(envWithBucket, job)
+
+		await recordMintedRenderToken(envWithBucket, job, token)
+
+		const stored = JSON.stringify([...(envWithBucket.THUMBNAILS as any).store])
+		expect(stored).not.toContain(token)
+		expect(stored).toContain('tokenHash')
 	})
 })

--- a/apps/dotcom/sync-worker/src/utils/renderTokens.ts
+++ b/apps/dotcom/sync-worker/src/utils/renderTokens.ts
@@ -1,11 +1,11 @@
-import { Environment, ThumbnailBoardKind } from '../types'
+import { Environment, ThumbnailBoardAccess, ThumbnailBoardKind } from '../types'
 import { base64UrlDecode, base64UrlEncode } from './base64'
+import { sha256 } from './hash'
 
-// Short-lived signed render jobs. The MCP screenshot route and OG queue mint one of these per
-// capture, and the worker's browser session only ever visits the tldraw-owned render page with this
-// token; the render page exchanges the token for snapshot data via /app/thumbnail-render/snapshot.
-// Board identity and render parameters ride inside the signed payload so they cannot be tampered
-// with in transit.
+// Short-lived signed render jobs, minted one per capture. The browser session only ever visits the
+// tldraw-owned render page with this token, which the page exchanges for snapshot data via
+// /app/thumbnail-render/snapshot. Board identity and render parameters ride inside the signed payload
+// so they cannot be tampered with in transit.
 export interface ThumbnailRenderJob {
 	v: 1
 	/**
@@ -16,14 +16,33 @@ export interface ThumbnailRenderJob {
 	/** The board slug: the `:slug` in tldraw.com/p/:slug (published) or /f/:slug (shared file) */
 	slug: string
 	/**
+	 * The gate the snapshot route applies when it serves this job's board, signed so a caller cannot
+	 * widen it. `public` is what the MCP tool mints: it renders only boards anyone could already fetch,
+	 * so the token guards nothing and no minted-token record is kept for it. `render` is what the OG
+	 * pipeline mints, and it can read a *private* board's whole document — that is the case the record
+	 * exists for. See recordMintedRenderToken.
+	 *
+	 * Absent only on a token minted before this field existed. Read as `public`, which is both the
+	 * narrower gate and the one that worker version actually applied — it served every board through
+	 * the anonymous-share check and wrote no records. Reading them as `render` instead would widen
+	 * them past what they were minted under *and* demand a record no old mint ever wrote, so every
+	 * capture in flight across a rolling deploy would 403 until the old tokens expired. Every mint
+	 * since sets this explicitly, from the gate the board was resolved under.
+	 */
+	access?: ThumbnailBoardAccess
+	/**
 	 * A version that rotates when the rendered content changes, so it can key the thumbnail cache.
 	 * Published boards use the file's `lastPublished` timestamp; shared files use the persisted
 	 * room snapshot's R2 etag.
 	 */
 	version: string | number
 	/**
-	 * When omitted, the render page uses x/y/z directly. `content` tells the render page to fit the
-	 * board's current page content into the requested output size.
+	 * `content` fits the board's current page content into the requested output size; when omitted, the
+	 * render page uses x/y/z directly.
+	 *
+	 * Every surface mints `content`, so the explicit-viewport path is unexercised in production. Worth
+	 * carrying anyway: the render page ships with the client and deploys separately, so a worker that
+	 * wants to send a viewport can only do so once the client already understands one.
 	 */
 	camera?: 'content'
 	/**
@@ -31,6 +50,7 @@ export interface ThumbnailRenderJob {
 	 * the snapshot opens to (used by OG images). The worker takes one screenshot of the rendered page.
 	 */
 	pageId?: string
+	/** The viewport the render page sets directly when `camera` is omitted. */
 	x: number
 	y: number
 	z: number
@@ -41,7 +61,8 @@ export interface ThumbnailRenderJob {
 	exp: number
 }
 
-export const THUMBNAIL_RENDER_TOKEN_TTL_MS = 5 * 60_000
+// The token lifetime (THUMBNAIL_RENDER_TOKEN_TTL_MS) lives in config.ts; expiry rides inside the
+// signed payload as `exp`, minted immediately before the capture.
 
 export async function mintThumbnailRenderToken(
 	env: Environment,
@@ -99,6 +120,7 @@ export async function verifyThumbnailRenderToken(
 		job.v !== 1 ||
 		(job.kind !== 'published' && job.kind !== 'shared_file') ||
 		typeof job.slug !== 'string' ||
+		(job.access !== undefined && job.access !== 'public' && job.access !== 'render') ||
 		(job.camera !== undefined && job.camera !== 'content') ||
 		(job.pageId !== undefined && typeof job.pageId !== 'string') ||
 		typeof job.exp !== 'number'
@@ -110,6 +132,14 @@ export async function verifyThumbnailRenderToken(
 	return job
 }
 
+/**
+ * The gate a job is read under. Absent means a token minted before the field existed, read as `public`
+ * — the narrower gate, and the one those tokens were minted under. See ThumbnailRenderJob.access.
+ */
+export function renderJobAccess(job: Pick<ThumbnailRenderJob, 'access'>): ThumbnailBoardAccess {
+	return job.access ?? 'public'
+}
+
 async function getHmacKey(secret: string) {
 	return crypto.subtle.importKey(
 		'raw',
@@ -118,4 +148,101 @@ async function getHmacKey(secret: string) {
 		false,
 		['sign', 'verify']
 	)
+}
+
+/**
+ * A signature alone is not proof that *we* minted a token — only that whoever made it holds the secret.
+ * So every mint also records the token in R2 and the snapshot route requires that record to be there,
+ * which makes a leaked `MCP_SCREENSHOT_TOKEN_SECRET` survivable: an attacker can forge signatures, but
+ * without write access to our bucket the forgeries have no record and are refused. The secret is one of
+ * two required factors, not the sole authority over every private board's contents.
+ *
+ * Keyed per board rather than per token, so each render overwrites its board's record and the space is
+ * bounded by board count. Nothing accumulates, so there is no lifecycle rule to add — and none must
+ * ever be added to this bucket, where a rule with a missing or mistyped prefix would delete every
+ * board's live thumbnail.
+ *
+ * Records are **not** deleted after a capture. Expiry lives in the signed `exp` and is checked before
+ * this is consulted, so a leftover record cannot extend a token's life; deleting would only tighten the
+ * window from `exp` to the render's duration, which buys nothing against an attacker who cannot get a
+ * record written at all. A hash is stored rather than the token, in `customMetadata` so that checking
+ * one is a `head` and the record costs no stored bytes.
+ */
+const RENDER_TOKEN_RECORD_PREFIX = 'render-tokens'
+
+function renderTokenRecordKey(job: Pick<ThumbnailRenderJob, 'kind' | 'slug'>) {
+	return `${RENDER_TOKEN_RECORD_PREFIX}/${job.kind}/${job.slug}`
+}
+
+/**
+ * Records a freshly minted token as ours. Errors are **not** swallowed: a record that failed to write
+ * means the render is about to fail its own token check, and a confusing "invalid token" is worse to
+ * debug than the write error that caused it.
+ *
+ * **Only `render` jobs are recorded.** A `public` job renders a board anyone could already fetch, so a
+ * forged token for one grants nothing and the record would buy no security — it would only put the MCP
+ * tool into the same key space as the OG pipeline, where the two would clobber each other.
+ *
+ * That exclusion is what keeps the key safely per board. The OG pipeline is single-flighted per board
+ * by the `.pending` marker, so its renders do not overlap, and a newer mint superseding an older
+ * in-flight token is then the intended behaviour rather than a collision between unrelated captures.
+ *
+ * **If the MCP tool ever mints `render` jobs** — which authenticating those endpoints would invite,
+ * since it would let them screenshot private boards — this key must be namespaced by surface first.
+ * Without that, two MCP captures of different pages of one board, or an edit-triggered render landing
+ * during a capture, invalidate each other's tokens and fail with a 403.
+ */
+export async function recordMintedRenderToken(
+	env: Environment,
+	job: ThumbnailRenderJob,
+	token: string
+): Promise<void> {
+	if (renderJobAccess(job) !== 'render') return
+	// Unbound only in local dev and tests, where skipping leaves signature-only verification. Deployed
+	// environments all bind THUMBNAILS, so the two-factor check is never optional where it matters.
+	if (!env.THUMBNAILS) return
+	await env.THUMBNAILS.put(renderTokenRecordKey(job), new Uint8Array(), {
+		customMetadata: { tokenHash: await sha256(token) },
+	})
+}
+
+/**
+ * Whether this token is one we minted. Call only after `verifyThumbnailRenderToken` has accepted the
+ * signature and expiry — the `job` argument is what that returns, so the key is derived from signed
+ * data rather than from anything the caller supplied.
+ *
+ * Vacuously true for a `public` job, which is not recorded: the board it names is one the caller could
+ * fetch without any of this, so the signature is the whole gate. See recordMintedRenderToken.
+ */
+export async function isMintedRenderToken(
+	env: Environment,
+	job: ThumbnailRenderJob,
+	token: string
+): Promise<boolean> {
+	if (renderJobAccess(job) !== 'render') return true
+	// See recordMintedRenderToken: with no bucket there is no record to check against, so this trusts
+	// the signature alone rather than refusing every render.
+	if (!env.THUMBNAILS) return true
+
+	const record = await env.THUMBNAILS.head(renderTokenRecordKey(job))
+	if (!record) return false
+	return record.customMetadata?.tokenHash === (await sha256(token))
+}
+
+/**
+ * Drops a board's record. Only hard deletion calls this, and not for security: expiry lives in the
+ * signed `exp` and is checked before the record is ever consulted, so a leftover record cannot extend
+ * a token's life. It is about orphans. These keys carry no version and `THUMBNAILS` has no lifecycle
+ * rule, so a record left behind by a board that no longer exists is an object nothing will ever read
+ * or overwrite again.
+ *
+ * Best effort, like the image deletion it runs beside: a board is being torn down, and failing to
+ * tidy up one small object must not abort that.
+ */
+export async function deleteRenderTokenRecord(
+	env: Environment,
+	job: Pick<ThumbnailRenderJob, 'kind' | 'slug'>
+): Promise<void> {
+	if (!env.THUMBNAILS) return
+	await env.THUMBNAILS.delete(renderTokenRecordKey(job)).catch(() => {})
 }

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -187,7 +187,7 @@ const router = createRouter<Environment>()
 	// The board's rendered social preview image, referenced by the og:image tags getSocialPreview
 	// emits. Lives under the social-preview route family so the crawler HTML and its image share one
 	// path prefix. Registered with .all (like the sibling HTML route) so HEAD probes are handled;
-	// getOgImage serves headers only and skips the render enqueue for anything but GET.
+	// getOgImage serves headers only for anything but GET.
 	.all('/app/social-preview/:prefix/:slug/image', getOgImage)
 	.get('/app/thumbnail-render/snapshot', getThumbnailSnapshot)
 	// end app

--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -331,7 +331,10 @@ binding = "USER_DO_SNAPSHOTS"
 bucket_name = "user-do-snapshots"
 
 #################### Thumbnails R2 bucket ####################
-# cache for Browser Run-generated board thumbnails (MCP screenshots)
+# cache for board thumbnails / OG images (`og/…` keys) plus their pending-render markers and render
+# token records. No key carries a version, so nothing accumulates here, and the bucket has NO
+# expiration rule — the current thumbnail has to outlive any lifecycle window. See "Why two buckets"
+# in apps/dotcom/browser-run-thumbnails.md.
 # in dev, we write to the preview bucket and need a `preview_bucket_name`
 [[env.dev.r2_buckets]]
 binding = "THUMBNAILS"
@@ -351,6 +354,27 @@ bucket_name = "thumbnails-preview"
 [[env.production.r2_buckets]]
 binding = "THUMBNAILS"
 bucket_name = "thumbnails"
+
+#################### MCP data R2 bucket ####################
+# cache for MCP tool screenshots (`mcp/…` keys). Separate from THUMBNAILS because the retention is the
+# opposite: this key includes the board's content version, so every edit strands the previous object.
+# These buckets carry an expiration lifecycle rule (see the ops setup in browser-run-thumbnails.md).
+[[env.dev.r2_buckets]]
+binding = "MCP_DATA_BUCKET"
+bucket_name = "dotcom-mcp-data-preview"
+preview_bucket_name = "dotcom-mcp-data-preview"
+
+[[env.preview.r2_buckets]]
+binding = "MCP_DATA_BUCKET"
+bucket_name = "dotcom-mcp-data-preview"
+
+[[env.staging.r2_buckets]]
+binding = "MCP_DATA_BUCKET"
+bucket_name = "dotcom-mcp-data-preview"
+
+[[env.production.r2_buckets]]
+binding = "MCP_DATA_BUCKET"
+bucket_name = "dotcom-mcp-data"
 
 #################### Browser Rendering binding ####################
 # Drives the thumbnail render page through a Cloudflare-hosted headless browser (see
@@ -482,55 +506,87 @@ type = "ratelimit"
 namespace_id = "1004"
 simple = { limit = 600, period = 60 }
 
-# MCP screenshot per-IP and per-board request guard
+# MCP server per-IP request guard.
+# A binding carries one `limit` applied per key, so per-IP and per-board need separate bindings to hold
+# different numbers. `period` must be 10 or 60. Keep these in step with the fallback constants in
+# sharedBoardScreenshotMcp.ts, which are all that unit tests can see.
+# The name is the odd one out in this family: it keeps MCP_SCREENSHOT_ because it is deployed and
+# counting. Authentication on the MCP server deletes this budget along with the per-board one and
+# limits by logged-in user instead, so renaming live state on its way out buys nothing.
 [[env.dev.unsafe.bindings]]
 name = "MCP_SCREENSHOT_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1005"
-simple = { limit = 2, period = 60 }
+simple = { limit = 10, period = 60 }
 
 [[env.preview.unsafe.bindings]]
 name = "MCP_SCREENSHOT_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1006"
-simple = { limit = 2, period = 60 }
+simple = { limit = 10, period = 60 }
 
 [[env.staging.unsafe.bindings]]
 name = "MCP_SCREENSHOT_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1007"
-simple = { limit = 2, period = 60 }
+simple = { limit = 10, period = 60 }
 
 [[env.production.unsafe.bindings]]
 name = "MCP_SCREENSHOT_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1008"
+simple = { limit = 10, period = 60 }
+
+# MCP server per-board capture guard, kept tighter than the per-IP one so no single board can absorb
+# a caller's whole allowance.
+[[env.dev.unsafe.bindings]]
+name = "MCP_SERVER_BOARD_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1013"
 simple = { limit = 2, period = 60 }
 
-# global cap on Browser Run invocations from MCP screenshots (keyed on a single shared key)
-[[env.dev.unsafe.bindings]]
-name = "MCP_SCREENSHOT_BROWSER_RATE_LIMITER"
-type = "ratelimit"
-namespace_id = "1009"
-simple = { limit = 6, period = 60 }
-
 [[env.preview.unsafe.bindings]]
-name = "MCP_SCREENSHOT_BROWSER_RATE_LIMITER"
+name = "MCP_SERVER_BOARD_RATE_LIMITER"
 type = "ratelimit"
-namespace_id = "1010"
-simple = { limit = 6, period = 60 }
+namespace_id = "1014"
+simple = { limit = 2, period = 60 }
 
 [[env.staging.unsafe.bindings]]
-name = "MCP_SCREENSHOT_BROWSER_RATE_LIMITER"
+name = "MCP_SERVER_BOARD_RATE_LIMITER"
 type = "ratelimit"
-namespace_id = "1011"
-simple = { limit = 6, period = 60 }
+namespace_id = "1015"
+simple = { limit = 2, period = 60 }
 
 [[env.production.unsafe.bindings]]
-name = "MCP_SCREENSHOT_BROWSER_RATE_LIMITER"
+name = "MCP_SERVER_BOARD_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1016"
+simple = { limit = 2, period = 60 }
+
+# global cap on Browser Run invocations from the MCP server (keyed on a single shared key)
+[[env.dev.unsafe.bindings]]
+name = "MCP_SERVER_BROWSER_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1009"
+simple = { limit = 20, period = 60 }
+
+[[env.preview.unsafe.bindings]]
+name = "MCP_SERVER_BROWSER_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1010"
+simple = { limit = 20, period = 60 }
+
+[[env.staging.unsafe.bindings]]
+name = "MCP_SERVER_BROWSER_RATE_LIMITER"
+type = "ratelimit"
+namespace_id = "1011"
+simple = { limit = 20, period = 60 }
+
+[[env.production.unsafe.bindings]]
+name = "MCP_SERVER_BROWSER_RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1012"
-simple = { limit = 6, period = 60 }
+simple = { limit = 20, period = 60 }
 
 #################### Queues ####################
 [[env.dev.queues.producers]]

--- a/internal/scripts/fetch-screenshot-metrics.ts
+++ b/internal/scripts/fetch-screenshot-metrics.ts
@@ -5,9 +5,8 @@
  * render consumer).
  *
  * Render time is wall-clock time around each Browser Run capture (double3), not Cloudflare's billed
- * browser milliseconds: the BROWSER binding does not surface a per-render billed-ms figure the way
- * the old REST path did (double4 is always -1), so wall-clock render time is the available proxy for
- * Browser Run spend.
+ * browser milliseconds: the BROWSER binding does not surface a per-render billed-ms figure (double4 is
+ * always -1), so wall-clock render time is the available proxy for Browser Run spend.
  *
  * Usage:
  *   npx tsx internal/scripts/fetch-screenshot-metrics.ts [options]
@@ -169,8 +168,13 @@ async function fetchMetrics(opts: Options): Promise<SourceMetrics[]> {
 	`)
 
 	// double3 is the wall-clock render duration, positive only on rows that actually invoked Browser
-	// Run (cache hits and pre-render failures leave it at -1). It replaces double4 (X-Browser-Ms-Used),
-	// which the BROWSER binding no longer surfaces and is always -1.
+	// Run (cache hits and pre-render failures leave it at -1). It is the spend proxy: double4 holds
+	// billed browser ms, which the BROWSER binding does not surface, so it is always -1.
+	//
+	// Failed captures count here too, deliberately: a render that threw still created a browser and
+	// held it, often for the whole timeout, so excluding it would understate spend by exactly the
+	// renders most worth knowing the cost of. Queue rows are per delivery, so a job that retried
+	// three times contributes three captures — again, that is what it spent.
 	const spendRows = await queryAnalyticsEngine(`
 		SELECT
 			blob3 AS source,

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -144,6 +144,11 @@ export const THUMBNAIL_RENDER_TIMEOUT_MS = 45_000
 export const THUMBNAIL_SETTLE_TIMEOUT_MS = 10_000
 
 export interface ThumbnailRenderParams {
+	/**
+	 * `content` fits the page's content to the requested output size. When omitted, the render page
+	 * sets the x/y/z viewport below directly. Every surface mints `content` today; the viewport path
+	 * is kept because the render page and the worker deploy separately (see ThumbnailRenderJob).
+	 */
 	camera?: 'content'
 	/** The TLPageId of the single page to render. When omitted, the page the snapshot opens to. */
 	pageId?: string


### PR DESCRIPTION
This is a hotfix PR for dotcom deployment.

**Original PR:** [#9667](https://github.com/tldraw/tldraw/pull/9667)
**Original Title:** feat(dotcom): render board thumbnails ahead of the first share
**Original Author:** @driev

This PR cherry-picks 160f8dd334 from `main` onto the `hotfixes` branch for immediate dotcom deployment. The cherry-pick applied cleanly; the only difference from `main` in the touched files is the absence of unrelated post-deploy commits (#9809's MCP flag), which are intentionally not part of this hotfix. Verified locally: sync-worker tests pass (413 tests, including the new thumbnail and OG-render debounce tests) and the repo typecheck is clean.