### PR TITLE
docs(skills): tell write-tbp to draft plainly for a human editor

### DIFF
--- a/skills/write-tbp/SKILL.md
+++ b/skills/write-tbp/SKILL.md
@@ -64,22 +64,36 @@ If you can't find an interesting angle, the topic may not be suitable for a tech
 
 Create `assets/<topic>/draft.md` following the blog-guide structure:
 
-1. **Frame the problem** — Hook the reader with context and tension
+1. **State the problem** — What the system does and what would go wrong without it
 2. **Show the insight** — The key idea that makes it work
 3. **Walk through the implementation** — Code and explanation, building complexity
 4. **Wrap up** — Where it lives, tradeoffs, links to files
 
 Target 800-1500 words.
 
+#### Draft plainly
+
+The draft is raw material for a human editor, not the finished post. Keep it clean and let the content carry it. The editor will add the personality, anecdotes, and punch where they want them; that is much easier to do on top of a plain, correct draft than to strip out of an overwritten one.
+
+Concretely:
+
+- Open by saying what the system does and what the post covers. Do not open with a scene, an anecdote, or a hypothetical user ("your train goes into a tunnel..."). Those read as AI filler and the editor will cut them.
+- Build the story from the mechanism: what problem each piece solves, in the order the pieces depend on each other. Tension comes from the design (a scan can't see deletions; the pruner used to leave a hole), not from prose.
+- State journeys and bugs flatly. "An earlier version of the pruner did not advance the watermark, so stale clients received diffs with no deletes" is enough. Skip "we learned this the hard way" and similar narration.
+- No punchline sentences, no chiasmus, no closing zingers. If a sentence exists to sound good rather than to say something, cut it.
+- One em dash per paragraph at most; usually zero.
+- Keep opinions to the wrap-up, and keep them short and specific ("we accept a full redownload for clients gone long enough, in exchange for bounded metadata").
+- Where the human parts belong (opening, provenance, tradeoffs), leave the paragraph plain rather than inventing color. Mention those spots in your handoff.
+
 ### 5. Self-evaluate
 
 Check the draft against the blog-guide checklist:
 
-- [ ] **Opening** — Does it frame a problem before diving into solution?
-- [ ] **Insight** — Is there a clear "aha" moment or key idea?
+- [ ] **Opening** — Does it state the problem plainly before the solution, without a staged anecdote?
+- [ ] **Insight** — Is there a clear key idea, and does the structure build toward it?
 - [ ] **Specificity** — Is this grounded in tldraw's actual implementation?
 - [ ] **Code** — Do examples build understanding, not just show syntax?
-- [ ] **Tone** — Warm and personal, but not rambling?
+- [ ] **Tone** — Plain and direct? No pathos, no punchlines, nothing an editor would recognize as AI cruft?
 - [ ] **Links** — Points to actual code in the repo?
 - [ ] **Length** — Appropriate depth for the topic?
 
@@ -87,7 +101,7 @@ Revise the draft to address any gaps.
 
 ### 6. Output
 
-Present the final draft to the user for review. The draft remains in `assets/<topic>/draft.md` until the user is satisfied, at which point they can move it to the appropriate location.
+Present the final draft to the user for review, and point out where a human editor is most likely to want to add color (usually the opening, any provenance or bug story, and the tradeoffs). The draft remains in `assets/<topic>/draft.md` until the user is satisfied, at which point they can move it to the appropriate location.
 
 ## References
 


### PR DESCRIPTION
In order to get technical blog drafts that a human editor can shape without first stripping out AI filler, this PR tells the `write-tbp` skill to draft plainly. Drafts from the skill were opening with staged anecdotes (a hypothetical user, a train going into a tunnel), narrating bugs with pathos ("we learned this the hard way"), and ending on punchline sentences. Editing those out is more work than adding color to a clean, correct draft.

The skill gains a "Draft plainly" section: state what the system does up front, build tension from the mechanism rather than the prose, describe journeys and bugs flatly, no punchlines, and leave the places a human will want to add color (opening, provenance, tradeoffs) plain rather than inventing it. The step 4 arc, the self-evaluation checklist, and the handoff step are reworded to match. `skills/shared/blog-guide.md` is unchanged since it describes the finished post's voice and is shared with other skills.

### Change type

- [x] `other`

### Test plan

Skill guidance only; nothing to run.

### Code changes

| Section        | LOC change |
| -------------- | ---------- |
| Config/tooling | +19 / -5   |