### PR TITLE
fix(vscode): bump past rejected version when marketplace listing is stale

### DIFF
--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -12,7 +12,6 @@ const env = makeEnv(['VSCE_PAT', 'OVSX_PAT', 'TLDRAW_ENV'])
 const EXTENSION_DIR = 'apps/vscode/extension'
 const DISTRIBUTION_DIR = 'apps/vscode/extension/release'
 const MAX_RETRIES = 5
-const RETRY_DELAY_MS = 60_000
 
 function isVersionConflictError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : ''
@@ -34,8 +33,8 @@ async function fetchMarketplaceVersion(): Promise<string> {
 	return version
 }
 
-async function bumpVersion(): Promise<string> {
-	const currentVersion = await fetchMarketplaceVersion()
+async function bumpVersion(fromVersion?: string): Promise<string> {
+	const currentVersion = fromVersion ?? (await fetchMarketplaceVersion())
 	const semVer = parse(currentVersion)
 	if (!semVer) {
 		throw new Error(`Could not parse the published version: ${currentVersion}`)
@@ -97,10 +96,12 @@ async function main() {
 	await exec('yarn', ['lazy', 'run', 'build', '--filter=packages/*'])
 
 	// When two pushes to main happen in quick succession, the concurrency group serializes
-	// the runs but the marketplace API has propagation delay — both runs can compute the same
-	// next version. If publish fails with "already exists", re-fetch and retry.
+	// the runs but `vsce show` can lag a fresh publish by 10+ minutes, so both runs compute
+	// the same next version. The "already exists" rejection is authoritative, so on conflict
+	// bump past the rejected version locally instead of re-fetching the stale listing.
+	let conflictedVersion: string | undefined
 	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-		const version = await bumpVersion()
+		const version = await bumpVersion(conflictedVersion)
 
 		try {
 			switch (env.TLDRAW_ENV) {
@@ -116,10 +117,10 @@ async function main() {
 			}
 		} catch (err) {
 			if (isVersionConflictError(err) && attempt < MAX_RETRIES) {
+				conflictedVersion = version
 				nicelog(
-					`Version conflict detected (attempt ${attempt}/${MAX_RETRIES}), retrying in ${RETRY_DELAY_MS / 1000}s...`
+					`Version ${version} already exists (attempt ${attempt}/${MAX_RETRIES}), bumping past it and retrying...`
 				)
-				await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
 				continue
 			}
 			throw err

--- a/internal/scripts/publish-editor-extensions.ts
+++ b/internal/scripts/publish-editor-extensions.ts
@@ -12,6 +12,7 @@ const env = makeEnv(['VSCE_PAT', 'OVSX_PAT', 'TLDRAW_ENV'])
 const EXTENSION_DIR = 'apps/vscode/extension'
 const DISTRIBUTION_DIR = 'apps/vscode/extension/release'
 const MAX_RETRIES = 5
+const RETRY_DELAY_MS = 60_000
 
 function isVersionConflictError(err: unknown): boolean {
 	const message = err instanceof Error ? err.message : ''
@@ -119,8 +120,9 @@ async function main() {
 			if (isVersionConflictError(err) && attempt < MAX_RETRIES) {
 				conflictedVersion = version
 				nicelog(
-					`Version ${version} already exists (attempt ${attempt}/${MAX_RETRIES}), bumping past it and retrying...`
+					`Version ${version} already exists (attempt ${attempt}/${MAX_RETRIES}), bumping past it and retrying in ${RETRY_DELAY_MS / 1000}s...`
 				)
+				await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS))
 				continue
 			}
 			throw err


### PR DESCRIPTION
Fixes the recurring "Publish editor extensions" CI failure (e.g. [this run](https://github.com/tldraw/tldraw/actions/runs/31781779545/job/94708903712)).

When two pushes to main land close together, the second run derives its next extension version from `vsce show`, but the marketplace listing can lag a fresh publish by 10+ minutes. Every retry re-fetched the same stale listing, computed the same already-published version, and the job failed after 5 attempts with `v2.331.1 already exists`.

The `already exists` rejection from the publish endpoint is authoritative, so on conflict the retry now bumps past the rejected version locally instead of re-fetching the stale listing. The 60s delay between attempts is kept.

### Change type

- [x] `bugfix`

### Release notes

- Fixed a version race that made the VS Code extension publish workflow fail when two pushes to main landed close together.