### PR TITLE
chore(dotcom): add MCP server metrics and an MCP dashboard

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/tla/screenshotTestHelpers.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/screenshotTestHelpers.ts
@@ -168,6 +168,26 @@ export function blobsWithPrefix(env: Environment, prefix: string): string[] {
 		.filter(Boolean)
 }
 
+// The datapoints for one event name (blob1). The MCP route writes two events per screenshot tool
+// call — the render ledger and the protocol-level tool call — and they share prefixes (`reason:`), so
+// a test asserting on one has to say which.
+export function datapointsNamed(
+	env: Environment,
+	name: string
+): { blobs: string[]; doubles?: number[] }[] {
+	return (env.MEASURE as any).writeDataPoint.mock.calls
+		.map((call: any[]) => call[0])
+		.filter((point: any) => (point.blobs as string[])[0] === name)
+}
+
+// The `<prefix>:…` blobs of one event's datapoints, with the prefix stripped, in write order.
+export function blobValuesOf(env: Environment, name: string, prefix: string): string[] {
+	return datapointsNamed(env, name)
+		.map((point) => point.blobs.find((blob) => blob.startsWith(`${prefix}:`)))
+		.filter((blob): blob is string => Boolean(blob))
+		.map((blob) => blob.slice(prefix.length + 1))
+}
+
 export function failureBlobsOf(env: Environment) {
 	return blobsWithPrefix(env, 'failure:')
 }

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
@@ -5,6 +5,8 @@ import { verifyThumbnailRenderToken } from '../../utils/renderTokens'
 import { getPublishedFileInfo, getPublishedRoomSnapshot } from './getPublishedFile'
 import { getSharedFileInfo } from './getSharedFile'
 import {
+	blobValuesOf,
+	datapointsNamed,
 	makeFakeThumbnailsBucket,
 	makeMeasuringBrowserBinding,
 	makeScreenshotTestEnv,
@@ -13,6 +15,7 @@ import {
 } from './screenshotTestHelpers'
 import {
 	isMcpScreenshotEnabled,
+	normalizeMcpClient,
 	parseBoardInfoInput,
 	parseClusterInfoInput,
 	parseClusterScreenshotInput,
@@ -58,10 +61,17 @@ function makeEnv(overrides: Partial<Record<string, unknown>> = {}) {
 	return env
 }
 
-function makeRpcRequest(method: string, params?: unknown) {
+function makeRpcRequest(
+	method: string,
+	params?: unknown,
+	{ userAgent }: { userAgent?: string } = {}
+) {
 	return new Request('https://sync.tldraw.xyz/app/mcp', {
 		method: 'POST',
-		headers: { 'cf-connecting-ip': `203.0.113.${++requestId}` },
+		headers: {
+			'cf-connecting-ip': `203.0.113.${++requestId}`,
+			...(userAgent ? { 'user-agent': userAgent } : {}),
+		},
 		body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
 	}) as any
 }
@@ -321,5 +331,121 @@ describe('shape screenshots', () => {
 			env
 		)
 		expect(missing.isError).toBe(true)
+	})
+})
+
+// The render ledger (mcp_shared_board_screenshot) only fires when a screenshot is attempted, so on its
+// own it cannot see the info tools, the early failures, or who is calling. These datapoints are that
+// missing half: one per tools/call, plus the calling application's own name at initialize.
+const TOOL_CALL_EVENT = 'mcp_server_tool_call'
+const INITIALIZE_EVENT = 'mcp_server_initialize'
+
+describe('protocol telemetry', () => {
+	it('records one datapoint per tool call, with the tool, outcome and duration', async () => {
+		mockPublishedBoard()
+		const env = makeEnv()
+		await callTool('get_board_info', { boardId: 'abc' }, env)
+
+		const points = datapointsNamed(env, TOOL_CALL_EVENT)
+		expect(points).toHaveLength(1)
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'tool')).toEqual(['get_board_info'])
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'outcome')).toEqual(['ok'])
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'reason')).toEqual(['none'])
+		expect(points[0].doubles![0]).toBeGreaterThanOrEqual(0)
+	})
+
+	// get_board_info spends no Browser Run and so writes no render telemetry at all — without this
+	// event, a client hammering the info tools is invisible.
+	it('records the info tools, which write no render telemetry', async () => {
+		mockPublishedBoard()
+		const env = makeEnv()
+		await callTool('get_page_info', { boardId: 'abc' }, env)
+
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'tool')).toEqual(['get_page_info'])
+		expect(datapointsNamed(env, 'mcp_shared_board_screenshot')).toHaveLength(0)
+	})
+
+	it('records the reason a call failed, and never reports a failure as ok', async () => {
+		mockPublishedBoard()
+		const env = makeEnv()
+		// Missing boardId, then a tool that does not exist.
+		await callTool('get_board_info', {}, env)
+		await callTool('get_nothing', {}, env)
+
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'tool')).toEqual(['get_board_info', 'unknown'])
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'outcome')).toEqual(['error', 'error'])
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'reason')).toEqual(['invalid_input', 'unknown_tool'])
+	})
+
+	// The per-IP limit on the clustering tools rejected callers silently before this: it returns a tool
+	// error without reaching the render path that writes the screenshot ledger.
+	it('records a rate-limited info call', async () => {
+		mockPublishedBoard()
+		const env = makeEnv()
+		for (let i = 0; i < MCP_PER_IP_RATE_LIMIT + 2; i++) {
+			await callFromSameIp(env, '203.0.113.202', 'get_page_info', { boardId: 'abc' })
+		}
+
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'reason')).toContain('rate_limited_ip')
+	})
+
+	// A handler is supposed to catch its own failures, so an escaped throw is a bug — which is exactly
+	// when the datapoint matters most. The rate limit check is the one step that sits outside a
+	// handler's try, so a limiter binding that rejects is the reachable version of that bug. The error
+	// still propagates; only the recording is added.
+	it('records a tool that throws, and still lets the error through', async () => {
+		mockPublishedBoard()
+		const env = makeEnv({
+			MCP_SCREENSHOT_RATE_LIMITER: {
+				limit: async () => {
+					throw new Error('limiter unavailable')
+				},
+			},
+		})
+
+		await expect(callTool('get_page_info', { boardId: 'abc' }, env)).rejects.toThrow(
+			'limiter unavailable'
+		)
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'reason')).toEqual(['unhandled_error'])
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'outcome')).toEqual(['error'])
+	})
+
+	it('records the client family from the user agent', async () => {
+		mockPublishedBoard()
+		const env = makeEnv()
+		await sharedBoardScreenshotMcp(
+			makeRpcRequest(
+				'tools/call',
+				{ name: 'get_board_info', arguments: { boardId: 'abc' } },
+				{ userAgent: 'python-httpx/0.27.0' }
+			),
+			env
+		)
+
+		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'client')).toEqual(['python'])
+	})
+
+	it('records the calling application named at initialize', async () => {
+		const env = makeEnv()
+		await sharedBoardScreenshotMcp(
+			makeRpcRequest('initialize', { clientInfo: { name: 'Claude', version: '1.0' } }),
+			env
+		)
+
+		expect(blobValuesOf(env, INITIALIZE_EVENT, 'client')).toEqual(['claude'])
+		// The raw name is kept alongside the family, so a client we do not recognize yet can be found.
+		expect(blobValuesOf(env, INITIALIZE_EVENT, 'raw')).toEqual(['Claude'])
+		expect(blobValuesOf(env, INITIALIZE_EVENT, 'ua')).toEqual(['none'])
+	})
+
+	it('normalizes client strings into a bounded set of families', () => {
+		expect(normalizeMcpClient('claude-ai/1.0')).toBe('claude')
+		// A Claude user agent also says Mozilla, so the more specific match has to win.
+		expect(normalizeMcpClient('Mozilla/5.0 (Macintosh) Claude/1.2')).toBe('claude')
+		expect(normalizeMcpClient('python-httpx/0.27.0')).toBe('python')
+		expect(normalizeMcpClient('Mozilla/5.0 (Macintosh)')).toBe('browser')
+		// Unrecognized agents collapse to one value rather than becoming a new dimension each.
+		expect(normalizeMcpClient('some-new-agent/1.0')).toBe('other')
+		expect(normalizeMcpClient(null)).toBe('none')
 	})
 })

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
@@ -410,6 +410,44 @@ describe('protocol telemetry', () => {
 		expect(blobValuesOf(env, TOOL_CALL_EVENT, 'outcome')).toEqual(['error'])
 	})
 
+	// The tool name comes straight off the wire, so the lookup must not resolve inherited names. A
+	// plain object would hand back Object.prototype's own methods and call them as tools: `constructor`
+	// would echo the caller's arguments back as a successful result, and `__proto__` would 500.
+	it('reports inherited property names as unknown tools rather than calling them', async () => {
+		for (const name of ['constructor', 'toString', '__proto__', 'valueOf', 'hasOwnProperty']) {
+			const env = makeEnv()
+			const response = await sharedBoardScreenshotMcp(
+				makeToolCall(name, { secret: 'echo-me' }),
+				env
+			)
+			const body = (await response.json()) as any
+
+			expect(body.error, name).toMatchObject({ code: -32602 })
+			expect(body.result, name).toBeUndefined()
+			expect(blobValuesOf(env, TOOL_CALL_EVENT, 'tool'), name).toEqual(['unknown'])
+			expect(blobValuesOf(env, TOOL_CALL_EVENT, 'reason'), name).toEqual(['unknown_tool'])
+		}
+	})
+
+	// clientInfo is whatever the client put in the body. Before the telemetry existed, initialize
+	// ignored params entirely, so a loose serializer sending a non-string name still connected.
+	it('handles a non-string clientInfo.name at initialize', async () => {
+		for (const name of [123, true, ['a'], { x: 1 }, null]) {
+			const env = makeEnv()
+			const response = await sharedBoardScreenshotMcp(
+				makeRpcRequest('initialize', { clientInfo: { name } }),
+				env
+			)
+
+			expect(response.status, String(name)).toBe(200)
+			expect((await response.json()) as any, String(name)).toMatchObject({
+				result: { protocolVersion: expect.any(String) },
+			})
+			expect(blobValuesOf(env, INITIALIZE_EVENT, 'client'), String(name)).toEqual(['none'])
+			expect(blobValuesOf(env, INITIALIZE_EVENT, 'raw'), String(name)).toEqual(['none'])
+		}
+	})
+
 	it('records the client family from the user agent', async () => {
 		mockPublishedBoard()
 		const env = makeEnv()

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
@@ -101,9 +101,11 @@ interface JsonRpcRequest {
 	params?: {
 		name?: string
 		arguments?: unknown
+		// Typed as unknown because it is whatever the client put in the request body; the telemetry
+		// writer narrows it rather than trusting it.
 		clientInfo?: {
-			name?: string
-			version?: string
+			name?: unknown
+			version?: unknown
 		}
 	}
 }
@@ -139,8 +141,10 @@ const MCP_CLIENT_FAMILIES: ReadonlyArray<readonly [needle: string, family: strin
 	['mozilla', 'browser'],
 ]
 
-export function normalizeMcpClient(value: string | null | undefined): string {
-	if (!value) return 'none'
+// Takes unknown because one caller passes a header and the other passes a field parsed straight out
+// of the request body, which is whatever the client chose to send.
+export function normalizeMcpClient(value: unknown): string {
+	if (typeof value !== 'string' || value === '') return 'none'
 	const lower = value.toLowerCase()
 	for (const [needle, family] of MCP_CLIENT_FAMILIES) {
 		if (lower.includes(needle)) return family
@@ -175,18 +179,22 @@ function writeMcpToolCallTelemetry(
 function writeMcpInitializeTelemetry(
 	env: Environment,
 	request: Request,
-	clientInfo: { name?: string; version?: string } | undefined
+	clientInfo: { name?: unknown; version?: unknown } | undefined
 ) {
+	const name = clientInfo?.name
 	writeDataPoint(undefined, env.MEASURE, env, 'mcp_server_initialize', {
 		blobs: [
-			`client:${normalizeMcpClient(clientInfo?.name)}`,
-			`raw:${(clientInfo?.name ?? 'none').slice(0, 64)}`,
+			`client:${normalizeMcpClient(name)}`,
+			`raw:${typeof name === 'string' ? name.slice(0, 64) : 'none'}`,
 			`ua:${normalizeMcpClient(request.headers.get('user-agent'))}`,
 		],
 	})
 }
 
-const TOOL_HANDLERS: Record<
+// A Map rather than an object literal, because the key comes straight off the wire: a plain object
+// would resolve inherited names too, so `tools/call` for `constructor` or `toString` would find one
+// of Object's own methods and call it as a tool instead of reporting an unknown tool.
+const TOOL_HANDLERS = new Map<
 	string,
 	(
 		argumentsValue: unknown,
@@ -194,12 +202,12 @@ const TOOL_HANDLERS: Record<
 		env: Environment,
 		ctx?: ExecutionContext
 	) => Promise<ToolCallResult>
-> = {
-	[BOARD_INFO_TOOL_NAME]: callBoardInfoTool,
-	[PAGE_INFO_TOOL_NAME]: callPageInfoTool,
-	[CLUSTER_INFO_TOOL_NAME]: callClusterInfoTool,
-	[CLUSTER_SCREENSHOT_TOOL_NAME]: callClusterScreenshotTool,
-}
+>([
+	[BOARD_INFO_TOOL_NAME, callBoardInfoTool],
+	[PAGE_INFO_TOOL_NAME, callPageInfoTool],
+	[CLUSTER_INFO_TOOL_NAME, callClusterInfoTool],
+	[CLUSTER_SCREENSHOT_TOOL_NAME, callClusterScreenshotTool],
+])
 
 export async function sharedBoardScreenshotMcp(
 	request: IRequest,
@@ -252,7 +260,7 @@ export async function sharedBoardScreenshotMcp(
 			})
 		case 'tools/call': {
 			const toolName = rpcRequest.params?.name ?? ''
-			const toolHandler = TOOL_HANDLERS[toolName]
+			const toolHandler = TOOL_HANDLERS.get(toolName)
 			if (!toolHandler) {
 				// The requested name is not recorded — it is caller-controlled and unbounded, so it would
 				// leak cardinality into the dataset. `unknown_tool` plus the JSON-RPC error is enough.
@@ -264,23 +272,15 @@ export async function sharedBoardScreenshotMcp(
 				return jsonRpcError(rpcRequest.id, -32602, `Unknown tool: ${rpcRequest.params?.name}`)
 			}
 			const startedAt = Date.now()
+			let called: ToolCallResult
+			// Scoped to the handler call alone, so that only a failure inside the tool can be recorded as
+			// unhandled_error. Every tool catches its own failures and returns a toolError, so reaching the
+			// catch means a bug rather than a bad request; it is recorded and rethrown, because the
+			// datapoint is worth most on the path nobody anticipated and swallowing it here would turn a
+			// 500 into a silently empty result.
 			try {
-				const { telemetryReason, ...result } = await toolHandler(
-					rpcRequest.params?.arguments,
-					request,
-					env,
-					ctx
-				)
-				writeMcpToolCallTelemetry(env, request, {
-					tool: toolName,
-					reason: telemetryReason,
-					durationMs: Date.now() - startedAt,
-				})
-				return jsonRpcResult(rpcRequest.id, result)
+				called = await toolHandler(rpcRequest.params?.arguments, request, env, ctx)
 			} catch (error) {
-				// Every tool catches its own failures and returns a toolError, so reaching here means a bug
-				// rather than a bad request. Recorded and rethrown: the datapoint is worth most on the path
-				// nobody anticipated, and swallowing it here would turn a 500 into a silent empty result.
 				writeMcpToolCallTelemetry(env, request, {
 					tool: toolName,
 					reason: 'unhandled_error',
@@ -288,6 +288,13 @@ export async function sharedBoardScreenshotMcp(
 				})
 				throw error
 			}
+			const { telemetryReason, ...result } = called
+			writeMcpToolCallTelemetry(env, request, {
+				tool: toolName,
+				reason: telemetryReason,
+				durationMs: Date.now() - startedAt,
+			})
+			return jsonRpcResult(rpcRequest.id, result)
 		}
 		default:
 			return jsonRpcError(rpcRequest.id, -32601, `Method not found: ${rpcRequest.method}`)
@@ -473,9 +480,6 @@ async function callBoardInfoTool(
 			})),
 		})
 	} catch (error) {
-		// The caller gets a bounded description, but nothing else records it: this tool writes no
-		// telemetry (it spends no Browser Run), so without a report a failing board lookup is
-		// invisible to us.
 		reportThumbnailError(error, {
 			ctx,
 			env,
@@ -484,9 +488,15 @@ async function callBoardInfoTool(
 			extras: { boardId: input.boardId },
 		})
 		const failureReason = classifyScreenshotFailure(error)
+		// The classifier reads render failures, and this tool starts no render: it resolves the board
+		// and reads its snapshot, and the lookup goes through a Postgres pool whose timeouts the
+		// classifier would otherwise report as `browser_timeout`. Only the snapshot-read class can
+		// honestly apply here, so everything else is recorded as what it is.
+		const telemetryReason =
+			failureReason === 'snapshot_read_error' ? failureReason : 'board_lookup_error'
 		return toolError(
 			`Could not read board info: ${describeThumbnailFailure(failureReason)}.`,
-			failureReason
+			telemetryReason
 		)
 	}
 }

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
@@ -14,6 +14,7 @@ import {
 	MCP_RATE_LIMIT_WINDOW_MS,
 } from '../../config'
 import { Environment } from '../../types'
+import { writeDataPoint } from '../../utils/analytics'
 import { arrayBufferToBase64 } from '../../utils/base64'
 import { sha256 } from '../../utils/hash'
 import { getDocumentNameFromSnapshot } from '../getDocumentNameFromSnapshot'
@@ -100,6 +101,10 @@ interface JsonRpcRequest {
 	params?: {
 		name?: string
 		arguments?: unknown
+		clientInfo?: {
+			name?: string
+			version?: string
+		}
 	}
 }
 
@@ -110,6 +115,90 @@ interface JsonRpcRequest {
 export function isMcpScreenshotEnabled(env: Environment) {
 	const value = env.MCP_SCREENSHOT_ENABLED?.trim().toLowerCase()
 	return value === undefined || value === '' || value === 'true'
+}
+
+// --- MCP protocol telemetry ---
+
+// Known MCP client families, matched as case-insensitive substrings against the User-Agent header
+// and the clientInfo.name from initialize. Bounded on purpose: raw agent strings are
+// unbounded-cardinality, so anything unrecognized lands in `other`, and the initialize event keeps a
+// truncated raw name for spotting families worth adding here. Order matters where strings overlap —
+// a Claude UA also says Mozilla, so `mozilla` sits last.
+const MCP_CLIENT_FAMILIES: ReadonlyArray<readonly [needle: string, family: string]> = [
+	['claude', 'claude'],
+	['anthropic', 'claude'],
+	['chatgpt', 'openai'],
+	['openai', 'openai'],
+	['cursor', 'cursor'],
+	['python', 'python'],
+	['httpx', 'python'],
+	['aiohttp', 'python'],
+	['node', 'node'],
+	['undici', 'node'],
+	['curl', 'curl'],
+	['mozilla', 'browser'],
+]
+
+export function normalizeMcpClient(value: string | null | undefined): string {
+	if (!value) return 'none'
+	const lower = value.toLowerCase()
+	for (const [needle, family] of MCP_CLIENT_FAMILIES) {
+		if (lower.includes(needle)) return family
+	}
+	return 'other'
+}
+
+// One datapoint per tools/call dispatch, whatever the tool did: the render path's
+// mcp_shared_board_screenshot event only fires when a screenshot is attempted, so without this the
+// info tools (and every early failure) are invisible. Written at the dispatcher rather than inside
+// the tools, so a new tool cannot ship unmetered.
+function writeMcpToolCallTelemetry(
+	env: Environment,
+	request: Request,
+	data: { tool: string; durationMs: number; reason?: string }
+) {
+	writeDataPoint(undefined, env.MEASURE, env, 'mcp_server_tool_call', {
+		blobs: [
+			`tool:${data.tool}`,
+			`outcome:${data.reason ? 'error' : 'ok'}`,
+			`reason:${data.reason ?? 'none'}`,
+			`client:${normalizeMcpClient(request.headers.get('user-agent'))}`,
+		],
+		doubles: [data.durationMs],
+	})
+}
+
+// initialize is the one request where the calling application names itself, so it gets its own
+// event. The raw name is kept (truncated) alongside the normalized family: initializes are rare
+// enough that the cardinality is affordable, and it is how new families get discovered. The UA
+// family rides along as a cross-check for hosts whose header and clientInfo disagree.
+function writeMcpInitializeTelemetry(
+	env: Environment,
+	request: Request,
+	clientInfo: { name?: string; version?: string } | undefined
+) {
+	writeDataPoint(undefined, env.MEASURE, env, 'mcp_server_initialize', {
+		blobs: [
+			`client:${normalizeMcpClient(clientInfo?.name)}`,
+			`raw:${(clientInfo?.name ?? 'none').slice(0, 64)}`,
+			`ua:${normalizeMcpClient(request.headers.get('user-agent'))}`,
+		],
+	})
+}
+
+const TOOL_HANDLERS: Record<
+	string,
+	(
+		argumentsValue: unknown,
+		request: Request,
+		env: Environment,
+		ctx?: ExecutionContext
+	) => Promise<ToolCallResult>
+> = {
+	[BOARD_INFO_TOOL_NAME]: callBoardInfoTool,
+	[PAGE_INFO_TOOL_NAME]: callPageInfoTool,
+	[CLUSTER_INFO_TOOL_NAME]: callClusterInfoTool,
+	[CLUSTER_SCREENSHOT_TOOL_NAME]: callClusterScreenshotTool,
 }
 
 export async function sharedBoardScreenshotMcp(
@@ -138,6 +227,7 @@ export async function sharedBoardScreenshotMcp(
 
 	switch (rpcRequest.method) {
 		case 'initialize':
+			writeMcpInitializeTelemetry(env, request, rpcRequest.params?.clientInfo)
 			return jsonRpcResult(rpcRequest.id, {
 				protocolVersion: MCP_PROTOCOL_VERSION,
 				capabilities: { tools: {} },
@@ -160,31 +250,45 @@ export async function sharedBoardScreenshotMcp(
 					getClusterScreenshotToolDefinition(),
 				],
 			})
-		case 'tools/call':
-			switch (rpcRequest.params?.name) {
-				case BOARD_INFO_TOOL_NAME:
-					return jsonRpcResult(
-						rpcRequest.id,
-						await callBoardInfoTool(rpcRequest.params.arguments, request, env, ctx)
-					)
-				case PAGE_INFO_TOOL_NAME:
-					return jsonRpcResult(
-						rpcRequest.id,
-						await callPageInfoTool(rpcRequest.params.arguments, request, env, ctx)
-					)
-				case CLUSTER_INFO_TOOL_NAME:
-					return jsonRpcResult(
-						rpcRequest.id,
-						await callClusterInfoTool(rpcRequest.params.arguments, request, env, ctx)
-					)
-				case CLUSTER_SCREENSHOT_TOOL_NAME:
-					return jsonRpcResult(
-						rpcRequest.id,
-						await callClusterScreenshotTool(rpcRequest.params.arguments, request, env, ctx)
-					)
-				default:
-					return jsonRpcError(rpcRequest.id, -32602, `Unknown tool: ${rpcRequest.params?.name}`)
+		case 'tools/call': {
+			const toolName = rpcRequest.params?.name ?? ''
+			const toolHandler = TOOL_HANDLERS[toolName]
+			if (!toolHandler) {
+				// The requested name is not recorded — it is caller-controlled and unbounded, so it would
+				// leak cardinality into the dataset. `unknown_tool` plus the JSON-RPC error is enough.
+				writeMcpToolCallTelemetry(env, request, {
+					tool: 'unknown',
+					reason: 'unknown_tool',
+					durationMs: 0,
+				})
+				return jsonRpcError(rpcRequest.id, -32602, `Unknown tool: ${rpcRequest.params?.name}`)
 			}
+			const startedAt = Date.now()
+			try {
+				const { telemetryReason, ...result } = await toolHandler(
+					rpcRequest.params?.arguments,
+					request,
+					env,
+					ctx
+				)
+				writeMcpToolCallTelemetry(env, request, {
+					tool: toolName,
+					reason: telemetryReason,
+					durationMs: Date.now() - startedAt,
+				})
+				return jsonRpcResult(rpcRequest.id, result)
+			} catch (error) {
+				// Every tool catches its own failures and returns a toolError, so reaching here means a bug
+				// rather than a bad request. Recorded and rethrown: the datapoint is worth most on the path
+				// nobody anticipated, and swallowing it here would turn a 500 into a silent empty result.
+				writeMcpToolCallTelemetry(env, request, {
+					tool: toolName,
+					reason: 'unhandled_error',
+					durationMs: Date.now() - startedAt,
+				})
+				throw error
+			}
+		}
 		default:
 			return jsonRpcError(rpcRequest.id, -32601, `Method not found: ${rpcRequest.method}`)
 	}
@@ -333,7 +437,7 @@ async function callBoardInfoTool(
 	try {
 		input = parseBoardInfoInput(argumentsValue)
 	} catch (error) {
-		return toolError(error instanceof Error ? error.message : String(error))
+		return toolError(error instanceof Error ? error.message : String(error), 'invalid_input')
 	}
 
 	// Not rate limited: the limiters here bound Browser Run, and this call spends none. The clustering
@@ -346,13 +450,14 @@ async function callBoardInfoTool(
 			return toolError(
 				resolved.reason === 'board_empty'
 					? 'This board has no saved content yet.'
-					: 'No public board was found with this id. Only published boards and files shared via link are supported.'
+					: 'No public board was found with this id. Only published boards and files shared via link are supported.',
+				resolved.reason === 'board_empty' ? 'board_empty' : 'not_found'
 			)
 		}
 
 		const snapshot = await loadBoardSnapshot(env, resolved.board, { access: 'public' })
 		if (!snapshot) {
-			return toolError('This board has no saved content yet.')
+			return toolError('This board has no saved content yet.', 'board_empty')
 		}
 		const pages = enumerateBoardPages(snapshot)
 		return toolJsonResult({
@@ -378,8 +483,10 @@ async function callBoardInfoTool(
 			surface: 'mcp_board_info',
 			extras: { boardId: input.boardId },
 		})
+		const failureReason = classifyScreenshotFailure(error)
 		return toolError(
-			`Could not read board info: ${describeThumbnailFailure(classifyScreenshotFailure(error))}.`
+			`Could not read board info: ${describeThumbnailFailure(failureReason)}.`,
+			failureReason
 		)
 	}
 }
@@ -395,7 +502,7 @@ async function callPageInfoTool(
 	try {
 		input = parsePageInfoInput(argumentsValue)
 	} catch (error) {
-		return toolError(error instanceof Error ? error.message : String(error))
+		return toolError(error instanceof Error ? error.message : String(error), 'invalid_input')
 	}
 
 	if (
@@ -404,7 +511,8 @@ async function callPageInfoTool(
 		})
 	) {
 		return toolError(
-			`Rate limited. Requests are limited to about ${MCP_PER_IP_RATE_LIMIT} per minute per IP.`
+			`Rate limited. Requests are limited to about ${MCP_PER_IP_RATE_LIMIT} per minute per IP.`,
+			'rate_limited_ip'
 		)
 	}
 
@@ -437,8 +545,10 @@ async function callPageInfoTool(
 			surface: 'mcp_board_info',
 			extras: { boardId: input.boardId },
 		})
+		const failureReason = classifyScreenshotFailure(error)
 		return toolError(
-			`Could not read page info: ${describeThumbnailFailure(classifyScreenshotFailure(error))}.`
+			`Could not read page info: ${describeThumbnailFailure(failureReason)}.`,
+			failureReason
 		)
 	}
 }
@@ -468,19 +578,20 @@ async function resolveBoardPage(
 			result: toolError(
 				resolved.reason === 'board_empty'
 					? 'This board has no saved content yet.'
-					: 'No public board was found with this id. Only published boards and files shared via link are supported.'
+					: 'No public board was found with this id. Only published boards and files shared via link are supported.',
+				resolved.reason === 'board_empty' ? 'board_empty' : 'not_found'
 			),
 		}
 	}
 
 	const snapshot = await loadBoardSnapshot(env, resolved.board, { access: 'public' })
 	if (!snapshot) {
-		return { ok: false, result: toolError('This board has no saved content yet.') }
+		return { ok: false, result: toolError('This board has no saved content yet.', 'board_empty') }
 	}
 
 	const pages = enumerateBoardPages(snapshot)
 	if (pages.length === 0) {
-		return { ok: false, result: toolError('This board has no pages.') }
+		return { ok: false, result: toolError('This board has no pages.', 'board_empty') }
 	}
 
 	const targetPage = page.kind === 'id' ? pages.find((p) => p.id === page.id) : pages[page.ordinal]
@@ -490,7 +601,8 @@ async function resolveBoardPage(
 			result: toolError(
 				page.kind === 'id'
 					? `No page with id "${page.id}" on this board. Call get_board_info to list its pages; a page id is stable across reordering, an index is not.`
-					: `Page ${page.ordinal} is out of range: this board has ${pages.length} page(s) (0–${pages.length - 1}). Call get_board_info to list them.`
+					: `Page ${page.ordinal} is out of range: this board has ${pages.length} page(s) (0–${pages.length - 1}). Call get_board_info to list them.`,
+				'page_not_found'
 			),
 		}
 	}
@@ -550,7 +662,7 @@ async function callClusterInfoTool(
 	try {
 		input = parseClusterInfoInput(argumentsValue)
 	} catch (error) {
-		return toolError(error instanceof Error ? error.message : String(error))
+		return toolError(error instanceof Error ? error.message : String(error), 'invalid_input')
 	}
 
 	if (
@@ -559,7 +671,8 @@ async function callClusterInfoTool(
 		})
 	) {
 		return toolError(
-			`Rate limited. Requests are limited to about ${MCP_PER_IP_RATE_LIMIT} per minute per IP.`
+			`Rate limited. Requests are limited to about ${MCP_PER_IP_RATE_LIMIT} per minute per IP.`,
+			'rate_limited_ip'
 		)
 	}
 
@@ -570,7 +683,8 @@ async function callClusterInfoTool(
 		const cluster = (await clusterPage(env, resolved)).find((c) => c.id === input.clusterId)
 		if (!cluster) {
 			return toolError(
-				`No cluster with id "${input.clusterId}" on page ${describePageSelector(input.page)}. Call get_page_info to list this page's clusters.`
+				`No cluster with id "${input.clusterId}" on page ${describePageSelector(input.page)}. Call get_page_info to list this page's clusters.`,
+				'cluster_not_found'
 			)
 		}
 
@@ -594,8 +708,10 @@ async function callClusterInfoTool(
 				clusterId: input.clusterId,
 			},
 		})
+		const failureReason = classifyScreenshotFailure(error)
 		return toolError(
-			`Could not read cluster info: ${describeThumbnailFailure(classifyScreenshotFailure(error))}.`
+			`Could not read cluster info: ${describeThumbnailFailure(failureReason)}.`,
+			failureReason
 		)
 	}
 }
@@ -646,7 +762,8 @@ async function renderShapeSetScreenshot(
 	) {
 		telemetry({ cacheStatus: 'miss', rateLimitAllowed: false, failureReason: 'rate_limited_ip' })
 		return toolError(
-			`Rate limited. Screenshots are limited to about ${MCP_PER_IP_RATE_LIMIT} requests per minute per IP.`
+			`Rate limited. Screenshots are limited to about ${MCP_PER_IP_RATE_LIMIT} requests per minute per IP.`,
+			'rate_limited_ip'
 		)
 	}
 
@@ -694,7 +811,10 @@ async function renderShapeSetScreenshot(
 				rateLimitAllowed: false,
 				failureReason: 'rate_limited_board',
 			})
-			return toolError('Rate limited. This board is being screenshotted too frequently.')
+			return toolError(
+				'Rate limited. This board is being screenshotted too frequently.',
+				'rate_limited_board'
+			)
 		}
 		if (await isGlobalBrowserRunRateLimited(env)) {
 			telemetry({
@@ -702,7 +822,10 @@ async function renderShapeSetScreenshot(
 				rateLimitAllowed: false,
 				failureReason: 'rate_limited_global',
 			})
-			return toolError('Rate limited. Screenshot capacity is busy, try again in a minute.')
+			return toolError(
+				'Rate limited. Screenshot capacity is busy, try again in a minute.',
+				'rate_limited_global'
+			)
 		}
 
 		const render = await captureThumbnailScreenshot(env, resolved.board, {
@@ -748,7 +871,10 @@ async function renderShapeSetScreenshot(
 			failureReason,
 			browserRunDurationMs: browserRunDurationOf(error),
 		})
-		return toolError(`Screenshot failed: ${describeThumbnailFailure(failureReason)}.`)
+		return toolError(
+			`Screenshot failed: ${describeThumbnailFailure(failureReason)}.`,
+			failureReason
+		)
 	}
 }
 
@@ -770,7 +896,7 @@ async function callClusterScreenshotTool(
 			cacheStatus: 'miss',
 			failureReason: 'invalid_input',
 		})
-		return toolError(error instanceof Error ? error.message : String(error))
+		return toolError(error instanceof Error ? error.message : String(error), 'invalid_input')
 	}
 
 	return renderShapeSetScreenshot(request, env, ctx, {
@@ -789,7 +915,8 @@ async function callClusterScreenshotTool(
 				return {
 					ok: false,
 					result: toolError(
-						`No cluster on page ${describePageSelector(input.page)} with id ${missing.map((id) => `"${id}"`).join(', ')}. Call get_page_info to list this page's clusters.`
+						`No cluster on page ${describePageSelector(input.page)} with id ${missing.map((id) => `"${id}"`).join(', ')}. Call get_page_info to list this page's clusters.`,
+						'cluster_not_found'
 					),
 				}
 			}
@@ -806,14 +933,25 @@ async function callClusterScreenshotTool(
 	})
 }
 
-function toolError(message: string) {
+interface ToolCallResult {
+	content: Array<Record<string, unknown>>
+	isError?: boolean
+	/**
+	 * Machine-readable failure code for the mcp_server_tool_call datapoint, read and stripped by the
+	 * tools/call dispatcher before the result is serialized — callers never see it.
+	 */
+	telemetryReason?: string
+}
+
+function toolError(message: string, reason: string): ToolCallResult {
 	return {
 		content: [{ type: 'text', text: message }],
 		isError: true,
+		telemetryReason: reason,
 	}
 }
 
-function toolPageResult(name: string, base64: string) {
+function toolPageResult(name: string, base64: string): ToolCallResult {
 	return {
 		content: [
 			{ type: 'text', text: name },
@@ -822,7 +960,7 @@ function toolPageResult(name: string, base64: string) {
 	}
 }
 
-function toolJsonResult(value: unknown) {
+function toolJsonResult(value: unknown): ToolCallResult {
 	return {
 		content: [{ type: 'text', text: JSON.stringify(value) }],
 	}

--- a/internal/grafana/README.md
+++ b/internal/grafana/README.md
@@ -4,9 +4,11 @@
 
 This directory currently provisions:
 
-- Nine dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP app sessions`, and `Bemo analytics` in the `Dotcom` folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
+- Ten dashboards: `Zero on Fly.io — service health` (`zero-fly-health`), `Zero slow queries` (`slow-queries`), and `Zero-cache HTTP edge (Fly.io)` (`ni7hhgd`) in the `Zero` folder; `Anthropic scrape overview` in the `Anthropic` folder; `Dotcom events` (`ni5k8zc`), `Dotcom events V1` (`adgumkhou3chsd`), `File effect outbox`, `MCP server (shared boards)` (`mcp-server`), `MCP app sessions` (`kotx6wj`), and `Bemo analytics` in the `Dotcom` folder. The events pipeline currently reports from **staging** — set the environment variable accordingly when a dashboard looks empty.
 - All 12 Grafana-managed alert rules (Zero replication/errors/backups, Fly.io container health, Anthropic cost/usage)
-- The folders `Zero` (dashboards + 9 rules), `Dotcom` (5 dashboards), and `Anthropic` (1 dashboard + 3 cost rules)
+- The folders `Zero` (dashboards + 9 rules), `Dotcom` (6 dashboards), and `Anthropic` (1 dashboard + 3 cost rules)
+
+There are two MCP dashboards, for two different servers. `MCP server (shared boards)` covers the public server on the sync worker at `POST /app/mcp` (`apps/dotcom/sync-worker`), which reads its protocol metrics from the `MEASURE` dataset. `MCP app sessions` covers the separate tldraw MCP app worker (`apps/mcp-app`) and its own `MCP_ANALYTICS` dataset. Neither one's panels belong on `Dotcom events` — that dashboard covers the sync worker's own events.
 
 Contact points, notification policies, and data sources are hand-managed in Grafana on purpose.
 

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mcp-server.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mcp-server.yaml
@@ -1,0 +1,1812 @@
+apiVersion: dashboard.grafana.app/v2
+kind: Dashboard
+metadata:
+  annotations:
+    grafana.app/folder: dotcom
+  labels: {}
+  name: mcp-server
+  namespace: stacks-890472
+spec:
+  annotations:
+    - kind: AnnotationQuery
+      spec:
+        builtIn: true
+        enable: true
+        hide: true
+        iconColor: rgba(0, 211, 255, 1)
+        name: Annotations & Alerts
+        query:
+          datasource:
+            name: -- Grafana --
+          group: grafana
+          kind: DataQuery
+          spec: {}
+          version: v0
+  cursorSync: Crosshair
+  description:
+    The public MCP server on the sync worker at POST /app/mcp, which serves get_board_info,
+    get_page_info, get_cluster_info and get_cluster_screenshot for published and link-shared
+    tldraw.com boards. Protocol traffic comes from the mcp_server_tool_call and mcp_server_initialize
+    events; the render panels are the source:mcp slice of mcp_shared_board_screenshot, whose
+    cross-surface view (og and queue too) stays on Dotcom events. This server only — the separate
+    tldraw MCP app worker (apps/mcp-app) and its own MCP_ANALYTICS dataset are on MCP app
+    sessions.
+  editable: true
+  elements:
+    panel-1:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: |-
+                        SELECT count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      rawQuery: |-
+                        SELECT count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Every tools/call the MCP server dispatched, including ones that failed
+          before doing any work.
+        id: 1
+        links: []
+        title: Tool calls
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds: &id001
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+            version: 13.2.0-29854286369
+    panel-10:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob6, 8) as client, count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, client
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob6, 8) as client, count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, client
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Client family, normalized from the User-Agent header into a bounded set
+          (claude, openai, cursor, python, node, curl, browser, other, none). `none` means
+          the caller sent no User-Agent.
+        id: 10
+        links: []
+        title: Tool calls by client
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-11:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: |-
+                        SELECT substring(blob3, 8) as client, count() as handshakes
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_initialize'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY client
+                        ORDER BY handshakes DESC
+                      rawQuery: |-
+                        SELECT substring(blob3, 8) as client, count() as handshakes
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_initialize'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY client
+                        ORDER BY handshakes DESC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Which applications opened connections, taken from the clientInfo.name
+          each one sends at initialize rather than from its User-Agent.
+        id: 11
+        links: []
+        title: Handshakes by client
+        vizConfig:
+          group: piechart
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                unit: short
+              overrides: []
+            options:
+              displayLabels:
+                - percent
+              legend:
+                displayMode: list
+                overflow: ellipsis
+                placement: right
+                showLegend: true
+                values: []
+              pieType: donut
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: true
+              sort: desc
+              tooltip:
+                hideZeros: false
+                mode: single
+                sort: none
+            version: 13.2.0-29854286369
+    panel-12:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: |-
+                        SELECT substring(blob4, 5) as client_name, substring(blob5, 4) as user_agent, count() as handshakes
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_initialize'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY client_name, user_agent
+                        ORDER BY handshakes DESC
+                        LIMIT 50
+                      rawQuery: |-
+                        SELECT substring(blob4, 5) as client_name, substring(blob5, 4) as user_agent, count() as handshakes
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_initialize'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY client_name, user_agent
+                        ORDER BY handshakes DESC
+                        LIMIT 50
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: The raw clientInfo.name each caller reported, beside the User-Agent family
+          it arrived with. This is where a client that currently lands in `other` gets identified
+          — add it to MCP_CLIENT_FAMILIES in sharedBoardScreenshotMcp.ts and it gets its own
+          series in the panels above.
+        id: 12
+        links: []
+        title: Client names seen at initialize
+        vizConfig:
+          group: table
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                custom:
+                  align: auto
+                  cellOptions:
+                    type: auto
+                  inspect: false
+                thresholds: *id001
+              overrides: []
+            options:
+              cellHeight: sm
+              footer:
+                countRows: false
+                fields: ''
+                reducer:
+                  - sum
+                show: false
+              showHeader: true
+            version: 13.2.0-29854286369
+    panel-13:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double3, _sample_interval) as p50, quantileWeighted(0.95, double3, _sample_interval) as p95, quantileWeighted(0.99, double3, _sample_interval) as p99
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND double3 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double3, _sample_interval) as p50, quantileWeighted(0.95, double3, _sample_interval) as p95, quantileWeighted(0.99, double3, _sample_interval) as p99
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND double3 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Time spent in Browser Run per screenshot for this server only (source:mcp).
+          The cross-surface view, including the og route and the background queue, is on the
+          Dotcom events dashboard.
+        id: 13
+        links: []
+        title: Browser Run render duration percentiles
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 10
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-14:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob4, 7) as cache_status, count() as total
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, cache_status
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob4, 7) as cache_status, count() as total
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, cache_status
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Cache outcome per screenshot attempt: hit (served a cached PNG), miss
+          (had to render). Only misses spend Browser Run, so a falling hit rate is what makes
+          render spend climb.'
+        id: 14
+        links: []
+        title: Screenshot cache status
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-15:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob5, 9) as reason, count() as total
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND blob5 != 'failure:none'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, reason
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob5, 9) as reason, count() as total
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND blob5 != 'failure:none'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, reason
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Render-path failures for this server only. browser_timeout and browser_failed
+          are Browser Run problems; snapshot_read_error is the board load; the rest are caller-shaped.
+        id: 15
+        links: []
+        title: Screenshot failures by reason
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-16:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob5, 9) as reason, count() as blocked
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND blob6 = 'rate_limit:blocked'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, reason
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob5, 9) as reason, count() as blocked
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND blob6 = 'rate_limit:blocked'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, reason
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Which limiter turned a screenshot away: rate_limited_ip is one caller
+          over its per-IP budget, rate_limited_board is one board being screenshotted too
+          often, and rate_limited_global means the shared Browser Run cap is saturated — that
+          last one is shared with the og and queue surfaces.'
+        id: 16
+        links: []
+        title: Rate-limited screenshot events
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-2:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: |-
+                        SELECT countIf(blob4 = 'outcome:error') / count() * 100 as error_rate
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      rawQuery: |-
+                        SELECT countIf(blob4 = 'outcome:error') / count() * 100 as error_rate
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Share of tool calls that returned an error, for any reason — bad input,
+          a board that could not be found, a rate limit, or a failed render.
+        id: 2
+        links: []
+        title: Tool call error rate
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds: *id001
+                unit: percent
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+            version: 13.2.0-29854286369
+    panel-3:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: |-
+                        SELECT count() as handshakes
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_initialize'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      rawQuery: |-
+                        SELECT count() as handshakes
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_initialize'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'initialize requests: one per client session opening a connection to
+          the server. Compare with tool calls to see clients that connect and then never ask
+          for anything.'
+        id: 3
+        links: []
+        title: Handshakes
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+            version: 13.2.0-29854286369
+    panel-4:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: table
+                      formatAs: table
+                      intervalFactor: 1
+                      query: |-
+                        SELECT count() as renders
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND double3 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      rawQuery: |-
+                        SELECT count() as renders
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_shared_board_screenshot'
+                        AND blob3 = 'source:mcp'
+                        AND double3 > 0
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: Tool calls that actually spent Browser Run capacity (double3 carries
+          a render duration; -1 means no render happened). Cache hits and failures are excluded.
+        id: 4
+        links: []
+        title: Screenshots rendered
+        vizConfig:
+          group: stat
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: thresholds
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              colorMode: value
+              graphMode: area
+              justifyMode: auto
+              orientation: auto
+              percentChangeColorMode: standard
+              reduceOptions:
+                calcs:
+                  - lastNotNull
+                fields: ''
+                values: false
+              showPercentChange: false
+              textMode: auto
+              wideLayout: true
+            version: 13.2.0-29854286369
+    panel-5:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob3, 6) as tool, count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, tool
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob3, 6) as tool, count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, tool
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Which of the four tools callers actually use: get_board_info, get_page_info,
+          get_cluster_info and get_cluster_screenshot. `unknown` is a call for a tool name
+          this server does not have.'
+        id: 5
+        links: []
+        title: Tool calls by tool
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-6:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob4, 9) as outcome, count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, outcome
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob4, 9) as outcome, count() as calls
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, outcome
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: ok against error, for every tool together. A healthy server is mostly
+          ok with a thin, steady error band; a step change in error usually means one caller
+          found a broken path.
+        id: 6
+        links: []
+        title: Tool call outcomes
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-7:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob5, 8) as reason, count() as errors
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob4 = 'outcome:error'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, reason
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob5, 8) as reason, count() as errors
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob4 = 'outcome:error'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, reason
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: 'Bounded reason codes: invalid_input, not_found, board_empty, page_not_found,
+          cluster_not_found, unknown_tool, the rate_limited_* codes, and the render failure
+          classes. Caller mistakes (invalid_input, *_not_found) are expected traffic; the
+          render classes are ours. unhandled_error means a tool threw instead of returning
+          an error, which is always a bug.'
+        id: 7
+        links: []
+        title: Tool call errors by reason
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: short
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-8:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double1, _sample_interval) as p50, quantileWeighted(0.95, double1, _sample_interval) as p95, quantileWeighted(0.99, double1, _sample_interval) as p99
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, quantileWeighted(0.5, double1, _sample_interval) as p50, quantileWeighted(0.95, double1, _sample_interval) as p95, quantileWeighted(0.99, double1, _sample_interval) as p99
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: End-to-end time inside the tools/call handler, weighted by _sample_interval
+          to account for Analytics Engine sampling. Includes the board lookup, any measure
+          render, and the screenshot itself.
+        id: 8
+        links: []
+        title: Tool call duration percentiles
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 10
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+    panel-9:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob3, 6) as tool, quantileWeighted(0.95, double1, _sample_interval) as p95
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, tool
+                        ORDER BY date ASC
+                      rawQuery: |-
+                        SELECT toStartOfInterval(timestamp, INTERVAL '$interval' SECOND) as date, substring(blob3, 6) as tool, quantileWeighted(0.95, double1, _sample_interval) as p95
+                        FROM 'MEASURE'
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+                        AND blob1 = 'mcp_server_tool_call'
+                        AND blob2 = '${environment}-tldraw-multiplayer'
+                        GROUP BY date, tool
+                        ORDER BY date ASC
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: The same p95, split per tool. get_board_info reads a snapshot and should
+          stay fast; the clustering tools each pay for a measure render, so they sit an order
+          of magnitude higher.
+        id: 9
+        links: []
+        title: Tool call p95 duration by tool
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 10
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds: *id001
+                unit: ms
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+            version: 13.2.0-29854286369
+  layout:
+    kind: GridLayout
+    spec:
+      items:
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-1
+            height: 4
+            width: 6
+            x: 0
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-2
+            height: 4
+            width: 6
+            x: 6
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-3
+            height: 4
+            width: 6
+            x: 12
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-4
+            height: 4
+            width: 6
+            x: 18
+            y: 0
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-5
+            height: 8
+            width: 12
+            x: 0
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-6
+            height: 8
+            width: 6
+            x: 12
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-7
+            height: 8
+            width: 6
+            x: 18
+            y: 4
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-8
+            height: 8
+            width: 12
+            x: 0
+            y: 12
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-9
+            height: 8
+            width: 12
+            x: 12
+            y: 12
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-10
+            height: 8
+            width: 8
+            x: 0
+            y: 20
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-11
+            height: 8
+            width: 8
+            x: 8
+            y: 20
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-12
+            height: 8
+            width: 8
+            x: 16
+            y: 20
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-13
+            height: 8
+            width: 12
+            x: 0
+            y: 28
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-14
+            height: 8
+            width: 12
+            x: 12
+            y: 28
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-15
+            height: 8
+            width: 12
+            x: 0
+            y: 36
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-16
+            height: 8
+            width: 12
+            x: 12
+            y: 36
+  links: []
+  liveNow: false
+  preload: false
+  tags:
+    - tldraw
+    - analytics-engine
+    - mcp
+    - provisioned
+    - repo:tldraw/tldraw
+  timeSettings:
+    autoRefresh: ''
+    autoRefreshIntervals:
+      - 30s
+      - 1m
+      - 5m
+      - 15m
+      - 30m
+      - 1h
+      - 2h
+      - 1d
+    fiscalYearStartMonth: 0
+    from: now-24h
+    hideTimepicker: false
+    timezone: browser
+    to: now
+  title: MCP server (shared boards)
+  variables:
+    - kind: TextVariable
+      spec:
+        current:
+          text: production
+          value: production
+        description: Environment to filter by. Use production, staging, or your pr number
+          (pr-42). Every panel here reads the MEASURE dataset, so it applies to all of them.
+        hide: dontHide
+        label: 'Environment: production | staging | pr-42'
+        name: environment
+        query: production
+        skipUrlSync: false

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mcp-server.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/mcp-server.yaml
@@ -110,7 +110,7 @@ spec:
               showPercentChange: false
               textMode: auto
               wideLayout: true
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-10:
       kind: Panel
       spec:
@@ -220,7 +220,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-11:
       kind: Panel
       spec:
@@ -308,7 +308,7 @@ spec:
                 hideZeros: false
                 mode: single
                 sort: none
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-12:
       kind: Panel
       spec:
@@ -387,7 +387,7 @@ spec:
                   - sum
                 show: false
               showHeader: true
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-13:
       kind: Panel
       spec:
@@ -501,7 +501,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-14:
       kind: Panel
       spec:
@@ -613,7 +613,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-15:
       kind: Panel
       spec:
@@ -726,7 +726,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-16:
       kind: Panel
       spec:
@@ -841,7 +841,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-2:
       kind: Panel
       spec:
@@ -915,7 +915,7 @@ spec:
               showPercentChange: false
               textMode: auto
               wideLayout: true
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-3:
       kind: Panel
       spec:
@@ -990,7 +990,7 @@ spec:
               showPercentChange: false
               textMode: auto
               wideLayout: true
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-4:
       kind: Panel
       spec:
@@ -1068,7 +1068,7 @@ spec:
               showPercentChange: false
               textMode: auto
               wideLayout: true
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-5:
       kind: Panel
       spec:
@@ -1178,7 +1178,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-6:
       kind: Panel
       spec:
@@ -1288,7 +1288,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-7:
       kind: Panel
       spec:
@@ -1339,10 +1339,13 @@ spec:
             queryOptions: {}
             transformations: []
         description: 'Bounded reason codes: invalid_input, not_found, board_empty, page_not_found,
-          cluster_not_found, unknown_tool, the rate_limited_* codes, and the render failure
-          classes. Caller mistakes (invalid_input, *_not_found) are expected traffic; the
-          render classes are ours. unhandled_error means a tool threw instead of returning
-          an error, which is always a bug.'
+          cluster_not_found, unknown_tool, board_lookup_error, the rate_limited_* codes, and
+          the render failure classes. Caller mistakes (invalid_input, *_not_found) are expected
+          traffic; the render classes are ours. unhandled_error means a tool threw instead
+          of returning an error, which is always a bug. Caveat on the clustering tools: they
+          resolve the board and then render it under one catch, so a Postgres stall during
+          the lookup can be reported as browser_timeout — check Postgres before trusting a
+          browser class from get_page_info or get_cluster_info.'
         id: 7
         links: []
         title: Tool call errors by reason
@@ -1402,7 +1405,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-8:
       kind: Panel
       spec:
@@ -1430,6 +1433,7 @@ spec:
                         FROM 'MEASURE'
                         WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
                         AND blob1 = 'mcp_server_tool_call'
+                        AND blob5 NOT IN ('reason:unknown_tool', 'reason:invalid_input')
                         AND blob2 = '${environment}-tldraw-multiplayer'
                         GROUP BY date
                         ORDER BY date ASC
@@ -1438,6 +1442,7 @@ spec:
                         FROM 'MEASURE'
                         WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
                         AND blob1 = 'mcp_server_tool_call'
+                        AND blob5 NOT IN ('reason:unknown_tool', 'reason:invalid_input')
                         AND blob2 = '${environment}-tldraw-multiplayer'
                         GROUP BY date
                         ORDER BY date ASC
@@ -1452,7 +1457,9 @@ spec:
             transformations: []
         description: End-to-end time inside the tools/call handler, weighted by _sample_interval
           to account for Analytics Engine sampling. Includes the board lookup, any measure
-          render, and the screenshot itself.
+          render, and the screenshot itself. Calls rejected before doing any work (an unknown
+          tool name, or arguments that failed to parse) are excluded — they always measure
+          zero, and a client looping one would otherwise hold the reported p50 at zero.
         id: 8
         links: []
         title: Tool call duration percentiles
@@ -1512,7 +1519,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
     panel-9:
       kind: Panel
       spec:
@@ -1622,7 +1629,7 @@ spec:
                 maxHeight: 600
                 mode: multi
                 sort: desc
-            version: 13.2.0-29854286369
+          version: 13.2.0-29854286369
   layout:
     kind: GridLayout
     spec:

--- a/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
+++ b/internal/grafana/resources/dashboards.v2.dashboard.grafana.app/ni5k8zc.yaml
@@ -3351,364 +3351,6 @@ spec:
                 mode: single
                 sort: none
           version: 13.2.0-29854286369
-    panel-30:
-      kind: Panel
-      spec:
-        data:
-          kind: QueryGroup
-          spec:
-            queries:
-              - kind: PanelQuery
-                spec:
-                  hidden: false
-                  query:
-                    datasource:
-                      name: bdgu7tk03irr4e
-                    group: vertamedia-clickhouse-datasource
-                    kind: DataQuery
-                    spec:
-                      dateTimeType: DATETIME
-                      editorMode: code
-                      extrapolate: true
-                      format: time_series
-                      formatAs: time_series
-                      intervalFactor: 1
-                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
-                        SECOND) as date, count() as sessions
-
-                        FROM 'MCP_ANALYTICS'
-
-                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
-
-                        AND blob1 = 'session_start'
-
-                        GROUP BY date
-
-                        ORDER BY date ASC"
-                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
-                        SECOND) as date, count() as sessions
-
-                        FROM 'MCP_ANALYTICS'
-
-                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
-
-                        AND blob1 = 'session_start'
-
-                        GROUP BY date
-
-                        ORDER BY date ASC"
-                      round: 0s
-                      showFormattedSQL: false
-                      showHelp: false
-                      skip_comments: true
-                      step: ''
-                    version: v0
-                  refId: A
-            queryOptions: {}
-            transformations: []
-        description: session_start events from the tldraw MCP server (MCP_ANALYTICS
-          dataset). Requires the MCP_ANALYTICS table in this datasource.
-        id: 30
-        links: []
-        title: MCP sessions started
-        vizConfig:
-          group: timeseries
-          kind: VizConfig
-          spec:
-            fieldConfig:
-              defaults:
-                color:
-                  mode: palette-classic
-                custom:
-                  axisBorderShow: false
-                  axisCenteredZero: false
-                  axisColorMode: text
-                  axisLabel: ''
-                  axisPlacement: auto
-                  barAlignment: 0
-                  barWidthFactor: 0.8
-                  drawStyle: bars
-                  fillOpacity: 80
-                  gradientMode: none
-                  hideFrom:
-                    legend: false
-                    tooltip: false
-                    viz: false
-                  insertNulls: false
-                  lineInterpolation: linear
-                  lineWidth: 0
-                  pointSize: 5
-                  scaleDistribution:
-                    type: linear
-                  showPoints: never
-                  showValues: false
-                  spanNulls: false
-                  stacking:
-                    group: A
-                    mode: none
-                  thresholdsStyle:
-                    mode: 'off'
-                thresholds:
-                  mode: absolute
-                  steps:
-                    - color: green
-                      value: 0
-              overrides: []
-            options:
-              annotations:
-                clustering: -1
-                multiLane: false
-              legend:
-                calcs: []
-                displayMode: list
-                enableFacetedFilter: false
-                overflow: ellipsis
-                placement: bottom
-                showLegend: false
-              tooltip:
-                hideZeros: false
-                maxHeight: 600
-                mode: multi
-                sort: desc
-          version: 13.2.0-29854286369
-    panel-31:
-      kind: Panel
-      spec:
-        data:
-          kind: QueryGroup
-          spec:
-            queries:
-              - kind: PanelQuery
-                spec:
-                  hidden: false
-                  query:
-                    datasource:
-                      name: bdgu7tk03irr4e
-                    group: vertamedia-clickhouse-datasource
-                    kind: DataQuery
-                    spec:
-                      dateTimeType: DATETIME
-                      editorMode: code
-                      extrapolate: true
-                      format: time_series
-                      formatAs: time_series
-                      intervalFactor: 1
-                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
-                        SECOND) as date, blob2 as tool, count() as calls
-
-                        FROM 'MCP_ANALYTICS'
-
-                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
-
-                        AND blob1 = 'tool_called'
-
-                        GROUP BY date, tool
-
-                        ORDER BY date ASC"
-                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
-                        SECOND) as date, blob2 as tool, count() as calls
-
-                        FROM 'MCP_ANALYTICS'
-
-                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
-
-                        AND blob1 = 'tool_called'
-
-                        GROUP BY date, tool
-
-                        ORDER BY date ASC"
-                      round: 0s
-                      showFormattedSQL: false
-                      showHelp: false
-                      skip_comments: true
-                      step: ''
-                    version: v0
-                  refId: A
-            queryOptions: {}
-            transformations: []
-        description: tool_called events split by tool name (search, exec).
-        id: 31
-        links: []
-        title: MCP tool calls by tool
-        vizConfig:
-          group: timeseries
-          kind: VizConfig
-          spec:
-            fieldConfig:
-              defaults:
-                color:
-                  mode: palette-classic
-                custom:
-                  axisBorderShow: false
-                  axisCenteredZero: false
-                  axisColorMode: text
-                  axisLabel: ''
-                  axisPlacement: auto
-                  barAlignment: 0
-                  barWidthFactor: 0.8
-                  drawStyle: bars
-                  fillOpacity: 80
-                  gradientMode: none
-                  hideFrom:
-                    legend: false
-                    tooltip: false
-                    viz: false
-                  insertNulls: false
-                  lineInterpolation: linear
-                  lineWidth: 0
-                  pointSize: 5
-                  scaleDistribution:
-                    type: linear
-                  showPoints: never
-                  showValues: false
-                  spanNulls: false
-                  stacking:
-                    group: A
-                    mode: normal
-                  thresholdsStyle:
-                    mode: 'off'
-                thresholds:
-                  mode: absolute
-                  steps:
-                    - color: green
-                      value: 0
-              overrides: []
-            options:
-              annotations:
-                clustering: -1
-                multiLane: false
-              legend:
-                calcs: []
-                displayMode: list
-                enableFacetedFilter: false
-                overflow: ellipsis
-                placement: bottom
-                showLegend: true
-              tooltip:
-                hideZeros: false
-                maxHeight: 600
-                mode: multi
-                sort: desc
-          version: 13.2.0-29854286369
-    panel-32:
-      kind: Panel
-      spec:
-        data:
-          kind: QueryGroup
-          spec:
-            queries:
-              - kind: PanelQuery
-                spec:
-                  hidden: false
-                  query:
-                    datasource:
-                      name: bdgu7tk03irr4e
-                    group: vertamedia-clickhouse-datasource
-                    kind: DataQuery
-                    spec:
-                      dateTimeType: DATETIME
-                      editorMode: code
-                      extrapolate: true
-                      format: time_series
-                      formatAs: time_series
-                      intervalFactor: 1
-                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
-                        SECOND) as date, count() as reads
-
-                        FROM 'MCP_ANALYTICS'
-
-                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
-
-                        AND blob1 = 'resource_called'
-
-                        GROUP BY date
-
-                        ORDER BY date ASC"
-                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
-                        SECOND) as date, count() as reads
-
-                        FROM 'MCP_ANALYTICS'
-
-                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
-
-                        AND blob1 = 'resource_called'
-
-                        GROUP BY date
-
-                        ORDER BY date ASC"
-                      round: 0s
-                      showFormattedSQL: false
-                      showHelp: false
-                      skip_comments: true
-                      step: ''
-                    version: v0
-                  refId: A
-            queryOptions: {}
-            transformations: []
-        description: resource_called events for the tldraw-canvas UI resource.
-        id: 32
-        links: []
-        title: MCP canvas resource reads
-        vizConfig:
-          group: timeseries
-          kind: VizConfig
-          spec:
-            fieldConfig:
-              defaults:
-                color:
-                  mode: palette-classic
-                custom:
-                  axisBorderShow: false
-                  axisCenteredZero: false
-                  axisColorMode: text
-                  axisLabel: ''
-                  axisPlacement: auto
-                  barAlignment: 0
-                  barWidthFactor: 0.8
-                  drawStyle: line
-                  fillOpacity: 25
-                  gradientMode: opacity
-                  hideFrom:
-                    legend: false
-                    tooltip: false
-                    viz: false
-                  insertNulls: false
-                  lineInterpolation: linear
-                  lineWidth: 1.5
-                  pointSize: 5
-                  scaleDistribution:
-                    type: linear
-                  showPoints: never
-                  showValues: false
-                  spanNulls: false
-                  stacking:
-                    group: A
-                    mode: none
-                  thresholdsStyle:
-                    mode: 'off'
-                thresholds:
-                  mode: absolute
-                  steps:
-                    - color: green
-                      value: 0
-              overrides: []
-            options:
-              annotations:
-                clustering: -1
-                multiLane: false
-              legend:
-                calcs: []
-                displayMode: list
-                enableFacetedFilter: false
-                overflow: ellipsis
-                placement: bottom
-                showLegend: false
-              tooltip:
-                hideZeros: false
-                maxHeight: 600
-                mode: multi
-                sort: desc
-          version: 13.2.0-29854286369
     panel-33:
       kind: Panel
       spec:
@@ -5009,38 +4651,11 @@ spec:
           spec:
             element:
               kind: ElementReference
-              name: panel-30
-            height: 8
-            width: 8
-            x: 0
-            y: 87
-        - kind: GridLayoutItem
-          spec:
-            element:
-              kind: ElementReference
-              name: panel-31
-            height: 8
-            width: 8
-            x: 8
-            y: 87
-        - kind: GridLayoutItem
-          spec:
-            element:
-              kind: ElementReference
-              name: panel-32
-            height: 8
-            width: 8
-            x: 16
-            y: 87
-        - kind: GridLayoutItem
-          spec:
-            element:
-              kind: ElementReference
               name: panel-33
             height: 4
             width: 6
             x: 0
-            y: 95
+            y: 87
         - kind: GridLayoutItem
           spec:
             element:
@@ -5049,7 +4664,7 @@ spec:
             height: 4
             width: 6
             x: 6
-            y: 95
+            y: 87
         - kind: GridLayoutItem
           spec:
             element:
@@ -5058,7 +4673,7 @@ spec:
             height: 4
             width: 6
             x: 12
-            y: 95
+            y: 87
         - kind: GridLayoutItem
           spec:
             element:
@@ -5067,7 +4682,7 @@ spec:
             height: 4
             width: 6
             x: 18
-            y: 95
+            y: 87
         - kind: GridLayoutItem
           spec:
             element:
@@ -5076,7 +4691,7 @@ spec:
             height: 8
             width: 8
             x: 0
-            y: 99
+            y: 91
         - kind: GridLayoutItem
           spec:
             element:
@@ -5085,7 +4700,7 @@ spec:
             height: 8
             width: 8
             x: 8
-            y: 99
+            y: 91
         - kind: GridLayoutItem
           spec:
             element:
@@ -5094,7 +4709,7 @@ spec:
             height: 8
             width: 8
             x: 16
-            y: 99
+            y: 91
         - kind: GridLayoutItem
           spec:
             element:
@@ -5103,7 +4718,7 @@ spec:
             height: 8
             width: 12
             x: 0
-            y: 107
+            y: 99
         - kind: GridLayoutItem
           spec:
             element:
@@ -5112,7 +4727,7 @@ spec:
             height: 8
             width: 12
             x: 12
-            y: 107
+            y: 99
   links: []
   liveNow: false
   preload: false
@@ -5145,8 +4760,8 @@ spec:
           text: production
           value: production
         description: Environment to filter by. Use production, staging, or your pr number
-          (pr-42). Applies to MEASURE panels only — the demo server and MCP sections
-          query their own datasets.
+          (pr-42). Applies to MEASURE panels only — the demo server panels query their
+          own dataset.
         hide: dontHide
         label: 'Environment: production | staging | pr-42'
         name: environment

--- a/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
+++ b/internal/grafana/resources/dashboards.v2beta1.dashboard.grafana.app/kotx6wj.yaml
@@ -510,6 +510,364 @@ spec:
               textMode: auto
               wideLayout: true
           version: 13.0.0-22478626928
+    panel-7:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as sessions
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'session_start'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as sessions
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'session_start'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: session_start events from the tldraw MCP server (MCP_ANALYTICS
+          dataset). Requires the MCP_ANALYTICS table in this datasource.
+        id: 7
+        links: []
+        title: MCP sessions started
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-8:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob2 as tool, count() as calls
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'tool_called'
+
+                        GROUP BY date, tool
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, blob2 as tool, count() as calls
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'tool_called'
+
+                        GROUP BY date, tool
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: tool_called events split by tool name (search, exec).
+        id: 8
+        links: []
+        title: MCP tool calls by tool
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: bars
+                  fillOpacity: 80
+                  gradientMode: none
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 0
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: normal
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: true
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
+    panel-9:
+      kind: Panel
+      spec:
+        data:
+          kind: QueryGroup
+          spec:
+            queries:
+              - kind: PanelQuery
+                spec:
+                  hidden: false
+                  query:
+                    datasource:
+                      name: bdgu7tk03irr4e
+                    group: vertamedia-clickhouse-datasource
+                    kind: DataQuery
+                    spec:
+                      dateTimeType: DATETIME
+                      editorMode: code
+                      extrapolate: true
+                      format: time_series
+                      formatAs: time_series
+                      intervalFactor: 1
+                      query: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as reads
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'resource_called'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      rawQuery: "SELECT toStartOfInterval(timestamp, INTERVAL '$interval'
+                        SECOND) as date, count() as reads
+
+                        FROM 'MCP_ANALYTICS'
+
+                        WHERE timestamp >= toDateTime($from) AND timestamp <= toDateTime($to)
+
+                        AND blob1 = 'resource_called'
+
+                        GROUP BY date
+
+                        ORDER BY date ASC"
+                      round: 0s
+                      showFormattedSQL: false
+                      showHelp: false
+                      skip_comments: true
+                      step: ''
+                    version: v0
+                  refId: A
+            queryOptions: {}
+            transformations: []
+        description: resource_called events for the tldraw-canvas UI resource.
+        id: 9
+        links: []
+        title: MCP canvas resource reads
+        vizConfig:
+          group: timeseries
+          kind: VizConfig
+          spec:
+            fieldConfig:
+              defaults:
+                color:
+                  mode: palette-classic
+                custom:
+                  axisBorderShow: false
+                  axisCenteredZero: false
+                  axisColorMode: text
+                  axisLabel: ''
+                  axisPlacement: auto
+                  barAlignment: 0
+                  barWidthFactor: 0.8
+                  drawStyle: line
+                  fillOpacity: 25
+                  gradientMode: opacity
+                  hideFrom:
+                    legend: false
+                    tooltip: false
+                    viz: false
+                  insertNulls: false
+                  lineInterpolation: linear
+                  lineWidth: 1.5
+                  pointSize: 5
+                  scaleDistribution:
+                    type: linear
+                  showPoints: never
+                  showValues: false
+                  spanNulls: false
+                  stacking:
+                    group: A
+                    mode: none
+                  thresholdsStyle:
+                    mode: 'off'
+                thresholds:
+                  mode: absolute
+                  steps:
+                    - color: green
+                      value: 0
+              overrides: []
+            options:
+              annotations:
+                clustering: -1
+                multiLane: false
+              legend:
+                calcs: []
+                displayMode: list
+                enableFacetedFilter: false
+                overflow: ellipsis
+                placement: bottom
+                showLegend: false
+              tooltip:
+                hideZeros: false
+                maxHeight: 600
+                mode: multi
+                sort: desc
+          version: 13.2.0-29854286369
   layout:
     kind: GridLayout
     spec:
@@ -568,6 +926,33 @@ spec:
             width: 6
             x: 18
             y: 13
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-7
+            height: 8
+            width: 8
+            x: 0
+            y: 26
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-8
+            height: 8
+            width: 8
+            x: 8
+            y: 26
+        - kind: GridLayoutItem
+          spec:
+            element:
+              kind: ElementReference
+              name: panel-9
+            height: 8
+            width: 8
+            x: 16
+            y: 26
   links: []
   liveNow: false
   preload: false


### PR DESCRIPTION
In order to see how the public board-screenshot MCP server is actually being used, this adds protocol-level metrics to it and gives it a dashboard of its own. Relates to #9497.

Until now the only thing that server wrote telemetry for was its render path, so we could account for Browser Run spend and almost nothing else. Three of its four tools spend no Browser Run at all and were therefore entirely invisible — including the per-IP rate limit on the clustering tools, which turned callers away without recording that it had happened. There was also no way to tell which client was calling.

Two new events cover the protocol itself. Both are written at the `tools/call` dispatcher rather than inside the individual tools, so a tool added later can't ship unmetered:

- `mcp_server_tool_call`, one per dispatch: tool name, outcome, a bounded reason code, the client family, and how long the call took.
- `mcp_server_initialize`: the `clientInfo.name` the calling application reports, normalized to a bounded family and also kept raw, so a client we don't recognize yet can be identified.

The one intrusive part is getting the reason code out of the tools. `toolError()` gained a second argument, and the dispatcher reads that reason off the result and strips it before serializing — so the JSON-RPC response callers see is unchanged.

Two things the dispatch rewrite got wrong on the first pass, both caught in review and fixed in 2af3bab325, both worth knowing about because they were regressions rather than gaps. Replacing the `switch` with an object-literal lookup meant the tool name — which comes straight off the wire — resolved inherited properties: `tools/call` for `constructor` called `Object`'s own constructor and returned the caller's arguments back to them as a *successful* result, and `__proto__` and a dozen other prototype members turned a clean `-32602` into a 500 on a public unauthenticated endpoint. It's a `Map` now. Separately, reading `clientInfo.name` crashed `initialize` when a client sent a non-string name, on a request that previously ignored `params` entirely — so a loose serializer that used to connect fine couldn't. It's narrowed rather than trusted, and `normalizeMcpClient` takes `unknown` so the compiler keeps it that way. Both have tests.

### Dashboards

`MCP server (shared boards)` is new and covers that server alone, pairing the two new events with the `source:mcp` slice of the existing screenshot telemetry. The cross-surface screenshot panels stay on `Dotcom events`, since they also cover the og route and the render queue.

The three `MCP …` panels on `Dotcom events` read the `MCP_ANALYTICS` dataset, which belongs to the separate MCP app worker in `apps/mcp-app` rather than to this server, so they move to `MCP app sessions` — that worker's dashboard. They moved verbatim, which means `MCP sessions started` now sits next to that dashboard's existing `Sessions by Time` and `Total Sessions` and duplicates them. Worth tidying, but I'd rather not redesign that dashboard in this PR.

### Decisions worth a second opinion

- **`raw:` on the initialize event is the one unbounded blob, and it's on the one unlimited path.** Everything else on both events is a closed set. `initialize` is dispatched ahead of every limiter (the tools sit behind `MCP_SCREENSHOT_RATE_LIMITER`; `initialize` and `ping` sit behind nothing) and does no I/O before the write, so a script sending a fresh random `clientInfo.name` can add a distinct value per request at full request rate — which is what panel 12 groups by. The 64-char cap bounds length, not distinctness. It's kept because it's the only way to identify a client that currently lands in `other`, and every other client panel reads the bounded family instead. If that trade isn't worth it, dropping blob4 costs one panel.
- **`get_page_info` and `get_cluster_info` can still misattribute a Postgres stall as a browser failure.** Those tools resolve the board and render it under one `try`, and the shared classifier maps any message matching `/timeout/` to `browser_timeout` — so a pool timeout during the lookup is indistinguishable from a real render timeout. `get_board_info` starts no render, so its failures are recorded as `board_lookup_error` rather than run through that classifier. Splitting the other two would mean restructuring their error handling, which felt out of scope here; the panel description carries the caveat instead.
- **Counts use `count()`, not `sum(_sample_interval)`.** This matches the neighbouring screenshot panels so the numbers stay comparable across dashboards, but it will undercount if Analytics Engine ever starts sampling this dataset.
- **The moved panels carry newer viz options** than `kotx6wj`'s originals, having come from a `v2` document into a `v2beta1` one. `gcx` accepts it and those keys are plugin-opaque, but the render is worth a glance once it deploys.

### On trusting the grafana CI check

`Validate grafana resources (dry run)` passing is weaker evidence than it looks. Tested directly: both `gcx resources validate` and `gcx resources push --dry-run --on-error abort` accept a layout item pointing at a non-existent element, an out-of-range grid width, and a bogus viz type. Neither checks referential integrity between `layout` and `elements`, nor grid geometry. So the structural claims here rest on explicit verification rather than on CI: all 16 queries were executed against the datasource, the `substring()` offsets were checked against the emitting code, and both dashboards' layouts were verified as referentially complete with every row filling exactly 24 columns and no gaps.

### Overlapping PRs

This is intended to land before #9791, which will then absorb it.

Every file here is also touched by open work, though none of it is the same change. Restructuring the `tools/call` dispatch and every `toolError()` call site is what collides. Measured with `git merge-tree` against each branch, and against `main` as a baseline so the pre-existing drift is separated out:

| PR                    | Conflicts this PR adds                                     | Already conflicting with `main` |
| --------------------- | ---------------------------------------------------------- | ------------------------------- |
| #9791 mcp-server-authz | `sharedBoardScreenshotMcp.ts`, `sharedBoardScreenshotMcp.test.ts` | 3 files, unrelated to this  |
| #9962 mcp-v2          | `sharedBoardScreenshotMcp.ts`                              | none                            |
| #9965 mcp-v2-stacked  | `sharedBoardScreenshotMcp.ts`, `sharedBoardScreenshotMcp.test.ts` | same 3 as #9791             |
| #9956 pg-panels       | `ni5k8zc.yaml`                                             | none                            |

Two things that might have been expected to conflict and don't: `screenshotTestHelpers.ts` merges cleanly with #9791 despite both touching it, and `ni5k8zc.yaml` merges cleanly with #9791 too — #9956 is the only PR this collides with on that dashboard.

### Change type

- [x] `other`

### Test plan

1. Call `POST /app/mcp`: `initialize`, then `tools/call` for each of the four tools.
2. Check `MCP server (shared boards)` shows those calls split by tool, each with a duration and a client family, and that `initialize` shows up under handshakes.
3. Exceed the per-IP limit on `get_page_info` and confirm it lands as `reason:rate_limited_ip` rather than disappearing.
4. Confirm `Dotcom events` has no `MCP_ANALYTICS` panels left and no gap in its layout, and that `MCP app sessions` shows the three moved panels.
5. Open both dashboards in Grafana after deploy and confirm every panel renders — see the CI caveat above.

- [x] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change   |
| -------------- | ------------ |
| Tests          | +186 / -2    |
| Apps           | +199 / -51   |
| Config/tooling | +2219 / -398 |
