### PR TITLE
feat(dotcom): admin action to force-close a file room's sessions

### DIFF
--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -130,6 +130,36 @@ function ResolveDoId() {
 	const match = result?.match
 	const history = result?.history
 
+	const [isClosing, setIsClosing] = useState(false)
+	const onForceClose = useCallback(async () => {
+		if (!match) return
+		const objectId = input.trim()
+		if (
+			!window.confirm(
+				`Force-close ${match.connectedSockets} session(s) on ${match.slug}? ` +
+					'Every connected tab (including anyone actively editing) is disconnected and shown ' +
+					'a "please reload" screen.'
+			)
+		) {
+			return
+		}
+		setError(null)
+		setIsClosing(true)
+		try {
+			const res = await fetch(`/api/app/admin/close-do-sessions/${objectId}`, { method: 'POST' })
+			if (!res.ok) {
+				setError(res.statusText + ': ' + (await res.text()))
+				return
+			}
+			// re-resolve so the socket count and verdict reflect the drain
+			await onResolve()
+		} catch (err) {
+			setError(err instanceof Error ? err.message : 'Force-close failed')
+		} finally {
+			setIsClosing(false)
+		}
+	}, [input, match, onResolve])
+
 	return (
 		<div>
 			<div className={styles.searchContainer}>
@@ -179,6 +209,14 @@ function ResolveDoId() {
 										: '') +
 									`latest ${history.latestSizeBytes !== null ? formatBytes(history.latestSizeBytes) : '-'} · ` +
 									`total ${formatBytes(history.totalSizeBytes)}`}
+						</div>
+					)}
+					{match.connectedSockets > 0 && (
+						<div>
+							<AdminButton variant="danger" onClick={onForceClose} isLoading={isClosing}>
+								Force-close {match.connectedSockets} session
+								{match.connectedSockets === 1 ? '' : 's'}
+							</AdminButton>
 						</div>
 					)}
 				</div>

--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -101,15 +101,14 @@ function ResolveDoId() {
 	const [isRunning, setIsRunning] = useState(false)
 	const [error, setError] = useState(null as string | null)
 	const [result, setResult] = useState(
-		null as { match: ResolvedDoRoom | null; history: ResolvedDoHistory | null } | null
+		null as {
+			objectId: string
+			match: ResolvedDoRoom | null
+			history: ResolvedDoHistory | null
+		} | null
 	)
 
-	const onResolve = useCallback(async () => {
-		const objectId = input.trim()
-		if (!/^[0-9a-f]{64}$/.test(objectId)) {
-			setError('Paste a 64-character lowercase hex durable object id')
-			return
-		}
+	const resolve = useCallback(async (objectId: string) => {
 		setError(null)
 		setResult(null)
 		setIsRunning(true)
@@ -119,21 +118,31 @@ function ResolveDoId() {
 				setError(res.statusText + ': ' + (await res.text()))
 				return
 			}
-			setResult(await res.json())
+			setResult({ objectId, ...(await res.json()) })
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Resolve failed')
 		} finally {
 			setIsRunning(false)
 		}
-	}, [input])
+	}, [])
+
+	const onResolve = useCallback(async () => {
+		const objectId = input.trim()
+		if (!/^[0-9a-f]{64}$/.test(objectId)) {
+			setError('Paste a 64-character lowercase hex durable object id')
+			return
+		}
+		await resolve(objectId)
+	}, [input, resolve])
 
 	const match = result?.match
 	const history = result?.history
 
 	const [isClosing, setIsClosing] = useState(false)
 	const onForceClose = useCallback(async () => {
-		if (!match) return
-		const objectId = input.trim()
+		// target the id that was resolved, not the live input — the admin may have edited the
+		// input since, and the button describes the resolved room
+		if (!result || !match) return
 		if (
 			!window.confirm(
 				`Force-close ${match.connectedSockets} session(s) on ${match.slug}? ` +
@@ -146,19 +155,21 @@ function ResolveDoId() {
 		setError(null)
 		setIsClosing(true)
 		try {
-			const res = await fetch(`/api/app/admin/close-do-sessions/${objectId}`, { method: 'POST' })
+			const res = await fetch(`/api/app/admin/close-do-sessions/${result.objectId}`, {
+				method: 'POST',
+			})
 			if (!res.ok) {
 				setError(res.statusText + ': ' + (await res.text()))
 				return
 			}
-			// re-resolve so the socket count and verdict reflect the drain
-			await onResolve()
+			// re-resolve the same object so the socket count and verdict reflect the drain
+			await resolve(result.objectId)
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Force-close failed')
 		} finally {
 			setIsClosing(false)
 		}
-	}, [input, match, onResolve])
+	}, [result, match, resolve])
 
 	return (
 		<div>

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -2787,24 +2787,40 @@ export class TLFileDurableObject extends DurableObject {
 		const sockets = this.ctx.getWebSockets()
 		if (sockets.length === 0) return { closedSockets: 0 }
 
-		const room = this._documentInfo ? await this.getRoom() : null
+		// A room that can't boot (a hard-deleted legacy room with tabs still attached, a transient
+		// storage error) must not abort the drain — the raw close below suffices on its own for
+		// every non-legacy-protocol client.
+		let room: TLSocketRoom<TLRecord, SessionMeta> | null = null
+		if (this._documentInfo) {
+			try {
+				room = await this.getRoom()
+			} catch (e) {
+				this.log.debug('closeAllSessions: room failed to boot, falling back to raw closes', e)
+			}
+		}
 		for (const ws of sockets) {
 			const attachment = this.getSocketAttachment(ws)
 			const sessionId = attachment?.sessionId
+			// If the DO was hibernating, this session was never re-added to the room; resume it
+			// so closeSession can reject it with the session's negotiated protocol.
+			if (room && sessionId && attachment.snapshot && !room.getSessionSnapshot(sessionId)) {
+				room.handleSocketResume({
+					sessionId,
+					socket: ws,
+					snapshot: attachment.snapshot,
+					meta: attachment.meta,
+				})
+			}
+			// Drop the stored snapshot before closing: the close handshake queues a
+			// webSocketClose event, and handleWebSocketEnd would otherwise resume the
+			// just-rejected session into the room again (duplicate leave, possible room re-boot).
+			if (attachment?.snapshot) {
+				ws.serializeAttachment({ ...attachment, snapshot: undefined })
+			}
 			if (room && sessionId) {
-				// If the DO was hibernating, this session was never re-added to the room; resume
-				// it so closeSession can reject it with the session's negotiated protocol.
-				if (attachment.snapshot && !room.getSessionSnapshot(sessionId)) {
-					room.handleSocketResume({
-						sessionId,
-						socket: ws,
-						snapshot: attachment.snapshot,
-						meta: attachment.meta,
-					})
-				}
 				room.closeSession(sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
 			}
-			// Backstop for sockets the room never saw (mid-handshake, or no documentInfo):
+			// Backstop for sockets the room never saw (mid-handshake, or the room didn't boot):
 			// close directly with the same terminal code. Closing twice is a no-op.
 			try {
 				ws.close(TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -2772,6 +2772,49 @@ export class TLFileDurableObject extends DurableObject {
 		}
 	}
 
+	/**
+	 * Force-closes every connected session with CLIENT_TOO_OLD, which shipped clients treat as
+	 * terminal: they stop reconnecting and show a "please reload" screen. This is the admin drain
+	 * for rooms held awake around the clock by parked background tabs reconnect-looping on stale
+	 * bundles — clients that predate the background-tab fix can only be stopped from the server.
+	 *
+	 * Boots the room (a one-time cost per drain), because rejection must run the protocol-aware
+	 * path: legacy-protocol clients need an incompatibility_error message rather than a close
+	 * code, and a hibernated session must be resumed into the room first so presence removal is
+	 * broadcast and the leave is logged.
+	 */
+	async __admin__closeAllSessions() {
+		const sockets = this.ctx.getWebSockets()
+		if (sockets.length === 0) return { closedSockets: 0 }
+
+		const room = this._documentInfo ? await this.getRoom() : null
+		for (const ws of sockets) {
+			const attachment = this.getSocketAttachment(ws)
+			const sessionId = attachment?.sessionId
+			if (room && sessionId) {
+				// If the DO was hibernating, this session was never re-added to the room; resume
+				// it so closeSession can reject it with the session's negotiated protocol.
+				if (attachment.snapshot && !room.getSessionSnapshot(sessionId)) {
+					room.handleSocketResume({
+						sessionId,
+						socket: ws,
+						snapshot: attachment.snapshot,
+						meta: attachment.meta,
+					})
+				}
+				room.closeSession(sessionId, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
+			}
+			// Backstop for sockets the room never saw (mid-handshake, or no documentInfo):
+			// close directly with the same terminal code. Closing twice is a no-op.
+			try {
+				ws.close(TLSyncErrorCloseEventCode, TLSyncErrorCloseEventReason.CLIENT_TOO_OLD)
+			} catch {
+				// an already-closed socket is fine
+			}
+		}
+		return { closedSockets: sockets.length }
+	}
+
 	async __admin__hardDeleteIfLegacy() {
 		if (!this._documentInfo || this.documentInfo.deleted || this.documentInfo.isApp) return false
 		this.setDocumentInfo({

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -227,6 +227,23 @@ export const adminRoutes = createRouter<Environment>()
 			},
 		})
 	})
+	// Force-closes every session on a file room with CLIENT_TOO_OLD. Shipped clients treat that
+	// as terminal — no reconnect, a "please reload" screen — so a room held awake around the
+	// clock by parked background tabs on stale bundles can finally hibernate. Resolve the id
+	// first and check the verdict: this closes actively edited sessions just the same.
+	.post('/app/admin/close-do-sessions/:objectId', async (res, env) => {
+		const objectId = res.params.objectId
+		if (!/^[0-9a-f]{64}$/.test(objectId)) {
+			throw new StatusError(400, 'objectId must be a 64-char lowercase hex string')
+		}
+		let roomDo: ReturnType<typeof getRoomDurableObjectById>
+		try {
+			roomDo = getRoomDurableObjectById(env, objectId)
+		} catch {
+			throw new StatusError(400, 'not a valid durable object id for the file namespace')
+		}
+		return json(await roomDo.__admin__closeAllSessions())
+	})
 	.get('/app/admin/feature-flags', getFeatureFlagsAdmin)
 	.post('/app/admin/feature-flags', async (req, env) => {
 		const body: any = await req.json()


### PR DESCRIPTION
In order to drain the ~3,700 file rooms held awake around the clock by parked background tabs (~84% of our durable object duration bill), this PR adds an admin action that force-closes every session on a room with `CLIENT_TOO_OLD`.

The background-tab reconnect-loop fix (#9964) only reaches tabs that load the new bundle — a parked tab never reloads, so the existing stuck population keeps storming on stale code until the tab dies. Shipped clients do already treat a `CLIENT_TOO_OLD` rejection as terminal: the socket adapter maps close code 4099 to a fatal error, `useSync` disposes the client, and the app shows a "Please reload" screen. That path has been in production bundles for a long time, so the server can stop old clients that the client-side fix can't reach.

The drain is a `__admin__closeAllSessions()` RPC on the file durable object, exposed as `POST /app/admin/close-do-sessions/:objectId` and as a force-close button on the durable object lookup panel (#9975), which is how a room gets diagnosed as parked in the first place. The RPC boots the room so rejection runs the protocol-aware path (legacy-protocol clients need an `incompatibility_error` message rather than a close code, and hibernated sessions are resumed first so presence removal is broadcast and the leave is logged); if the room can't boot — a hard-deleted legacy room with tabs still attached — it falls back to raw 4099 closes, which cover every non-legacy client on their own. Stored session snapshots are dropped before closing so the queued `webSocketClose` events don't resume just-rejected sessions into the room.

This intentionally closes all sessions, active editors included — the lookup panel's verdict line (actively edited / parked / idle) is the guard, and the confirm dialog says so. A follow-up could add an automatic backstop (same-sessionId replacement storms → reject), but a manual, targeted drain is the low-risk way to verify the whales actually hibernate after rejection before automating anything.

Relates to #9964, #9975.

### Change type

- [x] `other`

### Test plan

1. As an admin, resolve a durable object id with at least one connected socket (Files & templates → Durable object lookup).
2. Click "Force-close N session(s)" and confirm: connected tabs should immediately show the "Please reload" screen and stop reconnecting (no further WS attempts in devtools).
3. The panel re-resolves after the drain: expect 0 sockets connected.
4. Resolve a garbage-but-valid id with no sockets: force-close button is not shown.
