### PR TITLE
feat(dotcom): admin endpoint to resolve durable object ids to file ids

### DIFF
--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -45,16 +45,63 @@ export function FilesSection() {
 	)
 }
 
+interface ResolvedDoRoom {
+	slug: string
+	isApp: boolean
+	deleted: boolean
+	connectedSockets: number
+	roomLoaded: boolean
+}
+
+interface ResolvedDoHistory {
+	saves: number
+	firstSaveAt: string | null
+	lastSaveAt: string | null
+	avgSecondsBetweenSaves: number | null
+	latestSizeBytes: number | null
+	totalSizeBytes: number
+	listTruncated: boolean
+}
+
+function formatAgo(iso: string) {
+	const seconds = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 1000))
+	if (seconds < 120) return `${seconds}s ago`
+	if (seconds < 7200) return `${Math.round(seconds / 60)}m ago`
+	if (seconds < 172800) return `${Math.round(seconds / 3600)}h ago`
+	return `${Math.round(seconds / 86400)}d ago`
+}
+
+function formatInterval(seconds: number) {
+	if (seconds < 120) return `${seconds}s`
+	if (seconds < 7200) return `${Math.round(seconds / 60)}m`
+	return `${(seconds / 3600).toFixed(1)}h`
+}
+
+/** The question this section exists to answer: is anyone actually using this room? */
+function activityVerdict(match: ResolvedDoRoom, history: ResolvedDoHistory) {
+	const lastSaveAgeMs = history.lastSaveAt
+		? Date.now() - new Date(history.lastSaveAt).getTime()
+		: Infinity
+	if (match.connectedSockets === 0) {
+		return 'idle — no tabs connected'
+	}
+	if (lastSaveAgeMs < 60 * 60 * 1000) {
+		return 'actively edited — connected and saving'
+	}
+	return 'parked tab(s) — connected but not editing'
+}
+
 /**
- * Maps a durable object id (from Cloudflare analytics or the dash) back to its room slug. The
- * object stores its own identity, so the resolver asks it directly.
+ * Maps a durable object id (from Cloudflare analytics or the dash) back to its room slug, with
+ * liveness and persist-history signals. The object stores its own identity, so the resolver asks
+ * it directly.
  */
 function ResolveDoId() {
 	const [input, setInput] = useState('')
 	const [isRunning, setIsRunning] = useState(false)
 	const [error, setError] = useState(null as string | null)
-	const [match, setMatch] = useState(
-		null as { slug: string; isApp: boolean; deleted: boolean } | 'none' | null
+	const [result, setResult] = useState(
+		null as { match: ResolvedDoRoom | null; history: ResolvedDoHistory | null } | null
 	)
 
 	const onResolve = useCallback(async () => {
@@ -64,7 +111,7 @@ function ResolveDoId() {
 			return
 		}
 		setError(null)
-		setMatch(null)
+		setResult(null)
 		setIsRunning(true)
 		try {
 			const res = await fetch(`/api/app/admin/resolve-do-id/${objectId}`)
@@ -72,15 +119,16 @@ function ResolveDoId() {
 				setError(res.statusText + ': ' + (await res.text()))
 				return
 			}
-			const body: { match: { slug: string; isApp: boolean; deleted: boolean } | null } =
-				await res.json()
-			setMatch(body.match ?? 'none')
+			setResult(await res.json())
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Resolve failed')
 		} finally {
 			setIsRunning(false)
 		}
 	}, [input])
+
+	const match = result?.match
+	const history = result?.history
 
 	return (
 		<div>
@@ -98,20 +146,41 @@ function ResolveDoId() {
 				</AdminButton>
 			</div>
 			{error && <div className={styles.errorMessage}>{error}</div>}
-			{match === 'none' && (
+			{result && !match && (
 				<div className={styles.subTitle}>No room for that id (never initialized)</div>
 			)}
-			{match && match !== 'none' && (
+			{match && (
 				<div className={styles.subTitle}>
-					<a
-						href={match.isApp ? `/f/${match.slug}` : `/r/${match.slug}`}
-						target="_blank"
-						rel="noreferrer"
-					>
-						{match.slug}
-					</a>{' '}
-					— {match.isApp ? 'app file' : 'legacy room'}
-					{match.deleted ? ' (deleted)' : ''}
+					<div>
+						<a
+							href={match.isApp ? `/f/${match.slug}` : `/r/${match.slug}`}
+							target="_blank"
+							rel="noreferrer"
+						>
+							{match.slug}
+						</a>{' '}
+						— {match.isApp ? 'app file' : 'legacy room'}
+						{match.deleted ? ' (deleted)' : ''}
+					</div>
+					<div>
+						{history ? <b>{activityVerdict(match, history)}</b> : null} · {match.connectedSockets}{' '}
+						socket{match.connectedSockets === 1 ? '' : 's'} connected · room{' '}
+						{match.roomLoaded ? 'loaded in memory' : 'not loaded (hibernated or idle)'}
+					</div>
+					{history && (
+						<div>
+							{history.saves === 0
+								? 'No snapshots in the history bucket (retention window)'
+								: `${history.saves.toLocaleString()}${history.listTruncated ? '+' : ''} saves · ` +
+									`last ${history.lastSaveAt ? formatAgo(history.lastSaveAt) : '-'} · ` +
+									`first ${history.firstSaveAt ? formatAgo(history.firstSaveAt) : '-'} · ` +
+									(history.avgSecondsBetweenSaves !== null
+										? `every ~${formatInterval(history.avgSecondsBetweenSaves)} · `
+										: '') +
+									`latest ${history.latestSizeBytes !== null ? formatBytes(history.latestSizeBytes) : '-'} · ` +
+									`total ${formatBytes(history.totalSizeBytes)}`}
+						</div>
+					)}
 				</div>
 			)}
 		</div>

--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -31,7 +31,7 @@ export function FilesSection() {
 			</section>
 			<section className={styles.adminSection}>
 				<h3 className={styles.sectionTitle}>Durable object lookup</h3>
-				<ResolveDoIds />
+				<ResolveDoId />
 			</section>
 			<section className={styles.adminSection}>
 				<h3 className={styles.sectionTitle}>Welcome template</h3>
@@ -46,68 +46,35 @@ export function FilesSection() {
 }
 
 /**
- * Maps durable object ids (from Cloudflare analytics or the dash) back to file ids by looping the
- * cursor-paged resolver endpoint until every id is matched or the file table is exhausted.
+ * Maps a durable object id (from Cloudflare analytics or the dash) back to its room slug. The
+ * object stores its own identity, so the resolver asks it directly.
  */
-function ResolveDoIds() {
+function ResolveDoId() {
 	const [input, setInput] = useState('')
 	const [isRunning, setIsRunning] = useState(false)
 	const [error, setError] = useState(null as string | null)
-	const [progress, setProgress] = useState(null as { scanned: number; found: number } | null)
-	const [matches, setMatches] = useState([] as { objectId: string; fileId: string }[])
-	const [unmatched, setUnmatched] = useState([] as string[])
-	const cancelRef = useRef(false)
+	const [match, setMatch] = useState(
+		null as { slug: string; isApp: boolean; deleted: boolean } | 'none' | null
+	)
 
 	const onResolve = useCallback(async () => {
-		const ids = Array.from(new Set(input.split(/[\s,]+/).filter(Boolean)))
-		if (ids.length === 0) {
-			setError('Paste at least one durable object id')
-			return
-		}
-		if (ids.length > 500) {
-			setError('At most 500 ids per run')
-			return
-		}
-		if (ids.some((id) => !/^[0-9a-f]{64}$/.test(id))) {
-			setError('Ids must be 64-character lowercase hex strings')
+		const objectId = input.trim()
+		if (!/^[0-9a-f]{64}$/.test(objectId)) {
+			setError('Paste a 64-character lowercase hex durable object id')
 			return
 		}
 		setError(null)
-		setMatches([])
-		setUnmatched([])
-		setProgress({ scanned: 0, found: 0 })
+		setMatch(null)
 		setIsRunning(true)
-		cancelRef.current = false
 		try {
-			const remaining = new Set(ids)
-			const found: { objectId: string; fileId: string }[] = []
-			let cursor: string | null = null
-			let scanned = 0
-			do {
-				const res = await fetch('/api/app/admin/resolve-do-ids', {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ ids: Array.from(remaining), cursor }),
-				})
-				if (!res.ok) {
-					setError(res.statusText + ': ' + (await res.text()))
-					return
-				}
-				const body: {
-					matches: { objectId: string; fileId: string }[]
-					scanned: number
-					nextCursor: string | null
-				} = await res.json()
-				for (const m of body.matches) {
-					remaining.delete(m.objectId)
-					found.push(m)
-				}
-				scanned += body.scanned
-				cursor = body.nextCursor
-				setProgress({ scanned, found: found.length })
-				setMatches([...found])
-			} while (cursor && remaining.size > 0 && !cancelRef.current)
-			setUnmatched(Array.from(remaining))
+			const res = await fetch(`/api/app/admin/resolve-do-id/${objectId}`)
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			const body: { match: { slug: string; isApp: boolean; deleted: boolean } | null } =
+				await res.json()
+			setMatch(body.match ?? 'none')
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Resolve failed')
 		} finally {
@@ -117,54 +84,34 @@ function ResolveDoIds() {
 
 	return (
 		<div>
-			<textarea
-				className={styles.searchInput}
-				rows={4}
-				placeholder="Durable object ids, one per line (or comma separated)"
-				value={input}
-				onChange={(e) => setInput(e.target.value)}
-				disabled={isRunning}
-			/>
-			<div className={styles.fileOperations}>
+			<div className={styles.searchContainer}>
+				<input
+					className={styles.searchInput}
+					placeholder="Durable object id (64-char hex)"
+					value={input}
+					onChange={(e) => setInput(e.target.value)}
+					onKeyDown={(e) => e.key === 'Enter' && onResolve()}
+					disabled={isRunning}
+				/>
 				<AdminButton variant="primary" onClick={onResolve} isLoading={isRunning}>
 					Resolve
 				</AdminButton>
-				{isRunning && <AdminButton onClick={() => (cancelRef.current = true)}>Cancel</AdminButton>}
 			</div>
 			{error && <div className={styles.errorMessage}>{error}</div>}
-			{progress && (
-				<div className={styles.subTitle}>
-					Scanned {progress.scanned.toLocaleString()} files, matched {progress.found}
-					{isRunning ? '…' : ''}
-				</div>
+			{match === 'none' && (
+				<div className={styles.subTitle}>No room for that id (never initialized)</div>
 			)}
-			{matches.length > 0 && (
-				<table className={styles.diagnosticsTable}>
-					<thead>
-						<tr>
-							<th>Durable object id</th>
-							<th>File</th>
-						</tr>
-					</thead>
-					<tbody>
-						{matches.map((m) => (
-							<tr key={m.objectId}>
-								<td>
-									<code>{m.objectId.slice(0, 16)}…</code>
-								</td>
-								<td>
-									<a href={`/f/${m.fileId}`} target="_blank" rel="noreferrer">
-										{m.fileId}
-									</a>
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			)}
-			{!isRunning && unmatched.length > 0 && (
+			{match && match !== 'none' && (
 				<div className={styles.subTitle}>
-					{unmatched.length} unmatched (legacy room, hard-deleted file, or scan cancelled early)
+					<a
+						href={match.isApp ? `/f/${match.slug}` : `/r/${match.slug}`}
+						target="_blank"
+						rel="noreferrer"
+					>
+						{match.slug}
+					</a>{' '}
+					— {match.isApp ? 'app file' : 'legacy room'}
+					{match.deleted ? ' (deleted)' : ''}
 				</div>
 			)}
 		</div>

--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -30,6 +30,10 @@ export function FilesSection() {
 				<UndeleteFileById />
 			</section>
 			<section className={styles.adminSection}>
+				<h3 className={styles.sectionTitle}>Durable object lookup</h3>
+				<ResolveDoIds />
+			</section>
+			<section className={styles.adminSection}>
 				<h3 className={styles.sectionTitle}>Welcome template</h3>
 				<WelcomeTemplate />
 			</section>
@@ -38,6 +42,132 @@ export function FilesSection() {
 				<HardDeleteFile />
 			</section>
 		</>
+	)
+}
+
+/**
+ * Maps durable object ids (from Cloudflare analytics or the dash) back to file ids by looping the
+ * cursor-paged resolver endpoint until every id is matched or the file table is exhausted.
+ */
+function ResolveDoIds() {
+	const [input, setInput] = useState('')
+	const [isRunning, setIsRunning] = useState(false)
+	const [error, setError] = useState(null as string | null)
+	const [progress, setProgress] = useState(null as { scanned: number; found: number } | null)
+	const [matches, setMatches] = useState([] as { objectId: string; fileId: string }[])
+	const [unmatched, setUnmatched] = useState([] as string[])
+	const cancelRef = useRef(false)
+
+	const onResolve = useCallback(async () => {
+		const ids = Array.from(new Set(input.split(/[\s,]+/).filter(Boolean)))
+		if (ids.length === 0) {
+			setError('Paste at least one durable object id')
+			return
+		}
+		if (ids.length > 500) {
+			setError('At most 500 ids per run')
+			return
+		}
+		if (ids.some((id) => !/^[0-9a-f]{64}$/.test(id))) {
+			setError('Ids must be 64-character lowercase hex strings')
+			return
+		}
+		setError(null)
+		setMatches([])
+		setUnmatched([])
+		setProgress({ scanned: 0, found: 0 })
+		setIsRunning(true)
+		cancelRef.current = false
+		try {
+			const remaining = new Set(ids)
+			const found: { objectId: string; fileId: string }[] = []
+			let cursor: string | null = null
+			let scanned = 0
+			do {
+				const res = await fetch('/api/app/admin/resolve-do-ids', {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ ids: Array.from(remaining), cursor }),
+				})
+				if (!res.ok) {
+					setError(res.statusText + ': ' + (await res.text()))
+					return
+				}
+				const body: {
+					matches: { objectId: string; fileId: string }[]
+					scanned: number
+					nextCursor: string | null
+				} = await res.json()
+				for (const m of body.matches) {
+					remaining.delete(m.objectId)
+					found.push(m)
+				}
+				scanned += body.scanned
+				cursor = body.nextCursor
+				setProgress({ scanned, found: found.length })
+				setMatches([...found])
+			} while (cursor && remaining.size > 0 && !cancelRef.current)
+			setUnmatched(Array.from(remaining))
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Resolve failed')
+		} finally {
+			setIsRunning(false)
+		}
+	}, [input])
+
+	return (
+		<div>
+			<textarea
+				className={styles.searchInput}
+				rows={4}
+				placeholder="Durable object ids, one per line (or comma separated)"
+				value={input}
+				onChange={(e) => setInput(e.target.value)}
+				disabled={isRunning}
+			/>
+			<div className={styles.fileOperations}>
+				<AdminButton variant="primary" onClick={onResolve} isLoading={isRunning}>
+					Resolve
+				</AdminButton>
+				{isRunning && <AdminButton onClick={() => (cancelRef.current = true)}>Cancel</AdminButton>}
+			</div>
+			{error && <div className={styles.errorMessage}>{error}</div>}
+			{progress && (
+				<div className={styles.subTitle}>
+					Scanned {progress.scanned.toLocaleString()} files, matched {progress.found}
+					{isRunning ? '…' : ''}
+				</div>
+			)}
+			{matches.length > 0 && (
+				<table className={styles.diagnosticsTable}>
+					<thead>
+						<tr>
+							<th>Durable object id</th>
+							<th>File</th>
+						</tr>
+					</thead>
+					<tbody>
+						{matches.map((m) => (
+							<tr key={m.objectId}>
+								<td>
+									<code>{m.objectId.slice(0, 16)}…</code>
+								</td>
+								<td>
+									<a href={`/f/${m.fileId}`} target="_blank" rel="noreferrer">
+										{m.fileId}
+									</a>
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			)}
+			{!isRunning && unmatched.length > 0 && (
+				<div className={styles.subTitle}>
+					{unmatched.length} unmatched (legacy room, hard-deleted file, or scan cancelled early)
+				</div>
+			)}
+		</div>
 	)
 }
 

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -2754,6 +2754,15 @@ export class TLFileDurableObject extends DurableObject {
 		await this.persistToDatabase()
 	}
 
+	/**
+	 * Reports this object's stored identity without booting the room. Reads raw storage so rooms
+	 * with a stale documentInfo version still resolve; null for a never-initialized object.
+	 */
+	async __admin__getDocumentInfo() {
+		const info = (await this.storage.get('documentInfo')) as DocumentInfo | null
+		return info ? { slug: info.slug, isApp: !!info.isApp, deleted: !!info.deleted } : null
+	}
+
 	async __admin__hardDeleteIfLegacy() {
 		if (!this._documentInfo || this.documentInfo.deleted || this.documentInfo.isApp) return false
 		this.setDocumentInfo({

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -2755,12 +2755,21 @@ export class TLFileDurableObject extends DurableObject {
 	}
 
 	/**
-	 * Reports this object's stored identity without booting the room. Reads raw storage so rooms
-	 * with a stale documentInfo version still resolve; null for a never-initialized object.
+	 * Reports this object's stored identity and liveness without booting the room. Reads raw
+	 * storage so rooms with a stale documentInfo version still resolve; null for a
+	 * never-initialized object. `connectedSockets` counts hibernation-API sockets, so it is
+	 * accurate even while the room itself is not loaded.
 	 */
 	async __admin__getDocumentInfo() {
 		const info = (await this.storage.get('documentInfo')) as DocumentInfo | null
-		return info ? { slug: info.slug, isApp: !!info.isApp, deleted: !!info.deleted } : null
+		if (!info) return null
+		return {
+			slug: info.slug,
+			isApp: !!info.isApp,
+			deleted: !!info.deleted,
+			connectedSockets: this.ctx.getWebSockets().length,
+			roomLoaded: this._room !== null,
+		}
 	}
 
 	async __admin__hardDeleteIfLegacy() {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -26,6 +26,7 @@ import { undeleteFile } from './undeleteFile'
 import {
 	getFileEffectProcessor,
 	getRoomDurableObject,
+	getRoomDurableObjectById,
 	getUserDurableObject,
 } from './utils/durableObjects'
 import { FEATURE_FLAG_KEYS, getFeatureFlagsAdmin, setFeatureFlag } from './utils/featureFlags'
@@ -157,48 +158,16 @@ export const adminRoutes = createRouter<Environment>()
 			await db.destroy()
 		}
 	})
-	// Maps durable object ids back to file ids. The DO id is a one-way hash of the room name, so
-	// the only way back is forward: hash every file id and compare. One call scans one page of the
-	// file table; loop with the returned cursor until it is null or every id is matched.
-	.post('/app/admin/resolve-do-ids', async (req, env) => {
-		const body = (await req.json().catch(() => null)) as {
-			ids?: string[]
-			cursor?: string
-			batchSize?: number
-		} | null
-		const ids = body?.ids
-		if (!Array.isArray(ids) || ids.length === 0 || ids.length > 500) {
-			throw new StatusError(400, 'ids must be an array of 1-500 durable object ids')
+	// Maps a durable object id back to its room slug. The id is a one-way hash of the room name,
+	// but the room object stores its own identity, so it is asked directly — a never-initialized
+	// id resolves to null. The brief wake is storage-read only; no room boot.
+	.get('/app/admin/resolve-do-id/:objectId', async (res, env) => {
+		const objectId = res.params.objectId
+		if (!/^[0-9a-f]{64}$/.test(objectId)) {
+			throw new StatusError(400, 'objectId must be a 64-char lowercase hex string')
 		}
-		if (!ids.every((id) => typeof id === 'string' && /^[0-9a-f]{64}$/.test(id))) {
-			throw new StatusError(400, 'ids must be 64-char lowercase hex strings')
-		}
-		const batchSize = Math.min(Math.max(body?.batchSize ?? 50_000, 1_000), 200_000)
-		const wanted = new Set(ids)
-		const db = createPostgresConnectionPool(env, '/app/admin/resolve-do-ids')
-		try {
-			let query = db.selectFrom('file').select('id').orderBy('id').limit(batchSize)
-			if (typeof body?.cursor === 'string') {
-				query = query.where('id', '>', body.cursor)
-			}
-			const rows = await query.execute()
-			const matches: { objectId: string; fileId: string }[] = []
-			for (const row of rows) {
-				// mirrors getRoomDurableObject's naming; legacy (pre-app) room slugs are not in the
-				// file table, so their ids come back unmatched
-				const objectId = env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${row.id}`).toString()
-				if (wanted.has(objectId)) {
-					matches.push({ objectId, fileId: row.id })
-				}
-			}
-			return json({
-				matches,
-				scanned: rows.length,
-				nextCursor: rows.length === batchSize ? rows[rows.length - 1].id : null,
-			})
-		} finally {
-			await db.destroy()
-		}
+		const info = await getRoomDurableObjectById(env, objectId).__admin__getDocumentInfo()
+		return json({ match: info })
 	})
 	.get('/app/admin/feature-flags', getFeatureFlagsAdmin)
 	.post('/app/admin/feature-flags', async (req, env) => {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -157,6 +157,49 @@ export const adminRoutes = createRouter<Environment>()
 			await db.destroy()
 		}
 	})
+	// Maps durable object ids back to file ids. The DO id is a one-way hash of the room name, so
+	// the only way back is forward: hash every file id and compare. One call scans one page of the
+	// file table; loop with the returned cursor until it is null or every id is matched.
+	.post('/app/admin/resolve-do-ids', async (req, env) => {
+		const body = (await req.json().catch(() => null)) as {
+			ids?: string[]
+			cursor?: string
+			batchSize?: number
+		} | null
+		const ids = body?.ids
+		if (!Array.isArray(ids) || ids.length === 0 || ids.length > 500) {
+			throw new StatusError(400, 'ids must be an array of 1-500 durable object ids')
+		}
+		if (!ids.every((id) => typeof id === 'string' && /^[0-9a-f]{64}$/.test(id))) {
+			throw new StatusError(400, 'ids must be 64-char lowercase hex strings')
+		}
+		const batchSize = Math.min(Math.max(body?.batchSize ?? 50_000, 1_000), 200_000)
+		const wanted = new Set(ids)
+		const db = createPostgresConnectionPool(env, '/app/admin/resolve-do-ids')
+		try {
+			let query = db.selectFrom('file').select('id').orderBy('id').limit(batchSize)
+			if (typeof body?.cursor === 'string') {
+				query = query.where('id', '>', body.cursor)
+			}
+			const rows = await query.execute()
+			const matches: { objectId: string; fileId: string }[] = []
+			for (const row of rows) {
+				// mirrors getRoomDurableObject's naming; legacy (pre-app) room slugs are not in the
+				// file table, so their ids come back unmatched
+				const objectId = env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${row.id}`).toString()
+				if (wanted.has(objectId)) {
+					matches.push({ objectId, fileId: row.id })
+				}
+			}
+			return json({
+				matches,
+				scanned: rows.length,
+				nextCursor: rows.length === batchSize ? rows[rows.length - 1].id : null,
+			})
+		} finally {
+			await db.destroy()
+		}
+	})
 	.get('/app/admin/feature-flags', getFeatureFlagsAdmin)
 	.post('/app/admin/feature-flags', async (req, env) => {
 		const body: any = await req.json()

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -158,16 +158,54 @@ export const adminRoutes = createRouter<Environment>()
 			await db.destroy()
 		}
 	})
-	// Maps a durable object id back to its room slug. The id is a one-way hash of the room name,
-	// but the room object stores its own identity, so it is asked directly — a never-initialized
-	// id resolves to null. The brief wake is storage-read only; no room boot.
+	// Maps a durable object id back to its room slug and reports activity signals. The id is a
+	// one-way hash of the room name, but the room object stores its own identity, so it is asked
+	// directly — a never-initialized id resolves to null. The brief wake is storage-read only; no
+	// room boot. Persist history comes from the version-cache bucket: one timestamped snapshot per
+	// persist, so save cadence separates an actively edited room from a parked tab holding a
+	// socket open.
 	.get('/app/admin/resolve-do-id/:objectId', async (res, env) => {
 		const objectId = res.params.objectId
 		if (!/^[0-9a-f]{64}$/.test(objectId)) {
 			throw new StatusError(400, 'objectId must be a 64-char lowercase hex string')
 		}
 		const info = await getRoomDurableObjectById(env, objectId).__admin__getDocumentInfo()
-		return json({ match: info })
+		if (!info) return json({ match: null, history: null })
+
+		const prefix = `${getR2KeyForRoom({ slug: info.slug, isApp: info.isApp })}/`
+		const saves: { uploaded: number; size: number }[] = []
+		let cursor: string | undefined
+		let listTruncated = false
+		do {
+			const page = await env.ROOMS_HISTORY_EPHEMERAL.list({ prefix, cursor })
+			for (const obj of page.objects) {
+				saves.push({ uploaded: obj.uploaded.getTime(), size: obj.size })
+			}
+			cursor = page.truncated ? page.cursor : undefined
+			if (saves.length >= 10_000) {
+				listTruncated = true
+				break
+			}
+		} while (cursor)
+		saves.sort((a, b) => a.uploaded - b.uploaded)
+
+		const first = saves[0]
+		const last = saves[saves.length - 1]
+		return json({
+			match: info,
+			history: {
+				saves: saves.length,
+				firstSaveAt: first ? new Date(first.uploaded).toISOString() : null,
+				lastSaveAt: last ? new Date(last.uploaded).toISOString() : null,
+				avgSecondsBetweenSaves:
+					saves.length > 1
+						? Math.round((last.uploaded - first.uploaded) / 1000 / (saves.length - 1))
+						: null,
+				latestSizeBytes: last?.size ?? null,
+				totalSizeBytes: saves.reduce((sum, s) => sum + s.size, 0),
+				listTruncated,
+			},
+		})
 	})
 	.get('/app/admin/feature-flags', getFeatureFlagsAdmin)
 	.post('/app/admin/feature-flags', async (req, env) => {

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -169,40 +169,60 @@ export const adminRoutes = createRouter<Environment>()
 		if (!/^[0-9a-f]{64}$/.test(objectId)) {
 			throw new StatusError(400, 'objectId must be a 64-char lowercase hex string')
 		}
-		const info = await getRoomDurableObjectById(env, objectId).__admin__getDocumentInfo()
+		let roomDo: ReturnType<typeof getRoomDurableObjectById>
+		try {
+			// idFromString rejects hex that fails the namespace checksum (garbage, or an id copied
+			// from another durable object class)
+			roomDo = getRoomDurableObjectById(env, objectId)
+		} catch {
+			throw new StatusError(400, 'not a valid durable object id for the file namespace')
+		}
+		const info = await roomDo.__admin__getDocumentInfo()
 		if (!info) return json({ match: null, history: null })
 
+		// Stream the stats instead of collecting objects, so any number of snapshots fits. Keys are
+		// ISO timestamps (oldest first); min/max tracking keeps the newest save correct either way.
 		const prefix = `${getR2KeyForRoom({ slug: info.slug, isApp: info.isApp })}/`
-		const saves: { uploaded: number; size: number }[] = []
+		let saves = 0
+		let totalBytes = 0
+		let firstAt: number | null = null
+		let lastAt: number | null = null
+		let latestSize: number | null = null
 		let cursor: string | undefined
+		let pages = 0
 		let listTruncated = false
 		do {
 			const page = await env.ROOMS_HISTORY_EPHEMERAL.list({ prefix, cursor })
 			for (const obj of page.objects) {
-				saves.push({ uploaded: obj.uploaded.getTime(), size: obj.size })
+				saves++
+				totalBytes += obj.size
+				const t = obj.uploaded.getTime()
+				if (firstAt === null || t < firstAt) firstAt = t
+				if (lastAt === null || t > lastAt) {
+					lastAt = t
+					latestSize = obj.size
+				}
 			}
 			cursor = page.truncated ? page.cursor : undefined
-			if (saves.length >= 10_000) {
+			// subrequest backstop: 500 pages = 500k snapshots, far beyond any real room
+			if (++pages >= 500 && cursor) {
 				listTruncated = true
 				break
 			}
 		} while (cursor)
-		saves.sort((a, b) => a.uploaded - b.uploaded)
 
-		const first = saves[0]
-		const last = saves[saves.length - 1]
 		return json({
 			match: info,
 			history: {
-				saves: saves.length,
-				firstSaveAt: first ? new Date(first.uploaded).toISOString() : null,
-				lastSaveAt: last ? new Date(last.uploaded).toISOString() : null,
+				saves,
+				firstSaveAt: firstAt !== null ? new Date(firstAt).toISOString() : null,
+				lastSaveAt: lastAt !== null ? new Date(lastAt).toISOString() : null,
 				avgSecondsBetweenSaves:
-					saves.length > 1
-						? Math.round((last.uploaded - first.uploaded) / 1000 / (saves.length - 1))
+					saves > 1 && firstAt !== null && lastAt !== null
+						? Math.round((lastAt - firstAt) / 1000 / (saves - 1))
 						: null,
-				latestSizeBytes: last?.size ?? null,
-				totalSizeBytes: saves.reduce((sum, s) => sum + s.size, 0),
+				latestSizeBytes: latestSize,
+				totalSizeBytes: totalBytes,
 				listTruncated,
 			},
 		})

--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -33,6 +33,10 @@ export function getRoomDurableObject(env: Environment, roomId: string) {
 	) as any as TLFileDurableObject
 }
 
+export function getRoomDurableObjectById(env: Environment, objectId: string) {
+	return env.TLDR_DOC.get(env.TLDR_DOC.idFromString(objectId)) as any as TLFileDurableObject
+}
+
 function shouldRecordStats(env: Environment): boolean {
 	return env.TLDRAW_ENV === 'production'
 }


### PR DESCRIPTION
In order to name the rooms behind the file DOs that dominate our duration bill (the ~24h-awake cohort from the usage audit) — and to tell whether such a room is actually in use or just a parked background tab — this PR adds an admin lookup that maps a durable object id to its room slug plus activity signals.

The DO id is a one-way hash of the room name: Cloudflare analytics rank hot objects by id, our Analytics Engine events are indexed by it, and the dash truncates ids and names in most views. But the room object stores its own identity, so `GET /app/admin/resolve-do-id/:objectId` addresses it via `idFromString` and asks it directly through a new `__admin__getDocumentInfo()` RPC — raw storage read, no room boot, no timers armed; works for legacy pre-app rooms and stale documentInfo versions. A never-initialized id resolves to null.

The response also answers "is anyone using this room":

- from the object: `connectedSockets` (hibernation-API socket count, accurate while hibernated) and `roomLoaded` (in-memory or not)
- from the version-cache bucket (one timestamped snapshot per persist): save count, first/last save, average save cadence, latest and total snapshot size

The admin panel (Files & templates → Durable object lookup) renders the slug as an `/f/` or `/r/` link with a verdict line: actively edited (connected and saving), parked tab (connected, not editing), or idle (no sockets).

An earlier revision scanned the file table and forward-hashed every file id; asking the object directly is O(1) instead of O(files) and covers rooms that aren't in the file table at all.

### Change type

- [x] `other`

### Test plan

1. As an admin, resolve a DO id from the Cloudflare dash (full 64-char id, not the truncated display string) and confirm the slug matches the dash's `/r/` name.
2. Resolve a room you have open in another tab: expect ≥1 connected socket, and after making an edit the last-save age should drop to seconds with the verdict flipping to actively edited.
3. Resolve a garbage 64-hex id: "no room for that id".

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +218 / -0  |
