### PR TITLE
fix(tldraw): don't resolve an absent bookmark image against the page

### DIFF
--- a/apps/vscode/editor/src/utils/bookmarks.ts
+++ b/apps/vscode/editor/src/utils/bookmarks.ts
@@ -41,10 +41,13 @@ export async function onCreateAssetFromUrl({ url }: TLUrlExternalContent): Promi
 				description:
 					doc.head.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',
 			}
-			if (!meta.image.startsWith('http')) {
+			// Only resolve an image or favicon we actually found. Resolving an empty
+			// string against the page would yield the page's own address, and the
+			// bookmark would then try to render an HTML document as an <img>.
+			if (meta.image && !meta.image.startsWith('http')) {
 				meta.image = new URL(meta.image, url).href
 			}
-			if (!meta.favicon.startsWith('http')) {
+			if (meta.favicon && !meta.favicon.startsWith('http')) {
 				meta.favicon = new URL(meta.favicon, url).href
 			}
 		} catch (error) {

--- a/apps/vscode/editor/src/utils/bookmarks.ts
+++ b/apps/vscode/editor/src/utils/bookmarks.ts
@@ -41,9 +41,6 @@ export async function onCreateAssetFromUrl({ url }: TLUrlExternalContent): Promi
 				description:
 					doc.head.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',
 			}
-			// Only resolve an image or favicon we actually found. Resolving an empty
-			// string against the page would yield the page's own address, and the
-			// bookmark would then try to render an HTML document as an <img>.
 			if (meta.image && !meta.image.startsWith('http')) {
 				meta.image = new URL(meta.image, url).href
 			}

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -278,9 +278,6 @@ export async function defaultHandleExternalUrlAsset(
 			description:
 				doc.head.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',
 		}
-		// Only resolve an image or favicon we actually found. Resolving an empty
-		// string against the page would yield the page's own address, and the
-		// bookmark would then try to render an HTML document as an <img>.
 		if (meta.image && !meta.image.startsWith('http')) {
 			meta.image = new URL(meta.image, url).href
 		}

--- a/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
+++ b/packages/tldraw/src/lib/defaultExternalContentHandlers.ts
@@ -278,10 +278,13 @@ export async function defaultHandleExternalUrlAsset(
 			description:
 				doc.head.querySelector('meta[property="og:description"]')?.getAttribute('content') ?? '',
 		}
-		if (!meta.image.startsWith('http')) {
+		// Only resolve an image or favicon we actually found. Resolving an empty
+		// string against the page would yield the page's own address, and the
+		// bookmark would then try to render an HTML document as an <img>.
+		if (meta.image && !meta.image.startsWith('http')) {
 			meta.image = new URL(meta.image, url).href
 		}
-		if (!meta.favicon.startsWith('http')) {
+		if (meta.favicon && !meta.favicon.startsWith('http')) {
 			meta.favicon = new URL(meta.favicon, url).href
 		}
 	} catch (error) {

--- a/packages/tldraw/src/test/bookmark-shapes.test.ts
+++ b/packages/tldraw/src/test/bookmark-shapes.test.ts
@@ -1,5 +1,6 @@
 import { AssetRecordType, TLBookmarkShape, createShapeId, getHashForString } from '@tldraw/editor'
 import { vi } from 'vitest'
+import { defaultHandleExternalUrlAsset } from '../lib/defaultExternalContentHandlers'
 import {
 	createBookmarkFromUrl,
 	getBookmarkShapeHeight,
@@ -480,5 +481,58 @@ describe('createBookmarkFromUrl', () => {
 		// resolved short bookmark, not the 320px placeholder.
 		expect(getBookmarkShapeHeight(editor, redone)).toBe(shortHeight)
 		expect(editor.getShapeGeometry(redone.id).bounds.height).toBe(shortHeight)
+	})
+})
+
+describe('defaultHandleExternalUrlAsset', () => {
+	const url = 'https://example.com/some/page'
+
+	const opts = {
+		toasts: { addToast: vi.fn(), removeToast: vi.fn(), clearToasts: vi.fn() },
+		msg: (id: string) => id,
+	} as any
+
+	function mockPageHead(head: string) {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn().mockResolvedValue({
+				text: async () => `<html><head>${head}</head><body></body></html>`,
+			})
+		)
+	}
+
+	afterEach(() => {
+		vi.unstubAllGlobals()
+	})
+
+	it('leaves the image and favicon empty when the page provides neither', async () => {
+		mockPageHead('<title>Example</title>')
+
+		const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
+
+		// An absent image must stay absent. Resolving '' against the page would
+		// point the bookmark's <img> at the page's own HTML document.
+		expect(asset.props.image).toBe('')
+		expect(asset.props.favicon).toBe('')
+	})
+
+	it('resolves relative image and favicon urls against the page', async () => {
+		mockPageHead(
+			'<meta property="og:image" content="/img/preview.png" />' +
+				'<link rel="icon" href="favicon.ico" />'
+		)
+
+		const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
+
+		expect(asset.props.image).toBe('https://example.com/img/preview.png')
+		expect(asset.props.favicon).toBe('https://example.com/some/favicon.ico')
+	})
+
+	it('leaves absolute image urls alone', async () => {
+		mockPageHead('<meta property="og:image" content="https://cdn.example.com/preview.png" />')
+
+		const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
+
+		expect(asset.props.image).toBe('https://cdn.example.com/preview.png')
 	})
 })

--- a/packages/tldraw/src/test/bookmark-shapes.test.ts
+++ b/packages/tldraw/src/test/bookmark-shapes.test.ts
@@ -487,23 +487,28 @@ describe('createBookmarkFromUrl', () => {
 describe('defaultHandleExternalUrlAsset', () => {
 	const url = 'https://example.com/some/page'
 
-	const opts = {
-		toasts: { addToast: vi.fn(), removeToast: vi.fn(), clearToasts: vi.fn() },
-		msg: (id: string) => id,
-	} as any
+	let opts: any
+	let fetchMock: ReturnType<typeof vi.fn>
 
-	function mockPageHead(head: string) {
-		vi.stubGlobal(
-			'fetch',
-			vi.fn().mockResolvedValue({
-				text: async () => `<html><head>${head}</head><body></body></html>`,
-			})
-		)
-	}
+	beforeEach(() => {
+		opts = {
+			toasts: { addToast: vi.fn(), removeToast: vi.fn(), clearToasts: vi.fn() },
+			msg: (id: string) => id,
+		}
+	})
 
 	afterEach(() => {
 		vi.unstubAllGlobals()
 	})
+
+	function mockResponseBody(html: string) {
+		fetchMock = vi.fn().mockResolvedValue({ text: async () => html })
+		vi.stubGlobal('fetch', fetchMock)
+	}
+
+	function mockPageHead(head: string) {
+		mockResponseBody(`<html><head>${head}</head><body></body></html>`)
+	}
 
 	it('leaves the image and favicon empty when the page provides neither', async () => {
 		mockPageHead('<title>Example</title>')
@@ -534,5 +539,67 @@ describe('defaultHandleExternalUrlAsset', () => {
 		const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
 
 		expect(asset.props.image).toBe('https://cdn.example.com/preview.png')
+	})
+
+	it('toasts and returns a blank bookmark when the fetch throws', async () => {
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+		fetchMock = vi.fn().mockRejectedValue(new Error('CORS'))
+		vi.stubGlobal('fetch', fetchMock)
+
+		const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
+
+		expect(opts.toasts.addToast).toHaveBeenCalledWith(
+			expect.objectContaining({ severity: 'error' })
+		)
+		expect(asset.props.src).toBe(url)
+		expect(asset.props.image).toBe('')
+		expect(asset.props.title).toBe('')
+
+		consoleSpy.mockRestore()
+	})
+
+	// These pin down behaviour that is currently wrong or incomplete. They exist
+	// so that changing it is a deliberate act with a visible diff, rather than
+	// something that can drift either way unnoticed.
+	describe('behaviour to revisit', () => {
+		it('extracts nothing at all from a cross-origin page', async () => {
+			// The fetch below uses `mode: 'no-cors'`, which yields an opaque
+			// response for any cross-origin URL, and an opaque response's body is
+			// always the empty string. So every querySelector in this handler is
+			// dead code for the cross-origin case — which is essentially every
+			// pasted link.
+			mockResponseBody('')
+
+			const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
+
+			expect(fetchMock).toHaveBeenCalledWith(url, expect.objectContaining({ mode: 'no-cors' }))
+			expect(asset.props.image).toBe('')
+			expect(asset.props.favicon).toBe('')
+			expect(asset.props.description).toBe('')
+			// The only thing salvaged is the address we already had. Note this
+			// differs from the fetch-throws path above, which leaves title empty.
+			expect(asset.props.title).toBe(url)
+			// ...and no toast, so the user is told nothing.
+			expect(opts.toasts.addToast).not.toHaveBeenCalled()
+		})
+
+		it('ignores twitter card tags, og:image:secure_url and <title>', async () => {
+			mockPageHead(
+				'<title>Example</title>' +
+					'<meta property="og:image:secure_url" content="https://cdn.example.com/secure.png" />' +
+					'<meta name="twitter:image" content="https://cdn.example.com/twitter.png" />' +
+					'<meta name="twitter:title" content="Example, from twitter" />' +
+					'<meta name="description" content="A plain meta description" />'
+			)
+
+			const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
+
+			// cloudflare-workers-unfurl reads all four of these. This handler reads
+			// only the plain `og:` tags, so a page carrying twitter cards and no
+			// Open Graph tags unfurls to nothing even when the body is readable.
+			expect(asset.props.image).toBe('')
+			expect(asset.props.description).toBe('')
+			expect(asset.props.title).toBe(url)
+		})
 	})
 })

--- a/packages/tldraw/src/test/bookmark-shapes.test.ts
+++ b/packages/tldraw/src/test/bookmark-shapes.test.ts
@@ -515,8 +515,6 @@ describe('defaultHandleExternalUrlAsset', () => {
 
 		const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
 
-		// An absent image must stay absent. Resolving '' against the page would
-		// point the bookmark's <img> at the page's own HTML document.
 		expect(asset.props.image).toBe('')
 		expect(asset.props.favicon).toBe('')
 	})
@@ -558,16 +556,11 @@ describe('defaultHandleExternalUrlAsset', () => {
 		consoleSpy.mockRestore()
 	})
 
-	// These pin down behaviour that is currently wrong or incomplete. They exist
-	// so that changing it is a deliberate act with a visible diff, rather than
-	// something that can drift either way unnoticed.
+	// Pins behaviour we'd like to change, so that changing it is deliberate.
 	describe('behaviour to revisit', () => {
 		it('extracts nothing at all from a cross-origin page', async () => {
-			// The fetch below uses `mode: 'no-cors'`, which yields an opaque
-			// response for any cross-origin URL, and an opaque response's body is
-			// always the empty string. So every querySelector in this handler is
-			// dead code for the cross-origin case — which is essentially every
-			// pasted link.
+			// `mode: 'no-cors'` makes the response opaque cross-origin, and an
+			// opaque body always reads as ''.
 			mockResponseBody('')
 
 			const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
@@ -576,10 +569,7 @@ describe('defaultHandleExternalUrlAsset', () => {
 			expect(asset.props.image).toBe('')
 			expect(asset.props.favicon).toBe('')
 			expect(asset.props.description).toBe('')
-			// The only thing salvaged is the address we already had. Note this
-			// differs from the fetch-throws path above, which leaves title empty.
 			expect(asset.props.title).toBe(url)
-			// ...and no toast, so the user is told nothing.
 			expect(opts.toasts.addToast).not.toHaveBeenCalled()
 		})
 
@@ -594,9 +584,8 @@ describe('defaultHandleExternalUrlAsset', () => {
 
 			const asset = await defaultHandleExternalUrlAsset(editor, { type: 'url', url }, opts)
 
-			// cloudflare-workers-unfurl reads all four of these. This handler reads
-			// only the plain `og:` tags, so a page carrying twitter cards and no
-			// Open Graph tags unfurls to nothing even when the body is readable.
+			// cloudflare-workers-unfurl reads all four of these; this handler
+			// reads only the plain `og:` tags.
 			expect(asset.props.image).toBe('')
 			expect(asset.props.description).toBe('')
 			expect(asset.props.title).toBe(url)


### PR DESCRIPTION
In order to stop every cross-origin paste from producing a bookmark with a broken preview image, this PR only resolves a relative `og:image`/icon when we actually found one.

`defaultHandleExternalUrlAsset` fetches the page with `mode: 'no-cors'`, so `resp.text()` is `''` for any cross-origin URL and nothing parses out. `meta.image` is then `''` — and `''.startsWith('http')` is false, so `new URL('', pageUrl).href` writes the page's *own address* into the asset. The bookmark shape renders `<img src="…an HTML document">`, which is the broken image you see on essentially every pasted link.

Guarding on truthiness (as `cloudflare-workers-unfurl` already does) leaves `image` empty, and `BookmarkShapeUtil` skips the whole image container when it is — so a link that yields no metadata becomes the clean compact bookmark instead of a broken one.

The same block is copy-pasted into the VS Code extension's fallback path, fixed here too.

### Where it came from

- #3914 added the resolution as `if (meta.image.startsWith('/'))` — safe, since `''` doesn't start with `/`.
- #4022 broadened it to `if (!meta.image.startsWith('http'))` across four call sites. `unfurl.ts` kept a truthiness guard because its values were `string | undefined`; the three DOM-based copies typed theirs as `string` defaulting to `''`, so they lost it. That's the regression.

### Why it went unnoticed

Nothing serious runs this code. dotcom, the VS Code extension, all three sync templates, and every internal app call `registerExternalAssetHandler('url', ...)` with their own server-side unfurl. The default path is nobody's real path — which is an argument for fixing it, not against: it's what every new SDK user gets on day one.

dotcom used to carry the same copy-pasted block and no longer does (its fallback is now a blank bookmark), so with the VS Code copy fixed here, these two were the last of the four sites #4022 touched.

### Not fixed here

`mode: 'no-cors'` can only ever yield an unreadable body, which makes the entire `doc.head.querySelector(...)` block below it dead code for cross-origin URLs. It traces back to the v1 VS Code extension, where this was the *fallback* for when the `vscode:bookmark` extension-host RPC failed, and rode along into the SDK default via #1550. No PR description or comment ever justifies it, and it reads like a misunderstanding of what `no-cors` does.

One caveat for whoever picks it up, which writing the tests made obvious: swapping to default `cors` mode is not a free win. Pages that allow CORS would start unfurling properly, but pages that refuse would now **throw**, and the existing catch fires an error toast — so the common case goes from silently doing nothing to an error toast on most pasted links. That's noisier, not better. The shape that probably works is `cors` *plus* treating a CORS rejection as "no metadata" quietly, keeping the toast for genuine failures.

The richer extraction `cloudflare-workers-unfurl` does (twitter card tags, `<title>`, `meta[name=description]`, `og:image:secure_url`) is only worth anything once the body is readable, so it waits on that call too. Same for `title: … ?? url`, which only exists because the parse never succeeds.

Rather than leave all this as prose, the tests pin it. A `behaviour to revisit` block asserts that an unreadable body yields a completely empty bookmark **with no toast at all**, that the fetch asks for `mode: 'no-cors'` in the first place, and that twitter cards, `og:image:secure_url` and `<title>` are ignored. Whoever removes `no-cors` has to deliberately edit those assertions, and the fetch-throws test right above shows them the toast they'd be signing up for. (jsdom can't enforce real CORS semantics, so the causal chain is pinned in two halves — the mode we pass, and what an empty body yields — rather than end to end.)

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fixed pasted links showing a broken preview image when the linked page has no Open Graph image.
