### PR TITLE
docs: review and correct the SDK features and docs guides

### DIFF
--- a/apps/docs/content/docs/ai.mdx
+++ b/apps/docs/content/docs/ai.mdx
@@ -13,15 +13,9 @@ keywords:
   - generative
 ---
 
-The tldraw SDK provides a foundation for AI-powered canvas applications. You can use language models to read, interpret, and generate content on the canvas—either by driving the editor APIs directly, or by building reactive systems where AI participates in visual workflows.
+You can use language models to read the tldraw canvas and to create shapes on it. This page covers three patterns for doing that: using the canvas as an output surface for generated content, building visual workflows where AI models are nodes in a graph, and giving an agent direct control of the editor. It also covers exporting canvas content so a model can read it.
 
-## Approaches
-
-There are three main patterns for integrating AI with tldraw:
-
-1. **Canvas as output** — Use the canvas to display AI-generated content like images, diagrams, or interactive websites
-2. **Visual workflows** — Use shapes and bindings to create node-based systems where AI models participate in data flows
-3. **AI agents** — Give language models direct access to read and manipulate the canvas through the editor APIs
+If you're feeding the docs themselves to a model, see [LLM documentation](/docs/llm-docs). To turn model-generated diagram text into shapes, see [Mermaid diagrams](/docs/mermaid). To let an agent simulate user input instead of calling editor methods, see [Driving the editor](/docs/driver).
 
 ## Canvas as output
 
@@ -32,7 +26,6 @@ The simplest AI integration uses the canvas as a surface for displaying generate
 Use the [EmbedShapeUtil](?) to display websites, or create custom shapes to render generated images and HTML content:
 
 ```tsx
-// Create a shape to display AI-generated content
 editor.createShape({
 	type: 'embed',
 	x: 100,
@@ -44,6 +37,8 @@ editor.createShape({
 	},
 })
 ```
+
+Embeds from hosts that aren't in the util's embed definitions render in a restricted sandbox. To allow a host of your own, use `EmbedShapeUtil.configure({ embedDefinitions })`. For content you generate yourself, a custom shape (below) is usually the better fit.
 
 For generated images, use the [AssetRecordType](?) to create an asset from a blob or URL, then create an image shape:
 
@@ -79,7 +74,10 @@ editor.createShape({
 For richer AI output, create a custom shape that renders generated content. This approach works well for live HTML previews, interactive prototypes, or any content that needs special rendering:
 
 ```tsx
-// Abbreviated example—a full ShapeUtil also requires getDefaultProps, getGeometry, and getIndicatorPath
+import { HTMLContainer, ShapeUtil } from 'tldraw'
+
+// Abbreviated: a full ShapeUtil also needs getDefaultProps, getGeometry, and
+// getIndicatorPath. See the Shapes docs for a complete custom shape.
 class PreviewShapeUtil extends ShapeUtil<PreviewShape> {
 	static override type = 'preview' as const
 
@@ -97,7 +95,7 @@ class PreviewShapeUtil extends ShapeUtil<PreviewShape> {
 }
 ```
 
-This pattern is useful for "make real" style applications where users sketch a UI and an AI model generates working code to preview alongside the original drawing.
+This pattern is useful for "make real" style applications where users sketch a UI and an AI model generates working code to preview alongside the original drawing. See [Shapes](/docs/shapes) for how to write the rest of the util.
 
 ## Visual workflows
 
@@ -119,7 +117,8 @@ See the [Workflow starter kit](/starter-kits/workflow) for a complete implementa
 To add AI capabilities to a workflow, create node types that call AI models:
 
 ```tsx
-// Illustrative pseudocode—see the workflow starter kit for the full NodeDefinition interface
+// Abbreviated: a real NodeDefinition also declares a validator, ports, a default
+// value, and a body height. See the workflow starter kit for the full interface.
 class LLMNode extends NodeDefinition<LLMNodeData> {
 	static type = 'llm'
 
@@ -134,7 +133,7 @@ class LLMNode extends NodeDefinition<LLMNodeData> {
 }
 ```
 
-Workflow systems let users compose AI operations visually. They connect prompt sources to models, route outputs to other processing steps, and build complex pipelines without writing code. This is similar to tools like ComfyUI for image generation workflows but uses the tldraw canvas as a foundation.
+Workflow systems let users compose AI operations visually: connect a prompt source to a model, route its output to other steps, and build a pipeline without writing code.
 
 ## AI agents
 
@@ -142,14 +141,14 @@ For full canvas control, you can give AI models direct access to read and manipu
 
 ### Agent architecture
 
-The [Agent starter kit](/starter-kits/agent) provides a complete implementation. The agent gathers visual context through screenshots and structured shape data. This gives the model an understanding of the current canvas state. The agent operates through a modular action system with utilities for creating shapes, drawing, and arranging elements. Responses stream in real-time so users see the agent's work as it happens. A memory system maintains conversation history and context across interactions.
+The [Agent starter kit](/starter-kits/agent) is a complete implementation. The agent gathers context from screenshots and structured shape data, applies the model's responses through a set of typed actions, and streams results onto the canvas as they arrive. Chat history carries across prompts.
 
 ### Using the agent programmatically
 
 The agent exposes a simple API for triggering canvas operations:
 
 ```tsx
-// Inside a component wrapped by TldrawAgentAppProvider
+// Inside a component wrapped by the starter kit's TldrawAgentAppProvider
 const agent = useAgent()
 
 // Simple prompt
@@ -172,27 +171,27 @@ The agent builds context from multiple sources:
 - The user's current selection and recent actions
 - Conversation history from the session
 
-This dual approach—visual screenshots plus structured data—gives the model both spatial understanding and precise information about shape properties.
-
 ### How agents manipulate the canvas
 
 Agents perform operations through typed action schemas. Each action has a defined structure, and the agent system validates, sanitizes, and applies actions to the editor:
 
 ```tsx
-// Simplified illustration—the actual implementation converts through an intermediate
-// shape format. See CreateActionUtil in the agent starter kit for the full code.
+// Abbreviated from CreateActionUtil in the agent starter kit. The model describes
+// shapes in a simplified format that the util converts to a real shape record.
 class CreateActionUtil extends AgentActionUtil<CreateAction> {
 	override applyAction(action: Streaming<CreateAction>, helpers: AgentHelpers) {
-		if (!action.complete) return
+		const { shape } = action
+		if (!shape || !shape._type) return
 
-		const position = helpers.removeOffsetFromVec({ x: action.x, y: action.y })
-
-		this.editor.createShape({
-			type: action.shapeType,
-			x: position.x,
-			y: position.y,
-			props: action.props,
+		// Translate from the model's coordinate space back to the page
+		const shapePartial = helpers.removeOffsetFromShapePartial(shape)
+		const result = convertPartialFocusedShapeToTldrawShape(this.editor, shapePartial, {
+			defaultShape: getDefaultShape(shape._type, action.complete),
+			complete: action.complete,
 		})
+		if (!result.shape) return
+
+		this.editor.createShape(result.shape)
 	}
 }
 ```
@@ -214,7 +213,7 @@ const { blob } = await editor.toImage(editor.getCurrentPageShapes(), { format: '
 
 ### Structured data
 
-Access shape data directly from the store for text extraction or structured analysis. Use [ShapeUtil#getText](?) to extract a shape's text content as a plain string:
+Access shape data directly from the store for text extraction or structured analysis. Use [ShapeUtil#getText](?) to extract a shape's text content as a plain string. It returns `undefined` for shapes with no text:
 
 ```tsx
 const shapes = editor.getCurrentPageShapes()
@@ -227,9 +226,7 @@ const textContent = shapes.map((shape) => ({
 }))
 ```
 
-### Combining approaches
-
-For best results, send both visual and structured data to the model. The visual representation shows spatial relationships and styling, while the structured data provides exact values for text and positions.
+Sending both to the model works best: the image shows spatial relationships and styling, and the structured data gives exact text and positions.
 
 ## Starter kits
 
@@ -244,8 +241,9 @@ We provide several starter kits for AI integrations:
 
 ## Related
 
-- [Agent starter kit](/starter-kits/agent) — Complete AI agent implementation
-- [Workflow starter kit](/starter-kits/workflow) — Visual programming with node graphs
+- [LLM documentation](/docs/llm-docs) — Feeding the tldraw docs to a model
+- [Mermaid diagrams](/docs/mermaid) — Turning diagram text into shapes
+- [Driving the editor](/docs/driver) — Simulating user input programmatically
 - [Shapes](/docs/shapes) — Creating custom shapes for AI-generated content
 - [Bindings](/sdk-features/bindings) — Connecting shapes for workflow systems
 - [Image export](/sdk-features/image-export) — Exporting canvas content for AI analysis

--- a/apps/docs/content/docs/assets.mdx
+++ b/apps/docs/content/docs/assets.mdx
@@ -19,16 +19,45 @@ For the complete guide to working with assets, see the [Assets](/sdk-features/as
 
 ## Default storage behavior
 
-[`TLAssetStore`](?) controls how assets are stored and retrieved. The default behavior depends on your store setup:
+[TLAssetStore](?) controls how assets are uploaded and resolved. The default depends on your store setup:
 
-- **In-memory only** (default): [`inlineBase64AssetStore`](?) converts images to data URLs
-- **With [`persistenceKey`](/sdk-features/persistence)**: Assets are stored in the browser's [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API)
-- **With a [sync server](/docs/sync)**: Implement `TLAssetStore` to upload to a storage service like S3
+| Setup                                         | Asset store                                  | Where files go                                                                            |
+| --------------------------------------------- | -------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| In-memory only (default)                      | [inlineBase64AssetStore](?)                  | Data URLs inside the document                                                             |
+| [`persistenceKey`](/sdk-features/persistence) | Built in, overridable with the `assets` prop | The browser's [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) |
+| [Sync server](/docs/sync)                     | Your own `TLAssetStore`, passed to `useSync` | A storage service like S3 or R2                                                           |
+
+To use your own storage, implement `upload` and `resolve` and pass the store to `<Tldraw>` (or to `useSync`):
+
+```tsx
+import { Tldraw, TLAssetStore } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+const myAssetStore: TLAssetStore = {
+	async upload(asset, file) {
+		const url = await uploadToMyServer(file)
+		return { src: url }
+	},
+	resolve(asset) {
+		return asset.props.src
+	},
+}
+
+export default function App() {
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw assets={myAssetStore} />
+		</div>
+	)
+}
+```
+
+`resolve` also receives a [TLAssetContext](?) with the current screen scale and DPR, so you can serve a resized image instead of the original. Pasted and dropped files go through the [external content](/sdk-features/external-content) handlers before they become assets.
 
 ## Examples
 
-- [Using hosted images](/examples/data/assets/hosted-images)
-- [Customizing default asset options](/examples/configuration/asset-props)
-- [Handling pasted/dropped external content](/examples/data/assets/external-content-sources)
-- [Simple asset store with server upload](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/client/App.tsx)
-- [Asset store with image optimization](https://github.com/tldraw/tldraw/blob/main/packages/sync/src/useSyncDemo.ts#L178-L256)
+- [Using hosted images](/examples/data/assets/hosted-images) — Reference images by URL without uploading them
+- [Customizing default asset options](/examples/configuration/asset-props) — Size and dimension limits for uploaded assets
+- [Handling pasted/dropped external content](/examples/data/assets/external-content-sources) — Turn pasted content into assets
+- [Simple asset store with server upload](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/client/App.tsx) — Upload files to a Node server
+- [Asset store with image optimization](https://github.com/tldraw/tldraw/blob/main/packages/sync/src/useSyncDemo.ts) — The demo server's `createDemoAssetStore`, which resolves resized images

--- a/apps/docs/content/docs/collaboration.mdx
+++ b/apps/docs/content/docs/collaboration.mdx
@@ -34,20 +34,25 @@ npm install @tldraw/sync
 ```tsx
 import { Tldraw } from 'tldraw'
 import { useSyncDemo } from '@tldraw/sync'
+import 'tldraw/tldraw.css'
 
-function MyApp() {
-	const store = useSyncDemo({ roomId: 'my-unique-room-id' })
-	return <Tldraw store={store} />
+export default function App() {
+	const store = useSyncDemo({ roomId: 'my-company-my-unique-room-id' })
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw store={store} />
+		</div>
+	)
 }
 ```
 
-Any apps connecting to the same room ID will enter a shared collaboration session. Open your project in an incognito window or different browser to test it out.
+Any apps connecting to the same room ID will enter a shared collaboration session. The room ID namespace is shared by everyone using the demo server, so prefix it with your company or project name. Open your project in an incognito window or different browser to test it out.
 
-The demo server is great for prototyping, but data only lasts 24 hours and rooms are publicly accessible. For production, you'll need to self-host the tldraw sync server—see our full guide on [tldraw sync](/docs/sync).
+The demo server is great for prototyping, but data is deleted after about a day and rooms are publicly accessible. For production, you'll need to self-host the tldraw sync server. See our full guide on [tldraw sync](/docs/sync).
 
 ## Comments
 
-Collaborators can also leave anchored comments on the canvas. The `@tldraw/commenting` package provides a comment tool, pins that stick to points and shapes, thread popovers with replies, mentions, reactions, and resolve, and a sidebar list of threads.
+Collaborators can also leave anchored comments on the canvas. The `@tldraw/commenting` package provides a comment tool and pins that stick to points and shapes. Each pin opens a thread popover with replies, mentions, reactions, and resolving, and a sidebar lists every thread.
 
 ```tsx
 import {
@@ -89,24 +94,12 @@ function MyApp() {
 }
 ```
 
-Comment records are opt-in, so register `commentSchemaRecords` on your server's schema too. Commenting is a licensed feature. See [Commenting](/docs/commenting) for an introduction, or the [full guide](/sdk-features/commenting) for anchors, options, and server setup.
+Comment records are opt-in, so register `commentSchemaRecords` on your server's schema too, and list the comment record types in the room's `objectTypes` (see [Comments and the object-store lane](/docs/sync#comments-and-the-object-store-lane)). Commenting is a licensed feature. See the [commenting overview](/docs/commenting) for an introduction, or the [commenting reference](/sdk-features/commenting) for anchors, options, and server setup.
 
 ## Using other backends
 
 While [tldraw sync](/docs/sync) is our recommended solution, the tldraw SDK works with any real-time data backend. For example, [Liveblocks offers a tldraw integration](https://liveblocks.io/examples/tldraw-whiteboard), and many teams have connected tldraw to their own infrastructure.
 
-Collaboration involves three concerns:
+A custom backend has to handle a few things. Document changes need to get in and out of the [store](/sdk-features/store); see [Persistence](/docs/persistence) for the basics and the [collaboration deep dive](/sdk-features/collaboration) for building custom sync. Presence (cursor positions, selections, viewports) is shared through presence records, covered in the same deep dive; [Cursors](/sdk-features/cursors) explains how to customize collaborator cursors, and [User following](/sdk-features/user-following) covers tracking another user's viewport.
 
-- **Synchronizing data** — Getting document changes in and out of the [store](/sdk-features/store). See [Persistence](/docs/persistence) for the basics, or [Collaboration](/sdk-features/collaboration) for building custom sync.
-- **User presence** — Sharing cursor positions, selections, and viewports with other users. See [Collaboration](/sdk-features/collaboration) for presence APIs and [Cursors](/sdk-features/cursors) for customizing how collaborator cursors appear.
-- **Collaboration UI** — The visual elements that show other users on the canvas. See [UI components](/sdk-features/ui-components) for overriding components like `SharePanel`. The [OverlayUtil](?) system renders collaborator cursors, brushes, scribbles, and selection indicators—see [Overlay utils](/sdk-features/overlay-utils).
-
-## Related
-
-- [tldraw sync](/docs/sync) — Our recommended multiplayer solution
-- [Collaboration](/sdk-features/collaboration) — Deep dive on presence, sync hooks, and building custom sync
-- [Commenting](/docs/commenting) — Anchored comment threads on the canvas
-- [Cursors](/sdk-features/cursors) — Cursor types and collaborator cursor customization
-- [User following](/sdk-features/user-following) — Track collaborator viewports in real-time
-- [Store](/sdk-features/store) — Understanding the reactive store
-- [UI components](/sdk-features/ui-components) — Override collaboration UI components
+The visual side is handled by the default UI. Override components like `SharePanel` through [UI components](/sdk-features/ui-components). The [OverlayUtil](?) system renders collaborator cursors, brushes, scribbles, and selection indicators; see [Overlay utils](/sdk-features/overlay-utils).

--- a/apps/docs/content/docs/commenting.mdx
+++ b/apps/docs/content/docs/commenting.mdx
@@ -1,6 +1,7 @@
 ---
 title: Commenting
 status: published
+author: steveruizok
 date: 7/27/2026
 order: 7
 keywords:
@@ -65,15 +66,13 @@ export default function App() {
 
 Pick the comment tool from Quick Actions, or press `C`, then click the canvas to start a thread.
 
-The layer's two required inputs are both about identity: `currentUserId` is the id stamped on whatever the user posts, and `resolveAuthor` turns an author id into a name, a color, and an optional avatar image. Commenting reads no user directory of its own, so these are where you connect it to whatever your app already knows about its users. With the read-status and mention callbacks they make up the `CommentingContext`, which `CanvasCommentsSidebar` takes too — build it once and spread it into both.
+The layer's two required inputs are both about identity. `currentUserId` is the id stamped on whatever the user posts. `resolveAuthor` turns an author id into a name, plus an optional color and avatar image. Commenting reads no user directory of its own, so these are where you connect it to whatever your app already knows about its users. Together with the read-status and mention callbacks they make up the `CommentingContext`, which the sidebar takes too.
 
 ## Comments are records
 
-Comment threads and comments are records in the editor's store, exactly like shapes. That's the fact most worth holding onto, because almost everything else follows from it.
+Comment threads and comments are records in the editor's store, exactly like shapes. They aren't in the default schema, so you opt in by registering `commentSchemaRecords`. Once you have, comments persist and sync however your document already does. Adding a `persistenceKey` or a sync backend carries them along with no extra work.
 
-They aren't in the default schema, so you opt in by registering `commentSchemaRecords`. Once you have, comments persist and sync however your document already does. Adding a `persistenceKey` or a sync backend carries them along with no extra work.
-
-It also means you can read and write them yourself. Query the store for threads, seed a document with review notes, or build a panel that does something the built-in sidebar doesn't.
+It also means you can read and write them yourself: query the store for threads, seed a document with review notes, or build a panel that does something the built-in sidebar doesn't. Comment records aren't part of the `TLRecord` union, so use the package's typed helpers and hooks rather than `editor.store` directly.
 
 ```tsx
 import { useCommentThreads } from '@tldraw/commenting'
@@ -90,7 +89,7 @@ function OpenThreadCount() {
 
 What pins a thread to the canvas is its anchor. A thread can anchor to a point on the page, to a shape it then follows as that shape moves and resizes, to a rectangular region, or to the page as a whole.
 
-Clicking empty canvas gives you a point anchor and clicking a shape gives you a shape anchor. Region anchors are off by default; turn them on and dragging the tool out covers an area.
+Clicking empty canvas gives you a point anchor and clicking a shape gives you a shape anchor. Region anchors are off by default (`enableRegions`); with them on, dragging the tool out covers an area.
 
 Shape-anchored threads outlive their shape. Delete the shape and the thread converts to a point anchor where its pin last sat, so the conversation doesn't disappear along with the thing it was about.
 
@@ -98,14 +97,15 @@ Shape-anchored threads outlive their shape. Delete the shape and the thread conv
 
 The comments layer covers the whole flow out of the box:
 
-| Feature      | Description                                                        |
-| ------------ | ------------------------------------------------------------------ |
-| Threads      | Pins on the canvas, opening to replies, edit, resolve, and delete. |
-| Mentions     | `@`-mentions in composers, resolved against a roster you supply.   |
-| Reactions    | Emoji reactions on comments, with a pluggable palette.             |
-| A sidebar    | A filterable list of threads beside the canvas.                    |
-| Clustering   | Nearby pins fold into count badges as you zoom out.                |
-| Unread state | Pin badges and an unread filter, driven by your app's read data.   |
+| Feature      | Description                                                             |
+| ------------ | ----------------------------------------------------------------------- |
+| Threads      | Pins on the canvas, opening to replies, edit, resolve, and delete.      |
+| Shortcuts    | `C` picks the tool, `Shift+C` hides the pins, `Escape` closes a thread. |
+| Mentions     | `@`-mentions in composers, resolved against a roster you supply.        |
+| Reactions    | Emoji reactions on comments, with a pluggable palette.                  |
+| A sidebar    | A filterable list of threads beside the canvas.                         |
+| Clustering   | Nearby pins fold into count badges as you zoom out.                     |
+| Unread state | Pin badges and an unread filter, driven by your app's read data.        |
 
 Each of these has options, and each visible piece is a component slot you can replace. See [Commenting](/sdk-features/commenting) for the full guide.
 
@@ -114,16 +114,18 @@ Each of these has options, and each visible piece is a component slot you can re
 Commenting options live on the tool. `CommentTool.configure()` returns a configured subclass to register, mirroring `ShapeUtil.configure`:
 
 ```tsx
+import { CommentTool } from '@tldraw/commenting'
+
 const tools = [CommentTool.configure({ enableRegions: true })]
 ```
 
-The option worth knowing about first is `history`. Comment writes default to `'ignore'`, which keeps them off the undo stack, and that default matters in a shared document: an undoable delete would resurrect a thread a collaborator already removed. See [Comments and undo](/sdk-features/commenting#comments-and-undo).
+The option worth knowing about first is `history`. Comment writes default to `'ignore'`, which keeps them off the undo stack, and that default matters in a shared document: an undoable resolve would revert a thread a collaborator has since reopened. Deletes are never undoable, whatever `history` says. See [Comments and undo](/sdk-features/commenting#comments-and-undo).
 
 ## Permissions
 
-`canComment` decides whether the viewer may participate, and the UI follows it: composers give way to a fallback slot and the action affordances hide. `canModifyComment` decides the writes that belong to someone in particular — editing a comment, deleting a comment, deleting a thread. Unset, each is its record's owner's to make; a callback widens that (a workspace admin who may remove anyone's comment) or narrows it.
+`canComment` decides whether the viewer may participate, and the UI follows it: composers give way to a fallback slot and the action affordances hide. `canModifyComment` decides the writes that belong to someone in particular: editing a comment, deleting a comment, deleting a thread. Unset, only the comment's author may edit or delete it, and only the thread's creator may delete the thread. A callback widens that, say for a workspace admin who may remove anyone's comment, or narrows it.
 
-They're UI-level controls and nothing more. Comment records carry a client-supplied author id, so rules about who may post, edit, or delete belong in your sync server's record authorization, where each incoming record is checked against the session's identity.
+They're UI-level controls and nothing more. Comment records carry a client-supplied author id, so rules about who may post, edit, or delete belong on your sync server, which checks each incoming record against the session's identity.
 
 ## Syncing
 

--- a/apps/docs/content/docs/driver.mdx
+++ b/apps/docs/content/docs/driver.mdx
@@ -15,7 +15,7 @@ keywords:
   - simulation
 ---
 
-You can drive the tldraw editor programmatically with the **`@tldraw/driver`** package. It wraps an [`Editor`](?) with an imperative, fluent API for simulating user input. You can use it for scripting, automation, REPL sessions, and writing tests.
+You can drive the tldraw editor programmatically with the `@tldraw/driver` package. It wraps an [Editor](?) with an imperative, fluent API for simulating user input, using only public editor methods. You can use it for scripting, automation, REPL sessions, and writing tests.
 
 ## Quick start
 
@@ -25,25 +25,36 @@ Install the package alongside `tldraw`:
 npm install @tldraw/driver
 ```
 
-Wrap an [`Editor`](?) instance with a [`Driver`](?) and dispatch input:
+Wrap an [Editor](?) instance with a [Driver](?) and dispatch input:
 
-```ts
+```tsx
 import { Driver } from '@tldraw/driver'
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
 
-const driver = new Driver(editor)
+export default function App() {
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw
+				onMount={(editor) => {
+					const driver = new Driver(editor)
 
-driver.click(100, 200).pointerDown(300, 400).pointerMove(500, 600).pointerUp()
+					driver.click(100, 200).pointerDown(300, 400).pointerMove(500, 600).pointerUp()
+					driver.keyPress('a')
 
-driver.keyPress('a')
-
-driver.dispose()
+					return () => driver.dispose()
+				}}
+			/>
+		</div>
+	)
+}
 ```
 
-Every input method returns `this`, so calls can be chained. Call `dispose` when you're done so the driver can clean up its side-effect handlers.
+Every input method returns `this`, so calls can be chained. Coordinates default to the current pointer position when omitted, which is why `pointerUp()` needs none. Call `dispose` when you're done so the driver can clean up its side-effect handlers.
 
 ## Simulating input
 
-Pointer, keyboard, wheel, and pinch events all flow through `editor.dispatch`, so they go through the editor's normal tool state machines. A `pointerDown` → `pointerMove` → `pointerUp` sequence with the draw tool active creates real draw shapes:
+Pointer, keyboard, wheel, and pinch events all flow through `editor.dispatch`, so they go through the editor's normal tool state machines. A pointerDown, pointerMove, pointerUp sequence with the draw tool active creates real draw shapes:
 
 ```ts
 editor.setCurrentTool('draw')
@@ -55,13 +66,21 @@ driver.pointerUp()
 
 Pointer coordinates are in screen space. For page-space positions, use `editor.pageToScreen` to convert before dispatching.
 
-Keyboard helpers track modifier state automatically:
+Pointer methods take two optional trailing arguments. The third is either a partial `TLPointerEventInfo` or a shape id, which targets that shape. The fourth overrides modifier keys for that one event:
+
+```ts
+driver.click(100, 100, shapeId, { shiftKey: true })
+```
+
+Modifiers pressed with `keyDown` carry into later pointer events, because the driver reads modifier state from `editor.inputs`:
 
 ```ts
 driver.keyDown('Shift')
 driver.click(100, 100, { target: 'canvas' })
 driver.keyUp('Shift')
 ```
+
+Each input method emits a tick after dispatching. Tools that do work over several frames may need more; call `forceTick(count)` to emit extra ticks.
 
 ## Manipulating the selection
 
@@ -75,27 +94,27 @@ driver.resizeSelection({ scaleX: 2 }, 'bottom_right')
 
 ## Clipboard
 
-The driver keeps its own in-memory clipboard, independent of the system clipboard. Useful for scripted copy/paste flows and testing:
+The driver keeps its own in-memory clipboard, independent of the system clipboard. Useful for scripted copy, cut, and paste flows and testing:
 
 ```ts
 driver.copy() // copies the current selection
-driver.paste({ x: 400, y: 400 })
+driver.paste({ x: 400, y: 400 }) // page point; ignored while Shift is held
 ```
 
 ## Queries
 
-The driver uses `editor.sideEffects` to track the shapes it creates, so you can grab the most recent result of a scripted action:
+The driver registers an `editor.sideEffects` handler that records every shape created while it's attached, whatever created it, so you can grab the most recent result of a scripted action:
 
 ```ts
 const shape = driver.getLastCreatedShape()
 const lastFive = driver.getLastCreatedShapes(5)
 ```
 
-See [`Driver`](?) for the full list of query helpers (shape/selection page centers, rotations, arrows bound to a shape, etc.).
+See [Driver](?) for the full list of query helpers: shape and selection page centers, rotations, and arrows bound to a shape.
 
 ## Related
 
-- [`Driver`](?) — Full reference for every input, selection, clipboard, and query method
-- [`Editor`](?) — The editor class the driver wraps
+- [Driver](?) — Full reference for every input, selection, clipboard, and query method
+- [Editor](?) — The editor class the driver wraps
 - [Shapes](/docs/shapes) — Defining shape types that driver-produced input will interact with
 - [Tools](/docs/tools) — Understanding the tool state machines that process simulated events

--- a/apps/docs/content/docs/editor.mdx
+++ b/apps/docs/content/docs/editor.mdx
@@ -13,7 +13,7 @@ keywords:
 
 The [Editor](?) class is the main way of controlling tldraw's editor. You can use it to manage the editor's internal state, make changes to the document, or respond to changes that have occurred.
 
-By design, the [Editor](?)'s surface area is very large. Almost everything is available through it. Need to create some shapes? Use [Editor#createShapes](?). Need to delete them? Use [Editor#deleteShapes](?). Need a sorted array of every shape on the current page? Use [Editor#getCurrentPageShapesSorted](?).
+By design, the editor's surface area is very large. Almost everything is available through it. Need to create some shapes? Use [Editor#createShapes](?). Need to delete them? Use [Editor#deleteShapes](?). Need a sorted array of every shape on the current page? Use [Editor#getCurrentPageShapesSorted](?).
 
 ## Accessing the editor
 
@@ -37,7 +37,7 @@ function App() {
 
 ### The useEditor hook
 
-The [useEditor](?) hook returns the editor instance. It must be called from within the JSX of the [Tldraw](?) component.
+The [useEditor](?) hook returns the editor instance. Call it from a component rendered inside [Tldraw](?) (or [TldrawEditor](?)).
 
 ```tsx
 function InsideOfContext() {
@@ -59,32 +59,39 @@ function App() {
 
 ## Reactive state
 
-The editor's state is reactive. Methods like [Editor#getSelectedShapeIds](?) or [Editor#getCurrentPageShapes](?) return values that automatically update when the underlying data changes. You can use these values directly in React components with the `track` wrapper or [useValue](?) hook.
+The editor's state is reactive. Methods like [Editor#getSelectedShapeIds](?) or [Editor#getCurrentPageShapes](?) return values that automatically update when the underlying data changes. You can use these values directly in React components with the [track](?) wrapper or [useValue](?) hook.
 
 ```tsx
-import { track, useEditor } from 'tldraw'
+import { track, useEditor, useValue } from 'tldraw'
 
 export const SelectedShapeIdsCount = track(() => {
 	const editor = useEditor()
 	return <div>{editor.getSelectedShapeIds().length}</div>
 })
+
+export function CurrentTool() {
+	const editor = useEditor()
+	const toolId = useValue('current tool', () => editor.getCurrentToolId(), [editor])
+	return <div>{toolId}</div>
+}
 ```
 
 See the [Signals](/sdk-features/signals) article for more on tldraw's reactive state system.
 
 ## Batching changes
 
-Each change to the editor happens within a transaction. You can batch multiple changes into a single transaction using the [Editor#run](?) method. Batching improves performance and reduces overhead for persisting or distributing changes.
+Each change to the editor happens within a transaction. You can batch multiple changes into a single transaction using the [Editor#run](?) method. Batching groups the changes into a single undo step and reduces overhead for persisting or distributing changes.
 
 ```ts
+// myShapes is an array of shape partials, each with an id from createShapeId()
 editor.run(() => {
 	editor.createShapes(myShapes)
-	editor.sendToBack(myShapes)
+	editor.sendToBack(myShapes.map((shape) => shape.id))
 	editor.selectNone()
 })
 ```
 
-The `run` method also accepts options to control history and locked shape behavior:
+The `run` method also accepts options to control history and locked shape behavior. Set `history` to `'ignore'` to leave undo/redo alone, or `'record-preserveRedoStack'` to record without clearing the redo stack:
 
 ```ts
 // Make changes without affecting undo/redo history
@@ -106,46 +113,29 @@ editor.run(
 
 ## Capabilities
 
-The editor provides methods and properties organized around these areas:
+The editor's methods and properties are organized around these areas:
 
-### Data
-
-- **[Signals](/sdk-features/signals)** — Reactive state primitives
-- **[Store](/sdk-features/store)** — The reactive database holding all records
-- **[Shapes](/sdk-features/shapes)** — Create, read, update, and delete shapes
-- **[Bindings](/sdk-features/bindings)** — Relationships between shapes
-- **[Pages](/sdk-features/pages)** — Manage document pages
-- **[Assets](/sdk-features/assets)** — Images, videos, and other media
-
-### Interaction
-
-- **[Tools](/sdk-features/tools)** — The state machine that handles user input
-- **[Selection](/sdk-features/selection)** — Manage which shapes are selected
-- **[Input handling](/sdk-features/input-handling)** — Pointer and keyboard state
-- **[Events](/sdk-features/events)** — Subscribe to user interactions and state changes
-
-### View
-
-- **[Camera](/sdk-features/camera)** — Control viewport position and zoom
-- **[Coordinates](/sdk-features/coordinates)** — Convert between screen and page space
-
-### State management
-
-- **[Instance state](/sdk-features/instance-state)** — Per-editor settings like current tool and focus
-- **[Visibility](/sdk-features/visibility)** — Control which shapes are shown
-- **[History](/sdk-features/history)** — Undo, redo, and history management
-- **[Side effects](/sdk-features/side-effects)** — React to record lifecycle changes
-
-### Configuration
-
-- **[User preferences](/sdk-features/user-preferences)** — Cross-instance settings like dark mode
-- **[Readonly mode](/sdk-features/readonly)** — Disable editing
-- **[Locked shapes](/sdk-features/locked-shapes)** — Prevent changes to specific shapes
-
-### Output
-
-- **[Image export](/sdk-features/image-export)** — Export to SVG, PNG, and other formats
-
----
+| Area          | Topic                                              | Description                                      |
+| ------------- | -------------------------------------------------- | ------------------------------------------------ |
+| Data          | [Signals](/sdk-features/signals)                   | Reactive state primitives                        |
+|               | [Store](/sdk-features/store)                       | The reactive database holding all records        |
+|               | [Shapes](/sdk-features/shapes)                     | Create, read, update, and delete shapes          |
+|               | [Bindings](/sdk-features/bindings)                 | Relationships between shapes                     |
+|               | [Pages](/sdk-features/pages)                       | Manage document pages                            |
+|               | [Assets](/sdk-features/assets)                     | Images, videos, and other media                  |
+| Interaction   | [Tools](/sdk-features/tools)                       | The state machine that handles user input        |
+|               | [Selection](/sdk-features/selection)               | Manage which shapes are selected                 |
+|               | [Input handling](/sdk-features/input-handling)     | Pointer and keyboard state                       |
+|               | [Events](/sdk-features/events)                     | Subscribe to user interactions and state changes |
+| View          | [Camera](/sdk-features/camera)                     | Control viewport position and zoom               |
+|               | [Coordinates](/sdk-features/coordinates)           | Convert between screen and page space            |
+| State         | [Instance state](/sdk-features/instance-state)     | Per-editor settings like current tool and focus  |
+|               | [Visibility](/sdk-features/visibility)             | Control which shapes are shown                   |
+|               | [History](/sdk-features/history)                   | Undo, redo, and history management               |
+|               | [Side effects](/sdk-features/side-effects)         | React to record lifecycle changes                |
+| Configuration | [User preferences](/sdk-features/user-preferences) | Cross-instance settings like dark mode           |
+|               | [Readonly mode](/sdk-features/readonly)            | Disable editing                                  |
+|               | [Locked shapes](/sdk-features/locked-shapes)       | Prevent changes to specific shapes               |
+| Output        | [Image export](/sdk-features/image-export)         | Export to SVG, PNG, and other formats            |
 
 See the [Editor](?) API reference for the complete list of methods and properties.

--- a/apps/docs/content/docs/handles.mdx
+++ b/apps/docs/content/docs/handles.mdx
@@ -90,7 +90,7 @@ For more control over handle interactions, implement these additional methods:
 
 ## Handle snapping
 
-Handles can snap to other shapes' geometry. Set `snapType` on the handle. Snapping engages while the user holds Ctrl (Cmd on Mac), or always if they've turned on snap mode in preferences. The older `canSnap: true` flag is deprecated; use `snapType: 'point'` instead.
+Handles can snap to other shapes' geometry. Set `snapType` on the handle. Snapping engages while the user holds Ctrl (Cmd on Mac); with snap mode turned on in preferences, it's the reverse: snapping is on and Ctrl disables it. The older `canSnap: true` flag is deprecated; use `snapType: 'point'` instead.
 
 ```tsx
 {

--- a/apps/docs/content/docs/handles.mdx
+++ b/apps/docs/content/docs/handles.mdx
@@ -15,7 +15,7 @@ In tldraw, handles are interactive control points on shapes that let users manip
 
 ## Handle basics
 
-Handles appear when a shape is selected. Each handle has a position, type, and optional snapping behavior. You define handles by implementing `getHandles` on your [ShapeUtil](?):
+Handles appear when a single shape is selected with the select tool. Each handle has a position, type, and optional snapping behavior. You define handles by implementing `getHandles` on your [ShapeUtil](?):
 
 ```tsx
 import { ShapeUtil, TLHandle, ZERO_INDEX_KEY } from 'tldraw'
@@ -54,7 +54,7 @@ Most custom shapes use `vertex` handles. The arrow shape uses a `virtual` handle
 
 ## Responding to handle drags
 
-When a user drags a handle, tldraw calls `onHandleDrag` with the updated handle position. Return the updated shape:
+When a user drags a handle, tldraw calls `onHandleDrag` with the updated handle position. Return a partial of the shape with the changed props:
 
 ```tsx
 import { ShapeUtil, TLHandleDragInfo } from 'tldraw'
@@ -64,18 +64,19 @@ class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 
 	override onHandleDrag(shape: SpeechBubbleShape, { handle }: TLHandleDragInfo<SpeechBubbleShape>) {
 		return {
-			...shape,
-			props: {
-				...shape.props,
-				tailX: handle.x,
-				tailY: handle.y,
-			},
+			props: { tailX: handle.x, tailY: handle.y },
 		}
 	}
 }
 ```
 
-The `handle` object in `TLHandleDragInfo` contains the updated `x` and `y` coordinates. Use these to update your shape's props.
+The `handle` in [TLHandleDragInfo](?) carries the new `x` and `y` after any snapping. The info object also has these fields:
+
+| Field             | Description                                                             |
+| ----------------- | ----------------------------------------------------------------------- |
+| `initial`         | The shape as it was when the drag started                               |
+| `isPrecise`       | Whether the user is dragging precisely, for example by holding Alt      |
+| `isCreatingShape` | Whether the handle drag is part of creating the shape, like a new arrow |
 
 ### Lifecycle callbacks
 
@@ -89,7 +90,7 @@ For more control over handle interactions, implement these additional methods:
 
 ## Handle snapping
 
-Handles can snap to other shapes' geometry. Set `snapType` on the handle:
+Handles can snap to other shapes' geometry. Set `snapType` on the handle. Snapping engages while the user holds Ctrl (Cmd on Mac), or always if they've turned on snap mode in preferences. The older `canSnap: true` flag is deprecated; use `snapType: 'point'` instead.
 
 ```tsx
 {
@@ -104,14 +105,14 @@ Handles can snap to other shapes' geometry. Set `snapType` on the handle:
 
 The `snapType` options are:
 
-| Value     | Behavior                                               |
-| --------- | ------------------------------------------------------ |
-| `'point'` | Snaps to key points on other shapes (corners, centers) |
-| `'align'` | Snaps to alignment guides from other shapes            |
+| Value     | Behavior                                                                               |
+| --------- | -------------------------------------------------------------------------------------- |
+| `'point'` | Snaps to key points on other shapes first, then to the nearest point on their outlines |
+| `'align'` | Snaps the handle's x and y independently to the x and y of key points on other shapes  |
 
 ### Angle snapping
 
-When the user holds Shift while dragging, handles snap to 15-degree angles. By default, the angle is measured relative to an adjacent vertex handle on the shape. You can use a different reference handle by setting `snapReferenceHandleId`:
+When the user holds Shift while dragging, handles snap to 15-degree angles. By default, the angle is measured relative to the next vertex handle on the shape. You can snap relative to a specific handle by setting `snapReferenceHandleId`:
 
 ```tsx
 {
@@ -125,11 +126,11 @@ When the user holds Shift while dragging, handles snap to 15-degree angles. By d
 }
 ```
 
-This is useful for bezier curves where control points should snap to angles relative to their associated endpoint.
+Bezier curves use this so control points snap to angles relative to their associated endpoint.
 
 ### Custom snap geometry
 
-By default, handles snap to a shape's outline and key points. Override `getHandleSnapGeometry` to customize what handles snap to:
+By default, handles snap to a shape's outline (its geometry) and to no key points. Override `getHandleSnapGeometry` to customize what handles snap to:
 
 ```tsx
 import { HandleSnapGeometry, ShapeUtil } from 'tldraw'
@@ -156,12 +157,27 @@ class BezierCurveUtil extends ShapeUtil<BezierCurveShape> {
 
 The `HandleSnapGeometry` object has these properties:
 
-| Property             | Description                                                    |
-| -------------------- | -------------------------------------------------------------- |
-| `outline`            | Custom outline geometry for snapping (default: shape geometry) |
-| `points`             | Key points to snap to (corners, centers, etc.)                 |
-| `getSelfSnapOutline` | Returns outline for self-snapping given a handle               |
-| `getSelfSnapPoints`  | Returns points for self-snapping given a handle                |
+| Property             | Description                                                               |
+| -------------------- | ------------------------------------------------------------------------- |
+| `outline`            | Outline geometry to snap to (default: shape geometry; `null` disables it) |
+| `points`             | Key points to snap to, like corners or centers (default: none)            |
+| `getSelfSnapOutline` | Returns outline for self-snapping given a handle                          |
+| `getSelfSnapPoints`  | Returns points for self-snapping given a handle                           |
+
+## Reading handles
+
+Use [Editor#getShapeHandles](?) to get the handles for any shape:
+
+```ts
+const handles = editor.getShapeHandles(shape)
+if (handles) {
+	for (const handle of handles) {
+		console.log(handle.id, handle.x, handle.y)
+	}
+}
+```
+
+Returns `undefined` if the shape doesn't have handles.
 
 ## Complete example
 
@@ -171,6 +187,8 @@ Here's a speech bubble shape with a draggable tail handle:
 import {
 	Polygon2d,
 	ShapeUtil,
+	SVGContainer,
+	T,
 	TLHandle,
 	TLHandleDragInfo,
 	TLShape,
@@ -190,6 +208,7 @@ type SpeechBubbleShape = TLShape<typeof SPEECH_BUBBLE_TYPE>
 
 class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 	static override type = SPEECH_BUBBLE_TYPE
+	static override props = { w: T.number, h: T.number, tailX: T.number, tailY: T.number }
 
 	getDefaultProps(): SpeechBubbleShape['props'] {
 		return { w: 200, h: 100, tailX: 100, tailY: 150 }
@@ -226,21 +245,16 @@ class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 
 	override onHandleDrag(shape: SpeechBubbleShape, { handle }: TLHandleDragInfo<SpeechBubbleShape>) {
 		return {
-			...shape,
-			props: {
-				...shape.props,
-				tailX: handle.x,
-				tailY: handle.y,
-			},
+			props: { tailX: handle.x, tailY: handle.y },
 		}
 	}
 
 	component(shape: SpeechBubbleShape) {
 		const geometry = this.getGeometry(shape)
 		return (
-			<svg className="tl-svg-container">
+			<SVGContainer>
 				<path d={geometry.getSvgPathData()} fill="white" stroke="black" />
-			</svg>
+			</SVGContainer>
 		)
 	}
 
@@ -250,21 +264,6 @@ class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 	}
 }
 ```
-
-## Reading handles
-
-Use [Editor#getShapeHandles](?) to get the handles for any shape:
-
-```ts
-const handles = editor.getShapeHandles(shape)
-if (handles) {
-	for (const handle of handles) {
-		console.log(handle.id, handle.x, handle.y)
-	}
-}
-```
-
-Returns `undefined` if the shape doesn't have handles.
 
 ## Examples
 

--- a/apps/docs/content/docs/indicators.mdx
+++ b/apps/docs/content/docs/indicators.mdx
@@ -12,35 +12,15 @@ keywords:
   - custom shapes
 ---
 
-Indicators are the outlines that appear around shapes when they're selected or hovered. They show which shapes are active and where each shape's bounds are.
+Indicators are the outlines that appear around shapes when they're selected or hovered.
 
 ## How indicators work
 
-When you select a shape in tldraw, an indicator appears as a stroke around the shape's geometry. Indicators are separate from the shape's visual appearance so they can be styled consistently across all shape types.
-
-Each [ShapeUtil](?) defines how its indicator should be drawn by implementing the required `getIndicatorPath` method:
+Indicators are drawn on a canvas overlay in the theme's selection color, separate from the shape's own rendering. Each [ShapeUtil](?) defines its indicator by implementing the required [ShapeUtil#getIndicatorPath](?) method. It returns a `Path2D` in the shape's local coordinate space; the [ShapeIndicatorOverlayUtil](?) included with `<Tldraw>` transforms it into page space and strokes it. Return `undefined` to draw no indicator for a shape.
 
 ```tsx
-import { HTMLContainer, Rectangle2d, ShapeUtil } from 'tldraw'
-
 class CardShapeUtil extends ShapeUtil<CardShape> {
-	static override type = 'card'
-
-	getDefaultProps(): CardShape['props'] {
-		return { w: 100, h: 100 }
-	}
-
-	getGeometry(shape: CardShape) {
-		return new Rectangle2d({
-			width: shape.props.w,
-			height: shape.props.h,
-			isFilled: true,
-		})
-	}
-
-	component(shape: CardShape) {
-		return <HTMLContainer>Hello</HTMLContainer>
-	}
+	// ...
 
 	getIndicatorPath(shape: CardShape) {
 		const path = new Path2D()
@@ -50,39 +30,33 @@ class CardShapeUtil extends ShapeUtil<CardShape> {
 }
 ```
 
-The `getIndicatorPath` method returns paths in the shape's local coordinate space. The editor automatically positions and styles these paths based on selection state.
-
-## When indicators appear
-
-By default, indicators appear in these situations:
-
-| State    | Description                                             |
-| -------- | ------------------------------------------------------- |
-| Selected | The shape is in the current selection                   |
-| Hovered  | The pointer is over the shape (desktop only, not touch) |
-| Hinting  | The shape is being referenced during an operation       |
-
-Indicators are hidden during certain interactions, like when changing styles or during tool operations that would make indicators distracting.
-
-## Defining paths
-
-For most shapes, return a `Path2D`:
+For shapes with more complex outlines, build the path from the shape's geometry:
 
 ```tsx
-class MyShapeUtil extends ShapeUtil<MyShape> {
-	override getIndicatorPath(shape: MyShape): Path2D | undefined {
-		const path = new Path2D()
-		path.rect(0, 0, shape.props.w, shape.props.h)
-		return path
-	}
+getIndicatorPath(shape: MyShape) {
+	return new Path2D(this.editor.getShapeGeometry(shape).toSimpleSvgPath())
 }
 ```
 
-Indicators are drawn on a single canvas layer, which is efficient when many shapes are selected.
+See [Shapes](/docs/shapes) for the rest of the ShapeUtil.
 
-### Complex canvas indicators
+## When indicators appear
 
-For indicators that need clipping or multiple paths (like arrows with labels), return an object instead of a plain `Path2D`:
+The select tool shows indicators in these situations:
+
+| State    | Description                                                                                                        |
+| -------- | ------------------------------------------------------------------------------------------------------------------ |
+| Selected | The shape is in the current selection                                                                              |
+| Hovered  | The pointer is over the shape while the select tool is idle (fine pointers only, not touch)                        |
+| Hinting  | The shape is in [Editor#getHintingShapeIds](?), set with [Editor#setHintingShapes](?); drawn with a thicker stroke |
+
+Indicators are hidden while the user is changing styles, while another tool is active, and for locked shapes.
+
+All plain `Path2D` indicators are batched into a single stroke call, so many selected shapes stay cheap to draw.
+
+## Complex canvas indicators
+
+For indicators that need clipping or multiple paths (like arrows with labels), return a [TLIndicatorPath](?) object instead of a plain `Path2D`. The `clipPath` is applied as an even-odd clip region before stroking `path`, so to cut a hole for a label, add an outer rectangle plus the label rectangle. `additionalPaths` are stroked afterwards without the clip:
 
 ```tsx
 override getIndicatorPath(shape: MyShape): TLIndicatorPath | undefined {
@@ -95,25 +69,27 @@ override getIndicatorPath(shape: MyShape): TLIndicatorPath | undefined {
 	arrowheadPath.lineTo(100, 100)
 	arrowheadPath.lineTo(95, 90)
 
-	const labelClipPath = new Path2D()
-	labelClipPath.rect(40, 40, 20, 20)
+	// Even-odd: the outer rect keeps everything, the inner rect punches a hole
+	const clipPath = new Path2D()
+	clipPath.rect(-100, -100, 300, 300)
+	clipPath.rect(40, 40, 20, 20)
 
 	return {
 		path: bodyPath,
-		clipPath: labelClipPath, // Areas to exclude from the main path
-		additionalPaths: [arrowheadPath], // Extra paths to stroke
+		clipPath,
+		additionalPaths: [arrowheadPath],
 	}
 }
 ```
 
 ## Collaborator indicators
 
-In multiplayer sessions, indicators show other users' selections. These appear with the collaborator's assigned color and slightly reduced opacity. The canvas indicator system handles collaborator indicators automatically.
+In multiplayer sessions, [CollaboratorShapeIndicatorOverlayUtil](?) draws other users' selections in each collaborator's color at reduced opacity, underneath the local indicators.
 
 ## Related topics
 
-| Topic                                                      | Description                                |
-| ---------------------------------------------------------- | ------------------------------------------ |
-| [Shapes](/docs/shapes)                                     | Creating custom shapes with ShapeUtil      |
-| [User interface](/docs/user-interface)                     | Customizing tldraw's UI components         |
-| [Custom indicators example](/examples/ui/indicators-logic) | Working example of indicator customization |
+| Topic                                                      | Description                                                         |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| [Shapes](/docs/shapes)                                     | Creating custom shapes with ShapeUtil                               |
+| [User interface](/docs/user-interface)                     | Customizing tldraw's UI components                                  |
+| [Custom indicators example](/examples/ui/indicators-logic) | Subclass `ShapeIndicatorOverlayUtil` to change when indicators show |

--- a/apps/docs/content/docs/indicators.mdx
+++ b/apps/docs/content/docs/indicators.mdx
@@ -47,7 +47,7 @@ The select tool shows indicators in these situations:
 | State    | Description                                                                                                        |
 | -------- | ------------------------------------------------------------------------------------------------------------------ |
 | Selected | The shape is in the current selection                                                                              |
-| Hovered  | The pointer is over the shape while the select tool is idle (fine pointers only, not touch)                        |
+| Hovered  | The pointer is over the shape while the select tool is idle or editing a shape (fine pointers only, not touch)     |
 | Hinting  | The shape is in [Editor#getHintingShapeIds](?), set with [Editor#setHintingShapes](?); drawn with a thicker stroke |
 
 Indicators are hidden while the user is changing styles, while another tool is active, and for locked shapes.

--- a/apps/docs/content/docs/llm-docs.mdx
+++ b/apps/docs/content/docs/llm-docs.mdx
@@ -15,21 +15,21 @@ keywords:
   - agent
 ---
 
-The tldraw docs are optimized for use with large language models (LLMs). Whether you're using an AI coding assistant, building an agent that works with tldraw, or prompting a chat model, you can access our documentation in formats designed for LLM consumption.
+The tldraw docs are available in formats built for large language models (LLMs): plain-text bundles you can hand to a coding assistant or agent, and a copy-as-markdown button on every article.
 
 ## llms.txt
 
-We publish our documentation at [tldraw.dev/llms.txt](https://tldraw.dev/llms.txt), following the [llms.txt standard](https://llmstxt.org/) for providing LLM-friendly content. This file serves as an index to all SDK documentation, examples, and release notes.
+We publish [tldraw.dev/llms.txt](https://tldraw.dev/llms.txt), following the [llms.txt convention](https://llmstxt.org/). It indexes the SDK feature articles, the examples, and the release notes, and links to several bundles of the same content. The bundles are regenerated on every docs build.
 
-The index includes links to several focused exports:
+| File                                                      | Contents                                     |
+| --------------------------------------------------------- | -------------------------------------------- |
+| [llms.txt](https://tldraw.dev/llms.txt)                   | Index with links to all resources            |
+| [llms-full.txt](https://tldraw.dev/llms-full.txt)         | SDK feature articles, releases, and examples |
+| [llms-docs.txt](https://tldraw.dev/llms-docs.txt)         | SDK feature articles only                    |
+| [llms-releases.txt](https://tldraw.dev/llms-releases.txt) | Release notes only                           |
+| [llms-examples.txt](https://tldraw.dev/llms-examples.txt) | Examples with full source code               |
 
-| File                                                      | Contents                             |
-| --------------------------------------------------------- | ------------------------------------ |
-| [llms.txt](https://tldraw.dev/llms.txt)                   | Index with links to all resources    |
-| [llms-full.txt](https://tldraw.dev/llms-full.txt)         | All SDK docs, releases, and examples |
-| [llms-docs.txt](https://tldraw.dev/llms-docs.txt)         | SDK feature documentation only       |
-| [llms-releases.txt](https://tldraw.dev/llms-releases.txt) | Release notes only                   |
-| [llms-examples.txt](https://tldraw.dev/llms-examples.txt) | Examples with full source code       |
+The guides in this section of the site (under `/docs`) aren't in the bundles. Use the copy button below for those.
 
 ### Using llms.txt with AI assistants
 
@@ -40,24 +40,17 @@ When working with an AI coding assistant, you can provide context by including t
 - Use `llms-releases.txt` when asking about recent changes or migration between versions
 - Use `llms-full.txt` when you need comprehensive context across all documentation
 
-Many AI tools support fetching URLs directly, so you can reference these files by URL in your prompts.
+Many AI tools fetch URLs directly, so you can reference these files by URL in your prompts:
+
+```
+Read https://tldraw.dev/llms-docs.txt, then add a custom shape to my app.
+```
 
 ## Copy markdown button
 
-Every documentation page on tldraw.dev includes a "Copy markdown" button in the header. Click it to copy the page content as clean markdown, ready to paste into any LLM conversation.
+Every article on tldraw.dev has a "Copy markdown" button in its header. Click it to copy the article as markdown, ready to paste into an LLM conversation. The copy keeps headings, code blocks, and links, and strips the site navigation.
 
-This is useful when you want to:
+## Related
 
-- Ask an AI assistant about a specific feature
-- Include documentation context in a prompt
-- Reference our docs in your own documentation or notes
-
-The copied markdown preserves headings, code blocks, links, and other formatting while removing site-specific elements that aren't relevant in a plain text context.
-
-## Building AI-powered apps
-
-If you're building AI-powered applications with tldraw, see our [AI integrations](/docs/ai) guide. It covers patterns for using the canvas with AI models, including:
-
-- Using the canvas to display AI-generated content
-- Building visual workflows with AI nodes
-- Creating AI agents that can read and manipulate the canvas
+- [AI integrations](/docs/ai) — Using the canvas with AI models: generated content, workflows, and agents
+- [Mermaid diagrams](/docs/mermaid) — Turning model-generated diagram text into shapes

--- a/apps/docs/content/docs/mermaid.mdx
+++ b/apps/docs/content/docs/mermaid.mdx
@@ -17,7 +17,7 @@ keywords:
   - visualization
 ---
 
-You can turn [Mermaid](https://mermaid.js.org/) diagram syntax into native, editable tldraw shapes with the **`@tldraw/mermaid`** package. Instead of rendering a static SVG, it parses Mermaid text and creates real geo shapes, arrows, frames, and groups on the canvas—so users can move, resize, restyle, and connect them like any other shape.
+You can turn [Mermaid](https://mermaid.js.org/) diagram syntax into native, editable tldraw shapes with the `@tldraw/mermaid` package. Instead of rendering a static SVG, it parses Mermaid text and creates real geo shapes, arrows, and groups on the canvas. Users can move, resize, restyle, and connect them like any other shape.
 
 ## Quick start
 
@@ -27,7 +27,7 @@ Install the package alongside `tldraw`:
 npm install @tldraw/mermaid
 ```
 
-Then call [`createMermaidDiagram`](?) with an [`Editor`](?) and a Mermaid source string:
+Then call [createMermaidDiagram](?) with an [Editor](?) and a Mermaid source string:
 
 ```tsx
 import { createMermaidDiagram } from '@tldraw/mermaid'
@@ -43,18 +43,20 @@ await createMermaidDiagram(
 )
 ```
 
-By default the diagram is centered on the current viewport. Pass a `blueprintRender.position` to place it at a specific page point, and set `centerOnPosition: false` to anchor its top-left corner instead of its center.
+By default the diagram is centered on the viewport, or on the pointer when the user's paste-at-cursor preference is on. Pass a `blueprintRender.position` to place it at a specific page point, and set `centerOnPosition: false` to anchor its top-left corner instead of its center. The finished diagram is a single group. Pass `mermaidConfig` to override Mermaid's layout settings, such as node spacing or font size.
 
 ## Supported diagram types
 
-| Diagram type     | Mermaid keyword      | What you get                                                        |
-| ---------------- | -------------------- | ------------------------------------------------------------------- |
-| Flowchart        | `flowchart`, `graph` | Geo shapes, arrows, subgraph frames                                 |
-| Sequence diagram | `sequenceDiagram`    | Actor shapes, lifelines, signal arrows, fragment frames             |
-| State diagram    | `stateDiagram-v2`    | State shapes, transitions, compound state frames, fork/join, choice |
-| Mindmap          | `mindmap`            | Colored geo shapes, parent-child edges, tree hierarchy              |
+| Diagram type     | Mermaid keyword                   | What you get                                                            |
+| ---------------- | --------------------------------- | ----------------------------------------------------------------------- |
+| Flowchart        | `flowchart`, `graph`              | Geo shapes, arrows, subgraph containers                                 |
+| Sequence diagram | `sequenceDiagram`                 | Actor shapes, lifelines, signal arrows, fragment containers             |
+| State diagram    | `stateDiagram`, `stateDiagram-v2` | State shapes, transitions, compound state containers, fork/join, choice |
+| Mindmap          | `mindmap`                         | Colored geo shapes, parent-child edges, tree hierarchy                  |
 
-For unsupported types (pie, gantt, class, ER, etc.) pass an `onUnsupportedDiagram` callback—for example, to fall back to importing Mermaid's rendered SVG:
+Subgraphs, fragments, and compound states become geo rectangles with their child shapes parented to them.
+
+For unsupported types such as pie, gantt, class, and ER, pass an `onUnsupportedDiagram` callback. Here it falls back to importing Mermaid's rendered SVG:
 
 ```tsx
 await createMermaidDiagram(editor, text, {
@@ -64,7 +66,7 @@ await createMermaidDiagram(editor, text, {
 })
 ```
 
-Without a callback, `createMermaidDiagram` throws a [`MermaidDiagramError`](?) for unsupported types and parse failures.
+Without a callback, `createMermaidDiagram` throws a [MermaidDiagramError](?) for unsupported types and parse failures.
 
 ## Handling pasted Mermaid text
 
@@ -104,24 +106,28 @@ export function MermaidPasteHandler() {
 }
 ```
 
-Drop `<MermaidPasteHandler />` inside your [`Tldraw`](?) component and pasting Mermaid text will render it as shapes.
+Drop `<MermaidPasteHandler />` inside your [Tldraw](?) component and pasting Mermaid text will render it as shapes. The [Mermaid pasting example](/examples/use-cases/mermaid-pasting) extends this with markdown fence stripping and a toast for unsupported diagrams.
 
 <Callout type="info">
-	The `mermaid` dependency is ~2 MB. The pattern above pre-screens with a lightweight regex and
-	lazy-loads `@tldraw/mermaid` only when the text matches, so users who never paste Mermaid don't
+	The `mermaid` dependency is ~2 MB. `createMermaidDiagram` loads it lazily on first call, and the
+	regex above keeps it from being called for ordinary text, so users who never paste Mermaid don't
 	pay the cost.
 </Callout>
 
 ## Customizing node shapes
 
-By default, blueprint nodes are materialized as tldraw geo shapes. If you want to render them as your own custom shape type instead—for example, sticky notes for mindmap leaves, or a bespoke "actor" shape for sequence diagrams—pass `mapNodeToRenderSpec` on `blueprintRender`:
+By default, blueprint nodes are materialized as tldraw geo shapes. To render them as your own custom shape type instead, pass `mapNodeToRenderSpec` on `blueprintRender`:
 
 ```tsx
 await createMermaidDiagram(editor, text, {
 	blueprintRender: {
 		mapNodeToRenderSpec(input) {
-			if (input.diagramKind === 'mindmap') {
-				return { variant: 'shape', type: 'note', props: {} }
+			if (input.diagramKind === 'flowchart') {
+				return {
+					variant: 'shape',
+					type: 'pipeline-step',
+					props: { mermaidNodeId: input.nodeId },
+				}
 			}
 			// Return undefined to keep the package default for this node.
 			return undefined
@@ -130,16 +136,17 @@ await createMermaidDiagram(editor, text, {
 })
 ```
 
-The callback receives `diagramKind`, `nodeId`, `kind`, and the full [`MermaidBlueprintNode`](?), and returns a [`MermaidBlueprintNodeRenderSpec`](?)—either a `geo` variant or a custom `shape` type that's registered on the editor. See [`createMermaidDiagram`](?) and [`renderBlueprint`](?) in the reference for the full API.
+The callback receives `diagramKind`, `nodeId`, `kind`, and the full [MermaidBlueprintNode](?), and returns a [MermaidBlueprintNodeRenderSpec](?): either a `geo` variant or a custom `shape` type that's registered on the editor. The package sets `w`, `h`, `fill`, `color`, `dash`, `size`, `richText`, `align`, and `verticalAlign` on every node it creates, so a custom shape's props must accept those keys or validation will fail. See [createMermaidDiagram](?) and [renderBlueprint](?) in the reference for the full API.
 
 ## Examples
 
-- [Hundreds of mermaid diagrams](/examples/use-cases/hundred-mermaids) — A runnable demo rendering many diagram types at once
-- [Customizing mermaid diagrams](/examples/use-cases/custom-shape-mermaids) — Converting mermaid diagram nodes into custom shapes
+- [Hundreds of Mermaid diagrams](/examples/use-cases/hundred-mermaids) — A runnable demo rendering many diagram types at once
+- [Customize Mermaid diagrams](/examples/use-cases/custom-shape-mermaids) — Converting Mermaid diagram nodes into custom shapes
+- [Pasting Mermaid code as shapes](/examples/use-cases/mermaid-pasting) — The paste handler above, end to end
 
 ## Related
 
-- [`createMermaidDiagram`](?), [`renderBlueprint`](?), [`MermaidDiagramError`](?) — Entry points and errors
-- [`DiagramMermaidBlueprint`](?), [`MermaidBlueprintNode`](?), [`MermaidBlueprintNodeRenderSpec`](?) — The data model you can customize
+- [createMermaidDiagram](?), [renderBlueprint](?), [MermaidDiagramError](?) — Entry points and errors
+- [DiagramMermaidBlueprint](?), [MermaidBlueprintNode](?), [MermaidBlueprintNodeRenderSpec](?) — The data model you can customize
 - [Shapes](/docs/shapes) — Define a custom shape you can map Mermaid nodes to
 - [External content handlers](/sdk-features/external-content) — More on `registerExternalContentHandler` for the paste integration

--- a/apps/docs/content/docs/persistence.mdx
+++ b/apps/docs/content/docs/persistence.mdx
@@ -13,11 +13,11 @@ keywords:
   - localstorage
 ---
 
-Persistence means storing the editor's state to a database and restoring it later. The tldraw SDK provides several approaches: automatic local persistence with a single prop, manual snapshots for custom storage backends, and a migration system for handling schema changes.
+Persistence means storing the editor's state to a database and restoring it later. The simplest option is the `persistenceKey` prop, which saves to the browser automatically. Snapshots and the `store` prop give you more control, and migrations bring old data up to date.
 
 ## Local persistence
 
-The simplest approach is the `persistenceKey` prop. This automatically saves to IndexedDB and syncs across browser tabs:
+The simplest approach is the `persistenceKey` prop. This automatically saves the document and any uploaded [assets](/docs/assets) to IndexedDB and syncs across browser tabs:
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -46,17 +46,17 @@ const { document, session } = getSnapshot(editor.store)
 await saveToDatabase(document)
 
 // Load
-const document = await loadFromDatabase()
-loadSnapshot(editor.store, { document })
+const saved = await loadFromDatabase()
+loadSnapshot(editor.store, { document: saved })
 ```
 
-The snapshot has two parts: `document` (shapes, pages, bindings) which you typically save to a server, and `session` (camera, selection, UI state) which you keep per-user locally.
+The snapshot has two parts: `document` (shapes, pages, bindings) which you typically save to a server, and `session` (camera, selection, UI state) which you keep per-user locally. Loading a snapshot replaces the current document.
 
-See [Persistence](/sdk-features/persistence) for complete coverage of snapshots, async loading with `TLStoreWithStatus`, and auto-save patterns.
+To load a snapshot once on startup, pass it to the `snapshot` prop of `<Tldraw>` instead. See [Persistence](/sdk-features/persistence) for complete coverage of snapshots, async loading with [TLStoreWithStatus](?), and auto-save patterns.
 
 ## The store
 
-The editor's [store](/sdk-features/store) is a reactive database that holds all records. You can create a standalone store, load data into it, and pass it to the editor:
+The editor's [store](/sdk-features/store) is a reactive database that holds all records. You can create a standalone store with [createTLStore](?), load data into it, and pass it to the editor:
 
 ```tsx
 import { useState } from 'react'
@@ -80,7 +80,7 @@ See [Store](/sdk-features/store) for details on store operations, listening to c
 
 ## Multiplayer sync
 
-For real-time collaboration, use the `@tldraw/sync` package. Multiple users can edit the same document simultaneously, see each other's cursors, and follow each other's viewports:
+For real-time collaboration, use the `@tldraw/sync` package and its [useSyncDemo](?) hook. Multiple users can edit the same document simultaneously, see each other's cursors, and follow each other's viewports:
 
 ```tsx
 import { useSyncDemo } from '@tldraw/sync'
@@ -102,8 +102,8 @@ See [Persistence](/sdk-features/persistence#migrations) for details on shape pro
 
 ## Examples
 
-- [Persistence key](/examples/data/persistence-key) — Automatic local persistence with a single prop
-- [Snapshots](/examples/data/snapshots) — Saving and loading editor state
-- [Local storage](/examples/data/local-storage) — Custom persistence with throttled auto-save
-- [Store events](/examples/data/store-events) — Listening to store changes
-- [Shape with migrations](/examples/data/shape-with-migrations) — Migrations for custom shape props
+- [Persistence key](/examples/configuration/persistence-key) — Automatic local persistence with a single prop
+- [Snapshots](/examples/editor-api/snapshots) — Saving and loading editor state
+- [Local storage](/examples/data/assets/local-storage) — Custom persistence with throttled auto-save
+- [Store events](/examples/events/store-events) — Listening to store changes
+- [Shape with migrations](/examples/shapes/tools/shape-with-migrations) — Migrations for custom shape props

--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -47,7 +47,7 @@ type CardShape = TLShape<typeof CARD_TYPE>
 
 ### Creating a ShapeUtil
 
-Implement the required methods: `getDefaultProps`, `getGeometry`, `component`, and `getIndicatorPath`. Set `static props` so the store validates your shape's props; without it, `props` accepts any JSON value and you can't add [migrations](/sdk-features/persistence#migrations) later.
+Implement the required methods: `getDefaultProps`, `getGeometry`, `component`, and `getIndicatorPath`. Set `static props` so the store validates your shape's props; without it, `props` accepts any JSON value and typos or stale data pass through unchecked.
 
 ```tsx
 import { HTMLContainer, Rectangle2d, ShapeUtil, T } from 'tldraw'

--- a/apps/docs/content/docs/shapes.mdx
+++ b/apps/docs/content/docs/shapes.mdx
@@ -13,17 +13,13 @@ keywords:
   - metadata
 ---
 
-In tldraw, a shape is something that can exist on the page, like an arrow, an image, or some text. This article provides an overview of shapes and how to create custom ones.
+In tldraw, a shape is something that can exist on the page, like an arrow, an image, or some text.
 
 ## Shape basics
 
-Shapes are JSON records stored in the editor's [store](/sdk-features/store). Each shape has base properties (position, rotation, opacity) plus a `props` object for shape-specific data. See [Shapes](/sdk-features/shapes) for the full shape system architecture.
+Shapes are JSON records stored in the editor's [store](/sdk-features/store). Each shape has base properties (position, rotation, opacity) plus a `props` object for shape-specific data. Each shape type has a [ShapeUtil](?) class that defines its behavior: how it renders, its geometry for hit testing, and how it responds to interactions.
 
-The [Tldraw](?) component includes [default shapes](/sdk-features/default-shapes) like geo, text, arrow, and draw. The only core shape (always present) is the [group](/sdk-features/groups).
-
-## ShapeUtil
-
-Each shape type has a [ShapeUtil](?) class that defines its behavior: how it renders, its geometry for hit testing, and how it responds to interactions. See [Shapes](/sdk-features/shapes#shapeutil) for details on ShapeUtil methods, lifecycle hooks, and configuration.
+The [Tldraw](?) component includes [default shapes](/sdk-features/default-shapes) like geo, text, arrow, and draw. The only core shape (always present) is the [group](/sdk-features/groups). See [Shapes](/sdk-features/shapes) for the full shape system architecture, including ShapeUtil methods, lifecycle hooks, and configuration.
 
 ## Custom shapes
 
@@ -51,13 +47,14 @@ type CardShape = TLShape<typeof CARD_TYPE>
 
 ### Creating a ShapeUtil
 
-Implement the required methods: `getDefaultProps`, `getGeometry`, `component`, and `getIndicatorPath`:
+Implement the required methods: `getDefaultProps`, `getGeometry`, `component`, and `getIndicatorPath`. Set `static props` so the store validates your shape's props; without it, `props` accepts any JSON value and you can't add [migrations](/sdk-features/persistence#migrations) later.
 
 ```tsx
-import { HTMLContainer, Rectangle2d, ShapeUtil } from 'tldraw'
+import { HTMLContainer, Rectangle2d, ShapeUtil, T } from 'tldraw'
 
 class CardShapeUtil extends ShapeUtil<CardShape> {
 	static override type = CARD_TYPE
+	static override props = { w: T.number, h: T.number }
 
 	getDefaultProps(): CardShape['props'] {
 		return { w: 100, h: 100 }
@@ -132,7 +129,7 @@ editor.updateShapes<ShapeWithMyMeta>([
 
 ### Initial meta
 
-When [Editor#createShapes](?) creates a shape, it sets the shape's meta using [Editor#getInitialMetaForShape](?). By default this method returns an empty object. Replace it to provide your own initial meta:
+When [Editor#createShapes](?) creates a shape, it merges the result of [Editor#getInitialMetaForShape](?) with any `meta` you passed. Your explicit `meta` wins. By default this method returns an empty object. Replace it to provide your own initial meta:
 
 ```tsx
 editor.getInitialMetaForShape = (shape) => {
@@ -187,12 +184,11 @@ export default function App() {
 }
 ```
 
-Bindings, assets, and user records accept meta validators the same way. For user records, see our [custom user metadata example](/examples/users/custom-user).
+When you build the schema yourself, include your custom shapes' `props` and `migrations` in the `shapes` map too. Bindings, assets, and user records accept meta validators the same way. For user records, see our [custom user metadata example](/examples/users/custom-user).
 
 ## Extending shapes
 
-- **[BaseBoxShapeUtil](?)** - Extend this for standard rectangular shape behavior
-- **[ShapeUtil#configure](?)** - Customize built-in shapes without subclassing
+Extend [BaseBoxShapeUtil](?) for standard rectangular shape behavior. Use [ShapeUtil#configure](?) to customize a built-in shape's options without subclassing it.
 
 ## Related topics
 

--- a/apps/docs/content/docs/sync.mdx
+++ b/apps/docs/content/docs/sync.mdx
@@ -33,7 +33,7 @@ There are two main ways to go about hosting tldraw sync:
 
 ### Use our Cloudflare template
 
-The best way to get started hosting your own backend is to clone and deploy [our Cloudflare template](https://github.com/tldraw/tldraw-sync-cloudflare). The template provides the same setup that runs on tldraw.com.
+The best way to get started hosting your own backend is to clone and deploy [our Cloudflare template](https://github.com/tldraw/tldraw/tree/main/templates/sync-cloudflare). The template provides the same setup that runs on tldraw.com.
 
 It uses:
 
@@ -44,13 +44,13 @@ There are some features that we have not provided and you might want to add your
 
 Make sure you also read the section below about [deployment concerns](#deployment-concerns).
 
-[Get started with the Cloudflare template](https://github.com/tldraw/tldraw-sync-cloudflare).
+[Get started with the Cloudflare template](https://github.com/tldraw/tldraw/tree/main/templates/sync-cloudflare).
 
 ### Integrate tldraw sync into your own backend
 
 We recommend Cloudflare. The `@tldraw/sync-core` library also integrates tldraw sync into any JavaScript server environment that supports WebSockets.
 
-We have a [simple server example](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example), supporting both NodeJS and Bun, to use as a reference for how things should be stitched together.
+We have a [simple Node.js server example](https://github.com/tldraw/tldraw/tree/main/templates/simple-server-example) to use as a reference for how things should be stitched together.
 
 ## What does a tldraw sync backend do?
 
@@ -60,17 +60,18 @@ A backend for tldraw sync consists of two or three parts:
 - An **asset storage** provider for large binary files like images and videos.
 - (If using the built-in bookmark shape) An **unfurling service** to extract metadata about bookmark URLs.
 
-On the frontend, there is just one part: the **sync client**, created using the [`useSync`](?) hook from the `@tldraw/sync` package.
+On the frontend, there is just one part: the **sync client**, created using the [useSync](?) hook from the `@tldraw/sync` package.
 
 Here's a simple client implementation:
 
 ```tsx
 import { Tldraw, TLAssetStore, Editor } from 'tldraw'
 import { useSync } from '@tldraw/sync'
+import 'tldraw/tldraw.css'
 import { uploadFileAndReturnUrl } from './assets'
 import { convertUrlToBookmarkAsset } from './unfurl'
 
-function MyEditorComponent({ myRoomId }) {
+function MyEditorComponent({ myRoomId }: { myRoomId: string }) {
 	// This hook creates a sync client that manages the websocket connection to the server
 	// and coordinates updates to the document state.
 	const store = useSync({
@@ -103,13 +104,19 @@ And [here's a full working example](https://github.com/tldraw/tldraw/blob/main/t
 
 ### WebSocket server
 
-The `@tldraw/sync-core` package exports a class called [`TLSocketRoom`](?) that should be created server-side on a per-document basis.
+The `@tldraw/sync-core` package exports a class called [TLSocketRoom](?) that should be created server-side on a per-document basis.
 
-`TLSocketRoom` is used to
+`TLSocketRoom` stores the authoritative copy of the document, relays changes between sync clients over WebSockets, and exposes hooks for persisting the document when it changes.
 
-- Store an authoritative copy of the document state.
-- Transparently set up communication between multiple sync clients via WebSockets.
-- Provide hooks for persisting the document state when it changes.
+Attach each incoming WebSocket to the room and forward its events:
+
+```tsx
+room.handleSocketConnect({ sessionId, socket })
+// If your platform doesn't let the room add listeners to the socket itself
+// (Bun.serve, Cloudflare hibernation), forward events by hand:
+room.handleSocketMessage(sessionId, message)
+room.handleSocketClose(sessionId)
+```
 
 <Callout type="info">
 	You should make sure that there's only ever one `TLSocketRoom` globally for each room in your app.
@@ -118,7 +125,7 @@ The `@tldraw/sync-core` package exports a class called [`TLSocketRoom`](?) that 
 	tldraw.com.
 </Callout>
 
-Read the reference docs for [`TLSocketRoom`](?), and see an example of how to use it in the [simple server example](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/server/rooms.ts).
+Read the reference docs for [TLSocketRoom](?), and see an example of how to use it in the [simple server example](https://github.com/tldraw/tldraw/blob/main/templates/simple-server-example/src/server/rooms.ts).
 
 ### Storage backends
 
@@ -126,7 +133,7 @@ Read the reference docs for [`TLSocketRoom`](?), and see an example of how to us
 
 #### InMemorySyncStorage (default)
 
-[`InMemorySyncStorage`](?) keeps all document state in memory. It's simple to use, but data is lost when the process restarts. To persist data, pass an `onChange` callback to the constructor and save snapshots to your database.
+[InMemorySyncStorage](?) keeps all document state in memory. It's simple to use, but data is lost when the process restarts. To persist data, pass an `onChange` callback to the constructor and save snapshots to your database.
 
 ```tsx
 import { InMemorySyncStorage, TLSocketRoom } from '@tldraw/sync-core'
@@ -144,9 +151,9 @@ const room = new TLSocketRoom({ storage })
 
 #### SQLiteSyncStorage (recommended for persistence)
 
-[`SQLiteSyncStorage`](?) stores document state in SQLite. Data survives process restarts automatically. This is the recommended approach for production deployments.
+[SQLiteSyncStorage](?) stores document state in SQLite. Data survives process restarts automatically. This is the recommended approach for production deployments.
 
-**For Cloudflare Durable Objects:**
+##### Cloudflare Durable Objects
 
 ```tsx
 import { DurableObject } from 'cloudflare:workers'
@@ -164,7 +171,7 @@ export class TLSyncDurableObject extends DurableObject {
 }
 ```
 
-**For Node.js with better-sqlite3 or node:sqlite:**
+##### Node.js with better-sqlite3 or node:sqlite
 
 ```tsx
 import Database from 'better-sqlite3' // replace with 'node:sqlite' if using
@@ -184,7 +191,7 @@ const room = new TLSocketRoom({ storage })
 
 ### WebSocket hibernation
 
-Some serverless platforms let WebSocket connections survive while the surrounding object hibernates. [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/best-practices/websockets/) is the most common example. The platform keeps the sockets open, but your in-memory state (including the `TLSocketRoom`) is gone when the object wakes back up. Every wake would force every client to reconnect from scratch.
+Some serverless platforms let WebSocket connections survive while the surrounding object hibernates. [Cloudflare Durable Objects](https://developers.cloudflare.com/durable-objects/best-practices/websockets/) is the most common example. The platform keeps the sockets open, but your in-memory state (including the `TLSocketRoom`) is gone when the object wakes back up. Without help, every wake forces every client to reconnect.
 
 `TLSocketRoom` exposes three APIs for hibernation. The `onSessionSnapshot` callback fires when a session has had no message activity for about 5 seconds, so you can persist its state. [TLSocketRoom#getSessionSnapshot](?) returns that snapshot on demand. [TLSocketRoom#handleSocketResume](?) restores a session straight into `Connected` state when the object wakes back up.
 
@@ -244,30 +251,30 @@ export class TldrawDurableObject extends DurableObject {
 }
 ```
 
-Three pieces make this work. The `onSessionSnapshot` callback persists each session's state to its WebSocket's attachment so the snapshot is still around after hibernation. When the object wakes up with sockets still open, `handleSocketResume` replays each saved snapshot and the session lands straight in `Connected` state without the client noticing. Setting `clientTimeout: Infinity` disables the room's idle timer; hibernating platforms handle keep-alive themselves and would otherwise see the room disconnect perfectly fine clients.
+Three pieces make this work. The `onSessionSnapshot` callback persists each session's state to its WebSocket's attachment so the snapshot is still around after hibernation. When the object wakes up with sockets still open, `handleSocketResume` replays each saved snapshot and the session lands straight in `Connected` state; the client never sees a reconnect. Setting `clientTimeout: Infinity` disables the room's idle timer; hibernating platforms handle keep-alive themselves and would otherwise see the room disconnect healthy clients.
 
 For a complete implementation, including the hibernation event handlers that populate `sessionIdToWs`, see the [sync-cloudflare template](https://github.com/tldraw/tldraw/tree/main/templates/sync-cloudflare).
 
-For non-hibernating environments (Node servers, long-lived processes), you don't need any of this. The in-memory `TLSocketRoom` outlives individual sockets, and the default `clientTimeout` keeps idle sessions tidy.
+For non-hibernating environments (Node servers, long-lived processes), you don't need any of this. The in-memory `TLSocketRoom` outlives individual sockets, and the default `clientTimeout` (20 seconds) removes idle sessions.
 
 ### Asset storage
 
 Tldraw also needs a way to store and retrieve large binary assets like images and videos.
 
 You'll need to make sure your backend can handle asset uploads & downloads, then implement
-[`TLAssetStore`](?) to connect it to tldraw.
+[TLAssetStore](?) to connect it to tldraw.
 
 - Read about [how assets work in tldraw](/docs/assets).
-- Read the [`TLAssetStore`](?) reference docs.
+- Read the [TLAssetStore](?) reference docs.
 - See a complete example of an asset store in the
-  [`tldraw-sync-cloudflare`](https://github.com/tldraw/tldraw/blob/main/templates/sync-cloudflare/client/multiplayerAssetStore.tsx)
+  [`sync-cloudflare`](https://github.com/tldraw/tldraw/blob/main/templates/sync-cloudflare/client/multiplayerAssetStore.tsx)
   template.
 
 ### Unfurling service
 
 If you want to use the built-in bookmark shape, you'll need to use or implement an unfurling service that returns metadata about URLs.
 
-This should be registered with the [`Editor`](?) when it loads.
+This should be registered with the [Editor](?) when it loads.
 
 ```tsx
 <Tldraw
@@ -313,9 +320,9 @@ function MyApp() {
 
 #### On the server
 
-Use [`createTLSchema`](?) to create a store schema, and pass that into [`TLSocketRoom`](?). You can
-use shape/binding utils here, but the schema will only look at two properties:
-[`props`](/reference/editor/ShapeUtil#props) and
+Use [createTLSchema](?) to create a store schema, and pass that into [TLSocketRoom](?). You can
+use shape/binding utils here, but the schema only reads three properties:
+[`props`](/reference/editor/ShapeUtil#props), `meta`, and
 [`migrations`](/sdk-features/persistence#migrations). You need to provide the default shape
 schemas if you're using them.
 
@@ -353,8 +360,10 @@ clients on different versions won't be able to collaborate without errors.
 
 ### Comments and the object-store lane
 
+A room can serve some record types through a second partition, the object-store lane, which is persisted and permissioned separately from the document. Comments are the main use for it.
+
 Comment threads, comments, and reactions are record types that aren't in the default schema. Register
-them with the `records` option on both ends—`useSync` on the client, [`createTLSchema`](?) on the
+them with the `records` option on both ends: `useSync` on the client, [createTLSchema](?) on the
 server. Both sides must register the same types, or the connection will fail schema validation.
 
 ```ts
@@ -383,10 +392,12 @@ room.handleSocketConnect({
 })
 ```
 
-`objectAccess` is `'read'` or `'write'` and defaults to `'write'`. Read the lane's contents with
-[`TLSocketRoom`](?)'s `getCurrentObjectsSnapshot()`, and use the room's `onCommittedChanges` callback to
-mirror committed records into your own database. See [Commenting](/sdk-features/commenting) for the
-client side.
+`objectAccess` is `'read'` or `'write'` and defaults to `'write'` on connect. Read the lane's contents with
+[TLSocketRoom#getCurrentObjectsSnapshot](?), and use the room's `onCommittedChanges` callback to
+mirror committed records into your own database. That callback only fires for client pushes, not for
+`updateStore`, `loadSnapshot`, or direct storage writes. For per-record rules like "only the author
+may edit a comment", pass authorizers to the room's `authorizeRecord` option (see [TLRecordAuthorizers](?)).
+See [Commenting](/sdk-features/commenting) for the client side and the ready-made comment authorizers.
 
 ### Deployment concerns
 
@@ -403,9 +414,9 @@ client side.
 
 If you have been using some other solution for data sync, you can migrate your existing data to the tldraw sync format.
 
-Both [`InMemorySyncStorage`](?) and [`SQLiteSyncStorage`](?) support loading [`TLStoreSnapshot`](?) snapshots, so you can add a backwards-compatibility layer that lazily imports data from your old system and converts it to a `TLStoreSnapshot`.
+[SQLiteSyncStorage](?) accepts a [TLStoreSnapshot](?) directly, and [TLSocketRoom#loadSnapshot](?) accepts one for any storage backend, so you can add a backwards-compatibility layer that lazily imports data from your old system and converts it to a `TLStoreSnapshot`.
 
-**Example with SQLiteSyncStorage (recommended):**
+#### With SQLiteSyncStorage (recommended)
 
 ```tsx
 import { SQLiteSyncStorage, NodeSqliteWrapper, TLSocketRoom } from '@tldraw/sync-core'
@@ -434,12 +445,13 @@ function loadOrMakeRoom(roomId: string, db: Database.Database) {
 }
 ```
 
-**Example with InMemorySyncStorage:**
+#### With InMemorySyncStorage
 
 ```tsx
 import { InMemorySyncStorage, TLSocketRoom } from '@tldraw/sync-core'
 
 async function loadOrMakeRoom(roomId: string) {
+	// InMemorySyncStorage takes a RoomSnapshot, which is what getSnapshot() returns.
 	const data = await loadRoomDataFromCurrentStore(roomId)
 	if (data) {
 		const storage = new InMemorySyncStorage({ snapshot: data })
@@ -449,9 +461,10 @@ async function loadOrMakeRoom(roomId: string) {
 	if (legacyData) {
 		// Convert your old data to a TLStoreSnapshot.
 		const snapshot = convertOldDataToSnapshot(legacyData)
-		// Load it into the room.
-		const storage = new InMemorySyncStorage({ snapshot })
+		// Load it into the room. loadSnapshot accepts a TLStoreSnapshot.
+		const storage = new InMemorySyncStorage()
 		const room = new TLSocketRoom({ storage })
+		room.loadSnapshot(snapshot)
 		// Save an updated copy of the snapshot in the new place
 		// so that next time we can load it directly.
 		await saveRoomData(roomId, storage.getSnapshot())
@@ -469,7 +482,7 @@ async function loadOrMakeRoom(roomId: string) {
 
 If you were previously using R2 to store room snapshots (as shown in earlier versions of the sync-cloudflare template), you can migrate to SQLite storage while preserving existing data.
 
-**Step 1: Update wrangler.toml if needed**
+#### Step 1: Update wrangler.toml if needed
 
 If your Durable Object class was originally created _without_ SQLite support, you need to add a new migration with a new Durable Object class that uses SQLite storage.
 You need to keep the old class for at least one release because it can't be deleted while it's still being used, but you can convert it to an empty class.
@@ -492,7 +505,7 @@ bindings = [
 ]
 ```
 
-**Step 2: Rename your Durable Object and add fallback loading**
+#### Step 2: Rename your Durable Object and add fallback loading
 
 Rename your existing class (e.g. `TldrawDurableObject` → `TldrawDurableObjectSqlite`) and update the loading logic to check SQLite first, then fall back to R2:
 
@@ -558,7 +571,7 @@ export class TldrawDurableObjectSqlite {
 }
 ```
 
-**Step 3: Update your worker exports**
+#### Step 3: Update your worker exports
 
 Make sure both classes are exported from your worker entry point:
 

--- a/apps/docs/content/docs/tools.mdx
+++ b/apps/docs/content/docs/tools.mdx
@@ -20,18 +20,19 @@ In tldraw, a **tool** is a top-level state in our state chart. The select tool, 
 
 ## Default and custom tools
 
-The `<Tldraw>` component includes default tools like [select](/reference/tldraw/SelectTool), [hand](/reference/tldraw/HandTool), [draw](/reference/tldraw/DrawShapeTool), and [arrow](/reference/tldraw/ArrowShapeTool). The core `@tldraw/editor` package has no built-in tools—if you use `<TldrawEditor>` directly, you provide your own.
+The `<Tldraw>` component includes default tools like [SelectTool](?), [HandTool](?), [DrawShapeTool](?), and [ArrowShapeTool](?). The core `@tldraw/editor` package has no built-in tools. If you use `<TldrawEditor>` directly, you provide your own.
 
-You can create custom tools by extending [StateNode](/reference/editor/StateNode) and passing them to the `tools` prop:
+You can create custom tools by extending [StateNode](?) and passing them to the `tools` prop:
 
 ```tsx
-import { StateNode, TLPointerEventInfo, Tldraw } from 'tldraw'
+import { StateNode, Tldraw, toRichText } from 'tldraw'
 
 class StampTool extends StateNode {
 	static override id = 'stamp'
 
-	override onPointerDown(info: TLPointerEventInfo) {
-		// Create a shape at the click position
+	override onPointerDown() {
+		const { x, y } = this.editor.inputs.getCurrentPagePoint()
+		this.editor.createShape({ type: 'text', x, y, props: { richText: toRichText('❤️') } })
 	}
 }
 
@@ -40,27 +41,32 @@ export default function App() {
 }
 ```
 
+Registering a tool adds it to the state chart but not to the toolbar. To add a toolbar button and keyboard shortcut, see the [add tool to toolbar example](/examples/ui/add-tool-to-toolbar). Tools with multiple states declare child states with `static children()`; see the [Tools](/sdk-features/tools) guide.
+
 ## Changing tools
 
-Change the active tool with [editor.setCurrentTool](/reference/editor/Editor#setCurrentTool):
+Change the active tool with [Editor#setCurrentTool](?), and read it with [Editor#getCurrentToolId](?):
 
 ```ts
 editor.setCurrentTool('select')
 editor.setCurrentTool('hand')
 editor.setCurrentTool('draw')
+editor.getCurrentToolId() // 'draw'
 ```
 
 ## Learn more
 
-These guides cover the tool system in depth:
-
-- **[Tools](/sdk-features/tools)** — Full guide to the tool system: state hierarchy, event handling, child states, tool lock, creating custom tools, and overriding defaults
-- **[Events](/sdk-features/events)** — How the editor dispatches events and how to subscribe to them
-- **[Input handling](/sdk-features/input-handling)** — Pointer tracking, keyboard state, and the `editor.inputs` API
-- **[Ticks](/sdk-features/ticks)** — Frame-synchronized updates for animations and continuous interactions
+| Guide                                          | Covers                                                                                                   |
+| ---------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| [Tools](/sdk-features/tools)                   | State hierarchy, event handling, child states, tool lock, creating custom tools, and overriding defaults |
+| [Events](/sdk-features/events)                 | How the editor dispatches events and how to subscribe to them                                            |
+| [Input handling](/sdk-features/input-handling) | Pointer tracking, keyboard state, and the `editor.inputs` API                                            |
+| [Ticks](/sdk-features/ticks)                   | Frame-synchronized updates for animations and continuous interactions                                    |
 
 ## Examples
 
-- [Custom tool](/examples/shapes/tools/custom-tool) — A simple tool that adds stickers to the canvas
-- [Tool with child states](/examples/shapes/tools/tool-with-child-states) — A tool with multiple states for complex interactions
-- [Screenshot tool](/examples/shapes/tools/screenshot-tool) — A tool for capturing canvas regions
+| Example                                                                 | Description                                          |
+| ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| [Custom tool](/examples/shapes/tools/custom-tool)                       | A simple tool that adds stickers to the canvas       |
+| [Tool with child states](/examples/shapes/tools/tool-with-child-states) | A tool with multiple states for complex interactions |
+| [Screenshot tool](/examples/shapes/tools/screenshot-tool)               | A tool for capturing canvas regions                  |

--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -22,16 +22,42 @@ notes: 'Brief intro that links to sdk-features articles.'
 
 The `tldraw` package includes a complete user interface with menus, toolbars, keyboard shortcuts, and style panels. You can hide it entirely, listen to events, or customize individual components.
 
+Each of those is a prop on `<Tldraw>`:
+
+```tsx
+import { Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+export default function App() {
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw
+				// hideUi hides the whole default interface
+				hideUi={false}
+				// components replaces or removes individual pieces
+				components={{ PageMenu: null }}
+				// onUiEvent fires for every UI interaction
+				onUiEvent={(name, data) => console.log(name, data)}
+			/>
+		</div>
+	)
+}
+```
+
 ## Learn more
 
-- [UI components](/sdk-features/ui-components) - Component architecture, overrides, and customization
-- [UI primitives](/sdk-features/ui-primitives) - Buttons, menus, dialogs for building custom interfaces
-- [Internationalization](/sdk-features/internationalization) - Translations and language support
+- [UI components](/sdk-features/ui-components) — Component architecture, overrides, and customization
+- [UI primitives](/sdk-features/ui-primitives) — Buttons, menus, dialogs for building custom interfaces
+- [Actions](/sdk-features/actions) — Add or override actions and keyboard shortcuts
+- [Styles](/sdk-features/styles) — The style panel and custom style properties
+- [Themes](/sdk-features/themes) — Color modes and custom color palettes
+- [Accessibility](/sdk-features/accessibility) — Keyboard navigation and screen reader support
+- [Internationalization](/sdk-features/internationalization) — Translations and language support
 
 ## Examples
 
-- [Hide UI](/examples/hide-ui) - Hide the entire default interface
-- [Custom UI](/examples/custom-ui) - Build a completely custom interface
-- [Hide UI components](/examples/ui-components-hidden) - Selectively hide specific components
-- [Action overrides](/examples/action-overrides) - Customize actions and shortcuts
-- [UI events](/examples/ui-events) - Track user interactions
+- [Hide UI](/examples/ui/hide-ui) — Hide the entire default interface
+- [Custom UI](/examples/ui/custom-ui) — Build a completely custom interface
+- [Hide UI components](/examples/ui/ui-components-hidden) — Selectively hide specific components
+- [Action overrides](/examples/ui/action-overrides) — Customize actions and shortcuts
+- [UI events](/examples/events/ui-events) — Track user interactions

--- a/apps/docs/content/docs/user-interface.mdx
+++ b/apps/docs/content/docs/user-interface.mdx
@@ -22,7 +22,7 @@ notes: 'Brief intro that links to sdk-features articles.'
 
 The `tldraw` package includes a complete user interface with menus, toolbars, keyboard shortcuts, and style panels. You can hide it entirely, listen to events, or customize individual components.
 
-Each of those is a prop on `<Tldraw>`:
+Each of those is a prop on `<Tldraw>`: `hideUi` hides everything, `components` replaces or removes individual pieces, and `onUiEvent` reports every UI interaction:
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -32,11 +32,8 @@ export default function App() {
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
-				// hideUi hides the whole default interface
 				hideUi={false}
-				// components replaces or removes individual pieces
 				components={{ PageMenu: null }}
-				// onUiEvent fires for every UI interaction
 				onUiEvent={(name, data) => console.log(name, data)}
 			/>
 		</div>

--- a/apps/docs/content/sdk-features/accessibility.mdx
+++ b/apps/docs/content/sdk-features/accessibility.mdx
@@ -54,17 +54,17 @@ export default function App() {
 }
 ```
 
-The `priority` option accepts `'polite'` or `'assertive'`. Polite announcements wait for a pause in speech, while assertive announcements interrupt immediately.
+The `priority` option accepts `'polite'` or `'assertive'` and defaults to `'assertive'`. Polite announcements wait for a pause in speech, while assertive announcements interrupt immediately. See [TLUiA11y](?) for the message type.
 
 > See the [screen reader accessibility example](/examples/ui/screen-reader-accessibility) for custom shape descriptions and announcements.
 
 ## Keyboard navigation
 
-Users can navigate between shapes using the keyboard. Tab moves focus to the next shape in reading order, and Shift+Tab moves to the previous shape. Arrow keys with Ctrl/Cmd move selection to the nearest shape in that direction.
+Users can navigate between shapes using the keyboard. With a shape selected, Tab moves selection to the next shape in reading order and Shift+Tab moves to the previous shape. Arrow keys with Ctrl/Cmd move selection to the nearest shape in that direction, and Ctrl/Cmd+Shift+Down or Up select a group's first child or its parent. [Editor#selectAdjacentShape](?) is the programmatic equivalent.
 
 Tldraw determines reading order by analyzing shape positions on the canvas. Shapes are grouped into rows based on their vertical position, then sorted left-to-right within each row. This creates a natural top-to-bottom, left-to-right reading order similar to text. You can access this order programmatically with [Editor#getCurrentPageShapesInReadingOrder](?).
 
-A "Skip to main content" link appears when users Tab into the editor, allowing keyboard users to jump directly to the first shape on the canvas.
+A "Skip to main content" link appears when users Tab into the editor. It selects the first shape on the canvas and zooms to it.
 
 ### Excluding shapes from keyboard navigation
 
@@ -122,9 +122,9 @@ class CardShapeUtil extends ShapeUtil<CardShape> {
 If your shape has visible text, override [ShapeUtil#getText](?) instead. The announcement system checks `getAriaDescriptor()` first, then falls back to `getText()`:
 
 ```tsx
-class NoteShapeUtil extends ShapeUtil<NoteShape> {
-	getText(shape: NoteShape) {
-		return shape.props.content
+class CardShapeUtil extends ShapeUtil<CardShape> {
+	getText(shape: CardShape) {
+		return shape.props.title
 	}
 
 	// ...
@@ -162,7 +162,7 @@ Users can toggle reduced motion through the accessibility menu, found under Pref
 
 ## Enhanced accessibility mode
 
-The `enhancedA11yMode` user preference adds visible labels to UI elements that normally rely on icons alone. When enabled, the style panel shows text labels for each section like "Color", "Opacity", and "Align", making the interface more navigable for users who need additional context.
+The `enhancedA11yMode` user preference adds visible labels to UI elements that normally rely on icons alone. When enabled, the style panel shows text labels for each section like "Color", "Opacity", and "Align". This helps users who need more context than an icon provides.
 
 Toggle this setting programmatically:
 
@@ -208,17 +208,9 @@ See [AccessibilityMenu](?) for the default implementation.
 
 ## Best practices for custom shapes
 
-When building custom shapes, consider these accessibility guidelines:
+Override `getAriaDescriptor()` or `getText()` to give screen reader users context about what the shape contains. A shape announced as "card" is less useful than "Meeting notes: Q4 planning session".
 
-**Provide meaningful descriptions.** Override `getAriaDescriptor()` or `getText()` to give screen reader users context about what the shape contains. A shape labeled "card" is less useful than "Meeting notes: Q4 planning session".
-
-**Use semantic HTML where possible.** The shape's `component()` renders inside an HTML container. Use appropriate heading levels, lists, and other semantic elements rather than styled divs.
-
-**Support keyboard interaction.** If your shape has interactive elements, ensure they're focusable and operable with the keyboard. Use standard focus indicators and ARIA attributes where needed.
-
-**Respect motion preferences.** Check `usePrefersReducedMotion()` before showing animations. Provide static alternatives for animated content.
-
-**Consider contrast.** Shape colors must meet WCAG contrast requirements against typical backgrounds. The default color styles are designed with accessibility in mind.
+The shape's `component()` renders inside an HTML container, so the usual web accessibility rules apply: use semantic elements rather than styled divs, make interactive elements focusable and operable with the keyboard, and check `usePrefersReducedMotion()` before showing animations.
 
 For more on creating custom shapes, see [Custom shapes](/docs/shapes).
 

--- a/apps/docs/content/sdk-features/actions.mdx
+++ b/apps/docs/content/sdk-features/actions.mdx
@@ -49,11 +49,11 @@ export default function App() {
 }
 ```
 
-The `tldraw` package includes nearly 100 default actions covering editing, arrangement, export, zoom, and preferences. You can override any of these or add your own through the `overrides` prop.
+The `tldraw` package includes nearly 100 default actions covering editing, arrangement, export, zoom, and preferences. You can override any of these or add your own through the `overrides` prop, typed as [TLUiOverrides](?).
 
 ## How actions work
 
-Actions live in a React context provided by `ActionsProvider`. When the UI mounts, it registers all default actions, applies any overrides you've provided, and makes them available through the `useActions` hook. Menus and toolbars look up actions by ID and render them with their labels, icons, and keyboard shortcuts.
+Actions live in a React context inside the tldraw UI. When the UI mounts, it registers all default actions, applies any overrides you've provided, and makes them available through the [useActions](?) hook. Menus and toolbars look up actions by ID and render them with their labels, icons, and keyboard shortcuts.
 
 Each action has an `onSelect` handler that receives a source parameter indicating where it was triggered:
 
@@ -65,39 +65,26 @@ const duplicateAction = actions['duplicate']
 duplicateAction.onSelect('toolbar')
 ```
 
-Keyboard shortcuts are bound automatically. The `useKeyboardShortcuts` hook parses each action's `kbd` property and registers hotkey handlers. When a shortcut fires, it calls the action's `onSelect` with `'kbd'` as the source.
+Keyboard shortcuts are bound automatically. The [useKeyboardShortcuts](?) hook parses each action's `kbd` property and registers hotkey handlers. When a shortcut fires, it calls the action's `onSelect` with `'kbd'` as the source.
 
 ## Action structure
 
-The `TLUiActionItem` interface defines what an action contains:
-
-```typescript
-interface TLUiActionItem {
-	id: string
-	label?: string | { [key: string]: string }
-	icon?: string | React.ReactElement
-	kbd?: string
-	readonlyOk?: boolean
-	checkbox?: boolean
-	isRequiredA11yAction?: boolean
-	onSelect(source: TLUiEventSource): Promise<void> | void
-}
-```
+The [TLUiActionItem](?) interface defines what an action contains:
 
 | Property               | Description                                                                                                                                                   |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `id`                   | Unique identifier for the action (e.g., `'duplicate'`, `'zoom-in'`)                                                                                           |
 | `label`                | Translation key for display text. Can be a string or an object mapping contexts to different keys (see [Context-sensitive labels](#context-sensitive-labels)) |
 | `icon`                 | Icon name from tldraw's icon set, or a custom React element                                                                                                   |
-| `kbd`                  | Keyboard shortcut string. Use commas to separate platform alternatives: `'cmd+g,ctrl+g'` binds Cmd+G on Mac and Ctrl+G elsewhere                              |
+| `kbd`                  | Keyboard shortcut string. Use commas to bind several combinations, e.g. `'cmd+g,ctrl+g'` (see [Keyboard shortcuts](#keyboard-shortcuts))                      |
 | `readonlyOk`           | When `true`, the action works in readonly mode. Defaults to `false`                                                                                           |
 | `checkbox`             | When `true`, renders as a toggle with a checkmark indicator in menus                                                                                          |
 | `isRequiredA11yAction` | When `true`, the keyboard shortcut works even when shortcuts are normally disabled (e.g., while editing a shape). Used for accessibility actions              |
-| `onSelect`             | Handler called when the action is triggered. Receives a `source` parameter indicating the trigger origin (`'kbd'`, `'menu'`, `'toolbar'`, etc.)               |
+| `onSelect`             | Handler called when the action is triggered. Receives a [TLUiEventSource](?) indicating the trigger origin (`'kbd'`, `'menu'`, `'toolbar'`, etc.)             |
 
 ## Accessing actions
 
-Use the `useActions` hook to get all registered actions:
+Use the [useActions](?) hook to get all registered actions:
 
 ```typescript
 import { useActions } from 'tldraw'
@@ -117,21 +104,18 @@ The hook returns a record mapping action IDs to action objects. You can iterate 
 
 ## Default actions
 
-The default actions cover most editing operations you'd expect in a canvas application. Here are some common categories:
+The default actions cover most editing operations you'd expect in a canvas application. Some common ones, by category:
 
-**Editing**: `undo`, `redo`, `duplicate`, `delete`, `copy`, `cut`, `paste`
+| Category    | Action ids                                                                                                                                                                 |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Editing     | `undo`, `redo`, `duplicate`, `delete`, `copy`, `cut`, `paste`                                                                                                              |
+| Grouping    | `group`, `ungroup`                                                                                                                                                         |
+| Arrangement | `bring-to-front`, `bring-forward`, `send-backward`, `send-to-back`, `align-left`, `align-center-horizontal`, `align-right`, `distribute-horizontal`, `distribute-vertical` |
+| Export      | `export-as-svg`, `export-as-png`, `copy-as-svg`, `copy-as-png`                                                                                                             |
+| Zoom        | `zoom-in`, `zoom-out`, `zoom-to-100`, `zoom-to-fit`, `zoom-to-selection`, `select-zoom-tool`                                                                               |
+| Preferences | `toggle-dark-mode`, `toggle-snap-mode`, `toggle-grid`, `toggle-focus-mode`                                                                                                 |
 
-**Grouping**: `group`, `ungroup`
-
-**Arrangement**: `bring-to-front`, `bring-forward`, `send-backward`, `send-to-back`, `align-left`, `align-center-horizontal`, `align-right`, `distribute-horizontal`, `distribute-vertical`
-
-**Export**: `export-as-svg`, `export-as-png`, `copy-as-svg`, `copy-as-png`
-
-**Zoom**: `zoom-in`, `zoom-out`, `zoom-to-100`, `zoom-to-fit`, `zoom-to-selection`, `select-zoom-tool`
-
-**Preferences**: `toggle-dark-mode`, `toggle-snap-mode`, `toggle-grid`, `toggle-focus-mode`
-
-Most actions guard themselves inside their handlers. For example, `group` and the arrangement actions do nothing unless shapes are selected and the select tool is active.
+The full list is in the [default actions source](https://github.com/tldraw/tldraw/blob/main/packages/tldraw/src/lib/ui/context/actions.tsx). Most actions guard themselves inside their handlers. For example, `group` and the arrangement actions do nothing unless shapes are selected and the select tool is active.
 
 ## Overriding actions
 
@@ -156,6 +140,8 @@ function App() {
 	return <Tldraw overrides={overrides} />
 }
 ```
+
+The `copy`, `cut`, and `paste` shortcuts are handled by native clipboard events rather than the `kbd` system, so changing their `kbd` has no effect.
 
 ### Modifying behavior
 
@@ -202,11 +188,11 @@ const overrides: TLUiOverrides = {
 }
 ```
 
-Custom actions integrate with the keyboard shortcut system automatically. To add them to menus, you'll also need to override the menu components.
+Custom actions integrate with the keyboard shortcut system automatically. To add them to menus, override the menu components; see [Actions in menus](#actions-in-menus) and the [custom menus example](/examples/ui/custom-menus).
 
 ### Using helper utilities
 
-The override function receives a `helpers` object with useful utilities:
+The override function receives a `helpers` object ([TLUiOverrideHelpers](?), the return value of [useDefaultHelpers](?)):
 
 ```typescript
 const overrides: TLUiOverrides = {
@@ -252,21 +238,21 @@ Available helpers:
 
 ## Keyboard shortcuts
 
-Shortcuts use a simple string format with modifier keys separated by `+`. Use commas to specify alternatives for different platforms:
+Shortcuts use a simple string format with modifier keys separated by `+`. Use commas to bind several combinations to the same action. Every combination is active on every platform; the conventional `cmd+…,ctrl+…` pair covers Mac and everything else, and only the shortcut hint shown in menus ([TldrawUiKbd](?)) is platform-specific:
 
 ```typescript
-kbd: 'cmd+g,ctrl+g' // Cmd+G on Mac, Ctrl+G elsewhere
-kbd: 'shift+1' // Shift+1 on all platforms
-kbd: 'cmd+shift+s,ctrl+shift+s' // Cmd+Shift+S on Mac, Ctrl+Shift+S elsewhere
+kbd: 'cmd+g,ctrl+g' // Cmd+G or Ctrl+G
+kbd: 'shift+1' // Shift+1
+kbd: 'cmd+shift+s,ctrl+shift+s' // Cmd+Shift+S or Ctrl+Shift+S
 ```
 
-Available modifiers are `cmd`, `ctrl`, `shift`, and `alt`. Special keys include `del`, `backspace`, `enter`, `escape`, and arrow keys.
+Modifiers are `cmd` (alias `meta`), `ctrl`, `shift`, and `alt` (alias `option`). Special keys include `del`, `backspace`, `enter`, `escape`, `space`, and the arrow keys (`left`, `right`, `up`, `down`).
 
-Shortcuts are disabled when a menu is open, a shape is being edited, the editor has a crashing error, or the user has disabled keyboard shortcuts in preferences. Actions marked with `isRequiredA11yAction: true` bypass this check for accessibility purposes.
+Shortcuts only fire while the editor is focused and the key event does not target a text input. They are also disabled when a menu is open, a shape is being edited, the editor has a crashing error, or the user has disabled keyboard shortcuts in preferences. In readonly mode, only actions with `readonlyOk` are bound. Actions marked with `isRequiredA11yAction: true` bypass the disabled check for accessibility purposes.
 
 ## Actions in menus
 
-The default UI uses `TldrawUiMenuActionItem` to render actions in menus:
+The default UI uses [TldrawUiMenuActionItem](?) to render actions in menus:
 
 ```typescript
 import { TldrawUiMenuActionItem, TldrawUiMenuGroup } from 'tldraw'
@@ -282,11 +268,11 @@ function CustomMenu() {
 }
 ```
 
-This component looks up the action by ID and renders it with the correct label, icon, shortcut hint, and disabled state. For toggle actions, use `TldrawUiMenuActionCheckboxItem` which displays a checkmark when active.
+This component looks up the action by ID and renders it with the correct label, icon, and shortcut hint. Pass `disabled` yourself if the item should be disabled. For toggle actions, use [TldrawUiMenuActionCheckboxItem](?) with a `checked` prop.
 
 ## Context-sensitive labels
 
-Some actions show different labels depending on where they appear. The `label` property can be an object mapping context names to translation keys:
+Some actions show different labels depending on where they appear. The `label` property can be an object mapping menu context types ([TLUiMenuContextType](?), plus `default`) to translation keys:
 
 ```typescript
 actions['export-as-svg'] = {
@@ -320,6 +306,6 @@ actions['custom-action'] = {
 
 ## Related examples
 
-- [Action overrides](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/action-overrides) — Add custom actions and modify existing action shortcuts using the overrides prop.
-- [Keyboard shortcuts](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/keyboard-shortcuts) — Change keyboard shortcuts for tools and actions.
-- [Custom menus](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/custom-menus) — Build custom menus that use actions with proper labels and shortcuts.
+- [Action overrides](/examples/ui/action-overrides) - Add custom actions and modify existing action shortcuts using the overrides prop.
+- [Keyboard shortcuts](/examples/ui/keyboard-shortcuts) - Change keyboard shortcuts for tools and actions.
+- [Custom menus](/examples/ui/custom-menus) - Build custom menus that use actions with proper labels and shortcuts.

--- a/apps/docs/content/sdk-features/animation.mdx
+++ b/apps/docs/content/sdk-features/animation.mdx
@@ -17,23 +17,17 @@ accuracy: 9
 notes: Voice issues with "enable" and passive constructions ("are interpolated", "is useful for").
 ---
 
-The animation system controls smooth transitions for shapes and camera movements. Shape animations handle properties like position, rotation, and opacity. Camera animations manage viewport transitions for panning and zooming.
-
-Shape animations run independently and can be interrupted or replaced. Camera animations integrate with the camera system and respect user animation speed preferences for accessibility.
+The animation system drives smooth transitions for shapes and for the camera. Shape animations interpolate a shape's position, rotation, opacity, and props. Camera animations move the viewport for pans and zooms.
 
 ## How it works
 
-Animations in tldraw use the tick system to drive frame-by-frame updates. On each tick, active animations calculate elapsed time, apply easing functions to determine progress, and interpolate between start and end values.
+Animations run on the editor's [tick system](/sdk-features/ticks). When you call [Editor#animateShape](?) or a camera method with an `animation` option, the editor subscribes to `tick` events, applies the easing function to the elapsed time, and interpolates between the start and end values until the animation completes.
 
-The editor emits `tick` events at the browser's animation frame rate. The animation methods handle all of this internally: when you call `animateShape()` or `setCamera()` with animation options, the editor subscribes to tick events, calculates progress using the easing function, and updates the shape or camera state until the animation completes.
-
-Camera animations respect the user's animation speed preference, which can be set to zero to disable animations entirely. Shape animations do not check this preference. If you need reduced motion support for shape animations, check `editor.user.getAnimationSpeed()` yourself and skip the animation when it returns zero.
+Camera animations respect the user's animation speed preference; shape animations don't. See [User preferences](#user-preferences) below.
 
 ## Shape animations
 
-Shape animations transition individual shape properties smoothly. The editor tracks each animating shape independently, so multiple animations can run at once.
-
-Use `animateShape()` to animate a single shape or `animateShapes()` to animate multiple shapes simultaneously:
+Use [Editor#animateShape](?) to animate a single shape or [Editor#animateShapes](?) to animate several at once. The editor tracks each animating shape independently, so multiple animations can run at the same time:
 
 ```typescript
 import { createShapeId, EASINGS } from 'tldraw'
@@ -48,14 +42,9 @@ editor.animateShape(
 
 ### Animated properties
 
-The animation system handles interpolation for core shape properties that are common across all shape types. These built-in properties use linear interpolation (lerp) to calculate intermediate values between the start and end states:
+The editor linearly interpolates the properties common to every shape: `x`, `y`, `rotation` (in radians), and `opacity` (0 to 1).
 
-- `x` - Horizontal position
-- `y` - Vertical position
-- `opacity` - Shape transparency (0 to 1)
-- `rotation` - Shape rotation angle in radians
-
-For shape-specific properties like width, height, or custom values, shape utilities define their own interpolation logic by implementing the `getInterpolatedProps()` method. For example, box shapes interpolate their dimensions:
+For shape-specific props like width and height, the shape util implements [ShapeUtil#getInterpolatedProps](?). If a util doesn't implement it, the props jump to their end values on the first frame. This is how [BaseBoxShapeUtil](?) interpolates its dimensions (`lerp` is exported from `tldraw`):
 
 ```typescript
 getInterpolatedProps(startShape: Shape, endShape: Shape, t: number) {
@@ -69,19 +58,15 @@ getInterpolatedProps(startShape: Shape, endShape: Shape, t: number) {
 
 ### Animation lifecycle
 
-Each animation receives a unique ID when started. The editor maintains a map of shape IDs to animation IDs to track which shapes are currently animating.
+Shape animations default to a duration of 500 ms and `linear` easing. Intermediate frames don't create history entries; when the animation finishes the editor calls `updateShapes()` with the final values, so a single undo restores the starting state.
 
-You can interrupt animations in two ways. Calling `updateShapes()` on an animating shape cancels its animation and immediately applies the new values. Starting a new animation for a shape automatically cancels any existing animation for that shape.
+You can interrupt an animation in two ways. Calling `updateShapes()` on an animating shape cancels its animation and applies the new values immediately. Starting a new animation for a shape cancels the existing one.
 
-User interactions always take precedence over ongoing animations. If you drag a shape that's currently animating, the animation stops and the shape responds to your input immediately.
+User interaction wins over ongoing animations. If you drag a shape that's animating, the animation stops and the shape follows your pointer.
 
 ## Camera animations
 
-Camera animations move the viewport smoothly using easing functions. These animations integrate with the camera system and can be interrupted by user input like panning or zooming.
-
-### Viewport animations
-
-The `setCamera()` method accepts an animation option to smoothly transition to a new camera position:
+The camera-move methods ([Editor#setCamera](?), [Editor#zoomToBounds](?), [Editor#zoomToFit](?), and the rest) accept an `animation` option in [TLCameraMoveOptions](?). Without it, or with a `duration` of `0`, the camera jumps straight to the target. See [Camera](/sdk-features/camera) for the full set of methods.
 
 ```typescript
 editor.setCamera(
@@ -90,20 +75,14 @@ editor.setCamera(
 )
 ```
 
-Camera animations automatically stop when the user interacts with the viewport through mouse wheel, pinch gestures, or keyboard navigation.
+Camera animations default to `easeInOutCubic` easing. They stop as soon as the user pans, zooms, or pinches, and you can stop them yourself with [Editor#stopCameraAnimation](?). If the camera is locked, camera methods do nothing unless you pass `force: true`.
 
 ### Zooming to bounds
 
-Use `zoomToBounds()` to animate the camera so a specific area fills the viewport. Use it to focus on shapes or build slideshow-style transitions:
+Use `zoomToBounds()` to animate the camera so a specific area fills the viewport, for example to focus on shapes or build slideshow-style transitions. You can also cap the zoom with `targetZoom` and add screen-space padding with `inset`:
 
 ```typescript
 const bounds = { x: 0, y: 0, w: 800, h: 600 }
-editor.zoomToBounds(bounds, { animation: { duration: 500 } })
-```
-
-You can also specify a target zoom level and inset padding:
-
-```typescript
 editor.zoomToBounds(bounds, {
 	animation: { duration: 500 },
 	targetZoom: 1, // zoom to 100%
@@ -111,7 +90,7 @@ editor.zoomToBounds(bounds, {
 })
 ```
 
-The `zoomToFit()` method is a convenience wrapper that zooms to fit all shapes on the current page:
+`zoomToFit()` is a convenience wrapper that zooms to fit all shapes on the current page:
 
 ```typescript
 editor.zoomToFit({ animation: { duration: 200 } })
@@ -119,39 +98,27 @@ editor.zoomToFit({ animation: { duration: 200 } })
 
 ### Camera slide
 
-The `slideCamera()` method creates momentum-based camera movement that gradually decelerates:
+[Editor#slideCamera](?) creates momentum-based camera movement that decelerates under friction:
 
 ```typescript
 editor.slideCamera({
-	speed: 2,
+	speed: 1,
 	direction: { x: 1, y: 0 },
 	friction: 0.1,
 })
 ```
 
-This method respects the user's animation speed preference. If animation speed is set to zero, the slide animation is disabled.
-
 ## Easing functions
 
-Easing functions control the rate of change during an animation. The right curve makes movement feel natural rather than mechanical. Use `easeOut` variants when responding to user actions (the animation starts fast and settles), `easeIn` for exits or dismissals (gradual start, quick finish), and `easeInOut` for autonomous movements like camera transitions (smooth start and end).
+Easing functions control the rate of change during an animation. Use an `easeOut` curve when responding to user actions (fast start, gentle settle), `easeIn` for exits (gentle start, quick finish), and `easeInOut` for autonomous moves like camera transitions.
 
-The editor provides these easing functions in `EASINGS`:
-
-- `linear` - Constant rate of change, useful for progress indicators
-- `easeInQuad`, `easeOutQuad`, `easeInOutQuad` - Subtle, gentle curves
-- `easeInCubic`, `easeOutCubic`, `easeInOutCubic` - Balanced, natural-feeling motion
-- `easeInQuart`, `easeOutQuart`, `easeInOutQuart` - More pronounced acceleration
-- `easeInQuint`, `easeOutQuint`, `easeInOutQuint` - Strong acceleration curves
-- `easeInSine`, `easeOutSine`, `easeInOutSine` - Very gentle, sinusoidal curves
-- `easeInExpo`, `easeOutExpo`, `easeInOutExpo` - Dramatic, exponential curves
-
-Shape animations default to `linear` easing. Camera animations default to `easeInOutCubic`. For shape animations responding to user actions, `easeOutCubic` or `easeOutQuad` often feel more responsive since the animation starts fast and settles gradually.
+[EASINGS](?) provides `linear` plus the standard `easeIn`, `easeOut`, and `easeInOut` variants of `Quad`, `Cubic`, `Quart`, `Quint`, `Sine`, and `Expo`, for example `EASINGS.easeOutCubic` or `EASINGS.easeInOutSine`.
 
 ## User preferences
 
-Camera animations check `editor.user.getAnimationSpeed()` before running. This value is a speed multiplier: the editor divides animation durations by it, so users can speed up, slow down, or disable animations entirely.
+Camera animations check `editor.user.getAnimationSpeed()` before running. This value is a speed multiplier: the editor divides animation durations by it, so users can speed up, slow down, or disable animations entirely. It defaults to `0` when the operating system reports `prefers-reduced-motion`.
 
-When animation speed is zero, camera methods like `setCamera()`, `slideCamera()`, `zoomToBounds()`, and `zoomToFit()` skip the animation and jump immediately to the final position. Shape animations via `animateShape()` and `animateShapes()` do not check this preference automatically. If you need reduced motion support for shape animations, check the animation speed yourself:
+When animation speed is zero, `setCamera()`, `zoomToBounds()`, `zoomToFit()`, and the other camera-move methods jump straight to the target, and `slideCamera()` does nothing. `animateShape()` and `animateShapes()` do not check this preference. If you need reduced motion support for shape animations, check the animation speed yourself:
 
 ```typescript
 if (editor.user.getAnimationSpeed() > 0) {
@@ -166,4 +133,6 @@ if (editor.user.getAnimationSpeed() > 0) {
 
 ## Related examples
 
-The [slideshow example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/use-cases/slideshow) uses camera animations to smoothly transition between slides using `zoomToBounds` with animation options. The [camera options example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/camera-options) demonstrates camera constraints and animations for bounded canvas experiences.
+- [Shape animation](/examples/editor-api/shape-animation) - Animate shapes with `animateShape` and easing functions.
+- [Slideshow](/examples/use-cases/slideshow) - Transition between slides with `zoomToBounds` and animation options.
+- [Reduced motion](/examples/configuration/reduced-motion) - Respect the user's animation speed preference and `prefers-reduced-motion`.

--- a/apps/docs/content/sdk-features/arrow-shape.mdx
+++ b/apps/docs/content/sdk-features/arrow-shape.mdx
@@ -13,7 +13,7 @@ status: draft
 date: 1/31/2026
 ---
 
-The arrow shape draws a connector between two points on the canvas. Arrows can bind to other shapes, so they stay attached when those shapes move. They support two routing modes (curved arcs and right-angled elbows), nine arrowhead styles, and rich text labels.
+The arrow shape draws a connector between two points on the canvas. Arrows can bind to other shapes, so they stay attached when those shapes move. Arrows route as curved arcs or right-angled elbows, take one of nine arrowhead styles at each end, and can carry a rich text label.
 
 ## Creating arrows
 
@@ -45,7 +45,26 @@ export default function App() {
 }
 ```
 
-See [TLArrowShape](?) for the full list of props.
+The full set of props on [TLArrowShape](?):
+
+| Property         | Type                         | Description                                           |
+| ---------------- | ---------------------------- | ----------------------------------------------------- |
+| `kind`           | `TLArrowShapeKind`           | Routing mode: `arc` (default) or `elbow`              |
+| `start`          | `VecModel`                   | Start terminal position, relative to the shape origin |
+| `end`            | `VecModel`                   | End terminal position                                 |
+| `bend`           | `number`                     | Curvature for arc arrows (`0` = straight)             |
+| `elbowMidPoint`  | `number`                     | Position (0–1) of the middle segment for elbow arrows |
+| `color`          | `TLDefaultColorStyle`        | Stroke color                                          |
+| `fill`           | `TLDefaultFillStyle`         | Fill style for arrowheads                             |
+| `dash`           | `TLDefaultDashStyle`         | Stroke pattern                                        |
+| `size`           | `TLDefaultSizeStyle`         | Stroke width preset                                   |
+| `arrowheadStart` | `TLArrowShapeArrowheadStyle` | Arrowhead at the start (default `none`)               |
+| `arrowheadEnd`   | `TLArrowShapeArrowheadStyle` | Arrowhead at the end (default `arrow`)                |
+| `richText`       | `TLRichText`                 | Optional text label                                   |
+| `labelPosition`  | `number`                     | Label position along the arrow (0 = start, 1 = end)   |
+| `labelColor`     | `TLDefaultColorStyle`        | Label text color                                      |
+| `font`           | `TLDefaultFontStyle`         | Font family for the label                             |
+| `scale`          | `number`                     | Scale factor applied to the shape                     |
 
 ## Binding arrows to shapes
 
@@ -80,7 +99,7 @@ Three binding props control where the arrow attaches. See [TLArrowBindingProps](
 | `isPrecise`        | When `true`, the arrow points at the `normalizedAnchor` position. When `false`, it points at the shape's center                                           |
 | `isExact`          | When `true`, the arrowhead travels all the way to the anchor point, entering the shape. When `false`, the arrow stops at the edge of the shape's geometry |
 
-When drawing with the arrow tool, users get imprecise center bindings by default. Hovering over a spot inside a shape for a moment, or holding the pointer still while dragging a terminal, switches to a precise binding at that spot.
+When drawing with the arrow tool, users get imprecise center bindings by default. Hovering over a spot inside a shape for a moment, pausing while dragging a terminal, or holding Alt switches to a precise binding at that spot. The `hoverPreciseTimeout` and `pointingPreciseTimeout` options control the delays, and holding Ctrl skips binding entirely (`shouldIgnoreTargets`).
 
 ## Routing: arc and elbow
 
@@ -88,7 +107,7 @@ The `kind` prop selects between the two routing modes. It's a style prop, so use
 
 Arc arrows (`kind: 'arc'`, the default) draw a straight line or a circular arc between their terminals. The `bend` prop is the perpendicular distance from the straight line to the arc's midpoint: `0` draws a straight line, positive and negative values curve to either side. Users adjust the bend by dragging the arrow's middle handle.
 
-Elbow arrows (`kind: 'elbow'`) route with right-angled segments, like connectors in a flowchart. The `elbowMidPoint` prop (0–1) positions the middle segment between the two ends. For elbow arrows, the binding's `snap` prop records what the terminal snapped to when drawn: `'center'`, `'edge-point'`, `'edge'`, or `'none'`.
+Elbow arrows (`kind: 'elbow'`) route with right-angled segments, like connectors in a flowchart. The `elbowMidPoint` prop (0–1) positions the middle segment between the two ends. The binding's `snap` prop records what the terminal snapped to when drawn: `'center'`, `'edge'`, `'edge-point'`, or `'none'`. The edge values are only produced for elbow arrows, which use them when routing.
 
 ## Arrowheads
 

--- a/apps/docs/content/sdk-features/assets.mdx
+++ b/apps/docs/content/sdk-features/assets.mdx
@@ -30,15 +30,15 @@ The SDK includes three asset types: image, video, and bookmark. Each asset recor
 
 Assets live in the store alongside shapes and pages. Each asset record contains metadata (dimensions, MIME type, name) but not the actual file bytes—those live in your storage backend.
 
-When someone drops an image onto the canvas, tldraw creates two records: an asset record with dimensions and metadata, and a shape record with position and size. The shape references the asset through its `assetId` property. Multiple shapes can reference the same asset, so deleting one image shape won't remove the asset if other shapes still use it.
+When someone drops an image onto the canvas, tldraw creates two records: an asset record with dimensions and metadata, and a shape record with position and size. The shape references the asset through its `assetId` property. Multiple shapes can reference the same asset. Deleting a shape never deletes its asset: call [Editor#deleteAssets](?) yourself when you know an asset is no longer referenced.
 
-Asset records have a `props` object for type-specific properties and a `meta` object for your custom data. The `src` property in props holds the URL returned by your upload handler—this can be an HTTP URL, a data URL, or any string your resolve handler understands.
+Asset records have a `props` object for type-specific properties and a `meta` object for your custom data. The `src` property in props holds the URL returned by your upload handler. This can be an HTTP URL, a data URL, or any string your resolve handler understands.
 
 ### Asset types
 
 The SDK defines three built-in asset types.
 
-**Image assets** store raster images like PNG, JPEG, or GIF. They track width, height, MIME type, animation status, and file size. The `isAnimated` flag is true for animated GIFs.
+**Image assets** store raster images like PNG, JPEG, or GIF. They track width, height, MIME type, animation status, file size, and an optional `pixelRatio` for @2x images. The `isAnimated` flag is true for animated GIF, WebP, AVIF, and APNG files.
 
 ```typescript
 const imageAsset: TLImageAsset = {
@@ -53,6 +53,7 @@ const imageAsset: TLImageAsset = {
 		mimeType: 'image/jpeg', // can be null if unknown
 		src: 'https://storage.example.com/uploads/photo.jpg', // can be null before upload
 		fileSize: 245000, // optional
+		pixelRatio: 2, // optional
 	},
 	meta: {},
 }
@@ -100,11 +101,7 @@ const bookmarkAsset: TLBookmarkAsset = {
 
 [TLAssetStore](?) defines how tldraw talks to your storage backend. You provide an implementation when creating the editor, and tldraw calls your handlers whenever someone adds or accesses assets.
 
-The default behavior depends on your store setup:
-
-- **In-memory only** (default): [`inlineBase64AssetStore`](?) converts images to data URLs—quick for prototyping but doesn't persist across sessions
-- **With [`persistenceKey`](/sdk-features/persistence#The-persistenceKey-prop)**: Assets are stored in the browser's [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) alongside other document data
-- **With a [sync server](/docs/sync)**: Implement `TLAssetStore` to upload files to a storage service like S3, Google Cloud Storage, or your own API
+The default behavior depends on your store setup. With an in-memory store (the default), [inlineBase64AssetStore](?) converts every uploaded file to a data URL: quick for prototyping, but nothing persists across sessions. With a [`persistenceKey`](/sdk-features/persistence#The-persistenceKey-prop), assets are stored in the browser's [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) alongside the document. With a [sync server](/docs/sync), implement `TLAssetStore` yourself to upload files to S3, Google Cloud Storage, or your own API.
 
 The interface has three methods:
 
@@ -120,13 +117,13 @@ The **upload** method receives an asset record (with metadata already populated)
 async upload(asset: TLAsset, file: File, abortSignal?: AbortSignal): Promise<{ src: string; meta?: JsonObject }>
 ```
 
-The **resolve** method receives an asset and a [TLAssetContext](?) describing how the asset is being displayed. Return the URL to use for rendering, or null if unavailable. This is where you can get clever—return optimized thumbnails when zoomed out, high-resolution images for export, or add authentication tokens.
+The **resolve** method receives an asset and a [TLAssetContext](?) describing how the asset is being displayed. It can be sync or async. Return the URL to use for rendering, or `null` if the asset is unavailable (shapes then render a broken-asset placeholder). This is where you can get clever: return optimized thumbnails when zoomed out, high-resolution images for export, or add authentication tokens.
 
 ```typescript
 resolve(asset: TLAsset, ctx: TLAssetContext): Promise<string | null> | string | null
 ```
 
-The **remove** method receives asset IDs that are no longer needed—clean up the stored files to free space. This method is optional.
+The **remove** method receives asset IDs that are no longer needed. Clean up the stored files to free space. This method is optional.
 
 ```typescript
 async remove(assetIds: TLAssetId[]): Promise<void>
@@ -169,12 +166,12 @@ When resolving assets, tldraw gives you a [TLAssetContext](?) with information a
 | Property                  | Type             | Description                                                                                                       |
 | ------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `screenScale`             | `number`         | How much the asset is scaled relative to native dimensions. A 1000px image rendered at 500px has screenScale 0.5. |
-| `steppedScreenScale`      | `number`         | screenScale rounded to the nearest power of 2, useful for tiered caching.                                         |
+| `steppedScreenScale`      | `number`         | screenScale rounded up to the next power of 2, useful for tiered caching.                                         |
 | `dpr`                     | `number`         | Device pixel ratio. Retina displays are 2 or 3.                                                                   |
 | `networkEffectiveType`    | `string \| null` | Browser's connection type: 'slow-2g', '2g', '3g', or '4g'.                                                        |
-| `shouldResolveToOriginal` | `boolean`        | True when exporting or copy-pasting. Return full quality.                                                         |
+| `shouldResolveToOriginal` | `boolean`        | True for copy/paste and for SVG exports without an explicit `pixelRatio`. Return full quality.                    |
 
-Here's a resolve handler that serves optimized images based on context—notice how you can tailor the response to network conditions and zoom level:
+Here's a resolve handler that serves optimized images based on network conditions and zoom level:
 
 ```typescript
 resolve(asset, ctx) {
@@ -212,13 +209,13 @@ The [Editor](?) class provides methods for managing assets:
 | [Editor#getAssets](?)       | Get all assets in the store               |
 | [Editor#resolveAssetUrl](?) | Resolve an asset ID to a renderable URL   |
 
-Asset operations happen outside the undo/redo history since they're typically part of larger operations like pasting images—you don't want "undo" to magically un-upload a file.
+Asset operations happen outside the undo/redo history since they're typically part of larger operations like pasting images. You don't want "undo" to magically un-upload a file.
 
 ```typescript
 // Create an asset
 editor.createAssets([imageAsset])
 
-// Update an asset. Spread the existing props: the update replaces them wholesale
+// Update an asset. updateAssets shallow-merges the record, so spread the existing props
 editor.updateAssets([
 	{
 		...imageAsset,
@@ -246,13 +243,13 @@ This separation pays off:
 - Duplicate a shape without duplicating storage
 - Implement lazy loading where assets only load when shapes become visible
 
-When you delete an asset, shapes referencing it fall back to displaying the URL directly or show a placeholder.
+When you delete an asset, shapes referencing it render a broken-asset placeholder.
 
 ## Extension points
 
 ### Custom storage backends
 
-Implement [TLAssetStore](?) to integrate with any storage backend. For local development, convert files to data URLs. For production, upload to S3, Google Cloud Storage, or your own API—whatever works for you.
+Implement [TLAssetStore](?) to integrate with any storage backend. For local development, convert files to data URLs. For production, upload to S3, Google Cloud Storage, or your own API.
 
 Here's an example that uploads to a custom API:
 
@@ -293,14 +290,12 @@ const assetStore: TLAssetStore = {
 
 ### Custom asset types
 
-Custom asset types let you store domain-specific media alongside images, videos, and bookmarks. Each asset type has a corresponding [AssetUtil](?) that defines type-specific behavior: which MIME types it accepts, how to derive an asset record from a dropped file, and what default props new instances start with. The built-in `ImageAssetUtil`, `VideoAssetUtil`, and `BookmarkAssetUtil` follow this pattern and live in `defaultAssetUtils`.
+[AssetUtil](?) is the asset-side counterpart to `ShapeUtil`. Each asset type has one, and it defines which MIME types the type accepts, how to derive an asset record from a dropped file, and what default props new instances start with. The built-in `ImageAssetUtil`, `VideoAssetUtil`, and `BookmarkAssetUtil` live in `defaultAssetUtils`.
 
-`AssetUtil` is the asset-side counterpart to `ShapeUtil`. You register one util per type on the editor at startup, and the editor calls its methods whenever a file enters the system.
-
-Register your asset's props on `TLGlobalAssetPropsMap` via TypeScript module augmentation, then implement an `AssetUtil` for it:
+To add your own type, register its props on `TLGlobalAssetPropsMap` via TypeScript module augmentation, then implement an `AssetUtil` for it. Set `static props` so the store validates and migrates your records:
 
 ```typescript
-import { AssetUtil, TLAsset, TLAssetId } from 'tldraw'
+import { AssetUtil, T, TLAsset, TLAssetId } from 'tldraw'
 
 const AUDIO_TYPE = 'audio'
 
@@ -318,6 +313,11 @@ type TLAudioAsset = TLAsset<typeof AUDIO_TYPE>
 
 class AudioAssetUtil extends AssetUtil<TLAudioAsset> {
 	static override type = AUDIO_TYPE
+	static override props = {
+		src: T.string.nullable(),
+		mimeType: T.string.nullable(),
+		name: T.string,
+	}
 
 	override getDefaultProps(): TLAudioAsset['props'] {
 		return { src: null, mimeType: null, name: '' }
@@ -343,23 +343,23 @@ class AudioAssetUtil extends AssetUtil<TLAudioAsset> {
 }
 ```
 
-Pass the util to the `<Tldraw>` component alongside whichever defaults you still want:
+Pass the util to the `<Tldraw>` component. The default asset utils are always included; a custom util with the same `type` replaces the built-in one:
 
 ```tsx
-import { Tldraw, defaultAssetUtils } from 'tldraw'
+import { Tldraw } from 'tldraw'
 
-const assetUtils = [...defaultAssetUtils, AudioAssetUtil]
+const assetUtils = [AudioAssetUtil]
 
 export default function App() {
 	return <Tldraw assetUtils={assetUtils} />
 }
 ```
 
-When a file is dropped or pasted, the editor finds the first registered util whose `getSupportedMimeTypes()` includes the file's MIME type and calls its `getAssetFromFile()`. The returned asset record then flows through your `TLAssetStore.upload` handler, which assigns the final `src`. Custom shape utils that render audio (or whatever else you registered) read the resolved URL through `editor.resolveAssetUrl()` like the built-in shapes do.
+When a file is dropped or pasted, the editor checks it against `maxAssetSize`, then finds the first registered util whose `acceptsMimeType()` returns true for the file's MIME type and calls its `getAssetFromFile()`. The returned asset record then flows through your `TLAssetStore.upload` handler, which assigns the final `src`. To place the asset on the canvas, a shape util must declare the asset type in `static handledAssetTypes` and implement `createShapeForAsset()`; that shape reads the resolved URL through `editor.resolveAssetUrl()` like the built-in shapes do. See the [custom asset type example](/examples/data/assets/custom-asset-type) for the full pattern.
 
 ### Configuring built-in asset utils
 
-Use [AssetUtil#configure](?) to tweak options on a built-in util without subclassing it. For example, lock image uploads down to PNG:
+The simplest way to configure the built-in utils is through the `<Tldraw>` props `maxAssetSize`, `maxImageDimension`, `acceptedImageMimeTypes`, and `acceptedVideoMimeTypes`. For anything else, use [AssetUtil#configure](?) to tweak options on a built-in util without subclassing it. For example, lock image uploads down to PNG:
 
 ```tsx
 import { ImageAssetUtil, defaultAssetUtils, Tldraw } from 'tldraw'
@@ -375,13 +375,13 @@ const assetUtils = defaultAssetUtils.map((util) =>
 <Tldraw assetUtils={assetUtils} />
 ```
 
-`ImageAssetUtil` exposes `maxDimension` and `supportedMimeTypes` options. `VideoAssetUtil` exposes `supportedMimeTypes`.
+`ImageAssetUtil` exposes `maxDimension` and `supportedMimeTypes` options. `VideoAssetUtil` exposes `supportedMimeTypes`. If you also pass the matching `<Tldraw>` props, those win.
 
 ### Asset validation and migrations
 
 Asset records use the migration system to evolve their schema. Each asset type has its own migration sequence that handles adding properties, renaming fields, and validating data. When you load a document with old asset records, migrations transform them to the current schema automatically.
 
-Validators ensure asset data matches the expected structure at runtime. Use [createAssetValidator](?) to build a validator for your custom asset type—it produces a discriminated union on the `type` field. Add migration sequences to handle schema changes over time.
+Validators ensure asset data matches the expected structure at runtime. Setting `static props` on your `AssetUtil` is enough for the store to validate it. If you need a standalone validator, [createAssetValidator](?) builds one for a single asset type (id, `typeName`, `type` literal, props, and meta). Add migration sequences via `static migrations` to handle schema changes over time.
 
 ## Security
 
@@ -391,14 +391,14 @@ SVG files can contain scripts, event handlers, and external resource references 
 
 - Strips `<script>`, `<iframe>`, `<object>`, `<embed>`, and other dangerous elements
 - Removes all `on*` event handler attributes (`onerror`, `onload`, etc.)
-- Blocks `javascript:` and `data:` URIs in links
+- Allows only `http:`, `https:`, and `mailto:` links
 - Restricts `<image>` and `<feImage>` hrefs to `data:` URIs only
 - Restricts `<use>` hrefs to fragment references (`#id`) only
 - Sanitizes CSS to remove `@import`, `expression()`, and external `url()` references
 - Preserves `<foreignObject>` content (needed for text rendering) with a separate HTML allowlist
 - Preserves `<style>` elements with `data:` font URLs (needed for embedded fonts)
 
-For stronger guarantees, we recommend using [DOMPurify](https://github.com/cure53/DOMPurify) — a battle-tested, widely-audited sanitizer. We don't bundle it to avoid imposing a ~17KB dependency, but if your app already uses it or you want the extra assurance, you can wire it into your external content handlers. Note that DOMPurify's default SVG profile strips `<foreignObject>` and `<style>` elements, which tldraw uses for text rendering and embedded fonts — you'll need to configure it to preserve those for tldraw's SVG output to round-trip correctly.
+For stronger guarantees, we recommend [DOMPurify](https://github.com/cure53/DOMPurify), a widely used and audited sanitizer. We don't bundle it (it's a ~17KB dependency), but if your app already uses it you can wire it into your external content handlers. Note that DOMPurify's default SVG profile strips `<foreignObject>` and `<style>` elements, which tldraw uses for text rendering and embedded fonts. Configure it to preserve those so tldraw's SVG output round-trips correctly.
 
 If you're implementing custom external content handlers, you can also import our built-in sanitizer directly:
 
@@ -428,7 +428,7 @@ Content-Security-Policy:
 ```
 
 - **`script-src 'self'`** prevents inline scripts in SVGs from executing
-- **`style-src 'self' 'unsafe-inline'`** allows tldraw's inline styles while blocking external stylesheet loading (`'unsafe-inline'` is needed for tldraw's runtime styles)
+- **`style-src 'self' 'unsafe-inline'`** allows tldraw's runtime inline styles while blocking external stylesheets
 - **`img-src 'self' data: blob:`** allows data URLs for embedded images and blob URLs for asset previews, while blocking loads to arbitrary external origins
 - **`object-src 'none'`** blocks `<object>` and `<embed>` elements entirely
 - **`base-uri 'self'`** prevents `<base>` tag injection that could redirect relative URLs
@@ -439,8 +439,9 @@ We recommend serving user-uploaded assets from a completely separate domain (e.g
 
 ## Related examples
 
-- [Hosted images](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/hosted-images) - Implement a TLAssetStore that uploads images to a server
-- [Local images](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/local-images) - Create image shapes from local asset records
-- [Local videos](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/local-videos) - Create video shapes from local asset records
-- [Asset options](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/asset-props) - Control allowed asset types, max size, and dimensions
-- [Static assets](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/static-assets) - Pre-load custom fonts and icons
+- [Hosted images](/examples/data/assets/hosted-images) - Implement a TLAssetStore that uploads images to a server
+- [Local images](/examples/editor-api/local-images) - Create image shapes from local asset records
+- [Local videos](/examples/editor-api/local-videos) - Create video shapes from local asset records
+- [Asset options](/examples/configuration/asset-props) - Control allowed asset types, max size, and dimensions
+- [Custom asset type](/examples/data/assets/custom-asset-type) - Register a custom AssetUtil and a shape that renders it
+- [Static assets](/examples/data/assets/static-assets) - Pre-load custom fonts and icons

--- a/apps/docs/content/sdk-features/attribution.mdx
+++ b/apps/docs/content/sdk-features/attribution.mdx
@@ -13,18 +13,18 @@ keywords:
   - getAttributionUser
   - getReferencedUserIds
   - createCachedUserResolve
-  - textFirstEditedBy
+  - textLastEditedBy
   - UserRecordType
   - createUserId
 status: published
 date: 3/30/2026
 ---
 
-The attribution system lets you track which users create or edit shapes. Connect tldraw to your auth system through a `TLUserStore` to resolve display names, render attribution labels, and persist user records alongside your document data. The built-in note shape uses attribution to show who first edited a note's text, and you can add similar tracking to custom shapes.
+The attribution system lets you track which users create or edit shapes. Connect tldraw to your auth system through a [TLUserStore](?) to resolve display names, render attribution labels, and persist user records alongside your document data. The built-in note shape uses attribution to show who last edited a note's text, and you can add similar tracking to custom shapes.
 
 ## User store
 
-A `TLUserStore` provides a reactive `currentUser` signal for the active user and an optional `resolve` method for looking up other users by ID. Pass it as the `users` prop on the [Tldraw](?) component or sync hooks:
+A `TLUserStore` provides a reactive `currentUser` signal for the active user and an optional `resolve` method for looking up other users by ID. Pass it as the `users` prop on the [Tldraw](?) component or the [useSync](?) hook:
 
 ```tsx
 import { computed, createUserId, Tldraw, TLUserStore, UserRecordType } from 'tldraw'
@@ -51,11 +51,11 @@ export default function App() {
 }
 ```
 
-When no `users` prop is provided, the editor falls back to user preferences and collaborator presence for display names.
+When no `users` prop is provided, the editor derives the current user from [user preferences](/sdk-features/user-preferences). With `useSync`, other users are resolved from collaborator presence.
 
 ### Resolving other users
 
-The optional `resolve` method looks up users by their raw ID string. This is called when rendering attribution labels for shapes edited by other users:
+The optional `resolve` method looks up users by their raw ID string. The editor calls it first whenever it needs a display name or user record for an ID:
 
 ```tsx
 import {
@@ -81,19 +81,19 @@ const users: TLUserStore = {
 }
 ```
 
-The `createCachedUserResolve` helper wraps a lookup function so that each user ID gets a single stable reactive signal, avoiding redundant re-evaluations.
+The [createCachedUserResolve](?) helper wraps a lookup function so that each user ID gets a single stable reactive signal. If you write your own `resolve`, return the same signal for repeated calls with the same ID.
 
 ## How attribution works
 
-Attribution is opt-in per shape type. Each shape util decides what to track and when to stamp a user ID. When a shape stores a user ID in its props, the editor persists a corresponding `user:` record in the store so that display names survive across sessions, clipboard paste, and `.tldr` file exports.
+Attribution is opt-in per shape type. Each shape util decides what to track and when to stamp a user ID. When you stamp a user ID with [Editor#getAttributionUserId](?), the editor also writes a corresponding `user:` record to the store so that display names survive across sessions, clipboard paste, and `.tldr` file exports.
 
 ### Note shape attribution
 
-The built-in note shape tracks who first added text. When a user types in an empty note, `NoteShapeUtil` sets the `textFirstEditedBy` prop to the current user's ID via `editor.getAttributionUserId()`. Subsequent edits by other users don't change this value. Clearing the text resets it to `null`. The note renders the first editor's name as a small label in the corner.
+The built-in note shape tracks who last edited its text. Whenever a note's rich text changes and is non-empty, [NoteShapeUtil](?) sets the `textLastEditedBy` prop to the current user's ID via `editor.getAttributionUserId()`. Clearing the text resets it to `null`, and duplicating or pasting a note with text re-stamps the copy to the current user. The note renders the last editor's first name as a small label in the corner.
 
 ## Reading attribution
 
-The [Editor](?) provides three methods for working with attribution. These methods check the `TLUserStore` first, then fall back to `user:` records in the store:
+The [Editor](?) provides three methods for working with attribution. [Editor#getAttributionUserId](?) returns the current user's raw ID string (without the `user:` prefix). [Editor#getAttributionDisplayName](?) and [Editor#getAttributionUser](?) check the `TLUserStore` first, then fall back to `user:` records in the store:
 
 ```tsx
 import { useEditor, useValue } from 'tldraw'
@@ -113,7 +113,7 @@ function AttributionLabel({ userId }: { userId: string }) {
 
 ## Custom shape attribution
 
-Add attribution tracking to your own shapes by storing a user ID in your shape's props and overriding `getReferencedUserIds` on your [ShapeUtil](?):
+Add attribution tracking to your own shapes by storing a user ID in your shape's props and overriding [ShapeUtil#getReferencedUserIds](?):
 
 ```tsx
 import { ShapeUtil, T, TLBaseShape } from 'tldraw'
@@ -139,7 +139,7 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-Overriding `getReferencedUserIds` ensures that when shapes are copied to the clipboard or exported, the referenced `user:` records are included so that display names remain available on the other side.
+When shapes are copied to the clipboard or exported, the editor includes the `user:` records returned by `getReferencedUserIds`. Display names then remain available on the other side.
 
 To stamp the current user when creating shapes:
 
@@ -175,24 +175,21 @@ Custom metadata is validated and persisted alongside the standard user fields. A
 
 ## API reference
 
-| Method                                     | Description                                                             |
-| ------------------------------------------ | ----------------------------------------------------------------------- |
-| `editor.getAttributionUserId()`            | Get the current user's ID for stamping shapes. Returns `string \| null` |
-| `editor.getAttributionDisplayName(userId)` | Resolve a display name from a user ID. Returns `string \| null`         |
-| `editor.getAttributionUser(userId)`        | Resolve a full [TLUser](?) record from a user ID                        |
-
-| Type                      | Description                                          |
-| ------------------------- | ---------------------------------------------------- |
-| `TLUserStore`             | Interface for connecting to your auth/user system    |
-| [TLUser](?)               | A user record in the store                           |
-| `UserRecordType`          | The default user record type                         |
-| `createUserId`            | Create a typed user ID                               |
-| `createCachedUserResolve` | Create a cached resolve function for `TLUserStore`   |
-| `createUserRecordType`    | Build a user record type with custom meta validators |
+| Symbol                                | Description                                                             |
+| ------------------------------------- | ----------------------------------------------------------------------- |
+| [Editor#getAttributionUserId](?)      | Get the current user's ID for stamping shapes. Returns `string \| null` |
+| [Editor#getAttributionDisplayName](?) | Resolve a display name from a user ID. Returns `string \| null`         |
+| [Editor#getAttributionUser](?)        | Resolve a full [TLUser](?) record from a user ID                        |
+| [TLUserStore](?)                      | Interface for connecting to your auth/user system                       |
+| [TLUser](?)                           | A user record in the store                                              |
+| [UserRecordType](?)                   | The default user record type                                            |
+| [createUserId](?)                     | Create a typed user ID                                                  |
+| [createCachedUserResolve](?)          | Create a cached resolve function for `TLUserStore`                      |
+| [createUserRecordType](?)             | Build a user record type with custom meta validators                    |
 
 For setting up user identity in multiplayer, see the [Collaboration](/sdk-features/collaboration#user-identity) page.
 
 ## Related examples
 
-- [Attribution](/examples/users/attribution) — Basic attribution with a user switcher and attribution inspector
-- [Attribution timeline](/examples/users/attribution-timeline) — Timeline scrubber with per-user filtering
+- [Attribution](/examples/users/attribution): basic attribution with a user switcher and attribution inspector
+- [Attribution timeline](/examples/users/attribution-timeline): timeline scrubber with per-user filtering

--- a/apps/docs/content/sdk-features/bindings.mdx
+++ b/apps/docs/content/sdk-features/bindings.mdx
@@ -19,7 +19,7 @@ notes: Minor passive phrasing in places. Add API links using [BindingUtil](?) fo
 
 Bindings create persistent relationships between shapes. When you draw an arrow to a rectangle, a binding stores that connection so the arrow stays attached when you move the rectangle. Bindings power features like arrows that follow shapes, stickers that stick to other shapes, and layout constraints that keep shapes aligned.
 
-The SDK handles bookkeeping for you: when you delete a shape, its bindings are cleaned up automatically, and lifecycle hooks let bound shapes react to changes.
+The SDK handles bookkeeping for you: when you delete a shape, its bindings are cleaned up automatically, and lifecycle hooks on the binding's [BindingUtil](?) let you react to changes.
 
 ## How it works
 
@@ -27,10 +27,10 @@ When you create a binding, the editor stores it as a record with `fromId` and `t
 
 The system handles several scenarios automatically:
 
-- When a shape is deleted, all its bindings are removed and the remaining shapes receive isolation callbacks
+- When a shape is deleted, all its bindings are removed and their binding utils receive isolation and deletion callbacks
 - When shapes are copied, only bindings between copied shapes are duplicated
 - When shapes are moved to different pages, cross-page bindings are automatically removed
-- When bound shapes are transformed together, the binding maintains their relationship
+- When both bound shapes are copied or duplicated together, the binding is copied with them
 
 The bindings index is a computed value that updates incrementally as bindings change. Lookups are fast and never scan all records.
 
@@ -40,11 +40,11 @@ The bindings index is a computed value that updates incrementally as bindings ch
 
 Every binding has direction. The `fromId` points to the source shape, and the `toId` points to the target shape. For arrows, the arrow is always the "from" shape and the shape it points to is the "to" shape. This directionality determines which lifecycle hooks fire and lets the system know which shape "owns" the relationship.
 
-The distinction matters when shapes change. If you move a rectangle that an arrow points to, the arrow's `onAfterChangeToShape` hook fires. If you move the arrow itself, its `onAfterChangeFromShape` hook fires. Both hooks can update the arrow's position, but they're called in different contexts.
+The distinction matters when shapes change. If you move a rectangle that an arrow points to, the arrow binding's `onAfterChangeToShape` hook fires. If you move the arrow itself, `onAfterChangeFromShape` fires instead.
 
 ### Binding records
 
-A binding record contains just enough information to identify the relationship and store relationship-specific data:
+A binding record ([TLBaseBinding](?)) contains just enough information to identify the relationship and store relationship-specific data:
 
 ```typescript
 interface TLBaseBinding<Type, Props> {
@@ -62,29 +62,30 @@ The `props` field holds binding-specific data. Arrow bindings store the normaliz
 
 ### BindingUtil lifecycle
 
-Each binding type implements a `BindingUtil` class that responds to events throughout the binding's lifetime. The lifecycle hooks fall into several categories:
+Each binding type implements a [BindingUtil](?) class that responds to events throughout the binding's lifetime:
 
-**Creation and changes** - `onBeforeCreate`, `onAfterCreate`, `onBeforeChange`, and `onAfterChange` fire when the binding record itself is modified. These hooks can return new binding records to override the changes.
-
-**Shape changes** - `onAfterChangeFromShape` and `onAfterChangeToShape` fire when the bound shapes change. These are the most commonly used hooks for keeping shapes synchronized. Arrow bindings use these to update the arrow's position and parent when the target shape moves.
-
-**Deletion and isolation** - `onBeforeDelete` and `onAfterDelete` fire when the binding is removed. More importantly, `onBeforeIsolateFromShape` and `onBeforeIsolateToShape` fire before a binding is removed due to separation (deletion, copy, or duplication). Isolation hooks let shapes "bake in" the binding's current state before it disappears.
-
-**Batch completion** - `onOperationComplete` fires after all binding operations in a transaction finish. This is useful for computing aggregate updates across multiple related bindings.
+| Hooks                                                                | When they fire                                                                                                                                                                         |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `onBeforeCreate`, `onAfterCreate`, `onBeforeChange`, `onAfterChange` | The binding record itself is created or modified. The `onBefore*` hooks can return a replacement binding record.                                                                       |
+| `onAfterChangeFromShape`, `onAfterChangeToShape`                     | A bound shape changes. These are the most common hooks for keeping shapes synchronized. Arrow bindings use them to update the arrow's position and parent when the target shape moves. |
+| `onBeforeDelete`, `onAfterDelete`                                    | The binding record is removed.                                                                                                                                                         |
+| `onBeforeDeleteFromShape`, `onBeforeDeleteToShape`                   | A bound shape is about to be deleted.                                                                                                                                                  |
+| `onBeforeIsolateFromShape`, `onBeforeIsolateToShape`                 | The bound shapes are about to be separated (one is deleted, copied, or duplicated without the other). Use these to "bake in" the binding's current state before it disappears.         |
+| `onOperationComplete`                                                | All binding operations in a transaction have finished. Use it to compute aggregate updates across many related bindings.                                                               |
 
 ### Isolation vs deletion
 
-Isolation callbacks handle a specific problem: when an arrow's target shape is deleted, the arrow shouldn't suddenly point to empty space. The `onBeforeIsolateFromShape` hook lets the arrow update its terminal position to match the current attachment point before the binding is removed. The arrow then appears to "let go" of the shape naturally.
+Isolation callbacks handle a specific problem: when an arrow's target shape is deleted, the arrow shouldn't suddenly point to empty space. The `onBeforeIsolateFromShape` hook receives the binding and the `removedShape`, and lets the arrow update its terminal position to match the current attachment point before the binding is removed. The arrow then appears to "let go" of the shape naturally.
 
 Isolation also occurs during copy and duplicate operations. If you copy an arrow but not its target, the copied arrow needs to convert its binding into a fixed position. The isolation callback handles this transformation.
 
-Use isolation callbacks for consistency updates that should happen whenever shapes separate. Use deletion callbacks for actions specific to deletion, like removing a sticker when its parent shape is deleted.
+Use isolation callbacks for consistency updates that should happen whenever shapes separate. Use `onBeforeDeleteFromShape` and `onBeforeDeleteToShape` for actions specific to deletion, like removing a sticker when its parent shape is deleted.
 
 ## API patterns
 
 ### Creating bindings
 
-Create bindings using [Editor#createBinding](?) or [Editor#createBindings](?). You must provide the binding type, fromId, and toId. The BindingUtil supplies default props.
+Create bindings using [Editor#createBinding](?) or [Editor#createBindings](?). You must provide the binding type, `fromId`, and `toId`. The BindingUtil supplies default props for anything you leave out. The editor checks both shapes' `canBind()` first and skips the binding if either refuses.
 
 ```typescript
 editor.createBinding({
@@ -103,7 +104,7 @@ editor.createBinding({
 
 ### Querying bindings
 
-The editor provides several methods for finding bindings:
+The editor provides several methods for finding bindings: [Editor#getBinding](?), [Editor#getBindingsFromShape](?), [Editor#getBindingsToShape](?), and [Editor#getBindingsInvolvingShape](?).
 
 ```typescript
 // Get a specific binding by ID
@@ -121,16 +122,17 @@ const all = editor.getBindingsInvolvingShape(shape.id, 'arrow')
 
 ### Updating and deleting bindings
 
-Update bindings with partials, just like shapes:
+Update bindings with [Editor#updateBinding](?), passing a partial with the binding's `id` and `type`:
 
 ```typescript
 editor.updateBinding({
 	id: binding.id,
+	type: 'arrow',
 	props: { normalizedAnchor: { x: 0.8, y: 0.2 } },
 })
 ```
 
-Delete bindings directly or let the system remove them automatically when shapes are deleted. Pass `isolateShapes: true` to trigger isolation callbacks:
+Delete bindings with [Editor#deleteBinding](?), or let the system remove them automatically when shapes are deleted. Pass `isolateShapes: true` to trigger isolation callbacks:
 
 ```typescript
 editor.deleteBinding(binding.id, { isolateShapes: true })
@@ -142,24 +144,28 @@ Shapes control whether they accept bindings by implementing [ShapeUtil#canBind](
 
 ```typescript
 class MyShapeUtil extends ShapeUtil<MyShape> {
-	canBind({ fromShape, toShape, bindingType }: TLShapeUtilCanBindOpts) {
+	static override type = 'my-shape' as const
+
+	override canBind({ toShape, bindingType }: TLShapeUtilCanBindOpts) {
 		// Only allow arrow bindings where this shape is the target
-		return bindingType === 'arrow' && toShape.type === this.type
+		return bindingType === 'arrow' && toShape.type === 'my-shape'
 	}
 }
 ```
 
-The editor calls both shapes' `canBind()` methods before creating a binding. If either returns false, the binding is not created.
+The editor calls both shapes' `canBind()` methods before creating or updating a binding. If either returns false, the binding is skipped. Use [Editor#canBindShapes](?) to run the same check yourself.
 
 ## Extension points
 
-Custom binding types let you create new kinds of relationships between shapes. The process involves defining the binding's data structure, implementing its behavior, and registering it with the editor.
+Custom binding types let you create new kinds of relationships between shapes.
 
 ### Defining the binding type
 
-First, extend the type system to include your binding's props. Use TypeScript's module augmentation to add your binding type to the global binding props map:
+First, extend the type system to include your binding's props. Use TypeScript's module augmentation to add your binding type to [TLGlobalBindingPropsMap](?), then derive the binding type from [TLBinding](?):
 
 ```typescript
+import { TLBinding, VecModel } from 'tldraw'
+
 declare module 'tldraw' {
 	export interface TLGlobalBindingPropsMap {
 		myBinding: {
@@ -168,25 +174,43 @@ declare module 'tldraw' {
 		}
 	}
 }
+
+type MyBinding = TLBinding<'myBinding'>
 ```
 
 ### Implementing BindingUtil
 
-Create a class extending `BindingUtil` with your binding type. At minimum, implement `getDefaultProps()`. Add lifecycle hooks based on what behavior you need:
+Create a class extending [BindingUtil](?) with your binding type. At minimum, implement `getDefaultProps()`. Add lifecycle hooks based on what behavior you need:
 
 ```typescript
+import {
+	BindingOnShapeChangeOptions,
+	BindingOnShapeIsolateOptions,
+	BindingUtil,
+	RecordProps,
+	T,
+	vecModelValidator,
+} from 'tldraw'
+
 class MyBindingUtil extends BindingUtil<MyBinding> {
-	static override type = 'myBinding'
+	static override type = 'myBinding' as const
+	static override props: RecordProps<MyBinding> = {
+		anchor: vecModelValidator,
+		strength: T.number,
+	}
 
 	override getDefaultProps() {
 		return { anchor: { x: 0.5, y: 0.5 }, strength: 1 }
 	}
 
-	override onAfterChangeToShape({ binding, shapeAfter }) {
+	override onAfterChangeToShape({ binding, shapeAfter }: BindingOnShapeChangeOptions<MyBinding>) {
 		// Update the "from" shape when the "to" shape moves
 	}
 
-	override onBeforeIsolateFromShape({ binding }) {
+	override onBeforeIsolateFromShape({
+		binding,
+		removedShape,
+	}: BindingOnShapeIsolateOptions<MyBinding>) {
 		// Bake in current state before the binding is removed
 	}
 }
@@ -204,6 +228,7 @@ Pass your BindingUtil to the editor via the `bindingUtils` prop:
 
 The examples app includes several binding implementations that demonstrate different use cases:
 
-- **[Sticker bindings](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/sticker-bindings)** - Shapes that stick to other shapes and follow them when moved. Demonstrates `onAfterChangeToShape` for position updates and `onBeforeDeleteToShape` for cascading deletion.
-- **[Pin bindings](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/pin-bindings)** - Pins that connect networks of shapes together, moving them as a group. Demonstrates `onOperationComplete` for computing aggregate updates across multiple related bindings.
-- **[Layout bindings](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/layout-bindings)** - Constraining shapes to layout positions. Demonstrates using bindings to enforce spatial relationships between shapes.
+- [Sticker bindings](/examples/shapes/tools/sticker-bindings) - Shapes that stick to other shapes and follow them when moved. Demonstrates `onAfterChangeToShape` for position updates and `onBeforeDeleteToShape` for cascading deletion.
+- [Pin bindings](/examples/shapes/tools/pin-bindings) - Pins that connect networks of shapes together, moving them as a group. Demonstrates `onOperationComplete` for computing aggregate updates across multiple related bindings.
+- [Layout bindings](/examples/shapes/tools/layout-bindings) - Constraining shapes to layout positions. Demonstrates using bindings to enforce spatial relationships between shapes.
+- [Arrow binding options](/examples/shapes/tools/arrow-binding-options) - Configuring how the built-in arrow binding attaches to shapes.

--- a/apps/docs/content/sdk-features/camera.mdx
+++ b/apps/docs/content/sdk-features/camera.mdx
@@ -18,31 +18,28 @@ accuracy: 9
 notes: Could use more direct "you" address and questions-as-transitions per voice guide. Some passive constructions remain.
 ---
 
-The camera system controls how users view and navigate the infinite canvas. It manages viewport position and zoom level, and transforms coordinates between screen space and page space. The editor uses these transformations to map mouse positions to canvas locations and render shapes at any zoom level.
-
-The camera handles user input for panning and zooming, supports constraints for bounded experiences, and provides methods for programmatic movement with smooth animations. It also integrates with collaboration features for real-time viewport following.
+The camera controls which part of the infinite canvas is visible. It holds the viewport's position and zoom, converts between screen space and page space, and responds to user input like wheel, trackpad, keyboard, and touch. You can constrain it to a bounded area, move it programmatically with animation, and follow other users' viewports in collaborative sessions.
 
 ## How it works
 
 The camera represents the viewport's position and zoom using three values: `x` and `y` for position in page space, and `z` for zoom level. A zoom of `1` means 100%, `0.5` is 50%, and `2` is 200%. The camera's `x` and `y` are the page-space offset of the viewport: the page point at the viewport's top-left corner is `(-x, -y)`.
 
-The camera transforms between two coordinate spaces:
-
-- **Screen space** - Browser pixels from the document origin
-- **Page space** - The infinite canvas coordinate system
-
-The `screenToPage()` method converts mouse positions to canvas coordinates, while `pageToScreen()` converts canvas coordinates to screen positions:
+The camera converts between screen space (browser pixels) and page space (the canvas). Use [Editor#screenToPage](?) to turn a mouse position into a canvas point and [Editor#pageToScreen](?) to go the other way. See [Coordinates](/sdk-features/coordinates) for the full set of conversions.
 
 ```typescript
 const pagePoint = editor.screenToPage({ x: event.clientX, y: event.clientY })
 const screenPoint = editor.pageToScreen({ x: shape.x, y: shape.y })
 ```
 
-The camera responds to user input through mouse wheel, trackpad gestures, keyboard shortcuts, and touch events. The `wheelBehavior` option determines whether scrolling pans or zooms the viewport.
+Read the camera with [Editor#getCamera](?) or [Editor#getZoomLevel](?), and read the visible page area with [Editor#getViewportPageBounds](?). All of these are reactive, so you can use them in `track` components or `useValue`.
 
 ## Camera options
 
-Camera behavior is configured through `TLCameraOptions`:
+Configure the camera with [TLCameraOptions](?). Pass the initial options through the `options.camera` prop, or change them at runtime with [Editor#setCameraOptions](?), which re-applies the constraints to the current camera immediately:
+
+```tsx
+<Tldraw options={{ camera: { wheelBehavior: 'zoom' } }} />
+```
 
 ```typescript
 editor.setCameraOptions({
@@ -54,13 +51,13 @@ editor.setCameraOptions({
 })
 ```
 
-The `isLocked` option prevents all camera movement, useful for fixed-viewport experiences.
+Set `isLocked` to freeze the camera for fixed-viewport apps. Camera methods then do nothing unless you pass `force: true`.
 
-The `wheelBehavior` option determines how mouse wheel or trackpad scroll affects the viewport: `'pan'` for navigating large diagrams, `'zoom'` for detail work, or `'none'` to disable wheel interaction.
+`wheelBehavior` decides what the mouse wheel or trackpad scroll does: `'pan'`, `'zoom'`, or `'none'`. If the user has set an input mode in their preferences, that preference wins: `'trackpad'` pans and `'mouse'` zooms.
 
-The `panSpeed` and `zoomSpeed` multipliers adjust input sensitivity. Values below 1 slow down movement, values above 1 speed it up.
+`panSpeed` and `zoomSpeed` are multipliers on input sensitivity. Values below 1 slow movement down, values above 1 speed it up.
 
-The `zoomSteps` array defines discrete zoom levels. The first value sets minimum zoom, the last sets maximum zoom, and intermediate values determine snap points for zoom controls.
+`zoomSteps` lists the discrete zoom levels used by zoom in and zoom out. The first value is the minimum zoom and the last is the maximum; the camera clamps to this range even without constraints.
 
 ## Camera constraints
 
@@ -81,35 +78,37 @@ editor.setCameraOptions({
 
 The `bounds` define the constrained area in page space. The camera restricts panning outside this rectangle based on the `behavior` setting.
 
-The `padding` adds screen space margin inside the viewport so content doesn't touch the screen edges.
+The `padding` adds a screen-space margin inside the viewport so content doesn't touch the edges.
 
-The `origin` determines how bounds are positioned within the viewport when using `'fixed'` behavior. Values of `{ x: 0.5, y: 0.5 }` center the bounds, while `{ x: 0, y: 0 }` aligns to the top-left.
+The `origin` positions the bounds within the viewport when an axis uses `'fixed'` behavior, when `'contain'` is zoomed out below the fit zoom, and when the camera resets. `{ x: 0.5, y: 0.5 }` centers the bounds; `{ x: 0, y: 0 }` aligns them top-left.
 
 ### Zoom fitting
 
-The `initialZoom` and `baseZoom` options control how content fits the viewport:
+`initialZoom` is the zoom the camera starts at and returns to on reset. `baseZoom` is the zoom that `zoomSteps` are multiplied by, so a step of `1` means "the base zoom" rather than 100%. Both accept the same values:
 
-- `'default'`: 100% zoom, showing content at actual size
-- `'fit-min'`: Fit the smaller axis so the full bounds stay visible
-- `'fit-max'`: Fit the larger axis; the other axis may extend past the viewport
-- `'fit-x'`: Fit horizontally, filling the viewport width
-- `'fit-y'`: Fit vertically, filling the viewport height
-- `'fit-x-100'`: Fit horizontally or use 100%, whichever is smaller
-- `'fit-y-100'`: Fit vertically or use 100%, whichever is smaller
-- `'fit-min-100'`: Fit the smaller axis or use 100%, whichever is smaller
-- `'fit-max-100'`: Fit the larger axis or use 100%, whichever is smaller
-
-The `initialZoom` sets the starting zoom when the camera resets. The `baseZoom` defines the reference point for zoom steps, affecting how zoom in/out operations scale relative to the viewport.
+| Value           | Description                                                             |
+| --------------- | ----------------------------------------------------------------------- |
+| `'default'`     | 100% zoom                                                               |
+| `'fit-x'`       | The bounds' width fills the viewport width                              |
+| `'fit-y'`       | The bounds' height fills the viewport height                            |
+| `'fit-min'`     | The smaller axis fills the viewport; the larger axis may extend past it |
+| `'fit-max'`     | The larger axis fills the viewport, so the full bounds stay visible     |
+| `'fit-x-100'`   | `fit-x` or 100%, whichever is smaller                                   |
+| `'fit-y-100'`   | `fit-y` or 100%, whichever is smaller                                   |
+| `'fit-min-100'` | `fit-min` or 100%, whichever is smaller                                 |
+| `'fit-max-100'` | `fit-max` or 100%, whichever is smaller                                 |
 
 ### Constraint behaviors
 
-The `behavior` option controls how bounds constrain camera movement:
+The `behavior` option controls how the bounds constrain camera movement:
 
-- `'free'`: Bounds are ignored, allowing unlimited panning
-- `'fixed'`: Bounds are positioned at the origin regardless of pan attempts
-- `'inside'`: Bounds must stay completely within the viewport
-- `'outside'`: Bounds must stay touching the viewport edges
-- `'contain'`: Uses `'fixed'` when zoomed out and `'inside'` when zoomed in
+| Value       | Description                                                                     |
+| ----------- | ------------------------------------------------------------------------------- |
+| `'free'`    | The bounds are ignored                                                          |
+| `'fixed'`   | The bounds are pinned at the origin; the user can't pan                         |
+| `'inside'`  | The bounds stay completely within the viewport                                  |
+| `'outside'` | The bounds stay touching the viewport                                           |
+| `'contain'` | `'fixed'` when zoomed out below the fit zoom, `'inside'` when zoomed in past it |
 
 Set behavior per axis for asymmetric constraints:
 
@@ -122,11 +121,12 @@ behavior: {
 
 ## Camera methods
 
-The editor provides methods for programmatic camera control. All methods accept an optional options object with:
+The camera-move methods below ([Editor#setCamera](?), [Editor#centerOnPoint](?), [Editor#zoomIn](?), [Editor#zoomOut](?), [Editor#zoomToFit](?), [Editor#zoomToSelection](?), [Editor#zoomToBounds](?), and [Editor#resetZoom](?)) accept optional [TLCameraMoveOptions](?):
 
-- `animation` - add smooth transitions with `duration` and `easing`
+- `animation` - animate the move with `duration` and `easing`
 - `immediate` - move the camera immediately rather than on the next tick
 - `force` - move the camera even when `isLocked` is true
+- `reset` - reset the camera to the constraints' initial zoom and origin
 
 ### Basic navigation
 
@@ -161,7 +161,7 @@ editor.zoomToFit()
 // Fit the current selection
 editor.zoomToSelection()
 
-// Reset zoom to 100% (or initial zoom if constraints are set)
+// Reset zoom to 100%. With constraints, toggles between the initial zoom and 100%
 editor.resetZoom()
 
 // Fit specific bounds with padding
@@ -169,15 +169,11 @@ const bounds = { x: 0, y: 0, w: 1000, h: 800 }
 editor.zoomToBounds(bounds, { inset: 100 })
 ```
 
-The `zoomToBounds` method accepts `inset` to add padding around the bounds and `targetZoom` to limit the maximum zoom level.
-
-### Quick zoom navigation
-
-The default tldraw UI includes a quick zoom tool activated by pressing `z`. This zooms out to show the entire canvas with a viewport brush that marks where you'll zoom to. Move the cursor to reposition the target viewport, then release to zoom to that location. Press Escape to cancel and return to the original view.
+`zoomToBounds` accepts `inset` to add screen-space padding around the bounds and `targetZoom` to cap the zoom level.
 
 ### Animated movement
 
-Add smooth transitions using the `animation` option. The `EASINGS` object provides common easing functions:
+Add smooth transitions with the `animation` option. The [EASINGS](?) object provides common easing functions:
 
 ```typescript
 import { EASINGS } from 'tldraw'
@@ -193,36 +189,38 @@ editor.setCamera(
 )
 ```
 
-Camera animations stop automatically when users pan or zoom: user input takes precedence over programmatic movement. You can also stop camera animations at any time with the editor's `stopCameraAnimation()` method.
+Camera animations stop automatically when the user pans or zooms: user input takes precedence over programmatic movement. You can also stop them at any time with [Editor#stopCameraAnimation](?). See [Animation](/sdk-features/animation) for more on animation options and user preferences.
 
 ### Momentum scrolling
 
-Create momentum-based camera movement:
+Use [Editor#slideCamera](?) for kinetic scrolling, for example to keep the camera moving after a gesture ends:
 
 ```typescript
 editor.slideCamera({
-	speed: 2,
+	speed: 1,
 	direction: { x: 1, y: 0 },
 	friction: 0.1,
 	speedThreshold: 0.01,
 })
 ```
 
-The `speed` and `direction` control initial velocity. The `friction` value determines how fast the camera decelerates (higher friction stops movement faster). The `speedThreshold` sets the minimum speed before the animation stops completely. Use this for kinetic scrolling or to continue movement after gesture completion.
+`speed` is clamped to a maximum of `1` and `direction` sets the initial velocity. A `z` component on `direction` slides the zoom as well. `friction` controls how fast the camera decelerates (higher stops sooner) and defaults to `editor.options.cameraSlideFriction`. The slide ends once the speed drops below `speedThreshold`.
+
+### Quick zoom navigation
+
+The default tldraw UI has a quick zoom mode. Press `z` to select the zoom tool, then hold Shift. The camera zooms out to show your current viewport plus everything on the page, and a brush marks where you'll land. Move the cursor to place the brush and release Shift to zoom there. Press Escape to cancel and return to the original view.
 
 ## Collaboration features
 
-The camera system integrates with collaboration through user following. When following another user, the camera tracks their viewport position and zoom.
+Call [Editor#startFollowingUser](?) to track another user's viewport, or [Editor#zoomToUser](?) to jump to their cursor once. While following, the camera fits the other user's viewport inside yours: if the aspect ratios differ, the zoom adjusts so their whole viewport stays visible.
 
-User following respects the follower's viewport size. If aspect ratios differ, the system adjusts zoom to keep the followed user's content visible while maintaining the follower's viewport dimensions.
-
-See [User following](/sdk-features/user-following) for implementation details.
+See [User following](/sdk-features/user-following) for details.
 
 ## Related examples
 
-- **[Camera options](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/camera-options)** - Configure the camera's options and constraints including zoom behavior, pan speed, and camera bounds.
-- **[Image annotator](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/use-cases/image-annotator)** - An image annotator that demonstrates how to configure camera options for fixed-viewport annotation apps.
-- **[Slideshow (fixed camera)](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/use-cases/slideshow)** - A simple slideshow app with a fixed camera using camera constraints.
-- **[Lock camera zoom](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/lock-camera-zoom)** - Lock the camera at a specific zoom level using the camera controls API.
-- **[Zoom to bounds](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/zoom-to-bounds)** - Programmatically zoom the camera to specific bounds using the editor's `zoomToBounds` method.
-- **[Scrollable container](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/layout/scroll)** - Use the editor inside a scrollable container with proper mousewheel event handling.
+- [Camera options](/examples/configuration/camera-options) - Configure the camera's options and constraints, including zoom behavior, pan speed, and camera bounds.
+- [Image annotator](/examples/use-cases/image-annotator) - Configure camera options for a fixed-viewport annotation app.
+- [Slideshow (fixed camera)](/examples/use-cases/slideshow) - A slideshow with a fixed camera using camera constraints.
+- [Lock camera zoom](/examples/editor-api/lock-camera-zoom) - Lock the camera at a specific zoom level.
+- [Zoom to bounds](/examples/editor-api/zoom-to-bounds) - Zoom the camera to specific bounds with `zoomToBounds`.
+- [Scrollable container](/examples/layout/scroll) - Use the editor inside a scrollable container with mousewheel handling.

--- a/apps/docs/content/sdk-features/click-detection.mdx
+++ b/apps/docs/content/sdk-features/click-detection.mdx
@@ -17,7 +17,7 @@ accuracy: 10
 notes: Could add a simpler opening hook per voice guide ("Have five minutes?"-style).
 ---
 
-In tldraw, the click detection system turns a pair of nearby clicks into a `double_click` event. The [ClickManager](?) tracks consecutive pointer down events using a state machine, dispatching a double-click event when timing and distance thresholds are met.
+In tldraw, the click detection system turns a pair of nearby clicks into a `double_click` event. The [ClickManager](?) tracks consecutive pointer downs with a small state machine and emits `double_click` when the timing and distance thresholds are met.
 
 After a double-click, extra nearby clicks are treated as overflow. Overflow clicks do not dispatch additional click events; they suppress the sequence long enough to prevent a rapid double-double-click from becoming two double-clicks.
 
@@ -25,7 +25,7 @@ After a double-click, extra nearby clicks are treated as overflow. Overflow clic
 
 When a pointer down event occurs, the manager either starts a new sequence, detects a double-click, or moves the sequence into overflow. Each state has a timeout that determines how long to wait before returning to idle.
 
-Two timeout durations control the detection speed. The first click uses `doubleClickDurationMs` (450ms by default), giving users time to initiate a double-click sequence. After a double-click, `multiClickDurationMs` (200ms by default) controls both the settle delay and the overflow suppression window. The option name is historical; it now controls only the post-double-click window.
+Two timeout durations control the detection speed. The first click uses `doubleClickDurationMs` (450ms by default), which is how long the user has to make the second click. After a double-click, `multiClickDurationMs` (200ms by default) controls both the settle delay and the overflow suppression window. The option name is historical; it now controls only the post-double-click window.
 
 ### State transitions
 
@@ -38,7 +38,7 @@ The click state machine progresses through these states:
 | `pendingOverflow` | Double-click registered, waiting for overflow |
 | `overflow`        | Extra clicks detected after the double-click  |
 
-The second pointer down dispatches a `double_click` event immediately and starts waiting for overflow. If the timeout expires before another click, the manager dispatches a double-click settle event and returns to idle. If another pointer down arrives first, the sequence moves to overflow and no further click events are dispatched until the overflow timeout expires.
+The second pointer down still reaches the state chart as a `pointer_down`, followed immediately by a `double_click` event, and the manager starts waiting for overflow. If the timeout expires before another click, the manager dispatches a double-click settle event and returns to idle. If another pointer down arrives first, the sequence moves to overflow and no further click events are dispatched until the overflow timeout expires.
 
 ### Distance validation
 
@@ -46,7 +46,7 @@ Consecutive clicks must occur within a maximum distance of 40 pixels (screen spa
 
 ### Click event phases
 
-Click events are dispatched with a `phase` property indicating when in the sequence the event fired:
+Each click event carries a `phase` that says when in the sequence it fired:
 
 | Phase         | When it fires                                                       |
 | ------------- | ------------------------------------------------------------------- |
@@ -59,7 +59,9 @@ The phase system lets tools respond at different points in the click sequence. M
 
 ### Movement cancellation
 
-If the pointer moves too far during a pending click sequence, the system cancels the sequence and returns to idle. This prevents double-click detection during click-drag operations. The movement threshold differs for coarse pointers (touchscreens) and fine pointers (mouse, stylus).
+If the pointer moves too far during a pending click sequence, the system cancels the sequence and returns to idle. This prevents double-click detection during click-drag operations. The movement threshold is `dragDistanceSquared` for fine pointers (mouse, stylus) and `coarseDragDistanceSquared` for coarse pointers (touchscreens), both editor [options](/sdk-features/options).
+
+The manager only sees pointer events that match the current pen mode: in pen mode, finger taps don't produce double-clicks, and outside pen mode, pen taps don't.
 
 ## Handling click events
 
@@ -74,7 +76,9 @@ class ZoomTool extends StateNode {
 
 	override onDoubleClick(info: TLClickEventInfo) {
 		if (info.phase !== 'down') return
-		this.editor.zoomIn(info.point, { animation: { duration: 200 } })
+		// info.point is in client space; zoomIn wants a point relative to the viewport
+		const screenPoint = this.editor.inputs.getCurrentScreenPoint()
+		this.editor.zoomIn(screenPoint, { animation: { duration: 200 } })
 	}
 }
 
@@ -94,9 +98,9 @@ export default function App() {
 }
 ```
 
-Tools can handle [StateNode#onDoubleClick](?) events. The handler receives a [TLClickEventInfo](?) object with details about the click. Use `phase: 'down'` for behavior that should start on the second pointer down, or a settle phase for behavior that should wait until the overflow window has passed.
+Use `phase: 'down'` for behavior that should start on the second pointer down, or a settle phase for behavior that should wait until the overflow window has passed.
 
-The select tool routes shape double-clicks to [ShapeUtil#onDoubleClick](?). Return a partial shape object to apply changes:
+The select tool routes shape double-clicks to [ShapeUtil#onDoubleClick](?), and double-clicks on handles, edges, and corners to [ShapeUtil#onDoubleClickHandle](?), [ShapeUtil#onDoubleClickEdge](?), and [ShapeUtil#onDoubleClickCorner](?). Return a partial shape object to apply changes:
 
 ```tsx
 override onDoubleClick(shape: MyShape) {
@@ -110,22 +114,23 @@ override onDoubleClick(shape: MyShape) {
 
 The [TLClickEventInfo](?) type includes these properties:
 
-| Property    | Type                                             | Description                                            |
-| ----------- | ------------------------------------------------ | ------------------------------------------------------ |
-| `type`      | `'click'`                                        | Event type identifier                                  |
-| `name`      | `'double_click'`                                 | Which click event this is                              |
-| `point`     | `VecLike`                                        | Pointer position in client space                       |
-| `pointerId` | `number`                                         | Unique identifier for the pointer                      |
-| `button`    | `number`                                         | Mouse button (0 = left, 1 = middle, 2 = right)         |
-| `phase`     | `'down' \| 'up' \| 'settle-down' \| 'settle-up'` | When in the click sequence this fired                  |
-| `target`    | `'canvas' \| 'selection' \| 'shape' \| 'handle'` | What was clicked                                       |
-| `shape`     | `TLShape \| undefined`                           | The shape, when target is `'shape'` or `'handle'`      |
-| `handle`    | `TLHandle \| undefined`                          | The handle, when target is `'handle'`                  |
-| `shiftKey`  | `boolean`                                        | Whether Shift was held                                 |
-| `altKey`    | `boolean`                                        | Whether Alt/Option was held                            |
-| `ctrlKey`   | `boolean`                                        | Whether Control was held                               |
-| `metaKey`   | `boolean`                                        | Whether Meta/Command was held                          |
-| `accelKey`  | `boolean`                                        | Platform accelerator key (Cmd on Mac, Ctrl on Windows) |
+| Property    | Type                                                          | Description                                            |
+| ----------- | ------------------------------------------------------------- | ------------------------------------------------------ |
+| `type`      | `'click'`                                                     | Event type identifier                                  |
+| `name`      | `'double_click'`                                              | Which click event this is                              |
+| `point`     | `VecLike`                                                     | Pointer position in client space                       |
+| `pointerId` | `number`                                                      | Unique identifier for the pointer                      |
+| `button`    | `number`                                                      | Mouse button (0 = left, 1 = middle, 2 = right)         |
+| `phase`     | `'down' \| 'up' \| 'settle-down' \| 'settle-up'`              | When in the click sequence this fired                  |
+| `target`    | `'canvas' \| 'selection' \| 'shape' \| 'handle' \| 'overlay'` | What was clicked                                       |
+| `shape`     | `TLShape \| undefined`                                        | The shape, when target is `'shape'` or `'handle'`      |
+| `handle`    | `TLHandle \| TLSelectionHandle \| undefined`                  | The handle, when target is `'handle'` or `'selection'` |
+| `overlay`   | `TLOverlay \| undefined`                                      | The overlay, when target is `'overlay'`                |
+| `shiftKey`  | `boolean`                                                     | Whether Shift was held                                 |
+| `altKey`    | `boolean`                                                     | Whether Alt/Option was held                            |
+| `ctrlKey`   | `boolean`                                                     | Whether Control (or Command) was held                  |
+| `metaKey`   | `boolean`                                                     | Whether Meta/Command was held                          |
+| `accelKey`  | `boolean`                                                     | Platform accelerator key (Cmd on Mac, Ctrl on Windows) |
 
 ## Timing configuration
 
@@ -138,6 +143,6 @@ Click timing is configured through the editor's [options](/sdk-features/options)
 
 ## Related examples
 
-- [Canvas events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/canvas-events) — logs pointer events including click sequences to understand the event flow
-- [Custom double-click behavior](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/custom-double-click-behavior) — overrides the default double-click handler in the SelectTool
-- [Custom shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/custom-shape) — implements `onDoubleClick` and other click handlers in custom shapes
+- [Canvas events](/examples/events/canvas-events) — logs pointer events including click sequences to understand the event flow
+- [Custom double-click behavior](/examples/events/custom-double-click-behavior) — overrides the default double-click handler in the SelectTool
+- [Shape with onDoubleClickEdge](/examples/shapes/tools/shape-with-onDoubleClickEdge) — implements `onDoubleClickEdge` in a custom shape

--- a/apps/docs/content/sdk-features/clipboard.mdx
+++ b/apps/docs/content/sdk-features/clipboard.mdx
@@ -25,7 +25,7 @@ Clipboard operations have two flows: extracting content (copy/cut) and placing c
 
 ### Extracting content
 
-When you copy or cut shapes, the editor calls [Editor#getContentFromCurrentPage](?) to serialize them into a [TLContent](?) object:
+When you copy or cut shapes, the editor calls [Editor#getContentFromCurrentPage](?) to serialize them into a [TLContent](?) object (or `undefined` if the selection is empty):
 
 ```ts
 const content = editor.getContentFromCurrentPage(editor.getSelectedShapeIds())
@@ -53,39 +53,39 @@ editor.putContentOntoCurrentPage(content, {
 })
 ```
 
-The method migrates the content through the store's schema system to handle version differences, remaps shape and binding IDs to prevent collisions, and finds an appropriate parent for the pasted shapes.
+The method migrates the content through the store's schema system to handle version differences (it throws if `content.schema` is missing), remaps shape and binding IDs to prevent collisions, and finds an appropriate parent for the pasted shapes.
 
-The parent selection logic works like this: if shapes are selected when pasting, the editor finds the selected shape with the fewest ancestors and uses its parent. This creates intuitive behavior where pasting with a frame selected places shapes inside the frame, while pasting with shapes on the page pastes beside them. When pasting at a specific point (like the cursor position), the editor looks for an appropriate parent at that location.
+Parent selection depends on how you paste. With a `point`, the editor uses the deepest shape under that point that can receive every pasted root shape (via `ShapeUtil#canReceiveNewChildrenOfType`). Without a point, it looks at the current selection: for each selected shape it takes the nearest container that accepts the content (the shape itself, an accepting ancestor, or its parent), and if the selection spans several containers it uses their deepest common accepting ancestor. A shape is never pasted into itself. Shapes that land on the page are then reparented into any frame that contains their center.
 
 ### Browser clipboard integration
 
-The editor writes clipboard data in multiple formats. For HTML-aware applications, it embeds serialized [TLContent](?) in a `<div data-tldraw>` element. For plain text, it extracts text from text shapes. This multi-format approach preserves tldraw-specific data while staying compatible with other applications.
+The editor writes clipboard data in multiple formats. For HTML-aware applications, it embeds serialized [TLContent](?) in a `<div data-tldraw>` element. For plain text, it extracts the text of the copied shapes.
 
-The clipboard uses a versioned format with compression. Version 3 (the current format) stores assets as plain JSON and compresses other data using LZ compression. This reduces payload size while keeping asset information quickly accessible.
+The clipboard uses a versioned format with compression. Version 3 (the current format) stores assets as plain JSON and compresses other data using LZ compression. This keeps the payload small while asset information stays quickly accessible. Older version 1 and 2 payloads are still read on paste.
 
-When pasting, the editor tries the browser's Clipboard API first because it preserves metadata that the clipboard event API strips out. If that fails, it falls back to reading from the paste event's clipboard data. The editor handles images, files, URLs, HTML, and plain text, routing each through the appropriate handler.
+When pasting, the editor tries the browser's Clipboard API first because it preserves metadata that the clipboard event API strips out. If that fails, it falls back to reading from the paste event's clipboard data, and it prefers the event's files when the API only returned file names. The editor handles images, files, URLs, HTML, and plain text, routing each through the appropriate handler. To copy shapes as an image instead, use [copyAs](?), which shares the same pipeline.
+
+Three hooks on [TldrawOptions](?) let you intercept these flows. `onClipboardPasteRaw` fires before tldraw parses the clipboard, so you can read the raw `ClipboardEvent` yourself; return `false` to short-circuit the default pipeline. `onBeforePasteFromClipboard` receives the parsed external content and can transform it or return `false` to cancel. `onBeforeCopyToClipboard` receives the [TLContent](?) about to be written and can transform it or return `false` to cancel the copy (for a cut, nothing is deleted).
 
 ### Asset resolution
 
-Before writing to the clipboard, the editor calls [Editor#resolveAssetsInContent](?) to convert asset references into data URLs:
+Before writing to the clipboard, the editor calls [Editor#resolveAssetsInContent](?). Image and video assets whose `src` isn't already a data or http URL (for example, assets stored in IndexedDB) are resolved and inlined as data URLs; hosted URLs are copied unchanged:
 
 ```ts
 const content = editor.getContentFromCurrentPage(editor.getSelectedShapeIds())
 const resolved = await editor.resolveAssetsInContent(content)
-// resolved.assets now contain data URLs instead of asset references
+// local assets in resolved.assets now have data URLs for src
 ```
 
-This embeds images and videos directly in the clipboard data rather than relying on URLs that might not be accessible when pasting elsewhere. The resolved content becomes fully portable across editor instances.
+This makes the content portable across editor instances without relying on URLs that only work in the source app.
 
 ### Cut operations
 
-Cut combines copy and delete. The editor first copies the selected shapes to the clipboard, then deletes the originals. This order ensures the clipboard has the data before shapes disappear, preventing data loss if the copy fails.
+Cut combines copy and delete. The editor first copies the selected shapes to the clipboard, then deletes the originals, so a failed copy leaves your shapes intact.
 
 ### Plain text paste
 
-`Cmd+Shift+V` (or `Ctrl+Shift+V` on Windows and Linux) pastes the clipboard as plain text. HTML and rich formatting are stripped. This is the standard "paste without formatting" shortcut. It's handy when styled text from a browser or word processor would otherwise bring its fonts and colors onto the canvas with it.
-
-To extend or override this behavior, use the `onClipboardPasteRaw` hook on [TldrawOptions](?). It fires before tldraw parses the clipboard, so you can read the raw `ClipboardEvent` data yourself. Return `false` to short-circuit the default pipeline, or `void` to let it continue.
+`Cmd+Shift+V` (or `Ctrl+Shift+V` on Windows and Linux) pastes the clipboard as plain text. HTML and rich formatting are stripped. This is the standard "paste without formatting" shortcut. It's handy when styled text from a browser or word processor would otherwise bring its fonts and colors onto the canvas with it. If the clipboard has no plain text (a copied PNG, say), the shortcut falls through to the normal paste.
 
 ## Content structure
 
@@ -107,21 +107,22 @@ interface TLContent {
 - `bindings` holds relationships between shapes, like arrows connected to boxes
 - `assets` includes images, videos, and other external resources
 - `schema` preserves the store schema version, so content from a different editor version can be migrated on paste
-- `users` carries any user records referenced by the copied shapes, so [attribution](/sdk-features/attribution) display names survive the paste
+- `users` carries any user records referenced by the copied shapes, so [attribution](/sdk-features/attribution) display names survive the paste; on paste, only users not already in the store are created
 
 ## Position handling
 
 [Editor#putContentOntoCurrentPage](?) offers flexible positioning:
 
-- By default, shapes paste at a slight offset from their original position so it's clear that new shapes were created
-- When pasting with the shift key pressed (or with paste-at-cursor mode enabled), shapes paste at the cursor position
-- The `preservePosition` option places shapes at their exact stored coordinates, skipping offset calculation entirely
+- By default, shapes paste in place if any of them is on screen; otherwise the group is centered in the viewport
+- When pasting into a selected container, shapes are centered in that container
+- With the `point` option, shapes are centered on that point. The UI passes the cursor position when the paste-at-cursor preference is on, when you paste from the context menu, or when you press `Cmd+Option+V` (`Ctrl+Alt+V`), which inverts the preference for one paste
+- The `preservePosition` option places shapes at their exact stored coordinates
 
 The editor uses `preservePosition` internally when moving shapes between pages, where position preservation matters.
 
 ## ID remapping
 
-Shape and binding IDs get remapped during paste to prevent collisions with existing shapes. The editor creates a mapping from old IDs to new IDs, then updates all references throughout the pasted content: parent-child relationships, binding endpoints, and asset references all get the new IDs.
+Shape and binding IDs get remapped during paste to prevent collisions with existing shapes. The editor creates a mapping from old IDs to new IDs, then updates parent-child relationships and binding endpoints to match. Asset IDs are not remapped: assets already in the store are reused, and new ones are created under their original IDs.
 
 The `preserveIds` option disables remapping. The editor uses it when moving shapes between pages, where the shapes should keep their existing IDs.
 
@@ -152,9 +153,9 @@ await editor.putExternalContent({
 })
 ```
 
-Register custom handlers with [Editor#registerExternalContentHandler](?) to customize how different content types are processed. See [External content](/sdk-features/external-content) for details on the handler system.
+Serialized tldraw content goes through the same route: `editor.putExternalContent({ type: 'tldraw', content })` marks a history stopping point, pastes with [Editor#putContentOntoCurrentPage](?), and selects the result. Register custom handlers with [Editor#registerExternalContentHandler](?) to customize how different content types are processed. See [External content](/sdk-features/external-content) for details on the handler system.
 
 ## Related examples
 
-- [Custom paste behavior](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/custom-paste) shows how to customize paste by registering an external content handler that changes where pasted shapes are positioned.
-- [External content sources](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/external-content-sources) shows how to handle different content types when pasting into tldraw, including custom handling for HTML content.
+- [Custom paste behavior](/examples/data/assets/custom-paste) shows how to customize paste by registering an external content handler that changes where pasted shapes are positioned.
+- [External content sources](/examples/data/assets/external-content-sources) shows how to handle different content types when pasting into tldraw, including custom handling for HTML content.

--- a/apps/docs/content/sdk-features/collaboration.mdx
+++ b/apps/docs/content/sdk-features/collaboration.mdx
@@ -22,13 +22,13 @@ accuracy: 9
 notes: Some sections could be more direct.
 ---
 
-The `@tldraw/sync` package provides real-time multiplayer collaboration for tldraw. Multiple users can edit the same document simultaneously, see each other's cursors, and follow each other's viewports. The sync system handles connection management, conflict resolution, and presence synchronization automatically.
+The `@tldraw/sync` package provides real-time multiplayer collaboration for tldraw. Multiple users can edit the same document simultaneously, see each other's cursors, and follow each other's viewports. The sync system handles connection management, conflict resolution, and presence.
 
 Collaboration requires a server component to coordinate changes between clients. Use tldraw's demo server for prototyping, or run your own server for production.
 
 ## Quick start with the demo server
 
-The fastest way to add multiplayer is with `useSyncDemo`. This hook connects to a hosted demo server that handles synchronization:
+The fastest way to add multiplayer is with [useSyncDemo](?). This hook connects to a hosted demo server that handles synchronization:
 
 ```tsx
 import { useSyncDemo } from '@tldraw/sync'
@@ -50,7 +50,7 @@ Anyone who opens the app with the same `roomId` will see the same document and e
 
 ## Production setup with useSync
 
-For production, use the `useSync` hook with your own server:
+For production, use the [useSync](?) hook with your own server:
 
 ```tsx
 import { useSync } from '@tldraw/sync'
@@ -79,7 +79,7 @@ export default function Room({ roomId }: { roomId: string }) {
 }
 ```
 
-The `useSync` hook returns a `RemoteTLStoreWithStatus` object with three possible states:
+The `useSync` hook returns a [RemoteTLStoreWithStatus](?) object with three possible states:
 
 | Status          | Description                                                    |
 | --------------- | -------------------------------------------------------------- |
@@ -89,7 +89,7 @@ The `useSync` hook returns a `RemoteTLStoreWithStatus` object with three possibl
 
 ### Asset storage
 
-Production setups require an asset store for handling images, videos, and other files:
+Production setups require a [TLAssetStore](?) for handling images, videos, and other files:
 
 ```tsx
 const myAssetStore: TLAssetStore = {
@@ -117,7 +117,7 @@ See the [Assets](/docs/assets) documentation for more on implementing asset stor
 
 ## User identity
 
-By default, users get a default name and a random color, stored in localStorage. To customize this, pass a `users` store whose methods return reactive `Signal` values:
+By default, users get a default name and a random color, stored in localStorage. To customize this, pass a [TLUserStore](?) as `users`, whose methods return reactive `Signal` values:
 
 ```tsx
 import { computed, UserRecordType, createUserId } from 'tldraw'
@@ -149,7 +149,7 @@ const users: TLUserStore = {
 
 ### Integrating with useTldrawCurrentUser
 
-If you need to let users edit their preferences through tldraw's UI, use `useTldrawCurrentUser`:
+If you need to let users edit their preferences through tldraw's UI, use [useTldrawCurrentUser](?):
 
 ```tsx
 import { useSyncDemo } from '@tldraw/sync'
@@ -184,7 +184,7 @@ export default function App({ roomId }: { roomId: string }) {
 			return UserRecordType.create({
 				id: createUserId(p.id),
 				name: p.name ?? '',
-				color: p.color ?? undefined,
+				color: p.color ?? '',
 			})
 		})
 		return { currentUser }
@@ -218,7 +218,7 @@ The connection status reflects the WebSocket connection state. When offline, cha
 
 ## Custom presence
 
-The presence system controls what information is shared with other users. By default, it includes cursor position, selected shapes, and viewport bounds. You can customize this with `getUserPresence`:
+The presence system controls what information is shared with other users. By default, it includes cursor position, selected shapes, and viewport bounds. You can customize this with `getUserPresence`, starting from [getDefaultUserPresence](?):
 
 ```tsx
 import { getDefaultUserPresence } from 'tldraw'
@@ -258,22 +258,21 @@ The `uri` option accepts a function that returns a string or Promise. This runs 
 
 ## Running your own server
 
-For production, you'll need to run a sync server. The `@tldraw/sync-core` package provides `TLSocketRoom` for server-side room management.
+For production, you'll need to run a sync server. The `@tldraw/sync-core` package provides [TLSocketRoom](?) for server-side room management.
 
-We provide a complete Cloudflare Workers template that includes:
+Our [Cloudflare Workers template](https://github.com/tldraw/tldraw-sync-cloudflare) is the same setup that runs tldraw.com. It includes:
 
 - WebSocket sync via Durable Objects (one per room)
 - Asset storage with R2
 - Bookmark unfurling for URL previews
-- Production-ready architecture that scales automatically
 
 Get started with the template:
 
 ```bash
-npx create-tldraw@latest --template sync-cloudflare
+npm create tldraw@latest -- --template multiplayer
 ```
 
-Or copy the relevant pieces to your existing infrastructure. The template handles the complexity of room lifecycle, connection management, and state persistence.
+Or copy the relevant pieces into your existing infrastructure. See [Sync](/docs/sync) for other server setups.
 
 ### Server architecture
 
@@ -326,6 +325,8 @@ export default function App({ roomId }: { roomId: string }) {
 
 Pass the shape and binding utilities to both the sync hook (for schema registration) and the Tldraw component (for rendering). If they don't match, shapes may fail to sync or render correctly.
 
+`useSyncDemo` adds tldraw's default utilities for you. `useSync` doesn't: when you pass `shapeUtils` or `bindingUtils` to `useSync`, include the defaults yourself, for example `shapeUtils: [...defaultShapeUtils, MyCustomShapeUtil]`.
+
 ## Comments
 
 Comment threads sync the same way, through record types you opt into with the `records` option:
@@ -341,20 +342,17 @@ const store = useSync({
 })
 ```
 
-Your server's schema needs the same registration. On the server you can also serve comments through
-the room's object-store lane, which gates them by their own per-session permission—so a viewer who
-can't edit the document can still comment. See [Commenting](/sdk-features/commenting) for the tool,
-the canvas layer, and the server setup.
+Your server's schema needs the same registration. On the server you can also serve comments through the room's object-store lane, which gates them by their own per-session permission. A viewer who can't edit the document can still comment. See [Commenting](/sdk-features/commenting) for the tool, the canvas layer, and the server setup.
 
 ## Building custom sync
 
-The `@tldraw/sync` package handles many complexities: connection management, reconnection, conflict resolution, and protocol versioning. For most applications, it's the right choice. However, you might need custom sync when integrating with existing infrastructure, using a different transport (like WebRTC), or implementing specialized conflict resolution.
+The `@tldraw/sync` package handles connection management, reconnection, conflict resolution, and protocol versioning. For most applications, it's the right choice. You might need custom sync when integrating with existing infrastructure, using a different transport (like WebRTC), or implementing specialized conflict resolution.
 
 tldraw's store provides the primitives you need to build your own sync layer.
 
 ### Listening to changes
 
-The store's `listen` method notifies you when records change:
+The store's [Store#listen](?) method notifies you when records change:
 
 ```tsx
 const unsubscribe = editor.store.listen(
@@ -381,7 +379,7 @@ For sync, you typically want `source: 'user'` (only local changes) and `scope: '
 
 ### Change structure
 
-Changes arrive as a `RecordsDiff` object with three categories:
+Changes arrive as a [RecordsDiff](?) object with three categories:
 
 ```tsx
 interface RecordsDiff<R> {
@@ -395,7 +393,7 @@ Each entry is keyed by record ID. For updates, you get both the previous and cur
 
 ### Applying remote changes
 
-When you receive changes from other clients, wrap them in `mergeRemoteChanges`:
+When you receive changes from other clients, wrap them in [Store#mergeRemoteChanges](?):
 
 ```tsx
 function applyRemoteChanges(records: TLRecord[], deletedIds: TLRecord['id'][]) {
@@ -410,7 +408,7 @@ function applyRemoteChanges(records: TLRecord[], deletedIds: TLRecord['id'][]) {
 }
 ```
 
-This marks the changes as `'remote'` source, so your own listener won't echo them back to the server. It also batches the operations into a single history entry.
+This marks the changes as `'remote'` source, so your own listener won't echo them back to the server. It also batches the operations into a single transaction, and remote changes never enter the undo/redo history.
 
 ### Snapshots and serialization
 
@@ -433,30 +431,20 @@ The snapshot format includes schema information, so tldraw can automatically mig
 
 ### Presence records
 
-User presence (cursors, selections, viewports) uses special `instance_presence` records:
+User presence (cursors, selections, viewports) uses [InstancePresenceRecordType](?) records. Only `userId`, `userName`, and `currentPageId` are required; everything else has a default:
 
 ```tsx
-import { InstancePresenceRecordType } from 'tldraw'
+import { createUserId, InstancePresenceRecordType } from 'tldraw'
 
-// Create a presence record for a remote user
+// Create a presence record for a remote user, keyed by that client's session id
 const presence = InstancePresenceRecordType.create({
-	id: InstancePresenceRecordType.createId(
-		editor.store.id // Store ID identifies this client
-	),
-	userId: 'user-123',
+	id: InstancePresenceRecordType.createId(remoteSessionId),
+	userId: createUserId('user-123'),
 	userName: 'Alice',
 	color: '#ff6b6b',
 	currentPageId: editor.getCurrentPageId(),
 	cursor: { x: 100, y: 200, type: 'default', rotation: 0 },
-	selectedShapeIds: [],
-	camera: { x: 0, y: 0, z: 1 },
-	screenBounds: { x: 0, y: 0, w: 1920, h: 1080 },
 	lastActivityTimestamp: Date.now(),
-	chatMessage: '',
-	brush: null,
-	scribbles: [],
-	followingUserId: null,
-	meta: {},
 })
 
 // Add to store
@@ -465,7 +453,7 @@ editor.store.put([presence])
 // Update cursor position
 editor.store.update(presence.id, (record) => ({
 	...record,
-	cursor: { ...record.cursor, x: 150, y: 250 },
+	cursor: { x: 150, y: 250, type: 'default', rotation: 0 },
 }))
 
 // Remove when user disconnects
@@ -490,10 +478,12 @@ Here's a minimal example using a WebSocket for broadcast sync (no conflict resol
 
 ```tsx
 import { useEffect, useRef, useState } from 'react'
-import { Tldraw, createTLStore, defaultShapeUtils } from 'tldraw'
+import { Tldraw, createTLStore, defaultBindingUtils, defaultShapeUtils } from 'tldraw'
 
 function App() {
-	const [store] = useState(() => createTLStore({ shapeUtils: defaultShapeUtils }))
+	const [store] = useState(() =>
+		createTLStore({ shapeUtils: defaultShapeUtils, bindingUtils: defaultBindingUtils })
+	)
 	const wsRef = useRef<WebSocket | null>(null)
 
 	useEffect(() => {
@@ -540,11 +530,12 @@ function App() {
 }
 ```
 
-This example omits important concerns like initial state sync, reconnection handling, and conflict resolution. For production use, consider starting with `@tldraw/sync` and customizing it, or studying its implementation for guidance on handling these edge cases.
+This example omits initial state sync, reconnection handling, and conflict resolution. For production, start with `@tldraw/sync` and customize it, or study its implementation for how it handles these cases.
 
 ## Related examples
 
 - [Multiplayer sync](/examples/collaboration/sync-demo) — Basic multiplayer setup with the demo server
-- [Custom user](/examples/collaboration/sync-custom-user) — Setting custom user identity for multiplayer
+- [Custom user](/examples/users/sync-custom-user) — Setting custom user identity for multiplayer
 - [Custom presence](/examples/collaboration/sync-custom-presence) — Customizing presence data sent to collaborators
 - [Custom shapes](/examples/collaboration/sync-custom-shape) — Syncing custom shapes with multiplayer
+- [User presence](/examples/collaboration/user-presence) — Manually creating and updating presence records

--- a/apps/docs/content/sdk-features/collaboration.mdx
+++ b/apps/docs/content/sdk-features/collaboration.mdx
@@ -260,7 +260,7 @@ The `uri` option accepts a function that returns a string or Promise. This runs 
 
 For production, you'll need to run a sync server. The `@tldraw/sync-core` package provides [TLSocketRoom](?) for server-side room management.
 
-Our [Cloudflare Workers template](https://github.com/tldraw/tldraw-sync-cloudflare) is the same setup that runs tldraw.com. It includes:
+Our [Cloudflare Workers template](https://github.com/tldraw/tldraw/tree/main/templates/sync-cloudflare) is the same setup that runs tldraw.com. It includes:
 
 - WebSocket sync via Durable Objects (one per room)
 - Asset storage with R2

--- a/apps/docs/content/sdk-features/commenting.mdx
+++ b/apps/docs/content/sdk-features/commenting.mdx
@@ -19,7 +19,7 @@ date: 7/27/2026
 
 In tldraw, a comment is a message pinned to a place on the canvas. Comments group into threads, one conversation per pin. Every comment records who wrote it and comments can mention other people.
 
-The `@tldraw/commenting` package works at two levels. `CanvasComments` is a comments layer you render in front of the canvas: it draws the pins, opens the threads, and reads and writes the records itself. Everything it's built from is exported too, so you can replace any part of it or assemble your own layer from the pieces.
+The `@tldraw/commenting` package works at two levels. `CanvasComments` is a comments layer you render in front of the canvas: it draws the pins, opens the threads, and reads and writes the records itself. The parts it's built from are exported too, so you can replace any of them or assemble your own layer from the pieces.
 
 Commenting is a licensed feature. It runs in development without a key. In production it needs a tldraw license that includes commenting.
 
@@ -39,7 +39,10 @@ import { commentSchemaRecords, createTLSchema, createTLStore, TLComponents, Tldr
 import '@tldraw/commenting/commenting.css'
 import 'tldraw/tldraw.css'
 
-// Your app's user directory. Any id you can't resolve falls back to a generic byline.
+// In production, a tldraw license key that includes commenting. Not needed in development.
+const YOUR_LICENSE_KEY = undefined
+
+// Your app's user directory. Any id you can't resolve renders as an anonymous user.
 const AUTHORS: Record<string, CommentAuthor> = {
 	me: { name: 'You', color: '#EC5E41' },
 	ada: { name: 'Ada Lovelace', color: '#0E9F6E' },
@@ -70,9 +73,11 @@ export default function App() {
 }
 ```
 
-Comments are records in the editor's store, exactly like shapes. `commentSchemaRecords` registers the `comment-thread` and `comment` types, which aren't in the default schema. Once they're registered, comments persist and sync however your document already does: add a `persistenceKey` or a sync backend and they come along with it.
+Comments are records in the editor's store, exactly like shapes. [commentSchemaRecords](?) registers the `comment-thread`, `comment`, and `comment-reaction` types, which aren't in the default schema. Once they're registered, comments persist and sync however your document already does: add a `persistenceKey` or a sync backend and they come along with it.
 
-`CanvasComments` needs two things, and both are about identity. `currentUserId` is the id of the person commenting, or `null` for a viewer who can read comments but not post them. `resolveAuthor` maps an author id to a `CommentAuthor`: a `name`, an optional `color` for their avatar and pin, and an optional `image`. Return `undefined` for an id you can't resolve and the layer falls back to an anonymous user. Together with the read-status and mention callbacks below they make up the `CommentingContext`, which the sidebar takes too — so a host mounting both surfaces builds one object and spreads it into each.
+`CanvasComments` needs two things, and both are about identity. `currentUserId` is the id of the person commenting, or `null` for a viewer who can read comments but not post them. `resolveAuthor` maps an author id to a `CommentAuthor`: a `name`, an optional `color` for their avatar and pin, and an optional `image`. Return `undefined` for an id you can't resolve and the layer falls back to an anonymous user.
+
+These two props, plus the read-status and mention callbacks below, make up the `CommentingContext`. The sidebar takes the same context, so a host mounting both surfaces builds one object and spreads it into each.
 
 Mount the layer through the `InFrontOfTheCanvas` component slot so it sits above the canvas but below the UI, and import `commenting.css` alongside `tldraw.css`.
 
@@ -169,9 +174,9 @@ Return `() => false` for shape-level anchoring throughout, or `(editor, { altKey
 
 Comment writes are not undoable by default. The `history` option governs all of them, including posting, replying, editing and resolving, and it defaults to `'ignore'`. It covers your own writes too: a record you write with `putCommentRecords` lands on the undo stack, or doesn't, exactly like one the built-in UI writes.
 
-In a shared document an undoable delete resurrects a thread a collaborator already removed, and an undoable resolve reverts their newer state. `'record'` is safe single-player, or against a comment store that isn't synced.
+In a shared document an undoable delete resurrects a thread a collaborator already removed, and an undoable resolve reverts their newer state. `'record'` is safe in a single-player app, or when the comment store isn't synced.
 
-Deleting is the one write `history` doesn't reach. It's never undoable, for a reason particular to how deletes work — see [Deleting is a soft delete](#deleting-is-a-soft-delete).
+Deleting is the one write `history` doesn't reach. It's never undoable, because of how deletes work: see [Deleting is a soft delete](#deleting-is-a-soft-delete).
 
 Pin drags are the exception worth configuring separately. Re-anchoring a comment is a spatial edit that may reasonably undo alongside the shape move that prompted it, so `dragHistory` overrides `history` for drags alone:
 
@@ -200,9 +205,9 @@ When `canComment` returns false, composers give way to the `ComposerFallback` sl
 
 ## Who can edit and delete
 
-`canComment` is about the viewer; `canModifyComment` is about the viewer and one particular record. It's asked for the three writes that belong to someone in particular — editing a comment, deleting a comment, deleting a thread — and where it returns false, that affordance isn't rendered.
+`canComment` is about the viewer; `canModifyComment` is about the viewer and one particular record. It's asked for three writes: editing a comment, deleting a comment, and deleting a thread. Where it returns false, that affordance isn't rendered.
 
-Left unset, each is its record's owner's to make: you edit and delete your own comments, and delete threads you started. Pass a callback to widen that, composing with `defaultCanModifyComment` so the owner keeps what they already had:
+By default, only a comment's author can edit or delete it, and only a thread's creator can delete the thread. Pass a callback to widen that, composing with `defaultCanModifyComment` so the owner keeps what they already had:
 
 ```tsx
 import { CommentTool, defaultCanModifyComment } from '@tldraw/commenting'
@@ -219,7 +224,7 @@ The `ctx` carries the editor, the viewer's `currentUserId`, and the write itself
 
 Resolving, reopening, reacting, and moving a pin aren't asked about: none of them is anyone's in particular, so `canComment` is the only gate on them. `canModifyComment` is checked after `canComment`, so a viewer who may not participate gets no action affordances whatever it returns. Like `canComment`, it's read during render (through `useCanModifyComment`), so a callback that reads signals re-evaluates when they change.
 
-Whatever you decide here, decide it again on the server: `createCommentAuthorizers` takes a `canModifyComment` of its own, and it's the one that counts. See [enforcing the same rules on the server](#syncing-comments).
+Enforce the same rule on the server: `createCommentAuthorizers` takes a `canModifyComment` of its own, and that one is authoritative. See [Syncing comments](#syncing-comments).
 
 <Callout type="warning">
 	`canComment` and `canModifyComment` hide UI. They don't enforce anything. Comment records carry a
@@ -334,19 +339,19 @@ The sidebar's filters cover resolved threads, only comments you made, only unrea
 
 ## Unread state
 
-The layer doesn't track who has read what. That data lives in your app. Supply it as two callbacks. `isCommentUnread` reports whether a comment is unread, and `onCommentRead` fires for each unread comment the user actually sees in an open thread.
+The layer doesn't track who has read what. That data lives in your app. Supply it as two callbacks. `isCommentUnread` reports whether a comment is unread, and `onCommentsRead` fires once per report with every unread comment the user actually sees in an open thread, so you can record read receipts in one write.
 
 ```tsx
 <CanvasComments
 	currentUserId="me"
 	resolveAuthor={resolveAuthor}
 	isCommentUnread={(commentId) => !readReceipts.has(commentId)}
-	onCommentRead={(commentId) => markCommentRead(commentId)}
+	onCommentsRead={(commentIds) => markCommentsRead(commentIds)}
 	onPostComment={(comment) => notifyMentionedUsers(comment)}
 />
 ```
 
-Unread state drives the pin badges and the sidebar's unread filter. Without `isCommentUnread`, both are hidden. `onPostComment` fires when this user posts a comment through one of the built-in composers — a new thread or a reply — which is where notifications and mention emails belong. It does not fire for comments arriving over sync, so the sender is the one who notifies.
+Unread state drives the sidebar's unread filter and the receipts reported through `onCommentsRead`. Without `isCommentUnread`, the filter is hidden and nothing is reported. `onPostComment` fires when this user posts a comment through one of the built-in composers, whether a new thread or a reply. This is where notifications and mention emails belong. It does not fire for comments arriving over sync, so the sender is the one who notifies. See the [comment notifications example](/examples/collaboration/comment-notifications).
 
 ## Custom components
 
@@ -378,14 +383,15 @@ function PriorityBody({ comment }: { comment: TLComment }) {
 const tools = [CommentTool.configure({ components: { CommentBody: PriorityBody } })]
 ```
 
-Both record types carry a `meta` field the layer never reads. Use it for priorities, categories, external ticket ids, or anything else your app tracks alongside a comment.
+Every comment record type carries a `meta` field the layer never reads. Use it for priorities, categories, external ticket ids, or anything else your app tracks alongside a comment.
 
 `ThreadRow` and `ThreadActions` are the two slots that add to a surface rather than replace a piece of it, so they get the records behind what's on screen.
 
-`ThreadRow` receives the summarized row along with the thread record, and the default row is exported — so a row that only adds something can spread the props into `CommentListItem` rather than start over:
+`ThreadRow` receives the summarized row along with the thread record, and the default row is exported. A row that only adds something can spread the props into `CommentListItem` rather than start over:
 
 ```tsx
-import { CommentListItem, CommentTool } from '@tldraw/commenting'
+import { CommentListItem, CommentListItemRenderProps, CommentTool } from '@tldraw/commenting'
+import { TLCommentThread } from 'tldraw'
 
 function StatusRow({ thread, ...row }: CommentListItemRenderProps & { thread: TLCommentThread }) {
 	return (
@@ -399,9 +405,12 @@ function StatusRow({ thread, ...row }: CommentListItemRenderProps & { thread: TL
 const tools = [CommentTool.configure({ components: { ThreadRow: StatusRow } })]
 ```
 
-`ThreadActions` adds controls to an open thread's header, ahead of the built-in resolve and dismiss buttons. This is where host verbs go — assign a thread, link it to a ticket, mark it as a to-do. It adds alongside the built-in actions rather than replacing them, so a thread never loses the ability to be resolved.
+`ThreadActions` adds controls to an open thread's header, ahead of the built-in resolve and dismiss buttons. This is where host verbs go: assign a thread, link it to a ticket, mark it as a to-do. It adds alongside the built-in actions rather than replacing them, so a thread never loses the ability to be resolved.
 
 ```tsx
+import { CommentTool } from '@tldraw/commenting'
+import { TLCommentThread } from 'tldraw'
+
 function AssignAction({ thread }: { thread: TLCommentThread }) {
 	return (
 		<button type="button" className="tlui-cmt-thread__action" onClick={() => assign(thread.id)}>
@@ -429,7 +438,7 @@ Comment records aren't part of the `TLRecord` union, so `editor.store` doesn't k
 | `putCommentRecords`     | Write threads and comments.                                                          |
 | `removeCommentRecords`  | Remove them by id. Rarely what you want — see [Writing comments](#writing-comments). |
 
-Prefer the live reads. Deleting a comment doesn't remove its record — it flags it and lets the server prune it, as [Writing comments](#writing-comments) explains — so the unfiltered reads include records that nothing renders. `getLiveCommentThreads` also drops threads whose comments have all gone, which have no surface left.
+Prefer the live reads. Deleting a comment doesn't remove its record: it flags it and lets the server prune it, as [Writing comments](#writing-comments) explains. So the unfiltered reads include records that nothing renders. `getLiveCommentThreads` also drops threads whose comments have all gone, which have no surface left.
 
 Those reads are non-reactive. In React use the hooks instead, which read the live set: `useCommentThreads`, `useComments`, and `useThreadComments` for one thread's replies, oldest first.
 
@@ -469,7 +478,7 @@ const comment = createComment({
 putCommentRecords(editor, [thread, comment])
 ```
 
-The other writes each have a rule attached — a timestamp to stamp, or the delete protocol below — so they come as functions. The built-in thread view calls exactly these, so a UI of your own behaves like the one in the box.
+The other writes each have a rule attached (a timestamp to stamp, or the delete protocol below), so they come as functions. The built-in thread view calls exactly these, so a UI of your own behaves like the one in the box.
 
 | Helper                          | Description                                            |
 | ------------------------------- | ------------------------------------------------------ |
@@ -485,13 +494,13 @@ resolveThread(editor, thread, currentUserId)
 deleteComment(editor, comment)
 ```
 
-The record you pass says which comment or thread to act on; the change itself lands on the version currently in the store. So a record you took a copy of earlier is safe to pass: it won't put back a field that has moved since — a thread's anchor changes on its own as pinned shapes move, and a comment's body changes when its author edits it elsewhere — and it won't re-create a record that has already been deleted, which a plain `putCommentRecords` of a stale copy would. If the record is gone, the call does nothing.
+The record you pass says which comment or thread to act on; the change itself lands on the version currently in the store. So a record you took a copy of earlier is safe to pass. It won't put back a field that has moved since, such as a thread's anchor after its pinned shape moved, or a comment's body after its author edited it elsewhere. And it won't re-create a record that has already been deleted, which a plain `putCommentRecords` of a stale copy would. If the record is gone, the call does nothing.
 
 ### Deleting is a soft delete
 
 `deleteComment` and `deleteThread` don't remove records. They set an `isDeleted` flag and leave the pruning to the server, which then removes the thread, its comments, and their reactions.
 
-That indirection is what makes deleting safe in a shared document. A reaction belongs to whoever left it, not to whoever is deleting the comment underneath it, so no client should be removing it — and a server enforcing per-record permissions gets a write it can check against the session's identity rather than a deletion it can only refuse. `removeCommentRecords` is a hard delete, and against such a server it will simply be rejected. Reach for it on a local, unsynced comment store.
+That indirection is what makes deleting safe in a shared document. A reaction belongs to whoever left it, not to whoever is deleting the comment underneath it, so no client should be removing it. And a server enforcing per-record permissions gets a write it can check against the session's identity rather than a deletion it can only refuse. `removeCommentRecords` is a hard delete, and such a server rejects it. Reach for it on a local, unsynced comment store.
 
 The flag is write-once server-side, so deletes are never undoable, whatever `history` says: an undo clearing the flag would be vetoed and rebased rather than bring the comment back.
 
@@ -508,7 +517,7 @@ import { revealThread } from '@tldraw/commenting'
 revealThread(editor, commentId)
 ```
 
-An unserved request is inert, so it's safe to call before the records have synced in. `useRevealThreadPending` returns the id of a request that hasn't been served yet, which is how you notice a deep link to a comment that no longer exists — give it a grace period first, since a request also sits there while its records are still arriving, and re-check with `getRevealThreadPending(editor)` when the grace period elapses so you don't act on a request that cleared inside it.
+An unserved request is inert, so it's safe to call before the records have synced in. `useRevealThreadPending` returns the id of a request that hasn't been served yet, which is how you notice a deep link to a comment that no longer exists. Give it a grace period first, since a request also sits there while its records are still arriving. When the grace period elapses, re-check with `getRevealThreadPending(editor)` so you don't act on a request that cleared inside it.
 
 For a thread you already hold, `focusThread(editor, thread)` centers and opens it directly.
 
@@ -526,7 +535,7 @@ The other half of a deep link is producing one. Give the commenting context a `g
 
 Sidebar rows become anchors, so ctrl/cmd-click and middle-click open a thread in a new tab, and an open thread's header menu offers **Copy link**. A relative href is resolved against the current document before it reaches the clipboard, so what gets pasted is a whole URL.
 
-Without `getThreadHref` neither appears — a link the host can't construct isn't one the layer can invent.
+Without `getThreadHref`, neither appears.
 
 ## Pin clustering
 
@@ -550,7 +559,7 @@ const store = useSync({
 })
 ```
 
-On the server, pass the same map to [`createTLSchema`](?):
+On the server, pass the same map to [createTLSchema](?):
 
 ```ts
 import { TLSocketRoom } from '@tldraw/sync-core'
@@ -576,7 +585,7 @@ room.handleSocketConnect({
 })
 ```
 
-`objectAccess` is `'read'` or `'write'` and defaults to `'write'`. To persist the lane separately, read it with [`TLSocketRoom`](?)'s `getCurrentObjectsSnapshot()`. To mirror comments into your own database as they commit, use the room's `onCommittedChanges` callback:
+`objectAccess` is `'read'` or `'write'` and defaults to `'write'`. To persist the lane separately, read it with [TLSocketRoom#getCurrentObjectsSnapshot](?). To mirror comments into your own database as they commit, use the room's `onCommittedChanges` callback:
 
 ```ts
 const room = new TLSocketRoom({
@@ -611,9 +620,11 @@ const room = new TLSocketRoom({
 })
 ```
 
-It stamps authorship from the session so nothing can be posted or resolved in someone else's name, keeps `isDeleted` write-once, and — through `canModifyComment` — decides who may edit a comment, delete a comment, or delete a thread. That last one is the same question the client's [`canModifyComment`](#who-can-edit-and-delete) answers, and this is the answer that counts: the client's only decides which affordances the UI offers. Widen the two together. A moderator offered a delete the server then rejects sees the comment disappear and come back, with nothing to explain it.
+It stamps authorship from the session so nothing can be posted or resolved in someone else's name, keeps `isDeleted` write-once, and, through `canModifyComment`, decides who may edit a comment, delete a comment, or delete a thread. Left unset, `canModifyComment` defaults to the record's owner, matching the client. It's asked after the structural rules, so widening it grants those three writes and nothing else: attribution stays immutable, a soft delete stays write-once, and clients still can't hard-delete a record.
 
-Left unset it defaults to the record's owner, matching the client. The callback is asked after the structural rules, so widening it grants those three writes and nothing else: attribution stays immutable, a soft delete stays write-once, and clients still can't hard-delete a record.
+This is the same question the client's [`canModifyComment`](#who-can-edit-and-delete) answers, and the server's answer is the one that counts: the client's only decides which affordances the UI offers. Widen the two together. A moderator offered a delete the server then rejects sees the comment disappear and come back, with nothing to explain it.
+
+`createCommentAuthorizers` also takes a `canComment` callback, checked before every comment write. It defaults to `({ isReadonly }) => !isReadonly`, so a read-only session can't post even with `objectAccess: 'write'`. To let read-only viewers comment, as in the `handleSocketConnect` example above, pass `canComment: () => true` (or a rule based on the session's `meta`).
 
 ## Building your own comments UI
 

--- a/apps/docs/content/sdk-features/coordinates.mdx
+++ b/apps/docs/content/sdk-features/coordinates.mdx
@@ -20,7 +20,13 @@ notes: Could use more questions-as-transitions per voice guide. Consider adding 
 
 The editor uses three coordinate systems: screen space, viewport space, and page space. When you move the mouse over the canvas, the browser gives you screen coordinates. To create a shape at that location, you need to convert those coordinates to page space.
 
-The editor provides methods to convert between these coordinate systems. You'll use these when building custom tools, positioning DOM overlays, or responding to pointer events.
+The editor provides methods to convert between these coordinate systems. You'll use these when building custom tools, positioning DOM overlays, or responding to pointer events. The [Camera](/sdk-features/camera) article explains the camera values these conversions depend on.
+
+| Method                     | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| [Editor#screenToPage](?)   | Convert a screen point to page space.                               |
+| [Editor#pageToScreen](?)   | Convert a page point to screen space.                               |
+| [Editor#pageToViewport](?) | Convert a page point to viewport space (relative to the container). |
 
 ## The three coordinate systems
 
@@ -32,11 +38,11 @@ Screen space uses pixel coordinates from the browser window's top-left corner. T
 
 Viewport space uses pixel coordinates from the editor container's top-left corner. This accounts for where the editor sits on the page. If the editor is embedded in a scrollable element or positioned away from the browser's origin, viewport coordinates differ from screen coordinates by that offset.
 
-The editor tracks the container's position in `editor.getViewportScreenBounds()`.
+The editor tracks the container's position in [Editor#getViewportScreenBounds](?).
 
 ### Page space
 
-Page space is the infinite canvas itself. A shape at `x: 100, y: 200` stays at those coordinates regardless of how the user pans or zooms. All shape positions are stored in page space.
+Page space is the infinite canvas itself. A shape at `x: 100, y: 200` stays at those coordinates regardless of how the user pans or zooms. Top-level shapes store their position in page space; children of frames and groups store it relative to their parent. See [Parenting](/sdk-features/parenting) for the helpers that convert between shape space and page space.
 
 The camera determines which part of page space is visible. When you zoom in, the same page-space region takes up more screen pixels. When you pan, different page-space coordinates come into view.
 
@@ -44,7 +50,7 @@ The camera determines which part of page space is visible. When you zoom in, the
 
 ### Screen to page space
 
-Use `editor.screenToPage()` to convert screen coordinates to page coordinates:
+Use [Editor#screenToPage](?) to convert screen coordinates to page coordinates. This is the most common transformation. It accounts for the editor container's position, the camera position, and the zoom level:
 
 ```typescript
 // Convert mouse event coordinates to page space
@@ -59,15 +65,14 @@ editor.createShape({
 })
 ```
 
-This is the most common transformation. It accounts for the editor container's position, the camera position, and the zoom level.
-
 ### Page to screen space
 
-Use `editor.pageToScreen()` to convert page coordinates to screen coordinates:
+Use [Editor#pageToScreen](?) to convert page coordinates to screen coordinates, for example to position a DOM element that lives outside the editor container:
 
 ```typescript
 // Convert shape position to screen coordinates
 const shape = editor.getShape(shapeId)
+if (!shape) return
 const screenPoint = editor.pageToScreen({ x: shape.x, y: shape.y })
 
 // Position a DOM element at the shape's screen location
@@ -75,11 +80,9 @@ element.style.left = `${screenPoint.x}px`
 element.style.top = `${screenPoint.y}px`
 ```
 
-Use this when positioning DOM elements relative to shapes on the canvas.
-
 ### Page to viewport space
 
-Use `editor.pageToViewport()` to convert page coordinates to viewport coordinates:
+Use [Editor#pageToViewport](?) to convert page coordinates to viewport coordinates. This is `pageToScreen()` without the container offset, so use it for canvas rendering or for positioning elements inside the editor container:
 
 ```typescript
 // Get viewport coordinates for a page point
@@ -94,11 +97,9 @@ const isVisible =
 	viewportPoint.y <= viewportBounds.h
 ```
 
-This is like `pageToScreen()` but relative to the editor container rather than the browser window. Use this for canvas rendering or when you don't care about the editor's position on the page.
-
 ## Viewport bounds
 
-Use `editor.getViewportScreenBounds()` to get the editor container's position and size in screen space:
+Use [Editor#getViewportScreenBounds](?) to get the editor container's position and size in screen space:
 
 ```typescript
 const screenBounds = editor.getViewportScreenBounds()
@@ -106,7 +107,7 @@ const screenBounds = editor.getViewportScreenBounds()
 // screenBounds.w, screenBounds.h - container dimensions in pixels
 ```
 
-Use `editor.getViewportPageBounds()` to get the visible area in page space:
+Use [Editor#getViewportPageBounds](?) to get the visible area in page space:
 
 ```typescript
 const pageBounds = editor.getViewportPageBounds()
@@ -114,11 +115,11 @@ const pageBounds = editor.getViewportPageBounds()
 // pageBounds.w, pageBounds.h - visible area dimensions in page units
 ```
 
-The page bounds change when the user pans or zooms. At higher zoom levels, the visible page-space area is smaller.
+Both are reactive, so you can read them inside `track` components or `useValue` and re-render when the user pans or zooms. At higher zoom levels, the visible page-space area is smaller.
 
 ## Using the inputs manager
 
-The editor's inputs manager tracks the current pointer position in both coordinate systems. This is useful when you need to access the pointer position from anywhere in your code:
+The editor's inputs manager tracks the current pointer position, so you can read it from anywhere in your code:
 
 ```typescript
 // Get the current pointer position
@@ -130,7 +131,9 @@ const originScreenPoint = editor.inputs.getOriginScreenPoint()
 const originPagePoint = editor.inputs.getOriginPagePoint()
 ```
 
-In custom tools, you can also convert the event's `point` property (which is in screen space) to page space:
+Despite the name, the inputs manager's "screen point" is relative to the editor container, which this article calls viewport space. Don't pass it to `screenToPage()` and don't subtract `getViewportScreenBounds()` from it.
+
+Pointer event info is different: its `point` property holds `clientX`/`clientY`, so it is in screen space and converts with `screenToPage()`:
 
 ```typescript
 editor.on('event', (event) => {
@@ -141,21 +144,7 @@ editor.on('event', (event) => {
 })
 ```
 
-### Positioning custom overlays
-
-To position a DOM element over a shape, convert the shape's page coordinates to screen coordinates. Then subtract the viewport's screen position to get coordinates relative to the editor container:
-
-```typescript
-const shape = editor.getShape(shapeId)
-const screenBounds = editor.getViewportScreenBounds()
-const screenPoint = editor.pageToScreen({ x: shape.x, y: shape.y })
-
-// Position relative to the editor container
-overlay.style.left = `${screenPoint.x - screenBounds.x}px`
-overlay.style.top = `${screenPoint.y - screenBounds.y}px`
-```
-
 ## Related examples
 
-- [Reactive inputs](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/reactive-inputs) - Display page and screen coordinates reactively as the pointer moves.
-- [Selection UI](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/selection-ui) - Use selection bounds in screen space to position custom UI around shapes.
+- [Reactive inputs](/examples/editor-api/reactive-inputs) - Display page and screen coordinates reactively as the pointer moves.
+- [Selection UI](/examples/ui/selection-ui) - Use selection bounds in screen space to position custom UI around shapes.

--- a/apps/docs/content/sdk-features/cross-tab-sync.mdx
+++ b/apps/docs/content/sdk-features/cross-tab-sync.mdx
@@ -31,7 +31,7 @@ Open this app in two tabs and draw in one of them. The other tab shows the shape
 
 ## How it works
 
-Each tab opens a [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) named after the persistence key. When the user changes the document, the editor posts the change as a diff to the channel. Other tabs merge incoming diffs into their stores as remote changes, so they don't echo the same changes back.
+Each tab opens a [BroadcastChannel](https://developer.mozilla.org/en-US/docs/Web/API/Broadcast_Channel_API) named after the persistence key. When the user changes the document, the editor posts the change as a diff to the channel. Other tabs merge incoming diffs into their stores with [Store#mergeRemoteChanges](?), so they don't echo the same changes back. The internal `useLocalStore` hook sets all of this up when you pass a `persistenceKey`.
 
 The channel only carries live updates. The document itself persists to IndexedDB on a throttle (about 350ms), so a tab opened later loads the latest saved state from the database, then stays current through the channel.
 
@@ -43,7 +43,7 @@ The channel only carries live updates. The document itself persists to IndexedDB
 | Session state (camera, selection, current page)    | Per tab                |
 | User preferences (name, color, color scheme)       | Synced across all tabs |
 
-Only document-scoped records sync between tabs. Each tab keeps its own camera position, selection, and other [instance state](/sdk-features/instance-state), so users can look at different parts of the same document in different tabs.
+Only document-scoped records sync between tabs. Each tab keeps its own camera position, selection, and other [instance state](/sdk-features/instance-state), so users can look at different parts of the same document in different tabs. That per-tab session state is still saved to IndexedDB, keyed by the `sessionId` prop (which defaults to [TAB_ID](?)), so it survives a reload.
 
 tldraw's default user preferences sync across tabs on a separate channel, independent of the persistence key. If you manage preferences yourself through the `user` prop, syncing them is up to you — see [User preferences](/sdk-features/user-preferences).
 
@@ -60,7 +60,7 @@ If a tab is still out of date right after reloading — for example, when a cach
 
 Cross-tab sync works within one browser on one origin. It doesn't sync between devices or users. For multiplayer collaboration, use [tldraw sync](/docs/sync) — see the [Collaboration](/sdk-features/collaboration) page.
 
-It also requires the `persistenceKey` prop. If you create your own store and pass it through the `store` prop, you won't get cross-tab sync or local persistence — you'll need to handle both yourself.
+It also requires the `persistenceKey` prop. If you create your own store and pass it through the `store` prop, you won't get cross-tab sync or local persistence. See [custom persistence with store](/sdk-features/persistence#custom-persistence-with-store) for handling that yourself.
 
 There's no separate toggle: tabs that share a persistence key always sync. To keep tabs independent, give them different persistence keys.
 

--- a/apps/docs/content/sdk-features/culling.mdx
+++ b/apps/docs/content/sdk-features/culling.mdx
@@ -19,11 +19,11 @@ notes: Example link path may need verification. Could add more contractions for 
 
 The culling system optimizes rendering performance by hiding shapes that are outside the viewport.
 
-Culled shapes remain in the DOM but have their `display` property set to `none`, so they don't incur any rendering cost. The system uses incremental derivations to track visibility changes efficiently as the camera moves or shapes change. Performance stays consistent even with thousands of shapes on the canvas.
+Culled shapes stay in the DOM with `display: none`, so they cost nothing to render, and they stay in the store, so they can still be selected, hit-tested, and exported. The culling set is an incremental derivation that updates as the camera moves or shapes change. See [Performance](/sdk-features/performance) for how culling fits with the other rendering optimizations.
 
 ## Using the culling APIs
 
-The editor provides two methods for working with culled shapes:
+The editor exposes two sets of shape IDs. [Editor#getNotVisibleShapes](?) returns the shapes whose page bounds don't intersect the viewport and whose shape util allows culling. [Editor#getCulledShapes](?) removes the selected shapes and the shape being edited from that set, so users can always see what they're working with. Both are reactive, and `getCulledShapes()` returns the same `Set` instance while its contents are unchanged, so it's cheap to read in `track` components or `useValue`.
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -49,19 +49,13 @@ export default function CullingExample() {
 }
 ```
 
-Use [Editor#getNotVisibleShapes](?) to get the IDs of all shapes whose bounds don't intersect the viewport. Use [Editor#getCulledShapes](?) to get the final set of shape IDs that won't render. The difference between these is that `getCulledShapes` excludes selected shapes and the shape currently being edited, so users can always see what they're working with.
-
 ## How it works
 
-The culling system operates in two layers.
-
-The first layer identifies all shapes whose page bounds don't intersect with the viewport. It queries the editor's spatial index for shapes inside the viewport bounds, then marks everything else as not visible.
-
-The second layer refines this set by removing shapes that should remain visible despite being outside the viewport. Selected shapes and the currently editing shape are never culled. This means users can scroll a shape partially or fully out of view while still seeing and interacting with it.
+The first layer queries the editor's spatial index for shapes whose page bounds intersect the viewport and marks everything else as not visible, skipping shapes whose util's `canCull` returns `false`. The second layer removes the selected shapes and the editing shape, so a user can scroll a shape partly or fully out of view while still seeing and interacting with it.
 
 ## Shape-level control
 
-Each shape type can opt out of culling by overriding the `canCull` method on its ShapeUtil. By default, `canCull` returns `true`, so most shapes participate in culling.
+A shape type opts out of culling by overriding [ShapeUtil#canCull](?). The default returns `true`. When your override returns `false`, the shape never enters the not-visible set, so it never gets `display: none`:
 
 ```tsx
 import { ShapeUtil, TLBaseShape, RecordProps, T, Rectangle2d } from 'tldraw'
@@ -105,14 +99,8 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-When `canCull` returns `false`, the culling system treats that shape as always visible regardless of its position.
-
-Common reasons to disable culling:
-
-- Shapes with visual effects (shadows, glows) that extend beyond their bounds
-- Shapes that measure their DOM content and need to stay rendered
-- Shapes with animations that should continue even when off-screen
+Shapes whose util overrides `canCull` are subscribed to individually inside the culling derivation, so a `canCull` that reads many props re-runs the derivation more often. Shapes using the default fast path don't pay this cost. Disable culling only for shapes that need it: visual effects that extend past the bounds, shapes that measure their DOM, or animations that should keep running off-screen. See [Performance](/sdk-features/performance#disable-culling-only-when-necessary) for guidance.
 
 ## Related examples
 
-- **[Size from DOM](/examples/shapes/size-from-dom)** - A shape that disables culling because it measures its DOM element to determine size.
+- [Size from DOM](/examples/shapes/tools/size-from-dom) - A shape that disables culling because it measures its DOM element to determine size.

--- a/apps/docs/content/sdk-features/cursor-chat.mdx
+++ b/apps/docs/content/sdk-features/cursor-chat.mdx
@@ -14,24 +14,25 @@ status: published
 date: 01/31/2026
 ---
 
-Cursor chat lets users send short messages that appear as bubbles near their cursor. It's designed for quick, ephemeral communication during collaborative sessions—a fast "look here" or "nice work" that doesn't interrupt the canvas workflow.
+Cursor chat lets users send short messages that appear as bubbles near their cursor. It's designed for quick, ephemeral communication during collaborative sessions: a fast "look here" or "nice work" that doesn't interrupt the canvas workflow.
+
+Cursor chat only appears when collaboration UI is enabled, which means the store has to be collaborative. The simplest way to get one is [useSyncDemo](?):
 
 ```tsx
+import { useSyncDemo } from '@tldraw/sync'
 import { Tldraw } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 export default function App() {
+	const store = useSyncDemo({ roomId: 'my-cursor-chat-room' })
+
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
+				store={store}
 				onMount={(editor) => {
-					// Start chatting programmatically
-					editor.updateInstanceState({ isChatting: true })
-
-					// Or set a message directly
-					editor.updateInstanceState({
-						chatMessage: 'Hello from the canvas!',
-					})
+					// Show a message bubble at the cursor
+					editor.updateInstanceState({ chatMessage: 'Hello from the canvas!' })
 				}}
 			/>
 		</div>
@@ -39,7 +40,7 @@ export default function App() {
 }
 ```
 
-Cursor chat only appears when collaboration UI is enabled. On desktop, users press `/` to open the chat input, type their message (up to 64 characters), and press Enter to send. The message follows their cursor for a few seconds, then fades away.
+On desktop, users press `/` to open the chat input, type their message (up to 64 characters), and press Enter to send. The message follows their cursor. Once the input closes, the message stays visible for two seconds and then clears.
 
 ## Chat state
 
@@ -78,14 +79,15 @@ When a user starts chatting:
 1. The `CursorChatBubble` component renders an input field at the cursor position
 2. The input tracks the cursor via `pointermove` events
 3. As the user types, `chatMessage` updates in instance state
-4. When they press Escape, press Enter with an empty input, or the input loses focus, `isChatting` becomes `false`
-5. The message stays visible for 2 seconds, then clears automatically
+4. When they press Enter with text in the input, the input clears and the message becomes its placeholder; the input stays open for another message
+5. When they press Escape, press Enter with an empty input, or the input loses focus, `isChatting` becomes `false`
+6. The message stays visible for 2 seconds, then clears automatically
 
 While the input is open, chat times out after 5 seconds of inactivity.
 
 ## Keyboard shortcuts
 
-The default keyboard action for cursor chat is `/`. You can find it under the action ID `open-cursor-chat`:
+The default keyboard action for cursor chat is `/`. You can find it under the action ID `open-cursor-chat`. The action is only registered when collaboration UI is enabled, and the default context menu shows it as [CursorChatItem](?):
 
 ```tsx
 import { Tldraw, useActions } from 'tldraw'
@@ -101,23 +103,23 @@ function ChatButton() {
 
 Inside the chat input:
 
-| Key      | Action                                                            |
-| -------- | ----------------------------------------------------------------- |
-| `Enter`  | Clear input (if content exists) or stop chatting (if input empty) |
-| `Escape` | Stop chatting                                                     |
+| Key      | Action                                                                 |
+| -------- | ---------------------------------------------------------------------- |
+| `Enter`  | Send the message (if content exists) or stop chatting (if input empty) |
+| `Escape` | Stop chatting                                                          |
 
 ## Presence synchronization
 
 In multiplayer sessions, chat messages synchronize automatically through presence records. The `chatMessage` field in [TLInstancePresence](?) contains the message other users see:
 
 ```tsx
-import { InstancePresenceRecordType, Tldraw } from 'tldraw'
+import { createUserId, InstancePresenceRecordType } from 'tldraw'
 
-// Creating a remote user's presence with a chat message
+// Inside onMount: create a remote user's presence with a chat message
 const peerPresence = InstancePresenceRecordType.create({
 	id: InstancePresenceRecordType.createId(editor.store.id),
 	currentPageId: editor.getCurrentPageId(),
-	userId: 'peer-1',
+	userId: createUserId('peer-1'),
 	userName: 'Alice',
 	cursor: { x: 100, y: 200, type: 'default', rotation: 0 },
 	chatMessage: 'Check out this arrow!',
@@ -128,13 +130,14 @@ editor.store.mergeRemoteChanges(() => {
 })
 ```
 
-The presence derivation automatically includes the local user's `chatMessage` from instance state. Changes broadcast to other users automatically.
+The presence derivation includes the local user's `chatMessage` from instance state, so changes broadcast to other users without any extra work.
 
 ## Customizing the chat bubble
 
-You can replace the default chat bubble by providing a custom `CursorChatBubble` component:
+You can replace the default chat bubble by providing a custom `CursorChatBubble` component through [TLUiComponents](?). The slot is only rendered when collaboration UI is enabled, so this example needs a collaborative store too:
 
 ```tsx
+import { useSyncDemo } from '@tldraw/sync'
 import { Tldraw, TLUiComponents, useEditor, track } from 'tldraw'
 import 'tldraw/tldraw.css'
 
@@ -167,15 +170,16 @@ const components: TLUiComponents = {
 }
 
 export default function App() {
+	const store = useSyncDemo({ roomId: 'my-cursor-chat-room' })
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
-			<Tldraw components={components} />
+			<Tldraw store={store} components={components} />
 		</div>
 	)
 }
 ```
 
-Remote users' chat messages render as part of the collaborator cursor, in the DOM cursor layer. To customize how they appear, replace the `CollaboratorCursor` component — see [Cursors](/sdk-features/cursors#rendering-collaborator-cursors) for details.
+Remote users' chat messages render as part of the collaborator cursor, in the DOM cursor layer. To customize how they appear, replace the `CollaboratorCursor` component. See [Cursors](/sdk-features/cursors#rendering-collaborator-cursors) for details.
 
 ## Availability
 
@@ -184,7 +188,7 @@ Cursor chat requires:
 - Collaboration enabled (`editor.store.props.collaboration !== undefined`)
 - A non-touch device (disabled on mobile/tablet)
 
-Check availability before triggering chat programmatically:
+Setting `isChatting` isn't gated, but the bubble won't render without both, so check availability before triggering chat programmatically:
 
 ```tsx
 const hasCollaboration = editor.store.props.collaboration !== undefined

--- a/apps/docs/content/sdk-features/cursors.mdx
+++ b/apps/docs/content/sdk-features/cursors.mdx
@@ -18,7 +18,7 @@ The cursor system controls what cursor users see when interacting with the canva
 
 ## Cursor state
 
-The cursor state consists of a type and a rotation angle. Access it through [Editor#getInstanceState](?):
+The cursor state is a [TLCursor](?): a [TLCursorType](?) and a rotation angle. Access it through [Editor#getInstanceState](?):
 
 ```typescript
 const { type, rotation } = editor.getInstanceState().cursor
@@ -30,31 +30,31 @@ The `type` determines the visual appearance—like `'default'`, `'grab'`, or `'n
 
 tldraw supports these cursor types:
 
-| Type            | Description                                    |
-| --------------- | ---------------------------------------------- |
-| `default`       | Standard pointer arrow                         |
-| `pointer`       | Hand indicating clickable element              |
-| `cross`         | Crosshair for precise positioning              |
-| `grab`          | Open hand for draggable content                |
-| `grabbing`      | Closed hand while dragging                     |
-| `text`          | I-beam for text editing                        |
-| `move`          | Four-way arrow for moving elements             |
-| `zoom-in`       | Magnifying glass with plus                     |
-| `zoom-out`      | Magnifying glass with minus                    |
-| `ew-resize`     | Horizontal resize (east-west)                  |
-| `ns-resize`     | Vertical resize (north-south)                  |
-| `nesw-resize`   | Diagonal resize (northeast-southwest)          |
-| `nwse-resize`   | Diagonal resize (northwest-southeast)          |
-| `resize-edge`   | Edge resize (used for edge handles)            |
-| `resize-corner` | Corner resize (used for corner handles)        |
-| `nesw-rotate`   | Rotation handle (northeast-southwest position) |
-| `nwse-rotate`   | Rotation handle (northwest-southeast position) |
-| `senw-rotate`   | Rotation handle (southeast-northwest position) |
-| `swne-rotate`   | Rotation handle (southwest-northeast position) |
-| `rotate`        | General rotation cursor                        |
-| `none`          | Hidden cursor                                  |
+| Type          | Description                                    |
+| ------------- | ---------------------------------------------- |
+| `default`     | Standard pointer arrow                         |
+| `pointer`     | Hand indicating clickable element              |
+| `cross`       | Crosshair for precise positioning              |
+| `comment`     | Speech bubble for placing comments             |
+| `grab`        | Open hand for draggable content                |
+| `grabbing`    | Closed hand while dragging                     |
+| `text`        | I-beam for text editing                        |
+| `move`        | Four-way arrow for moving elements             |
+| `zoom-in`     | Magnifying glass with plus                     |
+| `zoom-out`    | Magnifying glass with minus                    |
+| `ew-resize`   | Horizontal resize (east-west)                  |
+| `ns-resize`   | Vertical resize (north-south)                  |
+| `nesw-resize` | Diagonal resize (northeast-southwest)          |
+| `nwse-resize` | Diagonal resize (northwest-southeast)          |
+| `nesw-rotate` | Rotation handle (northeast-southwest position) |
+| `nwse-rotate` | Rotation handle (northwest-southeast position) |
+| `senw-rotate` | Rotation handle (southeast-northwest position) |
+| `swne-rotate` | Rotation handle (southwest-northeast position) |
+| `none`        | Hidden cursor                                  |
 
-Static cursors like `default`, `pointer`, and `grab` use CSS cursor values directly. Dynamic cursors like the resize and rotate types render as custom SVGs with rotation applied.
+Static cursors like `default`, `pointer`, and `grab` are prerendered SVG cursors defined as CSS custom properties in tldraw's stylesheet (`--tl-cursor-default`, `--tl-cursor-grab`, and so on). Dynamic cursors like the resize and rotate types are generated at runtime as SVGs with the current rotation applied. The canvas reads the result from the `--tl-cursor` variable.
+
+> `TLCursorType` also includes `resize-edge`, `resize-corner`, and `rotate` for schema compatibility. The default cursor rendering doesn't support them, so don't pass them to `setCursor`.
 
 ## Setting the cursor
 
@@ -71,7 +71,7 @@ You can update just the type or just the rotation—the other property keeps its
 editor.setCursor({ type: 'grab' })
 
 // Change only the rotation
-editor.setCursor({ type: 'nwse-resize', rotation: Math.PI / 4 })
+editor.setCursor({ rotation: Math.PI / 4 })
 ```
 
 ### Cursor rotation
@@ -113,7 +113,7 @@ For tools with child states, each state can set its own cursor. A drawing state 
 
 ## Cursor colors
 
-Dynamic cursors (resize and rotate types) adapt to the current color scheme. In light mode, the cursor style color is set to black. In dark mode, it's set to white. The SVG patterns themselves have fixed black and white fills for contrast. This happens automatically through the internal `useCursor` hook.
+Dynamic cursors (resize and rotate types) receive the active [theme](/sdk-features/themes)'s `cursor` color for the current color mode: black in the default light theme, white in the default dark theme. The built-in SVGs use fixed black and white fills for contrast, so this color only shows in custom cursor SVGs.
 
 ## Collaborator cursors
 
@@ -121,7 +121,7 @@ In multiplayer sessions, each user's cursor appears on other users' canvases. Th
 
 ### User color palette
 
-When a user first loads tldraw, they're assigned a random color from this palette:
+When a user first loads tldraw, they're assigned a random color from the built-in `USER_COLORS` palette:
 
 ```typescript
 const USER_COLORS = [
@@ -158,7 +158,7 @@ Remote cursors render as DOM elements in a dedicated layer stacked above the can
 - The user's name as a label next to the cursor
 - Any active chat message in a bubble
 
-A collaborator whose cursor is outside your viewport shows as a small hint arrow clamped to the viewport edge, pointing toward them — the hints stay canvas-drawn ([CollaboratorHintOverlayUtil](?)), like the other drawing chrome.
+A collaborator whose cursor is outside your viewport shows as a small hint arrow clamped to the viewport edge, pointing toward them. [CollaboratorHintOverlayUtil](?) draws the hints on the overlay canvas rather than as DOM elements.
 
 To customize the cursor, pass your own component via the `components` prop's `CollaboratorCursor` slot (see [DefaultCursor](?) and [TLCursorProps](?)):
 
@@ -195,8 +195,6 @@ export default function App() {
 }
 ```
 
-Cursor components are positioned in page space inside a camera-transformed layer, so `point` can be used directly as a translation; sizes in screen pixels stay constant on screen by scaling with `1 / zoom` (the default components do this via their `zoom` prop).
-
 ### Cursor position in presence
 
 Collaborator cursor positions are stored in presence records ([TLInstancePresence](?)). The cursor field includes position, type, and rotation:
@@ -212,7 +210,7 @@ Collaborator cursor positions are stored in presence records ([TLInstancePresenc
 }
 ```
 
-The editor automatically broadcasts cursor position updates to other users in the same room. Cursor position is null when the user's pointer is outside the canvas.
+The editor automatically broadcasts cursor position updates to other users in the same room. `cursor` is `null` only when presence hasn't been populated yet or a custom presence derivation omits it. The editor hides a collaborator's cursor when it's outside your viewport or the user has been inactive.
 
 ## Related articles
 
@@ -220,7 +218,7 @@ The editor automatically broadcasts cursor position updates to other users in th
 - [Tools](/sdk-features/tools) - Learn how tools handle input and set cursors
 - [Collaboration](/sdk-features/collaboration) - User presence and multiplayer features
 - [User preferences](/sdk-features/user-preferences) - Manage user colors and other preferences
-- [Overlay utils](/sdk-features/overlay-utils) - Canvas overlays, including the collaborator cursor overlay
+- [Overlay utils](/sdk-features/overlay-utils) - Canvas overlays, including the collaborator cursor hint overlay
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/deep-links.mdx
+++ b/apps/docs/content/sdk-features/deep-links.mdx
@@ -34,29 +34,29 @@ export default function App() {
 }
 ```
 
-With `deepLinks` enabled, the URL updates as users navigate. Anyone opening the URL sees the same page and viewport position.
+With `deepLinks` enabled, the editor reads the `d` query parameter on mount and navigates to it, then keeps the URL up to date as users navigate. Anyone opening the URL sees the same page and viewport position.
 
-For more control, use the editor methods directly: `createDeepLink()` generates URLs with encoded state, `navigateToDeepLink()` moves the editor to a specified location, and `registerDeepLinkListener()` updates URLs automatically as users navigate.
+For more control, use the editor methods directly. [Editor#createDeepLink](?) generates URLs with encoded state, [Editor#navigateToDeepLink](?) moves the editor to a specified location, and [Editor#registerDeepLinkListener](?) updates URLs automatically as users navigate.
 
 ## Deep link types
 
-| Type       | Purpose                      | Encoded prefix | Example use case                  |
-| ---------- | ---------------------------- | -------------- | --------------------------------- |
-| `shapes`   | Links to specific shapes     | `s`            | Share selected shapes with a team |
-| `viewport` | Links to a bounding box view | `v`            | Share current viewport position   |
-| `page`     | Links to a specific page     | `p`            | Navigate to a particular page     |
+A [TLDeepLink](?) is one of three types:
 
-Shape links focus the editor on specific elements. Viewport links preserve the exact camera position and zoom level. Page links navigate to particular pages in multi-page documents.
+| Type       | Purpose                                             | Encoded prefix |
+| ---------- | --------------------------------------------------- | -------------- |
+| `shapes`   | Links to specific shapes, zooming to fit them       | `s`            |
+| `viewport` | Links to a bounding box view, with an optional page | `v`            |
+| `page`     | Links to a specific page, zoomed to fit its content | `p`            |
 
 ## How it works
 
 Deep links are encoded as compact strings with a single-character prefix identifying the type:
 
 - Shape links (`s`) encode shape IDs separated by dots: `s<id1>.<id2>.<id3>`
-- Viewport links (`v`) encode bounding box coordinates: `v<x>.<y>.<w>.<h>` with optional page ID
+- Viewport links (`v`) encode rounded bounding box coordinates: `v<x>.<y>.<w>.<h>` with optional page ID
 - Page links (`p`) encode a page ID: `p<pageId>`
 
-All IDs are URL-encoded to handle special characters. The default query parameter is `d`, but you can customize this. When navigating to a shapes deep link, the editor switches to the page containing the most shapes and zooms to fit them. Viewport links set the camera to the exact specified bounds.
+All IDs are URL-encoded to handle special characters. The default query parameter is `d`, but you can customize this with the `param` option. When navigating to a shapes deep link, the editor switches to the page containing the most shapes and zooms to fit them. Viewport links set the camera to the exact specified bounds. If the parameter is missing or invalid, or the shapes or page no longer exist, the editor zooms to fit the page content instead. Use [createDeepLinkString](?) and [parseDeepLinkString](?) to encode and decode these strings without an editor.
 
 ## API methods
 
@@ -64,7 +64,7 @@ All IDs are URL-encoded to handle special characters. The default query paramete
 
 Creates a URL with a deep link query parameter encoding the current viewport and page:
 
-```typescript
+```ts
 // Create a link to the current viewport
 const url = editor.createDeepLink()
 navigator.clipboard.writeText(url.toString())
@@ -72,7 +72,7 @@ navigator.clipboard.writeText(url.toString())
 
 Specify a target to link to specific shapes:
 
-```typescript
+```ts
 // Link to currently selected shapes
 const url = editor.createDeepLink({
 	to: { type: 'shapes', shapeIds: editor.getSelectedShapeIds() },
@@ -83,7 +83,9 @@ const url = editor.createDeepLink({
 
 Navigates the editor to the location specified by a deep link URL or object:
 
-```typescript
+```ts
+import { TLShapeId } from 'tldraw'
+
 // Navigate using the current URL's query parameter
 editor.navigateToDeepLink()
 
@@ -101,7 +103,7 @@ editor.navigateToDeepLink({
 
 Sets up automatic URL updates as the viewport changes. The listener debounces updates (500ms by default) to avoid excessive history entries:
 
-```typescript
+```ts
 // Use default behavior (replaces the current URL without adding history entries)
 const unlisten = editor.registerDeepLinkListener()
 
@@ -117,8 +119,28 @@ const unlisten = editor.registerDeepLinkListener({
 unlisten()
 ```
 
-You can also enable this via the `deepLinks` option on the Tldraw component instead of calling this method directly.
+The `deepLinks` option on the Tldraw component calls this for you. Pass a [TLDeepLinkOptions](?) object instead of `true` to customize it; both the option and the method accept the same fields:
+
+| Option       | Description                                                                                  |
+| ------------ | -------------------------------------------------------------------------------------------- |
+| `param`      | The query parameter name. Defaults to `'d'`                                                  |
+| `debounceMs` | How long to wait before updating the URL. Defaults to `500`                                  |
+| `getTarget`  | Returns the [TLDeepLink](?) to encode. Defaults to the current page and viewport             |
+| `getUrl`     | Returns the URL to add the parameter to. If you supply this, you must also supply `onChange` |
+| `onChange`   | Called with the updated URL. Defaults to `window.history.replaceState`                       |
+
+```tsx
+<Tldraw
+	options={{
+		deepLinks: {
+			param: 'view',
+			getUrl: () => window.location.href,
+			onChange: (url) => router.replace(url.toString()),
+		},
+	}}
+/>
+```
 
 ## Related examples
 
-- **[Deep links](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/deep-links)** - Demonstrates how to use the `deepLinks` option to enable URL-based navigation and how to create, parse, and handle deep links manually using the editor methods.
+- [Deep links](/examples/configuration/deep-links) - Using the `deepLinks` option and creating, parsing, and handling deep links manually with the editor methods.

--- a/apps/docs/content/sdk-features/default-shapes.mdx
+++ b/apps/docs/content/sdk-features/default-shapes.mdx
@@ -45,7 +45,7 @@ The default shapes loosely fall into five categories based on their primary func
 
 ### Geo
 
-The geo shape renders geometric primitives with optional text labels. It supports 20 different geometric forms—rectangles, ellipses, triangles, stars, polygons, directional arrows, and special shapes like clouds and hearts. Geo shapes can display rich text labels with configurable alignment, making them the foundation for flowcharts, diagrams, and annotated illustrations.
+The geo shape renders geometric primitives with optional text labels. It supports 20 different geometric forms—rectangles, ellipses, triangles, stars, polygons, directional arrows, and special shapes like clouds and hearts. Geo shapes can display rich text labels with configurable alignment, which makes them the usual building block for flowcharts and diagrams.
 
 For complete documentation on geometric forms, label positioning, tool interactions, and configuration, see [Geo shape](/sdk-features/geo-shape).
 
@@ -68,6 +68,8 @@ Quick reference:
 | `growY`         | `number`                        | Additional vertical space for text overflow |
 | `url`           | `string`                        | Optional hyperlink URL                      |
 | `scale`         | `number`                        | Scale factor applied to the shape           |
+| `flipX`         | `boolean`                       | Mirror the shape horizontally               |
+| `flipY`         | `boolean`                       | Mirror the shape vertically                 |
 
 ### Text
 
@@ -132,28 +134,33 @@ editor.createShape({
 
 ### Draw
 
-The draw shape captures freehand strokes and straight line segments. It supports pressure-sensitive input from pens and styluses, automatic shape closing, angle snapping when holding Shift, and hybrid freehand/straight-line drawing modes. Points are stored in a delta-encoded base64 format for efficiency.
+The draw shape captures freehand strokes and straight line segments. It supports pressure-sensitive input from pens and styluses, automatic shape closing, angle snapping when holding Shift, and hybrid freehand/straight-line drawing modes. Points are stored in a delta-encoded base64 format; strokes from devices without pressure are stored as 2D (`dim: 2`) and pen strokes keep the pressure value.
 
 For complete documentation on the draw shape and draw tool, including drawing modes, pen support, angle snapping, and programmatic creation, see the [Draw shape](/sdk-features/draw-shape) article.
 
 Quick reference:
 
-| Property     | Type                   | Description                                                |
-| ------------ | ---------------------- | ---------------------------------------------------------- |
-| `color`      | `TLDefaultColorStyle`  | Stroke color                                               |
-| `fill`       | `TLDefaultFillStyle`   | Fill style (applies when `isClosed` is true)               |
-| `dash`       | `TLDefaultDashStyle`   | Stroke pattern                                             |
-| `size`       | `TLDefaultSizeStyle`   | Stroke width preset                                        |
-| `segments`   | `TLDrawShapeSegment[]` | Array of segments with `type` and base64-encoded `path`    |
-| `isComplete` | `boolean`              | Whether the user has finished drawing this stroke          |
-| `isClosed`   | `boolean`              | Whether the path forms a closed shape                      |
-| `isPen`      | `boolean`              | Whether drawn with a stylus (enables pressure-based width) |
+| Property     | Type                   | Description                                                                           |
+| ------------ | ---------------------- | ------------------------------------------------------------------------------------- |
+| `color`      | `TLDefaultColorStyle`  | Stroke color                                                                          |
+| `fill`       | `TLDefaultFillStyle`   | Fill style (applies when `isClosed` is true)                                          |
+| `dash`       | `TLDefaultDashStyle`   | Stroke pattern                                                                        |
+| `size`       | `TLDefaultSizeStyle`   | Stroke width preset                                                                   |
+| `segments`   | `TLDrawShapeSegment[]` | Array of segments with `type`, base64-encoded `path`, and optional `dim` (`2` or `3`) |
+| `isComplete` | `boolean`              | Whether the user has finished drawing this stroke                                     |
+| `isClosed`   | `boolean`              | Whether the path forms a closed shape                                                 |
+| `isPen`      | `boolean`              | Whether drawn with a stylus (enables pressure-based width)                            |
+| `scale`      | `number`               | Scale factor applied to the shape                                                     |
+| `scaleX`     | `number`               | Horizontal scale factor for lazy resize                                               |
+| `scaleY`     | `number`               | Vertical scale factor for lazy resize                                                 |
 
 ### Line
 
-The line shape creates multi-point lines with draggable handles. Unlike draw shapes, line shapes have explicit control points that you can manipulate after creation. Each point has an ID and index for ordering, allowing points to be added, removed, or repositioned. Lines support both straight segments and smooth cubic spline interpolation.
+The line shape creates multi-point lines with draggable handles. Unlike draw shapes, line shapes have explicit control points that you can manipulate after creation. Each point has an ID and a fractional index for ordering. You can add, remove, or reposition points. Lines support both straight segments and smooth cubic spline interpolation.
 
 ```tsx
+import { IndexKey } from 'tldraw'
+
 editor.createShape({
 	type: 'line',
 	x: 100,
@@ -164,9 +171,9 @@ editor.createShape({
 		size: 'm',
 		spline: 'line',
 		points: {
-			a1: { id: 'a1', index: 'a1', x: 0, y: 0 },
-			a2: { id: 'a2', index: 'a2', x: 100, y: 50 },
-			a3: { id: 'a3', index: 'a3', x: 200, y: 0 },
+			a1: { id: 'a1', index: 'a1' as IndexKey, x: 0, y: 0 },
+			a2: { id: 'a2', index: 'a2' as IndexKey, x: 100, y: 50 },
+			a3: { id: 'a3', index: 'a3' as IndexKey, x: 200, y: 0 },
 		},
 		scale: 1,
 	},
@@ -188,9 +195,11 @@ Line shapes don't have configuration options.
 
 ### Highlight
 
-The highlight shape works like draw but renders semi-transparently for marking up content. It simulates a highlighter pen, rendering with configurable opacity layers that create the characteristic translucent appearance. Like draw shapes, highlights support pressure-sensitive input and automatic shape splitting for long strokes.
+The highlight shape works like draw but renders semi-transparently for marking up content. It draws two passes with configurable opacities to imitate a highlighter pen. Like draw shapes, highlights support pressure-sensitive input and automatic shape splitting for long strokes.
 
 ```tsx
+import { b64Vecs } from 'tldraw'
+
 editor.createShape({
 	type: 'highlight',
 	x: 100,
@@ -198,7 +207,16 @@ editor.createShape({
 	props: {
 		color: 'yellow',
 		size: 'l',
-		segments: [],
+		segments: [
+			{
+				type: 'free',
+				path: b64Vecs.encodePoints([
+					{ x: 0, y: 0, z: 0.5 },
+					{ x: 100, y: 10, z: 0.5 },
+					{ x: 200, y: 0, z: 0.5 },
+				]),
+			},
+		],
 		isComplete: true,
 		isPen: false,
 		scale: 1,
@@ -208,16 +226,16 @@ editor.createShape({
 
 Properties:
 
-| Property     | Type                   | Description                                  |
-| ------------ | ---------------------- | -------------------------------------------- |
-| `color`      | `TLDefaultColorStyle`  | Highlight color (yellow, green, blue, etc.)  |
-| `size`       | `TLDefaultSizeStyle`   | Stroke width preset                          |
-| `segments`   | `TLDrawShapeSegment[]` | Array of segments with base64-encoded points |
-| `isComplete` | `boolean`              | Whether the user has finished this stroke    |
-| `isPen`      | `boolean`              | Whether drawn with a stylus                  |
-| `scale`      | `number`               | Scale factor applied to the shape            |
-| `scaleX`     | `number`               | Horizontal scale factor for lazy resize      |
-| `scaleY`     | `number`               | Vertical scale factor for lazy resize        |
+| Property     | Type                   | Description                                                                               |
+| ------------ | ---------------------- | ----------------------------------------------------------------------------------------- |
+| `color`      | `TLDefaultColorStyle`  | Highlight color (yellow, green, blue, etc.)                                               |
+| `size`       | `TLDefaultSizeStyle`   | Stroke width preset                                                                       |
+| `segments`   | `TLDrawShapeSegment[]` | Array of segments with base64-encoded points (see [Draw shape](/sdk-features/draw-shape)) |
+| `isComplete` | `boolean`              | Whether the user has finished this stroke                                                 |
+| `isPen`      | `boolean`              | Whether drawn with a stylus                                                               |
+| `scale`      | `number`               | Scale factor applied to the shape                                                         |
+| `scaleX`     | `number`               | Horizontal scale factor for lazy resize                                                   |
+| `scaleY`     | `number`               | Vertical scale factor for lazy resize                                                     |
 
 Configuration options:
 
@@ -240,7 +258,7 @@ const ConfiguredHighlightUtil = HighlightShapeUtil.configure({
 
 ### Image
 
-The image shape displays raster images with support for cropping, flipping, and animation control. Images link to asset records that store the actual image data (either as base64 or URLs). The shape maintains aspect ratio during resize and supports circular cropping for profile photos or decorative effects.
+The image shape displays raster images with support for cropping and flipping. Images link to asset records that store the actual image data (either as base64 or URLs). The shape maintains aspect ratio during resize and supports circular cropping.
 
 ```tsx
 editor.createShape({
@@ -263,23 +281,23 @@ editor.createShape({
 
 Properties:
 
-| Property  | Type                  | Description                                                     |
-| --------- | --------------------- | --------------------------------------------------------------- |
-| `w`       | `number`              | Display width in pixels                                         |
-| `h`       | `number`              | Display height in pixels                                        |
-| `assetId` | `TLAssetId \| null`   | Reference to asset record containing image data                 |
-| `url`     | `string`              | Direct URL (used when no asset)                                 |
-| `crop`    | `TLShapeCrop \| null` | Crop region with `topLeft`, `bottomRight` (0-1), and `isCircle` |
-| `flipX`   | `boolean`             | Mirror the image horizontally                                   |
-| `flipY`   | `boolean`             | Mirror the image vertically                                     |
-| `playing` | `boolean`             | Whether animated images (GIFs) should play                      |
-| `altText` | `string`              | Accessibility description                                       |
+| Property  | Type                  | Description                                                                                           |
+| --------- | --------------------- | ----------------------------------------------------------------------------------------------------- |
+| `w`       | `number`              | Display width in pixels                                                                               |
+| `h`       | `number`              | Display height in pixels                                                                              |
+| `assetId` | `TLAssetId \| null`   | Reference to asset record containing image data                                                       |
+| `url`     | `string`              | Direct URL (used when no asset)                                                                       |
+| `crop`    | `TLShapeCrop \| null` | Crop region with `topLeft`, `bottomRight` (0-1), and `isCircle`                                       |
+| `flipX`   | `boolean`             | Mirror the image horizontally                                                                         |
+| `flipY`   | `boolean`             | Mirror the image vertically                                                                           |
+| `playing` | `boolean`             | Whether animated images (GIFs) should play (stored on the record; the default util always plays them) |
+| `altText` | `string`              | Accessibility description                                                                             |
 
 Image shapes don't have configuration options. Image handling behavior is controlled through the editor's asset management system.
 
 ### Video
 
-The video shape displays video content with playback controls. Like images, videos link to asset records. The shape tracks playback position and state, and supports autoplay for automatic playback when the shape becomes visible.
+The video shape displays video content with playback controls. Like images, videos link to asset records. Videos autoplay by default and respect the user's `prefers-reduced-motion` setting. The `time` and `playing` props are stored on the record, but the default util does not drive playback from them.
 
 ```tsx
 editor.createShape({
@@ -326,7 +344,7 @@ const ConfiguredVideoUtil = VideoShapeUtil.configure({
 
 ### Bookmark
 
-The bookmark shape displays a URL as a card with metadata including title, description, and preview image. Bookmarks are created when you paste URLs onto the canvas. The editor fetches metadata from the URL and stores it in an associated asset record. Bookmark shapes have fixed dimensions and can't be resized.
+The bookmark shape displays a URL as a card with metadata including title, description, and preview image. The editor creates a bookmark when you paste a URL onto the canvas. It fetches metadata from the URL and stores it in an associated asset record. Bookmark shapes have fixed dimensions and can't be resized.
 
 ```tsx
 editor.createShape({
@@ -386,6 +404,8 @@ Properties:
 
 The frame shape provides a visual container for organizing shapes. Shapes inside a frame are clipped to its bounds and move with the frame when it's repositioned. Frames display a header with the frame's name, and optionally colored borders and backgrounds. They're useful for creating sections, organizing content into logical groups, or defining artboard-like regions for export.
 
+For a complete guide, see [Frame shape](/sdk-features/frame-shape).
+
 ```tsx
 editor.createShape({
 	type: 'frame',
@@ -429,7 +449,7 @@ To build your own container shape that behaves like a frame, extend `BaseFrameLi
 
 ### Group
 
-The group shape logically combines multiple shapes without visual representation. Groups let you move and transform shapes together while preserving their relative positions. The group's geometry is computed as the union of all child shapes' geometries. Groups are created through the editor API rather than directly, and they delete themselves automatically when their last child is removed or ungrouped.
+The group shape logically combines multiple shapes without visual representation. Groups let you move and transform shapes together while preserving their relative positions. The group's geometry is computed as the union of all child shapes' geometries. You create groups through the editor API rather than directly. A group deletes itself when it has one child or none left.
 
 ```tsx
 // Create a group from selected shapes
@@ -444,13 +464,13 @@ const children = editor.getSortedChildIdsForParent(groupId)
 
 Groups have no visual properties; their `props` object is empty. All visual characteristics come from their child shapes. Arrows can't bind to groups. Double-click a group to enter it and edit its children directly.
 
-Group shapes don't have configuration options.
+Group shapes don't have configuration options. For a complete guide, see [Groups](/sdk-features/groups).
 
 ## Connectors
 
 ### Arrow
 
-The arrow shape creates lines that can bind to other shapes. Arrows automatically update when their connected shapes move, maintaining the visual connection. They support two routing modes: `arc` for smooth curves controlled by a bend parameter, and `elbow` for right-angle routing that navigates around obstacles. Arrows can display text labels positioned along their length, and offer multiple arrowhead styles for both terminals.
+The arrow shape creates lines that can bind to other shapes. Arrows update automatically when their connected shapes move. They support two routing modes: `arc` for smooth curves controlled by a bend parameter, and `elbow` for right-angle routing that navigates around obstacles. Arrows can display text labels positioned along their length, and offer multiple arrowhead styles for both terminals.
 
 The arrow binding system creates connections automatically when arrow terminals are dragged near other shapes. Bindings can be "precise" (connecting to a specific point) or "imprecise" (connecting to the shape's center or edge).
 
@@ -503,28 +523,26 @@ Properties:
 
 The available arrowhead styles are: `none`, `arrow`, `triangle`, `square`, `dot`, `pipe`, `diamond`, `inverted`, `bar`
 
-Configuration options:
+Configuration options control snap behavior, timing, and rendering:
 
-Arrows have extensive configuration options that control snap behavior, timing, and rendering:
-
-| Option                                      | Type                                 | Default                              | Description                                                                                          |
-| ------------------------------------------- | ------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `expandElbowLegLength`                      | `Record<TLDefaultSizeStyle, number>` | `{ s: 28, m: 36, l: 44, xl: 66 }`    | How far elbow arrows extend from target shapes, per size.                                            |
-| `minElbowLegLength`                         | `Record<TLDefaultSizeStyle, number>` | Based on stroke width × 3            | Minimum length of an elbow arrow's leg segment.                                                      |
-| `minElbowHandleDistance`                    | `number`                             | `16`                                 | Minimum screen pixels between two elbow handles. Closer handles are hidden.                          |
-| `arcArrowCenterSnapDistance`                | `number`                             | `16`                                 | Screen pixels at which arc arrows snap to target shape centers. Set to 0 to disable.                 |
-| `elbowArrowCenterSnapDistance`              | `number`                             | `24`                                 | Screen pixels at which elbow arrows snap to target shape centers.                                    |
-| `elbowArrowEdgeSnapDistance`                | `number`                             | `20`                                 | Screen pixels at which elbow arrows snap to target shape edges.                                      |
-| `elbowArrowPointSnapDistance`               | `number`                             | `24`                                 | Screen pixels at which elbow arrows snap to directional points (top, right, bottom, left) of shapes. |
-| `elbowArrowAxisSnapDistance`                | `number`                             | `16`                                 | Screen pixels at which elbow arrows snap to axes through shape centers.                              |
-| `labelCenterSnapDistance`                   | `number`                             | `10`                                 | Screen pixels at which arrow labels snap to the arrow's center when dragged.                         |
-| `elbowMidpointSnapDistance`                 | `number`                             | `10`                                 | Screen pixels at which elbow midpoint handles snap to the midpoint between shapes.                   |
-| `elbowMinSegmentLengthToShowMidpointHandle` | `number`                             | `20`                                 | Minimum segment length before showing the midpoint drag handle.                                      |
-| `hoverPreciseTimeout`                       | `number`                             | `600`                                | Milliseconds to wait while hovering before switching to precise targeting.                           |
-| `pointingPreciseTimeout`                    | `number`                             | `320`                                | Milliseconds to wait while pointing/dragging before switching to precise targeting.                  |
-| `shouldBeExact`                             | `(editor: Editor) => boolean`        | Returns `editor.inputs.getAltKey()`  | Function determining whether arrows stop exactly at pointer vs. at shape edges.                      |
-| `shouldIgnoreTargets`                       | `(editor: Editor) => boolean`        | Returns `editor.inputs.getCtrlKey()` | Function determining whether to skip binding to target shapes.                                       |
-| `showTextOutline`                           | `boolean`                            | `true`                               | Whether to show a text outline on arrow labels for readability.                                      |
+| Option                                      | Type                                              | Default                              | Description                                                                                          |
+| ------------------------------------------- | ------------------------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `expandElbowLegLength`                      | `Record<TLDefaultSizeStyle, number>`              | `{ s: 28, m: 36, l: 44, xl: 66 }`    | How far elbow arrows extend from target shapes, per size.                                            |
+| `minElbowLegLength`                         | `Record<TLDefaultSizeStyle, number>`              | Based on stroke width × 3            | Minimum length of an elbow arrow's leg segment.                                                      |
+| `minElbowHandleDistance`                    | `number`                                          | `16`                                 | Minimum screen pixels between two elbow handles. Closer handles are hidden.                          |
+| `arcArrowCenterSnapDistance`                | `number`                                          | `16`                                 | Screen pixels at which arc arrows snap to target shape centers. Set to 0 to disable.                 |
+| `elbowArrowCenterSnapDistance`              | `number`                                          | `24`                                 | Screen pixels at which elbow arrows snap to target shape centers.                                    |
+| `elbowArrowEdgeSnapDistance`                | `number`                                          | `20`                                 | Screen pixels at which elbow arrows snap to target shape edges.                                      |
+| `elbowArrowPointSnapDistance`               | `number`                                          | `24`                                 | Screen pixels at which elbow arrows snap to directional points (top, right, bottom, left) of shapes. |
+| `elbowArrowAxisSnapDistance`                | `number`                                          | `16`                                 | Screen pixels at which elbow arrows snap to axes through shape centers.                              |
+| `labelCenterSnapDistance`                   | `number`                                          | `10`                                 | Screen pixels at which arrow labels snap to the arrow's center when dragged.                         |
+| `elbowMidpointSnapDistance`                 | `number`                                          | `10`                                 | Screen pixels at which elbow midpoint handles snap to the midpoint between shapes.                   |
+| `elbowMinSegmentLengthToShowMidpointHandle` | `number`                                          | `20`                                 | Minimum segment length before showing the midpoint drag handle.                                      |
+| `hoverPreciseTimeout`                       | `number`                                          | `600`                                | Milliseconds to wait while hovering before switching to precise targeting.                           |
+| `pointingPreciseTimeout`                    | `number`                                          | `320`                                | Milliseconds to wait while pointing/dragging before switching to precise targeting.                  |
+| `shouldBeExact`                             | `(editor: Editor, isPrecise: boolean) => boolean` | Returns `editor.inputs.getAltKey()`  | Function determining whether arrows stop exactly at pointer vs. at shape edges.                      |
+| `shouldIgnoreTargets`                       | `(editor: Editor) => boolean`                     | Returns `editor.inputs.getCtrlKey()` | Function determining whether to skip binding to target shapes.                                       |
+| `showTextOutline`                           | `boolean`                                         | `true`                               | Whether to show a text outline on arrow labels for readability.                                      |
 
 ```tsx
 const ConfiguredArrowUtil = ArrowShapeUtil.configure({

--- a/apps/docs/content/sdk-features/drag-and-drop.mdx
+++ b/apps/docs/content/sdk-features/drag-and-drop.mdx
@@ -12,48 +12,22 @@ status: published
 date: 2/4/2026
 ---
 
-The drag and drop system lets shapes respond when other shapes are dragged over them. Frames use this to reparent shapes when you drag them inside. You can use the same callbacks in your [ShapeUtil](?) to build custom container shapes, slot-based layouts, or any shape that should react to shapes being dragged over it.
+The drag and drop system lets shapes respond when other shapes are dragged over them. Frames use this to reparent shapes when you drag them inside. You can use the same callbacks in your [ShapeUtil](?) to build custom container shapes or any shape that should react to shapes being dragged over it.
 
-```tsx
-import { ShapeUtil, TLShape, TLDragShapesOutInfo } from 'tldraw'
-
-class MyContainerShapeUtil extends ShapeUtil<MyContainerShape> {
-	static override type = 'my-container' as const
-
-	// Called when shapes are first dragged into this shape
-	override onDragShapesIn(shape: MyContainerShape, draggingShapes: TLShape[]) {
-		// Reparent the shapes to become children of this container
-		this.editor.reparentShapes(draggingShapes, shape.id)
-	}
-
-	// Called when shapes are dragged out of this shape
-	override onDragShapesOut(
-		shape: MyContainerShape,
-		draggingShapes: TLShape[],
-		info: TLDragShapesOutInfo
-	) {
-		// If not dragging into another shape, move back to the page
-		if (!info.nextDraggingOverShapeId) {
-			this.editor.reparentShapes(draggingShapes, this.editor.getCurrentPageId())
-		}
-	}
-
-	// ... other required methods
-}
-```
+If you want frame-like behavior (accept children, reparent them on drag in and out, clip them), extend [BaseFrameLikeShapeUtil](?), which implements all of the callbacks below. Implement them yourself when you need something different.
 
 ## Drag callbacks
 
-When a user drags shapes across the canvas, the editor tracks which shape (if any) is under the cursor. Your shape util can implement these callbacks to respond:
+While the select tool translates shapes, it tracks which shape (if any) is under the cursor using [Editor#getDraggingOverShape](?). Your shape util can implement these callbacks to respond:
 
-| Callback           | When it fires                                                                     |
-| ------------------ | --------------------------------------------------------------------------------- |
-| `onDragShapesIn`   | Shapes are first dragged over this shape                                          |
-| `onDragShapesOver` | Shapes continue being dragged over this shape (on an interval, when cursor moves) |
-| `onDragShapesOut`  | Shapes are dragged away from this shape                                           |
-| `onDropShapesOver` | Shapes are dropped onto this shape                                                |
+| Callback                        | When it fires                                                                     |
+| ------------------------------- | --------------------------------------------------------------------------------- |
+| [ShapeUtil#onDragShapesIn](?)   | Shapes are first dragged over this shape                                          |
+| [ShapeUtil#onDragShapesOver](?) | Shapes continue being dragged over this shape (on an interval, when cursor moves) |
+| [ShapeUtil#onDragShapesOut](?)  | Shapes are dragged away from this shape                                           |
+| [ShapeUtil#onDropShapesOver](?) | Shapes are dropped onto this shape                                                |
 
-The callbacks receive the target shape (the one being dragged over), an array of the shapes being dragged, and an info object with context about the drag operation.
+The callbacks receive the target shape (the one being dragged over), an array of the shapes being dragged, and an info object with context about the drag operation. Locked shapes are never dragged, and if every child of a group is being dragged, the group is dragged instead of its children.
 
 ### onDragShapesIn
 
@@ -71,7 +45,7 @@ override onDragShapesIn(shape: MyContainerShape, draggingShapes: TLShape[]) {
 
 ### onDragShapesOver
 
-Called on an interval while shapes are being dragged over this shape, but only when the cursor moves. Use it for visual feedback or grid snapping:
+Called on an interval while shapes are being dragged over this shape, but only when the cursor moves. Use it for visual feedback or custom snapping:
 
 ```typescript
 override onDragShapesOver(shape: MyGridShape, draggingShapes: TLShape[]) {
@@ -94,7 +68,7 @@ override onDragShapesOver(shape: MyGridShape, draggingShapes: TLShape[]) {
 
 ### onDragShapesOut
 
-Called when shapes are dragged away from this shape. Use it to reparent shapes back to the page:
+Called when shapes are dragged away from this shape, including when the drag moves into another shape. Use it to reparent shapes back to the page:
 
 ```typescript
 override onDragShapesOut(
@@ -159,13 +133,13 @@ Some callbacks have additional properties:
 | `prevDraggingOverShapeId` | `onDragShapesIn`  | The previous shape that was dragged over |
 | `nextDraggingOverShapeId` | `onDragShapesOut` | The next shape being dragged into        |
 
-The `initialParentIds` and `initialIndices` maps let you restore shapes to their original positions. Frames use this to preserve z-ordering when shapes are dragged back to their original parent.
+The `initialParentIds` and `initialIndices` maps let you restore shapes to their original positions. Frames use them to preserve z-ordering when shapes are dragged back to their original parent.
 
 ## Determining what's under the cursor
 
-The editor automatically determines which shape is being dragged over by checking which shape's geometry contains the cursor point. It tests shapes from front to back and returns the first hit.
+[Editor#getDraggingOverShape](?) determines which shape is being dragged over by checking which shape's geometry contains the cursor point. It tests shapes from front to back, skipping locked shapes, hidden shapes, and the shapes being dragged, and returns the first hit.
 
-Only shapes that implement drag callbacks are considered as drop targets. If your shape util doesn't override any drag callbacks, shapes will pass through it when being dragged.
+Only shapes that implement drag callbacks are considered as drop targets. If your shape util doesn't override any drag callbacks, shapes will pass through it when being dragged. While shapes are dragged over a target that accepts them, the editor hints the target with [Editor#setHintingShapes](?).
 
 ## Controlling which shapes can be dropped
 
@@ -182,7 +156,7 @@ The default is `false`, so any shape that should accept dropped children must ov
 
 ## Controlling which shapes can be dragged out
 
-Use the [ShapeUtil#canRemoveChildrenOfType](?) method to control which child shape types can be dragged out of your container. The editor uses it to decide whether `onDragShapesOut` fires for a child shape, and to decide whether the editor should automatically reparent a child that has moved outside its parent's geometry:
+Use the [ShapeUtil#canRemoveChildrenOfType](?) method to control which child shape types can be dragged out of your container. The editor uses it to decide whether `onDragShapesOut` fires for a child shape, and to decide whether to automatically [reparent](/sdk-features/parenting) a child that has moved outside its parent's geometry:
 
 ```typescript
 override canRemoveChildrenOfType(shape: MyContainerShape, type: TLShape['type']) {
@@ -280,10 +254,6 @@ class SlotContainerShapeUtil extends ShapeUtil<SlotContainerShape> {
 }
 ```
 
-## External content
-
-For handling content dragged from outside the browser (files, URLs, images), see [External content handling](/sdk-features/external-content). The callbacks on this page are for shape-to-shape drag and drop within the canvas.
-
 ## Related examples
 
 - [Drag and drop](/examples/shapes/tools/drag-and-drop) - Custom shapes that can be dragged onto each other.
@@ -291,5 +261,5 @@ For handling content dragged from outside the browser (files, URLs, images), see
 
 ## Related docs
 
-- [External content handling](/sdk-features/external-content) - Handle files, URLs, and other content dragged from outside the browser.
+- [External content handling](/sdk-features/external-content) - Handle files, URLs, and other content dragged from outside the browser. The callbacks on this page are for shape-to-shape drag and drop within the canvas.
 - [Parenting and ancestors](/sdk-features/parenting) - Learn about parent-child relationships and the [Editor#reparentShapes](?) method.

--- a/apps/docs/content/sdk-features/draw-shape.mdx
+++ b/apps/docs/content/sdk-features/draw-shape.mdx
@@ -18,16 +18,16 @@ status: published
 date: 1/31/2026
 ---
 
-The draw shape captures freehand strokes and straight line segments. It supports pressure-sensitive input, automatic shape closing, angle snapping, and hybrid freehand/straight-line drawing modes. The draw tool detects pen and stylus input and produces variable-width strokes that respond to pressure.
+The draw shape captures freehand strokes and straight line segments. The draw tool produces pressure-sensitive strokes from pens and styluses, snaps straight lines to 15° angles when you hold Shift, and closes shapes automatically when a stroke ends near its start. Its keyboard shortcuts are D, B, and X, and holding Ctrl (or Cmd) while pressing down switches temporarily to the eraser.
 
 ## Drawing modes
 
 The draw tool supports two segment types that you can switch between while drawing:
 
-| Mode     | Trigger                  | Behavior                                                         |
-| -------- | ------------------------ | ---------------------------------------------------------------- |
-| Freehand | Default                  | Captures natural hand motion with optional pressure sensitivity  |
-| Straight | Hold Shift while drawing | Creates straight line segments that snap to 15° angle increments |
+| Mode     | Trigger                  | Behavior                                                                     |
+| -------- | ------------------------ | ---------------------------------------------------------------------------- |
+| Freehand | Default                  | Captures natural hand motion with optional pressure sensitivity              |
+| Straight | Hold Shift while drawing | Creates straight line segments that snap to 15° angle increments (see below) |
 
 You can mix both modes in a single stroke. Start drawing freehand, then hold Shift to switch to straight lines. Release Shift to return to freehand. Each mode change creates a new segment in the shape.
 
@@ -35,14 +35,11 @@ You can mix both modes in a single stroke. Start drawing freehand, then hold Shi
 
 Freehand mode captures your natural hand motion. The tool records points as you drag and interpolates them into smooth curves. When you draw with a pen or stylus, the tool captures pressure data and produces variable-width strokes.
 
-The stroke appearance depends on the dash style:
-
-- **Draw** style uses the freehand algorithm to create organic, hand-drawn strokes with natural width variation
-- **Solid**, **dashed**, and **dotted** styles render uniform-width strokes
+The stroke appearance depends on the dash style. The `draw` style uses the freehand algorithm to create hand-drawn strokes with natural width variation. The `solid`, `dashed`, and `dotted` styles render uniform-width strokes.
 
 ### Straight line mode
 
-Hold Shift while drawing to create straight line segments. The line snaps to 15° angle increments relative to the previous point, making it easy to draw horizontal, vertical, and diagonal lines.
+Hold Shift while drawing to create straight line segments. The line snaps to 15° angle increments (24 divisions of a full circle) relative to the previous point, which covers horizontal and vertical lines, 45° diagonals, and the 30° and 60° angles used in isometric drawings. Hold Ctrl to disable angle snapping temporarily.
 
 Release Shift to continue with freehand drawing from the current endpoint. The transition creates a smooth connection between the straight segment and the freehand stroke.
 
@@ -61,7 +58,7 @@ The draw tool distinguishes between mouse/touch input and pen/stylus input. When
 | Mouse/touch | Simulates pressure based on velocity—faster strokes appear thinner |
 | Pen/stylus  | Uses actual pressure data for variable stroke width                |
 
-The tool detects stylus input through the pressure value in pointer events. Values between 0 and 0.5 (exclusive) or between 0.5 and 1 (exclusive) indicate stylus input, as mice report exactly 0.5.
+The tool treats input as a pen when the browser reports a pen pointer with non-zero pressure, or when the pressure value is strictly between 0 and 0.5 or between 0.5 and 1. Mice report exactly 0.5.
 
 The shape stores pen detection in the `isPen` property. This affects how the stroke renders—pen strokes use a different stroke profile optimized for real pressure data.
 
@@ -71,8 +68,8 @@ Draw shapes can automatically close when you bring the endpoint near the startin
 
 The shape closes when:
 
-- The path length exceeds 4× the stroke width
-- The endpoint is near the starting point, within a threshold based on stroke width and zoom level
+- The path length exceeds 4× the scaled stroke width
+- The endpoint is within a small distance of the starting point (roughly the stroke width plus a margin, boosted at low zoom levels)
 
 When a shape closes, the shape sets `isClosed` to true and fills according to its fill style. Highlight shapes don't support closing.
 
@@ -82,20 +79,9 @@ When drawing straight lines with Shift held, you can snap to previous segments i
 
 - Enable snap mode in user preferences, or hold Ctrl (when snap mode is disabled) to temporarily enable snapping
 - Hold Ctrl (when snap mode is enabled) to temporarily disable snapping
-- The tool snaps to the nearest point on previous straight segments within 8 pixels (adjusted for zoom)
+- The tool snaps to the nearest point on earlier straight segments (excluding the current and previous segment) within 8 screen pixels
 
 Visual snap indicators appear when snapping is active.
-
-## Angle snapping
-
-Straight line segments snap to 15° increments (24 divisions of a full circle). This makes it easy to draw:
-
-- Horizontal lines (0°, 180°)
-- Vertical lines (90°, 270°)
-- 45° diagonals
-- 30° and 60° angles for isometric-style drawings
-
-Hold Ctrl while in straight line mode to disable angle snapping temporarily.
 
 ## Dynamic resize mode
 
@@ -113,27 +99,27 @@ editor.user.updateUserPreferences({ isDynamicSizeMode: true })
 
 ## Shape properties
 
-Draw shapes store their path data in an efficient delta-encoded base64 format. The first point uses full Float32 precision (12 bytes), with subsequent points stored as Float16 deltas (6 bytes each).
+Draw shapes store their path data in a delta-encoded base64 format. Segments from pens and styluses store x, y, and z (pressure): the first point uses full Float32 precision (12 bytes) and each subsequent point is a Float16 delta (6 bytes). Segments from mice and touch input drop the constant pressure value and store only x and y, marked with `dim: 2` (8 bytes for the first point, 4 bytes per delta).
 
-| Property     | Type                   | Description                                                 |
-| ------------ | ---------------------- | ----------------------------------------------------------- |
-| `color`      | `TLDefaultColorStyle`  | Stroke color                                                |
-| `fill`       | `TLDefaultFillStyle`   | Fill style (applies when `isClosed` is true)                |
-| `dash`       | `TLDefaultDashStyle`   | Stroke pattern: `draw`, `solid`, `dashed`, `dotted`, `none` |
-| `size`       | `TLDefaultSizeStyle`   | Stroke width preset: `s`, `m`, `l`, `xl`                    |
-| `segments`   | `TLDrawShapeSegment[]` | Array of segments with `type` and base64-encoded `path`     |
-| `isComplete` | `boolean`              | Whether the user has finished drawing this stroke           |
-| `isClosed`   | `boolean`              | Whether the path forms a closed shape                       |
-| `isPen`      | `boolean`              | Whether drawn with a stylus (enables pressure-based width)  |
-| `scale`      | `number`               | Scale factor applied to the shape                           |
-| `scaleX`     | `number`               | Horizontal scale factor for lazy resize                     |
-| `scaleY`     | `number`               | Vertical scale factor for lazy resize                       |
+| Property     | Type                   | Description                                                              |
+| ------------ | ---------------------- | ------------------------------------------------------------------------ |
+| `color`      | `TLDefaultColorStyle`  | Stroke color                                                             |
+| `fill`       | `TLDefaultFillStyle`   | Fill style (applies when `isClosed` is true)                             |
+| `dash`       | `TLDefaultDashStyle`   | Stroke pattern: `draw`, `solid`, `dashed`, `dotted`, `none`              |
+| `size`       | `TLDefaultSizeStyle`   | Stroke width preset: `s`, `m`, `l`, `xl`                                 |
+| `segments`   | `TLDrawShapeSegment[]` | Array of segments with `type`, base64-encoded `path`, and optional `dim` |
+| `isComplete` | `boolean`              | Whether the user has finished drawing this stroke                        |
+| `isClosed`   | `boolean`              | Whether the path forms a closed shape                                    |
+| `isPen`      | `boolean`              | Whether drawn with a stylus (enables pressure-based width)               |
+| `scale`      | `number`               | Scale factor applied to the shape                                        |
+| `scaleX`     | `number`               | Horizontal scale factor for lazy resize                                  |
+| `scaleY`     | `number`               | Vertical scale factor for lazy resize                                    |
 
-Each segment has a `type` of `'free'` or `'straight'` and a `path` containing the encoded point data with x, y, and z (pressure) values.
+Each segment has a `type` of `'free'` or `'straight'`, a `path` containing the encoded points, and an optional `dim` of `2` (x and y only) or `3` (x, y, and pressure; the default when omitted). Resizing a draw shape doesn't re-encode its points; it updates `scaleX` and `scaleY` instead.
 
 ## Configuration options
 
-Configure the draw shape utility to adjust behavior:
+Configure [DrawShapeUtil](?) to adjust behavior:
 
 | Option              | Type     | Default | Description                                              |
 | ------------------- | -------- | ------- | -------------------------------------------------------- |
@@ -189,34 +175,32 @@ editor.createShape({
 })
 ```
 
-The `b64Vecs.encodePoints` function converts an array of point objects to the delta-encoded base64 format. Use `b64Vecs.decodePoints` to read points back from a segment's path.
+[b64Vecs](?)`.encodePoints` converts an array of point objects to the delta-encoded base64 format; pass `2` as the second argument to store x and y only. Use `b64Vecs.decodePoints(segment.path, segment.dim)` to read points back.
 
 ## Stroke rendering
 
-The draw shape uses a freehand stroke algorithm to render organic-looking lines. The algorithm applies:
-
-- **Streamline**: Smooths the path by pulling points toward the stroke's center
-- **Smoothing**: Applies curve fitting for natural-looking strokes
-- **Thinning**: Varies stroke width based on velocity (for mouse) or pressure (for pen)
+The draw shape uses a freehand stroke algorithm to render organic-looking lines. Streamlining reduces jitter by interpolating each new point toward the previous one, smoothing rounds the outline, and thinning varies stroke width by velocity (for mouse) or pressure (for pen).
 
 When `dash` is set to `'draw'`, the shape renders using the full freehand algorithm. Other dash styles use simpler uniform-width strokes with the appropriate dash pattern.
 
-At low zoom levels, the shape automatically switches to solid rendering for performance. This happens when the zoom level is below 50% and also below a threshold based on stroke width (`zoomLevel < 1.5 / strokeWidth`).
+At low zoom levels, the shape switches to solid rendering for performance. This happens when the zoom level is below 50% and also below a threshold based on the scaled stroke width.
 
 ## Geometry
 
 The shape's geometry depends on its content:
 
-- **Single point (dot)**: Returns a [Circle2d](?) centered at the point with radius equal to the stroke width
-- **Closed path**: Returns a [Polygon2d](?) that can be filled
-- **Open path**: Returns a [Polyline2d](?) following the stroke's center line
+| Content                          | Geometry                                                         |
+| -------------------------------- | ---------------------------------------------------------------- |
+| Tiny single-segment stroke (dot) | A [Circle2d](?) with a radius of roughly the scaled stroke width |
+| Closed path                      | A [Polygon2d](?) that can be filled                              |
+| Open path                        | A [Polyline2d](?) following the stroke's center line             |
 
 The geometry uses the processed stroke points (after applying streamline and smoothing), not the raw input points.
 
 ## Related shapes
 
-- **[Highlight](/sdk-features/default-shapes#highlight)**: Uses the same point capture system but renders semi-transparently for marking up content
-- **[Line](/sdk-features/default-shapes#line)**: Creates editable multi-point lines with draggable handles
+- [Highlight](/sdk-features/default-shapes#highlight) uses the same point capture system but renders semi-transparently for marking up content
+- [Line](/sdk-features/default-shapes#line) creates editable multi-point lines with draggable handles
 
 ## Related articles
 

--- a/apps/docs/content/sdk-features/edge-scrolling.mdx
+++ b/apps/docs/content/sdk-features/edge-scrolling.mdx
@@ -17,85 +17,45 @@ accuracy: 9
 notes: Could be more code-first in technical sections. Mention getIsEdgeScrolling() earlier for UI use cases.
 ---
 
-Edge scrolling automatically pans the camera when you drag shapes toward the viewport edges. This lets you move shapes across the canvas without releasing the drag to scroll manually.
-
-The system activates only during drag operations. It requires three conditions: you must be dragging (not panning), the camera must be unlocked, and the pointer must be within a proximity zone at the viewport edge.
+Edge scrolling pans the camera automatically when you drag shapes toward the viewport edges. This lets you move shapes across the canvas without releasing the drag to scroll manually.
 
 ## How it works
 
-Tools that support edge scrolling call `editor.edgeScrollManager.updateEdgeScrolling(elapsed)` on every tick during drag operations. The manager checks the pointer position against the viewport bounds and calculates a proximity factor for each axis.
+Tool states that support edge scrolling call [EdgeScrollManager#updateEdgeScrolling](?) on every tick while the user is dragging. The manager reads the pointer position from the editor's inputs, works out how close it is to each viewport edge, and moves the camera. It does nothing while the camera is locked.
 
-When the pointer enters the edge scroll zone, the manager tracks elapsed time. After a configurable delay, scrolling starts and gradually accelerates using an easing function. The camera moves on each tick until the pointer leaves the edge zone or the drag ends.
+The built-in select tool does this in its Translating (moving shapes), Brushing (selection box), and Resizing (dragging handles) states. The tool state, not the manager, decides when edge scrolling applies: the built-in states skip the call unless `editor.inputs.getIsDragging()` is true and `editor.inputs.getIsPanning()` is false.
+
+## Tool integration
+
+To add edge scrolling to a custom tool, call `updateEdgeScrolling()` from the tick handler of the state where dragging happens, and only while the user is dragging:
 
 ```typescript
-override onTick({ elapsed }: TLTickEventInfo) {
-	this.editor.edgeScrollManager.updateEdgeScrolling(elapsed)
+import { StateNode, TLTickEventInfo } from 'tldraw'
+
+export class CustomDragState extends StateNode {
+	static override id = 'dragging'
+
+	override onTick({ elapsed }: TLTickEventInfo) {
+		const { editor } = this
+		if (!editor.inputs.getIsDragging() || editor.inputs.getIsPanning()) return
+		editor.edgeScrollManager.updateEdgeScrolling(elapsed)
+	}
 }
 ```
 
-The built-in select tool uses edge scrolling in three states: Translating (moving shapes), Brushing (selection box), and Resizing (dragging handles).
-
-## Edge detection
-
-The manager determines edge proximity by comparing the pointer position to the viewport bounds. An edge scroll zone extends inward from each screen edge by a distance defined in `editor.options.edgeScrollDistance` (default: 8 pixels).
-
-### Proximity calculation
-
-When the pointer enters this zone, the manager calculates a proximity factor from 0 to 1 based on how deeply the pointer penetrates the zone. At the zone boundary, the factor is 0. At the screen edge (or beyond), it reaches 1. Each axis is calculated independently.
-
-### Touch input
-
-For touch input, the system expands the effective pointer size using `editor.options.coarsePointerWidth` (default: 12 pixels). The expanded pointer area is centered on the touch point, making edge scrolling easier to trigger on mobile devices.
-
-### Inset handling
-
-Edge detection respects screen insets from the editor's instance state. The insets array records whether each edge of the editor is flush with the browser window, in CSS order: `[top, right, bottom, left]`.
-
-When an edge is flush with the window, the pointer can't move past it, so the scroll zone extends inward from that edge. When an edge is inset—the editor is embedded with other page content beside it—the zone starts at the editor's boundary instead, and scrolling begins once the pointer moves outside the editor.
-
-## Scrolling behavior
-
-Once the pointer enters the edge zone, the manager waits for `editor.options.edgeScrollDelay` milliseconds (default: 200ms) before starting to scroll. This delay prevents accidental scrolling when the pointer briefly crosses the edge.
-
-After the delay, scrolling begins with gradual acceleration controlled by `editor.options.edgeScrollEaseDuration` (default: 200ms). The manager applies `EASINGS.easeInCubic` to create smooth acceleration from zero to full speed.
-
-### Speed calculation
-
-The scroll speed combines several factors. The base speed comes from `editor.options.edgeScrollSpeed` (default: 25 pixels per tick) multiplied by the user preference from `editor.user.getEdgeScrollSpeed()` (default: 1).
-
-The proximity factor (0 to 1) scales speed based on how close the pointer is to the screen edge. Scrolling is slower near the zone boundary and faster at the edge itself.
-
-On smaller displays, a screen size factor of 0.612 applies when that viewport dimension is below 1000 pixels. This reduces speed independently for each axis. The final scroll delta divides by the current zoom level to maintain consistent canvas-space velocity.
-
-```typescript
-const pxSpeed = editor.user.getEdgeScrollSpeed() * editor.options.edgeScrollSpeed
-const screenSizeFactorX = screenBounds.w < 1000 ? 0.612 : 1
-const screenSizeFactorY = screenBounds.h < 1000 ? 0.612 : 1
-const scrollDeltaX = (pxSpeed * proximityFactor.x * screenSizeFactorX) / zoomLevel
-const scrollDeltaY = (pxSpeed * proximityFactor.y * screenSizeFactorY) / zoomLevel
-```
-
-### Conditions for scrolling
-
-The camera only moves when all these conditions are met:
-
-- The user is dragging, not panning. The built-in tool states check `editor.inputs.getIsDragging()` and `editor.inputs.getIsPanning()` before calling `updateEdgeScrolling()`.
-- The camera is not locked (`editor.getCameraOptions().isLocked` is false)
-- The proximity factor is non-zero for at least one axis
-
-When the pointer leaves the edge zone, scrolling stops and the internal duration timer resets.
+[EdgeScrollManager#getIsEdgeScrolling](?) returns true while the pointer is inside the edge zone, including during the start delay, and false once it leaves. Use it to show an indicator in your own UI.
 
 ## Configuration options
 
-You can customize edge scrolling through the editor's options:
+Customize edge scrolling through [TldrawOptions](?). Set `edgeScrollSpeed` to `0` to turn it off entirely.
 
-| Option                   | Default | Description                                        |
-| ------------------------ | ------- | -------------------------------------------------- |
-| `edgeScrollDelay`        | 200     | Milliseconds to wait before starting scroll        |
-| `edgeScrollEaseDuration` | 200     | Milliseconds to accelerate from zero to full speed |
-| `edgeScrollSpeed`        | 25      | Base scroll speed in pixels per tick               |
-| `edgeScrollDistance`     | 8       | Width of the edge scroll zone in pixels            |
-| `coarsePointerWidth`     | 12      | Expanded pointer size for touch input (pixels)     |
+| Option                   | Default | Description                                                             |
+| ------------------------ | ------- | ----------------------------------------------------------------------- |
+| `edgeScrollDelay`        | 200     | Milliseconds the pointer must stay in the edge zone before scrolling    |
+| `edgeScrollEaseDuration` | 200     | Milliseconds to ramp up to full speed after the delay                   |
+| `edgeScrollSpeed`        | 25      | Base scroll speed in pixels per tick                                    |
+| `edgeScrollDistance`     | 8       | Width of the edge scroll zone in pixels                                 |
+| `coarsePointerWidth`     | 12      | Extra pointer width on each side for coarse (touch) pointers, in pixels |
 
 Set these options when creating the editor:
 
@@ -121,27 +81,15 @@ export default function App() {
 
 Edge scroll speed is also a user preference. `editor.user.getEdgeScrollSpeed()` returns a multiplier that defaults to 1, and you can change it with `editor.user.updateUserPreferences({ edgeScrollSpeed: 2 })`. The preference persists across sessions and scales all edge scrolling without changing the base configuration.
 
-## Tool integration
+## Edge detection and speed
 
-To add edge scrolling to your custom tool, call `updateEdgeScrolling()` in the tick handler. The manager reads the pointer position from the editor's input system, so you only need to pass the elapsed time. Like the built-in tool states, skip the call unless the user is dragging:
+The edge zone extends inward from each edge of the viewport by `edgeScrollDistance`. Inside it, the manager computes a signed proximity factor per axis between -1 and 1: 0 at the zone boundary, ±1 at the screen edge or beyond, with the sign giving the scroll direction. For coarse pointers (`isCoarsePointer` in the instance state) the pointer is widened by `coarsePointerWidth` on each side, so touch reaches the zone sooner.
 
-```typescript
-import { StateNode, TLTickEventInfo } from '@tldraw/editor'
+Edge detection respects the instance state's `insets` array, in CSS order `[top, right, bottom, left]`. An entry is `true` when that edge of the editor is inset from the browser window rather than flush with it. For a flush edge the pointer can't move past the window, so the zone extends inward from the edge. For an inset edge the zone starts at the editor's boundary instead, and scrolling begins once the pointer moves outside the editor.
 
-export class CustomDragState extends StateNode {
-	static override id = 'dragging'
+Once the pointer enters the zone, the manager waits `edgeScrollDelay` before moving the camera, which prevents accidental scrolling when the pointer briefly crosses the edge. It then ramps up over `edgeScrollEaseDuration` using `EASINGS.easeInCubic`. Leaving the zone stops scrolling and resets the timer.
 
-	override onTick({ elapsed }: TLTickEventInfo) {
-		const { editor } = this
-		if (!editor.inputs.getIsDragging() || editor.inputs.getIsPanning()) return
-		editor.edgeScrollManager.updateEdgeScrolling(elapsed)
-	}
-}
-```
-
-The manager tracks whether edge scrolling is active using `getIsEdgeScrolling()`. This returns true when the pointer is in the edge zone and scrolling has started (after the delay).
-
-Only call `updateEdgeScrolling()` during states where edge scrolling makes sense. The built-in select tool calls it during translating, brushing, and resizing, but not during idle or pointing states.
+The scroll delta per tick is `edgeScrollSpeed` multiplied by the user's edge scroll speed preference, the proximity factor, and a 0.612 factor on any axis where the viewport is narrower than 1000 pixels. It is divided by the zoom level so canvas-space velocity stays constant across zoom levels.
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/editor.mdx
+++ b/apps/docs/content/sdk-features/editor.mdx
@@ -17,7 +17,7 @@ accuracy: 10
 notes: ''
 ---
 
-The [Editor](?) class is the main way of controlling tldraw's editor. It provides methods for creating, reading, updating, and deleting shapes; managing selection and history; controlling the camera; and responding to user input. By design, the editor's surface area is very large—almost everything is available through it.
+The [Editor](?) class is the main way of controlling tldraw's editor. It has methods for creating, reading, updating, and deleting shapes, for managing selection and history, for controlling the camera, and for responding to user input. By design, the editor's surface area is very large: almost everything is available through it.
 
 Need to create some shapes? Use [Editor#createShapes](?). Need to delete them? Use [Editor#deleteShapes](?). Want a sorted array of every shape on the current page? Use [Editor#getCurrentPageShapesSorted](?). The editor is your primary interface for interacting with the canvas.
 
@@ -65,7 +65,7 @@ function App() {
 
 ## Architecture overview
 
-The editor orchestrates several interconnected systems. Understanding how they fit together helps when building on top of tldraw.
+The editor coordinates several interconnected systems.
 
 ### Store
 
@@ -127,26 +127,18 @@ editor.isInAny('select.idle', 'hand.idle') // true if in either state
 
 #### State transitions
 
-Tools transition between child states as the user interacts. For example, the select tool has states like `idle`, `pointing`, `brushing`, and `translating`. When you click and drag on the canvas, the state might flow like this:
+Tools transition between child states as the user interacts. For example, the select tool has states like `idle`, `pointing_canvas`, `pointing_shape`, `brushing`, and `translating`. When you click and drag on empty canvas, the state flows like this:
 
 1. `select.idle` — waiting for input
-2. `select.pointing` — pointer down, waiting to see if this is a click or drag
+2. `select.pointing_canvas` — pointer down on the canvas, waiting to see if this is a click or drag
 3. `select.brushing` — dragging to create a selection box
 4. `select.idle` — pointer up, back to waiting
 
-Each state handles events differently. The `idle` state responds to `pointer_down` by transitioning to `pointing`. The `brushing` state responds to `pointer_move` by updating the brush bounds and `pointer_up` by completing the selection.
+Each state handles events differently. The `idle` state responds to `pointer_down` on the canvas by transitioning to `pointing_canvas`. The `brushing` state updates the brush bounds on `pointer_move` and completes the selection on `pointer_up`.
 
 #### Event flow
 
-Events flow from the root state down through active children. When you press a key or move the pointer, the editor dispatches an event that each active state can handle:
-
-```ts
-// Events bubble through: root → select → idle
-// Each state can:
-// - Handle the event and stop propagation
-// - Handle the event and let it continue
-// - Ignore the event entirely
-```
+Events flow from the root state down through active children: `root` → `select` → `idle`. Each state runs its own handler first, then passes the event to its active child. If a handler transitions to a different child, the new child does not receive the same event.
 
 States define handlers for events like `onPointerDown`, `onPointerMove`, `onKeyDown`, and `onEnter`/`onExit` for state transitions. The active state chain determines which handlers run.
 
@@ -156,28 +148,26 @@ See [Tools](/sdk-features/tools) for building custom tools.
 
 The editor delegates specialized functionality to manager classes:
 
-| Manager                     | Responsibility                                |
-| --------------------------- | --------------------------------------------- |
-| [HistoryManager](?)         | Undo/redo stack and history marks             |
-| [SnapManager](?)            | Shape snapping during transforms              |
-| FocusManager                | Focus state and keyboard event handling       |
-| [TextManager](?)            | Text measurement and layout                   |
-| [FontManager](?)            | Font loading and management                   |
-| TickManager                 | Animation frame scheduling                    |
-| [InputsManager](?)          | Pointer position and modifier key tracking    |
-| [ClickManager](?)           | Click, double-click, and long-press detection |
-| [ScribbleManager](?)        | Brush and scribble interactions               |
-| [EdgeScrollManager](?)      | Auto-scroll at viewport edges                 |
-| [UserPreferencesManager](?) | User settings persistence                     |
+| Manager                     | Responsibility                                   |
+| --------------------------- | ------------------------------------------------ |
+| [HistoryManager](?)         | Undo/redo stack and history marks                |
+| [SnapManager](?)            | Shape snapping during transforms                 |
+| [TextManager](?)            | Text measurement and layout                      |
+| [FontManager](?)            | Font loading and management                      |
+| [InputsManager](?)          | Pointer position and modifier key tracking       |
+| [ClickManager](?)           | Click, double-click, and long-press detection    |
+| [ScribbleManager](?)        | Scribble trails (eraser, laser, scribble select) |
+| [EdgeScrollManager](?)      | Auto-scroll at viewport edges                    |
+| [UserPreferencesManager](?) | User settings persistence                        |
 
-Access managers through the editor instance:
+Access managers through properties on the editor instance:
 
 ```ts
-// Mark history for undo
-editor.markHistoryStoppingPoint('my-action')
-
-// Check snap points
 editor.snaps.getIndicators()
+editor.inputs.getCurrentPagePoint()
+editor.user.getUserPreferences()
+editor.scribbles.addScribble({ color: 'accent' })
+editor.edgeScrollManager.updateEdgeScrolling(elapsed)
 ```
 
 ## Working with shapes
@@ -252,7 +242,7 @@ See [Shapes](/sdk-features/shapes) for the complete shape system.
 
 ## Selection
 
-The editor tracks which shapes are selected. Selection drives many operations—transform handles, copy/paste, delete, and more.
+The editor tracks which shapes are selected. Selection drives transform handles, copy/paste, and delete.
 
 ```ts
 // Select shapes
@@ -365,7 +355,7 @@ See [Camera](/sdk-features/camera) and [Coordinates](/sdk-features/coordinates) 
 
 ## Input state
 
-The [Editor#inputs](?) object tracks the user's current input state: cursor position, pressed keys, drag state, and more. All values on the inputs object are reactive signals—when you access them inside a tracked component or computed, your code automatically re-runs when those values change.
+The [Editor#inputs](?) object tracks the user's current input state: cursor position, pressed keys, and drag state. All values on the inputs object are reactive signals. When you read them inside a tracked component or computed, your code re-runs when they change.
 
 ```ts
 // Cursor position in page coordinates (reactive)
@@ -392,7 +382,7 @@ See [Input handling](/sdk-features/input-handling) for input details.
 
 ## Instance state
 
-The editor maintains per-instance state in a [TLInstance](?) record. This includes which page is current, whether the editor is in readonly mode, the current tool, tool lock state, and UI state.
+The editor maintains per-instance state in a [TLInstance](?) record. This includes which page is current, whether the editor is in readonly mode, tool lock state, and UI state. See [Instance state](/sdk-features/instance-state) and [Readonly mode](/sdk-features/readonly).
 
 ```ts
 // Get instance state

--- a/apps/docs/content/sdk-features/embed-shape.mdx
+++ b/apps/docs/content/sdk-features/embed-shape.mdx
@@ -16,7 +16,7 @@ status: published
 date: 1/31/2026
 ---
 
-The embed shape displays interactive content from external services within an iframe. When you paste a URL from a supported service onto the canvas, tldraw automatically converts it to an embed with the appropriate dimensions and settings.
+The embed shape displays interactive content from external services within an iframe. When you paste a URL from a supported service onto the canvas, tldraw converts it to an embed with the appropriate dimensions and settings. See [EmbedShapeUtil](?) and [TLEmbedShape](?).
 
 ## Creating embeds
 
@@ -39,44 +39,40 @@ The embed system recognizes URLs from supported services and converts them to th
 
 ### Pasting iframe code
 
-You can also paste raw `<iframe>` HTML directly onto the canvas to create an embed shape, even when the source URL doesn't match a known provider. tldraw extracts the iframe's `src` attribute and creates an embed pointing at it. If the iframe element is missing `width` and `height`, the embed uses default dimensions instead.
+You can also paste raw `<iframe>` HTML directly onto the canvas to create an embed shape, even when the source URL doesn't match a known provider. tldraw extracts the iframe's `src` attribute and creates an embed pointing at it. For size, it reads the `width` and `height` attributes, then pixel values from the `style` attribute, and otherwise uses 425×350.
 
-This covers services tldraw doesn't know about — OpenStreetMap, SoundCloud, Loom, internal tools — without a custom embed definition. Iframes pasted this way receive a stricter sandbox than the built-in providers (no `allow-same-origin`, no forms, no popups), since tldraw can't make any safety guarantees about the source.
+This covers services tldraw doesn't know about (OpenStreetMap, SoundCloud, Loom, internal tools) without a custom embed definition. Iframes pasted this way receive a stricter sandbox than the built-in providers ([unknownEmbedShapePermissionOverrides](?): no `allow-same-origin`, no forms, no popups), since tldraw can't make any safety guarantees about the source.
 
 ## Supported services
 
-| Service         | Hostnames                             | Resizable | Aspect ratio locked |
-| --------------- | ------------------------------------- | --------- | ------------------- |
-| tldraw          | tldraw.com, beta.tldraw.com           | Yes       | No                  |
-| Figma           | figma.com                             | Yes       | No                  |
-| YouTube         | youtube.com, \*.youtube.com, youtu.be | Yes       | Yes                 |
-| Google Maps     | google.\*                             | Yes       | No                  |
-| Google Calendar | calendar.google.\*                    | Yes       | No                  |
-| Google Slides   | docs.google.\*                        | Yes       | No                  |
-| CodeSandbox     | codesandbox.io                        | Yes       | No                  |
-| CodePen         | codepen.io                            | Yes       | No                  |
-| Scratch         | scratch.mit.edu                       | No        | No                  |
-| Val Town        | val.town                              | Yes       | No                  |
-| GitHub Gist     | gist.github.com                       | Yes       | No                  |
-| Replit          | replit.com                            | Yes       | No                  |
-| Felt            | felt.com                              | Yes       | No                  |
-| Spotify         | open.spotify.com                      | Yes       | No                  |
-| Vimeo           | vimeo.com, player.vimeo.com           | Yes       | Yes                 |
-| Observable      | observablehq.com                      | Yes       | No                  |
-| Desmos          | desmos.com                            | Yes       | No                  |
-| Canva           | canva.com                             | Yes       | No                  |
+| Service         | Hostnames                                   | Resizable | Aspect ratio locked |
+| --------------- | ------------------------------------------- | --------- | ------------------- |
+| tldraw          | tldraw.com, beta.tldraw.com, localhost:3000 | Yes       | No                  |
+| Figma           | figma.com                                   | Yes       | No                  |
+| YouTube         | youtube.com, \*.youtube.com, youtu.be       | Yes       | Yes                 |
+| Google Maps     | google.\*                                   | Yes       | No                  |
+| Google Calendar | calendar.google.\*                          | Yes       | No                  |
+| Google Slides   | docs.google.\*                              | Yes       | No                  |
+| CodeSandbox     | codesandbox.io                              | Yes       | No                  |
+| CodePen         | codepen.io                                  | Yes       | No                  |
+| Scratch         | scratch.mit.edu                             | No        | No                  |
+| Val Town        | val.town                                    | Yes       | No                  |
+| GitHub Gist     | gist.github.com                             | Yes       | No                  |
+| Replit          | replit.com                                  | Yes       | No                  |
+| Felt            | felt.com                                    | Yes       | No                  |
+| Spotify         | open.spotify.com                            | Yes       | No                  |
+| Vimeo           | vimeo.com, player.vimeo.com                 | Yes       | Yes                 |
+| Observable      | observablehq.com                            | Yes       | No                  |
+| Desmos          | desmos.com                                  | Yes       | No                  |
+| Canva           | canva.com                                   | Yes       | No                  |
 
-Each service has default dimensions appropriate for its content type. YouTube embeds default to 800×450 (16:9), while Spotify defaults to 720×500.
+Each service has default dimensions appropriate for its content type. YouTube embeds default to 800×450 (16:9), while Spotify defaults to 720×500. Vimeo starts at 640×360 and corrects itself to the video's real aspect ratio after creation (`sizeToContentAspectRatio`). Google Maps takes an API key through `EmbedShapeUtil.configure({ embedConfig: { google_maps: { apiKey } } })`.
 
 ## Interacting with embeds
 
-Embed shapes behave differently from other shapes because they contain live interactive content.
+Embed shapes behave differently from other shapes because they contain live interactive content. Clicking an embed selects the shape rather than interacting with the content. Double-click it (or press Enter while it's selected) to enter editing mode. In editing mode, pointer events pass through to the iframe so you can scroll, click buttons, and use the embedded application. Click outside the shape or press Escape to exit.
 
-**Locked embeds**: When an embed shape is locked, you can interact with the content inside—play videos, scroll through code, use the embedded application—without accidentally moving the shape. This is the recommended way to use embeds for viewing content.
-
-**Unlocked embeds**: When an embed is unlocked, clicking on it selects the shape rather than interacting with the content. To interact with an unlocked embed, double-click it to enter editing mode.
-
-**Editing mode**: In editing mode, pointer events pass through to the iframe. You can scroll, click buttons, and interact with the embedded content. Click outside the shape or press Escape to exit editing mode.
+Locking an embed doesn't block this: [ShapeUtil#canEditWhileLocked](?) returns `true` for embeds (unless the definition sets `canEditWhileLocked: false`), so a locked embed can still enter editing mode and stays put while you use it. Editing also works in readonly mode.
 
 ## URL transformation
 
@@ -87,13 +83,13 @@ Each embed definition includes two transformation functions:
 - `toEmbedUrl`: Converts a shareable URL to an embeddable URL
 - `fromEmbedUrl`: Converts an embed URL back to the original URL
 
-This bidirectional transformation means the shape can display the original URL to users while rendering the embed version internally.
+The shape stores the original URL and renders the embed version.
 
 ## Fallback to bookmarks
 
 When you paste a URL that no embed definition recognizes, the default URL handler creates a [bookmark shape](/sdk-features/default-shapes#bookmark) instead of an embed. An existing embed shape whose URL doesn't match any definition still renders the URL in an iframe, using the stricter sandbox for unknown sources.
 
-You can check whether a URL is embeddable before creating a shape:
+Use [getEmbedInfo](?) to check whether a URL is embeddable before creating a shape:
 
 ```tsx
 import { getEmbedInfo, DEFAULT_EMBED_DEFINITIONS } from 'tldraw'
@@ -111,7 +107,7 @@ if (embedInfo) {
 
 ## Iframe security
 
-Embeds run in sandboxed iframes with restricted permissions. The default sandbox settings are:
+Embeds run in sandboxed iframes with restricted permissions. The defaults live in [embedShapePermissionDefaults](?):
 
 | Permission                                | Default | Description                                       |
 | ----------------------------------------- | ------- | ------------------------------------------------- |
@@ -119,53 +115,57 @@ Embeds run in sandboxed iframes with restricted permissions. The default sandbox
 | `allow-same-origin`                       | Yes     | Allow access to same-origin storage and APIs      |
 | `allow-forms`                             | Yes     | Allow form submission                             |
 | `allow-popups`                            | Yes     | Allow opening new windows (for linking to source) |
+| `allow-popups-to-escape-sandbox`          | No      | Popups inherit the sandbox                        |
 | `allow-downloads`                         | No      | Block file downloads                              |
+| `allow-downloads-without-user-activation` | No      | Block automatic downloads                         |
 | `allow-modals`                            | No      | Block modal dialogs like `window.prompt()`        |
+| `allow-orientation-lock`                  | No      | Block screen orientation lock                     |
 | `allow-pointer-lock`                      | No      | Block pointer lock API                            |
+| `allow-presentation`                      | No      | Block the Presentation API                        |
 | `allow-top-navigation`                    | No      | Block navigating away from tldraw                 |
+| `allow-top-navigation-by-user-activation` | No      | Block navigating away, even on user gesture       |
 | `allow-storage-access-by-user-activation` | No      | Block access to parent storage                    |
 
-Individual embed definitions can override these defaults. YouTube embeds allow `allow-presentation` for fullscreen video. Tldraw embeds allow `allow-top-navigation` so users can open rooms in new tabs.
+Individual embed definitions override these defaults with `overridePermissions`. YouTube and Google Maps allow `allow-presentation` for fullscreen; YouTube, Google Calendar, and Google Slides allow `allow-popups-to-escape-sandbox`; tldraw embeds allow `allow-top-navigation` so users can open rooms in new tabs.
 
-GitHub Gist embeds receive special handling: they use `srcDoc` instead of `src` to load the gist script, with an additional security check that restricts gist IDs to hexadecimal characters only. This prevents JSONP callback attacks.
+GitHub Gist embeds receive special handling: they use `srcDoc` instead of `src` to load the gist script, drop `allow-same-origin`, and restrict gist IDs to hexadecimal characters. This prevents JSONP callback attacks. See the [embed permissions example](/examples/configuration/embed-permissions).
 
 ## Custom embed definitions
 
-Replace or extend the default embed definitions using `EmbedShapeUtil.configure()`:
+Replace or extend the default embed definitions using `EmbedShapeUtil.configure()`. Type custom definitions as [CustomEmbedDefinition](?) and give them an `icon` so they show up in the Insert embed dialog:
 
 ```tsx
-import { Tldraw, EmbedShapeUtil, DEFAULT_EMBED_DEFINITIONS } from 'tldraw'
+import { Tldraw, EmbedShapeUtil, DEFAULT_EMBED_DEFINITIONS, CustomEmbedDefinition } from 'tldraw'
 import 'tldraw/tldraw.css'
 
-// Add a custom embed definition
-const myEmbedDefinitions = [
-	...DEFAULT_EMBED_DEFINITIONS,
-	{
-		type: 'myservice',
-		title: 'My Service',
-		hostnames: ['myservice.com'],
-		width: 600,
-		height: 400,
-		doesResize: true,
-		toEmbedUrl: (url) => {
-			const match = url.match(/myservice\.com\/item\/(\w+)/)
-			if (match) {
-				return `https://myservice.com/embed/${match[1]}`
-			}
-			return undefined
-		},
-		fromEmbedUrl: (url) => {
-			const match = url.match(/myservice\.com\/embed\/(\w+)/)
-			if (match) {
-				return `https://myservice.com/item/${match[1]}`
-			}
-			return undefined
-		},
-		embedOnPaste: true,
+const myService: CustomEmbedDefinition = {
+	type: 'myservice',
+	title: 'My Service',
+	hostnames: ['myservice.com'],
+	width: 600,
+	height: 400,
+	doesResize: true,
+	icon: 'https://myservice.com/favicon.png',
+	toEmbedUrl: (url) => {
+		const match = url.match(/myservice\.com\/item\/(\w+)/)
+		if (match) {
+			return `https://myservice.com/embed/${match[1]}`
+		}
+		return undefined
 	},
-]
+	fromEmbedUrl: (url) => {
+		const match = url.match(/myservice\.com\/embed\/(\w+)/)
+		if (match) {
+			return `https://myservice.com/item/${match[1]}`
+		}
+		return undefined
+	},
+	embedOnPaste: true,
+}
 
-const shapeUtils = [EmbedShapeUtil.configure({ embedDefinitions: myEmbedDefinitions })]
+const shapeUtils = [
+	EmbedShapeUtil.configure({ embedDefinitions: [...DEFAULT_EMBED_DEFINITIONS, myService] }),
+]
 
 export default function App() {
 	return (
@@ -178,25 +178,27 @@ export default function App() {
 
 ### Embed definition properties
 
-| Property                | Type                                   | Required | Description                                                               |
-| ----------------------- | -------------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `type`                  | `string`                               | Yes      | Unique identifier for this embed type                                     |
-| `title`                 | `string`                               | Yes      | Display name shown in the UI                                              |
-| `hostnames`             | `string[]`                             | Yes      | URL hostnames to match (supports glob patterns like `*.youtube.com`)      |
-| `width`                 | `number`                               | Yes      | Default width in pixels                                                   |
-| `height`                | `number`                               | Yes      | Default height in pixels                                                  |
-| `doesResize`            | `boolean`                              | Yes      | Whether the shape can be resized                                          |
-| `toEmbedUrl`            | `(url: string) => string \| undefined` | Yes      | Convert shareable URL to embed URL                                        |
-| `fromEmbedUrl`          | `(url: string) => string \| undefined` | Yes      | Convert embed URL to shareable URL                                        |
-| `minWidth`              | `number`                               | No       | Minimum width when resizing                                               |
-| `minHeight`             | `number`                               | No       | Minimum height when resizing                                              |
-| `isAspectRatioLocked`   | `boolean`                              | No       | Lock aspect ratio when resizing                                           |
-| `canEditWhileLocked`    | `boolean`                              | No       | Allow interaction when shape is locked (default: true)                    |
-| `overridePermissions`   | `TLEmbedShapePermissions`              | No       | Custom iframe sandbox permissions                                         |
-| `backgroundColor`       | `string`                               | No       | Background color for the embed container                                  |
-| `overrideOutlineRadius` | `number`                               | No       | Custom border radius (Spotify uses 12px)                                  |
-| `embedOnPaste`          | `boolean`                              | No       | When true, URLs are auto-converted to embeds on paste                     |
-| `instructionLink`       | `string`                               | No       | Help URL for services requiring setup (like Google Calendar public links) |
+| Property                   | Type                                   | Required | Description                                                               |
+| -------------------------- | -------------------------------------- | -------- | ------------------------------------------------------------------------- |
+| `type`                     | `string`                               | Yes      | Unique identifier for this embed type                                     |
+| `title`                    | `string`                               | Yes      | Display name shown in the UI                                              |
+| `hostnames`                | `string[]`                             | Yes      | URL hostnames to match (supports glob patterns like `*.youtube.com`)      |
+| `width`                    | `number`                               | Yes      | Default width in pixels                                                   |
+| `height`                   | `number`                               | Yes      | Default height in pixels                                                  |
+| `doesResize`               | `boolean`                              | Yes      | Whether the shape can be resized                                          |
+| `toEmbedUrl`               | `(url: string) => string \| undefined` | Yes      | Convert shareable URL to embed URL                                        |
+| `fromEmbedUrl`             | `(url: string) => string \| undefined` | Yes      | Convert embed URL to shareable URL                                        |
+| `minWidth`                 | `number`                               | No       | Minimum width when resizing                                               |
+| `minHeight`                | `number`                               | No       | Minimum height when resizing                                              |
+| `isAspectRatioLocked`      | `boolean`                              | No       | Lock aspect ratio when resizing                                           |
+| `canEditWhileLocked`       | `boolean`                              | No       | Allow interaction when shape is locked (default: true)                    |
+| `overridePermissions`      | `TLEmbedShapePermissions`              | No       | Custom iframe sandbox permissions                                         |
+| `sizeToContentAspectRatio` | `boolean`                              | No       | Correct the size to the content's real aspect ratio after creation        |
+| `icon`                     | `string`                               | No       | Icon URL for the Insert embed dialog (`CustomEmbedDefinition` only)       |
+| `backgroundColor`          | `string`                               | No       | Background color for the embed container                                  |
+| `overrideOutlineRadius`    | `number`                               | No       | Custom border radius (Spotify uses 12px)                                  |
+| `embedOnPaste`             | `boolean`                              | No       | When true, URLs are auto-converted to embeds on paste                     |
+| `instructionLink`          | `string`                               | No       | Help URL for services requiring setup (like Google Calendar public links) |
 
 ## Embed-on-paste behavior
 
@@ -206,17 +208,17 @@ The tldraw embed definition sets `embedOnPaste: false`, so pasting a tldraw.com 
 
 ## Shape properties
 
-| Property | Type     | Description                                          |
-| -------- | -------- | ---------------------------------------------------- |
-| `url`    | `string` | The original URL (converted to embed URL internally) |
-| `w`      | `number` | Width of the embed container                         |
-| `h`      | `number` | Height of the embed container                        |
+| Property | Type     | Description                                                        |
+| -------- | -------- | ------------------------------------------------------------------ |
+| `url`    | `string` | The original URL (converted to embed URL internally); default `''` |
+| `w`      | `number` | Width of the embed container; default `300`                        |
+| `h`      | `number` | Height of the embed container; default `300`                       |
 
 ## SVG export
 
 Embed shapes render as blank rectangles in SVG exports. The iframe content can't be captured directly, so exports show a placeholder with the embed's background color and border radius.
 
-## Related
+## Related articles
 
 - [Default shapes](/sdk-features/default-shapes) — Overview of all built-in shape types
 - [Bookmark shape](/sdk-features/default-shapes#bookmark) — URL link cards (fallback for non-embeddable URLs)

--- a/apps/docs/content/sdk-features/environment.mdx
+++ b/apps/docs/content/sdk-features/environment.mdx
@@ -48,10 +48,6 @@ tlenv.isTouchDevice // true if the device has a touch screen
 
 `isTouchDevice` reflects the hardware, so it stays true on a touchscreen laptop even while the user is using a mouse. For the pointer currently in use, read `isCoarsePointer` from `tlenvReactive` below.
 
-```typescript
-
-```
-
 ### Common patterns
 
 **Platform-specific keyboard shortcuts:**
@@ -125,7 +121,7 @@ Note: We force fine pointer mode on Firefox desktop regardless of the actual inp
 
 When the editor is mounted inside an iframe, an Electron pop-out window, or an Obsidian plugin, the global `document` and `window` aren't necessarily the ones the editor's DOM lives in. Reading `document.activeElement` or attaching a listener to the global `window` will silently fail or target the wrong frame.
 
-Use the editor's container helpers instead of bare globals. These are currently marked internal, but they are what the SDK itself uses:
+Use the editor's container helpers instead of bare globals. They are marked internal, so their signatures may change, but they are what the SDK itself uses:
 
 ```typescript
 const doc = editor.getContainerDocument() // the document the editor is mounted in

--- a/apps/docs/content/sdk-features/environment.mdx
+++ b/apps/docs/content/sdk-features/environment.mdx
@@ -22,7 +22,7 @@ accuracy: 10
 notes: ''
 ---
 
-The tldraw SDK provides two objects for detecting the user's environment: `tlenv` for fixed browser and platform information, and `tlenvReactive` for values that change during a session (like whether the user is using touch input). We use these internally to work around browser quirks, and you can use them in custom shapes or tools.
+The tldraw SDK provides two objects for detecting the user's environment. [tlenv](?) holds fixed browser and platform information. [tlenvReactive](?) holds values that change during a session, like whether the user is currently using touch input. We use these internally to work around browser quirks, and you can use them in custom shapes or tools.
 
 ## Static environment: tlenv
 
@@ -43,6 +43,13 @@ tlenv.isDarwin // true if macOS
 
 // Capability detection
 tlenv.hasCanvasSupport // true if Promise and HTMLCanvasElement exist
+tlenv.isTouchDevice // true if the device has a touch screen
+```
+
+`isTouchDevice` reflects the hardware, so it stays true on a touchscreen laptop even while the user is using a mouse. For the pointer currently in use, read `isCoarsePointer` from `tlenvReactive` below.
+
+```typescript
+
 ```
 
 ### Common patterns
@@ -50,8 +57,12 @@ tlenv.hasCanvasSupport // true if Promise and HTMLCanvasElement exist
 **Platform-specific keyboard shortcuts:**
 
 ```typescript
-// Use Cmd on Mac, Ctrl elsewhere
-const accelKey = tlenv.isDarwin ? e.metaKey : e.ctrlKey
+import { isAccelKey } from 'tldraw'
+
+// Cmd on Mac, Ctrl elsewhere
+if (isAccelKey(e)) {
+	// Handle the shortcut
+}
 ```
 
 **Mobile detection:**
@@ -74,7 +85,7 @@ if (tlenv.isSafari) {
 
 ## Reactive environment: tlenvReactive
 
-The `tlenvReactive` atom contains values that can change during a session, like the current pointer type. Use `useValue` to subscribe to changes in React components.
+The `tlenvReactive` atom contains values that can change during a session: `isCoarsePointer` (the current pointer type) and `supportsP3ColorSpace` (whether the current display supports the P3 color gamut). Use [useValue](?) to subscribe to changes in React components.
 
 ```tsx
 import { tlenvReactive, useValue } from 'tldraw'
@@ -93,7 +104,7 @@ function TouchFriendlyButton() {
 
 ### Coarse pointer detection
 
-The `isCoarsePointer` value tracks whether the user is currently using touch input. We detect this two ways: by listening to the `(any-pointer: coarse)` media query, and by checking `pointerType` on each pointer down event. This dual approach handles devices that support both mouse and touch—like laptops with touchscreens—where the user might switch input methods mid-session.
+The `isCoarsePointer` value tracks whether the user is currently using touch input. We detect this two ways: by listening to the `(any-pointer: coarse)` media query, and by checking `pointerType` on each pointer down event. Any pointer that isn't a mouse counts as coarse, so pen input switches to coarse mode too. Laptops with touchscreens can switch input methods mid-session; the pointer down check catches that.
 
 ```typescript
 import { tlenvReactive, react } from 'tldraw'
@@ -114,7 +125,7 @@ Note: We force fine pointer mode on Firefox desktop regardless of the actual inp
 
 When the editor is mounted inside an iframe, an Electron pop-out window, or an Obsidian plugin, the global `document` and `window` aren't necessarily the ones the editor's DOM lives in. Reading `document.activeElement` or attaching a listener to the global `window` will silently fail or target the wrong frame.
 
-Use the editor's container helpers instead of bare globals:
+Use the editor's container helpers instead of bare globals. These are currently marked internal, but they are what the SDK itself uses:
 
 ```typescript
 const doc = editor.getContainerDocument() // the document the editor is mounted in
@@ -130,7 +141,7 @@ const doc = getOwnerDocument(node)
 const win = getOwnerWindow(node)
 ```
 
-These are what the editor uses internally for export, measurement, focus tracking, and event listeners. Custom shapes and tools that touch the DOM directly should use them too — anything that calls `document` or `window` directly will break the moment your app is embedded in a context with multiple realms.
+These are what the editor uses internally for export, measurement, focus tracking, and event listeners. Custom shapes and tools that touch the DOM directly should use them too. Anything that calls `document` or `window` directly will target the wrong realm once your app is embedded in an iframe or pop-out window.
 
 ## Browser quirks we handle
 
@@ -138,8 +149,10 @@ Here's a sample of what we use environment detection for internally.
 
 **Safari** has the most workarounds. During SVG-to-image export, Safari fires the image's load event before the fonts inside the SVG have loaded, so we wait an extra 250ms—a WebKit bug that's been open for years. Text outlines are a performance problem on Safari, so we disable them there.
 
-**iOS** support for coalesced pointer events is unreliable—`getCoalescedEvents` is sometimes missing entirely—so we skip coalesced events on iOS and dispatch individual pointer events instead.
+**iOS** support for coalesced pointer events is unreliable (`getCoalescedEvents` is sometimes missing entirely), so we skip coalesced events on iOS and dispatch individual pointer events instead. We also skip Safari's proprietary `GestureEvent` on iOS.
 
 **Firefox** desktop's `(any-pointer: coarse)` media query reports false positives when a touchscreen is present but not in use. We force fine pointer mode on Firefox desktop to avoid jumpy UI.
 
-**Chrome for iOS** has its own print implementation that doesn't trigger the standard `beforeprint` event, so we detect it and handle printing manually.
+**Chrome for iOS** has its own print implementation that doesn't trigger the standard `beforeprint` event, so we call our print handler manually before printing. Safari desktop needs `document.execCommand('print')` instead of `window.print()`.
+
+See [Instance state](/sdk-features/instance-state) for `isCoarsePointer` on the instance record, which mirrors `tlenvReactive`.

--- a/apps/docs/content/sdk-features/eraser.mdx
+++ b/apps/docs/content/sdk-features/eraser.mdx
@@ -29,11 +29,13 @@ export default function App() {
 
 ## Click vs. drag
 
-A click erases the shapes under the pointer. Hold Cmd/Ctrl while clicking to erase only the topmost shape.
+A click erases the shapes under the pointer. Hold Cmd/Ctrl while clicking to erase only the topmost shape. A click that hits a shape inside a frame doesn't also erase the frame.
 
-Dragging (or long-pressing, on touch devices) starts scribble erasing. A scribble trail follows the pointer, and every shape the path crosses is marked for deletion. Shapes aren't deleted until you release: marked shapes render at reduced opacity (32% of normal) so the user can see what's about to go.
+Dragging (or long-pressing) starts scribble erasing. A scribble trail follows the pointer, and every shape the path crosses is marked for deletion. Shapes aren't deleted until you release: marked shapes render at reduced opacity (32% of normal) so the user can see what's about to go.
 
-Releasing the pointer deletes the marked shapes. Pressing Escape cancels the gesture and restores them.
+Releasing the pointer deletes the marked shapes. Pressing Escape cancels the gesture and unmarks them.
+
+The draw and highlight tools use the eraser too: hold Cmd/Ctrl and press down to erase without leaving the tool. They switch to `eraser.pointing` with `onInteractionEnd` set to their own id, and the eraser returns to that tool when the gesture ends.
 
 Each erase gesture is a single history stopping point, so one undo brings back everything it deleted.
 
@@ -58,11 +60,11 @@ editor.getErasingShapeIds()
 editor.getErasingShapes()
 ```
 
-The eraser uses these methods internally. You can use them from your own tools to get the same faded preview before deleting shapes with [Editor#deleteShapes](?).
+The eraser uses [Editor#setErasingShapes](?), [Editor#getErasingShapeIds](?), and [Editor#getErasingShapes](?) internally. You can use them from your own tools to get the same faded preview before deleting shapes with [Editor#deleteShapes](?).
 
 ## Tool states
 
-The eraser is a [StateNode](?) with the id `eraser` and three child states:
+The eraser is an [EraserTool](?) with the id `eraser` and three child states. Tool lock doesn't apply to it. Pressing Escape in `idle` returns to the select tool.
 
 | State      | Description                                                                                                        |
 | ---------- | ------------------------------------------------------------------------------------------------------------------ |
@@ -70,7 +72,7 @@ The eraser is a [StateNode](?) with the id `eraser` and three child states:
 | `pointing` | The pointer is down. Shapes under the point are marked; releasing deletes them. Dragging transitions to `erasing`. |
 | `erasing`  | Scribble erasing. Marks every shape the pointer path crosses; releasing deletes them.                              |
 
-Hit testing during scribble erasing uses the segment between the previous and current pointer positions, with a margin of `editor.options.hitTestMargin` divided by the zoom level. This catches shapes even when the pointer moves quickly.
+Hit testing during scribble erasing uses the segment between the previous and current pointer positions, with a margin of [Editor#getHitTestMargin](?) (`hitTestMargin`, or `coarseHitTestMargin` for touch, divided by the zoom level). This catches shapes even when the pointer moves quickly. Shapes clipped by a frame are skipped unless the pointer is inside the clip.
 
 ## Related
 

--- a/apps/docs/content/sdk-features/errors.mdx
+++ b/apps/docs/content/sdk-features/errors.mdx
@@ -19,43 +19,27 @@ accuracy: 9
 notes: Add API reference links. Add context about common error sources.
 ---
 
-The editor uses multiple layers of React error boundaries to isolate failures. When a shape throws during render, only that shape shows a fallback. The rest of the editor keeps working. This matters because custom shapes are a common extension point, and third-party code should not crash the whole experience.
+The editor uses multiple layers of React error boundaries to isolate failures. When a shape throws during render, only that shape shows a fallback. The rest of the editor keeps working. This matters because custom shapes are a common extension point, and third-party code should not crash the whole editor.
 
 ## Error boundary layers
 
-Error boundaries exist at three levels:
+Error boundaries exist at two levels.
 
-**Application level.** Wraps the entire editor. If something throws here, we show a full-screen error with options to refresh or reset local data. This is the last resort.
+At the application level, a boundary wraps the entire editor. If something throws here, the editor shows a full-screen error with options to refresh or reset local data. This is the last resort. There are actually two of these: an outer one that catches errors before the [Editor](?) exists, and an inner one that has access to the editor, so it can annotate the error and still try to render your document behind the error screen.
 
-**Shape level.** Each shape renders inside its own boundary. A broken shape disappears, but the user can still interact with everything else. ShapeUtil code is the most likely place for bugs, especially in custom shapes.
-
-**Indicator level.** Selection indicators have their own boundaries, separate from shape content. A shape can render correctly even if its indicator throws, and vice versa.
-
-```tsx
-// The editor automatically wraps your content
-<TldrawEditor>
-	<OptionalErrorBoundary fallback={ErrorFallback}>
-		{/* Your shapes, each with their own boundary */}
-		<Shape>
-			<OptionalErrorBoundary fallback={ShapeErrorFallback}>
-				{/* Shape content */}
-			</OptionalErrorBoundary>
-		</Shape>
-	</OptionalErrorBoundary>
-</TldrawEditor>
-```
+At the shape level, each shape's component (and its background component, if it has one) renders inside its own boundary. A broken shape shows a fallback, but the user can still interact with everything else. ShapeUtil code is the most likely place for bugs, especially in custom shapes.
 
 ## Default fallbacks
 
 Each boundary level has a default fallback component.
 
-`DefaultErrorFallback` shows a modal with the error message and stack trace. It tries to render the canvas behind the modal so users can see their work is probably still there. The modal offers buttons to copy the error, refresh the page, or reset local data.
+[DefaultErrorFallback](?) shows a modal with the error message and stack trace. It tries to render the canvas behind the modal so users can see their work is probably still there. The modal offers buttons to copy the error, refresh the page, or reset local data.
 
-`DefaultShapeErrorFallback` renders an empty div with the class `tl-shape-error-boundary`. The shape vanishes, but nothing else breaks. Style this class if you want broken shapes to be more visible.
+The default shape fallback renders a div with the class `tl-shape-error-boundary`, which the default CSS styles as a muted box labeled "Error" in the shape's place. Override this class if you want broken shapes to look different.
 
 ## Customizing error components
 
-Replace any error fallback through the `components` prop:
+Replace either fallback through the `ErrorFallback` and `ShapeErrorFallback` keys of the [TLEditorComponents](?) `components` prop:
 
 ```tsx
 import { Tldraw, TLErrorFallbackComponent, TLShapeErrorFallbackComponent } from 'tldraw'
@@ -82,11 +66,11 @@ const MyShapeErrorFallback: TLShapeErrorFallbackComponent = ({ error }) => {
 />
 ```
 
-Set a fallback to `null` to disable the error boundary at that level. Errors will propagate to the parent boundary instead.
+Passing `null` for a fallback (with a cast, since the props are typed as components) disables the error boundary at that level. Errors propagate to the parent boundary instead.
 
 ## Crash handling
 
-When the editor encounters a fatal error during event processing, it enters a crashed state. Listen for this with the `crash` event:
+When an error is thrown inside a store transaction (anything wrapped in [Editor#run](?), which includes most editor methods), the history manager catches it, annotates it, and puts the editor into a crashed state. Listen for this with the `crash` event:
 
 ```tsx
 editor.on('crash', ({ error }) => {
@@ -95,11 +79,11 @@ editor.on('crash', ({ error }) => {
 })
 ```
 
-When crashed, the editor stops processing new events to prevent further damage. The error boundary displays the fallback UI, giving users options to recover.
+When crashed, the editor stops processing new events to prevent further damage and marks the store as possibly corrupted. The application-level error boundary then shows the fallback UI with its refresh and reset options.
 
 ## Error annotations
 
-The SDK can attach debugging metadata to errors. Use `getErrorAnnotations` to retrieve tags and extra context, which is useful for error tracking services like Sentry:
+The SDK attaches debugging metadata to errors it catches, and you can add your own with `annotateError` from `@tldraw/utils`. Use `getErrorAnnotations` to read the tags and extras back, which is useful for error tracking services like Sentry:
 
 ```tsx
 import { getErrorAnnotations, TLErrorFallbackComponent } from 'tldraw'
@@ -122,11 +106,11 @@ const MyErrorFallback: TLErrorFallbackComponent = ({ error }) => {
 }
 ```
 
-Annotations include `tags` (key-value pairs for categorization) and `extras` (additional context data).
+Annotations include `tags` (key-value pairs for categorization) and `extras` (additional context data). `getErrorAnnotations` is currently marked internal, so its signature may change between versions.
 
 ## ErrorBoundary component
 
-Use the exported `ErrorBoundary` component directly in your own code:
+Use the exported [ErrorBoundary](?) component directly in your own code:
 
 ```tsx
 import { ErrorBoundary, TLErrorFallbackComponent } from 'tldraw'
@@ -144,39 +128,21 @@ function MyComponent() {
 }
 ```
 
-The `fallback` prop accepts a component that receives `{ error: unknown; editor?: Editor }`. The `onError` callback fires when an error is caught, before the fallback renders.
+The `fallback` prop accepts a [TLErrorFallbackComponent](?), which receives `{ error: unknown; editor?: Editor }`. `ErrorBoundary` itself only passes `error`; `editor` is provided by the editor's inner application-level boundary. The `onError` callback fires when an error is caught, before the fallback renders.
 
 ## API reference
 
-### Components
-
-| Component            | Props                              | Description                       |
-| -------------------- | ---------------------------------- | --------------------------------- |
-| `ErrorFallback`      | `{ error, editor? }`               | Application-level error screen    |
-| `ShapeErrorFallback` | `{ error }`                        | Per-shape error placeholder       |
-| `ErrorBoundary`      | `{ fallback, onError?, children }` | Reusable error boundary component |
-
-### Types
-
-| Type                            | Description                                          |
-| ------------------------------- | ---------------------------------------------------- |
-| `TLErrorFallbackComponent`      | `ComponentType<{ error: unknown; editor?: Editor }>` |
-| `TLShapeErrorFallbackComponent` | `ComponentType<{ error: any }>`                      |
-| `TLErrorBoundaryProps`          | Props for the ErrorBoundary component                |
-
-### Functions
-
-| Function                     | Description                                          |
-| ---------------------------- | ---------------------------------------------------- |
-| `getErrorAnnotations(error)` | Retrieve tags and extras attached to an error object |
-
-### Events
-
-| Event   | Payload              | Description                                |
-| ------- | -------------------- | ------------------------------------------ |
-| `crash` | `{ error: unknown }` | Fired when the editor enters crashed state |
+| Symbol                             | Description                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------ |
+| [ErrorBoundary](?)                 | Reusable error boundary component; see [TLErrorBoundaryProps](?)               |
+| [DefaultErrorFallback](?)          | Default application-level error screen                                         |
+| [TLErrorFallbackComponent](?)      | `ComponentType<{ error: unknown; editor?: Editor }>`, used for `ErrorFallback` |
+| [TLShapeErrorFallbackComponent](?) | `ComponentType<{ error: any }>`, used for `ShapeErrorFallback`                 |
+| `annotateError`                    | Attach tags and extras to an error                                             |
+| `getErrorAnnotations(error)`       | Read tags and extras from an error (internal)                                  |
+| `crash` event                      | Emitted with `{ error: unknown }` when the editor enters the crashed state     |
 
 ## Related examples
 
-- **[Error boundary](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/error-boundary)** — Customize ShapeErrorFallback to display a custom message when shapes throw errors.
-- **[Custom error capture](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/custom-error-capture)** — Override ErrorFallback to create a custom error screen with annotations for debugging.
+- [Error boundary](/examples/ui/error-boundary): customize `ShapeErrorFallback` to display a custom message when shapes throw errors.
+- [Custom error capture](/examples/ui/custom-error-capture): override `ErrorFallback` to create a custom error screen with annotations for debugging.

--- a/apps/docs/content/sdk-features/errors.mdx
+++ b/apps/docs/content/sdk-features/errors.mdx
@@ -139,7 +139,7 @@ The `fallback` prop accepts a [TLErrorFallbackComponent](?), which receives `{ e
 | [TLErrorFallbackComponent](?)      | `ComponentType<{ error: unknown; editor?: Editor }>`, used for `ErrorFallback` |
 | [TLShapeErrorFallbackComponent](?) | `ComponentType<{ error: any }>`, used for `ShapeErrorFallback`                 |
 | `annotateError`                    | Attach tags and extras to an error                                             |
-| `getErrorAnnotations(error)`       | Read tags and extras from an error (internal)                                  |
+| `getErrorAnnotations(error)`       | Read tags and extras from an error; marked internal                            |
 | `crash` event                      | Emitted with `{ error: unknown }` when the editor enters the crashed state     |
 
 ## Related examples

--- a/apps/docs/content/sdk-features/events.mdx
+++ b/apps/docs/content/sdk-features/events.mdx
@@ -18,11 +18,11 @@ accuracy: 9
 notes: Input events table could mention TLEventInfo link more prominently. Add API links for types like HistoryEntry.
 ---
 
-The editor emits events for user interactions, state changes, and lifecycle moments. You subscribe using `on()` and `off()` methods inherited from EventEmitter. Events range from low-level input (pointer moves, key presses) to high-level changes (shapes created, camera moved). Use them to build analytics, sync external state, or extend editor behavior.
+The editor emits events for input, store changes, and lifecycle moments. Subscribe with `editor.on()` and unsubscribe with `editor.off()`. Use events to build analytics, sync external state, or extend editor behavior.
 
 ## Subscribing to events
 
-The `Editor` extends EventEmitter and provides typed event subscriptions:
+The [Editor](?) extends EventEmitter, and every event name and payload is typed by [TLEventMap](?):
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -46,7 +46,7 @@ export default function App() {
 Unsubscribe by calling `off()` with the same handler:
 
 ```tsx
-const handleEvent = (info) => {
+const handleEvent: TLEventMapHandler<'event'> = (info) => {
 	console.log('Event:', info.type)
 }
 
@@ -54,11 +54,11 @@ editor.on('event', handleEvent)
 editor.off('event', handleEvent)
 ```
 
-Always unsubscribe when your component unmounts to prevent memory leaks. In React, return a cleanup function from your effect:
+Unsubscribe when the listener outlives the code that registered it. In React, return a cleanup function from your effect:
 
 ```tsx
 useEffect(() => {
-	const handleChange = (entry) => {
+	const handleChange: TLEventMapHandler<'change'> = (entry) => {
 		console.log('Store changed:', entry.changes)
 	}
 
@@ -71,7 +71,7 @@ useEffect(() => {
 
 ### Input events
 
-The `event` and `before-event` events fire for all user interactions. Each receives a [TLEventInfo](?) object describing the input.
+The `event` and `before-event` events fire for every event the editor dispatches: user input plus the `misc` events (`cancel`, `complete`, `interrupt`, `tick`) that tools use internally. Each receives a [TLEventInfo](?) object describing the event.
 
 ```tsx
 editor.on('event', (info) => {
@@ -81,9 +81,9 @@ editor.on('event', (info) => {
 })
 ```
 
-The `before-event` fires before the event reaches the tool state machine. Use it to inspect or log events before processing. The `event` fires after tool processing completes.
+`before-event` fires before the event reaches the tool state machine, and `event` fires after the tools have handled it.
 
-Input events have different types:
+Events have different types:
 
 | Type       | Names                                                                                     | Description                         |
 | ---------- | ----------------------------------------------------------------------------------------- | ----------------------------------- |
@@ -92,8 +92,9 @@ Input events have different types:
 | `keyboard` | `key_down`, `key_up`, `key_repeat`                                                        | Keyboard input                      |
 | `wheel`    | `wheel`                                                                                   | Scroll wheel and trackpad scrolling |
 | `pinch`    | `pinch_start`, `pinch`, `pinch_end`                                                       | Two-finger pinch gestures           |
+| `misc`     | `cancel`, `complete`, `interrupt`, `tick`                                                 | Internal tool lifecycle events      |
 
-Pointer events include the target—what the pointer is over:
+Pointer events include the target—what the pointer is over: `canvas`, `shape`, `selection`, `handle`, or `overlay`.
 
 ```tsx
 editor.on('event', (info) => {
@@ -111,6 +112,9 @@ editor.on('event', (info) => {
 			case 'handle':
 				console.log('Clicked handle on:', info.shape.id)
 				break
+			case 'overlay':
+				console.log('Clicked overlay:', info.overlay.type)
+				break
 		}
 	}
 })
@@ -118,18 +122,18 @@ editor.on('event', (info) => {
 
 ### Shape events
 
-Shape events fire when shapes change. These are convenience wrappers around store changes—you can also use the `change` event to track all store modifications.
+Shape events fire from [Editor#createShapes](?), [Editor#updateShapes](?), and [Editor#deleteShapes](?), just before the store is written. Changes from other sources (remote sync, undo/redo, direct `store.put` calls) don't fire them—use the `change` event for those.
 
 | Event            | Payload       | Description                      |
 | ---------------- | ------------- | -------------------------------- |
-| `created-shapes` | `TLRecord[]`  | Shapes were added                |
-| `edited-shapes`  | `TLRecord[]`  | Shapes were modified             |
-| `deleted-shapes` | `TLShapeId[]` | Shapes were removed              |
+| `created-shapes` | `TLRecord[]`  | Shapes about to be added         |
+| `edited-shapes`  | `TLRecord[]`  | Shapes about to be updated       |
+| `deleted-shapes` | `TLShapeId[]` | Shapes about to be removed       |
 | `edit`           | None          | Fires alongside any of the above |
 
 ```tsx
 editor.on('created-shapes', (shapes) => {
-	console.log('Created:', shapes.map((s) => s.type).join(', '))
+	console.log('Created:', shapes.length, 'shapes')
 })
 
 editor.on('deleted-shapes', (ids) => {
@@ -180,12 +184,12 @@ editor.on('change', (entry) => {
 
 ### Frame events
 
-Two events fire on every animation frame:
+Two events fire on every animation frame, both carrying the milliseconds elapsed since the previous frame:
 
-| Event   | Payload  | Description                   |
-| ------- | -------- | ----------------------------- |
-| `tick`  | `number` | Milliseconds since last tick  |
-| `frame` | `number` | Milliseconds since last frame |
+| Event   | Payload  | Description                                              |
+| ------- | -------- | -------------------------------------------------------- |
+| `frame` | `number` | Fires first; used internally (for example, for velocity) |
+| `tick`  | `number` | Fires immediately after `frame`                          |
 
 ```tsx
 editor.on('tick', (elapsed) => {
@@ -201,9 +205,10 @@ These fire frequently (60+ times per second). Keep handlers fast to avoid droppi
 | Event     | Payload              | Description                  |
 | --------- | -------------------- | ---------------------------- |
 | `mount`   | None                 | Editor finished initializing |
+| `unmount` | None                 | Editor component unmounted   |
 | `dispose` | None                 | Editor is being cleaned up   |
 | `crash`   | `{ error: unknown }` | Editor encountered an error  |
-| `update`  | None                 | Editor state updated         |
+| `update`  | None                 | A store operation completed  |
 
 ```tsx
 editor.on('mount', () => {
@@ -217,14 +222,14 @@ editor.on('crash', ({ error }) => {
 
 ### UI and camera events
 
-| Event                   | Payload                   | Description                    |
-| ----------------------- | ------------------------- | ------------------------------ |
-| `resize`                | `BoxModel`                | Viewport dimensions changed    |
-| `stop-camera-animation` | None                      | Camera animation interrupted   |
-| `stop-following`        | None                      | Stopped following another user |
-| `select-all-text`       | `{ shapeId: TLShapeId }`  | Triple-clicked to select text  |
-| `place-caret`           | `{ shapeId, point }`      | Text caret positioned          |
-| `max-shapes`            | `{ name, pageId, count }` | Page reached shape limit       |
+| Event                   | Payload                   | Description                            |
+| ----------------------- | ------------------------- | -------------------------------------- |
+| `resize`                | `BoxModel`                | Viewport dimensions changed            |
+| `stop-camera-animation` | None                      | Camera animation interrupted           |
+| `stop-following`        | None                      | Stopped following another user         |
+| `select-all-text`       | `{ shapeId: TLShapeId }`  | Editing started with all text selected |
+| `place-caret`           | `{ shapeId, point }`      | Text caret positioned                  |
+| `max-shapes`            | `{ name, pageId, count }` | Page reached shape limit               |
 
 ```tsx
 editor.on('resize', (bounds) => {
@@ -252,7 +257,7 @@ UI events track actions like selecting tools, grouping shapes, toggling dark mod
 
 ## Listening to store changes directly
 
-For fine-grained control over store subscriptions, use `editor.store.listen()` instead of editor events:
+The `change` event is `editor.store.listen()` with no filters. For fine-grained control, call `listen()` directly:
 
 ```tsx
 const cleanup = editor.store.listen(
@@ -275,6 +280,6 @@ See [Side effects](/sdk-features/side-effects) for registering handlers that can
 
 ## Related examples
 
-- **[Canvas events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/canvas-events)** - Log pointer, keyboard, and wheel events as you interact with the canvas.
-- **[Store events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/store-events)** - Track shape creation, updates, and deletion through store change events.
-- **[UI events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/ui-events)** - Capture high-level UI interactions like tool selection and menu actions.
+- [Canvas events](/examples/events/canvas-events) - Log pointer, keyboard, and wheel events as you interact with the canvas.
+- [Store events](/examples/events/store-events) - Track shape creation, updates, and deletion through store change events.
+- [UI events](/examples/events/ui-events) - Capture high-level UI interactions like tool selection and menu actions.

--- a/apps/docs/content/sdk-features/external-content.mdx
+++ b/apps/docs/content/sdk-features/external-content.mdx
@@ -21,7 +21,7 @@ notes: None - previously identified issues were fixed.
 The external content system handles content from outside the editor: pasted text, dropped files, embedded URLs, and more. You register handlers for specific content types, and the editor routes incoming content to the appropriate handler.
 
 ```tsx
-import { Tldraw, Editor, defaultHandleExternalTextContent } from 'tldraw'
+import { Tldraw, Editor, defaultHandleExternalTextContent, toRichText } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 export default function App() {
@@ -36,7 +36,7 @@ export default function App() {
 					type: 'text',
 					x: center.x,
 					y: center.y,
-					props: { text: 'Custom HTML handling!' },
+					props: { richText: toRichText('Custom HTML handling!') },
 				})
 			} else {
 				// Fall back to default behavior
@@ -55,47 +55,48 @@ export default function App() {
 
 ## How it works
 
-Two systems handle external content: content handlers and asset handlers.
-
-**Content handlers** transform external content into shapes. When a user pastes text, drops an image, or embeds a URL, the content handler for that type processes the data and creates shapes on the canvas.
-
-**Asset handlers** process external assets into asset records. When an image file arrives, the asset handler extracts dimensions, uploads the file, and returns an asset record with the uploaded URL. The content handler then creates a shape referencing that asset.
+Two systems handle external content. Content handlers transform external content into shapes: when a user pastes text, drops an image, or embeds a URL, the content handler for that type creates shapes on the canvas. Asset handlers turn external files and URLs into asset records: when an image file arrives, the asset handler extracts dimensions, uploads the file, and returns an asset record with the uploaded URL. The content handler then creates a shape referencing that asset.
 
 The flow works like this:
 
 1. Content arrives (paste, drop, or API call)
-2. The editor calls `putExternalContent` with the content object
+2. The editor calls `putExternalContent` with the content object (a no-op in readonly mode unless you pass `{ force: true }`)
 3. The registered handler for that content type processes it
 4. The handler creates shapes, assets, or both
 
+`<Tldraw>` registers the default handlers before it runs your `onMount`, so any handler you register in `onMount` replaces the default for that type.
+
 ## Content types
 
-The system supports these content types:
+Every content type carries an optional `point` (where to place the content) and `sources`, the other formats found on the clipboard alongside it (`text` with a `subtype` of `html`, `text`, `url`, or `json`, plus `tldraw`, `excalidraw`, and `error`).
+
+```typescript
+interface TLBaseExternalContent {
+	sources?: TLExternalContentSource[]
+	point?: VecLike
+}
+```
 
 ### Text
 
-Text content comes from clipboard paste operations. The handler receives `text` (plain text), optional `html` (HTML markup), and `point` (where to place the content). The default handler creates text shapes, detecting right-to-left languages and handling multi-line text.
+Text content comes from clipboard paste operations. The handler receives `text` (plain text) and optional `html`. The default handler creates a text shape, converting HTML to rich text when it's present, detecting right-to-left languages, and left-aligning multi-line text.
 
 ```typescript
-interface TLTextExternalContent {
+interface TLTextExternalContent extends TLBaseExternalContent {
 	type: 'text'
 	text: string
 	html?: string
-	point?: VecLike
-	sources?: TLExternalContentSource[]
 }
 ```
 
 ### Files
 
-File content represents one or more files dropped onto the canvas. The handler receives an array of `File` objects and validates file types and sizes before creating shapes.
+File content represents one or more files dropped onto the canvas. The handler receives an array of `File` objects and validates file types and sizes before creating shapes. The `<Tldraw>` props `maxAssetSize`, `maxImageDimension`, `acceptedImageMimeTypes`, and `acceptedVideoMimeTypes` control those limits, and `editor.options.maxFilesAtOnce` caps the batch.
 
 ```typescript
-interface TLFilesExternalContent {
+interface TLFilesExternalContent extends TLBaseExternalContent {
 	type: 'files'
 	files: File[]
-	point?: VecLike
-	ignoreParent?: boolean
 }
 ```
 
@@ -103,15 +104,14 @@ The default handler creates temporary previews for images, uploads the files, an
 
 ### File replace
 
-File replace content handles replacing an existing image or video shape's asset. This is used when a user drags a new file onto an existing image shape.
+File replace content swaps an existing image or video shape's asset. The Replace media action dispatches it through [Editor#replaceExternalContent](?).
 
 ```typescript
-interface TLFileReplaceExternalContent {
+interface TLFileReplaceExternalContent extends TLBaseExternalContent {
 	type: 'file-replace'
 	file: File
 	shapeId: TLShapeId
 	isImage: boolean // Deprecated: no longer used by the default handler
-	point?: VecLike
 }
 ```
 
@@ -119,25 +119,23 @@ The default handler validates the file, creates a new asset, and updates the tar
 
 ### URLs
 
-URL content represents a URL to insert. The default handler checks if the URL matches a known embed pattern (YouTube, Figma, etc.) and creates an embed shape. Otherwise, it fetches Open Graph metadata and creates a bookmark shape.
+URL content represents a URL to insert. The default handler rejects invalid URLs with a toast, then checks if the URL matches a known embed pattern (YouTube, Figma, etc.) and creates an embed shape. Otherwise, it fetches Open Graph metadata and creates a bookmark shape.
 
 ```typescript
-interface TLUrlExternalContent {
+interface TLUrlExternalContent extends TLBaseExternalContent {
 	type: 'url'
 	url: string
-	point?: VecLike
 }
 ```
 
 ### SVG text
 
-SVG text content handles raw SVG markup. The handler parses the SVG, extracts dimensions, creates an image asset, and inserts an image shape.
+SVG text content handles raw SVG markup. The handler sanitizes and parses the SVG, extracts dimensions, creates an image asset, and inserts an image shape.
 
 ```typescript
-interface TLSvgTextExternalContent {
+interface TLSvgTextExternalContent extends TLBaseExternalContent {
 	type: 'svg-text'
 	text: string
-	point?: VecLike
 }
 ```
 
@@ -146,11 +144,10 @@ interface TLSvgTextExternalContent {
 Embed content creates embed shapes for embeddable URLs like YouTube videos. This content type is usually invoked by the URL handler when it detects an embeddable URL.
 
 ```typescript
-interface TLEmbedExternalContent<EmbedDefinition> {
+interface TLEmbedExternalContent<EmbedDefinition> extends TLBaseExternalContent {
 	type: 'embed'
 	url: string
 	embed: EmbedDefinition
-	point?: VecLike
 }
 ```
 
@@ -159,10 +156,9 @@ interface TLEmbedExternalContent<EmbedDefinition> {
 These handlers process serialized content from other tldraw editors or Excalidraw. The `tldraw` handler calls `putContentOntoCurrentPage` to insert shapes. The `excalidraw` handler converts Excalidraw shapes to tldraw equivalents.
 
 ```typescript
-interface TLTldrawExternalContent {
+interface TLTldrawExternalContent extends TLBaseExternalContent {
 	type: 'tldraw'
 	content: TLContent
-	point?: VecLike
 }
 ```
 
@@ -170,14 +166,16 @@ interface TLTldrawExternalContent {
 
 Asset handlers turn external files and URLs into asset records. There are two asset handler types:
 
-| Type   | Input         | Output                                  |
-| ------ | ------------- | --------------------------------------- |
-| `file` | `File` object | Image or video asset record             |
-| `url`  | URL string    | Bookmark asset with Open Graph metadata |
+| Type   | Input         | Output                                                                                          |
+| ------ | ------------- | ----------------------------------------------------------------------------------------------- |
+| `file` | `File` object | An asset record from whichever [AssetUtil](?) accepts the MIME type (image or video by default) |
+| `url`  | URL string    | Bookmark asset with Open Graph metadata                                                         |
 
-The `file` handler extracts dimensions and file size, uploads the file via `editor.uploadAsset`, and returns an asset record. The `url` handler fetches the page's Open Graph metadata (title, description, image) and creates a bookmark asset.
+The default `file` handler checks the file's type and size, sanitizes SVGs, asks the matching asset util for an asset record, uploads the file via `editor.uploadAsset`, and returns the record. To support a new file type, register a custom [AssetUtil](?) (see [Assets](/sdk-features/assets)) rather than replacing this handler. The `url` handler fetches the page's Open Graph metadata (title, description, image) and creates a bookmark asset.
 
 ```typescript
+import { AssetRecordType, MediaHelpers } from 'tldraw'
+
 editor.registerExternalAssetHandler('file', async ({ file, assetId }) => {
 	const size = await MediaHelpers.getImageSize(file)
 
@@ -191,7 +189,7 @@ editor.registerExternalAssetHandler('file', async ({ file, assetId }) => {
 			w: size.w,
 			h: size.h,
 			mimeType: file.type,
-			isAnimated: false,
+			isAnimated: await MediaHelpers.isAnimated(file),
 			fileSize: file.size,
 		},
 		meta: {},
@@ -248,44 +246,36 @@ editor.registerExternalContentHandler('text', null)
 
 ## Customizing handlers
 
-Register a new handler to replace the default behavior for any content type. Your handler receives the content object and can create shapes, insert assets, or do anything else.
+Register a new handler to replace the default behavior for any content type. Your handler receives the content object and can create shapes, insert assets, or do anything else. To extend rather than replace, call the default handler from your custom handler, as the example at the top of this page does for text.
 
-To extend rather than replace, call the default handler from your custom handler:
+The default handlers are exported from `tldraw`. Some of them take a third [TLDefaultExternalContentHandlerOpts](?) argument carrying `toasts`, `msg`, and the file limits from `<Tldraw>`; get `toasts` and `msg` from [useToasts](?) and [useTranslation](?) (or [useDefaultHelpers](?)) inside the UI.
+
+| Handler                                   | Extra options |
+| ----------------------------------------- | ------------- |
+| `defaultHandleExternalTextContent`        | No            |
+| `defaultHandleExternalSvgTextContent`     | No            |
+| `defaultHandleExternalEmbedContent`       | No            |
+| `defaultHandleExternalTldrawContent`      | No            |
+| `defaultHandleExternalExcalidrawContent`  | No            |
+| `defaultHandleExternalFileContent`        | Yes           |
+| `defaultHandleExternalFileReplaceContent` | Yes           |
+| `defaultHandleExternalUrlContent`         | Yes           |
+| `defaultHandleExternalFileAsset`          | Yes           |
+| `defaultHandleExternalUrlAsset`           | Yes           |
 
 ```typescript
-import { defaultHandleExternalTextContent } from 'tldraw'
+import { defaultHandleExternalFileContent, useToasts, useTranslation } from 'tldraw'
 
-editor.registerExternalContentHandler('text', async (content) => {
-	// Custom handling for HTML
-	const htmlSource = content.sources?.find((s) => s.type === 'text' && s.subtype === 'html')
-	if (htmlSource) {
-		const center = content.point ?? editor.getViewportPageBounds().center
-		editor.createShape({
-			type: 'my-html-shape',
-			x: center.x,
-			y: center.y,
-			props: { html: htmlSource.data },
-		})
-		return
-	}
+const toasts = useToasts()
+const msg = useTranslation()
 
-	// Fall back to default for plain text
-	await defaultHandleExternalTextContent(editor, content)
+editor.registerExternalContentHandler('files', async (content) => {
+	const small = content.files.filter((file) => file.size < 1024 * 1024)
+	await defaultHandleExternalFileContent(editor, { ...content, files: small }, { toasts, msg })
 })
 ```
 
-The default handlers are exported from `tldraw`:
-
-- `defaultHandleExternalTextContent`
-- `defaultHandleExternalFileContent`
-- `defaultHandleExternalUrlContent`
-- `defaultHandleExternalSvgTextContent`
-- `defaultHandleExternalEmbedContent`
-- `defaultHandleExternalTldrawContent`
-- `defaultHandleExternalExcalidrawContent`
-- `defaultHandleExternalFileAsset`
-- `defaultHandleExternalUrlAsset`
-- `defaultHandleExternalFileReplaceContent`
+For clipboard-only hooks that run before parsing or before the handler (`onClipboardPasteRaw`, `onBeforePasteFromClipboard`, `onBeforeCopyToClipboard`), see [Clipboard](/sdk-features/clipboard).
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/focus.mdx
+++ b/apps/docs/content/sdk-features/focus.mdx
@@ -18,7 +18,7 @@ accuracy: 10
 notes: ''
 ---
 
-Focus determines whether the editor receives keyboard shortcuts, scroll wheel gestures, and pointer move events. When focused, these inputs go to the editor. When unfocused, they pass through to the rest of your page.
+Focus determines whether the editor receives keyboard shortcuts and scroll wheel gestures. When focused, these inputs go to the editor. When unfocused, they pass through to the rest of your page.
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -27,7 +27,16 @@ import 'tldraw/tldraw.css'
 export default function App() {
 	return (
 		<div style={{ position: 'fixed', inset: 0 }}>
-			<Tldraw autoFocus={true} />
+			<Tldraw
+				autoFocus={false}
+				onMount={(editor) => {
+					// Focus later, for example when the user clicks the canvas
+					const container = editor.getContainer()
+					const focus = () => editor.focus()
+					container.addEventListener('pointerdown', focus)
+					return () => container.removeEventListener('pointerdown', focus)
+				}}
+			/>
 		</div>
 	)
 }
@@ -50,18 +59,20 @@ editor.focus({ focusContainer: false })
 editor.blur({ blurContainer: false })
 ```
 
+Both are no-ops when the editor is already in that state. If the editor is focused but the container has lost DOM focus, call `editor.getContainer().focus()` directly.
+
 ### Focus/blur options
 
 | Method  | Option           | Default | Description                                             |
 | ------- | ---------------- | ------- | ------------------------------------------------------- |
-| `focus` | `focusContainer` | `true`  | Whether to also dispatch a DOM focus event to container |
-| `blur`  | `blurContainer`  | `true`  | Whether to also dispatch a DOM blur event to container  |
+| `focus` | `focusContainer` | `true`  | Whether to also call `focus()` on the container element |
+| `blur`  | `blurContainer`  | `true`  | Whether to also call `blur()` on the container element  |
 
 ## Why focus is separate from DOM focus
 
-The editor tracks focus separately from the browser's DOM focus. The browser's focus model isn't reliable enough for an editor like tldraw. Iframes aren't considered descendants of their parent elements, many menus are portalled into different parts of the document tree, and the document's active element can be unpredictable.
+The editor tracks focus separately from the browser's DOM focus. The browser's focus model isn't reliable enough for an editor like tldraw: iframes aren't considered descendants of their parent elements, and many menus are portalled into other parts of the document tree.
 
-The editor maintains its own `isFocused` state in the instance record. This lets you distinguish between "editor focus" (whether the editor responds to keyboard shortcuts) and "element focus" (which HTML element is active in the DOM).
+The editor maintains its own `isFocused` state in the instance record, readable with the reactive [Editor#getIsFocused](?). This lets you distinguish between "editor focus" (whether the editor responds to keyboard shortcuts) and "element focus" (which HTML element is active in the DOM).
 
 When `isFocused` changes, the editor adds or removes the `tl-container__focused` CSS class on the container. Use this class for styling instead of `:focus` or `:focus-within` pseudo-selectors, which can't reliably detect editor focus.
 
@@ -77,17 +88,21 @@ The `autoFocus` prop controls whether the editor focuses when it mounts. It defa
 
 The editor manages focus ring visibility for accessibility. Focus rings appear around focused elements during keyboard navigation but are hidden during mouse interactions.
 
-When you press Tab, ArrowUp, or ArrowDown, the editor removes the `tl-container__no-focus-ring` class to show focus rings. Mouse clicks add the class back to hide them. Focus rings also stay hidden during shape editing.
+When you press Tab, ArrowUp, or ArrowDown, the editor removes the `tl-container__no-focus-ring` class to show focus rings. Mouse clicks add the class back to hide them. Focus rings stay hidden while editing a shape, and while the container itself is focused with shapes selected (arrow keys nudge shapes then).
 
 ## Completing interactions on blur
 
-When you call `editor.blur()`, it calls `editor.complete()` to finish any ongoing interaction like a drag or draw operation. This prevents the editor from being left in an incomplete state when focus is lost.
+When you call `editor.blur()`, it calls `editor.complete()` to finish any ongoing interaction like a drag or draw operation. This prevents the editor from being left mid-interaction when focus is lost.
 
 ## Multiple editors
 
 When you have multiple editors on the same page, you'll need to manage focus yourself. The browser's DOM focus alone isn't enough to reliably switch which editor receives keyboard input.
 
 ```tsx
+import { useState } from 'react'
+import { Editor, Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
 function MultipleEditors() {
 	const [editors, setEditors] = useState<Editor[]>([])
 
@@ -114,7 +129,9 @@ function MultipleEditors() {
 }
 ```
 
+This switches focus when a wrapper receives DOM focus. To also blur when the user clicks elsewhere on the page, listen for pointer down on the page as the [multiple editors example](/examples/layout/multiple) does.
+
 ## Related examples
 
-- [Editor focus](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/editor-focus) - Control editor focus with focus and blur methods.
-- [Multiple editors](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/layout/multiple) - Manage focus between multiple tldraw instances.
+- [Editor focus](/examples/editor-api/editor-focus) - Control editor focus with focus and blur methods.
+- [Multiple editors](/examples/layout/multiple) - Manage focus between multiple tldraw instances.

--- a/apps/docs/content/sdk-features/frame-shape.mdx
+++ b/apps/docs/content/sdk-features/frame-shape.mdx
@@ -13,7 +13,7 @@ status: published
 date: 5/6/2026
 ---
 
-The frame shape is a container with a labeled header that holds other shapes. Children of a frame are clipped to its bounds, follow the frame when it moves, and export together as a single image. Frames are useful for laying out artboards, screen mockups, slides, and any visual region that should travel as one unit.
+The frame shape is a container with a labeled header that holds other shapes. Children of a frame are clipped to its bounds, follow the frame when it moves, and export together as a single image. Frames are useful for laying out artboards, screen mockups, slides, and any visual region that should travel as one unit. See [FrameShapeUtil](?) and [TLFrameShape](?).
 
 ```tsx
 editor.createShape({
@@ -31,7 +31,7 @@ editor.createShape({
 
 ## Creating frames
 
-You can create a frame programmatically with `editor.createShape`, or interactively with the frame tool. The frame tool ships in the default toolbar; users can also press `F` to switch to it.
+You can create a frame programmatically with [Editor#createShape](?), or interactively with the frame tool. The frame tool ships in the default toolbar; users can also press `F` to switch to it. The **Frame selection** action (`Cmd/Ctrl+Alt+G`) wraps the current selection in a new frame.
 
 When the user drags a frame around existing shapes, the frame tool reparents any sibling shapes that fall fully inside the frame's bounds. Locked shapes are skipped. This is what makes "draw a frame around the things I want to group" work as a single gesture.
 
@@ -39,15 +39,15 @@ Children inside a frame use coordinates relative to the frame's origin. Moving t
 
 ## Frame header
 
-Every frame renders a heading above its top edge that displays the frame's `name` property. Double-click the heading to start editing the name. The heading rotates with the frame to stay above whichever edge is currently "up", so it remains readable.
+Every frame renders a heading above its top edge that displays the frame's `name` property. Click the heading to edit the name; pressing Enter with a frame selected does not enter edit mode. The heading rotates with the frame to stay above whichever edge is currently "up", so it remains readable.
 
-Empty names render as `Frame` in exports so unnamed frames still get a label. The shape's `name` is also exposed via [ShapeUtil#getAriaDescriptor](?) so screen readers announce it during keyboard navigation.
+Empty names render as `Frame` so unnamed frames still get a label. The shape's `name` is also exposed via [ShapeUtil#getAriaDescriptor](?) so screen readers announce it during keyboard navigation.
 
 ## Child clipping
 
-Frames clip their children to the frame's rectangle during rendering. A shape that extends past the frame edge is rendered up to the boundary and then cut off. Clipping is purely visual — the shape's geometry, hit testing, and bounds are unchanged.
+Frames clip their children to the frame's rectangle during rendering. A shape that extends past the frame edge is rendered up to the boundary and then cut off. Clipping doesn't change the child's geometry or its own bounds, but hit testing respects the mask: you can't click the clipped-off part of a shape, and [Editor#getShapeMaskedPageBounds](?) returns only the visible portion. Arrows are exempt from clipping so connectors can leave a frame.
 
-The `BaseFrameLikeShapeUtil` base class implements clipping via `getClipPath`. If you need clipping for a custom container shape, see the [Frames](/sdk-features/shapes#frames) section in the Shapes guide.
+The [BaseFrameLikeShapeUtil](?) base class implements clipping via `getClipPath` and the arrow exemption via `shouldClipChild`. If you need clipping for a custom container shape, see the [Frames](/sdk-features/shapes#frames) section in the Shapes guide.
 
 ## Shape properties
 
@@ -85,25 +85,15 @@ export default function App() {
 }
 ```
 
-When `showColors` is on, `color` becomes a real style property — users can change it from the style panel and it syncs across selections like other styles. With `showColors` off (the default), `color` still validates and persists, but the frame renders with a neutral palette so it doesn't compete visually with the shapes inside it.
+When `showColors` is on, `color` becomes a real style property: users can change it from the style panel and it syncs across selections like other styles. With `showColors` off (the default), `color` still validates and persists, but the frame renders with a neutral palette so it doesn't compete visually with the shapes inside it.
 
 ## Frame helpers
 
-The editor exposes helpers that work with frames and any other shape that opts into frame-like behavior.
-
-### Detecting frames
-
-```tsx
-// Check whether a shape is a frame (or a custom frame-like shape)
-const shape = editor.getShape(shapeId)
-if (shape && editor.isShapeFrameLike(shape)) {
-	// ...
-}
-```
+The editor exposes helpers that work with frames and any other shape that opts into frame-like behavior. Use [Editor#isShapeFrameLike](?) to check whether a shape is a frame or a custom frame-like shape.
 
 ### Fitting a frame to its content
 
-`fitFrameToContent` resizes a frame so it tightly wraps its children, with a configurable padding. Use it after the user has finished arranging shapes inside an artboard:
+[fitFrameToContent](?) resizes a frame so it tightly wraps its children, with a configurable padding (50 by default). Double-clicking a frame's corner handle does the same with a padding of 10; double-clicking an edge handle fits only that axis.
 
 ```tsx
 import { fitFrameToContent } from 'tldraw'
@@ -116,7 +106,7 @@ fitFrameToContent(editor, frameId, { padding: 24 })
 
 ### Removing a frame
 
-`removeFrame` deletes a frame but preserves its children — they're moved out of the frame and reselected so they survive:
+[removeFrame](?) deletes a frame but preserves its children: they're moved out of the frame and reselected.
 
 ```tsx
 import { removeFrame } from 'tldraw'
@@ -124,28 +114,28 @@ import { removeFrame } from 'tldraw'
 removeFrame(editor, [frameId])
 ```
 
-This is also wired up to the **Remove frame** action (`Cmd/Ctrl+Shift+F`) and the **Fit frame to content** action in the actions menu and context menu when a frame is selected.
+The **Remove frame** and **Fit frame to content** actions in the main menu and the context menu's Edit submenu call these helpers when a frame is selected. **Frame selection** (`Cmd/Ctrl+Alt+G`) also removes frames when every selected shape is a frame.
 
 ## Exporting frames
 
-Frames are export bounds containers — `FrameShapeUtil.isExportBoundsContainer()` returns `true`. When a frame contains all the other shapes in an export, the export pipeline skips the usual padding around the result and uses the frame's bounds exactly. The export still includes every descendant of the frame.
+Frames are export bounds containers: [ShapeUtil#isExportBoundsContainer](?) returns `true`. When a frame contains all the other shapes in an export, the export pipeline skips the usual padding around the result and uses the frame's bounds exactly. The export still includes every descendant of the frame.
 
-This makes frames ideal for mockup-style workflows where you need pixel-perfect output at a specific aspect ratio — design the frame, drop content inside, export.
+This suits mockup workflows where you need output at a specific aspect ratio: design the frame, drop content inside, export.
 
 ## Frames vs. groups
 
 Frames and groups both contain other shapes, but they solve different problems:
 
-|                              | Frame                                   | Group                            |
-| ---------------------------- | --------------------------------------- | -------------------------------- |
-| Visible on the canvas        | Yes — bordered rectangle with a heading | No — no visual representation    |
-| Clips children to its bounds | Yes                                     | No                               |
-| Has a fixed size and shape   | Yes (`w`, `h`, position)                | No (geometry follows children)   |
-| Used for export bounds       | Yes                                     | No                               |
-| Auto-deletes when empty      | No                                      | Yes (when last child is removed) |
-| Created by                   | Frame tool or `editor.createShape`      | `editor.groupShapes(...)`        |
+|                              | Frame                                    | Group                                   |
+| ---------------------------- | ---------------------------------------- | --------------------------------------- |
+| Visible on the canvas        | Yes, a bordered rectangle with a heading | No                                      |
+| Clips children to its bounds | Yes                                      | No                                      |
+| Has a fixed size and shape   | Yes (`w`, `h`, position)                 | No (geometry follows children)          |
+| Used for export bounds       | Yes                                      | No                                      |
+| Auto-deletes when empty      | No                                       | Yes (collapses at one or zero children) |
+| Created by                   | Frame tool or `editor.createShape`       | [Editor#groupShapes](?)                 |
 
-Reach for a frame when you want a labeled, bounded region — a slide, a screen, an artboard. Reach for a group when you just need to move several shapes together without changing their visual layout.
+Reach for a frame when you want a labeled, bounded region: a slide, a screen, an artboard. Reach for a group when you need to move several shapes together without changing their visual layout.
 
 ## Related articles
 

--- a/apps/docs/content/sdk-features/geo-shape.mdx
+++ b/apps/docs/content/sdk-features/geo-shape.mdx
@@ -19,7 +19,7 @@ status: published
 date: 1/31/2026
 ---
 
-The geo shape is one of the default shapes in tldraw. It renders geometric primitives—rectangles, ellipses, stars, clouds, and 16 other forms—with optional rich text labels. Geo shapes are the usual building blocks for flowcharts and diagrams.
+The geo shape is one of the default shapes in tldraw. It renders one of 20 built-in geometric forms (rectangles, ellipses, stars, clouds, and more) with an optional rich text label. Geo shapes are the usual building blocks for flowcharts and diagrams.
 
 ## Geometric forms
 
@@ -115,7 +115,7 @@ editor.createShape({
 })
 ```
 
-The label text automatically wraps within the shape bounds. When text overflows the shape height, the shape grows vertically to accommodate it. The `growY` property tracks this additional height.
+The label text wraps within the shape bounds. When text overflows the shape height, the shape grows vertically and tracks the extra height in `growY`. If the label's minimum width is wider than the shape, the shape widens to fit it.
 
 ### Changing the geometric form
 
@@ -140,6 +140,8 @@ import { GeoShapeGeoStyle } from 'tldraw'
 // Set the default geo style to star
 editor.setStyleForNextShapes(GeoShapeGeoStyle, 'star')
 ```
+
+The geo tool's toolbar shortcuts are R for rectangle and O for ellipse.
 
 ## Using the geo tool
 
@@ -186,10 +188,12 @@ When tool lock is enabled (via the toolbar or `editor.updateInstanceState({ isTo
 | `growY`         | `number`                        | Additional vertical space for text overflow                 |
 | `url`           | `string`                        | Optional hyperlink URL                                      |
 | `scale`         | `number`                        | Scale factor applied to the shape                           |
+| `flipX`         | `boolean`                       | Mirror the shape horizontally                               |
+| `flipY`         | `boolean`                       | Mirror the shape vertically                                 |
 
 ## Configuration options
 
-Configure the geo shape utility to adjust rendering behavior:
+Configure [GeoShapeUtil](?) to adjust rendering behavior:
 
 | Option            | Type      | Default | Description                                                                                      |
 | ----------------- | --------- | ------- | ------------------------------------------------------------------------------------------------ |
@@ -211,7 +215,7 @@ Pass the configured utility to the `shapeUtils` prop:
 
 ## Custom geo types
 
-Register custom geo types via `customGeoTypes` to add new shapes that inherit all standard geo behavior — labels, fill/dash/color styling, resizing, SVG export, and hyperlinks — while providing their own path geometry, snap behavior, creation size, and style panel icon. This lets you extend the built-in geo enum without forking `GeoShapeUtil`.
+Register custom geo types via `customGeoTypes` to add new forms without forking [GeoShapeUtil](?). Custom types inherit all standard geo behavior (labels, fill/dash/color styling, resizing, SVG export, and hyperlinks) and provide their own path geometry, snap behavior, creation size, and style panel icon.
 
 ```tsx
 import { GeoShapeUtil, PathBuilder } from 'tldraw'
@@ -241,7 +245,7 @@ const MyGeoShapeUtil = GeoShapeUtil.configure({
 })
 ```
 
-Each entry in `customGeoTypes` is a `GeoTypeDefinition`:
+Each entry in `customGeoTypes` is a [GeoTypeDefinition](?). Keys that collide with a built-in form are ignored with a console warning.
 
 | Field           | Type                                        | Description                                                                                          |
 | --------------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
@@ -279,9 +283,11 @@ When the label text exceeds the shape's height, the shape automatically grows by
 
 Geo shapes resize from any corner or edge handle. When resizing a shape with a label:
 
-- The shape respects a minimum unscaled size of 51 × 51 pixels when it contains text
-- The shape won't shrink smaller than the label's required dimensions
-- `growY` resets to 0 when you resize, letting the shape recalculate the needed height
+- The shape won't shrink smaller than the label's measured dimensions
+- `growY` resets to 0 when you resize, and the shape recalculates the needed height
+- Dragging a handle past the opposite edge flips the shape by toggling `flipX` or `flipY`
+
+When you first add a label to a shape smaller than 51 × 51 unscaled pixels, the shape grows to at least that size and becomes square.
 
 ## Special interactions
 
@@ -295,10 +301,7 @@ The cloud shape generates its bumps procedurally based on the shape's ID. Each c
 
 ### Handle snap geometry
 
-Arrows snap to geo shapes at meaningful positions:
-
-- **Polygon-based shapes** (rectangle, triangle, pentagon, etc.): Arrows snap to each vertex and the center
-- **Curved shapes** (ellipse, oval, cloud, heart): Arrows snap only to the center point
+When you drag a line handle (or any custom handle with `snapType` set) near a geo shape, it snaps to the shape's outline. Polygon-based forms (rectangle, triangle, pentagon, and so on) also snap to each vertex and the center; curved forms (ellipse, oval, cloud, heart) snap only to the center. Arrow terminals bind to geo shapes through a separate system; see [Bindings](/sdk-features/bindings).
 
 ## Dynamic resize mode
 
@@ -331,7 +334,7 @@ Click the link button to open the URL in a new tab.
 
 ## Path rendering
 
-Geo shapes use a path-based rendering system. Each geometric form—built-in or custom—has a `GeoTypeDefinition` whose `getPath` method generates the outline used for both fills and strokes. The same path drives solid, semi-transparent, and pattern fills as well as solid, dashed, and dotted stroke styles. Path calculations are cached per shape.
+Geo shapes use a path-based rendering system. Each geometric form, built-in or custom, has a [GeoTypeDefinition](?) whose `getPath` method generates the outline used for both fills and strokes. The same path drives solid, semi-transparent, and pattern fills as well as solid, dashed, and dotted stroke styles. Path calculations are cached per shape.
 
 When the `dash` property is set to `'draw'`, the shape renders with organic, hand-drawn strokes. The randomness is seeded by the shape's ID, so each shape's hand-drawn look stays stable across renders.
 
@@ -342,7 +345,7 @@ The shape's geometry returns a [Group2d](?) containing:
 1. The outline path geometry (polygon or curve depending on the form)
 2. A label rectangle for hit testing text interactions
 
-This compound geometry enables accurate point-in-shape detection for both the shape outline and its text label.
+The label rectangle is excluded from the shape's bounds but used for hit testing.
 
 ## Related articles
 

--- a/apps/docs/content/sdk-features/geometry.mdx
+++ b/apps/docs/content/sdk-features/geometry.mdx
@@ -18,11 +18,11 @@ accuracy: 9
 notes: Point2d margin parameter documentation could clarify its actual usage in hitTestLineSegment.
 ---
 
-Geometry in tldraw is a mathematical description of a shape's form. Each shape has a [Geometry2d](?) that defines its outline, bounds, and spatial properties. When you click to select a shape, the geometry determines whether the click hit. When you brush a selection box, the geometry calculates intersections. When you snap an arrow to a shape's edge, the geometry provides the nearest point. For the broader shape system, see [Shapes](/docs/shapes).
+Geometry in tldraw is a mathematical description of a shape's form. Each shape has a [Geometry2d](?) that defines its outline, bounds, and spatial properties. The editor uses it to decide whether a click hit the shape, whether a selection brush intersects it, and where an arrow should snap to its edge. For the broader shape system, see [Shapes](/sdk-features/shapes).
 
 ## How geometry works
 
-Each [ShapeUtil](?) implements a [ShapeUtil#getGeometry](?) method that returns a [Geometry2d](?) instance. The editor calls this method to calculate bounds, test hits, find intersections, and measure distances.
+Each [ShapeUtil](?) implements a [ShapeUtil#getGeometry](?) method that returns a [Geometry2d](?) instance. The editor calls this method to calculate bounds, test hits, find intersections, and measure distances. It receives an optional [TLGeometryOpts](?) with a `context` string, and callers can pass the same option to [Editor#getShapeGeometry](?) to request context-specific geometry.
 
 ```typescript
 class MyShapeUtil extends ShapeUtil<MyShape> {
@@ -220,7 +220,7 @@ new Group2d({
 })
 ```
 
-Group2d is essential for shapes with multiple parts. The geo shape uses it to combine its outline with its label bounds. The arrow shape uses it to combine the arrow body with its label.
+Use Group2d for shapes with multiple parts. The geo shape uses it to combine its outline with its label bounds. The arrow shape uses it to combine the arrow body with its label. Nested groups are flattened: a Group2d passed as a child contributes its own children.
 
 ## Geometry operations
 
@@ -244,7 +244,7 @@ Get the points that define the geometry's outline:
 const vertices = geometry.vertices // Vec[]
 ```
 
-For curves, this returns a discretized approximation with enough points to represent the curve accurately.
+For curves, this returns a discretized approximation. By default `vertices` excludes label geometry.
 
 ### Hit testing
 
@@ -256,11 +256,13 @@ geometry.hitTestPoint(point, margin, hitInside)
 
 The `margin` expands the hit area. The `hitInside` parameter controls whether points inside unfilled shapes count as hits.
 
-Test if a line segment intersects the geometry:
+Test if a line segment passes within `distance` of the geometry:
 
 ```typescript
 geometry.hitTestLineSegment(A, B, distance)
 ```
+
+After a hit succeeds, the editor calls `geometry.ignoreHit(point)`. Override it to reject hits at specific points and let shapes behind this one be selected instead; the image shape uses this for transparent pixels.
 
 ### Distance and intersection
 
@@ -278,10 +280,12 @@ const distance = geometry.distanceToPoint(point)
 
 Negative distances mean the point is inside a filled geometry.
 
-Get intersection points with a line segment:
+Get intersection points with a line segment, circle, polygon, or polyline:
 
 ```typescript
 const intersections = geometry.intersectLineSegment(A, B)
+const circleHits = geometry.intersectCircle(center, radius)
+const polygonHits = geometry.intersectPolygon(points)
 ```
 
 ### Length, area, and interpolation
@@ -292,6 +296,8 @@ Get the perimeter length and area:
 const length = geometry.length // perimeter length
 const area = geometry.area // enclosed area (0 for open paths)
 ```
+
+A Group2d reports the area of its first child, not the union of its children.
 
 Find a point at a fraction along the edge:
 
@@ -356,7 +362,7 @@ getGeometry(shape: MyShape) {
 }
 ```
 
-The `isLabel` property marks geometry that represents text labels. This affects filtering in some operations.
+The `isLabel` property marks geometry that represents text labels; see [Geometry filtering](#Geometry-filtering).
 
 ### Custom polygons
 
@@ -416,7 +422,7 @@ const geometry = editor.getShapeGeometry(shape)
 const pageBounds = editor.getShapePageBounds(shape)
 ```
 
-The cache invalidates automatically when shape props change. You don't need to manage invalidation yourself.
+The cache invalidates automatically when a shape's props or meta change. You don't need to manage invalidation yourself.
 
 ## Geometry filtering
 
@@ -449,7 +455,7 @@ The geometry system provides filter presets for common scenarios:
 | `EXCLUDE_LABELS`       | No              | Yes               |
 | `EXCLUDE_INTERNAL`     | Yes             | No                |
 
-Most operations use `EXCLUDE_NON_STANDARD` by default, which gives you the shape's main outline without labels or internal geometry.
+The `vertices` and `length` getters, and Group2d's hit tests, default to `EXCLUDE_LABELS`: labels are left out but internal geometry is included. Arrow routing passes `EXCLUDE_NON_STANDARD` to get the bare outline. Pass a filter explicitly to any method that accepts one when you need something else.
 
 ## Advanced options
 
@@ -471,11 +477,9 @@ const label = new Rectangle2d({
 })
 ```
 
-This is useful for labels and other auxiliary geometry that shouldn't change the shape's overall size.
-
 ### ignore
 
-When set on geometry inside a Group2d, that geometry is placed in an `ignoredChildren` array and won't participate in the group's operations like hit testing, bounds calculation, or rendering.
+When set on geometry inside a Group2d, that geometry is placed in an `ignoredChildren` array and won't participate in the group's hit testing, bounds, or other queries. The geometry debug view still draws it.
 
 ```typescript
 new Group2d({
@@ -502,20 +506,20 @@ new Rectangle2d({
 })
 ```
 
-Enable the geometry debug view through the debug panel to visualize shape geometry during development.
+Turn on the `debugGeometry` flag in the debug menu to draw shape geometry on the canvas during development.
 
 ## Transformed geometry
 
-The [TransformedGeometry2d](?) class wraps a geometry with a transformation matrix. This is useful when you need geometry in a different coordinate space without creating new geometry objects.
+The [TransformedGeometry2d](?) class wraps a geometry with a transformation matrix, so you can query it in a different coordinate space without rebuilding it. Group shapes use this to combine their children's geometry in the group's local space.
 
 ```typescript
 const transformed = geometry.transform(matrix)
 ```
 
-All operations on the transformed geometry apply the transformation automatically. One limitation: transformed geometry doesn't support `getSvgPathData()`—you'll need to transform the path data yourself if you need it.
+All operations on the transformed geometry apply the transformation automatically. One limitation: transformed geometry throws from `getSvgPathData()`. Call it on the source geometry and transform the result if you need path data.
 
 ## Related examples
 
-- **[Custom shape geometry](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-geometry)** - A house-shaped custom shape using Polygon2d and Group2d geometry.
-- **[Cubic bezier curve shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/cubic-bezier-shape)** - Interactive bezier curve editing with CubicBezier2d geometry and custom handles.
-- **[Custom bounds snapping](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/bounds-snapping-shape)** - Playing card shapes with custom snap geometry so they stack with visible icons.
+- **[Custom shape geometry](/examples/shapes/tools/shape-with-geometry)** - A house-shaped custom shape using Polygon2d and Group2d geometry.
+- **[Cubic bezier curve shape](/examples/shapes/tools/cubic-bezier-shape)** - Interactive bezier curve editing with CubicBezier2d geometry and custom handles.
+- **[Custom bounds snapping](/examples/shapes/tools/bounds-snapping-shape)** - Playing card shapes with custom snap geometry so they stack with visible icons.

--- a/apps/docs/content/sdk-features/grid.mdx
+++ b/apps/docs/content/sdk-features/grid.mdx
@@ -58,12 +58,22 @@ When grid mode is on, the editor snaps positions to multiples of `gridSize` duri
 
 - Creating a shape by clicking or dragging with a box tool
 - Translating shapes with the select tool
-- Resizing shapes with the selection handles
+- Resizing and cropping shapes with the selection handles
+- Nudging shapes with the arrow keys (one grid unit per press, five with Shift)
+- Dragging unbound arrow and line handles
 - Dropping external content (like images) onto the canvas
 
-Holding Cmd (Ctrl on Windows) while translating or resizing bypasses grid snapping. During translation, grid snapping also yields to [shape snapping](/sdk-features/snapping): if the selection has snapped to another shape's alignment guides, the grid is ignored.
+Holding Cmd (Ctrl on Windows) while translating, resizing, or cropping bypasses grid snapping. During translation, grid snapping also yields to [shape snapping](/sdk-features/snapping): if the selection has snapped to another shape's alignment guides, the grid is ignored.
 
-To snap your own values to the grid, use [Vec#snapToGrid](?):
+To snap your own values to the grid, use [maybeSnapToGrid](?), which returns the point snapped when grid mode is on and unchanged otherwise:
+
+```tsx
+import { maybeSnapToGrid } from 'tldraw'
+
+const point = maybeSnapToGrid(editor.inputs.getCurrentPagePoint(), editor)
+```
+
+To snap regardless of grid mode, use [Vec#snapToGrid](?) with the size from [Editor#getDocumentSettings](?):
 
 ```tsx
 const gridSize = editor.getDocumentSettings().gridSize
@@ -77,10 +87,10 @@ The [DefaultGrid](?) component draws the grid as SVG dot patterns. It renders on
 | Field  | Description                                           |
 | ------ | ----------------------------------------------------- |
 | `step` | Dot spacing as a multiple of the document's grid size |
-| `min`  | Zoom level below which the dots are hidden            |
+| `min`  | Zoom level at which the dots start to fade in         |
 | `mid`  | Zoom level at which the dots reach full opacity       |
 
-The defaults show fine dots when zoomed in and progressively coarser dots when zoomed out, so the grid stays readable at any zoom level. You can change the steps through the `options` prop:
+The defaults show fine dots when zoomed in and progressively coarser dots when zoomed out, so the grid stays readable at any zoom level. Style the dots with the `.tl-grid-dot` CSS class. You can change the steps through the `options` prop:
 
 ```tsx
 <Tldraw

--- a/apps/docs/content/sdk-features/groups.mdx
+++ b/apps/docs/content/sdk-features/groups.mdx
@@ -17,13 +17,15 @@ accuracy: 9
 notes: Add API link formatting using [Editor#methodName](?) syntax. Fix blockquote formatting for examples link.
 ---
 
-Groups are logical containers that combine multiple shapes into a single selectable unit. Unlike frames, groups have no visual representation—they exist purely to organize shapes. Their geometry is the union of their children's geometries, their bounds update automatically as children change, and they clean themselves up when their contents are deleted. Groups can be nested inside other groups.
+Groups are logical containers that combine multiple shapes into a single selectable unit. Unlike frames, groups draw nothing of their own apart from a dashed outline while the group is focused. Their geometry is the union of their children's geometries, their bounds update automatically as children change, and they clean themselves up when their contents are deleted. Groups can be nested inside other groups.
 
 ## Creating groups
 
 Use [Editor#groupShapes](?) to combine shapes into a group. Pass an array of shape IDs or shape objects, and the method creates a new group containing those shapes:
 
 ```typescript
+import { createShapeId } from 'tldraw'
+
 // Group selected shapes
 editor.groupShapes(editor.getSelectedShapeIds())
 
@@ -37,9 +39,9 @@ editor.groupShapes([shapeId1, shapeId2], {
 })
 ```
 
-Grouping requires at least two shapes. The method does nothing if you pass fewer. Users can also group shapes with Ctrl+G (Cmd+G on Mac).
+Grouping requires at least two shapes. The method does nothing if you pass fewer, and it skips [locked shapes](/sdk-features/locked-shapes). Users can also group shapes with Ctrl+G (Cmd+G on Mac); when the only selected shape is a group, the same shortcut ungroups it.
 
-The new group is positioned at the top-left of the combined bounds of all grouped shapes. Its z-index matches the highest z-index among the grouped shapes, so it appears at the front of the layer stack.
+The new group is positioned at the top-left of the combined bounds of all grouped shapes. It takes the z-index of the topmost grouped shape, so it sits where that shape was in its parent's layer stack.
 
 ## Ungrouping
 
@@ -56,13 +58,15 @@ editor.ungroupShapes([groupId])
 editor.ungroupShapes([groupId], { select: false })
 ```
 
-Ungrouping moves children to the group's parent, preserving their exact page positions and rotations. The layer order is maintained—children appear where the group was in the z-stack. If you pass a mix of groups and non-groups, only the groups are ungrouped; the non-groups remain selected. Users can ungroup with Ctrl+Shift+G (Cmd+Shift+G on Mac).
+Ungrouping moves children to the group's parent and preserves their page positions and rotations. Layer order is maintained: children appear where the group was in the z-stack. If you pass a mix of groups and non-groups, only the groups are ungrouped and the non-groups stay selected. Users can ungroup with Ctrl+Shift+G (Cmd+Shift+G on Mac).
 
 Ungrouping is not recursive. If a group contains other groups, those inner groups remain intact. Ungroup them separately if needed.
 
 ## Focused groups
 
-The editor tracks a **focused group** that defines the current editing scope. When you're focused inside a group, you can select and manipulate the shapes within it. Without focus, clicking a shape inside a group selects the group itself, not the individual shape.
+The editor tracks a focused group that defines the current editing scope. When you're focused inside a group, you can select and manipulate the shapes within it. Without focus, clicking a shape inside a group selects the group itself, not the individual shape.
+
+Use [Editor#getFocusedGroup](?), [Editor#getFocusedGroupId](?), [Editor#setFocusedGroup](?), and [Editor#popFocusedGroupId](?):
 
 ```typescript
 // Get the current focused group
@@ -74,7 +78,7 @@ const focusedId = editor.getFocusedGroupId()
 // Focus a specific group
 editor.setFocusedGroup(groupId)
 
-// Exit the current focused group
+// Exit the current focused group and select it
 editor.popFocusedGroupId()
 ```
 
@@ -83,6 +87,7 @@ The editor manages focus automatically based on selection:
 - Selecting a shape inside a group focuses that group
 - Selecting shapes across multiple groups focuses their common ancestor
 - Pressing Escape pops focus one level up (or back to the page)
+- Pressing Enter with only groups selected selects their children
 - Clearing selection keeps the current focus
 
 ### Layered selection
@@ -122,10 +127,7 @@ When grouping shapes that already have different parents, the editor finds their
 
 ## Automatic cleanup
 
-Groups maintain themselves automatically through the `onChildrenChange` lifecycle hook:
-
-- **Empty groups delete themselves.** If you delete all children of a group, the group is removed.
-- **Single-child groups ungroup themselves.** If a group ends up with only one child (after deleting others), it dissolves and reparents that child to the group's parent.
+Groups maintain themselves through the [ShapeUtil#onChildrenChange](?) lifecycle hook. If you delete all children of a group, the group is removed. If a group ends up with only one child, it dissolves and reparents that child to the group's parent.
 
 This cleanup happens immediately when children change, so you never end up with degenerate groups.
 
@@ -138,14 +140,14 @@ editor.deleteShapes([boxA])
 
 ## Bounds and transforms
 
-Group bounds are computed from their children's geometries. The `Group2d` geometry class aggregates all child geometries for hit testing and bounds calculation:
+Group bounds are computed from their children's geometries. The [Group2d](?) geometry class aggregates all child geometries for hit testing and bounds calculation:
 
 ```typescript
 // Get a group's bounds
 const bounds = editor.getShapePageBounds(groupId)
 
 // Bounds update automatically when children move
-editor.updateShape({ id: childId, x: newX, y: newY })
+editor.updateShape({ id: childId, type: 'geo', x: newX, y: newY })
 const updatedBounds = editor.getShapePageBounds(groupId)
 ```
 
@@ -155,7 +157,7 @@ Position preservation works both ways. When you group shapes, their page positio
 
 ## Creating shapes inside groups
 
-When you create new shapes while focused inside a group, those shapes automatically become children of the focused group:
+When you create new shapes while focused inside a group, those shapes become children of the focused group unless they're positioned over a container such as a frame, which takes precedence:
 
 ```typescript
 // Focus a group by selecting a shape inside it
@@ -176,14 +178,12 @@ If no group is focused, new shapes are created on the current page.
 
 ## Limitations
 
-Groups have a few constraints worth knowing about.
+Arrows can't bind to groups. [ShapeUtil#canBind](?) returns `false` for group shapes, so arrows must bind to individual shapes within the group.
 
-Arrows can't bind to groups. The `canBind()` method returns `false` for group shapes, so arrows must bind to individual shapes within the group.
+Groups have no visual properties. You can't style a group itself, only its children.
 
-Groups have no visual properties—they're purely structural containers. You can't style a group itself, only its children.
-
-Both grouping and ungrouping require the select tool to be active. If you're in the middle of another interaction, the editor cancels it before running the operation.
+Both grouping and ungrouping require the select tool to be active, and do nothing in readonly mode. If you're in the middle of another interaction, the editor cancels it before running the operation.
 
 ## Related examples
 
-- **[Layer panel](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/layer-panel)** - Build a hierarchical layer panel that shows shape and group structure with visibility controls.
+- [Layer panel](/examples/ui/layer-panel) - Build a hierarchical layer panel that shows shape and group structure with visibility controls.

--- a/apps/docs/content/sdk-features/handles.mdx
+++ b/apps/docs/content/sdk-features/handles.mdx
@@ -14,7 +14,7 @@ In tldraw, handles are interactive control points on shapes that let users manip
 
 ## Handle basics
 
-Handles appear when a shape is selected. Each handle has a position, type, and optional snapping behavior. You define handles by implementing `getHandles` on your [ShapeUtil](?):
+Handles appear when a single shape is selected with the select tool. Each handle has a position, type, and optional snapping behavior. You define handles by implementing [ShapeUtil#getHandles](?) on your [ShapeUtil](?):
 
 ```tsx
 import { ShapeUtil, TLHandle, ZERO_INDEX_KEY } from 'tldraw'
@@ -42,18 +42,18 @@ Handle coordinates are in the shape's local coordinate system, where `(0, 0)` is
 
 There are four handle types:
 
-| Type      | Description                                                                    |
-| --------- | ------------------------------------------------------------------------------ |
-| `vertex`  | A primary control point that defines part of the shape's geometry              |
-| `virtual` | A secondary handle between vertices. Use it to add new points to a path.       |
-| `create`  | A handle for extending geometry. Line shapes use these to add endpoints.       |
-| `clone`   | A handle for duplicating the shape. Note shapes use these for adjacent copies. |
+| Type      | Description                                                                   |
+| --------- | ----------------------------------------------------------------------------- |
+| `vertex`  | A primary control point that defines part of the shape's geometry             |
+| `virtual` | A secondary handle that isn't a vertex, like the arrow's midpoint bend handle |
+| `create`  | A handle for adding new geometry, like inserting a point into a line segment  |
+| `clone`   | A handle for duplicating the shape, used by notes for quick adjacent copies   |
 
-Most custom shapes use `vertex` handles. The `virtual` and `create` types are used by the line shape to let users add points to a path.
+Most custom shapes use `vertex` handles. The arrow shape uses a `virtual` handle for its midpoint, and the line shape uses `create` handles to let users add points between vertices.
 
 ## Responding to handle drags
 
-When a user drags a handle, tldraw calls `onHandleDrag` with the updated handle position. Return the new shape props:
+When a user drags a handle, tldraw calls [ShapeUtil#onHandleDrag](?) with the updated handle position. Return a partial of the shape with the changed props:
 
 ```tsx
 import { ShapeUtil, TLHandleDragInfo } from 'tldraw'
@@ -63,18 +63,19 @@ class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 
 	override onHandleDrag(shape: SpeechBubbleShape, { handle }: TLHandleDragInfo<SpeechBubbleShape>) {
 		return {
-			...shape,
-			props: {
-				...shape.props,
-				tailX: handle.x,
-				tailY: handle.y,
-			},
+			props: { tailX: handle.x, tailY: handle.y },
 		}
 	}
 }
 ```
 
-The `handle` object in `TLHandleDragInfo` contains the updated `x` and `y` coordinates. Use these to update your shape's props.
+The `handle` in [TLHandleDragInfo](?) carries the new `x` and `y` after any snapping. The info object also has these fields:
+
+| Field             | Description                                                             |
+| ----------------- | ----------------------------------------------------------------------- |
+| `initial`         | The shape as it was when the drag started                               |
+| `isPrecise`       | Whether the user is dragging precisely, for example by holding Alt      |
+| `isCreatingShape` | Whether the handle drag is part of creating the shape, like a new arrow |
 
 ### Lifecycle callbacks
 
@@ -88,7 +89,7 @@ For more control over handle interactions, implement these additional methods:
 
 ## Handle snapping
 
-Handles can snap to other shapes' geometry. Set `snapType` on the handle:
+Handles can snap to other shapes' geometry. Set `snapType` on the handle. Snapping engages while the user holds Ctrl (Cmd on Mac), or always if they've turned on snap mode in preferences. The older `canSnap: true` flag is deprecated; use `snapType: 'point'` instead, and don't set both. See [Snapping](/sdk-features/snapping) for how snapping works across the editor.
 
 ```tsx
 {
@@ -103,20 +104,20 @@ Handles can snap to other shapes' geometry. Set `snapType` on the handle:
 
 The `snapType` options are:
 
-| Value     | Behavior                                               |
-| --------- | ------------------------------------------------------ |
-| `'point'` | Snaps to key points on other shapes (corners, centers) |
-| `'align'` | Snaps to alignment guides from other shapes            |
+| Value     | Behavior                                                                               |
+| --------- | -------------------------------------------------------------------------------------- |
+| `'point'` | Snaps to key points on other shapes first, then to the nearest point on their outlines |
+| `'align'` | Snaps the handle's x and y independently to the x and y of key points on other shapes  |
 
 ### Angle snapping
 
-When the user holds Shift while dragging, handles snap to 15-degree angles. By default, the angle is measured relative to an adjacent vertex handle on the shape. You can snap relative to a specific handle by setting `snapReferenceHandleId`:
+When the user holds Shift while dragging, handles snap to 15-degree angles. By default, the angle is measured relative to the next vertex handle on the shape. You can snap relative to a specific handle by setting `snapReferenceHandleId`:
 
 ```tsx
 {
 	id: 'controlPoint',
 	type: 'vertex',
-	index: indices[1],
+	index: getIndexAbove(ZERO_INDEX_KEY),
 	x: shape.props.cpX,
 	y: shape.props.cpY,
 	snapType: 'align',
@@ -128,7 +129,7 @@ Bezier curves use this so control points snap to angles relative to their associ
 
 ### Custom snap geometry
 
-By default, handles snap to a shape's outline and key points. Override `getHandleSnapGeometry` to customize what handles snap to:
+By default, handles snap to a shape's outline (its geometry) and to no key points. Override [ShapeUtil#getHandleSnapGeometry](?) to customize what handles snap to:
 
 ```tsx
 import { HandleSnapGeometry, ShapeUtil } from 'tldraw'
@@ -153,12 +154,12 @@ class BezierCurveUtil extends ShapeUtil<BezierCurveShape> {
 }
 ```
 
-The `HandleSnapGeometry` object has these properties:
+The [HandleSnapGeometry](?) object has these properties:
 
 | Property             | Description                                                    |
 | -------------------- | -------------------------------------------------------------- |
 | `outline`            | Custom outline geometry for snapping (default: shape geometry) |
-| `points`             | Key points to snap to (corners, centers, etc.)                 |
+| `points`             | Key points to snap to (default: none)                          |
 | `getSelfSnapOutline` | Returns outline for self-snapping given a handle               |
 | `getSelfSnapPoints`  | Returns points for self-snapping given a handle                |
 
@@ -215,7 +216,7 @@ class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 			{
 				id: 'tail',
 				type: 'vertex',
-				label: 'Move tail',
+				label: 'Move tail', // Accessible name for the handle
 				index: ZERO_INDEX_KEY,
 				x: shape.props.tailX,
 				y: shape.props.tailY,
@@ -225,12 +226,7 @@ class SpeechBubbleUtil extends ShapeUtil<SpeechBubbleShape> {
 
 	override onHandleDrag(shape: SpeechBubbleShape, { handle }: TLHandleDragInfo<SpeechBubbleShape>) {
 		return {
-			...shape,
-			props: {
-				...shape.props,
-				tailX: handle.x,
-				tailY: handle.y,
-			},
+			props: { tailX: handle.x, tailY: handle.y },
 		}
 	}
 

--- a/apps/docs/content/sdk-features/handles.mdx
+++ b/apps/docs/content/sdk-features/handles.mdx
@@ -89,7 +89,7 @@ For more control over handle interactions, implement these additional methods:
 
 ## Handle snapping
 
-Handles can snap to other shapes' geometry. Set `snapType` on the handle. Snapping engages while the user holds Ctrl (Cmd on Mac), or always if they've turned on snap mode in preferences. The older `canSnap: true` flag is deprecated; use `snapType: 'point'` instead, and don't set both. See [Snapping](/sdk-features/snapping) for how snapping works across the editor.
+Handles can snap to other shapes' geometry. Set `snapType` on the handle. Snapping engages while the user holds Ctrl (Cmd on Mac); with snap mode turned on in preferences, it's the reverse: snapping is on and Ctrl disables it. The older `canSnap: true` flag is deprecated; use `snapType: 'point'` instead. See [Snapping](/sdk-features/snapping) for how snapping works across the editor.
 
 ```tsx
 {

--- a/apps/docs/content/sdk-features/highlighting.mdx
+++ b/apps/docs/content/sdk-features/highlighting.mdx
@@ -40,7 +40,7 @@ export default function App() {
 
 ## Hover highlighting
 
-The editor automatically tracks which shape is under the pointer and displays a selection-style indicator around it. This happens during idle states when the pointer moves over the canvas.
+The editor automatically tracks which shape is under the pointer and displays a selection-style indicator around it. Hovering a child of a group hovers the group, unless that group is focused or selected, in which case the child itself is hovered.
 
 ### Reading hover state
 
@@ -60,7 +60,7 @@ if (hoveredShape) {
 
 ### Setting hover manually
 
-Use [Editor#setHoveredShape](?) to override the automatic hover detection:
+Use [Editor#setHoveredShape](?) to set the hover state yourself:
 
 ```typescript
 // Set hover by shape or ID
@@ -71,22 +71,23 @@ editor.setHoveredShape(myShape.id)
 editor.setHoveredShape(null)
 ```
 
-Use this to highlight a shape that isn't directly under the pointer, such as when implementing custom interaction logic.
+The select tool overwrites this value on the next pointer move while it's idle or editing, so a manual hover only sticks inside your own tool or state. For programmatic emphasis, use hints instead.
 
 ### Automatic hover detection
 
-The editor's select tool automatically updates hover state as the pointer moves. The hover indicator appears when:
+The select tool updates hover state as the pointer moves (throttled to 32ms, and paused while the camera is moving). The hover indicator appears when:
 
-- The editor is idle or editing a shape
+- The select tool is in `idle` or `editing_shape`
 - The pointer is over the canvas (not UI elements)
-- The input is not coarse (not touch input)
+- The pointer is not coarse (touch, and pen on some devices)
 - The editor is not changing styles
+- The shape is not already selected
 
 Touch devices don't show hover indicators because touch has no hovering concept.
 
 ## Hint highlighting
 
-Hints let you highlight multiple shapes programmatically. Unlike hover (single shape, automatic), hints are manually controlled and can include any number of shapes.
+Hints let you highlight multiple shapes programmatically. Unlike hover (single shape, automatic), hints are set explicitly and can include any number of shapes. The select tool uses them too: it hints the drop target during drag-and-drop and the shapes a new frame will enclose, so hints you set may be replaced while the user is dragging.
 
 ### Reading hints
 
@@ -113,32 +114,18 @@ editor.setHintingShapes([shape1.id, shape2.id])
 editor.setHintingShapes([])
 ```
 
-Hinted shapes render with a thicker stroke (2.5px) than selected or hovered shapes (1.5px). This makes them stand out when you need to draw attention to specific shapes.
+Hinted shapes render with a thicker stroke (2.5 screen pixels) than selected or hovered shapes (1.5). Setting hints never creates an undo entry, and ids are deduplicated on write.
 
-### Common use cases
-
-**Draw attention to shapes during a tutorial:**
+For example, to hint the arrows bound to the selected shape, react to the selection:
 
 ```typescript
-function highlightNextStep(editor: Editor, shapeId: TLShapeId) {
-	editor.setHintingShapes([shapeId])
-	// Clear after 3 seconds
-	setTimeout(() => {
-		editor.setHintingShapes([])
-	}, 3000)
-}
-```
+import { react } from 'tldraw'
 
-**Show connected arrows when a shape is selected:**
-
-```typescript
-editor.sideEffects.registerAfterChangeHandler('instance_page_state', (prev, next) => {
-	const selected = next.selectedShapeIds
-	if (selected.length === 1) {
-		// Highlight the arrows bound to the selected shape
-		const bindings = editor.getBindingsToShape(selected[0], 'arrow')
-		const arrowIds = bindings.map((b) => b.fromId)
-		editor.setHintingShapes(arrowIds)
+const stop = react('hint bound arrows', () => {
+	const selected = editor.getOnlySelectedShape()
+	if (selected) {
+		const bindings = editor.getBindingsToShape(selected, 'arrow')
+		editor.setHintingShapes(bindings.map((b) => b.fromId))
 	} else {
 		editor.setHintingShapes([])
 	}
@@ -147,15 +134,7 @@ editor.sideEffects.registerAfterChangeHandler('instance_page_state', (prev, next
 
 ## Visual rendering
 
-Both hover and hint indicators use the theme's selection color. The editor renders them on the canvas using the shape's [ShapeUtil#getIndicatorPath](?) implementation.
-
-| State    | Stroke width | Condition                          |
-| -------- | ------------ | ---------------------------------- |
-| Selected | 1.5px        | Shape is in selection              |
-| Hovered  | 1.5px        | Pointer is over shape (automatic)  |
-| Hinted   | 2.5px        | Shape is in hinting array (manual) |
-
-Collaborator selections render at 1.5px with their user color at reduced opacity.
+Both hover and hint indicators use the theme's selection color. The [ShapeIndicatorOverlayUtil](?) strokes them on a canvas overlay using each shape's [ShapeUtil#getIndicatorPath](?). Collaborator selections render at 1.5px in the collaborator's color at 0.7 opacity. See [Indicators](/sdk-features/indicators) for the stroke widths and how to customize them.
 
 ## Page state storage
 
@@ -172,6 +151,7 @@ Both properties are ephemeral—they don't persist across sessions or sync betwe
 
 ## Related articles
 
+- [Indicators](/sdk-features/indicators) — How indicator outlines are drawn and customized
 - [Instance state](/sdk-features/instance-state) — Session state including page state
 - [Selection](/sdk-features/selection) — Working with selected shapes
 - [Cursors](/sdk-features/cursors) — Cursor types and customization

--- a/apps/docs/content/sdk-features/history.mdx
+++ b/apps/docs/content/sdk-features/history.mdx
@@ -19,9 +19,9 @@ accuracy: 10
 notes: ''
 ---
 
-The editor's history system tracks changes to the [store](/sdk-features/store) and provides undo/redo functionality. Changes are organized into batches separated by marks, which act as stopping points. This lets complex interactions be undone as single atomic operations rather than individual edits.
+The editor's history system tracks changes to the [store](/sdk-features/store) and provides undo/redo. Changes are organized into batches separated by marks, which act as stopping points, so a complex interaction undoes as one step instead of many.
 
-The history manager captures all user-initiated changes automatically. Multiple rapid changes are compressed into cohesive undo steps, and you can control which changes are recorded using history options.
+The history manager captures all user-initiated store changes automatically and batches rapid changes into single undo steps. You control which changes are recorded with history options. The default UI binds undo to Cmd/Ctrl+Z and redo to Cmd/Ctrl+Shift+Z.
 
 ## How it works
 
@@ -40,7 +40,7 @@ When you undo, the manager reverses all changes back to the previous mark, moves
 
 ## Marks and stopping points
 
-Marks define where undo and redo operations stop. Create marks at the start of user interactions so that complex operations can be undone in one step.
+Marks define where undo and redo operations stop. Create marks with [Editor#markHistoryStoppingPoint](?) at the start of user interactions so that complex operations can be undone in one step. The optional name only shows up in the mark id, which is useful for debugging.
 
 ```typescript
 const markId = editor.markHistoryStoppingPoint('rotate shapes')
@@ -48,7 +48,7 @@ editor.rotateShapesBy(editor.getSelectedShapeIds(), Math.PI / 4)
 // Undoing will return to this mark
 ```
 
-Each mark has a unique identifier that you can use with [bailToMark](#bailing) or [squashToMark](#squashing). Creating a mark flushes pending changes and clears the redo stack.
+Each mark has a unique identifier that you can use with [bailToMark](#bailing) or [squashToMark](#squashing). Creating a mark flushes pending changes onto the undo stack. It doesn't clear the redo stack; the next recorded change does that.
 
 ## Basic operations
 
@@ -65,7 +65,9 @@ Both methods return the editor instance for chaining.
 
 The [Editor#canUndo](?) and [Editor#canRedo](?) methods are reactive, so you can use them to update UI button states automatically:
 
-```typescript
+```tsx
+import { useEditor, useValue } from 'tldraw'
+
 function UndoButton() {
 	const editor = useEditor()
 	const canUndo = useValue('canUndo', () => editor.canUndo(), [editor])
@@ -109,7 +111,9 @@ The three history modes are:
 
 > We use `record-preserveRedoStack` when selecting shapes. This way you can undo, select some shapes, copy them, and then redo back to where you were. The selection goes on the undo stack, but existing redos aren't cleared.
 
-> We use `ignore` for live cursor positions. Showing where collaborators' pointers are doesn't need to be undoable.
+> We use `ignore` when writing your own pointer position for collaborators to see. Where your cursor was doesn't need to be undoable. (Changes that arrive from other users are marked `'remote'` and are never recorded.)
+
+Nested `run` calls keep the outer mode unless they set their own, and no mode is applied while an undo or redo is in progress.
 
 ## Advanced features
 
@@ -126,7 +130,7 @@ editor.bailToMark(markId) // Roll back and discard all changes since mark
 
 [Editor#bail](?) reverts to the most recent mark. [Editor#bailToMark](?) reverts to a specific mark by ID.
 
-> We use bailing while cloning shapes. A user can switch between translating and cloning by pressing or releasing the control modifier key during a drag. When this changes, we bail on the changes since the interaction started, then apply the new mode's changes.
+> We use bailing while cloning shapes. A user can switch between translating and cloning by pressing or releasing the alt (option) key during a drag. When this changes, we bail on the changes since the interaction started, then apply the new mode's changes.
 
 ### Squashing
 
@@ -140,9 +144,9 @@ editor.nudgeShapes(shapes, { x: -5, y: -5 })
 editor.squashToMark(markId) // All three nudges become one undo step
 ```
 
-Squashing doesn't change the current state, only how history is organized.
+Squashing doesn't change the current state, only how history is organized. If the mark isn't on the undo stack, `squashToMark` logs an error and does nothing.
 
-> We use squashing during image cropping. As the user adjusts the crop, each change is recorded, allowing undo/redo of individual adjustments. When the user finishes cropping and exits this mode, we squash all the intermediate changes into one history entry. A single undo restores the image to its state before cropping began.
+> We use squashing during image cropping. While the user adjusts the crop, each change is recorded and can be undone individually. When the user exits crop mode, we squash the intermediate changes into one history entry. A single undo restores the image to its state before cropping began.
 
 ### Clearing history
 
@@ -155,19 +159,11 @@ editor.clearHistory() // Start with clean history
 
 ## Integration with the store
 
-The history manager listens to [store](/sdk-features/store) changes through a history interceptor. It only captures changes marked with source `'user'`, ignoring internal updates and external synchronization.
+The history manager listens to [store](/sdk-features/store) changes through a history interceptor. It only captures changes with source `'user'`; changes merged from other clients (source `'remote'`) are ignored, and internal writes that shouldn't be undoable use `history: 'ignore'`. Only store records take part in undo/redo; state held outside the store, like your own atoms, does not.
 
-Internally, the manager has three states:
-
-| State                        | Captures changes | Clears redo stack |
-| ---------------------------- | ---------------- | ----------------- |
-| `Recording`                  | Yes              | Yes               |
-| `RecordingPreserveRedoStack` | Yes              | No                |
-| `Paused`                     | No               | No                |
-
-The `Paused` state is used during undo/redo operations, which prevents them from creating new history entries while they apply diffs.
+The three history modes map onto three internal states: `Recording`, `RecordingPreserveRedoStack`, and `Paused`. The manager pauses itself while applying an undo or redo so those writes don't create new entries.
 
 ## Related examples
 
-- [Timeline scrubber](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/use-cases/timeline-scrubber) - A visual timeline that lets users scrub through document history.
-- [Store events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/store-events) - Listen to store changes, which is how the history manager tracks modifications.
+- [Timeline scrubber](/examples/use-cases/timeline-scrubber) - A visual timeline that lets users scrub through document history.
+- [Store events](/examples/events/store-events) - Listen to store changes, which is how the history manager tracks modifications.

--- a/apps/docs/content/sdk-features/image-export.mdx
+++ b/apps/docs/content/sdk-features/image-export.mdx
@@ -27,10 +27,16 @@ Export has two stages: SVG generation and optional raster conversion. The SVG st
 
 The editor gathers the shapes to export, calculates their bounding box, creates a React tree representing the SVG, renders it into a temporary DOM element, and processes it to be self-contained.
 
-Each shape defines how it renders to SVG through its [ShapeUtil](?):
+Each shape defines how it renders to SVG through its [ShapeUtil](?). If the shape implements [ShapeUtil#toSvg](?) or [ShapeUtil#toBackgroundSvg](?), those methods return React SVG elements. Otherwise the editor renders the shape's normal HTML inside an SVG `<foreignObject>` element.
 
-- If the shape implements [ShapeUtil#toSvg](?) or [ShapeUtil#toBackgroundSvg](?), those methods generate native SVG elements
-- If the shape doesn't implement SVG methods, the editor renders its normal HTML representation inside an SVG `<foreignObject>` element
+```tsx
+override toSvg(shape: MyShape, ctx: SvgExportContext) {
+	const fill = ctx.isDarkMode ? '#333' : '#eee'
+	return <rect width={shape.props.w} height={shape.props.h} fill={fill} />
+}
+```
+
+The [SvgExportContext](?) tells you the color mode, `scale`, and `pixelRatio` of the export, resolves asset URLs at the right size via `resolveAssetUrl`, and lets you defer the snapshot with `waitUntil` while an image loads. Shapes rendered through `<foreignObject>` can do the same with [useDelaySvgExport](?).
 
 The temporary render step is necessary because CSS and layout aren't computed until elements are in the document. `<foreignObject>` elements in particular need their styles and content inlined to work when the SVG is extracted.
 
@@ -38,17 +44,17 @@ The temporary render step is necessary because CSS and layout aren't computed un
 
 SVG files must be self-contained to work outside the document. The editor processes the rendered SVG to embed all external resources:
 
-**Font embedding**: The `FontEmbedder` traverses document stylesheets to find `@font-face` declarations, fetches font files, converts them to data URLs, and inlines them in the SVG. Text renders identically regardless of what fonts the viewer has installed.
+Fonts come first. The `FontEmbedder` finds `@font-face` declarations in the document's stylesheets, fetches the font files, and inlines them as data URLs, so text renders identically regardless of what the viewer has installed.
 
-**Style inlining**: The `StyleEmbedder` reads computed styles from every element in `<foreignObject>` sections and applies them as inline styles. This removes reliance on external stylesheets. Pseudo-elements like `::before` and `::after` can't be inlined, so the editor extracts their styles into a `<style>` tag within the SVG.
+Then styles. The `StyleEmbedder` reads computed styles from every element inside `<foreignObject>` sections and writes them as inline styles. Pseudo-elements like `::before` and `::after` can't be inlined, so their rules go into a `<style>` tag within the SVG.
 
-**Media conversion**: The `embedMedia` function converts images, videos, and canvas elements to embedded formats. Images become data URLs, videos become single-frame images, and canvas elements become images via `toDataURL()`.
+Finally media. `embedMedia` converts images to data URLs, videos to a single captured frame, and canvas elements to images via `toDataURL()`.
 
 ### Raster conversion
 
 Once the editor generates the SVG, it can convert it to a raster image. The `getSvgAsImage` function loads the SVG into an `Image` element, draws it to a canvas at the requested resolution, and exports the canvas as a blob.
 
-The `pixelRatio` option controls output resolution. For high-DPI displays, use a pixel ratio of 2 or higher for sharp rendering. The editor automatically clamps dimensions to browser canvas limits to avoid out-of-memory errors.
+The `pixelRatio` option controls output resolution. The default of 2 is sharp on high-DPI displays; raise it for print. The editor automatically clamps dimensions to browser canvas limits to avoid out-of-memory errors.
 
 ## Export options
 
@@ -56,22 +62,24 @@ SVG export methods (`getSvgElement`, `getSvgString`) accept [TLSvgExportOptions]
 
 **Shared options (all export methods):**
 
-| Option                | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bounds`              | The bounding box in page coordinates to export. If omitted, the editor calculates bounds from the shapes.                                                                                                                                                                                                                                                                                                                                                                 |
-| `scale`               | Logical scale multiplier. A scale of 2 doubles the SVG size.                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `pixelRatio`          | For SVG exports, passed to the asset store so it can provide appropriately sized assets. For raster exports, multiplies output dimensions. Defaults to `undefined` for SVG and `2` for raster formats.                                                                                                                                                                                                                                                                    |
-| `background`          | Whether to include the background color. If `false`, the export is transparent (for formats that support it).                                                                                                                                                                                                                                                                                                                                                             |
-| `padding`             | Space around the shape bounds. Accepts `number` (fixed pixels) or `'auto'` (default). In `'auto'` mode, the export trims to visual content bounds, capturing overflow like thick strokes and arrowheads without extra whitespace. A numeric value adds fixed padding and clips overflow beyond it. When exporting a single frame, padding is not applied (the frame itself serves as the boundary). When exporting shapes inside an image shape, padding is also skipped. |
-| `darkMode`            | Whether to render in dark mode. Defaults to the current theme setting.                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `preserveAspectRatio` | The SVG `preserveAspectRatio` attribute.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| Option                | Description                                                                                                                                                                                            |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `bounds`              | The bounding box in page coordinates to export. If omitted, the editor calculates bounds from the shapes.                                                                                              |
+| `scale`               | Logical scale multiplier. A scale of 2 doubles the SVG size. Defaults to `1`.                                                                                                                          |
+| `pixelRatio`          | For SVG exports, passed to the asset store so it can provide appropriately sized assets. For raster exports, multiplies output dimensions. Defaults to `undefined` for SVG and `2` for raster formats. |
+| `background`          | Whether to include the background color. If `false`, the export is transparent (for formats that support it). Defaults to the `exportBackground` instance state.                                       |
+| `padding`             | Space around the shape bounds: `'auto'` (default), a `number` of pixels, or `0`. See below.                                                                                                            |
+| `darkMode`            | Whether to render in dark mode. Defaults to the current theme setting.                                                                                                                                 |
+| `preserveAspectRatio` | The SVG `preserveAspectRatio` attribute.                                                                                                                                                               |
 
-**Raster-only options (toImage, toImageDataUrl):**
+In `'auto'` padding mode the editor renders with `editor.options.defaultSvgPadding` (32px), then trims to the visual content bounds. This captures overflow like thick strokes and arrowheads without extra whitespace. A numeric value adds fixed padding and clips overflow beyond it; `0` means no padding and no trimming. Padding is skipped when exporting a single frame, and when a shape whose [ShapeUtil#isExportBoundsContainer](?) returns true (images and frames by default) contains every other exported shape.
 
-| Option    | Description                                                                     |
-| --------- | ------------------------------------------------------------------------------- |
-| `format`  | Output format: `'svg'`, `'png'`, `'jpeg'`, or `'webp'`. Defaults to `'png'`.    |
-| `quality` | Compression quality for lossy formats (JPEG, WebP) as a number between 0 and 1. |
+**`toImage` and `toImageDataUrl` options:**
+
+| Option    | Description                                                                                               |
+| --------- | --------------------------------------------------------------------------------------------------------- |
+| `format`  | Output format: `'png'`, `'jpeg'`, `'webp'`, or `'svg'`. Defaults to `'png'`. `'svg'` returns an SVG blob. |
+| `quality` | Compression quality for lossy formats (JPEG, WebP) as a number between 0 and 1.                           |
 
 ## Editor export methods
 
@@ -79,7 +87,7 @@ The [Editor](?) class provides four methods for exporting shapes. All methods ac
 
 ### getSvgElement
 
-[Editor#getSvgElement](?) returns the SVG as a DOM element along with its dimensions. Use this when you need to manipulate the SVG programmatically or insert it into the DOM.
+[Editor#getSvgElement](?) returns the SVG as a DOM element along with its width and height. Use this when you need to manipulate the SVG programmatically or insert it into the DOM.
 
 ```typescript
 const result = await editor.getSvgElement(shapes, { scale: 2 })
@@ -101,7 +109,7 @@ if (result) {
 
 ### toImage
 
-[Editor#toImage](?) returns a blob of the exported image in the specified format. This is the primary method for raster images.
+[Editor#toImage](?) returns a blob of the exported image in the specified format. This is the primary method for raster images. For a ready-made download or copy-to-clipboard flow, use [exportAs](?) and [copyAs](?) from `tldraw`, which wrap it.
 
 ```typescript
 const result = await editor.toImage(shapes, {
@@ -154,6 +162,6 @@ The raster conversion automatically clamps dimensions to stay within browser can
 
 ## Related examples
 
-- [Export canvas as image](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/export-canvas-as-image) - Export the entire canvas using [Editor#toImage](?) and download it.
-- [Export canvas as image (with settings)](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/export-canvas-settings) - Export with configurable format, scale, background, and other options.
-- [Custom shape SVG export](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/toSvg-method-example) - Define how custom shapes render when exported using [ShapeUtil#toSvg](?) and [ShapeUtil#toBackgroundSvg](?).
+- [Export canvas as image](/examples/data/assets/export-canvas-as-image) - Export the entire canvas using [Editor#toImage](?) and download it.
+- [Export canvas as image (with settings)](/examples/data/assets/export-canvas-settings) - Export with configurable format, scale, background, and other options.
+- [Custom shape SVG export](/examples/shapes/tools/toSvg-method-example) - Define how custom shapes render when exported using [ShapeUtil#toSvg](?) and [ShapeUtil#toBackgroundSvg](?).

--- a/apps/docs/content/sdk-features/indicators.mdx
+++ b/apps/docs/content/sdk-features/indicators.mdx
@@ -18,26 +18,32 @@ Indicators are the colored outlines that appear around shapes when they're selec
 
 ## How indicators work
 
-When you hover over or select a shape, tldraw draws an outline that matches the shape's geometry. The indicator is separate from the shape itself—it renders in an overlay layer above the canvas.
+When you hover over or select a shape, tldraw draws an outline that matches the shape's geometry. The indicator is separate from the shape itself: the [ShapeIndicatorOverlayUtil](?) strokes it on a canvas overlay above the shapes, in the theme's selection color.
 
 Indicators appear in three contexts:
 
-| Context  | When it appears                               | Stroke weight |
-| -------- | --------------------------------------------- | ------------- |
-| Selected | Shape is in the current selection             | 1.5px         |
-| Hovered  | Pointer is over an unselected shape           | 1.5px         |
-| Hinting  | Shape is a drop target during drag operations | 2.5px         |
+| Context  | When it appears                                                                                   | Stroke weight |
+| -------- | ------------------------------------------------------------------------------------------------- | ------------- |
+| Selected | Shape is in the current selection                                                                 | 1.5px         |
+| Hovered  | Pointer is over an unselected shape while the select tool is idle (fine pointers only, not touch) | 1.5px         |
+| Hinting  | Shape is a drop target during drag operations                                                     | 2.5px         |
 
-For collaborative editing, indicators also show which shapes other users have selected. These render in each collaborator's cursor color. Locked shapes never show indicators.
+For collaborative editing, [CollaboratorShapeIndicatorOverlayUtil](?) also shows which shapes other users have selected, in each collaborator's cursor color. Locked shapes never show indicators.
 
 ## Defining an indicator
 
-Every [ShapeUtil](?) must implement the `getIndicatorPath` method. This method returns a `Path2D`, or a richer `TLIndicatorPath` object for indicators that need clipping or additional stroked paths:
+Every [ShapeUtil](?) must implement the `getIndicatorPath` method. This method returns a `Path2D`, a richer [TLIndicatorPath](?) object for indicators that need clipping or additional stroked paths, or `undefined` to draw no indicator:
 
 ```tsx
-import { ShapeUtil, TLBaseShape, Rectangle2d, T, RecordProps } from 'tldraw'
+import { ShapeUtil, TLShape, Rectangle2d, T, RecordProps } from 'tldraw'
 
-type MyShape = TLBaseShape<'myshape', { w: number; h: number }>
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		myshape: { w: number; h: number }
+	}
+}
+
+type MyShape = TLShape<'myshape'>
 
 class MyShapeUtil extends ShapeUtil<MyShape> {
 	static override type = 'myshape' as const
@@ -74,16 +80,6 @@ The `getIndicatorPath` method receives the shape and returns paths in the shape'
 
 ### Common indicator patterns
 
-For rectangular shapes, return a rectangle path:
-
-```tsx
-getIndicatorPath(shape: MyShape) {
-	const path = new Path2D()
-	path.rect(0, 0, shape.props.w, shape.props.h)
-	return path
-}
-```
-
 For circular shapes, use an ellipse path:
 
 ```tsx
@@ -106,15 +102,20 @@ getIndicatorPath(shape: MyShape) {
 
 ### Indicators with labels
 
-Shapes with labels may need to clip the indicator where the label appears. Arrow shapes do this to prevent the indicator from overlapping label text. Return an object with additional path information:
+Shapes with labels may need to clip the indicator where the label appears. Arrow shapes do this to prevent the indicator from overlapping label text. Return an object with `path`, an optional `clipPath`, and optional `additionalPaths`. The clip is applied even-odd before stroking `path`, so an outer rectangle plus the label rectangle punches a hole for the label. `additionalPaths` are stroked afterwards without the clip:
 
 ```tsx
 override getIndicatorPath(shape: MyShape) {
-	return {
-		path: mainPath,
-		clipPath: labelClipPath,
-		additionalPaths: [extraPath],
-	}
+	const path = new Path2D()
+	path.moveTo(0, 0)
+	path.lineTo(shape.props.w, shape.props.h)
+
+	// Even-odd: the outer rect keeps everything, the inner rect punches a hole
+	const clipPath = new Path2D()
+	clipPath.rect(-100, -100, shape.props.w + 200, shape.props.h + 200)
+	clipPath.rect(40, 40, 20, 20)
+
+	return { path, clipPath }
 }
 ```
 
@@ -130,13 +131,25 @@ editor.setHintingShapes([targetShapeId])
 editor.setHintingShapes([])
 ```
 
-Hinting indicators render with a thicker stroke (2.5px vs 1.5px) to distinguish them from regular selection.
+## Customizing indicators
+
+The stroke widths and paint order live on `ShapeIndicatorOverlayUtil.options` (`lineWidth`, `hintedLineWidth`, `zIndex`). Adjust them with `configure`, or subclass the util and override `getOverlays()` to change which shapes get indicators, then pass it through the `overlayUtils` prop. See [Overlay utils](/sdk-features/overlay-utils) for how overlay utils are registered and replaced.
+
+```tsx
+import { ShapeIndicatorOverlayUtil, Tldraw } from 'tldraw'
+
+const ThickIndicators = ShapeIndicatorOverlayUtil.configure({ lineWidth: 3 })
+
+function App() {
+	return <Tldraw overlayUtils={[ThickIndicators]} />
+}
+```
 
 ## Related articles
 
 - [Shapes](/sdk-features/shapes) - Learn how to create custom shapes with their own indicators
 - [Selection](/sdk-features/selection) - Understand how selection state controls indicator visibility
-- [UI components](/sdk-features/ui-components) - Customize canvas components including indicators
+- [Overlay utils](/sdk-features/overlay-utils) - The overlay system that draws indicators
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/input-handling.mdx
+++ b/apps/docs/content/sdk-features/input-handling.mdx
@@ -24,12 +24,9 @@ All input state is reactive. The manager stores values as atoms from `@tldraw/st
 
 ## Pointer position tracking
 
-The manager tracks pointer positions in two coordinate spaces:
+The manager tracks pointer positions in two coordinate spaces. Screen space is pixels relative to the canvas container's origin. Page space is the position on the infinite canvas, adjusted for camera position and zoom.
 
-- **Screen space**: Pixels relative to the canvas container's origin
-- **Page space**: Coordinates in the infinite canvas, adjusted for camera position and zoom
-
-For each space, the manager maintains three position snapshots: current, previous, and origin.
+In each space, the manager keeps three positions: current, previous, and origin.
 
 ### Current and previous positions
 
@@ -56,7 +53,7 @@ editor.inputs.getOriginScreenPoint() // Where pointer_down occurred in screen sp
 editor.inputs.getOriginPagePoint() // Where pointer_down occurred in page space
 ```
 
-Tools use the origin to calculate drag distances and determine whether an interaction has moved far enough to trigger behaviors like dragging. The origin resets on every `pointer_down` event and when pinch gestures start.
+Tools use the origin to calculate drag distances and determine whether an interaction has moved far enough to trigger behaviors like dragging. The origin resets on every `pointer_down` event and continuously while a pinch is in progress.
 
 ### Coordinate space conversion
 
@@ -76,21 +73,19 @@ The manager tracks pointer velocity for gesture detection:
 editor.inputs.getPointerVelocity() // Vec with x/y velocity in pixels per millisecond
 ```
 
-Velocity is calculated on each animation frame tick (not on each pointer event). The `TickManager` calls `updatePointerVelocity()` every frame, calculating the distance traveled since the last tick. The velocity is smoothed by interpolating with the previous value, and very small values (below 0.01) are clamped to zero to prevent jitter.
+The manager listens to the editor's `frame` event and recomputes velocity once per frame (not on each pointer event) from the screen-space distance traveled since the previous frame. It smooths the result against the previous value and clamps components below 0.01 to zero to prevent jitter.
 
-Tools use velocity to distinguish between slow, precise interactions and fast flick gestures. Velocity resets to zero on `pointer_down` events and when pinch gestures start.
+Tools use velocity to distinguish between slow, precise interactions and fast flick gestures. Velocity resets to zero on `pointer_down` events and continuously while a pinch is in progress.
 
 ## Input device detection
 
-The manager tracks whether the current input comes from a pen device:
+The manager tracks whether the most recent pointer event came from a pen (`pointerType === 'pen'`):
 
 ```typescript
 editor.inputs.getIsPen() // true for stylus input
 ```
 
-This enables pen-specific behaviors like pen mode, which ignores non-pen input to prevent accidental touch interactions while using a stylus.
-
-> Many stylus devices identify as 'mouse' rather than 'pen'. We use heuristics to detect these devices and correctly account for pressure.
+Pen mode ignores non-pen input to prevent accidental touch interactions while using a stylus. The editor only turns pen mode on automatically for direct-display pens (Apple Pencil, Surface Pen), flagged as `isPenDirect` on the pointer event; desktop graphics tablets still draw as pens without enabling it.
 
 ## Modifier keys and button states
 
@@ -127,7 +122,7 @@ editor.inputs.keys.has('Space')
 editor.inputs.keys.has('ShiftLeft')
 ```
 
-Keys are added on `key_down` and removed on `key_up`. Tools can use this to detect held keys during pointer operations. For example, the select tool detects when Space is held to temporarily activate the hand tool.
+The editor adds keys on `key_down` and removes them on `key_up`. Tools can use this to detect held keys during pointer operations. For example, the editor checks `keys.has('Space')` on pointer up to decide whether to keep spacebar panning active.
 
 ## Interaction state flags
 
@@ -135,6 +130,7 @@ The manager tracks the current interaction state:
 
 ```typescript
 editor.inputs.getIsPointing() // Pointer button is down
+editor.inputs.getIsRightPointing() // Right button is down, before the drag threshold
 editor.inputs.getIsDragging() // Pointer moved beyond drag threshold while pointing
 editor.inputs.getIsPinching() // Two-finger pinch gesture active
 editor.inputs.getIsEditing() // Editing text or other content
@@ -142,18 +138,21 @@ editor.inputs.getIsPanning() // Panning the canvas
 editor.inputs.getIsSpacebarPanning() // Panning via spacebar (vs. other panning modes)
 ```
 
-The editor sets these flags during event processing. For example, `isPointing` becomes true on `pointer_down` and false on `pointer_up`. The `isDragging` flag becomes true when the pointer moves beyond the drag distance threshold while pointing.
+The editor sets these flags during event processing. For example, `isPointing` becomes true on `pointer_down` and false on `pointer_up`. The `isDragging` flag becomes true when the pointer moves beyond the drag distance threshold (`dragDistanceSquared` or `coarseDragDistanceSquared` in the editor's [options](/sdk-features/options)) while pointing.
 
 ## Event processing flow
 
 When an input event occurs, the editor processes it through these stages:
 
 1. The browser fires a native DOM event
-2. The editor's UI layer captures the event and transforms it into a typed event info object
-3. For pointer, pinch, and wheel events, the editor calls `updateFromEvent()` on the `InputsManager`
-4. For pointer events, the editor dispatches to the `ClickManager` for double-click detection and overflow suppression
-5. The editor sends the event to the state machine via `root.handleEvent()`
-6. The state machine propagates the event through active tool states
+2. The canvas event handlers transform it into a typed event info object and call [Editor#dispatch](?)
+3. `pointer_move`, `wheel`, and `pinch` events are queued and flushed once per frame; other events flush immediately
+4. The editor emits `before-event`, then updates modifier key state
+5. For pointer, pinch, and wheel events, the editor calls `updateFromEvent()` on the `InputsManager`
+6. For pointer events, the editor updates buttons and interaction flags, then hands the event to the `ClickManager` for double-click detection
+7. The editor sends the event to the state machine via `root.handleEvent()`, which propagates it through active tool states, then emits `event`
+
+See [Events](/sdk-features/events) for subscribing to `before-event` and `event`.
 
 The typed event info objects are:
 
@@ -169,9 +168,9 @@ In collaborative sessions, `updateFromEvent()` also updates the user's pointer p
 
 ## Input normalization
 
-The editor normalizes input across different device types. Touch events convert to pointer events, and the manager tracks the device type through the `isPen` flag.
+The editor listens to Pointer Events, so mouse, touch, and pen input arrive through the same handlers, and the manager tracks the device type through the `isPen` flag.
 
-Pointer positions include a z coordinate representing pressure or hover distance, defaulting to 0.5 for devices that don't report pressure. The normalization layer accounts for the canvas container's position in the document, so the editor works correctly in nested layouts and scrolled containers.
+Pointer positions include a `z` coordinate carrying the pointer event's pressure; synthetic events without a `z` default to 0.5. The manager subtracts the container's screen bounds from client coordinates, so the editor works correctly in nested layouts and scrolled containers.
 
 ## State serialization
 
@@ -187,5 +186,5 @@ We use this serialized form when generating crash reports.
 
 ## Related examples
 
-- [Reactive inputs](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/reactive-inputs) - Display pointer positions, velocity, and other input state reactively
-- [Canvas events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/canvas-events) - Log pointer, keyboard, and wheel events to see the event flow
+- [Reactive inputs](/examples/editor-api/reactive-inputs) - Display pointer positions, velocity, and other input state reactively
+- [Canvas events](/examples/events/canvas-events) - Log pointer, keyboard, and wheel events to see the event flow

--- a/apps/docs/content/sdk-features/instance-state.mdx
+++ b/apps/docs/content/sdk-features/instance-state.mdx
@@ -18,7 +18,9 @@ status: published
 date: 1/31/2026
 ---
 
-Instance state is the per-tab state that tracks your current session. It includes which page you're viewing, whether the grid is visible, if debug mode is on, and transient interaction state like the current cursor position. Unlike document state (shapes, pages, assets), instance state belongs to a single browser tab and isn't synced between collaborators.
+Instance state is the per-tab state that tracks your current session. It includes which page you're viewing, whether the grid is visible, if debug mode is on, and transient interaction state like the current cursor.
+
+Unlike document state (shapes, pages, assets), instance state belongs to a single browser tab and isn't synced between collaborators.
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -52,7 +54,7 @@ const instance = editor.getInstanceState()
 instance.isGridMode // true if grid is visible
 instance.isDebugMode // true if debug overlays are shown
 instance.isFocusMode // true if UI is minimized
-instance.isPenMode // true if stylus input detected
+instance.isPenMode // true once a direct-display stylus (e.g. Apple Pencil) is used
 instance.isToolLocked // true if tool stays active after creating shapes
 instance.isReadonly // true if editing is disabled
 
@@ -103,7 +105,7 @@ const { isGridMode } = editor.getInstanceState()
 editor.updateInstanceState({ isGridMode: !isGridMode })
 ```
 
-Changes take effect immediately and persist for the session. When using a `persistenceKey`, some properties persist across sessions (see [Session persistence](#session-persistence) below).
+Changes take effect immediately. By default they are not added to the undo stack; pass `{ history: 'record' }` as the second argument to record them. When using a `persistenceKey`, some properties persist across sessions (see [Session persistence](#session-persistence) below).
 
 Note that `currentPageId` cannot be changed through `updateInstanceState`. Use [Editor#setCurrentPage](?) instead.
 
@@ -113,47 +115,47 @@ Note that `currentPageId` cannot be changed through `updateInstanceState`. Use [
 
 These boolean flags control major editor behaviors:
 
-| Property       | Description                                     | Persists |
-| -------------- | ----------------------------------------------- | -------- |
-| `isGridMode`   | Show grid overlay on the canvas                 | Yes      |
-| `isDebugMode`  | Show debug information overlays                 | Yes      |
-| `isFocusMode`  | Minimize the UI to just the canvas              | Yes      |
-| `isToolLocked` | Keep current tool active after creating a shape | Yes      |
-| `isReadonly`   | Prevent all document modifications              | Yes      |
-| `isPenMode`    | Track whether stylus input has been detected    | No       |
-| `isFocused`    | Whether the editor currently has keyboard focus | Yes      |
+| Property       | Description                                                                                           | Persists |
+| -------------- | ----------------------------------------------------------------------------------------------------- | -------- |
+| `isGridMode`   | Show grid overlay on the canvas                                                                       | Yes      |
+| `isDebugMode`  | Show the debug panel (current tool state, debug menu)                                                 | Yes      |
+| `isFocusMode`  | Minimize the UI to just the canvas                                                                    | Yes      |
+| `isToolLocked` | Keep current tool active after creating a shape                                                       | Yes      |
+| `isReadonly`   | Prevent document edits, except for shapes whose util allows editing in readonly                       | No       |
+| `isPenMode`    | Set automatically when a direct-display stylus (e.g. Apple Pencil) is used; touch is ignored while on | No       |
+| `isFocused`    | Whether the editor currently has keyboard focus                                                       | No       |
 
 ### Display state
 
 Properties that track the current display environment:
 
-| Property           | Description                                                   | Persists |
-| ------------------ | ------------------------------------------------------------- | -------- |
-| `screenBounds`     | Viewport position and dimensions (x, y, w, h)                 | Yes      |
-| `devicePixelRatio` | Display scaling factor (e.g., 2 for Retina)                   | Yes      |
-| `isCoarsePointer`  | Indicates touch or low-precision input is active              | Yes      |
-| `isHoveringCanvas` | Whether pointer is over the canvas (null if no hover support) | No       |
-| `insets`           | Safe area insets as `[top, right, bottom, left]` booleans     | Yes      |
+| Property           | Description                                                                                      | Persists |
+| ------------------ | ------------------------------------------------------------------------------------------------ | -------- |
+| `screenBounds`     | Viewport position and dimensions (x, y, w, h)                                                    | No       |
+| `devicePixelRatio` | Display scaling factor (e.g., 2 for Retina)                                                      | No       |
+| `isCoarsePointer`  | Indicates touch or low-precision input is active; mirrors `tlenvReactive`                        | No       |
+| `isHoveringCanvas` | Whether pointer is over the canvas (null if no hover support)                                    | No       |
+| `insets`           | Whether the container is inset from the document edge on each side, `[top, right, bottom, left]` | No       |
 
 ### Navigation state
 
-| Property        | Description                      | Persists |
-| --------------- | -------------------------------- | -------- |
-| `currentPageId` | ID of the currently active page  | No       |
-| `openMenus`     | Array of currently open menu IDs | No       |
+| Property        | Description                                            | Persists |
+| --------------- | ------------------------------------------------------ | -------- |
+| `currentPageId` | ID of the currently active page                        | Yes      |
+| `openMenus`     | Unused by the SDK; open menus are tracked by `tlmenus` | No       |
 
 ### Interaction state
 
 Temporary state used during user interactions:
 
-| Property          | Description                                      | Persists |
-| ----------------- | ------------------------------------------------ | -------- |
-| `cursor`          | Current cursor type and rotation                 | No       |
-| `brush`           | Selection brush bounds during drag selection     | No       |
-| `zoomBrush`       | Zoom brush bounds during zoom-to-area            | No       |
-| `scribbles`       | Active scribble animations (eraser trails, etc.) | No       |
-| `isChangingStyle` | True while style picker is active                | No       |
-| `cameraState`     | Whether the camera is `'idle'` or `'moving'`     | No       |
+| Property          | Description                                                  | Persists |
+| ----------------- | ------------------------------------------------------------ | -------- |
+| `cursor`          | Current cursor type and rotation                             | No       |
+| `brush`           | Selection brush bounds during drag selection                 | No       |
+| `zoomBrush`       | Zoom brush bounds during zoom-to-area                        | No       |
+| `scribbles`       | Active scribble animations (eraser trails, etc.)             | No       |
+| `isChangingStyle` | Set after a style change; resets after 1s or on pointer move | No       |
+| `cameraState`     | Whether the camera is `'idle'` or `'moving'`                 | No       |
 
 ### Shape creation
 
@@ -183,6 +185,8 @@ Properties for multiplayer features:
 | `meta`             | Arbitrary JSON data for your application | No       |
 | `exportBackground` | Include background color when exporting  | Yes      |
 
+The "Persists" column shows what a `persistenceKey` saves between sessions. Separately, when you call `loadSnapshot`, a wider set of instance properties (screen bounds, pointer type, readonly, and the mode flags above) is preserved from the existing store rather than overwritten by the snapshot; see [TLSessionStateSnapshot](?).
+
 ## Common patterns
 
 ### Focus mode
@@ -201,11 +205,11 @@ Show a grid overlay to help with alignment:
 editor.updateInstanceState({ isGridMode: true })
 ```
 
-The grid respects the camera zoom level. You can customize the grid appearance by overriding the `Grid` component.
+The grid respects the camera zoom level. You can customize the grid appearance by overriding the `Grid` component via the `components` prop.
 
 ### Debug mode
 
-Debug mode shows useful overlays including shape bounds, geometry points, and performance information:
+Debug mode shows the debug panel: the current tool state path, an optional FPS counter, and the debug menu:
 
 ```typescript
 editor.updateInstanceState({ isDebugMode: true })
@@ -216,13 +220,7 @@ editor.updateInstanceState({ isDebugMode: true })
 When tool lock is enabled, the current tool stays active after creating a shape instead of returning to the select tool:
 
 ```typescript
-// Enable tool lock
 editor.updateInstanceState({ isToolLocked: true })
-
-// Check if locked
-if (editor.getInstanceState().isToolLocked) {
-	// Tool will stay active after creating shapes
-}
 ```
 
 Custom tools should check this property to decide whether to return to select after completing their action. See [Tools](/sdk-features/tools#tool-lock) for implementation details.
@@ -256,13 +254,13 @@ The value updates automatically when the user switches between mouse and touch.
 
 ## Session persistence
 
-When you use a `persistenceKey` on the [Tldraw](?) component, some instance properties persist across browser sessions. Properties marked "Persists: Yes" in the tables above are saved and restored.
+When you use a `persistenceKey` on the [Tldraw](?) component, some instance properties persist across browser sessions. Properties marked "Persists: Yes" in the tables above are saved and restored, along with each page's camera and selection.
 
-Temporary state like cursor position, selection brushes, and open menus always reset when the page reloads. Navigation state like `currentPageId` doesn't persist because the referenced page might not exist in a fresh session.
+Temporary state like cursor position, selection brushes, and scribbles always resets when the page reloads. `currentPageId` is restored only if that page still exists in the document.
 
 ## Instance state vs page state
 
-Instance state ([TLInstance](?)) is global to the editor—there's one instance record per browser tab. Page state ([TLInstancePageState](?)) is per-page and tracks page-specific information like selection:
+Instance state ([TLInstance](?)) is global to the editor: there's one instance record per browser tab. Page state ([TLInstancePageState](?)) is per-page and tracks selection, hover, editing, cropping, and focused group for that page. See [Selection](/sdk-features/selection).
 
 ```typescript
 // Instance state: global to the editor

--- a/apps/docs/content/sdk-features/internationalization.mdx
+++ b/apps/docs/content/sdk-features/internationalization.mdx
@@ -23,26 +23,9 @@ Tldraw's UI supports 49 languages out of the box, including right-to-left langua
 
 ## Setting the locale
 
-The user's locale is stored in [user preferences](/sdk-features/user-preferences). By default, tldraw detects the browser's language and selects the closest match from supported languages.
+The user's locale is stored in [user preferences](/sdk-features/user-preferences). By default, tldraw detects the browser's language and selects the closest match from supported languages. The default main menu also includes a language submenu where users can change it.
 
-The simplest way to set the locale is with the `locale` prop on the `Tldraw` component:
-
-```tsx
-import { Tldraw } from 'tldraw'
-import 'tldraw/tldraw.css'
-
-export default function App() {
-	return (
-		<div style={{ position: 'fixed', inset: 0 }}>
-			<Tldraw locale="fr" />
-		</div>
-	)
-}
-```
-
-The `locale` prop takes priority over both the browser's language preferences and the user's locale preference. When set, your application controls the displayed language.
-
-You can also set the locale imperatively after the editor mounts:
+To set the locale from your application, update the user's locale preference. The UI reads its language from `editor.user.getLocale()`, so this takes effect immediately:
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -65,30 +48,32 @@ export default function App() {
 }
 ```
 
-The `locale` value uses standard language codes: `'en'`, `'fr'`, `'de'`, `'ja'`, `'zh-cn'`, `'ar'`, and so on.
+The `locale` value uses lowercase language codes: `'en'`, `'fr'`, `'de'`, `'ja'`, `'zh-cn'`, `'ar'`, and so on.
+
+The `Tldraw` component also has a `locale` prop. Today it only sets the language for the outer translation provider (used by the loading screen); the editor UI itself keeps reading the user preference, so prefer `updateUserPreferences` to change the visible language.
 
 ### Automatic detection
 
-When no locale is set, tldraw uses `getDefaultTranslationLocale()` to detect the user's preferred language from the browser:
+When no locale is set, tldraw uses [getDefaultTranslationLocale](?) to detect the user's preferred language from the browser:
 
 ```ts
-import { getDefaultTranslationLocale } from '@tldraw/tlschema'
+import { getDefaultTranslationLocale } from 'tldraw'
 
 // Returns 'fr', 'en', 'zh-cn', etc. based on browser settings
 const locale = getDefaultTranslationLocale()
 ```
 
-The detection algorithm:
+For each entry in the browser's `navigator.languages` array, in order, it:
 
-1. Reads the browser's `navigator.languages` array
-2. Tries an exact match against supported languages
-3. Falls back to language-only match (e.g., `'fr-CA'` → `'fr'`)
-4. Applies region defaults for Chinese (`'zh'` → `'zh-cn'`), Portuguese (`'pt'` → `'pt-br'`), Korean (`'ko'` → `'ko-kr'`), and Hindi (`'hi'` → `'hi-in'`)
-5. Defaults to `'en'` if no match is found
+1. Tries an exact match against supported languages
+2. Falls back to a language-only match (e.g., `'fr-CA'` → `'fr'`)
+3. Applies region defaults for Chinese (`'zh'` → `'zh-cn'`), Portuguese (`'pt'` → `'pt-br'`), Korean (`'ko'` → `'ko-kr'`), and Hindi (`'hi'` → `'hi-in'`)
+
+The first entry that matches wins. If none match, it defaults to `'en'`.
 
 ## Using translations in components
 
-The `useTranslation` hook returns a function for looking up translation strings:
+The [useTranslation](?) hook returns a function for looking up translation strings. Unknown keys are returned as-is, so you can pass plain text or your own keys:
 
 ```tsx
 import { useTranslation } from 'tldraw'
@@ -99,7 +84,7 @@ function CopyButton() {
 }
 ```
 
-For access to the full translation object including locale and text direction:
+Use [useCurrentTranslation](?) for the full translation object, including locale and text direction:
 
 ```tsx
 import { useCurrentTranslation } from 'tldraw'
@@ -143,7 +128,7 @@ function App() {
 }
 ```
 
-Overrides are merged with the base translations for each language. English serves as the fallback—any key missing from the target language uses the English string.
+Overrides are merged with the base translations for each language. English is the fallback: any key missing from the target language uses the English string. If you add your own keys (for example a custom tool label), provide at least an `en` override for them.
 
 ### Translation keys
 
@@ -159,10 +144,10 @@ const key: TLUiTranslationKey = 'action.copy'
 
 ## Supported languages
 
-Import `LANGUAGES` from `@tldraw/tlschema` for the complete list of supported languages:
+Import [LANGUAGES](?) from `tldraw` for the complete list of supported languages:
 
 ```tsx
-import { LANGUAGES } from '@tldraw/tlschema'
+import { LANGUAGES } from 'tldraw'
 
 function LanguageSelector() {
 	return (
@@ -177,7 +162,7 @@ function LanguageSelector() {
 }
 ```
 
-Each entry in `LANGUAGES` has a `locale` code and a `label` in that language's native script.
+Each entry in `LANGUAGES` is a [TLLanguage](?) with a `locale` code and a `label` in that language's native script. Translation files are only loaded for locales in this list, so you can't add a new language by supplying a translation file alone.
 
 The supported languages include: English, Spanish, French, German, Italian, Portuguese (Brazilian and European), Dutch, Russian, Polish, Czech, Danish, Finnish, Swedish, Hungarian, Norwegian, Romanian, Turkish, Ukrainian, Greek, Croatian, Slovenian, Arabic, Hebrew, Farsi, Urdu, Hindi, Tamil, Telugu, Malayalam, Kannada, Bengali, Gujarati, Nepali, Marathi, Punjabi, Thai, Khmer, Vietnamese, Indonesian, Malay, Filipino, Somali, Japanese, Korean, Simplified Chinese, Traditional Chinese (Taiwan), Catalan, and Galician.
 
@@ -185,7 +170,7 @@ The supported languages include: English, Spanish, French, German, Italian, Port
 
 Languages like Arabic, Hebrew, Farsi, and Urdu automatically set `dir: 'rtl'` in the translation object. The tldraw UI respects this direction. Layout and text alignment mirror automatically. The `dir` attribute is set on the editor's root container, and the built-in components use CSS logical properties (`margin-inline-start`, `inset-inline-end`, and so on) so they flip without per-component code.
 
-When building custom UI components, use the `useDirection` hook to get the current text direction. It returns `'ltr'` or `'rtl'` from the active translation context — the same value you'd read from `useCurrentTranslation().dir`, but without pulling the rest of the translation object into the component:
+When building custom UI components, use the [useDirection](?) hook to get the current text direction. It returns `'ltr'` or `'rtl'` from the active translation context, the same value as `useCurrentTranslation().dir`:
 
 ```tsx
 import { useDirection } from 'tldraw'
@@ -203,8 +188,7 @@ Use `useCurrentTranslation` instead when you also need the locale, label, or `me
 Here's a language picker that updates the user's locale preference:
 
 ```tsx
-import { useEditor, useValue } from 'tldraw'
-import { LANGUAGES } from '@tldraw/tlschema'
+import { LANGUAGES, useEditor, useValue } from 'tldraw'
 
 function LanguagePicker() {
 	const editor = useEditor()
@@ -240,6 +224,8 @@ Translations load asynchronously when the locale changes. The system:
 
 During loading, the UI uses the previous translations to avoid flicker. If loading fails, English remains as the fallback.
 
+To use translations outside the full tldraw UI, wrap your components in [TldrawUiTranslationProvider](?) (inside an `AssetUrlsProvider`).
+
 ## Related examples
 
-- **[Custom translations and overrides](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/custom-language-translations)** — Override translation strings and use them in custom UI.
+- [Custom translations and overrides](/examples/ui/custom-language-translations) - Override translation strings and use them in custom UI.

--- a/apps/docs/content/sdk-features/license-key.mdx
+++ b/apps/docs/content/sdk-features/license-key.mdx
@@ -31,15 +31,40 @@ export default function App() {
 
 ## How license keys work
 
-License keys are validated on the client. They can be public—you can safely include them in your frontend code. The SDK decodes and verifies the key locally without making network requests to a license server.
+License keys are validated on the client. They can be public: you can safely include them in your frontend code. The SDK decodes and verifies the key's signature locally without making network requests to a license server.
 
-Each key encodes:
+Each key encodes the allowed hosts (the domains where the license is valid), the license type (trial, commercial, or hobby), and the expiration date.
 
-- **Allowed hosts**: The domains where the license is valid
-- **License type**: Trial, commercial, or hobby
-- **Expiration date**: When the license stops working
+## Using the license key
 
-The SDK determines development vs production by checking the protocol and hostname. HTTPS on a non-localhost domain is considered production; HTTP or localhost is development.
+Pass the key to the `licenseKey` prop on [Tldraw](?), [TldrawEditor](?), or [TldrawImage](?):
+
+```tsx
+<Tldraw licenseKey="tldraw-abc123..." />
+```
+
+```tsx
+<TldrawImage snapshot={snapshot} licenseKey="tldraw-abc123..." />
+```
+
+You can also reference an environment variable explicitly:
+
+```tsx
+<Tldraw licenseKey={process.env.NEXT_PUBLIC_TLDRAW_LICENSE_KEY} />
+```
+
+### Automatic environment variable detection
+
+The SDK also checks for license keys in common environment variables. If you set one of these, you don't need to pass the `licenseKey` prop:
+
+- `TLDRAW_LICENSE_KEY`
+- `NEXT_PUBLIC_TLDRAW_LICENSE_KEY` (Next.js)
+- `REACT_APP_TLDRAW_LICENSE_KEY` (Create React App)
+- `GATSBY_TLDRAW_LICENSE_KEY` (Gatsby)
+- `VITE_TLDRAW_LICENSE_KEY` (Vite)
+- `PUBLIC_TLDRAW_LICENSE_KEY` (SvelteKit, etc.)
+
+The SDK checks both `process.env` and `import.meta.env` versions of each variable.
 
 ## License types
 
@@ -59,97 +84,52 @@ Request a commercial license through the [plans form](https://tldraw.dev/get-a-l
 
 ### Hobby licenses
 
-For non-commercial projects, request a [hobby license](https://tldraw.dev/get-a-license/hobby). Hobby licenses keep the "made with tldraw" watermark visible. They're discretionary. The team reviews each request.
+For non-commercial projects, request a [hobby license](https://tldraw.dev/get-a-license/hobby). Hobby licenses keep the "made with tldraw" watermark visible. They're discretionary: we review each request.
 
 ## Development vs production
 
-In development environments, the SDK works without a license key. It detects development by checking:
+In development environments, the SDK works without a license key. The SDK treats the environment as development if any of these are true: the protocol is not HTTPS, the hostname is `localhost` or a loopback address (`127.x.x.x`, `::1`), or `NODE_ENV` is not `'production'`.
 
-- **Protocol**: HTTP (not HTTPS) indicates development
-- **Hostname**: `localhost` indicates development
-- **Build mode**: `NODE_ENV !== 'production'` indicates development
+In production (HTTPS on a non-loopback domain with `NODE_ENV=production`), the SDK requires a valid license key. Without one, the SDK logs errors to the console and, after five seconds, stops rendering the editor.
 
-If any of these conditions are true, you're in development mode and the SDK works normally without a key.
-
-In production (HTTPS on a non-localhost domain with `NODE_ENV=production`), the SDK requires a valid license key. Without one, you'll see console errors about the missing or invalid license.
+Keys are only verified when `crypto.subtle` is available. On plain HTTP in development, the browser doesn't expose it, so the SDK skips verification and logs a note asking you to check the key in production separately.
 
 ## Domain validation
 
 License keys specify which domains they work on. The SDK validates the current hostname against the allowed hosts in the key.
 
-Domain matching supports:
-
-- **Exact matches**: `example.com` matches `example.com` and `www.example.com`
-- **Wildcards**: `*.example.com` matches any subdomain
-- **All domains**: Some enterprise licenses allow `*` for any domain
+An exact host like `example.com` matches `example.com` and `www.example.com`. A wildcard like `*.example.com` matches any subdomain. Some enterprise licenses allow `*` for any domain.
 
 If you deploy to a domain not covered by your license, the SDK treats it as unlicensed.
 
 ## Grace period
 
-Annual and perpetual licenses have a 30-day grace period after expiration. During this period, the SDK continues working but logs warnings to the console. This gives you time to renew without service interruption.
+Annual and perpetual licenses have a 30-day grace period after expiration. During this period, the SDK continues working but logs a message to the console. This gives you time to renew without service interruption. After the grace period the SDK stops rendering the editor.
 
-Evaluation (trial) licenses have no grace period—they stop working immediately on expiration.
+Evaluation (trial) licenses have no grace period. They stop working immediately on expiration.
 
 ## Perpetual licenses
 
-Perpetual licenses don't have a time-based expiration. Instead, they're tied to a version: they work with any patch release indefinitely, but major or minor versions released after the license expiration date require renewal.
+Perpetual licenses don't have a time-based expiration. Instead, they're tied to a version: they work with any patch release indefinitely, but major or minor versions released after the license expiration date (plus the 30-day grace period) require renewal.
 
 Early versions of tldraw were sold with a perpetual license. While we no longer sell these licenses (except in exceptional cases), we still support them for existing customers.
-
-## Using the license key
-
-### Automatic environment variable detection
-
-The SDK automatically checks for license keys in common environment variables. If you set one of these, you don't need to pass the `licenseKey` prop:
-
-- `TLDRAW_LICENSE_KEY`
-- `NEXT_PUBLIC_TLDRAW_LICENSE_KEY` (Next.js)
-- `REACT_APP_TLDRAW_LICENSE_KEY` (Create React App)
-- `GATSBY_TLDRAW_LICENSE_KEY` (Gatsby)
-- `VITE_TLDRAW_LICENSE_KEY` (Vite)
-- `PUBLIC_TLDRAW_LICENSE_KEY` (SvelteKit, etc.)
-
-The SDK checks both `process.env` and `import.meta.env` versions of each variable.
-
-### Passing the key directly
-
-Pass the key to the `licenseKey` prop on `<Tldraw>` or `<TldrawEditor>`:
-
-```tsx
-<Tldraw licenseKey="tldraw-abc123..." />
-```
-
-For `<TldrawImage>`, the same prop works:
-
-```tsx
-<TldrawImage snapshot={snapshot} licenseKey="tldraw-abc123..." />
-```
-
-You can also reference an environment variable explicitly:
-
-```tsx
-<Tldraw licenseKey={process.env.NEXT_PUBLIC_TLDRAW_LICENSE_KEY} />
-```
-
-Since keys are validated client-side and are domain-restricted, exposing them in your bundle is safe.
 
 ## Data collection
 
 Data collection differs by license type:
 
-| License type | Data sent                                  |
-| ------------ | ------------------------------------------ |
-| Commercial   | None                                       |
-| Hobby        | License ID, SDK version, and page URL      |
-| Trial        | License ID, SDK version, and page URL      |
-| Unlicensed   | SDK version and page URL (production only) |
+| License type | Data sent                                           |
+| ------------ | --------------------------------------------------- |
+| Commercial   | None                                                |
+| Hobby        | License ID, license type, SDK version, and page URL |
+| Trial        | License ID, license type, SDK version, and page URL |
+| Unlicensed   | SDK version and page URL (production only)          |
 
-Trial and hobby licenses ping tldraw's servers with the license ID, SDK version, and deployment URL for analytics. No user data, canvas content, or personally identifiable information is collected. Nothing is sent from development environments.
+Trial and hobby licenses ping tldraw's servers with the license ID, license type, SDK version, build environment, and deployment URL for analytics. No user data, canvas content, or personally identifiable information is collected. Nothing is sent from development environments.
 
 ## Troubleshooting
 
-**Console shows "No tldraw license key provided" and "A license is required for production deployments"**: You're in production without a key. Add a valid `licenseKey` prop or set an environment variable.
+**Console shows "No tldraw license key provided" and "A license is required for production deployments"**: You're in production without a key, and the editor will stop rendering after five seconds. Add a valid `licenseKey` prop or set an environment variable.
 
 **Console shows "License key is not valid for this domain"**: Your key doesn't include the current domain. Contact sales@tldraw.com to update your allowed domains.
 

--- a/apps/docs/content/sdk-features/locked-shapes.mdx
+++ b/apps/docs/content/sdk-features/locked-shapes.mdx
@@ -62,10 +62,12 @@ Locked shapes resist most operations:
 | ------------ | -------------------------------------------------------------------------------------------------------- |
 | Selection    | Clicking a locked shape doesn't select it. Brush selection and [Editor#selectAll](?) skip locked shapes. |
 | Movement     | Pointer drags pass through locked shapes to the canvas.                                                  |
-| Modification | [Editor#updateShape](?) calls on locked shapes are ignored.                                              |
-| Deletion     | [Editor#deleteShapes](?) skips locked shapes.                                                            |
-| Grouping     | Locked shapes can't be added to groups.                                                                  |
+| Modification | [Editor#updateShape](?) ignores locked shapes, except for an update that unlocks them.                   |
+| Deletion     | [Editor#deleteShapes](?) and [Editor#duplicateShapes](?) skip locked shapes.                             |
+| Grouping     | [Editor#groupShapes](?) and [Editor#ungroupShapes](?) skip locked shapes.                                |
 | Editing      | Double-clicking a locked shape doesn't enter edit mode.                                                  |
+
+Right-clicking a locked shape still selects it so the context menu can offer an unlock option. If you want left-click, brush, and scribble selection to include locked shapes too, set the `selectLockedShapes` option in [TldrawOptions](?). The shapes stay protected from moves, edits, and deletes; `selectAll` still skips them.
 
 ## Ancestor locking
 
@@ -76,7 +78,7 @@ Lock state inherits through the shape hierarchy. If a shape's ancestor is locked
 const isProtected = editor.isShapeOrAncestorLocked(shape)
 ```
 
-Locking a frame or group protects all its children without needing to lock each shape individually.
+Locking a frame or group protects its children from pointer interactions and [Editor#updateShapes](?) without locking each shape individually. Bulk operations such as [Editor#deleteShapes](?) only check each shape's own `isLocked`, so a child of a locked frame can still be deleted programmatically.
 
 ## Bypassing locks programmatically
 
@@ -93,15 +95,15 @@ editor.run(
 )
 ```
 
-This bypasses the lock check for all operations inside the callback. Use it carefully since the lock exists to protect shapes from unintended changes.
+This bypasses the lock check for all operations inside the callback.
 
-Even with `ignoreShapeLock: true`, some behaviors remain unchanged: locked shapes still can't be selected by clicking, pointer events still pass through to the canvas, and `selectAll()` still skips locked shapes. The flag affects store operations (create, update, delete), not the selection and interaction model.
+Even with `ignoreShapeLock: true`, some behaviors remain unchanged: locked shapes still can't be selected by clicking, pointer events still pass through to the canvas, and `selectAll()` still skips locked shapes. The flag affects [Editor#updateShapes](?), [Editor#deleteShapes](?), [Editor#duplicateShapes](?), [Editor#groupShapes](?), and [Editor#ungroupShapes](?), not the selection and interaction model.
 
 ## Shapes that can be edited while locked
 
 Some shapes have interactive content that should remain usable even when locked. Embed shapes (YouTube videos, Figma files, interactive maps) are a good example: you might want the embed locked in place but still playable or navigable.
 
-[ShapeUtils](/sdk-features/shapes#shapeutil) can override [ShapeUtil#canEditWhileLocked](?) to allow editing interactions on locked shapes:
+[ShapeUtils](/sdk-features/shapes#shapeutil) can override [ShapeUtil#canEditWhileLocked](?) (default `false`) to allow editing interactions on locked shapes. The built-in embed shape returns `true` unless its embed definition says otherwise:
 
 ```typescript
 class MyInteractiveShapeUtil extends ShapeUtil<MyShape> {
@@ -111,12 +113,12 @@ class MyInteractiveShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-When this returns `true`, double-clicking the locked shape enters edit mode, letting users interact with the shape's content without being able to move or resize it.
+When this returns `true`, [Editor#canEditShape](?) allows the shape to enter edit mode while locked, so users can interact with its content without moving or resizing it. It doesn't make the shape hit-testable on its own: with default options a double-click on a locked shape still passes through to the canvas. The shape enters edit mode when you call [Editor#setEditingShape](?), or when the user selects it (for example with `selectLockedShapes` enabled) and presses Enter or double-clicks.
 
 ## Locking in the UI
 
-In the default tldraw UI, users can lock shapes through the context menu or the keyboard shortcut (`Shift+L`). Users can right-click on a locked shape to access the context menu, which shows an unlock option.
+In the default tldraw UI, users can lock shapes through the context menu or the keyboard shortcut (`Shift+L`). Right-clicking a locked shape opens the context menu with an unlock option, and the main menu has an "Unlock all" action.
 
 ## Related examples
 
-- **[Locked shapes](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/locked-shapes)** — Create locked shapes and modify them with `ignoreShapeLock`.
+- [Locked shapes](/examples/editor-api/locked-shapes) - Create locked shapes and modify them with `ignoreShapeLock`.

--- a/apps/docs/content/sdk-features/note-shape.mdx
+++ b/apps/docs/content/sdk-features/note-shape.mdx
@@ -12,7 +12,7 @@ status: published
 date: 1/31/2026
 ---
 
-The note shape is one of the default shapes in tldraw. It renders as a sticky note with a colored background and text content. Notes have special interaction behaviors that make them ideal for brainstorming and clustering ideas: you can quickly spawn new notes adjacent to existing ones using clone handles or keyboard shortcuts.
+The note shape is a sticky note: a colored square with text. Notes are built for brainstorming: you can spawn new notes next to existing ones with clone handles or keyboard shortcuts, and they snap into a grid beside their neighbors. See [NoteShapeUtil](?) and [TLNoteShape](?).
 
 ```tsx
 import { toRichText } from 'tldraw'
@@ -35,7 +35,7 @@ editor.createShape({
 
 ## Sizing behavior
 
-Notes have a fixed base width of 200 pixels. Unlike most shapes, you can't manually resize a note by default. Instead, notes automatically grow vertically to fit their text content. The `growY` property tracks how much extra height the note needs beyond its base size.
+Notes have a fixed base width of 200 pixels (the `noteWidth` display value). Unlike most shapes, you can't manually resize a note by default. Instead, notes grow vertically to fit their text. The `growY` property tracks how much extra height the note needs beyond its base size.
 
 When text is too wide, the note shrinks the font size (down to a minimum of 14px) before allowing text to wrap. This keeps notes compact without hiding content.
 
@@ -43,26 +43,17 @@ When text is too wide, the note shrinks the font size (down to a minimum of 14px
 
 Notes display clone handles on their edges—small plus buttons at the top, right, bottom, and left sides. These handles let you quickly create adjacent notes.
 
-**Click a clone handle** to either:
+Click a clone handle to create a new note in that direction. If a note already exists there, tldraw selects it and starts editing instead. Drag a clone handle to create a new note and immediately start moving it; when you release, the new note enters edit mode.
 
-- Create a new note in that direction, or
-- If a note already exists there, select it and start editing
+Clone handles only appear when the note is selected and the effective zoom (zoom × note `scale`) is high enough. Below 25% they're hidden entirely, and between 25% and 50% only the bottom handle appears. Touch input never shows clone handles.
 
-**Drag a clone handle** to create a new note and immediately begin moving it. When you release, the new note enters edit mode. Spawn notes and position them freely.
-
-Clone handles only appear when the note is selected and the zoom level is high enough. At very low zoom levels (below 25%), handles are hidden entirely. Between 25-50% zoom, only the bottom handle appears to reduce visual clutter. Touch input never shows clone handles.
-
-```tsx
-// Clone handles are returned by getHandles on the note shape
-const handles = editor.getShapeHandles(noteShape)
-// Each handle has type: 'clone' and an id like 'top', 'right', 'bottom', 'left'
-```
+The handles come from [ShapeUtil#getHandles](?): each has `type: 'clone'` and an id of `top`, `right`, `bottom`, or `left`.
 
 ## Adjacent snapping
 
-When you create a new note with the note tool, tldraw checks if you're clicking near an "adjacent position"—an empty slot next to an existing note. If you're within 10 pixels of one of these slots, the new note snaps into place with consistent spacing.
+When you create a note with the note tool (`N` key) or drag an existing note, tldraw checks whether you're near an "adjacent position": an empty slot next to another note. If you're within 10 screen pixels of a slot, the note snaps into place with consistent spacing.
 
-This snapping only works between notes with the same rotation and scale. The spacing between adjacent notes uses `editor.options.adjacentShapeMargin` (10 pixels by default).
+Snapping only considers notes with the same `scale`. New notes created with the tool only snap next to unrotated notes; dragged notes snap next to notes with matching rotation. The spacing comes from `editor.options.adjacentShapeMargin` (10 pixels by default; see [TldrawOptions](?)).
 
 ## Keyboard navigation
 
@@ -75,15 +66,13 @@ When editing a note, you can use keyboard shortcuts to create adjacent notes:
 | **Cmd/Ctrl+Enter**       | Create or select note below |
 | **Shift+Cmd/Ctrl+Enter** | Create or select note above |
 
-These shortcuts respect the current note's rotation. They also handle right-to-left text: in RTL content, Tab moves left instead of right.
+These shortcuts respect the current note's rotation. They also handle right-to-left text: in RTL content, Tab moves left instead of right. When the cursor is inside a list, Tab indents the list item instead of creating a note.
 
 When moving down, the keyboard shortcut accounts for the current note's `growY`. This keeps notes from overlapping when one note has grown taller than the base size.
 
 ## Visual appearance
 
-Notes render with a subtle drop shadow that varies based on the shape's ID. Each note has slightly different lift and rotation. The shadow responds to the note's rotation on the canvas.
-
-In dark mode, shadows are replaced with a simple bottom border since shadows don't render well against dark backgrounds. Shadows are also hidden when zoomed out below 25% to improve performance.
+Notes render with a subtle drop shadow seeded from the shape's ID, so each note has slightly different lift and opacity. The shadow responds to the note's rotation on the canvas. Below 25% effective zoom (adjusted for the note's `scale`) the shadow is replaced with a plain bottom border to keep rendering cheap.
 
 The note's text color is determined by its `labelColor` property. When set to `'black'` (the default), the note uses a color that contrasts well with the background. Other label colors override this automatic selection.
 
@@ -102,7 +91,7 @@ The note's text color is determined by its `labelColor` property. When set to `'
 | `growY`              | `number`                        | Additional height beyond the base 200px (set automatically)                      |
 | `url`                | `string`                        | Optional hyperlink URL                                                           |
 | `scale`              | `number`                        | Scale factor applied to the shape                                                |
-| `textFirstEditedBy`  | `string \| null`                | ID of the user who first edited the note's text                                  |
+| `textLastEditedBy`   | `string \| null`                | ID of the user who last edited the note's text (set automatically)               |
 
 ## Configuration
 
@@ -131,21 +120,15 @@ export default function App() {
 }
 ```
 
-See the [note resizing example](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/resize-note) for a working demo.
+See the [note resizing example](/examples/configuration/resize-note) for a working demo. Other display values, such as `noteWidth`, `noteHeight`, and colors, can be customized through the display value hooks on `NoteShapeUtil` options; see [Themes](/sdk-features/themes).
 
 ## Dynamic resize mode
 
-When `editor.user.getIsDynamicResizeMode()` is true, new notes are created at a scale inversely proportional to the current zoom level. Notes stay visually consistent regardless of zoom level when created.
-
-```tsx
-// If dynamic resize mode is on and zoom is 2x, new notes get scale: 0.5
-// If zoom is 0.5x, new notes get scale: 2
-const scale = editor.getResizeScaleFactor()
-```
+When `editor.user.getIsDynamicResizeMode()` is true, new notes are created at a scale inversely proportional to the current zoom level, so they stay visually consistent regardless of zoom. [Editor#getResizeScaleFactor](?) returns that scale. See [Text shape](/sdk-features/text-shape#dynamic-resize-mode) for details.
 
 ## Related articles
 
-- [Attribution](/sdk-features/attribution) — How notes display "first edited by" labels in multiplayer sessions
+- [Attribution](/sdk-features/attribution) — How notes display who last edited them in multiplayer sessions
 - [Default shapes](/sdk-features/default-shapes) — Overview of all built-in shapes
 - [Rich text](/sdk-features/rich-text) — Working with formatted text content
 - [Styles](/sdk-features/styles) — Working with shape styles like color and size

--- a/apps/docs/content/sdk-features/options.mdx
+++ b/apps/docs/content/sdk-features/options.mdx
@@ -17,13 +17,13 @@ accuracy: 10
 notes: ''
 ---
 
-The tldraw editor accepts two kinds of configuration: **editor options** for core behavior (timing, limits, performance) and **component props** for features like persistence and custom shapes. Editor options are immutable after initialization; component props configure how the editor sets up.
+The tldraw editor accepts two kinds of configuration: **editor options** for core behavior (timing, limits, performance) and **component props** for UI, persistence, and content handling. Editor options are fixed after initialization; component props configure how the editor sets up.
 
 ## Editor options
 
-The `options` prop accepts a `Partial<TldrawOptions>` object that configures core editor behavior: limits like maximum pages and shapes, timing for interactions and animations, sizing for handles and hit testing, and feature toggles.
+The `options` prop accepts a `Partial<`[TldrawOptions](?)`>` object that configures core editor behavior: limits like maximum pages and shapes, timing for interactions and animations, sizing for handles and hit testing, and feature toggles.
 
-Options are set once when the editor initializes and cannot change afterward. Pass a partial options object to override specific values; everything else uses sensible defaults.
+Options are set once when the editor initializes and cannot change afterward. Pass a partial options object to override specific values; everything else uses the defaults.
 
 ```tsx
 import { Tldraw, TldrawOptions } from 'tldraw'
@@ -37,8 +37,6 @@ function App() {
 	return <Tldraw options={options} />
 }
 ```
-
-The `TldrawOptions` type defines all available options. Since you typically only need to customize a few values, pass `Partial<TldrawOptions>` to override specific options while accepting defaults for the rest.
 
 ## Reading options at runtime
 
@@ -55,7 +53,7 @@ The options object is readonly. Attempting to modify it has no effect and TypeSc
 
 ### Limits
 
-Control maximum quantities to prevent performance issues or enforce business rules:
+Cap shape, page, and file counts:
 
 | Option             | Default | Description                         |
 | ------------------ | ------- | ----------------------------------- |
@@ -72,7 +70,7 @@ Configure how the editor interprets user input timing:
 | Option                  | Default | Description                                       |
 | ----------------------- | ------- | ------------------------------------------------- |
 | `doubleClickDurationMs` | 450     | Maximum interval for double-click detection       |
-| `multiClickDurationMs`  | 200     | Double-click settle delay and overflow window     |
+| `multiClickDurationMs`  | 200     | Window for triple- and quadruple-click detection  |
 | `longPressDurationMs`   | 500     | Duration to trigger long press                    |
 | `animationMediumMs`     | 320     | Duration for camera animations (zoom, pan to fit) |
 
@@ -87,29 +85,30 @@ Control when pointer movement becomes a drag operation:
 | `uiDragDistanceSquared`       | 16      | Distance² for UI element drag (4px)      |
 | `uiCoarseDragDistanceSquared` | 625     | Distance² for touch UI drag (25px)       |
 
-Values are squared to avoid computing square roots during hit testing. The larger touch thresholds prevent accidental drags on mobile devices.
+Values are squared to avoid computing square roots during drag detection. The larger touch thresholds prevent accidental drags on mobile devices.
 
 ### Handle and hit testing
 
 Configure selection handles and click target areas:
 
-| Option               | Default | Description                                   |
-| -------------------- | ------- | --------------------------------------------- |
-| `handleRadius`       | 12      | Radius of selection handles                   |
-| `coarseHandleRadius` | 20      | Handle radius for touch input                 |
-| `coarsePointerWidth` | 12      | Expanded pointer size for touch               |
-| `hitTestMargin`      | 8       | Additional margin around shapes for hit tests |
+| Option                | Default | Description                                   |
+| --------------------- | ------- | --------------------------------------------- |
+| `handleRadius`        | 12      | Radius of selection handles                   |
+| `coarseHandleRadius`  | 20      | Handle radius for touch input                 |
+| `hitTestMargin`       | 3       | Additional margin around shapes for hit tests |
+| `coarseHitTestMargin` | 4       | Hit test margin when using a coarse pointer   |
 
 ### Edge scrolling
 
 Configure auto-scroll behavior when dragging near viewport edges:
 
-| Option                   | Default | Description                              |
-| ------------------------ | ------- | ---------------------------------------- |
-| `edgeScrollDelay`        | 200     | Milliseconds before scroll starts        |
-| `edgeScrollEaseDuration` | 200     | Milliseconds to accelerate to full speed |
-| `edgeScrollSpeed`        | 25      | Base scroll speed in pixels per tick     |
-| `edgeScrollDistance`     | 8       | Width of the edge scroll trigger zone    |
+| Option                   | Default | Description                                                              |
+| ------------------------ | ------- | ------------------------------------------------------------------------ |
+| `edgeScrollDelay`        | 200     | Milliseconds before scroll starts                                        |
+| `edgeScrollEaseDuration` | 200     | Milliseconds to accelerate to full speed                                 |
+| `edgeScrollSpeed`        | 25      | Base scroll speed, multiplied by the user's edge scroll speed preference |
+| `edgeScrollDistance`     | 8       | Width of the edge scroll trigger zone                                    |
+| `coarsePointerWidth`     | 12      | Pointer width used to widen the trigger zone for touch                   |
 
 See [Edge scrolling](/sdk-features/edge-scrolling) for details on how these options affect behavior.
 
@@ -117,20 +116,25 @@ See [Edge scrolling](/sdk-features/edge-scrolling) for details on how these opti
 
 Control camera movement and viewport behavior:
 
-| Option                    | Default | Description                                       |
-| ------------------------- | ------- | ------------------------------------------------- |
-| `cameraSlideFriction`     | 0.09    | Friction applied to camera momentum               |
-| `cameraMovingTimeoutMs`   | 64      | Time before camera is considered stopped          |
-| `followChaseViewportSnap` | 2       | Snap threshold when following collaborators       |
-| `spacebarPanning`         | true    | Enable spacebar to activate pan mode              |
-| `rightClickPanning`       | true    | Enable right-click and drag to pan the camera     |
-| `zoomToFitPadding`        | 128     | Padding around content when zooming to fit bounds |
+| Option                    | Default                  | Description                                                                       |
+| ------------------------- | ------------------------ | --------------------------------------------------------------------------------- |
+| `cameraSlideFriction`     | 0.09                     | Friction applied to camera momentum                                               |
+| `cameraMovingTimeoutMs`   | 64                       | Time before camera is considered stopped                                          |
+| `followChaseViewportSnap` | 2                        | Snap threshold when following collaborators                                       |
+| `spacebarPanning`         | true                     | Enable spacebar to activate pan mode                                              |
+| `rightClickPanning`       | true                     | Enable right-click and drag to pan the camera                                     |
+| `zoomToFitPadding`        | 128                      | Padding around content when zooming to fit bounds                                 |
+| `camera`                  | `DEFAULT_CAMERA_OPTIONS` | Initial [TLCameraOptions](?); change at runtime with [Editor#setCameraOptions](?) |
+| `deepLinks`               | undefined                | Sync camera state with the URL: `true` or a [TLDeepLinkOptions](?) object         |
+
+The `camera` and `deepLinks` options replace the deprecated `cameraOptions` and `deepLinks` props on the component. See [Camera](/sdk-features/camera) for the camera options.
 
 ### Snapping
 
-| Option          | Default | Description                                  |
-| --------------- | ------- | -------------------------------------------- |
-| `snapThreshold` | 8       | Distance in pixels at which snapping engages |
+| Option               | Default | Description                                                                                    |
+| -------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `snapThreshold`      | 8       | Distance in pixels at which snapping engages                                                   |
+| `selectLockedShapes` | false   | Allow left-clicking and brushing to select locked shapes (they still can't be moved or edited) |
 
 ### Collaboration
 
@@ -175,7 +179,7 @@ gridSteps: [
 ]
 ```
 
-Each entry defines a grid step size based on zoom level. The `min` and `mid` values define the zoom range where the `step` applies. At lower zoom levels, larger grid steps are used; at higher zoom levels, finer grid steps appear.
+Each entry defines a grid step size based on zoom level. The `min` and `mid` values define the zoom range where the `step` applies. Zoomed out, the grid uses larger steps; zoomed in, finer ones.
 
 ### Performance
 
@@ -192,30 +196,31 @@ When `debouncedZoom` is enabled and the page has more shapes than `debouncedZoom
 
 ### UI and features
 
-| Option                           | Default   | Description                                    |
-| -------------------------------- | --------- | ---------------------------------------------- |
-| `createTextOnCanvasDoubleClick`  | true      | Create text shape on empty canvas double-click |
-| `enableToolbarKeyboardShortcuts` | true      | Enable number keys (1-9) for toolbar items     |
-| `actionShortcutsLocation`        | 'swap'    | Where to show keyboard shortcuts in menus      |
-| `tooltipDelayMs`                 | 700       | Delay before showing tooltips                  |
-| `laserDelayMs`                   | 1200      | Duration laser pointer remains visible         |
-| `laserFadeoutMs`                 | 500       | Duration for laser pointer fadeout animation   |
-| `quickZoomPreservesScreenBounds` | true      | Whether quick zoom brush keeps viewport scale  |
-| `branding`                       | undefined | App name for accessibility labels              |
-| `nonce`                          | undefined | CSP nonce for inline styles                    |
+| Option                           | Default   | Description                                                                                             |
+| -------------------------------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `createTextOnCanvasDoubleClick`  | true      | Create text shape on empty canvas double-click                                                          |
+| `enableToolbarKeyboardShortcuts` | true      | Enable number keys (1-9, 0) for toolbar items                                                           |
+| `actionShortcutsLocation`        | 'swap'    | Where the quick actions (undo, redo, delete, duplicate) render                                          |
+| `tooltipDelayMs`                 | 700       | Delay before showing tooltips                                                                           |
+| `laserDelayMs`                   | 1200      | Duration laser pointer remains visible                                                                  |
+| `laserFadeoutMs`                 | 500       | Duration for laser pointer fadeout animation                                                            |
+| `quickZoomPreservesScreenBounds` | true      | Whether quick zoom brush keeps viewport scale                                                           |
+| `branding`                       | undefined | App name for accessibility labels                                                                       |
+| `nonce`                          | undefined | CSP nonce for inline styles                                                                             |
+| `adjacentShapeMargin`            | 10        | Gap used when placing adjacent notes, duplicating, stacking, and packing shapes                         |
+| `text`                           | `{}`      | [TLTextOptions](?): TipTap configuration and font handling (replaces the deprecated `textOptions` prop) |
 
-The `actionShortcutsLocation` option controls where keyboard shortcuts appear:
+The `actionShortcutsLocation` option controls where the quick actions render:
 
-- `'menu'` - Show shortcuts in menu items only
-- `'toolbar'` - Show shortcuts in toolbar tooltips only
-- `'swap'` - Show in menus when toolbar is collapsed, toolbar when expanded
+- `'menu'` - Always in the menu panel
+- `'toolbar'` - Always in the toolbar
+- `'swap'` - In the menu panel on tablet-sized screens and up, in the toolbar below that
 
 ### Asset handling
 
 | Option                            | Default | Description                                       |
 | --------------------------------- | ------- | ------------------------------------------------- |
 | `temporaryAssetPreviewLifetimeMs` | 180000  | How long temporary asset previews persist (3 min) |
-| `adjacentShapeMargin`             | 10      | Margin between auto-positioned shapes             |
 
 ### Clipboard hooks
 
@@ -237,7 +242,7 @@ See [Clipboard](/sdk-features/clipboard) for more details on clipboard operation
 
 ## Default values
 
-The `defaultTldrawOptions` export provides all default values:
+The [defaultTldrawOptions](?) export provides all default values:
 
 ```typescript
 import { defaultTldrawOptions } from 'tldraw'
@@ -343,9 +348,9 @@ These props configure how the editor initializes:
 | Prop                 | Type                                                    | Description                                             |
 | -------------------- | ------------------------------------------------------- | ------------------------------------------------------- |
 | `autoFocus`          | `boolean`                                               | Automatically focus the editor on mount                 |
-| `initialState`       | `string`                                                | Initial tool state (defaults to `'select'`)             |
-| `shapeUtils`         | `TLShapeUtilConstructor[]`                              | Custom shape utilities                                  |
-| `bindingUtils`       | `TLBindingUtilConstructor[]`                            | Custom binding utilities                                |
+| `initialState`       | `string`                                                | Initial tool state (`<Tldraw>` defaults to `'select'`)  |
+| `shapeUtils`         | `TLAnyShapeUtilConstructor[]`                           | Custom shape utilities                                  |
+| `bindingUtils`       | `TLAnyBindingUtilConstructor[]`                         | Custom binding utilities                                |
 | `overlayUtils`       | `TLAnyOverlayUtilConstructor[]`                         | Custom [overlay utilities](/sdk-features/overlay-utils) |
 | `tools`              | `TLStateNodeConstructor[]`                              | Custom tools                                            |
 | `onMount`            | `TLOnMountHandler`                                      | Callback when editor mounts                             |
@@ -353,6 +358,11 @@ These props configure how the editor initializes:
 | `user`               | `TLCurrentUser`                                         | Current user information                                |
 | `colorScheme`        | `'light' \| 'dark' \| 'system'`                         | Color scheme (defaults to `'light'`)                    |
 | `licenseKey`         | `string`                                                | License key to remove watermark                         |
+| `themes`             | `Partial<TLThemes>`                                     | Named themes for the editor                             |
+| `initialTheme`       | `TLThemeId`                                             | Initially active theme (defaults to `'default'`)        |
+| `locale`             | `string`                                                | UI locale; overrides browser and user preferences       |
+
+The `cameraOptions`, `deepLinks`, `textOptions`, and `embeds` props are deprecated. Use `options.camera`, `options.deepLinks`, `options.text`, and `EmbedShapeUtil.configure` instead.
 
 The `getShapeVisibility` callback lets you conditionally hide shapes based on their properties:
 

--- a/apps/docs/content/sdk-features/overlay-utils.mdx
+++ b/apps/docs/content/sdk-features/overlay-utils.mdx
@@ -16,7 +16,7 @@ keywords:
   - hit testing
 ---
 
-Overlay utils render ephemeral UI on the canvas — selection handles, brush rectangles, snap lines, scribbles, and shape handles. They draw directly to a `<canvas>` element using the Canvas 2D API and can optionally provide hit-test geometry for pointer interactions.
+Overlay utils render ephemeral UI on the canvas: selection handles, brush rectangles, snap lines, scribbles, and shape handles. They draw directly to a `<canvas>` element using the Canvas 2D API and can optionally provide hit-test geometry for pointer interactions.
 
 Each overlay util defines a specific type of canvas UI. The editor queries all registered overlay utils reactively: when the editor state changes, overlay utils determine whether they are active, produce overlay instances, and render them.
 
@@ -29,7 +29,9 @@ An [OverlayUtil](?) is an abstract class with four responsibilities:
 3. **Rendering** — `render()` draws overlays into a canvas 2D context
 4. **Hit testing** (optional) — `getGeometry()` returns geometry for interactive overlays
 
-The editor calls these methods reactively. When `isActive()` returns `false`, the overlay is skipped entirely. When it returns `true`, the editor calls `getOverlays()` and `render()` whenever the editor state they depend on changes, including camera movement.
+The editor calls these methods reactively. When `isActive()` returns `false`, the overlay is skipped entirely. When it returns `true`, `getOverlays()` re-runs whenever the editor state it reads changes, and `render()` re-runs on that plus camera movement and viewport resizes.
+
+Paint order across utils comes from `options.zIndex`: higher numbers paint on top and are hit-tested first, ties keep registration order, and the default is `0`. Built-in utils use values like 50, 100, 200, and 300 so custom utils can slot between them.
 
 ## Default overlay utils
 
@@ -58,7 +60,7 @@ These are exported as [defaultOverlayUtils](?) from `tldraw`.
 Extend the [OverlayUtil](?) class and implement at least `isActive()`, `getOverlays()`, and `render()`:
 
 ```tsx
-import { OverlayUtil, TLOverlay } from '@tldraw/editor'
+import { OverlayUtil, TLOverlay } from 'tldraw'
 
 interface MyHighlightOverlay extends TLOverlay {
 	props: {
@@ -141,7 +143,7 @@ override render(ctx: CanvasRenderingContext2D, overlays: MyOverlay[]): void {
 By default, overlays are non-interactive. To make an overlay respond to pointer events, implement `getGeometry()` to return a [Geometry2d](?) in page coordinates:
 
 ```tsx
-import { Circle2d, Geometry2d } from '@tldraw/editor'
+import { Circle2d, Geometry2d, TLCursorType } from 'tldraw'
 
 class MyInteractiveOverlayUtil extends OverlayUtil<MyOverlay> {
 	// ...isActive, getOverlays, render...
@@ -161,7 +163,7 @@ class MyInteractiveOverlayUtil extends OverlayUtil<MyOverlay> {
 }
 ```
 
-When the pointer moves over an overlay with geometry, the editor updates [OverlayManager#getHoveredOverlayId](?) and applies the cursor from `getCursor()`.
+While the select tool is idle, it hit-tests overlays on every pointer move, records the result with [OverlayManager#setHoveredOverlay](?), and applies the cursor from `getCursor()`. Overlays take priority over shapes for hover. To handle clicks yourself, implement `onPointerDown(overlay, info)`; it runs before the default routing, and returning `false` falls through to the default behavior.
 
 ## Registering overlay utils
 
@@ -179,7 +181,7 @@ export default function App() {
 }
 ```
 
-When using the [Tldraw](?) component, your custom overlay utils are merged with the defaults — you don't need to re-include them. If your custom overlay util has the same `type` as a default one, it replaces the default.
+When using the [Tldraw](?) component, your custom overlay utils are merged with the defaults, so you don't need to re-include them. If your custom overlay util has the same `type` as a default one, it replaces the default. [TldrawEditor](?) has no defaults; pass [defaultOverlayUtils](?) yourself if you want them.
 
 ## Customizing default overlays
 
@@ -215,16 +217,14 @@ export default function App() {
 }
 ```
 
-Since `BlueBrushOverlayUtil` inherits the same `type` as `BrushOverlayUtil`, it replaces the default brush overlay.
-
 ### Options via configure
 
-Overlay utils can define an `options` property for configuration. Use the static [OverlayUtil#configure](?) method to create a customized version without subclassing:
+Overlay utils can define an `options` property for configuration. Keep `zIndex` in it, since the base type is `{ zIndex?: number }`. Use the static [OverlayUtil#configure](?) method to create a customized version without subclassing:
 
 ```tsx
 class MyOverlayUtil extends OverlayUtil<MyOverlay> {
 	static override type = 'my_overlay'
-	override options = { color: 'red', radius: 10 }
+	override options = { zIndex: 50, color: 'red', radius: 10 }
 
 	// ...use this.options.color and this.options.radius in render()
 }
@@ -232,6 +232,8 @@ class MyOverlayUtil extends OverlayUtil<MyOverlay> {
 // Create a variant with different options
 const BlueOverlay = MyOverlayUtil.configure({ color: 'blue' })
 ```
+
+The built-in utils expose their colors and line widths as theme-aware display values, so you can recolor one with `configure({ getCustomDisplayValues })` instead of overriding `render()`. See [BrushOverlayUtilOptions](?) for an example.
 
 ## Accessing overlay utils at runtime
 
@@ -259,6 +261,6 @@ const hoveredId = editor.overlays.getHoveredOverlayId()
 
 ## Related examples
 
-- **[Custom overlay](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/custom-overlay)** — Draw a custom canvas overlay on top of the editor.
-- **[Replace a built-in overlay](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/replace-brush-overlay)** — Swap out the brush overlay for a custom implementation.
-- **[Hovered overlay](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/hovered-overlay)** — Read the overlay that the user is hovering.
+- [Custom overlay](/examples/editor-api/custom-overlay) - Draw a custom canvas overlay on top of the editor.
+- [Replace a built-in overlay](/examples/editor-api/replace-brush-overlay) - Swap out the brush overlay for a custom implementation.
+- [Hovered overlay](/examples/editor-api/hovered-overlay) - Read the overlay that the user is hovering.

--- a/apps/docs/content/sdk-features/pages.mdx
+++ b/apps/docs/content/sdk-features/pages.mdx
@@ -19,15 +19,15 @@ notes: Add API link syntax for automatic linking. Tighten wording in a few place
 
 The pages system provides multiple independent sub-documents within a single tldraw document. Each page acts as a separate scene graph root with its own shapes, camera position, and selection state.
 
-When you switch pages, the editor preserves your camera position and selected shapes on the previous page and restores the state you left on the new page. The page system integrates with collaboration, letting users see which pages their collaborators are viewing and follow them across page boundaries.
+When you switch pages, the editor preserves your camera position and selected shapes on the previous page and restores the state you left on the new page. In collaborative sessions, users can see which pages their collaborators are viewing and follow them across page boundaries.
 
 ## How it works
 
-Each page is a record in the store with a unique ID, a name for display, and an index for ordering. Pages belong to the document scope, meaning they persist across sessions and sync in collaborative environments. When you create a page, the editor automatically creates associated records for the camera position and instance page state.
+Each page is a [TLPage](?) record in the store with a unique ID, a name for display, an index for ordering, and a `meta` object for your own data. Pages belong to the document scope: they persist across sessions and sync in collaborative environments. When you create a page, the editor automatically creates associated records for the camera position and instance page state.
 
-The camera record associated with a page tracks viewport position and zoom for that page only. The editor's current camera is based on the current page: when you navigate to a different page, the editor automatically switches to the camera for that page. This per-page camera state lets each user maintain their own view of each page, independent of other users and other pages.
+The camera record associated with a page tracks viewport position and zoom for that page only. When you navigate to a different page, the editor switches to the camera for that page, so each user keeps their own view of each page. Camera options and constraints are editor-wide, not per page; they apply to whichever page is current.
 
-The instance page state record tracks selection, editing state, focused groups, and other transient UI state unique to both a page and a browser session. This state belongs to the session scope, meaning it doesn't sync in collaborative environments. Each user maintains their own instance page state for each page they visit.
+The instance page state record tracks selection, editing state, focused groups, and other transient UI state unique to both a page and a browser session. This state belongs to the session scope and doesn't sync in collaborative environments. Each user maintains their own instance page state for each page they visit.
 
 Pages are ordered. As with shapes, the page record's `index` property determines its order among other pages.
 
@@ -35,14 +35,14 @@ Pages are ordered. As with shapes, the page record's `index` property determines
 
 ### Access
 
-Get the current page or page ID:
+Get the current page or page ID with [Editor#getCurrentPage](?) and [Editor#getCurrentPageId](?):
 
 ```typescript
 const currentPage = editor.getCurrentPage()
 const currentPageId = editor.getCurrentPageId()
 ```
 
-Access any page by ID:
+Access any page by ID with [Editor#getPage](?), or list them all with [Editor#getPages](?):
 
 ```typescript
 import { TLPageId } from 'tldraw'
@@ -69,7 +69,7 @@ Create new pages with [Editor#createPage](?), which ensures unique page names an
 editor.createPage({ name: 'Wireframes' })
 ```
 
-The editor enforces a maximum page count through the `maxPages` option (default: 40). Attempts to create pages beyond this limit are ignored. Set `maxPages` to 1 to disable multi-page UI entirely.
+The editor enforces a maximum page count through the `maxPages` option (see [TldrawOptions](?), default: 40). Attempts to create pages beyond this limit are ignored. Set `maxPages` to 1 to disable multi-page UI entirely. All page mutations are no-ops when the editor is readonly.
 
 Delete pages with [Editor#deletePage](?):
 
@@ -77,7 +77,7 @@ Delete pages with [Editor#deletePage](?):
 editor.deletePage('page:page1' as TLPageId)
 ```
 
-When deleting the current page, the editor switches to an adjacent page automatically. The last remaining page cannot be deleted. When a page is deleted, all shapes on that page are removed and the associated camera and instance page state records are cleaned up.
+When deleting the current page, the editor switches to an adjacent page automatically. The last remaining page cannot be deleted. When a page is deleted, all shapes on that page are removed and the associated camera and instance page state records are cleaned up. If a collaborator deletes the page you're viewing, the editor moves you to another page.
 
 ### Duplicating pages
 
@@ -87,7 +87,7 @@ Use [Editor#duplicatePage](?) to copy an entire page including all its shapes an
 editor.duplicatePage('page:main' as TLPageId)
 ```
 
-The duplicated page receives a copy of all shapes from the source page, preserving their positions, properties, and bindings between copied shapes. The camera position is copied from the source page. The new page's name appends " Copy" to the original page name.
+The duplicated page receives a copy of all shapes from the source page, preserving their positions, properties, and bindings between copied shapes. The camera position is copied from the source page and the editor switches to the new page. The new page's name appends " Copy" to the original page name. Like `createPage`, this respects `maxPages`.
 
 ### Renaming and updating pages
 
@@ -97,24 +97,24 @@ Rename a page with [Editor#renamePage](?):
 editor.renamePage('page:page1' as TLPageId, 'New Name')
 ```
 
-For more complex updates like changing metadata, use [Editor#updatePage](?):
+For other updates, like changing the page's `meta`, use [Editor#updatePage](?):
 
 ```typescript
-editor.updatePage({ id: 'page:page1' as TLPageId, name: 'Updated Name' })
+editor.updatePage({ id: 'page:page1' as TLPageId, meta: { description: 'Main design page' } })
 ```
 
 ## Working with shapes across pages
 
 ### Page-specific shape queries
 
-Each page maintains its own shape hierarchy. Get shapes on the current page:
+Each page maintains its own shape hierarchy. Get shapes on the current page with [Editor#getCurrentPageShapes](?) and [Editor#getCurrentPageShapeIds](?):
 
 ```typescript
 const shapes = editor.getCurrentPageShapes()
 const shapeIds = editor.getCurrentPageShapeIds()
 ```
 
-Get shapes from any page:
+Get shape IDs from any page with [Editor#getPageShapeIds](?):
 
 ```typescript
 const pageShapeIds = editor.getPageShapeIds('page:page2' as TLPageId)
@@ -135,11 +135,13 @@ editor.moveShapesToPage(
 )
 ```
 
-The operation copies the shapes to the destination page at the same position and then removes them from the source page. The editor then switches to the destination page and selects the moved shapes. Bindings between moved shapes are preserved, but bindings to shapes not being moved are removed and receive isolation callbacks. The editor enforces per-page shape limits through the `maxShapesPerPage` option.
+The operation removes the shapes from the source page, switches to the destination page, and puts them there at the same position and with the same IDs. It then matches the source page's zoom, centers the camera on the moved shapes, and selects them.
+
+Bindings between moved shapes are preserved. Bindings to shapes that stay behind are removed, and their binding utils receive `onBeforeIsolateFromShape` callbacks. If the move would push the destination page over the `maxShapesPerPage` option, nothing moves and the editor emits a `max-shapes` event.
 
 ## Collaboration and pages
 
-In collaborative sessions, each user's current page is tracked through the presence system. The editor provides methods to see which pages collaborators are viewing:
+In collaborative sessions, each user's current page is tracked through the presence system. Use [Editor#getCollaboratorsOnCurrentPage](?) to see who is on your page:
 
 ```typescript
 const collaboratorsOnThisPage = editor.getCollaboratorsOnCurrentPage()
@@ -147,21 +149,19 @@ const collaboratorsOnThisPage = editor.getCollaboratorsOnCurrentPage()
 
 When following the viewport of a user who switches pages, your editor switches pages automatically to maintain the follow relationship. See [User following](/sdk-features/user-following) for details on cross-page following behavior.
 
-## Integration with other systems
-
-The pages system interacts with several editor features.
-
-In collaborative sessions, if a collaborator deletes a page you're viewing, the editor automatically moves you to the next available page.
-
-Each page has its own camera record, preserving zoom and position independently. Camera constraints and options apply per-page.
-
-Bindings can only connect shapes on the same page. When shapes move to different pages, their bindings are automatically removed.
+## Undo and deep links
 
 Undo and redo operations are document-wide, not page-specific. Undoing a page creation removes the page and all its shapes.
 
-URLs can encode specific page IDs with the deep links API, allowing direct navigation to a particular page when loading a document.
+URLs can encode a page ID with the [deep links](/sdk-features/deep-links) API, so a document can open directly on a particular page.
+
+## Related articles
+
+- [Camera](/sdk-features/camera) - Camera options and constraints
+- [User following](/sdk-features/user-following) - Following collaborators across pages
+- [Deep links](/sdk-features/deep-links) - Encoding pages and viewports in URLs
 
 ## Related examples
 
-- [Disable pages](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/disable-pages) - Disable page-related UI for single-page use cases by setting the `maxPages` option to 1.
-- [Deep links](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/deep-links) - Create URLs that navigate to specific pages using the deep links API.
+- [Disable pages](/examples/configuration/disable-pages) - Disable page-related UI for single-page use cases by setting the `maxPages` option to 1.
+- [Deep links](/examples/configuration/deep-links) - Create URLs that navigate to specific pages using the deep links API.

--- a/apps/docs/content/sdk-features/parenting.mdx
+++ b/apps/docs/content/sdk-features/parenting.mdx
@@ -18,7 +18,7 @@ accuracy: 10
 notes: ''
 ---
 
-Every shape in tldraw has a parent. A shape's parent is either the page it lives on or another shape that contains it. This parent-child relationship creates a hierarchy that affects how shapes move, transform, and render. Groups and frames use this hierarchy to contain other shapes; the editor tracks this hierarchy to manage transforms, selection, and rendering order.
+Every shape in tldraw has a parent: either the page it lives on or another shape that contains it. Groups and frames use this hierarchy to hold other shapes. The editor uses it for transforms, selection, and rendering order.
 
 ## The parentId property
 
@@ -167,27 +167,31 @@ editor.reparentShapes([shapeA, shapeB], editor.getCurrentPageId())
 
 The method handles coordinate transformation automatically. If the parent is rotated, children's positions and rotations are adjusted so they appear in the same place on the page.
 
-You can optionally specify an insert index to control z-ordering:
+You can pass an `IndexKey` (a fractional index string, not a numeric position) as the third argument to control z-ordering. The reparented shapes are inserted at that key among the new parent's children:
 
 ```typescript
-// Insert at a specific position in the parent's child stack
-editor.reparentShapes([newChild], parentId, insertIndex)
+// Put the child where the group sat in its parent's stack
+editor.reparentShapes([newChild], group.parentId, group.index)
 ```
+
+When you omit `parentId` from [Editor#createShapes](?), the editor picks one for you: the focused group, or a container such as a frame under the shape's `x` and `y`. Deleting a shape with [Editor#deleteShapes](?) also deletes its descendants.
 
 ## Transforms and coordinates
 
 Parent-child relationships affect coordinate systems. A child shape's `x` and `y` are relative to its parent, not the page.
 
-To convert between coordinate systems:
+Use [Editor#getPointInShapeSpace](?) and [Editor#getShapePageTransform](?) to convert between coordinate systems:
 
 ```typescript
-// Convert a page point to a shape's local space ([Editor#getPointInShapeSpace](?))
+// Convert a page point to a shape's local space
 const localPoint = editor.getPointInShapeSpace(parentShape, pagePoint)
 
-// Get a shape's position in page coordinates ([Editor#getShapePageTransform](?))
+// Get a shape's position in page coordinates
 const pageTransform = editor.getShapePageTransform(childShape)
 const pagePoint = pageTransform.point()
 ```
+
+[Editor#getShapeParentTransform](?) and [Editor#getShapeLocalTransform](?) give you the other two pieces of the composition.
 
 When you move a parent, all children move with it. Their local coordinates stay the same, but their page coordinates change.
 
@@ -219,28 +223,11 @@ if (editor.isShapeOrAncestorLocked(myShape)) {
 }
 ```
 
-This is what the editor uses internally to determine if shapes should respond to interactions.
+The editor uses this for pointer interactions and [Editor#updateShapes](?). Bulk operations such as [Editor#deleteShapes](?) only check each shape's own `isLocked`. See [Locked shapes](/sdk-features/locked-shapes).
 
 ## Hidden shapes
 
-The editor can track shape visibility through [Editor#isShapeHidden](?). This only works if you provide a `getShapeVisibility` callback when creating the editor:
-
-```typescript
-const editor = new Editor({
-	getShapeVisibility: (shape, editor) => {
-		// Return 'hidden', 'visible', or 'inherit'
-		return shape.meta.hidden ? 'hidden' : 'inherit'
-	},
-	// ... other options
-})
-
-// Now you can check visibility
-if (editor.isShapeHidden(myShape)) {
-	// Shape won't render (either it or an ancestor is hidden)
-}
-```
-
-A shape is hidden if its visibility is `'hidden'` or if any ancestor is hidden (unless the shape explicitly overrides with `'visible'`). Without a `getShapeVisibility` callback, `isShapeHidden()` always returns `false`.
+Visibility also inherits through the hierarchy: a shape is hidden if the `getShapeVisibility` prop returns `'hidden'` for it or for any ancestor, unless the shape returns `'visible'`. Check with [Editor#isShapeHidden](?). See [Visibility](/sdk-features/visibility).
 
 ## The focused group
 
@@ -248,5 +235,5 @@ The editor tracks a "focused group" that determines which level of the hierarchy
 
 ## Related examples
 
-- **[Layer panel](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/layer-panel)** - Build a hierarchical layer panel that shows parent-child relationships.
-- **[Drag and drop](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/drag-and-drop)** - Handle reparenting when dropping shapes onto containers.
+- [Layer panel](/examples/ui/layer-panel) - Build a hierarchical layer panel that shows parent-child relationships.
+- [Drag and drop](/examples/shapes/tools/drag-and-drop) - Handle reparenting when dropping shapes onto containers, using [ShapeUtil#canReceiveNewChildrenOfType](?) and [ShapeUtil#onDragShapesIn](?).

--- a/apps/docs/content/sdk-features/pen-mode.mdx
+++ b/apps/docs/content/sdk-features/pen-mode.mdx
@@ -12,7 +12,7 @@ status: draft
 date: 1/31/2026
 ---
 
-Pen mode restricts canvas input to stylus events. When a stylus like an Apple Pencil touches the canvas, the editor turns on pen mode and ignores other pointer input. Users can rest their palm on the screen while drawing without triggering accidental touches.
+Pen mode restricts canvas input to stylus events. When a stylus touches a touch-capable screen, like an Apple Pencil on an iPad, the editor turns on pen mode and ignores other pointer input. Users can rest their palm on the screen while drawing without triggering accidental touches.
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -24,10 +24,10 @@ export default function App() {
 			<Tldraw
 				onMount={(editor) => {
 					// Check whether pen mode is active
-					const { isPenMode } = editor.getInstanceState()
-
-					// Turn pen mode off
-					editor.updateInstanceState({ isPenMode: false })
+					if (editor.getInstanceState().isPenMode) {
+						// Turn pen mode off
+						editor.updateInstanceState({ isPenMode: false })
+					}
 				}}
 			/>
 		</div>
@@ -37,15 +37,15 @@ export default function App() {
 
 ## How pen mode activates
 
-The editor detects stylus input from the browser's pointer events: any pointer with `pointerType: 'pen'` is treated as a pen. The first time a pen touches the canvas, the editor sets `isPenMode` to `true` on the [instance state](/sdk-features/instance-state).
+The editor detects stylus input from the browser's pointer events: any pointer with `pointerType: 'pen'` is treated as a pen. Pen mode only turns on for direct-display pens, though. When a pen touches the canvas on a touch-capable device, the editor sets `isPenMode` to `true` on the [instance state](/sdk-features/instance-state) and interrupts any touch interaction in progress. A stylus on a desktop graphics tablet still draws as a pen but doesn't enable pen mode, since there's no palm to reject.
 
-Pen mode is session state. It doesn't persist across reloads, and it isn't synced between collaborators.
+Pen mode is session state. It doesn't persist across reloads, and it isn't synced between collaborators. There's no option to disable auto-enabling; if you don't want it, turn it back off with [Editor#updateInstanceState](?).
 
 ## Touch rejection
 
 While pen mode is on, the editor drops pointer down, move, and up events from any non-pen input. Finger touches and mouse clicks on the canvas do nothing. This is what makes palm rejection work: a hand resting on a tablet screen produces touch events, and pen mode filters them all out.
 
-The rest of the UI still works normally. Pen mode only filters events on the canvas, so users can still tap toolbar buttons and menus with a finger.
+The rest of the UI still works normally. Pen mode only filters events on the canvas, so users can still tap toolbar buttons and menus with a finger. Click detection follows the same rule: in pen mode only pen events produce double-clicks.
 
 ## Exiting pen mode
 
@@ -63,19 +63,19 @@ There's no way to turn pen mode off with a finger on the canvas itself, since th
 
 Pen pressure arrives on pointer events as the `z` component of the pointer's position, taken from the browser's `PointerEvent.pressure` value (0 to 1).
 
-The draw and highlighter tools use this pressure to vary stroke thickness. When a stroke is drawn with a real pen, the resulting draw shape records `isPen: true` in its props and keeps the raw pressure data in its points. Strokes drawn with a mouse or finger use simulated pressure instead.
+The draw tool uses this pressure to vary stroke thickness. When the input reports real pressure (a `pen` pointer with non-zero pressure, or any pointer whose pressure isn't a constant 0, 0.5, or 1), the resulting draw shape records `isPen: true` in its props and stores scaled pressure in its points. Strokes drawn with a mouse or finger use simulated pressure instead. The highlighter records `isPen` the same way but renders at constant width.
 
 ```tsx
 // Read the current pointer's pressure
 const { z } = editor.inputs.getCurrentPagePoint()
 
-// Check whether the most recent input was a pen
+// Check whether the most recent pointer event came from a pen
 const isPen = editor.inputs.getIsPen()
 ```
 
 ## Stylus erasers
 
-Some styluses, like the Surface Pen or Wacom pens, have a hardware eraser. When the editor receives a pointer down from an eraser button (button 5), it switches to the eraser tool, then restores the previous tool when the eraser lifts.
+Some styluses, like the Surface Pen or Wacom pens, have a hardware eraser. When the editor receives a pointer down from an eraser button (button 5), it switches to the eraser tool, then restores the previous tool when the eraser lifts. This works whether or not pen mode is on.
 
 ## Related articles
 

--- a/apps/docs/content/sdk-features/pen-mode.mdx
+++ b/apps/docs/content/sdk-features/pen-mode.mdx
@@ -23,9 +23,7 @@ export default function App() {
 		<div style={{ position: 'fixed', inset: 0 }}>
 			<Tldraw
 				onMount={(editor) => {
-					// Check whether pen mode is active
 					if (editor.getInstanceState().isPenMode) {
-						// Turn pen mode off
 						editor.updateInstanceState({ isPenMode: false })
 					}
 				}}

--- a/apps/docs/content/sdk-features/performance.mdx
+++ b/apps/docs/content/sdk-features/performance.mdx
@@ -16,7 +16,7 @@ keywords:
   - image resolution
 ---
 
-The tldraw SDK uses several techniques to maintain smooth performance even with thousands of shapes on the canvas. Understanding these systems helps you build custom shapes that perform well and avoid common pitfalls.
+The tldraw SDK uses several techniques to maintain smooth performance even with thousands of shapes on the canvas. This article covers what the SDK does for you and what to do in custom shapes.
 
 ## How tldraw optimizes rendering
 
@@ -24,7 +24,7 @@ The tldraw SDK uses several techniques to maintain smooth performance even with 
 
 Shapes outside the viewport don't need to render. The editor maintains a spatial index that tracks which shapes are visible, and hides off-screen shapes by setting `display: none` on their DOM elements. This means a canvas with 10,000 shapes might only render 50 if the rest are out of view.
 
-Culling happens automatically for all shapes. The shapes remain in the store and can still be selected or updated—they just don't incur rendering cost. See [Culling](/sdk-features/culling) for details on how to control this behavior for custom shapes.
+Culling happens automatically for all shapes. The shapes remain in the store and can still be selected or updated; they just don't incur rendering cost. Selected shapes and the shape being edited are never culled. See [Culling](/sdk-features/culling) for details on how to control this behavior for custom shapes.
 
 ### Reactive signals
 
@@ -62,27 +62,27 @@ editor.run(() => {
 
 When the camera moves, shape components receive the new zoom level to scale stroke widths and other visual properties. On documents with many shapes, recalculating everything mid-zoom causes jank.
 
-The editor provides `editor.getEfficientZoomLevel()` which returns a stable value during camera movement when the document has more than 500 shapes (configurable via the `debouncedZoomThreshold` option). Once the camera stops, the value updates to the true zoom level.
+The editor provides [Editor#getEfficientZoomLevel](?), which returns a stable value during camera movement when the document has more than 500 shapes (configurable via the `debouncedZoomThreshold` option). Once the camera stops, the value updates to the true zoom level.
 
 Shape components should use this value rather than `editor.getZoomLevel()` for properties that affect rendering:
 
 ```tsx
-function MyShapeComponent({ shape }) {
+function MyShapeComponent({ shape }: { shape: MyShape }) {
 	const editor = useEditor()
 	const zoom = useValue('zoom', () => editor.getEfficientZoomLevel(), [editor])
 
 	// Stroke width stays stable during camera movement
 	const strokeWidth = 2 / zoom
 
-	return <path strokeWidth={strokeWidth} ... />
+	return <path d={getPathForShape(shape)} strokeWidth={strokeWidth} />
 }
 ```
 
 ### Geometry caching
 
-Computing a shape's geometry—bounds, hit test regions, outline—can be expensive. The editor caches these computations and invalidates them only when a shape's props change.
+Computing a shape's geometry (bounds, hit test regions, outline) can be expensive. The editor caches these computations and invalidates them only when a shape's props change.
 
-Access cached geometry through `editor.getShapeGeometry(shapeId)` rather than calling `shapeUtil.getGeometry()` directly. The editor handles caching, transforms, and bounds calculation.
+Access cached geometry through [Editor#getShapeGeometry](?) rather than calling `shapeUtil.getGeometry()` directly. The editor handles caching, transforms, and bounds calculation.
 
 ### Level of detail
 
@@ -90,7 +90,7 @@ tldraw adjusts rendering fidelity based on zoom level and on-screen size, a tech
 
 **Image resolution scaling**
 
-When you zoom out or resize an image shape, tldraw requests a lower-resolution version from your asset store. The `resolve` method on [TLAssetStore](?) receives a [TLAssetContext](?) with `steppedScreenScale`—the ratio of the shape's on-screen size to the image's native size, rounded up to the nearest power of two. Use this to serve appropriately sized images:
+When you zoom out or resize an image shape, tldraw requests a lower-resolution version from your asset store. The `resolve` method on [TLAssetStore](?) receives a [TLAssetContext](?) with `steppedScreenScale`: the ratio of the shape's on-screen size (in CSS pixels) to the image's native size, rounded up to the nearest power of two. Multiply by `dpr` to get device pixels:
 
 ```ts
 const assetStore: TLAssetStore = {
@@ -104,18 +104,13 @@ const assetStore: TLAssetStore = {
 }
 ```
 
-A 4000px-wide photo zoomed out to take up 200px on screen only needs 200 device pixels worth of data. This reduces memory usage and decoding cost. Resolution updates are debounced so images don't thrash between sizes during zooming.
+A 4000px-wide photo zoomed out to take up 200px on screen has a screen scale of 0.05, which steps up to 0.0625, so you'd serve a 250px-wide image (times `dpr`) instead of the full 4000px. This reduces memory usage and decoding cost. Resolution updates are debounced so images don't thrash between sizes during zooming.
 
 **Built-in shape simplifications**
 
-The built-in shapes reduce rendering complexity at low zoom levels:
+The built-in shapes reduce rendering complexity at low zoom levels. Sticky notes drop their box shadow in favor of a plain bottom border. Dashed and dotted freehand strokes render as solid lines. The hatch pattern fill switches to a solid fallback color. Text outlines turn off below the `textShadowLod` threshold (default 0.35) to reduce compositing cost, and are always off on Safari.
 
-- **Note shadows** — Box shadows on sticky notes are hidden when zoomed out far enough, replaced by a simple border
-- **Draw shapes** — Freehand strokes switch from their detailed "draw" style to solid paths
-- **Pattern fills** — Hatch and cross-hatch fills switch to solid colors
-- **Text outlines** — Text shadow outlines disable below the `textShadowLod` threshold (default 0.35) to reduce compositing cost
-
-These transitions use [Editor#getEfficientZoomLevel](?) so they stay stable during camera movement rather than updating every frame. Custom shapes can use the same technique—see [Simplify at small sizes](#simplify-at-small-sizes) below.
+These transitions use [Editor#getEfficientZoomLevel](?) so they stay stable during camera movement rather than updating every frame. Custom shapes can use the same technique. See [Simplify at small sizes](#simplify-at-small-sizes) below.
 
 ## Tips for custom shapes
 
@@ -126,7 +121,7 @@ When shapes are very small on screen, fine details become invisible. Rendering s
 Use `editor.getEfficientZoomLevel()` to detect when shapes are small enough to simplify:
 
 ```tsx
-function MyShapeComponent({ shape }) {
+function MyShapeComponent({ shape }: { shape: MyShape }) {
 	const editor = useEditor()
 	const isSmall = useValue(
 		'is small',
@@ -148,31 +143,13 @@ function MyShapeComponent({ shape }) {
 }
 ```
 
-The built-in shapes use this pattern. Pattern fills switch to solid colors when zoomed out far enough, and text shadows disable at low zoom levels (controlled by the `textShadowLod` option).
-
 ### Avoid shape animations
 
 Animating shape properties causes continuous re-renders. A spinning shape triggers updates every frame. If you have many shapes or complex rendering, this adds up quickly.
 
-If you need animation, consider:
+If you need animation, use CSS animations for purely visual effects that don't change shape data, use a canvas for particle systems or complex effects, and keep the number of concurrently animating shapes small.
 
-- **CSS animations** for purely visual effects that don't change shape data
-- **Canvas rendering** for particle systems or complex animations
-- **Limiting concurrent animations** to a small number of shapes
-
-The [Animation](/sdk-features/animation) article covers the editor's animation system. The animation system handles camera movement and occasional shape transitions. It's not designed for continuous per-shape animation.
-
-### Use stable values for zoom-dependent calculations
-
-When calculating values that depend on zoom (stroke widths, font sizes, handle positions), use `getEfficientZoomLevel()` rather than `getZoomLevel()`. This prevents recalculations during camera movement:
-
-```tsx
-// Avoid: causes re-renders during zoom
-const strokeWidth = 2 / editor.getZoomLevel()
-
-// Better: stable during camera movement
-const strokeWidth = 2 / editor.getEfficientZoomLevel()
-```
+The [Animation](/sdk-features/animation) article covers the editor's animation system. It handles camera movement and occasional shape transitions. It's not designed for continuous per-shape animation.
 
 ### Keep component functions cheap
 
@@ -196,7 +173,7 @@ For calculations that affect hit testing or bounds, put them in `getGeometry()` 
 
 ### Disable culling only when necessary
 
-By default, all shapes participate in culling. Override `canCull()` to return `false` only for shapes that genuinely need to stay rendered off-screen:
+By default, all shapes participate in culling. Override [ShapeUtil#canCull](?) to return `false` only for shapes that genuinely need to stay rendered off-screen:
 
 ```ts
 class MyShapeUtil extends ShapeUtil<MyShape> {
@@ -207,13 +184,7 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-Common reasons to disable culling:
-
-- Shapes that measure their DOM content to determine size
-- Shapes with visual effects (shadows, glows) that extend beyond bounds
-- Shapes running animations that should continue off-screen
-
-For most shapes, leave culling enabled.
+Reasons to disable culling include shapes that measure their DOM content to determine size, shapes with visual effects (shadows, glows) that extend beyond their bounds, and shapes running animations that should continue off-screen. For most shapes, leave culling enabled.
 
 ## Editor options for performance
 
@@ -243,23 +214,13 @@ function App() {
 
 ## Measuring performance
 
-When investigating performance issues:
+When investigating performance issues, start with the numbers: `editor.getCurrentPageShapeIds().size` tells you how many shapes are on the current page and [Editor#getCulledShapes](?) tells you how many of them are hidden by culling. Then use React DevTools and Chrome's Performance tab to find slow components, and test with a production build, since development mode has overhead that production builds don't.
 
-1. **Check shape count** — `editor.getCurrentPageShapeIds().size` tells you how many shapes are on the current page
-2. **Check culled shapes** — `editor.getCulledShapes().size` shows how many are hidden by culling
-3. **Use browser profiler** — React DevTools and Chrome's Performance tab help identify slow components
-4. **Test with production builds** — Development mode has overhead that production builds don't
-
-If performance degrades with many shapes, look for:
-
-- Shapes that disable culling unnecessarily
-- Components that use `getZoomLevel()` instead of `getEfficientZoomLevel()`
-- Expensive calculations inside component render functions
-- Continuous animations on many shapes
+If performance degrades with many shapes, look for shapes that disable culling unnecessarily, components that use `getZoomLevel()` instead of `getEfficientZoomLevel()`, expensive calculations inside component render functions, and continuous animations on many shapes.
 
 ### Subscribing to performance events
 
-For programmatic monitoring — telemetry, RUM, or in-app dashboards — the editor exposes [PerformanceManager](?) at `editor.performance`. Subscribe to events and you'll get aggregated frame-time stats from real interactions, with no overhead when no listeners are attached:
+For programmatic monitoring (telemetry or in-app dashboards), the editor exposes [PerformanceManager](?) at `editor.performance`. Subscribe to events and you'll get aggregated frame-time stats from real interactions, with no overhead when no listeners are attached:
 
 ```ts
 const unsub = editor.performance.on('interaction-end', (event) => {
@@ -283,8 +244,8 @@ const adapter = new PerformanceApiAdapter(editor.performance)
 
 ## Related
 
-- [Culling](/sdk-features/culling) — How viewport culling works and how to control it
-- [Signals](/sdk-features/signals) — The reactive state system
-- [Store](/sdk-features/store) — How the reactive database batches changes
-- [Options](/sdk-features/options) — All available editor options
-- [Animation](/sdk-features/animation) — The shape and camera animation systems
+- [Culling](/sdk-features/culling): how viewport culling works and how to control it
+- [Signals](/sdk-features/signals): the reactive state system
+- [Store](/sdk-features/store): how the reactive database batches changes
+- [Options](/sdk-features/options): all available editor options
+- [Animation](/sdk-features/animation): the shape and camera animation systems

--- a/apps/docs/content/sdk-features/persistence.mdx
+++ b/apps/docs/content/sdk-features/persistence.mdx
@@ -39,7 +39,7 @@ export default function App() {
 }
 ```
 
-With this prop, the editor saves to IndexedDB whenever it changes, loads from IndexedDB on mount, synchronizes across browser tabs with the same key, and stores assets alongside the document.
+With this prop, the editor saves to IndexedDB whenever it changes and loads from IndexedDB on mount. It also stores assets alongside the document and keeps tabs with the same key in sync. Under the hood this is the internal `useLocalStore` hook.
 
 Each persistence key represents a separate document:
 
@@ -48,7 +48,7 @@ Each persistence key represents a separate document:
 <Tldraw persistenceKey="document-b" />
 ```
 
-Two editors with the same key share the same document and stay in sync. Each editor still maintains its own session state (camera position, selection, current page).
+Two editors with the same key share the same document and stay in sync. Each editor still maintains its own session state (camera position, selection, current page), saved per tab under the `sessionId` prop, which defaults to a unique id for the tab.
 
 ## Snapshots
 
@@ -56,7 +56,7 @@ For custom storage backends, use snapshots to save and load editor state. A snap
 
 ### Getting a snapshot
 
-Call [getSnapshot](?) with the editor's store to get the current state:
+Call [getSnapshot](?) with the editor's store (or [Editor#getSnapshot](?)) to get the current state:
 
 ```ts
 import { getSnapshot } from 'tldraw'
@@ -86,7 +86,7 @@ localStorage.setItem(`session-${documentId}`, JSON.stringify(session))
 
 ### Loading a snapshot
 
-Call [loadSnapshot](?) to restore state into an existing editor:
+Call [loadSnapshot](?) (or [Editor#loadSnapshot](?)) to restore state into an existing editor:
 
 ```ts
 import { loadSnapshot } from 'tldraw'
@@ -108,6 +108,8 @@ if (session) {
 	loadSnapshot(editor.store, { session })
 }
 ```
+
+Loading a `document` on its own preserves the editor's current session state. Pass `{ forceOverwriteSessionState: true }` as a third argument to replace it with the snapshot's session instead.
 
 ### Initial state
 
@@ -219,7 +221,7 @@ export default function App() {
 }
 ```
 
-The editor shows appropriate UI for each status. The possible values are:
+The editor shows the `LoadingScreen` component while the status is `loading`, throws the `error` to the nearest error boundary, and renders normally for the other statuses. The possible values are:
 
 | Status          | Meaning                                                             |
 | --------------- | ------------------------------------------------------------------- |
@@ -231,7 +233,7 @@ The editor shows appropriate UI for each status. The possible values are:
 
 ## Listening for changes
 
-Subscribe to store changes to implement auto-save or sync:
+Subscribe to store changes with [Store#listen](?) to implement auto-save or sync:
 
 ```ts
 const cleanup = editor.store.listen((entry) => {
@@ -270,7 +272,7 @@ editor.store.listen(handleChanges, { source: 'all', scope: 'document' })
 
 ### Throttled auto-save
 
-Here's a pattern for auto-saving with throttling:
+Here's a pattern for auto-saving with throttling (`lodash` isn't a tldraw dependency, so bring your own throttle):
 
 ```ts
 import { throttle } from 'lodash'
@@ -286,7 +288,7 @@ const cleanup = editor.store.listen(saveToStorage)
 
 ## Remote changes
 
-When synchronizing with a multiplayer backend, use [Store#mergeRemoteChanges](?) to apply updates from other users:
+When synchronizing with a multiplayer backend, use [Store#mergeRemoteChanges](?) with [Store#put](?) and [Store#remove](?) to apply updates from other users:
 
 ```ts
 myRemoteSource.on('change', (changes) => {
@@ -309,7 +311,7 @@ Changes inside `mergeRemoteChanges` are tagged with `source: 'remote'`. This let
 editor.store.listen(saveToServer, { source: 'user', scope: 'document' })
 ```
 
-For production multiplayer apps, consider using the [@tldraw/sync](/docs/sync) package instead of building your own sync layer.
+For production multiplayer apps, use the [@tldraw/sync](/docs/sync) package instead of building your own sync layer.
 
 ## Migrations
 
@@ -361,7 +363,7 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-The `down` migrations are used in multiplayer when a peer needs an older schema version.
+Multiplayer sync uses the `down` migrations when a peer is running an older schema version.
 
 ### General migrations
 
@@ -405,12 +407,13 @@ const store = createTLStore({ migrations: [migrations] })
 
 Migrations support different scopes depending on what you need to change:
 
-| Scope    | Use case                                                      |
-| -------- | ------------------------------------------------------------- |
-| `record` | Runs on individual records matching an optional filter        |
-| `store`  | Receives the entire serialized store for cross-record changes |
+| Scope     | Use case                                                                                                          |
+| --------- | ----------------------------------------------------------------------------------------------------------------- |
+| `record`  | Runs on individual records matching an optional filter                                                            |
+| `store`   | Receives the entire serialized store for cross-record changes                                                     |
+| `storage` | Receives a `SynchronousRecordStorage` with `get`, `set`, `delete`, `keys`, `values`, and `entries`. Has no `down` |
 
-Most migrations use `record` scope. Use `store` when you need to read or modify multiple records together.
+Most migrations use `record` scope. Use `store` or `storage` when you need to read or modify multiple records together.
 
 ## Examples
 

--- a/apps/docs/content/sdk-features/readonly.mdx
+++ b/apps/docs/content/sdk-features/readonly.mdx
@@ -38,7 +38,7 @@ export default function ReadOnlyViewer() {
 
 ## Enabling readonly mode
 
-Readonly state lives in the editor's instance state. Toggle it with `updateInstanceState`:
+Readonly state lives in the editor's instance state. Toggle it with [Editor#updateInstanceState](?) and read it with [Editor#getIsReadonly](?):
 
 ```typescript
 // Enable readonly mode
@@ -51,32 +51,34 @@ editor.updateInstanceState({ isReadonly: false })
 const isReadonly = editor.getIsReadonly()
 ```
 
-The state persists across sessions when using a `persistenceKey`. A document saved in readonly mode opens in readonly mode next time.
+Readonly state is session-scoped and is not saved by `persistenceKey`, so set it on every load, as the example above does in `onMount`. Loading a snapshot with [Editor#loadSnapshot](?) preserves the current in-memory value.
 
 ## What readonly mode blocks
 
-When readonly is enabled, the editor prevents all document mutations.
+When readonly is enabled, the editor prevents document mutations. Methods that block include:
 
-| Category   | Blocked methods                                                                                |
-| ---------- | ---------------------------------------------------------------------------------------------- |
-| Shapes     | `createShape`, `deleteShapes`, `updateShape`, `groupShapes`, `ungroupShapes`                   |
-| Pages      | `createPage`, `deletePage`, `renamePage`, `moveShapesToPage`                                   |
-| Assets     | `createAssets`, `updateAssets`, `deleteAssets`                                                 |
-| Transforms | `flipShapes`, `packShapes`, `alignShapes`, `distributeShapes`, `rotateShapesBy`, `resizeShape` |
-| Styles     | `setStyleForSelectedShapes`, `setOpacityForSelectedShapes`, `setOpacityForNextShapes`          |
-| Clipboard  | `putExternalContent`, `replaceExternalContent`, plus the `cut` and `paste` UI actions          |
+| Category   | Blocked methods                                                                                                                |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Shapes     | `createShape`, `deleteShapes`, `updateShape`, `groupShapes`, `ungroupShapes`, `toggleLock`                                     |
+| Pages      | `createPage`, `deletePage`, `renamePage`, `updatePage`, `moveShapesToPage`                                                     |
+| Assets     | `createAssets`, `updateAssets`, `deleteAssets`                                                                                 |
+| Transforms | `flipShapes`, `packShapes`, `stackShapes`, `alignShapes`, `distributeShapes`, `stretchShapes`, `rotateShapesBy`, `resizeShape` |
+| Styles     | `setStyleForSelectedShapes`, `setOpacityForSelectedShapes`                                                                     |
+| Content    | `putExternalContent`, `replaceExternalContent`, `putContentOntoCurrentPage`, plus the `cut` and `paste` UI actions             |
+
+Methods that only touch instance state, such as `setStyleForNextShapes` and `setOpacityForNextShapes`, still work.
 
 The toolbar automatically hides editing tools. Only the select tool, hand tool, and laser pointer remain visible. UI actions like undo and redo are also disabled in readonly mode.
 
 ## What readonly mode allows
 
-Navigation and viewing operations work normally. You can pan, zoom, and use camera methods like `zoomIn`, `zoomOut`, `zoomToFit`, and `zoomToSelection`. Selection works too: clicking shapes, brush selection, `selectAll`, and `selectNone` all function as expected.
+Navigation and viewing operations work normally. You can pan, zoom, and use camera methods like `zoomIn`, `zoomOut`, `zoomToFit`, and `zoomToSelection`. Selection works too: clicking shapes, brush selection, `selectAll`, and `selectNone`.
 
 You can also hover over shapes to inspect them and switch between pages. Exporting with the `exportAs` or `copyAs` helper functions works because exporting doesn't modify the document.
 
 ## Using the useReadonly hook
 
-In React components, the `useReadonly` hook provides reactive access to the readonly state. Import it from `tldraw`:
+In React components, the [useReadonly](?) hook provides reactive access to the readonly state (and returns `false` outside an editor context). Import it from `tldraw`:
 
 ```tsx
 import { useReadonly } from 'tldraw'
@@ -90,17 +92,19 @@ function ReadonlyIndicator() {
 }
 ```
 
-The component re-renders automatically when readonly state changes. Use this hook when building custom UI that needs to respond to the readonly state.
+The component re-renders automatically when readonly state changes.
 
 ## Actions in readonly mode
 
-Actions have a `readonlyOk` property that determines whether they work in readonly mode. When an action has `readonlyOk: false` (the default), triggering it in readonly mode does nothing.
+[TLUiActionItem](?) has a `readonlyOk` property that determines whether the UI offers the action in readonly mode. When an action has `readonlyOk: false` (the default), menus hide it and its keyboard shortcut is ignored in readonly mode.
 
 Built-in actions that work in readonly mode include zoom controls (`zoom-in`, `zoom-out`, `zoom-to-fit`, `zoom-to-selection`), selection actions (`select-all`, `select-none`, `copy`), export actions (`export-as-svg`, `export-as-png`, `print`), navigation (`back-to-content`, `change-page-prev`, `change-page-next`), and preference toggles like `toggle-dark-mode`.
 
 When defining custom actions, set `readonlyOk: true` if the action should work in readonly mode:
 
 ```typescript
+import { TLUiOverrides } from 'tldraw'
+
 const overrides: TLUiOverrides = {
 	actions(editor, actions, helpers) {
 		actions['share-link'] = {
@@ -119,9 +123,9 @@ const overrides: TLUiOverrides = {
 
 ## Shapes that remain interactive
 
-Some shapes have interactive content that works even when the document is readonly. Embed shapes (YouTube videos, Figma files, interactive maps) are a good example. The embed itself is locked in place, but users can still play videos or interact with the embedded content.
+Some shapes have interactive content that works even when the document is readonly. Embed shapes (YouTube videos, Figma files, interactive maps) are the built-in case: the embed itself is locked in place, but users can still play videos or interact with the embedded content.
 
-ShapeUtils can override `canEditInReadonly` to allow editing interactions on their shapes:
+ShapeUtils can override [ShapeUtil#canEditInReadonly](?) to allow editing interactions on their shapes:
 
 ```typescript
 class InteractiveWidgetUtil extends ShapeUtil<InteractiveWidget> {
@@ -135,14 +139,14 @@ When this returns `true`, double-clicking the shape enters edit mode even in rea
 
 ## Forcing operations in readonly mode
 
-For programmatic use cases like migrations or admin tools, you can bypass the readonly check by passing `force: true` to certain operations:
+For programmatic use cases like migrations or admin tools, you can bypass the readonly check by passing `force: true` to [Editor#putExternalContent](?) and [Editor#replaceExternalContent](?):
 
 ```typescript
 // This works even in readonly mode
 editor.putExternalContent({ type: 'files', files: myFiles, point: { x: 0, y: 0 } }, { force: true })
 ```
 
-Only `putExternalContent` and `replaceExternalContent` support this option. Use it sparingly since readonly mode exists to prevent unintended changes.
+Only these two methods support this option. Use it sparingly since readonly mode exists to prevent unintended changes.
 
 ## Collaboration and readonly mode
 
@@ -152,4 +156,4 @@ Changes from other collaborators still appear (the document updates in real time
 
 ## Related examples
 
-- **[Read-only](/examples/configuration/readonly)** — Set up a readonly editor that disables all editing functionality.
+- [Read-only](/examples/configuration/readonly): set up a readonly editor that disables all editing functionality.

--- a/apps/docs/content/sdk-features/rich-text.mdx
+++ b/apps/docs/content/sdk-features/rich-text.mdx
@@ -22,11 +22,11 @@ notes: ''
 
 Rich text lets you add formatted text to tldraw shapes. You get inline formatting like bold, italic, code, and highlighting, plus structural features like lists and links. Text, note, geo, and arrow label shapes all support rich text editing.
 
-Under the hood, tldraw uses TipTap (a React wrapper around ProseMirror) as the rich text engine. TipTap stores text as structured JSON rather than plain strings, which enables reliable formatting operations, custom extensions, and consistent serialization.
+Under the hood, tldraw uses TipTap (a headless editor toolkit built on ProseMirror) as the rich text engine. Text is stored as structured JSON rather than plain strings, which enables reliable formatting operations, custom extensions, and consistent serialization.
 
 ## How it works
 
-Rich text content is represented as a JSON tree. The root document contains paragraphs, and paragraphs contain text nodes with optional formatting marks. This structure aligns with TipTap's document model and makes it easy to extend.
+Rich text content is a JSON tree ([TLRichText](?)). The root document contains paragraphs, and paragraphs contain text nodes with optional formatting marks.
 
 ### Document structure
 
@@ -51,11 +51,11 @@ const richText: TLRichText = {
 }
 ```
 
-The `type` field identifies the node kind. The `content` array holds child nodes. Text nodes include a `marks` array for formatting information. You can combine formatting marks in any way you need.
+The `type` field identifies the node kind. The `content` array holds child nodes. Text nodes include a `marks` array for formatting information.
 
 ### Converting between formats
 
-Use `toRichText` to convert plain text strings to rich text documents. Each line becomes a separate paragraph:
+Use [toRichText](?) to convert plain text strings to rich text documents. Each line becomes a separate paragraph:
 
 ```typescript
 import { toRichText } from 'tldraw'
@@ -66,7 +66,7 @@ const richText = toRichText('First line\nSecond line')
 
 Note that `toRichText` treats all input as plain text—it doesn't parse markdown or other formatting. To create formatted content programmatically, build the rich text JSON structure directly or use the TipTap editor API.
 
-To extract plain text from a rich text document, use `renderPlaintextFromRichText`. It strips all formatting and preserves line breaks:
+To extract plain text from a rich text document, use [renderPlaintextFromRichText](?). It strips all formatting and preserves line breaks:
 
 ```typescript
 import { renderPlaintextFromRichText } from 'tldraw'
@@ -75,7 +75,7 @@ const text = renderPlaintextFromRichText(editor, shape.props.richText)
 // Returns: "First line\nSecond line"
 ```
 
-For HTML output, use `renderHtmlFromRichText`. It preserves all styling and structure, which is useful for rendering rich text outside the editor or exporting content:
+For HTML output, use [renderHtmlFromRichText](?). It preserves all styling and structure, which is useful for rendering rich text outside the editor or exporting content. [renderRichTextFromHTML](?) goes the other way, from HTML to `TLRichText`.
 
 ```typescript
 import { renderHtmlFromRichText } from 'tldraw'
@@ -86,43 +86,28 @@ const html = renderHtmlFromRichText(editor, shape.props.richText)
 
 ## TipTap integration
 
-TipTap handles the rich text editing experience. The editor appears when users double-click text shapes or press Enter while a text shape is selected. It manages focus, keyboard shortcuts, and formatting commands automatically.
+TipTap handles the rich text editing experience. The editor appears when users double-click a text shape or press Enter while one is selected, and it handles focus, keyboard shortcuts, and formatting commands.
 
 ### Default extensions
 
-The `tipTapDefaultExtensions` array includes TipTap's StarterKit plus customizations for tldraw. The StarterKit provides basic formatting like bold, italic, and lists. Additional extensions add code highlighting and custom keyboard behavior.
+[tipTapDefaultExtensions](?) is TipTap's StarterKit plus tldraw's customizations: the `Highlight` mark, a Shift+Enter tweak, and automatic text direction for right-to-left languages. StarterKit is configured to disable blockquotes, code blocks, and horizontal rules; headings, lists, links, and the standard marks stay on. Links don't open on click during editing, which prevents accidental navigation.
+
+To tweak StarterKit without losing tldraw's extensions, build the list with [getTipTapDefaultExtensions](?), which accepts StarterKit options:
 
 ```typescript
-export const tipTapDefaultExtensions: Extensions = [
-	StarterKit.configure({
-		blockquote: false,
-		codeBlock: false,
-		horizontalRule: false,
-		link: {
-			openOnClick: false,
-			autolink: true,
-		},
-		// Prevent trailing paragraph insertion after lists
-		trailingNode: {
-			notAfter: ['paragraph', 'bulletList', 'orderedList', 'listItem'],
-		},
-	}),
-	Highlight,
-	KeyboardShiftEnterTweakExtension,
-	extensions.TextDirection.configure({ direction: 'auto' }),
-]
-```
+import { getTipTapDefaultExtensions } from 'tldraw'
 
-This configuration disables blockquotes, code blocks, and horizontal rules to keep the interface focused on inline formatting. Links don't open on click during editing, which prevents accidental navigation. Text direction is set to automatic for right-to-left language support.
+// The default set, minus headings
+const extensions = getTipTapDefaultExtensions({ heading: false })
+```
 
 ### Custom extensions
 
-You can add custom TipTap extensions through the `options` prop on the Tldraw component. This lets you add new formatting options, custom keyboard shortcuts, or specialized behavior:
+You can add custom TipTap extensions through the `text` field of the `options` prop on the Tldraw component ([TLTextOptions](?)):
 
 ```tsx
 import { Mark, mergeAttributes } from '@tiptap/core'
-import { StarterKit } from '@tiptap/starter-kit'
-import { Tldraw } from 'tldraw'
+import { Tldraw, tipTapDefaultExtensions } from 'tldraw'
 import 'tldraw/tldraw.css'
 
 const CustomMark = Mark.create({
@@ -146,7 +131,7 @@ const CustomMark = Mark.create({
 const options = {
 	text: {
 		tipTapConfig: {
-			extensions: [StarterKit, CustomMark],
+			extensions: [...tipTapDefaultExtensions, CustomMark],
 		},
 	},
 }
@@ -160,13 +145,13 @@ export default function App() {
 }
 ```
 
-Note that you must provide a complete list of extensions. If you include custom extensions, also include any default extensions you want to keep. The example above replaces the entire extension list, so you control exactly which features are available.
+The `extensions` array replaces the default list entirely, so spread `tipTapDefaultExtensions` (or the result of `getTipTapDefaultExtensions`) to keep tldraw's defaults. Passing `[StarterKit, CustomMark]` alone drops highlighting and text direction, and StarterKit's default link config opens links on click while editing.
 
 ### Rich text toolbar
 
-The rich text toolbar appears when editing text shapes. It gives you quick access to formatting commands like bold, italic, and lists. The toolbar updates dynamically to show which formats are active at the current cursor position.
+The rich text toolbar appears when editing any rich-text shape (it's hidden on touch devices). It gives you quick access to formatting commands like bold, italic, and lists, and shows which formats are active at the current cursor position.
 
-You can customize the toolbar by overriding the `RichTextToolbar` component. Use `editor.getRichTextEditor()` to get the TipTap editor instance and execute formatting commands:
+You can customize the toolbar by overriding the `RichTextToolbar` component. Use [Editor#getRichTextEditor](?) to get the TipTap editor instance and execute formatting commands:
 
 ```tsx
 import {
@@ -208,103 +193,17 @@ export default function App() {
 }
 ```
 
-The `DefaultRichTextToolbar` component provides the default toolbar layout. Nest custom buttons inside it to extend the toolbar, or replace it entirely for complete control over the formatting interface.
+[DefaultRichTextToolbar](?) provides the toolbar frame and positioning. Passing children replaces the default buttons; render [DefaultRichTextToolbarContent](?) alongside your own buttons to keep them, or replace the component entirely.
 
 ## Shapes with rich text
 
-Four shape types support rich text: text shapes, note shapes, geo shapes, and arrow labels. Each renders rich text through the `RichTextLabel` component, which handles both display and editing modes.
-
-### Text shapes
-
-Text shapes are standalone text blocks you can place anywhere on the canvas. They support auto-sizing (where the shape grows to fit content) or fixed-width mode with text wrapping.
-
-```typescript
-editor.createShape({
-	type: 'text',
-	x: 100,
-	y: 100,
-	props: {
-		richText: toRichText('Sample text'),
-		font: 'draw',
-		size: 'm',
-		textAlign: 'start',
-		autoSize: true,
-	},
-})
-```
-
-The `autoSize` prop controls whether the shape expands automatically. When true, text never wraps and the shape width matches the content. When false, text wraps at the shape's width boundary.
-
-### Note shapes
-
-Note shapes display text on colored backgrounds. They always have fixed dimensions and wrap text to fit within those bounds.
-
-```typescript
-editor.createShape({
-	type: 'note',
-	x: 100,
-	y: 100,
-	props: {
-		richText: toRichText('Note content'),
-		font: 'draw',
-		size: 'm',
-		color: 'yellow',
-	},
-})
-```
-
-Notes work well for annotations, comments, or highlighting specific information on the canvas. The colored background provides visual distinction from regular text shapes.
-
-### Geo shapes
-
-Geo shapes include rectangles, ellipses, and other geometric forms that can contain text labels. Text appears centered within the shape bounds, with configurable alignment.
-
-```typescript
-editor.createShape({
-	type: 'geo',
-	x: 100,
-	y: 100,
-	props: {
-		geo: 'rectangle',
-		w: 200,
-		h: 100,
-		richText: toRichText('Label'),
-		font: 'draw',
-		size: 'm',
-		align: 'middle',
-		verticalAlign: 'middle',
-	},
-})
-```
-
-The `align` and `verticalAlign` props control text positioning within the shape. Text wraps when it exceeds the available width minus padding.
-
-### Arrow labels
-
-Arrows can have a text label that appears along the arrow path. The label is editable like other rich text and moves with the arrow when repositioned.
-
-```typescript
-editor.createShape({
-	type: 'arrow',
-	x: 100,
-	y: 100,
-	props: {
-		start: { x: 0, y: 0 },
-		end: { x: 200, y: 0 },
-		richText: toRichText('Arrow label'),
-		font: 'draw',
-		size: 'm',
-	},
-})
-```
-
-Arrow labels automatically position themselves based on the arrow's path and curvature. The label remains readable regardless of arrow orientation.
+Four default shapes have a `richText` prop: text, note, geo, and arrow. Each renders it through the [RichTextLabel](?) component, which handles both display and editing. [Text shapes](/sdk-features/text-shape) are standalone blocks that auto-size or wrap at a fixed width. [Note shapes](/sdk-features/note-shape) have a fixed width and grow taller to fit their text. Geo shapes position their label with `align` and `verticalAlign` (centered by default) and wrap inside the shape's padding. Arrow labels sit along the arrow path at `labelPosition` and move with the arrow.
 
 ## Font management
 
-Rich text can include multiple fonts and font styles within a single text block. The `FontManager` tracks which fonts are needed and loads them before rendering. This prevents layout shifts.
+Rich text can include multiple fonts and font styles within a single text block. Shapes report the fonts they need from [ShapeUtil#getFontFaces](?), and the font manager loads them before rendering to prevent layout shifts.
 
-Use `getFontsFromRichText` to collect all required font faces based on the text content and formatting marks:
+Use [getFontsFromRichText](?) to collect the required font faces from the text content and formatting marks:
 
 ```typescript
 import { getFontsFromRichText } from 'tldraw'
@@ -320,27 +219,24 @@ The function accepts an initial font state representing the base font. It walks 
 
 ### Custom font resolution
 
-You can override font resolution by providing a custom `addFontsFromNode` function through `options.text`. This lets you use custom fonts or alternative font mapping strategies:
+You can override font resolution by providing a custom `addFontsFromNode` function through `options.text`. The function receives the current node, the font state, and a callback to register required fonts. It returns the updated state, which is passed down to the node's children. Call `addFont` for every face the node needs; [defaultAddFontsFromNode](?) is the built-in implementation to wrap or copy:
 
 ```typescript
-const options = {
-	text: {
-		tipTapConfig: {
-			extensions: [StarterKit],
-		},
-		addFontsFromNode: (node, state, addFont) => {
-			// Custom font resolution logic
-			if (node.marks.some((m) => m.type.name === 'bold')) {
-				state = { ...state, weight: 'bold' }
-			}
-			// Call addFont() with required font faces
-			return state
-		},
+import { defaultAddFontsFromNode, TLTextOptions } from 'tldraw'
+import { myBrandFont } from './fonts'
+
+const textOptions: TLTextOptions = {
+	addFontsFromNode: (node, state, addFont) => {
+		if (node.marks.some((m) => m.type.name === 'brand')) {
+			addFont(myBrandFont)
+			return { ...state, family: myBrandFont.family }
+		}
+		return defaultAddFontsFromNode(node, state, addFont)
 	},
 }
 ```
 
-The function receives the current node, font state, and a callback to register required fonts. It returns the updated state, which is passed down when processing the node's children. This lets you walk the document tree while keeping track of the font context.
+See the [rich text font extensions example](/examples/shapes/tools/rich-text-font-extensions) for a full implementation.
 
 ## Programmatic formatting
 
@@ -356,11 +252,13 @@ if (textEditor) {
 
 The chain API lets you compose multiple operations. Each command returns a chainable object, and `run()` executes the composed command sequence.
 
-For operations outside the editing context, you can manipulate the rich text JSON directly. This is useful when programmatically generating or transforming content:
+For operations outside the editing context, you can manipulate the rich text JSON directly. `TLRichText.content` is typed as `unknown[]`, so cast to TipTap's `JSONContent` when walking the tree:
 
 ```typescript
+import { JSONContent } from '@tiptap/core'
+
 function makeAllTextBold(richText: TLRichText): TLRichText {
-	const content = richText.content.map((paragraph) => {
+	const content = (richText.content as JSONContent[]).map((paragraph) => {
 		if (!paragraph.content) return paragraph
 
 		return {
@@ -383,11 +281,9 @@ function makeAllTextBold(richText: TLRichText): TLRichText {
 }
 ```
 
-This approach requires understanding the TipTap document structure but gives you precise control over content transformation.
-
 ## Measurement and rendering
 
-Rich text measurement uses the same system as plain text, with HTML rendering replacing plain text content. The `TextManager` measures rich text by generating HTML, applying it to the measurement element, and reading the computed dimensions:
+Rich text measurement uses the same system as plain text, with HTML replacing the plain text content. [TextManager#measureHtml](?) measures rich text by rendering the HTML into the measurement element and reading the computed dimensions:
 
 ```typescript
 import { renderHtmlFromRichTextForMeasurement } from 'tldraw'
@@ -396,21 +292,13 @@ const html = renderHtmlFromRichTextForMeasurement(editor, richText)
 // Returns HTML wrapped in measurement container
 ```
 
-The measurement system accounts for formatting that affects layout, like bold text or lists. Font loading completes before measurement to ensure accurate dimensions.
+The measurement system accounts for formatting that affects layout, like bold text or lists. Font loading completes before measurement so dimensions are accurate.
 
-For SVG export, the `RichTextSVG` component renders rich text as a foreignObject element. Exported images keep the same formatting and layout as the canvas.
+For SVG export, the [RichTextSVG](?) component renders rich text as a `foreignObject` element. Exported images keep the same formatting and layout as the canvas.
 
-## Extension points
+## Text options
 
-The rich text system offers several ways to customize behavior:
-
-| Extension point              | Description                                                                    |
-| ---------------------------- | ------------------------------------------------------------------------------ |
-| **Custom TipTap extensions** | Add new marks, nodes, keyboard shortcuts, or commands                          |
-| **Custom toolbar**           | Replace or extend the rich text toolbar with different formatting controls     |
-| **Font resolution**          | Override font resolution to use custom fonts or alternative loading strategies |
-
-The `options.text` field accepts a `tipTapConfig` object that passes through to TipTap's editor configuration. All TipTap configuration options are available here:
+`options.text` ([TLTextOptions](?)) has two fields: `tipTapConfig`, which passes through to TipTap's editor configuration, and `addFontsFromNode` for font resolution:
 
 ```typescript
 const options = {
@@ -430,8 +318,6 @@ const options = {
 
 ## Related examples
 
-- **[Rich text with custom extension](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/rich-text-custom-extension)** - Adding a custom TipTap extension and toolbar button.
-
-- **[Rich text with font extensions](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/rich-text-font-extensions)** - Extending the editor with font-family and font-size controls.
-
-- **[Format rich text on multiple shapes](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/rich-text-on-multiple-shapes)** - Applying formatting to multiple selected shapes programmatically.
+- [Rich text with custom extension](/examples/shapes/tools/rich-text-custom-extension) — Adding a custom TipTap extension and toolbar button.
+- [Rich text with font extensions](/examples/shapes/tools/rich-text-font-extensions) — Extending the editor with font-family and font-size controls.
+- [Format rich text on multiple shapes](/examples/ui/rich-text-on-multiple-shapes) — Applying formatting to multiple selected shapes programmatically.

--- a/apps/docs/content/sdk-features/scribble.mdx
+++ b/apps/docs/content/sdk-features/scribble.mdx
@@ -20,33 +20,33 @@ notes: ''
 
 The scribble system draws temporary freehand paths for pointer-based interactions. Use scribbles to show visual feedback during tool operations like erasing, laser pointer drawing, or scribble-brush selection. Access the system through [Editor#scribbles](?).
 
-Scribbles exist only in instance state and fade out automatically after the tool operation completes. They're never persisted to the document.
+Scribbles exist only in instance state and fade out automatically after the tool operation completes. They're never persisted to the document, though they are broadcast to collaborators through presence so peers see your eraser and laser trails.
 
 ## How it works
 
 ### Scribble lifecycle
 
-Every scribble moves through five states:
+A scribble's `state` is one of five values from [TLScribble](?):
 
-| State    | Description                                                                                                                    |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Starting | The scribble collects points until it has more than 8. This prevents flickering for very short strokes.                        |
-| Paused   | Drawing pauses temporarily.                                                                                                    |
-| Active   | The scribble accumulates points as the pointer moves.                                                                          |
-| Complete | Drawing finishes but fading hasn't started yet. This allows taper effects to apply when the user lifts the pointer.            |
-| Stopping | The scribble fades out by progressively removing points from its tail. The manager deletes the scribble once all points clear. |
+| State    | Description                                                                                                                      |
+| -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Starting | The scribble collects points until it has more than 8. This prevents flickering for very short strokes.                          |
+| Active   | The scribble accumulates points as the pointer moves.                                                                            |
+| Complete | Drawing finished but fading hasn't started. Set with [ScribbleManager#complete](?) so the end cap tapers when the pointer lifts. |
+| Stopping | The scribble fades out by progressively removing points from its tail. The manager deletes the scribble once all points clear.   |
+| Paused   | Defined in the schema but not used by the manager.                                                                               |
 
 The [ScribbleManager#tick](?) method updates all scribbles on every animation frame, handling state transitions, point management, and fade-out timing.
 
 ### Fade-out behavior
 
-During fade-out, the scribble shrinks from the tail by removing points at regular intervals. Set `shrink` above zero for a smooth disappearance effect. The stroke width decreases along with the point count.
+During fade-out, the scribble shrinks from the tail by removing points at regular intervals. By default (`shrink: 0.1`) the stroke width also decreases as points are removed; set `shrink: 0` to fade at constant width.
 
-The `delay` property controls how long a scribble stays at full length before shrinking. Self-consuming scribbles (the default) remove points from the start as you draw, maintaining a constant length.
+The `delay` property controls how long a scribble stays at full length before shrinking. Stopping a scribble caps any remaining delay at 200ms. Self-consuming scribbles (the default) remove points from the start as you draw, maintaining a constant length.
 
 ## Using scribbles
 
-The [ScribbleManager](?) provides two APIs: a direct API for basic use cases and a session-based API for complex scenarios requiring grouped behavior or custom fade modes.
+The [ScribbleManager](?) provides two APIs: a direct API for single self-consuming strokes, and a session API for when several strokes should fade together, as the laser pointer's do.
 
 ### Direct API
 
@@ -84,35 +84,13 @@ export class Erasing extends StateNode {
 }
 ```
 
-**Creating a scribble**: Call [ScribbleManager#addScribble](?) with optional configuration. The method returns a [ScribbleItem](?) containing the scribble's ID:
+[ScribbleManager#addScribble](?) takes optional configuration and returns a [ScribbleItem](?) containing the scribble's ID. [ScribbleManager#addPoint](?) ignores points less than one page unit from the previous one; pass an optional `z` value after the coordinates (default `0.5`) for pressure-based width. [ScribbleManager#stop](?) moves the scribble to the stopping state, and the manager removes it once all points clear.
 
-```typescript
-const scribble = this.editor.scribbles.addScribble({
-	color: 'muted-1',
-	size: 12,
-})
-```
-
-**Adding points**: As the pointer moves, add points using the scribble ID. The [ScribbleManager#addPoint](?) method automatically deduplicates points that are too close together:
-
-```typescript
-const { x, y } = this.editor.inputs.getCurrentPagePoint()
-this.editor.scribbles.addPoint(scribble.id, x, y)
-```
-
-Pass an optional `z` value after the coordinates (defaults to `0.5`) to control point pressure for variable-width strokes.
-
-**Stopping a scribble**: When the tool operation completes, stop the scribble to begin fade-out:
-
-```typescript
-this.editor.scribbles.stop(scribble.id)
-```
-
-The scribble transitions to stopping state and removes itself once all points clear.
+The scribble-brush selection in the select tool uses the same API with `color: 'selection-stroke'`, `opacity: 0.32`, and `size: 12`.
 
 ### Session API
 
-For more complex scenarios, use sessions to group multiple scribbles together and control their behavior. The laser pointer uses sessions to create a trailing effect where all scribbles fade together:
+Sessions group multiple scribbles together and control how they fade. The laser pointer uses a session so that every stroke from one drawing burst fades together. Simplified from the real [LaserTool](?):
 
 ```typescript
 import { StateNode } from '@tldraw/editor'
@@ -120,6 +98,9 @@ import { StateNode } from '@tldraw/editor'
 export class LaserTool extends StateNode {
 	static override id = 'laser'
 	static override initial = 'idle'
+	static override children() {
+		return [Idle, Lasering]
+	}
 
 	private sessionId: string | null = null
 
@@ -149,7 +130,26 @@ export class LaserTool extends StateNode {
 }
 ```
 
-Child states add scribbles to the session and add points:
+The idle state adds a scribble to the session with [ScribbleManager#addScribbleToSession](?) and hands its id to the lasering state:
+
+```typescript
+export class Idle extends StateNode {
+	static override id = 'idle'
+
+	override onPointerDown() {
+		const sessionId = (this.parent as LaserTool).getSessionId()
+		const scribble = this.editor.scribbles.addScribbleToSession(sessionId, {
+			color: 'laser',
+			opacity: 0.7,
+			size: 4,
+			taper: false,
+		})
+		this.parent.transition('lasering', { sessionId, scribbleId: scribble.id })
+	}
+}
+```
+
+The lasering state adds points with [ScribbleManager#addPointToSession](?) and keeps the session alive with [ScribbleManager#extendSession](?):
 
 ```typescript
 export class Lasering extends StateNode {
@@ -194,7 +194,7 @@ Scribbles support these visual properties:
 | --------- | -------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `id`      | auto-generated | Unique identifier for the scribble                                                                                  |
 | `color`   | `'accent'`     | Canvas UI color: `'accent'`, `'white'`, `'black'`, `'selection-stroke'`, `'selection-fill'`, `'laser'`, `'muted-1'` |
-| `size`    | `20`           | Stroke width in pixels                                                                                              |
+| `size`    | `20`           | Stroke width in screen pixels                                                                                       |
 | `opacity` | `0.8`          | Transparency from 0 to 1                                                                                            |
 | `delay`   | `0`            | Milliseconds before shrinking starts (for self-consuming scribbles)                                                 |
 | `shrink`  | `0.1`          | Rate at which stroke width decreases during fade-out (0 to 1)                                                       |
@@ -215,15 +215,13 @@ When using the session API, you can configure how scribbles behave:
 | `fadeEasing`     | `'linear'` or `'ease-in'` | Easing for grouped fade. Defaults to `'ease-in'` when fadeMode is `'grouped'`       |
 | `fadeDurationMs` | `laserFadeoutMs` (500ms)  | Duration of the fade in milliseconds                                                |
 
-By default, points are removed from the start as you draw, maintaining a constant scribble length. This works well for tools like the eraser that need immediate visual feedback without a persistent trail.
-
-When `selfConsume` is `false`, points accumulate while the session is active and only fade after the session stops. The laser pointer uses this with grouped fade mode. All strokes from a drawing session disappear together.
+When `selfConsume` is `false`, points accumulate while the session is active and only fade after the session stops. A session stops when you call [ScribbleManager#stopSession](?), or automatically after `idleTimeoutMs` of no activity. In grouped fade mode, the manager removes points from all scribbles in the session proportionally over `fadeDurationMs`; `'ease-in'` removes them slowly at first and faster toward the end. [ScribbleManager#clearSession](?) removes everything immediately, and [ScribbleManager#isSessionActive](?) tells you whether a session is still accepting points.
 
 ## Customizing scribble rendering
 
-Scribbles are rendered on an HTML Canvas overlay via the [ScribbleOverlayUtil](?). You can customize scribble rendering by extending this class and passing your custom overlay util when creating the editor. See the [OverlayUtil](?) documentation for details on the overlay system.
+Scribbles are rendered on an HTML Canvas overlay via the [ScribbleOverlayUtil](?) from the `tldraw` package. To customize rendering, extend this class (keeping its static `type`) and pass it in the `overlayUtils` prop, which replaces the default util of the same type. See [Overlay utils](/sdk-features/overlay-utils) for how overlay utils are registered and replaced.
 
 ## Related articles
 
-- [Tools](/sdk-features/tools) - Learn how tools use state nodes and handle pointer events
-- [UI components](/sdk-features/ui-components) - Customize canvas components
+- [Tools](/sdk-features/tools) - How tools use state nodes and handle pointer events
+- [Overlay utils](/sdk-features/overlay-utils) - The canvas overlay system that renders scribbles

--- a/apps/docs/content/sdk-features/selection.mdx
+++ b/apps/docs/content/sdk-features/selection.mdx
@@ -17,11 +17,13 @@ accuracy: 9
 notes: Opening paragraph is dense - split into overview and details. "Serves as the source of truth" is hollow phrasing.
 ---
 
-The editor tracks which shapes are selected and gives you methods to change the selection, get the selected shapes, and compute their collective bounds and rotation. It automatically enforces rules like "you can't select both a group and its children at the same time" and manages focus groups when you select shapes inside groups.
+The editor tracks which shapes are selected. You can change the selection, read the selected shapes, and get their combined bounds and rotation.
+
+The editor also enforces a few rules on its own: you can't select both a group and its children at the same time, and selecting shapes inside a group focuses that group.
 
 ## Selected shape IDs
 
-The editor tracks selection through the `selectedShapeIds` array in the current page's instance state. This array holds the IDs of all currently selected shapes. Everything else about the selection (bounds, rotation, the selected shape records) is derived from it.
+The editor tracks selection through the `selectedShapeIds` array in the current page's [instance state](/sdk-features/instance-state). This array holds the IDs of all currently selected shapes. Everything else about the selection (bounds, rotation, the selected shape records) is derived from it.
 
 ```typescript
 // Get currently selected shape IDs
@@ -31,13 +33,13 @@ const selectedIds = editor.getSelectedShapeIds()
 const selectedShapes = editor.getSelectedShapes()
 ```
 
-The `getSelectedShapes()` method resolves the IDs to actual shape records, filtering out any IDs that no longer exist in the store.
+[Editor#getSelectedShapes](?) resolves the IDs to shape records and drops any IDs that no longer exist in the store.
 
 ## Selection methods
 
 ### Basic selection
 
-The editor provides several methods for changing the selection:
+Use [Editor#select](?), [Editor#setSelectedShapes](?), [Editor#deselect](?), and [Editor#selectNone](?) to change the selection:
 
 ```typescript
 // Select specific shapes (replaces current selection)
@@ -51,17 +53,15 @@ editor.deselect(shapeId1)
 editor.selectNone()
 ```
 
-Both `select()` and `setSelectedShapes()` replace the current selection entirely. Use `deselect()` to remove specific shapes while keeping others selected.
+Both `select()` and `setSelectedShapes()` replace the current selection entirely. Use `deselect()` to remove specific shapes while keeping others selected. Selection changes are recorded in history without clearing the redo stack.
 
 ### Select all
 
-The `selectAll()` method selects all unlocked shapes, with smart scoping based on the current selection:
+[Editor#selectAll](?) selects all unlocked shapes, scoped by the current selection:
 
 ```typescript
 editor.selectAll()
 ```
-
-The behavior adapts to context:
 
 - If nothing is selected, it selects all shapes on the current page
 - If the selected shapes share a common parent (like shapes inside a group), it selects all shapes within that parent
@@ -69,7 +69,7 @@ The behavior adapts to context:
 
 ### Adjacent selection
 
-Select the next or previous shape in reading order, or navigate by cardinal direction:
+Use [Editor#selectAdjacentShape](?) to select the next or previous shape in reading order, or to move by cardinal direction:
 
 ```typescript
 editor.selectAdjacentShape('next')
@@ -80,11 +80,11 @@ editor.selectAdjacentShape('up')
 editor.selectAdjacentShape('down')
 ```
 
-When selecting by cardinal direction, the system uses geometric distance and directional scoring to find the most appropriate adjacent shape.
+Cardinal directions score candidate shapes by distance and by how far they sit off the axis of travel, then pick the lowest score. If the selection is inside a group or frame, only siblings in that container are considered. Shapes whose util returns `false` from [ShapeUtil#canTabTo](?) are skipped. In the default UI, Tab and Shift+Tab move to the next and previous shape, and Cmd/Ctrl+Arrow moves by direction.
 
 ### Hierarchical selection
 
-Navigate the shape hierarchy:
+Use [Editor#selectParentShape](?) and [Editor#selectFirstChildShape](?) to move up and down the shape hierarchy:
 
 ```typescript
 // Select the parent of the currently selected shape
@@ -94,11 +94,11 @@ editor.selectParentShape()
 editor.selectFirstChildShape()
 ```
 
-Both methods automatically zoom to the selected shape if it's offscreen.
+`selectParentShape()` only acts when exactly one shape is selected. `selectFirstChildShape()` picks the first child (in reading order) of the first selected shape. Both zoom to the new selection if it's offscreen. In the default UI these are bound to Cmd/Ctrl+Shift+Up and Cmd/Ctrl+Shift+Down.
 
 ## Single shape helpers
 
-When you need to work with exactly one selected shape, use these convenience methods:
+When you need to work with exactly one selected shape, use [Editor#getOnlySelectedShapeId](?) and [Editor#getOnlySelectedShape](?):
 
 ```typescript
 // Get the ID if exactly one shape is selected, null otherwise
@@ -112,7 +112,7 @@ Both methods return `null` if zero shapes or multiple shapes are selected.
 
 ### Selected shape at point
 
-To find which selected shape is at a specific point (useful for hit testing during interactions), use `getSelectedShapeAtPoint()`:
+To find which selected shape is at a specific point (useful for hit testing during interactions), use [Editor#getSelectedShapeAtPoint](?):
 
 ```typescript
 const shape = editor.getSelectedShapeAtPoint({ x: 100, y: 200 })
@@ -126,7 +126,7 @@ The editor computes bounds for the current selection in two ways: axis-aligned a
 
 ### Axis-aligned bounds
 
-The `getSelectionPageBounds()` method returns the axis-aligned bounding box that contains all selected shapes:
+[Editor#getSelectionPageBounds](?) returns the axis-aligned bounding box that contains all selected shapes:
 
 ```typescript
 const bounds = editor.getSelectionPageBounds()
@@ -139,19 +139,19 @@ If the selection includes rotated shapes, these bounds represent the smallest ax
 
 ### Rotated bounds
 
-The `getSelectionRotatedPageBounds()` method returns bounds that respect the shared rotation of the selection:
+[Editor#getSelectionRotatedPageBounds](?) returns bounds that respect the shared rotation of the selection:
 
 ```typescript
 const rotatedBounds = editor.getSelectionRotatedPageBounds()
 ```
 
-The selection box UI uses this for display. If all selected shapes share the same rotation, the bounds rotate with them. If shapes have different rotations, this falls back to axis-aligned bounds.
+The selection box UI uses this for display. If all selected shapes share the same rotation, the bounds rotate with them. If shapes have different rotations, this falls back to axis-aligned bounds. It returns `undefined` if nothing is selected.
 
-You can access the shared rotation angle via `getSelectionRotation()`, which returns `0` if shapes have different rotations.
+You can access the shared rotation angle via [Editor#getSelectionRotation](?), which returns `0` if shapes have different rotations.
 
 ### Screen space bounds
 
-Both bound types have screen-space equivalents that account for the camera's zoom and pan:
+Both bound types have screen-space equivalents, [Editor#getSelectionScreenBounds](?) and [Editor#getSelectionRotatedScreenBounds](?), that account for the camera's zoom and pan:
 
 ```typescript
 const screenBounds = editor.getSelectionScreenBounds()
@@ -176,7 +176,7 @@ This prevents ambiguous situations where both a container and its contents are s
 
 ### Focused group management
 
-When you select shapes that are children of a group, the editor automatically updates the focused group. A **focused group** is the group shape that defines the current editing scope—it determines which shapes are available for selection and manipulation. When you enter a group by selecting its children, that group becomes focused, restricting your editing context to shapes within that group.
+When you select shapes that are children of a group, the editor automatically updates the focused group. The focused group is the group that defines the current editing scope: while a group is focused, clicks select shapes inside it rather than the group itself. See [Groups](/sdk-features/groups) for details.
 
 ```typescript
 // Selecting shapes inside a group focuses that group
@@ -184,7 +184,7 @@ editor.select(shapeInsideGroup)
 // The group becomes the focused group
 ```
 
-If all selected shapes share a common group ancestor, that group becomes focused. If you clear the selection or select shapes without a common group ancestor, the editor clears the focused group.
+If all selected shapes share a common group ancestor, that group becomes focused. If you select shapes without a common group ancestor, the editor clears the focused group. Clearing the selection leaves the focused group in place.
 
 ## Locked shapes
 
@@ -198,20 +198,20 @@ editor.selectAll()
 editor.deleteShapes(shapeIds) // Only deletes unlocked shapes
 ```
 
-Locks do not restrict individual shape selection through `select()`. You can still select locked shapes explicitly when needed.
+Locks don't restrict individual shape selection through `select()`. You can still select locked shapes explicitly when needed. By default, users can't select locked shapes by clicking or brushing; the `selectLockedShapes` option in [TldrawOptions](?) allows that while keeping the shapes protected from edits. See [Locked shapes](/sdk-features/locked-shapes).
 
 ## Ancestor checking
 
-To determine if a shape's ancestor is selected, use `isAncestorSelected()`:
+To determine if a shape's ancestor is selected, use [Editor#isAncestorSelected](?):
 
 ```typescript
 const hasSelectedAncestor = editor.isAncestorSelected(shape)
 ```
 
-This walks up the shape's parent chain and returns `true` if any ancestor is in the current selection. This is useful for determining whether a shape is implicitly selected through its parent.
+This walks up the shape's parent chain and returns `true` if any ancestor is in the current selection.
 
 ## Related examples
 
-- **[Selection UI](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/selection-ui)** - Add custom UI elements that appear around the current selection using selection bounds.
-- **[Prevent multi-shape selection](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/prevent-multi-shape-selection)** - Use side effects to restrict selection to a single shape at a time.
-- **[Lasso select tool](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/lasso-select-tool)** - Create a custom freehand selection tool.
+- [Selection UI](/examples/ui/selection-ui) - Add custom UI elements that appear around the current selection using selection bounds.
+- [Prevent multi-shape selection](/examples/events/prevent-multi-shape-selection) - Use side effects to restrict selection to a single shape at a time.
+- [Lasso select tool](/examples/editor-api/lasso-select-tool) - Create a custom freehand selection tool.

--- a/apps/docs/content/sdk-features/shape-clipping.mdx
+++ b/apps/docs/content/sdk-features/shape-clipping.mdx
@@ -18,11 +18,11 @@ accuracy: 10
 notes: ''
 ---
 
-Shape clipping lets parent shapes mask their children so content outside the parent's boundary is hidden. Frames are the primary example—drop shapes into a frame and they're cropped to the frame's edges. Custom shapes can define their own clip boundaries using any polygon.
+Shape clipping lets parent shapes mask their children so content outside the parent's boundary is hidden. Frames are the primary example: drop shapes into a frame and they're cropped to the frame's edges. Custom shapes can define their own clip boundaries using any polygon. For the wider shape system, see [Shapes](/sdk-features/shapes).
 
 ## How clipping works
 
-The clipping system uses two ShapeUtil methods that work together: `getClipPath` defines the clipping boundary as an array of points, and `shouldClipChild` controls which children get clipped.
+The clipping system uses two [ShapeUtil](?) methods that work together: [ShapeUtil#getClipPath](?) defines the clipping boundary as an array of points, and [ShapeUtil#shouldClipChild](?) controls which children get clipped. `shouldClipChild` is only consulted when `getClipPath` returns a polygon.
 
 When a shape is a child of a clipping parent, the editor:
 
@@ -31,19 +31,20 @@ When a shape is a child of a clipping parent, the editor:
 3. Transforms the clip path to page coordinates
 4. Applies it as a CSS clip-path during rendering
 
-If a shape has multiple clipping ancestors, their clip paths are intersected. A shape nested inside two clipping parents is clipped by both—only the overlapping region shows.
+If a shape has multiple clipping ancestors, their clip paths are intersected. A shape nested inside two clipping parents is clipped by both, so only the overlapping region shows.
 
 ## Implementing clipping
 
 To make a custom shape clip its children, implement `getClipPath` in your ShapeUtil:
 
 ```tsx
-import { Rectangle2d, ShapeUtil, TLBaseShape, Vec } from 'tldraw'
+import { Rectangle2d, ShapeUtil, SVGContainer, T, TLBaseShape, Vec } from 'tldraw'
 
 type MyClipShape = TLBaseShape<'my-clip', { w: number; h: number }>
 
 class MyClipShapeUtil extends ShapeUtil<MyClipShape> {
 	static override type = 'my-clip' as const
+	static override props = { w: T.number, h: T.number }
 
 	override getDefaultProps() {
 		return { w: 200, h: 200 }
@@ -54,7 +55,11 @@ class MyClipShapeUtil extends ShapeUtil<MyClipShape> {
 	}
 
 	override component(shape: MyClipShape) {
-		return <rect width={shape.props.w} height={shape.props.h} fill="transparent" stroke="black" />
+		return (
+			<SVGContainer>
+				<rect width={shape.props.w} height={shape.props.h} fill="transparent" stroke="black" />
+			</SVGContainer>
+		)
 	}
 
 	override getIndicatorPath(shape: MyClipShape) {
@@ -81,11 +86,11 @@ class MyClipShapeUtil extends ShapeUtil<MyClipShape> {
 
 The returned points define a polygon in the shape's local coordinate space. The editor transforms these points to page space before applying the clip. Return `undefined` to disable clipping entirely.
 
-> **Note for stroked shapes:** If your clipping shape has a stroke, consider insetting the clip path by half the stroke width so children are clipped to the inner boundary rather than the outer edge of the stroke. This prevents children from overlapping with the stroke itself.
+> If your clipping shape has a stroke, inset the clip path by half the stroke width so children are clipped to the inner edge of the stroke rather than its center line. Otherwise children overlap the stroke.
 
 ### Selective clipping
 
-By default, all children of a clipping parent are clipped. Override `shouldClipChild` to change this:
+By default, all children of a clipping parent are clipped. Override [ShapeUtil#shouldClipChild](?) to change this:
 
 ```typescript
 override shouldClipChild(child: TLShape): boolean {
@@ -95,29 +100,33 @@ override shouldClipChild(child: TLShape): boolean {
 }
 ```
 
-This lets you create clipping shapes where some content types break out of the boundary. You might clip geometric shapes but let labels extend beyond the edge.
+You might clip geometric shapes but let labels extend beyond the edge.
 
 ## Frame clipping
 
-Frames are the primary built-in example of clipping. FrameShapeUtil extends [BaseFrameLikeShapeUtil](?), which implements clipping by returning its geometry vertices:
+Frames are the primary built-in example of clipping. [FrameShapeUtil](?) extends [BaseFrameLikeShapeUtil](?), which implements clipping by returning its geometry vertices and skips clipping for arrows:
 
 ```typescript
 override getClipPath(shape: Shape): Vec[] | undefined {
 	return this.editor.getShapeGeometry(shape.id).vertices
 }
+
+override shouldClipChild(child: TLShape): boolean {
+	return child.type !== 'arrow'
+}
 ```
 
-This clips to the frame's rectangular boundary. Content that extends beyond the frame's edges is hidden during rendering but still exists in the document—you can ungroup or move shapes out of the frame to see the clipped portions.
+This clips to the frame's rectangular boundary. Content that extends beyond the frame's edges is hidden during rendering but still exists in the document; move the shapes out of the frame (or remove the frame) to see the clipped portions. If you're building your own container shape, extend `BaseFrameLikeShapeUtil` to get this behavior along with drag-and-drop reparenting and the other frame-like defaults.
 
 ## Reading shape masks
 
-The editor computes masks for any clipped shape. Use these methods to access mask data:
+The editor computes and caches a mask for any clipped shape. Use these methods to read it:
 
-| Method                     | Returns                  | Description                      |
-| -------------------------- | ------------------------ | -------------------------------- |
-| `getShapeMask`             | `VecLike[] \| undefined` | Mask polygon in page coordinates |
-| `getShapeClipPath`         | `string \| undefined`    | CSS `polygon(...)` string        |
-| `getShapeMaskedPageBounds` | `Box \| undefined`       | Bounds clipped by the mask       |
+| Method                               | Returns                  | Description                                    |
+| ------------------------------------ | ------------------------ | ---------------------------------------------- |
+| [Editor#getShapeMask](?)             | `VecLike[] \| undefined` | Mask polygon in page coordinates               |
+| [Editor#getShapeClipPath](?)         | `string \| undefined`    | CSS `polygon(...)` string in local coordinates |
+| [Editor#getShapeMaskedPageBounds](?) | `Box \| undefined`       | Page bounds intersected with the mask          |
 
 ```typescript
 const mask = editor.getShapeMask(shapeId)
@@ -130,7 +139,7 @@ const clippedBounds = editor.getShapeMaskedPageBounds(shapeId)
 // Returns the shape's page bounds intersected with its mask
 ```
 
-These methods are useful for custom rendering, SVG export, or building UI that needs to understand clipping relationships.
+When a shape is fully clipped (the mask is empty), `getShapeMask` returns an empty array and `getShapeClipPath` returns a degenerate `polygon(0px 0px, 0px 0px, 0px 0px)`.
 
 ## Non-rectangular clip paths
 
@@ -157,24 +166,16 @@ override getClipPath(shape: CircleShape): Vec[] | undefined {
 }
 ```
 
-More segments create smoother curves. The performance cost is minimal since clip paths are cached and only recomputed when the shape changes.
+More segments create smoother curves. Clip paths are cached and only recomputed when the shape changes, so the cost is minimal.
 
 ## Backgrounds and clipping
 
-Shapes that clip typically also provide backgrounds for their children. Override `providesBackgroundForChildren` to enable this:
-
-```typescript
-override providesBackgroundForChildren(): boolean {
-	return true
-}
-```
-
-When this returns true, child shapes with `backgroundComponent` methods have their backgrounds rendered above this shape rather than above the canvas background. This creates proper visual layering within clipping containers.
+Shapes that clip typically also provide a background for their children. `BaseFrameLikeShapeUtil` does this by returning `true` from `providesBackgroundForChildren`, which makes child shapes' background layers (their `backgroundComponent`) render above the container rather than above the canvas background. Both methods are internal APIs; extend `BaseFrameLikeShapeUtil` rather than overriding them yourself.
 
 ## Clipping and hit testing
 
-Clipping affects both rendering and hit testing. The [Editor#getShapeAtPoint](?) method filters out shapes when the click point falls outside the shape's mask—you can't select a clipped shape by clicking its hidden portions.
+Clipping affects more than rendering. [Editor#getShapeAtPoint](?) and [Editor#isPointInShape](?) reject points that fall outside the shape's mask, so you can't select a clipped shape by clicking its hidden portions. Brush selection, scribble selection, erasing, arrow binding, SVG export bounds, and the minimap also use the mask.
 
-Snapping and bounds calculations use the shape's full geometry, so a clipped shape's bounds may extend beyond what's visible. Only rendering and hit testing are masked.
+Snapping and [Editor#getShapePageBounds](?) use the shape's full geometry, so a clipped shape's bounds may extend beyond what's visible. Use [Editor#getShapeMaskedPageBounds](?) when you need the visible bounds.
 
 For an example of custom clipping shapes, see the [custom clipping shape example](/examples/editor-api/custom-clipping-shape).

--- a/apps/docs/content/sdk-features/shape-indexing.mdx
+++ b/apps/docs/content/sdk-features/shape-indexing.mdx
@@ -21,13 +21,13 @@ Every shape in tldraw has an `index` property that determines its visual stackin
 
 ## Why fractional indexing?
 
-Integer-based indexing has problems. If you have shapes at indices `[0, 1, 2]` and want to insert between 0 and 1, you'd need to renumber subsequent shapes or use floats that eventually lose precision.
+Integer indices don't leave room to insert. If you have shapes at indices `[0, 1, 2]` and want to insert between 0 and 1, you'd need to renumber subsequent shapes or use floats that eventually lose precision.
 
-Fractional indexing uses lexicographically sortable strings. You can always generate a new index between any two existing indices. Standard JavaScript string comparison sorts them correctly, and reordering only updates the moved shapes - not every shape on the canvas.
+Fractional indexing uses lexicographically sortable strings. You can always generate a new index between any two existing indices. Standard JavaScript string comparison sorts them correctly, and reordering only updates the moved shapes, not every shape on the canvas.
 
 ## Index structure
 
-Indices are strings like `'a1'`, `'a2'`, or `'a1V'`. The first letter is the integer part (base-62 encoded), and optional following characters are the fractional part for inserting between existing indices. The `@tldraw/utils` package uses the [jittered fractional indexing](https://www.npmjs.com/package/jittered-fractional-indexing) algorithm to generate these strings.
+Indices are strings like `'a1'`, `'a2'`, or `'a1V'`. The leading letter says how many characters make up the integer part (`a` means two characters, `b` means three, and so on), and anything after that is the fractional part for inserting between existing indices. Digits are base-62. The `@tldraw/utils` package uses a vendored copy of the [jittered fractional indexing](https://www.npmjs.com/package/jittered-fractional-indexing) algorithm to generate these strings.
 
 ## Generating indices
 
@@ -52,7 +52,7 @@ const between = getIndexBetween('a1' as IndexKey, 'a3' as IndexKey) // e.g. 'a2'
 const above = getIndexAbove('a1' as IndexKey) // e.g. 'a2'
 const below = getIndexBelow('a2' as IndexKey) // e.g. 'a1'
 
-// Generate multiple indices at once (exact values vary due to jittering)
+// Generate multiple indices at once
 const multipleAbove = getIndicesAbove('a0' as IndexKey, 3)
 const multipleBelow = getIndicesBelow('a2' as IndexKey, 2)
 const multipleBetween = getIndicesBetween('a0' as IndexKey, 'a2' as IndexKey, 2)
@@ -62,7 +62,9 @@ const shapes = [{ index: 'a2' as IndexKey }, { index: 'a1' as IndexKey }]
 shapes.sort(sortByIndex) // [{ index: 'a1' }, { index: 'a2' }]
 ```
 
-The algorithm includes jittering (randomization) to reduce conflicts in collaborative environments. When two users insert shapes at the same position simultaneously, jittering makes them generate different indices instead of identical ones.
+The algorithm jitters (randomizes) the generated keys, so the exact values above vary between calls. This reduces conflicts in collaborative environments: when two users insert shapes at the same position simultaneously, they generate different indices instead of identical ones, and both operations merge cleanly. Jittering is disabled when `NODE_ENV` is `test` so tests are deterministic.
+
+`getIndices(n, start?)` returns the starting index (default `'a1'`) followed by `n` indices above it. `ZERO_INDEX_KEY` is the first index, `'a0'`. To find the next free index in a parent, use [Editor#getHighestIndexForParent](?) with `getIndexAbove`.
 
 ## Reordering shapes
 
@@ -86,7 +88,7 @@ editor.sendBackward(['shape:abc123' as TLShapeId])
 editor.bringForward(['shape:abc123' as TLShapeId])
 ```
 
-By default, these methods only move shapes past other shapes they visually overlap. This makes keyboard shortcuts feel intuitive - pressing "send backward" moves a shape behind the shape it's actually covering, not behind some distant shape.
+By default, these methods only move shapes past other shapes whose page bounds overlap theirs. This makes keyboard shortcuts feel intuitive: pressing "send backward" moves a shape behind the shape it's actually covering, not behind some distant shape.
 
 To move past any shape regardless of overlap:
 
@@ -109,25 +111,21 @@ Shape indices are always relative to siblings within the same parent. When you r
 
 If shapes are already at the target position, no updates occur.
 
-## Collaboration
-
-Fractional indexing works well for real-time collaboration. When two users simultaneously reorder shapes, jittering means they generate different indices in the same region of index space. Both operations succeed and merge cleanly.
-
-Since reordering only updates the moved shapes' indices, it doesn't interfere with other concurrent edits to different shapes.
+If you need full control over ordering (for example in a layer panel), set a shape's `index` directly with [Editor#updateShapes](?).
 
 ## Index validation
 
-`IndexKey` is a branded type - you can't accidentally pass an arbitrary string as an index. Use `validateIndexKey` to check if a string is valid:
+`IndexKey` is a branded type, so you can't accidentally pass an arbitrary string as an index. To validate a string at runtime, use the `indexKey` validator from `@tldraw/validate`:
 
 ```ts
-import { validateIndexKey } from '@tldraw/utils'
+import { T } from 'tldraw'
 
-validateIndexKey('a1') // passes, 'a1' is a valid index
-validateIndexKey('invalid!') // throws an error
+T.indexKey.validate('a1') // returns 'a1' as IndexKey
+T.indexKey.validate('invalid!') // throws a ValidationError
 ```
 
 The store validates indices when you create or update shapes, so the editor won't enter an invalid state.
 
-## Related
+## Related examples
 
-- [Layer panel example](/examples/ui/layer-panel) - Shows shape hierarchy and z-order in a custom panel
+- [Layer panel](/examples/ui/layer-panel) - Shows shape hierarchy and z-order in a custom panel

--- a/apps/docs/content/sdk-features/shape-transforms.mdx
+++ b/apps/docs/content/sdk-features/shape-transforms.mdx
@@ -20,28 +20,31 @@ accuracy: 10
 notes: "Opening paragraph overly dense - break into shorter sentences. Voice issues: formulaic phrases ('These operations fall into two categories', 'particularly useful for'), passive 'is called' in rotation section."
 ---
 
-Shape transforms are operations that manipulate multiple shapes together: grouping, aligning, distributing, stacking, packing, flipping, and rotating. Each operation has a dedicated method on the Editor class.
+Shape transforms are operations that manipulate multiple shapes together: grouping, aligning, distributing, stacking, packing, stretching, flipping, and rotating. Each operation has a dedicated method on the [Editor](?) class.
 
-All transform operations respect the editor's parent-child coordinate system and work correctly with shapes that have different parents or rotations. Shapes connected by arrow bindings move together as clusters, so transforms preserve diagram relationships.
+All transform operations respect the editor's parent-child coordinate system and work with shapes that have different parents or rotations. Shapes connected by arrow bindings move together as clusters.
 
 ## Transform operations
 
-Transform methods accept either shape IDs or shape objects and typically operate on the current selection. Grouping changes the shape hierarchy. The spatial operations (alignment, distribution, stacking, packing, flipping, rotation) reposition shapes without changing their parent relationships.
+Transform methods take an array of shape IDs or shape objects; pass `editor.getSelectedShapeIds()` to operate on the selection. All of them are no-ops when the editor is read-only. Grouping changes the shape hierarchy. The spatial operations reposition shapes without changing their parent relationships.
 
 ### Grouping and ungrouping
 
-Grouping creates a new group shape that becomes the parent of the selected shapes. The editor calculates a common ancestor for the shapes being grouped and creates the group at the appropriate position in the hierarchy. The grouped shapes keep their visual positions on the page, but their coordinates become relative to the group.
+[Editor#groupShapes](?) creates a new group shape that becomes the parent of the given shapes. The editor finds the shapes' common ancestor and creates the group there. The grouped shapes keep their visual positions on the page, but their coordinates become relative to the group.
 
 ```typescript
 editor.groupShapes([shape1, shape2, shape3])
+editor.groupShapes([shape1, shape2], { groupId: myGroupId, select: false })
 editor.ungroupShapes([groupShape])
 ```
 
-Ungrouping reverses this process by moving the group's children back to the group's parent and removing the group shape itself. The shapes maintain their page positions but return to using their original parent's coordinate space.
+`groupShapes` only runs while the select tool is active, and it cancels any in-progress select interaction first. It needs at least two shapes.
+
+[Editor#ungroupShapes](?) reverses this: it moves the group's children back to the group's parent and deletes the group shape. The shapes keep their page positions but return to their original parent's coordinate space.
 
 ### Alignment
 
-Alignment moves shapes so they share a common edge or center line. The six single-axis operations are `left`, `right`, `top`, `bottom`, `center-horizontal`, and `center-vertical`. Use `center` to align shapes by both their horizontal and vertical centers in one call.
+[Editor#alignShapes](?) moves shapes so they share a common edge or center line. The six single-axis operations are `left`, `right`, `top`, `bottom`, `center-horizontal`, and `center-vertical`. Use `center` to align shapes by both their horizontal and vertical centers in one call.
 
 When aligning shapes, the editor first calculates the common bounding box of all selected shapes. It then moves each shape to the appropriate edge or center of that common box.
 
@@ -55,7 +58,7 @@ Selected shapes connected by arrow bindings move together as a cluster during al
 
 ### Distribution
 
-Distribution spaces shapes evenly between the outermost shapes in a selection. The editor identifies the first and last shapes based on their positions, then calculates the gap needed to distribute the remaining shapes evenly in the space between them. This can create negative gaps if shapes overlap.
+[Editor#distributeShapes](?) spaces shapes evenly between the outermost shapes in a selection. The editor identifies the first and last shapes based on their positions, then calculates the gap needed to distribute the remaining shapes evenly in the space between them. This can create negative gaps if shapes overlap.
 
 ```typescript
 editor.distributeShapes(editor.getSelectedShapeIds(), 'horizontal')
@@ -66,78 +69,69 @@ Distribution requires at least three shape clusters. Like alignment, shapes conn
 
 ### Stacking
 
-Stacking arranges shapes in a sequence with consistent gaps between them. Unlike distribution, which spaces shapes within a fixed range, stacking positions each shape relative to the previous one with a specified gap.
+[Editor#stackShapes](?) arranges shapes in a sequence with consistent gaps between them. Unlike distribution, which spaces shapes within a fixed range, stacking positions each shape relative to the previous one with a specified gap.
 
 ```typescript
 editor.stackShapes(editor.getSelectedShapeIds(), 'horizontal', 16)
 editor.stackShapes([box1, box2, box3], 'vertical')
 ```
 
-If you don't pass a gap, the editor uses its `adjacentShapeMargin` option. Pass a gap of `0` for automatic gap detection: the editor analyzes the current spacing between shapes and uses the most common gap, or the average gap if no pattern exists.
+If you don't pass a gap, the editor uses its `adjacentShapeMargin` [option](/sdk-features/options). Pass a gap of `0` for automatic gap detection: the editor measures the current spacing between shapes and uses the most common gap, or the average gap if no pattern exists. Automatic detection needs at least three clusters; with fewer, the call does nothing.
 
 ### Packing
 
-Packing arranges shapes into a compact grid layout using a bin-packing algorithm based on potpack. The editor groups shapes by their parent containers, then arranges each group into an efficient rectangular grid. The packed arrangement is centered on the shapes' original center point, which minimizes how far shapes move.
+[Editor#packShapes](?) arranges shapes into a compact grid using a bin-packing algorithm based on [potpack](https://github.com/mapbox/potpack). Shapes connected by arrows form clusters, and all clusters are packed into a single grid centered on the shapes' original center point, so shapes move as little as possible.
 
 ```typescript
 editor.packShapes(editor.getSelectedShapeIds(), 8)
 editor.packShapes([box1, box2, box3, box4])
 ```
 
-Packing is useful for cleaning up scattered shapes. The gap parameter controls the padding between packed shapes and defaults to the editor's `adjacentShapeMargin` option.
+The gap parameter controls the padding between packed shapes and defaults to the editor's `adjacentShapeMargin` option.
 
 ### Flipping
 
-Flipping mirrors shapes along either the horizontal or vertical axis. The operation uses the center point of all selected shapes' common bounding box as the flip origin. Shapes are scaled by -1 on the appropriate axis, which inverts their position and visual appearance while maintaining their size.
+[Editor#flipShapes](?) mirrors shapes along the horizontal or vertical axis. The flip origin is the center of the shapes' common bounding box. Each shape is scaled by -1 on that axis, which inverts its position and appearance while keeping its size.
 
 ```typescript
 editor.flipShapes(editor.getSelectedShapeIds(), 'horizontal')
 editor.flipShapes([box1, box2], 'vertical')
 ```
 
-When flipping groups, the editor automatically includes all children of the group to ensure the entire hierarchy is flipped together. Some shapes may opt out of flipping by returning false from their ShapeUtil's canBeLaidOut method.
+When flipping groups, the editor includes all children of the group so the whole hierarchy flips together. Shapes can opt out of flipping by returning `false` from [ShapeUtil#canBeLaidOut](?); arrows do this when the shape they're bound to isn't part of the flip.
 
 ### Rotation
 
-Rotation spins shapes around a common center point. The editor calculates the collective center of all selected shapes, then rotates each shape both around that center point and around its own center. This produces the expected result where shapes orbit the selection center while also rotating individually.
+[Editor#rotateShapesBy](?) rotates shapes by a delta in radians around a common center point. The editor calculates the center of all the shapes' rotated bounds, then rotates each shape around that point and around its own origin: shapes orbit the selection center while also rotating individually. Pass `{ center }` to rotate around a different point.
 
 ```typescript
 editor.rotateShapesBy(editor.getSelectedShapeIds(), Math.PI / 4)
+editor.rotateShapesBy([box1, box2], Math.PI / 2, { center: { x: 0, y: 0 } })
 ```
 
-The rotation system maintains a snapshot of the initial shape positions and rotations, which supports smooth incremental updates during drag operations. Shape utilities can respond to rotation events through the onRotateStart, onRotate, and onRotateEnd methods.
+Shape utils can respond to rotation through [ShapeUtil#onRotateStart](?), [ShapeUtil#onRotate](?), and [ShapeUtil#onRotateEnd](?). For a one-off `rotateShapesBy` call, all three fire in sequence; during an interactive rotate, `onRotate` fires on every update.
+
+### Stretching
+
+[Editor#stretchShapes](?) resizes shapes to fill their common bounding box along one axis. Only shapes whose page rotation is a multiple of 90 degrees participate.
+
+```typescript
+editor.stretchShapes(editor.getSelectedShapeIds(), 'horizontal')
+```
 
 ## Parent coordinate transforms
 
-When a shape has a rotated parent, the editor converts page-space movement deltas back into the parent's local coordinate space before updating the shape's position. Moving a child shape produces the correct visual result regardless of parent rotation or nesting depth.
-
-The conversion process uses the parent's page transform matrix to inverse-rotate the delta vector. For example, if a parent is rotated 45 degrees and you want to move a child 10 pixels to the right in page space, the editor calculates what movement in the parent's coordinate space would produce that page-space result.
-
-```typescript
-const parent = editor.getShapeParent(shape) // [1]
-if (parent) {
-	const parentTransform = editor.getShapePageTransform(parent) // [2]
-	if (parentTransform) shapeDelta.rot(-parentTransform.rotation()) // [3]
-}
-```
-
-1. Get the shape's parent to check if coordinate conversion is needed
-2. Retrieve the parent's full page transform matrix (position, rotation, scale)
-3. Rotate the movement delta by the negative of the parent's rotation to convert from page space to parent space
-
-Align, distribute, and stack all rely on this conversion: they calculate movement in page space but must apply it in each shape's local space.
+Align, distribute, stack, and pack calculate movement in page space but apply it in each shape's parent space. When a shape's parent is rotated, the editor rotates the page-space delta by the negative of the parent's rotation (from [Editor#getShapeParentTransform](?)) before updating the shape's `x` and `y`. Moving a child shape produces the correct visual result regardless of parent rotation or nesting depth. See [Coordinates](/sdk-features/coordinates).
 
 ## Shape clustering via arrow bindings
 
-Several transform operations group shapes into clusters based on arrow bindings. When shapes are connected by arrows, they form a logical unit that should move together during transforms. The editor uses a recursive algorithm to collect all shapes connected through arrow bindings, starting from each selected shape and traversing the binding graph.
+Align, distribute, stack, and pack group shapes into clusters based on arrow bindings. Starting from each shape, the editor follows arrow bindings recursively and collects every connected shape that is also in the input list. If A connects to B via an arrow but only A is passed in, B is not included.
 
-The clustering algorithm maintains a visited set to avoid processing shapes multiple times and only includes shapes that were part of the initial selection. This means that if A connects to B via an arrow, but only A is selected, then B will not be included in the transform unless B is also explicitly selected.
+Each cluster is treated as a single unit with a common bounding box. When the transform calculates movement for the cluster, it applies that movement to every shape in the cluster, so their relative positions and arrow relationships stay intact.
 
-Each cluster is treated as a single unit with a common bounding box. When the transform calculates movement for the cluster, it applies that movement to all shapes in the cluster. Their relative positions and arrow relationships stay intact.
+## Opting out with canBeLaidOut
 
-## Shape utility integration
-
-Shape utilities can control whether their shapes participate in transforms through the canBeLaidOut method. This method receives the transform type and the full list of shapes being transformed, so the utility can make context-aware decisions.
+Shape utils control whether their shapes participate in transforms through [ShapeUtil#canBeLaidOut](?). It receives the transform type and the full list of shapes being transformed, so the util can decide based on context.
 
 ```typescript
 canBeLaidOut(shape: MyShape, info: TLShapeUtilCanBeLaidOutOpts): boolean {
@@ -146,9 +140,7 @@ canBeLaidOut(shape: MyShape, info: TLShapeUtilCanBeLaidOutOpts): boolean {
 }
 ```
 
-For rotation operations, shape utilities can respond to rotation lifecycle events. The editor calls onRotateStart when rotation begins, onRotate for each update, and onRotateEnd when rotation completes. These methods can return shape partials to modify the shape during rotation.
-
 ## Related examples
 
-- **[Keyboard shortcuts](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/keyboard-shortcuts)** - Customize shortcuts for align, distribute, and other transform operations.
-- **[Selection UI](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/selection-ui)** - Build custom controls that can trigger transform operations on selected shapes.
+- **[Keyboard shortcuts](/examples/ui/keyboard-shortcuts)** - Customize shortcuts for align, distribute, and other transform operations.
+- **[Selection UI](/examples/ui/selection-ui)** - Build custom controls that can trigger transform operations on selected shapes.

--- a/apps/docs/content/sdk-features/shapes.mdx
+++ b/apps/docs/content/sdk-features/shapes.mdx
@@ -18,9 +18,9 @@ accuracy: 10
 notes: ''
 ---
 
-Shapes are the fundamental content elements on the tldraw canvas. Every rectangle, arrow, text box, and freehand stroke is a shape. The shape system separates data from behavior: shape records store immutable data in the store, while ShapeUtil classes define how each shape type renders, responds to interaction, and computes its geometry. This separation keeps the data layer simple and portable.
+In tldraw, a shape is something that can exist on the page: a rectangle, an arrow, a text box, a freehand stroke. Each shape is a record in the store, and each shape type has a [ShapeUtil](?) class that defines how it renders, responds to interaction, and computes its [geometry](/sdk-features/geometry).
 
-Shapes support parent-child hierarchies for grouping and frames, participate in a reactive rendering pipeline, and integrate with the binding system to form relationships with other shapes.
+Shapes can be parented to other shapes (see [Parent-child relationships](#Parent-child-relationships)), are stacked by [index](/sdk-features/shape-indexing), and can be related to other shapes through [bindings](/sdk-features/bindings). This article covers the shape system; for a tutorial on writing your own shape, see [Shapes](/docs/shapes).
 
 ## Shape records
 
@@ -44,25 +44,38 @@ Each type has a corresponding ShapeUtil that implements its behavior.
 
 ### Creating and accessing shapes
 
-The editor provides methods for working with shape records. Create shapes with `createShape`, passing the shape type, position, and props. Get shapes by ID with `getShape`, or get all shapes on the current page with `getCurrentPageShapes`. Update shapes with `updateShape`, passing the shape ID and properties to change. Delete shapes with `deleteShape`.
+The editor has methods for each step of a shape's life:
+
+| Method                           | Description                                            |
+| -------------------------------- | ------------------------------------------------------ |
+| [Editor#createShape](?)          | Create a shape from a partial (type, position, props). |
+| [Editor#getShape](?)             | Get a shape by ID.                                     |
+| [Editor#getCurrentPageShapes](?) | Get all shapes on the current page.                    |
+| [Editor#updateShape](?)          | Apply a partial update to an existing shape.           |
+| [Editor#deleteShape](?)          | Delete a shape and its descendants.                    |
 
 ```typescript
-// Create a geo shape
-editor.createShape({
-	type: 'geo',
-	x: 100,
-	y: 100,
-	props: { w: 200, h: 150, geo: 'rectangle' },
-})
+import { createShapeId, Editor } from 'tldraw'
 
-// Get a shape by ID
-const shape = editor.getShape(shapeId)
+function addRectangle(editor: Editor) {
+	const id = createShapeId()
 
-// Update a shape's position
-editor.updateShape({ id: shape.id, type: shape.type, x: 200 })
+	editor.createShape({
+		id,
+		type: 'geo',
+		x: 100,
+		y: 100,
+		props: { w: 200, h: 150, geo: 'rectangle' },
+	})
+
+	const shape = editor.getShape(id)!
+
+	// Move it to the right
+	editor.updateShape({ id: shape.id, type: shape.type, x: 200 })
+}
 ```
 
-Shapes are immutable records. When you update a shape, the editor creates a new record with the changes and stores it, replacing the old one. This immutability enables efficient change detection and undo/redo.
+Shapes are immutable records. When you update a shape, the editor creates a new record with the changes and stores it in place of the old one.
 
 ## ShapeUtil
 
@@ -70,11 +83,23 @@ A ShapeUtil class defines how a shape type behaves. The editor maintains one Sha
 
 ### Required methods
 
-Every ShapeUtil must implement four methods: `getDefaultProps` returns default property values for new shapes, `getGeometry` returns a mathematical representation for hit testing and bounds calculation, `component` returns a React component that renders the shape, and `getIndicatorPath` returns paths for the selection outline.
+Every ShapeUtil must implement four methods:
 
-```typescript
+| Method                          | Description                                                          |
+| ------------------------------- | -------------------------------------------------------------------- |
+| [ShapeUtil#getDefaultProps](?)  | Default props for new shapes.                                        |
+| [ShapeUtil#getGeometry](?)      | The shape's [Geometry2d](?), used for hit testing and bounds.        |
+| [ShapeUtil#component](?)        | A React component that renders the shape.                            |
+| [ShapeUtil#getIndicatorPath](?) | A `Path2D` for the selection outline, or `undefined` for no outline. |
+
+```tsx
+import { Geometry2d, HTMLContainer, Rectangle2d, ShapeUtil, T, TLBaseShape } from 'tldraw'
+
+type MyShape = TLBaseShape<'my-shape', { w: number; h: number }>
+
 class MyShapeUtil extends ShapeUtil<MyShape> {
 	static override type = 'my-shape' as const
+	static override props = { w: T.number, h: T.number }
 
 	getDefaultProps(): MyShape['props'] {
 		return { w: 100, h: 100 }
@@ -88,11 +113,11 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 		})
 	}
 
-	component(shape: MyShape): JSX.Element {
-		return <div style={{ width: shape.props.w, height: shape.props.h }} />
+	component(shape: MyShape) {
+		return <HTMLContainer style={{ width: shape.props.w, height: shape.props.h }} />
 	}
 
-	getIndicatorPath(shape: MyShape): Path2D | undefined {
+	getIndicatorPath(shape: MyShape) {
 		const path = new Path2D()
 		path.rect(0, 0, shape.props.w, shape.props.h)
 		return path
@@ -100,15 +125,17 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
+Wrap your rendered content in [HTMLContainer](?) or [SVGContainer](?) so it's positioned correctly on the canvas. `getIndicatorPath` can also return a [TLIndicatorPath](?) object with a `clipPath` and `additionalPaths` for shapes like arrows with labels.
+
 ### Capability methods
 
-ShapeUtils can override capability methods to declare what interactions the shape supports. These methods return booleans indicating whether the shape can be edited, resized, cropped, scrolled, or bound to other shapes. The `canReceiveNewChildrenOfType` method controls whether the shape can contain other shapes as children.
+ShapeUtils override capability methods to declare what interactions the shape supports. These return booleans: [ShapeUtil#canEdit](?), [ShapeUtil#canResize](?), [ShapeUtil#canCrop](?), [ShapeUtil#canScroll](?), [ShapeUtil#canBind](?), and so on. [ShapeUtil#canReceiveNewChildrenOfType](?) controls whether the shape can accept other shapes as children, and [ShapeUtil#canRemoveChildrenOfType](?) controls whether children can be dragged back out.
 
 ### Lifecycle hooks
 
-ShapeUtils can respond to shape changes through lifecycle hooks. The `onBeforeCreate` and `onBeforeUpdate` hooks intercept shape creation and updates before they reach the store, where you can modify or validate the shape. The `onResize`, `onRotate`, and `onTranslate` hooks respond to transformation operations. The `onChildrenChange` hook responds to changes in a shape's children. Interaction hooks like `onDoubleClick`, `onDragShapesOver`, and `onDropShapesOver` enable custom behavior for user interactions.
+ShapeUtils respond to shape changes through lifecycle hooks. [ShapeUtil#onBeforeCreate](?) and [ShapeUtil#onBeforeUpdate](?) intercept shape creation and updates before they reach the store, so you can modify the shape. [ShapeUtil#onResize](?), [ShapeUtil#onRotate](?), and [ShapeUtil#onTranslate](?) (with their `Start`/`End` variants) respond to transformations. [ShapeUtil#onChildrenChange](?) responds to changes in a shape's children. Interaction hooks like [ShapeUtil#onDoubleClick](?), [ShapeUtil#onDragShapesOver](?), and [ShapeUtil#onDropShapesOver](?) handle user interactions.
 
-The `onResize` hook requires careful implementation. When a shape resizes, the hook receives resize information including the scale factors and the handle being dragged. It returns a partial update containing just the props you want to change (without the `id` or `type`):
+`onResize` receives a [TLResizeInfo](?) with the scale factors and the handle being dragged. It returns a partial containing just the props you want to change (without `id` or `type`):
 
 ```typescript
 onResize(shape: MyShape, info: TLResizeInfo<MyShape>) {
@@ -183,27 +210,24 @@ Each shape util declares its own `options` object, and `configure` returns a new
 
 ### Registering ShapeUtils
 
-Register custom ShapeUtils when initializing tldraw by passing them to the `shapeUtils` prop. The editor creates one instance of each ShapeUtil and uses it for all shapes of that type.
+Register custom ShapeUtils by passing them to the `shapeUtils` prop of the [Tldraw](?) component. The editor creates one instance of each ShapeUtil and uses it for all shapes of that type.
 
-## Geometry system
+## Geometry
 
-The geometry system provides mathematical representations of shapes for hit testing, bounds calculation, snapping, and collision detection. Every ShapeUtil returns a [Geometry2d](?) instance from its `getGeometry` method. The system includes geometry classes for common shapes: [Rectangle2d](?) for axis-aligned rectangles, [Circle2d](?) for true circles (with center and radius), [Ellipse2d](?) for ellipses with different width/height, [Polygon2d](?) for arbitrary closed polygons, [Polyline2d](?) for open paths, [Arc2d](?) for circular arcs, [Stadium2d](?) for rounded rectangles, and [Group2d](?) for composite geometry.
-
-### Key geometry operations
-
-Geometry2d provides methods for spatial queries. Get the axis-aligned bounding box with the `bounds` property. Get boundary vertices with `getVertices`. Find the nearest point on the shape boundary with `nearestPoint`. Test if a point hits the shape with `hitTestPoint`, which accepts a `margin` parameter that expands the hit area and a `hitInside` parameter that controls whether points inside the shape count as hits for unfilled shapes. Test line segment intersection with `hitTestLineSegment` or get intersection points with `intersectLineSegment`.
-
-### Geometry caching
-
-The editor caches geometry computations to avoid recalculating bounds and hit test data on every frame. Without caching, dragging a selection box over hundreds of shapes would recompute each shape's geometry repeatedly, causing noticeable lag. The cache invalidates automatically when a shape's props change. Access cached geometry with `getShapeGeometry` or cached page bounds (geometry combined with transforms) with `getShapePageBounds`.
+Every ShapeUtil returns a [Geometry2d](?) from `getGeometry`. The editor uses it for hit testing, bounds, snapping, and collision detection. Geometry classes cover rectangles, circles, ellipses, polygons, polylines, arcs, and composites ([Group2d](?)). The editor caches each shape's geometry and page bounds; read them with [Editor#getShapeGeometry](?) and [Editor#getShapePageBounds](?). See [Geometry](/sdk-features/geometry) for the full system.
 
 ## Shape rendering
 
-The editor renders shapes through a React component hierarchy. Each shape is wrapped in a container that handles positioning, transforms, and culling. When a shape renders, the editor computes the shape's page transform by combining its local position and rotation with all ancestor transforms, extracts bounds from the shape's geometry, skips rendering if the shape is outside the viewport and supports culling, renders the shape's visual content through the ShapeUtil's `component` method, and if selected, renders the selection outline through the `getIndicatorPath` method.
+The editor renders shapes through a React component hierarchy. Each shape is wrapped in a container that handles positioning, transforms, and culling. When a shape renders, the editor:
+
+1. computes the shape's page transform by combining its local position and rotation with all ancestor transforms
+2. skips rendering if the shape is outside the viewport and its ShapeUtil allows culling
+3. renders the shape's content through the ShapeUtil's `component` method
+4. if the shape is selected, strokes the selection outline from `getIndicatorPath` on the canvas overlay
 
 ### Transform composition
 
-Shapes position relative to their parent's coordinate space. For a shape nested inside a rotated frame, the editor composes transforms. Get the transform from shape space to page space with `getShapePageTransform`. Get just the local transform with `getShapeLocalTransform`. Convert a page point to shape-local coordinates with `getPointInShapeSpace`.
+Shapes are positioned relative to their parent's coordinate space. Get the transform from shape space to page space with [Editor#getShapePageTransform](?), the local transform with [Editor#getShapeLocalTransform](?), and convert a page point to shape-local coordinates with [Editor#getPointInShapeSpace](?). See [Coordinates](/sdk-features/coordinates) for the coordinate spaces.
 
 ### Opacity
 
@@ -215,15 +239,15 @@ Shapes go through creation, updates, and deletion. The editor provides hooks and
 
 ### Creation flow
 
-When `createShape` is called, the editor assigns an ID if none provided, determines the parent either explicitly, inferred from position, or defaults to the current page, calculates the fractional index for z-ordering, calls `ShapeUtil.onBeforeCreate` for any modifications, validates the shape against the schema, and stores the shape in the store.
+When you call `createShape`, the editor assigns an ID if none is provided, determines the parent (explicit `parentId`, otherwise a container shape under the given position, otherwise the focused group or current page), calculates the fractional index for z-ordering, calls `ShapeUtil.onBeforeCreate` for any modifications, validates the shape against the schema, and puts it in the store.
 
 ### Update flow
 
-When `updateShape` is called, the editor checks if the shape or an ancestor is locked, merges the partial update with the existing shape, calls `ShapeUtil.onBeforeUpdate` for any modifications, validates and stores the updated shape, and emits update events.
+When you call `updateShape`, the editor skips the update if the shape or an ancestor is locked (unless the update unlocks it), merges the partial with the existing shape, calls `ShapeUtil.onBeforeUpdate` for any modifications, validates and stores the updated shape, and emits update events.
 
 ### Deletion flow
 
-When `deleteShape` is called, the editor collects all descendant shapes, removes bindings involving the shapes, calls deletion side effects, and removes all shapes from the store. Deleting a frame or group deletes all its children. Bindings are automatically cleaned up, and connected shapes receive isolation callbacks to update their state.
+When you call `deleteShape`, the editor collects all descendant shapes and removes them from the store. Deleting a frame or group deletes all its children. Store side effects clean up bindings that involve the deleted shapes; the binding utils receive `onBeforeIsolate*` and `onBeforeDelete*` callbacks so connected shapes like arrows can update. See [Bindings](/sdk-features/bindings).
 
 ## Parent-child relationships
 
@@ -237,17 +261,15 @@ To build your own container shape that behaves like a frame, extend `BaseFrameLi
 
 ### Groups
 
-Groups are logical containers without visual representation. Group selected shapes with `groupShapes`. Ungroup with `ungroupShapes`. Groups exist only to organize shapes. Their geometry is the union of their children's geometry. When you delete the last child of a group, the group deletes itself.
+Groups are logical containers without visual representation. Group shapes with [Editor#groupShapes](?) and ungroup with [Editor#ungroupShapes](?). A group's geometry is the union of its children's geometry. When a group is left with fewer than two children, it removes itself: an empty group is deleted, and a group with one child reparents that child to the group's parent and then deletes itself. See [Groups](/sdk-features/groups).
 
 ### Focused groups
 
-The editor tracks a **focused group** that defines the current editing scope. When you double-click a group, it becomes focused, and you can select and edit shapes inside it. Get the current focused group with `getFocusedGroup`. Focus a specific group with `setFocusedGroup`. Exit the focused group with `popFocusedGroupId`.
+The editor tracks a focused group that defines the current editing scope. When you double-click a group, it becomes focused, and you can select and edit shapes inside it. Get the current focused group with [Editor#getFocusedGroup](?), focus a group with [Editor#setFocusedGroup](?), and exit it with [Editor#popFocusedGroupId](?).
 
 ## Coordinate spaces
 
-The editor works with multiple coordinate spaces. Screen space uses the browser viewport top-left as the origin for mouse events and UI positioning. Page space uses the canvas origin at (0,0) for shape positions and bounds. Parent space uses the parent shape's top-left for nested shape positions. Local space uses the shape's own top-left for shape-internal coordinates.
-
-The editor provides methods to convert between spaces. Convert screen points to page points with `screenToPage`. Convert page points to screen points with `pageToScreen`. Convert page points to shape-local coordinates with `getPointInShapeSpace`. Get a shape's page-space transform matrix with `getShapePageTransform`.
+The editor works with four coordinate spaces: screen space (the browser viewport), page space (the canvas), parent space (a shape's parent), and local space (the shape itself). Convert between them with [Editor#screenToPage](?), [Editor#pageToScreen](?), and [Editor#getPointInShapeSpace](?). See [Coordinates](/sdk-features/coordinates).
 
 ## Shape derivations
 
@@ -255,30 +277,30 @@ The editor maintains computed derivations that update automatically as shapes ch
 
 ### Parents to children index
 
-Maps parent IDs to sorted arrays of child shape IDs. Updated incrementally as shapes are added, removed, or reparented. Get children of a shape or page, sorted by z-index, with `getSortedChildIdsForParent`.
+Maps parent IDs to sorted arrays of child shape IDs. Updated incrementally as shapes are added, removed, or reparented. Get children of a shape or page, sorted by z-index, with [Editor#getSortedChildIdsForParent](?).
 
 ### Culled shapes
 
-Tracks which shapes are outside the viewport. Shapes whose ShapeUtil returns `true` from `canCull()` are candidates for culling. Culled shapes are still in the DOM but have their `display` set to `none` for performance. Check if a shape is currently culled with `getCulledShapes().has(shapeId)`.
+Tracks which shapes are outside the viewport. Shapes whose ShapeUtil returns `true` from [ShapeUtil#canCull](?) are candidates for culling. Selected shapes and the shape being edited are never culled. Culled shapes stay in the DOM with `display: none`. Check whether a shape is culled with `editor.getCulledShapes().has(shapeId)`. See [Culling](/sdk-features/culling).
 
 ### Shape geometry cache
 
-Caches geometry computations per shape. Invalidates when shape props change. Access through `getShapeGeometry`, which returns cached geometry and only recomputes when needed.
+Caches each shape's geometry and page bounds, invalidating when the shape's props or meta change. See [Geometry](/sdk-features/geometry#Geometry-caching).
 
 ## Related examples
 
-- **[Custom shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/custom-shape)** - A simple custom shape demonstrating basic ShapeUtil implementation.
-- **[Editable custom shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/editable-shape)** - A custom shape that can be edited by double-clicking it, showing how to use the editing state.
-- **[Clickable custom shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/interactive-shape)** - A custom shape with onClick interactions demonstrating pointer event handling.
-- **[Custom shape geometry](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-geometry)** - A house-shaped custom shape demonstrating custom geometry implementation.
-- **[Custom shape with custom styles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-custom-styles)** - Shows how to create your own styles and use them in custom shapes.
-- **[Custom shape with tldraw styles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-tldraw-styles)** - Use tldraw's default styles in your custom shapes.
-- **[Custom shape migrations](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-migrations)** - Migrate shapes and their data between versions using the migrations system.
-- **[Custom shape with handles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/speech-bubble)** - A speech bubble shape with custom handles for interaction.
-- **[Shape options](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/configuration/configure-shape-util)** - Change the behavior of built-in shapes by setting their options via ShapeUtil.configure.
-- **[Custom snapping](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/bounds-snapping-shape)** - Custom shapes with special bounds snapping behavior, demonstrated with playing cards.
-- **[Cubic bezier curve shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/cubic-bezier-shape)** - A custom shape with interactive bezier curve editing using draggable control handles.
-- **[Data grid shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/ag-grid-shape)** - A custom shape that renders AG Grid, showing complex component integration.
-- **[Popup shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/popup-shape)** - Create a 3D illusion of depth with dynamic shadows and CSS transforms.
-- **[Custom clipping shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/custom-clipping-shape)** - Custom shapes that can clip their children with any polygon geometry.
-- **[DOM-based shape size](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/size-from-dom)** - A custom shape whose size is derived from its rendered DOM.
+- **[Custom shape](/examples/shapes/tools/custom-shape)** - A simple custom shape demonstrating basic ShapeUtil implementation.
+- **[Editable custom shape](/examples/shapes/tools/editable-shape)** - A custom shape that can be edited by double-clicking it, showing how to use the editing state.
+- **[Clickable custom shape](/examples/shapes/tools/interactive-shape)** - A custom shape with onClick interactions demonstrating pointer event handling.
+- **[Custom shape geometry](/examples/shapes/tools/shape-with-geometry)** - A house-shaped custom shape demonstrating custom geometry implementation.
+- **[Custom shape with custom styles](/examples/shapes/tools/shape-with-custom-styles)** - Shows how to create your own styles and use them in custom shapes.
+- **[Custom shape with tldraw styles](/examples/shapes/tools/shape-with-tldraw-styles)** - Use tldraw's default styles in your custom shapes.
+- **[Custom shape migrations](/examples/shapes/tools/shape-with-migrations)** - Migrate shapes and their data between versions using the migrations system.
+- **[Custom shape with handles](/examples/shapes/tools/speech-bubble)** - A speech bubble shape with custom handles for interaction.
+- **[Shape options](/examples/configuration/configure-shape-util)** - Change the behavior of built-in shapes by setting their options via ShapeUtil.configure.
+- **[Custom snapping](/examples/shapes/tools/bounds-snapping-shape)** - Custom shapes with special bounds snapping behavior, demonstrated with playing cards.
+- **[Cubic bezier curve shape](/examples/shapes/tools/cubic-bezier-shape)** - A custom shape with interactive bezier curve editing using draggable control handles.
+- **[Data grid shape](/examples/shapes/tools/ag-grid-shape)** - A custom shape that renders AG Grid, showing complex component integration.
+- **[Popup shape](/examples/shapes/tools/popup-shape)** - Create a 3D illusion of depth with dynamic shadows and CSS transforms.
+- **[Custom clipping shape](/examples/editor-api/custom-clipping-shape)** - Custom shapes that can clip their children with any polygon geometry.
+- **[DOM-based shape size](/examples/shapes/tools/size-from-dom)** - A custom shape whose size is derived from its rendered DOM.

--- a/apps/docs/content/sdk-features/shapes.mdx
+++ b/apps/docs/content/sdk-features/shapes.mdx
@@ -289,10 +289,10 @@ Caches each shape's geometry and page bounds, invalidating when the shape's prop
 
 ## Related examples
 
-- **[Custom shape](/examples/shapes/tools/custom-shape)** - A simple custom shape demonstrating basic ShapeUtil implementation.
-- **[Editable custom shape](/examples/shapes/tools/editable-shape)** - A custom shape that can be edited by double-clicking it, showing how to use the editing state.
-- **[Clickable custom shape](/examples/shapes/tools/interactive-shape)** - A custom shape with onClick interactions demonstrating pointer event handling.
-- **[Custom shape geometry](/examples/shapes/tools/shape-with-geometry)** - A house-shaped custom shape demonstrating custom geometry implementation.
+- **[Custom shape](/examples/shapes/tools/custom-shape)** - A minimal ShapeUtil.
+- **[Editable custom shape](/examples/shapes/tools/editable-shape)** - A custom shape that enters the editing state on double-click.
+- **[Clickable custom shape](/examples/shapes/tools/interactive-shape)** - A custom shape that responds to onClick.
+- **[Custom shape geometry](/examples/shapes/tools/shape-with-geometry)** - A house-shaped custom shape with custom geometry.
 - **[Custom shape with custom styles](/examples/shapes/tools/shape-with-custom-styles)** - Shows how to create your own styles and use them in custom shapes.
 - **[Custom shape with tldraw styles](/examples/shapes/tools/shape-with-tldraw-styles)** - Use tldraw's default styles in your custom shapes.
 - **[Custom shape migrations](/examples/shapes/tools/shape-with-migrations)** - Migrate shapes and their data between versions using the migrations system.
@@ -300,7 +300,7 @@ Caches each shape's geometry and page bounds, invalidating when the shape's prop
 - **[Shape options](/examples/configuration/configure-shape-util)** - Change the behavior of built-in shapes by setting their options via ShapeUtil.configure.
 - **[Custom snapping](/examples/shapes/tools/bounds-snapping-shape)** - Custom shapes with special bounds snapping behavior, demonstrated with playing cards.
 - **[Cubic bezier curve shape](/examples/shapes/tools/cubic-bezier-shape)** - A custom shape with interactive bezier curve editing using draggable control handles.
-- **[Data grid shape](/examples/shapes/tools/ag-grid-shape)** - A custom shape that renders AG Grid, showing complex component integration.
+- **[Data grid shape](/examples/shapes/tools/ag-grid-shape)** - A custom shape that renders AG Grid.
 - **[Popup shape](/examples/shapes/tools/popup-shape)** - Create a 3D illusion of depth with dynamic shadows and CSS transforms.
 - **[Custom clipping shape](/examples/editor-api/custom-clipping-shape)** - Custom shapes that can clip their children with any polygon geometry.
 - **[DOM-based shape size](/examples/shapes/tools/size-from-dom)** - A custom shape whose size is derived from its rendered DOM.

--- a/apps/docs/content/sdk-features/side-effects.mdx
+++ b/apps/docs/content/sdk-features/side-effects.mdx
@@ -19,27 +19,24 @@ notes: ''
 
 Side effects are lifecycle hooks that run when records are created, updated, or deleted. You can use them to intercept and modify records, validate changes, or react to completed operations by updating related data.
 
-The editor uses side effects internally to keep data consistent. When you delete a shape, the editor automatically removes its bindings. When a binding changes, the connected shapes get notified to update. These hooks let independent parts of the system stay in sync without being directly coupled.
+The editor uses side effects internally to keep data consistent. When you delete a shape, the editor automatically removes its bindings. When a binding changes, its `BindingUtil` gets a chance to update the connected shapes. These hooks let independent parts of the system stay in sync without being directly coupled. Side effects live on the [store](/sdk-features/store) and are exposed as [Editor#sideEffects](?), a [StoreSideEffects](?) instance.
 
 ## How it works
 
 ### Before and after handlers
 
-Side effects provide six handler types organized around three operations: create, change, and delete. Each operation has a "before" and "after" phase.
+Side effects provide six handler types organized around three operations: create, change, and delete. Each operation has a "before" and "after" phase. Handlers are registered per record `typeName` (`'shape'`, `'binding'`, `'page'`, or a custom type); check `shape.type` inside the handler if you only care about one kind of shape.
 
-**Before handlers** run during the operation and can modify or block changes:
+| Handler        | Runs                       | Return value                                                                  |
+| -------------- | -------------------------- | ----------------------------------------------------------------------------- |
+| `beforeCreate` | Before a record is stored  | The record to store. Return a modified copy to change it.                     |
+| `beforeChange` | Before an update is stored | The record to store. Return `prev` to block the change, or a modified `next`. |
+| `beforeDelete` | Before a record is removed | `false` to prevent deletion.                                                  |
+| `afterCreate`  | After a record is stored   | Nothing. Update other records in response.                                    |
+| `afterChange`  | After an update is stored  | Nothing. Update other records in response.                                    |
+| `afterDelete`  | After a record is removed  | Nothing. Clean up references or cascade deletions.                            |
 
-- `beforeCreate` transforms records before creation. Return a modified record to change what gets stored.
-- `beforeChange` intercepts updates. Return the previous record to block the change, or return a modified record.
-- `beforeDelete` can return `false` to prevent deletion.
-
-**After handlers** run once the operation completes. They can't modify the record that triggered them, but they can update other records:
-
-- `afterCreate` reacts to new records by updating related data.
-- `afterChange` responds to updates by maintaining relationships.
-- `afterDelete` cleans up orphaned references or cascades deletions.
-
-The key distinction: use before handlers to modify the record being operated on, and after handlers to update other records in response.
+Use before handlers to modify the record being operated on, and after handlers to update other records in response. Returning `prev` from `beforeChange` blocks the change because the store sees no difference from what's already stored and skips the write.
 
 ### Source tracking
 
@@ -60,11 +57,9 @@ You might auto-save only after user operations, or skip validation for trusted r
 Register side effects using the type-specific methods on `editor.sideEffects`. Each method returns a cleanup function you can call to remove the handler:
 
 ```typescript
-const cleanup = editor.sideEffects.registerAfterDeleteHandler('shape', (shape, source) => {
-	// Clean up bindings involving the deleted shape
-	const bindings = editor.getBindingsInvolvingShape(shape.id)
-	if (bindings.length) {
-		editor.deleteBindings(bindings)
+const cleanup = editor.sideEffects.registerAfterCreateHandler('shape', (shape, source) => {
+	if (shape.type === 'note') {
+		editor.updateShape({ id: shape.id, type: 'note', meta: { createdAt: Date.now() } })
 	}
 })
 
@@ -72,11 +67,13 @@ const cleanup = editor.sideEffects.registerAfterDeleteHandler('shape', (shape, s
 cleanup()
 ```
 
+To register several handlers at once, pass an object keyed by type name to `editor.sideEffects.register({ shape: { afterCreate, beforeDelete } })`; it returns a single cleanup function.
+
 ### Execution order
 
-Handlers execute in registration order. If you register three `afterCreate` handlers for shapes, they run in the sequence they were registered. This matters when handlers depend on each other's effects.
+Handlers execute in registration order. If one handler reads a value another handler writes, register the writer first.
 
-Side effects run within store transactions. All before handlers complete before any after handlers run. The `operationComplete` handler runs last, after all individual record handlers finish.
+Before handlers run inline as each record is written. After handlers are queued and run when the outermost store operation completes, so changes made inside them belong to the same transaction and the same undo step. If an after handler makes further changes, their handlers run in a follow-up pass. The `operationComplete` handler runs once at the end, after every pass has finished.
 
 ## Use cases
 
@@ -123,9 +120,8 @@ editor.sideEffects.registerOperationCompleteHandler((source) => {
 
 ## Related examples
 
-- [Before create/update shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/before-create-update-shape) - Constrain shapes to a circular area
-- [Before delete shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/before-delete-shape) - Prevent deletion of certain shapes
-- [After create/update shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/after-create-update-shape) - Ensure only one red shape exists at a time
-- [After delete shape](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/after-delete-shape) - Delete empty frames automatically
-- [Shape meta (on create)](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/meta-on-create) - Add creation timestamps to shapes
-- [Shape meta (on change)](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/meta-on-change) - Track modification history
+- [Before create/update shape](/examples/events/before-create-update-shape) - Constrain shapes to a circular area
+- [Before delete shape](/examples/events/before-delete-shape) - Prevent deletion of certain shapes
+- [After create/update shape](/examples/events/after-create-update-shape) - Ensure only one red shape exists at a time
+- [After delete shape](/examples/events/after-delete-shape) - Delete empty frames automatically
+- [Shape meta (on change)](/examples/events/meta-on-change) - Track modification history with a before-change handler

--- a/apps/docs/content/sdk-features/signals.mdx
+++ b/apps/docs/content/sdk-features/signals.mdx
@@ -19,9 +19,11 @@ accuracy: 10
 notes: ''
 ---
 
-The tldraw SDK uses signals for state management. Signals automatically track dependencies and update efficiently: when state changes, only the parts of your application that depend on that state will update.
+The tldraw SDK uses signals for state management. Signals automatically track dependencies: when state changes, only the parts of your application that depend on that state update.
 
-The editor exposes many of its internal values as signals. Methods like `editor.getSelectedShapeIds()` and `editor.getCurrentPageShapes()` return reactive values that update automatically when the underlying state changes. The React bindings connect these signals to components, so your UI stays in sync without manual subscription management.
+The editor exposes many of its internal values as signals. Methods like `editor.getSelectedShapeIds()` and `editor.getCurrentPageShapes()` return reactive values that update automatically when the underlying state changes. The React bindings connect these signals to components. You don't need to manage subscriptions yourself.
+
+The signals library lives in `@tldraw/state` and its React bindings in `@tldraw/state-react`. Both are re-exported from `tldraw`, so `import { atom, useValue, track } from 'tldraw'` also works.
 
 ## Core concepts
 
@@ -43,11 +45,7 @@ count.update((n) => n + 1)
 count.get() // 6
 ```
 
-The first argument is a name for debugging. The second is the initial value. Atoms support a few options:
-
-- `isEqual` — Custom equality function to determine if a value has changed
-- `historyLength` — Number of diffs to retain for incremental updates
-- `computeDiff` — Function to compute diffs between values
+The first argument is a name for debugging. The second is the initial value. Atoms accept an options object with `isEqual` (a custom equality function), `historyLength` (the number of diffs to retain for incremental updates), and `computeDiff` (a function to compute diffs between values, only used when `historyLength` is set).
 
 ### Computed values
 
@@ -213,7 +211,7 @@ Tracked components re-render when any signal accessed during render changes. Thi
 
 ### useAtom and useComputed
 
-Create component-local signals that persist across renders. Reading `.get()` during render only subscribes the component inside `track` (or `useValue`), so wrap the component:
+Create component-local signals that persist across renders. Reading `.get()` during render only subscribes the component if it's wrapped in `track` (otherwise read the value with `useValue`), so wrap the component:
 
 ```tsx
 import { track, useAtom, useComputed } from '@tldraw/state-react'
@@ -380,25 +378,24 @@ react('log name changes', () => {
 
 ### @tldraw/state
 
-| Export                       | Description                                                     |
-| ---------------------------- | --------------------------------------------------------------- |
-| `atom(name, value, options)` | Create a mutable signal                                         |
-| `computed(name, fn)`         | Create a derived signal                                         |
-| `@computed`                  | Decorator for computed class methods                            |
-| `react(name, fn, options)`   | Run an effect immediately, returns cleanup function             |
-| `reactor(name, fn, options)` | Create a controllable effect with `start()` and `stop()`        |
-| `transact(fn)`               | Batch changes into a single update                              |
-| `transaction(fn)`            | Batch changes with rollback support                             |
-| `isAtom(value)`              | Type guard for atoms                                            |
-| `isSignal(value)`            | Type guard for any signal                                       |
-| `getComputedInstance(o, p)`  | Get the underlying computed for a `@computed` decorated method  |
-| `whyAmIRunning()`            | Debug helper to trace update triggers                           |
-| `unsafe__withoutCapture(fn)` | Read signals without creating dependencies                      |
-| `RESET_VALUE`                | Symbol returned by `getDiffSince` when history is insufficient  |
-| `isUninitialized(value)`     | Check if a computed is running its first derivation             |
-| `withDiff(value, diff)`      | Manually provide a diff when returning from a computed          |
-| `localStorageAtom(name, v)`  | Returns `[atom, cleanup]` tuple; atom persists to localStorage  |
-| `deferAsyncEffects(fn)`      | Queue effects for async operations (used internally for stores) |
+| Export                               | Description                                                    |
+| ------------------------------------ | -------------------------------------------------------------- |
+| `atom(name, value, options)`         | Create a mutable signal                                        |
+| `computed(name, fn, options)`        | Create a derived signal                                        |
+| `@computed`                          | Decorator for computed class methods                           |
+| `react(name, fn, options)`           | Run an effect immediately, returns cleanup function            |
+| `reactor(name, fn, options)`         | Create a controllable effect with `start()` and `stop()`       |
+| `transact(fn)`                       | Batch changes into a single update                             |
+| `transaction(fn)`                    | Batch changes with rollback support                            |
+| `isAtom(value)`                      | Type guard for atoms                                           |
+| `isSignal(value)`                    | Type guard for any signal                                      |
+| `getComputedInstance(o, p)`          | Get the underlying computed for a `@computed` decorated method |
+| `whyAmIRunning()`                    | Debug helper to trace update triggers                          |
+| `unsafe__withoutCapture(fn)`         | Read signals without creating dependencies                     |
+| `RESET_VALUE`                        | Symbol returned by `getDiffSince` when history is insufficient |
+| `isUninitialized(value)`             | Check if a computed is running its first derivation            |
+| `withDiff(value, diff)`              | Manually provide a diff when returning from a computed         |
+| `localStorageAtom(name, v, options)` | Returns `[atom, cleanup]` tuple; atom persists to localStorage |
 
 ### @tldraw/state-react
 
@@ -415,4 +412,5 @@ react('log name changes', () => {
 
 ## Related examples
 
-- **[Reactive inputs](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/reactive-inputs)** — Using `useValue` with editor input state.
+- [Signals](/examples/events/signals) - Subscribing to store values and running side effects with `track`, `useValue`, and `useReactor`.
+- [Reactive inputs](/examples/editor-api/reactive-inputs) - Using `useValue` with editor input state.

--- a/apps/docs/content/sdk-features/snapping.mdx
+++ b/apps/docs/content/sdk-features/snapping.mdx
@@ -25,7 +25,7 @@ Snap lines appear when shapes come within the snap threshold.
 
 ## When snapping happens
 
-Snapping is off by default. Users hold Ctrl (Cmd on Mac) while translating, resizing, or dragging a handle to snap. Turning on snap mode inverts this: snapping is always on and holding Ctrl disables it. Snap mode is a [user preference](/sdk-features/user-preferences), toggled with Cmd+/ (Ctrl+/ on Windows) or from the Preferences submenu in the main menu:
+Snapping is off by default. Users hold Ctrl (Cmd on Mac) while translating, resizing, or dragging a handle to snap. Turning on snap mode inverts this: snapping is always on and holding Ctrl disables it. Snap mode is a [user preference](/sdk-features/user-preferences), toggled from the Preferences submenu in the main menu:
 
 ```typescript
 editor.user.updateUserPreferences({ isSnapMode: !editor.user.getIsSnapMode() })
@@ -175,7 +175,7 @@ Point snapping (`snapType: 'point'`) snaps to the single nearest location. The s
 
 Align snapping (`snapType: 'align'`) aligns the handle with nearby snap points on the x and y axes independently, with a snap line in each direction.
 
-> The older `canSnap` property on handles is deprecated. Use `snapType: 'point'` or `snapType: 'align'` instead, and don't set both: a handle with both set won't snap.
+> The older `canSnap` property on handles is deprecated. Use `snapType: 'point'` or `snapType: 'align'` instead. If both are set, `canSnap` wins and the handle uses point snapping.
 
 ### Snapping handles
 

--- a/apps/docs/content/sdk-features/snapping.mdx
+++ b/apps/docs/content/sdk-features/snapping.mdx
@@ -17,11 +17,21 @@ accuracy: 10
 notes: ''
 ---
 
-When you move or resize shapes, tldraw snaps them to key geometry on nearby shapes. This helps users achieve precise alignment without manual measurement.
+When you move or resize shapes, tldraw snaps them to key geometry on nearby shapes.
 
-The editor provides three types of snapping. Bounds snapping aligns edges, centers, and corners during movement and resizing. Handle snapping connects endpoints to outlines and key points, like arrow tips to shape edges. Gap snapping maintains consistent spacing between shapes.
+There are two snap systems. Bounds snapping aligns edges, centers, and corners during movement and resizing, and also keeps gaps between shapes consistent. Handle snapping connects handles to outlines and key points, like arrow tips to shape edges.
 
 Snap lines appear when shapes come within the snap threshold.
+
+## When snapping happens
+
+Snapping is off by default. Users hold Ctrl (Cmd on Mac) while translating, resizing, or dragging a handle to snap. Turning on snap mode inverts this: snapping is always on and holding Ctrl disables it. Snap mode is a [user preference](/sdk-features/user-preferences), toggled with Cmd+/ (Ctrl+/ on Windows) or from the Preferences submenu in the main menu:
+
+```typescript
+editor.user.updateUserPreferences({ isSnapMode: !editor.user.getIsSnapMode() })
+```
+
+Grid snapping is a separate system, controlled by the `isGridMode` flag on [TLInstance](?).
 
 ## SnapManager
 
@@ -29,21 +39,32 @@ The [SnapManager](?) coordinates all snapping behavior. Access it at `editor.sna
 
 ```typescript
 // The two snap systems
-editor.snaps.shapeBounds // BoundsSnaps - edge and center alignment
+editor.snaps.shapeBounds // BoundsSnaps - edge, center, and gap alignment
 editor.snaps.handles // HandleSnaps - precise point connections
 
 // Shared utilities
-editor.snaps.getSnapThreshold() // Distance threshold (8px / zoom)
+editor.snaps.getSnapThreshold() // Distance threshold (options.snapThreshold / zoom)
 editor.snaps.getSnappableShapes() // Which shapes can be snapped to
+editor.snaps.getIndicators() // Current snap indicators
 editor.snaps.setIndicators(indicators) // Update visual snap lines
 editor.snaps.clearIndicators() // Remove all snap indicators
 ```
 
-The snap threshold is 8 screen pixels, scaled by the current zoom level. At 100% zoom, shapes snap when within 8 pixels. At 200% zoom, the threshold becomes 4 canvas units (still 8 screen pixels).
+The snap threshold is `editor.options.snapThreshold` screen pixels (default 8), scaled by the current zoom level. At 100% zoom, shapes snap when within 8 pixels. At 200% zoom, the threshold becomes 4 canvas units (still 8 screen pixels).
 
 ### Snappable shape filtering
 
-The `getSnappableShapes()` method determines which shapes can be snapped to. It excludes currently selected shapes (you don't snap to what you're dragging), includes only shapes visible in the viewport for performance, and respects the shape utility's `canSnap()` method for opt-out behavior. Frame shapes are included as snap targets. For groups, the method recurses into children and snaps to them, but not to the group itself.
+[SnapManager#getSnappableShapes](?) determines which shapes can be snapped to. Starting from the selection's common ancestor, it walks down the shape tree and skips selected shapes (you don't snap to what you're dragging), shapes outside the viewport, and shapes whose util's [ShapeUtil#canSnap](?) returns `false`. Frames are included as snap targets. For groups, it recurses into children and snaps to them, but not to the group itself.
+
+To keep other shapes from snapping to your shape at all, override `canSnap()`:
+
+```typescript
+class MyShapeUtil extends ShapeUtil<MyShape> {
+	override canSnap() {
+		return false
+	}
+}
+```
 
 The method returns a computed set that updates reactively as shapes move, selection changes, or the viewport pans.
 
@@ -69,11 +90,11 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 }
 ```
 
-To disable snapping to a shape entirely, return `{ points: [] }`.
+Return `{ points: [] }` to drop point snapping for a shape while keeping it as a gap snapping target. To opt out of all snapping, use `canSnap()` instead.
 
 ### Translation snapping
 
-When moving shapes, `snapTranslateShapes()` finds the nearest snap alignment in each axis:
+When moving shapes, [BoundsSnaps#snapTranslateShapes](?) finds the nearest snap alignment in each axis:
 
 ```typescript
 const snapData = editor.snaps.shapeBounds.snapTranslateShapes({
@@ -91,7 +112,7 @@ The returned `nudge` vector indicates how much to adjust the drag delta to achie
 
 ### Resize snapping
 
-When resizing, `snapResizeShapes()` snaps the corners and edges being moved. Which snap points are used depends on the resize handle:
+When resizing, [BoundsSnaps#snapResizeShapes](?) snaps the corners and edges being moved. Which snap points are used depends on the resize handle:
 
 - Corner handles snap both x and y axes using that corner
 - Edge handles snap only the perpendicular axis using both corners on that edge
@@ -109,15 +130,15 @@ const snapData = editor.snaps.shapeBounds.snapResizeShapes({
 
 ### Gap snapping
 
-Gap snapping maintains consistent spacing between shapes. The system detects gaps between adjacent shapes and provides three types of snapping.
+Gap snapping is part of bounds snapping and keeps spacing between shapes consistent. It detects gaps between adjacent snappable shapes and snaps in two ways.
 
-Gap center snapping centers the selection within a gap larger than itself, with equal spacing on both sides. Gap duplication snapping duplicates an existing gap on the opposite side of a shape. For example, if two shapes have a 100px gap between them, dragging a third shape snaps to create another 100px gap. Adjacent gap detection finds all gaps with matching lengths and displays them together, so spacing stays consistent across many shapes.
+Gap center snapping centers the selection within a gap larger than itself, with equal spacing on both sides. Gap duplication snapping repeats an existing gap on the opposite side of a shape: if two shapes have a 100px gap between them, dragging a third shape snaps to create another 100px gap. When several gaps have matching lengths, the indicators show all of them together.
 
 Gaps are calculated separately for horizontal and vertical directions. A gap exists when two shapes don't overlap in one axis but have overlapping ranges in the perpendicular axis.
 
 ## Handle snapping
 
-Handle snapping enables precise connections between shapes. When dragging a handle (like an arrow endpoint), the [HandleSnaps](?) system snaps to nearby geometry.
+Handle snapping connects handles to other shapes. When dragging a handle (like an arrow endpoint), the [HandleSnaps](?) system snaps to nearby geometry. See [Handles](/sdk-features/handles) for how to define handles.
 
 ### Handle snap geometry
 
@@ -150,17 +171,15 @@ By default, handles cannot snap to their own shape. Moving the handle would chan
 
 Handles support two snap types controlled by the `snapType` property on [TLHandle](?).
 
-Point snapping (`snapType: 'point'`) snaps to the single nearest location. The system checks snap points first, then falls back to the nearest point on any outline. This magnetizes to a single best target.
+Point snapping (`snapType: 'point'`) snaps to the single nearest location. The system checks snap points first, then falls back to the nearest point on any outline.
 
-Align snapping (`snapType: 'align'`) aligns the handle with nearby points on the x and y axes independently, with perpendicular snap lines in each direction.
+Align snapping (`snapType: 'align'`) aligns the handle with nearby snap points on the x and y axes independently, with a snap line in each direction.
 
-Each handle uses one snap type based on its `snapType` property. Snap points always have higher priority than outlines.
-
-> **Note:** The older `canSnap` property on handles is deprecated. Use `snapType: 'point'` or `snapType: 'align'` instead.
+> The older `canSnap` property on handles is deprecated. Use `snapType: 'point'` or `snapType: 'align'` instead, and don't set both: a handle with both set won't snap.
 
 ### Snapping handles
 
-Tools call `snapHandle()` to snap a handle position:
+Tools call [HandleSnaps#snapHandle](?) to snap a handle position:
 
 ```typescript
 // Get the handle from the shape (TLHandle type)
@@ -183,11 +202,11 @@ The method returns `null` if no snap is found within the threshold, or a `SnapDa
 
 ## Snap indicators
 
-Snap indicators provide visual feedback when snapping occurs. The `SnapManager` maintains a reactive atom of current indicators that the UI renders as SVG overlays.
+Snap indicators provide visual feedback when snapping occurs. The `SnapManager` holds the current [SnapIndicator](?) list, which the UI renders as SVG overlays. Read it with `getIndicators()`.
 
-Two types of indicators exist. Points indicators (`type: 'points'`) display as lines connecting aligned points. When multiple snap points align on the same axis, they appear as a single continuous line spanning all aligned points. Gaps indicators (`type: 'gaps'`) display spacing between shapes with measurement lines at each gap. When multiple equal-sized gaps exist, all matching gaps are shown to highlight the consistent spacing pattern.
+There are two kinds. Points indicators (`type: 'points'`) display as lines connecting aligned points; when several snap points align on the same axis, they appear as one continuous line. Gaps indicators (`type: 'gaps'`) display spacing between shapes with measurement lines at each gap, and show every matching gap when several have equal size.
 
-The manager automatically deduplicates gap indicators to reduce visual noise. When gap breadths overlap and one is larger than another, only the smaller gap displays because it provides more specific information.
+The manager drops redundant gap indicators: if every gap in one indicator already appears in a larger indicator for the same direction, only the larger one is kept.
 
 Indicators are cleared automatically when dragging stops or when you call `clearIndicators()`.
 
@@ -196,4 +215,4 @@ Indicators are cleared automatically when dragging stops or when you call `clear
 For working examples of custom snapping, see:
 
 - [Custom bounds snapping](/examples/shapes/tools/bounds-snapping-shape): Create shapes with custom snap geometry so they snap to specific points, like playing cards that stack with visible icons.
-- [Custom relative snapping](/examples/shapes/tools/custom-relative-snapping): Customize snapping behavior between shapes using getBoundsSnapGeometry.
+- [Custom handle snap reference](/examples/shapes/tools/custom-relative-snapping): Use `snapReferenceHandleId` to control which handle Shift-angle snapping measures from.

--- a/apps/docs/content/sdk-features/store.mdx
+++ b/apps/docs/content/sdk-features/store.mdx
@@ -21,7 +21,7 @@ notes: ''
 
 The store is tldraw's reactive database. It holds all shapes, pages, bindings, assets, and other records that make up your document. The store is reactive: when data changes, the UI updates automatically. It validates all records against a schema and tracks every change for undo/redo, persistence, and synchronization.
 
-In most cases you won't interact with the store directly—the editor wraps it with higher-level methods like [Editor#createShapes](?) and [Editor#getCurrentPageShapes](?). But understanding the store helps when you need snapshots for persistence, want to listen for changes, or need direct access to records.
+In most cases you won't interact with the store directly. The editor wraps it with higher-level methods like [Editor#createShapes](?) and [Editor#getCurrentPageShapes](?). But understanding the store helps when you need snapshots for persistence, want to listen for changes, or need direct access to records.
 
 ## Records
 
@@ -56,19 +56,18 @@ Records have a scope that determines how they're persisted and synchronized:
 | `session`  | Optional  | No                    | Current page, camera position    |
 | `presence` | No        | Yes                   | Cursor positions, user selection |
 
-Document records are your actual drawing data—saved to storage and synced across instances. Session records are local to one editor instance, like which page you're viewing. Presence records sync to other users in real-time but aren't saved—they're for showing cursors and selections in multiplayer.
+Document records are your actual drawing data, saved to storage and synced across instances. Session records are local to one editor instance, like which page you're viewing. Presence records sync to other users in real time but aren't saved. They're for showing cursors and selections in multiplayer.
 
 ## Custom record types
 
-Shapes, bindings, and assets cover most drawing use cases, but some data doesn't fit any of them—comments threaded against a shape, per-user annotations, application state that should ride along with the document. Register a custom record type and these records live in the store like any other: validated, migrated, persisted, and synced according to the scope you pick.
+Shapes, bindings, and assets cover most drawing use cases, but some data doesn't fit any of them, like comments attached to a shape or per-user annotations. Register a custom record type and these records live in the store like any other: validated, migrated, persisted, and synced according to the scope you pick.
 
-Pass record definitions to [createTLSchema](?) under the `records` option:
+Pass record definitions to [createTLStore](?) under the `records` option, then give that store to the `Tldraw` component. (Under the hood this calls [createTLSchema](?) with the same `records` option, so you can also build a schema directly.)
 
-```ts
-import { createTLSchema, T, defaultShapeSchemas } from 'tldraw'
+```tsx
+import { createTLStore, T, Tldraw } from 'tldraw'
 
-const schema = createTLSchema({
-	shapes: defaultShapeSchemas,
+const store = createTLStore({
 	records: {
 		comment: {
 			scope: 'document',
@@ -84,18 +83,24 @@ const schema = createTLSchema({
 		},
 	},
 })
+
+function App() {
+	return <Tldraw store={store} />
+}
 ```
+
+For multiplayer, pass the same `records` option to `useSync`. Type names must not collide with tldraw's built-in types (`shape`, `page`, `asset`, and so on); `createTLSchema` throws if they do.
 
 Each entry is a [CustomRecordInfo](?):
 
-| Field                     | Type                                     | Description                                                                                                                 |
-| ------------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `scope`                   | `'document' \| 'session' \| 'presence'`  | Same scopes as built-in records — `document` for synced/persisted data, `session` for local-only, `presence` for ephemeral. |
-| `validator`               | `T.Validatable`                          | Validates the full record (including `id` and `typeName`) on every write.                                                   |
-| `createDefaultProperties` | `() => Record<string, unknown>`          | Optional. Default props applied when a record is created without them.                                                      |
-| `migrations`              | `MigrationSequence \| TLPropsMigrations` | Optional. Schema evolution for the record type. An empty sequence is created automatically if you omit it.                  |
+| Field                     | Type                                     | Description                                                                                                                                                                              |
+| ------------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scope`                   | `'document' \| 'session'`                | `document` for synced and persisted data, `session` for local-only data. Custom `presence`-scoped types aren't supported by tldraw sync, which allows only one presence type per schema. |
+| `validator`               | `T.Validatable`                          | Validates the full record (including `id` and `typeName`) on every write.                                                                                                                |
+| `createDefaultProperties` | `() => Record<string, unknown>`          | Optional. Default properties used when you build a record with `store.schema.types.<name>.create()`.                                                                                     |
+| `migrations`              | `MigrationSequence \| TLPropsMigrations` | Optional. Schema evolution for the record type. An empty sequence is created automatically if you omit it.                                                                               |
 
-For type-safe IDs and TypeScript narrowing across your app, augment [TLGlobalRecordPropsMap](?) so the rest of the SDK's `TLRecord` union knows about your record types:
+For type-safe IDs and TypeScript narrowing across your app, augment [TLGlobalRecordPropsMap](?) so the SDK's `TLRecord` union knows about your record types:
 
 ```ts
 import { BaseRecord, RecordId } from 'tldraw'
@@ -116,12 +121,12 @@ declare module 'tldraw' {
 
 ### Creating and reading custom records
 
-Use [createCustomRecordId](?) to mint IDs that match the `typeName:suffix` convention the store expects. The companion guards [isCustomRecordId](?) and [isCustomRecord](?) narrow values to your custom type:
+Use [createCustomRecordId](?) to mint IDs that match the `typeName:suffix` convention the store expects. It returns a generic record ID, so cast it to your own ID type. The companion guards [isCustomRecordId](?) and [isCustomRecord](?) check the type name but return plain booleans; they don't narrow the TypeScript type, so cast after checking:
 
 ```ts
-import { createCustomRecordId, isCustomRecord } from 'tldraw'
+import { createCustomRecordId, isCustomRecord, RecordId } from 'tldraw'
 
-const commentId = createCustomRecordId('comment')
+const commentId = createCustomRecordId('comment') as RecordId<TLComment>
 
 editor.store.put([
 	{
@@ -136,12 +141,12 @@ editor.store.put([
 
 for (const record of editor.store.allRecords()) {
 	if (isCustomRecord('comment', record)) {
-		console.log(record.text) // narrowed to your comment shape
+		console.log((record as TLComment).text)
 	}
 }
 ```
 
-Custom records appear in `store.listen` diffs, can be queried via `store.query.records('comment')`, and participate in undo/redo when written through the usual store APIs. Sync clients automatically include `document`-scoped records in the synced document; `presence`-scoped records are broadcast but not persisted.
+Custom records appear in `store.listen` diffs and participate in undo/redo when written through the usual store APIs. `editor.store.query.records('comment')` gives you a typed, reactive list of them. Sync clients include `document`-scoped records in the synced document automatically.
 
 ### Custom record migrations
 
@@ -165,7 +170,7 @@ const commentMigrations = createCustomRecordMigrationSequence({
 })
 ```
 
-Pass `commentMigrations` as the `migrations` field on the comment's `CustomRecordInfo` and the store will run them when loading older snapshots.
+Pass `commentMigrations` as the `migrations` field on the comment's `CustomRecordInfo` and the store will run them when loading older snapshots. See the [custom records example](/examples/data/assets/custom-records) for a complete app.
 
 ## Basic operations
 
@@ -191,23 +196,14 @@ The reactive [Store#get](?) integrates with tldraw's signals system. When you ca
 
 ### Creating and updating records
 
-The [Store#put](?) method handles both creation and updates:
+The [Store#put](?) method handles both creation and updates. A `put` with a new `id` creates the record; a `put` with an existing `id` replaces it. For shapes, [Editor#createShape](?) fills in the required fields for you, so you'll usually reach for `put` when updating:
 
 ```ts
-// Create a new record
-editor.store.put([
-	{
-		id: 'shape:my-shape' as TLShapeId,
-		typeName: 'shape',
-		type: 'geo',
-		x: 0,
-		y: 0,
-		// ... all required fields
-	},
-])
+// Create a shape through the editor, which fills in defaults
+editor.createShape({ id: shapeId, type: 'geo', x: 0, y: 0 })
 
 // Update an existing record (put with same id)
-const shape = editor.store.get(shapeId)
+const shape = editor.store.get(shapeId)!
 editor.store.put([{ ...shape, x: 100 }])
 ```
 
@@ -270,7 +266,7 @@ editor.store.listen(handleChanges, { source: 'all', scope: 'document' })
 
 The `source` indicates where the change came from: `'user'` for local edits, `'remote'` for synchronized changes from other users.
 
-For maintaining internal consistency—like cleaning up bindings when a shape is deleted—use [side effects](/sdk-features/side-effects) instead. Side effects are lifecycle hooks that can intercept and modify records during operations.
+To keep data internally consistent, like cleaning up bindings when a shape is deleted, use [side effects](/sdk-features/side-effects) instead. Side effects are lifecycle hooks that can intercept and modify records during operations.
 
 ## Snapshots
 
@@ -288,7 +284,7 @@ const { document, session } = getSnapshot(editor.store)
 localStorage.setItem('my-drawing', JSON.stringify({ document, session }))
 ```
 
-The `document` snapshot contains shapes, pages, bindings, and assets—everything that makes up the drawing itself. The `session` snapshot contains per-instance state like the current page and camera position.
+The `document` snapshot contains shapes, pages, bindings, and assets: everything that makes up the drawing itself. The `session` snapshot contains per-instance state like the current page and camera position.
 
 For multiplayer apps, you typically save document state to your server and session state per-user locally.
 
@@ -332,7 +328,7 @@ Snapshots include schema version information. When you load a snapshot from an o
 const migrated = editor.store.migrateSnapshot(oldSnapshot)
 ```
 
-The migration system handles schema changes between tldraw versions. You can also define custom migrations for your own record types—see [persistence](/docs/persistence) for details.
+The migration system handles schema changes between tldraw versions. You can also define migrations for custom shape props and custom record types. See [persistence](/sdk-features/persistence#migrations) for details.
 
 ## Queries
 
@@ -358,22 +354,21 @@ const textShapes = editor.store.query.records('shape', () => ({
 const allShapes = editor.store.query.records('shape')
 ```
 
-Query expressions support `eq` (equals), `neq` (not equals), and `gt` (greater than, for numbers). The `records()` method returns a computed array that updates when matching records change, while `index()` returns a map from property values to record IDs.
+Query expressions support `eq` (equals), `neq` (not equals), and `gt` (greater than, for numbers). The `records()` method returns a computed array that updates when matching records change, while `index()` returns a computed map from property values to sets of record IDs.
 
 ## Transactions
 
-Batch multiple changes into a single update with `Store.atomic`:
+Batch multiple changes with [Editor#run](?). Changes inside the callback are applied together, side effects see a consistent state, and the whole batch becomes one undo step:
 
 ```ts
-editor.store.atomic(() => {
+editor.run(() => {
 	editor.store.put([shape1, shape2])
 	editor.store.update(shape3Id, (s) => ({ ...s, x: 100 }))
 	editor.store.remove([shape4Id])
 })
-// All changes applied together, listeners notified once
 ```
 
-Without batching, each operation triggers listeners separately. Transactions ensure observers see a consistent state and reduce re-renders.
+Store listeners are already batched: the store collects changes and notifies listeners once per animation frame, squashing adjacent changes from the same source. See [history](/sdk-features/history) for the undo/redo options `run` accepts.
 
 ## Computed caches
 
@@ -411,6 +406,7 @@ Creating your own store is useful when you need to load data before mounting the
 
 ## Related examples
 
-- **[Store events](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/events/store-events)** — Listening to store changes and displaying them in real-time.
-- **[Snapshots](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/snapshots)** — Saving and loading editor state with `getSnapshot` and `loadSnapshot`.
-- **[Local storage](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/data/assets/local-storage)** — Persisting to localStorage with throttled saves.
+- [Store events](/examples/events/store-events) - Listening to store changes and displaying them in real time.
+- [Snapshots](/examples/editor-api/snapshots) - Saving and loading editor state with `getSnapshot` and `loadSnapshot`.
+- [Local storage](/examples/data/assets/local-storage) - Persisting to localStorage with throttled saves.
+- [Custom records](/examples/data/assets/custom-records) - Registering and rendering a custom record type.

--- a/apps/docs/content/sdk-features/styles.mdx
+++ b/apps/docs/content/sdk-features/styles.mdx
@@ -19,17 +19,17 @@ accuracy: 10
 notes: ''
 ---
 
-The styles system manages visual properties like color, size, font, fill, and dash patterns across shapes. Style properties differ from regular shape properties in two key ways: they apply consistently across multiple shapes at once, and the editor remembers the last-used value to automatically apply it to newly created shapes.
+The styles system manages visual properties like color, size, font, fill, and dash patterns across shapes. Style properties differ from regular shape properties in two ways: the same value can be set on many shapes at once, and the editor remembers the last-used value and applies it to newly created shapes.
 
-Styles are defined using [StyleProp](?) instances that specify valid values and defaults. The editor tracks "shared styles" across the current selection—computing whether all selected shapes share the same value or have different values—to drive the UI and enable batch updates.
+Styles are defined using [StyleProp](?) instances that specify valid values and defaults. The editor tracks "shared styles" across the current selection (whether all selected shapes share the same value or have different values) to drive the UI and enable batch updates.
 
 ## How it works
 
 ### StyleProp
 
-A [StyleProp](?) represents a reusable style property that can be applied across different shape types. Each `StyleProp` has a unique identifier, a default value, and optional validation. The editor treats `StyleProp` instances specially, automatically saving their values and applying them to new shapes.
+A [StyleProp](?) represents a reusable style property that can be applied across different shape types. Each `StyleProp` has a unique identifier, a default value, and optional validation.
 
-You define a `StyleProp` using one of two static methods:
+You define a `StyleProp` using one of two static methods, [StyleProp#define](?) for arbitrary types and [StyleProp#defineEnum](?) for a fixed list of values:
 
 ```typescript
 import { StyleProp, T } from 'tldraw'
@@ -51,21 +51,33 @@ The unique identifier should be namespaced to avoid conflicts with other style p
 
 ### Shape integration
 
-To use a style property in your shape, include the `StyleProp` instance in your shape's props definition. The editor recognizes `StyleProp` instances and handles them specially: it saves their values, applies them to new shapes, and tracks them across selections.
+To use a style property in your shape, include the `StyleProp` instance in your shape's props definition. This works the same way for your own styles and for tldraw's defaults. The editor recognizes `StyleProp` instances and handles them specially: it saves their values, applies them to new shapes, and tracks them across selections.
 
 ```typescript
-import { DefaultColorStyle, DefaultSizeStyle, RecordProps, T, TLBaseShape } from 'tldraw'
+import {
+	DefaultColorStyle,
+	DefaultSizeStyle,
+	RecordProps,
+	T,
+	TLDefaultColorStyle,
+	TLDefaultSizeStyle,
+	TLShape,
+} from 'tldraw'
 
-// Define your shape type with the value types for styles
-type TLMyShape = TLBaseShape<
-	'my-shape',
-	{
-		w: number
-		h: number
-		color: string // Will be one of the default color names
-		size: string // Will be one of the default size values
+// Register the shape type and its props
+declare module 'tldraw' {
+	export interface TLGlobalShapePropsMap {
+		'my-shape': {
+			w: number
+			h: number
+			color: TLDefaultColorStyle
+			size: TLDefaultSizeStyle
+			lineWidth: number
+		}
 	}
->
+}
+
+type TLMyShape = TLShape<'my-shape'>
 
 // Pass StyleProp instances in the props object for validation
 const myShapeProps: RecordProps<TLMyShape> = {
@@ -73,6 +85,7 @@ const myShapeProps: RecordProps<TLMyShape> = {
 	h: T.number,
 	color: DefaultColorStyle,
 	size: DefaultSizeStyle,
+	lineWidth: LineWidthStyle,
 }
 ```
 
@@ -92,7 +105,7 @@ editor.createShape({
 
 ### Shared styles
 
-The editor computes shared styles across the current selection. Use [Editor#getSharedStyles](?) to get a map of each style property to its status: either "shared" (all shapes have the same value) or "mixed" (shapes have different values).
+The editor computes shared styles across the current selection. Use [Editor#getSharedStyles](?) to get a [ReadonlySharedStyleMap](?) from each style property to its [SharedStyle](?) status: either "shared" (all shapes have the same value) or "mixed" (shapes have different values).
 
 ```typescript
 const sharedStyles = editor.getSharedStyles()
@@ -115,76 +128,7 @@ const color = sharedStyles.getAsKnownValue(DefaultColorStyle)
 
 The `getSharedStyles` method examines each selected shape, extracts its style values, and compares them. For groups, it recursively examines the group's children rather than the group itself, since groups don't have visual styles.
 
-When no shapes are selected, `getSharedStyles` returns the styles for the current tool if that tool creates shapes. This lets the UI show and modify the styles that will be applied to the next shape.
-
-### Style persistence
-
-When you set a style on selected shapes, the editor saves that value as the "style for next shapes." The next shape you create will automatically have the same style value.
-
-```typescript
-// Set color for selected shapes - also saves it for next shapes
-editor.setStyleForSelectedShapes(DefaultColorStyle, 'blue')
-
-// Create a new shape - it will be blue because 'blue' was saved
-editor.createShape({ type: 'geo', props: { w: 100, h: 100 } })
-```
-
-You can set the style for next shapes without affecting the current selection using [Editor#setStyleForNextShapes](?):
-
-```typescript
-editor.setStyleForNextShapes(DefaultColorStyle, 'green')
-```
-
-## Default styles
-
-The `@tldraw/tlschema` package provides a set of default style properties that the built-in shapes use. These styles cover the most common visual properties and integrate with tldraw's theme system for consistent appearance.
-
-**Color styles** control the visual color of shapes and their labels. Colors reference theme values rather than raw hex codes, so shapes adapt to light and dark modes.
-
-- [DefaultColorStyle](?) - Primary shape color (black, red, blue, green, etc.)
-
-**Appearance styles** affect how shapes are drawn and filled. These work together to create the hand-drawn aesthetic that defines tldraw's visual style.
-
-- [DefaultFillStyle](?) - Fill pattern (none, semi, solid, pattern, fill, lined-fill)
-- [DefaultDashStyle](?) - Stroke style (draw, solid, dashed, dotted, none)
-- [DefaultSizeStyle](?) - Relative size scale (s, m, l, xl)
-
-**Text styles** control typography for text shapes and labels. The alignment styles handle both the text itself and how content positions within shape bounds.
-
-- [DefaultFontStyle](?) - Font family (draw, sans, serif, mono)
-- [DefaultTextAlignStyle](?) - Horizontal text alignment (start, middle, end)
-- [DefaultHorizontalAlignStyle](?) - Horizontal content alignment within bounds
-- [DefaultVerticalAlignStyle](?) - Vertical content alignment within bounds
-
-**Shape-specific styles** apply to particular shape types rather than being universal. These are defined alongside their respective shape utilities.
-
-- [GeoShapeGeoStyle](?) - Geometric shape type (rectangle, ellipse, triangle, etc.)
-- [ArrowShapeArrowheadStartStyle](?) - Start arrowhead type
-- [ArrowShapeArrowheadEndStyle](?) - End arrowhead type
-
-Note that opacity is not a style property. It's a regular property on the base shape ([TLBaseShape](?)) that all shapes inherit, and it doesn't persist to new shapes or sync across selections like style properties do.
-
-## Using styles
-
-### Getting styles
-
-Use `getSharedStyles` to examine the current selection's styles:
-
-```typescript
-const styles = editor.getSharedStyles()
-
-// Check if all shapes share a color
-const color = styles.get(DefaultColorStyle)
-if (color?.type === 'shared') {
-	console.log('Shared color:', color.value)
-}
-```
-
-To get the style value for the next shape to be created, use [Editor#getStyleForNextShape](?):
-
-```typescript
-const nextColor = editor.getStyleForNextShape(DefaultColorStyle)
-```
+When you're not in the select tool with a selection, `getSharedStyles` returns the styles for the current tool if that tool creates shapes. This lets the UI show and modify the styles that will be applied to the next shape.
 
 ### Setting styles
 
@@ -200,70 +144,65 @@ editor.setStyleForSelectedShapes(DefaultSizeStyle, 'l')
 
 This method recursively applies the style to all shapes in the selection, including shapes nested inside groups. It only updates shapes that support the given style property.
 
-Use [Editor#setStyleForNextShapes](?) to change the style for subsequently created shapes:
+Use [Editor#setStyleForNextShapes](?) to change the style for subsequently created shapes, and [Editor#getStyleForNextShape](?) to read it:
 
 ```typescript
 // Next shapes will be blue
 editor.setStyleForNextShapes(DefaultColorStyle, 'blue')
+
+// Create a new shape - it will be blue
+editor.createShape({ type: 'geo', props: { w: 100, h: 100 } })
+
+const nextColor = editor.getStyleForNextShape(DefaultColorStyle) // 'blue'
 ```
 
-## Custom styles
-
-You can create custom style properties for your shapes using [StyleProp#define](?) or [StyleProp#defineEnum](?).
-
-### Defining a custom style
-
-For numeric or complex types, use `StyleProp.define`:
+`setStyleForSelectedShapes` only updates the selected shapes; it does not change the value for next shapes. The style panel calls both methods when the user picks a value, so the change applies to the selection and carries over to the next shape. Do the same in your own code if you want that behavior:
 
 ```typescript
-import { StyleProp, T } from 'tldraw'
-
-export const MyLineWidthStyle = StyleProp.define('myApp:lineWidth', {
-	defaultValue: 2,
-	type: T.number,
+editor.run(() => {
+	editor.setStyleForSelectedShapes(DefaultColorStyle, 'blue')
+	editor.setStyleForNextShapes(DefaultColorStyle, 'blue')
 })
 ```
 
-For enumerated values, use `StyleProp.defineEnum`:
+## Default styles
+
+The `@tldraw/tlschema` package provides a set of default style properties that the built-in shapes use. Colors reference theme values rather than raw hex codes, so shapes adapt to light and dark modes.
+
+| Style                              | Values                                                | Used for                                   |
+| ---------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| [DefaultColorStyle](?)             | black, red, blue, green, and other named colors       | Primary shape color                        |
+| [DefaultFillStyle](?)              | none, semi, solid, pattern, fill, lined-fill          | Fill pattern                               |
+| [DefaultDashStyle](?)              | draw, solid, dashed, dotted, none                     | Stroke style                               |
+| [DefaultSizeStyle](?)              | s, m, l, xl                                           | Relative size scale                        |
+| [DefaultFontStyle](?)              | draw, sans, serif, mono                               | Font family                                |
+| [DefaultTextAlignStyle](?)         | start, middle, end                                    | Horizontal text alignment                  |
+| [DefaultHorizontalAlignStyle](?)   | start, middle, end                                    | Horizontal content alignment within bounds |
+| [DefaultVerticalAlignStyle](?)     | start, middle, end                                    | Vertical content alignment within bounds   |
+| [GeoShapeGeoStyle](?)              | rectangle, ellipse, triangle, and other geo types     | Geometric shape type                       |
+| [ArrowShapeArrowheadStartStyle](?) | arrow, triangle, dot, none, and other arrowhead types | Start arrowhead                            |
+| [ArrowShapeArrowheadEndStyle](?)   | Same values as the start style                        | End arrowhead                              |
+| [ArrowShapeKindStyle](?)           | arc, elbow                                            | Arrow routing                              |
+| [LineShapeSplineStyle](?)          | line, cubic                                           | Line spline type                           |
+
+The shape-specific styles are defined in `@tldraw/tlschema` next to their shape's record type.
+
+Opacity is not a `StyleProp`. It's a regular property on the base shape ([TLBaseShape](?)) that all shapes inherit, but it behaves like a style through its own methods: [Editor#getSharedOpacity](?), [Editor#setOpacityForSelectedShapes](?), and [Editor#setOpacityForNextShapes](?).
+
+## Customizing default styles
+
+Change the default value of any style with `setDefaultValue`. Enum styles also support `addValues` and `removeValues` for extending the built-in set at runtime:
 
 ```typescript
-export const MyPatternStyle = StyleProp.defineEnum('myApp:pattern', {
-	defaultValue: 'solid',
-	values: ['solid', 'striped', 'dotted', 'checkered'],
-})
+import { DefaultSizeStyle } from 'tldraw'
+
+DefaultSizeStyle.setDefaultValue('s')
 ```
-
-### Using custom styles in shapes
-
-Include your custom style in your shape's props definition:
-
-```typescript
-import { RecordProps, T, TLBaseShape } from 'tldraw'
-
-type TLMyShape = TLBaseShape<
-	'my-shape',
-	{
-		w: number
-		h: number
-		lineWidth: number
-		pattern: string
-	}
->
-
-const myShapeProps: RecordProps<TLMyShape> = {
-	w: T.number,
-	h: T.number,
-	lineWidth: MyLineWidthStyle,
-	pattern: MyPatternStyle,
-}
-```
-
-The editor automatically recognizes `StyleProp` instances in your props and handles them during shape creation, selection, and updates.
 
 ## Related examples
 
-- **[Custom shape with custom styles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-custom-styles)** - Create your own custom styles and use them in custom shapes.
-- **[Custom shape with tldraw styles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/shape-with-tldraw-styles)** - Use tldraw's default styles in your custom shapes and integrate with the style panel.
-- **[Change default styles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/changing-default-style)** - Change the default value for a style property (e.g., setting size to small by default).
-- **[Change default colors](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/changing-default-colors)** - Customize the color values in the tldraw theme.
-- **[Easter egg styles](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/easter-egg-styles)** - Access hidden styles like white color, special fill variants, and label colors programmatically.
+- [Custom shape with custom styles](/examples/shapes/tools/shape-with-custom-styles) - Create your own custom styles and use them in custom shapes.
+- [Custom shape with tldraw styles](/examples/shapes/tools/shape-with-tldraw-styles) - Use tldraw's default styles in your custom shapes and integrate with the style panel.
+- [Change default styles](/examples/ui/changing-default-style) - Change the default value for a style property (e.g., setting size to small by default).
+- [Change default colors](/examples/ui/changing-default-colors) - Customize the color values in the tldraw theme.
+- [Easter egg styles](/examples/editor-api/easter-egg-styles) - Access hidden styles like white color, special fill variants, and label colors programmatically.

--- a/apps/docs/content/sdk-features/text-measurement.mdx
+++ b/apps/docs/content/sdk-features/text-measurement.mdx
@@ -20,7 +20,7 @@ accuracy: 9
 notes: Example links should use relative paths instead of GitHub URLs. measureHtml needs its own example. Performance section is dense - use bullet formatting.
 ---
 
-The editor measures text to calculate shape bounds, handle text wrapping, and enable precise hit testing. Two managers handle this: `TextManager` measures text dimensions using a hidden DOM element, and `FontManager` loads custom fonts before measurement so dimensions are accurate.
+The editor measures text to calculate shape bounds, handle text wrapping, and position labels. Two managers handle this: [TextManager](?) measures text dimensions using a hidden DOM element, and [FontManager](?) loads custom fonts before measurement so dimensions are accurate. Access them through `editor.textMeasure` and `editor.fonts`.
 
 ## How text measurement works
 
@@ -28,17 +28,17 @@ The `TextManager` creates a hidden measurement element on initialization and app
 
 ```typescript
 // Simplified for clarity - see TextManager.ts for full implementation
-const elm = document.createElement('div')
-elm.classList.add('tl-text-measure')
+const elm = this.editor.getContainerDocument().createElement('div')
+elm.classList.add('tl-text', 'tl-text-measure')
 elm.setAttribute('dir', 'auto')
 this.editor.getContainer().appendChild(elm)
 ```
 
-The element is hidden from users but remains part of the document flow so the browser's layout engine computes accurate dimensions.
+The element is absolutely positioned and hidden from users, but the browser still lays it out, so measurements are accurate.
 
 ### Measuring text
 
-The `measureText` method calculates text dimensions. Pass in text content and styling options, and it returns a box model with width and height.
+The `measureText` method calculates text dimensions. Pass in text content and [TLMeasureTextOpts](?), and it returns a box model with width and height.
 
 ```typescript
 const dimensions = editor.textMeasure.measureText('Hello world', {
@@ -55,7 +55,7 @@ const dimensions = editor.textMeasure.measureText('Hello world', {
 
 The method applies styles to the measurement element, reads the computed dimensions, then restores the previous styles. This means rapid successive measurements don't interfere with each other.
 
-You can also use `measureHtml` to measure HTML content directly instead of plain text.
+You can also use `measureHtml` to measure HTML content directly instead of plain text, or `measureHtmlBatch` to measure many pieces of HTML in one layout pass using a pool of elements.
 
 ### Text wrapping
 
@@ -78,7 +78,7 @@ Set `maxWidth: null` to preserve explicit line breaks and spaces without wrappin
 
 ## Measuring text spans
 
-For SVG export or precise text selection, `measureTextSpans` breaks text into individual spans based on line breaks and word boundaries.
+For SVG export or precise text selection, `measureTextSpans` breaks text into individual spans based on line breaks and word boundaries. It takes [TLMeasureTextSpanOpts](?):
 
 ```typescript
 const spans = editor.textMeasure.measureTextSpans('Hello world\nSecond line', {
@@ -95,26 +95,28 @@ const spans = editor.textMeasure.measureTextSpans('Hello world\nSecond line', {
 })
 ```
 
-Each span includes the text content and its bounding box:
+Each span includes the text content and its bounding box. Runs of whitespace become their own spans (widths are illustrative):
 
 ```typescript
 ;[
-	{ text: 'Hello ', box: { x: 0, y: 0, w: 45, h: 22 } },
+	{ text: 'Hello', box: { x: 0, y: 0, w: 40, h: 22 } },
+	{ text: ' ', box: { x: 40, y: 0, w: 5, h: 22 } },
 	{ text: 'world', box: { x: 45, y: 0, w: 40, h: 22 } },
-	{ text: 'Second ', box: { x: 0, y: 22, w: 52, h: 22 } },
+	{ text: 'Second', box: { x: 0, y: 22, w: 47, h: 22 } },
+	{ text: ' ', box: { x: 47, y: 22, w: 5, h: 22 } },
 	{ text: 'line', box: { x: 52, y: 22, w: 32, h: 22 } },
 ]
 ```
 
-The algorithm creates a `Range` object for each character, measures its position using `getClientRects()`, then groups characters into spans based on line position and word boundaries.
+The algorithm positions a `Range` around each grapheme, measures it with `getClientRects()`, then groups graphemes into spans wherever the line position changes or the text switches between whitespace and non-whitespace.
 
 ### Truncation handling
 
-The `overflow` option controls how text exceeding the available space is handled:
+The required `overflow` option controls how text exceeding the available space is handled:
 
 | Value               | Behavior                                              |
 | ------------------- | ----------------------------------------------------- |
-| `wrap`              | Text wraps to multiple lines (default)                |
+| `wrap`              | Text wraps to multiple lines                          |
 | `truncate-clip`     | Text truncates to the first line, no visual indicator |
 | `truncate-ellipsis` | Text truncates with an ellipsis character             |
 
@@ -126,11 +128,11 @@ The `FontManager` loads custom fonts before text measurement. If you measure tex
 
 ### Declaring font requirements
 
-Shapes declare which fonts they need through the `getFontFaces` method on their `ShapeUtil`:
+Shapes declare which fonts they need by overriding [ShapeUtil#getFontFaces](?) and returning [TLFontFace](?) objects:
 
 ```typescript
 class MyTextShapeUtil extends ShapeUtil<MyTextShape> {
-	getFontFaces(shape: MyTextShape): TLFontFace[] {
+	override getFontFaces(shape: MyTextShape): TLFontFace[] {
 		return [
 			{
 				family: 'MyCustomFont',
@@ -161,35 +163,32 @@ The manager caches font loading state to avoid redundant loading. Multiple concu
 
 ### Tracking fonts reactively
 
-For shapes that need reactive font tracking (so they re-render when fonts load), use `trackFontsForShape`:
+To make a computation re-run once a shape's fonts load, call `trackFontsForShape` inside it. [Editor#getShapeGeometry](?) already does this for you, so you only need it in your own caches, like a text size cache:
 
 ```typescript
-// In your ShapeUtil's getGeometry or component method
 editor.fonts.trackFontsForShape(shape)
 ```
 
-This sets up reactive tracking so the shape re-renders once its fonts are ready.
-
 ### Loading fonts for the current page
 
-Use `loadRequiredFontsForCurrentPage` to load all fonts needed by shapes on the current page. This is useful before exporting or taking screenshots:
+Use `loadRequiredFontsForCurrentPage` to load all fonts needed by shapes on the current page. The editor calls it before the first render and before exports:
 
 ```typescript
 await editor.fonts.loadRequiredFontsForCurrentPage()
-// All fonts for visible shapes are now loaded
+// All fonts for shapes on the current page are now loaded
 ```
 
-Pass a `limit` parameter to avoid loading too many fonts at once on pages with many different fonts.
+Pass a `limit` argument to skip the wait entirely when the page needs more than that many fonts. The editor uses the `maxFontsToLoadBeforeRender` option (see [TldrawOptions](?), default `Infinity`) for this, so a page with many fonts doesn't block the canvas.
 
 ## Performance considerations
 
-The `TextManager` doesn't cache measurements itself. Shape utilities typically cache their own results using reactive computed values, so text is only remeasured when font properties or content actually change.
+The `TextManager` doesn't cache measurements itself. Shape utilities cache their own results using reactive computed values, so text is only remeasured when font properties or content change.
 
-The `FontManager` optimizes font loading in several ways: font faces are computed per-shape and cached (only recalculating when shape props or meta change), multiple requests for the same font share a single loading promise, and `requestFonts` batches requests into a single microtask to reduce overhead.
+The `FontManager` computes each shape's font faces once and caches them until the shape's props or meta change. Concurrent requests for the same font share one loading promise, and `requestFonts` batches requests into a single microtask.
 
-The measurement element uses specific CSS properties for consistent measurements: `overflow-wrap: break-word` allows long words to break when needed, `width` and `max-width` control wrapping, unitless `line-height` ensures consistent spacing, and `dir="auto"` handles mixed LTR/RTL content.
+The measurement element sets `overflow-wrap: break-word` so long words can break, `width` and `max-width` to control wrapping, and `dir="auto"` for mixed LTR/RTL content. Line height is resolved to a whole pixel with [resolveLineHeightPx](?) so measurement, on-canvas rendering, and export agree across browsers, which otherwise disagree on fractional line boxes. Use the same helper anywhere you render text from a custom shape.
 
 ## Related examples
 
-- **[Rich text with font options](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/rich-text-font-extensions)** - Extend the TipTap text editor with font-family and font-size options.
-- **[Rich text custom extension](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/rich-text-custom-extension)** - Create custom TipTap extensions for rich text shapes.
+- [Speech bubble](/examples/shapes/tools/speech-bubble) - A custom shape that measures its text with `editor.textMeasure` to grow to fit.
+- [Rich text with font options](/examples/shapes/tools/rich-text-font-extensions) - Extend the TipTap text editor with font-family and font-size options.

--- a/apps/docs/content/sdk-features/text-shape.mdx
+++ b/apps/docs/content/sdk-features/text-shape.mdx
@@ -18,7 +18,7 @@ status: published
 date: 1/31/2026
 ---
 
-The text shape displays formatted text content on the canvas. Text shapes support rich text formatting, automatic sizing, and two distinct modes: auto-sized (where the shape expands to fit content) and fixed-width (where text wraps at a specified boundary). The text tool creates text shapes and manages text entry interactions.
+The text shape displays formatted text on the canvas. It has two modes: auto-size, where the shape grows to fit its content, and fixed-width, where text wraps at a set width. The text tool creates text shapes. See [TextShapeUtil](?) and [TLTextShape](?).
 
 ## Auto-size vs fixed-width
 
@@ -31,7 +31,7 @@ Text shapes operate in two modes controlled by the `autoSize` property:
 
 ### Auto-size mode
 
-When `autoSize` is true (the default), the text shape automatically adjusts its width to accommodate the text content. The shape grows horizontally as you type, and text never wraps to a new line unless you press Enter.
+When `autoSize` is true (the default), the shape grows to fit its text. The shape widens as you type, and text never wraps unless you press Enter.
 
 ```tsx
 import { toRichText } from 'tldraw'
@@ -47,11 +47,7 @@ editor.createShape({
 })
 ```
 
-Auto-sized text shapes maintain their position based on the `textAlign` property. When text expands:
-
-- **Start** alignment: Shape grows to the right; left edge stays fixed
-- **Middle** alignment: Shape grows equally in both directions; center stays fixed
-- **End** alignment: Shape grows to the left; right edge stays fixed
+Which edge stays put as an auto-sized shape grows depends on `textAlign`: with `start` the left edge stays fixed and the shape grows to the right, with `middle` the center stays fixed, and with `end` the right edge stays fixed.
 
 ### Fixed-width mode
 
@@ -70,7 +66,7 @@ editor.createShape({
 })
 ```
 
-To convert an auto-sized shape to fixed-width, resize it by dragging the left or right edge handles. The shape switches to fixed-width mode and maintains that width as you continue typing.
+To convert an auto-sized shape to fixed-width, drag its left or right edge handle. The shape switches to fixed-width mode and keeps that width as you type.
 
 ## Text alignment
 
@@ -100,7 +96,7 @@ Text shapes always align vertically to the middle of the shape's geometry.
 
 ## Creating text with the text tool
 
-The text tool (`T` key) provides two ways to create text shapes:
+The text tool (`T` key) creates text shapes in two ways. Double-clicking empty canvas with the select tool also creates an auto-sized text shape.
 
 ### Click to create auto-sized text
 
@@ -108,29 +104,27 @@ Click anywhere on the canvas to create an auto-sized text shape. The shape appea
 
 ### Drag to create fixed-width text
 
-Click and drag horizontally to create a fixed-width text shape. The drag distance determines the initial width. After dragging far enough (approximately 6× the base drag distance), the tool switches to resize mode—continue dragging to adjust the width, then release to start editing.
-
-The drag must exceed a minimum threshold (based on pointer type and timing) to trigger fixed-width creation. Quick, short drags create auto-sized shapes instead.
+Hold and drag horizontally to create a fixed-width text shape. Once the pointer has been down for at least 150ms and the horizontal drag exceeds about six times the base drag distance (larger for coarse pointers, scaled by zoom), the tool creates a fixed-width shape at that width and hands off to the select tool's resize state. Keep dragging to adjust the width, then release to start editing. Quick, short drags create auto-sized shapes instead.
 
 ### Tool shortcuts
 
-| Action                     | Result                                      |
-| -------------------------- | ------------------------------------------- |
-| **Click**                  | Create auto-sized text at click position    |
-| **Drag horizontally**      | Create fixed-width text with dragged width  |
-| **Enter** (shape selected) | Enter edit mode for the selected text shape |
-| **Escape**                 | Exit text tool, return to select tool       |
-| **Cmd/Ctrl+Enter**         | Confirm text and exit edit mode             |
+| Action                     | Result                                       |
+| -------------------------- | -------------------------------------------- |
+| **Click**                  | Create auto-sized text at click position     |
+| **Drag horizontally**      | Create fixed-width text with dragged width   |
+| **Enter** (shape selected) | Switch to the select tool and edit the shape |
+| **Escape**                 | Exit text tool, return to select tool        |
+| **Cmd/Ctrl+Enter**         | Confirm text and exit edit mode              |
 
 ## Editing text
 
 Double-click a text shape or press Enter while it's selected to enter edit mode. The shape displays a cursor and you can type, select, and format text using the rich text editor.
 
-Text shapes use the same rich text system as notes, geo shapes, and arrow labels. You get formatting options like bold, italic, code, and highlighting through keyboard shortcuts or the rich text toolbar.
+Text shapes use the same [rich text](/sdk-features/rich-text) system as notes, geo shapes, and arrow labels. You get bold, italic, code, highlighting, and more through keyboard shortcuts or the rich text toolbar.
 
 ### Empty text deletion
 
-When you exit edit mode (by clicking outside or pressing Escape), the shape checks if it contains only whitespace. Empty text shapes delete themselves automatically—you don't end up with invisible shapes cluttering the canvas.
+When editing ends, the shape deletes itself if its text is empty or only trailing whitespace. This keeps invisible shapes off the canvas.
 
 ## Scaling and resize
 
@@ -138,7 +132,7 @@ Text shapes support two resize behaviors:
 
 ### Aspect-ratio locked scaling
 
-Dragging corner handles scales the entire shape proportionally. The `scale` property tracks this multiplier. Scaling preserves the text's appearance while making it larger or smaller.
+Dragging any handle other than the left or right edges scales the whole shape proportionally. The `scale` property tracks this multiplier.
 
 ```tsx
 // A text shape at 2x scale
@@ -157,52 +151,38 @@ Dragging the left or right edge handles adjusts only the width. For auto-sized s
 
 ## Dynamic resize mode
 
-When `editor.user.getIsDynamicResizeMode()` is true, new text shapes are created with a scale inversely proportional to the current zoom level. At 200% zoom, new shapes get `scale: 0.5`; at 50% zoom, they get `scale: 2`. This keeps text visually consistent regardless of your zoom level when creating it.
+When `editor.user.getIsDynamicResizeMode()` is true, new text shapes are created with a scale inversely proportional to the current zoom level. At 200% zoom, new shapes get `scale: 0.5`; at 50% zoom, they get `scale: 2`. This keeps text visually consistent regardless of your zoom level when creating it. Use [Editor#getResizeScaleFactor](?) to get the same value:
 
 ```tsx
-const scale = editor.user.getIsDynamicResizeMode() ? 1 / editor.getZoomLevel() : 1
+const scale = editor.getResizeScaleFactor()
 ```
 
 ## Arrow bindings
 
-Arrows can bind to text shapes just like other shapes. The text shape's geometry includes extra horizontal padding (configurable via `extraArrowHorizontalPadding`) to prevent arrowheads from overlapping the text content.
-
-```tsx
-const ConfiguredTextUtil = TextShapeUtil.configure({
-	extraArrowHorizontalPadding: 20, // More space for arrows (default: 10)
-})
-```
+Arrows can bind to text shapes just like other shapes. When an arrow with no arrowhead binds to a text shape, the shape's geometry is widened by `extraArrowHorizontalPadding` on each side (10 by default) so the bare line ends short of the glyphs. Arrows with arrowheads bind to the unpadded box. See [Configuration](#configuration) to change the padding.
 
 ## Text outline
 
-Text shapes can display an outline effect using the canvas background color. This improves readability when text overlaps other shapes or complex backgrounds.
-
-The outline is implemented using CSS text-shadow and is enabled by default. On Safari, the outline is skipped because text-shadow is not performant on that browser.
-
-```tsx
-const ConfiguredTextUtil = TextShapeUtil.configure({
-	showTextOutline: false, // Disable the outline effect
-})
-```
+Text shapes display an outline in the canvas background color, which keeps text readable when it overlaps other shapes. The outline uses CSS `text-shadow` and is on by default. Safari skips it because `text-shadow` performs poorly there. Turn it off with the `showTextOutline` option (see [Configuration](#configuration)).
 
 ## Properties
 
-| Property    | Type                      | Description                                     |
-| ----------- | ------------------------- | ----------------------------------------------- |
-| `richText`  | `TLRichText`              | Text content with formatting                    |
-| `color`     | `TLDefaultColorStyle`     | Text color                                      |
-| `size`      | `TLDefaultSizeStyle`      | Font size preset (`s`, `m`, `l`, `xl`)          |
-| `font`      | `TLDefaultFontStyle`      | Font family (`draw`, `sans`, `serif`, `mono`)   |
-| `textAlign` | `TLDefaultTextAlignStyle` | Horizontal alignment (`start`, `middle`, `end`) |
-| `autoSize`  | `boolean`                 | When true, shape resizes to fit content         |
-| `w`         | `number`                  | Width when autoSize is false                    |
-| `scale`     | `number`                  | Scale factor applied to the shape               |
+| Property    | Type                      | Default   | Description                                     |
+| ----------- | ------------------------- | --------- | ----------------------------------------------- |
+| `richText`  | `TLRichText`              | empty     | Text content with formatting                    |
+| `color`     | `TLDefaultColorStyle`     | `'black'` | Text color                                      |
+| `size`      | `TLDefaultSizeStyle`      | `'m'`     | Font size preset (`s`, `m`, `l`, `xl`)          |
+| `font`      | `TLDefaultFontStyle`      | `'draw'`  | Font family (`draw`, `sans`, `serif`, `mono`)   |
+| `textAlign` | `TLDefaultTextAlignStyle` | `'start'` | Horizontal alignment (`start`, `middle`, `end`) |
+| `autoSize`  | `boolean`                 | `true`    | When true, shape resizes to fit content         |
+| `w`         | `number`                  | `8`       | Width when autoSize is false                    |
+| `scale`     | `number`                  | `1`       | Scale factor applied to the shape               |
 
 ## Configuration
 
 | Option                        | Type      | Default | Description                                                              |
 | ----------------------------- | --------- | ------- | ------------------------------------------------------------------------ |
-| `extraArrowHorizontalPadding` | `number`  | `10`    | Additional horizontal padding for arrow binding geometry                 |
+| `extraArrowHorizontalPadding` | `number`  | `10`    | Extra horizontal padding when an arrow without an arrowhead binds        |
 | `showTextOutline`             | `boolean` | `true`  | Display text outline for readability (skipped on Safari for performance) |
 
 ```tsx
@@ -225,7 +205,7 @@ export default function App() {
 
 ## Grid snapping
 
-When grid mode is enabled (`editor.getInstanceState().isGridMode`), new text shapes snap to grid positions. The tool calculates the snapped position after creating the shape and adjusts for the shape's alignment-based offset.
+When grid mode is enabled (`editor.getInstanceState().isGridMode`), the text tool snaps new text shapes to the grid.
 
 ## Programmatic text formatting
 
@@ -255,7 +235,7 @@ editor.createShape({
 })
 ```
 
-Available marks include `bold`, `italic`, `code`, `link`, and `highlight`. See [Rich text](/sdk-features/rich-text) for complete documentation on the formatting system.
+Marks include `bold`, `italic`, `strike`, `underline`, `code`, `link`, and `highlight`. See [Rich text](/sdk-features/rich-text) for the formatting system.
 
 ## Related articles
 
@@ -266,5 +246,5 @@ Available marks include `bold`, `italic`, `code`, `link`, and `highlight`. See [
 
 ## Related examples
 
-- [Programmatic text shape creation](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/text-shape-configuration) — Creating text shapes with various configurations
-- [Outlined text with TipTap mark](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/outlined-text) — Adding text outline styling via a custom TipTap mark extension
+- [Programmatic text shape creation](/examples/shapes/tools/text-shape-configuration) — Creating text shapes with various configurations
+- [Outlined text with TipTap mark](/examples/shapes/tools/outlined-text) — Adding text outline styling via a custom TipTap mark extension

--- a/apps/docs/content/sdk-features/themes.mdx
+++ b/apps/docs/content/sdk-features/themes.mdx
@@ -130,7 +130,7 @@ The palette also includes thirteen UI colors ([TLThemeUiColorKeys](?)) that ever
 
 In the default theme, `background` and `negativeSpace` have the same value, but custom themes can set them independently.
 
-> The `background` property only affects SVG exports. The visible canvas background comes from the `--tl-color-background` CSS variable. If you customize `background` in your theme, set the CSS variable to match, otherwise exports use a different background than the canvas.
+> The `background` property is used for SVG exports and the fill of selection handles, not for the canvas itself. The visible canvas background comes from the `--tl-color-background` CSS variable. If you customize `background` in your theme, set the CSS variable to match, otherwise exports use a different background than the canvas.
 
 In addition to colors, each theme has a `fontSize` (default `16`), `lineHeight` (default `1.35`), and `strokeWidth` (default `2`). All default shape font sizes are derived by multiplying the base `fontSize` by a per-shape-type multiplier, and stroke widths work the same way with `strokeWidth`, so changing these base values scales text and strokes proportionally. Because these are shared across light and dark modes, you only set them once per theme definition.
 

--- a/apps/docs/content/sdk-features/themes.mdx
+++ b/apps/docs/content/sdk-features/themes.mdx
@@ -33,20 +33,7 @@ export default function App() {
 				// Read the current theme and resolve colors for the active mode
 				const theme = editor.getCurrentTheme()
 				const colors = theme.colors[editor.getColorMode()]
-				console.log(colors.red.solid) // e.g. '#e03131'
-
-				// Customize the default theme's light colors
-				const defaultTheme = editor.getTheme('default')!
-				editor.updateTheme({
-					...defaultTheme,
-					colors: {
-						...defaultTheme.colors,
-						light: {
-							...defaultTheme.colors.light,
-							black: { ...defaultTheme.colors.light.black, solid: 'navy' },
-						},
-					},
-				})
+				console.log(colors.red.solid) // '#e03131'
 			}}
 		/>
 	)
@@ -55,7 +42,7 @@ export default function App() {
 
 ## Theme structure
 
-A theme definition is a [TLTheme](?) object with an `id`, color palettes for both light and dark modes, font definitions, and shared `fontSize`, `lineHeight`, and `strokeWidth` values:
+A theme definition is a [TLTheme](?) object with an `id`, color palettes ([TLThemeColors](?)) for both light and dark modes, font definitions, and shared `fontSize`, `lineHeight`, and `strokeWidth` values. [DEFAULT_THEME](?) is the built-in theme:
 
 ```typescript
 import { DEFAULT_THEME, TLTheme } from 'tldraw'
@@ -74,6 +61,7 @@ const myTheme: TLTheme = {
 			solid: '#fcfcfc',
 			cursor: '#000000',
 			noteBorder: '#e8e8e8',
+			// ... other UI colors (selection, brush, snap, laser)
 			black: {
 				solid: '#1d1d1d',
 				semi: '#e8e8e8',
@@ -124,9 +112,25 @@ Each color in the palette is a [TLDefaultColor](?) with variants for different c
 | `highlightSrgb`      | Highlighter color in sRGB color space          |
 | `highlightP3`        | Highlighter color in Display P3 color space    |
 
-The palette also includes thirteen base properties: `text` for default text color, `background` for the canvas background color used in SVG exports, `negativeSpace` for areas that should appear to "cut through" to the background (e.g. frame heading knockouts and text outlines), `solid` for the default solid surface color, `cursor` for the cursor color, `noteBorder` for note shape borders, `selectionStroke` and `selectionFill` for the selection box, `selectedContrast` for indicators drawn on top of selected shapes, `brushStroke` and `brushFill` for the selection-brush rectangle, `snap` for snap guides, and `laser` for the laser pointer. In the default themes, `background` and `negativeSpace` have the same value, but custom themes can set them independently.
+The palette also includes thirteen UI colors ([TLThemeUiColorKeys](?)) that every theme must define:
 
-> Note: The `background` property is used in SVG exports to set the canvas background, but the actual visible canvas background is set separately via the `--tl-color-background` CSS variable. If you customize `background` in your theme, make sure the CSS variable matches — otherwise exports may use a different background color than what's shown on the canvas.
+| Property                           | Purpose                                                                                    |
+| ---------------------------------- | ------------------------------------------------------------------------------------------ |
+| `text`                             | Default text color                                                                         |
+| `background`                       | Canvas background color used in SVG exports                                                |
+| `negativeSpace`                    | Areas that "cut through" to the background, e.g. frame heading knockouts and text outlines |
+| `solid`                            | Default solid surface color                                                                |
+| `cursor`                           | Cursor color                                                                               |
+| `noteBorder`                       | Note shape borders                                                                         |
+| `selectionStroke`, `selectionFill` | Selection box                                                                              |
+| `selectedContrast`                 | Indicators drawn on top of selected shapes                                                 |
+| `brushStroke`, `brushFill`         | Selection-brush rectangle                                                                  |
+| `snap`                             | Snap guides                                                                                |
+| `laser`                            | Laser pointer                                                                              |
+
+In the default theme, `background` and `negativeSpace` have the same value, but custom themes can set them independently.
+
+> The `background` property only affects SVG exports. The visible canvas background comes from the `--tl-color-background` CSS variable. If you customize `background` in your theme, set the CSS variable to match, otherwise exports use a different background than the canvas.
 
 In addition to colors, each theme has a `fontSize` (default `16`), `lineHeight` (default `1.35`), and `strokeWidth` (default `2`). All default shape font sizes are derived by multiplying the base `fontSize` by a per-shape-type multiplier, and stroke widths work the same way with `strokeWidth`, so changing these base values scales text and strokes proportionally. Because these are shared across light and dark modes, you only set them once per theme definition.
 
@@ -200,7 +204,7 @@ function MyComponent() {
 
 ## Customizing colors
 
-Use [Editor#updateTheme](?) to override specific colors in a theme. Get the current theme, modify it, and pass it back:
+Use [Editor#updateTheme](?) to override specific colors in a theme. Get the theme, modify it, and pass it back:
 
 ```typescript
 const theme = editor.getTheme('default')!
@@ -220,9 +224,11 @@ const theme = editor.getTheme('default')!
 editor.updateTheme({ ...theme, fontSize: 18, strokeWidth: 3 })
 ```
 
-You can also pass theme definitions as a prop on the [Tldraw](?) or [TldrawEditor](?) component. The prop is reactive: when it changes, the editor's themes update automatically.
+You can also pass theme definitions as the `themes` prop on the [Tldraw](?) or [TldrawEditor](?) component, typed as `Partial<`[TLThemes](?)`>`. The prop is reactive: when it changes, the editor's themes update automatically. Use the `initialTheme` prop or [Editor#setCurrentTheme](?) to pick which registered theme is active; see the [multiple themes example](/examples/ui/multiple-themes).
 
 ```tsx
+import { DEFAULT_THEME, TLThemes } from 'tldraw'
+
 const themes: Partial<TLThemes> = {
 	default: {
 		id: 'default',
@@ -254,8 +260,10 @@ declare module '@tldraw/tlschema' {
 }
 ```
 
+The augmentation is type-only; your theme definitions supply the runtime values:
+
 ```tsx
-import { DEFAULT_THEME, TLTheme } from 'tldraw'
+import { DEFAULT_THEME, TLThemes } from 'tldraw'
 
 const themes: Partial<TLThemes> = {
 	default: {
@@ -295,7 +303,7 @@ const themes: Partial<TLThemes> = {
 <Tldraw themes={themes} />
 ```
 
-tldraw validates shape properties (including colors) when data enters the store, for example when loading from IndexedDB or syncing from a server. Passing `themes` tells tldraw about your custom colors _before_ data is loaded, so they pass validation.
+tldraw validates shape properties (including colors) when data enters the store, for example when loading from IndexedDB or syncing from a server. Passing `themes` tells tldraw about your custom colors _before_ data is loaded, so they pass validation. If you create your own store, pass the same `themes` to [createTLStore](?) so the colors are registered before the store loads data.
 
 Every theme should include an entry for every custom color in both light and dark palettes. If a shape uses a color that doesn't exist in the active theme, it won't render correctly.
 
@@ -303,7 +311,7 @@ See the [Custom theme](/examples/ui/custom-theme) example for a complete demo.
 
 ## Removing colors
 
-To remove built-in palette colors, augment the `TLRemovedDefaultThemeColors` interface. Any key you add will be omitted from `TLThemeColors`, so TypeScript will no longer expect it in theme definitions:
+To remove built-in palette colors, augment the [TLRemovedDefaultThemeColors](?) interface. Any key you add is omitted from [TLThemeColors](?), so TypeScript no longer expects it in theme definitions:
 
 ```typescript
 declare module '@tldraw/tlschema' {
@@ -328,7 +336,7 @@ const {
 } = DEFAULT_THEME.colors.light
 ```
 
-Colors removed this way won't appear in the style panel. UI infrastructure colors (`text`, `background`, `solid`, `cursor`, `noteBorder`, `negativeSpace`, `selectionStroke`, `selectionFill`, `selectedContrast`, `brushStroke`, `brushFill`, `snap`, `laser`) cannot be removed.
+Colors that are absent from every registered theme are removed from the color style and won't appear in the style panel. The UI colors listed in [TLThemeUiColorKeys](?) cannot be removed.
 
 ## Using themes in shape utils
 
@@ -411,8 +419,11 @@ class MyShapeUtil extends ShapeUtil<MyShape> {
 | [Editor#getColorMode](?)      | Get the active color mode (`'light'` or `'dark'`) |
 | [Editor#setColorMode](?)      | Set the color mode (`'light'` or `'dark'`)        |
 
+These methods delegate to an internal [ThemeManager](?).
+
 ## Related examples
 
 - [Custom theme](/examples/ui/custom-theme) - Add a custom color, and adjust theme values with sliders.
 - [Changing default colors](/examples/ui/changing-default-colors) - Customize the default theme's color palette.
+- [Multiple themes](/examples/ui/multiple-themes) - Register several themes and switch between them.
 - [Display options](/examples/configuration/display-options) - Override how built-in shapes render using `getCustomDisplayValues`.

--- a/apps/docs/content/sdk-features/ticks.mdx
+++ b/apps/docs/content/sdk-features/ticks.mdx
@@ -17,9 +17,11 @@ accuracy: 10
 notes: ''
 ---
 
-The tick system provides a frame-synchronized update loop for the editor. The editor emits `tick` and `frame` events on every animation frame using `requestAnimationFrame`, passing the elapsed time since the last frame. This enables smooth animations, edge scrolling during drag operations, and time-based state updates. The `frame` event fires immediately before `tick` on each animation frame; the editor uses it internally, and `tick` is the one intended for application code.
+The tick system provides a frame-synchronized update loop for the editor. On every animation frame the editor emits a `frame` event and then a `tick` event, each with the elapsed time in milliseconds since the last frame.
 
 While pointer and keyboard events fire in response to user input, tick events fire continuously. Use them when you need updates that run every frame regardless of user interaction.
+
+> The editor emits `frame` first so its own bookkeeping (pointer velocity, following a collaborator) runs before `tick` handlers. Use `tick` in application code.
 
 ## Subscribing to tick events
 
@@ -50,14 +52,14 @@ export default function TickExample() {
 }
 ```
 
-Remember to unsubscribe when your component unmounts or when you no longer need tick updates. The elapsed time lets you create frame-rate-independent animations by scaling movement based on actual time passed rather than assuming a fixed framerate.
+Remember to unsubscribe when your component unmounts or when you no longer need tick updates. Scale movement by `elapsed` rather than assuming a fixed framerate. For one-off work on the next frame, use `editor.timers.requestAnimationFrame`, which is cleaned up when the editor is disposed.
 
 ## Tick events in tools
 
-When building custom tools using the state machine pattern, you can handle tick events by implementing the `onTick` method on your `StateNode`. The editor dispatches tick events through the state tree, so your active tool states receive them automatically:
+When building custom tools using the state machine pattern, you can handle tick events by implementing the `onTick` method on your [StateNode](?). The editor dispatches tick events through the state tree after flushing any pending pointer events for that frame, so your active tool states receive them automatically:
 
 ```typescript
-import { StateNode, TLTickEventInfo } from '@tldraw/editor'
+import { StateNode, TLTickEventInfo } from 'tldraw'
 
 export class MyDraggingState extends StateNode {
 	static override id = 'dragging'
@@ -73,46 +75,47 @@ export class MyDraggingState extends StateNode {
 }
 ```
 
-The `TLTickEventInfo` contains the elapsed time in milliseconds. Use this for time-based calculations rather than assuming a fixed frame duration.
+[TLTickEventInfo](?) contains the elapsed time in milliseconds.
 
 ## Edge scrolling example
 
 The most common use of `onTick` in tools is edge scrolling during drag operations. When you drag near the edge of the viewport, the canvas scrolls automatically. Here's how tldraw's built-in `Translating` state handles it:
 
 ```typescript
-import { StateNode, TLTickEventInfo } from '@tldraw/editor'
+import { StateNode, TLTickEventInfo } from 'tldraw'
 
 export class Translating extends StateNode {
 	static override id = 'translating'
 
 	override onTick({ elapsed }: TLTickEventInfo) {
-		this.editor.edgeScrollManager.updateEdgeScrolling(elapsed)
+		const { editor } = this
+		if (!editor.inputs.getIsDragging() || editor.inputs.getIsPanning()) return
+		editor.edgeScrollManager.updateEdgeScrolling(elapsed)
 	}
 }
 ```
 
-The `EdgeScrollManager` accumulates elapsed time to create a smooth acceleration effect. After a short delay, scrolling begins slowly and speeds up the longer you hold near the edge. This creates a natural feel where small adjustments are easy but you can also scroll quickly when needed.
+The [EdgeScrollManager](?) accumulates elapsed time to create a smooth acceleration effect. After a short delay, scrolling begins slowly and speeds up the longer you hold near the edge.
 
 For more details on edge scrolling, see the [edge scrolling](/sdk-features/edge-scrolling) documentation.
 
 ## How the editor uses ticks internally
 
-The editor uses tick events for several internal features:
+The editor uses tick and frame events for several internal features.
 
-**Scribble animations**: The `ScribbleManager` animates the visual trails you see during brush selection and laser pointer usage. On each tick, it adds new points to active scribbles and shrinks them from the tail, creating a fading trail effect.
+The [ScribbleManager](?) animates the trails you see while erasing, using the laser pointer, or scribble-selecting. On each tick it adds new points to active scribbles and shrinks them from the tail, so the trail fades.
 
-**Pointer velocity**: The editor tracks pointer velocity by measuring movement between ticks. This data is available via `editor.inputs.getPointerVelocity()` and is used for features like gesture detection.
+The [InputsManager](?) computes pointer velocity on each `frame` event. Read it with `editor.inputs.getPointerVelocity()`; the select tool uses it to decide when to snap or drop into a container.
 
-**Camera animations**: Methods like `editor.zoomIn()` and `editor.resetZoom()` animate smoothly by subscribing to tick events for the duration of the animation, then unsubscribing when complete.
+Camera methods like `editor.zoomIn()` and `editor.zoomToFit()` animate when you pass an `animation` option. The animation subscribes to `tick` for its duration and unsubscribes when complete.
 
 ## When to use tick events
 
 Tick events are appropriate when you need continuous updates that run every frame:
 
-- Animations that should run smoothly regardless of user input
+- Animations and interpolation that should run regardless of user input
 - Edge scrolling during drag operations
 - Physics simulations or particle systems
-- Smooth interpolation between values over time
 - Debouncing based on frame counts rather than timeouts
 
 Don't use tick events for responding to user input. Pointer, keyboard, and wheel events are better for that since they fire immediately when the user acts. Tick events add a frame of latency.

--- a/apps/docs/content/sdk-features/tools.mdx
+++ b/apps/docs/content/sdk-features/tools.mdx
@@ -21,55 +21,55 @@ accuracy: 10
 notes: ''
 ---
 
-Tools in tldraw define how the editor responds to user input. Each tool handles a specific interaction mode—selecting shapes, drawing, or panning the canvas. You implement tools as state machines using the `StateNode` class, which gives you a structured way to manage complex interactions through a hierarchy of states. The editor maintains a single active tool at any time and routes all input events through it. When you click the hand icon in the toolbar, the editor transitions from the select tool to the hand tool, changing how the canvas responds to your mouse movements and clicks.
+Tools in tldraw define how the editor responds to user input. Each tool handles one interaction mode: selecting shapes, drawing, panning the canvas. The editor has a single active tool at any time and routes all input events through it. When you click the hand icon in the toolbar, the editor transitions from the select tool to the hand tool, and the canvas starts responding to drags by panning.
 
-The state machine architecture lets you handle multi-step interactions cleanly. For example, when you use the select tool to resize a shape, the tool transitions through multiple states: idle, pointing the resize handle, and actively resizing. Each state handles different events and can transition to other states based on user input.
+You implement tools as state machines using the [StateNode](?) class. Multi-step interactions map onto child states: when you resize a shape with the select tool, the tool moves through `idle`, `pointing_resize_handle`, and `resizing`. Each state handles different events and can transition to other states.
 
 ## How it works
 
 Tools are organized in a hierarchical state machine where each node can handle events and contain child states. The editor creates a root state that contains all tools as children. When an input event occurs, it flows down from the root through the currently active tool and its active child state.
 
-The [StateNode](?) class provides the foundation for this system. Each state node has an id, optional children, and methods for handling events. State nodes come in three types: root nodes that contain tools, branch nodes that have child states, and leaf nodes that perform actual work. Tools themselves are typically branch nodes with child states representing different phases of an interaction.
+Each state node has an id, optional children, and methods for handling events. State nodes come in three types: root nodes that contain tools, branch nodes that have child states, and leaf nodes that perform actual work. Tools themselves are typically branch nodes with child states representing different phases of an interaction.
 
-When a state becomes active, its `onEnter` method runs. When it becomes inactive, its `onExit` method runs. Between these lifecycle events, the state handles input through event methods like `onPointerDown`, `onPointerMove`, and `onKeyDown`. If a state doesn't handle an event, it passes through without effect. Child states receive events after their parent, so both can respond.
+When a state becomes active, its `onEnter` method runs. When it becomes inactive, its `onExit` method runs. Between these lifecycle events, the state handles input through event methods like `onPointerDown`, `onPointerMove`, and `onKeyDown`. A state that doesn't implement a handler skips the event, and the event still continues down to the active child state, so a parent and its child can both respond.
 
-You trigger transitions between states explicitly through the `transition` method. When the select tool's idle state detects a pointer down on a shape, it calls `this.parent.transition('pointing_shape', info)` to move to the pointing state. The transition triggers the appropriate exit and enter handlers.
+You trigger transitions between states explicitly through [StateNode#transition](?). When the select tool's idle state detects a pointer down on a shape, it calls `this.parent.transition('pointing_shape', info)` to move to the pointing state. The transition runs the old state's `onExit` and the new state's `onEnter`.
 
 ## Key concepts
 
 ### State hierarchy
 
-Tools exist in a tree structure starting from a root node. The root contains all available tools like select, hand, eraser, and draw. Each tool can contain child states for different phases of its interaction. For example, the select tool has children including idle, pointing, translating, resizing, and rotating. When the select tool is active and the user starts dragging a shape, the active path becomes `select.translating`.
+Tools exist in a tree structure starting from a root node. The root contains all available tools like select, hand, eraser, and draw. Each tool can contain child states for different phases of its interaction. For example, the select tool has children including `idle`, `pointing_shape`, `translating`, `resizing`, and `rotating`. When the select tool is active and the user starts dragging a shape, the active path becomes `select.translating`.
 
-The hierarchy allows tools to share common behavior at higher levels while specializing at lower levels. The select tool handles keyboard shortcuts at its top level, while child states handle specific mouse interactions. This organization prevents duplicate logic across related states.
+The hierarchy lets a tool share behavior across its child states. The select tool's `onEnter` and `onExit` set up and tear down state that every child uses, while the child states handle pointer and keyboard interactions.
 
 ### Event handling
 
-State nodes implement event handler methods that match input event types. The handlers receive an info object containing event details like pointer position, keyboard modifiers, and the event target. Common handlers include `onPointerDown`, `onPointerMove`, `onPointerUp`, `onKeyDown`, and `onTick` for animation frame updates.
+State nodes implement event handler methods that match input event types. The handlers receive an info object containing event details like pointer position, keyboard modifiers, and the event target. The full set is `onPointerDown`, `onPointerMove`, `onPointerUp`, `onLongPress`, `onDoubleClick`, `onRightClick`, `onMiddleClick`, `onKeyDown`, `onKeyUp`, `onKeyRepeat`, `onWheel`, `onCancel`, `onComplete`, `onInterrupt`, and `onTick` for animation frame updates.
 
-Events flow through the state hierarchy. When a pointer move occurs, the root receives it first, then the current tool, then the tool's active child state. Each node can handle the event by implementing the corresponding method. The hand tool's dragging state implements `onPointerMove` to update the camera position as the user drags.
+The hand tool's dragging state implements `onPointerMove` to update the camera position as the user drags.
 
 ### State transitions
 
-The `transition` method moves between states by id. You can transition to a direct child using just its id, or to deeper descendants using dot notation like `'crop.pointing_crop_handle'`. Transitions are atomic - the old state's `onExit` runs, the new state's `onEnter` runs, and the state is updated.
+You can transition to a direct child using just its id, or to deeper descendants using dot notation like `'crop.pointing_crop_handle'`.
 
 Transitions carry information through their second parameter. When transitioning from idle to pointing, the pointer event info passes along so the pointing state knows where the interaction started. This data is available in both the exit handler of the old state and the enter handler of the new state.
 
 ### Tool registration
 
-Tools are registered with the editor through the root state. The `@tldraw/editor` package provides only the root state with no tools. The `tldraw` package extends this with a full suite of tools. Custom tools are added by creating a custom root state that includes them as children.
+Tools are registered with the editor through the root state. The `@tldraw/editor` package provides only the root state with no tools. The `tldraw` package adds its full suite of tools. Custom tools are added through the `tools` prop, described below.
 
-The editor's `setCurrentTool` method transitions the root state to a different tool by id. The `getCurrentTool` method returns the currently active tool state node. These methods provide the public API for tool management while the state machine handles the internal transitions.
+[Editor#setCurrentTool](?) transitions the root state to a different tool by id. [Editor#getCurrentTool](?) returns the active tool state node, and [Editor#getCurrentToolId](?) returns its id.
 
-### Event target detection
+### Event targets
 
-Event info objects include a target property indicating what the user interacted with. Possible targets include canvas, shape, handle, and selection. The select tool's idle state uses this to determine which child state to transition to. A pointer down on a shape transitions to pointing_shape, while a pointer down on the canvas transitions to pointing_canvas.
+Event info objects include a `target` property indicating what the user interacted with: `canvas`, `shape`, `handle`, `selection`, or `overlay`. The canvas dispatches every pointer event with `target: 'canvas'`. The select tool's idle state hit-tests the pointer position and re-dispatches the event to itself with a more specific target, then transitions to the matching child state: `pointing_shape` for a shape, `pointing_canvas` for empty canvas.
 
-Target detection happens before events reach tools, using the editor's geometry system to determine what's under the pointer. This separation means tools can focus on interaction logic without implementing hit testing.
+Custom tools that need to know what's under the pointer do their own hit testing with methods like [Editor#getShapeAtPoint](?).
 
 ### Tool lock
 
-Tool lock keeps the current tool active after completing an action. Normally, tools like draw or geo return to the select tool after creating a shape. With tool lock enabled, the tool stays active so you can create multiple shapes without reselecting the tool each time.
+Tool lock keeps the current tool active after completing an action. Normally, tools like geo, arrow, or note return to the select tool after creating a shape. With tool lock enabled, the tool stays active so you can create multiple shapes without reselecting the tool each time.
 
 Tool lock is stored in instance state:
 
@@ -85,56 +85,75 @@ const current = editor.getInstanceState().isToolLocked
 editor.updateInstanceState({ isToolLocked: !current })
 ```
 
-Custom tools should check `isToolLocked` when deciding whether to return to the select tool after completing their action.
+Tool lock is not enforced by the state machine. Custom tools check `isToolLocked` themselves when deciding where to go after completing their action:
+
+```ts
+if (this.editor.getInstanceState().isToolLocked) {
+	this.parent.transition('idle')
+} else {
+	this.editor.setCurrentTool('select')
+}
+```
 
 ## Creating custom tools
 
-To create a custom tool, extend the `StateNode` class and implement the required static properties and event handlers.
+To create a custom tool, extend the [StateNode](?) class and implement the static properties and event handlers you need. The simplest tool has no child states and handles events directly. Register it with the `tools` prop:
+
+```tsx
+import { StateNode, TLPointerEventInfo, Tldraw } from 'tldraw'
+import 'tldraw/tldraw.css'
+
+class MeasureTool extends StateNode {
+	static override id = 'measure'
+
+	override onEnter() {
+		this.editor.setCursor({ type: 'cross', rotation: 0 })
+	}
+
+	override onPointerDown(info: TLPointerEventInfo) {
+		const start = this.editor.inputs.getCurrentPagePoint()
+		// Start measuring from this point
+	}
+
+	override onPointerUp(info: TLPointerEventInfo) {
+		// Finalize measurement and return to select tool
+		this.editor.setCurrentTool('select')
+	}
+}
+
+const customTools = [MeasureTool]
+
+export default function App() {
+	return (
+		<div style={{ position: 'fixed', inset: 0 }}>
+			<Tldraw tools={customTools} />
+		</div>
+	)
+}
+```
+
+Define the tools array once, outside the component or in a `useMemo`, so the editor isn't recreated on each render.
+
+The `StateNode` class has these static properties:
+
+| Property             | Description                                                                                                                                           |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                 | Required. The unique identifier for this state                                                                                                        |
+| `initial`            | The id of the initial child state (required if the tool has children)                                                                                 |
+| `children()`         | A function returning an array of child state constructors                                                                                             |
+| `isLockable`         | Whether the toolbar shows the tool-lock toggle while this tool is active (default: `true`). The tool itself still has to check `isToolLocked`.        |
+| `useCoalescedEvents` | Whether to receive the browser's coalesced pointer move events for higher-fidelity input, as the draw tool does (default: `false`; always off on iOS) |
+
+Tools with multiple phases use child states. A tool with children sets `initial` and `children()`:
 
 ```typescript
-import { StateNode, TLPointerEventInfo } from '@tldraw/editor'
+import { StateNode } from 'tldraw'
 
 export class StampTool extends StateNode {
 	static override id = 'stamp'
 	static override initial = 'idle'
 	static override children() {
 		return [StampIdle, StampPointing]
-	}
-
-	override onEnter() {
-		this.editor.setCursor({ type: 'cross', rotation: 0 })
-	}
-}
-```
-
-The `StateNode` class has these static properties:
-
-| Property             | Description                                                                                                 |
-| -------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `id`                 | Required. The unique identifier for this state                                                              |
-| `initial`            | The id of the initial child state (required if the tool has children)                                       |
-| `children()`         | A function returning an array of child state constructors                                                   |
-| `isLockable`         | Whether tool lock applies to this tool (default: `true`)                                                    |
-| `useCoalescedEvents` | Whether to receive the browser's coalesced pointer move events for higher-fidelity input (default: `false`) |
-
-For a simple tool without child states, implement event handlers directly on the tool class:
-
-```typescript
-export class MeasureTool extends StateNode {
-	static override id = 'measure'
-
-	override onPointerDown(info: TLPointerEventInfo) {
-		const currentPagePoint = this.editor.inputs.getCurrentPagePoint()
-		// Start measuring from this point
-	}
-
-	override onPointerMove(info: TLPointerEventInfo) {
-		// Update measurement as pointer moves
-	}
-
-	override onPointerUp(info: TLPointerEventInfo) {
-		// Finalize measurement and return to select tool
-		this.editor.setCurrentTool('select')
 	}
 }
 ```
@@ -157,30 +176,15 @@ export class DrawingPointing extends StateNode {
 }
 ```
 
-Access the editor through `this.editor` to read input state, manipulate shapes, or transition tools. Access the parent state through `this.parent` to transition between sibling states. The editor instance provides the full API for querying and modifying the document.
-
-To register a custom tool, pass it to the Tldraw component via the `tools` prop:
-
-```tsx
-import { Tldraw } from 'tldraw'
-import 'tldraw/tldraw.css'
-
-const customTools = [StampTool, MeasureTool]
-
-export default function App() {
-	return <Tldraw tools={customTools} />
-}
-```
-
-The tools array should be defined outside the component to avoid recreation on each render.
+Access the editor through `this.editor` to read input state, manipulate shapes, or transition tools. Access the parent state through `this.parent` to transition between sibling states.
 
 ## Overriding default tools
 
-The tldraw component provides several ways to customize which tools are available. You can remove tools from the toolbar, add new tools, or dynamically register and unregister tools at runtime.
+You can remove tools from the UI, add custom tools to it, or register and unregister tools at runtime.
 
 ### Removing tools from the toolbar
 
-Use the `overrides` prop to modify which tools appear in the UI. The `tools` function receives the current tools object and returns a modified version:
+Use the `overrides` prop ([TLUiOverrides](?)) to modify which tools appear in the UI. The `tools` function receives the current tools object and returns a modified version:
 
 ```typescript
 import { Tldraw, TLUiOverrides } from 'tldraw'
@@ -198,11 +202,11 @@ function App() {
 }
 ```
 
-This removes the tool from the UI but doesn't remove it from the editor's state machine. Users can still activate the tool programmatically or via keyboard shortcuts. To fully disable a tool, you'd also need to remove its keyboard shortcut binding.
+This removes the tool from the toolbar, its keyboard shortcut, and the menus, since all of them read from the same tools object. It doesn't remove the tool from the editor's state machine: `editor.setCurrentTool('text')` still works.
 
 ### Adding custom tools to the toolbar
 
-When you create a custom tool, you need to add it both to the editor's state machine and to the UI. The `tools` prop registers the tool with the state machine, while `overrides.tools` adds it to the UI context:
+When you create a custom tool, you need to add it both to the editor's state machine and to the UI. The `tools` prop registers the tool with the state machine, while `overrides.tools` adds a [TLUiToolItem](?) to the UI context. The `kbd` you set here is what registers the keyboard shortcut:
 
 ```typescript
 import { Tldraw, TLUiOverrides, StateNode } from 'tldraw'
@@ -230,11 +234,11 @@ function App() {
 }
 ```
 
-To make the tool appear in the toolbar, override the `Toolbar` component and include your tool item. See the "Add a tool to the toolbar" example for the complete implementation.
+The `icon` is a key into the UI's asset URLs; a custom icon needs an `assetUrls` override, or you can reuse a built-in icon name. To make the tool appear in the toolbar, override the `Toolbar` component and include your tool item. See the [add a tool to the toolbar example](/examples/ui/add-tool-to-toolbar) for the complete implementation.
 
 ### Dynamic tool registration
 
-Tools can be added or removed at runtime using the `setTool` and `removeTool` methods on the editor. This is useful when tool availability depends on user permissions, feature flags, or application state.
+Tools can be added or removed at runtime using [Editor#setTool](?) and [Editor#removeTool](?). This is useful when tool availability depends on user permissions, feature flags, or application state.
 
 ```tsx
 import { useState } from 'react'
@@ -277,14 +281,14 @@ function App() {
 }
 ```
 
-When removing a tool, check whether the user is currently using it. If so, transition to a different tool like select to avoid leaving the editor in an invalid state. The `setTool` method adds a tool constructor to the state chart, while `removeTool` removes it.
+When removing a tool, check whether the user is currently using it. If so, transition to a different tool like select to avoid leaving the editor in an invalid state. `setTool` throws if a tool with the same id is already registered.
 
 ## Related examples
 
-- **[Custom tool (sticker)](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/custom-tool)** - A simple custom tool that adds a heart emoji sticker to the canvas when you click, demonstrating the basics of extending StateNode.
-- **[Custom tool with child states](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/tool-with-child-states)** - Expands on the sticker tool to show how to create a tool with complex interactions using child states in the state machine.
-- **[Screenshot tool](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/shapes/tools/screenshot-tool)** - A custom tool that takes a screenshot of a specific area of the canvas, demonstrating how to handle multi-step interactions.
-- **[Lasso select tool](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/lasso-select-tool)** - A custom selection tool that uses freehand drawing to select shapes, showing how to build alternative selection tools with reactive atoms and overlays.
-- **[Add a tool to the toolbar](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/add-tool-to-toolbar)** - Shows how to make your custom tool icon appear on tldraw's toolbar by overriding the toolbar component and providing custom assets.
-- **[Remove a tool from the toolbar](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/ui/remove-tool)** - Shows how to remove a default tool from the toolbar using UI overrides.
-- **[Dynamic tools with setTool and removeTool](https://github.com/tldraw/tldraw/tree/main/apps/examples/src/examples/editor-api/dynamic-tools)** - Demonstrates how to dynamically add and remove tools from the editor's state chart after initialization, useful for conditional tool availability.
+- [Custom tool (sticker)](/examples/shapes/tools/custom-tool) - A tool that adds a heart sticker to the canvas when you click.
+- [Custom tool with child states](/examples/shapes/tools/tool-with-child-states) - The sticker tool rebuilt with idle, pointing, and dragging child states.
+- [Screenshot tool](/examples/shapes/tools/screenshot-tool) - Drag a box on the canvas and export it as an image.
+- [Lasso select tool](/examples/editor-api/lasso-select-tool) - A freehand selection tool built with reactive atoms and overlays.
+- [Add a tool to the toolbar](/examples/ui/add-tool-to-toolbar) - Put a custom tool in the toolbar and keyboard shortcuts dialog with custom assets.
+- [Remove a tool from the toolbar](/examples/ui/remove-tool) - Remove a default tool with UI overrides.
+- [Dynamic tools with setTool and removeTool](/examples/editor-api/dynamic-tools) - Add and remove tools from the state chart after initialization.

--- a/apps/docs/content/sdk-features/ui-components.mdx
+++ b/apps/docs/content/sdk-features/ui-components.mdx
@@ -17,9 +17,9 @@ accuracy: 10
 notes: ''
 ---
 
-The `tldraw` package includes a complete React-based UI. It provides the menus, toolbars, panels, and dialogs that users interact with when creating and editing content. The UI is composed of named component slots that you can selectively override or hide, so you can customize the interface while still benefiting from the editor's reactive state management.
+The `tldraw` package includes a complete React-based UI: the menus, toolbars, panels, and dialogs that users interact with when creating and editing content. The UI is composed of named component slots that you can override or hide one at a time.
 
-The UI connects to the editor through React hooks and context providers. Components automatically update when editor state changes. You can replace individual parts of the interface without reimplementing the logic that connects UI actions to editor operations.
+The UI connects to the editor through React hooks and context providers. Components update automatically when editor state changes, so you can replace individual parts of the interface without reimplementing the logic that connects UI actions to editor operations.
 
 ## How it works
 
@@ -38,43 +38,27 @@ The UI divides the screen into distinct layout zones:
 └─────────────────────────────────────────────────────────┘
 ```
 
-The top zone contains the main menu, helper buttons (like "Back to content"), an empty top panel slot, and the share and style panels. The bottom zone houses navigation controls, the main toolbar with drawing tools, and the help menu. On desktop, the style panel appears in the top-right zone; on mobile it moves to a modal overlay.
+The top zone contains the main menu, helper buttons (like "Back to content"), an empty top panel slot, and the share and style panels. The bottom zone houses navigation controls, the main toolbar with drawing tools, and the help menu (if you provide one). On desktop, the style panel appears in the top-right zone; on mobile it moves into a popover opened from the toolbar.
 
-Each zone can host multiple components. The toolbar includes the tool selector, tool-specific options, and the tool lock button. These components share context and coordinate through the editor's state.
+Each zone can host multiple components. The toolbar includes the tool selector, tool-specific options, and the tool lock button.
 
 ### Context providers and state management
 
-The UI establishes a hierarchy of React context providers that manage different aspects of the interface. At the root, `TldrawUiContextProvider` coordinates all other providers and merges your overrides. Specialized providers handle translations, tooltips, dialogs, toasts, breakpoints for responsive behavior, and the component registry.
+The UI establishes a hierarchy of React context providers. At the root, [TldrawUiContextProvider](?) coordinates the other providers and applies your overrides. Specialized providers handle translations, tooltips, dialogs, toasts, UI events, accessibility announcements, breakpoints for responsive behavior, and the component registry.
 
-The actions and tools providers transform raw editor methods into UI-friendly actions with labels, icons, and keyboard shortcuts. When you click a toolbar button, the component calls an action from context, which invokes the appropriate editor method. This indirection means the same action can be triggered from multiple places (toolbar, menu, keyboard shortcut) with consistent behavior.
+The actions and tools providers turn editor methods into UI actions with labels, icons, and keyboard shortcuts. When you click a toolbar button, the component calls an action from context, which invokes the editor method. The same action can be triggered from the toolbar, a menu, or a keyboard shortcut. See [Actions](/sdk-features/actions) for details.
 
 ### Reactive UI updates
 
-UI components read editor state through hooks like `useEditor`, `useValue`, and `useReactor`. These hooks use the editor's reactive signal system to automatically re-render when relevant state changes. The style panel uses `useRelevantStyles` to determine which style controls to show based on the current selection—when you select a different shape, the hook detects the change and the panel updates.
-
-This reactive approach means you don't need to manually manage subscriptions or worry about stale state. Components declare their dependencies, and the reactivity system handles the rest.
+UI components read editor state through hooks like [useEditor](?) and [useValue](?). These hooks use the editor's reactive signal system to re-render when relevant state changes. The style panel uses [useRelevantStyles](?) to decide which style controls to show for the current selection: select a different shape and the panel updates.
 
 ## Key components
 
 ### Component slots
 
-The UI defines several component slots you can override or hide.
+The UI defines several component slots you can override or hide. The `Toolbar` holds the tool buttons. The `TopPanel` is an empty top-center slot with no default component; use it for your own UI like a document title or sync status. The `StylePanel` shows style controls for the selected shapes. The `MenuPanel` (top-left) groups the main menu, the page menu, and quick actions. The `NavigationPanel` (bottom-left) provides zoom controls and the minimap toggle. `HelperButtons` appear based on editor state, such as "Back to content" when the camera is far from shapes.
 
-The **Toolbar** contains the primary tool selector with buttons for each available tool (select, draw, shapes, etc.). On mobile, it hides automatically when editing text to make room for the virtual keyboard.
-
-The **TopPanel** is an empty slot in the top-center of the screen. It has no default component, so use it for your own UI like a document title or sync status.
-
-The **StylePanel** shows style controls for selected shapes: color, fill, dash, size, and opacity. It appears in the top-right on desktop and as a modal on mobile.
-
-The **MenuPanel** sits in the top-left corner. It groups the main menu, the page menu, and quick actions.
-
-The **NavigationPanel** provides zoom controls and the minimap toggle. It sits in the bottom-left area.
-
-**HelperButtons** are context-sensitive buttons that appear based on editor state—"Back to content" when the camera is far from shapes, "Exit pen mode" on touch devices.
-
-**ActionsMenu**, **ContextMenu**, and **HelpMenu** provide access to actions and information through different interaction patterns.
-
-Each slot is optional. Pass `null` as an override to hide a component entirely, or provide your own React component to replace the default implementation.
+Each slot is optional. Pass `null` to hide a component, or pass your own React component to replace the default. A few slots have no default: `TopPanel` and `HelpMenu` are `null` unless you provide a component (use [DefaultHelpMenu](?) to opt in to the built-in help menu), and `SharePanel` and `CursorChatBubble` only render when collaboration UI is enabled.
 
 ### Slot props
 
@@ -120,21 +104,19 @@ This table is an index; the authoritative list and types remain [TLUiComponents]
 
 Components access editor functionality through specialized hooks.
 
-`useEditor` returns the editor instance, providing direct access to all editor methods and state.
+[useEditor](?) returns the editor instance, with direct access to all editor methods and state.
 
-`useActions` returns a collection of UI actions (copy, paste, delete) with their labels, icons, and keyboard shortcuts. Each action is a function you can call from your custom UI.
+[useActions](?) returns the UI actions (copy, paste, delete, and so on) with their labels, icons, and keyboard shortcuts. Call an action's `onSelect` from your custom UI.
 
-`useTools` returns the available tools with their metadata. The toolbar uses this to render tool buttons.
+[useTools](?) returns the available tools with their metadata. The toolbar uses this to render tool buttons.
 
-`useRelevantStyles` determines which styles are relevant to the current selection and returns their values. It powers the style panel.
+[useRelevantStyles](?) returns the styles relevant to the current selection and their values. It powers the style panel.
 
-`useBreakpoint` returns a numeric breakpoint index (0-7) that maps to the `PORTRAIT_BREAKPOINT` enum. Compare against values like `PORTRAIT_BREAKPOINT.MOBILE` or `PORTRAIT_BREAKPOINT.TABLET_SM` to adapt layout for different screen sizes.
-
-These hooks encapsulate common UI patterns and keep your custom components in sync with editor state.
+[useBreakpoint](?) returns a numeric breakpoint index (0-7) matching the [PORTRAIT_BREAKPOINT](?) constants. Compare against values like `PORTRAIT_BREAKPOINT.MOBILE` or `PORTRAIT_BREAKPOINT.TABLET_SM` to adapt layout for different screen sizes.
 
 ## Hiding the UI
 
-You can hide the default tldraw user interface entirely using the `hideUi` prop. This turns off both the visuals and the keyboard shortcuts.
+You can hide the default tldraw user interface entirely using the `hideUi` prop. This hides the visual UI only: keyboard shortcuts and clipboard handling keep working.
 
 ```tsx
 import { Tldraw } from 'tldraw'
@@ -149,7 +131,7 @@ export default function App() {
 }
 ```
 
-When the UI is hidden, you can't select tools using keyboard shortcuts. You can still control the editor programmatically through `Editor` methods. Open the console and try:
+With the UI hidden, you can still control the editor programmatically through [Editor](?) methods. Open the console and try:
 
 ```ts
 editor.setCurrentTool('draw')
@@ -195,7 +177,7 @@ export default function App() {
 }
 ```
 
-The `useTools` hook returns an object mapping tool IDs to [TLUiToolItem](/reference/tldraw/TLUiToolItem) objects. Each tool item contains metadata like `id`, `label`, `icon`, and `kbd` (keyboard shortcut).
+The `useTools` hook returns an object mapping tool IDs to [TLUiToolItem](?) objects. Each tool item contains metadata like `id`, `label`, `icon`, and `kbd` (keyboard shortcut).
 
 ### Hiding components
 
@@ -204,9 +186,9 @@ Pass `null` to hide a component entirely. This is useful for focused experiences
 ```tsx
 <Tldraw
 	components={{
-		HelpMenu: null,
+		PageMenu: null,
 		DebugMenu: null,
-		SharePanel: null,
+		NavigationPanel: null,
 	}}
 />
 ```
@@ -215,11 +197,11 @@ See the [UI components hidden example](/examples/ui/ui-components-hidden) for a 
 
 ## Overrides
 
-Control tldraw's menu content with the `overrides` prop. This prop accepts a [TLUiOverrides](/reference/tldraw/TLUiOverrides) object, which has methods for `actions` and `tools`, and a `translations` property.
+Control tldraw's actions, tools, and translations with the `overrides` prop. This prop accepts a [TLUiOverrides](?) object, which has methods for `actions` and `tools`, and a `translations` property.
 
 ### Actions
 
-The user interface has a set of shared actions used in the menus and keyboard shortcuts. Override these by providing an `actions` method that receives the editor, the [default actions](https://github.com/tldraw/tldraw/blob/main/packages/tldraw/src/lib/ui/context/actions.tsx), and a helpers object, then returns a mutated actions object.
+The user interface has a set of shared actions used in the menus and keyboard shortcuts. Override these by providing an `actions` method that receives the editor, the [default actions](https://github.com/tldraw/tldraw/blob/main/packages/tldraw/src/lib/ui/context/actions.tsx), and a helpers object, then returns a mutated actions object. See [Actions](/sdk-features/actions) for the full story.
 
 ```tsx
 import { Tldraw, TLUiOverrides } from 'tldraw'
@@ -253,7 +235,7 @@ export default function App() {
 }
 ```
 
-The `actions` object is a map of [TLUiActionItem](/reference/tldraw/TLUiActionItem)s, keyed by their `id`. See the [action overrides example](/examples/ui/action-overrides) for more.
+The `actions` object is a map of [TLUiActionItem](?)s, keyed by their `id`. See the [action overrides example](/examples/ui/action-overrides) for more.
 
 ### Tools
 
@@ -265,7 +247,7 @@ const myOverrides: TLUiOverrides = {
 		// Create a tool item in the UI's context
 		tools.card = {
 			id: 'card',
-			icon: 'color',
+			icon: 'geo-rectangle',
 			label: 'tools.card',
 			kbd: 'c',
 			onSelect: () => {
@@ -277,7 +259,7 @@ const myOverrides: TLUiOverrides = {
 }
 ```
 
-The `tools` object is a map of [TLUiToolItem](/reference/tldraw/TLUiToolItem)s, keyed by their `id`. See the [add tool to toolbar example](/examples/ui/add-tool-to-toolbar) for a complete implementation.
+The `tools` object is a map of [TLUiToolItem](?)s, keyed by their `id`. See the [add tool to toolbar example](/examples/ui/add-tool-to-toolbar) for a complete implementation.
 
 ### Translations
 
@@ -316,7 +298,7 @@ export default function App() {
 }
 ```
 
-The callback receives the event name as a string and an object with information about the event's source (e.g. `menu` or `context-menu`) and other data specific to each event, such as the direction in an `align-shapes` event.
+The callback receives the event name as a string and an object with the event's `source` (e.g. `menu` or `context-menu`) and other data specific to each event, such as the `operation` in an `align-shapes` event.
 
 Note that `onUiEvent` only fires for UI interactions. Calling [Editor#alignShapes](?) directly won't trigger this callback. See the [UI events example](/examples/events/ui-events) for more.
 

--- a/apps/docs/content/sdk-features/ui-primitives.mdx
+++ b/apps/docs/content/sdk-features/ui-primitives.mdx
@@ -21,11 +21,11 @@ notes: ''
 
 The `tldraw` package exports a set of UI primitive components that you can use when building custom interfaces. These components match the look and feel of tldraw's default UI and integrate with the editor's theming, translations, and accessibility features.
 
-Use these primitives when you want your custom UI to feel like a natural part of tldraw rather than something bolted on.
+Use these primitives when you want your custom UI to feel like a natural part of tldraw rather than something bolted on. See the [UI primitives example](/examples/ui/ui-primitives) for all of them in one place.
 
 ## Buttons
 
-The button system consists of `TldrawUiButton` and its companion components for icons, labels, and state indicators.
+The button system consists of [TldrawUiButton](?) and its companion components for icons, labels, and check indicators.
 
 ### TldrawUiButton
 
@@ -70,11 +70,11 @@ The `type` prop controls the button's appearance:
 | `menu`    | Button style used inside menus           |
 | `help`    | Style used for help/info buttons         |
 
-Use `isActive` to indicate a selected or active state:
+Use `isActive` to indicate a selected or active state, and `tooltip` to show a tooltip on hover:
 
 ```tsx
-<TldrawUiButton type="tool" isActive={true}>
-	<TldrawUiButtonIcon icon="draw" />
+<TldrawUiButton type="tool" isActive={true} tooltip="Draw">
+	<TldrawUiButtonIcon icon="tool-pencil" />
 </TldrawUiButton>
 ```
 
@@ -83,13 +83,7 @@ Use `isActive` to indicate a selected or active state:
 Build up button contents using these components:
 
 ```tsx
-import {
-	TldrawUiButton,
-	TldrawUiButtonIcon,
-	TldrawUiButtonLabel,
-	TldrawUiButtonCheck,
-	TldrawUiButtonSpinner,
-} from 'tldraw'
+import { TldrawUiButton, TldrawUiButtonIcon, TldrawUiButtonLabel, TldrawUiButtonCheck } from 'tldraw'
 
 // Icon button
 <TldrawUiButton type="icon">
@@ -107,22 +101,16 @@ import {
 	<TldrawUiButtonCheck checked={true} />
 	<TldrawUiButtonLabel>Show grid</TldrawUiButtonLabel>
 </TldrawUiButton>
-
-// Button with loading spinner
-<TldrawUiButton type="normal" disabled>
-	<TldrawUiButtonSpinner />
-	<TldrawUiButtonLabel>Loading...</TldrawUiButtonLabel>
-</TldrawUiButton>
 ```
 
 ## Icons
 
-`TldrawUiIcon` renders icons from tldraw's icon set. Icons are SVG-based and inherit the current text color.
+[TldrawUiIcon](?) renders icons from tldraw's icon set. Icons are SVG masks filled with the current text color.
 
 ```tsx
 import { TldrawUiIcon } from 'tldraw'
 
-<TldrawUiIcon icon="draw" label="Draw tool" />
+<TldrawUiIcon icon="tool-pencil" label="Draw tool" />
 <TldrawUiIcon icon="arrow-left" label="Go back" small />
 <TldrawUiIcon icon="check" label="Complete" color="green" />
 ```
@@ -137,46 +125,51 @@ You can also pass a custom React element instead of an icon name:
 
 ## Menu primitives
 
-When adding items to tldraw's menus, use these components to match the default menu styling and behavior.
+When adding items to tldraw's menus, use these components to match the default menu styling and behavior. Menu primitives read a menu context to decide how to render, so they must be placed inside one of tldraw's menus (for example a custom `MainMenu` or `ContextMenu` component) or wrapped in a [TldrawUiMenuContextProvider](?). See the [custom menus example](/examples/ui/custom-menus).
 
 ### TldrawUiMenuItem
 
-The main component for menu items. It automatically adapts its rendering based on which menu it's in (dropdown, context menu, toolbar, etc.):
+[TldrawUiMenuItem](?) is the main component for menu items. It adapts its rendering to the menu it's in (dropdown, context menu, toolbar, and so on):
 
 ```tsx
-import { TldrawUiMenuItem, TldrawUiMenuGroup } from 'tldraw'
-;<TldrawUiMenuGroup id="my-actions">
-	<TldrawUiMenuItem
-		id="my-action"
-		label="Do something"
-		icon="plus"
-		kbd="cmd+shift+d"
-		onSelect={() => {
-			console.log('action triggered')
-		}}
-	/>
-</TldrawUiMenuGroup>
+import { TldrawUiMenuGroup, TldrawUiMenuItem } from 'tldraw'
+
+function MyMenuGroup() {
+	return (
+		<TldrawUiMenuGroup id="my-actions">
+			<TldrawUiMenuItem
+				id="my-action"
+				label="Do something"
+				iconLeft="plus"
+				kbd="cmd+shift+d"
+				onSelect={() => {
+					console.log('action triggered')
+				}}
+			/>
+		</TldrawUiMenuGroup>
+	)
+}
 ```
 
-Props:
+The props are:
 
-| Prop         | Description                                            |
-| ------------ | ------------------------------------------------------ |
-| `id`         | Unique identifier for the menu item                    |
-| `label`      | Display text (supports translation keys)               |
-| `icon`       | Icon to display (on right in menus)                    |
-| `iconLeft`   | Icon to display on the left side                       |
-| `kbd`        | Keyboard shortcut to display                           |
-| `onSelect`   | Called when the item is clicked                        |
-| `disabled`   | Whether the item is disabled                           |
-| `readonlyOk` | If true, item is shown even in readonly mode           |
-| `isSelected` | Whether the item shows as selected (for toolbar items) |
-| `spinner`    | Show a loading spinner                                 |
-| `noClose`    | Prevent the menu from closing when clicked             |
+| Prop         | Description                                                                     |
+| ------------ | ------------------------------------------------------------------------------- |
+| `id`         | Unique identifier for the menu item                                             |
+| `label`      | Display text (supports translation keys)                                        |
+| `icon`       | Icon for icon-style menus and toolbars (not shown in dropdown or context menus) |
+| `iconLeft`   | Icon shown on the left in dropdown and context menus                            |
+| `kbd`        | Keyboard shortcut to display                                                    |
+| `onSelect`   | Called when the item is clicked                                                 |
+| `disabled`   | Whether the item is disabled                                                    |
+| `readonlyOk` | If true, item is shown even in readonly mode                                    |
+| `isSelected` | Whether the item shows as selected (for toolbar items)                          |
+| `spinner`    | Show a loading spinner                                                          |
+| `noClose`    | Prevent the menu from closing when clicked                                      |
 
 ### TldrawUiMenuGroup
 
-Groups related menu items together. In dropdown menus, groups are separated by dividers:
+[TldrawUiMenuGroup](?) groups related menu items together. In dropdown menus, groups are separated by dividers:
 
 ```tsx
 <TldrawUiMenuGroup id="clipboard">
@@ -188,11 +181,10 @@ Groups related menu items together. In dropdown menus, groups are separated by d
 
 ### TldrawUiMenuSubmenu
 
-Creates a nested submenu:
+[TldrawUiMenuSubmenu](?) creates a nested submenu:
 
 ```tsx
-import { TldrawUiMenuSubmenu } from 'tldraw'
-;<TldrawUiMenuSubmenu id="export" label="Export as...">
+<TldrawUiMenuSubmenu id="export" label="Export as...">
 	<TldrawUiMenuGroup id="formats">
 		<TldrawUiMenuItem id="png" label="PNG" onSelect={exportPng} />
 		<TldrawUiMenuItem id="svg" label="SVG" onSelect={exportSvg} />
@@ -203,11 +195,10 @@ import { TldrawUiMenuSubmenu } from 'tldraw'
 
 ### TldrawUiMenuCheckboxItem
 
-A menu item with a checkbox:
+[TldrawUiMenuCheckboxItem](?) is a menu item with a checkbox:
 
 ```tsx
-import { TldrawUiMenuCheckboxItem } from 'tldraw'
-;<TldrawUiMenuCheckboxItem
+<TldrawUiMenuCheckboxItem
 	id="snap-to-grid"
 	label="Snap to grid"
 	checked={snapEnabled}
@@ -217,11 +208,13 @@ import { TldrawUiMenuCheckboxItem } from 'tldraw'
 />
 ```
 
-The `onSelect` callback receives a `source` parameter indicating where the action was triggered from (e.g., 'context-menu', 'menu'). You can ignore it if you don't need to differentiate between sources.
+The `onSelect` callback receives a `source` parameter, a [TLUiEventSource](?) such as `'main-menu'` or `'context-menu'`, taken from the surrounding menu context. Ignore it if you don't need to tell sources apart.
+
+To put an existing action or tool in a menu, use [TldrawUiMenuActionItem](?) or [TldrawUiMenuToolItem](?) with the action or tool id; they fill in the label, icon, and shortcut for you.
 
 ## Dialogs
 
-Build modal dialogs using tldraw's dialog primitives. These components handle accessibility, focus management, and styling.
+Build modal dialogs using tldraw's dialog primitives ([TldrawUiDialogHeader](?), [TldrawUiDialogTitle](?), [TldrawUiDialogCloseButton](?), [TldrawUiDialogBody](?), and [TldrawUiDialogFooter](?)) and open them with [useDialogs](?). These components handle accessibility, focus management, and styling.
 
 ```tsx
 import {
@@ -275,11 +268,10 @@ The `onClose` function is passed to your dialog component automatically. Call it
 
 ## Input
 
-`TldrawUiInput` is a styled text input with built-in handling for Enter (confirm) and Escape (cancel):
+[TldrawUiInput](?) is a styled text input with built-in handling for Enter (confirm) and Escape (cancel):
 
 ```tsx
-import { TldrawUiInput } from 'tldraw'
-;<TldrawUiInput
+<TldrawUiInput
 	label="Name"
 	defaultValue="Untitled"
 	onComplete={(value) => {
@@ -301,13 +293,13 @@ import { TldrawUiInput } from 'tldraw'
 Add icons to the input using `iconLeft` (left side) or `icon` (right side):
 
 ```tsx
-<TldrawUiInput iconLeft="search" placeholder="Search shapes..." onValueChange={setSearchQuery} />
+<TldrawUiInput iconLeft="zoom-in" placeholder="Search shapes..." onValueChange={setSearchQuery} />
 <TldrawUiInput icon="check" placeholder="Confirmed value" />
 ```
 
 ## Layout
 
-Layout primitives help organize UI controls with proper spacing and orientation-aware tooltips.
+[TldrawUiRow](?), [TldrawUiColumn](?), and [TldrawUiGrid](?) organize UI controls with proper spacing and orientation-aware tooltips.
 
 ```tsx
 import { TldrawUiRow, TldrawUiColumn, TldrawUiGrid } from 'tldraw'
@@ -315,7 +307,7 @@ import { TldrawUiRow, TldrawUiColumn, TldrawUiGrid } from 'tldraw'
 // Horizontal row of buttons
 <TldrawUiRow>
 	<TldrawUiButton type="icon"><TldrawUiButtonIcon icon="align-left" /></TldrawUiButton>
-	<TldrawUiButton type="icon"><TldrawUiButtonIcon icon="align-center" /></TldrawUiButton>
+	<TldrawUiButton type="icon"><TldrawUiButtonIcon icon="align-center-horizontal" /></TldrawUiButton>
 	<TldrawUiButton type="icon"><TldrawUiButtonIcon icon="align-right" /></TldrawUiButton>
 </TldrawUiRow>
 
@@ -335,26 +327,24 @@ import { TldrawUiRow, TldrawUiColumn, TldrawUiGrid } from 'tldraw'
 </TldrawUiGrid>
 ```
 
-These components automatically set up a `tooltipSide` context—tooltips appear below items in rows and to the right of items in columns, and nested components inherit this positioning.
+These components set up an orientation context. By default, tooltips appear below items in rows and to the right of items in columns; nested layouts inherit the side until the orientation changes. Pass `tooltipSide` to override it.
 
 ## Other primitives
 
 ### TldrawUiKbd
 
-Displays a keyboard shortcut:
+[TldrawUiKbd](?) displays a keyboard shortcut using platform-specific symbols. It is hidden on small mobile breakpoints unless you pass `visibleOnMobileLayout`:
 
 ```tsx
-import { TldrawUiKbd } from 'tldraw'
-;<TldrawUiKbd>cmd+shift+d</TldrawUiKbd>
+<TldrawUiKbd>cmd+shift+d</TldrawUiKbd>
 ```
 
 ### TldrawUiSlider
 
-A slider control. The slider uses discrete steps rather than a continuous range:
+[TldrawUiSlider](?) is a slider control with discrete integer steps rather than a continuous range:
 
 ```tsx
-import { TldrawUiSlider } from 'tldraw'
-;<TldrawUiSlider
+<TldrawUiSlider
 	title="Opacity"
 	label="style-panel.opacity"
 	value={5}
@@ -363,24 +353,24 @@ import { TldrawUiSlider } from 'tldraw'
 />
 ```
 
-Props:
+The props are:
 
-| Prop            | Description                                     |
-| --------------- | ----------------------------------------------- |
-| `title`         | Tooltip title text                              |
-| `label`         | Translation key for the label                   |
-| `value`         | Current value (0 to steps), or null             |
-| `steps`         | Maximum value (the slider goes from 0 to steps) |
-| `min`           | Optional minimum value (defaults to 0)          |
-| `onValueChange` | Called with the new value when it changes       |
+| Prop            | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `title`         | Title text, combined with the label for the tooltip and `aria-label` |
+| `label`         | Translation key for the label                                        |
+| `value`         | Current value (`min` to `steps`), or `null`                          |
+| `steps`         | Maximum value                                                        |
+| `min`           | Optional minimum value (defaults to 0)                               |
+| `onValueChange` | Called with the new value when it changes                            |
+| `onHistoryMark` | Called on pointer down so you can mark a history stopping point      |
 
 ### TldrawUiPopover
 
-A popover that appears next to a trigger element:
+[TldrawUiPopover](?) shows content next to a trigger element:
 
 ```tsx
-import { TldrawUiPopover, TldrawUiPopoverTrigger, TldrawUiPopoverContent } from 'tldraw'
-;<TldrawUiPopover id="my-popover">
+<TldrawUiPopover id="my-popover">
 	<TldrawUiPopoverTrigger>
 		<TldrawUiButton type="icon">
 			<TldrawUiButtonIcon icon="dots-vertical" />
@@ -396,19 +386,10 @@ The `id` prop is required and used to track the popover's open state. The `side`
 
 ### TldrawUiDropdownMenu
 
-A dropdown menu built on Radix UI:
+[TldrawUiDropdownMenuRoot](?) and its companions build a dropdown menu on Radix UI:
 
 ```tsx
-import {
-	TldrawUiDropdownMenuRoot,
-	TldrawUiDropdownMenuTrigger,
-	TldrawUiDropdownMenuContent,
-	TldrawUiDropdownMenuItem,
-	TldrawUiDropdownMenuGroup,
-	TldrawUiButton,
-	TldrawUiButtonLabel,
-} from 'tldraw'
-;<TldrawUiDropdownMenuRoot id="my-dropdown">
+<TldrawUiDropdownMenuRoot id="my-dropdown">
 	<TldrawUiDropdownMenuTrigger>
 		<TldrawUiButton type="normal">
 			<TldrawUiButtonLabel>Options</TldrawUiButtonLabel>
@@ -438,9 +419,11 @@ import {
 
 The `id` prop is required on `TldrawUiDropdownMenuRoot`. Each `TldrawUiDropdownMenuItem` wraps a child element (typically a button) and handles the dropdown behavior.
 
+Other exported primitives include [TldrawUiToolbar](?) and [TldrawUiToolbarButton](?), [TldrawUiTooltip](?), [TldrawUiSelect](?), [TldrawUiContextualToolbar](?), and the dropdown submenu and checkbox item components.
+
 ## Related examples
 
-- **[UI primitives](/examples/ui/ui-primitives)** — A showcase of the UI primitive components
-- **[Custom menus](/examples/ui/custom-menus)** — Add items to tldraw's menus using menu primitives
-- **[Toasts and dialogs](/examples/ui/toasts-and-dialogs)** — Show toasts and custom dialogs
-- **[Custom UI](/examples/ui/custom-ui)** — Build a completely custom interface
+- [UI primitives](/examples/ui/ui-primitives) - A showcase of the UI primitive components
+- [Custom menus](/examples/ui/custom-menus) - Add items to tldraw's menus using menu primitives
+- [Toasts and dialogs](/examples/ui/toasts-and-dialogs) - Show toasts and custom dialogs
+- [Custom UI](/examples/ui/custom-ui) - Build a completely custom interface

--- a/apps/docs/content/sdk-features/user-following.mdx
+++ b/apps/docs/content/sdk-features/user-following.mdx
@@ -143,7 +143,7 @@ The presence records from [Editor#getCollaborators](?) include each user's `foll
 
 ## Related articles
 
-- [Camera](/sdk-features/camera) - Learn about viewport and camera control
+- [Camera](/sdk-features/camera) - Viewport and camera control
 - [Collaboration](/docs/collaboration) - Set up multiplayer presence and sync
-- [Pages](/sdk-features/pages) - Understand page management
+- [Pages](/sdk-features/pages) - Page management
 - [UI components](/sdk-features/ui-components) - Customize UI elements like the following indicator

--- a/apps/docs/content/sdk-features/user-following.mdx
+++ b/apps/docs/content/sdk-features/user-following.mdx
@@ -17,9 +17,21 @@ accuracy: 9
 notes: Could use more question-style transitions per voice guide.
 ---
 
-User following lets you track a collaborator's viewport in real time. When you follow someone, your [camera](/sdk-features/camera) automatically moves to match their view, including page changes and zoom level. The editor handles follow chains (A follows B who follows C) and smoothly interpolates your viewport toward the target on each frame.
+User following lets you track a collaborator's viewport. When you follow someone, your [camera](/sdk-features/camera) moves to match their view, including page changes and zoom level. The editor handles follow chains (A follows B who follows C) and interpolates your viewport toward the target on each frame.
 
-Following works with the [collaboration](/docs/collaboration) presence system to track collaborators. It stops automatically when you interact with the canvas or when the followed user disconnects.
+Following works with the [collaboration](/docs/collaboration) presence system, so it needs a collaborative store. User ids are branded [TLUserId](?) values: take them from presence records, or create one with [createUserId](?). The default People menu already exposes this: clicking a collaborator zooms to them, and the follow button beside their name starts or stops following. The API below is what it calls.
+
+```ts
+import { createUserId } from 'tldraw'
+
+const userId = createUserId('user-abc-123')
+
+editor.startFollowingUser(userId)
+editor.stopFollowingUser()
+editor.zoomToUser(userId)
+```
+
+Following stops when you interact with the canvas or when the followed user disconnects.
 
 ## How it works
 
@@ -27,19 +39,19 @@ Following works with the [collaboration](/docs/collaboration) presence system to
 
 When you call [Editor#startFollowingUser](?), the editor stores the target user ID in `followingUserId` on the instance state and sets up two reactive processes: one watches for page changes and switches pages when the followed user navigates, and another runs on every frame to interpolate your camera toward their viewport.
 
-The frame handler calculates the difference between your current viewport and the target, then applies smooth interpolation using your animation speed preference. This creates an ease-out effect where the camera moves quickly at first and slows as it approaches. Once the viewport difference drops below the `followChaseViewportSnap` threshold (default 2 pixels), the editor locks onto the target and mirrors their viewport exactly instead of interpolating.
+The frame handler calculates the difference between your current viewport and the target, then interpolates using your animation speed preference. The camera moves quickly at first and slows as it approaches. Once the viewport difference drops below the `followChaseViewportSnap` threshold (default 2 pixels), the editor locks onto the target and mirrors their viewport exactly instead of interpolating. If the animation speed preference is 0, it locks on immediately.
 
 ### Viewport calculation
 
 The editor reads the followed user's camera state and screen bounds from their presence record, constructs their viewport in page space, then resizes your viewport to contain theirs while maintaining your screen's aspect ratio. You can see everything the followed user sees, regardless of screen size.
 
-The interpolation uses `lerp` on viewport bounds rather than camera values directly, which produces more natural movement when zoom levels differ. The interpolation factor clamps between 0.1 and 0.8 based on the animation speed preference, preventing both sluggish and aggressive following.
+The interpolation uses `lerp` on viewport bounds rather than camera values directly, which produces more natural movement when zoom levels differ. The interpolation factor clamps between 0.1 and 0.8 based on the animation speed preference, so following is never sluggish or aggressive.
 
 ### Page synchronization
 
 Page changes happen separately from camera movement. A reactive effect watches the followed user's `currentPageId` and immediately switches [pages](/sdk-features/pages) when it changes. The page switch uses a direct store update rather than `setCurrentPage()` to avoid triggering the automatic follow-stopping behavior that occurs on manual page changes.
 
-When switching pages to follow a user, the editor sets an internal `_isLockedOnFollowingUser` flag to prevent camera interpolation from running until the page switch completes. This avoids jarring camera movements during page transitions.
+When switching pages to follow a user, the editor pauses camera interpolation until the page switch completes. This avoids jarring camera movements during page transitions.
 
 ## API methods
 
@@ -48,14 +60,14 @@ When switching pages to follow a user, the editor sets an internal `_isLockedOnF
 Start following a user's viewport. Pass a user ID to set up frame handlers that track their camera and page.
 
 ```ts
-editor.startFollowingUser('user-abc-123')
+editor.startFollowingUser(userId)
 ```
 
 The editor automatically stops following any previously followed user before starting the new follow. If it can't find the target user's presence, the method returns early without starting follow mode.
 
 ### stopFollowingUser
 
-Stop following and return control to the local user. This commits the current camera position to the store and clears `followingUserId` from instance state.
+[Editor#stopFollowingUser](?) stops following and returns control to the local user. This commits the current camera position to the store, clears `followingUserId` from instance state, and emits the editor's `stop-following` event.
 
 ```ts
 editor.stopFollowingUser()
@@ -65,14 +77,14 @@ Following stops automatically when you pan or zoom the canvas. Manual page chang
 
 ### zoomToUser
 
-Animate the camera to a user's cursor position without entering follow mode. Use this for one-time navigation to a collaborator's location.
+[Editor#zoomToUser](?) animates the camera to a user's cursor position without entering follow mode. Use this for one-time navigation to a collaborator's location.
 
 ```ts
-editor.zoomToUser('user-abc-123')
-editor.zoomToUser('user-abc-123', { animation: { duration: 200 } })
+editor.zoomToUser(userId)
+editor.zoomToUser(userId, { animation: { duration: 200 } })
 ```
 
-If you're already following someone, `zoomToUser()` stops following first. The method switches pages if necessary, centers the camera on the user's cursor, and briefly highlights their cursor for visual feedback. The highlight clears after `collaboratorIdleTimeoutMs` (default 3 seconds).
+If you're already following someone, `zoomToUser()` stops following first. The method switches pages if necessary, centers the camera on the user's cursor, and briefly highlights their cursor. The highlight clears after `collaboratorIdleTimeoutMs` (default 3 seconds). If the user is on a different page, the camera jumps without animating.
 
 ## Follow chains
 
@@ -83,8 +95,8 @@ The traversal maintains a visited set to prevent infinite loops if users create 
 ```ts
 // A follows B follows C
 // A's camera tracks C's viewport, not B's viewport
-editor.startFollowingUser('user-b')
-// Internally resolves to user-c's presence if user-b is following user-c
+editor.startFollowingUser(userB)
+// Internally resolves to C's presence if B is following C
 ```
 
 The follow chain resolution runs on every frame, so changes in the chain (like B stopping following C) immediately affect A's target viewport without requiring A to restart following.
@@ -96,7 +108,7 @@ The follow chain resolution runs on every frame, so changes in the chain (like B
 The [DefaultFollowingIndicator](?) component displays a colored border around the canvas when you're following someone. It reads `followingUserId` from instance state and fetches the corresponding presence record to get the user's color.
 
 ```tsx
-import { useEditor, usePresence, useValue } from '@tldraw/editor'
+import { TLUserId, useEditor, usePresence, useValue } from 'tldraw'
 
 export function DefaultFollowingIndicator() {
 	const editor = useEditor()
@@ -107,14 +119,14 @@ export function DefaultFollowingIndicator() {
 	return <FollowingIndicatorInner userId={followingUserId} />
 }
 
-function FollowingIndicatorInner({ userId }: { userId: string }) {
+function FollowingIndicatorInner({ userId }: { userId: TLUserId }) {
 	const presence = usePresence(userId)
 	if (!presence) return null
 	return <div className="tlui-following-indicator" style={{ borderColor: presence.color }} />
 }
 ```
 
-You can override this component through the [UI customization](/sdk-features/ui-components) system to change its appearance or add the followed user's name.
+You can override it through the `FollowingIndicator` slot of [TLUiComponents](?) to change its appearance or add the followed user's name. See [UI components](/sdk-features/ui-components).
 
 ### Follow state detection
 
@@ -129,7 +141,7 @@ if (followingUserId) {
 
 The presence records from [Editor#getCollaborators](?) include each user's `followingUserId`, so you can visualize the entire follow graph and show which users are following whom.
 
-## Related
+## Related articles
 
 - [Camera](/sdk-features/camera) - Learn about viewport and camera control
 - [Collaboration](/docs/collaboration) - Set up multiplayer presence and sync

--- a/apps/docs/content/sdk-features/user-preferences.mdx
+++ b/apps/docs/content/sdk-features/user-preferences.mdx
@@ -18,7 +18,7 @@ accuracy: 9
 notes: Reading preferences snippet only shows 6 of 15 available getters. Some passive constructions. Persistence section could be condensed.
 ---
 
-User preferences store per-user settings that persist across sessions and synchronize across browser tabs. Access them through `editor.user`:
+User preferences store per-user settings that persist across sessions and synchronize across browser tabs. Access them through `editor.user`, a [UserPreferencesManager](?):
 
 ```tsx
 import { Tldraw, useEditor, useValue } from 'tldraw'
@@ -49,7 +49,9 @@ export default function App() {
 }
 ```
 
-Preferences fall into three categories: visual settings (color scheme, animation speed), interaction settings (snap mode, edge scroll speed), and identity properties (user name, color, locale). The system stores data in localStorage and uses the BroadcastChannel API to sync changes across tabs in real time.
+Preferences cover visual settings (color scheme, animation speed), interaction settings (snap mode, edge scroll speed), and identity (user name, color, locale). By default the editor stores them in localStorage and syncs them across tabs with a BroadcastChannel.
+
+To supply preferences from your own auth or state instead, pass a `user` created with [useTldrawCurrentUser](?) (or [createTLCurrentUser](?)) to the `Tldraw` component. Preferences you provide this way are yours to persist and sync. See [Collaboration](/sdk-features/collaboration#integrating-with-usetldrawcurrentuser) for a full example.
 
 ## Reading preferences
 
@@ -64,13 +66,18 @@ const userName = editor.user.getName()
 const userColor = editor.user.getColor()
 const isSnapMode = editor.user.getIsSnapMode()
 
-// All preferences as an object
+// The user's id as a `user:` prefixed record id, for presence and attribution
+const userId = editor.user.getRecordId()
+
+// All preferences as an object, with defaults resolved
 const allPrefs = editor.user.getUserPreferences()
 ```
 
+The tables below list the getter for each preference. Every preference in [TLUserPreferences](?) is optional; `null` or `undefined` means "use the default".
+
 ## Updating preferences
 
-Use `updateUserPreferences()` to change one or more preferences at once:
+Use [UserPreferencesManager#updateUserPreferences](?) to change one or more preferences at once:
 
 ```tsx
 editor.user.updateUserPreferences({
@@ -86,37 +93,35 @@ Changes apply immediately, save to localStorage, and broadcast to other tabs.
 
 ### Visual preferences
 
-| Preference         | Type                            | Default                        | Description                          |
-| ------------------ | ------------------------------- | ------------------------------ | ------------------------------------ |
-| `colorScheme`      | `'light' \| 'dark' \| 'system'` | `'light'`                      | Theme mode                           |
-| `animationSpeed`   | `number`                        | `1` (or `0` if reduced motion) | Multiplier for animation durations   |
-| `enhancedA11yMode` | `boolean`                       | `false`                        | Additional UI labels and visual aids |
-
-When `colorScheme` is `'system'`, the editor tracks the operating system's dark mode preference through a media query listener.
+| Preference         | Getter                | Type                            | Default                                        | Description                          |
+| ------------------ | --------------------- | ------------------------------- | ---------------------------------------------- | ------------------------------------ |
+| `colorScheme`      | `getIsDarkMode`       | `'light' \| 'dark' \| 'system'` | `'light'`                                      | Theme mode                           |
+| `animationSpeed`   | `getAnimationSpeed`   | `number`                        | `1`, or `0` if the user prefers reduced motion | Multiplier for animation durations   |
+| `enhancedA11yMode` | `getEnhancedA11yMode` | `boolean`                       | `false`                                        | Additional UI labels and visual aids |
 
 ### Interaction preferences
 
-| Preference                    | Type                            | Default | Description                                     |
-| ----------------------------- | ------------------------------- | ------- | ----------------------------------------------- |
-| `isSnapMode`                  | `boolean`                       | `false` | Snap shapes to other shapes and guides          |
-| `isWrapMode`                  | `boolean`                       | `false` | Enable text wrapping in text shapes             |
-| `isDynamicSizeMode`           | `boolean`                       | `false` | Live shape updates during resize                |
-| `isPasteAtCursorMode`         | `boolean`                       | `false` | Paste at cursor instead of original location    |
-| `edgeScrollSpeed`             | `number`                        | `1`     | Speed multiplier for edge scrolling during drag |
-| `areKeyboardShortcutsEnabled` | `boolean`                       | `true`  | Enable or disable keyboard shortcuts            |
-| `inputMode`                   | `'trackpad' \| 'mouse' \| null` | `null`  | Optimize behavior for input device              |
-| `isZoomDirectionInverted`     | `boolean`                       | `false` | Invert scroll-wheel zoom direction (mouse mode) |
+| Preference                    | Getter                           | Type                            | Default | Description                                                                    |
+| ----------------------------- | -------------------------------- | ------------------------------- | ------- | ------------------------------------------------------------------------------ |
+| `isSnapMode`                  | `getIsSnapMode`                  | `boolean`                       | `false` | Snap shapes to other shapes and guides                                         |
+| `isWrapMode`                  | `getIsWrapMode`                  | `boolean`                       | `false` | Brush selection only selects shapes fully inside the brush ("Select on wrap")  |
+| `isDynamicSizeMode`           | `getIsDynamicResizeMode`         | `boolean`                       | `false` | Scale new shapes with the zoom level so they stay the same size on screen      |
+| `isPasteAtCursorMode`         | `getIsPasteAtCursorMode`         | `boolean`                       | `false` | Paste at cursor instead of original location                                   |
+| `edgeScrollSpeed`             | `getEdgeScrollSpeed`             | `number`                        | `1`     | Speed multiplier for edge scrolling during drag                                |
+| `areKeyboardShortcutsEnabled` | `getAreKeyboardShortcutsEnabled` | `boolean`                       | `true`  | Enable or disable keyboard shortcuts                                           |
+| `inputMode`                   | `getInputMode`                   | `'trackpad' \| 'mouse' \| null` | `null`  | Optimize behavior for input device                                             |
+| `isZoomDirectionInverted`     | `getIsZoomDirectionInverted`     | `boolean`                       | `false` | Invert scroll-wheel zoom direction. Only applies when `inputMode` is `'mouse'` |
 
 ### Identity properties
 
-| Preference | Type     | Default             | Description                          |
-| ---------- | -------- | ------------------- | ------------------------------------ |
-| `id`       | `string` | Auto-generated      | Unique user identifier               |
-| `name`     | `string` | `''`                | Display name shown to collaborators  |
-| `color`    | `string` | Random from palette | User color for cursor and selections |
-| `locale`   | `string` | Browser locale      | Language code (e.g., `'en'`, `'fr'`) |
+| Preference | Getter                         | Type     | Default                          | Description                                                      |
+| ---------- | ------------------------------ | -------- | -------------------------------- | ---------------------------------------------------------------- |
+| `id`       | `getExternalId`, `getRecordId` | `string` | Auto-generated                   | Unique user identifier. `getRecordId` returns it as a `TLUserId` |
+| `name`     | `getName`                      | `string` | `''`                             | Display name shown to collaborators                              |
+| `color`    | `getColor`                     | `string` | Random from the built-in palette | User color for cursor and selections                             |
+| `locale`   | `getLocale`                    | `string` | Browser locale                   | Language code (e.g., `'en'`, `'fr'`)                             |
 
-The user color is randomly chosen from 12 visually distinct colors designed for collaboration.
+The user color is picked at random from `USER_COLORS`, a palette of 12 colors. The `id` is what [attribution](/sdk-features/attribution) and presence records use to identify the user.
 
 ## Dark mode
 
@@ -131,17 +136,9 @@ The editor-level `colorScheme` prop sets the default color scheme. When a user p
 
 ## Persistence and synchronization
 
-Preferences persist to localStorage under the key `TLDRAW_USER_DATA_v3`. Each save includes a version number, and the system runs migrations when loading older data to keep preferences compatible across tldraw releases.
+The default user persists preferences to localStorage under the key `TLDRAW_USER_DATA_v3`. Each save includes a version number, and the editor migrates older data on load so preferences stay compatible across tldraw releases. It validates the loaded data with [userTypeValidator](?) and falls back to fresh preferences if the data is invalid.
 
-The system uses the BroadcastChannel API to sync preference changes across browser tabs. When you change a preference in one tab, all other tabs update automatically. Each tab has a unique origin ID to avoid processing its own broadcasts.
-
-## Accessibility defaults
-
-The `animationSpeed` default respects the `prefers-reduced-motion` media query. Users with reduced motion enabled get `animationSpeed: 0` by default, disabling animations without manual configuration.
-
-## Validation
-
-Preferences are validated using `userTypeValidator` from `@tldraw/editor`. Invalid data falls back to fresh preferences rather than causing errors.
+The editor also broadcasts preference changes to other tabs over a BroadcastChannel. When you change a preference in one tab, all other tabs update automatically.
 
 ## Related examples
 

--- a/apps/docs/content/sdk-features/validation.mdx
+++ b/apps/docs/content/sdk-features/validation.mdx
@@ -17,12 +17,18 @@ accuracy: 9
 notes: Add more API links. Use more contractions for natural flow.
 ---
 
-The `@tldraw/validate` package handles validation across tldraw's schemas, record types, and shape props. Validators enforce runtime type safety and provide structured errors when data is malformed.
+The `@tldraw/validate` package handles validation across tldraw's schemas, record types, and shape props. Validators enforce runtime type safety and provide structured errors when data is malformed. The `T` namespace is re-exported from `tldraw`, so `import { T } from 'tldraw'` works too.
 
 ## Where validation runs
 
-- Shape and binding props via `RecordProps`
-- Record types in the Store via `createRecordType` and `StoreSchema`
+Validation runs whenever a record is written to the [store](/sdk-features/store):
+
+- Shape and binding props via [RecordProps](?)
+- Shape, binding, and user `meta` via the `meta` field on their schema config
+- Custom record types via [CustomRecordInfo](?)
+- Any record type in a store via [createRecordType](?) and [StoreSchema](?)
+
+If validation fails, the write throws and nothing is stored.
 
 ## Core validators
 
@@ -42,47 +48,27 @@ const user = userValidator.validate(input)
 
 Every validator has three key methods:
 
-- `validate(value)` - validates unknown input and returns a typed result
-- `isValid(value)` - returns true if valid, false otherwise (useful as a type guard)
-- `validateUsingKnownGoodVersion(knownGood, newValue)` - performance-optimized validation that reuses previously validated data
+- `validate(value)` validates unknown input and returns a typed result
+- `isValid(value)` returns true if valid, false otherwise (useful as a type guard)
+- `validateUsingKnownGoodVersion(knownGood, newValue)` reuses previously validated data to skip unchanged parts. The store calls this automatically when updating an existing record.
 
 ## Validator catalog
 
-### Primitives
+| Category     | Validators                                                                                                                             |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Primitives   | `T.unknown`, `T.any`, `T.string`, `T.number`, `T.boolean`, `T.bigint`                                                                  |
+| Numbers      | `T.positiveNumber`, `T.nonZeroNumber`, `T.nonZeroFiniteNumber`, `T.unitInterval`, `T.integer`, `T.positiveInteger`, `T.nonZeroInteger` |
+| Collections  | `T.array`, `T.arrayOf`, `T.object`, `T.unknownObject`, `T.dict`, `T.jsonDict`, `T.jsonValue`                                           |
+| Unions       | `T.literal`, `T.literalEnum`, `T.setEnum`, `T.union`, `T.numberUnion`, `T.or`                                                          |
+| URLs and IDs | `T.linkUrl`, `T.srcUrl`, `T.httpUrl`, `T.indexKey`                                                                                     |
+| Modifiers    | `.optional()`, `.nullable()`, `.refine()`, `.check()`, `T.optional()`, `T.nullable()`, `T.model()`                                     |
 
-- `T.unknown`, `T.any`
-- `T.string`, `T.number`, `T.boolean`, `T.bigint`
-
-### Numbers
-
-- `T.positiveNumber`, `T.nonZeroNumber`, `T.nonZeroFiniteNumber`
-- `T.unitInterval`, `T.integer`, `T.positiveInteger`, `T.nonZeroInteger`
-
-### Collections and objects
-
-- `T.array`, `T.arrayOf`, `T.object`, `T.unknownObject`
-- `T.dict`, `T.jsonDict`, `T.jsonValue`
-
-### Unions and enums
-
-- `T.literal`, `T.literalEnum`, `T.setEnum`
-- `T.union`, `T.or`
-
-### URLs and identifiers
-
-- `T.linkUrl`, `T.srcUrl`, `T.httpUrl`, `T.indexKey`
-
-### Modifiers and helpers
-
-- `validator.optional()`, `validator.nullable()`
-- `T.optional(...)`, `T.nullable(...)`
-- `validator.refine(...)`, `validator.check(...)`
-- `T.model(...)`
+Object validators also have `.extend()` to add fields and `.allowUnknownProperties()` to tolerate extra keys.
 
 ## Common validator patterns
 
 ```typescript
-import { T, ValidationError } from '@tldraw/validate'
+import { T } from '@tldraw/validate'
 
 const configValidator = T.object({
 	id: T.string,
@@ -92,33 +78,47 @@ const configValidator = T.object({
 })
 
 const evenNumber = T.number.check('even', (value) => {
-	if (value % 2 !== 0) throw new ValidationError('Expected even number')
+	if (value % 2 !== 0) throw new T.ValidationError('Expected even number')
 })
 ```
 
 ## Record props validation
 
-Shapes and bindings use `RecordProps` to validate their `props` at runtime. This keeps stored data consistent with the schema.
+Shapes and bindings use [RecordProps](?) to validate their `props` at runtime. Each key maps to a validator, and the store rejects any write whose props don't pass:
 
 ```typescript
-import { ShapeUtil, type RecordProps, T, DefaultColorStyle } from 'tldraw'
+import { DefaultColorStyle, RecordProps, T, TLBaseShape, TLDefaultColorStyle } from 'tldraw'
 
-class MyShapeUtil extends ShapeUtil<MyShape> {
-	static override props: RecordProps<MyShape> = {
-		color: DefaultColorStyle,
-		text: T.string,
-	}
+type CardShape = TLBaseShape<'card', { color: TLDefaultColorStyle; text: string }>
+
+const cardShapeProps: RecordProps<CardShape> = {
+	color: DefaultColorStyle,
+	text: T.string,
 }
 ```
 
+Assign this object to `static override props` on your `ShapeUtil`. See the [custom shape example](/examples/shapes/tools/custom-shape) for the full util.
+
 ## Store validation and recovery
 
-The Store validates records on write. You can provide `onValidationFailure` to recover or sanitize data:
+The store validates records on write. When you build your own [StoreSchema](?) you can pass `onValidationFailure` to recover or sanitize data instead of throwing:
 
 ```typescript
-import { StoreSchema, createRecordType } from '@tldraw/store'
+import { BaseRecord, RecordId, StoreSchema, createRecordType } from '@tldraw/store'
+import { T, idValidator } from 'tldraw'
 
-const Book = createRecordType<Book>('book', { scope: 'document' })
+interface Book extends BaseRecord<'book', RecordId<Book>> {
+	title: string
+}
+
+const Book = createRecordType<Book>('book', {
+	scope: 'document',
+	validator: T.object({
+		id: idValidator<RecordId<Book>>('book'),
+		typeName: T.literal('book'),
+		title: T.string,
+	}),
+})
 
 const schema = StoreSchema.create(
 	{ book: Book },
@@ -128,29 +128,24 @@ const schema = StoreSchema.create(
 )
 ```
 
-The `failure` object contains:
+The handler must return a valid record, or rethrow to abort the write. The `failure` object is a [StoreValidationFailure](?):
 
 | Property       | Description                                                                              |
 | -------------- | ---------------------------------------------------------------------------------------- |
-| `error`        | The validation error that occurred                                                       |
+| `error`        | The error that was thrown                                                                |
 | `store`        | The store instance where validation failed                                               |
 | `record`       | The invalid record                                                                       |
 | `phase`        | When validation failed: `'initialize'`, `'createRecord'`, `'updateRecord'`, or `'tests'` |
 | `recordBefore` | The previous record state (null for new records)                                         |
 
-## Validation lifecycle
-
-1. A record is created or updated.
-2. The record type validator runs.
-3. If validation fails, `onValidationFailure` receives the failure object.
-4. The handler can return a corrected record or throw to abort the write.
+tldraw's own schema from [createTLSchema](?) (and so [createTLStore](?) and the `Tldraw` component) uses a built-in handler that reports the error and rethrows. You can't override it there; if you need recovery, build the `StoreSchema` yourself.
 
 ## Error handling
 
-The `ValidationError` class provides structured information about what went wrong:
+`T.ValidationError` carries structured information about what went wrong:
 
 ```typescript
-import { T, ValidationError } from '@tldraw/validate'
+import { T } from '@tldraw/validate'
 
 const userValidator = T.object({
 	name: T.string,
@@ -160,7 +155,7 @@ const userValidator = T.object({
 try {
 	userValidator.validate({ name: 'Alice', settings: { theme: 'invalid' } })
 } catch (error) {
-	if (error instanceof ValidationError) {
+	if (error instanceof T.ValidationError) {
 		console.log(error.message) // 'At settings.theme: Expected "light" or "dark", got invalid'
 		console.log(error.rawMessage) // 'Expected "light" or "dark", got invalid'
 		console.log(error.path) // ['settings', 'theme']
@@ -168,19 +163,11 @@ try {
 }
 ```
 
-The error has two useful properties:
+`rawMessage` is the message without path information, and `path` is an array showing where in the data structure validation failed (for example `['items', 0, 'name']`). The full `message` combines them.
 
-- `rawMessage` - the error message without path information
-- `path` - an array showing where in the data structure validation failed (e.g., `['settings', 'theme']` or `['items', 0, 'name']`)
-
-The full `message` property combines these: `"At settings.theme: Expected..."`.
-
-## Gotchas
-
-- Validators must be pure and must not mutate input values.
-- If you use `onValidationFailure`, return a valid record or rethrow to abort the write.
+Validators must be pure and must not mutate input values.
 
 ## Related examples
 
-- **[Custom shape](/examples/shapes/tools/custom-shape)** - Define shape props with validators using RecordProps.
-- **[Shape meta (on create)](/examples/events/meta-on-create)** - Add custom metadata to shapes when they're created.
+- [Custom shape](/examples/shapes/tools/custom-shape) - Define shape props with validators using RecordProps.
+- [Custom validators for shape props](/examples/shapes/tools/custom-validators) - Add constraints with `.check()` and `.refine()`.

--- a/apps/docs/content/sdk-features/visibility.mdx
+++ b/apps/docs/content/sdk-features/visibility.mdx
@@ -13,11 +13,11 @@ keywords:
   - viewport
 ---
 
-The editor's visibility system determines which shapes are rendered on screen. It handles two separate concerns: **culling** (hiding off-screen shapes for performance) and **hidden shapes** (shapes your application explicitly hides).
+The editor's visibility system determines which shapes are rendered on screen. It handles two separate concerns: culling, which hides off-screen shapes for performance, and hidden shapes, which your application hides explicitly.
 
 ## Culling
 
-Culling is a performance optimization. Shapes outside the viewport are removed from the render output by setting `display: none` on their DOM elements. The shapes remain in the store and can still be selected, updated, or queried—they just don't render.
+Culling is a performance optimization. Shapes outside the viewport stay in the store and can still be selected, updated, or queried, but the editor sets `display: none` on their DOM elements. Selected shapes and the shape being edited are never culled. Return `false` from [ShapeUtil#canCull](?) to opt a shape out.
 
 You can get the set of culled shape IDs with [Editor#getCulledShapes](?):
 
@@ -25,40 +25,7 @@ You can get the set of culled shape IDs with [Editor#getCulledShapes](?):
 const culledIds = editor.getCulledShapes()
 ```
 
-Two kinds of shapes are never culled, even when off-screen:
-
-1. **Selected shapes** — the user might be dragging them back into view
-2. **The editing shape** — the user is actively working on it
-
-### How culling works
-
-The editor uses a spatial index (an R-tree) to quickly find which shapes are inside the viewport. Shapes outside the viewport are candidates for culling, but the final decision depends on [ShapeUtil#canCull](?):
-
-```ts
-class MyShapeUtil extends ShapeUtil<MyShape> {
-	override canCull(shape: MyShape): boolean {
-		return true // default behavior
-	}
-}
-```
-
-Return `false` from `canCull` to prevent a shape from being culled. You'd do this for shapes that need to keep running while off-screen—for example, shapes that measure their DOM content to determine their size:
-
-```ts
-class DynamicSizeShapeUtil extends ShapeUtil<DynamicSizeShape> {
-	override canCull() {
-		return false // keep rendering so we can measure DOM
-	}
-}
-```
-
-### Culling methods
-
-| Method                                          | Description                                                                   |
-| ----------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Editor#getCulledShapes](?)                     | Returns the set of shape IDs that are currently culled.                       |
-| [Editor#getNotVisibleShapes](?)                 | Returns shape IDs outside the viewport (before selection filtering).          |
-| [Editor#getCurrentPageRenderingShapesSorted](?) | Returns shapes that will actually render (excludes culled and hidden shapes). |
+See [Culling](/sdk-features/culling) for how the spatial index decides what to cull and for the full set of culling methods.
 
 ## Hidden shapes
 
@@ -84,11 +51,13 @@ export default function App() {
 
 The function can return:
 
-| Return value               | Behavior                                                |
-| -------------------------- | ------------------------------------------------------- |
-| `'inherit'` or `undefined` | Shape is visible unless its parent is hidden (default). |
-| `'hidden'`                 | Shape is always hidden.                                 |
-| `'visible'`                | Shape is always visible, even if parent is hidden.      |
+| Return value                        | Behavior                                                |
+| ----------------------------------- | ------------------------------------------------------- |
+| `'inherit'`, `undefined`, or `null` | Shape is visible unless its parent is hidden (default). |
+| `'hidden'`                          | Shape is always hidden.                                 |
+| `'visible'`                         | Shape is always visible, even if parent is hidden.      |
+
+The same prop is available on [TldrawEditor](?) and as an [Editor](?) constructor option. The editor caches the result per shape, so keep the callback pure.
 
 Hidden shapes are still in the store. They're just excluded from:
 
@@ -96,6 +65,8 @@ Hidden shapes are still in the store. They're just excluded from:
 - Hit tests ([Editor#getShapeAtPoint](?), [Editor#getShapesAtPoint](?))
 - [Editor#getRenderingShapes](?) and [Editor#getCurrentPageRenderingShapesSorted](?)
 - Image exports and printing
+- [Editor#getCurrentPageBounds](?) and [Editor#zoomToFit](?)
+- Drop targets and automatic parenting of new shapes
 
 You can check if a shape is hidden with [Editor#isShapeHidden](?):
 
@@ -107,7 +78,7 @@ if (editor.isShapeHidden(shapeId)) {
 
 ### Preventing hidden shapes from being selected
 
-Hidden shapes can still be selected via keyboard shortcuts like select-all. If you want to prevent this, filter the selection when it changes:
+Hidden shapes can still be selected via keyboard shortcuts like select-all. If you want to prevent this, filter the [selection](/sdk-features/selection) when it changes:
 
 ```tsx
 import { react, Tldraw } from 'tldraw'
@@ -137,7 +108,7 @@ For examples using hidden shapes, see the [collaboration private content example
 
 ## Opacity
 
-Each shape has an `opacity` property (0 to 1) that controls its transparency. When shapes are nested, opacity multiplies down the hierarchy—a shape at 0.5 opacity inside a parent at 0.5 opacity renders at 0.25 opacity.
+Each shape has an `opacity` property (0 to 1) that controls its transparency. When shapes are nested, opacity multiplies down the hierarchy: a shape at 0.5 opacity inside a parent at 0.5 opacity renders at 0.25 opacity.
 
 The editor calculates the cumulative opacity for each shape and passes it to the rendering layer. You can access the computed opacity through [Editor#getRenderingShapes](?):
 
@@ -169,4 +140,4 @@ interface TLRenderingShape {
 
 The `index` and `backgroundIndex` values control z-ordering. The editor uses CSS z-index rather than DOM ordering to position shapes visually. This keeps the DOM stable (shapes stay in ID order) and avoids expensive reflows when z-order changes.
 
-For most use cases, you won't need to work with rendering shapes directly—the editor's canvas handles this. But if you're building custom rendering or need to understand which shapes are visible at what opacity, this is the API to use.
+For most use cases, you won't need to work with rendering shapes directly; the editor's canvas handles this. Use it if you're building custom rendering or need to know which shapes are visible at what opacity.


### PR DESCRIPTION
In order to keep the guide pages accurate against the current SDK, this PR reviews all 93 articles under `apps/docs/content/sdk-features/` and `apps/docs/content/docs/` against the package source and API reports, and fixes what was wrong. Every article was scored on readability, voice, completeness, and accuracy; 28 of them scored 6/10 or lower on accuracy before the pass. Nothing new was added beyond small gap fills (a missing table row, an options table, a link to an existing example); no new sections.

The bulk of the diff is accuracy fixes:

- Snippets that didn't compile or used nonexistent APIs: `ValidationError` import, `updateBinding` without `type`, `TLTheme` missing required UI colors, `ShapeUtil<TLBaseShape<…>>`, `InMemorySyncStorage(TLStoreSnapshot)`, `props: { text }` on text shapes, empty highlight `segments`, `TldrawUiButtonSpinner`, invalid icon names.
- Renamed or removed APIs: `textFirstEditedBy` → `textLastEditedBy`, `onCommentRead` → `onCommentsRead`, the removed indicator-level error boundary, `hitTestMargin` default 8 → 3, `--template sync-cloudflare` → `multiplayer`.
- Behaviour claims that were wrong: `fit-min`/`fit-max` inverted, `hideUi` disabling shortcuts, readonly persisting with `persistenceKey`, marks clearing the redo stack, `setStyleForSelectedShapes` setting next-shape styles, a paste offset that doesn't exist, a `Cmd+Shift+F` frame shortcut that doesn't exist, locked embeds being interactive, edge-scrolling `insets` inverted, `EXCLUDE_LABELS` as the default geometry filter, snapping requiring Ctrl or snap mode (previously unstated), and the `<Tldraw locale>` prop (see #10032).
- Links: example links normalized to `/examples/<category>/<slug>`, `[Symbol](?)` autolinks added throughout and checked against the generated reference, links to `status: draft` articles removed so `check-links` passes.

Voice edits follow `VOICE.md` and the docs guide: bold-lead-in lists to prose or tables, redundant sections that repeated earlier examples cut, hedging and AI tells removed. Review-score frontmatter fields were left as they were.

Two SDK-side follow-ups came out of this and are filed separately rather than fixed here: #10032 (`locale` prop doesn't reach the UI provider) and #10033 (`markHistoryStoppingPoint` doc comment). #10034 tracks the `community/license.mdx` data-collection contradiction, which is outside these two directories.

### Change type

- [x] `other`

### Test plan

1. `cd apps/docs && yarn refresh-content && yarn check-links --fail` (validates every `(?)` autolink and internal link).
2. Spot-check a few of the heavier rewrites in the docs dev server: `sdk-features/snapping`, `sdk-features/options`, `sdk-features/instance-state`, `docs/sync`, `docs/indicators`.

### Release notes

- Corrected and tightened the SDK features and docs guide articles on tldraw.dev.