### PR TITLE
feat(examples): add examples for more complex frame-like shape layouts

### DIFF
--- a/apps/examples/src/examples/shapes/tools/frame-layouts/BoardLayouts.ts
+++ b/apps/examples/src/examples/shapes/tools/frame-layouts/BoardLayouts.ts
@@ -1,0 +1,161 @@
+import { TLShapeId } from 'tldraw'
+
+// There's a guide at the bottom of this file!
+
+export const BOARD_PADDING = 16
+export const BOARD_GAP = 12
+export const BOARD_HEADER_HEIGHT = 36
+
+const EMPTY_WIDTH = 240
+const EMPTY_HEIGHT = 168
+const CARD_HEIGHT = 120
+const CARD_WIDTH = 180
+const HERO_HEIGHT = 240
+const THUMBNAIL_HEIGHT = 80
+
+export type BoardLayoutMode = 'free' | 'row' | 'column' | 'grid' | 'spotlight'
+
+/** A child's box, relative to the board's content area. */
+export interface LayoutBox {
+	id: TLShapeId
+	x: number
+	y: number
+	w: number
+	h: number
+}
+
+export interface BoardLayout {
+	label: string
+	/** `null` arranges nothing, so the board behaves like a plain frame. */
+	arrange: ((children: LayoutBox[]) => { boxes: LayoutBox[]; w: number; h: number }) | null
+}
+
+const midX = (box: LayoutBox) => box.x + box.w / 2
+const midY = (box: LayoutBox) => box.y + box.h / 2
+
+/** Scale a box to a target height or width, keeping its aspect ratio. */
+const toHeight = (box: LayoutBox, h: number) => ({ ...box, w: (box.w / box.h) * h, h })
+const toWidth = (box: LayoutBox, w: number) => ({ ...box, w, h: (box.h / box.w) * w })
+
+// [1]
+export const BOARD_LAYOUTS: Record<BoardLayoutMode, BoardLayout> = {
+	free: {
+		label: 'Free',
+		arrange: null,
+	},
+	// [2]
+	row: {
+		label: 'Row',
+		arrange(children) {
+			let x = 0
+			const boxes = [...children]
+				.sort((a, b) => midX(a) - midX(b))
+				.map((box) => {
+					const next = { ...toHeight(box, CARD_HEIGHT), x, y: 0 }
+					x += next.w + BOARD_GAP
+					return next
+				})
+			return { boxes, w: x - BOARD_GAP, h: CARD_HEIGHT }
+		},
+	},
+	column: {
+		label: 'Column',
+		arrange(children) {
+			let y = 0
+			const boxes = [...children]
+				.sort((a, b) => midY(a) - midY(b))
+				.map((box) => {
+					const next = { ...toWidth(box, CARD_WIDTH), x: 0, y }
+					y += next.h + BOARD_GAP
+					return next
+				})
+			return { boxes, w: CARD_WIDTH, h: y - BOARD_GAP }
+		},
+	},
+	grid: {
+		label: 'Grid',
+		arrange(children) {
+			const cells = children.map((box) => toHeight(box, CARD_HEIGHT))
+			const cellW = Math.max(...cells.map((box) => box.w))
+			// Read the cards in rows: group them into horizontal bands, then left to right
+			const band = (box: LayoutBox) => Math.round(midY(box) / (CARD_HEIGHT + BOARD_GAP))
+			const sorted = cells.sort((a, b) => band(a) - band(b) || midX(a) - midX(b))
+			const columns = Math.ceil(Math.sqrt(sorted.length))
+			const rows = Math.ceil(sorted.length / columns)
+			const boxes = sorted.map((box, i) => ({
+				...box,
+				x: (i % columns) * (cellW + BOARD_GAP) + (cellW - box.w) / 2,
+				y: Math.floor(i / columns) * (CARD_HEIGHT + BOARD_GAP),
+			}))
+			return {
+				boxes,
+				w: columns * cellW + (columns - 1) * BOARD_GAP,
+				h: rows * CARD_HEIGHT + (rows - 1) * BOARD_GAP,
+			}
+		},
+	},
+	spotlight: {
+		label: 'Spotlight',
+		arrange(children) {
+			const [first, ...rest] = [...children].sort((a, b) => midX(a) - midX(b))
+			const hero = toHeight(first, HERO_HEIGHT)
+			const thumbnails = rest
+				.sort((a, b) => midY(a) - midY(b))
+				.map((box) => toHeight(box, THUMBNAIL_HEIGHT))
+
+			const stackH =
+				thumbnails.length * THUMBNAIL_HEIGHT + Math.max(0, thumbnails.length - 1) * BOARD_GAP
+			const h = Math.max(HERO_HEIGHT, stackH)
+			const stackW = Math.max(0, ...thumbnails.map((box) => box.w))
+
+			let y = (h - stackH) / 2
+			const boxes = [{ ...hero, x: 0, y: (h - HERO_HEIGHT) / 2 }]
+			for (const thumbnail of thumbnails) {
+				boxes.push({ ...thumbnail, x: hero.w + BOARD_GAP, y })
+				y += thumbnail.h + BOARD_GAP
+			}
+
+			return { boxes, w: hero.w + (thumbnails.length ? BOARD_GAP + stackW : 0), h }
+		},
+	},
+}
+
+// [3]
+export function arrangeBoard(mode: BoardLayoutMode, children: LayoutBox[]) {
+	const { arrange } = BOARD_LAYOUTS[mode]
+	if (!arrange) return null
+	const { boxes, w, h } = children.length ? arrange(children) : { boxes: [], w: 0, h: 0 }
+	return {
+		boxes,
+		w: Math.max(EMPTY_WIDTH, w + BOARD_PADDING * 2),
+		h: Math.max(EMPTY_HEIGHT, h + BOARD_HEADER_HEIGHT + BOARD_PADDING * 2),
+	}
+}
+
+/*
+This file is the layout engine, and it never touches the editor. A layout takes the boxes of
+a board's children and returns where they should go, which is why the same code arranges
+video cards, note cards, or any other shape the board accepts.
+
+[1]
+Each mode is one entry in a record: a label plus a function from boxes to boxes. Adding a
+mode (masonry, ring, timeline) means adding an entry here and a value to the board's `layout`
+prop validator.
+
+Every mode sorts the cards by their current position before assigning slots, so wherever you
+drop a card is where it lands in the order. There's no separate index to keep in sync.
+
+[2]
+Because a layout returns whole boxes rather than points, it sizes its children as well as
+placing them, and each mode decides what that means: a row gives every card the same height,
+a column the same width, and spotlight scales the left-most card up to a hero and the rest
+down to thumbnails. Drop a card to the left of the hero to promote it.
+
+Sizes come from constants rather than from the cards, so switching modes lands on the same
+result every time instead of compounding. The trade-off is that hand-resizing a card only
+sticks on a `free` board, where nothing else owns its size.
+
+[3]
+Arrange the children and add the board's padding and header back, with a minimum size so an
+empty board is still a usable drop target. Returns `null` for `free`, which arranges nothing.
+*/

--- a/apps/examples/src/examples/shapes/tools/frame-layouts/FrameLayoutsExample.tsx
+++ b/apps/examples/src/examples/shapes/tools/frame-layouts/FrameLayoutsExample.tsx
@@ -1,0 +1,407 @@
+import {
+	BaseFrameLikeShapeUtil,
+	Box,
+	EASINGS,
+	Editor,
+	Geometry2d,
+	Group2d,
+	HTMLContainer,
+	RecordProps,
+	Rectangle2d,
+	T,
+	TLComponents,
+	TLDragShapesOutInfo,
+	TLShape,
+	TLShapeId,
+	TLShapePartial,
+	Tldraw,
+	TldrawUiContextualToolbar,
+	TldrawUiToolbarButton,
+	createShapeId,
+	track,
+	useEditor,
+	useValue,
+} from 'tldraw'
+import 'tldraw/tldraw.css'
+import {
+	BOARD_HEADER_HEIGHT,
+	BOARD_LAYOUTS,
+	BOARD_PADDING,
+	BoardLayoutMode,
+	arrangeBoard,
+} from './BoardLayouts'
+import {
+	NOTE_CARD_SHAPE_TYPE,
+	NoteCardShapeUtil,
+	VIDEO_CARD_SHAPE_TYPE,
+	VideoCardShapeUtil,
+} from './MediaCardShapes'
+import './frame-layouts.css'
+
+// There's a guide at the bottom of this file!
+
+const BOARD_SHAPE_TYPE = 'layout-board'
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[BOARD_SHAPE_TYPE]: { w: number; h: number; name: string; layout: BoardLayoutMode }
+	}
+}
+
+type BoardShape = TLShape<typeof BOARD_SHAPE_TYPE>
+
+// [1]
+class LayoutBoardShapeUtil extends BaseFrameLikeShapeUtil<BoardShape> {
+	static override type = BOARD_SHAPE_TYPE
+	static override props: RecordProps<BoardShape> = {
+		w: T.nonZeroNumber,
+		h: T.nonZeroNumber,
+		name: T.string,
+		layout: T.literalEnum('free', 'row', 'column', 'grid', 'spotlight'),
+	}
+
+	override getDefaultProps(): BoardShape['props'] {
+		return { w: 320, h: 240, name: 'Board', layout: 'free' }
+	}
+
+	// [2]
+	override canReceiveNewChildrenOfType(shape: BoardShape, type: TLShape['type']) {
+		if (shape.isLocked) return false
+		return type === VIDEO_CARD_SHAPE_TYPE || type === NOTE_CARD_SHAPE_TYPE
+	}
+
+	// [3]
+	override canResize(shape: BoardShape) {
+		return shape.props.layout === 'free'
+	}
+
+	override hideResizeHandles(shape: BoardShape) {
+		return shape.props.layout !== 'free'
+	}
+
+	override canResizeChildren() {
+		return false
+	}
+
+	// [4]
+	override getGeometry(shape: BoardShape): Geometry2d {
+		return new Group2d({
+			children: [
+				new Rectangle2d({ width: shape.props.w, height: shape.props.h, isFilled: false }),
+				new Rectangle2d({
+					width: shape.props.w,
+					height: BOARD_HEADER_HEIGHT,
+					isFilled: true,
+					isLabel: true,
+				}),
+			],
+		})
+	}
+
+	// [5]
+	override onChildrenChange(shape: BoardShape) {
+		if (this.editor.isIn('select.translating')) return
+		return getBoardLayoutChanges(this.editor, shape)
+	}
+
+	// [6]
+	override onDropShapesOver(shape: BoardShape) {
+		animateBoardLayout(this.editor, shape.id)
+	}
+
+	override onDragShapesOut(shape: BoardShape, shapes: TLShape[], info: TLDragShapesOutInfo) {
+		super.onDragShapesOut(shape, shapes, info)
+		animateBoardLayout(this.editor, shape.id)
+	}
+
+	override component(shape: BoardShape) {
+		return <BoardComponent shape={shape} />
+	}
+
+	override getText(shape: BoardShape) {
+		return shape.props.name
+	}
+
+	override getIndicatorPath(shape: BoardShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+const EPSILON = 0.01
+
+// [7]
+function getBoardLayoutChanges(editor: Editor, board: BoardShape): TLShapePartial[] {
+	const children = editor
+		.getSortedChildIdsForParent(board.id)
+		.map((id) => editor.getShape(id))
+		.filter((child): child is TLShape => !!child)
+		.map((child) => ({ child, size: editor.getShapeGeometry(child).bounds }))
+
+	const byId = new Map(children.map((entry) => [entry.child.id, entry]))
+	const originX = BOARD_PADDING
+	const originY = BOARD_HEADER_HEIGHT + BOARD_PADDING
+
+	const result = arrangeBoard(
+		board.props.layout,
+		children.map(({ child, size }) => ({
+			id: child.id,
+			x: child.x - originX,
+			y: child.y - originY,
+			w: size.width,
+			h: size.height,
+		}))
+	)
+	if (!result) return []
+
+	const changes: TLShapePartial[] = []
+
+	for (const box of result.boxes) {
+		const { child, size } = byId.get(box.id)!
+		const x = originX + box.x
+		const y = originY + box.y
+		const moved = Math.abs(child.x - x) > EPSILON || Math.abs(child.y - y) > EPSILON
+		const resized =
+			Math.abs(size.width - box.w) > EPSILON || Math.abs(size.height - box.h) > EPSILON
+		if (!moved && !resized) continue
+		changes.push({
+			id: child.id,
+			type: child.type,
+			x,
+			y,
+			...(resized && { props: { w: box.w, h: box.h } }),
+		} as TLShapePartial)
+	}
+
+	if (
+		Math.abs(board.props.w - result.w) > EPSILON ||
+		Math.abs(board.props.h - result.h) > EPSILON
+	) {
+		changes.push({ id: board.id, type: board.type, props: { w: result.w, h: result.h } })
+	}
+
+	return changes
+}
+
+function applyBoardLayout(editor: Editor, boardId: TLShapeId) {
+	const board = editor.getShape<BoardShape>(boardId)
+	if (board) editor.updateShapes(getBoardLayoutChanges(editor, board))
+}
+
+function animateBoardLayout(editor: Editor, boardId: TLShapeId) {
+	const board = editor.getShape<BoardShape>(boardId)
+	if (!board) return
+	editor.animateShapes(getBoardLayoutChanges(editor, board), {
+		animation: { duration: 220, easing: EASINGS.easeInOutCubic },
+	})
+}
+
+function BoardComponent({ shape }: { shape: BoardShape }) {
+	const editor = useEditor()
+	const count = useValue('card count', () => editor.getSortedChildIdsForParent(shape.id).length, [
+		editor,
+		shape.id,
+	])
+	return (
+		<HTMLContainer className="layout-board" style={{ width: shape.props.w, height: shape.props.h }}>
+			<div className="layout-board__header" style={{ height: BOARD_HEADER_HEIGHT }}>
+				<span className="layout-board__name">{shape.props.name}</span>
+				<span className="layout-board__badge">
+					{BOARD_LAYOUTS[shape.props.layout].label} · {count}
+				</span>
+			</div>
+		</HTMLContainer>
+	)
+}
+
+// [8]
+const BoardLayoutToolbar = track(function BoardLayoutToolbar() {
+	const editor = useEditor()
+	const board = useValue(
+		'selected board',
+		() => {
+			if (!editor.isIn('select.idle')) return null
+			const shape = editor.getOnlySelectedShape()
+			return shape?.type === BOARD_SHAPE_TYPE ? (shape as BoardShape) : null
+		},
+		[editor]
+	)
+
+	if (!board) return null
+
+	const setLayout = (layout: BoardLayoutMode) => {
+		editor.markHistoryStoppingPoint('change board layout')
+		editor.run(() => {
+			editor.updateShape({ id: board.id, type: board.type, props: { layout } })
+			animateBoardLayout(editor, board.id)
+		})
+		editor.getContainer().focus()
+	}
+
+	const getSelectionBounds = () => {
+		const bounds = editor.getSelectionRotatedScreenBounds()
+		return bounds ? new Box(bounds.x, bounds.y, bounds.width, 0) : undefined
+	}
+
+	return (
+		<TldrawUiContextualToolbar getSelectionBounds={getSelectionBounds} label="Board layout">
+			{Object.entries(BOARD_LAYOUTS).map(([mode, { label }]) => (
+				<TldrawUiToolbarButton
+					key={mode}
+					type="icon"
+					title={label}
+					isActive={board.props.layout === mode}
+					onClick={() => setLayout(mode as BoardLayoutMode)}
+				>
+					{label}
+				</TldrawUiToolbarButton>
+			))}
+		</TldrawUiContextualToolbar>
+	)
+})
+
+const shapeUtils = [LayoutBoardShapeUtil, VideoCardShapeUtil, NoteCardShapeUtil]
+const components: TLComponents = { InFrontOfTheCanvas: BoardLayoutToolbar }
+
+// [9]
+const video = (url = '/fluid.mp4') => ({ type: VIDEO_CARD_SHAPE_TYPE, props: { url } }) as const
+const note = (text: string, color: string) =>
+	({ type: NOTE_CARD_SHAPE_TYPE, props: { text, color } }) as const
+
+const DEMO_BOARDS: Array<{
+	name: string
+	layout: BoardLayoutMode
+	x: number
+	y: number
+	w?: number
+	h?: number
+	cards: Array<ReturnType<typeof video> | ReturnType<typeof note>>
+}> = [
+	{
+		name: 'Video wall',
+		layout: 'grid',
+		x: 80,
+		y: 100,
+		cards: [video(), video('/bonk.webm'), video(), note('Pick a hero shot', '#ffd43b')],
+	},
+	{
+		name: 'Up next',
+		layout: 'column',
+		x: 860,
+		y: 100,
+		cards: [video('/bonk.webm'), note('Intro cut', '#b2f2bb'), note('Color pass', '#ffc9c9')],
+	},
+	{
+		name: 'Moodboard',
+		layout: 'free',
+		x: 1140,
+		y: 100,
+		w: 460,
+		h: 340,
+		cards: [video(), note('Loose vibes', '#eebefa')],
+	},
+	{
+		name: 'Filmstrip',
+		layout: 'row',
+		x: 80,
+		y: 560,
+		cards: [video(), video('/bonk.webm'), note('End card', '#99e9f2')],
+	},
+	{
+		name: 'Stage',
+		layout: 'spotlight',
+		x: 860,
+		y: 560,
+		cards: [video(), video('/bonk.webm'), video(), note('Now playing', '#ffd43b')],
+	},
+]
+
+function createDemoContent(editor: Editor) {
+	for (const { name, layout, cards, x, y, ...size } of DEMO_BOARDS) {
+		const id = createShapeId(name)
+		editor.createShape({ id, type: BOARD_SHAPE_TYPE, x, y, props: { name, layout, ...size } })
+		// Cascaded from the top of the content area, so every layout's position sort agrees
+		// with this order and a `free` board still looks hand-placed
+		editor.createShapes(
+			cards.map((card, i) => ({
+				...card,
+				parentId: id,
+				x: BOARD_PADDING + i * 130,
+				y: BOARD_HEADER_HEIGHT + BOARD_PADDING + i * 80,
+			}))
+		)
+		applyBoardLayout(editor, id)
+	}
+
+	// A few loose cards, ready to be dragged onto a board
+	editor.createShapes([
+		{ ...video('/bonk.webm'), x: 80, y: 960 },
+		{ ...note('Add captions', '#ffd43b'), x: 340, y: 940 },
+		{ ...note('B-roll', '#b2f2bb'), x: 560, y: 1000 },
+	])
+	editor.zoomToFit()
+}
+
+export default function FrameLayoutsExample() {
+	return (
+		<div className="tldraw__editor">
+			<Tldraw
+				shapeUtils={shapeUtils}
+				components={components}
+				onMount={(editor) => {
+					if (editor.getCurrentPageShapeIds().size > 0) return
+					createDemoContent(editor)
+				}}
+			/>
+		</div>
+	)
+}
+
+/*
+This example shows one frame-like container arranging the same children in different ways. A
+board shape has a `layout` prop, and swapping it swaps the arrangement. The layouts themselves
+are pure functions over boxes and live in `BoardLayouts.ts`; this file is the SDK integration.
+
+[1]
+BaseFrameLikeShapeUtil gives the board its frame behavior: clipping children, providing their
+background, and reparenting shapes in and out as they're dragged over it.
+
+[2]
+canReceiveNewChildrenOfType gates what the board picks up. This one takes cards only, so
+dragging a drawn shape over it does nothing.
+
+[3]
+Only `free` boards are resizable by hand. The arranging layouts size the board to fit their
+content, so its handles are hidden.
+
+[4]
+An unfilled body plus a filled header. Clicks inside the body pass through to the cards the way
+a frame's interior does, while the header stays clickable for selecting and moving the board.
+The header rectangle needs `isLabel` for that: frame-like shapes ignore interior fills so that
+brush selection works inside them.
+
+[5]
+onChildrenChange is the main trigger. It runs whenever a child is added, removed, deleted,
+restored by undo, moved, or resized, and whatever it returns gets applied. Re-running the
+layout produces no further changes once everything sits in its slot, so this settles in a pass
+rather than looping. The one case to skip is an in-progress drag, where correcting positions
+would fight the pointer.
+
+[6]
+Drags finish through the frame-like callbacks instead: onDropShapesOver when cards land on the
+board, onDragShapesOut when one leaves and the rest close the gap. Both animate, and because
+every shape here extends BaseBoxShapeUtil, animateShapes tweens size as well as position.
+
+[7]
+Turn a layout into store changes: a new position for each card that has drifted from its slot,
+new `w`/`h` for cards the layout resized, and a new size for the board so it hugs its content.
+
+[8]
+A contextual toolbar for the selected board, built from the same BOARD_LAYOUTS record that
+defines the modes.
+
+[9]
+Seed a board per mode plus a few loose cards. The cards start on a diagonal and applyBoardLayout
+snaps them into place, which is the same path the board takes at runtime.
+*/

--- a/apps/examples/src/examples/shapes/tools/frame-layouts/MediaCardShapes.tsx
+++ b/apps/examples/src/examples/shapes/tools/frame-layouts/MediaCardShapes.tsx
@@ -1,0 +1,106 @@
+import { BaseBoxShapeUtil, HTMLContainer, RecordProps, T, TLShape } from 'tldraw'
+
+// There's a guide at the bottom of this file!
+
+export const VIDEO_CARD_SHAPE_TYPE = 'video-card'
+export const NOTE_CARD_SHAPE_TYPE = 'media-note-card'
+
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		[VIDEO_CARD_SHAPE_TYPE]: { w: number; h: number; url: string }
+		[NOTE_CARD_SHAPE_TYPE]: { w: number; h: number; text: string; color: string }
+	}
+}
+
+export type VideoCardShape = TLShape<typeof VIDEO_CARD_SHAPE_TYPE>
+export type NoteCardShape = TLShape<typeof NOTE_CARD_SHAPE_TYPE>
+
+// [1]
+export class VideoCardShapeUtil extends BaseBoxShapeUtil<VideoCardShape> {
+	static override type = VIDEO_CARD_SHAPE_TYPE
+	static override props: RecordProps<VideoCardShape> = {
+		w: T.nonZeroNumber,
+		h: T.nonZeroNumber,
+		url: T.string,
+	}
+
+	override getDefaultProps(): VideoCardShape['props'] {
+		return { w: 192, h: 108, url: '/fluid.mp4' }
+	}
+
+	// [2]
+	override isAspectRatioLocked() {
+		return true
+	}
+
+	override component(shape: VideoCardShape) {
+		return (
+			<HTMLContainer
+				className="media-card media-card--video"
+				style={{ width: shape.props.w, height: shape.props.h }}
+			>
+				<video src={shape.props.url} autoPlay muted loop playsInline />
+			</HTMLContainer>
+		)
+	}
+
+	override getIndicatorPath(shape: VideoCardShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+export class NoteCardShapeUtil extends BaseBoxShapeUtil<NoteCardShape> {
+	static override type = NOTE_CARD_SHAPE_TYPE
+	static override props: RecordProps<NoteCardShape> = {
+		w: T.nonZeroNumber,
+		h: T.nonZeroNumber,
+		text: T.string,
+		color: T.string,
+	}
+
+	override getDefaultProps(): NoteCardShape['props'] {
+		return { w: 144, h: 96, text: 'Note', color: '#ffd43b' }
+	}
+
+	override component(shape: NoteCardShape) {
+		return (
+			<HTMLContainer
+				className="media-card media-card--note"
+				style={{
+					width: shape.props.w,
+					height: shape.props.h,
+					backgroundColor: shape.props.color,
+				}}
+			>
+				{shape.props.text}
+			</HTMLContainer>
+		)
+	}
+
+	override getText(shape: NoteCardShape) {
+		return shape.props.text
+	}
+
+	override getIndicatorPath(shape: NoteCardShape) {
+		const path = new Path2D()
+		path.rect(0, 0, shape.props.w, shape.props.h)
+		return path
+	}
+}
+
+/*
+Two shape types for the board to organize, with different default sizes so you can see how
+each layout handles a mix. Neither knows anything about the board: the board reads their
+geometry and moves them, so any shape type it accepts works the same way.
+
+[1]
+Both extend BaseBoxShapeUtil, which gives them `w`/`h` geometry, resize handles, and a
+`getInterpolatedProps` that tweens size. That last one is what lets the board animate a card
+to a new size rather than snapping it.
+
+[2]
+The video keeps its aspect ratio when you resize it by hand, and the layouts scale cards
+proportionally, so it never stretches.
+*/

--- a/apps/examples/src/examples/shapes/tools/frame-layouts/README.md
+++ b/apps/examples/src/examples/shapes/tools/frame-layouts/README.md
@@ -1,0 +1,31 @@
+---
+title: Frame layout modes
+component: ./FrameLayoutsExample.tsx
+category: shapes/tools
+priority: 3
+keywords:
+  [
+    frame,
+    container,
+    layout,
+    grid,
+    spotlight,
+    resize,
+    video,
+    reparent,
+    onChildrenChange,
+    BaseFrameLikeShapeUtil,
+  ]
+---
+
+A frame-like board shape that arranges its children in five swappable layouts.
+
+---
+
+This example shows how to give one frame-like container several ways to organize what's inside it. The board shape has a `layout` prop, and each mode is a small pure function from the children's boxes to new boxes, so adding an arrangement means adding one entry to a record.
+
+Because a layout returns boxes rather than points, it sizes its children as well as placing them. A row gives every card the same height, a column the same width, and spotlight scales the left-most card up to a hero with the rest as thumbnails beside it. The `free` mode arranges nothing and behaves like a plain frame.
+
+The board re-runs its layout from `onChildrenChange`, so it responds to cards being added, deleted, resized, or restored by undo. Select a board to switch its mode; drag cards between boards and they land wherever you drop them.
+
+For a container that hands layout to the browser instead, see the [flex layout shape](/examples/shapes/tools/flex-layout) example.

--- a/apps/examples/src/examples/shapes/tools/frame-layouts/frame-layouts.css
+++ b/apps/examples/src/examples/shapes/tools/frame-layouts/frame-layouts.css
@@ -1,0 +1,67 @@
+.layout-board {
+	box-sizing: border-box;
+	background-color: var(--tl-color-low);
+	border: 1px solid var(--tl-color-divider);
+	border-radius: 10px;
+}
+
+.layout-board__header {
+	box-sizing: border-box;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 0 12px;
+	background-color: var(--tl-color-panel);
+	border-bottom: 1px solid var(--tl-color-divider);
+	border-radius: 10px 10px 0 0;
+	font: var(--tl-font-body);
+	font-size: 13px;
+}
+
+.layout-board__name {
+	font-weight: 500;
+	color: var(--tl-color-text-1);
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.layout-board__badge {
+	flex-shrink: 0;
+	font-size: 11px;
+	color: var(--tl-color-text-3);
+	background-color: var(--tl-color-muted-2);
+	border-radius: 99px;
+	padding: 2px 8px;
+	white-space: nowrap;
+}
+
+.media-card {
+	box-sizing: border-box;
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: var(--tl-shadow-1);
+}
+
+.media-card--video {
+	background-color: var(--tl-color-text);
+}
+
+.media-card--video video {
+	display: block;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	pointer-events: none;
+}
+
+.media-card--note {
+	display: grid;
+	place-items: center;
+	padding: 8px;
+	text-align: center;
+	font: var(--tl-font-body);
+	font-size: 13px;
+	color: hsl(0, 0%, 15%);
+}


### PR DESCRIPTION
Brings in an example with additional ways to use the frame-like shapes to control child shape layouts including auto-resizing child shapes