### PR TITLE
feat(dotcom): resolve durable object lookup by room slug too

### DIFF
--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -135,6 +135,13 @@ function ResolveDoId() {
 
 	const onResolve = useCallback(async () => {
 		const idOrSlug = input.trim()
+		// hex is a subset of the slug charset — catch truncated/uppercase ids before they hash as slugs
+		if (/^[0-9a-fA-F]{16,}$/.test(idOrSlug) && !/^[0-9a-f]{64}$/.test(idOrSlug)) {
+			setError(
+				'Looks like a truncated or uppercase durable object id — paste the full 64-char lowercase hex'
+			)
+			return
+		}
 		if (!/^[0-9a-f]{64}$/.test(idOrSlug) && !/^[a-zA-Z0-9_-]+$/.test(idOrSlug)) {
 			setError('Paste a 64-character hex durable object id or a room slug')
 			return
@@ -187,11 +194,12 @@ function ResolveDoId() {
 	return (
 		<div>
 			<p>
-				Paste a durable object id (full 64-character hex, from the Cloudflare dash or analytics) or
-				a room slug — either resolves to the room&apos;s activity. <b>Sockets</b> are live tabs;
-				save stats come from the snapshot history bucket. Frequent recent saves = someone editing;
-				sockets with stale saves = parked background tabs; no sockets = idle. The slug is copyable
-				instead of linked — we do not open users&apos; files.
+				Paste a durable object id (full 64-character hex — dash lists truncate, grab the full id
+				from the search dropdown or GraphQL) or a room slug — either resolves to the room&apos;s
+				activity. <b>Sockets</b> are live tabs; save stats come from the snapshot history bucket.
+				Frequent recent saves = someone editing; sockets with stale saves = parked background tabs;
+				no sockets = idle. The slug is copyable instead of linked — we do not open users&apos;
+				files.
 			</p>
 			<div className={styles.searchContainer}>
 				<input

--- a/apps/dotcom/client/src/pages/admin/FilesSection.tsx
+++ b/apps/dotcom/client/src/pages/admin/FilesSection.tsx
@@ -96,9 +96,9 @@ const CF_ACCOUNT_TAG = 'c34edc4e76350954b63adebde86d5eb1'
 const CF_TLDR_DOC_NAMESPACE_ID = '5864db4344ac4c55bfd94e81dd25a043'
 
 /**
- * Maps a durable object id (from Cloudflare analytics or the dash) back to its room slug, with
- * liveness and persist-history signals. The object stores its own identity, so the resolver asks
- * it directly.
+ * Looks up a room by durable object id (from Cloudflare analytics or the dash) or by room slug,
+ * with liveness and persist-history signals. The server distinguishes the two forms and returns
+ * the canonical object id either way.
  */
 function ResolveDoId() {
 	const [input, setInput] = useState('')
@@ -113,18 +113,19 @@ function ResolveDoId() {
 		} | null
 	)
 
-	const resolve = useCallback(async (objectId: string) => {
+	const resolve = useCallback(async (idOrSlug: string) => {
 		setError(null)
 		setResult(null)
 		setCopied(false)
 		setIsRunning(true)
 		try {
-			const res = await fetch(`/api/app/admin/resolve-do-id/${objectId}`)
+			// the server resolves either form and returns the canonical object id
+			const res = await fetch(`/api/app/admin/resolve-do-id/${encodeURIComponent(idOrSlug)}`)
 			if (!res.ok) {
 				setError(res.statusText + ': ' + (await res.text()))
 				return
 			}
-			setResult({ objectId, ...(await res.json()) })
+			setResult(await res.json())
 		} catch (err) {
 			setError(err instanceof Error ? err.message : 'Resolve failed')
 		} finally {
@@ -133,12 +134,12 @@ function ResolveDoId() {
 	}, [])
 
 	const onResolve = useCallback(async () => {
-		const objectId = input.trim()
-		if (!/^[0-9a-f]{64}$/.test(objectId)) {
-			setError('Paste a 64-character lowercase hex durable object id')
+		const idOrSlug = input.trim()
+		if (!/^[0-9a-f]{64}$/.test(idOrSlug) && !/^[a-zA-Z0-9_-]+$/.test(idOrSlug)) {
+			setError('Paste a 64-character hex durable object id or a room slug')
 			return
 		}
-		await resolve(objectId)
+		await resolve(idOrSlug)
 	}, [input, resolve])
 
 	const onCopySlug = useCallback(async (slug: string) => {
@@ -186,23 +187,16 @@ function ResolveDoId() {
 	return (
 		<div>
 			<p>
-				Finds the room behind a durable object id. Cloudflare analytics (the durable objects dash,
-				GraphQL, our Analytics Engine events) rank hot objects by id, but the id is a one-way hash
-				of the room name — this asks the object itself for its stored identity. Paste the full
-				64-character id (dash lists often truncate; use the search dropdown or GraphQL for the full
-				one).
-			</p>
-			<p>
-				Reading the result: <b>sockets</b> are live browser tabs holding a connection, and the save
-				stats come from the snapshot history bucket (one snapshot per persist) — recent, frequent
-				saves mean someone is editing; a connected socket with stale saves is a parked background
-				tab; no sockets means the room is idle. The slug is copyable on purpose instead of linked —
-				we do not open users&apos; files.
+				Paste a durable object id (full 64-character hex, from the Cloudflare dash or analytics) or
+				a room slug — either resolves to the room&apos;s activity. <b>Sockets</b> are live tabs;
+				save stats come from the snapshot history bucket. Frequent recent saves = someone editing;
+				sockets with stale saves = parked background tabs; no sockets = idle. The slug is copyable
+				instead of linked — we do not open users&apos; files.
 			</p>
 			<div className={styles.searchContainer}>
 				<input
 					className={styles.searchInput}
-					placeholder="Durable object id (64-char hex)"
+					placeholder="Durable object id (64-char hex) or room slug"
 					value={input}
 					onChange={(e) => setInput(e.target.value)}
 					onKeyDown={(e) => e.key === 'Enter' && onResolve()}
@@ -214,7 +208,7 @@ function ResolveDoId() {
 			</div>
 			{error && <div className={styles.errorMessage}>{error}</div>}
 			{result && !match && (
-				<div className={styles.subTitle}>No room for that id (never initialized)</div>
+				<div className={styles.subTitle}>No room for that id or slug (never initialized)</div>
 			)}
 			{match && result && (
 				<div className={styles.subTitle}>

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -253,16 +253,21 @@ export const adminRoutes = createRouter<Environment>()
 		}
 		return json({ ok: true })
 	})
-	// Maps a durable object id back to its room slug and reports activity signals. The id is a
-	// one-way hash of the room name, but the room object stores its own identity, so it is asked
-	// directly — a never-initialized id resolves to null. The brief wake is storage-read only; no
-	// room boot. Persist history comes from the version-cache bucket: one timestamped snapshot per
-	// persist, so save cadence separates an actively edited room from a parked tab holding a
-	// socket open.
-	.get('/app/admin/resolve-do-id/:objectId', async (res, env) => {
-		const objectId = res.params.objectId
-		if (!/^[0-9a-f]{64}$/.test(objectId)) {
-			throw new StatusError(400, 'objectId must be a 64-char lowercase hex string')
+	// Maps a durable object id or room slug to the room's activity signals. The id is a one-way
+	// hash of the room name, but the room object stores its own identity, so it is asked directly —
+	// a never-initialized id resolves to null. A slug (anything that isn't 64-char hex) is hashed
+	// forward via idFromName. The brief wake is storage-read only; no room boot. Persist history
+	// comes from the version-cache bucket: one timestamped snapshot per persist, so save cadence
+	// separates an actively edited room from a parked tab holding a socket open.
+	.get('/app/admin/resolve-do-id/:objectIdOrSlug', async (res, env) => {
+		const param = res.params.objectIdOrSlug
+		let objectId: string
+		if (/^[0-9a-f]{64}$/.test(param)) {
+			objectId = param
+		} else if (/^[a-zA-Z0-9_-]+$/.test(param)) {
+			objectId = env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${param}`).toString()
+		} else {
+			throw new StatusError(400, 'pass a 64-char hex durable object id or a room slug')
 		}
 		let roomDo: ReturnType<typeof getRoomDurableObjectById>
 		try {
@@ -273,7 +278,7 @@ export const adminRoutes = createRouter<Environment>()
 			throw new StatusError(400, 'not a valid durable object id for the file namespace')
 		}
 		const info = await roomDo.__admin__getDocumentInfo()
-		if (!info) return json({ match: null, history: null })
+		if (!info) return json({ objectId, match: null, history: null })
 
 		// Stream the stats instead of collecting objects, so any number of snapshots fits. Keys are
 		// ISO timestamps (oldest first); min/max tracking keeps the newest save correct either way.
@@ -307,6 +312,7 @@ export const adminRoutes = createRouter<Environment>()
 		} while (cursor)
 
 		return json({
+			objectId,
 			match: info,
 			history: {
 				saves,

--- a/apps/dotcom/sync-worker/src/adminRoutes.ts
+++ b/apps/dotcom/sync-worker/src/adminRoutes.ts
@@ -29,6 +29,7 @@ import {
 	getFileEffectProcessor,
 	getRoomDurableObject,
 	getRoomDurableObjectById,
+	getRoomDurableObjectId,
 	getUserDurableObject,
 } from './utils/durableObjects'
 import { FEATURE_FLAG_KEYS, getFeatureFlagsAdmin, setFeatureFlag } from './utils/featureFlags'
@@ -264,8 +265,15 @@ export const adminRoutes = createRouter<Environment>()
 		let objectId: string
 		if (/^[0-9a-f]{64}$/.test(param)) {
 			objectId = param
+		} else if (/^[0-9a-fA-F]{16,}$/.test(param)) {
+			// hex is a subset of the slug charset — without this, a truncated or uppercase id would
+			// hash as a slug and report a confident "never initialized"
+			throw new StatusError(
+				400,
+				'looks like a truncated or uppercase durable object id — paste the full 64-char lowercase hex'
+			)
 		} else if (/^[a-zA-Z0-9_-]+$/.test(param)) {
-			objectId = env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${param}`).toString()
+			objectId = getRoomDurableObjectId(env, param).toString()
 		} else {
 			throw new StatusError(400, 'pass a 64-char hex durable object id or a room slug')
 		}

--- a/apps/dotcom/sync-worker/src/routes/joinExistingRoom.ts
+++ b/apps/dotcom/sync-worker/src/routes/joinExistingRoom.ts
@@ -1,7 +1,8 @@
-import { ROOM_PREFIX, RoomOpenMode } from '@tldraw/dotcom-shared'
+import { RoomOpenMode } from '@tldraw/dotcom-shared'
 import { notFound } from '@tldraw/worker-shared'
 import { IRequest } from 'itty-router'
 import { Environment } from '../types'
+import { getRoomDurableObjectId } from '../utils/durableObjects'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../utils/roomIdIsTooLong'
 import { getSlug } from '../utils/roomOpenMode'
 
@@ -17,7 +18,7 @@ export async function joinExistingRoom(
 	// This needs to be a websocket request!
 	if (request.headers.get('upgrade')?.toLowerCase() === 'websocket') {
 		// Set up the durable object for this room
-		const id = env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${roomId}`)
+		const id = getRoomDurableObjectId(env, roomId)
 		return env.TLDR_DOC.get(id).fetch(request)
 	}
 

--- a/apps/dotcom/sync-worker/src/routes/tla/forwardRoomRequest.ts
+++ b/apps/dotcom/sync-worker/src/routes/tla/forwardRoomRequest.ts
@@ -1,7 +1,7 @@
-import { ROOM_PREFIX } from '@tldraw/dotcom-shared'
 import { notFound } from '@tldraw/worker-shared'
 import { IRequest } from 'itty-router'
 import { Environment } from '../../types'
+import { getRoomDurableObjectId } from '../../utils/durableObjects'
 import { isRoomIdTooLong, roomIdIsTooLong } from '../../utils/roomIdIsTooLong'
 
 // Forwards a room request to the durable object associated with that room
@@ -12,6 +12,6 @@ export async function forwardRoomRequest(request: IRequest, env: Environment): P
 	if (isRoomIdTooLong(roomId)) return roomIdIsTooLong()
 
 	// Set up the durable object for this room
-	const id = env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${roomId}`)
+	const id = getRoomDurableObjectId(env, roomId)
 	return env.TLDR_DOC.get(id).fetch(request)
 }

--- a/apps/dotcom/sync-worker/src/utils/durableObjects.ts
+++ b/apps/dotcom/sync-worker/src/utils/durableObjects.ts
@@ -27,10 +27,12 @@ export function getLogger(env: Environment) {
 	return env.TL_LOGGER.get(env.TL_LOGGER.idFromName('logger')) as any as TLLoggerDurableObject
 }
 
+export function getRoomDurableObjectId(env: Environment, roomId: string) {
+	return env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${roomId}`)
+}
+
 export function getRoomDurableObject(env: Environment, roomId: string) {
-	return env.TLDR_DOC.get(
-		env.TLDR_DOC.idFromName(`/${ROOM_PREFIX}/${roomId}`)
-	) as any as TLFileDurableObject
+	return env.TLDR_DOC.get(getRoomDurableObjectId(env, roomId)) as any as TLFileDurableObject
 }
 
 export function getRoomDurableObjectById(env: Environment, objectId: string) {


### PR DESCRIPTION
Admin durable object lookup now accepts a room slug as well as a 64-char hex durable object id. Anything that isn't full hex is treated as a slug and hashed forward via `idFromName('/r/<slug>')`; the route returns the canonical object id either way, so the metrics link and force-close keep working. Instructions in the panel trimmed down and mention both input forms.

### Change type

- [x] `improvement`

### Release notes

- Admin durable object lookup accepts a room slug in addition to a durable object id.