### PR TITLE
[wip] fix(mcp-app): skip the isolate abort on session teardown

### DIFF
--- a/apps/mcp-app/package.json
+++ b/apps/mcp-app/package.json
@@ -37,6 +37,7 @@
 		"typescript": "^5.8.3",
 		"vite": "^8.0.16",
 		"vite-plugin-singlefile": "^2.3.2",
+		"vitest": "^4.1.7",
 		"wrangler": "^4.75.0"
 	}
 }

--- a/apps/mcp-app/src/agents-canary.test.ts
+++ b/apps/mcp-app/src/agents-canary.test.ts
@@ -10,15 +10,22 @@ const agentsDist = readFileSync(require.resolve('agents'), 'utf8')
 const mcpDist = readFileSync(require.resolve('agents/mcp'), 'utf8')
 
 describe('agents SDK assumptions behind the destroy() override', () => {
-	it('has exactly one ctx.abort("destroyed") call site (the one the override defuses)', () => {
+	it('has exactly one ctx.abort("destroyed") call site, inside destroy() (the one the override defuses)', () => {
 		expect(agentsDist.match(/ctx\.abort\("destroyed"\)/g)).toHaveLength(1)
+		const abortIndex = agentsDist.indexOf('ctx.abort("destroyed")')
+		const enclosingDestroy = agentsDist.lastIndexOf('async destroy()', abortIndex)
+		expect(enclosingDestroy).toBeGreaterThan(-1)
+		expect(abortIndex - enclosingDestroy).toBeLessThan(2000)
 	})
 
 	it('still defers session teardown via the condemned-marker alarm', () => {
 		expect(mcpDist).toContain('_cf_scheduleDestroy')
 	})
 
-	it('still routes initialize retries through setInitializeRequest (the fail-closed guard target)', () => {
-		expect(mcpDist).toContain('setInitializeRequest')
+	it('still rejects initialize requests that carry a session id before any DO lookup', () => {
+		// This router gate is why a condemned instance cannot be revived by an
+		// initialize retry; if it disappears, TldrawMCP needs a guard again.
+		expect(mcpDist).toContain('Initialization requests must not include a sessionId')
+		expect(mcpDist).toContain('await agent.setInitializeRequest(')
 	})
 })

--- a/apps/mcp-app/src/agents-canary.test.ts
+++ b/apps/mcp-app/src/agents-canary.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'fs'
+import { createRequire } from 'module'
+import { describe, expect, it } from 'vitest'
+
+// The TldrawMCP.destroy() override in worker.ts skips the SDK's isolate abort
+// and takes over its side effects. That is only sound while the SDK keeps the
+// shape asserted here; a bump that moves this path must re-audit the override.
+const require = createRequire(import.meta.url)
+const agentsDist = readFileSync(require.resolve('agents'), 'utf8')
+const mcpDist = readFileSync(require.resolve('agents/mcp'), 'utf8')
+
+describe('agents SDK assumptions behind the destroy() override', () => {
+	it('has exactly one ctx.abort("destroyed") call site (the one the override defuses)', () => {
+		expect(agentsDist.match(/ctx\.abort\("destroyed"\)/g)).toHaveLength(1)
+	})
+
+	it('still defers session teardown via the condemned-marker alarm', () => {
+		expect(mcpDist).toContain('_cf_scheduleDestroy')
+	})
+
+	it('still routes initialize retries through setInitializeRequest (the fail-closed guard target)', () => {
+		expect(mcpDist).toContain('setInitializeRequest')
+	})
+})

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -230,6 +230,16 @@ export class TldrawMCP extends McpAgent<Env> {
 		})
 	}
 
+	// The SDK ends destroy() by force-aborting the isolate; workerd attributes
+	// that abort to the surrounding invocation and logs an error-level
+	// "destroyed" event on every session teardown. The abort is redundant:
+	// storage is already wiped, so the idle instance evicts on its own.
+	override async destroy() {
+		this.ctx.abort = () => {}
+		this.logger.info('destroy: teardown with isolate abort skipped')
+		await super.destroy()
+	}
+
 	// --- Checkpoint helpers ---
 
 	saveCheckpoint(id: string, shapes: unknown[], assets: unknown[] = [], bindings: unknown[] = []) {

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -233,44 +233,46 @@ export class TldrawMCP extends McpAgent<Env> {
 	// The SDK ends destroy() by force-aborting the isolate; workerd attributes
 	// that abort to the surrounding invocation and logs an error-level
 	// "destroyed" event on every session teardown. Skipping the abort means we
-	// must take over its other jobs ourselves: sever live connections (or a
-	// client-held stream's keepalive pins the wiped DO awake, and a retained
-	// socket can wake it later and re-run init()), and fail closed while the
-	// condemned instance lingers until eviction (see the overrides below).
+	// must take over its other job ourselves: severing live connections —
+	// otherwise a client-held stream's keepalive pins the wiped DO awake, and
+	// a retained socket can wake it later and re-run init().
 	private selfDestroyed = false
+	private sessionEndSent = false
 
 	override async destroy() {
-		const firstEntry = !this.selfDestroyed
 		this.selfDestroyed = true
 		const abort = this.ctx.abort.bind(this.ctx)
 		this.ctx.abort = (reason?: string) => {
 			if (reason !== 'destroyed') abort(reason)
 		}
 		for (const conn of this.getConnections()) {
-			conn.close(1000, 'session destroyed')
+			// close() throws synchronously on an already-closing socket
+			// (partyserver guards its own closes the same way); a throw here
+			// would wedge teardown before the storage wipe.
+			try {
+				conn.close(1000, 'Session closed')
+			} catch {
+				// already closing/closed
+			}
 		}
 		await super.destroy()
-		if (firstEntry) {
+		if (!this.sessionEndSent) {
+			// After an interrupted-teardown resume this runs before init()
+			// hydrates sessionId, so fall back to the DO routing name.
+			this.sessionEndSent = true
 			this.env.MCP_ANALYTICS?.writeDataPoint({
-				blobs: ['session_end', this.sessionId],
+				blobs: ['session_end', this.sessionId || this.getMcpSessionId() || 'unknown'],
 				doubles: [Date.now()],
 			})
 		}
 		this.logger.info('destroy: teardown complete, isolate abort skipped')
 	}
 
-	// The router's initialize branch skips its session-exists gate, so a client
-	// retrying initialize with a cached session id can land on this condemned
-	// instance, whose one-time init() will not re-run against the dropped
-	// tables. Rejecting here makes the host fall back to a fresh sessionless
-	// initialize, which mints a working session on a new DO.
-	override async setInitializeRequest(
-		initializeRequest: Parameters<McpAgent['setInitializeRequest']>[0]
-	) {
-		if (this.selfDestroyed) throw new Error('session destroyed')
-		return super.setInitializeRequest(initializeRequest)
-	}
-
+	// Belt-and-braces for the eviction window: the router 404s dead sessions
+	// from storage before entering the DO, so this should be unreachable — if
+	// it is ever hit, the router surfaces it as a 500, which is still better
+	// than serving requests from a condemned instance whose one-time init()
+	// will not re-run against the dropped tables.
 	override async fetch(request: Request) {
 		if (this.selfDestroyed) return new Response('Session destroyed', { status: 404 })
 		return super.fetch(request)

--- a/apps/mcp-app/src/worker.ts
+++ b/apps/mcp-app/src/worker.ts
@@ -232,12 +232,48 @@ export class TldrawMCP extends McpAgent<Env> {
 
 	// The SDK ends destroy() by force-aborting the isolate; workerd attributes
 	// that abort to the surrounding invocation and logs an error-level
-	// "destroyed" event on every session teardown. The abort is redundant:
-	// storage is already wiped, so the idle instance evicts on its own.
+	// "destroyed" event on every session teardown. Skipping the abort means we
+	// must take over its other jobs ourselves: sever live connections (or a
+	// client-held stream's keepalive pins the wiped DO awake, and a retained
+	// socket can wake it later and re-run init()), and fail closed while the
+	// condemned instance lingers until eviction (see the overrides below).
+	private selfDestroyed = false
+
 	override async destroy() {
-		this.ctx.abort = () => {}
-		this.logger.info('destroy: teardown with isolate abort skipped')
+		const firstEntry = !this.selfDestroyed
+		this.selfDestroyed = true
+		const abort = this.ctx.abort.bind(this.ctx)
+		this.ctx.abort = (reason?: string) => {
+			if (reason !== 'destroyed') abort(reason)
+		}
+		for (const conn of this.getConnections()) {
+			conn.close(1000, 'session destroyed')
+		}
 		await super.destroy()
+		if (firstEntry) {
+			this.env.MCP_ANALYTICS?.writeDataPoint({
+				blobs: ['session_end', this.sessionId],
+				doubles: [Date.now()],
+			})
+		}
+		this.logger.info('destroy: teardown complete, isolate abort skipped')
+	}
+
+	// The router's initialize branch skips its session-exists gate, so a client
+	// retrying initialize with a cached session id can land on this condemned
+	// instance, whose one-time init() will not re-run against the dropped
+	// tables. Rejecting here makes the host fall back to a fresh sessionless
+	// initialize, which mints a working session on a new DO.
+	override async setInitializeRequest(
+		initializeRequest: Parameters<McpAgent['setInitializeRequest']>[0]
+	) {
+		if (this.selfDestroyed) throw new Error('session destroyed')
+		return super.setInitializeRequest(initializeRequest)
+	}
+
+	override async fetch(request: Request) {
+		if (this.selfDestroyed) return new Response('Session destroyed', { status: 404 })
+		return super.fetch(request)
 	}
 
 	// --- Checkpoint helpers ---

--- a/apps/mcp-app/tsconfig.json
+++ b/apps/mcp-app/tsconfig.json
@@ -13,7 +13,7 @@
 		"lib": ["ES2022", "DOM", "DOM.Iterable"],
 		"types": ["vite/client"]
 	},
-	"include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"],
+	"include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "vitest.config.ts"],
 	"exclude": ["node_modules", "dist"],
 	"references": [
 		{

--- a/apps/mcp-app/vitest.config.ts
+++ b/apps/mcp-app/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+// The vite config sets `root: 'src/widget'` for the singlefile widget build,
+// which would scope test discovery to the widget directory. Tests live across
+// `src/`, so give vitest its own config.
+export default defineConfig({
+	test: {
+		include: ['src/**/*.test.ts'],
+	},
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -24863,6 +24863,7 @@ __metadata:
     typescript: "npm:^5.8.3"
     vite: "npm:^8.0.16"
     vite-plugin-singlefile: "npm:^2.3.2"
+    vitest: "npm:^4.1.7"
     wrangler: "npm:^4.75.0"
     zod: "npm:^4.1.8"
   languageName: unknown


### PR DESCRIPTION
In order to stop every MCP session teardown from logging an error, this PR overrides `destroy()` in the `TldrawMCP` durable object to skip the SDK's isolate abort — and explicitly replaces the abort's other jobs so nothing regresses.

The `agents` SDK ends `Agent.destroy()` with `setTimeout(() => ctx.abort("destroyed"), 0)`. workerd attributes that abort to the surrounding invocation, so observability records an error-level `destroyed` event (fingerprint `ccc4dcd4ab1a221c784775fb1461b3b7`) on every teardown — ~1,600/hour of noise that drowns real errors. #10010 (agents 0.19.0) moved teardown off the session-DELETE request onto the DO's own alarm, which fixed the `origin: rpc` variant but re-surfaced the same event as `origin: alarm`. Upstream has no fix or report: the latest published `agents@0.20.1` still ends `destroy()` with the same abort, and the only related upstream work is cloudflare/agents#1745 (the deferral we already run).

The abort was doing three real things besides making noise, and the override takes over each one. It severed live connections — without that, a client-held notification stream's 30s SSE keepalive pins the wiped DO awake indefinitely, and a retained socket can wake the evicted DO later and re-run `init()`, minting a ghost session — so the override closes every connection before teardown. It guaranteed a dead instance — the router's initialize branch skips its session-exists gate, so a client retrying `initialize` with a cached session id could land on the condemned instance whose one-time `init()` never re-runs against dropped tables — so a `selfDestroyed` flag fails `setInitializeRequest` and `fetch` closed during the eviction window, pushing hosts to a fresh sessionless initialize that mints a working session (in local verification the transport already 400s such retries before reaching the guard; the guard covers ordering variants and the legacy SSE path). And it was the only prod-visible teardown signal — so a `session_end` analytics datapoint replaces it, without adding log volume (#9938). The abort stub is scoped to the `"destroyed"` reason so genuine aborts still work, and a canary test pins the SDK assumptions (single `ctx.abort("destroyed")` call site, condemned-marker teardown, `setInitializeRequest` routing) so an `agents` bump that moves this path fails CI loudly instead of silently un-fixing prod.

Verified against `wrangler dev`: session DELETE returns 204 and the id is invalid (404) after the deferred teardown; a GET notification stream held across DELETE is closed within ~2s (previously stayed open until the client gave up); an initialize retry with the dead session id fails cleanly and a follow-up sessionless initialize mints a working session; the `ctx.abort` reassignment sticks in workerd. Known non-goal: a tool call in flight at the exact teardown moment can see `no such table` for a few seconds until eviction — before this change the abort killed such calls mid-flight anyway.

Deploy acceptance check: the `destroyed` fingerprint flatlines in Workers observability while teardowns keep succeeding, `session_end` datapoints appear at roughly the `session_start` rate for polite teardowns, and DO duration stays roughly flat.

### Change type

- [x] `bugfix`

### Test plan

1. `cd apps/mcp-app && yarn test run src/agents-canary.test.ts` — SDK-assumption canary
2. `npx wrangler dev`, then: POST `initialize` → DELETE with the session id → 204; `tools/list` with the same id after ~2s → 404
3. Hold `curl -N /mcp` (GET, `Accept: text/event-stream`) open across the DELETE — the stream closes within ~2s of the teardown alarm
4. POST `initialize` again with the dead session id — clean 4xx, and a sessionless `initialize` right after mints a new working session