### PR TITLE
fix(editor): make development environment detection more accurate

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -422,7 +422,7 @@ describe('LicenseManager', () => {
 			expect(result.isDomainValid).toBe(true)
 		})
 
-		it('Is not development mode for a native app on a custom protocol', async () => {
+		it('Is not development mode on a custom protocol', async () => {
 			process.env.NODE_ENV = 'production'
 			try {
 				// @ts-ignore
@@ -447,34 +447,48 @@ describe('LicenseManager', () => {
 					isDomainValid: true,
 					isDevelopment: false,
 				})
+				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe('licensed')
 			} finally {
 				process.env.NODE_ENV = 'test'
 			}
 		})
 
-		it('Is unlicensed in production for a native app whose protocol does not match', async () => {
+		it('Validates the domain on a custom protocol', async () => {
 			process.env.NODE_ENV = 'production'
 			try {
 				// @ts-ignore
 				delete window.location
 				// @ts-ignore
-				window.location = new URL('blah-bundle://app/index.html')
+				window.location = new URL('app-bundle://app/index.html')
 
-				const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
-				nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
-				nativeLicenseInfo[PROPERTIES.HOSTS] = ['app-bundle:']
-				const nativeLicenseKey = await generateLicenseKey(
-					JSON.stringify(nativeLicenseInfo),
-					keyPair
-				)
-				const nativeLicenseManager = new LicenseManager('', keyPair.publicKey)
-				const result = (await nativeLicenseManager.getLicenseFromKey(
-					nativeLicenseKey
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const customProtocolLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await customProtocolLicenseManager.getLicenseFromKey(
+					licenseKey
 				)) as ValidLicenseKeyResult
 				expect(result).toMatchObject({ isDomainValid: false, isDevelopment: false })
 				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe(
 					'unlicensed-production'
 				)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Is development mode on a loopback host regardless of protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://localhost/index.html')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const loopbackLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await loopbackLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(true)
 			} finally {
 				process.env.NODE_ENV = 'test'
 			}

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -422,6 +422,64 @@ describe('LicenseManager', () => {
 			expect(result.isDomainValid).toBe(true)
 		})
 
+		it('Is not development mode for a native app on a custom protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://app/index.html')
+
+				const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+				nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
+				nativeLicenseInfo[PROPERTIES.HOSTS] = ['app-bundle:']
+				const nativeLicenseKey = await generateLicenseKey(
+					JSON.stringify(nativeLicenseInfo),
+					keyPair
+				)
+				const nativeLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await nativeLicenseManager.getLicenseFromKey(
+					nativeLicenseKey
+				)) as ValidLicenseKeyResult
+				expect(result).toMatchObject({
+					isLicenseParseable: true,
+					isNativeLicense: true,
+					isDomainValid: true,
+					isDevelopment: false,
+				})
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Is unlicensed in production for a native app whose protocol does not match', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('blah-bundle://app/index.html')
+
+				const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+				nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
+				nativeLicenseInfo[PROPERTIES.HOSTS] = ['app-bundle:']
+				const nativeLicenseKey = await generateLicenseKey(
+					JSON.stringify(nativeLicenseInfo),
+					keyPair
+				)
+				const nativeLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await nativeLicenseManager.getLicenseFromKey(
+					nativeLicenseKey
+				)) as ValidLicenseKeyResult
+				expect(result).toMatchObject({ isDomainValid: false, isDevelopment: false })
+				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe(
+					'unlicensed-production'
+				)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
 		it('Fails if it is a native app with the wrong protocol', async () => {
 			// @ts-ignore
 			delete window.location

--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -475,6 +475,25 @@ describe('LicenseManager', () => {
 			}
 		})
 
+		it('Is development mode over http on a non-loopback host', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('http://www.example.com')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const httpLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await httpLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(true)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
 		it('Is development mode on a loopback host regardless of protocol', async () => {
 			process.env.NODE_ENV = 'production'
 			try {

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -179,11 +179,13 @@ export class LicenseManager {
 		// Native apps are the exception: they serve the app from a custom protocol (e.g. `app-bundle:`)
 		// which would otherwise always look like development, so a native license opts out of the
 		// protocol check and relies on the loopback and NODE_ENV checks instead. We only know the
-		// license is native once it has been parsed, so this is recomputed in `getLicenseFromKey`.
-		const isNonProductionProtocol =
+		// license is native once it has been parsed, so this is recomputed in `getLicenseFromKey` —
+		// which also means a native app with a missing or unparseable key can't be recognised as
+		// native, and still falls back to being treated as development.
+		const failsProtocolCheck =
 			!opts?.isNativeLicense && !['https:', 'vscode-webview:'].includes(window.location.protocol)
 		return (
-			isNonProductionProtocol ||
+			failsProtocolCheck ||
 			this.isLoopbackHost(window.location.hostname) ||
 			process.env.NODE_ENV !== 'production'
 		)

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -173,10 +173,17 @@ export class LicenseManager {
 		return this.featureFlags.get()[feature]
 	}
 
-	private getIsDevelopment() {
-		// If we are using https on a non-loopback domain we assume it's a production env and a development one otherwise
+	private getIsDevelopment(opts?: { isNativeLicense?: boolean }) {
+		// If we are using https on a non-loopback domain we assume it's a production env and a development one otherwise.
+		//
+		// Native apps are the exception: they serve the app from a custom protocol (e.g. `app-bundle:`)
+		// which would otherwise always look like development, so a native license opts out of the
+		// protocol check and relies on the loopback and NODE_ENV checks instead. We only know the
+		// license is native once it has been parsed, so this is recomputed in `getLicenseFromKey`.
+		const isNonProductionProtocol =
+			!opts?.isNativeLicense && !['https:', 'vscode-webview:'].includes(window.location.protocol)
 		return (
-			!['https:', 'vscode-webview:'].includes(window.location.protocol) ||
+			isNonProductionProtocol ||
 			this.isLoopbackHost(window.location.hostname) ||
 			process.env.NODE_ENV !== 'production'
 		)
@@ -326,6 +333,15 @@ export class LicenseManager {
 
 		try {
 			const licenseInfo = await this.extractLicenseKey(cleanedLicenseKey)
+
+			const isNativeLicense = this.isNativeLicense(licenseInfo)
+			if (isNativeLicense) {
+				// The constructor couldn't know the license was for a native app, so the custom
+				// protocol will have been read as development. Now that we know, recompute it —
+				// everything downstream (license state, features, tracking) runs after this.
+				this.isDevelopment = this.getIsDevelopment({ isNativeLicense: true })
+			}
+
 			const expiryDate = new Date(licenseInfo.expiryDate)
 			const isAnnualLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.ANNUAL_LICENSE)
 			const isPerpetualLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.PERPETUAL_LICENSE)
@@ -359,7 +375,7 @@ export class LicenseManager {
 				isPerpetualLicense,
 				isPerpetualLicenseExpired,
 				isInternalLicense: this.isFlagEnabled(licenseInfo.flags, FLAGS.INTERNAL_LICENSE),
-				isNativeLicense: this.isNativeLicense(licenseInfo),
+				isNativeLicense,
 				isLicensedWithWatermark: this.isFlagEnabled(licenseInfo.flags, FLAGS.WITH_WATERMARK),
 				isEvaluationLicense,
 				isEvaluationLicenseExpired:

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -174,7 +174,11 @@ export class LicenseManager {
 	}
 
 	private getIsDevelopment() {
-		return this.isLoopbackHost(window.location.hostname) || process.env.NODE_ENV !== 'production'
+		return (
+			window.location.protocol === 'http:' ||
+			this.isLoopbackHost(window.location.hostname) ||
+			process.env.NODE_ENV !== 'production'
+		)
 	}
 
 	private isLoopbackHost(hostname: string) {

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -173,22 +173,8 @@ export class LicenseManager {
 		return this.featureFlags.get()[feature]
 	}
 
-	private getIsDevelopment(opts?: { isNativeLicense?: boolean }) {
-		// If we are using https on a non-loopback domain we assume it's a production env and a development one otherwise.
-		//
-		// Native apps are the exception: they serve the app from a custom protocol (e.g. `app-bundle:`)
-		// which would otherwise always look like development, so a native license opts out of the
-		// protocol check and relies on the loopback and NODE_ENV checks instead. We only know the
-		// license is native once it has been parsed, so this is recomputed in `getLicenseFromKey` —
-		// which also means a native app with a missing or unparseable key can't be recognised as
-		// native, and still falls back to being treated as development.
-		const failsProtocolCheck =
-			!opts?.isNativeLicense && !['https:', 'vscode-webview:'].includes(window.location.protocol)
-		return (
-			failsProtocolCheck ||
-			this.isLoopbackHost(window.location.hostname) ||
-			process.env.NODE_ENV !== 'production'
-		)
+	private getIsDevelopment() {
+		return this.isLoopbackHost(window.location.hostname) || process.env.NODE_ENV !== 'production'
 	}
 
 	private isLoopbackHost(hostname: string) {
@@ -335,15 +321,6 @@ export class LicenseManager {
 
 		try {
 			const licenseInfo = await this.extractLicenseKey(cleanedLicenseKey)
-
-			const isNativeLicense = this.isNativeLicense(licenseInfo)
-			if (isNativeLicense) {
-				// The constructor couldn't know the license was for a native app, so the custom
-				// protocol will have been read as development. Now that we know, recompute it —
-				// everything downstream (license state, features, tracking) runs after this.
-				this.isDevelopment = this.getIsDevelopment({ isNativeLicense: true })
-			}
-
 			const expiryDate = new Date(licenseInfo.expiryDate)
 			const isAnnualLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.ANNUAL_LICENSE)
 			const isPerpetualLicense = this.isFlagEnabled(licenseInfo.flags, FLAGS.PERPETUAL_LICENSE)
@@ -377,7 +354,7 @@ export class LicenseManager {
 				isPerpetualLicense,
 				isPerpetualLicenseExpired,
 				isInternalLicense: this.isFlagEnabled(licenseInfo.flags, FLAGS.INTERNAL_LICENSE),
-				isNativeLicense,
+				isNativeLicense: this.isNativeLicense(licenseInfo),
 				isLicensedWithWatermark: this.isFlagEnabled(licenseInfo.flags, FLAGS.WITH_WATERMARK),
 				isEvaluationLicense,
 				isEvaluationLicenseExpired:


### PR DESCRIPTION
In order for native apps to be licensed the same way as any other production deployment, this makes `LicenseManager`'s development-environment detection more accurate.

Previously the check keyed off the URL protocol: anything other than `https:` or `vscode-webview:` was assumed to be development. Native apps serve their bundle from a custom protocol (e.g. `app-bundle://app/index.html`), so a shipped native app never matched, and the `NATIVE_LICENSE` flag and its host patterns had no real effect.

Environment detection now names the development cases directly — `http:`, a loopback host, or a build where `NODE_ENV` isn't `production` — instead of inferring them from everything that isn't `https:`. `http:` keeps its existing development behavior; the change is that custom protocols are treated like any other production deployment, so the existing native-license host matching in `isDomainValid` does the work it was always meant to do. This also removes the need to know whether a license is native before classifying the environment.

One consequence worth flagging for review: native apps must register their custom scheme as a secure context for `crypto.subtle` to be available, otherwise signature verification can't run. In Electron that's `protocol.registerSchemesAsPrivileged([{ scheme: 'app-bundle', privileges: { standard: true, secure: true } }])`.

### Change type

- [x] `bugfix`

### Test plan

1. Build a native app on a custom protocol registered as a secure context, with a `NATIVE_LICENSE` key whose host patterns match the app's URL, and confirm it resolves to `licensed` with features gated by the license flags.
2. Confirm a key whose hosts don't match the app's URL resolves to `unlicensed-production`.
3. Confirm a local development build (http, a loopback host, or a non-production build) is unaffected.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix license validation treating native apps served from custom protocols as development environments.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -2    |
| Tests     | +91 / -0   |
