### PR TITLE
feat(dotcom): add board stats to the admin page

### DIFF
--- a/apps/dotcom/client/src/pages/admin/FileStats.tsx
+++ b/apps/dotcom/client/src/pages/admin/FileStats.tsx
@@ -1,0 +1,200 @@
+import { AdminFileStatsResponseBody } from '@tldraw/dotcom-shared'
+import { useCallback, useRef, useState } from 'react'
+import { fetch } from 'tldraw'
+import { AdminButton } from './AdminButton'
+import { formatBytes, StructuredDataDisplay } from './shared'
+import styles from './admin.module.css'
+
+function formatNumber(value: number) {
+	return value.toLocaleString()
+}
+
+/** "412 geo, 88 arrow, 3 frame" — biggest first, so the summary line leads with what matters. */
+function formatTally(tally: Record<string, number>) {
+	const entries = Object.entries(tally).sort((a, b) => b[1] - a[1])
+	if (entries.length === 0) return 'none'
+	return entries.map(([name, count]) => `${formatNumber(count)} ${name}`).join(', ')
+}
+
+function formatTimestamp(value: number) {
+	if (!value) return 'unknown'
+	return new Date(value).toISOString().slice(0, 10)
+}
+
+/**
+ * A content-free profile of a board: how many shapes, how deeply nested, how much text, how big the
+ * snapshot. Enough to reason about a slow or broken board — or to answer "what does a board this
+ * size actually look like" — without opening it or seeing anything on it.
+ */
+export function FileStats() {
+	const inputRef = useRef<HTMLInputElement>(null)
+	const [error, setError] = useState(null as string | null)
+	const [isLoading, setIsLoading] = useState(false)
+	const [stats, setStats] = useState(null as AdminFileStatsResponseBody | null)
+
+	const onGetStats = useCallback(async () => {
+		const slug = inputRef.current?.value?.trim()
+		if (!slug) {
+			setError('Please enter a file slug')
+			return
+		}
+		setError(null)
+		setStats(null)
+		setIsLoading(true)
+		try {
+			const res = await fetch(`/api/app/admin/file-stats/${encodeURIComponent(slug)}`)
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			setStats((await res.json()) as AdminFileStatsResponseBody)
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Failed to get board stats')
+		} finally {
+			setIsLoading(false)
+		}
+	}, [])
+
+	return (
+		<div className={styles.fileOperation}>
+			<p>
+				Counts and sizes for a board&apos;s last persisted snapshot. Nothing here is board content
+				or a person&apos;s identity, so a report is safe to paste into an issue or a support reply.
+			</p>
+			{error && <div className={styles.errorMessage}>{error}</div>}
+			<div className={styles.searchContainer}>
+				<input
+					type="text"
+					placeholder="File slug"
+					ref={inputRef}
+					className={styles.searchInput}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter') onGetStats()
+					}}
+				/>
+				<AdminButton onClick={onGetStats} variant="primary" isLoading={isLoading}>
+					Get stats
+				</AdminButton>
+			</div>
+			{stats && <FileStatsReport stats={stats} />}
+		</div>
+	)
+}
+
+function FileStatsReport({ stats }: { stats: AdminFileStatsResponseBody }) {
+	const { file, snapshot, pages, shapes, text, bindings, assets, collaboration } = stats
+	const { arrows } = bindings
+
+	const summary: Array<[string, string]> = [
+		[
+			'Snapshot size',
+			snapshot.sizeBytes === null ? 'check failed' : formatBytes(snapshot.sizeBytes),
+		],
+		['Records', `${formatNumber(snapshot.records)} (${formatTally(snapshot.recordsByTypeName)})`],
+		['Tombstones', formatNumber(snapshot.tombstones)],
+		[
+			'Pages',
+			`${formatNumber(pages.total)} (largest ${formatNumber(pages.maxShapesOnAPage)} shapes${
+				pages.empty > 0 ? `, ${formatNumber(pages.empty)} empty` : ''
+			})`,
+		],
+		['Shapes', `${formatNumber(shapes.total)} (${formatTally(shapes.byType)})`],
+		[
+			'Nesting depth',
+			shapes.maxDepth <= 1 ? 'flat' : `${shapes.maxDepth} levels of frames and groups`,
+		],
+		['Locked / rotated', `${formatNumber(shapes.locked)} / ${formatNumber(shapes.rotated)}`],
+		[
+			'Orphaned shapes',
+			shapes.orphaned === 0 ? 'none' : `⚠️ ${formatNumber(shapes.orphaned)} with no page`,
+		],
+		[
+			'Extent',
+			shapes.extent
+				? `${formatNumber(shapes.extent.width)} × ${formatNumber(shapes.extent.height)} (top-level shapes, unrotated)`
+				: 'no shapes',
+		],
+		[
+			'Text',
+			text.shapesWithText === 0
+				? 'none'
+				: `${formatNumber(text.shapesWithText)} shapes, ${formatNumber(text.totalCharacters)} chars (longest ${formatNumber(text.longestCharacters)})`,
+		],
+		['Bindings', `${formatNumber(bindings.total)} (${formatTally(bindings.byType)})`],
+		[
+			'Arrow ends',
+			`${formatNumber(arrows.boundBothEnds)} bound both, ${formatNumber(arrows.boundOneEnd)} bound one, ${formatNumber(arrows.unbound)} free${
+				arrows.dangling > 0 ? `, ⚠️ ${formatNumber(arrows.dangling)} dangling` : ''
+			}`,
+		],
+		[
+			'Assets',
+			assets.total === 0
+				? 'none'
+				: `${formatNumber(assets.total)} (${formatTally(assets.byType)}), ${formatBytes(assets.totalSizeBytes)} declared`,
+		],
+		[
+			'Collaboration',
+			`${formatNumber(collaboration.visitors)} visitors, ${formatNumber(collaboration.commentThreads)} threads, ${formatNumber(collaboration.comments)} comments`,
+		],
+		['Schema', snapshot.schemaVersion === null ? 'unknown' : `version ${snapshot.schemaVersion}`],
+		['Clock', `${snapshot.clock ?? 'unknown'} (document ${snapshot.documentClock ?? 'unknown'})`],
+		[
+			'File row',
+			file
+				? `${file.ownerType}-owned, created ${formatTimestamp(file.createdAt)}, updated ${formatTimestamp(file.updatedAt)}`
+				: 'none (legacy room?)',
+		],
+		[
+			'Sharing',
+			file
+				? [
+						file.shared ? `shared (${file.sharedLinkType})` : 'not shared',
+						file.published ? 'published' : null,
+						file.isDeleted ? 'deleted' : null,
+						file.isEmpty ? 'marked empty' : null,
+						file.createSourceKind ? `from ${file.createSourceKind}` : null,
+					]
+						.filter(Boolean)
+						.join(', ')
+				: 'unknown',
+		],
+	]
+
+	return (
+		<>
+			{stats.warnings.length > 0 && (
+				<div className={styles.errorMessage}>
+					{stats.warnings.length} check(s) failed — some counts below may be incomplete.{' '}
+					{stats.warnings.slice(0, 3).join('; ')}
+				</div>
+			)}
+			<div className={styles.userSummary}>
+				<div className={styles.summaryGrid}>
+					{summary.map(([label, value]) => (
+						<div key={label} className={styles.summaryItem}>
+							<span className={styles.fieldLabel}>{label}:</span>
+							<span className={styles.fieldValue}>{value}</span>
+						</div>
+					))}
+				</div>
+			</div>
+			{Object.keys(stats.styles).length > 0 && (
+				<>
+					<h4 className={styles.subTitle}>Styles</h4>
+					<div className={styles.summaryGrid}>
+						{Object.entries(stats.styles)
+							.sort((a, b) => a[0].localeCompare(b[0]))
+							.map(([prop, tally]) => (
+								<div key={prop} className={styles.summaryItem}>
+									<span className={styles.fieldLabel}>{prop}:</span>
+									<span className={styles.fieldValue}>{formatTally(tally)}</span>
+								</div>
+							))}
+					</div>
+				</>
+			)}
+			<StructuredDataDisplay data={stats} />
+		</>
+	)
+}

--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -2,6 +2,7 @@ import { AdminFileAssetsResponseBody } from '@tldraw/dotcom-shared'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetch } from 'tldraw'
 import { AdminButton } from './AdminButton'
+import { FileStats } from './FileStats'
 import { formatBytes, StructuredDataDisplay } from './shared'
 import styles from './admin.module.css'
 
@@ -15,6 +16,10 @@ export function FilesSection() {
 					<DownloadTldrFile legacy={true} />
 					<CreateLegacyFile />
 				</div>
+			</section>
+			<section className={styles.adminSection}>
+				<h3 className={styles.sectionTitle}>Board stats</h3>
+				<FileStats />
 			</section>
 			<section className={styles.adminSection}>
 				<h3 className={styles.sectionTitle}>Asset diagnostics</h3>

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -604,7 +604,9 @@ export const adminRoutes = createRouter<Environment>()
 				.executeTakeFirst(),
 			getFileSnapshot(env, slug, true),
 			env.ROOMS.head(getR2KeyForRoom({ slug, isApp: true })).catch((e) => {
-				warnings.push(`snapshot head failed: ${e}`)
+				// Label only: an R2 error stringifies to the object key, which names the board
+				console.error('file-stats snapshot head failed', e)
+				warnings.push('snapshot head failed')
 				return null
 			}),
 		])
@@ -624,7 +626,9 @@ export const adminRoutes = createRouter<Environment>()
 			try {
 				return Number((await query)?.count ?? 0)
 			} catch (e) {
-				warnings.push(`${label} count failed: ${e}`)
+				// Label only: a query error can carry table, column, and parameter detail
+				console.error(`file-stats ${label} count failed`, e)
+				warnings.push(`${label} count failed`)
 				return 0
 			}
 		}

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -1,5 +1,6 @@
 import {
 	AdminFileAssetsResponseBody,
+	AdminFileStatsResponseBody,
 	FILE_PREFIX,
 	FeatureFlagKey,
 	FriendsAndFamilyEntry,
@@ -15,6 +16,7 @@ import { StatusError, json } from 'itty-router'
 import { sql } from 'kysely'
 import PQueue from 'p-queue'
 import { getUploadObjectName } from './assetAssociation'
+import { summarizeSnapshotDocuments } from './fileStats'
 import { MAX_ATTEMPTS } from './outboxDrain'
 import { createPostgresConnectionPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
@@ -572,6 +574,124 @@ export const adminRoutes = createRouter<Environment>()
 			warnings,
 		}
 		return json(report)
+	})
+	// A board's shape without its contents. Answers "how big and how unusual is this board" for
+	// perf reports, migration bugs, and support threads without anyone having to open it — and
+	// without putting anything a user typed into the report. Read AdminFileStatsResponseBody
+	// before adding a field: staying content-free is the point of this endpoint.
+	.get('/app/admin/file-stats/:slug', async (res, env) => {
+		const slug = res.params.slug
+		assert(typeof slug === 'string', 'slug is required')
+
+		const warnings: string[] = []
+		const pg = createPostgresConnectionPool(env, '/app/admin/file-stats')
+		const [fileRow, snapshot, head] = await Promise.all([
+			pg
+				.selectFrom('file')
+				.where('id', '=', slug)
+				.select([
+					'ownerId',
+					'owningGroupId',
+					'createdAt',
+					'updatedAt',
+					'isDeleted',
+					'isEmpty',
+					'published',
+					'shared',
+					'sharedLinkType',
+					'createSource',
+				])
+				.executeTakeFirst(),
+			getFileSnapshot(env, slug, true),
+			env.ROOMS.head(getR2KeyForRoom({ slug, isApp: true })).catch((e) => {
+				warnings.push(`snapshot head failed: ${e}`)
+				return null
+			}),
+		])
+		if (!snapshot) {
+			throw new StatusError(404, `No persisted snapshot for ${slug}`)
+		}
+
+		const summary = summarizeSnapshotDocuments(snapshot.documents)
+
+		// file_visitor, comment_thread, and comment all have a fileId index. file_state is
+		// deliberately not counted here: its primary key is (userId, fileId), so counting by fileId
+		// would sequentially scan the whole table.
+		const countRows = async (
+			label: string,
+			query: Promise<{ count: number | string | bigint } | undefined>
+		) => {
+			try {
+				return Number((await query)?.count ?? 0)
+			} catch (e) {
+				warnings.push(`${label} count failed: ${e}`)
+				return 0
+			}
+		}
+		const [visitors, commentThreads, comments] = await Promise.all([
+			countRows(
+				'file_visitor',
+				pg
+					.selectFrom('file_visitor')
+					.where('fileId', '=', slug)
+					.select((eb) => eb.fn.countAll<number>().as('count'))
+					.executeTakeFirst()
+			),
+			countRows(
+				'comment_thread',
+				pg
+					.selectFrom('comment_thread')
+					.where('fileId', '=', slug)
+					.where('isDeleted', '=', false)
+					.select((eb) => eb.fn.countAll<number>().as('count'))
+					.executeTakeFirst()
+			),
+			countRows(
+				'comment',
+				pg
+					.selectFrom('comment')
+					.where('fileId', '=', slug)
+					.where('isDeleted', '=', false)
+					.select((eb) => eb.fn.countAll<number>().as('count'))
+					.executeTakeFirst()
+			),
+		])
+
+		const schema = snapshot.schema as
+			| { schemaVersion?: number; sequences?: Record<string, number> }
+			| undefined
+		const createSourceKind = fileRow?.createSource?.split('/')[0] ?? null
+
+		const { recordsByTypeName, ...snapshotStats } = summary
+		const stats: AdminFileStatsResponseBody = {
+			file: fileRow
+				? {
+						ownerType: fileRow.ownerId ? 'user' : fileRow.owningGroupId ? 'group' : 'none',
+						createdAt: fileRow.createdAt,
+						updatedAt: fileRow.updatedAt,
+						isDeleted: fileRow.isDeleted,
+						isEmpty: fileRow.isEmpty,
+						published: fileRow.published,
+						shared: fileRow.shared,
+						sharedLinkType: fileRow.sharedLinkType,
+						createSourceKind,
+					}
+				: null,
+			snapshot: {
+				sizeBytes: head?.size ?? null,
+				clock: snapshot.clock ?? null,
+				documentClock: snapshot.documentClock ?? null,
+				tombstones: Object.keys(snapshot.tombstones ?? {}).length,
+				records: snapshot.documents.length,
+				recordsByTypeName,
+				schemaVersion: schema?.schemaVersion ?? null,
+				sequences: schema?.sequences ?? null,
+			},
+			...snapshotStats,
+			collaboration: { visitors, commentThreads, comments },
+			warnings,
+		}
+		return json(stats)
 	})
 	.get('/app/admin/download-tldr/:fileSlug', async (res, env) => {
 		const fileSlug = res.params.fileSlug

--- a/apps/dotcom/sync-worker/src/fileStats.test.ts
+++ b/apps/dotcom/sync-worker/src/fileStats.test.ts
@@ -299,6 +299,18 @@ describe('summarizeSnapshotDocuments', () => {
 		expect(shapes.total).toBe(1)
 		expect(recordsByTypeName).toEqual({ page: 1, shape: 1 })
 	})
+
+	it('buckets a record with no type under `unknown` rather than tallying it as "undefined"', () => {
+		const { shapes, bindings, assets } = summarize([
+			page('page:1'),
+			shape({ id: 'shape:1', type: undefined }),
+			{ typeName: 'binding', id: 'binding:1', fromId: 'shape:1', toId: 'shape:1' },
+			{ typeName: 'asset', id: 'asset:1', props: { fileSize: 10 } },
+		])
+		expect(shapes.byType).toEqual({ unknown: 1 })
+		expect(bindings.byType).toEqual({ unknown: 1 })
+		expect(assets.byType).toEqual({ unknown: 1 })
+	})
 })
 
 describe('countRichTextCharacters', () => {

--- a/apps/dotcom/sync-worker/src/fileStats.test.ts
+++ b/apps/dotcom/sync-worker/src/fileStats.test.ts
@@ -1,0 +1,330 @@
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { describe, expect, it } from 'vitest'
+import { countRichTextCharacters, summarizeSnapshotDocuments } from './fileStats'
+
+function documents(records: unknown[]): RoomSnapshot['documents'] {
+	return records.map((state, i) => ({ state, lastChangedClock: i }) as any)
+}
+
+function summarize(records: unknown[]) {
+	return summarizeSnapshotDocuments(documents(records))
+}
+
+function page(id: string) {
+	return { typeName: 'page', id, name: 'Page', index: 'a1' }
+}
+
+function shape(overrides: Record<string, unknown> = {}) {
+	return {
+		typeName: 'shape',
+		id: 'shape:1',
+		type: 'geo',
+		parentId: 'page:1',
+		x: 0,
+		y: 0,
+		rotation: 0,
+		isLocked: false,
+		props: {},
+		...overrides,
+	}
+}
+
+function richText(text: string) {
+	return { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text }] }] }
+}
+
+describe('summarizeSnapshotDocuments', () => {
+	it('reports an empty snapshot as all zeroes rather than failing', () => {
+		expect(summarize([])).toEqual({
+			recordsByTypeName: {},
+			pages: { total: 0, maxShapesOnAPage: 0, empty: 0 },
+			shapes: {
+				total: 0,
+				byType: {},
+				maxDepth: 0,
+				locked: 0,
+				rotated: 0,
+				orphaned: 0,
+				extent: null,
+			},
+			text: { shapesWithText: 0, totalCharacters: 0, longestCharacters: 0 },
+			bindings: {
+				total: 0,
+				byType: {},
+				arrows: { boundBothEnds: 0, boundOneEnd: 0, unbound: 0, dangling: 0 },
+			},
+			styles: {},
+			assets: { total: 0, byType: {}, totalSizeBytes: 0 },
+		})
+	})
+
+	it('counts every record by type name, including ones it has no other opinion about', () => {
+		const { recordsByTypeName } = summarize([
+			page('page:1'),
+			shape({ id: 'shape:1' }),
+			shape({ id: 'shape:2' }),
+			{ typeName: 'document', id: 'document:document' },
+			{ typeName: 'camera', id: 'camera:1' },
+		])
+		expect(recordsByTypeName).toEqual({ page: 1, shape: 2, document: 1, camera: 1 })
+	})
+
+	it('tallies shapes by type, locked, and rotated', () => {
+		const { shapes } = summarize([
+			page('page:1'),
+			shape({ id: 'shape:1', type: 'geo', isLocked: true }),
+			shape({ id: 'shape:2', type: 'geo', rotation: 0.5 }),
+			shape({ id: 'shape:3', type: 'arrow' }),
+		])
+		expect(shapes.byType).toEqual({ geo: 2, arrow: 1 })
+		expect(shapes.total).toBe(3)
+		expect(shapes.locked).toBe(1)
+		expect(shapes.rotated).toBe(1)
+	})
+
+	describe('page and nesting resolution', () => {
+		it('follows parent chains through frames and groups to find each shape’s page', () => {
+			const { pages, shapes } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:frame', type: 'frame', parentId: 'page:1' }),
+				shape({ id: 'shape:group', type: 'group', parentId: 'shape:frame' }),
+				shape({ id: 'shape:leaf', parentId: 'shape:group' }),
+			])
+			expect(pages).toEqual({ total: 1, maxShapesOnAPage: 3, empty: 0 })
+			expect(shapes.maxDepth).toBe(3)
+			expect(shapes.orphaned).toBe(0)
+		})
+
+		it('reports the busiest page and counts pages with nothing on them', () => {
+			const { pages } = summarize([
+				page('page:1'),
+				page('page:2'),
+				page('page:3'),
+				shape({ id: 'shape:1', parentId: 'page:1' }),
+				shape({ id: 'shape:2', parentId: 'page:2' }),
+				shape({ id: 'shape:3', parentId: 'page:2' }),
+			])
+			expect(pages).toEqual({ total: 3, maxShapesOnAPage: 2, empty: 1 })
+		})
+
+		it('counts a shape whose parent is missing from the snapshot as orphaned', () => {
+			const { shapes, pages } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:1', parentId: 'shape:gone' }),
+			])
+			expect(shapes.orphaned).toBe(1)
+			expect(pages).toEqual({ total: 1, maxShapesOnAPage: 0, empty: 1 })
+		})
+
+		it('terminates on a parent cycle instead of recursing forever', () => {
+			const { shapes } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:a', parentId: 'shape:b' }),
+				shape({ id: 'shape:b', parentId: 'shape:a' }),
+			])
+			expect(shapes.orphaned).toBe(2)
+			expect(shapes.total).toBe(2)
+		})
+	})
+
+	describe('extent', () => {
+		it('covers the top-level shapes, using width and height where the shape has them', () => {
+			const { shapes } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:1', x: -100, y: -50, props: { w: 100, h: 50 } }),
+				shape({ id: 'shape:2', x: 400, y: 200, props: { w: 100, h: 100 } }),
+			])
+			expect(shapes.extent).toEqual({ width: 600, height: 350 })
+		})
+
+		it('ignores nested shapes, whose coordinates are relative to their parent', () => {
+			const { shapes } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:frame', type: 'frame', x: 0, y: 0, props: { w: 100, h: 100 } }),
+				// would blow the extent up to 100,000 wide if it were treated as page-space
+				shape({ id: 'shape:leaf', parentId: 'shape:frame', x: 100000, y: 0, props: {} }),
+			])
+			expect(shapes.extent).toEqual({ width: 100, height: 100 })
+		})
+
+		it('is null when a snapshot has pages but no shapes on them', () => {
+			expect(summarize([page('page:1')]).shapes.extent).toBeNull()
+		})
+	})
+
+	describe('text', () => {
+		it('measures rich text length across nested nodes without keeping the text', () => {
+			const { text } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:1', props: { richText: richText('hello') } }),
+				shape({
+					id: 'shape:2',
+					props: {
+						richText: {
+							type: 'doc',
+							content: [
+								{ type: 'paragraph', content: [{ type: 'text', text: 'one' }] },
+								{ type: 'paragraph', content: [{ type: 'text', text: 'twotwo' }] },
+							],
+						},
+					},
+				}),
+			])
+			expect(text).toEqual({ shapesWithText: 2, totalCharacters: 14, longestCharacters: 9 })
+		})
+
+		it('falls back to the pre-rich-text `text` prop that old snapshots still carry', () => {
+			const { text } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:1', type: 'text', props: { text: 'legacy' } }),
+			])
+			expect(text).toEqual({ shapesWithText: 1, totalCharacters: 6, longestCharacters: 6 })
+		})
+
+		it('does not count a shape whose rich text is empty', () => {
+			const { text } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:1', props: { richText: richText('') } }),
+			])
+			expect(text).toEqual({ shapesWithText: 0, totalCharacters: 0, longestCharacters: 0 })
+		})
+	})
+
+	describe('styles', () => {
+		it('tallies each allowlisted style prop by value', () => {
+			const { styles } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:1', props: { color: 'black', fill: 'solid', size: 'm' } }),
+				shape({ id: 'shape:2', props: { color: 'black', fill: 'none', size: 'l' } }),
+				shape({ id: 'shape:3', props: { color: 'red' } }),
+			])
+			expect(styles).toEqual({
+				color: { black: 2, red: 1 },
+				fill: { solid: 1, none: 1 },
+				size: { m: 1, l: 1 },
+			})
+		})
+
+		it('leaves out props that could hold something a user typed', () => {
+			const { styles } = summarize([
+				page('page:1'),
+				shape({
+					id: 'shape:1',
+					props: { color: 'black', text: 'a secret', url: 'https://example.com', name: 'Q3 plan' },
+				}),
+			])
+			expect(styles).toEqual({ color: { black: 1 } })
+		})
+	})
+
+	describe('bindings', () => {
+		function arrowBinding(id: string, fromId: string, toId: string, terminal: string) {
+			return { typeName: 'binding', type: 'arrow', id, fromId, toId, props: { terminal } }
+		}
+
+		it('splits arrows by how many ends are bound', () => {
+			const { bindings } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:box', type: 'geo' }),
+				shape({ id: 'shape:both', type: 'arrow' }),
+				shape({ id: 'shape:one', type: 'arrow' }),
+				shape({ id: 'shape:free', type: 'arrow' }),
+				arrowBinding('binding:1', 'shape:both', 'shape:box', 'start'),
+				arrowBinding('binding:2', 'shape:both', 'shape:box', 'end'),
+				arrowBinding('binding:3', 'shape:one', 'shape:box', 'end'),
+			])
+			expect(bindings).toEqual({
+				total: 3,
+				byType: { arrow: 3 },
+				arrows: { boundBothEnds: 1, boundOneEnd: 1, unbound: 1, dangling: 0 },
+			})
+		})
+
+		// The three bound/unbound counts partition arrows by how many terminals have a binding
+		// record; whether the target still exists is the separate `dangling` signal.
+		it('counts a binding pointing at a shape that is not in the snapshot as dangling', () => {
+			const { bindings } = summarize([
+				page('page:1'),
+				shape({ id: 'shape:arrow', type: 'arrow' }),
+				arrowBinding('binding:1', 'shape:arrow', 'shape:deleted', 'end'),
+			])
+			expect(bindings.arrows).toEqual({
+				boundBothEnds: 0,
+				boundOneEnd: 1,
+				unbound: 0,
+				dangling: 1,
+			})
+		})
+
+		it('tallies non-arrow bindings by type too', () => {
+			const { bindings } = summarize([
+				page('page:1'),
+				{ typeName: 'binding', type: 'layout', id: 'binding:1', fromId: 'a', toId: 'b', props: {} },
+			])
+			expect(bindings.total).toBe(1)
+			expect(bindings.byType).toEqual({ layout: 1 })
+		})
+	})
+
+	describe('assets', () => {
+		it('tallies assets by type and sums their declared sizes', () => {
+			const { assets } = summarize([
+				{ typeName: 'asset', type: 'image', id: 'asset:1', props: { fileSize: 1000 } },
+				{ typeName: 'asset', type: 'image', id: 'asset:2', props: { fileSize: 2000 } },
+				{ typeName: 'asset', type: 'bookmark', id: 'asset:3', props: {} },
+			])
+			expect(assets).toEqual({
+				total: 3,
+				byType: { image: 2, bookmark: 1 },
+				totalSizeBytes: 3000,
+			})
+		})
+
+		it('ignores the -1 file size that assets use for unknown', () => {
+			const { assets } = summarize([
+				{ typeName: 'asset', type: 'image', id: 'asset:1', props: { fileSize: -1 } },
+			])
+			expect(assets.totalSizeBytes).toBe(0)
+		})
+	})
+
+	it('reads a malformed record defensively rather than throwing', () => {
+		const { shapes, recordsByTypeName } = summarize([
+			page('page:1'),
+			// no props, non-numeric coordinates, missing parent
+			{ typeName: 'shape', id: 'shape:1', type: 'geo', x: null, y: undefined },
+			{ id: 'nope' },
+			null,
+		])
+		expect(shapes.total).toBe(1)
+		expect(recordsByTypeName).toEqual({ page: 1, shape: 1 })
+	})
+})
+
+describe('countRichTextCharacters', () => {
+	it('sums text nodes at any depth', () => {
+		expect(
+			countRichTextCharacters({
+				type: 'doc',
+				content: [
+					{
+						type: 'bulletList',
+						content: [
+							{
+								type: 'listItem',
+								content: [{ type: 'paragraph', content: [{ type: 'text', text: 'abc' }] }],
+							},
+						],
+					},
+					{ type: 'paragraph', content: [{ type: 'text', text: 'de' }] },
+				],
+			})
+		).toBe(5)
+	})
+
+	it('returns 0 for anything that is not a node', () => {
+		expect(countRichTextCharacters(null)).toBe(0)
+		expect(countRichTextCharacters(undefined)).toBe(0)
+		expect(countRichTextCharacters('not a node')).toBe(0)
+	})
+})

--- a/apps/dotcom/sync-worker/src/fileStats.ts
+++ b/apps/dotcom/sync-worker/src/fileStats.ts
@@ -1,0 +1,263 @@
+import { AdminFileStatsResponseBody } from '@tldraw/dotcom-shared'
+import { RoomSnapshot } from '@tldraw/sync-core'
+
+/**
+ * Shape props tallied by the board-stats report. These are the enum style props (`StyleProp.defineEnum`
+ * in tlschema) plus `align`, their pre-`horizontalAlign` name, which old snapshots still carry. The
+ * list is an allowlist rather than "every short string prop" on purpose: it's what keeps a stats
+ * report free of anything a user typed or pasted.
+ */
+const STYLE_PROP_NAMES = [
+	'align',
+	'arrowheadEnd',
+	'arrowheadStart',
+	'color',
+	'dash',
+	'fill',
+	'font',
+	'geo',
+	'horizontalAlign',
+	'kind',
+	'labelColor',
+	'size',
+	'spline',
+	'textAlign',
+	'verticalAlign',
+] as const
+
+/** Shapes nest, so a parent chain this long is a corrupted snapshot, not a deeply grouped board. */
+const MAX_PARENT_DEPTH = 100
+
+/**
+ * Total length of the text in a rich text document, without ever holding the text itself. Rich text
+ * is a ProseMirror document (see TLRichText), so the text lives in `text` nodes at arbitrary depth.
+ */
+export function countRichTextCharacters(node: unknown): number {
+	if (!node || typeof node !== 'object') return 0
+	const { text, content } = node as { text?: unknown; content?: unknown }
+	let total = typeof text === 'string' ? text.length : 0
+	if (Array.isArray(content)) {
+		for (const child of content) total += countRichTextCharacters(child)
+	}
+	return total
+}
+
+/** The parts of a board-stats report that come from the snapshot itself. */
+export type FileSnapshotStats = Pick<
+	AdminFileStatsResponseBody,
+	'pages' | 'shapes' | 'text' | 'bindings' | 'styles' | 'assets'
+> & { recordsByTypeName: Record<string, number> }
+
+/**
+ * Counts, tallies, and sizes for the records in a board's snapshot — never their contents. Records
+ * are read defensively rather than through the schema's validators: this runs on whatever is
+ * actually in R2, including snapshots too old or too broken to parse, which are exactly the ones
+ * worth asking about.
+ */
+export function summarizeSnapshotDocuments(
+	documents: RoomSnapshot['documents']
+): FileSnapshotStats {
+	const pageIds = new Set<string>()
+	const shapeIds = new Set<string>()
+	const parentIdByShapeId = new Map<string, string>()
+	const recordsByTypeName: Record<string, number> = {}
+	const shapesByType: Record<string, number> = {}
+	const bindingsByType: Record<string, number> = {}
+	const assetsByType: Record<string, number> = {}
+	const styles: Record<string, Record<string, number>> = {}
+	const arrowBindings: Array<{ fromId: unknown; toId: unknown; terminal: unknown }> = []
+	// x/y/w/h per shape, for the extent below. Kept until parents are resolved, since a shape's
+	// coordinates only mean something once we know whether it sits on a page.
+	const boxes: Array<{ id: string; x: number; y: number; w: number; h: number }> = []
+
+	let totalBindings = 0
+	let locked = 0
+	let rotated = 0
+	let shapesWithText = 0
+	let totalCharacters = 0
+	let longestCharacters = 0
+	let assetsTotal = 0
+	let assetSizeBytes = 0
+
+	for (const { state } of documents) {
+		const record = state as any
+		if (!record || typeof record !== 'object') continue
+		if (typeof record.typeName === 'string') {
+			recordsByTypeName[record.typeName] = (recordsByTypeName[record.typeName] ?? 0) + 1
+		}
+		switch (record.typeName) {
+			case 'page':
+				pageIds.add(record.id)
+				break
+			case 'shape': {
+				shapeIds.add(record.id)
+				if (typeof record.parentId === 'string') {
+					parentIdByShapeId.set(record.id, record.parentId)
+				}
+				shapesByType[record.type] = (shapesByType[record.type] ?? 0) + 1
+				if (record.isLocked) locked++
+				if (record.rotation) rotated++
+
+				const props = record.props ?? {}
+				for (const name of STYLE_PROP_NAMES) {
+					const value = props[name]
+					if (typeof value !== 'string') continue
+					const tally = (styles[name] ??= {})
+					tally[value] = (tally[value] ?? 0) + 1
+				}
+
+				// Shapes carried plain `text` before rich text; old snapshots still have it
+				const characters = props.richText
+					? countRichTextCharacters(props.richText)
+					: typeof props.text === 'string'
+						? props.text.length
+						: 0
+				if (characters > 0) {
+					shapesWithText++
+					totalCharacters += characters
+					longestCharacters = Math.max(longestCharacters, characters)
+				}
+
+				boxes.push({
+					id: record.id,
+					x: typeof record.x === 'number' ? record.x : 0,
+					y: typeof record.y === 'number' ? record.y : 0,
+					// Only some shapes have a width and height; the rest count as points
+					w: typeof props.w === 'number' ? props.w : 0,
+					h: typeof props.h === 'number' ? props.h : 0,
+				})
+				break
+			}
+			case 'binding': {
+				totalBindings++
+				bindingsByType[record.type] = (bindingsByType[record.type] ?? 0) + 1
+				if (record.type === 'arrow') {
+					arrowBindings.push({
+						fromId: record.fromId,
+						toId: record.toId,
+						terminal: record.props?.terminal,
+					})
+				}
+				break
+			}
+			case 'asset': {
+				assetsTotal++
+				assetsByType[record.type] = (assetsByType[record.type] ?? 0) + 1
+				const size = record.props?.fileSize
+				if (typeof size === 'number' && size > 0) assetSizeBytes += size
+				break
+			}
+		}
+	}
+
+	// Shapes nest inside frames and groups, so a shape's page sits at the top of its parent chain.
+	// Memoized, and capped so a snapshot with a parent cycle can't spin the worker.
+	const resolvedByShapeId = new Map<string, { depth: number; pageId: string | null }>()
+	function resolveShape(shapeId: string, hops: number): { depth: number; pageId: string | null } {
+		const cached = resolvedByShapeId.get(shapeId)
+		if (cached) return cached
+		const parentId = parentIdByShapeId.get(shapeId)
+		let resolved: { depth: number; pageId: string | null }
+		if (parentId !== undefined && pageIds.has(parentId)) {
+			resolved = { depth: 1, pageId: parentId }
+		} else if (
+			parentId === undefined ||
+			!parentIdByShapeId.has(parentId) ||
+			hops >= MAX_PARENT_DEPTH
+		) {
+			resolved = { depth: 1, pageId: null }
+		} else {
+			const parent = resolveShape(parentId, hops + 1)
+			resolved = { depth: parent.depth + 1, pageId: parent.pageId }
+		}
+		resolvedByShapeId.set(shapeId, resolved)
+		return resolved
+	}
+
+	const shapeCountByPageId = new Map<string, number>()
+	let maxDepth = 0
+	let orphaned = 0
+	for (const shapeId of shapeIds) {
+		const { depth, pageId } = resolveShape(shapeId, 0)
+		maxDepth = Math.max(maxDepth, depth)
+		if (pageId === null) {
+			orphaned++
+		} else {
+			shapeCountByPageId.set(pageId, (shapeCountByPageId.get(pageId) ?? 0) + 1)
+		}
+	}
+
+	let emptyPages = 0
+	let maxShapesOnAPage = 0
+	for (const pageId of pageIds) {
+		const count = shapeCountByPageId.get(pageId) ?? 0
+		if (count === 0) emptyPages++
+		maxShapesOnAPage = Math.max(maxShapesOnAPage, count)
+	}
+
+	// Only shapes parented to a page: a nested shape's x/y is relative to its frame or group, so
+	// mixing the two would give a meaningless box. Rotation is ignored — this is the extent of the
+	// unrotated boxes, which is all it needs to be for "is this board absurdly spread out".
+	let minX = Infinity
+	let minY = Infinity
+	let maxX = -Infinity
+	let maxY = -Infinity
+	for (const box of boxes) {
+		const resolved = resolvedByShapeId.get(box.id)
+		if (!resolved || resolved.depth !== 1 || resolved.pageId === null) continue
+		minX = Math.min(minX, box.x)
+		minY = Math.min(minY, box.y)
+		maxX = Math.max(maxX, box.x + box.w)
+		maxY = Math.max(maxY, box.y + box.h)
+	}
+	const extent =
+		minX === Infinity ? null : { width: Math.round(maxX - minX), height: Math.round(maxY - minY) }
+
+	// An arrow has one binding per bound terminal, so the terminals seen per arrow say whether it's
+	// bound at both ends, one, or neither
+	const terminalsByArrowId = new Map<string, Set<string>>()
+	let danglingBindings = 0
+	for (const binding of arrowBindings) {
+		if (typeof binding.toId !== 'string' || !shapeIds.has(binding.toId)) danglingBindings++
+		if (typeof binding.fromId !== 'string' || !shapeIds.has(binding.fromId)) continue
+		let terminals = terminalsByArrowId.get(binding.fromId)
+		if (!terminals) {
+			terminals = new Set<string>()
+			terminalsByArrowId.set(binding.fromId, terminals)
+		}
+		if (typeof binding.terminal === 'string') terminals.add(binding.terminal)
+	}
+	let boundBothEnds = 0
+	let boundOneEnd = 0
+	for (const terminals of terminalsByArrowId.values()) {
+		if (terminals.size >= 2) boundBothEnds++
+		else if (terminals.size === 1) boundOneEnd++
+	}
+
+	return {
+		recordsByTypeName,
+		pages: { total: pageIds.size, maxShapesOnAPage, empty: emptyPages },
+		shapes: {
+			total: shapeIds.size,
+			byType: shapesByType,
+			maxDepth,
+			locked,
+			rotated,
+			orphaned,
+			extent,
+		},
+		text: { shapesWithText, totalCharacters, longestCharacters },
+		bindings: {
+			total: totalBindings,
+			byType: bindingsByType,
+			arrows: {
+				boundBothEnds,
+				boundOneEnd,
+				unbound: Math.max(0, (shapesByType.arrow ?? 0) - boundBothEnds - boundOneEnd),
+				dangling: danglingBindings,
+			},
+		},
+		styles,
+		assets: { total: assetsTotal, byType: assetsByType, totalSizeBytes: assetSizeBytes },
+	}
+}

--- a/apps/dotcom/sync-worker/src/fileStats.ts
+++ b/apps/dotcom/sync-worker/src/fileStats.ts
@@ -29,6 +29,14 @@ const STYLE_PROP_NAMES = [
 const MAX_PARENT_DEPTH = 100
 
 /**
+ * A record's `type` as a tally key. Snapshots are read unvalidated, so a broken record can carry no
+ * type at all; those go in one bucket rather than becoming a literal `"undefined"` row in the report.
+ */
+function typeKey(type: unknown): string {
+	return typeof type === 'string' ? type : 'unknown'
+}
+
+/**
  * Total length of the text in a rich text document, without ever holding the text itself. Rich text
  * is a ProseMirror document (see TLRichText), so the text lives in `text` nodes at arbitrary depth.
  */
@@ -94,7 +102,8 @@ export function summarizeSnapshotDocuments(
 				if (typeof record.parentId === 'string') {
 					parentIdByShapeId.set(record.id, record.parentId)
 				}
-				shapesByType[record.type] = (shapesByType[record.type] ?? 0) + 1
+				const shapeType = typeKey(record.type)
+				shapesByType[shapeType] = (shapesByType[shapeType] ?? 0) + 1
 				if (record.isLocked) locked++
 				if (record.rotation) rotated++
 
@@ -130,8 +139,9 @@ export function summarizeSnapshotDocuments(
 			}
 			case 'binding': {
 				totalBindings++
-				bindingsByType[record.type] = (bindingsByType[record.type] ?? 0) + 1
-				if (record.type === 'arrow') {
+				const bindingType = typeKey(record.type)
+				bindingsByType[bindingType] = (bindingsByType[bindingType] ?? 0) + 1
+				if (bindingType === 'arrow') {
 					arrowBindings.push({
 						fromId: record.fromId,
 						toId: record.toId,
@@ -142,7 +152,8 @@ export function summarizeSnapshotDocuments(
 			}
 			case 'asset': {
 				assetsTotal++
-				assetsByType[record.type] = (assetsByType[record.type] ?? 0) + 1
+				const assetType = typeKey(record.type)
+				assetsByType[assetType] = (assetsByType[assetType] ?? 0) + 1
 				const size = record.props?.fileSize
 				if (typeof size === 'number' && size > 0) assetSizeBytes += size
 				break

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -387,3 +387,76 @@ export interface AdminFileAssetsResponseBody {
 	dbRows: { forThisFile: number; orphaned: number }
 	warnings: string[]
 }
+
+/**
+ * Response of the admin board-stats endpoint: the shape of a board without its contents.
+ *
+ * Every field is a count, an enum tally, a size, or a timestamp. Nothing here is text a user typed,
+ * a URL they pasted, a shape id, or a person's id — so a report can be pasted into an issue, a
+ * Sentry thread, or a support reply without leaking what's on the board or who made it. Anything
+ * added here has to hold that line; use the asset diagnostics report when you need identifiers.
+ */
+export interface AdminFileStatsResponseBody {
+	/** null when no `file` row exists — legacy rooms have a snapshot but no row */
+	file: {
+		ownerType: 'user' | 'group' | 'none'
+		createdAt: number
+		updatedAt: number
+		isDeleted: boolean
+		isEmpty: boolean
+		published: boolean
+		shared: boolean
+		sharedLinkType: string
+		/** Only the prefix (`file`, `room`, `publish`, `local`, …); the id half would name a board */
+		createSourceKind: string | null
+	} | null
+	snapshot: {
+		/** Stored size of the snapshot object in R2; null when the head check failed */
+		sizeBytes: number | null
+		clock: number | null
+		documentClock: number | null
+		tombstones: number
+		records: number
+		recordsByTypeName: Record<string, number>
+		/** Serialized schema version, for spotting boards stuck behind a migration */
+		schemaVersion: number | null
+		/** Per-record-type sequence numbers from the serialized schema, when it has them */
+		sequences: Record<string, number> | null
+	}
+	pages: { total: number; maxShapesOnAPage: number; empty: number }
+	shapes: {
+		total: number
+		byType: Record<string, number>
+		/** Deepest parent chain; 1 means every shape sits directly on a page */
+		maxDepth: number
+		locked: number
+		rotated: number
+		/** Shapes whose parent record is missing from the snapshot */
+		orphaned: number
+		/** Bounds covering every shape, from x/y plus w/h where the shape has them */
+		extent: { width: number; height: number } | null
+	}
+	/** Lengths only — never the text itself */
+	text: { shapesWithText: number; totalCharacters: number; longestCharacters: number }
+	bindings: {
+		total: number
+		byType: Record<string, number>
+		/**
+		 * The first three partition every arrow shape by how many of its terminals have a binding
+		 * record. Whether the bound shape still exists is the separate `dangling` count, so an arrow
+		 * bound to a deleted shape shows up in both `boundOneEnd` and `dangling`.
+		 */
+		arrows: {
+			boundBothEnds: number
+			boundOneEnd: number
+			unbound: number
+			/** Bindings pointing at a shape that isn't in the snapshot */
+			dangling: number
+		}
+	}
+	/** Value tallies for the enum style props, keyed by prop name then value */
+	styles: Record<string, Record<string, number>>
+	assets: { total: number; byType: Record<string, number>; totalSizeBytes: number }
+	collaboration: { visitors: number; commentThreads: number; comments: number }
+	warnings: string[]
+}

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -431,9 +431,16 @@ export interface AdminFileStatsResponseBody {
 		maxDepth: number
 		locked: number
 		rotated: number
-		/** Shapes whose parent record is missing from the snapshot */
+		/**
+		 * Shapes whose parent chain doesn't end at a page: a missing or unusable `parentId`, a chain
+		 * that stops on a record that isn't a page, or a chain long enough to be a cycle.
+		 */
 		orphaned: number
-		/** Bounds covering every shape, from x/y plus w/h where the shape has them */
+		/**
+		 * Bounds covering the shapes parented directly to a page, from x/y plus w/h where the shape
+		 * has them. Nested shapes are left out — their x/y is relative to their frame or group, so
+		 * mixing the two would give a meaningless box. Rotation is ignored.
+		 */
 		extent: { width: number; height: number } | null
 	}
 	/** Lengths only — never the text itself */


### PR DESCRIPTION
Last week's asset diagnostics tool (#9646) answers "are this board's assets healthy". This adds the companion for the other question we keep having to answer by hand — "how big and how unusual is this board" — for the cases where someone reports a board as slow, broken, or stuck, and we want to size up the problem without opening their board or seeing anything on it.

Given a file slug, `GET /app/admin/file-stats/:slug` reports counts, enum tallies, and sizes from the last persisted snapshot: records by type, shapes by type, how deeply they nest, page spread, text lengths, arrow binding health, style distributions, asset sizes, and visitor and comment counts. The admin page shows a summary grid, a per-style-prop breakdown, and raw JSON.

Read-only, and the same snapshot source as the asset diagnostics tool.

### Staying anonymous

The point of the endpoint is that the whole report is safe to paste into an issue, a Sentry thread, or a support reply — so every field is a count, a tally, a size, or a timestamp. No shape text, no URLs, no shape or user ids.

The place that's easy to get wrong is the style tally. It reads an **allowlist** of prop names (the `StyleProp.defineEnum` props, plus `align` for old snapshots) rather than "every short string prop", which is what keeps `text`, `url`, and `name` out of the report. That's the invariant to hold if anyone adds a field later; there's a note on `AdminFileStatsResponseBody` saying so.

### Decisions worth a look

- **`file_state` is deliberately not counted**, even though it's the obvious source for "how many people touched this board". Its primary key is `(userId, fileId)` and there's no `fileId` index, so counting by file would sequentially scan the table (~750k rows). `file_visitor`, `comment_thread`, and `comment` all have fileId indexes and answer the same question.
- **Extent covers only shapes parented to a page.** A nested shape's x/y is relative to its frame or group, so mixing the two gives a meaningless box — one grouped shape 100k units from its frame blows the extent up. Rotation is ignored, which is fine for "is this board absurdly spread out".
- **Arrow counts partition on binding records, not on whether the target survives.** `boundBothEnds`/`boundOneEnd`/`unbound` cover every arrow; an arrow bound to a deleted shape lands in `boundOneEnd` *and* in the separate `dangling` count.
- Snapshot analysis lives in `fileStats.ts` as a pure function rather than inline in the route, so it can be tested against hand-built snapshots — including malformed ones, since broken boards are exactly what this endpoint is for.

### Change type

- [x] `other`

### Test plan

1. In `/admin/files`, enter a file slug under "Board stats"
2. Check the shape, page, and text counts against what the board actually contains
3. Confirm nothing in the report (including the raw JSON) is board content or a user id

- [x] Unit tests
- [ ] End to end tests

Unit tests cover the snapshot analysis: nesting and page resolution, parent cycles, the extent rule above, rich text measurement, the style allowlist, arrow binding states, and malformed records. Not covered by tests: the Postgres counts and the R2 head, which need a running stack.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +73 / -0   |
| Tests     | +330 / -0  |
| Apps      | +588 / -0  |
