### PR TITLE
feat(dotcom): report client bundle size to PostHog

### DIFF
--- a/apps/dotcom/client/scripts/build.ts
+++ b/apps/dotcom/client/scripts/build.ts
@@ -15,6 +15,7 @@ import regexgen from 'regexgen'
 import { exec } from '../../../../internal/scripts/lib/exec'
 import { nicelog } from '../../../../internal/scripts/lib/nicelog'
 import { csp } from '../src/utils/csp'
+import { reportBundleSize } from './measure-bundle-size'
 import { getMultiplayerServerURL } from './multiplayer-server-url'
 import { Config } from './vercel-output-config'
 
@@ -242,6 +243,8 @@ async function build() {
 			2
 		)
 	)
+
+	await reportBundleSize('.vercel/output/static')
 }
 
 build()

--- a/apps/dotcom/client/scripts/measure-bundle-size.test.ts
+++ b/apps/dotcom/client/scripts/measure-bundle-size.test.ts
@@ -1,0 +1,250 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { gzipSync } from 'zlib'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+	BundleAsset,
+	getAssetCategory,
+	getBundleSizeEvents,
+	getInitialAssetNames,
+	measureBundleSize,
+	stripContentHash,
+	summarizeAssets,
+} from './measure-bundle-size'
+
+describe('getAssetCategory', () => {
+	it('categorizes assets by extension', () => {
+		expect(getAssetCategory('index-BdIhNi0J.js')).toBe('js')
+		expect(getAssetCategory('index-BdIhNi0J.css')).toBe('css')
+		expect(getAssetCategory('IBMPlexSans-Medium-CxYz1234.woff2')).toBe('font')
+		expect(getAssetCategory('0_merged-abcd1234.svg')).toBe('image')
+		expect(getAssetCategory('en-abcd1234.json')).toBe('json')
+		expect(getAssetCategory('something-abcd1234.wasm')).toBe('other')
+	})
+})
+
+describe('stripContentHash', () => {
+	it('removes the content hash so a chunk is comparable across builds', () => {
+		expect(stripContentHash('index-BdIhNi0J.js')).toBe('index.js')
+		expect(stripContentHash('TlaEditor-_a1B2c3D.js')).toBe('TlaEditor.js')
+		expect(stripContentHash('IBMPlexSans-Medium-CxYz1234.woff2')).toBe('IBMPlexSans-Medium.woff2')
+	})
+
+	it('leaves names without a hash alone', () => {
+		expect(stripContentHash('index.js')).toBe('index.js')
+		expect(stripContentHash('IBMPlexSans-Medium.woff2')).toBe('IBMPlexSans-Medium.woff2')
+	})
+})
+
+describe('getInitialAssetNames', () => {
+	it('collects every asset index.html references', () => {
+		const html = `<!doctype html><html><head>
+			<script type="module" crossorigin src="/assets/index-BdIhNi0J.js"></script>
+			<link rel="modulepreload" crossorigin href="/assets/vendor-CxYz1234.js">
+			<link rel="stylesheet" crossorigin href="/assets/index-DeFg5678.css">
+			<link rel="preload" href="/assets/IBMPlexSans-Medium-HiJk9012.woff2" as="font">
+			<link rel="preload" href="/assets/0_merged-LmNo3456.svg" as="image">
+			<link rel="icon" href="/favicon.svg">
+		</head><body></body></html>`
+
+		expect(getInitialAssetNames(html)).toEqual(
+			new Set([
+				'index-BdIhNi0J.js',
+				'vendor-CxYz1234.js',
+				'index-DeFg5678.css',
+				'IBMPlexSans-Medium-HiJk9012.woff2',
+				'0_merged-LmNo3456.svg',
+			])
+		)
+	})
+
+	it('ignores query strings and assets outside /assets', () => {
+		const html = `<script src="/assets/index-BdIhNi0J.js?v=1"></script><img src="/logo.png">`
+		expect(getInitialAssetNames(html)).toEqual(new Set(['index-BdIhNi0J.js']))
+	})
+})
+
+describe('summarizeAssets', () => {
+	function asset(overrides: Partial<BundleAsset>): BundleAsset {
+		return {
+			fileName: 'index-BdIhNi0J.js',
+			name: 'index.js',
+			category: 'js',
+			bytes: 100,
+			gzipBytes: 40,
+			isInitial: false,
+			...overrides,
+		}
+	}
+
+	const noAssets = {
+		font: { count: 0, bytes: 0, gzipBytes: 0 },
+		image: { count: 0, bytes: 0, gzipBytes: 0 },
+		json: { count: 0, bytes: 0, gzipBytes: 0 },
+		other: { count: 0, bytes: 0, gzipBytes: 0 },
+	}
+
+	it('totals assets overall, by category, and across the initial payload', () => {
+		const report = summarizeAssets([
+			asset({ bytes: 100, gzipBytes: 40, isInitial: true }),
+			asset({ bytes: 200, gzipBytes: 60 }),
+			asset({ category: 'css', bytes: 50, gzipBytes: 20, isInitial: true }),
+		])
+
+		expect(report.total).toEqual({ count: 3, bytes: 350, gzipBytes: 120 })
+		expect(report.initial).toEqual({ count: 2, bytes: 150, gzipBytes: 60 })
+		expect(report.byCategory).toEqual({
+			js: { count: 2, bytes: 300, gzipBytes: 100 },
+			css: { count: 1, bytes: 50, gzipBytes: 20 },
+			...noAssets,
+		})
+		expect(report.initialByCategory).toEqual({
+			js: { count: 1, bytes: 100, gzipBytes: 40 },
+			css: { count: 1, bytes: 50, gzipBytes: 20 },
+			...noAssets,
+		})
+	})
+})
+
+describe('measureBundleSize', () => {
+	let staticDir: string
+
+	beforeEach(() => {
+		staticDir = mkdtempSync(join(tmpdir(), 'bundle-size-'))
+		mkdirSync(join(staticDir, 'assets'))
+	})
+
+	afterEach(() => {
+		rmSync(staticDir, { recursive: true, force: true })
+	})
+
+	function writeAsset(fileName: string, contents: string) {
+		writeFileSync(join(staticDir, 'assets', fileName), contents)
+	}
+
+	it('measures raw and gzipped sizes, and marks assets index.html loads as initial', () => {
+		const entry = 'a'.repeat(1000)
+		const lazy = 'b'.repeat(500)
+		writeAsset('index-BdIhNi0J.js', entry)
+		writeAsset('TlaEditor-CxYz1234.js', lazy)
+		writeFileSync(
+			join(staticDir, 'index.html'),
+			`<script type="module" src="/assets/index-BdIhNi0J.js"></script>`
+		)
+
+		const report = measureBundleSize(staticDir)
+
+		expect(report.assets).toEqual([
+			{
+				fileName: 'index-BdIhNi0J.js',
+				name: 'index.js',
+				category: 'js',
+				bytes: 1000,
+				gzipBytes: gzipSync(entry).byteLength,
+				isInitial: true,
+			},
+			{
+				fileName: 'TlaEditor-CxYz1234.js',
+				name: 'TlaEditor.js',
+				category: 'js',
+				bytes: 500,
+				gzipBytes: gzipSync(lazy).byteLength,
+				isInitial: false,
+			},
+		])
+		expect(report.initial.bytes).toBe(1000)
+	})
+
+	it('skips source maps, which are only downloaded with devtools open', () => {
+		writeAsset('index-BdIhNi0J.js', 'console.log(1)')
+		writeAsset('index-BdIhNi0J.js.map', 'x'.repeat(10000))
+		writeFileSync(join(staticDir, 'index.html'), '<html></html>')
+
+		const report = measureBundleSize(staticDir)
+
+		expect(report.assets.map((asset) => asset.fileName)).toEqual(['index-BdIhNi0J.js'])
+	})
+})
+
+describe('getBundleSizeEvents', () => {
+	it('reports totals once and the largest assets individually', () => {
+		const report = summarizeAssets([
+			{
+				fileName: 'index-BdIhNi0J.js',
+				name: 'index.js',
+				category: 'js',
+				bytes: 100,
+				gzipBytes: 40,
+				isInitial: true,
+			},
+		])
+
+		const [summary, ...assets] = getBundleSizeEvents(report, { git_commit: 'abc123' })
+
+		expect(summary).toEqual({
+			event: 'dotcom_bundle_size',
+			distinctId: 'dotcom-bundle-size',
+			properties: {
+				git_commit: 'abc123',
+				total_bytes: 100,
+				total_gzip_bytes: 40,
+				total_count: 1,
+				initial_bytes: 100,
+				initial_gzip_bytes: 40,
+				initial_count: 1,
+				js_bytes: 100,
+				js_gzip_bytes: 40,
+				js_count: 1,
+				initial_js_bytes: 100,
+				initial_js_gzip_bytes: 40,
+				initial_js_count: 1,
+				css_bytes: 0,
+				css_gzip_bytes: 0,
+				css_count: 0,
+				initial_css_bytes: 0,
+				initial_css_gzip_bytes: 0,
+				initial_css_count: 0,
+				font_bytes: 0,
+				font_gzip_bytes: 0,
+				font_count: 0,
+				initial_font_bytes: 0,
+				initial_font_gzip_bytes: 0,
+				initial_font_count: 0,
+				image_bytes: 0,
+				image_gzip_bytes: 0,
+				image_count: 0,
+				initial_image_bytes: 0,
+				initial_image_gzip_bytes: 0,
+				initial_image_count: 0,
+				json_bytes: 0,
+				json_gzip_bytes: 0,
+				json_count: 0,
+				initial_json_bytes: 0,
+				initial_json_gzip_bytes: 0,
+				initial_json_count: 0,
+				other_bytes: 0,
+				other_gzip_bytes: 0,
+				other_count: 0,
+				initial_other_bytes: 0,
+				initial_other_gzip_bytes: 0,
+				initial_other_count: 0,
+			},
+		})
+		expect(assets).toEqual([
+			{
+				event: 'dotcom_bundle_size_asset',
+				distinctId: 'dotcom-bundle-size',
+				properties: {
+					git_commit: 'abc123',
+					asset_name: 'index.js',
+					asset_file_name: 'index-BdIhNi0J.js',
+					asset_category: 'js',
+					asset_is_initial: true,
+					bytes: 100,
+					gzip_bytes: 40,
+				},
+			},
+		])
+	})
+})

--- a/apps/dotcom/client/scripts/measure-bundle-size.ts
+++ b/apps/dotcom/client/scripts/measure-bundle-size.ts
@@ -1,0 +1,268 @@
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { extname, join } from 'path'
+import { gzipSync } from 'zlib'
+import { nicelog } from '../../../../internal/scripts/lib/nicelog'
+import { captureCiMetricEvents, CiMetricEvent } from '../../../../internal/scripts/lib/posthog'
+
+// How many of the largest assets we report individually alongside the totals — enough to attribute
+// a jump in the total to the chunk that caused it, without sending an event per file on every
+// deploy. Assets in the initial payload are always reported, however small: they're the ones we
+// most want to be able to explain a change in.
+const TOP_ASSET_COUNT = 25
+
+export type AssetCategory = 'js' | 'css' | 'font' | 'image' | 'json' | 'other'
+
+const EXTENSIONS_BY_CATEGORY: Record<Exclude<AssetCategory, 'other'>, string[]> = {
+	js: ['.js', '.mjs'],
+	css: ['.css'],
+	font: ['.woff2', '.woff', '.ttf', '.otf'],
+	image: ['.svg', '.png', '.jpg', '.jpeg', '.webp', '.avif', '.gif', '.ico'],
+	// mostly the compiled translations, which are worth telling apart from everything else
+	json: ['.json'],
+}
+
+export const ASSET_CATEGORIES: AssetCategory[] = ['js', 'css', 'font', 'image', 'json', 'other']
+
+export interface BundleAsset {
+	fileName: string
+	/** `fileName` with the content hash removed, so the same chunk is comparable across builds. */
+	name: string
+	category: AssetCategory
+	bytes: number
+	gzipBytes: number
+	/** Whether the browser downloads this asset to render the app, before any lazy loading. */
+	isInitial: boolean
+}
+
+export interface BundleSizeGroup {
+	count: number
+	bytes: number
+	gzipBytes: number
+}
+
+export interface BundleSizeReport {
+	assets: BundleAsset[]
+	total: BundleSizeGroup
+	initial: BundleSizeGroup
+	byCategory: Record<AssetCategory, BundleSizeGroup>
+	/**
+	 * The initial payload split up, because its two halves move for unrelated reasons: the js grows
+	 * when we add application code, the fonts only when we change which ones we preload.
+	 */
+	initialByCategory: Record<AssetCategory, BundleSizeGroup>
+}
+
+export function getAssetCategory(fileName: string): AssetCategory {
+	const extension = extname(fileName).toLowerCase()
+	for (const [category, extensions] of Object.entries(EXTENSIONS_BY_CATEGORY)) {
+		if (extensions.includes(extension)) return category as AssetCategory
+	}
+	return 'other'
+}
+
+/**
+ * Strip vite's content hash from an asset file name, so `index-BdIhNi0J.js` becomes `index.js` and
+ * the same chunk can be followed from one build to the next. Hashes are 8 url-safe base64 chars,
+ * which is short enough that a real name segment could look like one — but only if it's exactly 8
+ * characters and sits right before the extension, which is rare enough to live with.
+ */
+export function stripContentHash(fileName: string) {
+	return fileName.replace(/-[A-Za-z0-9_-]{8}(\.[A-Za-z0-9]+)$/, '$1')
+}
+
+/**
+ * The assets referenced directly by index.html: the entry chunk, its modulepreloads, stylesheets,
+ * and the fonts and sprite sheet the build script preloads. Together these are what a visitor
+ * downloads before anything renders, which is the number that matters most for load time.
+ */
+export function getInitialAssetNames(indexHtml: string) {
+	const names = new Set<string>()
+	for (const match of indexHtml.matchAll(/(?:src|href)="\/assets\/([^"?#]+)/g)) {
+		names.add(match[1])
+	}
+	return names
+}
+
+function emptyGroup(): BundleSizeGroup {
+	return { count: 0, bytes: 0, gzipBytes: 0 }
+}
+
+function addToGroup(group: BundleSizeGroup, asset: BundleAsset) {
+	group.count += 1
+	group.bytes += asset.bytes
+	group.gzipBytes += asset.gzipBytes
+}
+
+function emptyCategoryGroups() {
+	return Object.fromEntries(ASSET_CATEGORIES.map((category) => [category, emptyGroup()])) as Record<
+		AssetCategory,
+		BundleSizeGroup
+	>
+}
+
+export function summarizeAssets(assets: BundleAsset[]): BundleSizeReport {
+	const report: BundleSizeReport = {
+		assets,
+		total: emptyGroup(),
+		initial: emptyGroup(),
+		byCategory: emptyCategoryGroups(),
+		initialByCategory: emptyCategoryGroups(),
+	}
+
+	for (const asset of assets) {
+		addToGroup(report.total, asset)
+		addToGroup(report.byCategory[asset.category], asset)
+		if (asset.isInitial) {
+			addToGroup(report.initial, asset)
+			addToGroup(report.initialByCategory[asset.category], asset)
+		}
+	}
+
+	return report
+}
+
+/**
+ * Measure every file in the built assets directory. Source maps are skipped: we serve them, but
+ * they're only fetched when devtools is open, so counting them would swamp the numbers a visitor
+ * actually pays for. Files in `public/` are skipped too — they're copied verbatim rather than
+ * bundled, so they don't move when application code changes.
+ */
+export function measureBundleSize(staticDir: string): BundleSizeReport {
+	const assetsDir = join(staticDir, 'assets')
+	const initialAssetNames = getInitialAssetNames(
+		readFileSync(join(staticDir, 'index.html'), 'utf8')
+	)
+
+	const assets = readdirSync(assetsDir)
+		.filter(
+			(fileName) => !fileName.endsWith('.map') && statSync(join(assetsDir, fileName)).isFile()
+		)
+		.map((fileName): BundleAsset => {
+			const contents = readFileSync(join(assetsDir, fileName))
+			return {
+				fileName,
+				name: stripContentHash(fileName),
+				category: getAssetCategory(fileName),
+				bytes: contents.byteLength,
+				gzipBytes: gzipSync(contents).byteLength,
+				isInitial: initialAssetNames.has(fileName),
+			}
+		})
+		.sort((a, b) => b.gzipBytes - a.gzipBytes)
+
+	return summarizeAssets(assets)
+}
+
+function formatKb(bytes: number) {
+	return `${(bytes / 1024).toFixed(1)} kB`
+}
+
+export function formatBundleSizeReport(report: BundleSizeReport) {
+	function section(label: string, total: BundleSizeGroup, groups: Record<string, BundleSizeGroup>) {
+		return [
+			[label, total] as [string, BundleSizeGroup],
+			...ASSET_CATEGORIES.filter((category) => groups[category].count > 0).map(
+				(category): [string, BundleSizeGroup] => [`  ${category}`, groups[category]]
+			),
+		]
+	}
+
+	const rows = [
+		...section('initial payload', report.initial, report.initialByCategory),
+		...section('all assets', report.total, report.byCategory),
+	]
+
+	const labelWidth = Math.max(...rows.map(([label]) => label.length))
+	return rows
+		.map(
+			([label, group]) =>
+				`  ${label.padEnd(labelWidth)}  ${formatKb(group.gzipBytes).padStart(10)} gzipped` +
+				`  ${formatKb(group.bytes).padStart(10)} raw  (${group.count} files)`
+		)
+		.join('\n')
+}
+
+export function getBundleSizeEvents(
+	report: BundleSizeReport,
+	context: Record<string, unknown>
+): CiMetricEvent[] {
+	const categoryProperties: Record<string, number> = {}
+	for (const category of ASSET_CATEGORIES) {
+		for (const [prefix, groups] of [
+			['', report.byCategory],
+			['initial_', report.initialByCategory],
+		] as const) {
+			const group = groups[category]
+			categoryProperties[`${prefix}${category}_bytes`] = group.bytes
+			categoryProperties[`${prefix}${category}_gzip_bytes`] = group.gzipBytes
+			categoryProperties[`${prefix}${category}_count`] = group.count
+		}
+	}
+
+	return [
+		{
+			event: 'dotcom_bundle_size',
+			distinctId: 'dotcom-bundle-size',
+			properties: {
+				...context,
+				total_bytes: report.total.bytes,
+				total_gzip_bytes: report.total.gzipBytes,
+				total_count: report.total.count,
+				initial_bytes: report.initial.bytes,
+				initial_gzip_bytes: report.initial.gzipBytes,
+				initial_count: report.initial.count,
+				...categoryProperties,
+			},
+		},
+		...report.assets
+			.filter((asset, index) => asset.isInitial || index < TOP_ASSET_COUNT)
+			.map(
+				(asset): CiMetricEvent => ({
+					event: 'dotcom_bundle_size_asset',
+					distinctId: 'dotcom-bundle-size',
+					properties: {
+						...context,
+						asset_name: asset.name,
+						asset_file_name: asset.fileName,
+						asset_category: asset.category,
+						asset_is_initial: asset.isInitial,
+						bytes: asset.bytes,
+						gzip_bytes: asset.gzipBytes,
+					},
+				})
+			),
+	]
+}
+
+/**
+ * Measure the built client and, when `BUNDLE_SIZE_ANALYTICS_ENABLED` is set, send the results to
+ * PostHog so we can watch the bundle over time. Reporting never fails the build: a bundle size
+ * datapoint isn't worth breaking a deploy over.
+ *
+ * Call this on the finished `.vercel/output/static` directory, and before the deploy script
+ * coalesces previous deploys' assets into it — those older files are still served for open tabs,
+ * but they aren't part of this build.
+ */
+export async function reportBundleSize(staticDir: string) {
+	try {
+		const report = measureBundleSize(staticDir)
+		nicelog(`Bundle size:\n${formatBundleSizeReport(report)}`)
+
+		if (process.env.BUNDLE_SIZE_ANALYTICS_ENABLED !== 'true') {
+			nicelog('Bundle size analytics disabled, not reporting to PostHog')
+			return
+		}
+
+		// See https://eu.posthog.com/project/45972
+		await captureCiMetricEvents(
+			getBundleSizeEvents(report, {
+				git_commit: process.env.RELEASE_COMMIT_HASH || process.env.GITHUB_SHA,
+				git_branch: process.env.GITHUB_REF_NAME,
+				tldraw_env: process.env.TLDRAW_ENV,
+				ci_environment: process.env.GITHUB_ACTIONS ? 'github-actions' : 'local',
+			})
+		)
+	} catch (error) {
+		console.error('Failed to measure or report bundle size:', error)
+	}
+}

--- a/internal/scripts/deploy-dotcom.ts
+++ b/internal/scripts/deploy-dotcom.ts
@@ -479,7 +479,12 @@ async function prepareDotcomApp() {
 	// pre-build the app:
 	await exec('yarn', ['build-app'], {
 		env: {
+			// the build script measures the finished bundle and sends the numbers to PostHog, so we
+			// can see the client's size over time. every deploy reports; the events carry
+			// TLDRAW_ENV so a trend can be filtered down to production.
+			BUNDLE_SIZE_ANALYTICS_ENABLED: 'true',
 			NEXT_PUBLIC_TLDRAW_RELEASE_INFO: `${env.RELEASE_COMMIT_HASH} ${new Date().toISOString()}`,
+			RELEASE_COMMIT_HASH: env.RELEASE_COMMIT_HASH,
 			MULTIPLAYER_SERVER: env.MULTIPLAYER_SERVER,
 			USER_CONTENT_URL: env.USER_CONTENT_URL,
 			ZERO_SERVER: getZeroUrl(),

--- a/internal/scripts/lib/posthog.ts
+++ b/internal/scripts/lib/posthog.ts
@@ -1,0 +1,53 @@
+import { nicelog } from './nicelog'
+
+/**
+ * The PostHog project we send CI engineering metrics to. `phc_` keys are public, write-only
+ * ingest keys, so keeping this in the repo is fine — it's the same project the e2e performance
+ * reporter writes to. See https://eu.posthog.com/project/45972
+ */
+const CI_METRICS_API_KEY = 'phc_i8oKgMzgV38sn3GfjswW9mevQ3gFlo7bJXekZFeDN6'
+const DEFAULT_API_HOST = 'https://analytics.tldraw.com/ingest'
+
+export interface CiMetricEvent {
+	event: string
+	/**
+	 * Groups a series together in PostHog. Use a stable string per metric (e.g.
+	 * `dotcom-bundle-size`) rather than a per-run id, so a trend over time is one person's events
+	 * instead of thousands of one-off people.
+	 */
+	distinctId: string
+	properties: Record<string, unknown>
+}
+
+/**
+ * Send events to the CI metrics PostHog project. Events are sent one at a time against the same
+ * `/capture/` endpoint the e2e performance reporter uses.
+ */
+export async function captureCiMetricEvents(events: CiMetricEvent[]) {
+	const apiHost = process.env.POSTHOG_API_HOST || DEFAULT_API_HOST
+	const timestamp = new Date().toISOString()
+
+	for (const { event, distinctId, properties } of events) {
+		const response = await fetch(`${apiHost}/capture/`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				api_key: CI_METRICS_API_KEY,
+				event,
+				properties: {
+					...properties,
+					distinct_id: distinctId,
+					$lib: 'tldraw-ci-metrics',
+					$lib_version: '1.0.0',
+				},
+				timestamp,
+			}),
+		})
+
+		if (!response.ok) {
+			throw new Error(`PostHog API error: ${response.status} ${response.statusText}`)
+		}
+	}
+
+	nicelog(`Sent ${events.length} event(s) to PostHog`)
+}

--- a/internal/scripts/lib/posthog.ts
+++ b/internal/scripts/lib/posthog.ts
@@ -20,19 +20,23 @@ export interface CiMetricEvent {
 }
 
 /**
- * Send events to the CI metrics PostHog project. Events are sent one at a time against the same
- * `/capture/` endpoint the e2e performance reporter uses.
+ * Send events to the CI metrics PostHog project. Everything goes in a single request to the
+ * `/batch/` endpoint: a build reports a few dozen events, and sending them one at a time would
+ * mean a few dozen round trips at the tail of a deploy, where a failure partway through leaves a
+ * build with some of its events recorded and the rest missing.
  */
 export async function captureCiMetricEvents(events: CiMetricEvent[]) {
+	if (events.length === 0) return
+
 	const apiHost = process.env.POSTHOG_API_HOST || DEFAULT_API_HOST
 	const timestamp = new Date().toISOString()
 
-	for (const { event, distinctId, properties } of events) {
-		const response = await fetch(`${apiHost}/capture/`, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				api_key: CI_METRICS_API_KEY,
+	const response = await fetch(`${apiHost}/batch/`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			api_key: CI_METRICS_API_KEY,
+			batch: events.map(({ event, distinctId, properties }) => ({
 				event,
 				properties: {
 					...properties,
@@ -41,12 +45,12 @@ export async function captureCiMetricEvents(events: CiMetricEvent[]) {
 					$lib_version: '1.0.0',
 				},
 				timestamp,
-			}),
-		})
+			})),
+		}),
+	})
 
-		if (!response.ok) {
-			throw new Error(`PostHog API error: ${response.status} ${response.statusText}`)
-		}
+	if (!response.ok) {
+		throw new Error(`PostHog API error: ${response.status} ${response.statusText}`)
 	}
 
 	nicelog(`Sent ${events.length} event(s) to PostHog`)


### PR DESCRIPTION
In order to know whether the dotcom client is getting slower to load, this measures the built client on every deploy and sends the numbers to PostHog. Today we have no size history for it at all: the only bundle tooling in the repo is a hard byte limit on the Cloudflare workers, which fails a build when it trips and then gets raised by hand (#9901 bumped the sync worker to 1.8mb last week). The client has nothing — its initial payload is currently 733 kB of gzipped JS, and nobody can say whether that's up or down from a month ago, or which chunk moved.

The build script measures `.vercel/output/static/assets` at the end of a build: raw and gzipped bytes per file, grouped by category, with vite's content hashes stripped so a chunk can be followed across builds. The initial payload — what a visitor downloads before anything renders — is derived by scanning the built `index.html` for `/assets/…` references, which picks up the entry chunk, its modulepreloads, the stylesheet, and the fonts and sprite sheet the build script preloads. That split matters: the headline 1.1 MB initial payload is a third fonts, which only move when we change what we preload, so `initial_js_gzip_bytes` is the number worth trending.

Two events per build, both tagged with `git_commit`, `git_branch` and `tldraw_env`: `dotcom_bundle_size` with the totals, and `dotcom_bundle_size_asset` for the largest assets plus every initial one, so a jump in the total can be attributed rather than just noticed.

Decisions worth a look:

- **Every deploy reports, not just production.** Preview and staging builds report too, tagged by env, so a PR that doubles a chunk shows up before it merges. Filter to `tldraw_env = production` for the clean series.
- **It reuses the CI metrics PostHog project** (the one `apps/examples/e2e/fixtures/analytics-reporter.ts` already writes perf results to), so build metrics and perf metrics live together. That reporter's inline `phc_` key moved into `internal/scripts/lib/posthog.ts` for reuse; it's a public write-only ingest key.
- **Reporting can't fail a deploy.** Everything is wrapped in a try/catch that logs — a size datapoint isn't worth breaking a release over. It's gated on `BUNDLE_SIZE_ANALYTICS_ENABLED`, which only the deploy script sets, so local builds just print the table.
- **Source maps and `public/` are excluded.** Maps are served but only fetched with devtools open; `public/` is copied verbatim and doesn't move when application code does.

Relates to #9255, which asks for a standalone "size of all packages" script. This isn't that — it's the dotcom client specifically, measured where it's already being built — but the measuring code is structured so workers and SDK packages could feed the same events later.

```
  initial payload   1108.7 kB gzipped   2976.9 kB raw  (14 files)
    js               732.9 kB gzipped   2454.1 kB raw  (7 files)
    css               18.5 kB gzipped    102.6 kB raw  (1 files)
    font             331.8 kB gzipped    331.6 kB raw  (4 files)
    image             25.5 kB gzipped     88.6 kB raw  (2 files)
  all assets        3826.2 kB gzipped  10083.5 kB raw  (257 files)
    js              2041.2 kB gzipped   6953.1 kB raw  (151 files)
    css               48.0 kB gzipped    239.5 kB raw  (16 files)
    font            1337.5 kB gzipped   1336.8 kB raw  (16 files)
    image             48.5 kB gzipped    111.3 kB raw  (21 files)
    json             351.0 kB gzipped   1442.8 kB raw  (53 files)
```

### Change type

- [x] `other`

### Test plan

1. Run `yarn build-app` and check the bundle size summary printed at the end of the build.
2. The PostHog leg has **not** been exercised against the live endpoint yet — it posts to the same `/capture/` endpoint the e2e perf reporter uses, but no events have been sent. Worth confirming events land before relying on the dashboard.

- [x] Unit tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Tests          | +250 / -0  |
| Apps           | +271 / -0  |
| Config/tooling | +58 / -0   |
