### PR TITLE
feat(dotcom): send a monotonic build id on sync connections

### DIFF
--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaEditor.tsx
@@ -34,7 +34,7 @@ import { usePerformanceTracking } from '../../../hooks/usePerformanceTracking'
 import { useRoomLoadTracking } from '../../../hooks/useRoomLoadTracking'
 import { trackEvent, useHandleUiEvents } from '../../../utils/analytics'
 import { assetUrls } from '../../../utils/assetUrls'
-import { MULTIPLAYER_SERVER } from '../../../utils/config'
+import { CLIENT_BUILD_TIMESTAMP, MULTIPLAYER_SERVER } from '../../../utils/config'
 import { createAssetFromUrl } from '../../../utils/createAssetFromUrl'
 import { embedShapeUtils } from '../../../utils/embedShapeUtil'
 import { isProductionEnv } from '../../../utils/env'
@@ -235,6 +235,7 @@ function TlaEditorInner({ fileSlug, deepLinks }: TlaEditorProps) {
 	const store = useSync({
 		uri: useCallback(async () => {
 			const url = new URL(`${MULTIPLAYER_SERVER}/app/file/${fileSlug}`)
+			url.searchParams.set('v', CLIENT_BUILD_TIMESTAMP)
 			if (hasUser) {
 				url.searchParams.set('accessToken', await getUserToken())
 			}

--- a/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
+++ b/apps/dotcom/client/src/tla/components/TlaEditor/TlaLegacyFileEditor.tsx
@@ -13,7 +13,7 @@ import { useLegacyUrlParams } from '../../../hooks/useLegacyUrlParams'
 import { useRoomLoadTracking } from '../../../hooks/useRoomLoadTracking'
 import { trackEvent, useHandleUiEvents } from '../../../utils/analytics'
 import { assetUrls } from '../../../utils/assetUrls'
-import { MULTIPLAYER_SERVER } from '../../../utils/config'
+import { CLIENT_BUILD_TIMESTAMP, MULTIPLAYER_SERVER } from '../../../utils/config'
 import { createAssetFromUrl } from '../../../utils/createAssetFromUrl'
 import { embedShapeUtils } from '../../../utils/embedShapeUtil'
 import { globalEditor } from '../../../utils/globalEditor'
@@ -76,7 +76,7 @@ function TlaEditorInner({
 	const assets = useMemo(() => multiplayerAssetStore(), [])
 
 	const storeWithStatus = useSync({
-		uri: `${MULTIPLAYER_SERVER}/${RoomOpenModeToPath[roomOpenMode]}/${fileSlug}`,
+		uri: `${MULTIPLAYER_SERVER}/${RoomOpenModeToPath[roomOpenMode]}/${fileSlug}?v=${CLIENT_BUILD_TIMESTAMP}`,
 		roomId: fileSlug,
 		assets,
 		trackAnalyticsEvent: trackEvent,

--- a/apps/dotcom/client/src/utils/config.ts
+++ b/apps/dotcom/client/src/utils/config.ts
@@ -23,3 +23,8 @@ export const ZERO_SERVER =
 	(isStagingEnv || isProductionEnv || isPreviewEnv) && typeof location !== 'undefined'
 		? process.env.ZERO_SERVER
 		: 'http://localhost:4848/'
+
+// Monotonic build identifier (epoch ms at build time, baked in by vite). Sent as `?v=` on sync
+// websocket connections so the server can tell how stale a client bundle is. '0' outside a vite
+// build (unit tests).
+export const CLIENT_BUILD_TIMESTAMP: string = process.env.CLIENT_BUILD_TIMESTAMP ?? '0'

--- a/apps/dotcom/client/vite.config.ts
+++ b/apps/dotcom/client/vite.config.ts
@@ -98,6 +98,10 @@ export default defineConfig((env) => ({
 			8789
 		),
 		'process.env.TLDRAW_ENV': JSON.stringify(process.env.TLDRAW_ENV ?? 'development'),
+		// A monotonic build identifier (epoch ms at build time). Sent as `?v=` on sync websocket
+		// connections so the server can tell how old a client bundle is — parked background tabs
+		// keep running whatever bundle they loaded, potentially for weeks.
+		'process.env.CLIENT_BUILD_TIMESTAMP': JSON.stringify(Date.now().toString()),
 		'process.env.TLDRAW_LICENSE': JSON.stringify(process.env.TLDRAW_LICENSE ?? ''),
 		// Fall back to staging DSN for local develeopment, although you still need to
 		// modify the env check in 'sentry.client.config.ts' to get it reporting errors

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -147,6 +147,9 @@ interface SocketAttachment {
 	isReadonly: boolean
 	// optional: attachments serialized before the object-store lane existed lack this field
 	objectAccess?: TLObjectStoreAccess
+	// The client bundle's monotonic build timestamp (epoch ms), from the `?v=` connect param.
+	// Absent for bundles that predate the param — which itself marks them as older than it.
+	clientVersion?: string
 	snapshot: SessionStateSnapshot | null
 }
 
@@ -724,6 +727,8 @@ export class TLFileDurableObject extends DurableObject {
 		// handle legacy param names
 		sessionId ??= params.sessionKey ?? params.instanceId
 		storeId ??= params.localClientId
+		// the client bundle's build timestamp; length-capped because it lands in analytics
+		const clientVersion = params.v?.slice(0, 32)
 		const isNewSession = !this._room
 
 		// Create the websocket pair for the client; use hibernation API
@@ -829,6 +834,7 @@ export class TLFileDurableObject extends DurableObject {
 				meta,
 				isReadonly,
 				objectAccess,
+				clientVersion,
 				snapshot: null,
 			}
 			serverWebSocket.serializeAttachment(attachment)
@@ -861,6 +867,7 @@ export class TLFileDurableObject extends DurableObject {
 				type: 'client',
 				name: 'enter',
 				instanceId: sessionId,
+				clientVersion,
 			})
 
 			requestTimer.report('on_request_total')
@@ -1086,6 +1093,12 @@ export class TLFileDurableObject extends DurableObject {
 			case 'client': {
 				if (event.name === 'rate_limited') {
 					this.writeEvent(event.name, { blobs: [event.userId ?? 'anon-user'] })
+				} else if (event.name === 'enter') {
+					// blob order is positional per event name; 'pre-v' marks bundles that predate
+					// the `?v=` connect param and is therefore older than any real timestamp
+					this.writeEvent(event.name, {
+						blobs: [event.instanceId, event.clientVersion ?? 'pre-v'],
+					})
 				} else {
 					this.writeEvent(event.name, { blobs: [event.instanceId] })
 				}

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -148,7 +148,7 @@ interface SocketAttachment {
 	// optional: attachments serialized before the object-store lane existed lack this field
 	objectAccess?: TLObjectStoreAccess
 	// The client bundle's monotonic build timestamp (epoch ms), from the `?v=` connect param.
-	// Absent for bundles that predate the param — which itself marks them as older than it.
+	// Absent for bundles that predate the param, or when the param didn't validate.
 	clientBuildTimestamp?: string
 	snapshot: SessionStateSnapshot | null
 }
@@ -727,8 +727,10 @@ export class TLFileDurableObject extends DurableObject {
 		// handle legacy param names
 		sessionId ??= params.sessionKey ?? params.instanceId
 		storeId ??= params.localClientId
-		// the client bundle's build timestamp; length-capped because it lands in analytics
-		const clientBuildTimestamp = params.v?.slice(0, 32)
+		// the client bundle's build timestamp. Unvalidated client input that lands in analytics, so
+		// only accept a plain epoch-ms number — anything else (empty, non-numeric, absurdly long)
+		// is treated the same as an absent param rather than recorded verbatim.
+		const clientBuildTimestamp = /^\d{1,16}$/.test(params.v ?? '') ? params.v : undefined
 		const isNewSession = !this._room
 
 		// Create the websocket pair for the client; use hibernation API
@@ -1094,10 +1096,11 @@ export class TLFileDurableObject extends DurableObject {
 				if (event.name === 'rate_limited') {
 					this.writeEvent(event.name, { blobs: [event.userId ?? 'anon-user'] })
 				} else if (event.name === 'enter') {
-					// blob order is positional per event name; 'pre-v' marks bundles that predate
-					// the `?v=` connect param and is therefore older than any real timestamp
+					// blob order is positional per event name. '0' covers bundles that predate the
+					// `?v=` connect param (and clients that sent a bogus one): it stays a number, so
+					// it sorts as the oldest possible build under both string and numeric ordering.
 					this.writeEvent(event.name, {
-						blobs: [event.instanceId, event.clientBuildTimestamp ?? 'pre-v'],
+						blobs: [event.instanceId, event.clientBuildTimestamp ?? '0'],
 					})
 				} else {
 					this.writeEvent(event.name, { blobs: [event.instanceId] })

--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -149,7 +149,7 @@ interface SocketAttachment {
 	objectAccess?: TLObjectStoreAccess
 	// The client bundle's monotonic build timestamp (epoch ms), from the `?v=` connect param.
 	// Absent for bundles that predate the param — which itself marks them as older than it.
-	clientVersion?: string
+	clientBuildTimestamp?: string
 	snapshot: SessionStateSnapshot | null
 }
 
@@ -728,7 +728,7 @@ export class TLFileDurableObject extends DurableObject {
 		sessionId ??= params.sessionKey ?? params.instanceId
 		storeId ??= params.localClientId
 		// the client bundle's build timestamp; length-capped because it lands in analytics
-		const clientVersion = params.v?.slice(0, 32)
+		const clientBuildTimestamp = params.v?.slice(0, 32)
 		const isNewSession = !this._room
 
 		// Create the websocket pair for the client; use hibernation API
@@ -834,7 +834,7 @@ export class TLFileDurableObject extends DurableObject {
 				meta,
 				isReadonly,
 				objectAccess,
-				clientVersion,
+				clientBuildTimestamp,
 				snapshot: null,
 			}
 			serverWebSocket.serializeAttachment(attachment)
@@ -867,7 +867,7 @@ export class TLFileDurableObject extends DurableObject {
 				type: 'client',
 				name: 'enter',
 				instanceId: sessionId,
-				clientVersion,
+				clientBuildTimestamp,
 			})
 
 			requestTimer.report('on_request_total')
@@ -1097,7 +1097,7 @@ export class TLFileDurableObject extends DurableObject {
 					// blob order is positional per event name; 'pre-v' marks bundles that predate
 					// the `?v=` connect param and is therefore older than any real timestamp
 					this.writeEvent(event.name, {
-						blobs: [event.instanceId, event.clientVersion ?? 'pre-v'],
+						blobs: [event.instanceId, event.clientBuildTimestamp ?? 'pre-v'],
 					})
 				} else {
 					this.writeEvent(event.name, { blobs: [event.instanceId] })

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -167,7 +167,8 @@ export type TLServerEvent =
 			name: 'room_create' | 'room_reopen' | 'enter' | 'leave' | 'last_out'
 			instanceId: string
 			// `enter` only: the client bundle's build timestamp from the `?v=` connect param,
-			// so bundle age is queryable per connect. Absent = a bundle from before the param.
+			// so bundle age is queryable per connect. Absent = a bundle from before the param,
+			// or a param that didn't validate as an epoch-ms number.
 			clientBuildTimestamp?: string
 	  }
 	| {

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -168,7 +168,7 @@ export type TLServerEvent =
 			instanceId: string
 			// `enter` only: the client bundle's build timestamp from the `?v=` connect param,
 			// so bundle age is queryable per connect. Absent = a bundle from before the param.
-			clientVersion?: string
+			clientBuildTimestamp?: string
 	  }
 	| {
 			type: 'client'

--- a/apps/dotcom/sync-worker/src/types.ts
+++ b/apps/dotcom/sync-worker/src/types.ts
@@ -166,6 +166,9 @@ export type TLServerEvent =
 			type: 'client'
 			name: 'room_create' | 'room_reopen' | 'enter' | 'leave' | 'last_out'
 			instanceId: string
+			// `enter` only: the client bundle's build timestamp from the `?v=` connect param,
+			// so bundle age is queryable per connect. Absent = a bundle from before the param.
+			clientVersion?: string
 	  }
 	| {
 			type: 'client'


### PR DESCRIPTION
In order to tell how old a client bundle is when it connects — the parked-background-tab investigation (#9964, #9980) showed tabs keep running whatever bundle they loaded, for weeks, and today the server has no way to see that — this PR bakes a monotonic build identifier into the dotcom client and sends it on every sync websocket connection.

The identifier is the epoch-ms build timestamp, defined by vite at build time and appended as `?v=` to the connect URL in both file editors (app files and legacy rooms). The sync worker reads it, stores it on the socket attachment, and adds it as a blob on the `enter` analytics event (`'pre-v'` when absent). Log-only: nothing enforces anything yet.

What this buys us:

- The bundle-age distribution of live connects becomes directly queryable in Analytics Engine — we can watch the old-bundle population decay after each deploy instead of inferring it from DO-concurrency regrowth.
- The param's absence is itself a demarcation line: from the moment this deploys, every `pre-v` connect is provably running a bundle older than this PR. A follow-up can add a flag-controlled minimum-build floor that rejects with the existing `CLIENT_TOO_OLD` path (which shipped clients already handle terminally with a reload screen), turning bundle staleness into something we can cap fleet-wide without schema-migration timing or protocol bumps.
- The version rides on the socket attachment, so later server-side policies (e.g. the reconnect-storm backstop) can see it per session, hibernation-safe.

Relates to #9964, #9980.

### Change type

- [x] `other`

### Test plan

1. Open an app file and a legacy `/r/` room with devtools Network → WS: the connect URL carries `?v=<epoch ms>`.
2. Reconnect (toggle offline): the param persists across reconnects.
3. In AE, `enter` events carry the build timestamp as the last blob; connects from older bundles read `pre-v`.
