### PR TITLE
fix(commenting): raise the iOS keyboard when the composer opens

### DIFF
--- a/packages/commenting/src/ui/comment-composer.tsx
+++ b/packages/commenting/src/ui/comment-composer.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react'
 import { isEqual, TLRichText, useMaybeEditor } from 'tldraw'
 import { commentTipTapExtensions, EMPTY_COMMENT, isCommentEmpty } from './comment-extensions'
+import { focusOnGestureEnd } from './gesture-focus'
 import { SendButton } from './send-button'
 
 /** @public */
@@ -257,6 +258,14 @@ export function CommentComposer({
 		if (!autoFocus || !editor) return
 		const raf = requestAnimationFrame(() => editor.commands.focus('end'))
 		return () => cancelAnimationFrame(raf)
+	}, [autoFocus, editor])
+
+	// The frame-later focus above places the caret but can't raise iOS's software keyboard, leaving
+	// the composer looking ready while it swallows every keystroke. Focus once more from the release
+	// that ends the placing gesture, which can.
+	useEffect(() => {
+		if (!autoFocus || !editor) return
+		return focusOnGestureEnd(editor.view.dom.ownerDocument, () => editor.commands.focus('end'))
 	}, [autoFocus, editor])
 
 	// The whole field behaves like the text input: clicking its empty area (the padding, or the

--- a/packages/commenting/src/ui/gesture-focus.test.ts
+++ b/packages/commenting/src/ui/gesture-focus.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+import { focusOnGestureEnd } from './gesture-focus'
+
+const pointer = (type: 'pointerdown' | 'pointerup') =>
+	document.dispatchEvent(new Event(type, { bubbles: true }))
+
+describe('focusOnGestureEnd', () => {
+	it('focuses on the release that ends the gesture the field was mounted during', () => {
+		const focus = vi.fn()
+		focusOnGestureEnd(document, focus)
+		pointer('pointerup')
+		expect(focus).toHaveBeenCalledTimes(1)
+	})
+
+	it('only focuses once, so later gestures leave the caret alone', () => {
+		const focus = vi.fn()
+		focusOnGestureEnd(document, focus)
+		pointer('pointerup')
+		pointer('pointerdown')
+		pointer('pointerup')
+		expect(focus).toHaveBeenCalledTimes(1)
+	})
+
+	it('gives up when a press comes first — that release belongs to another gesture', () => {
+		const focus = vi.fn()
+		focusOnGestureEnd(document, focus)
+		pointer('pointerdown')
+		pointer('pointerup')
+		expect(focus).not.toHaveBeenCalled()
+	})
+
+	it('stops listening once detached', () => {
+		const focus = vi.fn()
+		const stop = focusOnGestureEnd(document, focus)
+		stop()
+		pointer('pointerup')
+		expect(focus).not.toHaveBeenCalled()
+	})
+
+	it('can be detached more than once', () => {
+		const stop = focusOnGestureEnd(document, vi.fn())
+		stop()
+		expect(() => stop()).not.toThrow()
+	})
+})

--- a/packages/commenting/src/ui/gesture-focus.ts
+++ b/packages/commenting/src/ui/gesture-focus.ts
@@ -1,0 +1,29 @@
+/**
+ * iOS opens the software keyboard only for a focus that runs inside a user gesture's own task. A
+ * focus scheduled for a later frame still moves the caret, so a field can look ready while
+ * swallowing every keystroke until the reader taps it a second time.
+ *
+ * This covers the case where a field is mounted *during* a press — the comment composer opens on
+ * pointer down and settles its anchor on pointer up — by running `focus` from the native pointerup
+ * that ends the same gesture. That is late enough to survive the canvas taking focus for itself on
+ * pointer down, and still inside the gesture, so iOS raises the keyboard.
+ *
+ * A pointerdown arriving first means the mounting gesture had already ended (a field opened from a
+ * button, say), so the next release belongs to an unrelated gesture: give up rather than pull the
+ * caret somewhere the reader didn't ask for.
+ *
+ * Returns a function that detaches the listeners; safe to call more than once.
+ */
+export function focusOnGestureEnd(doc: Document, focus: () => void): () => void {
+	const stop = () => {
+		doc.removeEventListener('pointerup', onPointerUp, true)
+		doc.removeEventListener('pointerdown', stop, true)
+	}
+	function onPointerUp() {
+		stop()
+		focus()
+	}
+	doc.addEventListener('pointerup', onPointerUp, true)
+	doc.addEventListener('pointerdown', stop, true)
+	return stop
+}


### PR DESCRIPTION
On an iPad, tapping the canvas with the comment tool opened the composer with a caret already in it — but the software keyboard stayed shut, so the field looked ready and swallowed everything you typed until you tapped it a second time. In order to make placing a comment work on the first tap, this focuses the composer again from the pointerup that ends the placing gesture.

iOS opens the keyboard only for a focus that runs inside a user gesture's own task. The composer's autofocus runs a frame after mount — late enough to place the caret, too late to qualify. The comment tool opens the composer on pointer down and settles its anchor on pointer up, so that release is still to come; focusing from it is inside the gesture, and lands after the canvas has taken focus for itself. That canvas race is what the next-frame focus was there to avoid, so both remain.

A pointerdown arriving first means the mounting gesture had already ended — a composer opened from a button — so the next release belongs to an unrelated gesture and is ignored, rather than pulling the caret to the end of a body someone is part-way through editing.

Related: #9735, which raised iPad commenting problems but was closed needing specifics.

### Change type

- [x] `bugfix`

### Test plan

1. Open the commenting example on an iPad (or an iPad simulator running Safari).
2. Tap the comment button, then tap the canvas once.
3. The composer opens **and** the software keyboard comes up; typing lands without a second tap.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix the comment composer needing a second tap before you could type on iOS.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +38 / -0   |
| Tests     | +45 / -0   |
