### PR TITLE
fix(tldraw): close densely sampled draw shapes

### DIFF
--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
@@ -110,6 +110,7 @@ describe('Close threshold with zoom', () => {
 	})
 
 	it('Closes a small shape with densely sampled points', () => {
+		// Match the point density of the reported shape that exposed the length calculation bug.
 		const samples = 476
 		const radius = 20
 		const center = { x: 100, y: 100 }

--- a/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
+++ b/packages/tldraw/src/lib/shapes/draw/DrawShapeTool.test.ts
@@ -109,6 +109,24 @@ describe('Close threshold with zoom', () => {
 		expect(shape.props.isClosed).toBe(true)
 	})
 
+	it('Closes a small shape with densely sampled points', () => {
+		const samples = 476
+		const radius = 20
+		const center = { x: 100, y: 100 }
+
+		editor.setCurrentTool('draw')
+		editor.pointerDown(center.x + radius, center.y)
+		for (let i = 1; i <= samples; i++) {
+			const angle = (i / samples) * Math.PI * 2
+			editor.pointerMove(center.x + Math.cos(angle) * radius, center.y + Math.sin(angle) * radius)
+		}
+		editor.pointerUp()
+
+		const shapes = editor.getCurrentPageShapes() as TLDrawShape[]
+		expect(shapes).toHaveLength(1)
+		expect(shapes[0].props.isClosed).toBe(true)
+	})
+
 	it('Does not close a shape when the endpoint is far from the start', () => {
 		const shape = drawNearlyClosedShape(50)
 		expect(shape.props.isClosed).toBe(false)

--- a/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
+++ b/packages/tldraw/src/lib/shapes/draw/toolStates/Drawing.ts
@@ -733,11 +733,11 @@ export class Drawing extends StateNode {
 		for (let j = 0; j < segments.length; j++) {
 			const points = b64Vecs.decodePoints(segments[j].path, segments[j].dim)
 			for (let i = 0; i < points.length - 1; i++) {
-				length += Vec.Dist2(points[i], points[i + 1])
+				length += Vec.Dist(points[i], points[i + 1])
 			}
 		}
 
-		return Math.sqrt(length)
+		return length
 	}
 
 	override onPointerUp() {


### PR DESCRIPTION
In order to let small, slowly drawn loops close reliably, this PR corrects the draw tool length calculation so dense input sampling does not make a stroke appear shorter. The reported shape had a true path length of about 129 units but was measured as 6.98 units, causing it to fail the minimum-length guard despite its endpoints being close enough. Relates to #9625.

### Change type

- [x] `bugfix`

### Test plan

1. Zoom in and use the draw tool to slowly draw a small loop with medium ink.
2. End the stroke near its starting point.
3. Confirm the loop closes and uses the selected fill.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix small, slowly drawn loops sometimes failing to close.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +2 / -2    |
| Tests     | +19 / -0   |