### PR TITLE
test(dotcom): add local MCP eval fixture routes

### DIFF
--- a/apps/dotcom/sync-worker/src/routes/tla/boardTools.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/boardTools.ts
@@ -1,0 +1,611 @@
+import {
+	ClusterBounds,
+	DEFAULT_THUMBNAIL_HEIGHT,
+	DEFAULT_THUMBNAIL_WIDTH,
+	MAX_THUMBNAIL_PAGES,
+	getShapeClusters,
+	getShapeText,
+	type TLShapeWithPlainText,
+} from '@tldraw/dotcom-shared'
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { TLShape, isPage, isShape } from '@tldraw/tlschema'
+import { getDocumentNameFromSnapshot } from '../getDocumentNameFromSnapshot'
+
+// Everything about this MCP server that a model can perceive: the protocol handshake and its
+// instructions, the tool names, titles and descriptions, how arguments are parsed and how bad ones
+// are refused, how a page's shapes are grouped and labelled, what a shape record looks like once
+// it's readable, and the wording of every error a model has to recover from.
+//
+// Deliberately pure. It takes a room snapshot and a table of shape measurements — data — and returns
+// tool results. It knows nothing about Postgres, R2, Browser Rendering, rate limits, caching or
+// telemetry; sharedBoardScreenshotMcp.ts owns all of that and calls in here.
+//
+// The split is what makes this server evaluable. The private eval harness sends checked-in board
+// fixtures to the local-only route in evalsLocalMcp.ts, which serves these exact functions. A run
+// therefore exercises the real tool descriptions and error strings without a database, browser or
+// rate limiter. Anything a model can read must live here, or an eval stops being evidence about the
+// deployed server.
+
+export const MCP_PROTOCOL_VERSION = '2025-11-25'
+
+export const MCP_SERVER_INFO = {
+	name: 'tldraw-shared-board-screenshot',
+	title: 'tldraw shared board screenshots',
+	version: '2.0.0',
+}
+
+export const MCP_SERVER_INSTRUCTIONS =
+	'MCP server for public tldraw.com boards. Drill down in order: get_board_info lists a board’s pages, get_page_info lists one page’s clusters of shapes, and get_cluster_screenshot returns a PNG of one or more clusters. get_cluster_info describes the shapes inside a cluster when those matter. Accepts published tldraw.com/p/:slug boards and anonymously-shared tldraw.com/f/:slug files, rendered through a signed, tldraw-owned render job.'
+
+export const BOARD_INFO_TOOL_NAME = 'get_board_info'
+export const PAGE_INFO_TOOL_NAME = 'get_page_info'
+export const CLUSTER_INFO_TOOL_NAME = 'get_cluster_info'
+export const CLUSTER_SCREENSHOT_TOOL_NAME = 'get_cluster_screenshot'
+
+export const TOOL_NAMES = [
+	BOARD_INFO_TOOL_NAME,
+	PAGE_INFO_TOOL_NAME,
+	CLUSTER_INFO_TOOL_NAME,
+	CLUSTER_SCREENSHOT_TOOL_NAME,
+] as const
+
+// What a model is told when the board id it was given leads nowhere. The route decides *whether* a
+// board is missing or empty — that needs Postgres and R2 — but the wording lives here with the rest
+// of the model-facing surface, so a harness serving fixtures refuses an unknown id identically.
+export const BOARD_NOT_FOUND_MESSAGE =
+	'No public board was found with this id. Only published boards and files shared via link are supported.'
+export const BOARD_EMPTY_MESSAGE = 'This board has no saved content yet.'
+
+// --- Reading a snapshot -------------------------------------------------------------------------
+
+/** What one shape's measure render produced: its page bounds, plus the text its ShapeUtil reported. */
+export interface ShapeMeasurement extends ClusterBounds {
+	text?: string
+}
+
+// A board page in stable board order. `index` is the 0-based ordinal callers pass to the screenshot
+// tool; `id` is the internal TLPageId used to drive the render page.
+export interface EnumeratedPage {
+	index: number
+	id: string
+	name: string
+	hasContent: boolean
+}
+
+// Lists a board's pages in the same order the editor shows them. tldraw page indexes are fractional
+// indexes that sort lexicographically, so a plain string sort matches the editor's ordering. A page
+// "has content" when at least one shape sits directly on it (nested shapes always have a top-level
+// ancestor on their page, so checking direct children is sufficient).
+export function enumerateBoardPages(snapshot: RoomSnapshot): EnumeratedPage[] {
+	const records = snapshot.documents.map((d) => d.state)
+	const pageRecords = records.filter(isPage)
+	pageRecords.sort((a, b) => (a.index < b.index ? -1 : a.index > b.index ? 1 : 0))
+	const parentIdsWithShapes = new Set(records.filter(isShape).map((s) => s.parentId))
+	return pageRecords.slice(0, MAX_THUMBNAIL_PAGES).map((p, index) => ({
+		index,
+		id: String(p.id),
+		name: typeof p.name === 'string' && p.name.length > 0 ? p.name : `Page ${index + 1}`,
+		hasContent: parentIdsWithShapes.has(p.id),
+	}))
+}
+
+// The shapes belonging to one page, in snapshot order. Nested shapes carry their ancestor's id as
+// `parentId`, so membership is resolved by walking up to a top-level shape whose parent is the page.
+export function getShapesOnPage(snapshot: RoomSnapshot, pageId: string): TLShape[] {
+	const shapes = snapshot.documents.map((d) => d.state).filter(isShape)
+	const byId = new Map(shapes.map((s) => [s.id, s]))
+	return shapes.filter((shape) => {
+		let current: TLShape | undefined = shape
+		// Bounded by the ancestor chain, and guarded against a cyclic parentId in a corrupt snapshot.
+		for (let depth = 0; current && depth < 100; depth++) {
+			if (current.parentId === pageId) return true
+			current = byId.get(current.parentId as TLShape['id'])
+		}
+		return false
+	})
+}
+
+// --- Input parsing ------------------------------------------------------------------------------
+
+export function parseBoardInfoInput(input: unknown): { boardId: string } {
+	const value = requireArgumentsObject(input)
+	return { boardId: parseBoardId(value.boardId) }
+}
+
+export function parsePageInfoInput(input: unknown): { boardId: string; page: PageSelector } {
+	const value = requireArgumentsObject(input)
+	return { boardId: parseBoardId(value.boardId), page: parsePageSelector(value.page) }
+}
+
+export function parseClusterInfoInput(input: unknown): {
+	boardId: string
+	page: PageSelector
+	clusterId: string
+} {
+	const value = requireArgumentsObject(input)
+	return {
+		boardId: parseBoardId(value.boardId),
+		page: parsePageSelector(value.page),
+		clusterId: parseClusterId(value.clusterId),
+	}
+}
+
+export function parseClusterScreenshotInput(input: unknown): {
+	boardId: string
+	page: PageSelector
+	clusterIds: string[]
+	theme: 'light' | 'dark'
+} {
+	const value = requireArgumentsObject(input)
+	return {
+		boardId: parseBoardId(value.boardId),
+		page: parsePageSelector(value.page),
+		clusterIds: parseClusterIds(value.clusterIds),
+		theme: parseTheme(value.theme),
+	}
+}
+
+// Accepts one id or several. A single string is allowed because asking for one cluster is the common
+// case and making callers wrap it in an array is friction for nothing.
+export function parseClusterIds(value: unknown): string[] {
+	if (typeof value === 'string') return [parseClusterId(value)]
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new Error('clusterIds is required: a cluster id, or an array of them')
+	}
+	return value.map((id) => parseClusterId(id))
+}
+
+export function parseClusterId(value: unknown): string {
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error('clusterId is required')
+	}
+	return value
+}
+
+function requireArgumentsObject(input: unknown): Record<string, unknown> {
+	if (!input || typeof input !== 'object') {
+		throw new Error('Tool arguments must be an object')
+	}
+	return input as Record<string, unknown>
+}
+
+function parseBoardId(value: unknown): string {
+	if (typeof value !== 'string' || value.length === 0) {
+		throw new Error('boardId is required')
+	}
+	if (value.includes('/')) {
+		throw new Error('boardId must be a board id, not a URL')
+	}
+	return value
+}
+
+// Omitting the theme means light, but an unrecognized one is rejected rather than quietly treated
+// as light: a caller asking for `blue` gets a wrong-but-plausible image back and no signal that the
+// argument was ignored.
+function parseTheme(value: unknown): 'light' | 'dark' {
+	if (value === undefined || value === null) return 'light'
+	if (value !== 'light' && value !== 'dark') {
+		throw new Error(`theme must be 'light' or 'dark'`)
+	}
+	return value
+}
+
+// A page is named either by its 0-based ordinal or by its id. Ordinals read naturally but shift the
+// moment pages are reordered, so an id a caller is holding from an earlier call keeps pointing at the
+// same page. Both are accepted in the one argument so the tool surface stays small.
+export type PageSelector = { kind: 'ordinal'; ordinal: number } | { kind: 'id'; id: string }
+
+function parsePageSelector(value: unknown): PageSelector {
+	if (value === undefined || value === null) return { kind: 'ordinal', ordinal: 0 }
+	if (typeof value === 'string') {
+		if (!value.startsWith('page:')) {
+			throw new Error(
+				'page must be a 0-based page ordinal (a number) or a page id (the "page:…" string from get_board_info)'
+			)
+		}
+		return { kind: 'id', id: value }
+	}
+	if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+		throw new Error('page must be a non-negative integer (0-based page ordinal) or a page id')
+	}
+	return { kind: 'ordinal', ordinal: value }
+}
+
+/** How the page was named, for error messages that echo back what the caller actually passed. */
+export function describePageSelector(selector: PageSelector) {
+	return selector.kind === 'id' ? `"${selector.id}"` : String(selector.ordinal)
+}
+
+// --- Tool results -------------------------------------------------------------------------------
+
+export interface ToolResult {
+	content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>
+	isError?: boolean
+}
+
+export function toolError(message: string): ToolResult {
+	return {
+		content: [{ type: 'text', text: message }],
+		isError: true,
+	}
+}
+
+export function toolPageResult(name: string, base64: string): ToolResult {
+	return {
+		content: [
+			{ type: 'text', text: name },
+			{ type: 'image', data: base64, mimeType: 'image/png' },
+		],
+	}
+}
+
+export function toolJsonResult(value: unknown): ToolResult {
+	return {
+		content: [{ type: 'text', text: JSON.stringify(value) }],
+	}
+}
+
+// --- The tools ----------------------------------------------------------------------------------
+
+export function getBoardInfo(snapshot: RoomSnapshot): ToolResult {
+	const pages = enumerateBoardPages(snapshot)
+	return toolJsonResult({
+		name: getDocumentNameFromSnapshot(snapshot),
+		pageCount: pages.length,
+		// `id` is the stable handle: it survives page reordering, `index` does not. Either can be
+		// passed as `page` to the other tools.
+		pages: pages.map((p) => ({
+			index: p.index,
+			id: p.id,
+			name: p.name,
+			hasContent: p.hasContent,
+		})),
+	})
+}
+
+// Every page-scoped tool needs the same steps before it can do anything: validate the page selector
+// and pull that page's shapes. Returning the tool's own error shape on failure keeps the wording
+// identical across tools.
+//
+// Separate from the tools below because the caller has to know the page id before it can measure the
+// page, and measuring is what produces the `measurements` those tools need.
+export type ResolvedPage =
+	| { ok: true; pageId: string; pageName: string; shapes: TLShape[] }
+	| { ok: false; result: ToolResult }
+
+export function resolvePage(snapshot: RoomSnapshot, page: PageSelector): ResolvedPage {
+	const pages = enumerateBoardPages(snapshot)
+	if (pages.length === 0) {
+		return { ok: false, result: toolError('This board has no pages.') }
+	}
+
+	const targetPage = page.kind === 'id' ? pages.find((p) => p.id === page.id) : pages[page.ordinal]
+	if (!targetPage) {
+		return {
+			ok: false,
+			result: toolError(
+				page.kind === 'id'
+					? `No page with id "${page.id}" on this board. Call get_board_info to list its pages; a page id is stable across reordering, an index is not.`
+					: `Page ${page.ordinal} is out of range: this board has ${pages.length} page(s) (0–${pages.length - 1}). Call get_board_info to list them.`
+			),
+		}
+	}
+	return {
+		ok: true,
+		pageId: targetPage.id,
+		pageName: targetPage.name,
+		shapes: getShapesOnPage(snapshot, targetPage.id),
+	}
+}
+
+export type ResolvedPageOk = Extract<ResolvedPage, { ok: true }>
+
+// The measure render answers two things a Worker cannot: where each shape sits, and what
+// ShapeUtil.getText says it holds. Bounds drive the linkage; the text is attached to the shapes so
+// labelling reads the editor's answer rather than re-deriving one from props.
+function clusterPage(page: ResolvedPageOk, measurements: Record<string, ShapeMeasurement>) {
+	const shapes: TLShapeWithPlainText[] = page.shapes.map((shape) => {
+		const text = measurements[shape.id as string]?.text
+		return text ? { ...shape, plainText: text } : shape
+	})
+
+	return getShapeClusters(shapes, page.pageId, measurements)
+}
+
+export function getPageInfo(
+	page: ResolvedPageOk,
+	measurements: Record<string, ShapeMeasurement>
+): ToolResult {
+	// Scoped to the requested page: get_cluster_info and get_cluster_screenshot both resolve cluster
+	// ids against a single page, so listing every shape on the board here would hand out ids that
+	// neither of them can look up.
+	const clusters = clusterPage(page, measurements)
+	return toolJsonResult({
+		name: page.pageName,
+		clusterCount: clusters.length,
+		clusters: clusters.map((c) => ({
+			id: c.id,
+			label: c.label,
+			keywords: c.keywords,
+			numberOfShapes: c.numberOfShapes,
+		})),
+	})
+}
+
+export function getClusterInfo(
+	page: ResolvedPageOk,
+	measurements: Record<string, ShapeMeasurement>,
+	clusterId: string,
+	selector: PageSelector
+): ToolResult {
+	const cluster = clusterPage(page, measurements).find((c) => c.id === clusterId)
+	if (!cluster) {
+		return toolError(
+			`No cluster with id "${clusterId}" on page ${describePageSelector(selector)}. Call get_page_info to list this page's clusters.`
+		)
+	}
+
+	return toolJsonResult({
+		clusterId: cluster.id,
+		label: cluster.label,
+		keywords: cluster.keywords,
+		pageName: page.pageName,
+		numberOfShapes: cluster.numberOfShapes,
+		shapes: cluster.shapes.map(toReadableShape),
+	})
+}
+
+export type PickedShapes = { ok: true; shapeIds: string[] } | { ok: false; result: ToolResult }
+
+/**
+ * The shapes to draw for a `get_cluster_screenshot` call. Separate from the capture itself, which is
+ * the route's job: this only says *which* shapes, from ids the model supplied.
+ */
+export function pickClusterShapes(
+	page: ResolvedPageOk,
+	measurements: Record<string, ShapeMeasurement>,
+	clusterIds: string[],
+	selector: PageSelector
+): PickedShapes {
+	const clusters = clusterPage(page, measurements)
+	const byId = new Map(clusters.map((cluster) => [cluster.id, cluster]))
+
+	// Reject unknown ids rather than quietly rendering the subset that resolved — a caller asking for
+	// three clusters and getting a picture of two has no way to notice.
+	const missing = clusterIds.filter((id) => !byId.has(id))
+	if (missing.length > 0) {
+		return {
+			ok: false,
+			result: toolError(
+				`No cluster on page ${describePageSelector(selector)} with id ${missing.map((id) => `"${id}"`).join(', ')}. Call get_page_info to list this page's clusters.`
+			),
+		}
+	}
+
+	// Several clusters render as one framed image of their union, which is the point of taking more
+	// than one: seeing how they sit relative to each other.
+	return {
+		ok: true,
+		shapeIds: [
+			...new Set(
+				clusterIds.flatMap((id) => byId.get(id)!.shapes.map((shape) => shape.id as string))
+			),
+		],
+	}
+}
+
+// The shape as stored, with one substitution: `props.richText` — a ProseMirror document, deeply
+// nested and unreadable — is dropped in favour of the plain string the editor's ShapeUtil.getText
+// reported for that shape during the measure render. Everything else is passed through untouched, so
+// a caller still sees type, position, rotation, size, colour and the rest exactly as stored.
+//
+// This matters beyond readability: a geo shape's label is not in `props` at all under any key a
+// Worker could find, so without the editor's answer that text is simply invisible.
+function toReadableShape(shape: TLShapeWithPlainText) {
+	const { plainText, ...rest } = shape
+	const props = { ...(rest.props as Record<string, unknown>) }
+	delete props.richText
+
+	const text = plainText ?? getShapeText(shape)
+	if (text) props.text = text
+	else delete props.text
+
+	return { ...rest, props }
+}
+
+// --- Tool definitions ---------------------------------------------------------------------------
+
+export function getToolDefinitions() {
+	return [
+		getBoardInfoToolDefinition(),
+		getPageInfoToolDefinition(),
+		getClusterInfoToolDefinition(),
+		getClusterScreenshotToolDefinition(),
+	]
+}
+
+const BOARD_ID_PROPERTY = {
+	type: 'string',
+	description:
+		'The id of a public tldraw.com board: the :slug of a published board URL (https://www.tldraw.com/p/:slug) or of an anonymously-shared file URL (https://www.tldraw.com/f/:slug).',
+}
+
+const READ_ONLY_ANNOTATIONS = {
+	readOnlyHint: true,
+	idempotentHint: true,
+	openWorldHint: false,
+	destructiveHint: false,
+}
+
+function getBoardInfoToolDefinition() {
+	return {
+		name: BOARD_INFO_TOOL_NAME,
+		title: 'Get tldraw board info',
+		description:
+			'Return metadata for a public tldraw.com board: its name, page count, and the id, name, 0-based index, and hasContent flag for each page. Call this first, then pass a page id or index to get_page_info.',
+		inputSchema: {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				boardId: BOARD_ID_PROPERTY,
+			},
+			required: ['boardId'],
+		},
+		annotations: READ_ONLY_ANNOTATIONS,
+	}
+}
+
+function getPageInfoToolDefinition() {
+	return {
+		name: PAGE_INFO_TOOL_NAME,
+		title: 'Get tldraw page info',
+		description:
+			'List the shape clusters on one page of a public tldraw.com board. Each top-level shape is a cluster together with its descendants, so frames and groups stay together while ungrouped shapes remain individually addressable. Pass a cluster id to get_cluster_info or get_cluster_screenshot.',
+		inputSchema: {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				boardId: BOARD_ID_PROPERTY,
+				page: {
+					type: ['number', 'string'],
+					description:
+						'The page id or 0-based index from get_board_info. Defaults to 0, the first page.',
+					default: 0,
+				},
+			},
+			required: ['boardId'],
+		},
+		annotations: READ_ONLY_ANNOTATIONS,
+	}
+}
+
+function getClusterInfoToolDefinition() {
+	return {
+		name: CLUSTER_INFO_TOOL_NAME,
+		title: 'Get tldraw cluster info',
+		description:
+			"Describe one cluster from get_page_info: its label, keywords, and the full record of every shape it contains — type, position, rotation, size, style and so on. Each shape's rich text document is replaced by `props.text`, the plain string the editor reports for it, which also surfaces text that is not stored on the record at all (a geo shape's label, for instance).",
+		inputSchema: {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				boardId: BOARD_ID_PROPERTY,
+				page: {
+					type: ['number', 'string'],
+					description:
+						'The page id or 0-based index from get_board_info. Defaults to 0, the first page.',
+					default: 0,
+				},
+				clusterId: {
+					type: 'string',
+					description: 'The id of the cluster to get info for.',
+				},
+			},
+			required: ['boardId', 'clusterId'],
+		},
+		annotations: READ_ONLY_ANNOTATIONS,
+	}
+}
+
+function getClusterScreenshotToolDefinition() {
+	return {
+		name: CLUSTER_SCREENSHOT_TOOL_NAME,
+		title: 'Get tldraw cluster screenshot',
+		description: `Return a ${DEFAULT_THUMBNAIL_WIDTH}x${DEFAULT_THUMBNAIL_HEIGHT} PNG of one or more clusters from get_page_info, preceded by the page name. The camera fits the clusters requested and only their shapes are drawn, so nothing else on the page appears. Pass several ids to see how those clusters sit relative to each other in a single image. This is the direct route from a cluster id to a picture — get_cluster_info is only needed when the individual shapes matter.`,
+		inputSchema: {
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				boardId: BOARD_ID_PROPERTY,
+				page: {
+					type: ['number', 'string'],
+					description:
+						'Which page: either its 0-based index or its page id from get_board_info. Ids survive page reordering, indexes do not. Defaults to 0, the first page.',
+					default: 0,
+				},
+				clusterIds: {
+					type: 'array',
+					items: { type: 'string' },
+					description:
+						'One or more cluster ids from get_page_info. All of them must be on the given page. A bare string is also accepted for a single cluster.',
+				},
+				theme: {
+					type: 'string',
+					enum: ['light', 'dark'],
+					default: 'light',
+				},
+			},
+			required: ['boardId', 'page', 'clusterIds'],
+		},
+		annotations: READ_ONLY_ANNOTATIONS,
+	}
+}
+
+// --- JSON-RPC -----------------------------------------------------------------------------------
+//
+// The protocol envelope, shared so that a local harness and the deployed Worker present the same
+// handshake — including `instructions`, which a model reads before it calls anything.
+
+export type JsonRpcId = string | number | null
+
+export interface JsonRpcRequest {
+	jsonrpc?: string
+	id?: JsonRpcId
+	method?: string
+	params?: {
+		name?: string
+		arguments?: unknown
+	}
+}
+
+export type McpReply =
+	/** A notification (no id): acknowledged with 202 and no body. */
+	| { kind: 'accepted' }
+	| { kind: 'result'; id: JsonRpcId; result: unknown }
+	| { kind: 'error'; id: JsonRpcId; code: number; message: string }
+
+/**
+ * Dispatches one JSON-RPC request. Everything that depends on where the server runs — reading the
+ * board, spending a browser, rate limits — lives behind `callTool`, which the caller supplies.
+ */
+export async function handleMcpJsonRpc(
+	rpcRequest: JsonRpcRequest,
+	callTool: (name: string, args: unknown) => Promise<ToolResult>
+): Promise<McpReply> {
+	if (rpcRequest.id === undefined) {
+		return { kind: 'accepted' }
+	}
+	const id = rpcRequest.id
+
+	switch (rpcRequest.method) {
+		case 'initialize':
+			return {
+				kind: 'result',
+				id,
+				result: {
+					protocolVersion: MCP_PROTOCOL_VERSION,
+					capabilities: { tools: {} },
+					serverInfo: MCP_SERVER_INFO,
+					instructions: MCP_SERVER_INSTRUCTIONS,
+				},
+			}
+		case 'ping':
+			return { kind: 'result', id, result: {} }
+		case 'tools/list':
+			return { kind: 'result', id, result: { tools: getToolDefinitions() } }
+		case 'tools/call': {
+			const name = rpcRequest.params?.name
+			if (!name || !(TOOL_NAMES as readonly string[]).includes(name)) {
+				return { kind: 'error', id, code: -32602, message: `Unknown tool: ${name}` }
+			}
+			return { kind: 'result', id, result: await callTool(name, rpcRequest.params?.arguments) }
+		}
+		default:
+			return {
+				kind: 'error',
+				id,
+				code: -32601,
+				message: `Method not found: ${rpcRequest.method}`,
+			}
+	}
+}

--- a/apps/dotcom/sync-worker/src/routes/tla/evalsLocalMcp.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/evalsLocalMcp.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { testRoutes } from '../../testRoutes'
+import { getEvalsFixtureScreenshotPlan, resetEvalsFixtureSessionsForTests } from './evalsLocalMcp'
+import { makeSnapshot } from './screenshotTestHelpers'
+
+const localEnv = { IS_LOCAL: 'true', TLDRAW_ENV: 'development' } as never
+
+afterEach(resetEvalsFixtureSessionsForTests)
+
+function request(path: string, method: string, body?: unknown) {
+	return new Request(`http://localhost${path}`, {
+		method,
+		...(body === undefined
+			? null
+			: { headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) }),
+	})
+}
+
+describe('local eval fixture MCP', () => {
+	it('is unavailable outside local development', async () => {
+		const response = await testRoutes.fetch(request('/app/__test__/evals/plan', 'POST', {}), {
+			IS_LOCAL: 'false',
+			TLDRAW_ENV: 'production',
+		} as never)
+		expect(response.status).toBe(404)
+	})
+
+	it('plans fixture screenshots with the real clustering logic', () => {
+		const snapshot = makeSnapshot([{ id: 'page:one', index: 'a1', shapes: 1 }])
+		const plan = getEvalsFixtureScreenshotPlan(snapshot, {
+			'shape:page:one-0': { minX: 0, minY: 0, maxX: 80, maxY: 80, text: 'Q4' },
+		})
+
+		expect(plan).toHaveLength(1)
+		expect(plan[0]).toMatchObject({
+			pageId: 'page:one',
+			shapeIds: ['shape:page:one-0'],
+		})
+		expect(plan[0].clusterIds).toHaveLength(1)
+	})
+
+	it('serves uploaded boards through the real board tools', async () => {
+		const snapshot = makeSnapshot([{ id: 'page:one', index: 'a1', name: 'One', shapes: 1 }])
+		const boardResponse = await testRoutes.fetch(
+			request('/app/__test__/evals/sessions/session/boards/roadmap', 'PUT', {
+				snapshot,
+				measurements: {
+					'shape:page:one-0': { minX: 0, minY: 0, maxX: 80, maxY: 80, text: 'Q4' },
+				},
+				shots: {},
+			}),
+			localEnv
+		)
+		expect(boardResponse.status).toBe(201)
+
+		const mcpResponse = await testRoutes.fetch(
+			request('/app/__test__/evals/sessions/session/mcp', 'POST', {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: { name: 'get_board_info', arguments: { boardId: 'roadmap' } },
+			}),
+			localEnv
+		)
+		expect(mcpResponse.status).toBe(200)
+		const rpc = (await mcpResponse.json()) as any
+		expect(JSON.parse(rpc.result.content[0].text)).toMatchObject({
+			name: 'My Board',
+			pages: [{ id: 'page:one', name: 'One', hasContent: true }],
+		})
+	})
+})

--- a/apps/dotcom/sync-worker/src/routes/tla/evalsLocalMcp.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/evalsLocalMcp.ts
@@ -1,0 +1,198 @@
+import { RoomSnapshot } from '@tldraw/sync-core'
+import { IRequest } from 'itty-router'
+import { Environment } from '../../types'
+import {
+	BOARD_INFO_TOOL_NAME,
+	BOARD_NOT_FOUND_MESSAGE,
+	CLUSTER_INFO_TOOL_NAME,
+	CLUSTER_SCREENSHOT_TOOL_NAME,
+	PAGE_INFO_TOOL_NAME,
+	ShapeMeasurement,
+	ToolResult,
+	getBoardInfo,
+	getClusterInfo,
+	getPageInfo,
+	handleMcpJsonRpc,
+	parseBoardInfoInput,
+	parseClusterInfoInput,
+	parseClusterScreenshotInput,
+	parsePageInfoInput,
+	pickClusterShapes,
+	resolvePage,
+	toolError,
+	toolPageResult,
+} from './boardTools'
+
+const HARNESS_GAP_MARKER = '[harness-gap]'
+
+interface FixtureBoard {
+	snapshot: RoomSnapshot
+	measurements: Record<string, ShapeMeasurement>
+	shots: Record<string, string>
+}
+
+interface ScreenshotPlanEntry {
+	pageId: string
+	clusterIds: string[]
+	shapeIds: string[]
+}
+
+const sessions = new Map<string, Map<string, FixtureBoard>>()
+
+function notFoundUnlessLocal(env: Environment): Response | null {
+	return env.IS_LOCAL === 'true' ? null : new Response('Not Found', { status: 404 })
+}
+
+function screenshotFileName(clusterIds: string[], theme: 'light' | 'dark') {
+	const key = [...clusterIds]
+		.sort()
+		.join('+')
+		.replace(/[^a-zA-Z0-9+_-]/g, '_')
+	return `${key}.${theme}.png`
+}
+
+function textOf(result: ToolResult): string {
+	const block = result.content.find((part) => part.type === 'text')
+	if (!block || block.type !== 'text') throw new Error('Expected a text tool result')
+	return block.text
+}
+
+export function getEvalsFixtureScreenshotPlan(
+	snapshot: RoomSnapshot,
+	measurements: Record<string, ShapeMeasurement>
+): ScreenshotPlanEntry[] {
+	const pages = JSON.parse(textOf(getBoardInfo(snapshot))) as {
+		pages: Array<{ id: string }>
+	}
+	const plan: ScreenshotPlanEntry[] = []
+	for (const page of pages.pages) {
+		const selector = { kind: 'id', id: page.id } as const
+		const resolved = resolvePage(snapshot, selector)
+		if (!resolved.ok) continue
+		const info = JSON.parse(textOf(getPageInfo(resolved, measurements))) as {
+			clusters: Array<{ id: string }>
+		}
+		const clusterIds = info.clusters.map((cluster) => cluster.id)
+		const sets = [...clusterIds.map((id) => [id]), ...(clusterIds.length > 1 ? [clusterIds] : [])]
+		for (const set of sets) {
+			const picked = pickClusterShapes(resolved, measurements, set, selector)
+			if (!picked.ok || picked.shapeIds.length === 0) continue
+			plan.push({ pageId: page.id, clusterIds: set, shapeIds: picked.shapeIds })
+		}
+	}
+	return plan
+}
+
+export async function planEvalsFixtureScreenshots(
+	request: IRequest,
+	env: Environment
+): Promise<Response> {
+	const unavailable = notFoundUnlessLocal(env)
+	if (unavailable) return unavailable
+	const body = (await request.json()) as {
+		snapshot: RoomSnapshot
+		measurements: Record<string, ShapeMeasurement>
+	}
+	return Response.json({ plan: getEvalsFixtureScreenshotPlan(body.snapshot, body.measurements) })
+}
+
+export async function putEvalsFixtureBoard(request: IRequest, env: Environment): Promise<Response> {
+	const unavailable = notFoundUnlessLocal(env)
+	if (unavailable) return unavailable
+	const board = (await request.json()) as FixtureBoard
+	let session = sessions.get(request.params.sessionId)
+	if (!session) {
+		session = new Map()
+		sessions.set(request.params.sessionId, session)
+	}
+	session.set(request.params.boardId, board)
+	return Response.json({ stored: true }, { status: 201 })
+}
+
+export function deleteEvalsFixtureSession(request: IRequest, env: Environment): Response {
+	const unavailable = notFoundUnlessLocal(env)
+	if (unavailable) return unavailable
+	sessions.delete(request.params.sessionId)
+	return Response.json({ deleted: true })
+}
+
+async function callFixtureTool(
+	name: string,
+	args: unknown,
+	boards: Map<string, FixtureBoard>
+): Promise<ToolResult> {
+	try {
+		switch (name) {
+			case BOARD_INFO_TOOL_NAME: {
+				const { boardId } = parseBoardInfoInput(args)
+				const board = boards.get(boardId)
+				return board ? getBoardInfo(board.snapshot) : toolError(BOARD_NOT_FOUND_MESSAGE)
+			}
+			case PAGE_INFO_TOOL_NAME: {
+				const { boardId, page } = parsePageInfoInput(args)
+				const board = boards.get(boardId)
+				if (!board) return toolError(BOARD_NOT_FOUND_MESSAGE)
+				const resolved = resolvePage(board.snapshot, page)
+				return resolved.ok ? getPageInfo(resolved, board.measurements) : resolved.result
+			}
+			case CLUSTER_INFO_TOOL_NAME: {
+				const { boardId, page, clusterId } = parseClusterInfoInput(args)
+				const board = boards.get(boardId)
+				if (!board) return toolError(BOARD_NOT_FOUND_MESSAGE)
+				const resolved = resolvePage(board.snapshot, page)
+				return resolved.ok
+					? getClusterInfo(resolved, board.measurements, clusterId, page)
+					: resolved.result
+			}
+			case CLUSTER_SCREENSHOT_TOOL_NAME: {
+				const { boardId, page, clusterIds, theme } = parseClusterScreenshotInput(args)
+				const board = boards.get(boardId)
+				if (!board) return toolError(BOARD_NOT_FOUND_MESSAGE)
+				const resolved = resolvePage(board.snapshot, page)
+				if (!resolved.ok) return resolved.result
+				const picked = pickClusterShapes(resolved, board.measurements, clusterIds, page)
+				if (!picked.ok) return picked.result
+				const png = board.shots[screenshotFileName(clusterIds, theme)]
+				return png
+					? toolPageResult(resolved.pageName, png)
+					: toolError(
+							`${HARNESS_GAP_MARKER} No screenshot was built for this cluster set. Run against staging or production to see the real render.`
+						)
+			}
+			default:
+				return toolError(`Unknown tool: ${name}`)
+		}
+	} catch (error) {
+		return toolError(error instanceof Error ? error.message : String(error))
+	}
+}
+
+export async function evalsFixtureMcp(request: IRequest, env: Environment): Promise<Response> {
+	const unavailable = notFoundUnlessLocal(env)
+	if (unavailable) return unavailable
+	const boards = sessions.get(request.params.sessionId)
+	if (!boards) return new Response('Eval fixture session not found', { status: 404 })
+
+	let rpcRequest: Parameters<typeof handleMcpJsonRpc>[0]
+	try {
+		rpcRequest = (await request.json()) as Parameters<typeof handleMcpJsonRpc>[0]
+	} catch {
+		return Response.json(
+			{ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+			{ status: 200 }
+		)
+	}
+	const reply = await handleMcpJsonRpc(rpcRequest, (name, args) =>
+		callFixtureTool(name, args, boards)
+	)
+	if (reply.kind === 'accepted') return new Response(null, { status: 202 })
+	return Response.json(
+		reply.kind === 'result'
+			? { jsonrpc: '2.0', id: reply.id, result: reply.result }
+			: { jsonrpc: '2.0', id: reply.id, error: { code: reply.code, message: reply.message } }
+	)
+}
+
+export function resetEvalsFixtureSessionsForTests() {
+	sessions.clear()
+}

--- a/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/ogImageQueue.ts
@@ -14,10 +14,10 @@ import {
 	ThumbnailBoardRef,
 } from '../../types'
 import { deleteRenderTokenRecord } from '../../utils/renderTokens'
+import { enumerateBoardPages } from './boardTools'
 import {
 	ResolvedThumbnailBoard,
 	captureThumbnailScreenshot,
-	enumerateBoardPages,
 	loadBoardSnapshot,
 	putThumbnailPng,
 	resolveThumbnailBoard,

--- a/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/putThumbnailRenderResult.ts
@@ -2,7 +2,8 @@ import { ThumbnailRenderResultRequestBody } from '@tldraw/dotcom-shared'
 import { IRequest } from 'itty-router'
 import { Environment } from '../../types'
 import { verifyThumbnailRenderToken } from '../../utils/renderTokens'
-import { ShapeMeasurement, putRenderResult } from './thumbnailRender'
+import { ShapeMeasurement } from './boardTools'
+import { putRenderResult } from './thumbnailRender'
 
 // How measurements get out of the browser.
 //

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.test.ts
@@ -2,6 +2,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { MCP_PER_IP_RATE_LIMIT } from '../../config'
 import { Environment } from '../../types'
 import { verifyThumbnailRenderToken } from '../../utils/renderTokens'
+import {
+	parseBoardInfoInput,
+	parseClusterInfoInput,
+	parseClusterScreenshotInput,
+	parsePageInfoInput,
+} from './boardTools'
 import { getPublishedFileInfo, getPublishedRoomSnapshot } from './getPublishedFile'
 import { getSharedFileInfo } from './getSharedFile'
 import {
@@ -13,10 +19,6 @@ import {
 } from './screenshotTestHelpers'
 import {
 	isMcpScreenshotEnabled,
-	parseBoardInfoInput,
-	parseClusterInfoInput,
-	parseClusterScreenshotInput,
-	parsePageInfoInput,
 	resetRateLimitFallbackForTests,
 	sharedBoardScreenshotMcp,
 } from './sharedBoardScreenshotMcp'

--- a/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/sharedBoardScreenshotMcp.ts
@@ -1,11 +1,4 @@
-import {
-	DEFAULT_THUMBNAIL_HEIGHT,
-	DEFAULT_THUMBNAIL_WIDTH,
-	getShapeClusters,
-	getShapeText,
-	type TLShapeWithPlainText,
-} from '@tldraw/dotcom-shared'
-import { TLShape } from '@tldraw/tlschema'
+import { DEFAULT_THUMBNAIL_HEIGHT, DEFAULT_THUMBNAIL_WIDTH } from '@tldraw/dotcom-shared'
 import { IRequest } from 'itty-router'
 import {
 	MCP_GLOBAL_BROWSER_RUN_RATE_LIMIT,
@@ -16,13 +9,37 @@ import {
 import { Environment } from '../../types'
 import { arrayBufferToBase64, base64ToArrayBuffer } from '../../utils/base64'
 import { sha256 } from '../../utils/hash'
-import { getDocumentNameFromSnapshot } from '../getDocumentNameFromSnapshot'
+import {
+	BOARD_EMPTY_MESSAGE,
+	BOARD_INFO_TOOL_NAME,
+	BOARD_NOT_FOUND_MESSAGE,
+	CLUSTER_INFO_TOOL_NAME,
+	CLUSTER_SCREENSHOT_TOOL_NAME,
+	MCP_SERVER_INFO,
+	MCP_SERVER_INSTRUCTIONS,
+	PAGE_INFO_TOOL_NAME,
+	PageSelector,
+	ResolvedPageOk,
+	ShapeMeasurement,
+	ToolResult,
+	describePageSelector,
+	getBoardInfo,
+	getClusterInfo,
+	getPageInfo,
+	getToolDefinitions,
+	parseBoardInfoInput,
+	parseClusterInfoInput,
+	parseClusterScreenshotInput,
+	parsePageInfoInput,
+	pickClusterShapes,
+	resolvePage,
+	toolError,
+	toolPageResult,
+} from './boardTools'
 import {
 	ResolveThumbnailBoardResult,
 	ResolvedThumbnailBoard,
 	captureThumbnailScreenshot,
-	enumerateBoardPages,
-	getShapesOnPage,
 	loadBoardSnapshot,
 	measurePageShapes,
 	putThumbnailPng,
@@ -36,17 +53,13 @@ import {
 	reportThumbnailError,
 } from './thumbnailShared'
 
-// The MCP protocol surface over the shared render-and-cache core in thumbnailRender.ts: JSON-RPC
-// plumbing, tool definitions, input parsing, and the MCP tools' own per-IP/per-board rate limits
-// and `mcp/` cache keys.
+// What it takes to run the board tools on Cloudflare: board resolution against Postgres and R2,
+// Browser Rendering, the `mcp/` PNG cache, rate limits, telemetry, and the HTTP shell around the
+// JSON-RPC dispatch.
 //
-// The era is decided once in sharedBoardScreenshotMcp and only affects the result envelope and a
-// few status codes. Everything below the dispatch is era-agnostic.
-
-const BOARD_INFO_TOOL_NAME = 'get_board_info'
-const PAGE_INFO_TOOL_NAME = 'get_page_info'
-const CLUSTER_INFO_TOOL_NAME = 'get_cluster_info'
-const CLUSTER_SCREENSHOT_TOOL_NAME = 'get_cluster_screenshot'
+// The model-facing tools themselves live in boardTools.ts. That pure boundary lets the private eval
+// harness serve the exact same tool descriptions, parsing, clustering, and errors from local board
+// fixtures without needing a database or Browser Rendering.
 
 // The two protocol revisions this server speaks, newest first, as `server/discover` reports them.
 //
@@ -73,15 +86,6 @@ const UNSUPPORTED_PROTOCOL_VERSION = -32022
 // `_meta` keys the modern era uses for per-request version and identity.
 const META_PROTOCOL_VERSION = 'io.modelcontextprotocol/protocolVersion'
 const META_SERVER_INFO = 'io.modelcontextprotocol/serverInfo'
-
-const SERVER_INFO = {
-	name: 'tldraw-shared-board-screenshot',
-	title: 'tldraw shared board screenshots',
-	version: '2.0.0',
-}
-
-const SERVER_INSTRUCTIONS =
-	'MCP server for public tldraw.com boards. Drill down in order: get_board_info lists a board’s pages, get_page_info lists one page’s clusters of shapes, and get_cluster_screenshot returns a PNG of one or more clusters. get_cluster_info describes the shapes inside a cluster when those matter. Accepts published tldraw.com/p/:slug boards and anonymously-shared tldraw.com/f/:slug files, rendered through a signed, tldraw-owned render job.'
 
 // Modern `tools/list` is cacheable. This list is the same for every caller, so it's public — if the
 // tool set ever varies by caller, `cacheScope` has to drop to 'private'.
@@ -190,8 +194,8 @@ export async function sharedBoardScreenshotMcp(
 			// Answering with our legacy version regardless is how the handshake declines a version.
 			protocolVersion: MCP_PROTOCOL_VERSION_LEGACY,
 			capabilities: { tools: {} },
-			serverInfo: SERVER_INFO,
-			instructions: SERVER_INSTRUCTIONS,
+			serverInfo: MCP_SERVER_INFO,
+			instructions: MCP_SERVER_INSTRUCTIONS,
 		})
 	}
 
@@ -209,10 +213,10 @@ export async function sharedBoardScreenshotMcp(
 			resultType: 'complete',
 			supportedVersions: SUPPORTED_PROTOCOL_VERSIONS,
 			capabilities: { tools: {} },
-			instructions: SERVER_INSTRUCTIONS,
+			instructions: MCP_SERVER_INSTRUCTIONS,
 			ttlMs: TOOLS_LIST_TTL_MS,
 			cacheScope: TOOLS_LIST_CACHE_SCOPE,
-			_meta: { [META_SERVER_INFO]: SERVER_INFO },
+			_meta: { [META_SERVER_INFO]: MCP_SERVER_INFO },
 		})
 	}
 
@@ -238,12 +242,7 @@ export async function sharedBoardScreenshotMcp(
 				rpcRequest.id,
 				withResultEnvelope(
 					{
-						tools: [
-							getBoardInfoToolDefinition(),
-							getPageInfoToolDefinition(),
-							getClusterInfoToolDefinition(),
-							getClusterScreenshotToolDefinition(),
-						],
+						tools: getToolDefinitions(),
 						...(era === 'modern'
 							? { ttlMs: TOOLS_LIST_TTL_MS, cacheScope: TOOLS_LIST_CACHE_SCOPE }
 							: {}),
@@ -378,123 +377,10 @@ function withResultEnvelope(result: object, era: ProtocolEra) {
 	return {
 		resultType: 'complete',
 		...result,
-		_meta: { [META_SERVER_INFO]: SERVER_INFO },
+		_meta: { [META_SERVER_INFO]: MCP_SERVER_INFO },
 	}
 }
 
-export function parseBoardInfoInput(input: unknown): { boardId: string } {
-	const value = requireArgumentsObject(input)
-	return { boardId: parseBoardId(value.boardId) }
-}
-
-export function parsePageInfoInput(input: unknown): { boardId: string; page: PageSelector } {
-	const value = requireArgumentsObject(input)
-	return { boardId: parseBoardId(value.boardId), page: parsePageSelector(value.page) }
-}
-
-export function parseClusterInfoInput(input: unknown): {
-	boardId: string
-	page: PageSelector
-	clusterId: string
-} {
-	const value = requireArgumentsObject(input)
-	return {
-		boardId: parseBoardId(value.boardId),
-		page: parsePageSelector(value.page),
-		clusterId: parseClusterId(value.clusterId),
-	}
-}
-
-export function parseClusterScreenshotInput(input: unknown): {
-	boardId: string
-	page: PageSelector
-	clusterIds: string[]
-	theme: 'light' | 'dark'
-} {
-	const value = requireArgumentsObject(input)
-	return {
-		boardId: parseBoardId(value.boardId),
-		page: parsePageSelector(value.page),
-		clusterIds: parseClusterIds(value.clusterIds),
-		theme: parseTheme(value.theme),
-	}
-}
-
-// Accepts one id or several. A single string is allowed because asking for one cluster is the common
-// case and making callers wrap it in an array is friction for nothing.
-export function parseClusterIds(value: unknown): string[] {
-	if (typeof value === 'string') return [parseClusterId(value)]
-	if (!Array.isArray(value) || value.length === 0) {
-		throw new Error('clusterIds is required: a cluster id, or an array of them')
-	}
-	return value.map((id) => parseClusterId(id))
-}
-
-export function parseClusterId(value: unknown): string {
-	if (typeof value !== 'string' || value.length === 0) {
-		throw new Error('clusterId is required')
-	}
-	return value
-}
-
-function requireArgumentsObject(input: unknown): Record<string, unknown> {
-	if (!input || typeof input !== 'object') {
-		throw new Error('Tool arguments must be an object')
-	}
-	return input as Record<string, unknown>
-}
-
-function parseBoardId(value: unknown): string {
-	if (typeof value !== 'string' || value.length === 0) {
-		throw new Error('boardId is required')
-	}
-	if (value.includes('/')) {
-		throw new Error('boardId must be a board id, not a URL')
-	}
-	return value
-}
-
-// Omitting the theme means light, but an unrecognized one is rejected rather than quietly treated
-// as light: a caller asking for `blue` gets a wrong-but-plausible image back and no signal that the
-// argument was ignored.
-function parseTheme(value: unknown): 'light' | 'dark' {
-	if (value === undefined || value === null) return 'light'
-	if (value !== 'light' && value !== 'dark') {
-		throw new Error(`theme must be 'light' or 'dark'`)
-	}
-	return value
-}
-
-// A page is named either by its 0-based ordinal or by its id. Ordinals read naturally but shift the
-// moment pages are reordered, so an id a caller is holding from an earlier call keeps pointing at the
-// same page. Both are accepted in the one argument so the tool surface stays small.
-export type PageSelector = { kind: 'ordinal'; ordinal: number } | { kind: 'id'; id: string }
-
-function parsePageSelector(value: unknown): PageSelector {
-	if (value === undefined || value === null) return { kind: 'ordinal', ordinal: 0 }
-	if (typeof value === 'string') {
-		if (!value.startsWith('page:')) {
-			throw new Error(
-				'page must be a 0-based page ordinal (a number) or a page id (the "page:…" string from get_board_info)'
-			)
-		}
-		return { kind: 'id', id: value }
-	}
-	if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
-		throw new Error('page must be a non-negative integer (0-based page ordinal) or a page id')
-	}
-	return { kind: 'ordinal', ordinal: value }
-}
-
-/** How the page was named, for error messages that echo back what the caller actually passed. */
-function describePageSelector(selector: PageSelector) {
-	return selector.kind === 'id' ? `"${selector.id}"` : String(selector.ordinal)
-}
-
-// A board id is tried as a shared file id first (the /f/:slug namespace, where the slug is the
-// file id) and as a published-board slug (/p/:slug) second, so callers never need to know which
-// kind of board they hold. A shared file that resolves as empty is still the caller's board, so it
-// does not fall through to the published lookup and get misreported as not found.
 export async function resolveSharedBoardById(
 	env: Environment,
 	boardId: string
@@ -533,32 +419,9 @@ async function callBoardInfoTool(
 	// they are limited even though they read as "info" calls too.
 
 	try {
-		const resolved = await resolveSharedBoardById(env, input.boardId)
-		if (!resolved.ok) {
-			return toolError(
-				resolved.reason === 'board_empty'
-					? 'This board has no saved content yet.'
-					: 'No public board was found with this id. Only published boards and files shared via link are supported.'
-			)
-		}
-
-		const snapshot = await loadBoardSnapshot(env, resolved.board, { access: 'public' })
-		if (!snapshot) {
-			return toolError('This board has no saved content yet.')
-		}
-		const pages = enumerateBoardPages(snapshot)
-		return toolJsonResult({
-			name: getDocumentNameFromSnapshot(snapshot),
-			pageCount: pages.length,
-			// `id` is the stable handle: it survives page reordering, `index` does not. Either can be
-			// passed as `page` to the other tools.
-			pages: pages.map((p) => ({
-				index: p.index,
-				id: p.id,
-				name: p.name,
-				hasContent: p.hasContent,
-			})),
-		})
+		const loaded = await loadBoardForTool(env, input.boardId)
+		if (!loaded.ok) return loaded.result
+		return getBoardInfo(loaded.snapshot)
 	} catch (error) {
 		// The caller gets a bounded description, but nothing else records it: this tool writes no
 		// telemetry (it spends no Browser Run), so without a report a failing board lookup is
@@ -601,23 +464,11 @@ async function callPageInfoTool(
 	}
 
 	try {
-		// Scoped to the requested page: get_cluster_info and get_shapes_screenshot both resolve
-		// cluster ids against a single page, so listing every shape on the board here would hand out
-		// ids that neither of them can look up.
 		const resolved = await resolveBoardPage(env, input.boardId, input.page)
 		if (!resolved.ok) return resolved.result
 
-		const clusters = await clusterPage(env, resolved)
-		return toolJsonResult({
-			name: resolved.pageName,
-			clusterCount: clusters.length,
-			clusters: clusters.map((c) => ({
-				id: c.id,
-				label: c.label,
-				keywords: c.keywords,
-				numberOfShapes: c.numberOfShapes,
-			})),
-		})
+		const measurements = await measureFor(env, resolved)
+		return getPageInfo(resolved.page, measurements)
 	} catch (error) {
 		// The caller gets a bounded description, but nothing else records it: this tool writes no
 		// telemetry (it spends no Browser Run), so without a report a failing board lookup is
@@ -635,100 +486,48 @@ async function callPageInfoTool(
 	}
 }
 
-// Every page-scoped tool needs the same four steps before it can do anything: resolve the board,
-// load its snapshot, validate the page ordinal, and pull that page's shapes. Returning the tool's
-// own error shape on failure keeps the wording identical across tools.
-type ResolvedPage =
-	| {
-			ok: true
-			board: ResolvedThumbnailBoard
-			pageId: string
-			pageName: string
-			shapes: TLShape[]
-	  }
-	| { ok: false; result: ReturnType<typeof toolError> }
+type LoadedBoard =
+	| { ok: true; board: ResolvedThumbnailBoard; snapshot: import('@tldraw/sync-core').RoomSnapshot }
+	| { ok: false; result: ToolResult }
 
-async function resolveBoardPage(
-	env: Environment,
-	boardId: string,
-	page: PageSelector
-): Promise<ResolvedPage> {
+async function loadBoardForTool(env: Environment, boardId: string): Promise<LoadedBoard> {
 	const resolved = await resolveSharedBoardById(env, boardId)
 	if (!resolved.ok) {
 		return {
 			ok: false,
 			result: toolError(
-				resolved.reason === 'board_empty'
-					? 'This board has no saved content yet.'
-					: 'No public board was found with this id. Only published boards and files shared via link are supported.'
+				resolved.reason === 'board_empty' ? BOARD_EMPTY_MESSAGE : BOARD_NOT_FOUND_MESSAGE
 			),
 		}
 	}
 
 	const snapshot = await loadBoardSnapshot(env, resolved.board, { access: 'public' })
-	if (!snapshot) {
-		return { ok: false, result: toolError('This board has no saved content yet.') }
-	}
-
-	const pages = enumerateBoardPages(snapshot)
-	if (pages.length === 0) {
-		return { ok: false, result: toolError('This board has no pages.') }
-	}
-
-	const targetPage = page.kind === 'id' ? pages.find((p) => p.id === page.id) : pages[page.ordinal]
-	if (!targetPage) {
-		return {
-			ok: false,
-			result: toolError(
-				page.kind === 'id'
-					? `No page with id "${page.id}" on this board. Call get_board_info to list its pages; a page id is stable across reordering, an index is not.`
-					: `Page ${page.ordinal} is out of range: this board has ${pages.length} page(s) (0–${pages.length - 1}). Call get_board_info to list them.`
-			),
-		}
-	}
-	return {
-		ok: true,
-		board: resolved.board,
-		pageId: targetPage.id,
-		pageName: targetPage.name,
-		shapes: getShapesOnPage(snapshot, targetPage.id),
-	}
+	if (!snapshot) return { ok: false, result: toolError(BOARD_EMPTY_MESSAGE) }
+	return { ok: true, board: resolved.board, snapshot }
 }
 
-// Clustering needs real geometry, and the only way to get it is to run an editor in Browser
-// Rendering — the same cost as a screenshot. Every caller goes through here, so that cost is stated
-// once rather than implied in three places.
-async function clusterPage(env: Environment, resolved: Extract<ResolvedPage, { ok: true }>) {
-	const measured = await measurePageShapes(env, resolved.board, resolved.pageId)
+type ResolvedBoardPage =
+	| { ok: true; board: ResolvedThumbnailBoard; page: ResolvedPageOk }
+	| { ok: false; result: ToolResult }
 
-	// The render answers two things a Worker cannot: where each shape sits, and what
-	// ShapeUtil.getText says it holds. Bounds drive the linkage; the text is attached to the shapes
-	// so labelling reads the editor's answer rather than re-deriving one from props.
-	const shapes: TLShapeWithPlainText[] = resolved.shapes.map((shape) => {
-		const text = measured[shape.id as string]?.text
-		return text ? { ...shape, plainText: text } : shape
-	})
+async function resolveBoardPage(
+	env: Environment,
+	boardId: string,
+	page: PageSelector
+): Promise<ResolvedBoardPage> {
+	const loaded = await loadBoardForTool(env, boardId)
+	if (!loaded.ok) return loaded
 
-	return getShapeClusters(shapes, resolved.pageId, measured)
+	const pageResult = resolvePage(loaded.snapshot, page)
+	if (!pageResult.ok) return pageResult
+	return { ok: true, board: loaded.board, page: pageResult }
 }
 
-// The shape as stored, with one substitution: `props.richText` — a ProseMirror document, deeply
-// nested and unreadable — is dropped in favour of the plain string the editor's ShapeUtil.getText
-// reported for that shape during the measure render. Everything else is passed through untouched, so
-// a caller still sees type, position, rotation, size, colour and the rest exactly as stored.
-//
-// This matters beyond readability: a geo shape's label is not in `props` at all under any key a
-// Worker could find, so without the editor's answer that text is simply invisible.
-function toReadableShape(shape: TLShapeWithPlainText) {
-	const { plainText, ...rest } = shape
-	const props = { ...(rest.props as Record<string, unknown>) }
-	delete props.richText
-
-	const text = plainText ?? getShapeText(shape)
-	if (text) props.text = text
-	else delete props.text
-
-	return { ...rest, props }
+function measureFor(
+	env: Environment,
+	resolved: Extract<ResolvedBoardPage, { ok: true }>
+): Promise<Record<string, ShapeMeasurement>> {
+	return measurePageShapes(env, resolved.board, resolved.page.pageId)
 }
 
 async function callClusterInfoTool(
@@ -759,21 +558,8 @@ async function callClusterInfoTool(
 		const resolved = await resolveBoardPage(env, input.boardId, input.page)
 		if (!resolved.ok) return resolved.result
 
-		const cluster = (await clusterPage(env, resolved)).find((c) => c.id === input.clusterId)
-		if (!cluster) {
-			return toolError(
-				`No cluster with id "${input.clusterId}" on page ${describePageSelector(input.page)}. Call get_page_info to list this page's clusters.`
-			)
-		}
-
-		return toolJsonResult({
-			clusterId: cluster.id,
-			label: cluster.label,
-			keywords: cluster.keywords,
-			pageName: resolved.pageName,
-			numberOfShapes: cluster.numberOfShapes,
-			shapes: cluster.shapes.map(toReadableShape),
-		})
+		const measurements = await measureFor(env, resolved)
+		return getClusterInfo(resolved.page, measurements, input.clusterId, input.page)
 	} catch (error) {
 		reportThumbnailError(error, {
 			ctx,
@@ -812,7 +598,7 @@ async function renderShapeSetScreenshot(
 		/** Extra Sentry context identifying which tool asked. */
 		extras: Record<string, unknown>
 		pickShapes(
-			resolved: Extract<ResolvedPage, { ok: true }>
+			resolved: Extract<ResolvedBoardPage, { ok: true }>
 		): Promise<
 			{ ok: true; shapeIds: string[] } | { ok: false; result: ReturnType<typeof toolError> }
 		>
@@ -898,7 +684,7 @@ async function renderShapeSetScreenshot(
 		}
 
 		const render = await captureThumbnailScreenshot(env, resolved.board, {
-			pageId: resolved.pageId,
+			pageId: resolved.page.pageId,
 			shapeIds,
 			theme,
 			width: DEFAULT_THUMBNAIL_WIDTH,
@@ -909,7 +695,7 @@ async function renderShapeSetScreenshot(
 		// write is reported but never turns a good render into an error.
 		try {
 			await putThumbnailPng(env.THUMBNAILS, cacheKey, render.base64, resolved.board.version, {
-				pageName: encodeURIComponent(resolved.pageName),
+				pageName: encodeURIComponent(resolved.page.pageName),
 			})
 		} catch (error) {
 			reportThumbnailError(error, {
@@ -922,7 +708,7 @@ async function renderShapeSetScreenshot(
 		}
 
 		telemetry({ cacheStatus: 'miss', browserRunDurationMs: render.durationMs })
-		return toolPageResult(resolved.pageName, render.base64)
+		return toolPageResult(resolved.page.pageName, render.base64)
 	} catch (error) {
 		reportThumbnailError(error, {
 			ctx,
@@ -971,53 +757,10 @@ async function callClusterScreenshotTool(
 		theme: input.theme,
 		extras: { clusterIds: input.clusterIds.join(',') },
 		pickShapes: async (resolved) => {
-			const clusters = await clusterPage(env, resolved)
-			const byId = new Map(clusters.map((cluster) => [cluster.id, cluster]))
-
-			// Reject unknown ids rather than quietly rendering the subset that resolved — a caller
-			// asking for three clusters and getting a picture of two has no way to notice.
-			const missing = input.clusterIds.filter((id) => !byId.has(id))
-			if (missing.length > 0) {
-				return {
-					ok: false,
-					result: toolError(
-						`No cluster on page ${describePageSelector(input.page)} with id ${missing.map((id) => `"${id}"`).join(', ')}. Call get_page_info to list this page's clusters.`
-					),
-				}
-			}
-
-			// Several clusters render as one framed image of their union, which is the point of taking
-			// more than one: seeing how they sit relative to each other.
-			const shapeIds = [
-				...new Set(
-					input.clusterIds.flatMap((id) => byId.get(id)!.shapes.map((shape) => shape.id as string))
-				),
-			]
-			return { ok: true, shapeIds }
+			const measurements = await measureFor(env, resolved)
+			return pickClusterShapes(resolved.page, measurements, input.clusterIds, input.page)
 		},
 	})
-}
-
-function toolError(message: string) {
-	return {
-		content: [{ type: 'text', text: message }],
-		isError: true,
-	}
-}
-
-function toolPageResult(name: string, base64: string) {
-	return {
-		content: [
-			{ type: 'text', text: name },
-			{ type: 'image', data: base64, mimeType: 'image/png' },
-		],
-	}
-}
-
-function toolJsonResult(value: unknown) {
-	return {
-		content: [{ type: 'text', text: JSON.stringify(value) }],
-	}
 }
 
 function decodeThumbnailPageName(value: string | undefined): string {
@@ -1026,146 +769,6 @@ function decodeThumbnailPageName(value: string | undefined): string {
 		return decodeURIComponent(value)
 	} catch {
 		return value
-	}
-}
-
-function getBoardInfoToolDefinition() {
-	return {
-		name: BOARD_INFO_TOOL_NAME,
-		title: 'Get tldraw board info',
-		description:
-			'Return metadata for a public tldraw.com board: its name, page count, and the id, name, 0-based index, and hasContent flag for each page. Call this first, then pass a page id or index to get_page_info.',
-		inputSchema: {
-			type: 'object',
-			additionalProperties: false,
-			properties: {
-				boardId: {
-					type: 'string',
-					description:
-						'The id of a public tldraw.com board: the :slug of a published board URL (https://www.tldraw.com/p/:slug) or of an anonymously-shared file URL (https://www.tldraw.com/f/:slug).',
-				},
-			},
-			required: ['boardId'],
-		},
-		annotations: {
-			readOnlyHint: true,
-			idempotentHint: true,
-			openWorldHint: false,
-			destructiveHint: false,
-		},
-	}
-}
-
-function getPageInfoToolDefinition() {
-	return {
-		name: PAGE_INFO_TOOL_NAME,
-		title: 'Get tldraw page info',
-		description:
-			'List the shape clusters on one page of a public tldraw.com board. Each top-level shape is a cluster together with its descendants, so frames and groups stay together while ungrouped shapes remain individually addressable. Pass a cluster id to get_cluster_info or get_cluster_screenshot.',
-		inputSchema: {
-			type: 'object',
-			additionalProperties: false,
-			properties: {
-				boardId: {
-					type: 'string',
-					description:
-						'The id of a public tldraw.com board: the :slug of a published board URL (https://www.tldraw.com/p/:slug) or of an anonymously-shared file URL (https://www.tldraw.com/f/:slug).',
-				},
-				page: {
-					type: ['number', 'string'],
-					description:
-						'The page id or 0-based index from get_board_info. Defaults to 0, the first page.',
-					default: 0,
-				},
-			},
-			required: ['boardId'],
-		},
-		annotations: {
-			readOnlyHint: true,
-			idempotentHint: true,
-			openWorldHint: false,
-			destructiveHint: false,
-		},
-	}
-}
-
-function getClusterInfoToolDefinition() {
-	return {
-		name: CLUSTER_INFO_TOOL_NAME,
-		title: 'Get tldraw cluster info',
-		description:
-			"Describe one cluster from get_page_info: its label, keywords, and the full record of every shape it contains — type, position, rotation, size, style and so on. Each shape's rich text document is replaced by `props.text`, the plain string the editor reports for it, which also surfaces text that is not stored on the record at all (a geo shape's label, for instance).",
-		inputSchema: {
-			type: 'object',
-			additionalProperties: false,
-			properties: {
-				boardId: {
-					type: 'string',
-					description:
-						'The id of a public tldraw.com board: the :slug of a published board URL (https://www.tldraw.com/p/:slug) or of an anonymously-shared file URL (https://www.tldraw.com/f/:slug).',
-				},
-				page: {
-					type: ['number', 'string'],
-					description:
-						'The page id or 0-based index from get_board_info. Defaults to 0, the first page.',
-					default: 0,
-				},
-				clusterId: {
-					type: 'string',
-					description: 'The id of the cluster to get info for.',
-				},
-			},
-			required: ['boardId', 'clusterId'],
-		},
-		annotations: {
-			readOnlyHint: true,
-			idempotentHint: true,
-			openWorldHint: false,
-			destructiveHint: false,
-		},
-	}
-}
-
-function getClusterScreenshotToolDefinition() {
-	return {
-		name: CLUSTER_SCREENSHOT_TOOL_NAME,
-		title: 'Get tldraw cluster screenshot',
-		description: `Return a ${DEFAULT_THUMBNAIL_WIDTH}x${DEFAULT_THUMBNAIL_HEIGHT} PNG of one or more clusters from get_page_info, preceded by the page name. The camera fits the clusters requested and only their shapes are drawn, so nothing else on the page appears. Pass several ids to see how those clusters sit relative to each other in a single image. This is the direct route from a cluster id to a picture — get_cluster_info is only needed when the individual shapes matter.`,
-		inputSchema: {
-			type: 'object',
-			additionalProperties: false,
-			properties: {
-				boardId: {
-					type: 'string',
-					description:
-						'The id of a public tldraw.com board: the :slug of a published board URL (https://www.tldraw.com/p/:slug) or of an anonymously-shared file URL (https://www.tldraw.com/f/:slug).',
-				},
-				page: {
-					type: ['number', 'string'],
-					description:
-						'Which page: either its 0-based index or its page id from get_board_info. Ids survive page reordering, indexes do not. Defaults to 0, the first page.',
-					default: 0,
-				},
-				clusterIds: {
-					type: 'array',
-					items: { type: 'string' },
-					description:
-						'One or more cluster ids from get_page_info. All of them must be on the given page. A bare string is also accepted for a single cluster.',
-				},
-				theme: {
-					type: 'string',
-					enum: ['light', 'dark'],
-					default: 'light',
-				},
-			},
-			required: ['boardId', 'page', 'clusterIds'],
-		},
-		annotations: {
-			readOnlyHint: true,
-			idempotentHint: true,
-			openWorldHint: false,
-			destructiveHint: false,
-		},
 	}
 }
 

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.test.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.test.ts
@@ -1,7 +1,8 @@
 import { getShapeClusters } from '@tldraw/dotcom-shared'
 import { describe, expect, it } from 'vitest'
+import { enumerateBoardPages } from './boardTools'
 import { makeSnapshot } from './screenshotTestHelpers'
-import { buildThumbnailRenderUrl, enumerateBoardPages } from './thumbnailRender'
+import { buildThumbnailRenderUrl } from './thumbnailRender'
 
 describe('enumerateBoardPages', () => {
 	it('lists pages in fractional-index order with names and content flags', () => {

--- a/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/thumbnailRender.ts
@@ -1,14 +1,11 @@
 import {
 	DEFAULT_THUMBNAIL_HEIGHT,
 	DEFAULT_THUMBNAIL_WIDTH,
-	MAX_THUMBNAIL_PAGES,
 	THUMBNAIL_RENDER_PATH,
 	THUMBNAIL_RENDER_TIMEOUT_MS,
 	getThumbnailScreenshotRequestBody,
 } from '@tldraw/dotcom-shared'
-import { ClusterBounds } from '@tldraw/dotcom-shared'
 import { RoomSnapshot } from '@tldraw/sync-core'
-import { TLShape, isPage, isShape } from '@tldraw/tlschema'
 import { THUMBNAIL_RENDER_TOKEN_TTL_MS } from '../../config'
 import { getR2KeyForRoom } from '../../r2'
 import {
@@ -25,6 +22,7 @@ import {
 	mintThumbnailRenderToken,
 	recordMintedRenderToken,
 } from '../../utils/renderTokens'
+import { ShapeMeasurement } from './boardTools'
 import { getPublishedFileInfo, getPublishedRoomSnapshot } from './getPublishedFile'
 import {
 	SharedFileInfo,
@@ -140,32 +138,6 @@ export async function loadBoardSnapshot(
 	}
 }
 
-// A board page in stable board order. `index` is the 0-based ordinal callers pass to the screenshot
-// tool; `id` is the internal TLPageId used to drive the render page.
-export interface EnumeratedPage {
-	index: number
-	id: string
-	name: string
-	hasContent: boolean
-}
-
-// Lists a board's pages in the same order the editor shows them. tldraw page indexes are fractional
-// indexes that sort lexicographically, so a plain string sort matches the editor's ordering. A page
-// "has content" when at least one shape sits directly on it (nested shapes always have a top-level
-// ancestor on their page, so checking direct children is sufficient).
-export function enumerateBoardPages(snapshot: RoomSnapshot): EnumeratedPage[] {
-	const records = snapshot.documents.map((d) => d.state)
-	const pageRecords = records.filter(isPage)
-	pageRecords.sort((a, b) => (a.index < b.index ? -1 : a.index > b.index ? 1 : 0))
-	const parentIdsWithShapes = new Set(records.filter(isShape).map((s) => s.parentId))
-	return pageRecords.slice(0, MAX_THUMBNAIL_PAGES).map((p, index) => ({
-		index,
-		id: String(p.id),
-		name: typeof p.name === 'string' && p.name.length > 0 ? p.name : `Page ${index + 1}`,
-		hasContent: parentIdsWithShapes.has(p.id),
-	}))
-}
-
 export function buildThumbnailRenderUrl(renderOrigin: string, token: string) {
 	const url = new URL(THUMBNAIL_RENDER_PATH, renderOrigin)
 	url.searchParams.set('token', token)
@@ -240,22 +212,6 @@ export async function captureThumbnailScreenshot(
 	return renderThumbnailScreenshot(env, buildThumbnailRenderUrl(getRenderOrigin(env), token), {
 		width,
 		height,
-	})
-}
-
-// The shapes belonging to one page, in snapshot order. Nested shapes carry their ancestor's id as
-// `parentId`, so membership is resolved by walking up to a top-level shape whose parent is the page.
-export function getShapesOnPage(snapshot: RoomSnapshot, pageId: string): TLShape[] {
-	const shapes = snapshot.documents.map((d) => d.state).filter(isShape)
-	const byId = new Map(shapes.map((s) => [s.id, s]))
-	return shapes.filter((shape) => {
-		let current: TLShape | undefined = shape
-		// Bounded by the ancestor chain, and guarded against a cyclic parentId in a corrupt snapshot.
-		for (let depth = 0; current && depth < 100; depth++) {
-			if (current.parentId === pageId) return true
-			current = byId.get(current.parentId as TLShape['id'])
-		}
-		return false
 	})
 }
 
@@ -410,11 +366,6 @@ async function callLocalScreenshotService(
 // the same snapshot, waits for fonts, reads editor.getShapePageBounds for every shape, and POSTs the
 // result back. Stashed under the job's own token and read once, so it is a rendezvous for a single
 // in-flight render rather than a cache with a lifetime to manage.
-
-/** What one shape's measure render produced: its page bounds, plus the text its ShapeUtil reported. */
-export interface ShapeMeasurement extends ClusterBounds {
-	text?: string
-}
 
 function getRenderResultKey(token: string) {
 	return `render-result/${encodeURIComponent(token)}.json`

--- a/apps/dotcom/sync-worker/src/testRoutes.ts
+++ b/apps/dotcom/sync-worker/src/testRoutes.ts
@@ -2,6 +2,12 @@ import { DEFAULT_INITIAL_SNAPSHOT } from '@tldraw/sync-core'
 import { lns, uniqueId } from '@tldraw/utils'
 import { createRouter, notFound } from '@tldraw/worker-shared'
 import { getR2KeyForRoom, getR2KeyForSnapshot } from './r2'
+import {
+	deleteEvalsFixtureSession,
+	evalsFixtureMcp,
+	planEvalsFixtureScreenshots,
+	putEvalsFixtureBoard,
+} from './routes/tla/evalsLocalMcp'
 import { isDebugLogging, type Environment } from './types'
 import { getReplicator, getRoomDurableObject, getUserDurableObject } from './utils/durableObjects'
 
@@ -40,6 +46,10 @@ export const testRoutes = createRouter<Environment>()
 		await getUserDurableObject(env, req.params.userId).__test__prepareForTest(req.params.userId)
 		return new Response('ok')
 	})
+	.post('/app/__test__/evals/plan', planEvalsFixtureScreenshots)
+	.put('/app/__test__/evals/sessions/:sessionId/boards/:boardId', putEvalsFixtureBoard)
+	.post('/app/__test__/evals/sessions/:sessionId/mcp', evalsFixtureMcp)
+	.delete('/app/__test__/evals/sessions/:sessionId', deleteEvalsFixtureSession)
 	.post('/app/__test__/legacy-room', async (req, env) => {
 		const body = (await req.json().catch(() => ({}))) as CreateLegacyRoomBody
 		const slug = body.slug ?? uniqueId()


### PR DESCRIPTION
In order to evaluate the dotcom MCP board tools against checked-in private fixtures, this PR extracts the model-facing board logic from the Cloudflare integration and exposes it through local-only test routes. The production endpoint keeps the public-board behavior and 2025-11-25 / 2026-07-28 protocol handling from the base PR; the fixture route reuses the same tool descriptions, parsing, clustering, and errors while storing uploaded boards only in local worker memory.

The eval routes require both the existing debug-route guard and `IS_LOCAL=true`, which is supplied only by the local worker launcher.

### Change type

- [x] `improvement`

### Test plan

1. Run the focused dotcom worker tests for MCP, local eval fixtures, and thumbnail page enumeration.
2. Run the dotcom worker lint and repository typecheck.

- [x] Unit tests

### Code changes

| Section | LOC change |
| --- | --- |
| Tests | +80 / -5 |
| Apps | +901 / -527 |