### PR TITLE
chore(infra): adopt the Anthropic alert rules into the gcx tree

### DIFF
--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -31,6 +31,8 @@ Note the alert rules selector is `alertrules` — bare `rules` routes to the Ass
 
 Don't hand-reformat gcx output; it needs to round-trip. Exception: `zero-fly-health` is stored as JSON because gcx 1.0.0's YAML writer emits an invalid escape for emoji variation selectors in row titles (its own reader then rejects the file). If a pulled YAML file fails `gcx resources validate`, re-pull that resource with `-o json`.
 
+Alert rules created through Grafana's "import Prometheus rules" flow can't be pushed: they carry `converted_prometheus` provenance, and Grafana only accepts writes to a rule from the tool that owns its provenance. To adopt one, strip the `alerting.grafana.app/prometheus-rule-definition` annotation and set `grafana.com/provenance: ''` in the pulled file, then recreate the rule in Grafana with clear provenance so the push can take ownership: delete the imported group (`gcx api /api/convert/prometheus/config/v1/rules/<folder title>/<group> -X DELETE`), recreate it via `gcx api /api/v1/provisioning/folder/<folder uid>/rule-groups/<group> -X PUT -H 'X-Disable-Provenance: true' -d @group.json`, and push. Recreating grouped rules must go through that group endpoint — the resource API gcx pushes with can't add rules to groups, only update rules already in one. The three Anthropic cost rules went through this adoption on 2026-08-10 and are repo-owned now — don't re-run the integration's rule import for them, which would recreate the imported group alongside the adopted one and bring the provenance clash back.
+
 ## Deleting a resource
 
 Deleting a file here does **not** delete it in Grafana. Remove the file and run `gcx resources delete <type>/<uid>` manually.

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/8451fbba-5835-56e2-b2f5-7f5e44c520b8.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/8451fbba-5835-56e2-b2f5-7f5e44c520b8.yaml
@@ -2,22 +2,8 @@ apiVersion: rules.alerting.grafana.app/v0alpha1
 kind: AlertRule
 metadata:
   annotations:
-    alerting.grafana.app/prometheus-rule-definition: |
-      alert: AnthropicTokenRateAnomaly
-      expr: |
-          (
-            rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])
-            >
-            3 * avg_over_time(rate(gen_ai_usage_tokens_total{job=~"integrations/anthropic/.*"}[1h])[7d:1h])
-          )
-      for: 15m
-      labels:
-          severity: warning
-      annotations:
-          description: Token processing rate of {{ $value | humanize }} tokens/sec is 3x higher than the 7-day average for job {{ $labels.job }}.
-          summary: Anthropic API token rate anomaly detected.
     grafana.app/folder: anthropic
-    grafana.com/provenance: converted_prometheus
+    grafana.com/provenance: ''
     grafana.com/updateTimestamp: '2026-03-20T11:22:55Z'
     grafana.com/updatedBy: bf1wptf89bpq8d
   labels:

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/e75d2f6c-44cf-54bf-8a74-ced2e045fcb6.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/e75d2f6c-44cf-54bf-8a74-ced2e045fcb6.yaml
@@ -2,17 +2,8 @@ apiVersion: rules.alerting.grafana.app/v0alpha1
 kind: AlertRule
 metadata:
   annotations:
-    alerting.grafana.app/prometheus-rule-definition: |
-      alert: AnthropicDailyCostSpike
-      expr: "(\n  sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"}) \n  - \n  sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"} offset 1d)\n) / sum(gen_ai_cost{job=~\"integrations/anthropic/.*\"} offset 1d) > 0.5\n"
-      for: 5m
-      labels:
-          severity: warning
-      annotations:
-          description: 'Daily cost has increased by {{ $value | humanizePercentage }} compared to yesterday. Current cost increase: ${{ $value | humanize }}.'
-          summary: Anthropic API daily cost spike detected.
     grafana.app/folder: anthropic
-    grafana.com/provenance: converted_prometheus
+    grafana.com/provenance: ''
     grafana.com/updateTimestamp: '2026-03-20T11:22:55Z'
     grafana.com/updatedBy: bf1wptf89bpq8d
   labels:

--- a/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/eec2ad9e-30b9-5c8f-802f-53e26ab8fdc9.yaml
+++ b/internal/grafana/resources/alertrules.v0alpha1.rules.alerting.grafana.app/eec2ad9e-30b9-5c8f-802f-53e26ab8fdc9.yaml
@@ -2,18 +2,8 @@ apiVersion: rules.alerting.grafana.app/v0alpha1
 kind: AlertRule
 metadata:
   annotations:
-    alerting.grafana.app/prometheus-rule-definition: |
-      alert: AnthropicHighCostThreshold
-      expr: |
-          sum(gen_ai_cost{job=~"integrations/anthropic/.*"}) / 100 > 1000
-      for: 15m
-      labels:
-          severity: critical
-      annotations:
-          description: 'Total daily cost of ${{ $value | humanize }} has exceeded the $1000 threshold. Current cost: ${{ $value }}.'
-          summary: Anthropic API cost threshold exceeded.
     grafana.app/folder: anthropic
-    grafana.com/provenance: converted_prometheus
+    grafana.com/provenance: ''
     grafana.com/updateTimestamp: '2026-03-20T11:22:55Z'
     grafana.com/updatedBy: bf1wptf89bpq8d
   labels:


### PR DESCRIPTION
The first post-merge run of the Grafana deploy workflow hit Grafana's provenance guard on the three Anthropic cost rules: they were created through the "import Prometheus rules" flow, carry `converted_prometheus` provenance, and Grafana rejects writes to a rule from any tool but the one owning its provenance — so every `gcx resources push` 500'd on them, even though the same files pushed fine on 08-07 before Grafana Cloud tightened the check server-side. The rules have been adopted on the Grafana side (imported group deleted, recreated with clear provenance so the push can take ownership); this PR checks in the matching repo half — the pulled files with the `prometheus-rule-definition` annotation stripped and provenance cleared — and documents the adoption procedure in the README, including that these rules are repo-owned now and the import flow shouldn't be re-run for them.

### Change type

- [x] `other`

### Test plan

1. Merge triggers `deploy-grafana.yml`; the push should report the three Anthropic rules as in sync rather than erroring.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +5 / -36   |