### PR TITLE
perf(dotcom): clear the user DO boot timeout timer to unblock hibernation

### DIFF
--- a/apps/dotcom/sync-worker/src/UserDataSyncer.test.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.test.ts
@@ -1,0 +1,60 @@
+import { vi } from 'vitest'
+import { UserDataSyncer } from './UserDataSyncer'
+
+function makeSyncer(boot: () => Promise<void>) {
+	return Object.assign(Object.create(UserDataSyncer.prototype), {
+		numConsecutiveReboots: 0,
+		logEvent: vi.fn(),
+		log: { debug: vi.fn() },
+		queue: { push: (callback: () => Promise<void>) => callback() },
+		boot,
+		captureException: vi.fn(),
+	}) as UserDataSyncer
+}
+
+describe('UserDataSyncer', () => {
+	afterEach(() => {
+		vi.clearAllTimers()
+		vi.useRealTimers()
+		vi.restoreAllMocks()
+	})
+
+	test('clears the boot timeout when boot finishes', async () => {
+		vi.useFakeTimers()
+		const syncer = makeSyncer(async () => {})
+
+		await syncer.reboot({ delay: false, source: 'test' })
+
+		expect(vi.getTimerCount()).toBe(0)
+	})
+
+	test('clears a timeout whose timer id is zero', async () => {
+		const setTimeoutSpy = vi
+			.spyOn(globalThis, 'setTimeout')
+			.mockReturnValue(0 as unknown as ReturnType<typeof setTimeout>)
+		const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+		const syncer = makeSyncer(async () => {})
+
+		await syncer.reboot({ delay: false, source: 'test' })
+
+		expect(setTimeoutSpy).toHaveBeenCalledOnce()
+		expect(clearTimeoutSpy).toHaveBeenCalledWith(0)
+	})
+
+	test('clears the boot timeout if error reporting throws', async () => {
+		vi.useFakeTimers()
+		const syncer = makeSyncer(async () => {
+			throw new Error('boot failed')
+		})
+		Object.assign(syncer, {
+			captureException: () => {
+				throw new Error('error reporting failed')
+			},
+		})
+
+		await expect(syncer.reboot({ delay: false, source: 'test' })).rejects.toThrow(
+			'error reporting failed'
+		)
+		expect(vi.getTimerCount()).toBe(0)
+	})
+})

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -277,14 +277,21 @@ export class UserDataSyncer {
 					this.captureException(e, { source })
 					return 'error' as const
 				})
+			// The timeout timer must be cleared once boot settles — a pending timer is
+			// outstanding work that blocks DO hibernation, so losing the race would
+			// otherwise hold the DO in memory for the full 30 seconds after every boot.
+			let timeoutTimer: ReturnType<typeof setTimeout> | null = null
 			const res = await Promise.race([
 				bootPromise,
-				sleep(30_000).then(() => {
-					controller.abort()
-					return 'timeout' as const
+				new Promise<'timeout'>((resolve) => {
+					timeoutTimer = setTimeout(() => {
+						controller.abort()
+						resolve('timeout')
+					}, 30_000)
 				}),
 			])
 			await bootPromise
+			if (timeoutTimer) clearTimeout(timeoutTimer)
 			this.log.debug('rebooted', res)
 			if (res === 'ok') {
 				this.numConsecutiveReboots = 0

--- a/apps/dotcom/sync-worker/src/UserDataSyncer.ts
+++ b/apps/dotcom/sync-worker/src/UserDataSyncer.ts
@@ -281,17 +281,21 @@ export class UserDataSyncer {
 			// outstanding work that blocks DO hibernation, so losing the race would
 			// otherwise hold the DO in memory for the full 30 seconds after every boot.
 			let timeoutTimer: ReturnType<typeof setTimeout> | null = null
-			const res = await Promise.race([
-				bootPromise,
-				new Promise<'timeout'>((resolve) => {
-					timeoutTimer = setTimeout(() => {
-						controller.abort()
-						resolve('timeout')
-					}, 30_000)
-				}),
-			])
-			await bootPromise
-			if (timeoutTimer) clearTimeout(timeoutTimer)
+			let res: 'ok' | 'error' | 'timeout'
+			try {
+				res = await Promise.race([
+					bootPromise,
+					new Promise<'timeout'>((resolve) => {
+						timeoutTimer = setTimeout(() => {
+							controller.abort()
+							resolve('timeout')
+						}, 30_000)
+					}),
+				])
+				await bootPromise
+			} finally {
+				if (timeoutTimer !== null) clearTimeout(timeoutTimer)
+			}
 			this.log.debug('rebooted', res)
 			if (res === 'ok') {
 				this.numConsecutiveReboots = 0


### PR DESCRIPTION
In order to let idle user durable objects actually leave memory — Cloudflare bills wall-clock GB-seconds for every DO held awake, and duration is the bulk of our DO bill — this PR clears the 30-second boot timeout timer once boot settles.

`UserDataSyncer.reboot()` raced `boot()` against `sleep(30_000)`, and `Promise.race` doesn't cancel the loser: every boot, including every wake from hibernation, left a pending 30s timer behind. The Workers runtime treats a pending timer as outstanding work and won't evict the DO while one exists, so each wake held the DO in memory for ~40 seconds instead of the ~10-second idle window — a ~4x multiplier on wake cost across every user DO in the fleet. All race outcomes (boot ok, boot error, timeout + abort) behave exactly as before; the timer is just cleaned up.

### Change type

- [x] `improvement`

### Test plan

Focused unit tests cover successful boot, timer ID zero, and cleanup when error reporting throws.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +19 / -8   |
| Tests   | +60 / -0   |