### PR TITLE
chore(examples): add the comment tool to the develop page

### DIFF
--- a/apps/examples/src/misc/develop.tsx
+++ b/apps/examples/src/misc/develop.tsx
@@ -1,9 +1,21 @@
-import { getLicenseKey } from '@tldraw/dotcom-shared'
 import {
+	CanvasComments,
+	CommentAuthor,
+	CommentTool,
+	commentToolOverrides,
+} from '@tldraw/commenting'
+import { getLicenseKey } from '@tldraw/dotcom-shared'
+import { useMemo } from 'react'
+import {
+	commentSchemaRecords,
+	CommentToolbarItem,
+	createTLSchema,
 	DefaultContextMenu,
 	DefaultContextMenuContent,
 	DefaultDebugMenu,
 	DefaultDebugMenuContent,
+	DefaultToolbar,
+	DefaultToolbarContent,
 	ExampleDialog,
 	PerformanceApiAdapter,
 	TLComponents,
@@ -15,7 +27,9 @@ import {
 	track,
 	useDialogs,
 	useEditor,
+	useLocalStore,
 } from 'tldraw'
+import '@tldraw/commenting/commenting.css'
 import 'tldraw/tldraw.css'
 import { trackedShapes, useDebugging } from '../hooks/useDebugging'
 import { usePerformance } from '../hooks/usePerformance'
@@ -79,6 +93,19 @@ function A11yAudit() {
 	return <TldrawUiMenuItem id="a11y-audit" onSelect={runA11yAudit} label={'A11y audit'} />
 }
 
+// Comments are authored as the local user, so the develop page shows whatever name and color are
+// set in the preferences menu. Any other author id came from another tab of the same document.
+const Comments = track(() => {
+	const editor = useEditor()
+	const userId = editor.user.getExternalId()
+	const resolveAuthor = (id: string): CommentAuthor =>
+		id === userId
+			? { name: editor.user.getName() || 'You', color: editor.user.getColor() }
+			: { name: id }
+
+	return <CanvasComments currentUserId={userId} resolveAuthor={resolveAuthor} />
+})
+
 const components: TLComponents = {
 	ContextMenu,
 	DebugMenu: () => (
@@ -87,7 +114,18 @@ const components: TLComponents = {
 			<DefaultDebugMenuContent />
 		</DefaultDebugMenu>
 	),
+	InFrontOfTheCanvas: Comments,
+	// The default toolbar doesn't include the comment tool, so add it here.
+	Toolbar: () => (
+		<DefaultToolbar>
+			<CommentToolbarItem />
+			<DefaultToolbarContent />
+		</DefaultToolbar>
+	),
 }
+
+// Dragging the comment tool out anchors a comment to a rectangular region; a click anchors a pin.
+const tools = [CommentTool.configure({ enableRegions: true })]
 
 function afterChangeHandler(prev: any, next: any) {
 	const tracked = trackedShapes.get()
@@ -101,12 +139,18 @@ export default function Develop() {
 	const performanceOverrides = usePerformance()
 	const debuggingOverrides = useDebugging()
 
+	// The comment records live in the store alongside shapes, so the schema needs them registered
+	// before the persisted document loads.
+	const schema = useMemo(() => createTLSchema({ records: commentSchemaRecords }), [])
+	const store = useLocalStore({ persistenceKey: 'example', schema })
+
 	return (
 		<div className="tldraw__editor">
 			<Tldraw
 				licenseKey={getLicenseKey()}
-				overrides={[performanceOverrides, debuggingOverrides]}
-				persistenceKey="example"
+				overrides={[performanceOverrides, debuggingOverrides, commentToolOverrides]}
+				store={store}
+				tools={tools}
 				onMount={(editor) => {
 					;(window as any).app = editor
 					;(window as any).editor = editor


### PR DESCRIPTION
When we're working on commenting, the develop page is the one place we don't have it: trying a comment change means switching to one of the commenting examples, which has its own store and none of the develop page's debugging setup. In order to test commenting alongside everything else we use that page for, this adds the comment tool to it.

The develop page now registers `CommentTool` (with regions enabled) and `commentToolOverrides`, mounts `CanvasComments` in front of the canvas, and adds `CommentToolbarItem` to the toolbar — `DefaultToolbarContent` doesn't include it, so it needs to be added explicitly.

Comments are records in the same store as shapes, so the schema needs `commentSchemaRecords` registered before the persisted document loads. `persistenceKey` on `<Tldraw>` doesn't let you pass a schema, so the page calls `useLocalStore({ persistenceKey: 'example', schema })` itself and hands the result in as `store`. Same persistence key as before, so existing develop documents still load. Comments are authored as the local editor user, so the name and color come from the preferences menu (falling back to "You" when the name is empty).

### Change type

- [x] `other`

### Test plan

1. Run `yarn dev` and open `/develop`.
2. Click the comment button at the left of the toolbar (or press `c`), then click the canvas.
3. Write a comment and post it — a pin appears.
4. Reload the page. The pin and its thread are still there.
5. Drag the comment tool out instead of clicking to place a region comment.

### Code changes

| Section       | LOC change |
| ------------- | ---------- |
| Documentation | +46 / -2   |
