### PR TITLE
fix(dotcom): remove published history entries on unpublish

### DIFF
--- a/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
+++ b/apps/dotcom/sync-worker/src/TLFileDurableObject.ts
@@ -75,7 +75,7 @@ import {
 import { PERSIST_INTERVAL_MS } from './config'
 import { Logger } from './Logger'
 import { TLPostgresPool } from './postgres'
-import { getR2KeyForRoom } from './r2'
+import { getR2KeyForRoom, listAllObjectKeys } from './r2'
 import { RoomNotFoundError, shouldSkipMissingRoomEffect } from './roomEffectHelpers'
 import { getPublishedRoomSnapshot } from './routes/tla/getPublishedFile'
 import { deleteBoardThumbnails, enqueueOgImageRender } from './routes/tla/ogImageQueue'
@@ -2977,19 +2977,6 @@ export class TLFileDurableObject extends DurableObject {
 		await this.r2.rooms.put(key, JSON.stringify(DEFAULT_INITIAL_SNAPSHOT))
 		await this.getRoom()
 	}
-}
-
-async function listAllObjectKeys(bucket: R2Bucket, prefix: string): Promise<string[]> {
-	const keys: string[] = []
-	let cursor: string | undefined
-
-	do {
-		const result = await bucket.list({ prefix, cursor })
-		keys.push(...result.objects.map((o) => o.key))
-		cursor = result.truncated ? result.cursor : undefined
-	} while (cursor)
-
-	return keys
 }
 
 const PERSIST_RETRIES_NOTIFY_THRESHOLD = 10

--- a/apps/dotcom/sync-worker/src/r2.ts
+++ b/apps/dotcom/sync-worker/src/r2.ts
@@ -15,3 +15,16 @@ export function getR2KeyForSnapshot({
 	const slug = parentSlug ? `${parentSlug}/${snapshotSlug}` : snapshotSlug
 	return getR2KeyForRoom({ slug, isApp })
 }
+
+export async function listAllObjectKeys(bucket: R2Bucket, prefix: string): Promise<string[]> {
+	const keys: string[] = []
+	let cursor: string | undefined
+
+	do {
+		const result = await bucket.list({ prefix, cursor })
+		keys.push(...result.objects.map((o) => o.key))
+		cursor = result.truncated ? result.cursor : undefined
+	} while (cursor)
+
+	return keys
+}

--- a/apps/dotcom/sync-worker/src/utils/publishSnapshots.test.ts
+++ b/apps/dotcom/sync-worker/src/utils/publishSnapshots.test.ts
@@ -39,7 +39,16 @@ function file(partial: Partial<TlaFile>): TlaFile {
 function makeEnv() {
 	return {
 		ROOMS: { get: vi.fn() },
-		ROOM_SNAPSHOTS: { put: vi.fn(), delete: vi.fn() },
+		ROOM_SNAPSHOTS: {
+			put: vi.fn(),
+			delete: vi.fn(),
+			list: vi.fn(
+				async (): Promise<{ objects: { key: string }[]; truncated: boolean; cursor?: string }> => ({
+					objects: [],
+					truncated: false,
+				})
+			),
+		},
 		SNAPSHOT_SLUG_TO_PARENT_SLUG: { put: vi.fn(), delete: vi.fn() },
 		TLDR_DOC: {
 			idFromName: vi.fn(() => 'id'),
@@ -139,11 +148,34 @@ describe('unpublishSnapshot', () => {
 		expect(deleteOgImage).not.toHaveBeenCalled()
 	})
 
-	it('deletes the mapping and snapshot when publishedSlug is set', async () => {
+	it('deletes the mapping, the snapshot, and its history when publishedSlug is set', async () => {
 		const env = makeEnv()
+		env.ROOM_SNAPSHOTS.list
+			.mockResolvedValueOnce({
+				objects: [{ key: 'app_rooms/f1/slug-1' }, { key: 'app_rooms/f1/slug-1|t1' }],
+				truncated: true,
+				cursor: 'c1',
+			})
+			.mockResolvedValueOnce({
+				objects: [{ key: 'app_rooms/f1/slug-1|t2' }],
+				truncated: false,
+			})
 		await unpublishSnapshot(env as any as Environment, file({ id: 'f1', publishedSlug: 'slug-1' }))
 		expect(env.SNAPSHOT_SLUG_TO_PARENT_SLUG.delete).toHaveBeenCalledWith('slug-1')
+		expect(env.ROOM_SNAPSHOTS.list).toHaveBeenCalledWith({
+			prefix: 'app_rooms/f1/slug-1',
+			cursor: undefined,
+		})
+		expect(env.ROOM_SNAPSHOTS.list).toHaveBeenCalledWith({
+			prefix: 'app_rooms/f1/slug-1',
+			cursor: 'c1',
+		})
 		expect(env.ROOM_SNAPSHOTS.delete).toHaveBeenCalledTimes(1)
+		expect(env.ROOM_SNAPSHOTS.delete).toHaveBeenCalledWith([
+			'app_rooms/f1/slug-1',
+			'app_rooms/f1/slug-1|t1',
+			'app_rooms/f1/slug-1|t2',
+		])
 		// the published thumbnail depicts the snapshot being removed, so it goes with it
 		expect(deleteOgImage).toHaveBeenCalledWith(env, { kind: 'published', slug: 'slug-1' })
 	})

--- a/apps/dotcom/sync-worker/src/utils/publishSnapshots.ts
+++ b/apps/dotcom/sync-worker/src/utils/publishSnapshots.ts
@@ -1,5 +1,5 @@
 import { TlaFile } from '@tldraw/dotcom-shared'
-import { getR2KeyForRoom } from '../r2'
+import { getR2KeyForRoom, listAllObjectKeys } from '../r2'
 import { deleteOgImage, enqueuePublishThumbnailRender } from '../routes/tla/ogImageQueue'
 import { Environment } from '../types'
 import { getRoomDurableObject } from './durableObjects'
@@ -46,9 +46,14 @@ export async function unpublishSnapshot(env: Environment, file: TlaFile) {
 	// Partially-created rows can lack a slug; nothing published to remove.
 	if (!file.publishedSlug) return
 	await env.SNAPSHOT_SLUG_TO_PARENT_SLUG.delete(file.publishedSlug)
-	await env.ROOM_SNAPSHOTS.delete(
+	// The current snapshot plus every `|timestamp` history entry written by republishes.
+	const publishedKeys = await listAllObjectKeys(
+		env.ROOM_SNAPSHOTS,
 		getR2KeyForRoom({ slug: `${file.id}/${file.publishedSlug}`, isApp: true })
 	)
+	if (publishedKeys.length > 0) {
+		await env.ROOM_SNAPSHOTS.delete(publishedKeys)
+	}
 	// The published thumbnail goes with the published snapshot it depicts. Scoped to
 	// `kind: 'published'`, so the board's own file-keyed image is untouched. See deleteOgImage.
 	await deleteOgImage(env, { kind: 'published', slug: file.publishedSlug })


### PR DESCRIPTION
Looks like we never properly cleaned up historic snapshot entries, just the one that was stored last. Discovered this while testing #9894 
 
In order to stop unpublished boards leaving orphaned snapshots in R2, this PR makes `unpublishSnapshot` delete every object under the `app_rooms/{fileId}/{publishedSlug}` prefix instead of only the current key. Each publish/republish writes a `{slug}|{timestamp}` history entry next to the current snapshot; unpublish only ever removed the current one, so the history stuck around forever (with the slug mapping already gone, nothing could reach it). Hard delete already did the prefix sweep in `TLFileDurableObject`; the shared `listAllObjectKeys` helper now lives in `r2.ts` and both paths use it.

### Change type

- [x] `bugfix`

### Test plan

1. Publish a board, republish a couple times, unpublish.
2. Confirm nothing remains under `app_rooms/{fileId}/{publishedSlug}` in `ROOM_SNAPSHOTS`.

- [x] Unit tests
