### PR TITLE
docs: write down the comment rules, and sweep for slop in the PR skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,39 @@ Dependencies:
 - Every package a file imports must be declared in the owning workspace's own `package.json`. Yarn's `node-modules` linker hoists everything to the repo root, so an undeclared import still resolves here but breaks consumers on pnpm or Yarn PnP. The `tldraw/no-undeclared-dependencies` lint rule enforces this across `packages/*`; adding a workspace dependency also needs a matching `references` entry in that package's `tsconfig.json` (`yarn check-packages --fix`).
 - Dependency install/build scripts are off by default (`enableScripts: false` in `.yarnrc.yml`), which closes the main supply-chain `postinstall` code-execution path. Packages that genuinely need to build (native/napi modules, binary downloaders) are allowlisted with `built: true` under `dependenciesMeta` in the root `package.json`. When adding a dependency that ships a native addon or downloads a platform binary, add an allowlist entry — Yarn silently skips unlisted scripts, so a missing entry shows up as a runtime or build failure, not an install error.
 
+## Comments
+
+A comment earns its place by saying something the code cannot: why this way, what breaks otherwise, which bug it guards. Everything else is noise a reader wades through to reach the code — and enough of it teaches people to skip comments entirely, including the load-bearing ones.
+
+Delete on sight:
+
+- **Restatement.** `/** Get the toolbar element */` above `getToolbar()`. The name already said it.
+- **Narration.** `// Check if the shape is already selected` above the line that checks. `// Delete the shapes` above `editor.deleteShapes()`.
+- **Section banners.** `// ===== Locators =====`, `// --- internals ---`. A file that needs signposting needs splitting. Judge the label like any other comment once the rule is off it — `// Bug 3: arrow binding survives rotation` above `test('bug 3: arrow binding survives rotation')` is restatement wearing decoration.
+- **`@param` / `@returns` that restate the signature.** The types carry it. Keep the tag only for what the type can't say — units, a caller precondition, `0 = first button`.
+- **Rationale copy-pasted across sibling call sites.** State it once where the shared thing lives and point at it. Three copies become three subtly different claims, and then nobody knows which is current.
+- **Call-site lists.** `Used by: SelectTool, DrawTool, EraserTool…`. Find-references gives this for free and it rots on the next caller.
+
+Trim, rather than delete, when the reason is real but overlong. The test is whether a reviewer reads it or skips past it to get at the code: **once a comment is longer than the code it explains, it has stopped working.** A twenty-line rationale block is usually three good lines plus seventeen restating them — keep the three. One orienting header per file is fine; one per method is not.
+
+**Narrative belongs in a doc; the comment keeps the local fact and points at it.** Ask: does this knowledge span more than one file, and would you read it _before_ starting rather than while typing? Then it is narrative — put it in the project's doc (a `README.md` beside the code, a `SPEC.md`, an article in `apps/docs/content/`) and leave a header of a few lines carrying what this file's own reader needs, plus the reference. A guard comment fails that test and must stay at the line: it is read _during_ an edit, by the person about to delete the thing it guards, and nobody consults a doc before deleting a line.
+
+The pointer is the deliverable, not the leftover — extraction without one is deletion with extra steps. And extract, never copy: a duplicated narrative is the thing that rots, because each copy drifts into a slightly different claim and the stalest one is indistinguishable from the current one.
+
+**The litmus, in one line: a good comment names a failure mode, not a mechanism.** The mechanism is on screen. What is not on screen is what goes wrong without it — "otherwise the binding updates before the shape has its new page transform". Write the "otherwise" and the mechanism explains itself. Expect length, not category, to be the usual defect: most blocks worth editing already name a real force, and then say it three more times.
+
+What earns real length, and should not be trimmed for being long:
+
+- **A diagram.** Twenty lines of box-drawing beat any prose about geometry.
+- **An enumerated set of cases** the code must not break — the list is the specification.
+- **Provenance.** An issue number, "we tried X and it did Y", "modified from the upstream version to…".
+
+Keep, always: the non-obvious invariant, the bug or issue number, the constant nobody should tune blindly.
+
+**Application code is not library code.** In `packages/*`, doc comments on the `@public` surface are a deliverable — they become the API reference on tldraw.dev and land in `api-report.md`, and density there is expected. In `apps/*` and `templates/*` almost nothing is a published surface, so comment lines are explanation prose and cost reading time. App code carrying library-grade comment density, with no `@public` surface to justify it, is over-commented by definition.
+
+Applies to code you write **and** code you touch. Prior art: [#9824](https://github.com/tldraw/tldraw/pull/9824).
+
 ## Writing style
 
 - Use sentence case for Markdown headings, UI labels, docs titles, PR titles, and issue titles.

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -29,6 +29,7 @@ Use `../write-pr/SKILL.md` as the standards reference for PR titles, description
    - Does the change actually solve the stated problem, end to end, rather than papering over a symptom?
    - Does it leave the codebase better than we found it — clearer names, no dead or duplicated code, no drive-by regressions?
    - Any weird abstractions, premature generality, or unnecessary code that a reviewer would flag? Prefer the smaller, more direct version.
+   - Sweep the diff's added comments for slop, following `../write-pr/SKILL.md` § The comment sweep. On an update, this catches whatever the branch grew since the PR was opened, which on a long-lived branch is most of it.
    - Fix what's clearly worth fixing so the human review starts from a strong diff. If a finding needs a product or design call, raise it with the user instead of guessing.
    - Commit and push any fixes from this pass so the remote branch matches before the PR is created, updated, or shared. Never force push.
 5. If no PR exists, create one with `gh pr create`.

--- a/skills/write-pr/SKILL.md
+++ b/skills/write-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-pr
-description: Reference standards for writing pull request titles and descriptions in the tldraw repository. Use as supporting guidance when another skill or workflow needs PR content standards, not as the user-facing create/update PR workflow.
+description: Reference standards for writing pull request titles and descriptions in the tldraw repository, plus the pre-flight comment sweep over the diff. Use as supporting guidance when another skill or workflow needs PR content standards, not as the user-facing create/update PR workflow.
 ---
 
 # Writing pull requests
@@ -174,6 +174,26 @@ Create a table that includes net LOC changes for each of the following sections.
 ## Related issues
 
 Search for and link relevant issues that this PR addresses.
+
+## The comment sweep
+
+A pre-flight check on the diff, not the description: read the diff's added comments as carefully as its added code, and cut before opening the PR.
+
+```bash
+git diff origin/main...HEAD -U0 | grep -nE '^\+\s*(//|/\*|\*)'
+```
+
+Judge what that prints against **Comments** in the root `AGENTS.md`. That section is the rule and this one does not restate it — one test is worth carrying in your head as you read:
+
+> **A good comment names a failure mode, not a mechanism.**
+
+The mechanism is on screen already. What isn't is what goes wrong without it. A block that only describes what the code does is cuttable in full; a block that says "otherwise X" keeps that sentence and loses the paragraph explaining it twice.
+
+**Expect length, not category, to be the defect.** Most substantial comment blocks that need editing already name a real force — they are the right kind of comment at two or three times the necessary length. So the usual edit is a trim to the load-bearing lines, not a delete.
+
+Leave alone, or trim at most: diagrams, enumerated case lists where the list is the specification, provenance (an issue number, "we tried X and it did Y"), and anything carrying an invariant. In `packages/*`, doc comments on the `@public` surface are the API reference — hold them to the same "says something the code doesn't" bar, but they are a deliverable, not overhead.
+
+Pre-flight rather than post-review because it is cheap now and expensive later. A comment restating its own code reads as padding, costs a review round-trip to remove, and once merged nobody goes back for it. Explaining the change is the PR body's job — the diff is not where that belongs.
 
 ## Human notes (preserve exactly)
 


### PR DESCRIPTION
In order to stop slop comments accumulating in the codebase, this PR writes down what a comment has to earn its place and wires the check into the PR skills, so the standard stops depending on who happens to review the diff. #9824 did the cleanup by hand but never wrote the rule down, so nothing prevents the next branch from re-adding what it removed.

The rules are ported from a colleague's work in our internal repo (tldraw-internal#1324), which hit the same problem from the other direction — an app accumulating library-grade comment density with no published surface to justify it.

### The higher-level change

- A **Comments** section in the root `AGENTS.md`: what to delete on sight (restatement, narration, section banners, `@param` tags that restate the signature, rationale copy-pasted across call sites, call-site lists), what to trim rather than delete, what earns real length (diagrams, enumerated case lists, provenance), and what never to touch (invariants, issue numbers, constants nobody should tune blindly). The one-line litmus: **a good comment names a failure mode, not a mechanism.**
- A **comment sweep** in `write-pr` — the `grep` over the diff's added comment lines, plus how to read what it prints — wired into the `pr` skill's pre-review pass so it runs when a PR is opened and again on every update.

`AGENTS.md` is the only copy of the rules. The skill carries the reading method and points at it, rather than restating it in a second place that drifts.

### Decisions

- **The library/application split is the part adapted for this repo, and it's the part worth reviewing.** In `packages/*`, doc comments on the `@public` surface are a deliverable — they become the API reference on tldraw.dev and land in `api-report.md` — so density there is expected and the sweep should not touch them. In `apps/*` and `templates/*` almost nothing is a published surface, so the same density is pure reading cost. The internal version has no library half; conflating the two is how app code ends up over-commented.
- **Rules in `AGENTS.md`, not in a skill.** They apply to code you write and code you touch, not only to code that's on its way to a PR.
- **The sweep is pre-flight, not post-review.** A comment restating its own code costs a review round-trip to remove, and once merged nobody goes back for it.
- **Dropped one claim from the source.** The internal version states that roughly three quarters of substantial comment blocks already name a real force — a figure measured on that app by a detector that lives in that repo. Asserting it about this codebase would be a fabricated statistic, so the guidance it supports ("expect length, not category, to be the defect") is kept without the number.
- Examples are rewritten in this repo's terms — `getToolbar()`, `editor.deleteShapes()`, arrow bindings, `apps/docs/content/` as the place narrative goes — and the internal version's anecdote about a specific drifted comment is replaced by the general claim it was illustrating.

### Change type

- [x] `other`

### Test plan

Nothing to run: the diff is three markdown files with no code, no generated output, and no schema. `lint-staged` (`oxfmt`) ran clean on all three at commit time.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +55 / -1   |

### Related

- #9824 — the cleanup this codifies
- #9841 — also edits `AGENTS.md`, in the opposite direction (trimming derivable content). No textual conflict: that PR doesn't touch the region this section is inserted into. The two are consistent in spirit — these rules are exactly the kind of thing the tree and `package.json` can't tell you — but whichever lands second will want a rebase.
