### PR TITLE
fix(tldraw): give cursor chat its own context menu group

### DIFF
--- a/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenuContent.tsx
+++ b/packages/tldraw/src/lib/ui/components/ContextMenu/DefaultContextMenuContent.tsx
@@ -29,7 +29,11 @@ export function DefaultContextMenuContent() {
 
 	return (
 		<>
-			{showCollaborationUi && <CursorChatItem />}
+			{showCollaborationUi && (
+				<TldrawUiMenuGroup id="cursor-chat">
+					<CursorChatItem />
+				</TldrawUiMenuGroup>
+			)}
 			<TldrawUiMenuGroup id="modify">
 				<EditMenuSubmenu />
 				<ArrangeMenuSubmenu />


### PR DESCRIPTION
The "Cursor chat" item at the top of the context menu sat noticeably further from the item below it than any other pair of rows, so it read as a mis-padded row rather than a section.

It was the only item in `DefaultContextMenuContent` rendered outside a `TldrawUiMenuGroup`. Menu buttons carry `margin-top: -4px` to tighten rows within a group, so every group boundary is 4px wider than the rows inside it — that reads fine elsewhere because each group also draws a divider there. With no group of its own, cursor chat got the wider boundary gap and no divider to explain it.

Wrapping it in its own group gives it the same divider treatment as every other section. `.tlui-menu__group:empty { display: none }` already covers the case where `CursorChatItem` renders nothing (non-select tool, or coarse pointer), so no empty group or stray divider appears.

### Change type

- [x] `bugfix`

### Test plan

1. Open the multiplayer sync example (cursor chat only appears when a collaboration store is present).
2. Right-click the canvas.
3. "Cursor chat" should be separated from the next item by a divider, at the same spacing as every other section boundary.
4. Switch to a shape tool, or use a touch device, and confirm no empty group or leftover divider appears at the top of the menu.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix the spacing around the cursor chat item in the context menu.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +5 / -1    |
