### PR TITLE
fix(editor): make development environment detection more accurate

### DIFF
--- a/packages/editor/src/lib/license/LicenseManager.test.ts
+++ b/packages/editor/src/lib/license/LicenseManager.test.ts
@@ -422,6 +422,97 @@ describe('LicenseManager', () => {
 			expect(result.isDomainValid).toBe(true)
 		})
 
+		it('Is not development mode on a custom protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://app/index.html')
+
+				const nativeLicenseInfo = JSON.parse(STANDARD_LICENSE_INFO)
+				nativeLicenseInfo[PROPERTIES.FLAGS] = FLAGS.NATIVE_LICENSE
+				nativeLicenseInfo[PROPERTIES.HOSTS] = ['app-bundle:']
+				const nativeLicenseKey = await generateLicenseKey(
+					JSON.stringify(nativeLicenseInfo),
+					keyPair
+				)
+				const nativeLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await nativeLicenseManager.getLicenseFromKey(
+					nativeLicenseKey
+				)) as ValidLicenseKeyResult
+				expect(result).toMatchObject({
+					isLicenseParseable: true,
+					isNativeLicense: true,
+					isDomainValid: true,
+					isDevelopment: false,
+				})
+				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe('licensed')
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Validates the domain on a custom protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://app/index.html')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const customProtocolLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await customProtocolLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result).toMatchObject({ isDomainValid: false, isDevelopment: false })
+				expect(getLicenseState(result, () => {}, result.isDevelopment)).toBe(
+					'unlicensed-production'
+				)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Is development mode over http on a non-loopback host', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('http://www.example.com')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const httpLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await httpLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(true)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
+		it('Is development mode on a loopback host regardless of protocol', async () => {
+			process.env.NODE_ENV = 'production'
+			try {
+				// @ts-ignore
+				delete window.location
+				// @ts-ignore
+				window.location = new URL('app-bundle://localhost/index.html')
+
+				const licenseKey = await generateLicenseKey(STANDARD_LICENSE_INFO, keyPair)
+				const loopbackLicenseManager = new LicenseManager('', keyPair.publicKey)
+				const result = (await loopbackLicenseManager.getLicenseFromKey(
+					licenseKey
+				)) as ValidLicenseKeyResult
+				expect(result.isDevelopment).toBe(true)
+			} finally {
+				process.env.NODE_ENV = 'test'
+			}
+		})
+
 		it('Fails if it is a native app with the wrong protocol', async () => {
 			// @ts-ignore
 			delete window.location

--- a/packages/editor/src/lib/license/LicenseManager.ts
+++ b/packages/editor/src/lib/license/LicenseManager.ts
@@ -174,9 +174,8 @@ export class LicenseManager {
 	}
 
 	private getIsDevelopment() {
-		// If we are using https on a non-loopback domain we assume it's a production env and a development one otherwise
 		return (
-			!['https:', 'vscode-webview:'].includes(window.location.protocol) ||
+			window.location.protocol === 'http:' ||
 			this.isLoopbackHost(window.location.hostname) ||
 			process.env.NODE_ENV !== 'production'
 		)


### PR DESCRIPTION
In order for native apps to be licensed the same way as any other production deployment, this makes `LicenseManager`'s development-environment detection more accurate.

Previously the check keyed off the URL protocol: anything other than `https:` or `vscode-webview:` was assumed to be development. Native apps serve their bundle from a custom protocol (e.g. `app-bundle://app/index.html`), so a shipped native app never matched, and the `NATIVE_LICENSE` flag and its host patterns had no real effect.

Environment detection now names the development cases directly — `http:`, a loopback host, or a build where `NODE_ENV` isn't `production` — instead of inferring them from everything that isn't `https:`. `http:` keeps its existing development behavior; the change is that custom protocols are treated like any other production deployment, so the existing native-license host matching in `isDomainValid` does the work it was always meant to do. This also removes the need to know whether a license is native before classifying the environment.

One consequence worth flagging for review: native apps must register their custom scheme as a secure context for `crypto.subtle` to be available, otherwise signature verification can't run. In Electron that's `protocol.registerSchemesAsPrivileged([{ scheme: 'app-bundle', privileges: { standard: true, secure: true } }])`.

### Change type

- [x] `bugfix`

### Test plan

1. Build a native app on a custom protocol registered as a secure context, with a `NATIVE_LICENSE` key whose host patterns match the app's URL, and confirm it resolves to `licensed` with features gated by the license flags.
2. Confirm a key whose hosts don't match the app's URL resolves to `unlicensed-production`.
3. Confirm a local development build (http, a loopback host, or a non-production build) is unaffected.

- [x] Unit tests
- [ ] End to end tests

### Release notes

- Fix license validation treating native apps served from custom protocols as development environments.

### Code changes

| Section   | LOC change |
| --------- | ---------- |
| Core code | +1 / -2    |
| Tests     | +91 / -0   |

