### PR TITLE
fix(commenting): prune deleted threads from the held-pin set

### DIFF
--- a/packages/commenting/src/canvas/cluster-model.test.ts
+++ b/packages/commenting/src/canvas/cluster-model.test.ts
@@ -1,8 +1,9 @@
+import type { TLCommentThread } from 'tldraw'
 import { describe, expect, it } from 'vitest'
 import { createClusterRuntime } from '../clustering/runtime'
 import type { ClusterNode, ClusterTable, LeafInput } from '../clustering/types'
 import type { ClusterInput } from './cluster-input'
-import { anyFoldedLeafMoved, type ClusterModel } from './cluster-model'
+import { anyFoldedLeafMoved, type ClusterModel, pruneHeldThreadIds } from './cluster-model'
 
 function node(ids: string[], x = 0, y = 0): ClusterNode {
 	const members = ids.slice().sort()
@@ -84,5 +85,25 @@ describe('anyFoldedLeafMoved', () => {
 	it('holds the freeze on mismatched inputs rather than reading past the end', () => {
 		const next = input([leaf('t1', 40, 0), leaf('t2', 10, 0)])
 		expect(anyFoldedLeafMoved(input(AT_REST), next, rendered(0.5))).toBe(false)
+	})
+})
+
+describe('pruneHeldThreadIds', () => {
+	const threads = (...ids: string[]) => ids.map((id) => ({ id })) as unknown as TLCommentThread[]
+
+	it('returns null when nothing is held', () => {
+		expect(pruneHeldThreadIds(new Set(), threads('a'))).toBeNull()
+	})
+
+	it('returns null when every held id is still live (no needless state update)', () => {
+		expect(pruneHeldThreadIds(new Set(['a', 'b']), threads('a', 'b', 'c'))).toBeNull()
+	})
+
+	it('drops held ids whose thread no longer exists', () => {
+		expect(pruneHeldThreadIds(new Set(['a', 'b']), threads('a'))).toEqual(new Set(['a']))
+	})
+
+	it('returns an empty set when no held id is live, so the caller can clear it', () => {
+		expect(pruneHeldThreadIds(new Set(['a', 'b']), threads('c'))).toEqual(new Set())
 	})
 })

--- a/packages/commenting/src/canvas/cluster-model.ts
+++ b/packages/commenting/src/canvas/cluster-model.ts
@@ -198,6 +198,14 @@ export function useClusterModel(
 			setHeldThreadIds(EMPTY_SET)
 		})
 	}, [heldThreadIds, editor])
+	// Drop held ids whose thread no longer exists. The set is otherwise cleared only wholesale on
+	// zoom-out, so a held thread deleted before then would linger in it and keep the rejoin
+	// subscription above alive with no live member. Prune to live threads, clearing to EMPTY_SET
+	// when none remain so that subscription can unsubscribe.
+	useEffect(() => {
+		const pruned = pruneHeldThreadIds(heldThreadIds, threads)
+		if (pruned) setHeldThreadIds(pruned)
+	}, [threads, heldThreadIds])
 	// Adopt a pending rebuild only on zoom-out motion: folding deferred additions into clusters is
 	// a merge, and merging only happens while zooming out. While zooming in, the stale table still
 	// splits correctly on its own (split thresholds are direction-safe by the hysteresis invariant).
@@ -270,6 +278,23 @@ export function useClusterModel(
  * pointermove for the rest of the drag.
  * @internal
  */
+/**
+ * Held ids whose thread still exists, or `null` when nothing needs pruning (so the caller can skip
+ * a needless state update). `heldThreadIds` is otherwise cleared only wholesale on zoom-out, so
+ * without this a deleted held thread lingers in the set and keeps the rejoin subscription alive.
+ * @internal
+ */
+export function pruneHeldThreadIds(
+	held: ReadonlySet<string>,
+	threads: readonly TLCommentThread[]
+): ReadonlySet<string> | null {
+	if (held.size === 0) return null
+	const live = new Set<string>(threads.map((thread) => thread.id))
+	const kept = [...held].filter((id) => live.has(id))
+	if (kept.length === held.size) return null
+	return kept.length === 0 ? EMPTY_SET : new Set(kept)
+}
+
 export function anyFoldedLeafMoved(
 	prev: ClusterInput,
 	next: ClusterInput,


### PR DESCRIPTION
Stacked on #9898 and #9906 (spike). Independent of both — this touches `cluster-model.ts` only — but stacked per request; it could stand alone off `main`.

A pin held out of clustering (its anchor moved while folded inside a badge) is tracked in `heldThreadIds`, which is cleared only wholesale — on a zoom-out or page switch — never per id. A held thread deleted before the next zoom-out therefore lingered in the set: it grew across an add/delete session, and the `size > 0` guard kept the "rejoin on zoom-out" `react()` subscription alive with no live member left to rejoin.

The set is now pruned to live threads each render (cleared to empty when none remain, so the subscription can unsubscribe), preserving the intentional hold-until-zoom-out latch for live pins. The prune is a pure `pruneHeldThreadIds` helper with unit tests.

No user-visible change: `heldThreads` already filters to live threads, so nothing phantom rendered — this is a lifecycle/leak fix (a stale set and a lingering reaction), not a rendering bug.

**Verification:** unit tests cover the prune (drops dead ids; clears to empty; no-op when clean). The effect wiring that calls it isn't hook-tested — same missing `renderHook` harness. Identified by code inspection, not reproduced.

### Change type

- [x] `bugfix`

### Test plan

1. Unit: `cd packages/commenting && yarn test run cluster-model`.

- [x] Unit tests

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +25 / -0   |
| Tests     | +22 / -1   |
