### PR TITLE
chore(dotcom): stop serving the sync worker on workers.dev in staging and production

### DIFF
--- a/apps/dotcom/sync-worker/wrangler.toml
+++ b/apps/dotcom/sync-worker/wrangler.toml
@@ -133,7 +133,7 @@ LOCAL_SCREENSHOT_SERVICE_URL = "http://localhost:3000/__screenshot"
 # staging is the same as a preview on main:
 [env.staging]
 name = "main-tldraw-multiplayer"
-workers_dev = true # todo: remove this once clients are updated
+workers_dev = false
 
 [env.staging.vars]
 HEALTH_CHECK_DB_SIZE_THRESHOLD_GB = "4"
@@ -145,7 +145,7 @@ MCP_SCREENSHOT_ENABLED = "true"
 # production gets the proper name
 [env.production]
 name = "tldraw-multiplayer"
-workers_dev = true # todo: remove this once clients are updated
+workers_dev = false
 
 [env.production.vars]
 HEALTH_CHECK_DB_SIZE_THRESHOLD_GB = "10"


### PR DESCRIPTION
In order to retire a public entry point we no longer use, this turns off the sync worker's `workers.dev` subdomain in staging and production.

`workers_dev = true` was pinned on both environments in #4553 (September 2024), the PR that added the `sync.tldraw.xyz` custom domain. It was there to keep existing clients alive until they moved to the new host, marked `todo: remove this once clients are updated`. They have: `MULTIPLAYER_SERVER` is `wss://sync.tldraw.xyz` in production and `wss://staging-sync.tldraw.xyz` in staging, and nothing in the repo references the deployed workers.dev hosts. Both have kept serving all the same — `tldraw-multiplayer.tldraw.workers.dev` answers today — so the worker stays reachable on a hostname outside the zone its real routes sit behind.

Previews still need theirs, so the top-level `workers_dev = true` stays: preview inherits it, and `deploy-dotcom.ts` builds each preview's `MULTIPLAYER_SERVER` from `https://<preview>-tldraw-multiplayer.tldraw.workers.dev`.

Worth a reviewer's judgement: nothing can prove that hostname is unused. Worker invocation analytics carry no hostname dimension, workers.dev is not a zone we own so it is absent from the HTTP request datasets, the worker has no `observability` block, and MEASURE records no host. Over the last 7 days production served 64.2M invocations against 57.8M requests on `www.tldraw.com/api/*`; the ~6.4M remainder covers `sync.tldraw.xyz`, the queue consumer and any workers.dev traffic together, and can't be split further. So if something external wired itself to that hostname, this cuts it off. Re-enabling restores the identical hostname in one deploy.

### Change type

- [x] `other`

### Test plan

1. Deploy to staging and confirm `https://main-tldraw-multiplayer.tldraw.workers.dev/` no longer reaches the worker.
2. Confirm staging.tldraw.com still loads, syncs and saves — the routed hosts are untouched.
3. Confirm a preview deploy still gets a working `<preview>-tldraw-multiplayer.tldraw.workers.dev`.

### Code changes

| Section | LOC change |
| ------- | ---------- |
| Apps    | +2 / -2    |
