### PR TITLE
fix(commenting): give each cluster fade-out its own removal deadline

### DIFF
--- a/packages/commenting/src/canvas/cluster-fade.test.ts
+++ b/packages/commenting/src/canvas/cluster-fade.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { ClusterNode } from '../clustering/types'
+import { type ClusterFadeNode, reconcileFadeNodes } from './cluster-fade'
+
+function node(id: string): ClusterNode {
+	return { id, centroid: { x: 0, y: 0 }, count: 1, members: [id] }
+}
+
+describe('reconcileFadeNodes exit deadlines', () => {
+	it('stamps a departing node with its own exit deadline', () => {
+		const present: ClusterFadeNode[] = [{ node: node('a'), phase: 'present' }]
+		expect(reconcileFadeNodes(present, [], 1000)).toEqual([
+			{ node: node('a'), phase: 'exiting', exitAt: 1150 },
+		])
+	})
+
+	it('keeps the original deadline on later reconciles — unrelated churn cannot extend the fade', () => {
+		const exiting: ClusterFadeNode[] = [{ node: node('a'), phase: 'exiting', exitAt: 1150 }]
+		// A much later reconcile, with an unrelated node entering, must not re-stamp `a`.
+		const next = reconcileFadeNodes(exiting, [node('b')], 5000)
+		expect(next.find((i) => i.node.id === 'a')).toEqual({
+			node: node('a'),
+			phase: 'exiting',
+			exitAt: 1150,
+		})
+	})
+
+	it('clears the deadline when an exiting node reappears', () => {
+		const exiting: ClusterFadeNode[] = [{ node: node('a'), phase: 'exiting', exitAt: 1150 }]
+		expect(reconcileFadeNodes(exiting, [node('a')], 2000)).toEqual([
+			{ node: node('a'), phase: 'present' },
+		])
+	})
+
+	it('gives each node its own deadline as they depart at different times', () => {
+		const both: ClusterFadeNode[] = [
+			{ node: node('a'), phase: 'present' },
+			{ node: node('b'), phase: 'present' },
+		]
+		const afterAleft = reconcileFadeNodes(both, [node('b')], 1000)
+		expect(afterAleft.find((i) => i.node.id === 'a')?.exitAt).toBe(1150)
+
+		const afterBleft = reconcileFadeNodes(afterAleft, [], 1100)
+		expect(afterBleft.find((i) => i.node.id === 'a')?.exitAt).toBe(1150) // unchanged
+		expect(afterBleft.find((i) => i.node.id === 'b')?.exitAt).toBe(1250) // its own deadline
+	})
+})

--- a/packages/commenting/src/canvas/cluster-fade.ts
+++ b/packages/commenting/src/canvas/cluster-fade.ts
@@ -8,6 +8,13 @@ export type ClusterFadePhase = 'entering' | 'present' | 'exiting'
 export interface ClusterFadeNode {
 	node: ClusterNode
 	phase: ClusterFadePhase
+	/**
+	 * For an `exiting` node: the timestamp (ms) at which its fade completes and it should be
+	 * removed. Stamped once when the node starts exiting, so each node fades for its own
+	 * `CLUSTER_FADE_MS` and later partition changes can't restart a shared removal timer. Absent
+	 * for `entering`/`present`.
+	 */
+	exitAt?: number
 }
 
 /**
@@ -38,7 +45,7 @@ export function useFadeVisibleNodes(
 
 	useEffect(() => {
 		if (didReset) return
-		setFadeNodes((previous) => reconcileFadeNodes(previous, nodes))
+		setFadeNodes((previous) => reconcileFadeNodes(previous, nodes, Date.now()))
 	}, [didReset, nodes])
 
 	const hasEntering = renderedNodes.some((item) => item.phase === 'entering')
@@ -52,14 +59,29 @@ export function useFadeVisibleNodes(
 		return () => cancelAnimationFrame(frame)
 	}, [hasEntering, renderedNodes])
 
-	const hasExiting = renderedNodes.some((item) => item.phase === 'exiting')
+	// Remove each exiting node at its own deadline. Keying the timer on the earliest pending
+	// `exitAt` (a number) rather than the whole node array means a later-exiting node — or any
+	// unrelated partition change — can't restart the timer for a node already on its way out.
+	const nextExitAt = renderedNodes.reduce(
+		(earliest, item) =>
+			item.phase === 'exiting' && item.exitAt !== undefined
+				? Math.min(earliest, item.exitAt)
+				: earliest,
+		Infinity
+	)
 	useEffect(() => {
-		if (!hasExiting) return
-		const timeout = window.setTimeout(() => {
-			setFadeNodes((previous) => previous.filter((item) => item.phase !== 'exiting'))
-		}, CLUSTER_FADE_MS)
+		if (nextExitAt === Infinity) return
+		const timeout = window.setTimeout(
+			() => {
+				const now = Date.now()
+				setFadeNodes((previous) =>
+					previous.filter((item) => item.phase !== 'exiting' || (item.exitAt ?? 0) > now)
+				)
+			},
+			Math.max(0, nextExitAt - Date.now())
+		)
 		return () => window.clearTimeout(timeout)
-	}, [hasExiting, renderedNodes])
+	}, [nextExitAt])
 
 	return renderedNodes
 }
@@ -68,9 +90,11 @@ function toPresentFadeNodes(nodes: readonly ClusterNode[]): ClusterFadeNode[] {
 	return nodes.map((node) => ({ node, phase: 'present' }))
 }
 
-function reconcileFadeNodes(
+/** @internal — exported for unit testing the exit-deadline stamping. */
+export function reconcileFadeNodes(
 	previous: readonly ClusterFadeNode[],
-	nextNodes: readonly ClusterNode[]
+	nextNodes: readonly ClusterNode[],
+	now: number
 ): ClusterFadeNode[] {
 	const previousById = new Map(previous.map((item) => [item.node.id, item]))
 	const nextIds = new Set(nextNodes.map((node) => node.id))
@@ -91,7 +115,11 @@ function reconcileFadeNodes(
 
 	for (const item of previous) {
 		if (nextIds.has(item.node.id)) continue
-		next.push(item.phase === 'exiting' ? item : { ...item, phase: 'exiting' })
+		// Stamp the deadline once, when the node first starts exiting, and keep it thereafter so a
+		// later reconcile can't extend its fade.
+		next.push(
+			item.phase === 'exiting' ? item : { ...item, phase: 'exiting', exitAt: now + CLUSTER_FADE_MS }
+		)
 	}
 
 	return next


### PR DESCRIPTION
Stacked on #9898 (spike). It's independent of that refactor — this touches `cluster-fade.ts`, which #9898 doesn't — but stacked per request; it could equally stand alone off `main`.

`useFadeVisibleNodes` removed all `exiting` cluster nodes with a single 150ms timeout keyed on the whole `renderedNodes` array, so every partition change (a merge/split threshold crossing) tore the timer down and restarted it. During a sustained zoom crossing several thresholds within 150ms, an exiting node's removal kept deferring and the faded-out pin/badge lingered until the camera settled; and even without churn, a node that started exiting later shared the earlier one's timer and faded for less than its full 150ms.

Each node is now stamped with its own `exitAt` deadline when it starts exiting, and the removal timer keys on the earliest pending deadline rather than the node array — so a later-exiting node, or any unrelated partition change, can't restart a node already on its way out. `reconcileFadeNodes` takes an injected `now` and is exported for a unit test of the stamping.

**Verification:** unit tests cover the deadline stamping (each node its own deadline; unrelated churn can't extend it; resurrection clears it). The removal *timing itself* isn't hook-tested — the package has no `renderHook`/fake-timer harness, which is the gap that let this through. The bug was identified by code inspection, not reproduced (a tight sub-150ms multi-threshold zoom is hard to drive in automation).

### Change type

- [x] `bugfix`

### Test plan

1. Unit: `cd packages/commenting && yarn test run cluster-fade`.
2. Manual: fast-zoom (⌘/ctrl-scroll) over dense comment clusters — faded-out badges/pins shouldn't linger after the camera stops.

- [x] Unit tests

### Release notes

- Fix comment cluster pins occasionally lingering after they fade out during fast zooming.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +38 / -10  |
| Tests     | +47 / -0   |
