### PR TITLE
feat(dotcom): lazy board socket — load boards over REST, dial the websocket on demand

### DIFF
--- a/apps/dotcom/client/src/tla/app/shouldEnableCommenting.test.ts
+++ b/apps/dotcom/client/src/tla/app/shouldEnableCommenting.test.ts
@@ -6,6 +6,7 @@ const FLAGS_OFF: FeatureFlags = {
 	rum_enabled: { enabled: false },
 	commenting_enabled: { enabled: false },
 	mcp_friends_and_family: { enabled: false },
+	lazy_board_socket: { enabled: false },
 }
 
 const FLAGS_COMMENTING_ON: FeatureFlags = {

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -1,6 +1,6 @@
 import { CommentTool, commentToolOverrides } from '@tldraw/commenting'
 import { TLCustomServerEvent, getLicenseKey } from '@tldraw/dotcom-shared'
-import { useSync } from '@tldraw/sync'
+import { UseSyncSnapshot, useSync } from '@tldraw/sync'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
 	DefaultDebugMenu,
@@ -44,6 +44,8 @@ import { TldrawApp } from '../../app/TldrawApp'
 import { useMaybeApp } from '../../hooks/useAppState'
 import { useIsCommentingEnabled } from '../../hooks/useIsCommentingEnabled'
 import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
+import { useLazyBoardSnapshot } from '../../hooks/useLazyBoardSnapshot'
+import { LazyUpgradeReason, useLazySocketUpgrade } from '../../hooks/useLazySocketUpgrade'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
 import { useTldrawCurrentUser } from '../../hooks/useUser'
 import { maybeSlurp } from '../../utils/slurping'
@@ -95,18 +97,28 @@ interface TlaEditorProps {
 }
 
 export function TlaEditor(props: TlaEditorProps) {
+	// Lazy transport: resolve the flag and (maybe) fetch the board's REST snapshot before the
+	// editor mounts, so useSync can hydrate from it instead of dialing the websocket. Resolves to
+	// undefined — the plain websocket path — for anonymous users, flag-off, or any fetch failure.
+	const lazy = useLazyBoardSnapshot(props.fileSlug)
 	// force re-mount when the file slug changes to prevent state from leaking between files
 	return (
 		<>
 			<SneakySetDocumentTitle />
 			<ReadyWrapper key={props.fileSlug}>
-				<TlaEditorInner {...props} key={props.fileSlug} />
+				{lazy.state === 'ready' && (
+					<TlaEditorInner {...props} key={props.fileSlug} lazySnapshot={lazy.snapshot} />
+				)}
 			</ReadyWrapper>
 		</>
 	)
 }
 
-function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
+function TlaEditorInner({
+	fileSlug,
+	deepLinks,
+	lazySnapshot,
+}: TlaEditorProps & { lazySnapshot?: UseSyncSnapshot }) {
 	const handleUiEvent = useHandleUiEvents()
 	const app = useMaybeApp()
 
@@ -232,16 +244,24 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		}
 	}, [app?.tlUser.userPreferences])
 
+	// Written by useLazySocketUpgrade before it dials, read by the uri callback below so the
+	// server can attribute lazy upgrades by reason.
+	const upgradeReasonRef = useRef<LazyUpgradeReason | null>(null)
+
 	const store = useSync({
 		uri: useCallback(async () => {
 			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileSlug}`)
 			if (hasUser) {
 				url.searchParams.set('accessToken', await getUserToken())
 			}
+			if (upgradeReasonRef.current) {
+				url.searchParams.set('upgradeReason', upgradeReasonRef.current)
+			}
 			return url.toString()
 		}, [fileSlug, hasUser, getUserToken]),
 		assets,
 		users,
+		snapshot: lazySnapshot,
 		// Register the opt-in `comment` record type so comment records sync through the file room.
 		// Must match the server schema (see fileSyncSchema in TLFileDurableObject).
 		records: commentSchemaRecords,
@@ -249,6 +269,8 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 			trackEvent(message.type)
 		}, []),
 	})
+
+	useLazySocketUpgrade({ store, snapshot: lazySnapshot, upgradeReasonRef, fileSlug })
 
 	// we need to prevent calling onFileExit if the store is in an error state
 	const storeError = useRef(false)

--- a/apps/dotcom/client/src/tla/hooks/useLazyBoardSnapshot.ts
+++ b/apps/dotcom/client/src/tla/hooks/useLazyBoardSnapshot.ts
@@ -1,0 +1,80 @@
+import { UseSyncSnapshot } from '@tldraw/sync'
+import { useEffect, useState } from 'react'
+import { fetch } from 'tldraw'
+import { trackEvent } from '../../utils/analytics'
+import { fetchFeatureFlags } from '../utils/FeatureFlagPoller'
+import { useTldrawCurrentUser } from './useUser'
+
+const FLAG_RESOLVE_TIMEOUT_MS = 3000
+
+export type LazyBoardSnapshotState =
+	| { state: 'pending' }
+	| { state: 'ready'; snapshot: UseSyncSnapshot | undefined }
+
+/**
+ * Resolve whether this board load should use the lazy transport, and if so fetch its REST
+ * snapshot. Resolves to `snapshot: undefined` — meaning "use the plain websocket path" — for
+ * anonymous users, when the `lazy_board_socket` flag is off, and on any fetch failure (including
+ * the 404 a never-persisted new file returns).
+ */
+export function useLazyBoardSnapshot(fileSlug: string): LazyBoardSnapshotState {
+	const user = useTldrawCurrentUser()
+	const [result, setResult] = useState<LazyBoardSnapshotState>({ state: 'pending' })
+
+	useEffect(() => {
+		let cancelled = false
+		const finish = (snapshot: UseSyncSnapshot | undefined) => {
+			if (!cancelled) setResult({ state: 'ready', snapshot })
+		}
+		setResult({ state: 'pending' })
+
+		// The flag is percentage-based and signed-in only; anonymous visitors keep the plain
+		// websocket path.
+		if (!user) {
+			finish(undefined)
+			return
+		}
+
+		;(async () => {
+			try {
+				// Flags normally resolve well before an editor mounts; the timeout keeps a hung
+				// flags fetch from delaying the board.
+				const flags = await Promise.race([
+					fetchFeatureFlags(),
+					new Promise<null>((resolve) => setTimeout(() => resolve(null), FLAG_RESOLVE_TIMEOUT_MS)),
+				])
+				const enabled = user.isTldraw || (flags?.lazy_board_socket?.enabled ?? false)
+				if (!enabled) return finish(undefined)
+
+				const res = await fetch(`/api/app/file/${fileSlug}/snapshot`, {
+					headers: { Authorization: `Bearer ${await user.getToken()}` },
+				})
+				if (!res.ok) {
+					// Expected for brand-new files (404 not-persisted); everything else is worth a
+					// datapoint but never worth blocking the board — the socket path always works.
+					trackEvent('lazy-snapshot-fallback', { status: res.status })
+					return finish(undefined)
+				}
+				const data = await res.json()
+				if (!data?.snapshot?.schema || typeof data.snapshot.documentClock !== 'number') {
+					trackEvent('lazy-snapshot-fallback', { status: 'malformed' })
+					return finish(undefined)
+				}
+				finish({
+					snapshot: data.snapshot,
+					isReadonly: data.isReadonly,
+					objectAccess: data.objectAccess,
+				})
+			} catch (_e) {
+				trackEvent('lazy-snapshot-fallback', { status: 'error' })
+				finish(undefined)
+			}
+		})()
+
+		return () => {
+			cancelled = true
+		}
+	}, [fileSlug, user])
+
+	return result
+}

--- a/apps/dotcom/client/src/tla/hooks/useLazySocketUpgrade.ts
+++ b/apps/dotcom/client/src/tla/hooks/useLazySocketUpgrade.ts
@@ -1,0 +1,110 @@
+import { RemoteTLStoreWithStatus, UseSyncSnapshot } from '@tldraw/sync'
+import { RefObject, useEffect, useRef } from 'react'
+import { fetch } from 'tldraw'
+import { trackEvent } from '../../utils/analytics'
+
+const ACTIVITY_POLL_INTERVAL_MS = 15_000
+const ACTIVITY_POLL_JITTER_MS = 2000
+
+export type LazyUpgradeReason = 'first-edit' | 'others-present' | 'content-changed'
+
+interface RoomActivity {
+	activeSessions: number
+	documentClock: number | null
+	updatedAt: number
+}
+
+/**
+ * Drive the lazy transport's upgrade triggers while a board is rendered from a REST snapshot:
+ *
+ * - the first document-scope user change (the same changes the sync client buffers as speculative
+ *   edits) dials the websocket, so nothing can be edited without syncing;
+ * - a poll of the room's activity endpoint dials when someone else is in the room or the content
+ *   has moved past our snapshot. Polling pauses while the tab is hidden (with an immediate poll on
+ *   return) and stops permanently once dialed.
+ *
+ * The chosen reason is written to `upgradeReasonRef` before dialing so the websocket URI can carry
+ * it to the server's `lazy_socket_upgrade` metric.
+ */
+export function useLazySocketUpgrade({
+	store,
+	snapshot,
+	upgradeReasonRef,
+	fileSlug,
+}: {
+	store: RemoteTLStoreWithStatus
+	snapshot: UseSyncSnapshot | undefined
+	upgradeReasonRef: RefObject<LazyUpgradeReason | null>
+	fileSlug: string
+}) {
+	const connect = store.status === 'synced-remote' ? store.connect : undefined
+	const tlstore = store.status === 'synced-remote' ? store.store : undefined
+	const didDialRef = useRef(false)
+
+	useEffect(() => {
+		if (!connect || !tlstore || !snapshot) return
+
+		let stopped = false
+		let timer: number | undefined
+
+		const dial = (reason: LazyUpgradeReason) => {
+			if (didDialRef.current) return
+			didDialRef.current = true
+			upgradeReasonRef.current = reason
+			trackEvent('lazy-socket-upgrade', { reason })
+			connect()
+		}
+
+		const unsubscribeFromEdits = tlstore.listen(
+			() => {
+				unsubscribeFromEdits()
+				dial('first-edit')
+			},
+			{ source: 'user', scope: 'document' }
+		)
+
+		const seedClock = snapshot.snapshot.documentClock
+		const poll = async () => {
+			if (stopped || didDialRef.current || document.hidden) return
+			try {
+				const res = await fetch(`/api/app/file/${fileSlug}/activity`)
+				if (!res.ok) return
+				const activity = (await res.json()) as RoomActivity
+				if (activity.activeSessions > 0) {
+					dial('others-present')
+				} else if (
+					activity.documentClock !== null &&
+					seedClock !== undefined &&
+					activity.documentClock > seedClock
+				) {
+					dial('content-changed')
+				}
+			} catch (_e) {
+				// The poll is advisory; a failed poll never blocks reading, and editing always
+				// dials regardless.
+			}
+		}
+		const schedule = () => {
+			if (stopped || didDialRef.current) return
+			timer = window.setTimeout(
+				async () => {
+					await poll()
+					schedule()
+				},
+				ACTIVITY_POLL_INTERVAL_MS + Math.random() * ACTIVITY_POLL_JITTER_MS
+			)
+		}
+		const onVisibilityChange = () => {
+			if (!document.hidden) poll()
+		}
+		document.addEventListener('visibilitychange', onVisibilityChange)
+		schedule()
+
+		return () => {
+			stopped = true
+			unsubscribeFromEdits()
+			if (timer !== undefined) clearTimeout(timer)
+			document.removeEventListener('visibilitychange', onVisibilityChange)
+		}
+	}, [connect, tlstore, snapshot, fileSlug, upgradeReasonRef])
+}

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
@@ -13,6 +13,7 @@ function makeFlags(overrides: Partial<FeatureFlags> = {}): FeatureFlags {
 		rum_enabled: { enabled: false },
 		commenting_enabled: { enabled: false },
 		mcp_friends_and_family: { enabled: false },
+		lazy_board_socket: { enabled: false },
 		...overrides,
 	}
 }

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
@@ -8,6 +8,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
 	rum_enabled: { enabled: false },
 	commenting_enabled: { enabled: false },
 	mcp_friends_and_family: { enabled: false },
+	lazy_board_socket: { enabled: false },
 }
 
 let currentFlags: FeatureFlags = { ...DEFAULT_FLAGS }

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -66,7 +66,7 @@ import {
 	isCommentReactionFkViolation,
 	isCommentThreadFkViolation,
 	isCommentThreadIdFkViolation,
-	liveCommentDocuments,
+	loadLiveCommentDocuments,
 	mergeCommentDocumentsIntoSnapshot,
 	outboxEntriesToClear,
 	planCommentDrain,
@@ -76,6 +76,7 @@ import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
 import { getR2KeyForRoom } from './r2'
+import { RoomActivitySnapshot, getR2KeyForRoomActivity } from './roomActivity'
 import { getPublishedRoomSnapshot } from './routes/tla/getPublishedFile'
 import { deleteBoardThumbnails, enqueueOgImageRender } from './routes/tla/ogImageQueue'
 import { generateSnapshotChunks } from './snapshotUtils'
@@ -86,13 +87,11 @@ import { createSupabaseClient } from './utils/createSupabaseClient'
 import { getRoomDurableObject } from './utils/durableObjects'
 import { OgRenderDebouncer } from './utils/ogRenderDebounce'
 import { reconstructSnapshotFromPierre } from './utils/pierreSnapshot'
-import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
-import { getAuth, requireAdminAccess, requireWriteAccessToFile } from './utils/tla/getAuth'
+import { checkReadAccessToFile, getAuth, requireWriteAccessToFile } from './utils/tla/getAuth'
 import { getLegacyRoomData } from './utils/tla/getLegacyRoomData'
 import { getRole } from './utils/tla/getRole'
-import { isTestFile } from './utils/tla/isTestFile'
 import { resolveWelcomeSnapshot } from './welcome/resolveWelcomeSnapshot'
 
 const MAX_CONNECTIONS = 50
@@ -120,7 +119,7 @@ const R2_QUEUE_DEPTH_ALERT_THRESHOLD = 100
 
 // The kinds of R2 operation that share the connection budget, used to break queue depth down per
 // type in metrics.
-type R2OperationType = 'asset_copy' | 'snapshot_upload'
+type R2OperationType = 'asset_copy' | 'snapshot_upload' | 'activity_write'
 
 // Transient R2 failures worth retrying — dropped connections and the connection-limit error the
 // shared budget exists to avoid. Anything else (a bad request, missing object, etc.) is permanent,
@@ -148,18 +147,6 @@ interface SocketAttachment {
 	// optional: attachments serialized before the object-store lane existed lack this field
 	objectAccess?: TLObjectStoreAccess
 	snapshot: SessionStateSnapshot | null
-}
-
-async function canAccessTestProductionFile(
-	env: Environment,
-	auth: { userId: string } | null
-): Promise<boolean> {
-	try {
-		await requireAdminAccess(env, auth)
-		return true
-	} catch (_e) {
-		return false
-	}
 }
 
 function pruneUnusedAssetsForTldr(records: TLRecord[]): TLRecord[] {
@@ -299,7 +286,10 @@ export class TLFileDurableObject extends DurableObject {
 							instanceId: args.sessionId,
 						})
 
-						if (args.numSessionsRemaining > 0) return
+						if (args.numSessionsRemaining > 0) {
+							this.reportRoomActivity()
+							return
+						}
 						if (!this._room) return
 						this.logEvent({
 							type: 'client',
@@ -316,6 +306,8 @@ export class TLFileDurableObject extends DurableObject {
 						this._room = null
 						room.close()
 						this.logEvent({ type: 'room', name: 'room_empty' })
+						// The write lazy readers depend on most: the room is now empty and R2 is fresh.
+						this.reportRoomActivity()
 						await this._pool?.end()
 						this._pool = null
 						this._db = null
@@ -723,6 +715,12 @@ export class TLFileDurableObject extends DurableObject {
 		storeId ??= params.localClientId
 		const isNewSession = !this._room
 
+		// Lazy transport clients tag why they dialed (first-edit, others-present, ...) so the
+		// rollout can be judged by upgrade mix.
+		if (params.upgradeReason) {
+			this.writeEvent('lazy_socket_upgrade', { blobs: [params.upgradeReason] })
+		}
+
 		// Create the websocket pair for the client; use hibernation API
 		const { 0: clientWebSocket, 1: serverWebSocket } = new WebSocketPair()
 		this.state.acceptWebSocket(serverWebSocket)
@@ -745,63 +743,35 @@ export class TLFileDurableObject extends DurableObject {
 			const file = await this.getAppFileRecord()
 
 			if (file) {
-				if (file.isDeleted) {
-					return closeSocket(TLSyncErrorCloseEventReason.NOT_FOUND)
-				}
+				const accessTimer = this.timer()
+				const access = await checkReadAccessToFile({
+					env: this.env,
+					db: this.db,
+					file,
+					auth,
+					rateLimitKey: auth?.userId ?? sessionId,
+				})
+				accessTimer.report('on_request_access_check')
 
-				if (isTestFile(file.id) && !(await canAccessTestProductionFile(this.env, auth))) {
-					return closeSocket(TLSyncErrorCloseEventReason.NOT_FOUND)
-				}
-
-				if (!auth && !file.shared) {
-					return closeSocket(TLSyncErrorCloseEventReason.NOT_AUTHENTICATED)
-				}
-
-				const rateLimitTimer = this.timer()
-				if (auth?.userId) {
-					const rateLimited = await isRateLimited(this.env, auth.userId)
-					if (rateLimited) {
-						this.logEvent({
-							type: 'client',
-							userId: auth.userId,
-							name: 'rate_limited',
-						})
-						return closeSocket(TLSyncErrorCloseEventReason.RATE_LIMITED)
-					}
-				} else {
-					const rateLimited = await isRateLimited(this.env, sessionId)
-					if (rateLimited) {
-						this.logEvent({
-							type: 'client',
-							userId: auth?.userId,
-							name: 'rate_limited',
-						})
-						return closeSocket(TLSyncErrorCloseEventReason.RATE_LIMITED)
+				if (!access.ok) {
+					switch (access.reason) {
+						case 'not-found':
+							return closeSocket(TLSyncErrorCloseEventReason.NOT_FOUND)
+						case 'not-authenticated':
+							return closeSocket(TLSyncErrorCloseEventReason.NOT_AUTHENTICATED)
+						case 'rate-limited':
+							this.logEvent({
+								type: 'client',
+								userId: auth?.userId,
+								name: 'rate_limited',
+							})
+							return closeSocket(TLSyncErrorCloseEventReason.RATE_LIMITED)
+						case 'forbidden':
+							return closeSocket(TLSyncErrorCloseEventReason.FORBIDDEN)
 					}
 				}
-				rateLimitTimer.report('on_request_rate_limit')
 
-				// Check if user has owner access (directly or via group membership)
-				let hasOwnerAccess = false
-				if (file.ownerId && file.ownerId === auth?.userId) {
-					hasOwnerAccess = true
-				} else if (file.owningGroupId && auth?.userId) {
-					// Check the user can access the owning group's files
-					const groupCheckTimer = this.timer()
-					const role = await getRole(this.db, auth.userId, file.owningGroupId)
-					if (can(role, 'accessFiles')) {
-						hasOwnerAccess = true
-					}
-					groupCheckTimer.report('on_request_group_check')
-				}
-
-				if (!hasOwnerAccess && !file.shared) {
-					return closeSocket(TLSyncErrorCloseEventReason.FORBIDDEN)
-				}
-
-				// Guests only get canvas write on an `edit` link. `sharedLinkType` is a plain
-				// string column with legacy values in it, so anything else fails closed.
-				if (!hasOwnerAccess && file.sharedLinkType !== 'edit') {
+				if (access.isReadonly) {
 					openMode = ROOM_OPEN_MODE.READ_ONLY
 				}
 			}
@@ -847,6 +817,7 @@ export class TLFileDurableObject extends DurableObject {
 				isReadonly,
 				objectAccess,
 			})
+			this.reportRoomActivity()
 			if (isNewSession) {
 				this.logEvent({
 					type: 'client',
@@ -882,36 +853,31 @@ export class TLFileDurableObject extends DurableObject {
 
 		const auth = await getAuth(req, this.env)
 		const file = await this.getAppFileRecord()
-		if (!file || file.isDeleted) {
+		if (!file) {
 			return new Response('Not found', { status: 404 })
-		}
-
-		if (isTestFile(file.id) && !(await canAccessTestProductionFile(this.env, auth))) {
-			return new Response('Not found', { status: 404 })
-		}
-		if (!auth && !file.shared) {
-			return new Response('Unauthorized', { status: 401 })
 		}
 
 		const url = new URL(req.url)
 		const sessionId =
 			url.searchParams.get('instanceId') ?? url.searchParams.get('sessionId') ?? 'anon-download'
-		const rateLimitKey = auth?.userId ?? sessionId
-		if (await isRateLimited(this.env, rateLimitKey)) {
-			return new Response('Rate limited', { status: 429 })
-		}
-
-		let hasOwnerAccess = false
-		if (file.ownerId && file.ownerId === auth?.userId) {
-			hasOwnerAccess = true
-		} else if (file.owningGroupId && auth?.userId) {
-			const role = await getRole(this.db, auth.userId, file.owningGroupId)
-			if (can(role, 'accessFiles')) {
-				hasOwnerAccess = true
+		const access = await checkReadAccessToFile({
+			env: this.env,
+			db: this.db,
+			file,
+			auth,
+			rateLimitKey: auth?.userId ?? sessionId,
+		})
+		if (!access.ok) {
+			switch (access.reason) {
+				case 'not-found':
+					return new Response('Not found', { status: 404 })
+				case 'not-authenticated':
+					return new Response('Unauthorized', { status: 401 })
+				case 'rate-limited':
+					return new Response('Rate limited', { status: 429 })
+				case 'forbidden':
+					return new Response('Forbidden', { status: 403 })
 			}
-		}
-		if (!hasOwnerAccess && !file.shared) {
-			return new Response('Forbidden', { status: 403 })
 		}
 
 		const storage = await this.getStorage()
@@ -1002,6 +968,28 @@ export class TLFileDurableObject extends DurableObject {
 	triggerPersist = throttle(() => {
 		this.persistToDatabase()
 	}, PERSIST_INTERVAL_MS)
+
+	// Advisory activity object for lazy-transport readers (see roomActivity.ts). Written at moments
+	// the durable object is awake anyway; throttled so a join storm coalesces into one write. The
+	// write is fire-and-forget — activity is best-effort and must never fail a connect or persist.
+	private readonly reportRoomActivity = throttle(() => {
+		this.writeRoomActivity().catch(() => {
+			this.logEvent({ type: 'room', name: 'failed_activity_write' })
+		})
+	}, 2000)
+
+	private async writeRoomActivity() {
+		if (!this.documentInfo.isApp) return
+		const activeSessions = this._room ? (await this._room).getNumActiveSessions() : 0
+		const activity: RoomActivitySnapshot = {
+			activeSessions,
+			documentClock: this._lastPersistedClock,
+			updatedAt: Date.now(),
+		}
+		await this.addR2Operation('activity_write', () =>
+			this.env.ROOMS.put(getR2KeyForRoomActivity(this.documentInfo.slug), JSON.stringify(activity))
+		)
+	}
 
 	// Whether a persist on this board costs a thumbnail render, and why. The single source of truth for
 	// both the gate in `requestOgRenderForEdit` and the `sharedState` blob on `persist_success`, so the
@@ -1309,15 +1297,7 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	private async loadCommentsFromPostgres(): Promise<CommentLoadResult> {
-		const fileId = this.documentInfo.slug
-		const [threadRows, commentRows, reactionRows] = await Promise.all([
-			this.db.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
-			this.db.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
-			this.db.selectFrom('comment_reaction').where('fileId', '=', fileId).selectAll().execute(),
-		])
-		// Soft-deleted threads and their comments never re-enter a room, and neither do reactions
-		// whose comment doesn't; their rows stay in Postgres only (see liveCommentDocuments).
-		return liveCommentDocuments(threadRows, commentRows, reactionRows)
+		return loadLiveCommentDocuments(this.db, this.documentInfo.slug)
 	}
 
 	timer() {
@@ -1593,6 +1573,9 @@ export class TLFileDurableObject extends DurableObject {
 							sharedState: this.getBoardRenderState(),
 						})
 						this._lastPersistedClock = snapshot.documentClock
+						// Let lazy-transport pollers see the content clock advance while the room
+						// is occupied.
+						this.reportRoomActivity()
 						// The board's content just changed, so its thumbnail is out of date. Push the render
 						// deadline out rather than rendering now: the useful thumbnail is of the settled
 						// board, and a persist mid-session says more edits are probably coming. Costs one

--- a/apps/dotcom/sync-worker/src/commentRows.ts
+++ b/apps/dotcom/sync-worker/src/commentRows.ts
@@ -13,6 +13,7 @@ import {
 	isCommentThreadId,
 } from '@tldraw/tlschema'
 import { JsonObject } from '@tldraw/utils'
+import { Kysely } from 'kysely'
 
 /**
  * Conversions between the room's comment records and their Postgres rows. Postgres is the sole
@@ -253,6 +254,24 @@ export function rowsToSnapshotDocuments(
 			lastChangedClock: Number(row.lastChangedClock),
 		})),
 	]
+}
+
+/**
+ * Load a file's comment rows from Postgres and reduce them to the room-seedable subset. Shared by
+ * the DO's room load and the stateless snapshot route so both merge the same comment state.
+ */
+export async function loadLiveCommentDocuments(
+	db: Kysely<DB>,
+	fileId: string
+): Promise<CommentLoadResult> {
+	const [threadRows, commentRows, reactionRows] = await Promise.all([
+		db.selectFrom('comment_thread').where('fileId', '=', fileId).selectAll().execute(),
+		db.selectFrom('comment').where('fileId', '=', fileId).selectAll().execute(),
+		db.selectFrom('comment_reaction').where('fileId', '=', fileId).selectAll().execute(),
+	])
+	// Soft-deleted threads and their comments never re-enter a room, and neither do reactions
+	// whose comment doesn't; their rows stay in Postgres only (see liveCommentDocuments).
+	return liveCommentDocuments(threadRows, commentRows, reactionRows)
 }
 
 /** The room-seedable subset of a file's comment rows; see {@link liveCommentDocuments}. */

--- a/apps/dotcom/sync-worker/src/roomActivity.test.ts
+++ b/apps/dotcom/sync-worker/src/roomActivity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getR2KeyForRoomActivity, readRoomActivity } from './roomActivity'
+
+function makeEnv(getImpl: (key: string) => Promise<any>) {
+	return { ROOMS: { get: vi.fn(getImpl) } } as any
+}
+
+describe('getR2KeyForRoomActivity', () => {
+	it('namespaces activity objects away from room snapshots', () => {
+		expect(getR2KeyForRoomActivity('my-file')).toBe('app_rooms_activity/my-file')
+	})
+})
+
+describe('readRoomActivity', () => {
+	it('reads a valid activity object', async () => {
+		const activity = { activeSessions: 2, documentClock: 17, updatedAt: 123 }
+		const env = makeEnv(async () => ({ json: async () => activity }))
+		expect(await readRoomActivity(env, 'my-file')).toEqual(activity)
+		expect(env.ROOMS.get).toHaveBeenCalledWith('app_rooms_activity/my-file')
+	})
+
+	it('returns null for a missing object — absence means idle', async () => {
+		const env = makeEnv(async () => null)
+		expect(await readRoomActivity(env, 'my-file')).toBeNull()
+	})
+
+	it('returns null for an unparseable object', async () => {
+		const env = makeEnv(async () => ({
+			json: async () => {
+				throw new Error('bad json')
+			},
+		}))
+		expect(await readRoomActivity(env, 'my-file')).toBeNull()
+	})
+
+	it('returns null for a malformed object', async () => {
+		const env = makeEnv(async () => ({ json: async () => ({ nope: true }) }))
+		expect(await readRoomActivity(env, 'my-file')).toBeNull()
+	})
+
+	it('returns null when R2 itself fails', async () => {
+		const env = makeEnv(async () => {
+			throw new Error('r2 down')
+		})
+		expect(await readRoomActivity(env, 'my-file')).toBeNull()
+	})
+})

--- a/apps/dotcom/sync-worker/src/roomActivity.ts
+++ b/apps/dotcom/sync-worker/src/roomActivity.ts
@@ -1,0 +1,41 @@
+import { Environment } from './types'
+
+/**
+ * A tiny advisory object the file durable object writes to R2 whenever it is awake anyway
+ * (session connect, session removal, persist). Lazy-transport readers poll it through the
+ * stateless worker to learn "is anyone in this room" and "has the content moved past my
+ * snapshot" without waking the durable object.
+ *
+ * R2 is used (rather than KV) because reads are strongly consistent — a collaborator joining
+ * must be visible within one client poll period.
+ */
+export interface RoomActivitySnapshot {
+	activeSessions: number
+	/**
+	 * The documentClock of the snapshot currently persisted to R2, or null when the durable
+	 * object hasn't persisted since it last booted (the clock is only tracked in memory).
+	 */
+	documentClock: number | null
+	/** Epoch ms of the write, so clients can apply trust-window heuristics. */
+	updatedAt: number
+}
+
+export function getR2KeyForRoomActivity(slug: string): string {
+	return `app_rooms_activity/${slug}`
+}
+
+/** Read a room's activity snapshot. Returns null when absent or unparseable — both mean "idle". */
+export async function readRoomActivity(
+	env: Environment,
+	slug: string
+): Promise<RoomActivitySnapshot | null> {
+	try {
+		const obj = await env.ROOMS.get(getR2KeyForRoomActivity(slug))
+		if (!obj) return null
+		const parsed = (await obj.json()) as RoomActivitySnapshot
+		if (typeof parsed?.activeSessions !== 'number') return null
+		return parsed
+	} catch {
+		return null
+	}
+}

--- a/apps/dotcom/sync-worker/src/routes/tla/getLazyFileSnapshot.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getLazyFileSnapshot.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const mockGetAuth = vi.fn(async (): Promise<any> => null)
+vi.mock('../../utils/tla/getAuth', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../utils/tla/getAuth')>()
+	return { ...actual, getAuth: () => mockGetAuth() }
+})
+
+const mockLoadComments = vi.fn(async () => ({ documents: [] as any[], clockFloor: 0 }))
+vi.mock('../../commentRows', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('../../commentRows')>()
+	return { ...actual, loadLiveCommentDocuments: () => mockLoadComments() }
+})
+
+let currentFileRow: any
+vi.mock('../../postgres', () => ({
+	createPostgresConnectionPool: () => {
+		const chain: any = {
+			selectFrom: vi.fn(() => chain),
+			selectAll: vi.fn(() => chain),
+			select: vi.fn(() => chain),
+			where: vi.fn(() => chain),
+			executeTakeFirst: vi.fn(async () => currentFileRow),
+			execute: vi.fn(async () => []),
+			destroy: vi.fn(async () => {}),
+		}
+		return chain
+	},
+}))
+
+import { getLazyFileSnapshot } from './getLazyFileSnapshot'
+
+function makeRoomSnapshot() {
+	return {
+		documents: [{ state: { id: 'shape:a', typeName: 'shape' }, lastChangedClock: 3 }],
+		clock: 10,
+		documentClock: 10,
+		tombstones: { 'shape:gone': 5 },
+		tombstoneHistoryStartsAtClock: 2,
+		schema: { schemaVersion: 2, sequences: {} },
+	}
+}
+
+function makeEnv({
+	r2Snapshot = makeRoomSnapshot() as any,
+	rateLimited = false,
+}: { r2Snapshot?: any; rateLimited?: boolean } = {}) {
+	return {
+		ROOMS: {
+			get: vi.fn(async () => (r2Snapshot ? { json: async () => r2Snapshot } : null)),
+		},
+		RATE_LIMITER: { limit: vi.fn(async () => ({ success: !rateLimited })) },
+	} as any
+}
+
+function makeRequest(roomId = 'file-1') {
+	return { params: { roomId }, headers: new Headers() } as any
+}
+
+function makeFileRow(overrides: any = {}) {
+	return {
+		id: 'file-1',
+		name: 'My board',
+		ownerId: 'user-1',
+		owningGroupId: null,
+		shared: true,
+		sharedLinkType: 'view',
+		isDeleted: false,
+		...overrides,
+	}
+}
+
+describe('getLazyFileSnapshot', () => {
+	it('serves the snapshot with clocks, access bits, and no-store caching', async () => {
+		currentFileRow = makeFileRow()
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-2' })
+		const env = makeEnv()
+
+		const res = await getLazyFileSnapshot(makeRequest(), env)
+		expect(res.status).toBe(200)
+		expect(res.headers.get('Cache-Control')).toBe('no-store')
+		const body: any = await res.json()
+		expect(body.snapshot.documentClock).toBe(10)
+		expect(body.snapshot.tombstoneHistoryStartsAtClock).toBe(2)
+		// tombstones are server-internal and can be large; a fresh reader has no use for them
+		expect(body.snapshot.tombstones).toBeUndefined()
+		expect(body.isReadonly).toBe(true)
+		expect(body.objectAccess).toBe('write')
+		expect(body.fileName).toBe('My board')
+	})
+
+	it('merges comment documents from Postgres into the snapshot', async () => {
+		currentFileRow = makeFileRow()
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-2' })
+		mockLoadComments.mockResolvedValueOnce({
+			documents: [
+				{ state: { id: 'comment:c1', typeName: 'comment' } as any, lastChangedClock: 12 },
+			],
+			clockFloor: 12,
+		})
+		const env = makeEnv()
+
+		const res = await getLazyFileSnapshot(makeRequest(), env)
+		const body: any = await res.json()
+		expect(body.snapshot.documents.map((d: any) => d.state.id)).toContain('comment:c1')
+		// the merge advances the clocks past the comment rows so a socket upgrade can't regress them
+		expect(body.snapshot.documentClock).toBe(12)
+	})
+
+	it('404s with a not-persisted marker for files with no R2 object yet', async () => {
+		currentFileRow = makeFileRow()
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-2' })
+		const env = makeEnv({ r2Snapshot: null })
+
+		const res = await getLazyFileSnapshot(makeRequest(), env)
+		expect(res.status).toBe(404)
+		expect(await res.json()).toEqual({ error: 'not-persisted' })
+	})
+
+	it('404s for an unknown file', async () => {
+		currentFileRow = undefined
+		const res = await getLazyFileSnapshot(makeRequest(), makeEnv())
+		expect(res.status).toBe(404)
+		expect(await res.json()).toEqual({ error: 'not-found' })
+	})
+
+	it('maps access denials onto status codes', async () => {
+		// anonymous caller, unshared file → 401
+		currentFileRow = makeFileRow({ shared: false })
+		mockGetAuth.mockResolvedValueOnce(null)
+		expect((await getLazyFileSnapshot(makeRequest(), makeEnv())).status).toBe(401)
+
+		// signed-in stranger, unshared file → 403
+		currentFileRow = makeFileRow({ shared: false })
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-2' })
+		expect((await getLazyFileSnapshot(makeRequest(), makeEnv())).status).toBe(403)
+
+		// deleted file → 404
+		currentFileRow = makeFileRow({ isDeleted: true })
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-1' })
+		expect((await getLazyFileSnapshot(makeRequest(), makeEnv())).status).toBe(404)
+
+		// rate limited → 429
+		currentFileRow = makeFileRow()
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-2' })
+		expect((await getLazyFileSnapshot(makeRequest(), makeEnv({ rateLimited: true }))).status).toBe(
+			429
+		)
+	})
+
+	it('fails the request when the comments load fails, rather than serving without comments', async () => {
+		currentFileRow = makeFileRow()
+		mockGetAuth.mockResolvedValueOnce({ userId: 'user-2' })
+		mockLoadComments.mockRejectedValueOnce(new Error('pg down'))
+
+		await expect(getLazyFileSnapshot(makeRequest(), makeEnv())).rejects.toThrow('pg down')
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/tla/getLazyFileSnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getLazyFileSnapshot.ts
@@ -1,0 +1,119 @@
+import { TlaFile } from '@tldraw/dotcom-shared'
+import { RoomSnapshot, TLObjectStoreAccess } from '@tldraw/sync-core'
+import { IRequest } from 'itty-router'
+import { loadLiveCommentDocuments, mergeCommentDocumentsIntoSnapshot } from '../../commentRows'
+import { createPostgresConnectionPool } from '../../postgres'
+import { getR2KeyForRoom } from '../../r2'
+import { Environment } from '../../types'
+import { writeDataPoint } from '../../utils/analytics'
+import { checkReadAccessToFile, getAuth } from '../../utils/tla/getAuth'
+
+/**
+ * The payload for a lazy-transport board load. The snapshot's `documentClock` seeds the client's
+ * sync clock so a later websocket connect catches up incrementally instead of re-downloading the
+ * whole document.
+ */
+export interface LazyFileSnapshotResponse {
+	/** Comments merged in, tombstones stripped (server-only and can be large). */
+	snapshot: RoomSnapshot
+	isReadonly: boolean
+	objectAccess: TLObjectStoreAccess
+	fileName: string
+}
+
+const DENIAL_STATUS = {
+	'not-found': 404,
+	'not-authenticated': 401,
+	forbidden: 403,
+	'rate-limited': 429,
+} as const
+
+/**
+ * Serve a live app file's document from R2 without waking its durable object. This is the read
+ * path for the lazy board transport: the client renders from this snapshot and only dials the
+ * websocket on first edit or when the activity poll reports company.
+ *
+ * Freshness: R2 lags live state by up to the persist throttle while the room is occupied — but an
+ * occupied room is exactly what the activity poll reports, and the client dials the socket instead
+ * of trusting this snapshot. An unoccupied room's R2 is current as of the last-out persist.
+ */
+export async function getLazyFileSnapshot(request: IRequest, env: Environment): Promise<Response> {
+	const start = Date.now()
+	const roomId = request.params.roomId
+	const track = (outcome: string, sizeBytes = 0) =>
+		writeDataPoint(undefined, env.MEASURE, env, 'lazy_snapshot_load', {
+			blobs: [outcome],
+			doubles: [Date.now() - start, sizeBytes],
+		})
+
+	const db = createPostgresConnectionPool(env, 'getLazyFileSnapshot')
+	try {
+		const auth = await getAuth(request, env)
+
+		const file = (await db
+			.selectFrom('file')
+			.selectAll()
+			.where('id', '=', roomId)
+			.executeTakeFirst()) as TlaFile | undefined
+		if (!file) {
+			track('not-found')
+			return json({ error: 'not-found' }, 404)
+		}
+
+		const access = await checkReadAccessToFile({
+			env,
+			db,
+			file,
+			auth,
+			rateLimitKey: auth?.userId ?? request.headers.get('cf-connecting-ip') ?? 'anon',
+		})
+		if (!access.ok) {
+			track(access.reason)
+			return json({ error: access.reason }, DENIAL_STATUS[access.reason])
+		}
+
+		const [r2Object, comments] = await Promise.all([
+			env.ROOMS.get(getR2KeyForRoom({ slug: roomId, isApp: true })),
+			loadLiveCommentDocuments(db, roomId),
+		])
+
+		if (!r2Object) {
+			// A brand-new file has no R2 object until its first persist — the client falls back
+			// to the websocket path, which seeds the room.
+			track('not-persisted')
+			return json({ error: 'not-persisted' }, 404)
+		}
+
+		const snapshot = (await r2Object.json()) as RoomSnapshot
+		mergeCommentDocumentsIntoSnapshot(snapshot, comments)
+		// Tombstones exist so the room can serve incremental diffs to reconnecting clients; a
+		// fresh reader has no use for them and they can dwarf the document itself.
+		delete (snapshot as Partial<RoomSnapshot>).tombstones
+
+		const body: LazyFileSnapshotResponse = {
+			snapshot,
+			isReadonly: access.isReadonly,
+			objectAccess: access.objectAccess,
+			fileName: file.name,
+		}
+		const encoded = JSON.stringify(body)
+		track('ok', encoded.length)
+		return new Response(encoded, {
+			headers: {
+				'Content-Type': 'application/json',
+				// Embeds per-user isReadonly/objectAccess and auth-gated content; must never be
+				// cached by a shared cache.
+				'Cache-Control': 'no-store',
+			},
+		})
+	} finally {
+		await db.destroy()
+	}
+}
+
+function json(body: object, status: number): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+	})
+}

--- a/apps/dotcom/sync-worker/src/routes/tla/getRoomActivity.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/getRoomActivity.ts
@@ -1,0 +1,37 @@
+import { IRequest } from 'itty-router'
+import { RoomActivitySnapshot, readRoomActivity } from '../../roomActivity'
+import { Environment } from '../../types'
+import { writeDataPoint } from '../../utils/analytics'
+import { isRateLimited } from '../../utils/rateLimit'
+import { requireAuth } from '../../utils/tla/getAuth'
+
+const IDLE: RoomActivitySnapshot = { activeSessions: 0, documentClock: null, updatedAt: 0 }
+
+/**
+ * The lazy transport's poll target: "is anyone in this room, and has its content moved past my
+ * snapshot?" Reads the advisory R2 object the durable object writes while awake (see
+ * roomActivity.ts) — this route must never wake the durable object.
+ *
+ * Deliberately does NOT run the per-file Postgres access ladder: this is the hottest poll loop in
+ * the lazy transport, and a Postgres query per poll would re-create the cost problem the feature
+ * exists to fix. What a signed-in caller holding a slug can learn is only
+ * `{activeSessions, documentClock, updatedAt}` — no content, no identities — and the slug itself
+ * is already the sharing capability.
+ */
+export async function getRoomActivity(request: IRequest, env: Environment): Promise<Response> {
+	const start = Date.now()
+	// The lazy transport is gated to signed-in users; anonymous readers never poll.
+	const auth = await requireAuth(request, env)
+	if (await isRateLimited(env, auth.userId)) {
+		return new Response('Rate limited', { status: 429 })
+	}
+
+	const activity = (await readRoomActivity(env, request.params.roomId)) ?? IDLE
+	writeDataPoint(undefined, env.MEASURE, env, 'lazy_activity_poll', {
+		blobs: [activity.activeSessions > 0 ? '1' : '0'],
+		doubles: [Date.now() - start],
+	})
+	return new Response(JSON.stringify(activity), {
+		headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
+	})
+}

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -185,6 +185,7 @@ export type TLServerEvent =
 				| 'room_empty'
 				| 'fail_persist'
 				| 'room_start'
+				| 'failed_activity_write'
 	  }
 	| {
 			type: 'send_message'

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
@@ -285,6 +285,7 @@ describe('getFeatureFlagsAdmin (route handler)', () => {
 
 		expect(Object.keys(body).sort()).toEqual([
 			'commenting_enabled',
+			'lazy_board_socket',
 			'mcp_friends_and_family',
 			'rum_enabled',
 		])

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.ts
@@ -29,6 +29,13 @@ function getFlagDefaults(_env: Environment): Record<FeatureFlagKey, FeatureFlagV
 			description:
 				'Raises the /app/mcp rate limits for signed-in callers on the friends and family list (edited below)',
 		},
+		lazy_board_socket: {
+			type: 'percentage',
+			percentage: 0,
+			enabled: false,
+			description:
+				'Load boards from a REST snapshot and defer the websocket until first edit or until others are present. Users with a @tldraw.com email always have it, regardless of this flag',
+		},
 	}
 }
 

--- a/apps/dotcom/sync-worker/src/utils/tla/checkReadAccessToFile.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/checkReadAccessToFile.test.ts
@@ -1,0 +1,159 @@
+import { TlaFile } from '@tldraw/dotcom-shared'
+import { describe, expect, it, vi } from 'vitest'
+import { Environment } from '../../types'
+import { SignedInAuth, checkReadAccessToFile } from './getAuth'
+
+function makeFile(overrides: Partial<TlaFile> = {}): TlaFile {
+	return {
+		id: 'file-abc',
+		name: 'A file',
+		ownerId: 'user-owner',
+		owningGroupId: null,
+		thumbnail: '',
+		shared: true,
+		sharedLinkType: 'edit',
+		published: false,
+		lastPublished: 0,
+		publishedSlug: '',
+		createdAt: 0,
+		updatedAt: 0,
+		isEmpty: false,
+		isDeleted: false,
+		createSource: null,
+		...overrides,
+	} as TlaFile
+}
+
+function makeEnv({ rateLimited = false } = {}): Environment {
+	return {
+		RATE_LIMITER: {
+			limit: vi.fn(async () => ({ success: !rateLimited })),
+		},
+	} as any
+}
+
+/** A db stub whose group_user query resolves to the given role (or nobody). */
+function makeDb(role: string | null = null) {
+	const executeTakeFirst = vi.fn(async () => (role ? { role } : undefined))
+	const chain = {
+		selectFrom: vi.fn(() => chain),
+		select: vi.fn(() => chain),
+		where: vi.fn(() => chain),
+		executeTakeFirst,
+	}
+	return chain as any
+}
+
+const owner = { userId: 'user-owner' } as SignedInAuth
+const stranger = { userId: 'user-stranger' } as SignedInAuth
+
+function check(opts: {
+	file: TlaFile
+	auth?: SignedInAuth | null
+	env?: Environment
+	db?: any
+	rateLimitKey?: string
+}) {
+	return checkReadAccessToFile({
+		env: opts.env ?? makeEnv(),
+		db: opts.db ?? makeDb(),
+		file: opts.file,
+		auth: opts.auth ?? null,
+		rateLimitKey: opts.rateLimitKey ?? 'key',
+	})
+}
+
+// Table-driven over the ladder, in ladder order — the order is load-bearing (e.g. a deleted file
+// must 404 before any auth distinction leaks its existence).
+describe('checkReadAccessToFile', () => {
+	it('refuses a deleted file as not-found, even for its owner', async () => {
+		expect(await check({ file: makeFile({ isDeleted: true }), auth: owner })).toEqual({
+			ok: false,
+			reason: 'not-found',
+		})
+	})
+
+	it('refuses a test file as not-found for anonymous callers', async () => {
+		expect(await check({ file: makeFile({ id: 'test_abc' }) })).toEqual({
+			ok: false,
+			reason: 'not-found',
+		})
+	})
+
+	it('refuses anonymous access to an unshared file as not-authenticated', async () => {
+		expect(await check({ file: makeFile({ shared: false }) })).toEqual({
+			ok: false,
+			reason: 'not-authenticated',
+		})
+	})
+
+	it('refuses when rate limited', async () => {
+		expect(
+			await check({ file: makeFile(), auth: owner, env: makeEnv({ rateLimited: true }) })
+		).toEqual({ ok: false, reason: 'rate-limited' })
+	})
+
+	it('grants the owner read-write access with object writes', async () => {
+		expect(await check({ file: makeFile({ shared: false }), auth: owner })).toEqual({
+			ok: true,
+			isReadonly: false,
+			objectAccess: 'write',
+		})
+	})
+
+	it('grants a group member with accessFiles read-write access', async () => {
+		expect(
+			await check({
+				file: makeFile({ ownerId: null as any, owningGroupId: 'group-1', shared: false }),
+				auth: stranger,
+				db: makeDb('member'),
+			})
+		).toEqual({ ok: true, isReadonly: false, objectAccess: 'write' })
+	})
+
+	it('refuses a non-member of the owning group when the file is unshared', async () => {
+		expect(
+			await check({
+				file: makeFile({ ownerId: null as any, owningGroupId: 'group-1', shared: false }),
+				auth: stranger,
+				db: makeDb(null),
+			})
+		).toEqual({ ok: false, reason: 'forbidden' })
+	})
+
+	it('refuses a signed-in non-owner when the file is unshared', async () => {
+		expect(await check({ file: makeFile({ shared: false }), auth: stranger })).toEqual({
+			ok: false,
+			reason: 'forbidden',
+		})
+	})
+
+	it('gives guests canvas write only on an edit link', async () => {
+		expect(await check({ file: makeFile({ sharedLinkType: 'edit' }), auth: stranger })).toEqual({
+			ok: true,
+			isReadonly: false,
+			objectAccess: 'write',
+		})
+		expect(await check({ file: makeFile({ sharedLinkType: 'view' }), auth: stranger })).toEqual({
+			ok: true,
+			isReadonly: true,
+			objectAccess: 'write',
+		})
+	})
+
+	it('fails closed on legacy sharedLinkType values', async () => {
+		expect(
+			await check({ file: makeFile({ sharedLinkType: 'whatever' as any }), auth: stranger })
+		).toEqual({ ok: true, isReadonly: true, objectAccess: 'write' })
+	})
+
+	it('gives anonymous guests of a shared file readonly canvas and read-only objects', async () => {
+		expect(await check({ file: makeFile({ sharedLinkType: 'edit' }) })).toEqual({
+			ok: true,
+			// anonymous sessions can get canvas write on an edit link...
+			isReadonly: false,
+			// ...but never object-lane (comment) writes: comment authors need a user row
+			objectAccess: 'read',
+		})
+	})
+})

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -1,9 +1,13 @@
 import { ClerkClient, createClerkClient } from '@clerk/backend'
-import { can } from '@tldraw/dotcom-shared'
+import { DB, TlaFile, can } from '@tldraw/dotcom-shared'
+import { type TLObjectStoreAccess } from '@tldraw/sync-core'
 import { IRequest, StatusError } from 'itty-router'
+import { Kysely } from 'kysely'
 import { createPostgresConnectionPool } from '../../postgres'
 import { Environment } from '../../types'
+import { isRateLimited } from '../rateLimit'
 import { getRole } from './getRole'
+import { isTestFile } from './isTestFile'
 
 export async function requireAuth(request: IRequest, env: Environment): Promise<SignedInAuth> {
 	const auth = await getAuth(request, env)
@@ -120,6 +124,84 @@ export async function requireWriteAccessToFile(
 		// Ensure database connection is properly closed
 		await db.destroy()
 	}
+}
+
+export async function canAccessTestProductionFile(
+	env: Environment,
+	auth: { userId: string } | null
+): Promise<boolean> {
+	try {
+		await requireAdminAccess(env, auth)
+		return true
+	} catch (_e) {
+		return false
+	}
+}
+
+export type FileReadDenialReason = 'not-found' | 'not-authenticated' | 'forbidden' | 'rate-limited'
+
+export type FileReadAccess =
+	| { ok: false; reason: FileReadDenialReason }
+	| { ok: true; isReadonly: boolean; objectAccess: TLObjectStoreAccess }
+
+/**
+ * The read-access ladder for an app file, shared by the room's websocket connect, the .tldr
+ * download, and the REST snapshot route so the three can't drift. Order matters and mirrors the
+ * historical `TLFileDurableObject.onRequest` checks: deleted, test-file gate, anonymous access to
+ * unshared files, rate limit, owner/group access, unshared files for non-owners.
+ */
+export async function checkReadAccessToFile(opts: {
+	env: Environment
+	db: Kysely<DB>
+	file: TlaFile
+	auth: SignedInAuth | null
+	/** Rate-limit bucket: the user id when signed in, else a per-session/IP key. */
+	rateLimitKey: string
+}): Promise<FileReadAccess> {
+	const { env, db, file, auth, rateLimitKey } = opts
+
+	if (file.isDeleted) {
+		return { ok: false, reason: 'not-found' }
+	}
+
+	if (isTestFile(file.id) && !(await canAccessTestProductionFile(env, auth))) {
+		return { ok: false, reason: 'not-found' }
+	}
+
+	if (!auth && !file.shared) {
+		return { ok: false, reason: 'not-authenticated' }
+	}
+
+	if (await isRateLimited(env, rateLimitKey)) {
+		return { ok: false, reason: 'rate-limited' }
+	}
+
+	// Check if user has owner access (directly or via group membership)
+	let hasOwnerAccess = false
+	if (file.ownerId && file.ownerId === auth?.userId) {
+		hasOwnerAccess = true
+	} else if (file.owningGroupId && auth?.userId) {
+		// Check the user can access the owning group's files
+		const role = await getRole(db, auth.userId, file.owningGroupId)
+		if (can(role, 'accessFiles')) {
+			hasOwnerAccess = true
+		}
+	}
+
+	if (!hasOwnerAccess && !file.shared) {
+		return { ok: false, reason: 'forbidden' }
+	}
+
+	// Guests only get canvas write on an `edit` link. `sharedLinkType` is a plain string column
+	// with legacy values in it, so anything else fails closed.
+	const isReadonly = !hasOwnerAccess && file.sharedLinkType !== 'edit'
+
+	// Only authenticated users can write comments — authors are stored in Postgres with a foreign
+	// key to the user table, so an anonymous author can't be represented. Tier gating (view-only
+	// sessions) happens in `authorizeFileRecord` off the session's `isReadonly`.
+	const objectAccess: TLObjectStoreAccess = auth?.userId ? 'write' : 'read'
+
+	return { ok: true, isReadonly, objectAccess }
 }
 
 export async function requireAdminAccess(env: Environment, auth: { userId: string } | null) {

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -45,8 +45,10 @@ import { acceptInvite } from './routes/tla/acceptInvite'
 import { createFiles } from './routes/tla/createFiles'
 import { forwardRoomRequest } from './routes/tla/forwardRoomRequest'
 import { getInviteInfo } from './routes/tla/getInviteInfo'
+import { getLazyFileSnapshot } from './routes/tla/getLazyFileSnapshot'
 import { getOgImage } from './routes/tla/getOgImage'
 import { getPublishedFile } from './routes/tla/getPublishedFile'
+import { getRoomActivity } from './routes/tla/getRoomActivity'
 import { getThumbnailSnapshot } from './routes/tla/getThumbnailSnapshot'
 import { initUser } from './routes/tla/initUser'
 import { handleOgImageRenderMessage } from './routes/tla/ogImageQueue'
@@ -163,6 +165,10 @@ const router = createRouter<Environment>()
 		return notFound()
 	})
 	.get('/app/file/:roomId/download', forwardRoomRequest)
+	// Lazy board transport: REST read of the room snapshot and the activity poll, both served
+	// without waking the file durable object.
+	.get('/app/file/:roomId/snapshot', getLazyFileSnapshot)
+	.get('/app/file/:roomId/activity', getRoomActivity)
 	.get('/app/publish/:roomId', getPublishedFile)
 	.get('/app/uploads/:objectName', async (request, env, ctx) => {
 		return handleUserAssetGet({

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -311,6 +311,7 @@ export const FEATURE_FLAG_KEYS = [
 	'rum_enabled',
 	'commenting_enabled',
 	'mcp_friends_and_family',
+	'lazy_board_socket',
 ] as const
 export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[number]
 

--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -167,6 +167,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 
 - **CL1** If the socket is already online at construction, a connect message is sent immediately; otherwise it is sent when the socket first reports `'online'`.
 - **CL2** The connect message carries a fresh unique `connectRequestId`, the store's serialized schema, protocol version 8, and `lastServerClock` (−1 before any server contact, afterwards the last seen server clock).
+- **CL2a** The constructor accepts an optional `lastServerClock` seed for stores pre-hydrated from a snapshot that carries its `documentClock`; the first connect then sends the seed, so the server can answer with an incremental `wipe_presence` diff. A stale seed degrades safely to `wipe_all` (CL6) — user changes made before the first connect survive as speculative changes either way.
 - **CL3** `onLoad` fires on the first message received from the server, of any type.
 - **CL4** A `connect` response whose `connectRequestId` does not match the latest request is ignored.
 - **CL5** On a `connect` response with `hydrationType: 'wipe_presence'`, the client reverts its speculative changes, removes all presence records, applies the server's diff, then re-applies the speculative changes on top and pushes them as a new push request.

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -160,6 +160,25 @@ export class JsonChunkAssembler {
     };
 }
 
+// @internal
+export class LazyClientWebSocketAdapter implements TLPersistentClientSocket<TLSocketClientSentEvent<TLRecord>, TLSocketServerSentEvent<TLRecord>> {
+    constructor(getUri: () => Promise<string> | string);
+    // (undocumented)
+    close(): void;
+    // (undocumented)
+    get connectionStatus(): 'error' | 'offline' | 'online';
+    connectNow(): void;
+    readonly didRequestConnect: Atom<boolean>;
+    // (undocumented)
+    onReceiveMessage(cb: (msg: TLSocketServerSentEvent<TLRecord>) => void): () => void;
+    // (undocumented)
+    onStatusChange(cb: (event: TLSocketStatusChangeEvent) => void): () => void;
+    // (undocumented)
+    restart(): void;
+    // (undocumented)
+    sendMessage(msg: TLSocketClientSentEvent<TLRecord>): void;
+}
+
 // @public
 export function loadSnapshotIntoStorage<R extends UnknownRecord>(txn: TLSyncStorageTransaction<R>, schema: StoreSchema<R, any>, snapshot: RoomSnapshot | TLStoreSnapshot_2): void;
 
@@ -652,6 +671,7 @@ export type TLSqliteRow = Record<string, TLSqliteOutputValue>;
 // @public
 export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>> {
     constructor(config: {
+        lastServerClock?: number;
         didCancel?(): boolean;
         onAfterConnect?(self: TLSyncClient<R, S>, details: {
             isReadonly: boolean;

--- a/packages/sync-core/src/index.ts
+++ b/packages/sync-core/src/index.ts
@@ -1,6 +1,7 @@
 import { registerTldrawLibraryVersion } from '@tldraw/utils'
 export { chunk, JsonChunkAssembler } from './lib/chunk'
 export { ClientWebSocketAdapter, ReconnectManager } from './lib/ClientWebSocketAdapter'
+export { LazyClientWebSocketAdapter } from './lib/LazyClientWebSocketAdapter'
 export {
 	applyObjectDiff,
 	diffRecord,

--- a/packages/sync-core/src/lib/LazyClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/LazyClientWebSocketAdapter.test.ts
@@ -1,0 +1,124 @@
+import { sleep } from 'tldraw'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+// NOTE: setupVitest.js replaces the global WebSocket with the 'ws' package's WebSocket,
+// matching the WebSocketServer the tests connect to.
+import { WebSocketServer } from 'ws'
+import { LazyClientWebSocketAdapter } from './LazyClientWebSocketAdapter'
+
+async function waitFor(predicate: () => boolean) {
+	let safety = 0
+	while (!predicate()) {
+		if (safety++ > 1000) {
+			throw new Error('waitFor predicate timed out')
+		}
+		await sleep(10)
+	}
+}
+
+describe('LazyClientWebSocketAdapter', () => {
+	let wsServer: WebSocketServer
+	let adapter: LazyClientWebSocketAdapter
+	let connections: number
+
+	beforeEach(() => {
+		connections = 0
+		wsServer = new WebSocketServer({ port: 23456 })
+		wsServer.on('connection', () => {
+			connections++
+		})
+		adapter = new LazyClientWebSocketAdapter(() => 'ws://localhost:23456')
+	})
+
+	afterEach(() => {
+		adapter.close()
+		wsServer.close()
+	})
+
+	it('stays detached until connectNow: no connection, offline status, dial flag unset', async () => {
+		expect(adapter.connectionStatus).toBe('offline')
+		expect(adapter.didRequestConnect.get()).toBe(false)
+		await sleep(50)
+		expect(connections).toBe(0)
+	})
+
+	it('connectNow dials and forwards status events to listeners registered while detached', async () => {
+		const statuses: string[] = []
+		adapter.onStatusChange((event) => statuses.push(event.status))
+
+		adapter.connectNow()
+		expect(adapter.didRequestConnect.get()).toBe(true)
+
+		await waitFor(() => adapter.connectionStatus === 'online')
+		expect(connections).toBe(1)
+		expect(statuses).toContain('online')
+	})
+
+	it('forwards messages received after dialing to listeners registered while detached', async () => {
+		const received: any[] = []
+		adapter.onReceiveMessage((msg) => received.push(msg))
+		wsServer.on('connection', (ws) => {
+			ws.send(JSON.stringify({ type: 'pong' }))
+		})
+
+		adapter.connectNow()
+		await waitFor(() => received.length > 0)
+		expect(received[0]).toEqual({ type: 'pong' })
+	})
+
+	it('connectNow is idempotent', async () => {
+		adapter.connectNow()
+		adapter.connectNow()
+		await waitFor(() => adapter.connectionStatus === 'online')
+		await sleep(50)
+		expect(connections).toBe(1)
+	})
+
+	it('restart while detached dials; restart after dialing restarts the inner socket', async () => {
+		adapter.restart()
+		expect(adapter.didRequestConnect.get()).toBe(true)
+		await waitFor(() => adapter.connectionStatus === 'online')
+		expect(connections).toBe(1)
+
+		adapter.restart()
+		await waitFor(() => connections === 2)
+	})
+
+	it('close before dialing makes connectNow a no-op', async () => {
+		adapter.close()
+		adapter.connectNow()
+		await sleep(50)
+		expect(connections).toBe(0)
+		expect(adapter.connectionStatus).toBe('offline')
+	})
+
+	it('removed listeners stop receiving events', async () => {
+		const statuses: string[] = []
+		const unsubscribe = adapter.onStatusChange((event) => statuses.push(event.status))
+		unsubscribe()
+		adapter.connectNow()
+		await waitFor(() => adapter.connectionStatus === 'online')
+		expect(statuses).toHaveLength(0)
+	})
+})
+
+describe('LazyClientWebSocketAdapter (no server)', () => {
+	it('does not construct a websocket before connectNow', async () => {
+		const RealWebSocket = global.WebSocket
+		const constructed = vi.fn()
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		global.WebSocket = class extends (RealWebSocket as any) {
+			constructor(...args: any[]) {
+				constructed(...args)
+				super(...(args as [any]))
+			}
+		} as any
+		try {
+			const adapter = new LazyClientWebSocketAdapter(() => 'ws://localhost:9')
+			await sleep(50)
+			expect(constructed).not.toHaveBeenCalled()
+			adapter.close()
+		} finally {
+			global.WebSocket = RealWebSocket
+		}
+	})
+})

--- a/packages/sync-core/src/lib/LazyClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/LazyClientWebSocketAdapter.ts
@@ -1,0 +1,103 @@
+import { Atom, atom } from '@tldraw/state'
+import { TLRecord } from '@tldraw/tlschema'
+import { ClientWebSocketAdapter } from './ClientWebSocketAdapter'
+import { TLSocketClientSentEvent, TLSocketServerSentEvent } from './protocol'
+import {
+	TLPersistentClientSocket,
+	TLSocketStatusChangeEvent,
+	TLSocketStatusListener,
+} from './TLSyncClient'
+
+/**
+ * A `TLPersistentClientSocket` that stays detached ('offline') until told to dial. Used by the
+ * lazy board transport: the sync client is constructed against this adapter at mount so it
+ * captures user edits as speculative changes from the first keystroke, but no websocket exists —
+ * and no server room boots — until {@link LazyClientWebSocketAdapter.connectNow} is called.
+ *
+ * `ClientWebSocketAdapter` cannot be used directly because its constructor eagerly schedules a
+ * connection attempt; this facade constructs one lazily and forwards listeners registered while
+ * detached.
+ *
+ * @internal
+ */
+export class LazyClientWebSocketAdapter implements TLPersistentClientSocket<
+	TLSocketClientSentEvent<TLRecord>,
+	TLSocketServerSentEvent<TLRecord>
+> {
+	private inner: ClientWebSocketAdapter | null = null
+	private isDisposed = false
+	private readonly messageListeners = new Set<(msg: TLSocketServerSentEvent<TLRecord>) => void>()
+	private readonly statusListeners = new Set<TLSocketStatusListener>()
+	private readonly innerUnsubscribes: Array<() => void> = []
+
+	/** Reactive flag for presentation code: has a dial been requested yet? */
+	readonly didRequestConnect: Atom<boolean> = atom('didRequestConnect', false)
+
+	constructor(private readonly getUri: () => Promise<string> | string) {}
+
+	/**
+	 * Construct the real websocket adapter and start connecting. Idempotent; a no-op after
+	 * `close()`. Listeners registered while detached are forwarded to the inner adapter.
+	 */
+	connectNow(): void {
+		if (this.isDisposed || this.inner) return
+		this.didRequestConnect.set(true)
+		const inner = new ClientWebSocketAdapter(this.getUri)
+		this.inner = inner
+		this.innerUnsubscribes.push(
+			inner.onReceiveMessage((msg) => {
+				for (const listener of this.messageListeners) listener(msg)
+			}),
+			inner.onStatusChange((event) => {
+				for (const listener of this.statusListeners) listener(event)
+			})
+		)
+	}
+
+	// eslint-disable-next-line tldraw/no-setter-getter
+	get connectionStatus(): 'online' | 'offline' | 'error' {
+		return this.inner?.connectionStatus ?? 'offline'
+	}
+
+	sendMessage(msg: TLSocketClientSentEvent<TLRecord>) {
+		if (!this.inner) {
+			// Mirrors ClientWebSocketAdapter's behavior when offline: the sync client only sends
+			// while it believes the room is connected, so this indicates a bug.
+			console.warn('Tried to send message while detached', msg)
+			return
+		}
+		this.inner.sendMessage(msg)
+	}
+
+	onReceiveMessage(cb: (msg: TLSocketServerSentEvent<TLRecord>) => void) {
+		this.messageListeners.add(cb)
+		return () => {
+			this.messageListeners.delete(cb)
+		}
+	}
+
+	onStatusChange(cb: (event: TLSocketStatusChangeEvent) => void) {
+		this.statusListeners.add(cb)
+		return () => {
+			this.statusListeners.delete(cb)
+		}
+	}
+
+	restart() {
+		if (this.inner) {
+			this.inner.restart()
+		} else {
+			this.connectNow()
+		}
+	}
+
+	close() {
+		this.isDisposed = true
+		for (const unsubscribe of this.innerUnsubscribes) unsubscribe()
+		this.innerUnsubscribes.length = 0
+		this.messageListeners.clear()
+		this.statusListeners.clear()
+		this.inner?.close()
+		this.inner = null
+	}
+}

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -489,8 +489,18 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 			details: { isReadonly: boolean; objectAccess: TLObjectStoreAccess }
 		): void
 		didCancel?(): boolean
+		/**
+		 * Seed for the server clock, for stores pre-hydrated from a snapshot that carries its
+		 * `documentClock`. Lets the first connect catch up incrementally (`wipe_presence`) instead
+		 * of re-downloading the whole document. A stale seed is safe: the server falls back to
+		 * `wipe_all`, and speculative changes re-apply on top.
+		 */
+		lastServerClock?: number
 	}) {
 		this.didCancel = config.didCancel
+		if (config.lastServerClock !== undefined) {
+			this.lastServerClock = config.lastServerClock
+		}
 
 		this.presenceType = config.store.scopedTypes.presence.values().next().value ?? null
 

--- a/packages/sync-core/src/lib/TLSyncClientSeed.test.ts
+++ b/packages/sync-core/src/lib/TLSyncClientSeed.test.ts
@@ -1,0 +1,239 @@
+import { atom } from '@tldraw/state'
+import { Store } from '@tldraw/store'
+import {
+	DocumentRecordType,
+	PageRecordType,
+	TLDOCUMENT_ID,
+	TLRecord,
+	createTLSchema,
+} from '@tldraw/tlschema'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TestServer } from '../test/TestServer'
+import { TestSocketPair } from '../test/TestSocketPair'
+import { TLConnectRequest, TLSocketServerSentEvent } from './protocol'
+import { TLSyncClient } from './TLSyncClient'
+import { RoomSnapshot } from './TLSyncRoom'
+
+// These tests express SPEC.md rule CL2a: a client whose store was pre-hydrated from a snapshot
+// can seed `lastServerClock` and either catch up incrementally (wipe_presence) or degrade safely
+// to a full resync (wipe_all) — in both cases keeping edits made before the first connect.
+
+const schema = createTLSchema()
+
+const documentRecord = DocumentRecordType.create({ id: TLDOCUMENT_ID, gridSize: 10 })
+const page1 = PageRecordType.create({
+	id: PageRecordType.createId('page1'),
+	name: 'Page 1',
+	index: 'a1' as any,
+})
+const lateArrivingPage = PageRecordType.create({
+	id: PageRecordType.createId('late'),
+	name: 'Late page',
+	index: 'a2' as any,
+})
+
+function makeServer(snapshot: RoomSnapshot) {
+	return new TestServer<TLRecord>(schema, snapshot)
+}
+
+function makeStore() {
+	return new Store<TLRecord, any>({
+		schema,
+		props: {
+			defaultName: 'test',
+			assets: {
+				upload: async () => ({ src: 'mock://test' }),
+				resolve: (asset: any) => asset.src || 'mock://resolved',
+				remove: async () => {},
+			},
+			onMount: () => {},
+		},
+	})
+}
+
+describe('TLSyncClient with a seeded lastServerClock', () => {
+	let client: TLSyncClient<TLRecord, Store<TLRecord, any>> | undefined
+
+	beforeEach(() => {
+		vi.useFakeTimers()
+	})
+
+	afterEach(() => {
+		client?.close()
+		client = undefined
+		vi.useRealTimers()
+	})
+
+	function createSeededClient(
+		store: Store<TLRecord, any>,
+		pair: TestSocketPair<TLRecord>,
+		lastServerClock: number
+	) {
+		client = new TLSyncClient<TLRecord, Store<TLRecord, any>>({
+			store,
+			socket: pair.clientSocket,
+			presence: atom('presence', null),
+			lastServerClock,
+			onLoad: vi.fn(),
+			onSyncError: vi.fn((reason) => {
+				throw new Error('onSyncError: ' + reason)
+			}),
+		})
+		return client
+	}
+
+	/** Wrap the socket's message callback to record everything the client receives. */
+	function recordReceivedMessages(pair: TestSocketPair<TLRecord>) {
+		const received: TLSocketServerSentEvent<TLRecord>[] = []
+		const inner = pair.callbacks.onReceiveMessage!
+		pair.callbacks.onReceiveMessage = (msg) => {
+			received.push(msg)
+			inner(msg)
+		}
+		return received
+	}
+
+	it('[CL2a] sends the seeded clock in the connect request', async () => {
+		const server = makeServer({
+			documents: [
+				{ state: documentRecord, lastChangedClock: 1 },
+				{ state: page1, lastChangedClock: 1 },
+			],
+			clock: 10,
+			documentClock: 10,
+			tombstoneHistoryStartsAtClock: 0,
+			schema: schema.serialize(),
+		})
+		const pair = new TestSocketPair('seed-test', server)
+		const store = makeStore()
+		store.mergeRemoteChanges(() => store.put([documentRecord, page1]))
+
+		createSeededClient(store, pair, 10)
+		pair.connect()
+
+		const connectMsg = pair.clientSentEventQueue.find(
+			(m) => m.type === 'connect'
+		) as TLConnectRequest
+		expect(connectMsg).toBeDefined()
+		expect(connectMsg.lastServerClock).toBe(10)
+	})
+
+	it('[CL2a] catches up incrementally (wipe_presence) when the seed is within tombstone history', async () => {
+		const server = makeServer({
+			documents: [
+				{ state: documentRecord, lastChangedClock: 1 },
+				{ state: page1, lastChangedClock: 1 },
+				{ state: lateArrivingPage, lastChangedClock: 12 },
+			],
+			clock: 12,
+			documentClock: 12,
+			tombstoneHistoryStartsAtClock: 0,
+			schema: schema.serialize(),
+		})
+		const pair = new TestSocketPair('seed-test', server)
+		const store = makeStore()
+		// The snapshot the client fetched was at clock 10: it has page1 but not the late page.
+		store.mergeRemoteChanges(() => store.put([documentRecord, page1]))
+
+		createSeededClient(store, pair, 10)
+		const received = recordReceivedMessages(pair)
+		pair.connect()
+		await pair.flushAllEvents()
+
+		const connectResponse = received.find((m) => m.type === 'connect')
+		expect(connectResponse).toBeDefined()
+		expect(connectResponse).toMatchObject({ hydrationType: 'wipe_presence' })
+		// The incremental diff carries only what changed after the seed
+		expect(Object.keys((connectResponse as any).diff)).toEqual([lateArrivingPage.id])
+		expect(store.get(lateArrivingPage.id)).toMatchObject({ name: 'Late page' })
+		expect(store.get(page1.id)).toMatchObject({ name: 'Page 1' })
+	})
+
+	it('[CL2a][CP3] pushes edits made while detached after the first connect', async () => {
+		const server = makeServer({
+			documents: [
+				{ state: documentRecord, lastChangedClock: 1 },
+				{ state: page1, lastChangedClock: 1 },
+			],
+			clock: 10,
+			documentClock: 10,
+			tombstoneHistoryStartsAtClock: 0,
+			schema: schema.serialize(),
+		})
+		const pair = new TestSocketPair('seed-test', server)
+		const store = makeStore()
+		store.mergeRemoteChanges(() => store.put([documentRecord, page1]))
+
+		createSeededClient(store, pair, 10)
+
+		// User edits while no socket exists — captured as speculative changes
+		const offlinePage = PageRecordType.create({
+			id: PageRecordType.createId('offline'),
+			name: 'Offline page',
+			index: 'a3' as any,
+		})
+		store.put([offlinePage])
+		vi.advanceTimersByTime(100)
+		expect(pair.clientSentEventQueue).toHaveLength(0)
+
+		pair.connect()
+		await pair.flushAllEvents()
+		vi.advanceTimersByTime(100)
+		await pair.flushAllEvents()
+
+		// The server room now has the offline edit
+		const serverDocs = server.storage.getSnapshot().documents.map((d) => d.state.id)
+		expect(serverDocs).toContain(offlinePage.id)
+		expect(store.get(offlinePage.id)).toMatchObject({ name: 'Offline page' })
+	})
+
+	it('[CL2a][CL6] a stale seed degrades to wipe_all: snapshot records are replaced, detached edits survive', async () => {
+		const server = makeServer({
+			documents: [
+				{ state: documentRecord, lastChangedClock: 1 },
+				{ state: page1, lastChangedClock: 1 },
+			],
+			clock: 20,
+			documentClock: 20,
+			// Tombstone history starts after the client's seed, so no incremental diff is possible
+			tombstoneHistoryStartsAtClock: 15,
+			schema: schema.serialize(),
+		})
+		const pair = new TestSocketPair('seed-test', server)
+		const store = makeStore()
+		// A record the server no longer has, hydrated before the client exists — it is NOT a user
+		// change, so a full resync is expected to remove it
+		const zombiePage = PageRecordType.create({
+			id: PageRecordType.createId('zombie'),
+			name: 'Zombie page',
+			index: 'a4' as any,
+		})
+		store.mergeRemoteChanges(() => store.put([documentRecord, page1, zombiePage]))
+
+		createSeededClient(store, pair, 10)
+		const received = recordReceivedMessages(pair)
+
+		// A user edit made while detached — this must survive the wipe
+		const offlinePage = PageRecordType.create({
+			id: PageRecordType.createId('offline'),
+			name: 'Offline page',
+			index: 'a5' as any,
+		})
+		store.put([offlinePage])
+		vi.advanceTimersByTime(100)
+
+		pair.connect()
+		await pair.flushAllEvents()
+		vi.advanceTimersByTime(100)
+		await pair.flushAllEvents()
+
+		const connectResponse = received.find((m) => m.type === 'connect')
+		expect(connectResponse).toMatchObject({ hydrationType: 'wipe_all' })
+		// Snapshot-hydrated state was replaced by the server's
+		expect(store.get(zombiePage.id)).toBeUndefined()
+		// ...but the detached user edit survived and reached the server
+		expect(store.get(offlinePage.id)).toMatchObject({ name: 'Offline page' })
+		const serverDocs = server.storage.getSnapshot().documents.map((d) => d.state.id)
+		expect(serverDocs).toContain(offlinePage.id)
+	})
+})

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Editor } from 'tldraw';
+import { RoomSnapshot } from '@tldraw/sync-core';
 import { TLAssetStore } from 'tldraw';
 import { TLObjectStoreAccess } from '@tldraw/sync-core';
 import { TLPersistentClientSocket } from '@tldraw/sync-core';
@@ -20,6 +21,7 @@ import { TLUserStore } from 'tldraw';
 export type RemoteTLStoreWithStatus = (Extract<TLStoreWithStatus, {
     status: 'synced-remote';
 }> & {
+    connect?(): void;
     readonly objectAccess: TLObjectStoreAccess;
 }) | Exclude<TLStoreWithStatus, {
     status: 'not-synced';
@@ -65,6 +67,8 @@ export interface UseSyncOptionsBase {
     onMount?(editor: Editor): void;
     // @internal
     roomId?: string;
+    // @internal
+    snapshot?: UseSyncSnapshot;
     themes?: Partial<TLThemes>;
     // @internal (undocumented)
     trackAnalyticsEvent?(name: string, data: {
@@ -85,6 +89,13 @@ export interface UseSyncOptionsWithUri extends UseSyncOptionsBase {
     // (undocumented)
     connect?: never;
     uri: (() => Promise<string> | string) | string;
+}
+
+// @internal
+export interface UseSyncSnapshot {
+    isReadonly: boolean;
+    objectAccess?: TLObjectStoreAccess;
+    snapshot: RoomSnapshot;
 }
 
 

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -10,6 +10,7 @@ export {
 	type UseSyncOptionsBase,
 	type UseSyncOptionsWithConnectFn,
 	type UseSyncOptionsWithUri,
+	type UseSyncSnapshot,
 } from './useSync'
 export { useSyncDemo, type UseSyncDemoOptions } from './useSyncDemo'
 

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -1,6 +1,7 @@
-import { atom, transact } from '@tldraw/state'
+import { Signal, atom, transact } from '@tldraw/state'
 import {
-	ClientWebSocketAdapter,
+	LazyClientWebSocketAdapter,
+	RoomSnapshot,
 	TLCustomMessageHandler,
 	TLObjectStoreAccess,
 	TLPersistentClientSocket,
@@ -91,7 +92,31 @@ export type RemoteTLStoreWithStatus =
 			 * be allowed to comment without being allowed to edit. Defaults to `'write'`.
 			 */
 			readonly objectAccess: TLObjectStoreAccess
+			/**
+			 * Present only in snapshot mode (see `UseSyncOptionsBase.snapshot`): dial the deferred
+			 * websocket. Idempotent; a no-op once connected.
+			 *
+			 * @internal
+			 */
+			connect?(): void
 	  })
+
+/**
+ * A pre-fetched room snapshot for `useSync`'s lazy transport mode (see
+ * `UseSyncOptionsBase.snapshot`). Matches the shape persisted by the sync server: the snapshot's
+ * `documentClock` seeds the sync client's server clock so the deferred websocket connect catches
+ * up incrementally instead of re-downloading the document.
+ *
+ * @internal
+ */
+export interface UseSyncSnapshot {
+	/** The room snapshot, in the schema version it was persisted with. */
+	snapshot: RoomSnapshot
+	/** Whether this session may edit the canvas, as decided by the server at fetch time. */
+	isReadonly: boolean
+	/** Object-store lane (e.g. comments) access; defaults to `'write'`. */
+	objectAccess?: TLObjectStoreAccess
+}
 
 /**
  * Creates a reactive store synchronized with a multiplayer server for real-time collaboration.
@@ -181,6 +206,8 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		readyClient?: TLSyncClient<TLRecord, TLStore>
 		error?: Error
 		objectAccess?: TLObjectStoreAccess
+		presentedStatus?: Signal<'online' | 'offline'>
+		connect?(): void
 	} | null>(null)
 	const {
 		uri,
@@ -189,6 +216,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		users: _users,
 		onMount,
 		connect,
+		snapshot,
 		trackAnalyticsEvent: track,
 		getUserPresence: _getUserPresence,
 		onCustomMessageReceived: _onCustomMessageReceived,
@@ -261,9 +289,13 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			TLSocketClientSentEvent<TLRecord>,
 			TLSocketServerSentEvent<TLRecord>
 		>
+		let lazySocket: LazyClientWebSocketAdapter | null = null
 		if (connect) {
 			if (uri) {
 				throw new Error('uri and connect cannot be used together')
+			}
+			if (snapshot) {
+				throw new Error('snapshot cannot be used with a custom connect function')
 			}
 
 			socket = connect({
@@ -278,7 +310,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				throw new Error('uri and connect cannot be used together')
 			}
 
-			socket = new ClientWebSocketAdapter(async () => {
+			socket = lazySocket = new LazyClientWebSocketAdapter(async () => {
 				const uriString = typeof uri === 'string' ? uri : await uri()
 
 				// set sessionId as a query param on the uri
@@ -307,9 +339,20 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		function getConnectionStatus() {
 			return socket.connectionStatus === 'error' ? 'offline' : socket.connectionStatus
 		}
-		const collaborationStatusSignal = atom('collaboration status', getConnectionStatus())
-		const unsubscribeFromConnectionStatus = socket.onStatusChange(() => {
-			collaborationStatusSignal.set(getConnectionStatus())
+		const rawStatusSignal = atom('collaboration status', getConnectionStatus())
+		// While the lazy transport is deliberately detached — and for a grace window after it
+		// dials — the editor presents as online: the user isn't offline, they just don't have (or
+		// need) a socket yet. Once the socket has genuinely been online, presentation always
+		// follows the real status so mid-session disconnects surface as today.
+		const forcePresentOnline = atom('force present online', snapshot !== undefined && !!uri)
+		const collaborationStatusSignal = computed('presented collaboration status', () =>
+			forcePresentOnline.get() ? ('online' as const) : rawStatusSignal.get()
+		)
+		const unsubscribeFromConnectionStatus = socket.onStatusChange((event) => {
+			rawStatusSignal.set(getConnectionStatus())
+			if (event.status === 'online') {
+				forcePresentOnline.set(false)
+			}
 		})
 
 		const syncMode = atom('sync mode', 'readwrite' as 'readonly' | 'readwrite')
@@ -325,6 +368,34 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 				mode: syncMode,
 			},
 		})
+
+		// Snapshot mode: hydrate the store BEFORE the sync client is constructed, so none of the
+		// snapshot registers as local user changes (which the client would push as speculative
+		// edits). A migration or validation failure falls back to the plain websocket path — the
+		// connect handshake has real schema negotiation, and its wipe_all replaces any partially
+		// hydrated document records.
+		let seededServerClock: number | undefined
+		if (snapshot && lazySocket && snapshot.snapshot.schema) {
+			try {
+				const migrated = schema.migrateStoreSnapshot({
+					schema: snapshot.snapshot.schema,
+					store: Object.fromEntries(
+						snapshot.snapshot.documents.map((d) => [d.state.id, d.state as TLRecord])
+					),
+				})
+				if (migrated.type === 'success') {
+					store.mergeRemoteChanges(() => {
+						store.put(Object.values(migrated.value))
+						store.ensureStoreIsUsable()
+					})
+					syncMode.set(snapshot.isReadonly ? 'readonly' : 'readwrite')
+					seededServerClock = snapshot.snapshot.documentClock
+				}
+			} catch (e) {
+				console.error('Failed to hydrate sync store from snapshot, connecting instead', e)
+			}
+		}
+		const isLazyDetached = seededServerClock !== undefined
 
 		const presence = createPresenceStateDerivation(currentUser, {
 			getUserPresence,
@@ -346,6 +417,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		const client = new TLSyncClient<TLRecord, TLStore>({
 			store,
 			socket,
+			lastServerClock: seededServerClock,
 			didCancel: () => didCancel,
 			onLoad(client) {
 				track?.(MULTIPLAYER_EVENT_NAME, { name: 'load', roomId })
@@ -398,8 +470,37 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			presenceMode,
 		})
 
+		// After a deliberate lazy dial, give the handshake a grace window before the presented
+		// status falls through to the real socket status (and the offline indicator can appear).
+		const LAZY_CONNECT_GRACE_MS = 15_000
+		let graceTimeout: ReturnType<typeof setTimeout> | undefined
+		const dial = () => {
+			if (didCancel || !lazySocket) return
+			lazySocket.connectNow()
+			if (forcePresentOnline.get() && graceTimeout === undefined) {
+				graceTimeout = setTimeout(() => forcePresentOnline.set(false), LAZY_CONNECT_GRACE_MS)
+			}
+		}
+
+		if (isLazyDetached) {
+			// The store is fully usable from the snapshot: expose it (and the dial handle)
+			// immediately rather than waiting for a server round-trip.
+			setState({
+				readyClient: client,
+				objectAccess: snapshot?.objectAccess ?? 'write',
+				presentedStatus: collaborationStatusSignal,
+				connect: dial,
+			})
+		} else {
+			// Plain path (no snapshot, or snapshot hydration failed): dial straight away — this is
+			// the legacy behavior, running through the same transport.
+			dial()
+			setState({ presentedStatus: collaborationStatusSignal })
+		}
+
 		return () => {
 			didCancel = true
+			if (graceTimeout !== undefined) clearTimeout(graceTimeout)
 			unsubscribeFromConnectionStatus()
 			client.close()
 			socket.close()
@@ -408,6 +509,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		assets,
 		onMount,
 		connect,
+		snapshot,
 		_users,
 		roomId,
 		schema,
@@ -424,12 +526,15 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			if (!state) return { status: 'loading' }
 			if (state.error) return { status: 'error', error: state.error }
 			if (!state.readyClient) return { status: 'loading' }
-			const connectionStatus = state.readyClient.socket.connectionStatus
+			const connectionStatus = state.presentedStatus
+				? state.presentedStatus.get()
+				: state.readyClient.socket.connectionStatus
 			return {
 				status: 'synced-remote',
 				connectionStatus: connectionStatus === 'error' ? 'offline' : connectionStatus,
 				store: state.readyClient.store,
 				objectAccess: state.objectAccess ?? 'write',
+				connect: state.connect,
 			}
 		},
 		[state]
@@ -532,6 +637,18 @@ export interface UseSyncOptionsBase {
 	roomId?: string
 	/** @internal */
 	trackAnalyticsEvent?(name: string, data: { [key: string]: any }): void
+
+	/**
+	 * Lazy transport mode (requires `uri`): hydrate the store from this pre-fetched snapshot and
+	 * DON'T open the websocket — the returned status carries a `connect()` handle to dial it later
+	 * (on first edit, or when other collaborators are detected). The store is exposed with
+	 * `status: 'synced-remote'` immediately, edits made before dialing are pushed after the
+	 * handshake, and the snapshot's `documentClock` makes the catch-up incremental. Must be
+	 * referentially stable; it is read once per mount.
+	 *
+	 * @internal
+	 */
+	snapshot?: UseSyncSnapshot
 
 	/**
 	 * A reactive function that returns a {@link @tldraw/tlschema#TLInstancePresence} object.


### PR DESCRIPTION
In order to cut Durable Object wall-clock spend on tldraw.com — where ~98% of board traffic is a solo user, mostly reading — this PR loads boards from a REST snapshot instead of opening a websocket, and dials the socket only when it's actually needed: on the user's first document edit, or when an activity poll reports other people in the room (or the content moving past the loaded snapshot). Every board open today boots the file DO (R2→SQLite hydrate, auth ladder, session churn, last-out persist) even for a five-second look; with this, a pure read never touches the DO at all. Gated by a new signed-in percentage flag `lazy_board_socket`, default off; flag-off traffic runs through the identical transport with an instant dial, so there is no second code path to rot.

The sync protocol already did the hard parts: edits made while detached accumulate as speculative changes and push after the handshake (SPEC CP3/CL6), and seeding the client's `lastServerClock` from the snapshot's `documentClock` makes the eventual connect an incremental catch-up rather than a full re-download — a stale seed degrades safely to `wipe_all` with detached edits surviving on top. The new pieces:

- **sync-core**: `LazyClientWebSocketAdapter` (a `TLPersistentClientSocket` that stays offline until `connectNow()`), a `lastServerClock` constructor seed on `TLSyncClient`, and SPEC rule CL2a with tests against the real test server.
- **sync**: an `@internal` `snapshot` option on `useSync` — hydrates the store (via `mergeRemoteChanges`, strictly before the sync client exists, so nothing registers as a user edit), reports `synced-remote` immediately, presents as online while deliberately detached (15s grace after dialing), and exposes a `connect()` handle on the returned status.
- **sync-worker**: `GET /app/file/:id/snapshot` (R2 snapshot with comments merged from Postgres, tombstones stripped, clocks + readonly + object access, `no-store`; 404 `not-persisted` for never-persisted files → client falls back to the socket) and `GET /app/file/:id/activity`, which reads a tiny advisory R2 object the DO writes at moments it is awake anyway (connect, session removal, persist) — polls never wake the DO. The read-auth ladder that existed twice in the DO (`onRequest`, `onDownloadTldr`) is factored into one `checkReadAccessToFile` shared with the new route, so the three paths can't drift.
- **dotcom client**: `useLazyBoardSnapshot` (flag resolve + snapshot fetch, `@tldraw.com` dogfood override), `useLazySocketUpgrade` (once-only document-scope edit listener; 15s jittered, visibility-paused activity poll), wired into `TlaEditor`. Upgrades tag the ws URI with `upgradeReason` so the rollout can be judged by upgrade mix (`lazy_socket_upgrade` datapoint); `lazy_snapshot_load` / `lazy_activity_poll` cover the new routes. The headline metric is `room_start / (room_start + lazy_snapshot_load)`, which should fall toward the true collaboration rate.

Two deliberate v1 tradeoffs, called out for review: the activity endpoint does not run the per-file Postgres authz ladder (it is the hottest poll loop; a signed-in slug-holder can learn only `{activeSessions, documentClock, updatedAt}`, and the slug is already the sharing capability) — a 60s cached authz decision is the follow-up if security objects. And REST readers are invisible: they don't appear in the face pile and don't see others' cursors until the poll detects company and upgrades (within ~15s). Freshness: R2 lags live state by up to the 8s persist throttle only while a room is occupied — exactly the case the activity poll routes around; rare crashed-persist staleness reconciles via the seeded clock on upgrade.

Not covered here: anonymous shared-link viewers keep the plain websocket path (percentage flags can't bucket them), and there are no React-hook render tests (the client package has no testing-library infra) — transport semantics are covered in sync-core, endpoints in sync-worker.

### Change type

- [x] `improvement`

### Test plan

1. Enable `lazy_board_socket` in the admin Flags section (or use an `@tldraw.com` account).
2. Open a board signed-in: the network tab shows the snapshot fetch and no websocket; the editor is interactive with comments visible and no offline indicator.
3. Draw a shape: the websocket dials with `upgradeReason=first-edit`; the shape survives a reload.
4. Second browser joins and edits: the reader upgrades within ~15s and sees the collaborator's cursor.
5. Brand-new file: snapshot 404s, transparent socket fallback.
6. View-only shared file: readonly from first paint and still readonly after upgrade.

- [x] Unit tests
- [ ] End to end tests

### API changes

- Added `@internal` `LazyClientWebSocketAdapter` to `@tldraw/sync-core`
- Added optional `lastServerClock` to the `TLSyncClient` constructor config
- Added `@internal` `snapshot` option (`UseSyncSnapshot`) to `useSync`, and an `@internal` optional `connect()` on the `synced-remote` status variant of `RemoteTLStoreWithStatus`

### Code changes

| Section         | LOC change  |
| --------------- | ----------- |
| Core code       | +241 / -7   |
| Tests           | +730 / -0   |
| Automated files | +31 / -0    |
| Apps            | +616 / -108 |