### PR TITLE
fix(sync): stop background tabs from reconnect-looping

### DIFF
--- a/apps/dotcom/client/src/tla/app/TldrawApp.ts
+++ b/apps/dotcom/client/src/tla/app/TldrawApp.ts
@@ -91,6 +91,20 @@ export function shouldEnableCommenting(
 	return { value: flags.commenting_enabled?.enabled ?? false, reason: 'server feature flag' }
 }
 
+/**
+ * Whether the sync websocket should suspend in hidden tabs. Staff (@tldraw.com email) always have
+ * it; everyone else waits on the `hidden_tab_suspend` flag.
+ */
+export function shouldSuspendHiddenTab(
+	flags: FeatureFlags,
+	email?: string | null
+): { value: boolean; reason: string } {
+	if (email?.endsWith('@tldraw.com')) {
+		return { value: true, reason: '@tldraw.com email' }
+	}
+	return { value: flags.hidden_tab_suspend?.enabled ?? false, reason: 'server feature flag' }
+}
+
 /** When the user last opened the file (visit, else edit, else first visit), or undefined if never. */
 export function getFileVisitDate(state: TlaFileState | undefined): number | undefined {
 	return state?.lastVisitAt ?? state?.lastEditAt ?? state?.firstVisitAt ?? undefined
@@ -177,6 +191,9 @@ export class TldrawApp {
 	/** Whether this user gets the commenting UI — see {@link shouldEnableCommenting}. */
 	readonly isCommentingEnabled: boolean
 
+	/** Whether the sync websocket suspends in hidden tabs — see {@link shouldSuspendHiddenTab}. */
+	readonly isHiddenTabSuspendEnabled: boolean
+
 	private readonly abortController = new AbortController()
 	readonly disposables: (() => void)[] = [() => this.abortController.abort(), () => this.z.close()]
 	private getToken: () => Promise<string | undefined>
@@ -242,6 +259,7 @@ export class TldrawApp {
 		this.trackEvent = trackEvent
 		this.getToken = getToken
 		this.isCommentingEnabled = shouldEnableCommenting(flags, email).value
+		this.isHiddenTabSuspendEnabled = shouldSuspendHiddenTab(flags, email).value
 		// Exposed as __test__triggerClientTooOld below so e2e can exercise the real recovery UI
 		// without a live schema/protocol mismatch against zero-cache.
 		if (window.navigator.webdriver) {

--- a/apps/dotcom/client/src/tla/app/shouldEnableCommenting.test.ts
+++ b/apps/dotcom/client/src/tla/app/shouldEnableCommenting.test.ts
@@ -1,16 +1,22 @@
 import { describe, expect, it } from 'vitest'
 import type { FeatureFlags } from '../utils/FeatureFlagPoller'
-import { shouldEnableCommenting } from './TldrawApp'
+import { shouldEnableCommenting, shouldSuspendHiddenTab } from './TldrawApp'
 
 const FLAGS_OFF: FeatureFlags = {
 	rum_enabled: { enabled: false },
 	commenting_enabled: { enabled: false },
 	mcp_friends_and_family: { enabled: false },
+	hidden_tab_suspend: { enabled: false },
 }
 
 const FLAGS_COMMENTING_ON: FeatureFlags = {
 	...FLAGS_OFF,
 	commenting_enabled: { enabled: true },
+}
+
+const FLAGS_HIDDEN_TAB_SUSPEND_ON: FeatureFlags = {
+	...FLAGS_OFF,
+	hidden_tab_suspend: { enabled: true },
 }
 
 describe('shouldEnableCommenting', () => {
@@ -50,5 +56,35 @@ describe('shouldEnableCommenting', () => {
 	it('handles a null email', () => {
 		expect(shouldEnableCommenting(FLAGS_OFF, null).value).toBe(false)
 		expect(shouldEnableCommenting(FLAGS_COMMENTING_ON, null).value).toBe(true)
+	})
+})
+
+describe('shouldSuspendHiddenTab', () => {
+	it('is off with default flags and no email', () => {
+		expect(shouldSuspendHiddenTab(FLAGS_OFF)).toEqual({
+			value: false,
+			reason: 'server feature flag',
+		})
+	})
+
+	it('is on for a @tldraw.com email even when the flag is off', () => {
+		expect(shouldSuspendHiddenTab(FLAGS_OFF, 'dev@tldraw.com')).toEqual({
+			value: true,
+			reason: '@tldraw.com email',
+		})
+	})
+
+	it('is on for anyone when the flag is on', () => {
+		expect(shouldSuspendHiddenTab(FLAGS_HIDDEN_TAB_SUSPEND_ON, 'alice@example.com')).toEqual({
+			value: true,
+			reason: 'server feature flag',
+		})
+	})
+
+	it('is off for a non-tldraw email when the flag is off', () => {
+		expect(shouldSuspendHiddenTab(FLAGS_OFF, 'alice@example.com')).toEqual({
+			value: false,
+			reason: 'server feature flag',
+		})
 	})
 })

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -1,13 +1,16 @@
 import { CommentTool, commentToolOverrides } from '@tldraw/commenting'
 import { TLCustomServerEvent, getLicenseKey } from '@tldraw/dotcom-shared'
 import { useSync } from '@tldraw/sync'
+import { TLSyncClient } from '@tldraw/sync-core'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
 	DefaultDebugMenu,
 	DefaultDebugMenuContent,
 	Editor,
 	TLComponents,
+	TLRecord,
 	TLSessionStateSnapshot,
+	TLStore,
 	TLUiDialogsContextType,
 	TLUserStore,
 	Tldraw,
@@ -42,6 +45,7 @@ import { globalEditor } from '../../../utils/globalEditor'
 import { multiplayerAssetStore } from '../../../utils/multiplayerAssetStore'
 import { TldrawApp } from '../../app/TldrawApp'
 import { useMaybeApp } from '../../hooks/useAppState'
+import { useHiddenTabSuspend } from '../../hooks/useHiddenTabSuspend'
 import { useIsCommentingEnabled } from '../../hooks/useIsCommentingEnabled'
 import { ReadyWrapper, useSetIsReady } from '../../hooks/useIsReady'
 import { useNewRoomCreationTracking } from '../../hooks/useNewRoomCreationTracking'
@@ -232,6 +236,9 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		}
 	}, [app?.tlUser.userPreferences])
 
+	const syncClientRef = useRef<TLSyncClient<TLRecord, TLStore> | null>(null)
+	useHiddenTabSuspend(syncClientRef)
+
 	const store = useSync({
 		uri: useCallback(async () => {
 			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileSlug}`)
@@ -247,6 +254,9 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 		records: commentSchemaRecords,
 		onCustomMessageReceived: useCallback((message: TLCustomServerEvent) => {
 			trackEvent(message.type)
+		}, []),
+		onSyncClientCreated: useCallback((client: TLSyncClient<TLRecord, TLStore>) => {
+			syncClientRef.current = client
 		}, []),
 	})
 

--- a/apps/dotcom/client/src/tla/hooks/useHiddenTabSuspend.ts
+++ b/apps/dotcom/client/src/tla/hooks/useHiddenTabSuspend.ts
@@ -39,7 +39,11 @@ export function useHiddenTabSuspend(clientRef: RefObject<TLSyncClient<TLRecord, 
 			if (paused || document.visibilityState !== 'hidden' || hiddenAt === null) return
 			const client = clientRef.current
 			const adapter = getAdapter()
-			if (!client || !adapter) return
+			// client/adapter may not exist yet (or mid-recreation); keep retrying rather than giving up
+			if (!client || !adapter) {
+				timer = setTimeout(trySuspend, RETRY_INTERVAL_MS)
+				return
+			}
 			// unconfirmed changes must drain before we cut the socket; check again later
 			if (Date.now() - hiddenAt < SUSPEND_AFTER_HIDDEN_MS || client.hasPendingChanges()) {
 				timer = setTimeout(trySuspend, RETRY_INTERVAL_MS)
@@ -49,24 +53,34 @@ export function useHiddenTabSuspend(clientRef: RefObject<TLSyncClient<TLRecord, 
 			paused = true
 		}
 
+		// arms the suspend timer for an already-hidden tab; also covers tabs that mount hidden
+		function enterHidden() {
+			if (hiddenAt !== null) return
+			hiddenAt = Date.now()
+			timer = setTimeout(trySuspend, SUSPEND_AFTER_HIDDEN_MS)
+		}
+
 		function resume() {
 			hiddenAt = null
 			clearTimer()
-			if (!paused) return
-			paused = false
-			getAdapter()?.resume()
+			if (paused) {
+				paused = false
+				getAdapter()?.resume()
+			}
+			// spurious resume (e.g. synthetic input) while still hidden: restart the suspend chain
+			if (document.visibilityState === 'hidden') enterHidden()
 		}
 
 		function onVisibilityChange() {
 			if (document.visibilityState === 'hidden') {
-				if (hiddenAt === null) {
-					hiddenAt = Date.now()
-					timer = setTimeout(trySuspend, SUSPEND_AFTER_HIDDEN_MS)
-				}
+				enterHidden()
 			} else {
 				resume()
 			}
 		}
+
+		// a tab opened in the background starts hidden and gets no visibilitychange event until revealed
+		if (document.visibilityState === 'hidden') enterHidden()
 
 		// user input implies visible even if a visibility event was missed
 		document.addEventListener('visibilitychange', onVisibilityChange)
@@ -78,7 +92,7 @@ export function useHiddenTabSuspend(clientRef: RefObject<TLSyncClient<TLRecord, 
 			document.removeEventListener('visibilitychange', onVisibilityChange)
 			document.removeEventListener('pointerdown', resume, { capture: true })
 			document.removeEventListener('keydown', resume, { capture: true })
-			// never leave a socket paused behind us
+			// never leave a socket paused behind us; safe no-op if useSync's cleanup already closed the socket
 			if (paused) getAdapter()?.resume()
 		}
 	}, [enabled, clientRef])

--- a/apps/dotcom/client/src/tla/hooks/useHiddenTabSuspend.ts
+++ b/apps/dotcom/client/src/tla/hooks/useHiddenTabSuspend.ts
@@ -1,0 +1,85 @@
+import { ClientWebSocketAdapter, TLSyncClient } from '@tldraw/sync-core'
+import { RefObject, useEffect } from 'react'
+import { TLRecord, TLStore } from 'tldraw'
+import { useMaybeApp } from './useAppState'
+
+/** How long a tab must stay hidden before its sync socket is dropped; must comfortably exceed quick tab-switch flapping */
+const SUSPEND_AFTER_HIDDEN_MS = 2 * 60 * 1000
+/** Re-check cadence while waiting for pending changes to drain (the browser throttles this to ~1/min when hidden) */
+const RETRY_INTERVAL_MS = 10 * 1000
+
+/**
+ * Suspends the sync websocket while the tab is hidden so the server room can go idle,
+ * and resumes it the moment the tab is visible again. Gated by the hidden_tab_suspend flag.
+ */
+export function useHiddenTabSuspend(clientRef: RefObject<TLSyncClient<TLRecord, TLStore> | null>) {
+	const enabled = useMaybeApp()?.isHiddenTabSuspendEnabled ?? false
+
+	useEffect(() => {
+		if (!enabled) return
+
+		let hiddenAt: number | null = null
+		let timer: ReturnType<typeof setTimeout> | null = null
+		let paused = false
+
+		function getAdapter(): ClientWebSocketAdapter | null {
+			const socket = clientRef.current?.socket
+			return socket instanceof ClientWebSocketAdapter && !socket.isDisposed ? socket : null
+		}
+
+		function clearTimer() {
+			if (timer) {
+				clearTimeout(timer)
+				timer = null
+			}
+		}
+
+		function trySuspend() {
+			timer = null
+			if (paused || document.visibilityState !== 'hidden' || hiddenAt === null) return
+			const client = clientRef.current
+			const adapter = getAdapter()
+			if (!client || !adapter) return
+			// unconfirmed changes must drain before we cut the socket; check again later
+			if (Date.now() - hiddenAt < SUSPEND_AFTER_HIDDEN_MS || client.hasPendingChanges()) {
+				timer = setTimeout(trySuspend, RETRY_INTERVAL_MS)
+				return
+			}
+			adapter.pause()
+			paused = true
+		}
+
+		function resume() {
+			hiddenAt = null
+			clearTimer()
+			if (!paused) return
+			paused = false
+			getAdapter()?.resume()
+		}
+
+		function onVisibilityChange() {
+			if (document.visibilityState === 'hidden') {
+				if (hiddenAt === null) {
+					hiddenAt = Date.now()
+					timer = setTimeout(trySuspend, SUSPEND_AFTER_HIDDEN_MS)
+				}
+			} else {
+				resume()
+			}
+		}
+
+		// user input implies visible even if a visibility event was missed
+		document.addEventListener('visibilitychange', onVisibilityChange)
+		document.addEventListener('pointerdown', resume, { capture: true })
+		document.addEventListener('keydown', resume, { capture: true })
+
+		return () => {
+			clearTimer()
+			document.removeEventListener('visibilitychange', onVisibilityChange)
+			document.removeEventListener('pointerdown', resume, { capture: true })
+			document.removeEventListener('keydown', resume, { capture: true })
+			// never leave a socket paused behind us
+			if (paused) getAdapter()?.resume()
+		}
+	}, [enabled, clientRef])
+}

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.test.ts
@@ -13,6 +13,7 @@ function makeFlags(overrides: Partial<FeatureFlags> = {}): FeatureFlags {
 		rum_enabled: { enabled: false },
 		commenting_enabled: { enabled: false },
 		mcp_friends_and_family: { enabled: false },
+		hidden_tab_suspend: { enabled: false },
 		...overrides,
 	}
 }

--- a/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
+++ b/apps/dotcom/client/src/tla/utils/FeatureFlagPoller.tsx
@@ -8,6 +8,7 @@ export const DEFAULT_FLAGS: FeatureFlags = {
 	rum_enabled: { enabled: false },
 	commenting_enabled: { enabled: false },
 	mcp_friends_and_family: { enabled: false },
+	hidden_tab_suspend: { enabled: false },
 }
 
 let currentFlags: FeatureFlags = { ...DEFAULT_FLAGS }

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.test.ts
@@ -285,6 +285,7 @@ describe('getFeatureFlagsAdmin (route handler)', () => {
 
 		expect(Object.keys(body).sort()).toEqual([
 			'commenting_enabled',
+			'hidden_tab_suspend',
 			'mcp_friends_and_family',
 			'rum_enabled',
 		])

--- a/apps/dotcom/sync-worker/src/utils/featureFlags.ts
+++ b/apps/dotcom/sync-worker/src/utils/featureFlags.ts
@@ -29,6 +29,13 @@ function getFlagDefaults(_env: Environment): Record<FeatureFlagKey, FeatureFlagV
 			description:
 				'Raises the /app/mcp rate limits for signed-in callers on the friends and family list (edited below)',
 		},
+		hidden_tab_suspend: {
+			type: 'percentage',
+			percentage: 0,
+			enabled: false,
+			description:
+				'Suspend the sync websocket in tabs hidden for 2+ minutes so file rooms can hibernate. Users with a @tldraw.com email always have it, regardless of this flag',
+		},
 	}
 }
 

--- a/packages/dotcom-shared/src/types.ts
+++ b/packages/dotcom-shared/src/types.ts
@@ -338,6 +338,7 @@ export const FEATURE_FLAG_KEYS = [
 	'rum_enabled',
 	'commenting_enabled',
 	'mcp_friends_and_family',
+	'hidden_tab_suspend',
 ] as const
 export type FeatureFlagKey = (typeof FEATURE_FLAG_KEYS)[number]
 

--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -154,6 +154,8 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **CW8** `restart()` closes the current socket (notifying `'offline'`) and starts a reconnection attempt.
 - **CW9** `close()` disposes the adapter: `restart`, `sendMessage`, and listener registration then throw; `close` itself is idempotent.
 - **CW10** Events from orphaned sockets (a socket replaced after `restart`/offline handling) are ignored — they cannot change status.
+- **CW11** `pause()` closes the active socket (reporting `'offline'`) and puts the adapter into a paused state in which no reconnection attempts are made. Pausing an already-paused adapter is a no-op. After `close()` it throws.
+- **CW12** `resume()` leaves the paused state, resets the backoff, and immediately starts a reconnection attempt. Resuming a non-paused adapter is a no-op. After `close()` it throws.
 
 ## 18. `ReconnectManager` (RM) — internal
 
@@ -162,6 +164,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **RM3** The window `offline` event closes the active socket (which triggers the reconnect cycle).
 - **RM4** Reconnect hints (window `online`, the document becoming visible) call `maybeReconnected`: a socket that is OPEN is left alone; one that is CONNECTING for less than `ATTEMPT_TIMEOUT` (1s) is rechecked later; one CONNECTING for longer is closed and retried; otherwise the backoff is reset and a reconnect attempt happens immediately (honoring the minimum delay).
 - **RM5** `close()` cancels all timers and event listeners.
+- **RM6** While paused, both `disconnected()` and `maybeReconnected()` return without scheduling anything, so neither backoff timers nor reconnect hints (window `online`, document visibility, `navigator.connection` changes) can start a connection. Pausing cancels any already-scheduled attempt timers, and an in-flight attempt (a pending `getUri`) aborts before opening a socket.
 
 ## 19. `TLSyncClient` — connection lifecycle (CL)
 

--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -173,11 +173,12 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **CL6** With `hydrationType: 'wipe_all'`, all document records are additionally wiped before the server's diff is applied; speculative changes still re-apply on top afterwards.
 - **CL7** After connecting, `onAfterConnect` is called with `{ isReadonly }` from the connect message, and the current presence state (if any) is pushed.
 - **CL8** When the socket goes `'offline'`, the client resets: presence records are removed from the store, pending and unsent pushes are dropped, and the client waits to reconnect. When the socket reports `'error'`, `onSyncError(reason)` fires and the client closes permanently.
-- **CL9** While connected, a ping is sent every 5 seconds; if nothing has been heard from the server for 10 seconds, the client warns and restarts the socket.
+- **CL9** While connected, a ping is sent every 5 seconds; the client warns and restarts the socket only when nothing has been heard from the server for 10 seconds AND a ping has been outstanding and unanswered for more than 10 seconds (`PONG_TIMEOUT`). Staleness without an unanswered ping (e.g. a throttled hidden tab whose own ping loop stopped) never resets.
 - **CL10** A `pong` (or any server message) refreshes the server-interaction timestamp.
 - **CL11** When `didCancel` is provided and returns true, the next event causes the client to close instead of processing.
 - **CL12** `close()` disposes all listeners and timers and removes the `window.tlsync` debugging reference (which construction installs).
 - **CL13** An `incompatibility_error` server message is legacy: it is logged as an error and otherwise ignored.
+- **CL14** The unanswered-ping marker advances only when the previous ping was answered (oldest-outstanding semantics), so a half-open socket that still accepts sends cannot defer detection indefinitely. The marker clears on connection reset.
 
 ## 20. `TLSyncClient` — pushing changes (CP)
 

--- a/packages/sync-core/SPEC.md
+++ b/packages/sync-core/SPEC.md
@@ -192,6 +192,7 @@ These rules hold for both `InMemorySyncStorage` and `SQLiteSyncStorage`. The sha
 - **CP5** Presence pushes: the first send is `['put', record]`, subsequent sends are `['patch', diff]` against the last pushed state; an unchanged presence sends nothing; document and presence changes ride in the same push request when both are pending. After a reconnect, presence is re-put in full.
 - **CP6** In `'solo'` presence mode the presence signal is not pushed at all (document changes still are); the network throttle drops from 30fps to 1fps.
 - **CP7** When the store reports possible corruption, pushes stop.
+- **CP8** `hasPendingChanges()` reports whether any local document change is not yet confirmed by the server: an in-flight push request, an unsent document diff, or a non-empty speculative diff.
 
 ## 21. `TLSyncClient` — receiving and rebasing (CR)
 

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -47,9 +47,11 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<TLSocket
     isDisposed: boolean;
     onReceiveMessage(cb: (val: TLSocketServerSentEvent<TLRecord>) => void): () => void;
     onStatusChange(cb: TLSocketStatusListener): () => void;
+    pause(): void;
     // (undocumented)
     readonly _reconnectManager: ReconnectManager;
     restart(): void;
+    resume(): void;
     sendMessage(msg: TLSocketClientSentEvent<TLRecord>): void;
     // (undocumented)
     _setNewSocket(ws: WebSocket): void;
@@ -240,6 +242,8 @@ export class ReconnectManager {
     // (undocumented)
     intendedDelay: number;
     maybeReconnected(): void;
+    pause(): void;
+    resume(): void;
 }
 
 // @internal

--- a/packages/sync-core/api-report.api.md
+++ b/packages/sync-core/api-report.api.md
@@ -670,6 +670,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
         store: S;
     });
     close(): void;
+    // @internal
+    hasPendingChanges(): boolean;
     // @internal (undocumented)
     isConnectedToRoom: boolean;
     // @internal (undocumented)

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.test.ts
@@ -793,4 +793,91 @@ describe('ReconnectManager', () => {
 		// closing again is safe
 		expect(() => manager.close()).not.toThrow()
 	})
+
+	describe('pause and resume (CW11, CW12, RM6)', () => {
+		it('[CW11] pause closes the socket and reports offline', async () => {
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			const statuses: string[] = []
+			adapter.onStatusChange((e) => statuses.push(e.status))
+
+			adapter.pause()
+
+			expect(adapter._ws).toBeNull()
+			expect(adapter.connectionStatus).toBe('offline')
+			expect(statuses).toEqual(['offline'])
+		})
+
+		it('[RM6] no reconnection attempts happen while paused', async () => {
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			const connectionsBefore = connectMock.mock.calls.length
+
+			adapter.pause()
+			await vi.advanceTimersByTimeAsync(INACTIVE_MAX_DELAY * 2)
+
+			expect(adapter._ws).toBeNull()
+			expect(connectMock.mock.calls.length).toBe(connectionsBefore)
+		})
+
+		it('[RM6] reconnect hints are ignored while paused', async () => {
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			adapter.pause()
+
+			// what the window online/visibilitychange/connection-change listeners call
+			adapter._reconnectManager.maybeReconnected()
+			await vi.advanceTimersByTimeAsync(INACTIVE_MAX_DELAY * 2)
+
+			expect(adapter._ws).toBeNull()
+		})
+
+		it('[RM6] pausing while getUri is pending aborts the in-flight attempt', async () => {
+			let resolveUri: (uri: string) => void
+			const uriPromise = new Promise<string>((resolve) => {
+				resolveUri = resolve
+			})
+			const asyncAdapter = new ClientWebSocketAdapter(() => uriPromise)
+			try {
+				// the initial attempt is stuck waiting for getUri
+				expect(asyncAdapter._ws).toBeNull()
+				const connectionsBefore = connectMock.mock.calls.length
+
+				asyncAdapter.pause()
+				resolveUri!('ws://localhost:2233')
+				await vi.advanceTimersByTimeAsync(INACTIVE_MAX_DELAY * 2)
+
+				expect(asyncAdapter._ws).toBeNull()
+				expect(connectMock.mock.calls.length).toBe(connectionsBefore)
+			} finally {
+				asyncAdapter.close()
+			}
+		})
+
+		it('[CW12] resume reconnects promptly', async () => {
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			adapter.pause()
+
+			adapter.resume()
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			expect(adapter.connectionStatus).toBe('online')
+		})
+
+		it('[CW11][CW12] pause is idempotent and resume without pause is a no-op', async () => {
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+
+			adapter.resume() // not paused: no-op
+			expect(adapter._ws?.readyState).toBe(WebSocket.OPEN)
+
+			adapter.pause()
+			adapter.pause() // second pause: no-op, no throw
+			expect(adapter._ws).toBeNull()
+		})
+
+		it('[CW11] close() while paused disposes cleanly', async () => {
+			await waitFor(() => adapter._ws?.readyState === WebSocket.OPEN)
+			adapter.pause()
+			adapter.close()
+			expect(adapter.isDisposed).toBe(true)
+			expect(() => adapter.pause()).toThrow()
+			expect(() => adapter.resume()).toThrow()
+		})
+	})
 })

--- a/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
+++ b/packages/sync-core/src/lib/ClientWebSocketAdapter.ts
@@ -369,6 +369,26 @@ export class ClientWebSocketAdapter implements TLPersistentClientSocket<
 		this._closeSocket()
 		this._reconnectManager.maybeReconnected()
 	}
+
+	/**
+	 * Close the socket and stop all reconnection attempts until `resume()` is called.
+	 * @internal
+	 */
+	pause() {
+		assert(!this.isDisposed, 'Tried to pause a disposed socket')
+		// pause the manager first so the close event below cannot schedule a reconnect
+		this._reconnectManager.pause()
+		this._closeSocket()
+	}
+
+	/**
+	 * Leave the paused state and reconnect immediately.
+	 * @internal
+	 */
+	resume() {
+		assert(!this.isDisposed, 'Tried to resume a disposed socket')
+		this._reconnectManager.resume()
+	}
 }
 
 /**
@@ -445,6 +465,7 @@ export const ATTEMPT_TIMEOUT = 1000
  */
 export class ReconnectManager {
 	private isDisposed = false
+	private isPaused = false
 	private disposables: (() => void)[] = [
 		() => {
 			if (this.reconnectTimeout) clearTimeout(this.reconnectTimeout)
@@ -517,8 +538,9 @@ export class ReconnectManager {
 		assert(this.state === 'pendingAttempt')
 		debug('scheduling a connection attempt')
 		Promise.resolve(this.getUri()).then((uri) => {
-			// this can happen if the promise gets resolved too late
-			if (this.state !== 'pendingAttempt' || this.isDisposed) return
+			// the promise may resolve too late, or we may have been paused/disposed
+			// while getUri was pending
+			if (this.state !== 'pendingAttempt' || this.isDisposed || this.isPaused) return
 			assert(
 				this.socketAdapter._ws?.readyState !== WebSocket.OPEN,
 				'There should be no connection attempts while already connected'
@@ -570,6 +592,8 @@ export class ReconnectManager {
 	 */
 	maybeReconnected() {
 		debug('ReconnectManager.maybeReconnected')
+		if (this.isPaused) return
+
 		// It doesn't make sense to have another check scheduled if we're already checking it now.
 		// If we have a CONNECTING check scheduled and relevant, it'll be recreated below anyway
 		this.clearRecheckConnectingTimeout()
@@ -639,6 +663,8 @@ export class ReconnectManager {
 	 */
 	disconnected() {
 		debug('ReconnectManager.disconnected')
+		if (this.isPaused) return
+
 		// This either means we're freshly disconnected, or the last connection attempt failed;
 		// either way, time to try again.
 
@@ -708,6 +734,25 @@ export class ReconnectManager {
 			this.clearReconnectTimeout()
 			this.intendedDelay = ACTIVE_MIN_DELAY
 		}
+	}
+
+	/**
+	 * Stops all reconnection attempts and cancels pending timers until `resume()` is called.
+	 */
+	pause() {
+		this.isPaused = true
+		this.clearReconnectTimeout()
+		this.clearRecheckConnectingTimeout()
+	}
+
+	/**
+	 * Leaves the paused state, resets the backoff, and attempts to reconnect immediately.
+	 */
+	resume() {
+		if (!this.isPaused) return
+		this.isPaused = false
+		this.intendedDelay = ACTIVE_MIN_DELAY
+		this.maybeReconnected()
 	}
 
 	/**

--- a/packages/sync-core/src/lib/TLSyncClient.test.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.test.ts
@@ -894,6 +894,29 @@ describe('TLSyncClient', () => {
 			expect(socket.getSentMessages()).toHaveLength(0)
 		})
 
+		it('[CP8] hasPendingChanges reflects unconfirmed local changes', () => {
+			connectClient()
+			expect(client.hasPendingChanges()).toBe(false)
+
+			store.put([makePage('New page', 'a2')])
+			expect(client.hasPendingChanges()).toBe(true)
+
+			// the throttle sends the push; still pending until the server confirms
+			vi.advanceTimersByTime(100)
+			const push = getSentPushes()[0]
+			expect(push).toBeDefined()
+			expect(client.hasPendingChanges()).toBe(true)
+
+			socket.mockServerMessage({
+				type: 'push_result',
+				serverClock: 2,
+				clientClock: push.clientClock,
+				action: 'commit',
+			})
+			vi.advanceTimersByTime(100)
+			expect(client.hasPendingChanges()).toBe(false)
+		})
+
 		describe('push coalescing (multiple push() calls become a single network message)', () => {
 			/**
 			 * These tests verify that multiple store changes (each triggering push())

--- a/packages/sync-core/src/lib/TLSyncClient.test.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.test.ts
@@ -598,19 +598,22 @@ describe('TLSyncClient', () => {
 			expect(socket.getSentMessages().filter((m) => m.type === 'ping')).toHaveLength(2)
 		})
 
-		it('[CL9] warns and resets the connection after 10 seconds without server interaction', () => {
+		it('[CL9][CL14] resets when pings keep being sent but nothing comes back (half-open socket)', () => {
 			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 			client = createClient()
 			socket.mockServerMessage(createConnectMessage())
 
-			// advance time beyond the health check threshold
-			vi.advanceTimersByTime(15000)
+			// pings at 5s/10s go unanswered but the sends still "succeed"
+			vi.advanceTimersByTime(10_000)
+			// health tick at 10s: the oldest unanswered ping (t=5s) is only 5s old — not yet overdue
+			expect(client.isConnectedToRoom).toBe(true)
 
-			expect(consoleSpy).toHaveBeenCalledWith(
-				expect.stringContaining("Haven't heard from the server in a while")
-			)
+			vi.advanceTimersByTime(10_000)
+			// health tick at 20s: the t=5s ping is 15s overdue — evidence of a dead socket
 			expect(client.isConnectedToRoom).toBe(false)
-
+			expect(consoleSpy).toHaveBeenCalledWith(
+				expect.stringContaining("Haven't heard from the server")
+			)
 			consoleSpy.mockRestore()
 		})
 
@@ -626,10 +629,32 @@ describe('TLSyncClient', () => {
 			vi.advanceTimersByTime(4000)
 			expect(client.isConnectedToRoom).toBe(true)
 
-			// at t=20s nothing has been heard since the pong, so the connection resets
-			vi.advanceTimersByTime(10000)
+			// at t=20s the oldest unanswered ping (t=10s) is exactly 10s old — not yet overdue
+			vi.advanceTimersByTime(10_000)
+			expect(client.isConnectedToRoom).toBe(true)
+
+			// at t=30s it is 20s overdue — reset
+			vi.advanceTimersByTime(10_000)
 			expect(client.isConnectedToRoom).toBe(false)
 
+			consoleSpy.mockRestore()
+		})
+
+		it('[CL9] does not reset a healthy connection when timers wake infrequently (hidden-tab throttling)', () => {
+			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+			client = createClient()
+			socket.mockServerMessage(createConnectMessage())
+
+			// Chrome batches a hidden tab's timers to ~1/min wakes: the clock jumps, then the
+			// overdue ping + health ticks fire together, and the pong arrives right after.
+			for (let i = 0; i < 3; i++) {
+				vi.setSystemTime(Date.now() + 60_000)
+				vi.advanceTimersByTime(10_000)
+				expect(client.isConnectedToRoom).toBe(true)
+				socket.mockServerMessage({ type: 'pong' })
+			}
+
+			expect(consoleSpy).not.toHaveBeenCalled()
 			consoleSpy.mockRestore()
 		})
 

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -286,6 +286,8 @@ export interface TLPersistentClientSocket<
 
 const PING_INTERVAL = 5000
 const MAX_TIME_TO_WAIT_FOR_SERVER_INTERACTION_BEFORE_RESETTING_CONNECTION = PING_INTERVAL * 2
+/** How long an unanswered ping may stay outstanding before the connection is considered dead */
+const PONG_TIMEOUT = PING_INTERVAL * 2
 
 // Should connect support chunking the response to allow for large payloads?
 
@@ -367,6 +369,8 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	/** The last clock time from the most recent server update */
 	private lastServerClock = -1
 	private lastServerInteractionTimestamp = Date.now()
+	/** When the oldest ping that has not yet been answered was sent, or null if all pings were answered */
+	private firstUnansweredPingAt: number | null = null
 
 	/** The queue of in-flight push requests that have not yet been acknowledged by the server */
 	private pendingPushRequests: TLPushRequest<R>[] = []
@@ -600,6 +604,14 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 				this.debug('ping loop', { isConnectedToRoom: this.isConnectedToRoom })
 				if (!this.isConnectedToRoom) return
 				try {
+					// advance the marker only when the previous ping was answered: a half-open socket
+					// that accepts sends but returns nothing must not keep refreshing its own alibi
+					if (
+						this.firstUnansweredPingAt === null ||
+						this.lastServerInteractionTimestamp >= this.firstUnansweredPingAt
+					) {
+						this.firstUnansweredPingAt = Date.now()
+					}
 					this.socket.sendMessage({ type: 'ping' })
 				} catch (error) {
 					console.warn('ping failed, resetting', error)
@@ -618,7 +630,17 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 					MAX_TIME_TO_WAIT_FOR_SERVER_INTERACTION_BEFORE_RESETTING_CONNECTION
 				) {
 					this.debug('health check passed', { timeSinceLastServerInteraction })
-					// last ping was recent, so no need to take any action
+					return
+				}
+
+				// Silence alone is not evidence of a dead socket: in a throttled hidden tab our own ping
+				// loop stops, so the server had nothing to answer. Only reset on an unanswered ping.
+				const pingOverdue =
+					this.firstUnansweredPingAt !== null &&
+					this.lastServerInteractionTimestamp < this.firstUnansweredPingAt &&
+					Date.now() - this.firstUnansweredPingAt > PONG_TIMEOUT
+				if (!pingOverdue) {
+					this.debug('health check stale but no overdue ping', { timeSinceLastServerInteraction })
 					return
 				}
 
@@ -684,6 +706,7 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 		}
 		this.lastPushedPresenceState = null
 		this.isConnectedToRoom = false
+		this.firstUnansweredPingAt = null
 		this.pendingPushRequests = []
 		this.incomingDiffBuffer = []
 		this.unsentChanges.nextDiff = undefined

--- a/packages/sync-core/src/lib/TLSyncClient.ts
+++ b/packages/sync-core/src/lib/TLSyncClient.ts
@@ -843,6 +843,20 @@ export class TLSyncClient<R extends UnknownRecord, S extends Store<R> = Store<R>
 	}
 
 	/**
+	 * Whether any local document change has not yet been confirmed by the server.
+	 * @internal
+	 */
+	hasPendingChanges(): boolean {
+		return (
+			this.pendingPushRequests.length > 0 ||
+			this.unsentChanges.nextDiff !== undefined ||
+			Object.keys(this.speculativeChanges.added).length > 0 ||
+			Object.keys(this.speculativeChanges.updated).length > 0 ||
+			Object.keys(this.speculativeChanges.removed).length > 0
+		)
+	}
+
+	/**
 	 * Closes the sync client and cleans up all resources.
 	 *
 	 * Call this method when you no longer need the sync client to prevent

--- a/packages/sync/api-report.api.md
+++ b/packages/sync/api-report.api.md
@@ -9,9 +9,11 @@ import { TLAssetStore } from 'tldraw';
 import { TLObjectStoreAccess } from '@tldraw/sync-core';
 import { TLPersistentClientSocket } from '@tldraw/sync-core';
 import { TLPresenceStateInfo } from 'tldraw';
+import { TLRecord } from 'tldraw';
 import { TLStore } from 'tldraw';
 import { TLStoreSchemaOptions } from 'tldraw';
 import { TLStoreWithStatus } from 'tldraw';
+import { TLSyncClient } from '@tldraw/sync-core';
 import { TLThemes } from 'tldraw';
 import { TLUser } from 'tldraw';
 import { TLUserStore } from 'tldraw';
@@ -63,6 +65,8 @@ export interface UseSyncOptionsBase {
     onCustomMessageReceived?(data: any): void;
     // @internal (undocumented)
     onMount?(editor: Editor): void;
+    // @internal
+    onSyncClientCreated?(client: TLSyncClient<TLRecord, TLStore>): void;
     // @internal
     roomId?: string;
     themes?: Partial<TLThemes>;

--- a/packages/sync/src/useSync.ts
+++ b/packages/sync/src/useSync.ts
@@ -192,6 +192,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		trackAnalyticsEvent: track,
 		getUserPresence: _getUserPresence,
 		onCustomMessageReceived: _onCustomMessageReceived,
+		onSyncClientCreated: _onSyncClientCreated,
 		themes,
 		...schemaOpts
 	} = opts
@@ -210,6 +211,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		(_getUserPresence ?? getDefaultUserPresence) as typeof getDefaultUserPresence
 	)
 	const onCustomMessageReceived = useEvent(_onCustomMessageReceived ?? defaultCustomMessageHandler)
+	const onSyncClientCreated = useEvent(_onSyncClientCreated ?? (() => void 0))
 
 	useEffect(() => {
 		const storeId = uniqueId()
@@ -398,6 +400,8 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 			presenceMode,
 		})
 
+		onSyncClientCreated(client)
+
 		return () => {
 			didCancel = true
 			unsubscribeFromConnectionStatus()
@@ -416,6 +420,7 @@ export function useSync(opts: UseSyncOptions & TLStoreSchemaOptions): RemoteTLSt
 		uri,
 		getUserPresence,
 		onCustomMessageReceived,
+		onSyncClientCreated,
 	])
 
 	return useValue<RemoteTLStoreWithStatus>(
@@ -532,6 +537,8 @@ export interface UseSyncOptionsBase {
 	roomId?: string
 	/** @internal */
 	trackAnalyticsEvent?(name: string, data: { [key: string]: any }): void
+	/** @internal called with the sync client right after it is created; may fire again if the connection is recreated */
+	onSyncClientCreated?(client: TLSyncClient<TLRecord, TLStore>): void
 
 	/**
 	 * A reactive function that returns a {@link @tldraw/tlschema#TLInstancePresence} object.


### PR DESCRIPTION
In order to stop parked browser tabs from keeping ~3,500 file rooms awake around the clock (~80% of file DO duration cost), this PR fixes the client's connection health check and adds a flag-gated hidden-tab socket suspend for tldraw.com.

Chrome throttles a hidden tab's timers to about one wake per minute. That starves `TLSyncClient`'s 5s ping loop, so the 10s health check wakes to a minute of silence the client itself caused, declares the connection dead, and resets it. The reconnect succeeds and clears the reconnect backoff, so the visibility-aware `INACTIVE_MAX_DELAY` never engages — a parked tab reconnects roughly once a minute forever, and each cycle rebuilds the room (auth, Postgres, ~8s of hibernation-blocking timers). Confirmed with an instrumented client: exact 60s close/reconnect cycles while hidden.

Two stages:

- **Stage A (unconditional bugfix, sync-core):** the health check now requires evidence — it only resets when a ping was actually sent and went unanswered for `PONG_TIMEOUT` (10s). The unanswered-ping marker advances only when the previous ping was answered, so a half-open socket that still accepts sends can't refresh its own alibi; dead-connection detection still works, at most one health tick later than before. On a throttled wake the batched ping fires, the pong arrives event-driven milliseconds later, and the connection is correctly left alone.
- **Stage B (dotcom, behind the new `hidden_tab_suspend` flag, default off, staff always on):** after a tab is hidden for 2 minutes, the client pauses the websocket adapter entirely (no reconnect attempts from any path, including the online/visibility hint listeners), letting the room empty and the DO hibernate. Becoming visible or any input resumes with an immediate reconnect, which hydrates via diff off `lastServerClock`. Suspension waits for unconfirmed local changes to drain (`hasPendingChanges`), and tabs that *load* hidden (opened in the background) arm the suspend timer at mount.

Known limits, deliberate for now: stage B doesn't reach anonymous sessions or embeds (percentage flags need a userId), so their rooms stay open — stage A still stops their reconnect loops. Self-hosted SDK servers with the default 20s `SESSION_IDLE_TIMEOUT` will still prune throttled hidden tabs server-side; worth a follow-up docs note on `clientTimeout`.

### Change type

- [x] `bugfix`

### Test plan

1. Open a shared file on tldraw.com (staff account for stage B), open devtools Network → WS.
2. Hide the tab for 10+ minutes: no close/reconnect cycles (stage A); with the flag, the socket closes ~2min in and stays closed (stage B).
3. Reveal the tab: one immediate clean reconnect, canvas live.
4. Make an edit and hide the tab immediately: the socket stays up until the push confirms, then suspends.

- [x] Unit tests

### Release notes

- Fix background tabs repeatedly dropping and re-establishing their sync connection when the browser throttles timers.

### API changes

- Added internal `pause()` / `resume()` to `ClientWebSocketAdapter` and internal `hasPendingChanges()` to `TLSyncClient` (`@tldraw/sync-core`).
- Added internal `onSyncClientCreated` option to `useSync` (`@tldraw/sync`).
- No public API changes.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +99 / -4   |
| Tests           | +182 / -9  |
| Automated files | +10 / -0   |
| Apps            | +135 / -0  |