### PR TITLE
fix(video): show loading plate while video asset loads

### DIFF
--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -175,14 +175,19 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 		}
 	}, [isEditing, isLoaded])
 
+	// Show the same loading plate as the image shape until the video element is
+	// actually visible: the asset record may be missing, its src may still be
+	// uploading, or the video data may not have loaded yet.
+	const isVideoVisible = !!asset?.props.src && !!url && isLoaded
+
 	return (
 		<>
 			<HTMLContainer
 				id={shape.id}
 				style={{
 					color: 'var(--tl-color-text-3)',
-					backgroundColor: asset ? 'transparent' : 'var(--tl-color-low)',
-					border: asset ? 'none' : '1px solid var(--tl-color-low-border)',
+					backgroundColor: isVideoVisible ? 'transparent' : 'var(--tl-color-low)',
+					border: isVideoVisible ? 'none' : '1px solid var(--tl-color-low-border)',
 				}}
 			>
 				<div className="tl-counter-scaled">

--- a/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
+++ b/packages/tldraw/src/lib/shapes/video/VideoShapeUtil.tsx
@@ -175,10 +175,7 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 		}
 	}, [isEditing, isLoaded])
 
-	// Show the same loading plate as the image shape until the video element is
-	// actually visible: the asset record may be missing, its src may still be
-	// uploading, or the video data may not have loaded yet.
-	const isVideoVisible = !!asset?.props.src && !!url && isLoaded
+	const hasVideo = !!asset?.props.src && !!url && isLoaded
 
 	return (
 		<>
@@ -186,8 +183,8 @@ const VideoShape = memo(function VideoShape({ shape }: { shape: TLVideoShape }) 
 				id={shape.id}
 				style={{
 					color: 'var(--tl-color-text-3)',
-					backgroundColor: isVideoVisible ? 'transparent' : 'var(--tl-color-low)',
-					border: isVideoVisible ? 'none' : '1px solid var(--tl-color-low-border)',
+					backgroundColor: hasVideo ? 'transparent' : 'var(--tl-color-low)',
+					border: hasVideo ? 'none' : '1px solid var(--tl-color-low-border)',
 				}}
 			>
 				<div className="tl-counter-scaled">

--- a/packages/tldraw/src/test/VideoShapeUtil.test.tsx
+++ b/packages/tldraw/src/test/VideoShapeUtil.test.tsx
@@ -1,0 +1,126 @@
+import { act, fireEvent } from '@testing-library/react'
+import { AssetRecordType, Editor, TLAssetId, TLShapeId, createShapeId } from '@tldraw/editor'
+import { Tldraw } from '../lib/Tldraw'
+import { renderTldrawComponentWithEditor } from './testutils/renderTldrawComponent'
+
+const LOADING_BACKGROUND = 'var(--tl-color-low)'
+const LOADING_BORDER = '1px solid var(--tl-color-low-border)'
+
+let editor: Editor
+let videoShapeId: TLShapeId
+let videoAssetId: TLAssetId
+
+function getShapeContainer() {
+	const container = document.getElementById(videoShapeId)
+	expect(container).toBeTruthy()
+	return container!
+}
+
+beforeEach(async () => {
+	videoShapeId = createShapeId('video')
+	videoAssetId = AssetRecordType.createId('videoAsset')
+
+	const result = await renderTldrawComponentWithEditor((onMount) => <Tldraw onMount={onMount} />, {
+		waitForPatterns: false,
+	})
+	editor = result.editor
+})
+
+describe('VideoShapeUtil loading state', () => {
+	it('shows the loading plate when the asset record is missing', async () => {
+		await act(async () => {
+			editor.createShapes([
+				{ id: videoShapeId, type: 'video', x: 0, y: 0, props: { w: 100, h: 100 } },
+			])
+		})
+
+		const container = getShapeContainer()
+		expect(container.style.backgroundColor).toBe(LOADING_BACKGROUND)
+		expect(container.style.border).toBe(LOADING_BORDER)
+	})
+
+	it('shows the loading plate while the asset is uploading (no src)', async () => {
+		await act(async () => {
+			editor.createAssets([
+				{
+					id: videoAssetId,
+					type: 'video',
+					typeName: 'asset',
+					props: {
+						w: 100,
+						h: 100,
+						name: 'video.mp4',
+						isAnimated: true,
+						mimeType: 'video/mp4',
+						src: '',
+					},
+					meta: {},
+				},
+			])
+			editor.createShapes([
+				{
+					id: videoShapeId,
+					type: 'video',
+					x: 0,
+					y: 0,
+					props: { w: 100, h: 100, assetId: videoAssetId },
+				},
+			])
+		})
+
+		const container = getShapeContainer()
+		expect(container.style.backgroundColor).toBe(LOADING_BACKGROUND)
+		expect(container.style.border).toBe(LOADING_BORDER)
+	})
+
+	it('shows the loading plate until the video loads, then goes transparent', async () => {
+		await act(async () => {
+			editor.createAssets([
+				{
+					id: videoAssetId,
+					type: 'video',
+					typeName: 'asset',
+					props: {
+						w: 100,
+						h: 100,
+						name: 'video.mp4',
+						isAnimated: true,
+						mimeType: 'video/mp4',
+						src: 'http://localhost/video.mp4',
+					},
+					meta: {},
+				},
+			])
+			editor.createShapes([
+				{
+					id: videoShapeId,
+					type: 'video',
+					x: 0,
+					y: 0,
+					props: { w: 100, h: 100, assetId: videoAssetId },
+				},
+			])
+		})
+
+		// Wait for the async asset URL resolution so the <video> element renders
+		await act(async () => {
+			await new Promise((resolve) => setTimeout(resolve, 0))
+		})
+
+		const container = getShapeContainer()
+		const video = container.querySelector('video')
+		expect(video).toBeTruthy()
+
+		// The video element exists but hasn't fired loadeddata yet
+		expect(container.style.backgroundColor).toBe(LOADING_BACKGROUND)
+		expect(container.style.border).toBe(LOADING_BORDER)
+
+		await act(async () => {
+			fireEvent.loadedData(video!)
+		})
+
+		expect(container.style.backgroundColor).toBe('transparent')
+		// jsdom doesn't round-trip the `border: none` shorthand, so check the style directly
+		expect(container.style.borderStyle).toBe('none')
+	})
+})


### PR DESCRIPTION
In order to give video shapes the same loading feedback as image shapes, this PR shows the low-color plate and border while a video asset is uploading or loading.

- Previously the plate only rendered when the asset record was missing entirely, so while a pasted video uploaded (or before `loadeddata` fired) only a floating spinner was shown, with nothing marking the shape's position and size.
- Images already show a plate in this state — this aligns the two shapes visually.
- The container now stays on the plate until the video is loaded and shown; fullscreen is unaffected (`tl-video-is-fullscreen` only changes the video element's object-fit).

<img width="1400" height="340" alt="image" src="https://github.com/user-attachments/assets/e651e426-dc5c-4fe4-9bf5-5adf087c3044" />

### Change type

- [x] `bugfix`

### Test plan

1. Paste or drop a large video into the canvas (or throttle the network).
2. While the asset uploads and the video loads, the shape shows the same low-color plate and border as a loading image, with the spinner centered inside it.
3. Once the video plays, the plate and border disappear as before.

- [x] Unit tests

### Release notes

- Fix video shapes showing a floating spinner with no bounding box while the video asset uploads or loads. They now show the same loading plate as image shapes.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +4 / -2    |
| Tests     | +126 / -0  |
