### PR TITLE
chore(dotcom): add temporary replicator reboot debug logging

### DIFF
--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -101,6 +101,16 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	private lastRpmLogTime = Date.now()
 	private lastUserPruneTime = Date.now()
 
+	// TEMP DEBUG (branch mitja/replicator-reboot-debug-logging): visible-in-prod tracing for the
+	// reboot loop. console.* surfaces in `wrangler tail`; this.log.debug is gated off in prod.
+	private bootCount = 0
+	private messagesSinceBoot = 0
+	private lastBootStartTime = Date.now()
+	private dbg(...args: unknown[]) {
+		// eslint-disable-next-line no-console
+		console.warn('[REPL_DBG]', ...args)
+	}
+
 	// we need to guarantee in-order delivery of messages to users
 	// but DO RPC calls are not guaranteed to happen in order, so we need to
 	// use a queue per user
@@ -226,6 +236,14 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 			// If we haven't heard anything from postgres for 5 seconds, trigger a heartbeat.
 			// Otherwise, if we haven't heard anything for 10 seconds, do a soft reboot.
 			if (Date.now() - this.lastPostgresMessageTime > 10000) {
+				this.dbg(
+					'INACTIVITY reboot decision: msSinceLastMsg=',
+					Date.now() - this.lastPostgresMessageTime,
+					'msgsSinceBoot=',
+					this.messagesSinceBoot,
+					'state=',
+					this.state.type
+				)
 				this.log.debug('rebooting due to inactivity')
 				this.reboot('inactivity')
 			} else if (Date.now() - this.lastPostgresMessageTime > 5000) {
@@ -324,16 +342,26 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 				await sleep(2000)
 			}
 			const start = Date.now()
+			this.dbg(
+				'reboot begin: source=',
+				source,
+				'msgsSinceBoot=',
+				this.messagesSinceBoot,
+				'msSinceLastMsg=',
+				Date.now() - this.lastPostgresMessageTime
+			)
 			this.log.debug('rebooting', source)
 			const res = await Promise.race([
 				this.boot().then(() => 'ok'),
 				sleep(3000).then(() => 'timeout'),
 			]).catch((e) => {
 				this.logEvent({ type: 'reboot_error' })
+				this.dbg('reboot boot() threw:', (e as any)?.stack ?? e)
 				this.log.debug('reboot error', e.stack)
 				this.captureException(e)
 				return 'error'
 			})
+			this.dbg('reboot end: source=', source, 'result=', res, 'durationMs=', Date.now() - start)
 			this.log.debug('rebooted', res)
 			if (res === 'ok') {
 				this.logEvent({ type: 'reboot_duration', duration: Date.now() - start })
@@ -373,6 +401,10 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 
 	private async boot() {
 		this.log.debug('booting')
+		this.bootCount++
+		this.messagesSinceBoot = 0
+		this.lastBootStartTime = Date.now()
+		this.dbg('boot #', this.bootCount, 'start; slot=', this.slotName)
 		this.lastPostgresMessageTime = Date.now()
 		this.replicationService.removeAllListeners()
 
@@ -397,6 +429,17 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		}
 
 		this.replicationService.on('heartbeat', (lsn: string) => {
+			this.messagesSinceBoot++
+			if (this.messagesSinceBoot === 1) {
+				this.dbg(
+					'boot #',
+					this.bootCount,
+					'FIRST message (heartbeat) after',
+					Date.now() - this.lastBootStartTime,
+					'ms; lsn=',
+					lsn
+				)
+			}
 			this.log.debug('heartbeat', lsn)
 			this.lastPostgresMessageTime = Date.now()
 			this.reportPostgresUpdate()
@@ -408,7 +451,23 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		this.replicationService.addListener('data', (lsn: string, log: Wal2Json.Output) => {
 			// ignore events received after disconnecting, if that can even happen
 			try {
-				if (this.state.type !== 'connected') return
+				this.messagesSinceBoot++
+				if (this.messagesSinceBoot === 1) {
+					this.dbg(
+						'boot #',
+						this.bootCount,
+						'FIRST message (data) after',
+						Date.now() - this.lastBootStartTime,
+						'ms; lsn=',
+						lsn,
+						'state=',
+						this.state.type
+					)
+				}
+				if (this.state.type !== 'connected') {
+					this.dbg('DROPPING data: state=', this.state.type, 'lsn=', lsn)
+					return
+				}
 				this.postgresUpdates++
 				this.lastPostgresMessageTime = Date.now()
 				this.reportPostgresUpdate()
@@ -502,6 +561,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		})
 
 		this.replicationService.addListener('start', () => {
+			this.dbg('boot #', this.bootCount, "replication 'start' event fired")
 			if (!this.getCurrentLsn()) {
 				// make a request to force an updateLsn()
 				sql`insert into replicator_boot_id ("replicatorId", "bootId") values (${this.ctx.id.toString()}, ${uniqueId()}) on conflict ("replicatorId") do update set "bootId" = excluded."bootId"`.execute(
@@ -511,12 +571,16 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 		})
 
 		const handleError = (e: Error) => {
+			this.dbg('boot #', this.bootCount, 'replication ERROR:', (e as any)?.stack ?? e)
 			this.captureException(e)
 			this.reboot('retry')
 		}
 
 		this.replicationService.on('error', handleError)
-		this.replicationService.subscribe(this.wal2jsonPlugin, this.slotName).catch(handleError)
+		this.replicationService
+			.subscribe(this.wal2jsonPlugin, this.slotName)
+			.then(() => this.dbg('boot #', this.bootCount, 'subscribe() promise RESOLVED (stream ended)'))
+			.catch(handleError)
 
 		this.state = {
 			type: 'connected',

--- a/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
+++ b/apps/dotcom/sync-worker/src/TLPostgresReplicator.ts
@@ -108,7 +108,7 @@ export class TLPostgresReplicator extends DurableObject<Environment> {
 	private lastBootStartTime = Date.now()
 	private dbg(...args: unknown[]) {
 		// eslint-disable-next-line no-console
-		console.warn('[REPL_DBG]', ...args)
+		console.error('[REPL_DBG]', ...args)
 	}
 
 	// we need to guarantee in-order delivery of messages to users


### PR DESCRIPTION
In order to diagnose a production incident where the `TLPostgresReplicator` durable object is stuck in a reboot loop — the replication slot stays inactive, `restart_lsn` never advances, and WAL retention grows — this adds temporary console-level tracing to the replicator.

The blocker for diagnosis is that all existing replicator diagnostics go through `this.log.debug`, which `isDebugLogging` gates off in production, so `wrangler tail` shows nothing. These logs go through `console.warn` (prefixed `[REPL_DBG]`) so they surface in the tail, and they capture the specific unknowns: whether the walsender ever fires `start`, whether any heartbeat/data arrives after `subscribe()` (and how long after), whether data is dropped by the `state !== 'connected'` guard, whether the stream resolves early or errors, and the reason/timing of each reboot.

The current evidence is that boots succeed (~350ms) but no data flows and the DO inactivity-reboots every ~20s; these logs are meant to distinguish "connected but stream silent" from an early error or a state-machine drop.

Debug-only and intended to be reverted once the root cause is found — not a permanent change.

### Change type

- [x] `other`

### Test plan

1. Deploy to the affected stack.
2. `wrangler tail --env production` and filter for `[REPL_DBG]`.
3. Between a `boot # N start` and the next `INACTIVITY reboot`, confirm which appears: a `FIRST message` line (stream delivers), a `DROPPING data` line (state-machine drop), `replication ERROR` (throws), or `subscribe() promise RESOLVED` (stream ends early).

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +66 / -2   |
