### PR TITLE
docs: fix typo in v4.3.0 release notes

### DIFF
--- a/apps/docs/content/releases/v4.3.0.mdx
+++ b/apps/docs/content/releases/v4.3.0.mdx
@@ -223,7 +223,7 @@ Draw and highlight shape point data is now stored using a compact delta-encoded 
 <details>
 <summary>Breaking change details</summary>
 
-If you were reading or writing draw shape data programatically you might need to update your code to use the new format.
+If you were reading or writing draw shape data programmatically you might need to update your code to use the new format.
 
 - `TLDrawShapeSegment.points` renamed to `.path` and changed from `VecModel[]` to `string` (base64-encoded)
 - Added `scaleX` and `scaleY` properties to draw and highlight shapes


### PR DESCRIPTION
Fixes a spelling error in the v4.3.0 release notes: "programatically" → "programmatically".

Found by running `codespell` over `apps/docs`. It was the only genuine prose typo in the published docs content — the remaining hits were false positives (`LOD`, `doubleClick`) or code comments.

### Change type

- [ ] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [x] `other`

### Test plan

Docs-only copy change, no behaviour affected.

1. Open the [v4.3.0 release notes](https://tldraw.dev/releases/v4.3.0), expand "Breaking change details" under the draw shape storage section.
2. The sentence reads "reading or writing draw shape data programmatically".

- [ ] Unit tests
- [ ] End to end tests

### Release notes

- Fixed a typo in the v4.3.0 release notes.
