### PR TITLE
feat(commenting): keep the reaction palette open on shift-pick

### DIFF
--- a/packages/commenting/api-report.api.md
+++ b/packages/commenting/api-report.api.md
@@ -13,6 +13,7 @@ import { Editor } from 'tldraw';
 import { EditorAtom } from 'tldraw';
 import { filterMentionMembers } from '@tldraw/mentions';
 import { JSX } from 'react/jsx-runtime';
+import { KeyboardEvent as KeyboardEvent_2 } from 'react';
 import { Mention } from '@tldraw/mentions';
 import { MentionList } from '@tldraw/mentions';
 import { MentionListProps } from '@tldraw/mentions';
@@ -408,7 +409,7 @@ export function EmojiPicker({ emoji, selected, onSelect, renderReaction, }: Emoj
 // @public (undocumented)
 export interface EmojiPickerProps {
     emoji?: string[];
-    onSelect?(emoji: string): void;
+    onSelect?(emoji: string, event?: KeyboardEvent_2 | MouseEvent_2): void;
     renderReaction?: RenderReaction;
     selected?: string[];
 }

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -482,6 +482,8 @@ button.tlui-cmt-reaction--active:hover {
 
 .tlui-cmt-emoji-picker__item {
 	position: relative;
+	/* own stacking context so the z-index: -1 wash can't fall behind the menu panel */
+	isolation: isolate;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -512,8 +514,10 @@ button.tlui-cmt-reaction--active:hover {
 	background: var(--tl-color-muted-2);
 }
 
-.tlui-cmt-emoji-picker__item--active::after {
-	background: color-mix(in srgb, var(--tl-color-selected) 28%, var(--tl-color-panel));
+/* same greys as the style panel buttons: muted-2 on hover, hint when selected (also while hovered) */
+.tlui-cmt-emoji-picker__item--active::after,
+.tlui-cmt-emoji-picker__item--active:hover::after {
+	background: var(--tl-color-hint);
 }
 
 /* empty state */

--- a/packages/commenting/src/ui/comments.css
+++ b/packages/commenting/src/ui/comments.css
@@ -482,8 +482,6 @@ button.tlui-cmt-reaction--active:hover {
 
 .tlui-cmt-emoji-picker__item {
 	position: relative;
-	/* own stacking context so the z-index: -1 wash can't fall behind the menu panel */
-	isolation: isolate;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -514,10 +512,8 @@ button.tlui-cmt-reaction--active:hover {
 	background: var(--tl-color-muted-2);
 }
 
-/* same greys as the style panel buttons: muted-2 on hover, hint when selected (also while hovered) */
-.tlui-cmt-emoji-picker__item--active::after,
-.tlui-cmt-emoji-picker__item--active:hover::after {
-	background: var(--tl-color-hint);
+.tlui-cmt-emoji-picker__item--active::after {
+	background: color-mix(in srgb, var(--tl-color-selected) 28%, var(--tl-color-panel));
 }
 
 /* empty state */

--- a/packages/commenting/src/ui/emoji-picker.tsx
+++ b/packages/commenting/src/ui/emoji-picker.tsx
@@ -1,3 +1,4 @@
+import { type KeyboardEvent, type MouseEvent } from 'react'
 import { RenderReaction, defaultRenderReaction } from './reaction'
 
 /**
@@ -33,8 +34,8 @@ export interface EmojiPickerProps {
 	emoji?: string[]
 	/** Emoji the current user has already reacted with; shown as pressed. */
 	selected?: string[]
-	/** Called when an emoji is chosen. */
-	onSelect?(emoji: string): void
+	/** Called when an emoji is chosen. `event` is the DOM event behind the choice, if any. */
+	onSelect?(emoji: string, event?: MouseEvent | KeyboardEvent): void
 	/** How to draw each emoji token. Defaults to the token string (OS emoji font). */
 	renderReaction?: RenderReaction
 }
@@ -65,7 +66,7 @@ export function EmojiPicker({
 						}
 						aria-label={value}
 						aria-pressed={active}
-						onClick={() => onSelect?.(value)}
+						onClick={(e) => onSelect?.(value, e)}
 					>
 						{renderReaction(value)}
 					</button>

--- a/packages/commenting/src/ui/emoji-picker.tsx
+++ b/packages/commenting/src/ui/emoji-picker.tsx
@@ -34,7 +34,10 @@ export interface EmojiPickerProps {
 	emoji?: string[]
 	/** Emoji the current user has already reacted with; shown as pressed. */
 	selected?: string[]
-	/** Called when an emoji is chosen. `event` is the DOM event behind the choice, if any. */
+	/**
+	 * Called when an emoji is chosen. Custom palettes should forward their click or keydown event
+	 * so `ReactionPicker` can keep the palette open on shift-picks.
+	 */
 	onSelect?(emoji: string, event?: MouseEvent | KeyboardEvent): void
 	/** How to draw each emoji token. Defaults to the token string (OS emoji font). */
 	renderReaction?: RenderReaction

--- a/packages/commenting/src/ui/reaction-picker.test.ts
+++ b/packages/commenting/src/ui/reaction-picker.test.ts
@@ -1,0 +1,36 @@
+import { MouseEvent } from 'react'
+import { describe, expect, it } from 'vitest'
+import { isMultiSelectPick } from './reaction-picker'
+
+function click(overrides: Partial<MouseEvent> = {}): MouseEvent {
+	return {
+		metaKey: false,
+		ctrlKey: false,
+		shiftKey: false,
+		altKey: false,
+		button: 0,
+		...overrides,
+	} as MouseEvent
+}
+
+describe('isMultiSelectPick', () => {
+	it('keeps the palette open on a shift pick', () => {
+		expect(isMultiSelectPick(click({ shiftKey: true }))).toBe(true)
+	})
+
+	it('closes on a plain pick', () => {
+		expect(isMultiSelectPick(click())).toBe(false)
+	})
+
+	// custom palettes may call onSelect without an event; that must keep today's close-on-pick
+	it('closes when no event is given', () => {
+		expect(isMultiSelectPick(undefined)).toBe(false)
+	})
+
+	it.each(['metaKey', 'ctrlKey', 'altKey'] as const)(
+		'does not treat a %s pick as multi-select',
+		(modifier) => {
+			expect(isMultiSelectPick(click({ [modifier]: true }))).toBe(false)
+		}
+	)
+})

--- a/packages/commenting/src/ui/reaction-picker.tsx
+++ b/packages/commenting/src/ui/reaction-picker.tsx
@@ -40,7 +40,10 @@ export interface ReactionPickerProps {
 	className?: string
 }
 
-/** Whether a palette pick asked to keep the palette open (shift held) for multi-select. */
+/**
+ * Whether a palette pick asked to keep the palette open (shift held) for multi-select.
+ * @internal
+ */
 export function isMultiSelectPick(event?: MouseEvent | KeyboardEvent): boolean {
 	return !!event?.shiftKey
 }

--- a/packages/commenting/src/ui/reaction-picker.tsx
+++ b/packages/commenting/src/ui/reaction-picker.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useId, type ComponentType } from 'react'
+import { useCallback, useId, type ComponentType, type KeyboardEvent, type MouseEvent } from 'react'
 import {
 	TldrawUiButton,
 	TldrawUiDropdownMenuContent,
@@ -40,6 +40,11 @@ export interface ReactionPickerProps {
 	className?: string
 }
 
+/** Whether a palette pick asked to keep the palette open (shift held) for multi-select. */
+export function isMultiSelectPick(event?: MouseEvent | KeyboardEvent): boolean {
+	return !!event?.shiftKey
+}
+
 /**
  * The add-reaction affordance: a smiley button that opens an emoji grid.
  *
@@ -47,7 +52,8 @@ export interface ReactionPickerProps {
  * reactions are added and the row reflows.
  *
  * Picking an emoji dismisses the grid — adding and removing alike, since either way the picker has
- * done its job — and hands focus back to the trigger.
+ * done its job — and hands focus back to the trigger. Shift-picking keeps the grid open, for
+ * choosing several reactions in a row.
  * @public @react
  */
 export function ReactionPicker({
@@ -69,9 +75,11 @@ export function ReactionPicker({
 	// what closes it. The palette's tokens are plain buttons — a swappable component, not radix
 	// menu items — so nothing dismisses the menu on its own.
 	const handleSelect = useCallback(
-		(value: string) => {
+		(value: string, event?: MouseEvent | KeyboardEvent) => {
 			onSelect?.(value)
-			tlmenus.deleteOpenMenu(id, editor?.contextId)
+			if (!isMultiSelectPick(event)) {
+				tlmenus.deleteOpenMenu(id, editor?.contextId)
+			}
 		},
 		[onSelect, id, editor]
 	)


### PR DESCRIPTION
In order to react to a comment with several emoji without reopening the picker for each one, this PR keeps the reaction palette open when an emoji is picked with shift held. A plain pick still closes the palette, and shift-clicking anywhere else on the page is untouched — the check lives inside the palette token's own click handler.

The mechanism: the palette only ever closes on select because `ReactionPicker` deletes its menu id from the `tlmenus` registry after calling `onSelect`. `EmojiPicker` now forwards its click event through `onSelect` (an optional second parameter, so existing callers and custom palettes compile and behave unchanged), and `ReactionPicker` skips the delete when the event carries `shiftKey`. Custom palettes passed via the `palette` prop keep today's close-on-every-pick behavior unless they opt in by forwarding their own event; the `KeyboardEvent` member of the union exists for keyboard-driven custom palettes (for example Enter-to-select in a searchable palette), since our default palette only produces clicks — keyboard activation of a token arrives as a synthesized click, so shift+Enter multi-select works through the same path.

### Change type

- [x] `feature`

### Test plan

1. Open a comment thread and open the reaction palette from the smiley button.
2. Shift-click several emoji: each toggles immediately and the palette stays open.
3. Click an emoji without shift: it applies and the palette closes.
4. Focus a token and press shift+Enter: same keep-open behavior.

- [x] Unit tests

### Release notes

- Shift-click an emoji in the comment reaction palette to add several reactions without the palette closing.

### API changes

- Changed `EmojiPickerProps.onSelect` to accept an optional second `event` parameter (`MouseEvent | KeyboardEvent`) — non-breaking; custom palettes can forward their event to opt into shift multi-select.

### Code changes

| Section         | LOC change |
| --------------- | ---------- |
| Core code       | +22 / -7   |
| Tests           | +36 / -0   |
| Automated files | +2 / -1    |
