### PR TITLE
ci: close superseded release notes PRs

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -59,6 +59,20 @@ jobs:
           git checkout -b "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
 
+      # Recorded before the skill runs so the close step below can tell an
+      # already-open PR from an earlier run apart from the one this run opens.
+      - name: Find open release notes PRs
+        id: existing_prs
+        run: |
+          {
+            echo 'numbers<<PR_LIST_EOF'
+            gh pr list --state open --base main --limit 100 --json number,headRefName \
+              --jq '.[] | select(.headRefName | test("^(release-notes/update-|update-release-notes-)")) | .number'
+            echo 'PR_LIST_EOF'
+          } >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code
 
@@ -106,6 +120,36 @@ jobs:
             --base main \
             --head "${{ steps.branch.outputs.branch_name }}" \
             --label "docs-hotfix-please"
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+
+      # Each run regenerates the notes from scratch, so a PR opened by this run
+      # supersedes any release notes PR left open by an earlier run. The PR may come
+      # from the step above or from the skill itself, so this compares the currently
+      # open PRs against the ones recorded before the skill ran rather than relying on
+      # a single known PR number. When this run opened nothing, the older PR is still
+      # the pending update and is left alone.
+      - name: Close superseded PRs
+        run: |
+          EXISTING="${{ steps.existing_prs.outputs.numbers }}"
+          CURRENT=$(gh pr list --state open --base main --limit 100 --json number,headRefName \
+            --jq '.[] | select(.headRefName | test("^(release-notes/update-|update-release-notes-)")) | .number')
+
+          NEW_PRS=$(comm -13 <(echo "$EXISTING" | sort) <(echo "$CURRENT" | sort))
+          if [ -z "$NEW_PRS" ]; then
+            echo "This run did not open a release notes PR, nothing to supersede"
+            exit 0
+          fi
+
+          # The new PR is already open at this point, so a failure to tidy up an old
+          # one is a warning, not a reason to fail the run.
+          NEWEST=$(echo "$NEW_PRS" | sort -n | tail -n 1)
+          echo "$EXISTING" | while read -r PR; do
+            [ -n "$PR" ] || continue
+            echo "Closing superseded release notes PR #$PR"
+            gh pr close "$PR" --delete-branch --comment "Superseded by #$NEWEST." \
+              || echo "Warning: could not close #$PR"
+          done
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
In order to stop release notes PRs piling up unreviewed, this makes the update-release-notes workflow close the PR left over from its previous run.

The workflow runs on every push to `production`, and each run regenerates `next.mdx` from scratch — so the PR it opens fully supersedes the one before it. Nothing was closing the old ones, so they accumulated (26 have been opened, and the closures so far were all done by hand).

The tricky part is that the PR isn't always opened by the same thing. The workflow has its own `gh pr create` step on a `release-notes/update-*` branch, but the skill also pushes and opens a PR itself on an `update-release-notes-*` branch, and in practice either can be the one that lands. Rather than track a single known PR number, the job records which release-notes PRs are open *before* the skill runs and diffs that against what's open afterwards. Whatever opened the new PR, the older ones get closed with a comment pointing at it.

If a run opens no PR — the notes were already up to date — the existing PR is left alone, since it's still the pending update rather than a superseded one.

### Change type

- [x] `other`

### Test plan

The branch-matching filter was checked against the real PR history (it matches all 26 release-notes PRs across both branch prefixes), and the before/after set diff was exercised over its edge cases: no existing PRs, one and two existing PRs alongside a new one, an existing PR with no new one, nothing open on either side, and existing PRs that disappeared mid-run. Only the supersede cases close anything.

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +44 / -0   |
