### PR TITLE
fix(ci): build workspace types before deploying the templates

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -58,6 +58,11 @@ jobs:
 
       - uses: ./.github/actions/setup
 
+      # most templates run `tsc` as part of their build, which resolves the workspace packages
+      # through their project references and so needs the declarations built first
+      - name: Build types
+        run: yarn build-types
+
       - name: Deploy templates
         env:
           TEMPLATES_TLDRAW_LICENSE_KEY: ${{ secrets.TEMPLATES_TLDRAW_LICENSE_KEY }}


### PR DESCRIPTION
After #9941 fixed the credentials, `agent` deployed successfully but the other three failed on `tsc` ([run](https://github.com/tldraw/tldraw/actions/runs/31384851274)):

```
error TS6305: Output file 'packages/tldraw/.tsbuild/index.d.ts' has not been
built from source file 'packages/tldraw/src/index.ts'
```

`branching-chat`, `image-pipeline` and `sync-cloudflare` build with `tsc && vite build`. The `tsc` pass resolves the workspace packages through their project references, so it needs the declarations built first. `agent` builds with `vite build` alone, which is why it was the only one that got through — vite doesn't typecheck.

`yarn lazy prebuild` covers the generated CSS but not declarations, so this adds the `yarn build-types` step that every other deploy workflow already has.

Verified locally: `yarn build-types` followed by `yarn run build` in `templates/sync-cloudflare` succeeds, where the build alone reproduces the TS6305 failure. Also confirmed a `VITE_TLDRAW_LICENSE_KEY` set in the build environment is inlined into the built bundle, so the licensing premise holds end to end.

### Change type

- [x] `other`

### Test plan

1. Dispatch **Deploy templates** on `main`.
2. All four Cloudflare demos deploy — agent, branching-chat, image-pipeline, multiplayer — and none logs a license error.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +5 / -0    |
