### PR TITLE
fix(ci): run checks on release notes PRs

### DIFF
--- a/.github/workflows/update-release-notes.yml
+++ b/.github/workflows/update-release-notes.yml
@@ -5,9 +5,8 @@ on:
   # draft GitHub release synced by the skill) in step with each dotcom release —
   # the same production push that deploys dotcom and publishes the `next` package.
   # Production only: a push to main must not trigger a notes run on every merge.
-  # Release-notes commits carry `[skip ci]`, so a notes-only push does not re-trigger
-  # this workflow, and the job only ever opens a PR against main (it never pushes to
-  # production), so there is no deploy loop.
+  # Release-notes PR titles carry `[skip ci]` so their squash-merge commits skip main
+  # push workflows. Branch commits omit the marker so required PR checks run.
   push:
     branches:
       - production
@@ -103,7 +102,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         run: |
           gh pr create \
-            --title "docs: update release notes" \
+            --title "docs(releases): update release notes [skip ci]" \
             --body "$(cat <<'EOF'
           In order to keep the release notes up to date, this PR adds entries for PRs merged since the last update.
 

--- a/skills/update-release-notes/SKILL.md
+++ b/skills/update-release-notes/SKILL.md
@@ -176,14 +176,14 @@ Run this after every `next.mdx` update, including the release-week runs. On the 
 
 ### 10. Push changes
 
-After editing `next.mdx` (and any archive files), commit and push from the tldraw clone. Use a single commit whose message ends with `[skip ci]` so merging the change does not trigger a dotcom deploy or other push- and pull_request-triggered workflows (release-notes edits are docs-only):
+After editing `next.mdx` (and any archive files), commit and push from the tldraw clone. Do not add `[skip ci]` to the branch commit: required pull request checks will never start when the marker is present. The PR title below adds the marker to the eventual squash-merge commit instead.
 
 ```bash
 cd /tmp/tldraw
 BRANCH="update-release-notes-$(date -u +%Y%m%d-%H%M)"
 git checkout -b "$BRANCH"
 git add apps/docs/content/releases/
-git commit -m "docs(releases): update release notes [skip ci]"
+git commit -m "docs(releases): update release notes"
 git push -u origin "$BRANCH"
 ```
 
@@ -197,7 +197,7 @@ Then create the PR using the `../pr/SKILL.md` workflow and the standards in `../
 - **Description paragraph**: Start with "In order to..." and mention the source (`main` or `production`) and what was updated (new entries added, stale entries pruned, archival performed, draft GitHub release synced, etc.)
 - Include a **Code changes** table with a `Documentation` row
 
-**Why `[skip ci]`**: pushing to `production` (and the `hotfixes` → `production` promotion) triggers `deploy-dotcom.yml`. A merge commit containing `[skip ci]` is skipped by GitHub Actions entirely, so the release-notes change can land on `production` — ready to ride the next SDK release, which pushes the `production` ref to `docs-production` — without deploying tldraw.com.
+**Why `[skip ci]` is only in the PR title**: branch commits need to run the required pull request checks. GitHub's squash merge uses the PR title for the merge commit, so the marker skips push workflows when the notes-only change lands on `main`.
 
 `[skip ci]` does not interfere with the `docs-hotfix-please` label: `trigger-sdk-hotfix.yml` runs on `pull_request_target`, which GitHub's skip-ci markers do not affect, and the hotfix script strips skip-ci markers from the cherry-picked commit so the release-branch push still triggers the publish workflow. The trigger fires when a labeled PR is merged; to re-trigger it later, remove and re-add the label on the merged PR.
 


### PR DESCRIPTION
In order to prevent automated release notes PRs such as #10029 from waiting indefinitely for required checks, this PR removes `[skip ci]` from their branch commit while keeping it in the PR title used for the squash-merge commit. The workflow fallback now uses the same marked PR title.

### Change type

- [x] `bugfix`

### Test plan

- [ ] Unit tests
- [ ] End to end tests

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +6 / -7    |
