### PR TITLE
fix(tldraw): keep a stacked dialog open when the dialog above it closes on touch

### DIFF
--- a/apps/examples/e2e/tests/test-dialogs.spec.ts
+++ b/apps/examples/e2e/tests/test-dialogs.spec.ts
@@ -105,3 +105,30 @@ test.describe('stacked dialogs', () => {
 		await expect(page.getByTestId('dialog-parent')).toBeVisible()
 	})
 })
+
+// A touch press is checked against the dialog stack at the click that follows it, not at the
+// press, so this needs a genuine touch-to-click sequence to reproduce. The viewport is wide on
+// purpose: the editor cancels a touchstart close to the window's edges, which substitutes a
+// synthesised click and moves the check earlier than the real one, hiding the bug.
+test.describe('stacked dialogs on a wide touch viewport', () => {
+	test.use({ viewport: { width: 1024, height: 768 }, hasTouch: true, isMobile: true })
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('http://localhost:5420/toasts-and-dialogs')
+		await page.waitForSelector('.tl-canvas')
+	})
+
+	test('confirming the nested dialog by touch leaves the parent open', async ({ page }) => {
+		await page.getByTestId('show-nested-dialog').tap()
+		await expect(page.getByTestId('dialog-parent')).toBeVisible()
+
+		await page.getByTestId('dialog-parent.open-nested').tap()
+		await expect(page.getByTestId('dialog-nested')).toBeVisible()
+
+		// By the time the deferred check runs the nested dialog has unmounted, leaving the parent
+		// topmost — the press that closed the nested dialog must not read as a press outside it.
+		await page.getByTestId('dialog-nested.confirm').tap()
+		await expect(page.getByTestId('dialog-nested')).toHaveCount(0)
+		await expect(page.getByTestId('dialog-parent')).toBeVisible()
+	})
+})

--- a/packages/tldraw/src/lib/ui/components/Dialogs.tsx
+++ b/packages/tldraw/src/lib/ui/components/Dialogs.tsx
@@ -1,6 +1,6 @@
 import { useContainer, useValue } from '@tldraw/editor'
 import { Dialog as _Dialog } from 'radix-ui'
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useRef } from 'react'
 import { TLUiDialog, useDialogs } from '../context/dialogs'
 import { useDirection } from '../hooks/useTranslation/useTranslation'
 
@@ -10,6 +10,7 @@ const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }:
 
 	const container = useContainer()
 	const dir = useDirection()
+	const contentRef = useRef<HTMLDivElement>(null)
 
 	const handleOpenChange = useCallback(
 		(isOpen: boolean) => {
@@ -29,6 +30,7 @@ const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }:
 				<_Dialog.Overlay dir={dir} className="tlui-dialog__overlay" />
 				<div dir={dir} className="tlui-dialog__positioner">
 					<_Dialog.Content
+						ref={contentRef}
 						dir={dir}
 						className="tlui-dialog__content"
 						aria-describedby={undefined}
@@ -39,6 +41,20 @@ const TldrawUiDialog = ({ id, component: ModalContent, preventBackgroundClose }:
 							// both a pointer press and a focus shift outside the dialog; opt out of both
 							// when the dialog asks to stay open on background interactions (escape still
 							// closes it).
+
+							// A touch press is checked against the layers at the following click rather
+							// than at the press itself, so a press that closes a dialog stacked on top of
+							// this one arrives here once this one is topmost, and reads as a press
+							// outside it. A press inside another dialog is never outside this one, and
+							// stays so after that dialog unmounts and takes the press's target with it.
+							const target = e.detail.originalEvent.target
+							const pressedDialog =
+								target instanceof Element ? target.closest('.tlui-dialog__content') : null
+							if (pressedDialog && pressedDialog !== contentRef.current) {
+								e.preventDefault()
+								return
+							}
+
 							if (preventBackgroundClose) {
 								e.preventDefault()
 							}


### PR DESCRIPTION
Closes #10001.

Closing a stacked dialog by touch also closed the dialog beneath it. With a mouse it behaved correctly.

Radix's `DismissableLayer` checks a touch press against the layer stack at the `click` that follows it rather than at the press itself ([`react-dismissable-layer`](https://github.com/radix-ui/primitives/blob/main/packages/react/dismissable-layer/src/dismissable-layer.tsx), the `pointerType === 'touch'` branch), while handling mouse presses synchronously at `pointerdown`. Confirming the nested dialog unmounts it before that deferred check runs, so the dialog beneath is topmost by then and the same press reads as a press outside it.

The check is correct; it just runs against a DOM that changed after the press. Instrumenting Radix's deferral shows it registering on `pointerdown` and firing on the following `click` — at which point `event.detail.originalEvent.target.isConnected` is `false`. The element that was pressed no longer exists, because the dialog containing it has been unmounted in between.

`Dialogs.tsx` now ignores an outside interaction that originated inside another dialog. That's a fact about the press rather than about the layer stack, so it holds whether or not the dialog it landed in is still mounted — `closest()` still walks a detached subtree.

### Why the existing coverage missed it

`test-dialogs.spec.ts` already asserted the right thing and stayed green. The desktop e2e project has no touch, so it never takes the deferred path at all; the mobile project is narrow enough that the dialog sits where the editor cancels the `touchstart`, which substitutes a synthesised click and moves the check earlier than a real one. Two projects, two different reasons to miss the same bug.

That cancellation is itself a bug, fixed in #9989: the editor's edge guard compares a page coordinate against the container's width, so an editor inset from the page edge cancels touches across a wide band of its own canvas — on the examples app at a 393px viewport, all of it. Once #9989 lands, the existing `Mobile Chrome` case catches this bug too; it is currently red on that branch for exactly this reason, which is why #9989 is blocked on this PR.

The new test doesn't depend on any of that. It reproduces the bug through a genuine touch-to-click sequence on `main` as it stands, and changes one axis — viewport width — because that's the single thing both blind spots depend on.

### Change type

- [x] `bugfix`
- [ ] `improvement`
- [ ] `feature`
- [ ] `api`
- [ ] `other`

### Test plan

1. On a touch device, open the `toasts-and-dialogs` example
2. Tap **Show nested dialog**, then **Open nested dialog**
3. Tap **Confirm** — the nested dialog closes and the parent stays open

Covered by `stacked dialogs on a wide touch viewport › confirming the nested dialog by touch leaves the parent open`, which fails on `main` and passes here, on both e2e projects.

- [ ] Unit tests
- [x] End to end tests

### Release notes

- Fixed a bug where closing a stacked dialog by touch also closed the dialog beneath it.
