### PR TITLE
fix(editor): keep the tick loop alive when a listener throws

### DIFF
--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.test.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.test.ts
@@ -142,6 +142,19 @@ describe('TickManager', () => {
 			expect(mockEmit).toHaveBeenCalledWith('frame', 0)
 			expect(mockEmit).toHaveBeenCalledWith('tick', 0)
 		})
+
+		it('should schedule the next frame even when a listener throws', () => {
+			const staleCancel = vi.fn()
+			tickManager.cancelRaf = staleCancel
+			mockEmit.mockImplementation(() => {
+				throw new Error('listener blew up')
+			})
+
+			// the error still reaches the caller, but the loop lives on
+			expect(() => tickManager.tick()).toThrow('listener blew up')
+			expect(mockRequestAnimationFrame).toHaveBeenCalled()
+			expect(tickManager.cancelRaf).not.toBe(staleCancel)
+		})
 	})
 
 	describe('dispose method', () => {

--- a/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
+++ b/packages/editor/src/lib/editor/managers/TickManager/TickManager.ts
@@ -41,9 +41,15 @@ export class TickManager extends EditorManager {
 		const elapsed = now - this.now
 		this.now = now
 
-		this.editor.emit('frame', elapsed)
-		this.editor.emit('tick', elapsed)
-		this.cancelRaf = throttleToNextFrame(this.tick)
+		// Schedule the next frame even if a listener throws. Otherwise a single throwing listener
+		// ends the loop for good, which silently stops every frame-driven behavior — camera
+		// animations, edge scrolling, pointer velocity, following — instead of failing once.
+		try {
+			this.editor.emit('frame', elapsed)
+			this.editor.emit('tick', elapsed)
+		} finally {
+			this.cancelRaf = throttleToNextFrame(this.tick)
+		}
 	}
 
 	dispose() {


### PR DESCRIPTION
In order to stop a single bad frame from silently freezing the editor for the rest of the session, this PR makes `TickManager` schedule the next frame even when a tick listener throws. Came out of review on #9903.

`tick` reschedules only *after* emitting:

```ts
this.editor.emit('frame', elapsed)
this.editor.emit('tick', elapsed)
this.cancelRaf = throttleToNextFrame(this.tick)
```

So if any listener throws, `cancelRaf` is never reassigned and no next frame is queued — the raf loop is done for good. Everything frame-driven goes with it: camera animations, edge scrolling, pointer velocity, following. Nothing tells the user, and nothing recovers short of a reload.

That failure mode is easy to reach, because plenty of tick listeners write to the store. `_animateViewport` calls `_setCamera` on every frame, so any camera animation started with a non-finite value throws from inside the emit and takes the loop down. #9903 stops that particular value getting that far, but the underlying fragility isn't specific to the camera — it's any throwing listener.

Rescheduling in a `finally` keeps the error propagating exactly as before, so a real bug still surfaces rather than being swallowed; it just no longer costs the whole frame loop. A listener that throws every frame will now report every frame, which is noisy but recoverable, and much easier to diagnose than a dead canvas.

Deliberately left alone: one throwing listener still prevents later listeners in the same `emit` from running, and a throwing `'frame'` listener still stops `'tick'` from being emitted that frame. Both are `EventEmitter` semantics that apply anywhere in the codebase, and changing them is a wider decision than this fix.

### Change type

- [x] `bugfix`

### Test plan

Covered by a unit test asserting that a throwing listener still propagates its error, that a next frame is scheduled anyway, and that the stale canceller is replaced. Verified the test fails without the change.

- [x] Unit tests

### Release notes

- Fix the editor's frame loop stopping permanently if a `tick` or `frame` listener threw, which silently disabled camera animations, edge scrolling and other frame-driven behavior.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +9 / -3    |
| Tests     | +13 / -0   |

Made with [Cursor](https://cursor.com)