### PR TITLE
chore(mcp-app): cut worker log volume by ~16x

### DIFF
--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -81,6 +81,11 @@ export class TldrawMCP extends McpAgent<Env> {
 			instructions: MCP_SERVER_INSTRUCTIONS,
 		}
 	)
+	// The Agents SDK defaults `observability` to an implementation whose `emit()`
+	// is a bare `console.log(event)`, so every WebSocket connection logs a full
+	// JSON object. The streamable-HTTP transport opens a connection per request,
+	// making this the single noisiest thing the worker prints. Every call site
+	// uses `this.observability?.emit(...)`, so clearing it disables them all.
 	override observability = undefined
 	isDev = this.env.MCP_IS_DEV === 'true'
 	logsEnabled = this.isDev

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -81,6 +81,7 @@ export class TldrawMCP extends McpAgent<Env> {
 			instructions: MCP_SERVER_INSTRUCTIONS,
 		}
 	)
+	override observability = undefined
 	isDev = this.env.MCP_IS_DEV === 'true'
 	logsEnabled = this.isDev
 	activeCheckpointId: string | null = null

--- a/apps/mcp-app/wrangler.toml
+++ b/apps/mcp-app/wrangler.toml
@@ -48,8 +48,15 @@ namespace_id = "2001"
 limit = 30
 period = 60
 
+#################### Observability ####################
 [observability]
 enabled = true
 
+# Invocation logs record every invocation, including ones that produce no output
+# of their own. The Agents SDK spends three Durable Object invocations per MCP
+# request on session routing before any work happens (a `set-name` fetch, plus
+# `getInitializeRequest` and `updateProps` RPCs), so those empty records were
+# roughly 80% of this worker's log volume. Turning them off keeps `console`
+# output — head sampling would drop real errors along with the noise.
 [observability.logs]
 invocation_logs = false

--- a/apps/mcp-app/wrangler.toml
+++ b/apps/mcp-app/wrangler.toml
@@ -50,3 +50,6 @@ period = 60
 
 [observability]
 enabled = true
+
+[observability.logs]
+invocation_logs = false


### PR DESCRIPTION
The `tldraw-mcp-app` worker was flooding Cloudflare with logs. Tailing production for 194 seconds showed **11,005 log events against 1,536 real inbound requests** — about 57 events/second, or ~4.9M/day, at 7.2 log events per request. In order to make the worker's logs usable (and cheap) again, this turns off the two sources that produce almost all of that volume, neither of which is our own logging.

**Invocation logs.** `[observability]` had no `logs` block, and `invocation_logs` defaults to on, so every invocation wrote a record even when it printed nothing. That matters here because the Agents SDK spends three Durable Object invocations per MCP request on session routing before any work happens — a `/cdn-cgi/partyserver/set-name/` fetch whose handler just returns `{ok: true}`, plus `getInitializeRequest` and `updateProps` RPCs. Those three accounted for **70% of all log events** on their own.

**The SDK's own logger.** `Agent` defaults `this.observability` to an implementation whose `emit()` is a bare `console.log(event)` in production. It fired 1,372 times in the window — one full JSON object per WebSocket connection, and the streamable-HTTP transport opens a connection per request. We never opted into this; it comes with the base class.

Measured effect: **~4.9M → ~300k log events/day**, with 100% of genuine `console` output retained. Head-based sampling was considered and rejected — it applies to all logs within a sampled request, so it would have discarded real errors along with the noise.

Worth flagging, since it's the reason not to sample: the ~300k/day that remains is almost entirely `waitUntil() tasks did not complete within the allowed time` warnings. Those are **not** ours. All 627 in the window came from a single `Cursor/3.0.16 (linux x64)` client on one IP holding SSE response streams open until the runtime's 30s cutoff.

### Change type

- [x] `improvement`

### Test plan

1. Deploy, then run `wrangler tail tldraw-mcp-app --format json` and confirm records with empty `logs` arrays are gone.
2. Confirm `Connection established` events no longer appear.
3. Trigger an error path and confirm `console.error` output still reaches Workers Logs.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Apps           | +6 / -0    |
| Config/tooling | +10 / -0   |
