### PR TITLE
fix(editor): don't swallow touches when the editor is inset from the page edge

### DIFF
--- a/packages/editor/src/lib/hooks/useDocumentEvents.ts
+++ b/packages/editor/src/lib/hooks/useDocumentEvents.ts
@@ -240,19 +240,20 @@ export function useDocumentEvents() {
 
 		function handleTouchStart(e: TouchEvent) {
 			if (container.contains(e.target as Node)) {
-				// Center point of the touch area
-				const touchXPosition = e.touches[0].pageX
+				// Center point of the touch area, measured from the edge of the window the touch
+				// has to reach to trigger the navigation
+				const touchXPosition = e.touches[0].clientX
 				// Size of the touch area
 				const touchXRadius = e.touches[0].radiusX || 0
 
-				// We set a threshold (10px) on both sizes of the screen,
-				// if the touch area overlaps with the screen edges
-				// it's likely to trigger the navigation. We prevent the
-				// touchstart event in that case.
-				// todo: make this relative to the actual window, not the editor's screen bounds
+				// If the touch area overlaps with the screen edges it's likely to trigger the
+				// navigation. We prevent the touchstart event in that case. The gesture belongs to
+				// the window, so an editor inset from the window's edges — beside a sidebar, say —
+				// is not near an edge the system reacts to.
+				const windowWidth = editor.getContainerWindow().innerWidth
 				if (
 					touchXPosition - touchXRadius < 10 ||
-					touchXPosition + touchXRadius > editor.getViewportScreenBounds().width - 10
+					touchXPosition + touchXRadius > windowWidth - 10
 				) {
 					if ((e.target as HTMLElement)?.tagName === 'BUTTON') {
 						// Force a click before bailing


### PR DESCRIPTION
On iPad, a large region of the canvas silently ignored taps. Anything in it that wasn't a `<button>` — a text field, editable text, host UI placed on the canvas — could be tapped repeatedly with nothing happening: no click, no focus, no keyboard.

`handleTouchStart` prevents `touchstart` near the screen edges so a touch there isn't taken as the system's back/forward navigation gesture. It compared `pageX`, measured from the page's left edge, against the editor container's **width**:

```ts
touchXPosition + touchXRadius > editor.getViewportScreenBounds().width - 10
```

Those agree only when the container starts at page x 0, which was true when this was written and the editor filled the window. Once the editor is inset — tldraw.com's sidebar, or any host chrome beside the canvas — the right-hand threshold moves one inset into the canvas, and the left-hand one falls outside it and never fires.

Measured on an iPad (A16), iPadOS 26.5, tldraw.com:

| orientation | sidebar | container | guard fired above | should be |
| --- | --- | --- | --- | --- |
| portrait | closed | x=0 w=820 | 810 | 810 ✓ |
| portrait | **open** | x=260 w=560 | **550** | 810 |
| landscape | closed | x=0 w=1180 | 1170 | 1170 ✓ |
| landscape | **open** | x=260 w=920 | **910** | 1170 |

With the sidebar open that's 270px of a 560px canvas dead in portrait.

### The fix: measure against the window

The gesture belongs to the window — the system reacts to a touch near the edge of the *display*, and knows nothing about the editor. So the guard now asks the question in the window's frame, using `clientX`, which is already measured from it:

```ts
const windowWidth = editor.getContainerWindow().innerWidth
if (touchXPosition - touchXRadius < 10 || touchXPosition + touchXRadius > windowWidth - 10)
```

This needs no conversion and no cached bounds, which discharges the `todo` this line has carried since #2719 — *"make this relative to the actual window, not the editor's screen bounds"*. An editor inset from the window is simply not near an edge the system reacts to, so its left-hand guard correctly stays silent. `getContainerWindow()` rather than a global keeps the cross-window embedding support added in #8196.

It also fixes a third case neither version of the bug report covers: **pinch-zoom**. On iOS Safari `innerWidth` tracks the *visual* viewport, and so does `clientX`, so the pair rescales together. Measured at `scale = 3.59`, `visualViewport.offsetLeft = 296`:

| | unzoomed | zoomed |
| --- | --- | --- |
| `innerWidth` | 820 | 228 |
| threshold | `x<10 or x>810` | `x<10 or x>218` |
| touch at visible left edge | — | `clientX=5.01` → fires ✓ |
| touch at visible right edge | — | `clientX=225.11` → fires ✓ |

The old comparison saw `pageX` of 301 and 521 against a container width of 820 — neither near a threshold, so while zoomed the guard fired nowhere and the swipe went unprevented.

### Why this went unnoticed

The canvas takes input through pointer events, which a prevented `touchstart` does not suppress — only the compatibility mouse events (`mousedown`/`mouseup`/`click`) go, [per Touch Events §7](https://www.w3.org/TR/touch-events/#mouse-events). Panning, drawing and selecting inside the dead strip all work normally; only click- and focus-dependent elements break. On top of that, the handler force-clicks a `BUTTON` target before bailing, which exempts nearly all of the UI. What's left is text inputs, editable text, links and host content — things that could rarely be positioned in the affected strip until now.

### How this surfaced #10002

Correcting the guard made `[Mobile Chrome] stacked dialogs › a nested dialog stacks over its parent and stays interactive` fail — correctly, because it had been passing on account of this bug.

The examples app renders a 260px sidebar beside a 133px canvas on a 393px viewport, so under the old comparison *every* touch in the container exceeded the threshold and was cancelled. The handler force-clicks a `BUTTON` before bailing, so the dialog's confirm button received a synthesised click fired during `touchstart` — earlier in the gesture than a real one, and before React had unmounted the nested dialog. Radix's deferred outside-check therefore ran while that dialog was still topmost and correctly declined to dismiss the one beneath.

Restore the real click and the same check runs after `touchend`, past the commit, and answers the opposite way about the identical press. That was #10002, which reproduced on `main` without any of this — it simply could not reach CI, because the one test that would have caught it was the one place the bug could not manifest. Now that it has merged, the dialogs suite passes on this branch unchanged.

### Related

Three bugs now share a root: a quantity whose meaning depends on a frame of reference, typed as a bare `number`. #8500 (quick zoom, fixed by #8520) and #8684 (comma-key click, fixed by #8704) each applied the container's offset twice. #8684's repro is this one's — tldraw.com with the sidebar open.

The resolution differs, though, and the difference is the useful part. Those two belong in container space and the arithmetic was wrong. The edge guard never belonged there: it reasons about a system gesture, which is defined against the window, so the fix is to stop converting rather than to convert correctly.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. Open tldraw.com on an iPad in portrait with the sidebar open.
2. Place a comment in the right-hand half of the canvas and tap its text field.
3. Before: nothing happens, no matter how many times you tap. After: the field takes the tap and the software keyboard opens.
4. Repeat in landscape, and with the sidebar closed as a control.

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a bug where touches in part of the canvas were ignored on iOS when the editor was inset from the edge of the page, such as beside a sidebar.
