### PR TITLE
fix(dotcom): authenticate the Zero connection with a longer-lived token

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -230,8 +230,9 @@ export class TldrawApp {
 
 	private constructor(
 		public readonly userId: string,
-		initialToken: string | undefined,
+		initialZeroToken: string | undefined,
 		getToken: () => Promise<string | undefined>,
+		getZeroToken: () => Promise<string | undefined>,
 		onClientTooOld: () => void,
 		trackEvent: TLAppUiContextType,
 		navigate: ReturnType<typeof useNavigate>,
@@ -248,7 +249,7 @@ export class TldrawApp {
 			this.__test__triggerClientTooOld = () => onClientTooOld()
 		}
 		const z = new Zero<TlaSchema, TlaMutators, ZeroContext>({
-			auth: initialToken,
+			auth: initialZeroToken,
 			userID: userId,
 			schema: zeroSchema,
 			cacheURL: ZERO_SERVER,
@@ -262,8 +263,8 @@ export class TldrawApp {
 		})
 		this.z = z
 		// Refresh the token ahead of its own expiry and reschedule from whatever we get back, so the
-		// cadence follows the session-token lifetime rather than a hardcoded guess at it. In Zero
-		// 0.26+ this sends an updateAuth message without reconnecting.
+		// cadence follows the token's lifetime rather than a hardcoded guess at it. In Zero 0.26+
+		// this sends an updateAuth message without reconnecting.
 		let refreshTimeout: ReturnType<typeof setTimeout> | undefined
 		const scheduleRefresh = (token: string | undefined) => {
 			clearTimeout(refreshTimeout)
@@ -273,10 +274,10 @@ export class TldrawApp {
 				})
 			}, msUntilTokenRefresh(token))
 		}
-		// Reschedule on every outcome — a rejected getToken() or a throwing connect() must not kill
-		// the refresh chain, so scheduling happens before connect and in the reject path.
+		// Reschedule on every outcome — a rejected getZeroToken() or a throwing connect() must not
+		// kill the refresh chain, so scheduling happens before connect and in the reject path.
 		const refreshToken = () =>
-			getToken()
+			getZeroToken()
 				.catch((err) => {
 					scheduleRefresh(undefined)
 					throw err
@@ -288,11 +289,12 @@ export class TldrawApp {
 					}
 					return !!token
 				})
-		scheduleRefresh(initialToken)
+		scheduleRefresh(initialZeroToken)
 		this.disposables.push(() => clearTimeout(refreshTimeout))
-		// A hidden tab's timers are throttled to about once a minute, so a token that lives 60s
-		// expires under it however early we schedule. Refresh on the way back rather than leaving the
-		// user to interact with a connection whose token went stale while they were away.
+		// Timers in a hidden tab are throttled to about once a minute, so the refresh has to sit well
+		// inside that budget — see the `zero` JWT template's lifetime. Refreshing on the way back
+		// covers the cases no schedule can (a frozen tab, a slept laptop), where the token goes stale
+		// while nothing is running at all.
 		const onVisibilityChange = () => {
 			if (document.visibilityState !== 'visible') return
 			refreshToken().catch((err) => {
@@ -1021,7 +1023,10 @@ export class TldrawApp {
 		userId: string
 		email?: string | null
 		flags: FeatureFlags
+		/** Clerk session token, for this app's own REST endpoints. */
 		getToken(): Promise<string | undefined>
+		/** Token for the Zero connection — see {@link getZeroAuth} on the worker for why it differs. */
+		getZeroToken(): Promise<string | undefined>
 		onClientTooOld(): void
 		trackEvent: TLAppUiContextType
 		navigate: ReturnType<typeof useNavigate>
@@ -1032,11 +1037,12 @@ export class TldrawApp {
 
 		const { id: _id, name: _name, color, ...restOfPreferences } = getUserPreferences()
 		// Get initial token before creating Zero instance
-		const initialToken = await opts.getToken()
+		const initialZeroToken = await opts.getZeroToken()
 		const app = new TldrawApp(
 			opts.userId,
-			initialToken,
+			initialZeroToken,
 			opts.getToken,
+			opts.getZeroToken,
 			opts.onClientTooOld,
 			opts.trackEvent,
 			opts.navigate,

--- a/apps/dotcom/client/src/tla/hooks/useAppState.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useAppState.tsx
@@ -62,6 +62,14 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 					const token = await auth.getToken()
 					return token || undefined
 				},
+				// `skipCache` is load-bearing, not belt and braces: Clerk hands back a cached token
+				// until it is nearly expired, and the refresh schedules itself from the *remaining*
+				// life of whatever it is given. Cached tokens would shorten that interval on every
+				// pass — 90s, then 45s, then 22s — until it bottomed out against its floor.
+				getZeroToken: async () => {
+					const token = await auth.getToken({ template: 'zero', skipCache: true })
+					return token || undefined
+				},
 				onClientTooOld: () => {
 					isClientTooOld$.set(true)
 				},

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -1,4 +1,4 @@
-import { ClerkClient, createClerkClient } from '@clerk/backend'
+import { ClerkClient, createClerkClient, verifyToken } from '@clerk/backend'
 import { can } from '@tldraw/dotcom-shared'
 import { IRequest, StatusError } from 'itty-router'
 import { createPostgresConnectionPool } from '../../postgres'
@@ -62,6 +62,50 @@ export async function getAuth(request: IRequest, env: Environment): Promise<Sign
 	}
 
 	return res.toAuth() as SignedInAuth
+}
+
+/**
+ * Auth for the two endpoints zero-cache calls on the client's behalf (`/app/zero/query` and
+ * `/app/zero/mutate`).
+ *
+ * These take a token minted from the `zero` Clerk JWT template rather than a session token, because
+ * zero-cache holds the token for the life of a connection and reuses it for every transform and
+ * push behind that connection. A session token lives 60s and browsers throttle timers in hidden
+ * tabs to about once a minute, so a backgrounded tab cannot land a refresh before expiry — and an
+ * expired token here doesn't fail one request, it invalidates the whole connection. That produced a
+ * steady ~670 connection invalidations an hour in production.
+ *
+ * The trade is revocation latency: a template token isn't session-bound (no `sid`), so signing out
+ * doesn't invalidate one — it stays good until it expires. That's why the template is set to 3
+ * minutes rather than something longer: it only has to clear the ~1/minute timer budget, and every
+ * second beyond that is revocation window bought for nothing. Scoped deliberately to these two
+ * endpoints; everything else still authenticates with session tokens.
+ *
+ * Falls back to {@link getAuth} so a client running an older bundle, which still sends a session
+ * token, keeps working across the deploy.
+ */
+export async function getZeroAuth(
+	request: IRequest,
+	env: Environment
+): Promise<{ userId: string } | null> {
+	const header = request.headers.get('Authorization')
+	const token = header?.startsWith('Bearer ') ? header.slice('Bearer '.length) : null
+	if (token) {
+		try {
+			// the template does mint `azp`, so hold it to the same origin allowlist as a session
+			// token rather than accepting anything our instance signed
+			const { sub } = await verifyToken(token, {
+				secretKey: env.CLERK_SECRET_KEY,
+				authorizedParties: getAuthorizedParties(env),
+			})
+			if (sub) return { userId: sub }
+		} catch (e) {
+			// getAuth deliberately says nothing about why it rejected a token, which made an outage
+			// considerably harder to diagnose than it needed to be. Say it here.
+			console.error('[zero-auth] template token rejected:', (e as Error).message)
+		}
+	}
+	return getAuth(request, env)
 }
 
 export type SignedInAuth = ReturnType<

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -65,6 +65,14 @@ export async function getAuth(request: IRequest, env: Environment): Promise<Sign
 }
 
 /**
+ * The `purpose` claim the `zero` Clerk JWT template mints, and which {@link getZeroAuth} requires.
+ * It is what separates a token meant for these endpoints from any other token our Clerk instance
+ * signs. Configured in the Clerk dashboard under JWT Templates → zero → Claims; if you rename it
+ * there, the template has to carry both values until every worker is on the new name.
+ */
+const ZERO_TOKEN_PURPOSE = 'zero'
+
+/**
  * Auth for the two endpoints zero-cache calls on the client's behalf (`/app/zero/query` and
  * `/app/zero/mutate`).
  *
@@ -92,13 +100,21 @@ export async function getZeroAuth(
 	const token = header?.startsWith('Bearer ') ? header.slice('Bearer '.length) : null
 	if (token) {
 		try {
-			// the template does mint `azp`, so hold it to the same origin allowlist as a session
-			// token rather than accepting anything our instance signed
-			const { sub } = await verifyToken(token, {
+			// `verifyToken` accepts anything our Clerk instance signed, which is a wider door than we
+			// want: a token minted from some other JWT template — the kind you hand to a third-party
+			// integration — would otherwise be a valid credential for these two endpoints, mutate
+			// included. The `zero` template mints `purpose: 'zero'`; nothing else does.
+			const claims = await verifyToken(token, {
 				secretKey: env.CLERK_SECRET_KEY,
+				// holds the token to the same origin allowlist as a session token when it carries an
+				// `azp`; Clerk skips the check entirely on a token without one, so this narrows the
+				// door rather than closing it — the `purpose` check below is what actually gates.
 				authorizedParties: getAuthorizedParties(env),
 			})
-			if (sub) return { userId: sub }
+			if (claims.purpose !== ZERO_TOKEN_PURPOSE) {
+				throw new Error(`not a ${ZERO_TOKEN_PURPOSE}-template token`)
+			}
+			if (claims.sub) return { userId: claims.sub }
 		} catch (e) {
 			// getAuth deliberately says nothing about why it rejected a token, which made an outage
 			// considerably harder to diagnose than it needed to be. Say it here.

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -61,7 +61,7 @@ import {
 	getUserDurableObject,
 } from './utils/durableObjects'
 import { getFeatureFlags } from './utils/featureFlags'
-import { getAuth, requireAuth } from './utils/tla/getAuth'
+import { getAuth, getZeroAuth, requireAuth } from './utils/tla/getAuth'
 import { getRole } from './utils/tla/getRole'
 export { TLFileDurableObject } from './TLFileDurableObject'
 export { TLFileEffectProcessor } from './TLFileEffectProcessor'
@@ -217,7 +217,7 @@ const router = createRouter<Environment>()
 	.all('/health-check/*', healthCheckRoutes.fetch)
 	.all('/app/admin/*', adminRoutes.fetch)
 	.post('/app/zero/mutate', async (req, env, ctx) => {
-		const auth = await getAuth(req, env)
+		const auth = await getZeroAuth(req, env)
 		if (!auth) {
 			return Response.json({ error: 'Unauthorized' }, { status: 401 })
 		}
@@ -236,7 +236,7 @@ const router = createRouter<Environment>()
 		return json(result)
 	})
 	.post('/app/zero/query', async (req, env) => {
-		const auth = await getAuth(req, env)
+		const auth = await getZeroAuth(req, env)
 		if (!auth) {
 			return Response.json({ error: 'Unauthorized' }, { status: 401 })
 		}


### PR DESCRIPTION
In order to stop Zero connections being torn down by a token that expired underneath them, this authenticates the two endpoints zero-cache calls with a token minted from a new `zero` Clerk JWT template (3 minute lifetime) instead of a 60-second session token.

zero-cache holds the connection's token for the life of that connection and reuses it for every transform and push behind it. So an expired token there doesn't fail one request — it invalidates the whole connection, the client reconnects, and any queued mutation waits for the round trip. Measured over one hour in production: **671 invalidations across 318 client groups**. Two thirds of those groups are hit exactly once an hour and would never notice, but ~10 an hour sit in repeated churn at one reconnect every 2–5 minutes, which is a sidebar that keeps going stale.

The reason the existing proactive refresh can't fix this: session tokens live 60s, and browsers throttle timers in hidden tabs to roughly once a minute. A backgrounded tab cannot land a refresh before expiry — it's arithmetic we always lose, not a race we sometimes lose. #9842 made the cadence follow the token's own expiry, which is what lets a longer-lived token take effect here with no further change.

**Why 3 minutes and not longer.** The margin only has to clear the ~1/minute timer budget; at 180s the refresh lands at 90s with 90s to spare. Every second beyond that is revocation window bought for nothing — and a template token is *not* session-bound (no `sid`), so signing out doesn't invalidate one, it just expires. That trade is deliberately confined to `/app/zero/query` and `/app/zero/mutate`; every other endpoint keeps session tokens and their 60s window.

### Notes for review

- **`skipCache: true` is load-bearing.** Clerk returns a cached token until it is nearly expired, and our refresh schedules from the *remaining* life of whatever it is handed. Cached tokens would ratchet the interval down on every pass (90s → 45s → 22s) until it hit the floor.
- **Both endpoints fall back to session-token auth.** Client and worker deploy separately, and cached bundles outlive a deploy, so template-only would 401 anyone on older JS. Worth removing the fallback in a follow-up once old bundles have aged out.
- **The template does mint `azp`**, so `verifyToken` is given the same origin allowlist a session token gets. I had assumed it wouldn't and wrote the opposite comment first — worth a second pair of eyes on that call.
- `getZeroAuth` logs *why* a token was rejected. `getAuth` says nothing today, which cost real hours during the commenting outage.

### Change type

- [x] `bugfix`

### Test plan

1. Deploy the **worker first** and confirm nothing changes — every client is still on session tokens and hitting the fallback.
2. Deploy the client. In the console, `await Clerk.session.getToken({template:'zero'})` should decode to `exp - iat === 180`.
3. An hour later, compare against the baseline above — invalidations should drop sharply, and the >10/hr tail should empty out. If it doesn't move, the model is wrong and worth stopping to understand before going further.
4. Sign out and confirm you lose access to app data within ~3 minutes rather than ~60s. That's the expected regression, not a bug.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fix tldraw.com dropping and rebuilding its data connection when a tab has been in the background.
