### PR TITLE
feat(dotcom): restrict file history to tldraw staff

### DIFF
--- a/apps/dotcom/client/e2e/tests/legacy-routes.scenario.spec.ts
+++ b/apps/dotcom/client/e2e/tests/legacy-routes.scenario.spec.ts
@@ -61,19 +61,26 @@ test.describe('legacy routes', () => {
 		await expect(owner.page.getByTestId('tla-sidebar-layout')).toBeVisible()
 	})
 
-	test('legacy history routes load seeded versions', async ({ actors, scenario }) => {
+	test('legacy history routes are staff-only', async ({ actors, scenario }) => {
 		const owner = await actors.open('owner', { goto: false })
 		const fixture = await scenario.createLegacyRouteFixture(owner)
-		const visitor = await actors.open('visitor', { goto: false })
 
-		await visitor.page.goto(fixture.urls.history, { waitUntil: 'load' })
-		await expect(visitor.page.getByRole('heading', { name: 'Board history' })).toBeVisible()
+		// History is restricted to tldraw staff. The signed-in test users use @tldraw.com
+		// emails, so the owner is staff and can load history and restore versions.
+		await owner.page.goto(fixture.urls.history, { waitUntil: 'load' })
+		await expect(owner.page.getByRole('heading', { name: 'Board history' })).toBeVisible()
 		await expect
-			.poll(async () => await visitor.page.locator('.board-history').getByRole('link').count())
+			.poll(async () => await owner.page.locator('.board-history').getByRole('link').count())
 			.toBeGreaterThan(0)
 
-		await visitor.page.goto(fixture.urls.historySnapshot, { waitUntil: 'load' })
-		await visitor.homePage.isLoaded()
-		await expect(visitor.page.getByRole('button', { name: 'Restore version' })).toBeVisible()
+		await owner.page.goto(fixture.urls.historySnapshot, { waitUntil: 'load' })
+		await owner.homePage.isLoaded()
+		await expect(owner.page.getByRole('button', { name: 'Restore version' })).toBeVisible()
+
+		// Non-staff visitors (here, signed out) are redirected away from history.
+		const visitor = await actors.open('visitor', { goto: false })
+		await visitor.page.goto(fixture.urls.history, { waitUntil: 'load' })
+		await expect(visitor.page).not.toHaveURL(/history/)
+		await expect(visitor.page.getByRole('heading', { name: 'Board history' })).toHaveCount(0)
 	})
 })

--- a/apps/dotcom/client/src/routes.tsx
+++ b/apps/dotcom/client/src/routes.tsx
@@ -98,11 +98,6 @@ export function createAppRouter({
 					/>
 					{/* File view */}
 					<Route path={ROUTES.tlaFile} lazy={() => import('./tla/pages/file')} />
-					<Route path={ROUTES.tlaFileHistory} lazy={() => import('./tla/pages/file-history')} />
-					<Route
-						path={ROUTES.tlaFileHistorySnapshot}
-						lazy={() => import('./tla/pages/file-history-snapshot')}
-					/>
 					<Route
 						path={ROUTES.tlaFilePierreHistory}
 						lazy={() => import('./tla/pages/file-pierre-history')}
@@ -111,6 +106,21 @@ export function createAppRouter({
 						path={ROUTES.tlaFilePierreHistorySnapshot}
 						lazy={() => import('./tla/pages/file-pierre-history-snapshot')}
 					/>
+					<Route lazy={() => import('./tla/providers/RequireTldrawStaff')}>
+						<Route path={ROUTES.tlaFileHistory} lazy={() => import('./tla/pages/file-history')} />
+						<Route
+							path={ROUTES.tlaFileHistorySnapshot}
+							lazy={() => import('./tla/pages/file-history-snapshot')}
+						/>
+						<Route
+							path={ROUTES.tlaLegacyRoomHistory}
+							lazy={() => import('./tla/pages/legacy-history')}
+						/>
+						<Route
+							path={ROUTES.tlaLegacyRoomHistorySnapshot}
+							lazy={() => import('./tla/pages/legacy-history-snapshot')}
+						/>
+					</Route>
 
 					<Route path={ROUTES.tlaPublish} lazy={() => import('./tla/pages/publish')} />
 					<Route path={ROUTES.tlaImport} lazy={() => import('./tla/pages/import')} />
@@ -130,16 +140,6 @@ export function createAppRouter({
 					<Route
 						path={ROUTES.tlaLegacySnapshot}
 						lazy={() => import('./tla/pages/legacy-snapshot')}
-					/>
-					{/* Legacy history */}
-					<Route
-						path={ROUTES.tlaLegacyRoomHistory}
-						lazy={() => import('./tla/pages/legacy-history')}
-					/>
-					{/* Legacy history snapshot */}
-					<Route
-						path={ROUTES.tlaLegacyRoomHistorySnapshot}
-						lazy={() => import('./tla/pages/legacy-history-snapshot')}
 					/>
 					{/* Views that require login */}
 					<Route lazy={() => import('./tla/providers/RequireSignedInUser')}></Route>

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -352,37 +352,36 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 
 function CustomDebugMenu() {
 	const app = useMaybeApp()
+	const user = useTldrawCurrentUser()
 	const openAndTrack = useOpenUrlAndTrack('unknown')
 	const editor = useEditor()
 	const isReadOnly = useValue('isReadOnly', () => editor.getIsReadonly(), [editor])
 	return (
 		<DefaultDebugMenu>
 			<A11yAudit />
-			{!isReadOnly && app && (
-				<>
-					<TldrawUiMenuItem
-						id="user-manual"
-						label="File history"
-						readonlyOk
-						onSelect={() => {
-							const url = new URL(window.location.href)
-							url.pathname += '/history'
-							openAndTrack(url.toString())
-						}}
-					/>
-					{!isProductionEnv && (
-						<TldrawUiMenuItem
-							id="user-manual"
-							label="File history (pierre)"
-							readonlyOk
-							onSelect={() => {
-								const url = new URL(window.location.href)
-								url.pathname += '/pierre-history'
-								openAndTrack(url.toString())
-							}}
-						/>
-					)}
-				</>
+			{!isReadOnly && app && user?.isTldraw && (
+				<TldrawUiMenuItem
+					id="user-manual"
+					label="File history"
+					readonlyOk
+					onSelect={() => {
+						const url = new URL(window.location.href)
+						url.pathname += '/history'
+						openAndTrack(url.toString())
+					}}
+				/>
+			)}
+			{!isReadOnly && app && !isProductionEnv && (
+				<TldrawUiMenuItem
+					id="user-manual"
+					label="File history (pierre)"
+					readonlyOk
+					onSelect={() => {
+						const url = new URL(window.location.href)
+						url.pathname += '/pierre-history'
+						openAndTrack(url.toString())
+					}}
+				/>
 			)}
 			<DefaultDebugMenuContent />
 		</DefaultDebugMenu>

--- a/apps/dotcom/client/src/tla/hooks/getIsTldrawStaff.test.ts
+++ b/apps/dotcom/client/src/tla/hooks/getIsTldrawStaff.test.ts
@@ -1,0 +1,41 @@
+import type { UserResource } from '@clerk/types'
+import { describe, expect, it } from 'vitest'
+import { getIsTldrawStaff } from './useUser'
+
+function userWith(email: string | undefined, status: string | undefined): UserResource {
+	return {
+		primaryEmailAddress: email
+			? {
+					emailAddress: email,
+					verification: status ? { status } : undefined,
+				}
+			: null,
+	} as unknown as UserResource
+}
+
+describe('getIsTldrawStaff', () => {
+	it('is false for null/undefined users', () => {
+		expect(getIsTldrawStaff(null)).toBe(false)
+		expect(getIsTldrawStaff(undefined)).toBe(false)
+	})
+
+	it('is true for a verified @tldraw.com email', () => {
+		expect(getIsTldrawStaff(userWith('jane@tldraw.com', 'verified'))).toBe(true)
+	})
+
+	it('is false for a verified non-tldraw email', () => {
+		expect(getIsTldrawStaff(userWith('jane@gmail.com', 'verified'))).toBe(false)
+	})
+
+	it('is false for an unverified @tldraw.com email', () => {
+		expect(getIsTldrawStaff(userWith('jane@tldraw.com', 'unverified'))).toBe(false)
+	})
+
+	it('is false (not throwing) when verification is missing', () => {
+		expect(getIsTldrawStaff(userWith('jane@tldraw.com', undefined))).toBe(false)
+	})
+
+	it('is false when there is no primary email', () => {
+		expect(getIsTldrawStaff(userWith(undefined, undefined))).toBe(false)
+	})
+})

--- a/apps/dotcom/client/src/tla/hooks/useUser.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useUser.tsx
@@ -66,8 +66,3 @@ export function useLoggedInUser() {
 	if (!user) throw new Error('User not signed in')
 	return user
 }
-
-export function useIsTldrawStaff() {
-	const { user } = useClerkUser()
-	return getIsTldrawStaff(user)
-}

--- a/apps/dotcom/client/src/tla/hooks/useUser.tsx
+++ b/apps/dotcom/client/src/tla/hooks/useUser.tsx
@@ -12,6 +12,13 @@ interface TldrawUser {
 }
 const UserContext = createContext<null | TldrawUser>(null)
 
+export function getIsTldrawStaff(clerkUser: UserResource | null | undefined) {
+	return (
+		clerkUser?.primaryEmailAddress?.verification?.status === 'verified' &&
+		clerkUser.primaryEmailAddress.emailAddress.endsWith('@tldraw.com')
+	)
+}
+
 export function UserProvider({ children }: { children: ReactNode }) {
 	const { isLoaded, ...others } = useClerkUser()
 	const user = useShallowObjectIdentity(others.user)
@@ -33,9 +40,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
 		return {
 			id: storeUser.id,
 			clerkUser: user,
-			isTldraw:
-				user?.primaryEmailAddress?.verification.status === 'verified' &&
-				user.primaryEmailAddress.emailAddress.endsWith('@tldraw.com'),
+			isTldraw: getIsTldrawStaff(user),
 			getToken: async () => {
 				const token = await getToken()
 				assert(token)
@@ -60,4 +65,9 @@ export function useLoggedInUser() {
 	const user = useTldrawCurrentUser()
 	if (!user) throw new Error('User not signed in')
 	return user
+}
+
+export function useIsTldrawStaff() {
+	const { user } = useClerkUser()
+	return getIsTldrawStaff(user)
 }

--- a/apps/dotcom/client/src/tla/providers/RequireTldrawStaff.tsx
+++ b/apps/dotcom/client/src/tla/providers/RequireTldrawStaff.tsx
@@ -1,0 +1,14 @@
+import { useUser } from '@clerk/clerk-react'
+import { Navigate, Outlet } from 'react-router-dom'
+import { routes } from '../../routeDefs'
+import { getIsTldrawStaff } from '../hooks/useUser'
+
+export function Component() {
+	// Read isLoaded and user from the same Clerk subscription so we never decide
+	// staff-ness from a half-loaded user (which would fail closed and bounce staff).
+	const { isLoaded, user } = useUser()
+
+	if (!isLoaded) return null
+	if (!getIsTldrawStaff(user)) return <Navigate to={routes.tlaRoot()} replace />
+	return <Outlet />
+}

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -51,7 +51,7 @@ import {
 import { ExecutionQueue, assert, assertExists, exhaustiveSwitchError, retry } from '@tldraw/utils'
 import { createSentry, isValidR2ObjectName } from '@tldraw/worker-shared'
 import { DurableObject } from 'cloudflare:workers'
-import { IRequest, Router } from 'itty-router'
+import { IRequest, Router, StatusError } from 'itty-router'
 import { Kysely, PostgresDialect } from 'kysely'
 import PQueue from 'p-queue'
 import { collectAssetAssociationChanges } from './assetAssociation'
@@ -89,7 +89,7 @@ import { reconstructSnapshotFromPierre } from './utils/pierreSnapshot'
 import { isRateLimited } from './utils/rateLimit'
 import { getSlug } from './utils/roomOpenMode'
 import { throttle } from './utils/throttle'
-import { getAuth, requireAdminAccess, requireWriteAccessToFile } from './utils/tla/getAuth'
+import { getAuth, requireAdminAccess, requireAdminAccessToRequest } from './utils/tla/getAuth'
 import { getLegacyRoomData } from './utils/tla/getLegacyRoomData'
 import { getRole } from './utils/tla/getRole'
 import { isTestFile } from './utils/tla/isTestFile'
@@ -514,6 +514,11 @@ export class TLFileDurableObject extends DurableObject {
 		try {
 			return await this.router.fetch(req)
 		} catch (err) {
+			// Auth failures (e.g. non-staff hitting restore) are expected denials, not
+			// server errors: return their real status instead of a 500 + Sentry noise.
+			if (err instanceof StatusError) {
+				return new Response(err.message, { status: err.status })
+			}
 			console.error(err)
 			// eslint-disable-next-line @typescript-eslint/no-deprecated
 			sentry?.captureException(err)
@@ -581,9 +586,7 @@ export class TLFileDurableObject extends DurableObject {
 			if (isPierre && !this.documentInfo.isApp) {
 				return new Response('Pierre restore must be for an app file', { status: 400 })
 			}
-			if (this.documentInfo.isApp) {
-				await requireWriteAccessToFile(req, this.env, this.documentInfo.slug)
-			}
+			await requireAdminAccessToRequest(req, this.env)
 			let dataText = ''
 			const roomId = this.documentInfo.slug
 			const roomKey = getR2KeyForRoom({ slug: roomId, isApp: this.documentInfo.isApp })

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistory.ts
@@ -4,7 +4,7 @@ import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../r2'
 import { Environment } from '../types'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
-import { requireWriteAccessToFile } from '../utils/tla/getAuth'
+import { requireAdminAccessToRequest } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
 
 function getMonthPrefix(date: Date): string {
@@ -78,9 +78,7 @@ export async function getRoomHistory(
 	if (!roomId) return notFound()
 	if (isRoomIdTooLong(roomId)) return roomIdIsTooLong()
 
-	if (isApp) {
-		await requireWriteAccessToFile(request, env, roomId)
-	}
+	await requireAdminAccessToRequest(request, env)
 
 	if (isTestFile(roomId)) {
 		return new Response('Not found', { status: 404 })

--- a/apps/dotcom/sync-worker/src/routes/getRoomHistorySnapshot.ts
+++ b/apps/dotcom/sync-worker/src/routes/getRoomHistorySnapshot.ts
@@ -3,7 +3,7 @@ import { IRequest } from 'itty-router'
 import { getR2KeyForRoom } from '../r2'
 import { Environment } from '../types'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
-import { requireWriteAccessToFile } from '../utils/tla/getAuth'
+import { requireAdminAccessToRequest } from '../utils/tla/getAuth'
 import { isTestFile } from '../utils/tla/isTestFile'
 
 // Get a snapshot of the room at a given point in time
@@ -17,9 +17,7 @@ export async function getRoomHistorySnapshot(
 	if (!roomId) return notFound()
 	if (isRoomIdTooLong(roomId)) return roomIdIsTooLong()
 
-	if (isApp) {
-		await requireWriteAccessToFile(request, env, roomId)
-	}
+	await requireAdminAccessToRequest(request, env)
 
 	if (isTestFile(roomId)) {
 		return new Response('Not found', { status: 404 })

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authenticateRequest = vi.fn()
+const getUser = vi.fn()
+
+vi.mock('@clerk/backend', () => ({
+	createClerkClient: () => ({
+		authenticateRequest,
+		users: { getUser },
+	}),
+}))
+
+// Import after the mock is registered.
+import { requireAdminAccessToRequest } from './getAuth'
+
+const env = {
+	CLERK_SECRET_KEY: 'sk',
+	CLERK_PUBLISHABLE_KEY: 'pk',
+} as any
+
+function signedInAs(userId: string | null) {
+	authenticateRequest.mockResolvedValue({
+		isSignedIn: !!userId,
+		toAuth: () => (userId ? { userId } : null),
+	})
+}
+
+const request = {
+	url: 'https://tldraw.com/',
+	clone: () => request,
+	headers: new Headers(),
+} as any
+
+describe('requireAdminAccessToRequest', () => {
+	beforeEach(() => {
+		authenticateRequest.mockReset()
+		getUser.mockReset()
+	})
+
+	it('throws 401 when not signed in', async () => {
+		signedInAs(null)
+		await expect(requireAdminAccessToRequest(request, env)).rejects.toMatchObject({ status: 401 })
+	})
+
+	it('throws 403 for a non-staff email', async () => {
+		signedInAs('user_1')
+		getUser.mockResolvedValue({
+			primaryEmailAddress: { emailAddress: 'jane@gmail.com', verification: { status: 'verified' } },
+		})
+		await expect(requireAdminAccessToRequest(request, env)).rejects.toMatchObject({ status: 403 })
+	})
+
+	it('throws 403 for an unverified @tldraw.com email', async () => {
+		signedInAs('user_1')
+		getUser.mockResolvedValue({
+			primaryEmailAddress: {
+				emailAddress: 'jane@tldraw.com',
+				verification: { status: 'unverified' },
+			},
+		})
+		await expect(requireAdminAccessToRequest(request, env)).rejects.toMatchObject({ status: 403 })
+	})
+
+	it('resolves for a verified @tldraw.com email', async () => {
+		signedInAs('user_1')
+		const user = {
+			primaryEmailAddress: {
+				emailAddress: 'jane@tldraw.com',
+				verification: { status: 'verified' },
+			},
+		}
+		getUser.mockResolvedValue(user)
+		await expect(requireAdminAccessToRequest(request, env)).resolves.toBe(user)
+	})
+})

--- a/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
+++ b/apps/dotcom/sync-worker/src/utils/tla/getAuth.ts
@@ -135,3 +135,7 @@ export async function requireAdminAccess(env: Environment, auth: { userId: strin
 	}
 	return user
 }
+
+export async function requireAdminAccessToRequest(request: IRequest, env: Environment) {
+	return requireAdminAccess(env, await requireAuth(request, env))
+}


### PR DESCRIPTION
In order to make file history a staff-only tool, this PR restricts every history surface — the file (`/f/`) and legacy room (`/r/`) history lists, their snapshots, and restore — to verified tldraw staff (a verified `@tldraw.com` email). Previously any user with write access to a file could browse and restore its history, and legacy non-app `/r/` history had no auth at all.

Enforcement lives in the sync-worker, which is the real security boundary: the two history read handlers and the restore handler now call a new `requireAdminAccessToRequest` gate unconditionally (replacing the old per-file write-access check). Dropping the `isApp` conditionality is deliberate — it also closes the gap where legacy `/r/` history and restore were unauthenticated. The client changes are cosmetic defense-in-depth: a `RequireTldrawStaff` route guard redirects non-staff away from history URLs, and the "File history" debug-menu entry is hidden from non-staff.

Two behavior changes worth calling out for reviewers:

- File owners can no longer restore their own file's history — restore is staff-only now, full stop.
- Legacy non-app `/r/` room history and restore are now gated (they had no auth before).

Pierre history (a dev-only, non-production debug tool) is intentionally left untouched — it isn't backed by the R2 ephemeral history bucket this change is about.

As a side effect the file durable object now returns a thrown `StatusError`'s real status, so a denied restore surfaces as `403` instead of a generic `500` + Sentry noise.

### Change type

- [x] `improvement`

### Test plan

1. As a non-`@tldraw.com` user, open `/f/<fileSlug>/history` (and `/history/<timestamp>`) → redirected to `/`; the `/api/f/<slug>/history` request returns `403`.
2. As a staff (`@tldraw.com`) user, the history list, a snapshot, and restore all work.
3. Repeat for a legacy `/r/<roomId>/history` URL → same staff gating.
4. In an editor, open the debug menu: the "File history" item is present for staff, absent for non-staff.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Restrict file and legacy room history (viewing, snapshots, and restore) on tldraw.com to tldraw staff.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Tests           | +116 / -0  |
| Apps            | +77 / -56  |
