### PR TITLE
perf(dotcom): stop the OG render consumer resolving the same file twice

### DIFF
--- a/.github/workflows/deploy-dotcom.yml
+++ b/.github/workflows/deploy-dotcom.yml
@@ -63,7 +63,9 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: supabase/setup-cli@v1
         with:
-          version: latest
+          # Pinned: v2.112.0 rejects the Management API's own timestamps, which
+          # breaks `branches get` and `branches delete`. See supabase/cli#6115.
+          version: 2.111.0
 
       - name: Delete Supabase branch
         if: contains(github.event.pull_request.labels.*.name, 'reset-preview-db')

--- a/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest'
-import { SharedFileInfo, isFileAnonymouslyViewable, isFileRenderable } from './getSharedFile'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+	SharedFileInfo,
+	getSharedFileRoomSnapshot,
+	isFileAnonymouslyViewable,
+	isFileRenderable,
+} from './getSharedFile'
 
 function makeFile(overrides: Partial<SharedFileInfo> = {}): SharedFileInfo {
 	return { id: 'file-abc', shared: true, isDeleted: false, ...overrides }
@@ -49,5 +54,87 @@ describe('isFileAnonymouslyViewable', () => {
 
 	it('refuses a test file, which needs admin auth the anonymous tool never has', () => {
 		expect(isFileAnonymouslyViewable(makeFile({ id: 'test_abc' }))).toBe(false)
+	})
+})
+
+// The `file` option on getSharedFileRoomSnapshot. It decides whether the gate runs against a freshly
+// read row or one the caller already holds — never whether the gate runs at all. The Postgres pool is
+// faked rather than the reader mocked, so these exercise the real query path and can tell a skipped
+// round trip from a skipped check.
+const pg = vi.hoisted(() => {
+	const executeTakeFirst = vi.fn()
+	const db: any = {
+		selectFrom: () => db,
+		select: () => db,
+		where: () => db,
+		executeTakeFirst,
+		destroy: vi.fn(),
+	}
+	return { db, executeTakeFirst, createPostgresConnectionPool: vi.fn(() => db) }
+})
+
+vi.mock('../../postgres', () => ({
+	createPostgresConnectionPool: pg.createPostgresConnectionPool,
+}))
+
+describe('getSharedFileRoomSnapshot', () => {
+	const snapshot = { documents: [], schema: { schemaVersion: 2, sequences: {} } }
+
+	function makeEnv() {
+		return { ROOMS: { get: vi.fn().mockResolvedValue({ json: async () => snapshot }) } } as any
+	}
+
+	afterEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it('reads the file row when none is supplied', async () => {
+		pg.executeTakeFirst.mockResolvedValue(makeFile())
+
+		await expect(
+			getSharedFileRoomSnapshot(makeEnv(), 'file-abc', { access: 'public' })
+		).resolves.toEqual(snapshot)
+		expect(pg.createPostgresConnectionPool).toHaveBeenCalledTimes(1)
+	})
+
+	it('reuses a supplied row instead of asking Postgres again', async () => {
+		await expect(
+			getSharedFileRoomSnapshot(makeEnv(), 'file-abc', { access: 'public', file: makeFile() })
+		).resolves.toEqual(snapshot)
+		expect(pg.createPostgresConnectionPool).not.toHaveBeenCalled()
+	})
+
+	// The point of the option is to skip the round trip, not the check. A row that fails the gate is
+	// refused exactly as a freshly-read one would be, and the snapshot is never read.
+	it('still applies the gate to a supplied row', async () => {
+		const env = makeEnv()
+
+		await expect(
+			getSharedFileRoomSnapshot(env, 'file-abc', {
+				access: 'public',
+				file: makeFile({ shared: false }),
+			})
+		).rejects.toThrow('not shared')
+
+		await expect(
+			getSharedFileRoomSnapshot(env, 'file-abc', {
+				access: 'render',
+				file: makeFile({ isDeleted: true }),
+			})
+		).rejects.toThrow('not renderable')
+
+		expect(pg.createPostgresConnectionPool).not.toHaveBeenCalled()
+		expect(env.ROOMS.get).not.toHaveBeenCalled()
+	})
+
+	// A supplied row is gated under the *caller's* access level, not whichever one it was resolved
+	// under, so handing a render-gated row to a public read cannot widen what that read may see.
+	it('refuses a private row supplied to a public read', async () => {
+		await expect(
+			getSharedFileRoomSnapshot(makeEnv(), 'file-abc', {
+				access: 'public',
+				file: makeFile({ shared: false }),
+			})
+		).rejects.toThrow('not shared')
 	})
 })

--- a/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getSharedFile.ts
@@ -63,15 +63,29 @@ export function isFileViewableFor(
 	return access === 'public' ? isFileAnonymouslyViewable(file) : isFileRenderable(file)
 }
 
-// Read the live room snapshot for an app file from R2. Re-checks the caller's gate rather than
-// trusting whatever check happened earlier: a `public` read of a board un-shared since a render
-// token was minted must stop resolving inside that token's window.
+/**
+ * Read the live room snapshot for an app file from R2.
+ *
+ * The gate always runs here — never trust that whatever resolved this board already applied it. What
+ * `file` decides is only whether the row it runs against is re-read or reused:
+ *
+ * - **Omitted (the default): re-read.** The row is fetched fresh, so a board un-shared since the
+ *   caller last looked stops resolving. This is what a read separated from its resolve by a network
+ *   hop needs — `getThumbnailSnapshot` serves a *private* board's document to the render page inside
+ *   a token's window, and the un-share must land inside that window.
+ * - **Supplied: reuse.** For a caller that resolved this board microseconds ago in the same function,
+ *   a second query returns the same row and buys nothing but a Postgres connection. The gate is still
+ *   applied to the row that was passed, so the check is not skipped — only the round trip is.
+ *
+ * Pass it only where the resolve is genuinely adjacent to the read. Anywhere else, the freshness is
+ * the point.
+ */
 export async function getSharedFileRoomSnapshot(
 	env: Environment,
 	slug: string,
-	{ access }: { access: ThumbnailBoardAccess }
+	{ access, file: resolvedFile }: { access: ThumbnailBoardAccess; file?: SharedFileInfo }
 ): Promise<RoomSnapshot | undefined> {
-	const file = await getSharedFileInfo(env, slug)
+	const file = resolvedFile ?? (await getSharedFileInfo(env, slug))
 	if (!isFileViewableFor(file, access)) {
 		throw Error(access === 'public' ? 'not shared' : 'not renderable')
 	}

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.test.ts
@@ -584,6 +584,29 @@ describe('handleOgImageRenderMessage', () => {
 		).toBe('etag-1')
 	})
 
+	// The resolve above the snapshot read already fetched this row, so it is handed to the read rather
+	// than fetched again — one Postgres connection per job instead of two. The gate still runs, on the
+	// row that was passed (see getSharedFile.test.ts).
+	it('hands the resolved file row to the snapshot read instead of re-reading it', async () => {
+		const file = { id: 'shared-file', shared: true, isDeleted: false }
+		vi.mocked(getSharedFileInfo).mockResolvedValue(file)
+		vi.mocked(getSharedFileRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({
+			ROOMS: makeFakeRoomsBucket('etag-1'),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'shared_file', slug: 'shared-file' }))
+
+		expect(getSharedFileRoomSnapshot).toHaveBeenCalledWith(env, 'shared-file', {
+			access: 'render',
+			file,
+		})
+		// Once for the resolve, and not a second time for the read. The follow-up check re-resolves on
+		// purpose, so it is allowed its own.
+		expect(getSharedFileInfo).toHaveBeenCalledTimes(2)
+	})
+
 	it('skips rendering when the cached image already matches the current version', async () => {
 		vi.mocked(getPublishedFileInfo).mockResolvedValue({
 			id: 'file-1',

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.test.ts
@@ -602,9 +602,55 @@ describe('handleOgImageRenderMessage', () => {
 			access: 'render',
 			file,
 		})
-		// Once for the resolve, and not a second time for the read. The follow-up check re-resolves on
-		// purpose, so it is allowed its own.
-		expect(getSharedFileInfo).toHaveBeenCalledTimes(2)
+		// One read for the whole job: the resolve. The snapshot read reuses its row, and the follow-up
+		// check compares R2 etags without a gate. Two of the four this path used to cost.
+		expect(getSharedFileInfo).toHaveBeenCalledTimes(1)
+	})
+
+	// The follow-up check only asks "has the content moved since we captured?", and a shared file's
+	// version is its room etag — so it reads R2 and never Postgres. The gate it used to do redundantly
+	// belongs to the job it enqueues, which re-resolves in full before spending anything.
+	it('checks for a moved board without reading Postgres, and follows up when the etag changed', async () => {
+		vi.mocked(getSharedFileInfo).mockResolvedValue({
+			id: 'shared-file',
+			shared: true,
+			isDeleted: false,
+		})
+		vi.mocked(getSharedFileRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		// The board is captured at one etag and has moved on by the time the follow-up check runs.
+		let etag = 'etag-1'
+		const env = makeEnv({
+			ROOMS: { head: async () => ({ etag }) },
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+		vi.mocked(getSharedFileRoomSnapshot).mockImplementation(async () => {
+			etag = 'etag-2'
+			return makeOnePageSnapshot()
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'shared_file', slug: 'shared-file' }))
+
+		expect(getSharedFileInfo).toHaveBeenCalledTimes(1)
+		expect(env.QUEUE.send).toHaveBeenCalledWith(
+			expect.objectContaining({ kind: 'shared_file', slug: 'shared-file', followUp: true })
+		)
+	})
+
+	it('does not follow up when the board has not moved', async () => {
+		vi.mocked(getSharedFileInfo).mockResolvedValue({
+			id: 'shared-file',
+			shared: true,
+			isDeleted: false,
+		})
+		vi.mocked(getSharedFileRoomSnapshot).mockResolvedValue(makeOnePageSnapshot())
+		const env = makeEnv({
+			ROOMS: makeFakeRoomsBucket('etag-1'),
+			THUMBNAILS: makeFakeThumbnailsBucket(),
+		})
+
+		await handleOgImageRenderMessage(env, makeMessage({ kind: 'shared_file', slug: 'shared-file' }))
+
+		expect(env.QUEUE.send).not.toHaveBeenCalledWith(expect.objectContaining({ followUp: true }))
 	})
 
 	it('skips rendering when the cached image already matches the current version', async () => {

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
@@ -286,7 +286,13 @@ export async function handleOgImageRenderMessage(
 
 		// Loaded to target the first page that has content, so a board whose first page is empty still
 		// gets a meaningful unfurl image.
-		const snapshot = await loadBoardSnapshot(env, board, { access: 'render' })
+		//
+		// `file` is the row the resolve above already gated on, handed back so this read re-applies the
+		// gate without asking Postgres the same question a second time. Safe precisely here: the two are
+		// microseconds apart in one function, where a re-read would return the row we already hold. The
+		// render page's own read (getThumbnailSnapshot) deliberately does not do this — it is a separate
+		// request, and its re-read is what makes an un-share land inside the token's window.
+		const snapshot = await loadBoardSnapshot(env, board, { access: 'render', file: board.file })
 		if (!snapshot) {
 			// No persisted content. The render page reads the snapshot through the same functions, so it
 			// would 404 and come back as a render failure — after spending a Browser Run slot to learn

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
@@ -6,6 +6,7 @@ import {
 	OG_REPAIR_COOLDOWN_MS,
 	OG_RETRY_DELAY_SECONDS,
 } from '../../config'
+import { getR2KeyForRoom } from '../../r2'
 import {
 	Environment,
 	OgImageRenderQueueMessage,
@@ -374,11 +375,9 @@ async function enqueueFollowUpIfBoardMoved(
 ) {
 	if (message.body.followUp) return
 	try {
-		const resolved = await resolveThumbnailBoard(env, rendered.kind, rendered.slug, {
-			access: 'render',
-		})
-		if (!resolved.ok) return
-		if (String(resolved.board.version) === String(rendered.version)) return
+		const current = await readCurrentBoardVersion(env, rendered)
+		if (current === null) return
+		if (String(current) === String(rendered.version)) return
 		await enqueueOgImageRender(env, rendered, { reason, followUp: true })
 	} catch (error) {
 		reportThumbnailError(error, {
@@ -388,6 +387,32 @@ async function enqueueFollowUpIfBoardMoved(
 			extras: { kind: rendered.kind, followUpCheck: true },
 		})
 	}
+}
+
+/**
+ * The board's current content version, for the "did it move while we were capturing?" check above and
+ * nothing else. `null` means there is nothing to compare against, which is treated as "don't follow
+ * up".
+ *
+ * A shared file's version *is* the persisted room's R2 etag, so this reads that object's head rather
+ * than going through `resolveThumbnailBoard`. The Postgres half of a resolve answers the gate, and no
+ * gate is needed here: this decides whether to **enqueue**, and the job it enqueues re-resolves in
+ * full before spending any Browser Run. So a board soft-deleted inside this window costs one queue
+ * message that the next delivery drops as `board_not_viewable` — not a render, and not a leak.
+ *
+ * A published board's version is `lastPublished`, a column rather than an etag, so it has no R2
+ * shortcut and keeps the full resolve. Publishing is not the trigger that made this path hot.
+ */
+async function readCurrentBoardVersion(
+	env: Environment,
+	board: ResolvedThumbnailBoard
+): Promise<string | number | null> {
+	if (board.kind === 'published') {
+		const resolved = await resolveThumbnailBoard(env, board.kind, board.slug, { access: 'render' })
+		return resolved.ok ? resolved.board.version : null
+	}
+	const persisted = await env.ROOMS.head(getR2KeyForRoom({ slug: board.slug, isApp: true }))
+	return persisted?.etag ?? null
 }
 
 async function retryOrDrop(

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
@@ -24,7 +24,12 @@ import {
 	recordMintedRenderToken,
 } from '../../utils/renderTokens'
 import { getPublishedFileInfo, getPublishedRoomSnapshot } from './getPublishedFile'
-import { getSharedFileInfo, getSharedFileRoomSnapshot, isFileViewableFor } from './getSharedFile'
+import {
+	SharedFileInfo,
+	getSharedFileInfo,
+	getSharedFileRoomSnapshot,
+	isFileViewableFor,
+} from './getSharedFile'
 import { BoardSnapshotReadError, BrowserRenderError } from './thumbnailShared'
 
 // The render-and-cache core shared by every Browser Run screenshot surface: the MCP screenshot
@@ -48,6 +53,14 @@ export interface ResolvedThumbnailBoard extends ThumbnailBoardRef {
 	 * route reads the board back under it.
 	 */
 	access: ThumbnailBoardAccess
+	/**
+	 * The `file` row this resolution gated on, for `shared_file` boards only. Carried so a caller that
+	 * reads the snapshot in the same breath can hand it back to `loadBoardSnapshot` instead of asking
+	 * Postgres the same question twice — see the `file` option on `getSharedFileRoomSnapshot` for when
+	 * that is and is not appropriate. Never signed into a render job: the job carries the gate, and a
+	 * row that travelled inside a token could not be re-checked on the way back.
+	 */
+	file?: SharedFileInfo
 }
 
 export type ResolveThumbnailBoardResult =
@@ -85,7 +98,7 @@ export async function resolveThumbnailBoard(
 	const persisted = await env.ROOMS.head(getR2KeyForRoom({ slug, isApp: true }))
 	if (!persisted) return { ok: false, reason: 'board_empty' }
 
-	return { ok: true, board: { kind, slug, version: persisted.etag, access } }
+	return { ok: true, board: { kind, slug, version: persisted.etag, access, file } }
 }
 
 // Reads a resolved board's snapshot, keeping the two outcomes callers must tell apart distinct.
@@ -96,13 +109,24 @@ export async function resolveThumbnailBoard(
 export async function loadBoardSnapshot(
 	env: Environment,
 	board: ThumbnailBoardRef,
-	{ access }: { access: ThumbnailBoardAccess }
+	{
+		access,
+		file,
+	}: {
+		access: ThumbnailBoardAccess
+		/**
+		 * The row a caller has *just* resolved this board against, to be gated again rather than
+		 * re-fetched. Opt in per call site rather than reading it off `board`, so a surface takes the
+		 * staleness that comes with it deliberately. See `getSharedFileRoomSnapshot`.
+		 */
+		file?: SharedFileInfo
+	}
 ): Promise<RoomSnapshot | null> {
 	try {
 		const snapshot =
 			board.kind === 'published'
 				? await getPublishedRoomSnapshot(env, board.slug)
-				: await getSharedFileRoomSnapshot(env, board.slug, { access })
+				: await getSharedFileRoomSnapshot(env, board.slug, { access, file })
 		return snapshot ?? null
 	} catch (error) {
 		// Keep the original message in the wrapper's own text as well as its `cause`, so the Sentry


### PR DESCRIPTION
A shared-file render job read the same `file` row from Postgres four times. Each `createPostgresConnectionPool` call opens and tears down its own `pg.Pool`, so every one of those is a full connect handshake for a question we had already asked. This removes two of the four.

It didn't matter when publishing was the only trigger. #9667 added the edit trigger, and production went from ~50 to ~2,000 render jobs an hour; `getSharedFileInfo` connects went ~300/hr → ~8,400/hr, which is ~4 per job (8,061 excess ÷ 2,068 jobs = 3.9).

### 1. The snapshot read reuses the row the resolve just fetched

`getSharedFileRoomSnapshot` now takes an optional pre-resolved row. **The gate still runs — on the row that was passed.** Only the round trip is skipped, and the row is gated under the *caller's* access level rather than whichever one resolved it, so a render-gated row handed to a public read is still refused.

The queue consumer opts in, because its resolve is microseconds away in the same function where a re-read returns the row we already hold. `getThumbnailSnapshot` deliberately does not — see the call stack below. That's why this is opt-in per call site rather than read off the board: a surface has to take the staleness deliberately.

### 2. The moved-board check no longer reads Postgres at all

`enqueueFollowUpIfBoardMoved` ran a full `resolveThumbnailBoard` but used only the version from it. A shared file's version *is* the persisted room's R2 etag, so the Postgres half was answering a gate nothing there needs: it decides whether to **enqueue**, and the job it enqueues re-resolves in full before spending any Browser Run.

A board soft-deleted inside that window now costs one queue message that the next delivery drops as `board_not_viewable` — not a render, and not a leak. Published boards keep the resolve, since their version is `lastPublished`, a column rather than an etag.

### What's left, and why

```
worker (queue consumer)
  ├─ resolveThumbnailBoard ............. Postgres read #1  ← stays: freshness + coalescing
  ├─ loadBoardSnapshot ................. was #2, now reuses the row above
  ├─ mint token → env.BROWSER.quickAction('screenshot', { url })
  │     │
  │     └─ Chrome, in Cloudflare's Browser Rendering fleet
  │          └─ GET <client-origin>/thumbnail-render?token=…
  │               └─ fetch('/api/app/thumbnail-render/snapshot?token=…')
  │                    └─ back into the worker → getThumbnailSnapshot
  │                         └─ getSharedFileRoomSnapshot … Postgres read #2  ← stays: token gate
  └─ enqueueFollowUpIfBoardMoved ....... was #4, now an R2 head
```

The two survivors are load-bearing for different reasons.

**Read #1** is what drops a board deleted or unpublished while queued, and re-reads the version so a burst of enqueues coalesces into one capture of the newest content. Passing the row through the queue message would remove it, but that's precisely the one that must be fresh: the enqueue→render gap runs to minutes across retries, and a stale `version` in the message would either skip a needed render or stamp fresh pixels with an old version — which the OG route then serves as permanently `stale`.

**Read #2** arrives as a separate inbound request originated by the headless browser, authenticated solely by the render token. Nothing can be threaded into it: different request, different isolate, no shared memory, separated from the resolve by browser startup and navigation (captures measure 4–17s against a 60s token TTL). It is also the read that most has to stay fresh — that token grants read of a *private* board's full document, and this re-read is what makes an un-share or delete land inside its window.

### Why not pool the connections

That was the original plan and it doesn't work. Cloudflare forbid reusing a connection created in one request from another handler — ["create a new database client on every request instead of caching it in a global variable"](https://developers.cloudflare.com/hyperdrive/observability/troubleshooting/) — so a cached `pg.Pool` throws *Cannot perform I/O on behalf of a different request*. The per-call pool is correct-by-platform. If the handshake cost is ever worth removing properly, that's Hyperdrive, not a pool.

Worth saying plainly: this is not urgent. Postgres backends peaked at 146/240 once at deploy and returned to baseline, and DB CPU never moved. This is waste, not risk.

### Change type

- [x] `improvement`

### Test plan

Unit tests cover the reuse path, the re-read path, that a supplied row is still gated at both access levels, that a private row supplied to a public read is refused, that the consumer drops to a single Postgres read per job, and that the moved-board check still follows up on a changed etag and stays quiet on an unchanged one.

1. `cd apps/dotcom/sync-worker && yarn test run` — 462 pass.
2. After deploy, `getSharedFileInfo` on the [Events V2 postgres-by-pool panel](https://tldraw.grafana.net/d/ni5k8zc/events-v2) should roughly halve at constant render volume.

- [x] Unit tests
- [ ] End to end tests

Relates to #9667.
