### PR TITLE
chore(infra): provision grafana dashboards and alerts with gcx

### DIFF
--- a/.github/workflows/deploy-grafana.yml
+++ b/.github/workflows/deploy-grafana.yml
@@ -1,0 +1,53 @@
+name: Deploy grafana resources
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - 'internal/grafana/**'
+      - '.github/workflows/deploy-grafana.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'internal/grafana/**'
+      - '.github/workflows/deploy-grafana.yml'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    name: ${{ github.event_name == 'push' && 'Deploy grafana resources' || 'Validate grafana resources (dry run)' }}
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    concurrency: grafana-deploy-${{ github.event_name == 'push' && 'main' || github.ref }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install gcx
+        run: curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | sh
+
+      - name: Validate resources
+        run: gcx resources validate -p internal/grafana/resources
+        env:
+          GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+
+      - name: Dry run
+        if: github.event_name == 'pull_request'
+        run: gcx resources push -p internal/grafana/resources --dry-run --on-error abort
+        env:
+          GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+
+      - name: Push resources
+        if: github.event_name == 'push'
+        run: gcx resources push -p internal/grafana/resources --on-error abort
+        env:
+          GRAFANA_SERVER: ${{ secrets.GRAFANA_SERVER }}
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}

--- a/.github/workflows/deploy-grafana.yml
+++ b/.github/workflows/deploy-grafana.yml
@@ -18,9 +18,15 @@ defaults:
   run:
     shell: bash
 
+env:
+  GCX_VERSION: 1.0.0
+  GCX_SHA256: c88c65958d19d83dc3a192a2a5037e08307a9c776019f24249b89f369c9c4d41
+
 jobs:
   deploy:
     name: ${{ github.event_name == 'push' && 'Deploy grafana resources' || 'Validate grafana resources (dry run)' }}
+    # Validate and push both need the Grafana secrets, which fork PRs don't get.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     runs-on: ubuntu-latest
     concurrency: grafana-deploy-${{ github.event_name == 'push' && 'main' || github.ref }}
@@ -30,7 +36,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install gcx
-        run: curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | sh
+        run: |
+          curl -fsSL -o gcx.tar.gz "https://github.com/grafana/gcx/releases/download/v${GCX_VERSION}/gcx_${GCX_VERSION}_linux_amd64.tar.gz"
+          echo "${GCX_SHA256}  gcx.tar.gz" | sha256sum -c -
+          tar xzf gcx.tar.gz gcx
+          sudo mv gcx /usr/local/bin/gcx
+          gcx --version
 
       - name: Validate resources
         run: gcx resources validate -p internal/grafana/resources

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -4,9 +4,9 @@
 
 This directory currently provisions:
 
-- Nine dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP app sessions`, and `Bemo analytics` in the root folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- Nine dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP app sessions`, and `Bemo analytics` in the `Dotcom` folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
 - All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
-- The folders `Zero` (dashboard + 9 rules) and `Anthropic` (3 cost rules)
+- The folders `Zero` (dashboards + 9 rules), `Dotcom` (5 dashboards), and `Anthropic` (1 dashboard + 3 cost rules)
 
 Contact points, notification policies, and data sources are hand-managed in Grafana on purpose.
 

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -4,7 +4,7 @@
 
 This directory currently provisions:
 
-- Six dashboards: `Zero on Fly.io — service health` (`zero-fly-health`) and `Zero slow queries` (`slow-queries`) in the `Zero` folder, plus `Events`, `Events V2`, `File effect outbox`, and `MCP App Sessions` (root folder). The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- Seven dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache on Fly.io` (`ni7hhgd`) in the `Zero` folder, plus `Events`, `Events V2`, `File effect outbox`, and `MCP App Sessions` (root folder). The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
 - All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
 - The folders `Zero` (dashboard + 9 rules) and `Anthropic` (3 cost rules)
 

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -1,0 +1,40 @@
+# Grafana dashboards and alerts
+
+**TL;DR:** `resources/` is the source of truth for our Grafana Cloud dashboards and alert rules. CI pushes it with `gcx` on every merge to `main` that touches these files. Edit here, not in Grafana — UI edits get overwritten by the next deploy.
+
+This directory currently provisions:
+
+- Five dashboards: `Zero on Fly.io — service health` (`zero-fly-health`, in the `Zero` folder), plus `Events`, `Events V2`, `File effect outbox`, and `MCP App Sessions` (root folder). The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
+- The folders `Zero` (dashboard + 9 rules) and `Anthropic` (3 cost rules)
+
+Contact points, notification policies, and data sources are hand-managed in Grafana on purpose.
+
+## Conventions
+
+Every provisioned dashboard carries the tags `provisioned` and `repo:tldraw/tldraw`, so anyone looking at it in Grafana knows where it's managed from. Add both tags when adopting a new dashboard into this tree.
+
+## Making a change
+
+1. Edit the files under `resources/`.
+2. Open a PR. CI validates the resources and dry-runs the push so you can see what would change. (The alerting API doesn't support server-side dry-run, so alert rules show as "skipped: client-side check only" — that's expected, not an error.)
+3. Merge. The deploy workflow (`.github/workflows/deploy-grafana.yml`) pushes to Grafana Cloud.
+
+## Pulling fresh state
+
+If you prototyped a dashboard in the Grafana UI and want to adopt it, pull it into the tree with a local gcx context (`gcx login`):
+
+    gcx resources pull dashboards/<uid> -p internal/grafana/resources -o yaml
+    gcx resources pull alertrules -p internal/grafana/resources -o yaml
+
+Note the alert rules selector is `alertrules` — bare `rules` routes to the Asserts product and 403s on our stack.
+
+Don't hand-reformat gcx output; it needs to round-trip. Exception: `zero-fly-health` is stored as JSON because gcx 1.0.0's YAML writer emits an invalid escape for emoji variation selectors in row titles (its own reader then rejects the file). If a pulled YAML file fails `gcx resources validate`, re-pull that resource with `-o json`.
+
+## Deleting a resource
+
+Deleting a file here does **not** delete it in Grafana. Remove the file and run `gcx resources delete <type>/<uid>` manually.
+
+## Service account access
+
+CI authenticates with a Grafana service account token (`GRAFANA_SERVER` / `GRAFANA_TOKEN` repo secrets). The `zero-fly-health` dashboard has restricted permissions: the service account needs an explicit grant on it (or admin role) or pulls and pushes will 403.

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -4,7 +4,7 @@
 
 This directory currently provisions:
 
-- Five dashboards: `Zero on Fly.io — service health` (`zero-fly-health`, in the `Zero` folder), plus `Events`, `Events V2`, `File effect outbox`, and `MCP App Sessions` (root folder). The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- Six dashboards: `Zero on Fly.io — service health` (`zero-fly-health`) and `Zero slow queries` (`slow-queries`) in the `Zero` folder, plus `Events`, `Events V2`, `File effect outbox`, and `MCP App Sessions` (root folder). The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
 - All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
 - The folders `Zero` (dashboard + 9 rules) and `Anthropic` (3 cost rules)
 

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -4,7 +4,7 @@
 
 This directory currently provisions:
 
-- Seven dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache on Fly.io` (`ni7hhgd`) in the `Zero` folder, plus `Events`, `Events V2`, `File effect outbox`, and `MCP App Sessions` (root folder). The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- Nine dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP app sessions`, and `Bemo analytics` in the root folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
 - All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
 - The folders `Zero` (dashboard + 9 rules) and `Anthropic` (3 cost rules)
 

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/8451fbba-5835-56e2-b2f5-7f5e44c520b8.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/8451fbba-5835-56e2-b2f5-7f5e44c520b8.yaml
@@ -1,0 +1,127 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    alerting.grafana.app/prometheus-rule-definition: |
+      alert: AnthropicTokenRateAnomaly
+      expr: |
+          (
+            rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])
+            >
+            3 * avg_over_time(rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])[7d:1h])
+          )
+      for: 15m
+      labels:
+          severity: warning
+      annotations:
+          description: Token processing rate of {{ $value | humanize }} tokens/sec is 3x higher than the 7-day average for job {{ $labels.job }}.
+          summary: Anthropic API token rate anomaly detected.
+    grafana.app/folder: anthropic
+    grafana.com/provenance: converted_prometheus
+    grafana.com/updateTimestamp: '2026-03-20T11:22:55Z'
+    grafana.com/updatedBy: bf1wptf89bpq8d
+  labels:
+    grafana.app/folder: anthropic
+    grafana.com/group: anthropic
+    grafana.com/group-index: '1'
+  name: 8451fbba-5835-56e2-b2f5-7f5e44c520b8
+  namespace: stacks-890472
+spec:
+  annotations:
+    description: Token processing rate of {{ $value | humanize }} tokens/sec is 3x
+      higher than the 7-day average for job {{ $labels.job }}.
+    summary: Anthropic API token rate anomaly detected.
+  execErrState: Ok
+  expressions:
+    prometheus_math:
+      model:
+        datasource:
+          IsPrunable: false
+          access: ''
+          apiVersion: ''
+          basicAuth: false
+          basicAuthUser: ''
+          created: '0001-01-01T00:00:00Z'
+          database: ''
+          id: -100
+          isDefault: false
+          jsonData: {}
+          name: __expr__
+          readOnly: false
+          secureJsonData: {}
+          type: __expr__
+          uid: __expr__
+          updated: '0001-01-01T00:00:00Z'
+          url: ''
+          user: ''
+          withCredentials: false
+        expression: is_number($query) || is_nan($query) || is_inf($query)
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: prometheus_math
+        type: math
+      queryType: math
+    query:
+      datasourceUID: grafanacloud-prom
+      model:
+        datasource:
+          type: prometheus
+          uid: grafanacloud-prom
+        expr: |
+          (
+            rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])
+            >
+            3 * avg_over_time(rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])[7d:1h])
+          )
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        range: false
+        refId: query
+      queryType: prometheus
+      relativeTimeRange:
+        from: 11m0s
+        to: 1m0s
+    threshold:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0
+              type: gt
+        datasource:
+          IsPrunable: false
+          access: ''
+          apiVersion: ''
+          basicAuth: false
+          basicAuthUser: ''
+          created: '0001-01-01T00:00:00Z'
+          database: ''
+          id: -100
+          isDefault: false
+          jsonData: {}
+          name: __expr__
+          readOnly: false
+          secureJsonData: {}
+          type: __expr__
+          uid: __expr__
+          updated: '0001-01-01T00:00:00Z'
+          url: ''
+          user: ''
+          withCredentials: false
+        expression: prometheus_math
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: threshold
+        type: threshold
+      queryType: threshold
+      source: true
+  for: 15m0s
+  labels:
+    __converted_prometheus_rule__: 'true'
+    severity: warning
+  missingSeriesEvalsToResolve: 1
+  noDataState: Ok
+  title: AnthropicTokenRateAnomaly
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/afjn4kz1g4jk0a.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/afjn4kz1g4jk0a.yaml
@@ -1,0 +1,66 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-21T09:07:11Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-alerts-fast
+    grafana.com/group-index: '2'
+  name: afjn4kz1g4jk0a
+  namespace: stacks-890472
+spec:
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: grafanacloud-prom
+      model:
+        editorMode: code
+        expr: zero_replication_total_lag_millisecond{deployment_environment="production",
+          service_name="zero-rm"}
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 1000
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 5m0s
+  labels:
+    service: zero
+    severity: warning
+  noDataState: NoData
+  title: Zero replication lag elevated
+  trigger:
+    interval: 5m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/bfjyilovht2pse.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/bfjyilovht2pse.yaml
@@ -1,0 +1,81 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-28T08:48:46Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-fly-alerts
+    grafana.com/group-index: '5'
+  name: bfjyilovht2pse
+  namespace: stacks-890472
+spec:
+  annotations:
+    description: |-
+      Fires when the 5-minute rolling count of logs with detected_level error or fatal is greater than zero for service_name matching zero-(rm|vs) and deployment_environment=production.
+
+      Investigate in Grafana Explore (grafanacloud-tldraw-logs):
+
+      {service_name=~"zero-(rm|vs)", deployment_environment="production"} | detected_level=~"error|fatal"
+
+      Typical causes include failed upstream connections, auth/sync failures, or crashes; use log fields (component, worker, status, message) to narrow the blast radius.
+    summary: 'Production Zero: error/fatal logs in the last evaluation window.'
+  execErrState: Ok
+  expressions:
+    A:
+      datasourceUID: grafanacloud-logs
+      model:
+        datasource:
+          type: loki
+          uid: grafanacloud-logs
+        editorMode: code
+        expr:
+          sum(count_over_time({service_name=~"zero-(rm|vs)", deployment_environment="production"}
+          | detected_level=~"error|fatal" [5m]))
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        queryType: instant
+        refId: A
+      queryType: instant
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 1m0s
+  labels:
+    service: zero
+    severity: critical
+  noDataState: Ok
+  paused: true
+  title: Zero error log (production)
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/cfjnb1whljcowe.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/cfjnb1whljcowe.yaml
@@ -1,0 +1,72 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-28T08:48:46Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-fly-alerts
+    grafana.com/group-index: '2'
+  name: cfjnb1whljcowe
+  namespace: stacks-890472
+spec:
+  annotations:
+    summary: Zero container disk utilization exceeds 80%
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: afj5re4yk9og0e
+      model:
+        datasource:
+          type: prometheus
+          uid: afj5re4yk9og0e
+        editorMode: code
+        expr: |-
+          (fly_instance_filesystem_blocks{app=~"production-zero-rm|production-zero-vs"} - fly_instance_filesystem_blocks_avail{app=~"production-zero-rm|production-zero-vs"}) * fly_instance_filesystem_block_size{app=~"production-zero-rm|production-zero-vs"} /
+            (fly_instance_filesystem_blocks{app=~"production-zero-rm|production-zero-vs"} * fly_instance_filesystem_block_size{app=~"production-zero-rm|production-zero-vs"})
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0.8
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 10m0s
+  labels:
+    service: zero
+    severity: critical
+  noDataState: NoData
+  title: Flyio zero container disk high
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/cfjnbehzmlhxcc.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/cfjnbehzmlhxcc.yaml
@@ -1,0 +1,72 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-28T08:48:46Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-fly-alerts
+    grafana.com/group-index: '3'
+  name: cfjnbehzmlhxcc
+  namespace: stacks-890472
+spec:
+  annotations:
+    summary: Zero container CPU utilization exceeds 85%
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: afj5re4yk9og0e
+      model:
+        datasource:
+          type: prometheus
+          uid: afj5re4yk9og0e
+        editorMode: code
+        expr:
+          sum by (instance, app)(rate(fly_instance_cpu{app=~"production-zero-rm|production-zero-vs",mode!="idle"}[5m]))
+          / sum by (instance, app)(rate(fly_instance_cpu{app=~"production-zero-rm|production-zero-vs"}[5m]))
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0.85
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 15m0s
+  labels:
+    service: zero
+    severity: warning
+  noDataState: NoData
+  title: Flyio zero container cpu high
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/cfjyl9tbrury8b.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/cfjyl9tbrury8b.yaml
@@ -1,0 +1,80 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-28T08:48:46Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-fly-alerts
+    grafana.com/group-index: '6'
+  name: cfjyl9tbrury8b
+  namespace: stacks-890472
+spec:
+  annotations:
+    description: |-
+      Fires when the 5-minute rolling count of logs with detected_level error or fatal is greater than zero for service_name matching zero-(rm|vs) and deployment_environment=staging.
+
+      Investigate in Grafana Explore (grafanacloud-tldraw-logs):
+
+      {service_name=~"zero-(rm|vs)", deployment_environment="staging"} | detected_level=~"error|fatal"
+
+      Typical causes include failed upstream connections, auth/sync failures, or crashes; use log fields (component, worker, status, message) to narrow the blast radius.
+    summary: 'Staging Zero: error/fatal logs in the last evaluation window.'
+  execErrState: Ok
+  expressions:
+    A:
+      datasourceUID: grafanacloud-logs
+      model:
+        datasource:
+          type: loki
+          uid: grafanacloud-logs
+        editorMode: code
+        expr: sum(count_over_time({service_name=~"zero-(rm|vs)", deployment_environment="staging"}
+          | detected_level=~"error|fatal" [5m]))
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        queryType: instant
+        refId: A
+      queryType: instant
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 5m0s
+  labels:
+    service: zero
+    severity: warning
+  noDataState: Ok
+  paused: true
+  title: Zero error log (staging)
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/dfjn3qe3l7w8wc.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/dfjn3qe3l7w8wc.yaml
@@ -1,0 +1,69 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-21T09:06:29Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-alerts
+    grafana.com/group-index: '1'
+  name: dfjn3qe3l7w8wc
+  namespace: stacks-890472
+spec:
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: grafanacloud-prom
+      model:
+        editorMode: code
+        expr: zero_replica_backup_lag_millisecond{deployment_environment="production",
+          service_name="zero-rm"}
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 1200000
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 20m0s
+  labels:
+    service: zero
+    severity: critical
+  noDataState: NoData
+  notificationSettings:
+    receiver: Discord
+    type: SimplifiedRouting
+  title: Zero replica backup lag
+  trigger:
+    interval: 20m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/dfjn9xellhibka.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/dfjn9xellhibka.yaml
@@ -1,0 +1,72 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-28T08:48:46Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-fly-alerts
+    grafana.com/group-index: '1'
+  name: dfjn9xellhibka
+  namespace: stacks-890472
+spec:
+  annotations:
+    summary: Zero container memory utilization exceeds 90%
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: afj5re4yk9og0e
+      model:
+        datasource:
+          type: prometheus
+          uid: afj5re4yk9og0e
+        editorMode: code
+        expr: 1 - (fly_instance_memory_mem_available{app=~"production-zero-rm|production-zero-vs"}
+          / fly_instance_memory_mem_total{app=~"production-zero-rm|production-zero-vs"})
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0.9
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 1m0s
+  keepFiringFor: 5m0s
+  labels:
+    service: zero
+    severity: warning
+  noDataState: NoData
+  title: Flyio zero container memory high
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/e75d2f6c-44cf-54bf-8a74-ced2e045fcb6.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/e75d2f6c-44cf-54bf-8a74-ced2e045fcb6.yaml
@@ -1,0 +1,119 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    alerting.grafana.app/prometheus-rule-definition: |
+      alert: AnthropicDailyCostSpike
+      expr: "(\n  sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"}) \n  - \n  sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"} offset 1d)\n) / sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"} offset 1d) > 0.5\n"
+      for: 5m
+      labels:
+          severity: warning
+      annotations:
+          description: 'Daily cost has increased by {{ $value | humanizePercentage }} compared to yesterday. Current cost increase: ${{ $value | humanize }}.'
+          summary: Anthropic API daily cost spike detected.
+    grafana.app/folder: anthropic
+    grafana.com/provenance: converted_prometheus
+    grafana.com/updateTimestamp: '2026-03-20T11:22:55Z'
+    grafana.com/updatedBy: bf1wptf89bpq8d
+  labels:
+    grafana.app/folder: anthropic
+    grafana.com/group: anthropic
+    grafana.com/group-index: '0'
+  name: e75d2f6c-44cf-54bf-8a74-ced2e045fcb6
+  namespace: stacks-890472
+spec:
+  annotations:
+    description: 'Daily cost has increased by {{ $value | humanizePercentage }} compared
+      to yesterday. Current cost increase: ${{ $value | humanize }}.'
+    summary: Anthropic API daily cost spike detected.
+  execErrState: Ok
+  expressions:
+    prometheus_math:
+      model:
+        datasource:
+          IsPrunable: false
+          access: ''
+          apiVersion: ''
+          basicAuth: false
+          basicAuthUser: ''
+          created: '0001-01-01T00:00:00Z'
+          database: ''
+          id: -100
+          isDefault: false
+          jsonData: {}
+          name: __expr__
+          readOnly: false
+          secureJsonData: {}
+          type: __expr__
+          uid: __expr__
+          updated: '0001-01-01T00:00:00Z'
+          url: ''
+          user: ''
+          withCredentials: false
+        expression: is_number($query) || is_nan($query) || is_inf($query)
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: prometheus_math
+        type: math
+      queryType: math
+    query:
+      datasourceUID: grafanacloud-prom
+      model:
+        datasource:
+          type: prometheus
+          uid: grafanacloud-prom
+        expr: "(\n  sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"}) \n  - \n
+          \ sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"} offset 1d)\n) / sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"}
+          offset 1d) > 0.5\n"
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        range: false
+        refId: query
+      queryType: prometheus
+      relativeTimeRange:
+        from: 11m0s
+        to: 1m0s
+    threshold:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0
+              type: gt
+        datasource:
+          IsPrunable: false
+          access: ''
+          apiVersion: ''
+          basicAuth: false
+          basicAuthUser: ''
+          created: '0001-01-01T00:00:00Z'
+          database: ''
+          id: -100
+          isDefault: false
+          jsonData: {}
+          name: __expr__
+          readOnly: false
+          secureJsonData: {}
+          type: __expr__
+          uid: __expr__
+          updated: '0001-01-01T00:00:00Z'
+          url: ''
+          user: ''
+          withCredentials: false
+        expression: prometheus_math
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: threshold
+        type: threshold
+      queryType: threshold
+      source: true
+  for: 5m0s
+  labels:
+    __converted_prometheus_rule__: 'true'
+    severity: warning
+  missingSeriesEvalsToResolve: 1
+  noDataState: Ok
+  title: AnthropicDailyCostSpike
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/eec2ad9e-30b9-5c8f-802f-53e26ab8fdc9.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/eec2ad9e-30b9-5c8f-802f-53e26ab8fdc9.yaml
@@ -1,0 +1,119 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    alerting.grafana.app/prometheus-rule-definition: |
+      alert: AnthropicHighCostThreshold
+      expr: |
+          sum(gen_ai_cost{job=~"integrations/anthropic/.*"}) / 100 > 1000
+      for: 15m
+      labels:
+          severity: critical
+      annotations:
+          description: 'Total daily cost of ${{ $value | humanize }} has exceeded the $1000 threshold. Current cost: ${{ $value }}.'
+          summary: Anthropic API cost threshold exceeded.
+    grafana.app/folder: anthropic
+    grafana.com/provenance: converted_prometheus
+    grafana.com/updateTimestamp: '2026-03-20T11:22:55Z'
+    grafana.com/updatedBy: bf1wptf89bpq8d
+  labels:
+    grafana.app/folder: anthropic
+    grafana.com/group: anthropic
+    grafana.com/group-index: '2'
+  name: eec2ad9e-30b9-5c8f-802f-53e26ab8fdc9
+  namespace: stacks-890472
+spec:
+  annotations:
+    description: 'Total daily cost of ${{ $value | humanize }} has exceeded the $1000
+      threshold. Current cost: ${{ $value }}.'
+    summary: Anthropic API cost threshold exceeded.
+  execErrState: Ok
+  expressions:
+    prometheus_math:
+      model:
+        datasource:
+          IsPrunable: false
+          access: ''
+          apiVersion: ''
+          basicAuth: false
+          basicAuthUser: ''
+          created: '0001-01-01T00:00:00Z'
+          database: ''
+          id: -100
+          isDefault: false
+          jsonData: {}
+          name: __expr__
+          readOnly: false
+          secureJsonData: {}
+          type: __expr__
+          uid: __expr__
+          updated: '0001-01-01T00:00:00Z'
+          url: ''
+          user: ''
+          withCredentials: false
+        expression: is_number($query) || is_nan($query) || is_inf($query)
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: prometheus_math
+        type: math
+      queryType: math
+    query:
+      datasourceUID: grafanacloud-prom
+      model:
+        datasource:
+          type: prometheus
+          uid: grafanacloud-prom
+        expr: |
+          sum(gen_ai_cost{job=~"integrations/anthropic/.*"}) / 100 > 1000
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+        range: false
+        refId: query
+      queryType: prometheus
+      relativeTimeRange:
+        from: 11m0s
+        to: 1m0s
+    threshold:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0
+              type: gt
+        datasource:
+          IsPrunable: false
+          access: ''
+          apiVersion: ''
+          basicAuth: false
+          basicAuthUser: ''
+          created: '0001-01-01T00:00:00Z'
+          database: ''
+          id: -100
+          isDefault: false
+          jsonData: {}
+          name: __expr__
+          readOnly: false
+          secureJsonData: {}
+          type: __expr__
+          uid: __expr__
+          updated: '0001-01-01T00:00:00Z'
+          url: ''
+          user: ''
+          withCredentials: false
+        expression: prometheus_math
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: threshold
+        type: threshold
+      queryType: threshold
+      source: true
+  for: 15m0s
+  labels:
+    __converted_prometheus_rule__: 'true'
+    severity: critical
+  missingSeriesEvalsToResolve: 1
+  noDataState: Ok
+  title: AnthropicHighCostThreshold
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/efjn4hgdlhc00f.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/efjn4hgdlhc00f.yaml
@@ -1,0 +1,66 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-21T09:07:11Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-alerts-fast
+    grafana.com/group-index: '1'
+  name: efjn4hgdlhc00f
+  namespace: stacks-890472
+spec:
+  execErrState: Error
+  expressions:
+    A:
+      datasourceUID: grafanacloud-prom
+      model:
+        editorMode: code
+        expr: zero_replication_total_lag_millisecond{deployment_environment="production",
+          service_name="zero-rm"}
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 2000
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  for: 5m0s
+  labels:
+    service: zero
+    severity: critical
+  noDataState: NoData
+  title: Zero replication lag high
+  trigger:
+    interval: 5m

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/efjnbq9h4iha8a.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/efjnbq9h4iha8a.yaml
@@ -1,0 +1,69 @@
+apiVersion: rules.alerting.grafana.app/v0alpha1
+kind: AlertRule
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.com/provenance: ''
+    grafana.com/updateTimestamp: '2026-04-28T08:48:46Z'
+    grafana.com/updatedBy: ae5t47muqbegwf
+  labels:
+    grafana.app/folder: f6hsw6
+    grafana.com/group: zero-fly-alerts
+    grafana.com/group-index: '4'
+  name: efjnbq9h4iha8a
+  namespace: stacks-890472
+spec:
+  annotations:
+    summary: Zero container OOM kill detected
+  execErrState: Ok
+  expressions:
+    A:
+      datasourceUID: afj5re4yk9og0e
+      model:
+        datasource:
+          type: prometheus
+          uid: afj5re4yk9og0e
+        editorMode: code
+        expr: fly_instance_exit_oom{app=~"production-zero-rm|production-zero-vs"}
+        instant: true
+        intervalMs: 1000
+        legendFormat: __auto
+        maxDataPoints: 43200
+        range: false
+        refId: A
+      relativeTimeRange:
+        from: 10m0s
+        to: 0s
+    C:
+      model:
+        conditions:
+          - evaluator:
+              params:
+                - 0
+              type: gt
+            operator:
+              type: and
+            query:
+              params:
+                - C
+            reducer:
+              params: []
+              type: last
+            type: query
+        datasource:
+          type: __expr__
+          uid: __expr__
+        expression: A
+        intervalMs: 1000
+        maxDataPoints: 43200
+        refId: C
+        type: threshold
+      queryType: expression
+      source: true
+  labels:
+    service: zero
+    severity: critical
+  noDataState: Ok
+  title: Flyio zero container oom kill
+  trigger:
+    interval: 1m

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/adgumkhou3chsd.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/adgumkhou3chsd.yaml
@@ -1262,7 +1262,7 @@ spec:
       - 2h
       - 1d
   timezone: browser
-  title: Events
+  title: Dotcom events V1
   tags:
     - provisioned
     - repo:tldraw/tldraw

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/adgumkhou3chsd.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/adgumkhou3chsd.yaml
@@ -1,0 +1,1268 @@
+apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: ''
+    grafana.app/saved-from-ui: Grafana Cloud
+  labels: {}
+  name: adgumkhou3chsd
+  namespace: stacks-890472
+spec:
+  annotations:
+    list:
+      - builtIn: 1
+        datasource:
+          type: grafana
+          uid: -- Grafana --
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        type: dashboard
+  editable: true
+  fiscalYearStartMonth: 0
+  graphTooltip: 0
+  liveNow: false
+  panels:
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 21
+        w: 24
+        x: 0
+        y: 0
+      id: 1
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          maxHeight: 600
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, count() as total\n\tFROM 'MEASURE'\n    WHERE NOT\
+            \ endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n\tGROUP BY date, event\n\tORDER BY date\
+            \ ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob1 as event, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+            \tAND event != 'replicator'\n\tAND event != 'user_durable_object'\n\tGROUP\
+            \ BY date, event\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120' SECOND) as date,\
+            \ blob1 as event, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp >=\
+            \ toDateTime(1733213050) AND timestamp <= toDateTime(1733385850)\n\tAND blob2\
+            \ = 'pr-5028-tldraw-multiplayer'\n\tAND event != 'replicator'\n\tAND event\
+            \ != 'user_durable_object'\n\tGROUP BY date, event\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: true
+          showHelp: true
+          skip_comments: true
+          step: ''
+      title: Room events
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 8
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 21
+      id: 2
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: multi
+          sort: desc
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT \n    toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date,\n    blob3 as name,\n    max(double1) as total\nFROM 'MEASURE'\n\
+            WHERE \n    timestamp >= toDateTime($from) \n    AND timestamp <= toDateTime($to)\n\
+            \    AND blob1 = 'replicator'\n    AND blob2 = '${environment}-tldraw-multiplayer'\n\
+            \    AND blob3 = 'rpm'\nGROUP BY date, name\nORDER BY date ASC"
+          rawQuery: "SELECT \n    toStartOfInterval(timestamp, INTERVAL '120' SECOND)\
+            \ as date,\n    blob3 as name,\n    max(double1) as total\nFROM 'MEASURE'\n\
+            WHERE \n    timestamp >= toDateTime(1733133735) \n    AND timestamp <= toDateTime(1733392935)\n\
+            \    AND blob1 = 'replicator'\n    AND blob2 = 'pr-5028-tldraw-multiplayer'\n\
+            \    AND blob3 = 'rpm'\nGROUP BY date, name\nORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Replicator requests per minute
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: thresholds
+          custom:
+            align: auto
+            cellOptions:
+              type: auto
+            footer:
+              reducers: []
+            inspect: false
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        y: 21
+      id: 6
+      options:
+        cellHeight: sm
+        showHeader: false
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob1 as event, blob2 as env, blob3 as name, avg(double1) as avg_boot_duration\n\
+            \tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from) AND timestamp <=\
+            \ toDateTime($to)\n\tAND env = '${environment}-tldraw-multiplayer'\n    AND\
+            \ event = 'replicator'\n\tAND name = 'reboot_duration'\n\tGROUP BY env, date,\
+            \ event, name\n\tORDER BY date DESC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '60' SECOND) as date,\
+            \ blob1 as event, blob2 as env, blob3 as name, avg(double1) as avg_boot_duration\n\
+            \tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime(1733217590) AND timestamp\
+            \ <= toDateTime(1733390390)\n\tAND env = 'pr-5028-tldraw-multiplayer'\n  \
+            \  AND event = 'replicator'\n\tAND name = 'reboot_duration'\n\tGROUP BY env,\
+            \ date, event, name\n\tORDER BY date DESC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Replicator boot duration
+      type: table
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 29
+      id: 8
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n    AND blob1 = 'replicator'\n\
+            \tAND blob2 = '${environment}-tldraw-multiplayer'\n\tAND name != 'active_users'\n\
+            \tAND name != 'rpm'\n\tAND name != 'reboot_duration'\n\tGROUP BY date, name\n\
+            \tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '20' SECOND) as date,\
+            \ blob3 as name, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp >=\
+            \ toDateTime(1739393132) AND timestamp <= toDateTime(1739436332)\n    AND\
+            \ blob1 = 'replicator'\n\tAND blob2 = 'pr-5416-tldraw-multiplayer'\n\tAND\
+            \ name != 'active_users'\n\tAND name != 'rpm'\n\tAND name != 'reboot_duration'\n\
+            \tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Replicator events
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        y: 29
+      id: 12
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, blob4 as source, count() as total\n\tFROM 'MEASURE'\n\
+            \tWHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \    AND blob1 = 'replicator'\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+            \tAND name = 'reboot'\n\tGROUP BY date, name, source\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '20' SECOND) as date,\
+            \ blob3 as name, blob4 as source, count() as total\n\tFROM 'MEASURE'\n\tWHERE\
+            \ timestamp >= toDateTime(1739393303) AND timestamp <= toDateTime(1739436503)\n\
+            \    AND blob1 = 'replicator'\n\tAND blob2 = 'pr-5416-tldraw-multiplayer'\n\
+            \tAND name = 'reboot'\n\tGROUP BY date, name, source\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Replicator reboots
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 37
+      id: 11
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, max(double1) \n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n    AND blob1 = 'replicator'\n\
+            \tAND blob2 = '${environment}-tldraw-multiplayer'\n\tAND name = 'active_users'\n\
+            \tGROUP BY date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '300' SECOND) as date,\
+            \ blob3 as name, max(double1) \n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime(1738754410)\
+            \ AND timestamp <= toDateTime(1739359210)\n    AND blob1 = 'replicator'\n\t\
+            AND blob2 = 'production-tldraw-multiplayer'\n\tAND name = 'active_users'\n\
+            \tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Replicator registered users
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        y: 37
+      id: 4
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n\tAND blob1 = 'user_durable_object'\n\
+            \tAND blob2 = '${environment}-tldraw-multiplayer'   \n\tAND name != 'reboot_duration'\n\
+            \tAND name != 'cold_start_time'\n\tGROUP BY  date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '20' SECOND) as date,\
+            \ blob3 as name, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp >=\
+            \ toDateTime(1738886334) AND timestamp <= toDateTime(1738929534)\n\tAND blob1\
+            \ = 'user_durable_object'\n\tAND blob2 = 'pr-5380-tldraw-multiplayer'   \n\
+            \tAND name != 'reboot_duration'\n\tAND name != 'cold_start_time'\n\tGROUP\
+            \ BY  date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: User DO  + UserDataSyncer events
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: 3600000
+            lineInterpolation: stepAfter
+            lineStyle:
+              fill: solid
+            lineWidth: 1
+            pointSize: 6
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 45
+      id: 3
+      interval: 5m
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, avg(double1) as avg_boot_duration\n\tFROM 'MEASURE'\n\
+            \tWHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \    AND blob1 = 'user_durable_object'\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+            \tAND name = 'reboot_duration'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '300' SECOND) as date,\
+            \ blob3 as name, avg(double1) as avg_boot_duration\n\tFROM 'MEASURE'\n\tWHERE\
+            \ timestamp >= toDateTime(1738906685) AND timestamp <= toDateTime(1738928285)\n\
+            \    AND blob1 = 'user_durable_object'\n\tAND blob2 = 'production-tldraw-multiplayer'\n\
+            \tAND name = 'reboot_duration'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: ''
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      title: Average UserDataSyncer boot duration
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        y: 45
+      id: 9
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' MINUTE) as\
+            \ date, max(double1) as max_boot_duration\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n    AND blob1 = 'user_durable_object'\n\
+            \tAND blob2 = '${environment}-tldraw-multiplayer'\n\tAND blob3 = 'reboot_duration'\n\
+            \tGROUP BY date"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '300' MINUTE) as date,\
+            \ max(double1) as max_boot_duration\n\tFROM 'MEASURE'\n\tWHERE timestamp >=\
+            \ toDateTime(1738885901) AND timestamp <= toDateTime(1738929101)\n    AND\
+            \ blob1 = 'user_durable_object'\n\tAND blob2 = 'pr-5380-tldraw-multiplayer'\n\
+            \tAND blob3 = 'reboot_duration'\n\tGROUP BY date"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Maximum UserDataSyncer boot duration
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: 3600000
+            lineInterpolation: stepAfter
+            lineStyle:
+              fill: solid
+            lineWidth: 1
+            pointSize: 6
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 53
+      id: 10
+      interval: 5m
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, avg(double1) as avg_cold_start_duration\n\tFROM 'MEASURE'\n\
+            \tWHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \    AND blob1 = 'user_durable_object'\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+            \tAND name = 'cold_start_time'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '20' SECOND) as date,\
+            \ blob3 as name, avg(double1) as avg_cold_start_duration\n\tFROM 'MEASURE'\n\
+            \tWHERE timestamp >= toDateTime(1738885737) AND timestamp <= toDateTime(1738928937)\n\
+            \    AND blob1 = 'user_durable_object'\n\tAND blob2 = 'pr-5380-tldraw-multiplayer'\n\
+            \tAND name = 'cold_start_time'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      title: Average UserDataSyncer cold start duration
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: 3600000
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        y: 53
+      id: 7
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob3 as name, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n    AND blob1 = 'user_durable_object'\n\
+            \tAND blob2 = '${environment}-tldraw-multiplayer'\n\tAND name = 'reboot'\n\
+            \tGROUP BY date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120' SECOND) as date,\
+            \ blob3 as name, count() as total\n\tFROM 'MEASURE'\n\tWHERE timestamp >=\
+            \ toDateTime(1733217590) AND timestamp <= toDateTime(1733390390)\n    AND\
+            \ blob1 = 'user_durable_object'\n\tAND blob2 = 'pr-5028-tldraw-multiplayer'\n\
+            \tAND name = 'reboot'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: UserDataSyncer boot count
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: 3600000
+            lineInterpolation: stepAfter
+            lineStyle:
+              fill: solid
+            lineWidth: 1
+            pointSize: 6
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 61
+      id: 14
+      interval: 1d
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob1 as name, sum(double1) as avg_cold_start_duration\n\tFROM 'MEASURE'\n\
+            \tWHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\t\
+            AND blob2 = '${environment}-tldraw-multiplayer'\n\tAND name = 'pierre_incremental_write_chars'\n\
+            \tGROUP BY date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '86400' SECOND) as date,\
+            \ blob1 as name, sum(double1) as avg_cold_start_duration\n\tFROM 'MEASURE'\n\
+            \tWHERE timestamp >= toDateTime(1776072130) AND timestamp <= toDateTime(1776676930)\n\
+            \tAND blob2 = 'production-tldraw-multiplayer'\n\tAND name = 'pierre_incremental_write_chars'\n\
+            \tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      timeFrom: 7d
+      title: pierre incremental total bytes
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: right
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: 3600000
+            lineInterpolation: stepAfter
+            lineStyle:
+              fill: solid
+            lineWidth: 1
+            pointSize: 6
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            showValues: false
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          min: 0
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: 0
+              - color: red
+                value: 80
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 69
+      id: 13
+      interval: 5m
+      options:
+        annotations:
+          clustering: -1
+          multiLane: false
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: false
+        tooltip:
+          hideZeros: false
+          mode: single
+          sort: none
+      pluginVersion: 13.1.0-24556818486
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND)\
+            \ as date, blob1 as event, blob2 as type, blob3 as rpm\n\tFROM 'MEASURE'\n\
+            \    WHERE NOT endsWith(event, 'tldraw-multiplayer')\n\tAND timestamp >= toDateTime($from)\
+            \ AND timestamp <= toDateTime($to)\n    AND event = 'replicator'\n\tGROUP\
+            \ BY date, event, type, blob3\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as\
+            \ date, blob1 as name, max(double1) as avg_attempts\n\tFROM 'MEASURE'\n\t\
+            WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n  \
+            \  AND name = 'persist_success'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '300' SECOND) as date,\
+            \ blob1 as name, max(double1) as avg_attempts\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+            \ >= toDateTime(1762169567) AND timestamp <= toDateTime(1762180367)\n    AND\
+            \ name = 'persist_success'\n\tGROUP BY date, name\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      title: max attempts before persistence success
+      type: timeseries
+  preload: false
+  refresh: 5s
+  schemaVersion: 42
+  templating:
+    list:
+      - current:
+          text: production
+          value: production
+        description: Environment to filter by. Use production, staging, or your pr number
+          (pr-42).
+        hide: 0
+        label: 'Environment: production | staging | pr-42'
+        name: environment
+        query: production
+        skipUrlSync: false
+        type: textbox
+  time:
+    from: now-3h
+    to: now
+  timepicker:
+    refresh_intervals:
+      - 5s
+      - 10s
+      - 30s
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+  timezone: browser
+  title: Events
+  tags:
+    - provisioned
+    - repo:tldraw/tldraw

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/adgumkhou3chsd.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/adgumkhou3chsd.yaml
@@ -2,7 +2,7 @@ apiVersion: dashboard.grafana.app/v0alpha1
 kind: Dashboard
 metadata:
   annotations:
-    grafana.app/folder: ''
+    grafana.app/folder: dotcom
     grafana.app/saved-from-ui: Grafana Cloud
   labels: {}
   name: adgumkhou3chsd

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/anthropic-integration-scrape-overview.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/anthropic-integration-scrape-overview.yaml
@@ -1,0 +1,195 @@
+apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: anthropic
+    grafana.app/message: creating dashboard from the Cloud Connections plugin
+  labels: {}
+  name: anthropic-integration-scrape-overview
+  namespace: stacks-890472
+spec:
+  editable: false
+  fiscalYearStartMonth: 0
+  graphTooltip: 0
+  id: null
+  links:
+    - asDropdown: false
+      icon: external link
+      includeVars: true
+      keepTime: true
+      tags:
+        - anthropic-integration
+      targetBlank: true
+      title: Dashboards
+      type: dashboards
+  liveNow: false
+  panels:
+    - gridPos:
+        h: 12
+        w: 7
+        x: 0
+        y: 0
+      id: 1
+      options:
+        code:
+          language: plaintext
+          showLineNumbers: false
+          showMiniMap: false
+        content: <center><img style="width:auto;max-height:320px;" src="https://storage.googleapis.com/grafanalabs-integration-logos/anthropic-logo-dark.svg"></center>
+        mode: markdown
+      pluginVersion: 9.4.3
+      title: Logo
+      type: text
+    - datasource:
+        type: prometheus
+        uid: $datasource
+      description: Shows the number of samples received by metric name received for
+        this integration.
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            lineInterpolation: linear
+            lineStyle:
+              fill: solid
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          mappings: []
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: null
+              - color: red
+                value: 80
+          unit: pps
+        overrides: []
+      gridPos:
+        h: 12
+        w: 17
+        x: 7
+        y: 0
+      id: 7
+      options:
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: single
+          sort: none
+      targets:
+        - datasource:
+            type: prometheus
+            uid: $datasource
+          editorMode: code
+          expr: count by (__name__) ({__name__=~".+", job=~"integrations/anthropic/.+",
+            scrape_job=~"$scrape_job"})
+          legendFormat: __auto
+          range: true
+          refId: A
+      title: Samples Received
+      type: timeseries
+  refresh: 30s
+  revision: 1
+  schemaVersion: 38
+  style: dark
+  tags:
+    - anthropic-integration
+    - provisioned
+    - repo:tldraw/tldraw
+  templating:
+    list:
+      - current:
+          selected: false
+          text: default
+          value: default
+        hide: 0
+        includeAll: false
+        label: Data source
+        multi: false
+        name: datasource
+        options: []
+        query: prometheus
+        queryValue: ''
+        refresh: 1
+        regex: (?!grafanacloud-usage|grafanacloud-ml-metrics).+
+        skipUrlSync: false
+        type: datasource
+      - allValue: .+
+        current:
+          text: All
+          value:
+            - $__all
+        datasource: $datasource
+        definition: label_values({__name__=~".+", job=~"integrations/anthropic/.+"},
+          scrape_job)
+        hide: 0
+        includeAll: true
+        label: scrape_job
+        multi: true
+        name: scrape_job
+        options: []
+        query: label_values({__name__=~".+", job=~"integrations/anthropic/.+"}, scrape_job)
+        refresh: 2
+        regex: ''
+        skipUrlSync: false
+        sort: 0
+        tagValuesQuery: ''
+        tags: []
+        tagsQuery: ''
+        type: query
+        useTags: false
+      - allValue: integrations/anthropic/.+
+        current:
+          text: All
+          value:
+            - $__all
+        datasource: $datasource
+        definition: label_values({job=~"integrations/anthropic/.+"}, job)
+        hide: 0
+        includeAll: true
+        label: job
+        multi: true
+        name: job
+        options: []
+        query: label_values({job=~"integrations/anthropic/.+"}, job)
+        refresh: 2
+        regex: ''
+        skipUrlSync: false
+        sort: 0
+        tagValuesQuery: ''
+        tags: []
+        tagsQuery: ''
+        type: query
+        useTags: false
+  time:
+    from: now-30m
+    to: now
+  timepicker: {}
+  timezone: ''
+  title: Anthropic scrape overview
+  weekStart: ''

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/edrigjn435v5sf.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/edrigjn435v5sf.yaml
@@ -1,0 +1,374 @@
+apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  annotations: {}
+  labels: {}
+  name: edrigjn435v5sf
+  namespace: stacks-890472
+spec:
+  annotations:
+    list:
+      - builtIn: 1
+        datasource:
+          type: grafana
+          uid: -- Grafana --
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        type: dashboard
+  editable: true
+  fiscalYearStartMonth: 0
+  graphTooltip: 0
+  links: []
+  panels:
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: thresholds
+          mappings: []
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: null
+              - color: red
+                value: 80
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 0
+      id: 3
+      options:
+        minVizHeight: 75
+        minVizWidth: 75
+        orientation: auto
+        reduceOptions:
+          calcs:
+            - sum
+          fields: ''
+          values: false
+        showThresholdLabels: false
+        showThresholdMarkers: true
+        sizing: auto
+      pluginVersion: 11.3.0-77222
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT count(*)\n\tFROM 'BEMO_ANALYICS'\n    WHERE blob1 =\
+            \ 'connect'\n\tAND timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \tGROUP BY date\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' MINUTE) as\
+            \ date, count() as numConnects\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 =\
+            \ 'connect'\n\tAND timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \tGROUP BY date\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '1800' MINUTE) as date,\
+            \ count() as numConnects\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 = 'connect'\n\
+            \tAND timestamp >= toDateTime(1722620600) AND timestamp <= toDateTime(1725212600)\n\
+            \tGROUP BY date\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      title: Num Connects
+      type: gauge
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          mappings: []
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: null
+              - color: red
+                value: 80
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 12
+        y: 0
+      id: 1
+      options:
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: single
+          sort: none
+      pluginVersion: 11.3.0-77222
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT count(*)\n\tFROM 'BEMO_ANALYICS'\n    WHERE blob1 =\
+            \ 'connect'\n\tAND timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \tGROUP BY date\n\tORDER BY date ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' MINUTE) as\
+            \ date, count() as numConnects\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 =\
+            \ 'connect'\n\tAND timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+            \tGROUP BY date\n\tORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '3600' MINUTE) as date,\
+            \ count() as numConnects\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 = 'connect'\n\
+            \tAND timestamp >= toDateTime(1720773373) AND timestamp <= toDateTime(1726292377)\n\
+            \tGROUP BY date\n\tORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      title: Num Connects
+      type: timeseries
+    - datasource:
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: linear
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          mappings: []
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: null
+              - color: red
+                value: 80
+        overrides: []
+      gridPos:
+        h: 8
+        w: 12
+        x: 0
+        y: 8
+      id: 5
+      options:
+        legend:
+          calcs: []
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: single
+          sort: none
+      pluginVersion: 11.3.0-77222
+      targets:
+        - dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formattedQuery: SELECT $timeSeries as t, count() FROM $table WHERE $timeFilter
+            GROUP BY t ORDER BY t
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' MINUTE) as\
+            \ date, count() as numConnects,\n\tif(\n\t\tstartsWith(blob2, 'http://localhost')\
+            \ or startsWith(blob2, 'http://127.0.0.1'),\n\t\t'localhost',\n\t\tif(\n\t\
+            \t\tendsWith(blob2, '.csb.app'),\n\t\t\t'code sandbox',\n\t\t\tblob2\n\t\t\
+            )\n\t) as host\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 = 'connect'\n\tAND\
+            \ timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\t-- AND\
+            \ NOT(startsWith(host, 'http://localhost')) AND NOT(startsWith(host, 'http://127.0.0.1'))\n\
+            \tGROUP BY date, host\n    ORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '30' MINUTE) as date,\
+            \ count() as numConnects,\n\tif(\n\t\tstartsWith(blob2, 'http://localhost')\
+            \ or startsWith(blob2, 'http://127.0.0.1'),\n\t\t'localhost',\n\t\tif(\n\t\
+            \t\tendsWith(blob2, '.csb.app'),\n\t\t\t'code sandbox',\n\t\t\tblob2\n\t\t\
+            )\n\t) as host\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 = 'connect'\n\tAND\
+            \ timestamp >= toDateTime(1728620743) AND timestamp <= toDateTime(1728642343)\n\
+            \t\n\tGROUP BY date, host\n    ORDER BY date ASC"
+          refId: A
+          round: 0s
+          skip_comments: true
+      title: Num Connects
+      type: timeseries
+    - datasource:
+        type: vertamedia-clickhouse-datasource
+        uid: bdgu7tk03irr4e
+      fieldConfig:
+        defaults:
+          color:
+            mode: palette-classic
+          custom:
+            axisBorderShow: false
+            axisCenteredZero: false
+            axisColorMode: text
+            axisLabel: ''
+            axisPlacement: auto
+            barAlignment: 0
+            barWidthFactor: 0.6
+            drawStyle: line
+            fillOpacity: 0
+            gradientMode: none
+            hideFrom:
+              legend: false
+              tooltip: false
+              viz: false
+            insertNulls: false
+            lineInterpolation: smooth
+            lineWidth: 1
+            pointSize: 5
+            scaleDistribution:
+              type: linear
+            showPoints: auto
+            spanNulls: false
+            stacking:
+              group: A
+              mode: none
+            thresholdsStyle:
+              mode: 'off'
+          mappings: []
+          thresholds:
+            mode: absolute
+            steps:
+              - color: green
+                value: null
+              - color: red
+                value: 80
+        overrides: []
+      gridPos:
+        h: 19
+        w: 12
+        x: 12
+        y: 8
+      id: 4
+      options:
+        legend:
+          calcs: []
+          displayMode: table
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: single
+          sort: none
+      pluginVersion: 11.3.0-77222
+      targets:
+        - datasource:
+            type: vertamedia-clickhouse-datasource
+            uid: bdgu7tk03irr4e
+          dateTimeType: DATETIME
+          editorMode: builder
+          extrapolate: true
+          format: time_series
+          formatAs: time_series
+          formattedQuery: "SELECT count() as numConnects, blob2\n\tFROM 'BEMO_ANALYTICS'\n\
+            \    WHERE blob1 = 'connect'\n\tAND timestamp >= toDateTime($from) AND timestamp\
+            \ <= toDateTime($to)\n\tGROUP BY blob2\n    ORDER BY numConnects ASC"
+          intervalFactor: 1
+          query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval' MINUTE) as\
+            \ date, count() as numConnects,\n\tif(\n\t\tstartsWith(blob2, 'http://localhost')\
+            \ or startsWith(blob2, 'http://127.0.0.1'),\n\t\t'localhost',\n\t\tif(\n\t\
+            \t\tendsWith(blob2, '.csb.app'),\n\t\t\t'code sandbox',\n\t\t\tblob2\n\t\t\
+            )\n\t) as host\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 = 'connect'\n\tAND\
+            \ timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\t-- AND\
+            \ NOT(startsWith(host, 'http://localhost')) AND NOT(startsWith(host, 'http://127.0.0.1'))\n\
+            \tGROUP BY date, host\n    ORDER BY date ASC"
+          rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '3600' MINUTE) as date,\
+            \ count() as numConnects,\n\tif(\n\t\tstartsWith(blob2, 'http://localhost')\
+            \ or startsWith(blob2, 'http://127.0.0.1'),\n\t\t'localhost',\n\t\tif(\n\t\
+            \t\tendsWith(blob2, '.csb.app'),\n\t\t\t'code sandbox',\n\t\t\tblob2\n\t\t\
+            )\n\t) as host\n\tFROM 'BEMO_ANALYTICS'\n    WHERE blob1 = 'connect'\n\tAND\
+            \ timestamp >= toDateTime(1720773373) AND timestamp <= toDateTime(1726292377)\n\
+            \t\n\tGROUP BY date, host\n    ORDER BY date ASC"
+          refId: A
+          round: 0s
+          showFormattedSQL: false
+          showHelp: false
+          skip_comments: true
+          step: ''
+      title: Panel Title
+      type: timeseries
+  preload: false
+  schemaVersion: 40
+  tags:
+    - provisioned
+    - repo:tldraw/tldraw
+  templating:
+    list: []
+  time:
+    from: now-6h
+    to: now
+  timepicker: {}
+  timezone: browser
+  title: Bemo analytics
+  weekStart: ''

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/edrigjn435v5sf.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/edrigjn435v5sf.yaml
@@ -1,7 +1,8 @@
 apiVersion: dashboard.grafana.app/v0alpha1
 kind: Dashboard
 metadata:
-  annotations: {}
+  annotations:
+    grafana.app/folder: dotcom
   labels: {}
   name: edrigjn435v5sf
   namespace: stacks-890472

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/slow-queries.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/slow-queries.yaml
@@ -268,7 +268,7 @@ spec:
         h: 5
         w: 16
         x: 8
-        y: 6
+        y: 11
       id: 15
       options:
         legend:
@@ -304,7 +304,7 @@ spec:
         h: 1
         w: 24
         x: 0
-        y: 11
+        y: 16
       id: 7
       panels: []
       title: By statement
@@ -326,7 +326,7 @@ spec:
         h: 11
         w: 12
         x: 0
-        y: 12
+        y: 17
       id: 8
       options:
         showHeader: true
@@ -371,7 +371,7 @@ spec:
         h: 11
         w: 12
         x: 12
-        y: 12
+        y: 17
       id: 9
       options:
         showHeader: true
@@ -406,7 +406,7 @@ spec:
         h: 1
         w: 24
         x: 0
-        y: 23
+        y: 28
       id: 10
       panels: []
       title: By table
@@ -432,7 +432,7 @@ spec:
         h: 9
         w: 12
         x: 0
-        y: 24
+        y: 29
       id: 11
       options:
         legend:
@@ -473,7 +473,7 @@ spec:
         h: 9
         w: 12
         x: 12
-        y: 24
+        y: 29
       id: 12
       options:
         legend:
@@ -501,7 +501,7 @@ spec:
         h: 1
         w: 24
         x: 0
-        y: 33
+        y: 38
       id: 13
       panels: []
       title: Raw logs
@@ -513,7 +513,7 @@ spec:
         h: 12
         w: 24
         x: 0
-        y: 34
+        y: 39
       id: 14
       options:
         dedupStrategy: none

--- a/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/slow-queries.yaml
+++ b/internal/grafana/resources/dashboards.v0alpha1.dashboard.grafana.app/slow-queries.yaml
@@ -1,0 +1,605 @@
+apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/message: Add qtype split, env toggle, deploy annotations and restart
+      panel
+    grafana.app/folder: f6hsw6
+  labels: {}
+  name: slow-queries
+  namespace: stacks-890472
+spec:
+  annotations:
+    list:
+      - datasource:
+          type: loki
+          uid: grafanacloud-logs
+        enable: true
+        expr: '{service_name=~"$service", deployment_environment="$env"} |= "OpenTelemetry
+          SDK started" | process_worker="reaper"'
+        hide: false
+        iconColor: red
+        name: Deploys (machine restarts)
+        target:
+          expr: '{service_name=~"$service", deployment_environment="$env"} |= "OpenTelemetry
+            SDK started" | process_worker="reaper"'
+          queryType: range
+          refId: Anno
+        textFormat: '{{host_name}}'
+        titleFormat: zero-cache restart
+  editable: true
+  graphTooltip: 1
+  panels:
+    - collapsed: false
+      gridPos:
+        h: 1
+        w: 24
+        x: 0
+        y: 0
+      id: 1
+      panels: []
+      title: Overview
+      type: row
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: Total "Slow SQLite query" log lines from zero-cache in the selected
+        time range.
+      fieldConfig:
+        defaults:
+          unit: short
+        overrides: []
+      gridPos:
+        h: 5
+        w: 4
+        x: 0
+        y: 1
+      id: 2
+      options:
+        colorMode: value
+        graphMode: none
+        reduceOptions:
+          calcs:
+            - lastNotNull
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: sum(count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" [$__range]))
+          instant: true
+          queryType: instant
+          range: false
+          refId: A
+      title: Slow queries in range
+      type: stat
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: Longest slow query seen in the selected time range.
+      fieldConfig:
+        defaults:
+          unit: ms
+        overrides: []
+      gridPos:
+        h: 5
+        w: 4
+        x: 4
+        y: 1
+      id: 3
+      options:
+        colorMode: value
+        graphMode: none
+        reduceOptions:
+          calcs:
+            - lastNotNull
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: max(max_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" | regexp "Slow SQLite query (?P<duration_ms>[0-9.]+)"
+            | unwrap duration_ms [$__range]))
+          instant: true
+          queryType: instant
+          range: false
+          refId: A
+      title: Max duration in range
+      type: stat
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: Slow SQLite query log lines per interval, by Zero service (zero-vs
+        = view-syncer, zero-rm = replication-manager).
+      fieldConfig:
+        defaults:
+          custom:
+            fillOpacity: 8
+            lineWidth: 1
+            showPoints: never
+          unit: short
+        overrides: []
+      gridPos:
+        h: 10
+        w: 8
+        x: 8
+        y: 1
+      id: 4
+      options:
+        legend:
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: multi
+          sort: desc
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr:
+            sum by (service_name) (count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" [$__auto]))
+          legendFormat: '{{service_name}}'
+          queryType: range
+          refId: A
+      title: Slow query rate
+      type: timeseries
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: Duration parsed from the log line, in ms. Only queries over zero-cache's
+        slow threshold are logged, so these are percentiles of the slow tail, not of
+        all queries.
+      fieldConfig:
+        defaults:
+          custom:
+            fillOpacity: 8
+            lineWidth: 1
+            showPoints: never
+          unit: ms
+        overrides: []
+      gridPos:
+        h: 10
+        w: 8
+        x: 16
+        y: 1
+      id: 5
+      options:
+        legend:
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: multi
+          sort: desc
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: quantile_over_time(0.5, {service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" | regexp "Slow SQLite query (?P<duration_ms>[0-9.]+)"
+            | unwrap duration_ms [$__auto]) by ()
+          legendFormat: p50
+          queryType: range
+          refId: A
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: quantile_over_time(0.95, {service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" | regexp "Slow SQLite query (?P<duration_ms>[0-9.]+)"
+            | unwrap duration_ms [$__auto]) by ()
+          legendFormat: p95
+          queryType: range
+          refId: B
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: quantile_over_time(0.99, {service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" | regexp "Slow SQLite query (?P<duration_ms>[0-9.]+)"
+            | unwrap duration_ms [$__auto]) by ()
+          legendFormat: p99
+          queryType: range
+          refId: C
+      title: Slow query duration percentiles
+      type: timeseries
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: Which Fly machines are producing slow queries.
+      fieldConfig:
+        defaults:
+          custom:
+            fillOpacity: 8
+            lineWidth: 1
+            showPoints: never
+          unit: short
+        overrides: []
+      gridPos:
+        h: 5
+        w: 8
+        x: 0
+        y: 6
+      id: 6
+      options:
+        legend:
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: multi
+          sort: desc
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr:
+            sum by (host_name) (count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" [$__auto]))
+          legendFormat: '{{host_name}}'
+          queryType: range
+          refId: A
+      title: Slow queries by worker host
+      type: timeseries
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: Worker restarts (every zero-cache process logs one line per worker
+        on boot; a fleet-wide burst = a deploy) and post-restart auth failures from
+        the custom-query transform endpoint. Slow-query storms almost always line up
+        with these.
+      fieldConfig:
+        defaults:
+          custom:
+            drawStyle: bars
+            fillOpacity: 15
+            lineWidth: 1
+            showPoints: never
+          unit: short
+        overrides: []
+      gridPos:
+        h: 5
+        w: 16
+        x: 8
+        y: 6
+      id: 15
+      options:
+        legend:
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: multi
+          sort: desc
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: sum(count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |= "OpenTelemetry SDK started" [$__auto]))
+          legendFormat: worker restarts
+          queryType: range
+          refId: A
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: sum(count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |= "Connection auth validation failed" [$__auto]))
+          legendFormat: auth 401s on reconnect
+          queryType: range
+          refId: B
+      title: Deploys and reconnect storms
+      type: timeseries
+    - collapsed: false
+      gridPos:
+        h: 1
+        w: 24
+        x: 0
+        y: 11
+      id: 7
+      panels: []
+      title: By statement
+      type: row
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: The sql field is attached as structured metadata on each slow query
+        log line.
+      fieldConfig:
+        defaults:
+          custom:
+            align: auto
+            filterable: false
+            inspect: true
+          unit: short
+        overrides: []
+      gridPos:
+        h: 11
+        w: 12
+        x: 0
+        y: 12
+      id: 8
+      options:
+        showHeader: true
+        sortBy:
+          - desc: true
+            displayName: slow queries
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr:
+            topk(15, sum by (sql) (count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" [$__range])))
+          instant: true
+          queryType: instant
+          range: false
+          refId: A
+      title: Top statements by slow query count
+      transformations:
+        - id: organize
+          options:
+            excludeByName:
+              Time: true
+            renameByName:
+              Value: slow queries
+              'Value #A': slow queries
+      type: table
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: p95 of parsed duration, grouped by statement.
+      fieldConfig:
+        defaults:
+          custom:
+            align: auto
+            filterable: false
+            inspect: true
+          unit: ms
+        overrides: []
+      gridPos:
+        h: 11
+        w: 12
+        x: 12
+        y: 12
+      id: 9
+      options:
+        showHeader: true
+        sortBy:
+          - desc: true
+            displayName: p95 ms
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr:
+            topk(15, quantile_over_time(0.95, {service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" | regexp "Slow SQLite query (?P<duration_ms>[0-9.]+)"
+            | unwrap duration_ms [$__range]) by (sql))
+          instant: true
+          queryType: instant
+          range: false
+          refId: A
+      title: Top statements by p95 duration (ms)
+      transformations:
+        - id: organize
+          options:
+            excludeByName:
+              Time: true
+            renameByName:
+              Value: p95 ms
+              'Value #A': p95 ms
+      type: table
+    - collapsed: false
+      gridPos:
+        h: 1
+        w: 24
+        x: 0
+        y: 23
+      id: 10
+      panels: []
+      title: By table
+      type: row
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: "Table name extracted from the sql structured-metadata field. (Per-client
+        breakdowns are not possible here: more than 500 distinct clientGroupID values
+        per query window exceeds Loki's series limit.)"
+      fieldConfig:
+        defaults:
+          custom:
+            fillOpacity: 8
+            lineWidth: 1
+            showPoints: never
+            stacking:
+              group: A
+              mode: normal
+          unit: short
+        overrides: []
+      gridPos:
+        h: 9
+        w: 12
+        x: 0
+        y: 24
+      id: 11
+      options:
+        legend:
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: multi
+          sort: desc
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr:
+            sum by (tbl) (count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" | label_format tbl=`{{ regexReplaceAll
+            "(?s).*FROM .([a-zA-Z0-9._]+).*" .sql "$1" }}` [$__auto]))
+          legendFormat: '{{tbl}}'
+          queryType: range
+          refId: A
+      title: Slow queries by table
+      type: timeseries
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      description: zero-cache tags each statement event with class/method/type (e.g.
+        Statement/iterate/total).
+      fieldConfig:
+        defaults:
+          custom:
+            fillOpacity: 8
+            lineWidth: 1
+            showPoints: never
+          unit: short
+        overrides: []
+      gridPos:
+        h: 9
+        w: 12
+        x: 12
+        y: 24
+      id: 12
+      options:
+        legend:
+          displayMode: list
+          placement: bottom
+          showLegend: true
+        tooltip:
+          mode: multi
+          sort: desc
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr:
+            sum by (method, type) (count_over_time({service_name=~"$service", deployment_environment="$env"}
+            |~ "Slow SQLite query" | type=~"$qtype" [$__auto]))
+          legendFormat: '{{method}}/{{type}}'
+          queryType: range
+          refId: A
+      title: Slow queries by method / type
+      type: timeseries
+    - collapsed: false
+      gridPos:
+        h: 1
+        w: 24
+        x: 0
+        y: 33
+      id: 13
+      panels: []
+      title: Raw logs
+      type: row
+    - datasource:
+        type: loki
+        uid: grafanacloud-logs
+      gridPos:
+        h: 12
+        w: 24
+        x: 0
+        y: 34
+      id: 14
+      options:
+        dedupStrategy: none
+        enableLogDetails: true
+        showTime: true
+        sortOrder: Descending
+        wrapLogMessage: true
+      targets:
+        - datasource:
+            type: loki
+            uid: grafanacloud-logs
+          editorMode: code
+          expr: '{service_name=~"$service", deployment_environment="$env"} |~ "Slow SQLite
+            query" | type=~"$qtype"'
+          maxLines: 200
+          queryType: range
+          refId: A
+      title: Recent slow query logs
+      type: logs
+  refresh: ''
+  schemaVersion: 42
+  tags:
+    - zero
+    - loki
+    - slow-queries
+    - provisioned
+    - repo:tldraw/tldraw
+  templating:
+    list:
+      - allValue: zero-.+
+        current:
+          text:
+            - All
+          value:
+            - $__all
+        hide: 0
+        includeAll: true
+        label: Zero service
+        multi: true
+        name: service
+        options: []
+        query: zero-vs,zero-rm
+        type: custom
+      - current:
+          text: production
+          value: production
+        hide: 0
+        includeAll: false
+        label: Environment
+        multi: false
+        name: env
+        options:
+          - selected: true
+            text: production
+            value: production
+          - selected: false
+            text: staging
+            value: staging
+        query: production,staging
+        type: custom
+      - allValue: .*
+        current:
+          text: All
+          value: $__all
+        description: total = wall-clock across row iteration (includes syncer pipeline
+          stalls); sqlite = time inside the SQLite engine. Filter to sqlite to see whether
+          the database itself is slow.
+        hide: 0
+        includeAll: true
+        label: Query type
+        multi: false
+        name: qtype
+        options:
+          - selected: true
+            text: All
+            value: $__all
+          - selected: false
+            text: total
+            value: total
+          - selected: false
+            text: sqlite
+            value: sqlite
+        query: total,sqlite
+        type: custom
+  time:
+    from: now-6h
+    to: now
+  timezone: browser
+  title: Zero slow queries

--- a/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/zero-fly-health.json
+++ b/internal/grafana/resources/dashboards.v1.dashboard.grafana.app/zero-fly-health.json
@@ -1,0 +1,8358 @@
+{
+  "apiVersion": "dashboard.grafana.app/v1",
+  "kind": "Dashboard",
+  "metadata": {
+    "annotations": {
+      "grafana.app/message": "Switch per-machine filters from host_name to instance (PR 9865 promoted service.instance.id; host_name was never a metric label)",
+      "grafana.app/folder": "f6hsw6"
+    },
+    "labels": {},
+    "name": "zero-fly-health",
+    "namespace": "stacks-890472"
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "enable": true,
+          "expr": "sum by (service_name) (resets(zero_server_uptime_seconds{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$__interval])) > 0",
+          "hide": false,
+          "iconColor": "purple",
+          "name": "Deploys / restarts",
+          "target": {
+            "expr": "sum by (service_name) (resets(zero_server_uptime_seconds{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$__interval])) > 0",
+            "interval": "",
+            "legendFormat": "{{service_name}}",
+            "refId": "Anno"
+          },
+          "textFormat": "{{service_name}} restarted",
+          "titleFormat": "process restart"
+        }
+      ]
+    },
+    "description": "Operational dashboard for Zero (zero-cache) running on Fly.io. Organised top-down: client-visible freshness first, then the subsystems that cause it to degrade.",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 73,
+        "title": "\ud83d\udea6 Health overview",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Longest time any active client group has had replica changes ready but not yet delivered (IVM advance + CVR flush + pokeEnd). This is the closest thing Zero has to a user-facing staleness SLI. Sustained values above a few seconds mean users are looking at stale data.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 1000
+                },
+                {
+                  "color": "orange",
+                  "value": 5000
+                },
+                {
+                  "color": "red",
+                  "value": 15000
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 0,
+          "y": 1
+        },
+        "id": 1,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max(zero_sync_serving_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+            "instant": false,
+            "legendFormat": "max",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Client freshness (serving lag)",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "End-to-end Postgres \u2192 replica latency, measured by round-tripping a replication report. Grows as an estimate when the next report has not arrived, so a rising line here also means \"replication has stalled\".",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 2000
+                },
+                {
+                  "color": "orange",
+                  "value": 15000
+                },
+                {
+                  "color": "red",
+                  "value": 60000
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 4,
+          "y": 1
+        },
+        "id": 2,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max(zero_replication_total_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+            "instant": false,
+            "legendFormat": "max",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Replication lag (total)",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "One-hot health of the Postgres logical replication slot. \"unreserved\"/\"lost\"/\"missing\" mean WAL the replica still needs has been (or is about to be) discarded \u2014 recovering requires a full initial sync. Treat anything but OK as a page.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "color": "red",
+                    "index": 1,
+                    "text": "UNHEALTHY"
+                  },
+                  "1": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "OK"
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "green",
+                  "value": 1
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 8,
+          "y": 1
+        },
+        "id": 3,
+        "options": {
+          "colorMode": "background",
+          "graphMode": "none",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max({__name__=~\"zero_replication_slot_health(_ratio)?\", deployment_environment=~\"$env\", service_name=~\"$rm\", status=\"ok\"})",
+            "instant": false,
+            "legendFormat": "ok",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Replication slot",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Remaining WAL Postgres can still retain for this slot before it is declared lost (max_slot_wal_keep_size \u2212 retained). Falling toward zero means an imminent forced resync.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red",
+                  "value": 0
+                },
+                {
+                  "color": "orange",
+                  "value": 1073741824
+                },
+                {
+                  "color": "yellow",
+                  "value": 5368709120
+                },
+                {
+                  "color": "green",
+                  "value": 16106127360
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 12,
+          "y": 1
+        },
+        "id": 4,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "min(zero_replication_slot_safe_wal_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+            "instant": false,
+            "legendFormat": "headroom",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Slot WAL headroom",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Time since the newest replica change was captured by Litestream. Expected to saw-tooth between 0 and ZERO_LITESTREAM_INCREMENTAL_BACKUP_INTERVAL_MINUTES (default 15m). A flat, climbing line means backups are wedged \u2014 new view-syncers will not be able to restore.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 1200000
+                },
+                {
+                  "color": "orange",
+                  "value": 2100000
+                },
+                {
+                  "color": "red",
+                  "value": 2700000
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 16,
+          "y": 1
+        },
+        "id": 5,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max(zero_replica_backup_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+            "instant": false,
+            "legendFormat": "lag",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Backup lag",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "NOT TRUSTWORTHY until every zero-cache process carries a distinct instance label. This divides a counter rate by a gauge; while all machines share one series, Prometheus reads their overlapping cumulative counters as constant resets and the rate is inflated by orders of magnitude, climbing since the last deploy. WebSocket connection attempts divided by connected clients. A healthy client connects once and holds the socket, so this sits near zero. It rises when clients cannot complete a sync and retry in a loop. Normalising by client count is the point: the raw attempt rate moves with traffic and hides a partial outage, while this ratio is amplified by it, because broken clients generate many attempts and healthy ones generate none.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 1
+                },
+                {
+                  "color": "orange",
+                  "value": 5
+                },
+                {
+                  "color": "red",
+                  "value": 20
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 20,
+          "y": 1
+        },
+        "id": 6,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "60 * sum(rate(zero_sync_websocket_connection_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval])) / clamp_min(sum(zero_sync_active_clients{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}), 1)",
+            "instant": false,
+            "legendFormat": "reconnects",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Reconnects / client / min",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Currently connected sync clients, summed across view-syncers.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "fixed"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 3,
+          "x": 0,
+          "y": 5
+        },
+        "id": 7,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(zero_sync_active_clients{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+            "instant": false,
+            "legendFormat": "clients",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Active clients",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Active ViewSyncerService instances (one per client group / browser profile).",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "fixed"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 3,
+          "x": 3,
+          "y": 5
+        },
+        "id": 8,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(zero_sync_active_client_groups{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+            "instant": false,
+            "legendFormat": "groups",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Client groups",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Live IVM pipelines across all client groups.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "fixed"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 3,
+          "x": 6,
+          "y": 5
+        },
+        "id": 9,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(zero_sync_queries{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+            "instant": false,
+            "legendFormat": "queries",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Active queries",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Rows tracked in client view records. This is the main memory driver on view-syncers.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "fixed"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "short"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 3,
+          "x": 9,
+          "y": 5
+        },
+        "id": 10,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(zero_sync_rows{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+            "instant": false,
+            "legendFormat": "rows",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "CVR rows",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "db + WAL + WAL2 on the replication-manager volume. Compare against your Fly volume size.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "fixed"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "bytes"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 12,
+          "y": 5
+        },
+        "id": 11,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(zero_replica_db_size_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"} or vector(0)) + sum(zero_replica_wal_size_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"} or vector(0)) + sum(zero_replica_wal2_size_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"} or vector(0))",
+            "instant": false,
+            "legendFormat": "on disk",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Replica on disk",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "CRUD + custom mutations applied per second.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "fixed"
+            },
+            "decimals": 2,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "text",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "ops"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 16,
+          "y": 5
+        },
+        "id": 12,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(zero_mutation_crud_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval])) + sum(rate(zero_mutation_custom_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval]))",
+            "instant": false,
+            "legendFormat": "mutations",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Mutations /s",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Share of calls to your mutate/query/auth endpoints that did not succeed. This is your app server failing, not Zero.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "fixedColor": "text",
+              "mode": "thresholds"
+            },
+            "decimals": 2,
+            "max": 1,
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "yellow",
+                  "value": 0.01
+                },
+                {
+                  "color": "orange",
+                  "value": 0.05
+                },
+                {
+                  "color": "red",
+                  "value": 0.2
+                }
+              ]
+            },
+            "unit": "percentunit"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 4,
+          "w": 4,
+          "x": 20,
+          "y": 5
+        },
+        "id": 13,
+        "options": {
+          "colorMode": "value",
+          "graphMode": "area",
+          "justifyMode": "auto",
+          "orientation": "auto",
+          "percentChangeColorMode": "standard",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showPercentChange": false,
+          "textMode": "auto",
+          "wideLayout": true
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(zero_server_api_requests_total{deployment_environment=~\"$env\", service_name=~\"$vs\", result!=\"success\"}[$__rate_interval])) / clamp_min(sum(rate(zero_server_api_requests_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval])), 0.0001)",
+            "instant": false,
+            "legendFormat": "error ratio",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "User API error rate",
+        "type": "stat"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Distribution of unserved-change age across active client groups. p99/max diverging from p50 means a few heavy client groups are falling behind rather than a global slowdown.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "showValues": false,
+              "spanNulls": true,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "dashed"
+              }
+            },
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 15000
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "id": 14,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max by (stat) (zero_sync_serving_lag_stats_millisecond{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+            "instant": false,
+            "legendFormat": "{{stat}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Client freshness \u2014 serving lag distribution",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROM}"
+        },
+        "description": "Total = upstream (Postgres \u2192 change-streamer) + replica (change-streamer \u2192 SQLite). Whichever line dominates tells you whether to look at Postgres/WAL or at the replicator.",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 2,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "never",
+              "showValues": false,
+              "spanNulls": true,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "ms"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "total"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                },
+                {
+                  "id": "custom.lineWidth",
+                  "value": 3
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "upstream"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "orange",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "replica"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 12,
+          "y": 9
+        },
+        "id": 15,
+        "options": {
+          "legend": {
+            "calcs": [
+              "lastNotNull",
+              "max"
+            ],
+            "displayMode": "table",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "desc"
+          }
+        },
+        "pluginVersion": "13.2.0-30402795349",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max(zero_replication_total_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+            "instant": false,
+            "legendFormat": "total",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max(zero_replication_upstream_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+            "instant": false,
+            "legendFormat": "upstream",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "editorMode": "code",
+            "expr": "max(zero_replication_replica_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+            "instant": false,
+            "legendFormat": "replica",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "Replication lag breakdown",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 18
+        },
+        "id": 74,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "NOT TRUSTWORTHY until every zero-cache process carries a distinct instance label: both series divide a counter rate by a gauge, and while all machines share one series the counter rates are inflated by orders of magnitude. The shape is still readable, the absolute values are not. Both series are normalised per connected client, which is what makes a partial outage visible. The absolute rates on the panels below move with traffic, so a failure confined to a subset of users disappears into normal variation; these ratios go the other way, because a broken client produces many reconnects and no pokes while a healthy one does the opposite. Watch for the two lines crossing: reconnects climbing while pokes sag is clients connecting successfully and never being served \u2014 sockets are fine, data is not arriving. Note that pokes legitimately fall to zero when nothing is changing upstream, so read a low poke rate together with replication throughput before calling it broken.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "reconnects / client / min"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 3
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "pokes / client / min"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 19
+            },
+            "id": 17,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "60 * sum(rate(zero_sync_websocket_connection_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval])) / clamp_min(sum(zero_sync_active_clients{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}), 1)",
+                "instant": false,
+                "legendFormat": "reconnects / client / min",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "60 * sum(rate(zero_sync_poke_transactions_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval])) / clamp_min(sum(zero_sync_active_clients{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}), 1)",
+                "instant": false,
+                "legendFormat": "pokes / client / min",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Sync liveness per client",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Connected sync clients broken out by machine. Uneven distribution across Fly machines usually means sticky routing or a machine that failed to drain after a deploy.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 15,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 27
+            },
+            "id": 18,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (instance) (zero_sync_active_clients{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "{{instance}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Active clients per view-syncer",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Open sockets should track active clients closely. A persistent gap means sockets are being held open by clients that never completed initialization.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 27
+            },
+            "id": 19,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_websocket_open_connections{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "open sockets",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_active_clients{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "active clients",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Open WebSockets vs active clients",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Attempts, successes and failures per second. A churning attempt rate with flat active clients means clients are reconnect-looping \u2014 check auth, proxy timeouts and Fly health checks.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byRegexp",
+                    "options": "(failures|errors)"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "successes"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 35
+            },
+            "id": 20,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_websocket_connection_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "attempts",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_websocket_connection_successes_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "successes",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_websocket_connection_failures_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "failures",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_websocket_errors_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "errors",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "WebSocket connection rate",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "failures / attempts. Anything sustained above a few percent is a connectivity or auth bug.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.1
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 35
+            },
+            "id": 21,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_websocket_connection_failures_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval])) / clamp_min(sum(rate(zero_sync_websocket_connection_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval])), 0.0001)",
+                "instant": false,
+                "legendFormat": "failure ratio",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "WebSocket failure ratio",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Highest sync protocol version seen from connecting clients, and the number of distinct client schemas in use. Both jump during a rollout \u2014 useful for confirming clients picked up a new build.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 43
+            },
+            "id": 22,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_sync_max_protocol_version{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "max protocol version",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_client_schemas{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "client schemas",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Client protocol versions",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Client groups, live IVM pipelines and unique pipelines. pipelines_total \u226b pipelines_unique means many groups are running the same query \u2014 good dedupe headroom.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 43
+            },
+            "id": 23,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_active_client_groups{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "client groups",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_pipelines_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "pipelines (total)",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_pipelines_unique{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "pipelines (unique)",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Client groups & pipeline footprint",
+            "type": "timeseries"
+          }
+        ],
+        "title": "\ud83d\udc65 Clients & connections",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 19
+        },
+        "id": 75,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Replica-ready change \u2192 ViewSyncer output, as an exponential histogram. REQUIRES native histogram support on your Prometheus/Mimir. If this panel is empty, enable native histograms \u2014 the serving-lag gauges above are the fallback.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 20
+            },
+            "id": 25,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum(rate(zero_sync_view_syncer_lag_seconds{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum(rate(zero_sync_view_syncer_lag_seconds{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum(rate(zero_sync_view_syncer_lag_seconds{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "End-to-end view-syncer lag (native histogram)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Client groups with replica changes ready but not yet served. A steady non-zero count points at a few expensive queries; a rising count points at global saturation.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "lagging groups"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 20
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 20
+            },
+            "id": 26,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_serving_lagging_client_groups{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "lagging groups",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_sync_active_client_groups{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"})",
+                "instant": false,
+                "legendFormat": "total groups",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Lagging client groups",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time to hydrate (fully materialize) a query. This is the cost paid when a client adds a new query. p99 in the seconds means users wait on first paint \u2014 look for missing indexes or unbounded queries. Records on completion only, so a query slow enough that it never finishes contributes no sample here \u2014 read it alongside \"Sync liveness per client\".",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 2
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 0,
+              "y": 28
+            },
+            "id": 27,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_hydration_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_hydration_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_hydration_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_hydration_time_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_hydration_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Hydration latency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time to advance every query for a client group after a replica transaction. This runs on the hot path for every change \u2014 it directly sets serving lag.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 1
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 8,
+              "y": 28
+            },
+            "id": 28,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_advance_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_advance_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_advance_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_advance_time_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_advance_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Advance latency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time spent waiting for the per-client-group ViewSyncer lock. Rising p99 here with flat hydration/advance latency means contention, not slow work \u2014 usually too many client groups per syncer worker.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 16,
+              "y": 28
+            },
+            "id": 29,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_lock_wait_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_lock_wait_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_lock_wait_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_lock_wait_time_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_lock_wait_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "ViewSyncer lock wait",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Query hydrations per second vs pipeline advances per second. A hydration rate that tracks the advance rate means queries are being re-hydrated instead of incrementally maintained \u2014 check the pipeline reset panel.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 36
+            },
+            "id": 30,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_hydration_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "hydrations",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_advance_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "advances",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Hydration & advance throughput",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Every reset throws away IVM state and forces a full re-hydration. Steady non-zero rates are expensive; the `reason` label tells you why (schema change, version mismatch, error\u2026).",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 25,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 36
+            },
+            "id": 31,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (reason) (rate(zero_sync_pipeline_resets_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "{{reason}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Pipeline resets by reason",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time to advance IVM queries for a single change, isolated from transaction batching. This is the purest measure of query-graph cost.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 44
+            },
+            "id": 32,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_ivm_advance_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_ivm_advance_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_ivm_advance_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_ivm_advance_time_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_ivm_advance_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "IVM advance time (per change)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Pokes are the deltas pushed to clients. Rows/s is the real egress driver; poke time p99 rising with flat rows/s means client-side backpressure.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "poke p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "s"
+                    },
+                    {
+                      "id": "custom.axisPlacement",
+                      "value": "right"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 44
+            },
+            "id": 33,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_poke_rows_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "poked rows/s",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_poke_transactions_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "poke txns/s",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_poke_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "poke p99",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Poke throughput & latency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time to flush a client view record transaction to the CVR database. This is on the critical path for every poke \u2014 sustained p95 above ~500ms usually means CVR DB pressure.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 0,
+              "y": 52
+            },
+            "id": 34,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_cvr_flush_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_cvr_flush_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_cvr_flush_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_cvr_flush_time_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_cvr_flush_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "CVR flush latency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time to load a CVR, paid when a client group connects or moves between machines. Spikes here after a deploy are normal; sustained high values slow every reconnect.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 8,
+              "y": 52
+            },
+            "id": 35,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_cvr_load_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_cvr_load_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_cvr_load_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_cvr_load_duration_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_cvr_load_duration_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "CVR load latency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Rows flushed to CVRs and load/flush attempt rates. Rows flushed is the dominant CVR database write cost.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 16,
+              "y": 52
+            },
+            "id": 36,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_cvr_rows_flushed_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "rows flushed/s",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_cvr_flush_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "flush attempts/s",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_cvr_load_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "load attempts/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "CVR write volume",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Calls out to your API server to transform custom queries, plus how often the transform changed the query hash or was a no-op. High no-op rates are wasted round-trips you can cache.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 60
+            },
+            "id": 37,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_query_transformations_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "transformations/s",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_query_transformation_hash_changes_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "hash changes/s",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_query_transformation_no_ops_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "no-ops/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Query transformation (custom queries)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Row-set signature drifts (an unchanged query re-hydrating to a different row set), IVM conflict-row deletions, and forced config bumps. All are expected to be near zero \u2014 a sustained non-zero rate is a correctness smell worth a bug report.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byType",
+                    "options": "number"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.fillOpacity",
+                      "value": 20
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 60
+            },
+            "id": 38,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_query_row_set_signature_drifts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "row-set signature drifts/s",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_ivm_conflict_rows_deleted_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "ivm conflict rows deleted/s",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_query_same_hash_rehydrations_forced_bump_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "forced config bumps/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Correctness canaries",
+            "type": "timeseries"
+          }
+        ],
+        "title": "\u26a1 Sync engine (view-syncer)",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 20
+        },
+        "id": 76,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "One-hot slot status over time. `ok` is the only safe state. `unreserved` means Postgres has stopped guaranteeing the WAL this slot needs; `lost`/`missing` means a full initial sync is now required.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "fillOpacity": 85,
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineWidth": 0,
+                  "spanNulls": false
+                },
+                "mappings": [
+                  {
+                    "options": {
+                      "0": {
+                        "color": "transparent",
+                        "index": 0,
+                        "text": " "
+                      },
+                      "1": {
+                        "index": 1,
+                        "text": "active"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                }
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "ok"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "unreserved"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "lost"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "dark-red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "missing"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "dark-red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "unknown"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "text",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 21
+            },
+            "id": 40,
+            "options": {
+              "alignValue": "left",
+              "legend": {
+                "displayMode": "list",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "mergeValues": true,
+              "rowHeight": 0.9,
+              "showValue": "never",
+              "tooltip": {
+                "mode": "single",
+                "sort": "none"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max by (status) ({__name__=~\"zero_replication_slot_health(_ratio)?\", deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "{{status}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Replication slot health",
+            "type": "state-timeline"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "WAL bytes the slot is holding on Postgres, and how much more it may hold before being lost. Retained climbing while headroom falls is the classic \"replica is behind and Postgres disk is filling\" pattern.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "retained WAL"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "headroom before loss"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 21
+            },
+            "id": 41,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replication_slot_retained_wal_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "retained WAL",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "min(zero_replication_slot_safe_wal_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "headroom before loss",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Slot WAL retention vs headroom",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Transactions, changes (DML + DDL) and raw events replicated per second. A cliff to zero while the lag panel climbs is a stalled change stream.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 29
+            },
+            "id": 42,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replication_transactions_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "transactions/s",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replication_changes_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "changes/s",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replication_events_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "events/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Replication throughput",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Change-streamer half of forward-to-subscriber latency: from a transaction's BEGIN to forwarding its COMMIT. Large p99 here means big transactions upstream.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 29
+            },
+            "id": 43,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_replication_transaction_forward_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_replication_transaction_forward_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_replication_transaction_forward_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replication_transaction_forward_duration_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])) / sum(rate(zero_replication_transaction_forward_duration_seconds_count{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Transaction forward duration",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Active vs queued change-stream subscribers. Queued subscribers are view-syncers waiting for the current transaction to finish before they can attach \u2014 persistent queuing after a deploy means new machines are struggling to catch up.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "queued"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 0,
+              "y": 37
+            },
+            "id": 44,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_replication_flow_control_active_subscribers{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "active",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_replication_flow_control_queued_subscribers{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "queued",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Change-stream flow control \u2014 subscribers",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Bytes and messages buffered because subscribers have not caught up. Sustained growth is memory pressure on the replication-manager and a precursor to dropped subscribers.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "pending messages"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "short"
+                    },
+                    {
+                      "id": "custom.axisPlacement",
+                      "value": "right"
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 8,
+              "y": 37
+            },
+            "id": 45,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replication_flow_control_backlog_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "backlog bytes",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replication_flow_control_max_backlog_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "max single-subscriber bytes",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replication_flow_control_pending_messages{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "pending messages",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Change-stream backlog",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "How long replication pauses at flow-control checkpoints waiting for subscribers. Non-trivial values mean a slow view-syncer is throttling replication for everyone.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "checkpoints/s"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "ops"
+                    },
+                    {
+                      "id": "custom.axisPlacement",
+                      "value": "right"
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 16,
+              "y": 37
+            },
+            "id": 46,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_replication_flow_control_wait_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_replication_flow_control_wait_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replication_flow_control_waits_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "checkpoints/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Flow-control wait time",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Initial syncs are full copies of upstream. Outside of first boot or a deliberate reset, ANY activity here means the replica was rebuilt from scratch \u2014 investigate why (usually a lost replication slot).",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 45
+            },
+            "id": 47,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (result) (increase(zero_replication_initial_sync_runs_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "runs ({{result}})",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replication_initial_sync_rows_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "rows copied/s",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Initial sync",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Retained change-log rows and bytes on the replication-manager. This is what new view-syncers replay to catch up. Unbounded growth means purges are blocked \u2014 see the backup section.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "change-log bytes"
+                  },
+                  "properties": [
+                    {
+                      "id": "unit",
+                      "value": "bytes"
+                    },
+                    {
+                      "id": "custom.axisPlacement",
+                      "value": "right"
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 45
+            },
+            "id": 48,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_sqlite_change_log_rows{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "change-log rows",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_sqlite_change_log_file_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "change-log bytes",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_replica_sqlite_change_log_purged_rows_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "purged rows/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "SQLite change-log health",
+            "type": "timeseries"
+          }
+        ],
+        "title": "\ud83d\udd01 Replication (Postgres \u2192 replica)",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 21
+        },
+        "id": 77,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Main db file plus WAL sidecars. Sum these against your Fly volume size \u2014 a full volume wedges replication with no clean recovery path.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 15,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "bytes"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 22
+            },
+            "id": 50,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_db_size_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "db",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_wal_size_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "wal",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_wal2_size_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "wal2",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_sqlite_change_log_file_bytes{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "change-log",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Replica file sizes",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Expected saw-tooth from 0 to the configured incremental backup interval (default 15m). A monotonic climb means Litestream is not making progress.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 15,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 2700000
+                    }
+                  ]
+                },
+                "unit": "ms"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 22
+            },
+            "id": 51,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "max(zero_replica_backup_lag_millisecond{deployment_environment=~\"$env\", service_name=~\"$rm\"})",
+                "instant": false,
+                "legendFormat": "backup lag",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Backup lag",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Each increment is a Litestream backup subprocess exiting. Healthy deployments show a flat line. Repeated exits mean crash-looping backups \u2014 credentials, bucket policy or disk.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "bars",
+                  "fillOpacity": 25,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "purges blocked"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 30
+            },
+            "id": 52,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(increase(zero_replica_litestream_backup_process_runs_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "process exits",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(increase(zero_replica_purge_blocked_total{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "purges blocked",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Litestream backup process restarts",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time to list the backup destination and verify backup state. These run on the purge path \u2014 if they get slow, change-log purges stall and the replica volume grows.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 30
+            },
+            "id": 53,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_replica_litestream_backup_list_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "list p99",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_replica_litestream_backup_verification_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "verification p99",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_replica_litestream_snapshot_reservation_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "snapshot reservation p99",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Litestream backup timings",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Restore runs and attempts. Every new view-syncer machine on Fly restores from Litestream before it can serve \u2014 a spike here is normal at deploy time. Failures mean new machines cannot come up.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "bars",
+                  "fillOpacity": 40,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 38
+            },
+            "id": 54,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (result) (increase(zero_replica_litestream_restore_runs_total{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "runs ({{result}})",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(increase(zero_replica_litestream_restore_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "attempts",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Litestream restores (view-syncer startup)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Total restore wall-clock vs its phases (waiting for a snapshot reservation, the subprocess itself, and validation). This is your view-syncer cold-start budget on Fly.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "total p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 3
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 38
+            },
+            "id": 55,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_replica_litestream_restore_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "total p95",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_replica_litestream_restore_wait_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "wait p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_replica_litestream_restore_process_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "process p95",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_replica_litestream_restore_validation_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "validation p95",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Restore duration breakdown",
+            "type": "timeseries"
+          }
+        ],
+        "title": "\ud83d\udcbe Replica storage & Litestream backups",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 22
+        },
+        "id": 78,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "CRUD mutations, custom mutations, and pushes to your API server. Pushes \u226a custom mutations means batching is working.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 15,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 23
+            },
+            "id": 57,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_mutation_crud_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "crud/s",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_mutation_custom_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "custom/s",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_mutation_pushes_total{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "pushes/s",
+                "range": true,
+                "refId": "C"
+              }
+            ],
+            "title": "Mutation throughput",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Calls zero-cache makes to YOUR endpoints (mutate, query transform, cleanup, auth). Anything other than result=\"success\" is your app server rejecting or failing.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 23
+            },
+            "id": 58,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (operation, result) (rate(zero_server_api_requests_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "{{operation}} \u00b7 {{result}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "User API requests by operation & result",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Per-operation failure share. Splitting by operation tells you whether it is your mutate endpoint, your query transform endpoint, or auth validation that is broken.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.05
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 0,
+              "y": 31
+            },
+            "id": 59,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (operation) (rate(zero_server_api_requests_total{deployment_environment=~\"$env\", service_name=~\"$vs\", result!=\"success\"}[$__rate_interval])) / clamp_min(sum by (operation) (rate(zero_server_api_requests_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval])), 0.0001)",
+                "instant": false,
+                "legendFormat": "{{operation}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "User API error ratio by operation",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Full request duration including retry sleeps. This latency is paid inline on mutations and custom-query transforms, so it shows up directly as user-visible slowness.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 8,
+              "y": 31
+            },
+            "id": 60,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_server_api_request_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_server_api_request_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_server_api_request_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_server_api_request_duration_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$win])) / sum(rate(zero_server_api_request_duration_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "User API latency (end-to-end, incl. retries)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "HTTP attempts per logical request (1.0 = no retries) and requests currently in flight. Amplification above ~1.2 means your endpoint is flapping.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "short"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "in flight"
+                  },
+                  "properties": [
+                    {
+                      "id": "custom.axisPlacement",
+                      "value": "right"
+                    },
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "purple",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 16,
+              "y": 31
+            },
+            "id": 61,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_server_api_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval])) / clamp_min(sum(rate(zero_server_api_requests_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval])), 0.0001)",
+                "instant": false,
+                "legendFormat": "attempts per request",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(zero_server_api_in_flight{deployment_environment=~\"$env\", service_name=~\"$vs\"})",
+                "instant": false,
+                "legendFormat": "in flight",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "User API retry amplification & concurrency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Attempt outcomes bucketed by status class. A wall of 5xx is your server; 4xx is usually auth or a contract mismatch between client and API.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 20,
+                  "gradientMode": "opacity",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "normal"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 39
+            },
+            "id": 62,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (http_status_class, result) (rate(zero_server_api_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "{{http_status_class}} \u00b7 {{result}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "User API attempts by HTTP status class",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Time spent calling your API server to transform custom queries. This is paid before a query can hydrate, so it lands on first-paint latency.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p50"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p95"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "orange",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "p99"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "avg"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "blue",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 39
+            },
+            "id": 63,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.5, sum by (le) (rate(zero_sync_query_transformation_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p50",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_sync_query_transformation_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p95",
+                "range": true,
+                "refId": "B"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.99, sum by (le) (rate(zero_sync_query_transformation_time_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])))",
+                "instant": false,
+                "legendFormat": "p99",
+                "range": true,
+                "refId": "C"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum(rate(zero_sync_query_transformation_time_seconds_sum{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win])) / sum(rate(zero_sync_query_transformation_time_seconds_count{deployment_environment=~\"$env\", service_name=~\"$vs\", instance=~\"$inst\"}[$win]))",
+                "instant": false,
+                "legendFormat": "avg",
+                "range": true,
+                "refId": "D"
+              }
+            ],
+            "title": "Query transformation latency",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "HTTP status of zero-cache's calls to your query (transform) endpoint specifically. The status-class panel above spans every operation, so a transform 401 arrives mixed in with mutate and auth traffic and reads as ordinary logged-out noise. The two mean very different things: a mutate 401 is one user's token, a query 401 is zero-cache itself being rejected, which stops sync for every client it was serving. Sustained 401s here while clients are connected mean hydration is outrunning the auth token's lifetime.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "ops"
+              },
+              "overrides": [
+                {
+                  "matcher": {
+                    "id": "byRegexp",
+                    "options": "/4../"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "red",
+                        "mode": "fixed"
+                      }
+                    },
+                    {
+                      "id": "custom.lineWidth",
+                      "value": 3
+                    }
+                  ]
+                },
+                {
+                  "matcher": {
+                    "id": "byName",
+                    "options": "200"
+                  },
+                  "properties": [
+                    {
+                      "id": "color",
+                      "value": {
+                        "fixedColor": "green",
+                        "mode": "fixed"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 24,
+              "x": 0,
+              "y": 47
+            },
+            "id": 64,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "sum by (http_status_code) (rate(zero_server_api_attempts_total{deployment_environment=~\"$env\", service_name=~\"$vs\", operation=\"query\"}[$__rate_interval]))",
+                "instant": false,
+                "legendFormat": "{{http_status_code}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Transform endpoint auth failures",
+            "type": "timeseries"
+          }
+        ],
+        "title": "\u270d\ufe0f Mutations & user API",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 23
+        },
+        "id": 79,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "Uptime per process. Every saw-tooth reset is a restart. Unexplained restarts on view-syncers usually mean OOM \u2014 check Fly machine memory below.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 0,
+              "y": 24
+            },
+            "id": 66,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "min by (service_name, instance) (zero_server_uptime_seconds{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"})",
+                "instant": false,
+                "legendFormat": "{{service_name}} \u00b7 {{instance}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Process uptime (restart detector)",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "zero-cache and per-worker time-to-ready. On Fly this is your effective cold-start / deploy latency \u2014 dominated by the Litestream restore for view-syncers.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "s"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 24
+            },
+            "id": 67,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_server_startup_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "zero-cache p95",
+                "range": true,
+                "refId": "A"
+              },
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "histogram_quantile(0.95, sum by (le) (rate(zero_server_worker_startup_duration_seconds_bucket{deployment_environment=~\"$env\", service_name=~\"$vs|$rm\"}[$win])))",
+                "instant": false,
+                "legendFormat": "worker p95",
+                "range": true,
+                "refId": "B"
+              }
+            ],
+            "title": "Startup duration",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_FLY}"
+            },
+            "description": "Requires the Fly.io Prometheus datasource (set the $DS_FLY variable). View-syncers are memory-bound by CVR rows \u2014 this is the metric that predicts OOM restarts.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.9
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 0,
+              "y": 32
+            },
+            "id": 68,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_FLY}"
+                },
+                "editorMode": "code",
+                "expr": "1 - (fly_instance_memory_mem_available{app=~\"$fly_app\"} / fly_instance_memory_mem_total{app=~\"$fly_app\"})",
+                "instant": false,
+                "legendFormat": "{{app}} \u00b7 {{instance}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Fly \u00b7 memory used",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_FLY}"
+            },
+            "description": "Non-idle CPU per Fly machine, as a fraction of that machine total. Expressed as 1 - idle/total rather than as a bare rate: the rate of a CPU-time counter is cores-in-use, not a fraction, so feeding it to a percentunit axis reads 100% per busy core (a 4-core machine at half load showed 200%). Dividing by the same counter summed over all modes cancels whatever base unit Fly uses and always lands in 0-1. Requires the Fly.io Prometheus datasource.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 8,
+              "y": 32
+            },
+            "id": 69,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_FLY}"
+                },
+                "editorMode": "code",
+                "expr": "1 - (sum by (app, instance) (rate(fly_instance_cpu{app=~\"$fly_app\", mode=\"idle\"}[$__rate_interval])) / clamp_min(sum by (app, instance) (rate(fly_instance_cpu{app=~\"$fly_app\"}[$__rate_interval])), 0.0001))",
+                "instant": false,
+                "legendFormat": "{{app}} \u00b7 {{instance}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Fly \u00b7 CPU",
+            "type": "timeseries"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_FLY}"
+            },
+            "description": "Disk usage on the Fly volume holding the replica. A full volume wedges replication. Requires the Fly.io Prometheus datasource.",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisBorderShow": false,
+                  "axisCenteredZero": false,
+                  "axisColorMode": "text",
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "insertNulls": false,
+                  "lineInterpolation": "linear",
+                  "lineWidth": 2,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "never",
+                  "spanNulls": true,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "dashed"
+                  }
+                },
+                "max": 1,
+                "min": 0,
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "red",
+                      "value": 0.85
+                    }
+                  ]
+                },
+                "unit": "percentunit"
+              }
+            },
+            "gridPos": {
+              "h": 8,
+              "w": 8,
+              "x": 16,
+              "y": 32
+            },
+            "id": 70,
+            "options": {
+              "legend": {
+                "calcs": [
+                  "lastNotNull",
+                  "max"
+                ],
+                "displayMode": "table",
+                "placement": "bottom",
+                "showLegend": true
+              },
+              "tooltip": {
+                "hideZeros": false,
+                "mode": "multi",
+                "sort": "desc"
+              }
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_FLY}"
+                },
+                "editorMode": "code",
+                "expr": "1 - (fly_instance_filesystem_free_bytes{app=~\"$fly_app\"} / fly_instance_filesystem_size_bytes{app=~\"$fly_app\"})",
+                "instant": false,
+                "legendFormat": "{{app}} \u00b7 {{device}}",
+                "range": true,
+                "refId": "A"
+              }
+            ],
+            "title": "Fly \u00b7 volume used",
+            "type": "timeseries"
+          }
+        ],
+        "title": "\ud83d\udda5\ufe0f Process & Fly machines",
+        "type": "row"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 24
+        },
+        "id": 80,
+        "panels": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROM}"
+            },
+            "description": "If a panel above is empty, check here first. OTLP\u2192Prometheus naming appends unit and _total suffixes (zero.sync.hydration \u2192 zero_sync_hydration_total), and the exact suffix depends on your collector's translation strategy. Compare a panel's metric name against this list and adjust if they differ.",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {
+                  "align": "auto",
+                  "filterable": true,
+                  "inspect": false
+                }
+              }
+            },
+            "gridPos": {
+              "h": 12,
+              "w": 24,
+              "x": 0,
+              "y": 25
+            },
+            "id": 72,
+            "options": {
+              "cellHeight": "sm",
+              "footer": {
+                "countRows": true,
+                "fields": "",
+                "reducer": [
+                  "count"
+                ],
+                "show": true
+              },
+              "showHeader": true,
+              "sortBy": [
+                {
+                  "desc": false,
+                  "displayName": "__name__"
+                }
+              ]
+            },
+            "pluginVersion": "",
+            "targets": [
+              {
+                "datasource": {
+                  "type": "prometheus",
+                  "uid": "${DS_PROM}"
+                },
+                "editorMode": "code",
+                "expr": "group by (__name__) ({__name__=~\"zero_.+\", deployment_environment=~\"$env\"})",
+                "format": "table",
+                "instant": true,
+                "legendFormat": "",
+                "range": false,
+                "refId": "A"
+              }
+            ],
+            "title": "All zero_* series currently in Prometheus",
+            "transformations": [
+              {
+                "id": "organize",
+                "options": {
+                  "excludeByName": {
+                    "Time": true,
+                    "Value": true
+                  }
+                }
+              }
+            ],
+            "type": "table"
+          }
+        ],
+        "title": "\ud83d\udd0e Metric discovery (troubleshooting empty panels)",
+        "type": "row"
+      }
+    ],
+    "preload": false,
+    "refresh": "30s",
+    "schemaVersion": 42,
+    "tags": [
+      "zero",
+      "fly",
+      "production",
+      "provisioned",
+      "repo:tldraw/tldraw"
+    ],
+    "templating": {
+      "list": [
+        {
+          "allowCustomValue": true,
+          "current": {
+            "text": "grafanacloud-tldraw-prom",
+            "value": "grafanacloud-prom"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Prometheus",
+          "multi": false,
+          "name": "DS_PROM",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allValue": ".*",
+          "allowCustomValue": true,
+          "current": {
+            "text": "production",
+            "value": "production"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "definition": "label_values(zero_replica_db_size_bytes,deployment_environment)",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Environment",
+          "multi": false,
+          "name": "env",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(zero_replica_db_size_bytes,deployment_environment)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allValue": ".*",
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "definition": "label_values(zero_sync_active_client_groups{deployment_environment=~\"$env\"}, service_name)",
+          "description": "service.name of the view-syncer deployment. Auto-discovered from the sync metrics.",
+          "hide": 0,
+          "includeAll": true,
+          "label": "View-syncer service",
+          "multi": true,
+          "name": "vs",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(zero_sync_active_client_groups{deployment_environment=~\"$env\"}, service_name)",
+            "refId": "vs"
+          },
+          "refresh": 2,
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allValue": ".*",
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "definition": "label_values(zero_replication_total_lag_millisecond{deployment_environment=~\"$env\"}, service_name)",
+          "description": "service.name of the replication-manager deployment. Auto-discovered from the replication metrics.",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Replication-manager service",
+          "multi": true,
+          "name": "rm",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(zero_replication_total_lag_millisecond{deployment_environment=~\"$env\"}, service_name)",
+            "refId": "rm"
+          },
+          "refresh": 2,
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allValue": ".*",
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROM}"
+          },
+          "definition": "label_values(zero_sync_active_client_groups{deployment_environment=~\"$env\", service_name=~\"$vs\"}, instance)",
+          "description": "Fly machine / host. Requires OTEL_NODE_RESOURCE_DETECTORS to include \"host\". Leave on All if the instance label is not present.",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Machine",
+          "multi": true,
+          "name": "inst",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(zero_sync_active_client_groups{deployment_environment=~\"$env\", service_name=~\"$vs\"}, instance)",
+            "refId": "inst"
+          },
+          "refresh": 2,
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },
+        {
+          "allowCustomValue": true,
+          "current": {
+            "text": "5m",
+            "value": "5m"
+          },
+          "description": "Rate window used for histogram_quantile panels. Widen it if percentile lines look spiky.",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Quantile window",
+          "multi": false,
+          "name": "win",
+          "options": [],
+          "query": "1m,5m,10m,30m,1h",
+          "skipUrlSync": false,
+          "type": "custom",
+          "valuesFormat": "csv"
+        },
+        {
+          "allowCustomValue": true,
+          "current": {
+            "text": "flyio",
+            "value": "afj5re4yk9og0e"
+          },
+          "description": "Optional. Point at the Fly.io Prometheus datasource (https://api.fly.io/prometheus/<org>) to light up the machine-level panels. Leave unset if you have not configured it.",
+          "hide": 0,
+          "includeAll": false,
+          "label": "Fly.io Prometheus",
+          "multi": false,
+          "name": "DS_FLY",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        },
+        {
+          "allowCustomValue": true,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_FLY}"
+          },
+          "definition": "label_values(fly_instance_up{app=~\"$env.*\"}, app)",
+          "description": "Fly apps for the selected environment. Scoped by $env like every other variable here: unscoped it lists every app in the Fly org, so \"All\" pulled in each per-PR preview machine alongside the real ones and the machine panels summed across all of them.",
+          "hide": 0,
+          "includeAll": true,
+          "label": "Fly app",
+          "multi": true,
+          "name": "fly_app",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(fly_instance_up{app=~\"$env.*\"}, app)",
+            "refId": "fly_app"
+          },
+          "refresh": 2,
+          "regex": "",
+          "regexApplyTo": "value",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-3h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Zero on Fly.io \u2014 service health",
+    "weekStart": ""
+  }
+}

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mix4slb.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mix4slb.yaml
@@ -2,7 +2,7 @@ apiVersion: dashboard.grafana.app/v2
 kind: Dashboard
 metadata:
   annotations:
-    grafana.app/folder: ''
+    grafana.app/folder: dotcom
     grafana.app/saved-from-ui: Grafana Cloud
   labels: {}
   name: mix4slb

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mix4slb.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mix4slb.yaml
@@ -1,0 +1,819 @@
+apiVersion: dashboard.grafana.app/v2
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: ''
+    grafana.app/saved-from-ui: Grafana Cloud
+  labels: {}
+  name: mix4slb
+  namespace: stacks-890472
+spec:
+  annotations:
+    - kind: AnnotationQuery
+      spec:
+        builtIn: true
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        query:
+          datasource:
+            name: -- Grafana --
+          group: grafana
+          kind: DataQuery
+          spec: {}
+          version: v0
+  cursorSync: 'Off'
+  editable: true
+  elements:
+    panel-1:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, quantileWeighted(0.5)(double1,\
+                        \ _sample_interval) as p50_ms, quantileWeighted(0.95)(double1,\
+                        \ _sample_interval) as p95_ms, quantileWeighted(0.99)(double1,\
+                        \ _sample_interval) as p99_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+                        \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n\t\
+                        AND blob2 = '${environment}-tldraw-multiplayer'\n\tAND blob1\
+                        \ = 'outbox_effect'\n\tGROUP BY date\n\tORDER BY date ASC"
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, quantileWeighted(0.5)(double1, _sample_interval)\
+                        \ as p50_ms, quantileWeighted(0.95)(double1, _sample_interval)\
+                        \ as p95_ms, quantileWeighted(0.99)(double1, _sample_interval)\
+                        \ as p99_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_effect'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, quantileWeighted(0.5)(double1, _sample_interval)\
+                        \ as p50_ms, quantileWeighted(0.95)(double1, _sample_interval)\
+                        \ as p95_ms, quantileWeighted(0.99)(double1, _sample_interval)\
+                        \ as p99_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime(1762170000)\
+                        \ AND timestamp <= toDateTime(1762180000)\n\tAND blob2 = 'production-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_effect'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      round: 0s
+                      showFormattedSQL: true
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'End-to-end: time from a file change committing to its effect
+          completing (room notification / publish). double1 = ageMs.'
+        id: 1
+        links: []
+        title: Outbox effect latency (p50 / p95 / p99)
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: right
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 80
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-30616302309
+    panel-2:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, sum(double1) as processed, sum(double2)\
+                        \ as failed\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_drain'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, sum(double1) as processed, sum(double2) as\
+                        \ failed\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_drain'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, sum(double1) as processed, sum(double2) as\
+                        \ failed\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime(1762170000)\
+                        \ AND timestamp <= toDateTime(1762180000)\n\tAND blob2 = 'production-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_drain'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      round: 0s
+                      showFormattedSQL: true
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Per-drain summary. double1 = rows processed, double2 = rows failed
+          this drain.
+        id: 2
+        links: []
+        title: Outbox throughput (processed / failed)
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: right
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 80
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-30616302309
+    panel-3:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob4 as command, quantileWeighted(0.95)(double1,\
+                        \ _sample_interval) as p95_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+                        \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n\t\
+                        AND blob2 = '${environment}-tldraw-multiplayer'\n\tAND blob1\
+                        \ = 'outbox_effect'\n\tGROUP BY date, command\n\tORDER BY date\
+                        \ ASC"
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob4 as command, quantileWeighted(0.95)(double1,\
+                        \ _sample_interval) as p95_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+                        \ >= toDateTime($from) AND timestamp <= toDateTime($to)\n\t\
+                        AND blob2 = '${environment}-tldraw-multiplayer'\n\tAND blob1\
+                        \ = 'outbox_effect'\n\tGROUP BY date, command\n\tORDER BY date\
+                        \ ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob4 as command, quantileWeighted(0.95)(double1,\
+                        \ _sample_interval) as p95_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp\
+                        \ >= toDateTime(1762170000) AND timestamp <= toDateTime(1762180000)\n\
+                        \tAND blob2 = 'production-tldraw-multiplayer'\n\tAND blob1 =\
+                        \ 'outbox_effect'\n\tGROUP BY date, command\n\tORDER BY date\
+                        \ ASC"
+                      round: 0s
+                      showFormattedSQL: true
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: publish/unpublish ride the update command (awaitPersist) and
+          are the slowest. blob3=table, blob4=command.
+        id: 3
+        links: []
+        title: Outbox effect latency p95 by command
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: right
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 80
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-30616302309
+    panel-4:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, quantileWeighted(0.95)(double3,\
+                        \ _sample_interval) as drain_p95_ms\n\tFROM 'MEASURE'\n\tWHERE\
+                        \ timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)\n\
+                        \tAND blob2 = '${environment}-tldraw-multiplayer'\n\tAND blob1\
+                        \ = 'outbox_drain'\n\tGROUP BY date\n\tORDER BY date ASC"
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, quantileWeighted(0.95)(double3, _sample_interval)\
+                        \ as drain_p95_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_drain'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, quantileWeighted(0.95)(double3, _sample_interval)\
+                        \ as drain_p95_ms\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime(1762170000)\
+                        \ AND timestamp <= toDateTime(1762180000)\n\tAND blob2 = 'production-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_drain'\n\tGROUP BY date\n\tORDER BY date\
+                        \ ASC"
+                      round: 0s
+                      showFormattedSQL: true
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: double3 = drainMs. Rising with flat throughput = individual effects
+          getting slower.
+        id: 4
+        links: []
+        title: Outbox drain duration p95
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: right
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 80
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-30616302309
+    panel-5:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob4 as command, count() as\
+                        \ total\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_effect'\n\tGROUP BY date, command\n\t\
+                        ORDER BY date ASC"
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob4 as command, count() as total\n\tFROM\
+                        \ 'MEASURE'\n\tWHERE timestamp >= toDateTime($from) AND timestamp\
+                        \ <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_effect'\n\tGROUP BY date, command\n\t\
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob4 as command, count() as total\n\tFROM\
+                        \ 'MEASURE'\n\tWHERE timestamp >= toDateTime(1762170000) AND\
+                        \ timestamp <= toDateTime(1762180000)\n\tAND blob2 = 'production-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_effect'\n\tGROUP BY date, command\n\t\
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: true
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Volume of each effect type (insert / update / delete).
+        id: 5
+        links: []
+        title: Outbox effects by command
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: right
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 80
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-30616302309
+    panel-6:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      formattedQuery: "SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob4 as command, count() as\
+                        \ parked\n\tFROM 'MEASURE'\n\tWHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_parked'\n\tGROUP BY date, command\n\t\
+                        ORDER BY date ASC"
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob4 as command, count() as parked\n\tFROM\
+                        \ 'MEASURE'\n\tWHERE timestamp >= toDateTime($from) AND timestamp\
+                        \ <= toDateTime($to)\n\tAND blob2 = '${environment}-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_parked'\n\tGROUP BY date, command\n\t\
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob4 as command, count() as parked\n\tFROM\
+                        \ 'MEASURE'\n\tWHERE timestamp >= toDateTime(1762170000) AND\
+                        \ timestamp <= toDateTime(1762180000)\n\tAND blob2 = 'production-tldraw-multiplayer'\n\
+                        \tAND blob1 = 'outbox_parked'\n\tGROUP BY date, command\n\t\
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: true
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: A parked effect (10 failed attempts) is a data-loss event and
+          also fires Sentry. Any line here = investigate.
+        id: 6
+        links: []
+        title: Outbox parked effects (should be 0)
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: right
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 80
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-30616302309
+  layout:
+    kind: GridLayout
+    spec:
+      items:
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-1
+            height: 8
+            width: 12
+            x: 0
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-2
+            height: 8
+            width: 12
+            x: 12
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-3
+            height: 8
+            width: 12
+            x: 0
+            y: 8
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-4
+            height: 8
+            width: 12
+            x: 12
+            y: 8
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-5
+            height: 8
+            width: 12
+            x: 0
+            y: 16
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-6
+            height: 8
+            width: 12
+            x: 12
+            y: 16
+  links: []
+  liveNow: false
+  preload: false
+  tags:
+    - dotcom
+    - outbox
+    - sync-worker
+    - provisioned
+    - repo:tldraw/tldraw
+  timeSettings:
+    autoRefresh: ''
+    autoRefreshIntervals:
+      - 5s
+      - 10s
+      - 30s
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+    fiscalYearStartMonth: 0
+    from: now-6h
+    hideTimepicker: false
+    timezone: browser
+    to: now
+  title: File effect outbox
+  variables:
+    - kind: TextVariable
+      spec:
+        current:
+          text: production
+          value: production
+        description: Environment to filter by. Use production, staging, or your pr number
+          (pr-42).
+        hide: dontHide
+        label: 'Environment: production | staging | pr-42'
+        name: environment
+        query: production
+        skipUrlSync: false

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -1,0 +1,5154 @@
+apiVersion: dashboard.grafana.app/v2
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: ''
+    grafana.app/message: MCP metrics
+    grafana.app/saved-from-ui: Grafana Cloud
+  labels: {}
+  name: ni5k8zc
+  namespace: stacks-890472
+spec:
+  annotations:
+    - kind: AnnotationQuery
+      spec:
+        builtIn: true
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        query:
+          datasource:
+            name: -- Grafana --
+          group: grafana
+          kind: DataQuery
+          spec: {}
+          version: v0
+  cursorSync: Crosshair
+  editable: true
+  elements:
+    panel-1:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, max(double1) as active_users
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'active_users'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, max(double1) as active_users
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'active_users'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Latest active_users gauge reported by the replicator (registered
+          user DOs).
+        id: 1
+        links: []
+        title: Active users
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-2:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as rooms_started
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'room_start'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as rooms_started
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'room_start'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: room_start events in the selected time range.
+        id: 2
+        links: []
+        title: Rooms started
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-3:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as mutations
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object' AND blob3 = 'mutation'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as mutations
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object' AND blob3 = 'mutation'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: user_durable_object mutation events in the selected time range.
+        id: 3
+        links: []
+        title: Mutations accepted
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-4:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as rejected
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object' AND blob3 = 'reject_mutation'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as rejected
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object' AND blob3 = 'reject_mutation'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: user_durable_object reject_mutation events. Should be near zero.
+        id: 4
+        links: []
+        title: Mutations rejected
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: orange
+                      value: 1
+                    - color: red
+                      value: 50
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-5:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as failures
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'fail_persist'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as failures
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'fail_persist'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: fail_persist events (persist gave up after retries). Anything
+          above zero deserves a look.
+        id: 5
+        links: []
+        title: Persist failures
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 1
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-6:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as reboots
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'reboot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as reboots
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'reboot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Replicator reboot events in the selected time range.
+        id: 6
+        links: []
+        title: Replicator reboots
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: yellow
+                      value: 3
+                    - color: red
+                      value: 10
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-7:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('room_create', 'room_reopen', 'enter', 'leave',
+                        'last_out')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('room_create', 'room_reopen', 'enter', 'leave',
+                        'last_out')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Connection lifecycle from TLFileDurableObject: creates, reopens,
+          enters, leaves.'
+        id: 7
+        links: []
+        title: Room lifecycle events
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-8:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('room_start', 'room_empty', 'failed_load_from_db',
+                        'failed_persist_to_db', 'fail_persist')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('room_start', 'room_empty', 'failed_load_from_db',
+                        'failed_persist_to_db', 'fail_persist')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Room starts/empties plus every failure path: failed loads, failed
+          persist attempts, and persists that gave up.'
+        id: 8
+        links: []
+        title: Room health & persistence events
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-9:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as messages
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'send_message'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as messages
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'send_message'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: send_message events from room durable objects (one per outgoing
+          sync message).
+        id: 9
+        links: []
+        title: Sync messages sent
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 25
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-10:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob4 as message_type, sum(double1) as bytes
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'send_message'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, message_type
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob4 as message_type, sum(double1) as bytes
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'send_message'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, message_type
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Outgoing message payload volume, split by message type (blob4).
+          double1 is the message length.
+        id: 10
+        links: []
+        title: Sync message bytes by type
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 30
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: bytes
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-11:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT blob4 as message_type, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'send_message'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY message_type
+
+                        ORDER BY total DESC"
+                      rawQuery: "SELECT blob4 as message_type, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'send_message'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY message_type
+
+                        ORDER BY total DESC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Share of outgoing sync messages by type over the selected range.
+        id: 11
+        links: []
+        title: Message type mix
+        vizConfig:
+          group: piechart
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  fixedColor: '#73BF69'
+                  mode: palette-classic
+                custom:
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                unit: short
+              overrides: []
+            options:
+              displayLabels:
+                - percent
+              legend:
+                displayMode: list
+                overflow: ellipsis
+                placement: right
+                showLegend: true
+                values: []
+              pieType: donut
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: true
+              sort: desc
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-29854286369
+    panel-12:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, quantileWeighted(0.5, double1, _sample_interval)
+                        as p50, quantileWeighted(0.95, double1, _sample_interval) as
+                        p95, quantileWeighted(0.99, double1, _sample_interval) as p99
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'db_load_total'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, quantileWeighted(0.5, double1, _sample_interval)
+                        as p50, quantileWeighted(0.95, double1, _sample_interval) as
+                        p95, quantileWeighted(0.99, double1, _sample_interval) as p99
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'db_load_total'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Full room snapshot load time, weighted by _sample_interval to
+          account for Analytics Engine sampling.
+        id: 12
+        links: []
+        title: Room load latency percentiles (db_load_total)
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-13:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as stage, avg(double1) as avg_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
+                        'on_request_group_check', 'on_request_get_room')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, stage
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as stage, avg(double1) as avg_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
+                        'on_request_group_check', 'on_request_get_room')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, stage
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Average duration of each stage of a room connect request (auth,
+          rate limit, group check, get room, total).
+        id: 13
+        links: []
+        title: Connect request latency breakdown
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-14:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as stage, avg(double1) as avg_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('create_from_source_fetch_total', 'create_from_source_r2_put',
+                        'create_from_source_await_persist', 'create_from_source_r2_fetch',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, stage
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as stage, avg(double1) as avg_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('create_from_source_fetch_total', 'create_from_source_r2_put',
+                        'create_from_source_await_persist', 'create_from_source_r2_fetch',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, stage
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Average duration of file duplication stages and room load sub-stages.
+        id: 14
+        links: []
+        title: Create-from-source & load stage latency
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-15:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT blob1 as operation, avg(double1) as avg_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
+                        'on_request_group_check', 'on_request_get_room', 'get_file_record',
+                        'get_file_record_error', 'db_load_total', 'db_load_total_error',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'create_from_source_fetch_total', 'create_from_source_r2_put',
+                        'create_from_source_await_persist', 'create_from_source_r2_fetch')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY operation
+
+                        ORDER BY avg_ms DESC"
+                      rawQuery: "SELECT blob1 as operation, avg(double1) as avg_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('on_request_total', 'on_request_auth', 'on_request_rate_limit',
+                        'on_request_group_check', 'on_request_get_room', 'get_file_record',
+                        'get_file_record_error', 'db_load_total', 'db_load_total_error',
+                        'db_load_r2_fetch', 'db_load_supabase_fetch', 'db_load_create_from_source',
+                        'create_from_source_fetch_total', 'create_from_source_r2_put',
+                        'create_from_source_await_persist', 'create_from_source_r2_fetch')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY operation
+
+                        ORDER BY avg_ms DESC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Average duration of every timed operation in the selected range,
+          slowest first.
+        id: 15
+        links: []
+        title: Operation latency league table
+        vizConfig:
+          group: bargauge
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: continuous-GrYlRd
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              displayMode: gradient
+              legend:
+                calcs: []
+                displayMode: list
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              maxVizHeight: 300
+              minVizHeight: 16
+              minVizWidth: 8
+              namePlacement: auto
+              orientation: horizontal
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: true
+              showUnfilled: true
+              sizing: auto
+              valueMode: color
+          version: 13.2.0-29854286369
+    panel-16:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, max(double1) as active_users
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'active_users'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, max(double1) as active_users
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'active_users'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: active_users gauge from the postgres replicator.
+        id: 16
+        links: []
+        title: Replicator active users
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 25
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-17:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, max(double1) as rpm
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'rpm'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, max(double1) as rpm
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'rpm'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: rpm gauge — postgres updates processed per minute (logged at
+          most once per minute).
+        id: 17
+        links: []
+        title: Replicator postgres updates per minute
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 25
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-18:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob4 as source, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'reboot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, source
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob4 as source, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'reboot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, source
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Reboot events split by trigger: constructor, inactivity, retry,
+          subscription_closed, test.'
+        id: 18
+        links: []
+        title: Replicator reboots by source
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-19:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator'
+
+                        AND blob3 NOT IN ('rpm', 'active_users', 'reboot_duration')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator'
+
+                        AND blob3 NOT IN ('rpm', 'active_users', 'reboot_duration')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Counter events from TLPostgresReplicator (gauges and durations
+          excluded).
+        id: 19
+        links: []
+        title: Replicator event stream
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-20:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, avg(double1) as avg_ms, max(double1) as max_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'reboot_duration'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, avg(double1) as avg_ms, max(double1) as max_ms
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'replicator' AND blob3 = 'reboot_duration'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: How long replicator reboots take (avg and worst case per interval).
+        id: 20
+        links: []
+        title: Replicator reboot duration
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-21:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object'
+
+                        AND blob3 IN ('mutation', 'broadcast_message', 'replication_event',
+                        'woken_up_by_replication_event', 'reboot', 'found_snapshot',
+                        'full_data_fetch', 'full_data_fetch_hard')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object'
+
+                        AND blob3 IN ('mutation', 'broadcast_message', 'replication_event',
+                        'woken_up_by_replication_event', 'reboot', 'found_snapshot',
+                        'full_data_fetch', 'full_data_fetch_hard')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Healthy-path events from TLUserDurableObject / UserDataSyncer.
+        id: 21
+        links: []
+        title: User DO activity
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-22:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object'
+
+                        AND blob3 IN ('reject_mutation', 'rate_limited', 'connect_retry',
+                        'user_do_abort', 'reboot_error', 'not_enough_history_for_fast_reboot')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object'
+
+                        AND blob3 IN ('reject_mutation', 'rate_limited', 'connect_retry',
+                        'user_do_abort', 'reboot_error', 'not_enough_history_for_fast_reboot')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Failure-path events: rejects, rate limits, retries, aborts,
+          reboot errors, slow-boot fallbacks. Quiet is good.'
+        id: 22
+        links: []
+        title: User DO warning signs
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-23:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, quantileWeighted(0.5, double1, _sample_interval)
+                        as p50, quantileWeighted(0.95, double1, _sample_interval) as
+                        p95, quantileWeighted(0.99, double1, _sample_interval) as p99
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object' AND blob3 = 'cold_start_time'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, quantileWeighted(0.5, double1, _sample_interval)
+                        as p50, quantileWeighted(0.95, double1, _sample_interval) as
+                        p95, quantileWeighted(0.99, double1, _sample_interval) as p99
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object' AND blob3 = 'cold_start_time'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: cold_start_time from first request to ready, weighted by _sample_interval
+          to account for Analytics Engine sampling.
+        id: 23
+        links: []
+        title: User DO cold start percentiles
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-24:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object'
+
+                        AND blob3 NOT IN ('reboot_duration', 'cold_start_time')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY event
+
+                        ORDER BY total DESC"
+                      rawQuery: "SELECT blob3 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'user_durable_object'
+
+                        AND blob3 NOT IN ('reboot_duration', 'cold_start_time')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY event
+
+                        ORDER BY total DESC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Distribution of user durable object events over the selected
+          range (durations excluded).
+        id: 24
+        links: []
+        title: User DO event mix
+        vizConfig:
+          group: piechart
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  fixedColor: '#73BF69'
+                  mode: palette-classic
+                custom:
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                unit: short
+              overrides: []
+            options:
+              displayLabels:
+                - percent
+              legend:
+                displayMode: list
+                overflow: ellipsis
+                placement: right
+                showLegend: true
+                values: []
+              pieType: donut
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: true
+              sort: desc
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-29854286369
+    panel-25:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('postgres_client_connect', 'postgres_client_end',
+                        'postgres_client_error')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as event, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('postgres_client_connect', 'postgres_client_end',
+                        'postgres_client_error')
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, event
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Connection lifecycle from the logging pg client: connect, end,
+          error.'
+        id: 25
+        links: []
+        title: Postgres client connection events
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-26:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as pool, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'postgres_client_connect'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, pool
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob3 as pool, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'postgres_client_connect'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, pool
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: postgres_client_connect events split by the pool name (blob3)
+          that opened them — shows which routes churn connections.
+        id: 26
+        links: []
+        title: Postgres connections by pool
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 30
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-27:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob2 as origin, count() as connects
+
+                        FROM 'BEMO_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'connect'
+
+                        GROUP BY date, origin
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob2 as origin, count() as connects
+
+                        FROM 'BEMO_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'connect'
+
+                        GROUP BY date, origin
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: BEMO_ANALYTICS dataset (demo sync server). blob1 is the event
+          type here — there is no worker-name column and no environment filter. Requires
+          the BEMO_ANALYTICS table in this datasource.
+        id: 27
+        links: []
+        title: Demo server connects by origin
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-28:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as direction, count() as total
+
+                        FROM 'BEMO_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('send_message', 'receive_message')
+
+                        GROUP BY date, direction
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob1 as direction, count() as total
+
+                        FROM 'BEMO_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 IN ('send_message', 'receive_message')
+
+                        GROUP BY date, direction
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Messages sent/received by demo rooms (one data point per message).
+        id: 28
+        links: []
+        title: Demo server message throughput
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 20
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-29:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT blob2 as origin, count() as total
+
+                        FROM 'BEMO_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'connect'
+
+                        GROUP BY origin
+
+                        ORDER BY total DESC
+
+                        LIMIT 12"
+                      rawQuery: "SELECT blob2 as origin, count() as total
+
+                        FROM 'BEMO_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'connect'
+
+                        GROUP BY origin
+
+                        ORDER BY total DESC
+
+                        LIMIT 12"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Which domains embed the demo sync server, by connect count.
+        id: 29
+        links: []
+        title: Top embedding origins
+        vizConfig:
+          group: piechart
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  fixedColor: '#73BF69'
+                  mode: palette-classic
+                custom:
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                unit: short
+              overrides: []
+            options:
+              displayLabels:
+                - percent
+              legend:
+                displayMode: list
+                overflow: ellipsis
+                placement: right
+                showLegend: true
+                values: []
+              pieType: donut
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: true
+              sort: desc
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.2.0-29854286369
+    panel-30:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as sessions
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'session_start'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as sessions
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'session_start'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: session_start events from the tldraw MCP server (MCP_ANALYTICS
+          dataset). Requires the MCP_ANALYTICS table in this datasource.
+        id: 30
+        links: []
+        title: MCP sessions started
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-31:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob2 as tool, count() as calls
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'tool_called'
+
+                        GROUP BY date, tool
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob2 as tool, count() as calls
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'tool_called'
+
+                        GROUP BY date, tool
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: tool_called events split by tool name (search, exec).
+        id: 31
+        links: []
+        title: MCP tool calls by tool
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-32:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as reads
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'resource_called'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as reads
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'resource_called'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: resource_called events for the tldraw-canvas UI resource.
+        id: 32
+        links: []
+        title: MCP canvas resource reads
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 25
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-33:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as renders
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND double3 > 0
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as renders
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND double3 > 0
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Screenshot events that actually spent Browser Run capacity (double3
+          carries a render duration; -1 means no render happened). Cache hits and
+          failures are excluded.
+        id: 33
+        links: []
+        title: Board screenshots rendered
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-34:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT countIf(blob4 = 'cache:hit') / count() * 100
+                        as hit_rate
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob3 = 'source:og'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT countIf(blob4 = 'cache:hit') / count() * 100
+                        as hit_rate
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob3 = 'source:og'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Share of GET /app/social-preview requests (source:og) served
+          straight from the R2 cache. Stale-but-served and never-rendered responses
+          count against it, since both trigger a background render.
+        id: 34
+        links: []
+        title: OG image cache hit rate
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                max: 100
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: red
+                      value: 0
+                    - color: orange
+                      value: 50
+                    - color: green
+                      value: 80
+                unit: percent
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-35:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as failures
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob5 != 'failure:none'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as failures
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob5 != 'failure:none'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Events carrying a failure reason code, across all three surfaces.
+          Sustained non-zero means boards are missing their previews — break it down
+          in the failures-by-reason panel below.
+        id: 35
+        links: []
+        title: Screenshot failures
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 1
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-36:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: "SELECT count() as blocked
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob6 = 'rate_limit:blocked'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      rawQuery: "SELECT count() as blocked
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob6 = 'rate_limit:blocked'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Events blocked by a rate limiter (per-IP, per-board, or the shared
+          global Browser Run cap). Queue jobs blocked this way are requeued rather
+          than dropped.
+        id: 36
+        links: []
+        title: Rate-limited screenshot events
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: red
+                      value: 1
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: none
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-29854286369
+    panel-37:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob3, 8) as surface, count() as
+                        total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, surface
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob3, 8) as surface, count() as
+                        total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, surface
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'All screenshot telemetry split by the surface that emitted it:
+          mcp (the shared board screenshot tool), og (the social-preview route), and
+          queue (the background render consumer).'
+        id: 37
+        links: []
+        title: Screenshot events by surface
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-38:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob4, 7) as cache_status, count()
+                        as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, cache_status
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob4, 7) as cache_status, count()
+                        as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, cache_status
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Cache outcome per event: hit (fresh), stale (served old while
+          re-rendering), miss (nothing to serve).'
+        id: 38
+        links: []
+        title: Screenshot cache status
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-39:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob5, 9) as reason, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob5 != 'failure:none'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, reason
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob5, 9) as reason, count() as total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob5 != 'failure:none'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, reason
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Bounded failure reason codes: board_not_viewable, board_empty,
+          not_found, not_rendered_yet, no_pages, page_out_of_range, invalid_input,
+          and the rate_limited_* codes.'
+        id: 39
+        links: []
+        title: Screenshot failures by reason
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides:
+                - __systemRef: hideSeriesFrom
+                  matcher:
+                    id: byNames
+                    options:
+                      mode: exclude
+                      names:
+                        - not_rendered_yet
+                      prefix: 'All except:'
+                      readOnly: true
+                  properties:
+                    - id: custom.hideFrom
+                      value:
+                        legend: false
+                        tooltip: true
+                        viz: true
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-40:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, quantileWeighted(0.5, double3, _sample_interval)
+                        as p50, quantileWeighted(0.95, double3, _sample_interval) as
+                        p95, quantileWeighted(0.99, double3, _sample_interval) as p99
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND double3 > 0
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, quantileWeighted(0.5, double3, _sample_interval)
+                        as p50, quantileWeighted(0.95, double3, _sample_interval) as
+                        p95, quantileWeighted(0.99, double3, _sample_interval) as p99
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND double3 > 0
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Time spent in Browser Run per screenshot, weighted by _sample_interval
+          to account for Analytics Engine sampling. Only events that rendered (double3
+          > 0) are included.
+        id: 40
+        links: []
+        title: Browser Run render duration percentiles
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-41:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob3, 8) as surface, count() as
+                        total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob6 = 'rate_limit:blocked'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, surface
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, substring(blob3, 8) as surface, count() as
+                        total
+
+                        FROM 'MEASURE'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'mcp_shared_board_screenshot'
+
+                        AND blob6 = 'rate_limit:blocked'
+
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+
+                        GROUP BY date, surface
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Which surface is hitting a limiter. Sustained queue blocking
+          means the shared global Browser Run cap is saturated; mcp blocking is usually
+          a single caller hitting the per-IP limit.
+        id: 41
+        links: []
+        title: Rate-limited screenshots by surface
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+  layout:
+    kind: GridLayout
+    spec:
+      items:
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-1
+            height: 4
+            width: 4
+            x: 0
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-2
+            height: 4
+            width: 4
+            x: 4
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-3
+            height: 4
+            width: 4
+            x: 8
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-4
+            height: 4
+            width: 4
+            x: 12
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-5
+            height: 4
+            width: 4
+            x: 16
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-6
+            height: 4
+            width: 4
+            x: 20
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-7
+            height: 9
+            width: 12
+            x: 0
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-8
+            height: 9
+            width: 12
+            x: 12
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-9
+            height: 8
+            width: 8
+            x: 0
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-10
+            height: 8
+            width: 8
+            x: 8
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-11
+            height: 8
+            width: 8
+            x: 16
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-12
+            height: 9
+            width: 12
+            x: 0
+            y: 21
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-13
+            height: 9
+            width: 12
+            x: 12
+            y: 21
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-14
+            height: 8
+            width: 12
+            x: 0
+            y: 30
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-15
+            height: 8
+            width: 12
+            x: 12
+            y: 30
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-16
+            height: 8
+            width: 8
+            x: 0
+            y: 38
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-17
+            height: 8
+            width: 8
+            x: 8
+            y: 38
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-18
+            height: 8
+            width: 8
+            x: 16
+            y: 38
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-19
+            height: 8
+            width: 12
+            x: 0
+            y: 46
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-20
+            height: 8
+            width: 12
+            x: 12
+            y: 46
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-21
+            height: 9
+            width: 12
+            x: 0
+            y: 54
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-22
+            height: 9
+            width: 12
+            x: 12
+            y: 54
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-23
+            height: 8
+            width: 12
+            x: 0
+            y: 63
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-24
+            height: 8
+            width: 12
+            x: 12
+            y: 63
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-25
+            height: 8
+            width: 12
+            x: 0
+            y: 71
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-26
+            height: 8
+            width: 12
+            x: 12
+            y: 71
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-27
+            height: 8
+            width: 12
+            x: 0
+            y: 79
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-28
+            height: 8
+            width: 6
+            x: 12
+            y: 79
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-29
+            height: 8
+            width: 6
+            x: 18
+            y: 79
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-30
+            height: 8
+            width: 8
+            x: 0
+            y: 87
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-31
+            height: 8
+            width: 8
+            x: 8
+            y: 87
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-32
+            height: 8
+            width: 8
+            x: 16
+            y: 87
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-33
+            height: 4
+            width: 6
+            x: 0
+            y: 95
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-34
+            height: 4
+            width: 6
+            x: 6
+            y: 95
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-35
+            height: 4
+            width: 6
+            x: 12
+            y: 95
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-36
+            height: 4
+            width: 6
+            x: 18
+            y: 95
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-37
+            height: 8
+            width: 8
+            x: 0
+            y: 99
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-38
+            height: 8
+            width: 8
+            x: 8
+            y: 99
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-39
+            height: 8
+            width: 8
+            x: 16
+            y: 99
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-40
+            height: 8
+            width: 12
+            x: 0
+            y: 107
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-41
+            height: 8
+            width: 12
+            x: 12
+            y: 107
+  links: []
+  liveNow: false
+  preload: false
+  tags:
+    - tldraw
+    - analytics-engine
+    - provisioned
+    - repo:tldraw/tldraw
+  timeSettings:
+    autoRefresh: 5s
+    autoRefreshIntervals:
+      - 30s
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+    fiscalYearStartMonth: 0
+    from: now-3h
+    hideTimepicker: false
+    timezone: browser
+    to: now
+  title: Events V2
+  variables:
+    - kind: TextVariable
+      spec:
+        current:
+          text: production
+          value: production
+        description: Environment to filter by. Use production, staging, or your pr number
+          (pr-42). Applies to MEASURE panels only — the demo server and MCP sections
+          query their own datasets.
+        hide: dontHide
+        label: 'Environment: production | staging | pr-42'
+        name: environment
+        query: production
+        skipUrlSync: false

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -5137,7 +5137,7 @@ spec:
     hideTimepicker: false
     timezone: browser
     to: now
-  title: Events V2
+  title: Dotcom events
   variables:
     - kind: TextVariable
       spec:

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -2,7 +2,7 @@ apiVersion: dashboard.grafana.app/v2
 kind: Dashboard
 metadata:
   annotations:
-    grafana.app/folder: ''
+    grafana.app/folder: dotcom
     grafana.app/message: MCP metrics
     grafana.app/saved-from-ui: Grafana Cloud
   labels: {}

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni7hhgd.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni7hhgd.yaml
@@ -1148,7 +1148,7 @@ spec:
     hideTimepicker: false
     timezone: browser
     to: now
-  title: Zero-cache on Fly.io
+  title: Zero-cache HTTP edge (Fly.io)
   variables:
     - kind: TextVariable
       spec:

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni7hhgd.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni7hhgd.yaml
@@ -1,0 +1,1164 @@
+apiVersion: dashboard.grafana.app/v2
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: f6hsw6
+    grafana.app/message: 'using the fly.io datasource '
+    grafana.app/saved-from-ui: Grafana Cloud
+  labels: {}
+  name: ni7hhgd
+  namespace: stacks-890472
+spec:
+  annotations:
+    - kind: AnnotationQuery
+      spec:
+        builtIn: true
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        query:
+          datasource:
+            name: -- Grafana --
+          group: grafana
+          kind: DataQuery
+          spec: {}
+          version: v0
+  cursorSync: Crosshair
+  editable: true
+  elements:
+    panel-1:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: sum(rate(fly_app_http_responses_count{app=~"$app"}[$__rate_interval]))
+                      legendFormat: req/s
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Total HTTP requests/sec across the selected zero-cache apps.
+        id: 1
+        links: []
+        title: Request rate
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: reqps
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-28926505616
+    panel-2:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        sum(rate(fly_app_http_responses_count{app=~"$app", status=~"5.."}[$__rate_interval]))
+                        / sum(rate(fly_app_http_responses_count{app=~"$app"}[$__rate_interval]))
+                      legendFormat: 5xx ratio
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Share of responses with a 5xx status across selected apps.
+        id: 2
+        links: []
+        title: 5xx ratio
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: orange
+                      value: 0.01
+                    - color: red
+                      value: 0.05
+                unit: percentunit
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-28926505616
+    panel-3:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        histogram_quantile(0.99, sum(rate(fly_app_http_response_time_seconds_bucket{app=~"$app"}[$__rate_interval]))
+                        by (le))
+                      legendFormat: p99
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: App-level p99 HTTP response time across selected apps.
+        id: 3
+        links: []
+        title: p99 response time
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: orange
+                      value: 0.5
+                    - color: red
+                      value: 2
+                unit: s
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-28926505616
+    panel-4:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: max(1 - fly_instance_memory_mem_available{app=~"$app"} /
+                        fly_instance_memory_mem_total{app=~"$app"})
+                      legendFormat: max util
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Highest memory utilization among instances of the selected apps.
+        id: 4
+        links: []
+        title: Worst memory utilization
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                    - color: orange
+                      value: 0.8
+                    - color: red
+                      value: 0.9
+                unit: percentunit
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.2.0-28926505616
+    panel-5:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: sum(rate(fly_app_http_responses_count{app=~"$app"}[$__rate_interval]))
+                        by (status)
+                      legendFormat: '{{status}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Response rate split by HTTP status code — traffic and error signals
+          in one view.
+        id: 5
+        links: []
+        title: HTTP responses by status
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: reqps
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-6:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: sum(rate(fly_app_http_responses_count{app=~"$app"}[$__rate_interval]))
+                        by (app)
+                      legendFormat: '{{app}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: HTTP request rate per app (view syncers, replication manager,
+          PR previews).
+        id: 6
+        links: []
+        title: Request rate by app
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: reqps
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-7:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        histogram_quantile(0.5, sum(rate(fly_app_http_response_time_seconds_bucket{app=~"$app"}[$__rate_interval]))
+                        by (le, app))
+                      legendFormat: '{{app}} p50'
+                    version: v0
+                  refId: A
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        histogram_quantile(0.95, sum(rate(fly_app_http_response_time_seconds_bucket{app=~"$app"}[$__rate_interval]))
+                        by (le, app))
+                      legendFormat: '{{app}} p95'
+                    version: v0
+                  refId: B
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        histogram_quantile(0.99, sum(rate(fly_app_http_response_time_seconds_bucket{app=~"$app"}[$__rate_interval]))
+                        by (le, app))
+                      legendFormat: '{{app}} p99'
+                    version: v0
+                  refId: C
+            queryOptions: {}
+            transformations: []
+        description: p50 / p95 / p99 from the app-level response time histogram, per
+          app.
+        id: 7
+        links: []
+        title: App response time percentiles
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: s
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-8:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        sum(rate(fly_app_http_responses_count{app=~"$app", status=~"5.."}[$__rate_interval]))
+                        by (app) / sum(rate(fly_app_http_responses_count{app=~"$app"}[$__rate_interval]))
+                        by (app)
+                      legendFormat: '{{app}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Server error ratio per app over time. Flat at zero is the goal.
+        id: 8
+        links: []
+        title: 5xx ratio by app
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 25
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: percentunit
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-9:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: sum(rate(fly_edge_http_responses_count{app=~"$app"}[$__rate_interval]))
+                        by (region)
+                      legendFormat: '{{region}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Requests/sec entering through Fly edge nodes, by region — where
+          the WebSocket/zero-sync traffic comes from.
+        id: 9
+        links: []
+        title: Edge traffic by region
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: reqps
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-10:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr:
+                        histogram_quantile(0.95, sum(rate(fly_edge_http_response_time_seconds_bucket{app=~"$app"}[$__rate_interval]))
+                        by (le, region))
+                      legendFormat: '{{region}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Edge-measured p95 latency per region — includes network path,
+          so compare against the app-level histogram to separate network from compute.
+        id: 10
+        links: []
+        title: Edge p95 response time by region
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: s
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-11:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: sum(rate(fly_instance_cpu{app=~"$app", mode!="idle"}[$__rate_interval]))
+                        by (app, instance)
+                      legendFormat: '{{app}} {{instance}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Non-idle CPU time per instance (sum of user/system/etc. modes).
+          Values approach the machine core count at saturation.
+        id: 11
+        links: []
+        title: CPU busy by instance
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 12
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+    panel-12:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: flyio
+                    group: prometheus
+                    kind: DataQuery
+                    spec:
+                      expr: 1 - fly_instance_memory_mem_available{app=~"$app"} / fly_instance_memory_mem_total{app=~"$app"}
+                      legendFormat: '{{app}} {{instance}}'
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Fraction of memory in use (1 - available/total) per instance.
+          The replication manager and view syncers hold replica state in memory, so
+          this is the key saturation gauge for zero-cache.
+        id: 12
+        links: []
+        title: Memory utilization by instance
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 20
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                max: 1
+                min: 0
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: percentunit
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: multi
+                sort: desc
+          version: 13.2.0-28926505616
+  layout:
+    kind: GridLayout
+    spec:
+      items:
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-1
+            height: 4
+            width: 6
+            x: 0
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-2
+            height: 4
+            width: 6
+            x: 6
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-3
+            height: 4
+            width: 6
+            x: 12
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-4
+            height: 4
+            width: 6
+            x: 18
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-5
+            height: 9
+            width: 12
+            x: 0
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-6
+            height: 9
+            width: 12
+            x: 12
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-7
+            height: 9
+            width: 12
+            x: 0
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-8
+            height: 9
+            width: 12
+            x: 12
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-9
+            height: 8
+            width: 12
+            x: 0
+            y: 22
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-10
+            height: 8
+            width: 12
+            x: 12
+            y: 22
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-11
+            height: 8
+            width: 12
+            x: 0
+            y: 30
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-12
+            height: 8
+            width: 12
+            x: 12
+            y: 30
+  links: []
+  liveNow: false
+  preload: false
+  tags:
+    - tldraw
+    - flyio
+    - zero-cache
+    - platform
+    - provisioned
+    - repo:tldraw/tldraw
+  timeSettings:
+    autoRefresh: 30s
+    autoRefreshIntervals:
+      - 30s
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+    fiscalYearStartMonth: 0
+    from: now-6h
+    hideTimepicker: false
+    timezone: browser
+    to: now
+  title: Zero-cache on Fly.io
+  variables:
+    - kind: TextVariable
+      spec:
+        current:
+          text: .*
+          value: .*
+        description: App name regex. Use .* for all apps, production-zero-.* for production
+          only, or a PR app like pr-123-zero-cache.
+        hide: dontHide
+        label: 'App regex: .* | production-zero-.* | pr-…'
+        name: app
+        query: .*
+        skipUrlSync: false

--- a/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
+++ b/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
@@ -2,7 +2,7 @@ apiVersion: dashboard.grafana.app/v2beta1
 kind: Dashboard
 metadata:
   annotations:
-    grafana.app/folder: ''
+    grafana.app/folder: dotcom
     grafana.app/saved-from-ui: Grafana Cloud (steady)
   labels: {}
   name: kotx6wj

--- a/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
+++ b/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
@@ -1,0 +1,596 @@
+apiVersion: dashboard.grafana.app/v2beta1
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: ''
+    grafana.app/saved-from-ui: Grafana Cloud (steady)
+  labels: {}
+  name: kotx6wj
+  namespace: stacks-890472
+spec:
+  annotations:
+    - kind: AnnotationQuery
+      spec:
+        builtIn: true
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        query:
+          datasource:
+            name: -- Grafana --
+          group: grafana
+          kind: DataQuery
+          spec: {}
+          version: v0
+  cursorSync: 'Off'
+  description: How many sessions have been created with the MCP App
+  editable: true
+  elements:
+    panel-1:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
+                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      intervalFactor: 1
+                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob1 as event, count() as total\n  FROM\
+                        \ 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from) AND\
+                        \ timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob1 as event, count() as total\n  FROM\
+                        \ 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime(1772623318)\
+                        \ AND timestamp <= toDateTime(1772796118)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC"
+                      round: 0s
+                      skip_comments: true
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Sessions are created when you make a request to the MCP worker
+        id: 1
+        links: []
+        title: Sessions by Time
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.6
+                  drawStyle: line
+                  fillOpacity: 0
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: auto
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              legend:
+                calcs: []
+                displayMode: list
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+          version: 13.0.0-22478626928
+    panel-2:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
+                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      intervalFactor: 1
+                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'create_shapes'\n    GROUP BY date, tool\n\
+                        \    ORDER BY date ASC\n"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
+                        \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'create_shapes'\n    GROUP BY date, tool\n\
+                        \    ORDER BY date ASC"
+                      round: 0s
+                      skip_comments: true
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Sessions are created when you make a request to the MCP worker
+        id: 2
+        links: []
+        title: Tool Call (create_shapes)
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: center
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - sum
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.0.0-22478626928
+    panel-3:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
+                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      intervalFactor: 1
+                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'update_shapes'\n    GROUP BY date, tool\n\
+                        \    ORDER BY date ASC\n"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
+                        \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'update_shapes'\n    GROUP BY date, tool\n\
+                        \    ORDER BY date ASC"
+                      round: 0s
+                      skip_comments: true
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Sessions are created when you make a request to the MCP worker
+        id: 3
+        links: []
+        title: Tool Call (update_shapes)
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: yellow
+                      value: 0
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: center
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - sum
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.0.0-22478626928
+    panel-4:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
+                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      intervalFactor: 1
+                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'read_me'\n    GROUP BY date, tool\n    ORDER\
+                        \ BY date ASC\n"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
+                        \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'read_me'\n    GROUP BY date, tool\n    ORDER\
+                        \ BY date ASC"
+                      round: 0s
+                      skip_comments: true
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Sessions are created when you make a request to the MCP worker
+        id: 4
+        links: []
+        title: Tool Call (read_me)
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: blue
+                      value: 0
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: center
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - sum
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.0.0-22478626928
+    panel-5:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
+                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      intervalFactor: 1
+                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'delete_shapes'\n    GROUP BY date, tool\n\
+                        \    ORDER BY date ASC\n"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob2 as tool, count() as total\n    FROM\
+                        \ 'MCP_ANALYTICS'\n    WHERE timestamp >= toDateTime(1772623318)\
+                        \ AND timestamp <= toDateTime(1772796118)\n    AND blob1 = 'tool_called'\n\
+                        \    and blob2 = 'delete_shapes'\n    GROUP BY date, tool\n\
+                        \    ORDER BY date ASC"
+                      round: 0s
+                      skip_comments: true
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Tool calls
+        id: 5
+        links: []
+        title: Tool Call (delete_shapes)
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: red
+                      value: 0
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: center
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - sum
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.0.0-22478626928
+    panel-6:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: builder
+                      extrapolate: true
+                      format: time_series
+                      formattedQuery: "  SELECT toStartOfInterval(timestamp, INTERVAL\
+                        \ '$interval' SECOND) as date, blob1 as event, count() as total\n\
+                        \  FROM 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from)\
+                        \ AND timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      intervalFactor: 1
+                      query: "  SELECT toStartOfInterval(timestamp, INTERVAL '$interval'\
+                        \ SECOND) as date, blob1 as event, count() as total\n  FROM\
+                        \ 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime($from) AND\
+                        \ timestamp <= toDateTime($to)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC\n"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '120'\
+                        \ SECOND) as date, blob1 as event, count() as total\n  FROM\
+                        \ 'MCP_ANALYTICS'\n  WHERE timestamp >= toDateTime(1772622707)\
+                        \ AND timestamp <= toDateTime(1772795507)\n  AND blob1 = 'session_start'\n\
+                        \  GROUP BY date, event\n  ORDER BY date ASC"
+                      round: 0s
+                      skip_comments: true
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Sessions are created when you make a request to the MCP worker
+        id: 6
+        links: []
+        title: Total Sessions
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - sum
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+          version: 13.0.0-22478626928
+  layout:
+    kind: GridLayout
+    spec:
+      items:
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-6
+            height: 13
+            width: 12
+            x: 0
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-1
+            height: 13
+            width: 12
+            x: 12
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-4
+            height: 13
+            width: 6
+            x: 0
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-2
+            height: 13
+            width: 6
+            x: 6
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-3
+            height: 13
+            width: 6
+            x: 12
+            y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-5
+            height: 13
+            width: 6
+            x: 18
+            y: 13
+  links: []
+  liveNow: false
+  preload: false
+  tags:
+    - provisioned
+    - repo:tldraw/tldraw
+  timeSettings:
+    autoRefresh: ''
+    autoRefreshIntervals:
+      - 5s
+      - 10s
+      - 30s
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+    fiscalYearStartMonth: 0
+    from: now-6h
+    hideTimepicker: false
+    timezone: browser
+    to: now
+  title: MCP App Sessions
+  variables: []

--- a/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
+++ b/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
@@ -592,5 +592,5 @@ spec:
     hideTimepicker: false
     timezone: browser
     to: now
-  title: MCP App Sessions
+  title: MCP app sessions
   variables: []

--- a/internal/grafana/resources/folders.v1.folder.grafana.app/anthropic.yaml
+++ b/internal/grafana/resources/folders.v1.folder.grafana.app/anthropic.yaml
@@ -1,0 +1,9 @@
+apiVersion: folder.grafana.app/v1
+kind: Folder
+metadata:
+  annotations: {}
+  labels: {}
+  name: anthropic
+  namespace: stacks-890472
+spec:
+  title: Anthropic

--- a/internal/grafana/resources/folders.v1.folder.grafana.app/dotcom.yaml
+++ b/internal/grafana/resources/folders.v1.folder.grafana.app/dotcom.yaml
@@ -1,0 +1,9 @@
+apiVersion: folder.grafana.app/v1
+kind: Folder
+metadata:
+  annotations: {}
+  labels: {}
+  name: dotcom
+  namespace: stacks-890472
+spec:
+  title: Dotcom

--- a/internal/grafana/resources/folders.v1.folder.grafana.app/f6hsw6.yaml
+++ b/internal/grafana/resources/folders.v1.folder.grafana.app/f6hsw6.yaml
@@ -1,0 +1,9 @@
+apiVersion: folder.grafana.app/v1
+kind: Folder
+metadata:
+  annotations: {}
+  labels: {}
+  name: f6hsw6
+  namespace: stacks-890472
+spec:
+  title: Zero


### PR DESCRIPTION
In order to stop dashboard and alert-rule changes living only in the Grafana UI — where they're unversioned, unreviewable, and easy to break silently — this PR makes the repo the source of truth for our Grafana Cloud stack and adds a deploy workflow that pushes it with [gcx](https://github.com/grafana/gcx) (Grafana's official CLI). Sync is one-way by design: merges to `main` overwrite whatever is in Grafana; UI edits don't survive the next deploy.

The provisioned set was chosen by auditing all 19 user dashboards on the stack: 5 are alive or forward-looking and live here (`zero-fly-health`, Events, Events V2, File effect outbox, MCP App Sessions), along with all 12 alert rules and their two folders. The rest were stale, broken, or scratch and stay hand-managed in Grafana pending deletion. The initial push has already been applied manually, so Grafana currently matches this tree exactly.

How it works:

- `internal/grafana/resources/` is a `gcx resources pull` tree (round-trip verified). Don't hand-edit formatting; `zero-fly-health` is JSON because gcx 1.0.0's YAML writer breaks on emoji variation selectors.
- PRs touching `internal/grafana/**` get `gcx resources validate` + a dry-run push (alert rules show as "skipped" — the alerting API has no server-side dry-run). Merges to `main` do the real push.
- gcx is pinned to 1.0.0 with a checksum; the job is skipped on fork PRs since both validate and push need the `GRAFANA_SERVER`/`GRAFANA_TOKEN` repo secrets.
- Provisioned dashboards carry `provisioned` + `repo:tldraw/tldraw` tags so their origin is visible in the Grafana UI.

### Change type

- [x] `other`

### Test plan

1. `gcx resources validate -p internal/grafana/resources` and `gcx resources push --dry-run` pass against the live stack (verified locally).
2. The full tree has been pushed to Grafana and pulled back clean — tags, folder moves, and alert rules all round-trip.
3. After merge, check the `Deploy grafana resources` run is green and spot-check the Zero folder in Grafana.

### Code changes

| Section        | LOC change    |
| -------------- | ------------- |
| Config/tooling | +17329 / -0   |

(+17225 of that is generated `gcx resources pull` output under `internal/grafana/resources/`; the hand-written part is the workflow and README, +104.)