### PR TITLE
fix(ci): read cloudflare credentials from the deploy-production environment

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -15,12 +15,11 @@ on:
       - 'templates/**'
   workflow_dispatch:
   workflow_call:
+    # the cloudflare credentials aren't listed here: they're secrets on the deploy-production
+    # environment, which the job below selects. `workflow_call` has no `environment` keyword, so
+    # they can't be passed in by a caller — an environment secret always wins over a passed one.
     secrets:
       TEMPLATES_TLDRAW_LICENSE_KEY:
-        required: true
-      CLOUDFLARE_API_TOKEN:
-        required: true
-      CLOUDFLARE_ACCOUNT_ID:
         required: true
       DISCORD_DEPLOY_WEBHOOK_URL:
         required: false
@@ -40,6 +39,9 @@ permissions:
 jobs:
   deploy:
     name: Deploy templates
+    # CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID are secrets on this environment rather than on
+    # the repository, so the job has to select it to see them at all.
+    environment: deploy-production
     timeout-minutes: 60
     runs-on: ubuntu-latest-16-cores-arm-open
     # a release deploy and a template-change deploy can otherwise race each other onto the same

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,7 +297,5 @@ jobs:
     if: needs.publish.outputs.mode == 'new' || ((needs.publish.outputs.mode == 'patch' || needs.publish.outputs.mode == 'manual') && needs.publish.outputs.is_latest_version == 'true')
     secrets:
       TEMPLATES_TLDRAW_LICENSE_KEY: ${{ secrets.TEMPLATES_TLDRAW_LICENSE_KEY }}
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       DISCORD_DEPLOY_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
     needs: publish


### PR DESCRIPTION
The template deploy added in #9934 fails on every Cloudflare template with `Empty environment variables: CLOUDFLARE_API_TOKEN` ([run](https://github.com/tldraw/tldraw/actions/runs/31381545665)). `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are secrets on the `deploy-production` environment, not repository secrets, so in a job that selects no environment they expand to the empty string rather than failing to resolve. Every other workflow that touches Cloudflare — bemo, dotcom, analytics, mcp-app — declares an `environment:` for exactly this reason.

So the deploy job now selects `deploy-production`.

The credentials also come out of the `workflow_call` secrets block and the `publish.yml` pass-through. `workflow_call` has no `environment` keyword, so a caller can't supply environment secrets, and an environment secret takes precedence over a passed one anyway — passing them was misleading, and would have expanded to empty in the caller's context too. Both triggers now resolve them the same way.

`TEMPLATES_TLDRAW_LICENSE_KEY` stays a repository secret and is still passed through for the release path, since a called workflow doesn't otherwise see repository secrets. That part worked in the failing run — it got far enough to fail on the Cloudflare token.

### Change type

- [x] `other`

### Test plan

1. Dispatch **Deploy templates** on `main`.
2. All four Cloudflare demos deploy, and the four expired ones stop logging the license error: agent, branching-chat, image-pipeline, multiplayer.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +6 / -6    |
