### PR TITLE
chore(dotcom): stop the dev readiness probe from spamming outbox-status logs

### DIFF
--- a/apps/dotcom/process-compose.yaml
+++ b/apps/dotcom/process-compose.yaml
@@ -2,8 +2,7 @@
 
 version: '0.5'
 
-# Readiness = TCP connect (a portable node one-liner; wrangler's `/` 404s, so http_get won't do),
-# except sync-worker, which probes a real route (see its probe comment).
+# Readiness = TCP connect (a portable node one-liner; wrangler's `/` 404s, so http_get won't do).
 
 processes:
   # postgres + pgbouncer — the two containers (wal2json / logical replication)
@@ -64,17 +63,23 @@ processes:
     depends_on:
       zero-cache:
         condition: process_healthy
-    # Probing /app/outbox-status (not a bare TCP connect) also wakes the outbox processor DO —
-    # local workerd doesn't fire persisted alarms for an uninstantiated DO, so without this a
-    # restarted stack wouldn't drain trigger-only writes until the first mutation.
     readiness_probe:
-      http_get:
-        host: 127.0.0.1
-        port: 8787
-        path: /app/outbox-status
+      exec:
+        command: node -e "require('net').connect(8787,'127.0.0.1').on('connect',function(){this.end();process.exit(0)}).on('error',()=>process.exit(1))"
       initial_delay_seconds: 3
       period_seconds: 2
       failure_threshold: 60
+
+  # one-shot wake of the outbox processor DO — local workerd doesn't fire persisted alarms for an
+  # uninstantiated DO, so without this a restarted stack wouldn't drain trigger-only writes until
+  # the first mutation. A one-shot (not the readiness probe) so it doesn't poke every 2s forever.
+  wake-outbox:
+    command: node -e "fetch('http://127.0.0.1:8787/app/outbox-status').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+    depends_on:
+      sync-worker:
+        condition: process_healthy
+    availability:
+      restart: 'no'
 
   asset-upload-worker:
     command: yarn workspace dotcom-asset-upload dev

--- a/apps/dotcom/sync-worker/src/worker.ts
+++ b/apps/dotcom/sync-worker/src/worker.ts
@@ -151,7 +151,7 @@ const router = createRouter<Environment>()
 	})
 	// Dev/preview only. Wakes the outbox processor: local workerd doesn't fire persisted alarms
 	// for an uninstantiated DO, so without this a restarted dev stack drains nothing until the
-	// first mutation. The dev stack's readiness probe hits this route.
+	// first mutation. The dev stack's one-shot wake-outbox process hits this route on startup.
 	.get('/app/outbox-status', async (_, env) => {
 		if (!isDebugLogging(env)) return notFound()
 		await getFileEffectProcessor(env).poke()


### PR DESCRIPTION
In order to keep the dev stack's wrangler logs readable, this PR stops the sync-worker readiness probe from hitting `/app/outbox-status` every 2 seconds. #9893 pointed the probe at that route so a restarted dev stack wakes the outbox processor DO (local workerd doesn't fire persisted alarms for an uninstantiated DO), but process-compose readiness probes are health monitors that poll for the process's whole lifetime — so wrangler logged a `GET /app/outbox-status` line every 2s forever and the DO never idled.

This restores the plain TCP-connect readiness probe sync-worker had before #9893 and moves the wake to a one-shot `wake-outbox` process that hits the route once after sync-worker is healthy.

One-shot means the wake doesn't re-fire when sync-worker restarts or wrangler hot-reloads (process-compose never re-runs completed dependents; verified in the v1.116.0 source). That's fine: every zero mutation already pokes the processor via `waitUntil` on `/app/zero/mutate`, so any backlog drains on the next interaction — the one-shot only needs to cover a freshly started stack with pre-existing undrained rows.

### Change type

- [x] `other`

### Test plan

1. `yarn dev-app`
2. `wake-outbox` runs once and completes; sync-worker still reaches healthy and its dependents start.
3. No recurring `GET /app/outbox-status` lines in the sync-worker logs.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +15 / -10  |
