### PR TITLE
fix(worker-shared): don't log env object on invalid origin

### DIFF
--- a/packages/worker-shared/src/origins.ts
+++ b/packages/worker-shared/src/origins.ts
@@ -75,7 +75,7 @@ export async function blockUnknownOrigins(
 	if (!origin) return undefined
 
 	if (env.IS_LOCAL !== 'true' && !isAllowedOrigin(origin)) {
-		console.error('Attempting to connect from an invalid origin:', origin, env, request)
+		console.error('Attempting to connect from an invalid origin:', origin, request)
 		return new Response('Not allowed', { status: 403 })
 	}
 


### PR DESCRIPTION
In order to keep worker secrets out of our logs, this stops passing the `env` binding object to `console.error` when a request comes in from a disallowed origin. The `env` object holds all of the worker's secrets and bindings, so every invalid-origin hit was dumping them into our Cloudflare logs (visible in Supabase log tooling, etc.). We only need the origin and request to debug these, so drop `env` from the log call.

### Change type

- [x] `bugfix`

### Test plan

- Send a request from a disallowed origin to a worker using `blockUnknownOrigins`; confirm the 403 still returns and the error log no longer includes the `env` object.

### Release notes

- Stop logging the worker `env` object when blocking requests from invalid origins.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Core code      | +1 / -1    |